### PR TITLE
HSEARCH-652 Cache NumericField usage in Delete operation for single entity-per-index case

### DIFF
--- a/hibernate-search/src/main/java/org/hibernate/search/backend/impl/lucene/works/DeleteWorkDelegate.java
+++ b/hibernate-search/src/main/java/org/hibernate/search/backend/impl/lucene/works/DeleteWorkDelegate.java
@@ -72,7 +72,7 @@ class DeleteWorkDelegate implements LuceneWorkDelegate {
 		BooleanQuery entityDeletionQuery = new BooleanQuery();
 
 		Query idQueryTerm;
-		if ( isIdNumeric( entityType ) ) {
+		if ( isIdNumeric( entityType, builder ) ) {
 			idQueryTerm = NumericFieldUtils.createExactMatchQuery( builder.getIdentifierName(), id );
 		} else {
 			idQueryTerm = new TermQuery( builder.getTerm( id ) );
@@ -92,8 +92,8 @@ class DeleteWorkDelegate implements LuceneWorkDelegate {
 		}
 	}
 
-	protected boolean isIdNumeric(Class<?> entityType) {
-		TwoWayFieldBridge idBridge = workspace.getDocumentBuilder(entityType).getIdBridge();
+	protected static boolean isIdNumeric(Class<?> entityType, DocumentBuilderIndexedEntity<?> documentBuilder) {
+		TwoWayFieldBridge idBridge = documentBuilder.getIdBridge();
 		return idBridge instanceof NumericFieldBridge;
 	}
 

--- a/hibernate-search/src/main/java/org/hibernate/search/bridge/util/NumericFieldUtils.java
+++ b/hibernate-search/src/main/java/org/hibernate/search/bridge/util/NumericFieldUtils.java
@@ -3,7 +3,6 @@ package org.hibernate.search.bridge.util;
 import org.apache.lucene.document.NumericField;
 import org.apache.lucene.search.NumericRangeQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.util.NumericUtils;
 import org.hibernate.search.SearchException;
 
 /**
@@ -16,17 +15,17 @@ public class NumericFieldUtils {
 	public static Query createNumericRangeQuery(String fieldName, Object from, Object to,
 												boolean includeLower, boolean includeUpper) {
 		Class numericClass = from.getClass();
-		if (numericClass.isAssignableFrom(Double.class)) {
-			return NumericRangeQuery.newDoubleRange(fieldName, (Double) from, (Double) to, includeLower, includeUpper);
+		if ( numericClass.isAssignableFrom( Double.class ) ) {
+			return NumericRangeQuery.newDoubleRange( fieldName, (Double) from, (Double) to, includeLower, includeUpper );
 		}
-		if (numericClass.isAssignableFrom(Long.class)) {
-			return NumericRangeQuery.newLongRange(fieldName, (Long) from, (Long) to, includeLower, includeUpper);
+		if ( numericClass.isAssignableFrom( Long.class ) ) {
+			return NumericRangeQuery.newLongRange( fieldName, (Long) from, (Long) to, includeLower, includeUpper );
 		}
-		if (numericClass.isAssignableFrom(Integer.class)) {
-			return NumericRangeQuery.newIntRange(fieldName, (Integer) from, (Integer) to, includeLower, includeUpper);
+		if ( numericClass.isAssignableFrom( Integer.class ) ) {
+			return NumericRangeQuery.newIntRange( fieldName, (Integer) from, (Integer) to, includeLower, includeUpper );
 		}
-		if (numericClass.isAssignableFrom(Float.class)) {
-			return NumericRangeQuery.newFloatRange(fieldName, (Float) from, (Float) to, includeLower, includeUpper);
+		if ( numericClass.isAssignableFrom( Float.class ) ) {
+			return NumericRangeQuery.newFloatRange( fieldName, (Float) from, (Float) to, includeLower, includeUpper );
 		}
 		// TODO: check for type before in the mapping
 		throw new SearchException(
@@ -34,24 +33,31 @@ public class NumericFieldUtils {
 						"(int,long, short or double) ");
 	}
 
-
+	/**
+	 * Will create a RangeQuery matching exactly the provided value: lower
+	 * and upper value match, and bounds are included. This should perform
+	 * as efficiently as a TermQuery.
+	 * @param fieldName
+	 * @param value
+	 * @return the created Query
+	 */
 	public static Query createExactMatchQuery(String fieldName, Object value) {
 		return createNumericRangeQuery(fieldName, value, value, true, true);
 	}
 
 	public static void setNumericValue(Object value, NumericField numericField) {
 		Class numericClass = value.getClass();
-		if (numericClass.isAssignableFrom(Double.class)) {
-			numericField.setDoubleValue((Double) value);
+		if ( numericClass.isAssignableFrom( Double.class ) ) {
+			numericField.setDoubleValue( (Double) value );
 		}
-		if (numericClass.isAssignableFrom(Long.class)) {
-			numericField.setLongValue((Long) value);
+		if ( numericClass.isAssignableFrom( Long.class ) ) {
+			numericField.setLongValue( (Long) value );
 		}
-		if (numericClass.isAssignableFrom(Integer.class)) {
-			numericField.setIntValue((Integer) value);
+		if ( numericClass.isAssignableFrom( Integer.class ) ) {
+			numericField.setIntValue( (Integer) value );
 		}
-		if (numericClass.isAssignableFrom(Float.class)) {
-			numericField.setFloatValue((Float) value);
+		if ( numericClass.isAssignableFrom( Float.class ) ) {
+			numericField.setFloatValue( (Float) value );
 		}
 	}
 }

--- a/hibernate-search/src/main/java/org/hibernate/search/engine/DocumentBuilderIndexedEntity.java
+++ b/hibernate-search/src/main/java/org/hibernate/search/engine/DocumentBuilderIndexedEntity.java
@@ -541,7 +541,7 @@ public class DocumentBuilderIndexedEntity<T> extends AbstractDocumentBuilder<T> 
 	}
 
 	public String getIdentifierName() {
-		return idGetter.getName();
+		return idGetter.getName(); //TODO cache this, it's invoking reflection each time. Needs safe initialization.
 	}
 
 	public DirectoryProvider[] getDirectoryProviders() {


### PR DESCRIPTION
this time, containing all needed commits (as fixed history, single cleaned up commit)
