### PR TITLE
Temporarily disable a test which is troublesome on Sybase (until someone...

### DIFF
--- a/hibernate-search-orm/src/test/java/org/hibernate/search/test/embedded/depth/WorkDoneOnEntitiesTest.java
+++ b/hibernate-search-orm/src/test/java/org/hibernate/search/test/embedded/depth/WorkDoneOnEntitiesTest.java
@@ -42,6 +42,7 @@ import org.hibernate.search.indexes.IndexReaderAccessor;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.test.SearchTestCase;
 import org.hibernate.search.test.util.LeakingLuceneBackend;
+import org.hibernate.testing.SkipForDialect;
 
 /**
  * <pre>
@@ -73,6 +74,7 @@ import org.hibernate.search.test.util.LeakingLuceneBackend;
  * @author Davide D'Alto
  * @author Sanne Grinovero
  */
+@SkipForDialect(comment="looks like a database deadlock", value=org.hibernate.dialect.SybaseASE15Dialect.class, jiraKey="HSEARCH-1107")
 public class WorkDoneOnEntitiesTest extends SearchTestCase {
 	
 	private Session session = null;


### PR DESCRIPTION
... fixes HSEARCH-1107)

I know it's not the proper solution, but I guess other Jenkins users will appreciate a temporary disable, since it timeouts after hours..

I've created 
https://hibernate.onjira.com/browse/HSEARCH-1107

to track the problem being reported by the tests. This has been standing since far too long without being solved yet, so I'd suggest we disable the test until we're able to take the time to look into the problem.
I'm not having the tooling & bandwidth to look into it properly, + I don't think it's a problem of Search.
