### PR TITLE
HSEARCH-1249 Serialization protocol version being logged without enough ...

### DIFF
--- a/hibernate-search-engine/src/main/java/org/hibernate/search/indexes/impl/DirectoryBasedIndexManager.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/indexes/impl/DirectoryBasedIndexManager.java
@@ -48,6 +48,8 @@ import org.hibernate.search.spi.WorkerBuildContext;
 import org.hibernate.search.store.DirectoryProvider;
 import org.hibernate.search.store.impl.DirectoryProviderFactory;
 import org.hibernate.search.store.optimization.OptimizerStrategy;
+import org.hibernate.search.util.logging.impl.Log;
+import org.hibernate.search.util.logging.impl.LoggerFactory;
 
 /**
  * This implementation of IndexManager is coupled to a
@@ -56,7 +58,9 @@ import org.hibernate.search.store.optimization.OptimizerStrategy;
  * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
  */
 public class DirectoryBasedIndexManager implements IndexManager {
-	
+
+	private static Log log = LoggerFactory.make();
+
 	private String indexName;
 	private DirectoryProvider directoryProvider;
 	private Similarity similarity;
@@ -201,6 +205,7 @@ public class DirectoryBasedIndexManager implements IndexManager {
 		if ( serializer == null ) {
 			EmptyBuildContext buildContext = new EmptyBuildContext( serviceManager, boundSearchFactory );
 			serializer = serviceManager.requestService( SerializerService.class, buildContext );
+			log.indexManagerUsesSerializationService( this.indexName, this.serializer.describeSerializer() );
 		}
 		return serializer;
 	}

--- a/hibernate-search-engine/src/main/java/org/hibernate/search/indexes/serialization/avro/impl/AvroSerializationProvider.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/indexes/serialization/avro/impl/AvroSerializationProvider.java
@@ -140,4 +140,9 @@ public class AvroSerializationProvider implements SerializationProvider {
 		result.append( str.substring( s ) );
 		return result.toString();
 	}
+
+	@Override
+	public String toString() {
+		return "Avro SerializationProvider v" + getMajorVersion() + "." + getMinorVersion();
+	}
 }

--- a/hibernate-search-engine/src/main/java/org/hibernate/search/indexes/serialization/impl/PluggableSerializationLuceneWorkSerializer.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/indexes/serialization/impl/PluggableSerializationLuceneWorkSerializer.java
@@ -221,4 +221,9 @@ public class PluggableSerializationLuceneWorkSerializer implements LuceneWorkSer
 		}
 		serializer.addDocument( document.getBoost() );
 	}
+
+	@Override
+	public String describeSerializer() {
+		return provider.toString();
+	}
 }

--- a/hibernate-search-engine/src/main/java/org/hibernate/search/indexes/serialization/javaserialization/impl/JavaSerializationSerializationProvider.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/indexes/serialization/javaserialization/impl/JavaSerializationSerializationProvider.java
@@ -37,4 +37,9 @@ public class JavaSerializationSerializationProvider implements SerializationProv
 	public Deserializer getDeserializer() {
 		return new JavaSerializationDeserializer();
 	}
+
+	@Override
+	public String toString() {
+		return "Simple Java based SerializationProvider";
+	}
 }

--- a/hibernate-search-engine/src/main/java/org/hibernate/search/indexes/serialization/spi/LuceneWorkSerializer.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/indexes/serialization/spi/LuceneWorkSerializer.java
@@ -42,4 +42,9 @@ public interface LuceneWorkSerializer {
 	 */
 	List<LuceneWork> toLuceneWorks(byte[] data);
 
+	/**
+	 * @return a short label of this implementation and optionally version
+	 */
+	String describeSerializer();
+
 }

--- a/hibernate-search-engine/src/main/java/org/hibernate/search/indexes/serialization/spi/SerializationProvider.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/indexes/serialization/spi/SerializationProvider.java
@@ -42,6 +42,9 @@ package org.hibernate.search.indexes.serialization.spi;
  * If message's major version is < current version, the
  * implementation is strongly encouraged to parse and process them.
  * It is mandatory if only message's minor version is < current version.
+ * 
+ * Implementors are encouraged to implement a descriptive <code>toString()</code>
+ * method for logging purposes.
  *
  * @author Emmanuel Bernard <emmanuel@hibernate.org>
  */

--- a/hibernate-search-engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
@@ -39,6 +39,7 @@ import org.hibernate.search.SearchException;
 import org.hibernate.search.backend.impl.jgroups.JGroupsChannelProvider;
 import org.hibernate.search.backend.spi.WorkType;
 import org.hibernate.search.errors.EmptyQueryException;
+import org.hibernate.search.indexes.serialization.spi.LuceneWorkSerializer;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Cause;
 import org.jboss.logging.LogMessage;
@@ -378,7 +379,7 @@ public interface Log extends BasicLogger {
 	@Message(id = 78, value = "Timed out waiting to flush all operations to the backend of index %1$s")
 	void unableToShutdownAsynchronousIndexingByTimeout(String indexName);
 
-	@LogMessage(level = INFO)
+	@LogMessage(level = Level.DEBUG)
 	@Message(id = 79, value = "Serialization protocol version %1$d.%2$d initialized")
 	void serializationProtocol(int major, int minor);
 
@@ -663,4 +664,9 @@ public interface Log extends BasicLogger {
 
 	@Message(id = 167, value = "More than one @DocumentId specified on entity '%1$s'")
 	SearchException duplicateDocumentIdFound(String beanXClassName);
+
+	@LogMessage(level = Level.INFO)
+	@Message(id = 168, value = "Serialization service %2$s being used for index '%1$s'")
+	void indexManagerUsesSerializationService(String indexName, String serializerDescription);
+
 }


### PR DESCRIPTION
...context

This was being requested by both Ales and Randall (although at low priority), but I only expected to have to improve an existing logging message;
but we reuse SerializationProvider instances across different indexes, so instead I ended up breaking a "very internal" SPI.

I'd not expect people to implement this one yet, but WDYT?

Alternatives to merging are:
- to postpone this to 4.3
- to rely on #toString instead of adding an explicit method to desribe the service implementation

https://hibernate.onjira.com/browse/HSEARCH-1249
