### PR TITLE
HSEARCH-921 

### DIFF
--- a/hibernate-search/src/main/java/org/hibernate/search/util/impl/HibernateSearchResourceLoader.java
+++ b/hibernate-search/src/main/java/org/hibernate/search/util/impl/HibernateSearchResourceLoader.java
@@ -24,7 +24,6 @@
 package org.hibernate.search.util.impl;
 
 import java.io.BufferedReader;
-import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -34,19 +33,14 @@ import java.util.List;
 
 import org.apache.solr.common.ResourceLoader;
 import org.apache.solr.util.plugin.ResourceLoaderAware;
-import org.hibernate.search.util.logging.impl.Log;
 
 import org.hibernate.search.SearchException;
-import org.hibernate.search.util.logging.impl.LoggerFactory;
 
 /**
  * @author Emmanuel Bernard
  * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
  */
 public class HibernateSearchResourceLoader implements ResourceLoader {
-
-	private static final Log log = LoggerFactory.make();
-
 	private final String charset;
 
 	public HibernateSearchResourceLoader() {
@@ -58,7 +52,7 @@ public class HibernateSearchResourceLoader implements ResourceLoader {
 	}
 
 	public InputStream openResource(String resource) throws IOException {
-		return Thread.currentThread().getContextClassLoader().getResourceAsStream( resource );
+		return FileHelper.openResource( resource );
 	}
 
 	public List<String> getLines(String resource) throws IOException {
@@ -84,12 +78,12 @@ public class HibernateSearchResourceLoader implements ResourceLoader {
 				}
 			}
 			finally {
-				closeResource( reader );
+				FileHelper.closeResource( reader );
 			}
 			return Collections.unmodifiableList( results );
 		}
 		finally {
-			closeResource( stream );
+			FileHelper.closeResource( stream );
 		}
 	}
 
@@ -105,22 +99,5 @@ public class HibernateSearchResourceLoader implements ResourceLoader {
 			( (ResourceLoaderAware) instance ).inform( this );
 		}
 		return instance;
-	}
-
-	/**
-	 * Closes a resource without throwing IOExceptions
-	 *
-	 * @param resource the resource to close
-	 */
-	private void closeResource(Closeable resource) {
-		if ( resource != null ) {
-			try {
-				resource.close();
-			}
-			catch ( IOException e ) {
-				//we don't really care if we can't close
-				log.couldNotCloseResource( e );
-			}
-		}
 	}
 }

--- a/hibernate-search/src/main/java/org/hibernate/search/util/logging/impl/Log.java
+++ b/hibernate-search/src/main/java/org/hibernate/search/util/logging/impl/Log.java
@@ -191,7 +191,7 @@ public interface Log extends BasicLogger {
 	void version(String versionString);
 
 	@LogMessage(level = WARN)
-	@Message(id = 35, value = "could not close resource: ")
+	@Message(id = 35, value = "Could not close resource: ")
 	void couldNotCloseResource(@Cause Exception e);
 
 	@LogMessage(level = WARN)
@@ -488,4 +488,7 @@ public interface Log extends BasicLogger {
 
 	@Message(id = 113, value = "'null' is not a valid index name")
 	IllegalArgumentException nullIsInvalidIndexName();
+
+	@Message(id = 114, value = "Could not load resource: ")
+	SearchException unableToLoadResource(String fileName);
 }

--- a/hibernate-search/src/test/java/org/hibernate/search/test/util/ResourceLoadingTest.java
+++ b/hibernate-search/src/test/java/org/hibernate/search/test/util/ResourceLoadingTest.java
@@ -1,0 +1,54 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2010, Red Hat, Inc. and/or its affiliates or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat, Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+package org.hibernate.search.test.util;
+
+import org.junit.Test;
+
+import org.hibernate.search.SearchException;
+import org.hibernate.search.util.impl.FileHelper;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertNotNull;
+
+/**
+ * @author Hardy Ferentschik
+ */
+public class ResourceLoadingTest {
+
+	@Test
+	public void testOpenKnownResource() throws Exception {
+		// using a known resource for testing
+		String resource = "org/hibernate/search/remote/codex/avro/v1_0/Message.avro";
+		String resourceContent = FileHelper.readResourceAsString( resource );
+		assertNotNull( resourceContent );
+		assertFalse( resourceContent.isEmpty() );
+	}
+
+	@Test(expected = SearchException.class)
+	public void testUnKnownResource() throws Exception {
+		// using a known resource for testing
+		String resource = "foo";
+		FileHelper.readResourceAsString( resource );
+	}
+}


### PR DESCRIPTION
HSEARCH-921 Removing failing 'fullFileName.replace( '/', File.separatorChar )' call. Since we are loading from the classpath this is not needed

Also moving the file and resource handling into a static helper class (makes it reusable and testable). Access to classloader is also unified in one spot. This might be useful in case we need to revisit how we use classloaders.

Handling the case where a unknown resource is specified with an exception
