### PR TITLE
HSEARCH-662 

### DIFF
--- a/hibernate-search/src/main/java/org/hibernate/search/engine/impl/WorkPlan.java
+++ b/hibernate-search/src/main/java/org/hibernate/search/engine/impl/WorkPlan.java
@@ -27,8 +27,8 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Set;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import org.hibernate.search.Environment;
 import org.hibernate.search.SearchException;
@@ -41,40 +41,42 @@ import org.hibernate.search.engine.spi.DocumentBuilderContainedEntity;
 import org.hibernate.search.engine.spi.EntityIndexBinder;
 import org.hibernate.search.engine.spi.SearchFactoryImplementor;
 import org.hibernate.search.util.impl.HibernateHelper;
-import org.hibernate.search.util.logging.impl.LoggerFactory;
 import org.hibernate.search.util.logging.impl.Log;
+import org.hibernate.search.util.logging.impl.LoggerFactory;
 
 /**
  * Represents the set of changes going to be applied to the index for the entities. A stream of Work is feed as input, a
  * list of LuceneWork is output, and in the process we try to reduce the number of output operations to the minimum
  * needed to reach the same final state.
- * 
- * @since 3.3
+ *
  * @author Sanne Grinovero
+ * @author Hardy Ferentschik
+ * @since 3.3
  */
-@SuppressWarnings({ "rawtypes", "unchecked" })
+@SuppressWarnings( { "rawtypes", "unchecked" })
 public class WorkPlan {
-	
+
 	private static final Log log = LoggerFactory.make();
-	
+
 	private final HashMap<Class<?>, PerClassWork<?>> byClass = new HashMap<Class<?>, PerClassWork<?>>();
-	
+
 	private final SearchFactoryImplementor searchFactoryImplementor;
-	
+
 	public WorkPlan(SearchFactoryImplementor searchFactoryImplementor) {
 		this.searchFactoryImplementor = searchFactoryImplementor;
 	}
-	
+
 	/**
 	 * most work is split in two, some other might cancel one or more existing works,
 	 * we don't track the number accurately as that's not needed.
 	 */
 	private int approximateWorkQueueSize = 0;
-	
+
 	/**
 	 * Adds a work to be performed as part of the final plan.
+	 *
 	 * @param <T> the type of the work, or of the affected entity
-	 * @param work
+	 * @param work The work instance to add to the work plan
 	 */
 	public <T> void addWork(Work<T> work) {
 		approximateWorkQueueSize++;
@@ -82,7 +84,7 @@ public class WorkPlan {
 		PerClassWork classWork = getClassWork( entityClass );
 		classWork.addWork( work );
 	}
-	
+
 	/**
 	 * Removes all scheduled work
 	 */
@@ -90,21 +92,23 @@ public class WorkPlan {
 		byClass.clear();
 		approximateWorkQueueSize = 0;
 	}
-	
+
 	/**
-	 * Returns an approximation of the amount of work that
-	 * {@link #getPlannedLuceneWork(SearchFactoryImplementor)} would return.
+	 * Returns an approximation of the amount of work in the queue.
 	 * This is meant for resource control for auto flushing of large pending batches.
-	 * 
-	 * @see Environment#QUEUEINGPROCESSOR_BATCHSIZE
+	 *
 	 * @return the approximation
+	 *
+	 * @see Environment#QUEUEINGPROCESSOR_BATCHSIZE
 	 */
 	public int size() {
 		return approximateWorkQueueSize;
 	}
-	
+
 	/**
-	 * Retrieves (and creates if needed) the PerClassWork from the byClass map.
+	 * @param entityClass The entity class for which to retrieve the work
+	 *
+	 * @return returns (and creates if needed) the {@code PerClassWork} from the {@link #byClass} map.
 	 */
 	private <T> PerClassWork getClassWork(Class<T> entityClass) {
 		PerClassWork classWork = byClass.get( entityClass );
@@ -114,10 +118,10 @@ public class WorkPlan {
 		}
 		return classWork;
 	}
-	
+
 	/**
 	 * Makes sure that all additional work needed because of containedIn
-	 * is added to the work plan. 
+	 * is added to the work plan.
 	 */
 	public void processContainedInAndPrepareExecution() {
 		PerClassWork[] worksFromEvents = new PerClassWork[byClass.size()];
@@ -131,9 +135,10 @@ public class WorkPlan {
 			perClassWork.processContainedInAndPrepareExecution();
 		}
 	}
-	
+
 	/**
 	 * Used for recursive processing of containedIn
+	 *
 	 * @param value the entity to be processed
 	 */
 	public <T> void recurseContainedIn(T value) {
@@ -141,12 +146,9 @@ public class WorkPlan {
 		PerClassWork classWork = getClassWork( entityClass );
 		classWork.recurseContainedIn( value );
 	}
-	
+
 	/**
-	 * Converts the current plan into a list of LuceneWork,
-	 * something that the backends can actually perform to execute
-	 * the plan.
-	 * @return
+	 * @return returns the current plan converted as a list of {@code LuceneWork}
 	 */
 	public List<LuceneWork> getPlannedLuceneWork() {
 		List<LuceneWork> luceneQueue = new ArrayList<LuceneWork>();
@@ -155,21 +157,12 @@ public class WorkPlan {
 		}
 		return luceneQueue;
 	}
-	
+
 	/**
-	 * the workPlan organizes work per entity types
+	 * {@code PerClassWork} organizes work per entity type.
 	 */
 	class PerClassWork<T> {
-		
-		/**
-		 * The type of entities being managed by this instance.
-		 * @param clazz
-		 */
-		PerClassWork(Class<T> clazz) {
-			this.entityClass = clazz;
-			this.documentBuilder = getEntityBuilder( searchFactoryImplementor, clazz );
-		}
-		
+
 		/**
 		 * We further organize work per entity identifier so that we can cancel or adapt work being done
 		 * on the same entities.
@@ -178,27 +171,42 @@ public class WorkPlan {
 		 * {@link org.hibernate.search.annotations.DocumentId} or as last attempt {@link javax.persistence.Id}.
 		 */
 		private final HashMap<Serializable, PerEntityWork<T>> entityById = new HashMap<Serializable, PerEntityWork<T>>();
-		
+
 		/**
 		 * When a PurgeAll operation is send on the type, we can remove all previously scheduled work
 		 * and remember that the first operation on the index is going to be a purge all.
 		 */
 		private boolean purgeAll = false;
-		
+
 		/**
 		 * The type of all classes being managed
 		 */
 		private final Class<T> entityClass;
-		
+
 		/**
-		 * The ducomentBuilder relative to the type being managed
+		 * The DocumentBuilder relative to the type being managed
 		 */
 		private final AbstractDocumentBuilder<T> documentBuilder;
-		
+
+		/**
+		 * The entity {@link #entityClass} does not have its own index, but is only used in contained scenarios
+		 */
+		private final boolean containedInOnly;
+
+		/**
+		 * @param clazz The type of entities being managed by this instance
+		 */
+		PerClassWork(Class<T> clazz) {
+			this.entityClass = clazz;
+			this.documentBuilder = getEntityBuilder( searchFactoryImplementor, clazz );
+			this.containedInOnly = documentBuilder instanceof DocumentBuilderContainedEntity;
+		}
+
 		/**
 		 * Adds a work to the current plan. The entityClass of the work must be of the
 		 * type managed by this.
-		 * @param work
+		 *
+		 * @param work the {@code Work} instance to add to the plan
 		 */
 		public void addWork(Work<T> work) {
 			if ( work.getType() == WorkType.PURGE_ALL ) {
@@ -215,22 +223,28 @@ public class WorkPlan {
 				entityWork.addWork( work );
 			}
 		}
-		
+
 		/**
 		 * We need to make a difference on which value is used as identifier
 		 * according to use case and mapping options
-		 * @param work
+		 *
+		 * @param work The work instance from which to extract the id
+		 *
 		 * @return the appropriate id to use for this work
 		 */
 		private Serializable extractProperId(Work<T> work) {
+			// see HSEARCH-662
+			if ( containedInOnly ) {
+				return work.getId();
+			}
+
 			T entity = work.getEntity();
 			// 1) entity is null for purge operation, which requires to trust the work id
 			// 2) types mapped as provided id require to use the work id
 			// 3) when Hibernate identifier rollback is used && this identifier is our same id source, we need to get the value from work id
-			if ( entity == null ||
-					documentBuilder.requiresProvidedId() ||
-					( work.isIdentifierWasRolledBack() && documentBuilder.isIdMatchingJpaId() )
-					) {
+			if ( entity == null
+					|| documentBuilder.requiresProvidedId()
+					|| ( work.isIdentifierWasRolledBack() && documentBuilder.isIdMatchingJpaId() ) ) {
 				return work.getId();
 			}
 			else {
@@ -241,6 +255,7 @@ public class WorkPlan {
 		/**
 		 * Enqueues all work needed to be performed according to current state into
 		 * the LuceneWork queue.
+		 *
 		 * @param luceneQueue work will be appended to this list
 		 */
 		public void enqueueLuceneWork(List<LuceneWork> luceneQueue) {
@@ -254,7 +269,7 @@ public class WorkPlan {
 				perEntityWork.enqueueLuceneWork( entityClass, indexingId, documentBuilder, luceneQueue );
 			}
 		}
-		
+
 		/**
 		 * Starts processing the ContainedIn annotation for all instances stored in
 		 * byEntityId. Must be performed when no more work is being collected by the event
@@ -272,10 +287,11 @@ public class WorkPlan {
 				perEntityWork.processContainedIn( documentBuilder, WorkPlan.this );
 			}
 		}
-		
+
 		/**
 		 * Method to continue the recursion for ContainedIn processing, as started by {@link #processContainedInAndPrepareExecution()}
 		 * Additional work that needs to be processed will be added to this same WorkPlan.
+		 *
 		 * @param value the instance to be processed
 		 */
 		void recurseContainedIn(T value) {
@@ -301,39 +317,39 @@ public class WorkPlan {
 				}
 			}
 		}
-		
 	}
-	
+
 	/**
 	 * Keeps track of what needs to be done Lucene wise for each entity.
 	 * Each entity might need to be deleted from the index, added to the index,
 	 * or both; in this case delete will be performed first.
 	 */
 	private static class PerEntityWork<T> {
-		
+
 		private T entity;
-		
+
 		/**
 		 * When true, the Lucene Document representing this entity will be deleted
 		 * from the index.
 		 */
 		private boolean delete = false;
-		
+
 		/**
 		 * When true, the entity will be converted to a Lucene Document and added
 		 * to the index.
 		 */
 		private boolean add = false;
-		
+
 		/**
 		 * Needed to stop recursion for processing ContainedIn
 		 * of already processed instances.
 		 */
 		private boolean containedInProcessed = false;
-		
+
 		/**
 		 * Constructor to force an update of the entity even without
 		 * having a specific Work instance for it.
+		 *
 		 * @param entity the instance which needs to be updated in the index
 		 */
 		private PerEntityWork(T entity) {
@@ -343,95 +359,98 @@ public class WorkPlan {
 			this.add = true;
 			this.containedInProcessed = true;
 		}
-		
+
 		/**
 		 * Prepares the initial state of planned changes according
 		 * to the type of work being fired.
-		 * @param work
+		 *
+		 * @param work the work instance
 		 */
 		private PerEntityWork(Work<T> work) {
 			entity = work.getEntity();
 			WorkType type = work.getType();
 			// sets the initial state:
 			switch ( type ) {
-			case ADD:
-				add = true;
-				break;
-			case DELETE:
-			case PURGE:
-				delete = true;
-				break;
-			case COLLECTION:
-			case UPDATE:
-				delete = true;
-				add = true;
-				break;
-			case INDEX:
-				add = true;
-				delete = true;
-				break;
-			case PURGE_ALL:
-				// not breaking intentionally: PURGE_ALL should not reach this
-				// class
-			default:
-				throw new SearchException( "unexpected state:" + type );
+				case ADD:
+					add = true;
+					break;
+				case DELETE:
+				case PURGE:
+					delete = true;
+					break;
+				case COLLECTION:
+				case UPDATE:
+					delete = true;
+					add = true;
+					break;
+				case INDEX:
+					add = true;
+					delete = true;
+					break;
+				case PURGE_ALL:
+					// not breaking intentionally: PURGE_ALL should not reach this
+					// class
+				default:
+					throw new SearchException( "unexpected state:" + type );
 			}
 		}
-		
+
 		/**
 		 * Has different effects depending on the new type of work needed
 		 * and the previous scheduled work.
 		 * This way we never store more than a plan for each entity and order
 		 * of final execution is irrelevant, what matters is the order in which the
 		 * work is added to the plan.
-		 * @param work
+		 *
+		 * @param work the work instance to add
 		 */
 		public void addWork(Work<T> work) {
 			entity = work.getEntity();
 			WorkType type = work.getType();
 			switch ( type ) {
-			case INDEX:
-			case UPDATE:
-				if ( add && !delete ) {
-					// noop: the entity was newly created in this same unit of work
-					// so it needs to be added no need to delete
-				}
-				else {
+				case INDEX:
+				case UPDATE:
+					if ( add && !delete ) {
+						// noop: the entity was newly created in this same unit of work
+						// so it needs to be added no need to delete
+					}
+					else {
+						add = true;
+						delete = true;
+					}
+					break;
+				case ADD: // Is the only operation which doesn't imply a delete-before-add
 					add = true;
-					delete = true;
-				}
-				break;
-			case ADD: // Is the only operation which doesn't imply a delete-before-add
-				add = true;
-				// leave delete flag as-is
-				break;
-			case DELETE:
-			case PURGE:
-				if ( add && !delete ) {
-					// the entity was was newly created in this same unit of
-					// work so works counter each other
-					add = false;
-				}
-				else {
-					add = false;
-					delete = true;
-				}
-				break;
-			case COLLECTION:
-				if ( !add && !delete ) {
-					add = true;
-					delete = true;
-				}
-				// nothing to do, as something else was done
-				break;
-			case PURGE_ALL:
-			default:
-				throw new SearchException( "unexpected state:" + type );
+					// leave delete flag as-is
+					break;
+				case DELETE:
+				case PURGE:
+					if ( add && !delete ) {
+						// the entity was was newly created in this same unit of
+						// work so works counter each other
+						add = false;
+					}
+					else {
+						add = false;
+						delete = true;
+					}
+					break;
+				case COLLECTION:
+					if ( !add && !delete ) {
+						add = true;
+						delete = true;
+					}
+					// nothing to do, as something else was done
+					break;
+				case PURGE_ALL:
+				default:
+					throw new SearchException( "unexpected state:" + type );
 			}
 		}
-		
+
 		/**
 		 * Adds the needed LuceneWork to the queue for this entity instance
+		 *
 		 * @param entityClass the type
 		 * @param indexingId identifier of the instance
 		 * @param entityBuilder the DocumentBuilder for this type
@@ -442,16 +461,18 @@ public class WorkPlan {
 				entityBuilder.addWorkToQueue( entityClass, entity, indexingId, delete, add, luceneQueue );
 			}
 		}
-		
+
 		/**
 		 * Works via recursion passing the WorkPlan over, so that additional work can be planned
 		 * according to the needs of ContainedIn processing.
-		 * @see org.hibernate.search.annotations.ContainedIn
+		 *
 		 * @param entityBuilder the DocumentBuilder for this type
 		 * @param workplan the current WorkPlan, used for recursion
+		 *
+		 * @see org.hibernate.search.annotations.ContainedIn
 		 */
 		public void processContainedIn(AbstractDocumentBuilder<T> entityBuilder, WorkPlan workplan) {
-			if ( ! containedInProcessed ) {
+			if ( !containedInProcessed ) {
 				containedInProcessed = true;
 				if ( add || delete ) {
 					entityBuilder.appendContainedInWorkForInstance( entity, workplan );
@@ -459,19 +480,27 @@ public class WorkPlan {
 			}
 		}
 	}
-	
+
 	/**
 	 * Get and cache the DocumentBuilder for this type. Being this a perClassWork
 	 * we can fetch it once.
+	 *
+	 * @param searchFactoryImplementor the search factory (implementor)
+	 * @param entityClass the entity type for which to retrieve the document builder
+	 *
 	 * @return the DocumentBuilder for this type
 	 */
-	private static <T> AbstractDocumentBuilder<T> getEntityBuilder(SearchFactoryImplementor searchFactoryImplementor, Class entityClass) {
+	private static <T> AbstractDocumentBuilder<T> getEntityBuilder(SearchFactoryImplementor searchFactoryImplementor, Class<?> entityClass) {
 		EntityIndexBinder entityIndexBinding = searchFactoryImplementor.getIndexBindingForEntity( entityClass );
 		if ( entityIndexBinding == null ) {
-			DocumentBuilderContainedEntity entityBuilder = searchFactoryImplementor.getDocumentBuilderContainedEntity( entityClass );
+			DocumentBuilderContainedEntity entityBuilder = searchFactoryImplementor.getDocumentBuilderContainedEntity(
+					entityClass
+			);
 			if ( entityBuilder == null ) {
 				// should never happen but better be safe than sorry
-				throw new SearchException( "Unable to perform work. Entity Class is not @Indexed nor hosts @ContainedIn: " + entityClass );
+				throw new SearchException(
+						"Unable to perform work. Entity Class is not @Indexed nor hosts @ContainedIn: " + entityClass
+				);
 			}
 			else {
 				return entityBuilder;
@@ -481,6 +510,5 @@ public class WorkPlan {
 			return entityIndexBinding.getDocumentBuilder();
 		}
 	}
-
 }
 

--- a/hibernate-search/src/test/java/org/hibernate/search/test/embedded/update/ContainedInReindexPropagationTest.java
+++ b/hibernate-search/src/test/java/org/hibernate/search/test/embedded/update/ContainedInReindexPropagationTest.java
@@ -1,0 +1,129 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2010, Red Hat, Inc. and/or its affiliates or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat, Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.search.test.embedded.update;
+
+import java.util.List;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.TermQuery;
+
+import org.hibernate.Transaction;
+import org.hibernate.search.FullTextQuery;
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.Search;
+import org.hibernate.search.test.SearchTestCase;
+
+/**
+ * @author Hardy Ferentschik
+ */
+public class ContainedInReindexPropagationTest extends SearchTestCase {
+
+	// see HSEARCH-662
+	public void testUpdatingContainedInEntityPropagatesToAllEntities() throws Exception {
+		// source to move dads from
+		Grandpa source = new Grandpa( "grandpaSource" );
+		// source to move dads to
+		Grandpa target = new Grandpa( "grandpaTarget" );
+
+		Dad dad1 = new Dad( "dad1" );
+		dad1.setGrandpa( source );
+
+		Dad dad2 = new Dad( "dad2" );
+		dad2.setGrandpa( source );
+
+		Son son1 = new Son( "son1" );
+		dad1.add( son1 );
+
+		Son son2 = new Son( "son2" );
+		dad2.add( son2 );
+
+		// first operation -> save
+		FullTextSession session = Search.getFullTextSession( openSession() );
+		Transaction tx = session.beginTransaction();
+		session.save( source );
+		session.save( target );
+		session.save( dad1 );
+		session.save( dad2 );
+		session.save( son1 );
+		session.save( son2 );
+		tx.commit();
+		session.close();
+
+		final Long sourceGrandpaId = source.getId();
+		final Long targetGrandpaId = target.getId();
+
+		// assert that everything got saved correctly
+		session = Search.getFullTextSession( openSession() );
+		tx = session.beginTransaction();
+
+		// everything gets indexed correctly
+		assertEquals( getSonsGrandpaIdFromIndex( session, son1.getName() ), sourceGrandpaId );
+		assertEquals( getSonsGrandpaIdFromIndex( session, son2.getName() ), sourceGrandpaId );
+
+		tx.commit();
+		session.close();
+
+		//let's move dad's to a new grandpa!
+		dad1.setGrandpa( target );
+		dad2.setGrandpa( target );
+
+		session = Search.getFullTextSession( openSession() );
+		tx = session.beginTransaction();
+
+		session.update( dad1 );
+		session.update( dad2 );
+
+		tx.commit();
+		session.close();
+
+		//all right, let's assert that indexes got updated correctly
+		session = Search.getFullTextSession( openSession() );
+		tx = session.beginTransaction();
+
+		//NOTE: it looks like the last item in session (i.e. dad2) does get updated correctly
+		assertEquals( "must now point target!", getSonsGrandpaIdFromIndex( session, son2.getName() ), targetGrandpaId );
+		//this one will fail miserably
+		assertEquals( "must now point target!", getSonsGrandpaIdFromIndex( session, son1.getName() ), targetGrandpaId );
+
+		tx.commit();
+		session.close();
+	}
+
+	private Long getSonsGrandpaIdFromIndex(FullTextSession session, String name) {
+		FullTextQuery q = session.createFullTextQuery( new TermQuery( new Term( "name", name ) ), Son.class );
+		q.setProjection( "dad.grandpaId" );
+		@SuppressWarnings("unchecked")
+		List<Object[]> results = q.list();
+		if ( results.isEmpty() ) {
+			return null;
+		}
+		return (Long) results.get( 0 )[0];
+	}
+
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] {
+				Dad.class, Grandpa.class, Son.class
+		};
+	}
+}

--- a/hibernate-search/src/test/java/org/hibernate/search/test/embedded/update/Dad.java
+++ b/hibernate-search/src/test/java/org/hibernate/search/test/embedded/update/Dad.java
@@ -1,0 +1,103 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2011, Red Hat, Inc. and/or its affiliates or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat, Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.search.test.embedded.update;
+
+import java.util.HashSet;
+import java.util.Set;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Transient;
+
+import org.hibernate.search.annotations.ContainedIn;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Store;
+
+
+@Entity
+public class Dad {
+	private Long id;
+	private String name;
+	private Grandpa grandpa;
+	private Set<Son> sons = new HashSet<Son>();
+
+	public Dad() {
+	}
+
+	public Dad(String name) {
+		this.name = name;
+	}
+
+	@Id
+	@GeneratedValue
+	public Long getId() {
+		return id;
+	}
+
+	private void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@ManyToOne
+	public Grandpa getGrandpa() {
+		return grandpa;
+	}
+
+	public void setGrandpa(Grandpa grandpa) {
+		this.grandpa = grandpa;
+	}
+
+	@Field(store = Store.YES)
+	@Transient
+	public Long getGrandpaId() {
+		return grandpa != null ? grandpa.getId() : null;
+	}
+
+	@ContainedIn
+	@OneToMany
+	public Set<Son> getSons() {
+		return sons;
+	}
+
+	private void setSons(Set<Son> sons) {
+		this.sons = sons;
+	}
+
+	public boolean add(Son son) {
+		son.setDad( this );
+		return sons.add( son );
+	}
+}
+
+

--- a/hibernate-search/src/test/java/org/hibernate/search/test/embedded/update/Grandpa.java
+++ b/hibernate-search/src/test/java/org/hibernate/search/test/embedded/update/Grandpa.java
@@ -1,0 +1,64 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2011, Red Hat, Inc. and/or its affiliates or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat, Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.search.test.embedded.update;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+
+@Entity
+public class Grandpa {
+
+	private Long id;
+	private String name;
+
+	public Grandpa() {
+	}
+
+	public Grandpa(String name) {
+		this.name = name;
+	}
+
+	@Id
+	@GeneratedValue
+	public Long getId() {
+		return id;
+	}
+
+	private void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}
+
+
+

--- a/hibernate-search/src/test/java/org/hibernate/search/test/embedded/update/Son.java
+++ b/hibernate-search/src/test/java/org/hibernate/search/test/embedded/update/Son.java
@@ -1,0 +1,99 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2011, Red Hat, Inc. and/or its affiliates or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat, Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.search.test.embedded.update;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Index;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.IndexedEmbedded;
+
+@Entity
+@Indexed
+public class Son {
+	private Long id;
+	private String name;
+	private Dad dad;
+
+	public Son() {
+	}
+
+	public Son(String name) {
+		this.name = name;
+	}
+
+	@Id
+	@GeneratedValue
+	public Long getId() {
+		return id;
+	}
+
+	private void setId(Long id) {
+		this.id = id;
+	}
+
+	@Field(index = Index.UN_TOKENIZED)
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@IndexedEmbedded
+	@ManyToOne
+	public Dad getDad() {
+		return dad;
+	}
+
+	public void setDad(Dad dad) {
+		this.dad = dad;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if ( this == o ) {
+			return true;
+		}
+		if ( !( o instanceof Son ) ) {
+			return false;
+		}
+
+		Son son = (Son) o;
+		return name.equals( son.getName() );
+	}
+
+	@Override
+	public int hashCode() {
+		return name.hashCode();
+	}
+}
+
+
+


### PR DESCRIPTION
Adding 'containedInOnly' flag to PerClassWork to handle entities which are only used in contained scenarios differently than indexed entities.

The actual change is in PerClassWork#extractProperId(). Everything is just formatting and javadoc cleanups
