### PR TITLE
HSEARCH-1177 Update to Apache Lucene 3.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <slf4jVersion>1.6.1</slf4jVersion>
-        <luceneVersion>3.6.0</luceneVersion>
+        <luceneVersion>3.6.1</luceneVersion>
         <infinispanVersion>5.1.4.FINAL</infinispanVersion>
         <hibernateVersion>4.1.3.Final</hibernateVersion>
         <hibernateCommonsAnnotationVersion>4.0.1.Final</hibernateCommonsAnnotationVersion>


### PR DESCRIPTION
To not integrate yet - as it wasn't really released as of writing - should be ready in a couple of days.

Tested by pasting the following in your _settings.xml_ (and activating the profile), which implies final or other spins should be tested again after wiping your local repository cache:

```
<profile>
        <id>lucene-staging</id>
        <repositories>
            <repository>
                <id>lucene-staging</id>
                <name>Lucene pre-release</name>
                <url>http://people.apache.org/~uschindler/staging-area/lucene-solr-3.6.1-RC1-rev1362471/lucene/maven/</url>
                <layout>default</layout>
                <releases>
                    <enabled>true</enabled>
                </releases>
            </repository>
            <repository>
                <id>solr-staging</id>
                <name>Solr pre-release</name>
                <url>http://people.apache.org/~uschindler/staging-area/lucene-solr-3.6.1-RC1-rev1362471/solr/maven/</url>
                <layout>default</layout>
                <releases>
                    <enabled>true</enabled>
                </releases>
            </repository>
        </repositories>
    </profile>
```
