### PR TITLE
HSEARCH-953 Removing unused type parameter from EntityIndexBinder

### DIFF
--- a/hibernate-search-engine/src/main/java/org/hibernate/search/backend/impl/BatchedQueueingProcessor.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/backend/impl/BatchedQueueingProcessor.java
@@ -49,9 +49,9 @@ public class BatchedQueueingProcessor implements QueueingProcessor {
 
 	private final int batchSize;
 
-	private final Map<Class<?>, EntityIndexBinder<?>> entityIndexBinders;
+	private final Map<Class<?>, EntityIndexBinder> entityIndexBinders;
 
-	public BatchedQueueingProcessor(Map<Class<?>, EntityIndexBinder<?>> entityIndexBinders, Properties properties) {
+	public BatchedQueueingProcessor(Map<Class<?>, EntityIndexBinder> entityIndexBinders, Properties properties) {
 		this.entityIndexBinders = entityIndexBinders;
 		batchSize = ConfigurationParseHelper.getIntValue( properties, Environment.QUEUEINGPROCESSOR_BATCHSIZE, 0 );
 	}
@@ -88,7 +88,7 @@ public class BatchedQueueingProcessor implements QueueingProcessor {
 		WorkQueuePerIndexSplitter context = new WorkQueuePerIndexSplitter();
 		for ( LuceneWork work : sealedQueue ) {
 			final Class<?> entityType = work.getEntityClass();
-			EntityIndexBinder<?> entityIndexBinding = entityIndexBinders.get( entityType );
+			EntityIndexBinder entityIndexBinding = entityIndexBinders.get( entityType );
 			IndexShardingStrategy shardingStrategy = entityIndexBinding.getSelectionStrategy();
 			work.getWorkDelegate( TransactionalSelectionVisitor.INSTANCE )
 				.performOperation( work, shardingStrategy, context );

--- a/hibernate-search-engine/src/main/java/org/hibernate/search/backend/impl/batch/DefaultBatchBackend.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/backend/impl/batch/DefaultBatchBackend.java
@@ -58,7 +58,7 @@ public class DefaultBatchBackend implements BatchBackend {
 	
 	private void sendWorkToShards(LuceneWork work, boolean forceAsync) {
 		final Class<?> entityType = work.getEntityClass();
-		EntityIndexBinder<?> entityIndexBinding = searchFactoryImplementor.getIndexBindingForEntity( entityType );
+		EntityIndexBinder entityIndexBinding = searchFactoryImplementor.getIndexBindingForEntity( entityType );
 		IndexShardingStrategy shardingStrategy = entityIndexBinding.getSelectionStrategy();
 		if ( forceAsync ) {
 			work.getWorkDelegate( StreamingSelectionVisitor.INSTANCE ).performStreamOperation( work, shardingStrategy, forceAsync );

--- a/hibernate-search-engine/src/main/java/org/hibernate/search/engine/impl/DocumentBuilderHelper.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/engine/impl/DocumentBuilderHelper.java
@@ -242,7 +242,7 @@ public final class DocumentBuilderHelper {
 	}
 	
 	private static DocumentBuilderIndexedEntity<?> getDocumentBuilder(SearchFactoryImplementor searchFactoryImplementor, Class<?> clazz) {
-		EntityIndexBinder<?> entityIndexBinding = searchFactoryImplementor.getIndexBindingForEntity(
+		EntityIndexBinder entityIndexBinding = searchFactoryImplementor.getIndexBindingForEntity(
 				clazz
 		);
 		if ( entityIndexBinding == null ) {

--- a/hibernate-search-engine/src/main/java/org/hibernate/search/engine/impl/MutableEntityIndexBinding.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/engine/impl/MutableEntityIndexBinding.java
@@ -32,7 +32,7 @@ import org.hibernate.search.store.IndexShardingStrategy;
 /**
  * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
  */
-public class MutableEntityIndexBinding<T> implements EntityIndexBinder<T> {
+public class MutableEntityIndexBinding<T> implements EntityIndexBinder {
 
 	private final IndexShardingStrategy shardingStrategy;
 	private final Similarity similarityInstance;

--- a/hibernate-search-engine/src/main/java/org/hibernate/search/engine/impl/WorkPlan.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/engine/impl/WorkPlan.java
@@ -510,7 +510,7 @@ public class WorkPlan {
 			}
 		}
 		else {
-			return entityIndexBinding.getDocumentBuilder();
+			return (AbstractDocumentBuilder<T>) entityIndexBinding.getDocumentBuilder();
 		}
 	}
 }

--- a/hibernate-search-engine/src/main/java/org/hibernate/search/engine/spi/EntityIndexBinder.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/engine/spi/EntityIndexBinder.java
@@ -28,12 +28,12 @@ import org.hibernate.search.query.collector.impl.FieldCacheCollectorFactory;
 import org.hibernate.search.store.IndexShardingStrategy;
 
 /**
- * Specifies the relation and options from an indexed entity and it's index(es).
+ * Specifies the relation and options from an indexed entity to its index(es).
  * 
  * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
  * @since 4.0
  */
-public interface EntityIndexBinder<T> {
+public interface EntityIndexBinder {
 
 	/**
 	 * @return the Similarity used to search and index this entity

--- a/hibernate-search-engine/src/main/java/org/hibernate/search/engine/spi/SearchFactoryImplementor.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/engine/spi/SearchFactoryImplementor.java
@@ -33,14 +33,14 @@ import org.hibernate.search.spi.SearchFactoryIntegrator;
 import org.hibernate.search.stat.spi.StatisticsImplementor;
 
 /**
- * Interface which gives access to the metadata. Intended to be used by Search components
+ * Interface which gives access to the metadata. Intended to be used by Search components.
  *
  * @author Emmanuel Bernard
  * @author Hardy Ferentschik
  */
 public interface SearchFactoryImplementor extends SearchFactoryIntegrator {
 	
-	Map<Class<?>, EntityIndexBinder<?>> getIndexBindingForEntity();
+	Map<Class<?>, EntityIndexBinder> getIndexBindingForEntity();
 
 	<T> DocumentBuilderContainedEntity<T> getDocumentBuilderContainedEntity(Class<T> entityType);
 
@@ -75,8 +75,7 @@ public interface SearchFactoryImplementor extends SearchFactoryIntegrator {
 	IndexManagerHolder getAllIndexesManager();
 
 	/**
-	 * @return
+	 * @return returns an instance of {@code ClassNavigator} for class/object traversal.
 	 */
 	ClassNavigator getClassHelper();
-
 }

--- a/hibernate-search-engine/src/main/java/org/hibernate/search/impl/ImmutableSearchFactory.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/impl/ImmutableSearchFactory.java
@@ -88,7 +88,7 @@ public class ImmutableSearchFactory implements SearchFactoryImplementorWithShare
 
 	private static final Log log = LoggerFactory.make();
 
-	private final Map<Class<?>, EntityIndexBinder<?>> indexBindingForEntities;
+	private final Map<Class<?>, EntityIndexBinder> indexBindingForEntities;
 	private final Map<Class<?>, DocumentBuilderContainedEntity<?>> documentBuildersContainedEntities;
 	private final Worker worker;
 	private final Map<String, FilterDef> filterDefinitions;
@@ -186,13 +186,12 @@ public class ImmutableSearchFactory implements SearchFactoryImplementorWithShare
 		return documentBuildersContainedEntities;
 	}
 
-	public Map<Class<?>, EntityIndexBinder<?>> getIndexBindingForEntity() {
+	public Map<Class<?>, EntityIndexBinder> getIndexBindingForEntity() {
 		return indexBindingForEntities;
 	}
 
-	@SuppressWarnings("unchecked")
-	public <T> EntityIndexBinder<T> getIndexBindingForEntity(Class<T> entityType) {
-		return (EntityIndexBinder<T>) indexBindingForEntities.get( entityType );
+	public EntityIndexBinder getIndexBindingForEntity(Class<?> entityType) {
+		return indexBindingForEntities.get( entityType );
 	}
 
 	@SuppressWarnings("unchecked")

--- a/hibernate-search-engine/src/main/java/org/hibernate/search/impl/MutableSearchFactory.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/impl/MutableSearchFactory.java
@@ -79,11 +79,11 @@ public class MutableSearchFactory implements SearchFactoryImplementorWithShareab
 		return delegate.getFilterDefinitions();
 	}
 
-	public Map<Class<?>, EntityIndexBinder<?>> getIndexBindingForEntity() {
+	public Map<Class<?>, EntityIndexBinder> getIndexBindingForEntity() {
 		return delegate.getIndexBindingForEntity();
 	}
 
-	public <T> EntityIndexBinder<T> getIndexBindingForEntity(Class<T> entityType) {
+	public EntityIndexBinder getIndexBindingForEntity(Class<?> entityType) {
 		return delegate.getIndexBindingForEntity( entityType );
 	}
 

--- a/hibernate-search-engine/src/main/java/org/hibernate/search/impl/MutableSearchFactoryState.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/impl/MutableSearchFactoryState.java
@@ -52,7 +52,7 @@ import java.util.Properties;
  */
 public class MutableSearchFactoryState implements SearchFactoryState {
 	private Map<Class<?>, DocumentBuilderContainedEntity<?>> documentBuildersContainedEntities;
-	private Map<Class<?>, EntityIndexBinder<?>> indexBindingsPerEntity;
+	private Map<Class<?>, EntityIndexBinder> indexBindingsPerEntity;
 	private String indexingStrategy;
 	private Worker worker;
 	private BackendQueueProcessor backendQueueProcessor;
@@ -102,7 +102,7 @@ public class MutableSearchFactoryState implements SearchFactoryState {
 		return documentBuildersContainedEntities;
 	}
 
-	public Map<Class<?>, EntityIndexBinder<?>> getIndexBindingForEntity() {
+	public Map<Class<?>, EntityIndexBinder> getIndexBindingForEntity() {
 		return indexBindingsPerEntity;
 	}
 
@@ -150,7 +150,7 @@ public class MutableSearchFactoryState implements SearchFactoryState {
 		this.documentBuildersContainedEntities = documentBuildersContainedEntities;
 	}
 
-	public void setDocumentBuildersIndexedEntities(Map<Class<?>, EntityIndexBinder<?>> documentBuildersIndexedEntities) {
+	public void setDocumentBuildersIndexedEntities(Map<Class<?>, EntityIndexBinder> documentBuildersIndexedEntities) {
 		this.indexBindingsPerEntity = documentBuildersIndexedEntities;
 	}
 

--- a/hibernate-search-engine/src/main/java/org/hibernate/search/indexes/impl/DirectoryBasedIndexManager.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/indexes/impl/DirectoryBasedIndexManager.java
@@ -161,7 +161,7 @@ public class DirectoryBasedIndexManager implements IndexManager {
 	}
 	
 	//Not exposed on the IndexManager interface
-	public EntityIndexBinder<?> getIndexBindingForEntity(Class<?> entityType) {
+	public EntityIndexBinder getIndexBindingForEntity(Class<?> entityType) {
 		return boundSearchFactory.getIndexBindingForEntity( entityType );
 	}
 	

--- a/hibernate-search-engine/src/main/java/org/hibernate/search/indexes/serialization/impl/LuceneWorkHydrator.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/indexes/serialization/impl/LuceneWorkHydrator.java
@@ -392,7 +392,7 @@ public class LuceneWorkHydrator implements LuceneWorksBuilder {
 	}
 
 	private String objectIdInString(Class<?> entityClass, Serializable id) {
-		EntityIndexBinder<?> indexBindingForEntity = searchFactory.getIndexBindingForEntity( entityClass );
+		EntityIndexBinder indexBindingForEntity = searchFactory.getIndexBindingForEntity( entityClass );
 		if ( indexBindingForEntity == null ) {
 			throw new SearchException( "Unable to find entity type metadata while deserializing: " + entityClass );
 		}

--- a/hibernate-search-engine/src/main/java/org/hibernate/search/query/dsl/impl/FacetBuildingContext.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/query/dsl/impl/FacetBuildingContext.java
@@ -176,7 +176,7 @@ class FacetBuildingContext<T> {
 			throw new IllegalArgumentException( "null is an invalid field name" );
 		}
 
-		EntityIndexBinder<?> indexBinding = factory.getIndexBindingForEntity( entityType );
+		EntityIndexBinder indexBinding = factory.getIndexBindingForEntity( entityType );
 		if ( indexBinding == null ) {
 			throw new SearchException(
 					"Entity " + entityType.getName()

--- a/hibernate-search-engine/src/main/java/org/hibernate/search/query/dsl/impl/Helper.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/query/dsl/impl/Helper.java
@@ -100,7 +100,7 @@ class Helper {
 	static DocumentBuilderIndexedEntity<?> getDocumentBuilder(QueryBuildingContext queryContext) {
 		final SearchFactoryImplementor factory = queryContext.getFactory();
 		final Class<?> type = queryContext.getEntityType();
-		EntityIndexBinder<?> indexBinding = factory.getIndexBindingForEntity( type );
+		EntityIndexBinder indexBinding = factory.getIndexBindingForEntity( type );
 		if ( indexBinding == null ) {
 			throw new AssertionFailure( "Class in not indexed: " + type );
 		}

--- a/hibernate-search-engine/src/main/java/org/hibernate/search/query/engine/impl/HSQueryImpl.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/query/engine/impl/HSQueryImpl.java
@@ -503,7 +503,7 @@ public class HSQueryImpl implements HSQuery, Serializable {
 	 *         TODO change classesAndSubclasses by side effect, which is a mismatch with the Searcher return, fix that.
 	 */
 	private IndexSearcherWithPayload buildSearcher(SearchFactoryImplementor searchFactoryImplementor, Boolean forceScoring) {
-		Map<Class<?>, EntityIndexBinder<?>> builders = searchFactoryImplementor.getIndexBindingForEntity();
+		Map<Class<?>, EntityIndexBinder> builders = searchFactoryImplementor.getIndexBindingForEntity();
 		List<IndexManager> targetedIndexes = new ArrayList<IndexManager>();
 		Set<String> idFieldNames = new HashSet<String>();
 
@@ -535,7 +535,7 @@ public class HSQueryImpl implements HSQuery, Serializable {
 			Set<Class<?>> involvedClasses = new HashSet<Class<?>>( indexedTargetedEntities.size() );
 			involvedClasses.addAll( indexedTargetedEntities );
 			for ( Class<?> clazz : indexedTargetedEntities ) {
-				EntityIndexBinder<?> indexBinder = builders.get( clazz );
+				EntityIndexBinder indexBinder = builders.get( clazz );
 				if ( indexBinder != null ) {
 					DocumentBuilderIndexedEntity<?> builder = indexBinder.getDocumentBuilder();
 					involvedClasses.addAll( builder.getMappedSubclasses() );
@@ -583,7 +583,7 @@ public class HSQueryImpl implements HSQuery, Serializable {
 			}
 		}
 		else {
-			Map<Class<?>, EntityIndexBinder<?>> documentBuildersIndexedEntities = searchFactoryImplementor.getIndexBindingForEntity();
+			Map<Class<?>, EntityIndexBinder> documentBuildersIndexedEntities = searchFactoryImplementor.getIndexBindingForEntity();
 			this.classesAndSubclasses = documentBuildersIndexedEntities.keySet();
 		}
 
@@ -908,12 +908,12 @@ public class HSQueryImpl implements HSQuery, Serializable {
 	 * @return The FieldCacheCollectorFactory to use for this query, or null to not use FieldCaches
 	 */
 	private FieldCacheCollectorFactory getAppropriateIdFieldCollectorFactory() {
-		Map<Class<?>, EntityIndexBinder<?>> builders = searchFactoryImplementor.getIndexBindingForEntity();
+		Map<Class<?>, EntityIndexBinder> builders = searchFactoryImplementor.getIndexBindingForEntity();
 		Set<FieldCacheCollectorFactory> allCollectors = new HashSet<FieldCacheCollectorFactory>();
 		// we need all documentBuilder to agree on type, fieldName, and enabling the option:
 		FieldCacheCollectorFactory anyImplementation = null;
 		for ( Class<?> clazz : classesAndSubclasses ) {
-			EntityIndexBinder<?> docBuilder = builders.get( clazz );
+			EntityIndexBinder docBuilder = builders.get( clazz );
 			FieldCacheCollectorFactory fieldCacheCollectionFactory = docBuilder.getIdFieldCacheCollectionFactory();
 			if ( fieldCacheCollectionFactory == null ) {
 				// some implementation disable it, so we won't use it

--- a/hibernate-search-engine/src/main/java/org/hibernate/search/sandbox/standalone/LuceneFullTextManager.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/sandbox/standalone/LuceneFullTextManager.java
@@ -54,7 +54,7 @@ public class LuceneFullTextManager implements FullTextManager {
 	}
 
 	public <T> T get(Class<T> entityType, Serializable id) {
-		final EntityIndexBinder<?> entityIndexBinding = searchFactory.getIndexBindingForEntity( entityType );
+		final EntityIndexBinder entityIndexBinding = searchFactory.getIndexBindingForEntity( entityType );
 		if ( entityIndexBinding == null ) {
 			String msg = "Entity to retrueve is not an @Indexed entity: " + entityType.getClass().getName();
 			throw new IllegalArgumentException( msg );
@@ -97,7 +97,7 @@ public class LuceneFullTextManager implements FullTextManager {
 		Class<?> clazz = getClass( entity );
 		//TODO cache that at the FTSession level
 		//not strictly necessary but a small optimization
-		final EntityIndexBinder<?> entityIndexBinding = searchFactory.getIndexBindingForEntity( clazz );
+		final EntityIndexBinder entityIndexBinding = searchFactory.getIndexBindingForEntity( clazz );
 		if ( entityIndexBinding == null ) {
 			String msg = "Entity to index is not an @Indexed entity: " + entity.getClass().getName();
 			throw new IllegalArgumentException( msg );

--- a/hibernate-search-engine/src/main/java/org/hibernate/search/spi/SearchFactoryBuilder.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/spi/SearchFactoryBuilder.java
@@ -166,7 +166,7 @@ public class SearchFactoryBuilder {
 		//TODO programmatic mapping support
 		//FIXME The current initDocumentBuilders
 		initDocumentBuilders( cfg, reflectionManager, buildContext );
-		final Map<Class<?>, EntityIndexBinder<?>> documentBuildersIndexedEntities = factoryState.getIndexBindingForEntity();
+		final Map<Class<?>, EntityIndexBinder> documentBuildersIndexedEntities = factoryState.getIndexBindingForEntity();
 		Set<Class<?>> indexedClasses = documentBuildersIndexedEntities.keySet();
 		for ( EntityIndexBinder builder : documentBuildersIndexedEntities.values() ) {
 			//FIXME improve this algorithm to deal with adding new classes to the class hierarchy.
@@ -191,7 +191,7 @@ public class SearchFactoryBuilder {
 	private void removeClassesAlreadyManaged() {
 		Set<Class<?>> remove = new HashSet<Class<?>>();
 		final Map<Class<?>, DocumentBuilderContainedEntity<?>> containedEntities = rootFactory.getDocumentBuildersContainedEntities();
-		final Map<Class<?>, EntityIndexBinder<?>> indexedEntities = rootFactory.getIndexBindingForEntity();
+		final Map<Class<?>, EntityIndexBinder> indexedEntities = rootFactory.getIndexBindingForEntity();
 		for ( Class<?> entity : classes ) {
 			if ( indexedEntities.containsKey( entity ) || containedEntities.containsKey( entity ) ) {
 				remove.add( entity );
@@ -226,7 +226,7 @@ public class SearchFactoryBuilder {
 		factoryState.setDirectoryProviderIndexingParams( new HashMap<DirectoryProvider, LuceneIndexingParameters>() );
 		initDocumentBuilders( cfg, reflectionManager, buildContext );
 
-		final Map<Class<?>, EntityIndexBinder<?>> documentBuildersIndexedEntities = factoryState.getIndexBindingForEntity();
+		final Map<Class<?>, EntityIndexBinder> documentBuildersIndexedEntities = factoryState.getIndexBindingForEntity();
 		Set<Class<?>> indexedClasses = documentBuildersIndexedEntities.keySet();
 		for ( EntityIndexBinder builder : documentBuildersIndexedEntities.values() ) {
 			builder.postInitialize( indexedClasses );
@@ -255,10 +255,10 @@ public class SearchFactoryBuilder {
 
 	private void fillSimilarityMapping() {
 		//TODO cleanup: this logic to select the Similarity is too complex, should likely be done in a previous phase
-		final Map<Class<?>, EntityIndexBinder<?>> documentBuildersIndexedEntities = factoryState.getIndexBindingForEntity();
-		for ( Entry<Class<?>, EntityIndexBinder<?>> entry : documentBuildersIndexedEntities.entrySet() ) {
+		final Map<Class<?>, EntityIndexBinder> documentBuildersIndexedEntities = factoryState.getIndexBindingForEntity();
+		for ( Entry<Class<?>, EntityIndexBinder> entry : documentBuildersIndexedEntities.entrySet() ) {
 			Class<?> clazz = entry.getKey();
-			EntityIndexBinder<?> entityMapping = entry.getValue();
+			EntityIndexBinder entityMapping = entry.getValue();
 			Similarity entitySimilarity = entityMapping.getSimilarity();
 			if ( entitySimilarity == null ) {
 				//might have been read from annotations, fill the missing information in the EntityIndexBinder:
@@ -307,7 +307,7 @@ public class SearchFactoryBuilder {
 		if ( rootFactory == null ) {
 			//set the mutable structure of factory state
 			rootFactory = new MutableSearchFactory();
-			factoryState.setDocumentBuildersIndexedEntities( new ConcurrentHashMap<Class<?>, EntityIndexBinder<?>>() );
+			factoryState.setDocumentBuildersIndexedEntities( new ConcurrentHashMap<Class<?>, EntityIndexBinder>() );
 			factoryState.setDocumentBuildersContainedEntities( new ConcurrentHashMap<Class<?>, DocumentBuilderContainedEntity<?>>() );
 			factoryState.setFilterDefinitions( new ConcurrentHashMap<String, FilterDef>() );
 			factoryState.setIndexHierarchy( new PolymorphicIndexHierarchy() );
@@ -329,7 +329,7 @@ public class SearchFactoryBuilder {
 		initProgrammaticAnalyzers( context, reflectionManager );
 		initProgrammaticallyDefinedFilterDef( reflectionManager );
 		final PolymorphicIndexHierarchy indexingHierarchy = factoryState.getIndexHierarchy();
-		final Map<Class<?>, EntityIndexBinder<?>> documentBuildersIndexedEntities = factoryState.getIndexBindingForEntity();
+		final Map<Class<?>, EntityIndexBinder> documentBuildersIndexedEntities = factoryState.getIndexBindingForEntity();
 		final Map<Class<?>, DocumentBuilderContainedEntity<?>> documentBuildersContainedEntities = factoryState.getDocumentBuildersContainedEntities();
 		final Set<XClass> optimizationBlackListedTypes = new HashSet<XClass>();
 		final Map<XClass, Class> classMappings = initializeClassMappings( cfg, reflectionManager );
@@ -404,12 +404,12 @@ public class SearchFactoryBuilder {
 	 */
 	private void disableBlackListedTypesOptimization(Map<XClass, Class> classMappings,
 			Set<XClass> optimizationBlackListX,
-			Map<Class<?>, EntityIndexBinder<?>> documentBuildersIndexedEntities,
+			Map<Class<?>, EntityIndexBinder> documentBuildersIndexedEntities,
 			Map<Class<?>, DocumentBuilderContainedEntity<?>> documentBuildersContainedEntities) {
 		for ( XClass xClass : optimizationBlackListX ) {
 			Class type = classMappings.get( xClass );
 			if ( type != null ) {
-				EntityIndexBinder<?> entityIndexBinding = documentBuildersIndexedEntities.get( type );
+				EntityIndexBinder entityIndexBinding = documentBuildersIndexedEntities.get( type );
 				if ( entityIndexBinding != null ) {
 					log.tracef( "Dirty checking optimizations disabled for class %s", type );
 					entityIndexBinding.getDocumentBuilder().forceStateInspectionOptimizationsDisabled();

--- a/hibernate-search-engine/src/main/java/org/hibernate/search/spi/SearchFactoryIntegrator.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/spi/SearchFactoryIntegrator.java
@@ -46,7 +46,7 @@ import org.hibernate.search.query.engine.spi.TimeoutExceptionFactory;
  */
 public interface SearchFactoryIntegrator extends SearchFactory {
 	
-	<T> EntityIndexBinder<T> getIndexBindingForEntity(Class<T> entityType);
+	EntityIndexBinder getIndexBindingForEntity(Class<?> entityType);
 
 	/**
 	 * Add the following classes to the SearchFactory. If these classes are new to the SearchFactory this

--- a/hibernate-search-engine/src/main/java/org/hibernate/search/spi/internals/SearchFactoryState.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/spi/internals/SearchFactoryState.java
@@ -49,7 +49,7 @@ import java.util.Properties;
 public interface SearchFactoryState {
 	Map<Class<?>, DocumentBuilderContainedEntity<?>> getDocumentBuildersContainedEntities();
 
-	Map<Class<?>, EntityIndexBinder<?>> getIndexBindingForEntity();
+	Map<Class<?>, EntityIndexBinder> getIndexBindingForEntity();
 
 	String getIndexingStrategy();
 

--- a/hibernate-search-engine/src/test/java/org/hibernate/search/test/TestConstants.java
+++ b/hibernate-search-engine/src/test/java/org/hibernate/search/test/TestConstants.java
@@ -84,9 +84,10 @@ public class TestConstants {
 	/**
 	 * Return the root directory to store test indexes in. Tests should never use or delete this directly
 	 * but rather nest sub directories in it to avoid interferences across tests.
-	 * @return
+	 *
+	 * @return Return the root directory to store test indexes
 	 */
-	public static String getIndexdir() {
+	public static String getIndexDirectory() {
 		return indexDirPath;
 	}
 

--- a/hibernate-search-infinispan/src/test/java/org/hibernate/search/infinispan/ClusterTestHelper.java
+++ b/hibernate-search-infinispan/src/test/java/org/hibernate/search/infinispan/ClusterTestHelper.java
@@ -100,7 +100,7 @@ public class ClusterTestHelper {
 	 */
 	public static int clusterSize(FullTextSessionBuilder node, Class<?> entityType) {
 		SearchFactoryIntegrator searchFactory = (SearchFactoryIntegrator) node.getSearchFactory();
-		EntityIndexBinder<?> indexBinding = searchFactory.getIndexBindingForEntity( entityType );
+		EntityIndexBinder indexBinding = searchFactory.getIndexBindingForEntity( entityType );
 		DirectoryBasedIndexManager indexManager = (DirectoryBasedIndexManager) indexBinding.getIndexManagers()[0];
 		InfinispanDirectoryProvider directoryProvider = (InfinispanDirectoryProvider) indexManager.getDirectoryProvider();
 		EmbeddedCacheManager cacheManager = directoryProvider.getCacheManager();

--- a/hibernate-search-infinispan/src/test/java/org/hibernate/search/infinispan/sharedIndex/SharedIndexTest.java
+++ b/hibernate-search-infinispan/src/test/java/org/hibernate/search/infinispan/sharedIndex/SharedIndexTest.java
@@ -127,7 +127,7 @@ public class SharedIndexTest {
 	 */
 	protected int clusterSize(FullTextSessionBuilder node, Class<?> entityType) {
 		SearchFactoryIntegrator searchFactory = (SearchFactoryIntegrator) node.getSearchFactory();
-		EntityIndexBinder<Toaster> indexBinding = searchFactory.getIndexBindingForEntity( Toaster.class );
+		EntityIndexBinder indexBinding = searchFactory.getIndexBindingForEntity( Toaster.class );
 		DirectoryBasedIndexManager indexManager = (DirectoryBasedIndexManager) indexBinding.getIndexManagers()[0];
 		InfinispanDirectoryProvider directoryProvider = (InfinispanDirectoryProvider) indexManager.getDirectoryProvider();
 		EmbeddedCacheManager cacheManager = directoryProvider.getCacheManager();

--- a/hibernate-search-orm/src/main/java/org/hibernate/search/batchindexing/impl/EntityConsumerLuceneWorkProducer.java
+++ b/hibernate-search-orm/src/main/java/org/hibernate/search/batchindexing/impl/EntityConsumerLuceneWorkProducer.java
@@ -64,7 +64,7 @@ public class EntityConsumerLuceneWorkProducer implements SessionAwareRunnable {
 	
 	private final ProducerConsumerQueue<List<?>> source;
 	private final SessionFactory sessionFactory;
-	private final Map<Class<?>, EntityIndexBinder<?>> entityIndexBinders;
+	private final Map<Class<?>, EntityIndexBinder> entityIndexBinders;
 	private final MassIndexerProgressMonitor monitor;
 	private final CacheMode cacheMode;
 	private final CountDownLatch producerEndSignal;

--- a/hibernate-search-orm/src/main/java/org/hibernate/search/event/impl/FullTextIndexEventListener.java
+++ b/hibernate-search-orm/src/main/java/org/hibernate/search/event/impl/FullTextIndexEventListener.java
@@ -347,7 +347,7 @@ public class FullTextIndexEventListener implements PostDeleteEventListener,
 
 	private AbstractDocumentBuilder getDocumentBuilder(final Object entity) {
 		Class<?> clazz = entity.getClass();
-		EntityIndexBinder<?> entityIndexBinding = searchFactoryImplementor.getIndexBindingForEntity( clazz );
+		EntityIndexBinder entityIndexBinding = searchFactoryImplementor.getIndexBindingForEntity( clazz );
 		if ( entityIndexBinding != null ) {
 			return entityIndexBinding.getDocumentBuilder();
 		}

--- a/hibernate-search-orm/src/main/java/org/hibernate/search/query/hibernate/impl/MultiClassesQueryLoader.java
+++ b/hibernate-search-orm/src/main/java/org/hibernate/search/query/hibernate/impl/MultiClassesQueryLoader.java
@@ -72,7 +72,7 @@ public class MultiClassesQueryLoader extends AbstractLoader {
 		//     root entity could lead to quite inefficient queries in Hibernate when using table per class
 		if ( entityTypes.size() == 0 ) {
 			//support all classes
-			for( Map.Entry<Class<?>, EntityIndexBinder<?>> entry : searchFactoryImplementor.getIndexBindingForEntity().entrySet() ) {
+			for( Map.Entry<Class<?>, EntityIndexBinder> entry : searchFactoryImplementor.getIndexBindingForEntity().entrySet() ) {
 				//get only root entities to limit queries
 				if ( entry.getValue().getDocumentBuilder().isRoot() ) {
 					safeEntityTypes.add( entry.getKey() );
@@ -155,7 +155,7 @@ public class MultiClassesQueryLoader extends AbstractLoader {
 
 		RootEntityMetadata(Class<?> rootEntity, SearchFactoryImplementor searchFactoryImplementor) {
 			this.rootEntity = rootEntity;
-			EntityIndexBinder<?> provider = searchFactoryImplementor.getIndexBindingForEntity( rootEntity );
+			EntityIndexBinder provider = searchFactoryImplementor.getIndexBindingForEntity( rootEntity );
 			if ( provider == null) throw new AssertionFailure("Provider not found for class: " + rootEntity);
 			this.mappedSubclasses = provider.getDocumentBuilder().getMappedSubclasses();
 			this.criteria = null; //default

--- a/hibernate-search-orm/src/test/java/org/hibernate/search/test/SearchTestCase.java
+++ b/hibernate-search-orm/src/test/java/org/hibernate/search/test/SearchTestCase.java
@@ -206,7 +206,7 @@ public abstract class SearchTestCase extends TestCase {
 		// the constructor File(File, String) is broken too, see :
 		// http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=5066567
 		// So make sure to use File(String, String) in this case as TestConstants works with absolute paths!
-		File indexPath = new File( TestConstants.getIndexdir(), shortTestName );
+		File indexPath = new File( TestConstants.getIndexDirectory(), shortTestName );
 		return indexPath;
 	}
 

--- a/hibernate-search-orm/src/test/java/org/hibernate/search/test/backend/WorkQueueLengthConfiguredTest.java
+++ b/hibernate-search-orm/src/test/java/org/hibernate/search/test/backend/WorkQueueLengthConfiguredTest.java
@@ -44,7 +44,7 @@ public class WorkQueueLengthConfiguredTest extends SearchTestCase {
 	@Test
 	public void testNothingTest() {
 		MutableSearchFactory searchFactory = (MutableSearchFactory) getSearchFactory();
-		EntityIndexBinder<Clock> indexBindingForEntity = searchFactory.getIndexBindingForEntity( Clock.class );
+		EntityIndexBinder indexBindingForEntity = searchFactory.getIndexBindingForEntity( Clock.class );
 		IndexManager[] indexManagers = indexBindingForEntity.getIndexManagers();
 		assertEquals( 1, indexManagers.length );
 		DirectoryBasedIndexManager indexManager = (DirectoryBasedIndexManager) indexManagers[0];

--- a/hibernate-search-orm/src/test/java/org/hibernate/search/test/configuration/ShardsConfigurationTest.java
+++ b/hibernate-search-orm/src/test/java/org/hibernate/search/test/configuration/ShardsConfigurationTest.java
@@ -70,11 +70,11 @@ public class ShardsConfigurationTest extends ConfigurationReadTestCase {
 	}
 
 	public void testCorrectNumberOfShardsDetected() {
-		EntityIndexBinder<Document> indexBindingForDocument = getSearchFactory().getIndexBindingForEntity( Document.class );
+		EntityIndexBinder indexBindingForDocument = getSearchFactory().getIndexBindingForEntity( Document.class );
 		IndexManager[] documentManagers = indexBindingForDocument.getIndexManagers();
 		assertNotNull( documentManagers);
 		assertEquals( 4, documentManagers.length );
-		EntityIndexBinder<Book> indexBindingForBooks = getSearchFactory().getIndexBindingForEntity( Book.class );
+		EntityIndexBinder indexBindingForBooks = getSearchFactory().getIndexBindingForEntity( Book.class );
 		IndexManager[] bookManagers = indexBindingForBooks.getIndexManagers();
 		assertNotNull( bookManagers );
 		assertEquals( 2, bookManagers.length );

--- a/hibernate-search-orm/src/test/java/org/hibernate/search/test/configuration/mutablefactory/MutableFactoryTest.java
+++ b/hibernate-search-orm/src/test/java/org/hibernate/search/test/configuration/mutablefactory/MutableFactoryTest.java
@@ -278,7 +278,7 @@ public class MutableFactoryTest {
 					MutableFactoryTest.doIndexWork(entity, i, factory, context );
 					context.end();
 					
-					EntityIndexBinder<?> indexBindingForEntity = factory.getIndexBindingForEntity( aClass );
+					EntityIndexBinder indexBindingForEntity = factory.getIndexBindingForEntity( aClass );
 					assertNotNull( indexBindingForEntity );
 					IndexManager[] indexManagers = indexBindingForEntity.getIndexManagers();
 					assertEquals( 1, indexManagers.length );

--- a/hibernate-search-orm/src/test/java/org/hibernate/search/test/directoryProvider/DirectoryLifecycleTest.java
+++ b/hibernate-search-orm/src/test/java/org/hibernate/search/test/directoryProvider/DirectoryLifecycleTest.java
@@ -52,7 +52,7 @@ public class DirectoryLifecycleTest {
 		CloseCheckingDirectoryProvider directoryProvider;
 		try {
 			SearchFactoryIntegrator searchFactory = (SearchFactoryIntegrator) builder.getSearchFactory();
-			EntityIndexBinder<?> snowIndexBinder = searchFactory.getIndexBindingForEntity( SnowStorm.class );
+			EntityIndexBinder snowIndexBinder = searchFactory.getIndexBindingForEntity( SnowStorm.class );
 			IndexManager[] indexManagers = snowIndexBinder.getIndexManagers();
 			assertThat( indexManagers.length ).isEqualTo( 1 );
 			assertThat( indexManagers[0] ).isInstanceOf( DirectoryBasedIndexManager.class );

--- a/hibernate-search-orm/src/test/java/org/hibernate/search/test/directoryProvider/FSDirectorySelectionTest.java
+++ b/hibernate-search-orm/src/test/java/org/hibernate/search/test/directoryProvider/FSDirectorySelectionTest.java
@@ -77,7 +77,7 @@ public class FSDirectorySelectionTest extends SearchTestCase {
 
 		FullTextSession fullTextSession = Search.getFullTextSession( session );
 		SearchFactoryIntegrator searchFactoryIntegrator = (SearchFactoryIntegrator) fullTextSession.getSearchFactory();
-		EntityIndexBinder<?> snowIndexBinder = searchFactoryIntegrator.getIndexBindingForEntity( SnowStorm.class );
+		EntityIndexBinder snowIndexBinder = searchFactoryIntegrator.getIndexBindingForEntity( SnowStorm.class );
 		IndexManager[] indexManagers = snowIndexBinder.getIndexManagers();
 		assertTrue( "Wrong number of directory providers", indexManagers.length == 1 );
 		

--- a/hibernate-search-orm/src/test/java/org/hibernate/search/test/directoryProvider/FSSlaveAndMasterDPTest.java
+++ b/hibernate-search-orm/src/test/java/org/hibernate/search/test/directoryProvider/FSSlaveAndMasterDPTest.java
@@ -174,7 +174,7 @@ public class FSSlaveAndMasterDPTest extends MultipleSFTestCase {
 	
 	static File prepareDirectories(String testId) {
 
-		String superRootPath = TestConstants.getIndexdir();
+		String superRootPath = TestConstants.getIndexDirectory();
 		File root = new File( superRootPath, testId );
 
 		if ( root.exists() ) {

--- a/hibernate-search-orm/src/test/java/org/hibernate/search/test/directoryProvider/RetryInitializeTest.java
+++ b/hibernate-search-orm/src/test/java/org/hibernate/search/test/directoryProvider/RetryInitializeTest.java
@@ -42,7 +42,7 @@ import static org.hibernate.search.test.directoryProvider.FSSlaveAndMasterDPTest
 
 /**
  * Verifies basic behavior of FSSlaveDirectoryProvider around
- * {@link org.hibernate.search.store.impl.DirectoryProviderHelper#getRetryInitializePeriod(Properties, String)}
+ * {@link org.hibernate.search.store.impl.DirectoryProviderHelper#getRetryInitializePeriod(java.util.Properties, String)}
  * (HSEARCH-323)
  * 
  * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
@@ -87,7 +87,7 @@ public class RetryInitializeTest {
 		
 		SearchFactoryIntegrator searchFactory = (SearchFactoryIntegrator) slave.getSearchFactory();
 		
-		EntityIndexBinder<?> snowIndexBinder = searchFactory.getIndexBindingForEntity( SnowStorm.class );
+		EntityIndexBinder snowIndexBinder = searchFactory.getIndexBindingForEntity( SnowStorm.class );
 		IndexManager[] indexManagers = snowIndexBinder.getIndexManagers();
 		assertEquals( 1, indexManagers.length );
 		DirectoryBasedIndexManager indexManager = (DirectoryBasedIndexManager) indexManagers[0];

--- a/hibernate-search-orm/src/test/java/org/hibernate/search/test/errorhandling/LuceneErrorHandlingTest.java
+++ b/hibernate-search-orm/src/test/java/org/hibernate/search/test/errorhandling/LuceneErrorHandlingTest.java
@@ -61,7 +61,7 @@ public class LuceneErrorHandlingTest extends SearchTestCase {
 	
 	public void testErrorHandling() {
 		SearchFactoryImplementor searchFactory = getSearchFactoryImpl();
-		EntityIndexBinder<Document> mappingForEntity = searchFactory.getIndexBindingForEntity( Document.class );
+		EntityIndexBinder mappingForEntity = searchFactory.getIndexBindingForEntity( Document.class );
 		IndexManager indexManager = mappingForEntity.getIndexManagers()[0];
 		ErrorHandler errorHandler = searchFactory.getErrorHandler();
 		Assert.assertTrue( errorHandler instanceof MockErrorHandler );


### PR DESCRIPTION
Wondering whether _EntityIndexBinder_ should really not be _EntityIndexBinding_
