### PR TITLE
HSEARCH-829 Example IdHashShardingStrategy doesn't handle PurgeAll proper

### DIFF
--- a/hibernate-search-documentation/src/main/docbook/en-US/modules/advanced-features.xml
+++ b/hibernate-search-documentation/src/main/docbook/en-US/modules/advanced-features.xml
@@ -259,6 +259,15 @@ hibernate.search.Animal.3.indexName Animal03</programlisting>
         default indexName)</para>
       </listitem>
     </itemizedlist>
+
+   <para>When implementing a <classname>IndexShardingStrategy</classname> any field
+    can be used to determine the sharding selection. Consider that to handle deletions,
+    <literal>purge</literal> and <literal>purgeAll</literal> operations, the implementation
+    might need to return one or more indexes without being able to read all the field
+    values or the primary identifier; in case the information is not enough to pick a single
+    index, all indexes should be returned, so that the delete operation will be propagated
+    to all indexes potentially containing the documents to be deleted.</para>
+
   </section>
 
   <section id="section-sharing-indexes">

--- a/hibernate-search-engine/src/main/java/org/hibernate/search/store/IndexShardingStrategy.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/store/IndexShardingStrategy.java
@@ -56,7 +56,10 @@ public interface IndexShardingStrategy {
 
 	/**
 	 * return the IndexManager(s) where the given entity is stored and where the deletion operation needs to be applied
-	 * id and idInString can be null. If null, all the IndexManagers containing entity types should be returned
+	 * id and idInString could be null. If null, all the IndexManagers containing entity types should be returned
+	 * @param entity the type of the deleted entity
+	 * @param id the id in object form
+	 * @param idInString the id as transformed by the used TwoWayStringBridge
 	 */
 	IndexManager[] getIndexManagersForDeletion(Class<?> entity, Serializable id, String idInString);
 


### PR DESCRIPTION
HSEARCH-829 Example IdHashShardingStrategy doesn't handle PurgeAll properly

It seems we had the implementation fixed already; just added clarification in docs and javadoc.
