### PR TITLE
HSEARCH-499

### DIFF
--- a/hibernate-search/src/main/docbook/en-US/modules/batchindex.xml
+++ b/hibernate-search/src/main/docbook/en-US/modules/batchindex.xml
@@ -55,7 +55,7 @@
       <title>Indexing an entity via <methodname>FullTextSession.index(T
       entity)</methodname></title>
 
-      <programlisting>FullTextSession fullTextSession = Search.getFullTextSession(session);
+      <programlisting language="JAVA" role="JAVA">FullTextSession fullTextSession = Search.getFullTextSession(session);
 Transaction tx = fullTextSession.beginTransaction();
 Object customer = fullTextSession.load( Customer.class, 8 );
 <emphasis role="bold">fullTextSession.index(customer);</emphasis>
@@ -79,7 +79,7 @@ tx.commit(); //index only updated at commit time</programlisting>
     <example>
       <title>Purging a specific instance of an entity from the index</title>
 
-      <programlisting>FullTextSession fullTextSession = Search.getFullTextSession(session);
+      <programlisting language="JAVA" role="JAVA">FullTextSession fullTextSession = Search.getFullTextSession(session);
 Transaction tx = fullTextSession.beginTransaction();
 for (Customer customer : customers) {
     <emphasis role="bold">fullTextSession.purge( Customer.class, customer.getId() );</emphasis>
@@ -98,7 +98,7 @@ tx.commit(); //index is updated at commit time</programlisting>
     <example>
       <title>Purging all instances of an entity from the index</title>
 
-      <programlisting>FullTextSession fullTextSession = Search.getFullTextSession(session);
+      <programlisting language="JAVA" role="JAVA">FullTextSession fullTextSession = Search.getFullTextSession(session);
 Transaction tx = fullTextSession.beginTransaction();
 <emphasis role="bold">fullTextSession.purgeAll( Customer.class );</emphasis>
 //optionally optimize the index
@@ -175,7 +175,7 @@ tx.commit(); //index changes are applied at commit time    </programlisting>
       <example>
         <title>Index rebuilding using index() and flushToIndexes()</title>
 
-        <programlisting>fullTextSession.setFlushMode(FlushMode.MANUAL);
+        <programlisting language="JAVA" role="JAVA">fullTextSession.setFlushMode(FlushMode.MANUAL);
 fullTextSession.setCacheMode(CacheMode.IGNORE);
 transaction = fullTextSession.beginTransaction();
 //Scrollable results will avoid loading too many objects in memory
@@ -218,7 +218,7 @@ transaction.commit();</programlisting>
       <example>
         <title>Index rebuilding using a MassIndexer</title>
 
-        <programlisting>fullTextSession.createIndexer().startAndWait();</programlisting>
+        <programlisting language="JAVA" role="JAVA">fullTextSession.createIndexer().startAndWait();</programlisting>
       </example>
 
       <para>This will rebuild the index, deleting it and then reloading all
@@ -236,7 +236,7 @@ transaction.commit();</programlisting>
       <example>
         <title>Using a tuned MassIndexer</title>
 
-        <programlisting>fullTextSession
+        <programlisting language="JAVA" role="JAVA">fullTextSession
  .createIndexer( User.class )
  .batchSizeToLoadObjects( 25 )
  .cacheMode( CacheMode.NORMAL )
@@ -261,6 +261,29 @@ transaction.commit();</programlisting>
       useful to enable some other <literal>CacheMode</literal> depending on
       your data: it might increase performance if the main entity is relating
       to enum-like data included in the index.</para>
+      
+      <example>
+        <title>MassIndexer restricted on a specific range</title>
+        
+      <programlisting language="JAVA" role="JAVA">fullTextSession
+ .createIndexer( AncientBook.class )
+ .countQuery( "select count (*) from AncientBook a where a.id &lt;= :num" )
+ .primaryKeySelectingQuery( "select a.id from AncientBook a where a.id &lt;= :num" )
+ .queryParameter( "num", 20L )
+ .startAndWait();</programlisting>
+      </example>
+      
+      <para>This example will use the provided queries to restrict the entities
+      going to be added to the index. The <methodname>countQuery</methodname> and
+      <methodname>primaryKeySelectingQuery</methodname> must be both defined, or none,
+      and written in such a way that the first will count the number of elements
+      returned by the second one. <methodname>queryParameter</methodname> can be used
+      to pass parameters to the defined queries.</para>
+      
+      <para>As an alternative to writing custom <literal>HQL</literal> queries,
+      the method <classname>MassIndexer</classname>.<methodname>idLoadingStrategy</methodname>
+      makes it possible to use a custom implementation of <classname>IdentifierLoadingStrategy</classname>.
+      </para>
 
       <tip>
         <para>The "sweet spot" of number of threads to achieve best

--- a/hibernate-search/src/main/java/org/hibernate/search/batchindexing/BatchCoordinator.java
+++ b/hibernate-search/src/main/java/org/hibernate/search/batchindexing/BatchCoordinator.java
@@ -63,6 +63,7 @@ public class BatchCoordinator implements Runnable {
 	private final CountDownLatch endAllSignal;
 	private final MassIndexerProgressMonitor monitor;
 	private final long objectsLimit;
+	private final IdentifierLoadingStrategy customIdLoadingStrategy;
 
 	private BatchBackend backend;
 
@@ -73,7 +74,8 @@ public class BatchCoordinator implements Runnable {
 							int objectLoadingBatchSize, long objectsLimit,
 							boolean optimizeAtEnd,
 							boolean purgeAtStart, boolean optimizeAfterPurge,
-							MassIndexerProgressMonitor monitor, Integer writerThreads) {
+							MassIndexerProgressMonitor monitor, Integer writerThreads,
+							IdentifierLoadingStrategy customIdLoadingStrategy) {
 		this.rootEntities = rootEntities.toArray( new Class<?>[rootEntities.size()] );
 		this.searchFactoryImplementor = searchFactoryImplementor;
 		this.sessionFactory = sessionFactory;
@@ -87,6 +89,7 @@ public class BatchCoordinator implements Runnable {
 		this.monitor = monitor;
 		this.objectsLimit = objectsLimit;
 		this.writerThreads = writerThreads;
+		this.customIdLoadingStrategy = customIdLoadingStrategy;
 		this.endAllSignal = new CountDownLatch( rootEntities.size() );
 	}
 
@@ -123,7 +126,8 @@ public class BatchCoordinator implements Runnable {
 							searchFactoryImplementor, sessionFactory, type,
 							objectLoadingThreads, collectionLoadingThreads,
 							cacheMode, objectLoadingBatchSize,
-							endAllSignal, monitor, backend, objectsLimit
+							endAllSignal, monitor, backend, objectsLimit,
+							customIdLoadingStrategy
 					)
 			);
 		}

--- a/hibernate-search/src/main/java/org/hibernate/search/batchindexing/BatchIndexingWorkspace.java
+++ b/hibernate-search/src/main/java/org/hibernate/search/batchindexing/BatchIndexingWorkspace.java
@@ -25,6 +25,7 @@ package org.hibernate.search.batchindexing;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadPoolExecutor;
 
@@ -75,13 +76,15 @@ public class BatchIndexingWorkspace implements Runnable {
 	
 	private final long objectsLimit;
 
+	private final IdentifierLoadingStrategy customIdLoadingStrategy;
+
 	public BatchIndexingWorkspace(SearchFactoryImplementor searchFactoryImplementor, SessionFactory sessionFactory,
 			Class<?> entityType,
 			int objectLoadingThreads, int collectionLoadingThreads,
 			CacheMode cacheMode, int objectLoadingBatchSize,
 			CountDownLatch endAllSignal,
 			MassIndexerProgressMonitor monitor, BatchBackend backend,
-			long objectsLimit) {
+			long objectsLimit, IdentifierLoadingStrategy customIdLoadingStrategy) {
 		
 		this.indexedType = entityType;
 		this.searchFactory = searchFactoryImplementor;
@@ -95,6 +98,7 @@ public class BatchIndexingWorkspace implements Runnable {
 		this.cacheMode = cacheMode;
 		this.objectLoadingBatchSize = objectLoadingBatchSize;
 		this.backend = backend;
+		this.customIdLoadingStrategy = customIdLoadingStrategy;
 		
 		//executors: (quite expensive constructor)
 		//execIdentifiersLoader has size 1 and is not configurable: ensures the list is consistent as produced by one transaction
@@ -139,7 +143,7 @@ public class BatchIndexingWorkspace implements Runnable {
 			final IdentifierProducer producer = new IdentifierProducer(
 					fromIdentifierListToEntities, sessionFactory,
 					objectLoadingBatchSize, indexedType, monitor,
-					objectsLimit
+					objectsLimit, customIdLoadingStrategy
 			);
 			execIdentifiersLoader.execute( new OptionallyWrapInJTATransaction( sessionFactory, producer ) );
 			

--- a/hibernate-search/src/main/java/org/hibernate/search/batchindexing/CriteriaLoadingStrategy.java
+++ b/hibernate-search/src/main/java/org/hibernate/search/batchindexing/CriteriaLoadingStrategy.java
@@ -1,0 +1,58 @@
+/* 
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.hibernate.search.batchindexing;
+
+import org.hibernate.Criteria;
+import org.hibernate.ScrollMode;
+import org.hibernate.ScrollableResults;
+import org.hibernate.StatelessSession;
+import org.hibernate.criterion.Projections;
+
+/**
+ * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
+ *
+ */
+public class CriteriaLoadingStrategy implements IdentifierLoadingStrategy {
+	
+	private final Class<?> indexedType;
+	
+	CriteriaLoadingStrategy(Class<?> indexedType) {
+		this.indexedType = indexedType;
+	}
+
+	public ScrollableResults getToIndexIdentifiersScrollable(final StatelessSession session) {
+		Criteria criteria = session
+			.createCriteria( indexedType )
+			.setProjection( Projections.id() )
+			.setCacheable( false )
+			.setFetchSize( 100 );
+		return criteria.scroll( ScrollMode.FORWARD_ONLY );
+	}
+	
+	public Number countToBeIndexedEntities(final StatelessSession session) {
+		final Number countAsNumber = (Number) session
+			.createCriteria( indexedType )
+			.setProjection( Projections.rowCount() )
+			.setCacheable( false )
+			.uniqueResult();
+		return countAsNumber;
+	}
+	
+}

--- a/hibernate-search/src/main/java/org/hibernate/search/batchindexing/CustomHQLLoadingStrategy.java
+++ b/hibernate-search/src/main/java/org/hibernate/search/batchindexing/CustomHQLLoadingStrategy.java
@@ -1,0 +1,78 @@
+/* 
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.hibernate.search.batchindexing;
+
+import java.util.Map;
+
+import org.hibernate.Query;
+import org.hibernate.ScrollMode;
+import org.hibernate.ScrollableResults;
+import org.hibernate.StatelessSession;
+import org.hibernate.search.SearchException;
+
+/**
+ * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
+ *
+ */
+public class CustomHQLLoadingStrategy implements IdentifierLoadingStrategy {
+	
+	private final String countQueryHQL;
+	private final String idLoadingHQL;
+	private final Map<String,Object> customQueryParameters;
+	
+	public CustomHQLLoadingStrategy(String countQueryHQL, String idLoadingHQL, Map<String,Object> customQueryParameters) {
+		this.countQueryHQL = countQueryHQL;
+		this.idLoadingHQL = idLoadingHQL;
+		this.customQueryParameters = customQueryParameters;
+	}
+	
+	public ScrollableResults getToIndexIdentifiersScrollable(final StatelessSession session) {
+		Query idLoadingQuery = session.createQuery( idLoadingHQL );
+		applyQueryParameters( idLoadingQuery );
+		return idLoadingQuery.scroll( ScrollMode.FORWARD_ONLY );
+	}
+	
+	public Number countToBeIndexedEntities(final StatelessSession session) {
+		Query countingQuery = session.createQuery( countQueryHQL );
+		applyQueryParameters( countingQuery );
+		Object result = countingQuery.uniqueResult();
+		if (result instanceof Number) {
+			return (Number) result; 
+		}
+		else {
+			throw new SearchException( "The countQueryHQL is not returning a Number: '" + countQueryHQL + "'" );
+		}
+	}
+	
+	public void applyQueryParameters(Query query) {
+		for ( String parameterName : query.getNamedParameters() ) {
+			Object parameterValue = getParameterValue( parameterName );
+			query.setParameter( parameterName, parameterValue );
+		}
+	}
+	
+	private Object getParameterValue(String parameterName) {
+		if ( ! this.customQueryParameters.containsKey( parameterName ) ) {
+			throw new SearchException( "Required parameter missing: " + parameterName );
+		}
+		return this.customQueryParameters.get( parameterName );
+	}
+	
+}

--- a/hibernate-search/src/main/java/org/hibernate/search/batchindexing/IdentifierLoadingStrategy.java
+++ b/hibernate-search/src/main/java/org/hibernate/search/batchindexing/IdentifierLoadingStrategy.java
@@ -1,0 +1,54 @@
+/* 
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.hibernate.search.batchindexing;
+
+import org.hibernate.ScrollableResults;
+import org.hibernate.StatelessSession;
+import org.hibernate.search.MassIndexer;
+
+/**
+ * <p>Implementing a custom IdentifierLoadingStrategy you get full control on how
+ * and which entities are selected for indexing in the MassIndexer.</p>
+ * <p>It is not required to implement such a strategy, if none is provided either
+ * CriteriaLoadingStrategy or CustomHQLLoadingStrategy will be used; the latter
+ * if any custom HQL is provided.</p>
+ * 
+ * @see MassIndexer#idLoadingStrategy(IdentifierLoadingStrategy)
+ * @see MassIndexer#countQuery(String)
+ * @see MassIndexer#primaryKeySelectingQuery(String)
+ * @see CriteriaLoadingStrategy
+ * @see CustomHQLLoadingStrategy
+ * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
+ */
+public interface IdentifierLoadingStrategy {
+	
+	/**
+	 * @param session
+	 * @return a ScrollableResults iterating on all primary keys of the entities being indexed. 
+	 */
+	ScrollableResults getToIndexIdentifiersScrollable(final StatelessSession session);
+	
+	/**
+	 * @param session
+	 * @return the Number representing the count(*) of all entities being indexed.
+	 */
+	Number countToBeIndexedEntities(final StatelessSession session);
+	
+}

--- a/hibernate-search/src/test/java/org/hibernate/search/test/batchindexing/IndexingGeneratedCorpusTest.java
+++ b/hibernate-search/src/test/java/org/hibernate/search/test/batchindexing/IndexingGeneratedCorpusTest.java
@@ -71,9 +71,9 @@ public class IndexingGeneratedCorpusTest extends TestCase {
 				.setProperty( "hibernate.show_sql", "false" ) // too verbose for this test
 				.setProperty( LuceneBatchBackend.CONCURRENT_WRITERS, "4" )
 				.build();
-		createMany( Book.class, BOOK_NUM );
-		createMany( Dvd.class, DVD_NUM );
-		createMany( AncientBook.class, ANCIENTBOOK_NUM );
+        createMany( AncientBook.class, ANCIENTBOOK_NUM );
+        createMany( Book.class, BOOK_NUM );
+        createMany( Dvd.class, DVD_NUM );
 		createMany( SecretBook.class, SECRETBOOK_NUM );
 		storeAllBooksInNation();
 	}
@@ -139,6 +139,42 @@ public class IndexingGeneratedCorpusTest extends TestCase {
 		verifyResultNumbers(); // verify the count match again
 		reindexAll(); //tests that purgeAll is automatic:
 		verifyResultNumbers(); //..same numbers again
+	}
+
+	/**
+	 * Will create a partial index using custom HQL queries to define the subset of
+	 * data to be indexed.
+	 */
+	public void testSelectedBatchIndexing() throws InterruptedException {
+		verifyResultNumbers(); //initial count of entities should match expectations
+		purgeAll(); // empty indexes
+		verifyIsEmpty();
+		FullTextSession fullTextSession = builder.openFullTextSession();
+		SilentProgressMonitor progressMonitor = new SilentProgressMonitor();
+		Assert.assertEquals( 0l, progressMonitor.documentBuiltCounter.get() );
+		Assert.assertFalse( progressMonitor.finished );
+		long artificialLimit = 20l;
+		try {
+			fullTextSession.createIndexer( AncientBook.class )
+					.countQuery( "select count (*) from AncientBook a where a.id <= :num" )
+					.primaryKeySelectingQuery( "select a.id from AncientBook a where a.id <= :num" )
+					.queryParameter( "num", artificialLimit )
+					.threadsToLoadObjects( 1 )
+					.batchSizeToLoadObjects( 5 )
+					.progressMonitor( progressMonitor )
+					.startAndWait();
+		}
+		finally {
+			fullTextSession.close();
+		}
+		Assert.assertTrue( progressMonitor.finished );
+		Assert.assertEquals( artificialLimit, progressMonitor.documentBuiltCounter.get() );
+		Assert.assertEquals( artificialLimit, progressMonitor.objectsCounter.get() );
+		assertEquals(
+				artificialLimit,
+				countByFT( AncientBook.class )
+		);
+		reindexAll(); // rebuild the indexes
 	}
 
 	private void reindexAll() throws InterruptedException {
@@ -247,27 +283,24 @@ public class IndexingGeneratedCorpusTest extends TestCase {
 	private static class SilentProgressMonitor implements MassIndexerProgressMonitor {
 		
 		final AtomicLong objectsCounter = new AtomicLong();
+		final AtomicLong documentBuiltCounter = new AtomicLong();
 		
 		volatile boolean finished = false;
 
-		@Override
 		public void documentsAdded(long increment) {
 		}
 
-		@Override
 		public void documentsBuilt(int number) {
+			documentBuiltCounter.addAndGet( number );
 		}
 
-		@Override
 		public void entitiesLoaded(int size) {
 		}
 
-		@Override
 		public void addToTotalCount(long count) {
 			objectsCounter.addAndGet( count );
 		}
 
-		@Override
 		public void indexingCompleted() {
 			finished = true;
 			System.out.println( "Finished indexing " + objectsCounter.get() + " entities" );


### PR DESCRIPTION
We allow now to replace the identifier selection which defines which entities are going to be "MassIndexed"; the default implementation is the old Criteria "select all", refactored in a class.
People can easily customize this by providing custom HQL with named parameters, or if this doesn't proof flexible enough they can inject their own logic to create the needed Count(*) statement and ScrollableResultset by implementing a org.hibernate.search.batchindexing.IdentifierLoadingStrategy
