### PR TITLE
HSEARCH-721 Make sure criteria queries are lazily built

### DIFF
--- a/hibernate-search/src/main/java/org/hibernate/search/query/hibernate/impl/CriteriaObjectsInitializer.java
+++ b/hibernate-search/src/main/java/org/hibernate/search/query/hibernate/impl/CriteriaObjectsInitializer.java
@@ -66,6 +66,11 @@ public class CriteriaObjectsInitializer implements ObjectsInitializer {
 			return;
 		}
 
+		//criteria query not overridden, define one
+		if ( criteria == null ) {
+			criteria = session.createCriteria( entityType );
+		}
+
 		Set<Class<?>> indexedEntities = searchFactoryImplementor.getIndexedTypesPolymorphic( new Class<?>[] { entityType } );
 		DocumentBuilderIndexedEntity<?> builder = searchFactoryImplementor.getDocumentBuilderIndexedEntity(
 				indexedEntities.iterator().next()

--- a/hibernate-search/src/main/java/org/hibernate/search/query/hibernate/impl/MultiClassesQueryLoader.java
+++ b/hibernate-search/src/main/java/org/hibernate/search/query/hibernate/impl/MultiClassesQueryLoader.java
@@ -155,7 +155,7 @@ public class MultiClassesQueryLoader extends AbstractLoader {
 			DocumentBuilderIndexedEntity<?> provider = searchFactoryImplementor.getDocumentBuilderIndexedEntity( rootEntity );
 			if ( provider == null) throw new AssertionFailure("Provider not found for class: " + rootEntity);
 			this.mappedSubclasses = provider.getMappedSubclasses();
-			this.criteria = session.createCriteria( rootEntity );
+			this.criteria = null; //default
 		}
 	}
 }

--- a/hibernate-search/src/main/java/org/hibernate/search/query/hibernate/impl/QueryLoader.java
+++ b/hibernate-search/src/main/java/org/hibernate/search/query/hibernate/impl/QueryLoader.java
@@ -80,9 +80,6 @@ public class QueryLoader extends AbstractLoader {
 		if ( entityType == null ) {
 			throw new AssertionFailure( "EntityType not defined" );
 		}
-		if ( criteria == null ) {
-			criteria = session.createCriteria( entityType );
-		}
 
 		objectsInitializer.initializeObjects(
 				entityInfos,


### PR DESCRIPTION
When a custom criteria query is not passed, we used to eagerly create one.
This leads to issues in Habernate OGM which does not implement this method
