### PR TITLE
HSEARCH-631 Don't wrap FullText* instances when passed to Search.getFT*

### DIFF
--- a/hibernate-search/src/main/java/org/hibernate/search/Search.java
+++ b/hibernate-search/src/main/java/org/hibernate/search/Search.java
@@ -38,7 +38,7 @@ public final class Search {
 	}
 
 	public static FullTextSession getFullTextSession(Session session) {
-		if ( session instanceof FullTextSessionImpl ) {
+		if ( session instanceof FullTextSession ) {
 			return ( FullTextSession ) session;
 		}
 		else {

--- a/hibernate-search/src/main/java/org/hibernate/search/jpa/Search.java
+++ b/hibernate-search/src/main/java/org/hibernate/search/jpa/Search.java
@@ -43,7 +43,7 @@ public final class Search {
 	 * The underlying EM implementation has to be Hibernate EntityManager
 	 */
 	public static FullTextEntityManager getFullTextEntityManager(EntityManager em) {
-		if ( em instanceof FullTextEntityManagerImpl ) {
+		if ( em instanceof FullTextEntityManager ) {
 			return (FullTextEntityManager) em;
 		}
 		else {


### PR DESCRIPTION
We currently test for FT*Impl but that's not enough due to the tricks Seam does with proxies.
