### PR TITLE
Fixes typo in JavaDocs of Field#norms

### DIFF
--- a/hibernate-search-engine/src/main/java/org/hibernate/search/annotations/Field.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/annotations/Field.java
@@ -75,7 +75,7 @@ public @interface Field {
 	Analyze analyze() default Analyze.YES;
 
 	/**
-	 * @return Returns a {@code StoreNorm} enum defining whether the norms should be stored in the index or not. Defaults to {@code StoreNorm.YES}.
+	 * @return Returns a {@code Norms} enum defining whether the norms should be stored in the index or not. Defaults to {@code Norms.YES}.
 	 */
 	Norms norms() default Norms.YES;
 


### PR DESCRIPTION
Changed the documentation of Field#norms to refer the Norms enum instead of StoreNorm.
