### PR TITLE
Test case and fix for @IndexedEmbedded PersistentSet dirty analysis 

### DIFF
--- a/hibernate-search/src/main/java/org/hibernate/search/engine/AbstractDocumentBuilder.java
+++ b/hibernate-search/src/main/java/org/hibernate/search/engine/AbstractDocumentBuilder.java
@@ -374,14 +374,14 @@ public abstract class AbstractDocumentBuilder<T> implements DocumentBuilder {
 			List<XProperty> methods = currentClass.getDeclaredProperties( XClass.ACCESS_PROPERTY );
 			for ( XProperty method : methods ) {
 				initializeMemberLevelAnnotations(
-						method, propertiesMetadata, isRoot, prefix, processedClasses, context, optimizationBlackList, disableOptimizations
+						currentClass, method, propertiesMetadata, isRoot, prefix, processedClasses, context, optimizationBlackList, disableOptimizations
 				);
 			}
 
 			List<XProperty> fields = currentClass.getDeclaredProperties( XClass.ACCESS_FIELD );
 			for ( XProperty field : fields ) {
 				initializeMemberLevelAnnotations(
-						field, propertiesMetadata, isRoot, prefix, processedClasses, context, optimizationBlackList, disableOptimizations
+						currentClass, field, propertiesMetadata, isRoot, prefix, processedClasses, context, optimizationBlackList, disableOptimizations
 				);
 			}
 		}
@@ -431,13 +431,13 @@ public abstract class AbstractDocumentBuilder<T> implements DocumentBuilder {
 		}
 	}
 
-	private void initializeMemberLevelAnnotations(XProperty member, PropertiesMetadata propertiesMetadata, boolean isRoot,
+	private void initializeMemberLevelAnnotations(XClass currentClass, XProperty member, PropertiesMetadata propertiesMetadata, boolean isRoot,
 					String prefix, Set<XClass> processedClasses, ConfigContext context, Set<XClass> optimizationBlackList, boolean disableOptimizations) {
 		checkForField( member, propertiesMetadata, prefix, context );
 		checkForFields( member, propertiesMetadata, prefix, context );
 		checkForAnalyzerDefs( member, context );
 		checkForAnalyzerDiscriminator( member, propertiesMetadata );
-		checkForIndexedEmbedded( member, propertiesMetadata, prefix, processedClasses, context, optimizationBlackList, disableOptimizations );
+		checkForIndexedEmbedded( currentClass, member, propertiesMetadata, prefix, processedClasses, context, optimizationBlackList, disableOptimizations );
 		checkForContainedIn( member, propertiesMetadata );
 		documentBuilderSpecificChecks( member, propertiesMetadata, isRoot, prefix, context );
 	}
@@ -581,11 +581,11 @@ public abstract class AbstractDocumentBuilder<T> implements DocumentBuilder {
 		}
 	}
 
-	private void checkForIndexedEmbedded(XProperty member, PropertiesMetadata propertiesMetadata, String prefix,
+	private void checkForIndexedEmbedded(XClass currentClass, XProperty member, PropertiesMetadata propertiesMetadata, String prefix,
 			Set<XClass> processedClasses, ConfigContext context, Set<XClass> optimizationBlackList, boolean disableOptimizations) {
 		IndexedEmbedded embeddedAnn = member.getAnnotation( IndexedEmbedded.class );
 		if ( embeddedAnn != null ) {
-			this.indexedEmbeddedCollectionRoles.add( StringHelper.qualify( this.beanXClassName, member.getName() ) );
+			this.indexedEmbeddedCollectionRoles.add( StringHelper.qualify( currentClass.getName(), member.getName() ) );
 			int oldMaxLevel = maxLevel;
 			int potentialLevel = embeddedAnn.depth() + level;
 			if ( potentialLevel < 0 ) {

--- a/hibernate-search/src/test/java/org/hibernate/search/test/embedded/AbstractProduct.java
+++ b/hibernate-search/src/test/java/org/hibernate/search/test/embedded/AbstractProduct.java
@@ -1,0 +1,83 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2010, Red Hat, Inc. and/or its affiliates or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat, Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.search.test.embedded;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToMany;
+
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Index;
+import org.hibernate.search.annotations.IndexedEmbedded;
+
+/**
+ * Abstract base class for products, having e.g. abstract getCode()
+ * returning depending on product type isbn, issn or ean.
+ *
+ * @author Samppa Saarela
+ */
+@Entity
+public abstract class AbstractProduct {
+
+	@Id @GeneratedValue @DocumentId
+	private Integer id;
+
+	@Field(index= Index.TOKENIZED)
+	private String name;
+
+	@ManyToMany(mappedBy="product", cascade=CascadeType.ALL) //just to make the test easier, cascade doesn't really make any business sense
+	@IndexedEmbedded
+	private Set<ProductFeature> features = new HashSet<ProductFeature>();
+
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Set<ProductFeature> getFeatures() {
+		return features;
+	}
+
+	public void setFeatures(Set<ProductFeature> authors) {
+		this.features = authors;
+	}
+
+}

--- a/hibernate-search/src/test/java/org/hibernate/search/test/embedded/Book.java
+++ b/hibernate-search/src/test/java/org/hibernate/search/test/embedded/Book.java
@@ -1,0 +1,16 @@
+package org.hibernate.search.test.embedded;
+
+import javax.persistence.Entity;
+
+import org.hibernate.search.annotations.Indexed;
+
+/**
+ * Some product type
+ *
+ * @author Samppa Saarela
+ */
+@Entity
+@Indexed(index="AbstractProduct") // Indexed in common index
+public class Book extends AbstractProduct {
+
+}

--- a/hibernate-search/src/test/java/org/hibernate/search/test/embedded/ProductFeature.java
+++ b/hibernate-search/src/test/java/org/hibernate/search/test/embedded/ProductFeature.java
@@ -1,0 +1,78 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2010, Red Hat, Inc. and/or its affiliates or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat, Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.search.test.embedded;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+import org.hibernate.search.annotations.ContainedIn;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Index;
+
+/**
+ * A mapping from product to it's "features"
+ *
+ * @author Samppa Saarela
+ */
+@Entity
+public class ProductFeature {
+
+	@Id @GeneratedValue
+	private Integer id;
+
+	@Field(index= Index.UN_TOKENIZED)
+	private String name;
+
+	@ManyToOne
+	@ContainedIn
+	private AbstractProduct product;
+
+	// Some other fields justifying this class as an entity...
+
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public AbstractProduct getProduct() {
+		return product;
+	}
+
+	public void setProduct(AbstractProduct product) {
+		this.product = product;
+	}
+}


### PR DESCRIPTION
Wrong collectionRole is used for collection exclusion analysis in FullTextIndexEventListener.processCollectionEvent > AbstractDocumentBuilder.isCollectionRoleExcluded check. 

A PersistentSet of an abstract superclass has it's collection role bound to the superclass, but AbstractDocumentBuilder's indexedEmbeddedCollectionRoles contains roles that are bound to a specific subclass. Thus when the contents of a collection in superclass are changed, Hibernate Search fails to re-index the change as the collection gets excluded. 
