### PR TITLE
HSEARCH-943 Fix some tests from Jenkins feedback

### DIFF
--- a/hibernate-search-orm/src/test/java/org/hibernate/search/test/bridge/bigdecimal/NumericBigDecimalBridgeTest.java
+++ b/hibernate-search-orm/src/test/java/org/hibernate/search/test/bridge/bigdecimal/NumericBigDecimalBridgeTest.java
@@ -36,6 +36,9 @@ import org.apache.lucene.search.Query;
 
 import org.hibernate.Session;
 import org.hibernate.Transaction;
+import org.hibernate.dialect.SQLServer2008Dialect;
+import org.hibernate.dialect.Sybase11Dialect;
+import org.hibernate.dialect.SybaseASE15Dialect;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
 import org.hibernate.search.annotations.Field;
@@ -46,10 +49,13 @@ import org.hibernate.search.bridge.LuceneOptions;
 import org.hibernate.search.bridge.builtin.NumericFieldBridge;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.test.SearchTestCase;
+import org.hibernate.testing.SkipForDialect;
 
 /**
  * @author Hardy Ferentschik
  */
+@SkipForDialect(value = { SybaseASE15Dialect.class, Sybase11Dialect.class, SQLServer2008Dialect.class },
+	comment = "Sybase and MSSQL don't support range large enough for this test")
 public class NumericBigDecimalBridgeTest extends SearchTestCase {
 
 	public void testNumericFieldWithBigDecimals() throws Exception {

--- a/hibernate-search-orm/src/test/java/org/hibernate/search/test/spatial/Event.java
+++ b/hibernate-search-orm/src/test/java/org/hibernate/search/test/spatial/Event.java
@@ -30,6 +30,8 @@ import org.hibernate.search.annotations.Store;
 import org.hibernate.search.spatial.Coordinates;
 
 import java.util.Date;
+
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
@@ -48,11 +50,13 @@ public class Event {
 	String name;
 
 	@Field(store = Store.YES, index = Index.YES)
+	@Column(name="realdate")
 	Date date;
 
 	@Field(store = Store.YES, index = Index.YES)
 	@NumericField
 	double latitude;
+
 	@Field(store = Store.YES, index = Index.YES)
 	@NumericField
 	double longitude;

--- a/hibernate-search-orm/src/test/java/org/hibernate/search/test/spatial/RangeEvent.java
+++ b/hibernate-search-orm/src/test/java/org/hibernate/search/test/spatial/RangeEvent.java
@@ -29,6 +29,8 @@ import org.hibernate.search.annotations.Store;
 import org.hibernate.search.spatial.Coordinates;
 
 import java.util.Date;
+
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
@@ -47,6 +49,7 @@ public class RangeEvent {
 	String name;
 
 	@Field(store = Store.YES, index = Index.YES)
+	@Column(name="realdate")
 	Date date;
 
 	@Field(store = Store.YES, index = Index.YES)


### PR DESCRIPTION
- "date" is an illegal column name
- the big numbers tests uses out of range values for some databases

don't close the issue yet, we don't know if this solves all issues on Jenkins
