### PR TITLE
Test of HSEARCH-323 doesn't properly cleanup all directories

### DIFF
--- a/hibernate-search/src/test/java/org/hibernate/search/test/directoryProvider/RetryInitializeTest.java
+++ b/hibernate-search/src/test/java/org/hibernate/search/test/directoryProvider/RetryInitializeTest.java
@@ -53,9 +53,9 @@ public class RetryInitializeTest extends TestCase {
 
 	protected void tearDown() throws Exception {
 		super.tearDown();
-		FSSlaveAndMasterDPTest.cleanupDirectories();
 		if ( slave != null ) slave.close();
 		if ( master != null ) master.close();
+		FSSlaveAndMasterDPTest.cleanupDirectories();
 	}
 	
 	public void testStandardInitialization() {
@@ -113,7 +113,7 @@ public class RetryInitializeTest extends TestCase {
 		FullTextSessionBuilder builder = new FullTextSessionBuilder()
 			.addAnnotatedClass( SnowStorm.class )
 			.setProperty( "hibernate.search.default.sourceBase", root.getAbsolutePath() + masterCopy )
-			.setProperty( "hibernate.search.default.indexBase", root.getAbsolutePath() + slave )
+			.setProperty( "hibernate.search.default.indexBase", root.getAbsolutePath() + "/slave" )
 			.setProperty( "hibernate.search.default.directory_provider", FSSlaveDirectoryProviderTestingExtension.class.getName() );
 		if ( enableRetryInitializePeriod ) {
 			builder.setProperty( "hibernate.search.default.retry_initialize_period", "12" );


### PR DESCRIPTION
The test for HSEARCH-323 is creating a directory "lucenedirsnull" which shouldn't be created, is not needed, and as it's unexpected no method was cleaning it up.
