### PR TITLE
HSEARCH-1106 : Compile error on MappingModelMetadataProvider on some JVMs only

### DIFF
--- a/hibernate-search-engine/src/main/java/org/hibernate/search/impl/MappingModelMetadataProvider.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/impl/MappingModelMetadataProvider.java
@@ -154,7 +154,7 @@ public class MappingModelMetadataProvider implements MetadataProvider {
 			fullTextFilterDefAnnotation.setValue( entry.getKey(), entry.getValue() );
 		}
 
-		return createAnnotation( fullTextFilterDefAnnotation );
+		return (FullTextFilterDef) createAnnotation( fullTextFilterDefAnnotation );
 	}
 
 	private static FullTextFilterDef[] createFullTextFilterDefArray(Set<Map<String, Object>> fullTextFilterDefs) {
@@ -194,7 +194,7 @@ public class MappingModelMetadataProvider implements MetadataProvider {
 				analyzerDefAnnotation.setValue( entry.getKey(), entry.getValue() );
 			}
 		}
-		return createAnnotation( analyzerDefAnnotation );
+		return (AnalyzerDef) createAnnotation( analyzerDefAnnotation );
 	}
 
 	static private void addParamsToAnnotation(AnnotationDescriptor annotationDescriptor, Map.Entry<String, Object> entry) {
@@ -215,7 +215,7 @@ public class MappingModelMetadataProvider implements MetadataProvider {
 					filterAnn.setValue( filterEntry.getKey(), filterEntry.getValue() );
 				}
 			}
-			filtersArray[index] = createAnnotation( filterAnn );
+			filtersArray[index] = (TokenFilterDef) createAnnotation( filterAnn );
 			index++;
 		}
 		return filtersArray;
@@ -228,7 +228,7 @@ public class MappingModelMetadataProvider implements MetadataProvider {
 			AnnotationDescriptor paramAnnotation = new AnnotationDescriptor( Parameter.class );
 			paramAnnotation.setValue( "name", entry.get( "name" ) );
 			paramAnnotation.setValue( "value", entry.get( "value" ) );
-			paramArray[index] = createAnnotation( paramAnnotation );
+			paramArray[index] = (Parameter) createAnnotation( paramAnnotation );
 			index++;
 		}
 		return paramArray;
@@ -239,7 +239,7 @@ public class MappingModelMetadataProvider implements MetadataProvider {
 	 * @param annotation the AnnotationDescriptor
 	 * @return the proxy
 	 */
-	private static <T extends Annotation> T createAnnotation(AnnotationDescriptor annotation) {
+	private static Annotation createAnnotation(AnnotationDescriptor annotation) {
 		//This is a filthy workaround for the Annotations proxy generation,
 		//which is using the ContextClassLoader to define the proxy classes
 		//(not working fine in modular environments when Search is used by
@@ -619,7 +619,7 @@ public class MappingModelMetadataProvider implements MetadataProvider {
 					annotation.setValue( entry.getKey(), entry.getValue() );
 				}
 			}
-			return createAnnotation( annotation );
+			return (ClassBridge) createAnnotation( annotation );
 		}
 
 		private void createProvidedId(EntityDescriptor entity) {


### PR DESCRIPTION
This pull request simply changes MappingModelMetadataProvider.createAnnotation() to return Annotation (instead of <T extends Annotation>). When this method is used, the return value is cast to the expected type.

This was failing using my Java environment:

Java(TM) SE Runtime Environment (build 1.6.0_24-b07)
Java HotSpot(TM) 64-Bit Server VM (build 19.1-b02, mixed mode)

It compiles successfully using this pull request.
