### PR TITLE
HSEARCH-734 - NPE when deleting a collection which triggers @IndexedEmbed

### DIFF
--- a/hibernate-search/src/main/java/org/hibernate/search/event/FullTextIndexEventListener.java
+++ b/hibernate-search/src/main/java/org/hibernate/search/event/FullTextIndexEventListener.java
@@ -36,6 +36,7 @@ import org.slf4j.Logger;
 
 import org.hibernate.Session;
 import org.hibernate.cfg.Configuration;
+import org.hibernate.collection.PersistentCollection;
 import org.hibernate.engine.EntityEntry;
 import org.hibernate.event.AbstractCollectionEvent;
 import org.hibernate.event.AbstractEvent;
@@ -239,7 +240,14 @@ public class FullTextIndexEventListener implements PostDeleteEventListener,
 				//Should log really but we don't know if we're interested in this collection for indexing
 				return;
 			}
-			String collectionRole = event.getCollection().getRole();
+			PersistentCollection persistentCollection = event.getCollection();
+			final String collectionRole;
+			if ( persistentCollection != null ) {
+				collectionRole = persistentCollection.getRole();
+			}
+			else {
+				collectionRole = null;
+			}
 			AbstractDocumentBuilder<?> documentBuilder = getDocumentBuilder( entity );
 			
 			if ( documentBuilder != null && ! documentBuilder.isCollectionRoleExcluded( collectionRole ) ) {


### PR DESCRIPTION
I had to split the unit test to a second issue: I'm having a hard time reproducing it so we can do that later.
(with this fix I strongly doubt it's still able to NPE anyway)
