### PR TITLE
HSEARCH-951 excludeLimit() has no effect on QueryBuilder.range().above() 

### DIFF
--- a/hibernate-search-engine/src/main/java/org/hibernate/search/query/dsl/impl/ConnectedMultiFieldsRangeQueryBuilder.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/query/dsl/impl/ConnectedMultiFieldsRangeQueryBuilder.java
@@ -62,7 +62,7 @@ public class ConnectedMultiFieldsRangeQueryBuilder implements RangeTerminationEx
 			rangeContext.setExcludeTo( true );
 		}
 		else if ( rangeContext.getFrom() != null ) {
-			rangeContext.setExcludeTo( true );
+			rangeContext.setExcludeFrom( true );
 		}
 		else if ( rangeContext.getTo() != null ) {
 			rangeContext.setExcludeTo( true );


### PR DESCRIPTION
HSEARCH-951 excludeLimit() has no effect on QueryBuilder.range().above() queries
