### PR TITLE
HSEARCH-905 Upgrading to Lucene 3.4 

### DIFF
--- a/hibernate-search-archetype/src/test/java/com/example/IndexAndSearchTest.java
+++ b/hibernate-search-archetype/src/test/java/com/example/IndexAndSearchTest.java
@@ -134,7 +134,7 @@ public class IndexAndSearchTest {
 		FullTextEntityManager ftEm = org.hibernate.search.jpa.Search.getFullTextEntityManager( em );
 		Analyzer customAnalyzer = ftEm.getSearchFactory().getAnalyzer( "customanalyzer" );
 		QueryParser parser = new MultiFieldQueryParser(
-				Version.LUCENE_33, bookFields,
+				Version.LUCENE_34, bookFields,
 				customAnalyzer, boostPerField
 		);
 

--- a/hibernate-search/src/main/java/org/hibernate/search/Environment.java
+++ b/hibernate-search/src/main/java/org/hibernate/search/Environment.java
@@ -127,8 +127,8 @@ public final class Environment {
 	 * Provide a programmatic mapping model to Hibernate Search configuration
 	 * Accepts a fully populated SearchMapping object or a fully qualified
 	 * class name of a SearchMapping factory. Such a factory must have:
-	 *  - a no-arg constructor
-	 *  - a method returning SearchMapping and annotated with @Factory
+	 * - a no-arg constructor
+	 * - a method returning SearchMapping and annotated with @Factory
 	 */
 	public static final String MODEL_MAPPING = "hibernate.search.model_mapping";
 
@@ -180,4 +180,12 @@ public final class Environment {
 	 * When the limit is reached work producers are blocked until some work has been processed.
 	 */
 	public static final String MAX_QUEUE_LENGTH = "max_queue_length";
+
+	/**
+	 * If nothing else is specified we use {@code Version.LUCENE_CURRENT} as the default Lucene version. This version
+	 * parameter was introduced by Lucene to attempt providing backwards compatibility when upgrading Lucene versions
+	 * and not wanting to rebuild the index from scratch. It's highly recommended to specify a version, so that you
+	 * can upgrade Hibernate Search and control when to eventually upgrade the Lucene format.
+	 */
+	public static final org.apache.lucene.util.Version DEFAULT_LUCENE_MATCH_VERSION = org.apache.lucene.util.Version.LUCENE_CURRENT;
 }

--- a/hibernate-search/src/main/java/org/hibernate/search/backend/impl/lucene/IndexWriterHolder.java
+++ b/hibernate-search/src/main/java/org/hibernate/search/backend/impl/lucene/IndexWriterHolder.java
@@ -31,7 +31,8 @@ import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LogByteSizeMergePolicy;
 import org.apache.lucene.index.MergeScheduler;
 import org.apache.lucene.search.Similarity;
-import org.apache.lucene.util.Version;
+
+import org.hibernate.search.Environment;
 import org.hibernate.search.backend.impl.lucene.overrides.ConcurrentMergeScheduler;
 import org.hibernate.search.backend.spi.LuceneIndexingParameters;
 import org.hibernate.search.backend.spi.LuceneIndexingParameters.ParameterSet;
@@ -52,12 +53,12 @@ class IndexWriterHolder {
 	private static final Log log = LoggerFactory.make();
 	
 	/**
-	 * This Analyzer is never used in practice: during Add operation it's overriden.
+	 * This Analyzer is never used in practice: during Add operation it's overridden.
 	 * So we don't care for the Version, using whatever Lucene thinks is safer.
 	 */
-	private static final Analyzer SIMPLE_ANALYZER = new SimpleAnalyzer( Version.LUCENE_33 );
+	private static final Analyzer SIMPLE_ANALYZER = new SimpleAnalyzer( Environment.DEFAULT_LUCENE_MATCH_VERSION );
 	
-	private final IndexWriterConfig writerConfig = new IndexWriterConfig( Version.LUCENE_33, SIMPLE_ANALYZER );
+	private final IndexWriterConfig writerConfig = new IndexWriterConfig( Environment.DEFAULT_LUCENE_MATCH_VERSION , SIMPLE_ANALYZER );
 	private final LuceneIndexingParameters luceneParameters;
 	private final ErrorHandler errorHandler;
 	private final ParameterSet indexParameters;

--- a/hibernate-search/src/main/java/org/hibernate/search/impl/ConfigContext.java
+++ b/hibernate-search/src/main/java/org/hibernate/search/impl/ConfigContext.java
@@ -64,14 +64,6 @@ public final class ConfigContext {
 	private static final Log log = LoggerFactory.make();
 
 	/**
-	 * If nothing else is specified we use {@code Version.LUCENE_CURRENT} as the default Lucene version. This version
-	 * parameter was introduced by Lucene to attempt providing backwards compatibility when upgrading Lucene versions
-	 * and not wanting to rebuild the index from scratch. It's highly recommended to specify a version, so that you
-	 * can upgrade Hibernate Search and control when to eventually upgrade the Lucene format.
-	 */
-	private static final Version DEFAULT_LUCENE_MATCH_VERSION = Version.LUCENE_CURRENT;
-
-	/**
 	 * The default token for indexing null values. See {@link org.hibernate.search.annotations.Field#indexNullAs()}
 	 */
 	private static final String DEFAULT_NULL_INDEX_TOKEN = "_null_";
@@ -306,7 +298,7 @@ public final class ConfigContext {
 		String tmp = cfg.getProperty( Environment.LUCENE_MATCH_VERSION );
 		if ( StringHelper.isEmpty( tmp ) ) {
 			log.recommendConfiguringLuceneVersion();
-			version = DEFAULT_LUCENE_MATCH_VERSION;
+			version = Environment.DEFAULT_LUCENE_MATCH_VERSION;
 		}
 		else {
 			try {

--- a/hibernate-search/src/main/java/org/hibernate/search/store/impl/DirectoryProviderHelper.java
+++ b/hibernate-search/src/main/java/org/hibernate/search/store/impl/DirectoryProviderHelper.java
@@ -46,6 +46,7 @@ import org.apache.lucene.store.SimpleFSLockFactory;
 import org.apache.lucene.store.SingleInstanceLockFactory;
 import org.apache.lucene.util.Version;
 import org.hibernate.annotations.common.util.StringHelper;
+import org.hibernate.search.Environment;
 import org.hibernate.search.SearchException;
 import org.hibernate.search.store.LockFactoryProvider;
 import org.hibernate.search.util.configuration.impl.ConfigurationParseHelper;
@@ -79,13 +80,13 @@ public final class DirectoryProviderHelper {
 	 * Build a directory name out of a root and relative path, guessing the significant part
 	 * and checking for the file availability
 	 *
-	 * @param directoryProviderName
+	 * @param indexName the name of the index (directory) to create
 	 * @param properties the configuration properties
 	 * @param needWritePermissions when true the directory will be tested for read-write permissions.
 	 *
 	 * @return The file representing the source directory
 	 */
-	public static File getSourceDirectory(String directoryProviderName, Properties properties, boolean needWritePermissions) {
+	public static File getSourceDirectory(String indexName, Properties properties, boolean needWritePermissions) {
 		String root = properties.getProperty( ROOT_INDEX_PROP_NAME );
 		String relative = properties.getProperty( RELATIVE_INDEX_PROP_NAME );
 		File sourceDirectory;
@@ -99,7 +100,7 @@ public final class DirectoryProviderHelper {
 					);
 		}
 		if ( relative == null ) {
-			relative = directoryProviderName;
+			relative = indexName;
 		}
 		if ( StringHelper.isEmpty( root ) ) {
 			log.debug( "No root directory, go with relative " + relative );
@@ -111,9 +112,9 @@ public final class DirectoryProviderHelper {
 		}
 		else {
 			File rootDir = new File( root );
-			makeSanityCheckedDirectory( rootDir, directoryProviderName, needWritePermissions );
+			makeSanityCheckedDirectory( rootDir, indexName, needWritePermissions );
 			sourceDirectory = new File( root, relative );
-			makeSanityCheckedDirectory( sourceDirectory, directoryProviderName, needWritePermissions );
+			makeSanityCheckedDirectory( sourceDirectory, indexName, needWritePermissions );
 			log.debug( "Got directory from root + relative" );
 		}
 		return sourceDirectory;
@@ -150,7 +151,7 @@ public final class DirectoryProviderHelper {
 	 */
 	public static void initializeIndexIfNeeded(Directory directory) {
 		//version doesn't really matter as we won't use the Analyzer
-		Version version = Version.LUCENE_31;
+		Version version =  Environment.DEFAULT_LUCENE_MATCH_VERSION;
 		SimpleAnalyzer analyzer = new SimpleAnalyzer( version );
 		try {
 			if ( ! IndexReader.indexExists( directory ) ) {
@@ -318,12 +319,12 @@ public final class DirectoryProviderHelper {
 	 * "chunk size" for large file copy operations performed
 	 * by DirectoryProviders.
 	 *
-	 * @param directoryProviderName
+	 * @param indexName the index name
 	 * @param properties the configuration properties
 	 *
 	 * @return the number of Bytes to use as "chunk size" in file copy operations.
 	 */
-	public static long getCopyBufferSize(String directoryProviderName, Properties properties) {
+	public static long getCopyBufferSize(String indexName, Properties properties) {
 		String value = properties.getProperty( COPY_BUFFER_SIZE_PROP_NAME );
 		long size = FileHelper.DEFAULT_COPY_BUFFER_SIZE;
 		if ( value != null ) {
@@ -333,13 +334,13 @@ public final class DirectoryProviderHelper {
 			catch ( NumberFormatException nfe ) {
 				throw new SearchException(
 						"Unable to initialize index " +
-								directoryProviderName + "; " + COPY_BUFFER_SIZE_PROP_NAME + " is not numeric.", nfe
+								indexName + "; " + COPY_BUFFER_SIZE_PROP_NAME + " is not numeric.", nfe
 				);
 			}
 			if ( size <= 0 ) {
 				throw new SearchException(
 						"Unable to initialize index " +
-								directoryProviderName + "; " + COPY_BUFFER_SIZE_PROP_NAME + " needs to be greater than zero."
+								indexName + "; " + COPY_BUFFER_SIZE_PROP_NAME + " needs to be greater than zero."
 				);
 			}
 		}

--- a/hibernate-search/src/test/java/org/hibernate/search/test/util/ClassLoaderHelperTest.java
+++ b/hibernate-search/src/test/java/org/hibernate/search/test/util/ClassLoaderHelperTest.java
@@ -29,6 +29,7 @@ import org.apache.lucene.search.DefaultSimilarity;
 import org.apache.lucene.search.Similarity;
 
 import org.hibernate.Session;
+import org.hibernate.search.Environment;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.SearchException;
 import org.hibernate.search.backend.spi.BackendQueueProcessor;
@@ -116,7 +117,7 @@ public class ClassLoaderHelperTest {
 	@Test
 	public void testLoadingAnalyzerWithVersionConstructor() {
 		Analyzer analyzer = ClassLoaderHelper.analyzerInstanceFromClass(
-				StandardAnalyzer.class, org.apache.lucene.util.Version.LUCENE_30
+				StandardAnalyzer.class,  Environment.DEFAULT_LUCENE_MATCH_VERSION
 		);
 		assertNotNull( "We should be able to instantiate an analyzer with a Lucene version parameter", analyzer );
 	}
@@ -124,7 +125,7 @@ public class ClassLoaderHelperTest {
 	@Test
 	public void testLoadingAnalyzerWithDefaultConstructor() {
 		Analyzer analyzer = ClassLoaderHelper.analyzerInstanceFromClass(
-				FooAnalyzer.class, org.apache.lucene.util.Version.LUCENE_30
+				FooAnalyzer.class, Environment.DEFAULT_LUCENE_MATCH_VERSION
 		);
 		assertNotNull( "We should be able to instantiate an analyzer which has only a default constructor", analyzer );
 	}
@@ -133,7 +134,7 @@ public class ClassLoaderHelperTest {
 	public void testLoadingAnalyzerWithNoVersionOrDefaultConstructor() {
 		try {
 			ClassLoaderHelper.analyzerInstanceFromClass(
-					BarAnalyzer.class, org.apache.lucene.util.Version.LUCENE_30
+					BarAnalyzer.class, Environment.DEFAULT_LUCENE_MATCH_VERSION
 			);
 			fail( "We should not be able to instantiate a analyzer with no default constructor or simple Version parameter." );
 		}

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <slf4jVersion>1.6.1</slf4jVersion>
-        <luceneVersion>3.3.0</luceneVersion>
+        <luceneVersion>3.4.0</luceneVersion>
         <infinispanVersion>5.0.0.FINAL</infinispanVersion>
         <hibernateVersion>4.0.0.CR2</hibernateVersion>
         <hibernateCommonsAnnotationVersion>4.0.0.CR2</hibernateCommonsAnnotationVersion>


### PR DESCRIPTION
Upgrade of the version was easy, but I found a couple of _Version_ spread across the code and thought it would be nice to get rid of them. I moved _DEFAULT_LUCENE_MATCH_VERSION_ into _Environment_ and use this constant. Looking at some of the comments saying that the match version does not matter at certain points, it seems ok to me to do this...
