### PR TITLE
Build of documentation is disabled by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
         <license>
             <name>GNU Lesser General Public License</name>
             <url>http://www.gnu.org/licenses/lgpl-2.1.html</url>
+            <comments>See also: http://hibernate.org/license</comments>
         </license>
     </licenses>
 


### PR DESCRIPTION
unless a release is performed.

to enable build of the documentation during any build, enable the _docs_ profile
`mvn -Pdocs ...`
