### PR TITLE
HSEARCH-430 Use multiple threads for text analysis in MassIndexer

### DIFF
--- a/hibernate-search/src/main/docbook/en-US/modules/batchindex.xml
+++ b/hibernate-search/src/main/docbook/en-US/modules/batchindex.xml
@@ -241,6 +241,7 @@ transaction.commit();</programlisting>
  .batchSizeToLoadObjects( 25 )
  .cacheMode( CacheMode.NORMAL )
  .threadsToLoadObjects( 5 )
+ .threadsForIndexWriter( 3 )
  .threadsForSubsequentFetching( 20 )
  .startAndWait();</programlisting>
       </example>
@@ -249,7 +250,9 @@ transaction.commit();</programlisting>
       and will create 5 parallel threads to load the User instances using
       batches of 25 objects per query; these loaded User instances are then
       pipelined to 20 parallel threads to load the attached lazy collections
-      of User containing some information needed for the index.</para>
+      of User containing some information needed for the index. Finally,
+      3 parallel threads are being used to Analyze the text and write to the
+      index.</para>
 
       <para>It is recommended to leave cacheMode to
       <literal>CacheMode.IGNORE</literal> (the default), as in most reindexing
@@ -277,7 +280,7 @@ transaction.commit();</programlisting>
       </note>
     </section>
 
-    <para>Other parameters which also affect indexing time and memory
+    <para>Other parameters which affect indexing time and memory
     consumption are:</para>
 
     <itemizedlist>
@@ -308,10 +311,19 @@ transaction.commit();</programlisting>
       <listitem>
         <literal>hibernate.search.[default|&lt;indexname&gt;].indexwriter.batch.term_index_interval</literal>
       </listitem>
+      
+      <listitem>
+        <literal>hibernate.search.batchbackend.concurrent_writers</literal>
+      </listitem>
     </itemizedlist>
 
     <para>All <literal>.indexwriter</literal> parameters are Lucene specific
     and Hibernate Search is just passing these parameters through - see <xref
     linkend="lucene-indexing-performance" /> for more details.</para>
+    
+    <para><literal>hibernate.search.batchbackend.concurrent_writers</literal> defaults to
+        <literal>2</literal> and represent the number of threads being used at the Analysis
+        and indexwriter stage of the MassIndexing pipeline. The <classname>MassIndexer</classname>
+        .<methodname>threadsForIndexWriter(int)</methodname> method overrides this value.</para>
   </section>
 </chapter>

--- a/hibernate-search/src/main/java/org/hibernate/search/MassIndexer.java
+++ b/hibernate-search/src/main/java/org/hibernate/search/MassIndexer.java
@@ -61,14 +61,16 @@ public interface MassIndexer {
 	MassIndexer threadsForSubsequentFetching(int numberOfThreads);
 	
 	/**
-	 * Sets the number of threads to be used to analyze the documents
-	 * and write to the index.
+	 * <p>Sets the number of threads to be used to analyze the documents
+	 * and write to the index.</p><p>This overrides the global property
+	 * <tt>hibernate.search.batchbackend.concurrent_writers</tt>.</p><p>
+	 * Might be ignored by <code>BatchBackend</code> implementations other
+	 * than <code>org.hibernate.search.backend.impl.batchlucene.LuceneBatchBackend</code></p>
+	 * @see org.hibernate.search.backend.impl.batchlucene.LuceneBatchBackend.
 	 * @param numberOfThreads
-	 * @return
+	 * @return <tt>this</tt> for method chaining
 	 */
-	//TODO implement? performance improvement was found to be
-	//interesting in unusual setups only.
-	//MassIndexer threadsForIndexWriter(int numberOfThreads);
+	MassIndexer threadsForIndexWriter(int numberOfThreads);
 	
 	/**
 	 * Sets the cache interaction mode for the data loading tasks.

--- a/hibernate-search/src/main/java/org/hibernate/search/backend/impl/batchlucene/BatchBackend.java
+++ b/hibernate-search/src/main/java/org/hibernate/search/backend/impl/batchlucene/BatchBackend.java
@@ -45,7 +45,7 @@ public interface BatchBackend {
 	 *
 	 * @param props all configuration properties
 	 * @param monitor the indexing progress monitor
-	 * @param context the build context for the workers.
+	 * @param context the build context for the workers
 	 */
 	void initialize(Properties props, MassIndexerProgressMonitor monitor, WorkerBuildContext context);
 

--- a/hibernate-search/src/main/java/org/hibernate/search/backend/impl/batchlucene/LuceneBatchBackend.java
+++ b/hibernate-search/src/main/java/org/hibernate/search/backend/impl/batchlucene/LuceneBatchBackend.java
@@ -63,10 +63,7 @@ public class LuceneBatchBackend implements BatchBackend {
 
 	public void initialize(Properties cfg, MassIndexerProgressMonitor monitor, WorkerBuildContext context) {
 		this.searchFactoryImplementor = context.getUninitializedSearchFactory();
-		int maxThreadsPerIndex = ConfigurationParseHelper.getIntValue( cfg, "concurrent_writers", 2 );
-		if ( maxThreadsPerIndex < 1 ) {
-			throw new SearchException( "concurrent_writers for batch backend must be at least 1." );
-		}
+		final int maxThreadsPerIndex = definedIndexWriters( cfg );
 		ErrorHandler errorHandler = searchFactoryImplementor.getErrorHandler();
 		for ( DirectoryProvider<?> dp : context.getDirectoryProviders() ) {
 			DirectoryProviderWorkspace resources = new DirectoryProviderWorkspace( context, dp, monitor, maxThreadsPerIndex, errorHandler );
@@ -142,6 +139,18 @@ public class LuceneBatchBackend implements BatchBackend {
 			resourcesMap.get( dp ).doWorkInSync( work );
 		}
 		
+	}
+	
+	/**
+	 * @param cfg Configuration properties
+	 * @return the number of threads to be writing on the shared IndexWriter
+	 */
+	private static int definedIndexWriters(Properties cfg) {
+		final int indexWriters = ConfigurationParseHelper.getIntValue( cfg, "concurrent_writers", 2 );
+		if ( indexWriters < 1 ) {
+			throw new SearchException( "concurrent_writers for batch backend must be at least 1." );
+		}
+		return indexWriters;
 	}
 
 }

--- a/hibernate-search/src/main/java/org/hibernate/search/batchindexing/BatchCoordinator.java
+++ b/hibernate-search/src/main/java/org/hibernate/search/batchindexing/BatchCoordinator.java
@@ -56,6 +56,7 @@ public class BatchCoordinator implements Runnable {
 	private final int collectionLoadingThreads;
 	private final CacheMode cacheMode;
 	private final int objectLoadingBatchSize;
+	private final Integer writerThreads; //could be null: in case global configuration properties are applied
 	private final boolean optimizeAtEnd;
 	private final boolean purgeAtStart;
 	private final boolean optimizeAfterPurge;
@@ -72,7 +73,7 @@ public class BatchCoordinator implements Runnable {
 							int objectLoadingBatchSize, long objectsLimit,
 							boolean optimizeAtEnd,
 							boolean purgeAtStart, boolean optimizeAfterPurge,
-							MassIndexerProgressMonitor monitor) {
+							MassIndexerProgressMonitor monitor, Integer writerThreads) {
 		this.rootEntities = rootEntities.toArray( new Class<?>[rootEntities.size()] );
 		this.searchFactoryImplementor = searchFactoryImplementor;
 		this.sessionFactory = sessionFactory;
@@ -85,11 +86,12 @@ public class BatchCoordinator implements Runnable {
 		this.optimizeAfterPurge = optimizeAfterPurge;
 		this.monitor = monitor;
 		this.objectsLimit = objectsLimit;
+		this.writerThreads = writerThreads;
 		this.endAllSignal = new CountDownLatch( rootEntities.size() );
 	}
 
 	public void run() {
-		backend = searchFactoryImplementor.makeBatchBackend( monitor );
+		backend = searchFactoryImplementor.makeBatchBackend( monitor, writerThreads );
 		try {
 			beforeBatch(); // purgeAll and pre-optimize activities
 			doBatchWork();

--- a/hibernate-search/src/main/java/org/hibernate/search/engine/SearchFactoryImplementor.java
+++ b/hibernate-search/src/main/java/org/hibernate/search/engine/SearchFactoryImplementor.java
@@ -75,7 +75,7 @@ public interface SearchFactoryImplementor extends SearchFactoryIntegrator {
 
 	Set<Class<?>> getIndexedTypesPolymorphic(Class<?>[] classes);
 
-	BatchBackend makeBatchBackend(MassIndexerProgressMonitor progressMonitor);
+	BatchBackend makeBatchBackend(MassIndexerProgressMonitor progressMonitor, Integer writerThreads);
 
 	Similarity getSimilarity(DirectoryProvider<?> directoryProvider);
 
@@ -98,4 +98,5 @@ public interface SearchFactoryImplementor extends SearchFactoryIntegrator {
 	 * Can be disabled to get pre-3.4 behavior (always rebuild document)
 	 */
 	boolean isDirtyChecksEnabled();
+
 }

--- a/hibernate-search/src/main/java/org/hibernate/search/impl/ImmutableSearchFactory.java
+++ b/hibernate-search/src/main/java/org/hibernate/search/impl/ImmutableSearchFactory.java
@@ -347,8 +347,8 @@ public class ImmutableSearchFactory implements SearchFactoryImplementorWithShare
 		return indexHierarchy.getIndexedClasses( classes );
 	}
 
-	public BatchBackend makeBatchBackend(MassIndexerProgressMonitor progressMonitor) {
-		BatchBackend batchBackend;
+	public BatchBackend makeBatchBackend(MassIndexerProgressMonitor progressMonitor, Integer forceToNumWriterThreads) {
+		final BatchBackend batchBackend;
 		String impl = configurationProperties.getProperty( Environment.BATCH_BACKEND );
 		if ( StringHelper.isEmpty( impl ) || "LuceneBatch".equalsIgnoreCase( impl ) ) {
 			batchBackend = new LuceneBatchBackend();
@@ -359,8 +359,13 @@ public class ImmutableSearchFactory implements SearchFactoryImplementorWithShare
 					"batchbackend"
 			);
 		}
+		Properties cfg = this.configurationProperties;
+		if ( forceToNumWriterThreads != null ) {
+			cfg = new Properties( cfg );
+			cfg.put( LuceneBatchBackend.CONCURRENT_WRITERS, forceToNumWriterThreads.toString() );
+		}
 		Properties batchBackendConfiguration = new MaskedProperty(
-				this.configurationProperties, Environment.BATCH_BACKEND
+				cfg, Environment.BATCH_BACKEND
 		);
 		batchBackend.initialize( batchBackendConfiguration, progressMonitor, this );
 		return batchBackend;

--- a/hibernate-search/src/main/java/org/hibernate/search/impl/MassIndexerImpl.java
+++ b/hibernate-search/src/main/java/org/hibernate/search/impl/MassIndexerImpl.java
@@ -60,7 +60,7 @@ public class MassIndexerImpl implements MassIndexer {
 	// default settings defined here:
 	private int objectLoadingThreads = 2; //loading the main entity
 	private int collectionLoadingThreads = 4; //also responsible for loading of lazy @IndexedEmbedded collections
-//	private int writerThreads = 1; //also running the Analyzers
+	private Integer writerThreads = null; //could be null: in case global configuration is applied. Also affects number of running Analyzers.
 	private int objectLoadingBatchSize = 10;
 	private long objectsLimit = 0; //means no limit at all
 	private CacheMode cacheMode = CacheMode.IGNORE;
@@ -156,13 +156,12 @@ public class MassIndexerImpl implements MassIndexer {
 		return this;
 	}
 
-	//TODO see MassIndexer interface
-//	public MassIndexer threadsForIndexWriter(int numberOfThreads) {
-//		if ( numberOfThreads < 1 )
-//			throw new IllegalArgumentException( "numberOfThreads must be at least 1" );
-//		this.writerThreads = numberOfThreads;
-//		return this;
-//	}
+	public MassIndexer threadsForIndexWriter(int numberOfThreads) {
+		if ( numberOfThreads < 1 )
+			throw new IllegalArgumentException( "numberOfThreads must be at least 1" );
+		this.writerThreads = numberOfThreads;
+		return this;
+	}
 
 	public MassIndexer optimizeOnFinish(boolean optimize) {
 		this.optimizeAtEnd = optimize;
@@ -205,7 +204,7 @@ public class MassIndexerImpl implements MassIndexer {
 				objectLoadingThreads, collectionLoadingThreads,
 				cacheMode, objectLoadingBatchSize, objectsLimit,
 				optimizeAtEnd, purgeAtStart, optimizeAfterPurge,
-				monitor
+				monitor, writerThreads
 		);
 	}
 

--- a/hibernate-search/src/main/java/org/hibernate/search/impl/MutableSearchFactory.java
+++ b/hibernate-search/src/main/java/org/hibernate/search/impl/MutableSearchFactory.java
@@ -159,8 +159,8 @@ public class MutableSearchFactory implements SearchFactoryImplementorWithShareab
 		return delegate.getIndexedTypesPolymorphic( classes );
 	}
 
-	public BatchBackend makeBatchBackend(MassIndexerProgressMonitor progressMonitor) {
-		return delegate.makeBatchBackend( progressMonitor );
+	public BatchBackend makeBatchBackend(MassIndexerProgressMonitor progressMonitor, Integer writerThreads) {
+		return delegate.makeBatchBackend( progressMonitor, writerThreads );
 	}
 
 	public Similarity getSimilarity(DirectoryProvider<?> directoryProvider) {

--- a/hibernate-search/src/test/java/org/hibernate/search/test/batchindexing/BatchBackendConfigurationTest.java
+++ b/hibernate-search/src/test/java/org/hibernate/search/test/batchindexing/BatchBackendConfigurationTest.java
@@ -61,6 +61,25 @@ public class BatchBackendConfigurationTest extends TestCase {
 		fullTextSession.close();
 		fsBuilder.close();
 	}
+	
+	public void testConfigurationIsOverriden() throws InterruptedException {
+		FullTextSessionBuilder fsBuilder = new FullTextSessionBuilder()
+			.addAnnotatedClass( Book.class )
+			.addAnnotatedClass( Nation.class )
+		// illegal option:
+			.setProperty( LuceneBatchBackend.CONCURRENT_WRITERS, "0" ).build();
+		try {
+			FullTextSession fullTextSession = fsBuilder.openFullTextSession();
+			MassIndexer massIndexer = fullTextSession.createIndexer();
+			// "fixes" illegal option by override:
+			massIndexer.threadsForIndexWriter( 2 );
+			massIndexer.startAndWait();
+			fullTextSession.close();
+		}
+		finally {
+			fsBuilder.close();
+		}
+	}
 
 }
 


### PR DESCRIPTION
provides a significant speedup while indexing Wikipedia: from 2 to 6 threads, improvement is linear (three times faster), after that (>6) some little more can be squeezed out of it.
