### PR TITLE
HSEARCH-926 fix + test coverage

### DIFF
--- a/hibernate-search-infinispan/src/main/java/org/hibernate/search/infinispan/InfinispanDirectoryProvider.java
+++ b/hibernate-search-infinispan/src/main/java/org/hibernate/search/infinispan/InfinispanDirectoryProvider.java
@@ -26,21 +26,20 @@ package org.hibernate.search.infinispan;
 import java.io.IOException;
 import java.util.Properties;
 
-import org.infinispan.Cache;
-import org.infinispan.lucene.InfinispanDirectory;
-import org.infinispan.manager.EmbeddedCacheManager;
-import org.slf4j.Logger;
-
 import org.hibernate.search.SearchException;
 import org.hibernate.search.backend.configuration.ConfigurationParseHelper;
 import org.hibernate.search.spi.BuildContext;
 import org.hibernate.search.store.DirectoryProviderHelper;
 import org.hibernate.search.util.LoggerFactory;
+import org.infinispan.Cache;
+import org.infinispan.lucene.InfinispanDirectory;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.slf4j.Logger;
 
 /**
  * A DirectoryProvider using Infinispan to store the Index. This depends on the
  * CacheManagerServiceProvider to get a reference to the Infinispan {@link EmbeddedCacheManager}.
- *
+ * 
  * @author Sanne Grinovero
  */
 public class InfinispanDirectoryProvider implements org.hibernate.search.store.DirectoryProvider<InfinispanDirectory> {
@@ -72,9 +71,8 @@ public class InfinispanDirectoryProvider implements org.hibernate.search.store.D
 		metadataCacheName = properties.getProperty( "metadata_cachename", DEFAULT_INDEXESMETADATA_CACHENAME );
 		dataCacheName = properties.getProperty( "data_cachename", DEFAULT_INDEXESDATA_CACHENAME );
 		lockingCacheName = properties.getProperty( "locking_cachename", DEFAULT_LOCKING_CACHENAME );
-		chunkSize = ConfigurationParseHelper.getIntValue(
-				properties, "chunk_size", InfinispanDirectory.DEFAULT_BUFFER_SIZE
-		);
+		chunkSize = ConfigurationParseHelper.getIntValue( properties, "chunk_size",
+				InfinispanDirectory.DEFAULT_BUFFER_SIZE );
 	}
 
 	@Override
@@ -111,6 +109,23 @@ public class InfinispanDirectoryProvider implements org.hibernate.search.store.D
 
 	public EmbeddedCacheManager getCacheManager() {
 		return cacheManager;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ( obj == this ) {
+			return true;
+		}
+		if ( obj == null || !( obj instanceof InfinispanDirectoryProvider ) ) {
+			return false;
+		}
+		return directoryProviderName.equals( ( (InfinispanDirectoryProvider) obj ).directoryProviderName );
+	}
+
+	@Override
+	public int hashCode() {
+		int hash = 11;
+		return 37 * hash + directoryProviderName.hashCode();
 	}
 
 }

--- a/hibernate-search-infinispan/src/test/java/org/hibernate/search/infinispan/sharedIndex/Device.java
+++ b/hibernate-search-infinispan/src/test/java/org/hibernate/search/infinispan/sharedIndex/Device.java
@@ -1,0 +1,100 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2010, Red Hat, Inc. and/or its affiliates or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat, Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+
+package org.hibernate.search.infinispan.sharedIndex;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Index;
+
+@Entity
+public abstract class Device {
+
+	public Device(String manufacturer, String model, String serialNumber) {
+		this.manufacturer = manufacturer;
+		this.model = model;
+		this.serialNumber = serialNumber;
+	}
+
+	@Id
+	@GeneratedValue
+	public Long id;
+
+	@Field(index = Index.UN_TOKENIZED)
+	@Column(name = "mfg")
+	public String manufacturer = "";
+
+	@Field(index = Index.UN_TOKENIZED)
+	@Column(name = "model")
+	public String model = "";
+
+	@Field(index = Index.UN_TOKENIZED)
+	@Column(name = "serial_number")
+	public String serialNumber;
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ( ( manufacturer == null ) ? 0 : manufacturer.hashCode() );
+		result = prime * result + ( ( model == null ) ? 0 : model.hashCode() );
+		result = prime * result + ( ( serialNumber == null ) ? 0 : serialNumber.hashCode() );
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ( this == obj )
+			return true;
+		if ( obj == null )
+			return false;
+		if ( !( obj instanceof Device ) )
+			return false;
+		Device other = (Device) obj;
+		
+		if ( manufacturer == null ) {
+			if ( other.manufacturer != null )
+				return false;
+		}
+		else if ( !manufacturer.equals( other.manufacturer ) )
+			return false;
+		if ( model == null ) {
+			if ( other.model != null )
+				return false;
+		}
+		else if ( !model.equals( other.model ) )
+			return false;
+		if ( serialNumber == null ) {
+			if ( other.serialNumber != null )
+				return false;
+		}
+		else if ( !serialNumber.equals( other.serialNumber ) )
+			return false;
+		return true;
+	}
+}

--- a/hibernate-search-infinispan/src/test/java/org/hibernate/search/infinispan/sharedIndex/Robot.java
+++ b/hibernate-search-infinispan/src/test/java/org/hibernate/search/infinispan/sharedIndex/Robot.java
@@ -1,0 +1,42 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2010, Red Hat, Inc. and/or its affiliates or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat, Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+
+package org.hibernate.search.infinispan.sharedIndex;
+
+import javax.persistence.Entity;
+
+import org.hibernate.search.annotations.Indexed;
+
+@Entity
+@Indexed(index = "device")
+public class Robot extends Device {
+
+	public Robot() {
+		super( "Galactic", "Infinity1000", null );
+	}
+
+	public Robot(String serialNumber) {
+		super( "Galactic", "Infinity1000", serialNumber );
+	}
+}

--- a/hibernate-search-infinispan/src/test/java/org/hibernate/search/infinispan/sharedIndex/SharedIndexTest.java
+++ b/hibernate-search-infinispan/src/test/java/org/hibernate/search/infinispan/sharedIndex/SharedIndexTest.java
@@ -1,0 +1,153 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2010, Red Hat, Inc. and/or its affiliates or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat, Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ * 
+ */
+package org.hibernate.search.infinispan.sharedIndex;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import junit.framework.AssertionFailedError;
+
+import org.apache.lucene.search.Query;
+import org.hibernate.Transaction;
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.SearchFactory;
+import org.hibernate.search.infinispan.CacheManagerServiceProvider;
+import org.hibernate.search.infinispan.InfinispanDirectoryProvider;
+import org.hibernate.search.query.dsl.QueryBuilder;
+import org.hibernate.search.store.DirectoryProvider;
+import org.hibernate.search.test.util.FullTextSessionBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.remoting.transport.Address;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+
+/**
+ * Tests to verify HSEARCH-926
+ * 
+ * @author Zach Kurey
+ */
+public class SharedIndexTest {
+	FullTextSessionBuilder node;
+
+	@Test
+	public void testSingleResultFromDeviceIndex() {
+		assertEquals( 1, clusterSize( node, Toaster.class ) );
+		// index an entity:
+		{
+			FullTextSession fullTextSession = node.openFullTextSession();
+			Transaction transaction = fullTextSession.beginTransaction();
+			Toaster toaster = new Toaster( "A1" );
+			fullTextSession.save( toaster );
+			transaction.commit();
+			fullTextSession.close();
+			verifyResult( node );
+		}
+	}
+
+	private void verifyResult(FullTextSessionBuilder node) {
+		FullTextSession fullTextSession = node.openFullTextSession();
+		try {
+			Transaction transaction = fullTextSession.beginTransaction();
+			QueryBuilder queryBuilder = fullTextSession.getSearchFactory().buildQueryBuilder()
+					.forEntity( Toaster.class ).get();
+			Query query = queryBuilder.keyword().onField( "serialNumber" ).matching( "A1" ).createQuery();
+			List list = fullTextSession.createFullTextQuery( query ).list();
+			assertEquals( 1, list.size() );
+			Device device = (Device) list.get( 0 );
+
+			assertEquals( "GE", device.manufacturer );
+			transaction.commit();
+		}
+		finally {
+			fullTextSession.close();
+		}
+	}
+
+	@Before
+	public void setUp() throws Exception {
+
+		Set<Class<?>> annotatedTypes = new HashSet<Class<?>>();
+		annotatedTypes.add( Device.class );
+		annotatedTypes.add( Robot.class );
+		annotatedTypes.add( Toaster.class );
+
+		node = new FullTextSessionBuilder();
+		prepareCommonConfiguration( node, annotatedTypes );
+		node.build();
+		waitMembersCount( node, Toaster.class, 1 );
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		node.close();
+	}
+
+	protected void prepareCommonConfiguration(FullTextSessionBuilder cfg, Set<Class<?>> entityTypes) {
+		cfg.setProperty( "hibernate.search.default.directory_provider", "infinispan" );
+		cfg.setProperty( CacheManagerServiceProvider.INFINISPAN_CONFIGURATION_RESOURCENAME,
+				"testing-hibernatesearch-infinispan.xml" );
+		for ( Class<?> type : entityTypes ) {
+			cfg.addAnnotatedClass( type );
+		}
+	}
+
+	/**
+	 * Wait some time for the cluster to form
+	 */
+	protected void waitMembersCount(FullTextSessionBuilder node, Class<?> entityType, int expectedSize)
+			throws InterruptedException {
+		int currentSize = 0;
+		int loopCounter = 0;
+		while ( currentSize < expectedSize ) {
+			Thread.sleep( 10 );
+			currentSize = clusterSize( node, entityType );
+			if ( loopCounter > 200 ) {
+				throw new AssertionFailedError( "timeout while waiting for all nodes to join in cluster" );
+			}
+		}
+	}
+
+	/**
+	 * Counts the number of nodes in the cluster on this node
+	 * 
+	 * @param node
+	 *            the FullTextSessionBuilder representing the current node
+	 * @return
+	 */
+	protected int clusterSize(FullTextSessionBuilder node, Class<?> entityType) {
+		SearchFactory searchFactory = node.getSearchFactory();
+		DirectoryProvider[] directoryProviders = searchFactory.getDirectoryProviders( entityType );
+		assertEquals( 1, directoryProviders.length );
+		InfinispanDirectoryProvider directoryProvider = (InfinispanDirectoryProvider) directoryProviders[0];
+		EmbeddedCacheManager cacheManager = directoryProvider.getCacheManager();
+		List<Address> members = cacheManager.getMembers();
+		return members.size();
+	}
+}

--- a/hibernate-search-infinispan/src/test/java/org/hibernate/search/infinispan/sharedIndex/Toaster.java
+++ b/hibernate-search-infinispan/src/test/java/org/hibernate/search/infinispan/sharedIndex/Toaster.java
@@ -1,0 +1,42 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * Copyright (c) 2010, Red Hat, Inc. and/or its affiliates or third-party contributors as
+ * indicated by the @author tags or express copyright attribution
+ * statements applied by the authors.  All third-party contributions are
+ * distributed under license by Red Hat, Inc.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA  02110-1301  USA
+ */
+
+package org.hibernate.search.infinispan.sharedIndex;
+
+import javax.persistence.Entity;
+
+import org.hibernate.search.annotations.Indexed;
+
+@Entity
+@Indexed(index = "device")
+public class Toaster extends Device {
+
+	public Toaster() {
+		super( "GE", "Scorcher5000", null );
+	}
+
+	public Toaster(String serialNumber) {
+		super( "GE", "Scorcher5000", serialNumber );
+	}
+}


### PR DESCRIPTION
Fix for HSEARCH-926 and a test that verifies multiple types sharing the same index still
only result in one InfinispanDirectoryProvider getting created for the index.
