### PR TITLE
HSEARCH-1124: Log level for Log#indexDirectoryNotFoundCreatingNewOne should be INFO and not WARN

### DIFF
--- a/hibernate-search-engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
@@ -217,7 +217,7 @@ public interface Log extends BasicLogger {
 					"Hibernate Search might have to workaround this by slightly inaccurate faceting values or reduced performance.")
 	void unexpectedValueMissingFromFieldCache();
 
-	@LogMessage(level = WARN)
+	@LogMessage(level = INFO)
 	@Message(id = 41, value = "Index directory not found, creating: '%1$s'")
 	void indexDirectoryNotFoundCreatingNewOne(String absolutePath);
 


### PR DESCRIPTION
Changed the log level for Log#indexDirectoryNotFoundCreatingNewOne should be INFO and not WARN.
