### PR TITLE
HSEARCH-967 hibernate-search-analyzers also needs the project.parent.vers

### DIFF
--- a/hibernate-search-archetype/pom.xml
+++ b/hibernate-search-archetype/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <!-- 
@@ -75,6 +77,8 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-search-analyzers</artifactId>
+            <!-- When removing the <parent> node you will have to explicitly set the hibernate-search version -->
+            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>


### PR DESCRIPTION
HSEARCH-967 hibernate-search-analyzers also needs the project.parent.version

to test run in a tmp directory after running _mvn install_

```
mvn archetype:generate -DarchetypeCatalog=local
```
