### PR TITLE
HSEARCH-1296 JGroups backends always behaves like an ASYNC backend

### DIFF
--- a/hibernate-search-engine/src/main/java/org/hibernate/search/backend/impl/jgroups/ChannelMessageSender.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/backend/impl/jgroups/ChannelMessageSender.java
@@ -28,6 +28,7 @@ import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 import org.jgroups.Channel;
 import org.jgroups.Message;
+import org.jgroups.Message.Flag;
 
 /**
  * Channel message sender.
@@ -67,7 +68,10 @@ final class ChannelMessageSender extends AbstractMessageSender {
 		}
 	}
 
-	public void send(final Message message) throws Exception {
+	public void send(final Message message, final boolean synchronous) throws Exception {
+		if ( synchronous ) {
+			message.setFlag( Flag.RSVP );
+		}
 		channel.send( message );
 	}
 }

--- a/hibernate-search-engine/src/main/java/org/hibernate/search/backend/impl/jgroups/DispatcherMessageSender.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/backend/impl/jgroups/DispatcherMessageSender.java
@@ -46,8 +46,9 @@ class DispatcherMessageSender extends AbstractMessageSender {
 		dispatcher.stop();
 	}
 
-	public void send(final Message message) throws Exception {
-		dispatcher.castMessage( null, message, RequestOptions.ASYNC() );
+	public void send(final Message message, final boolean synchronous) throws Exception {
+		final RequestOptions options = synchronous ? RequestOptions.SYNC() : RequestOptions.ASYNC();
+		dispatcher.castMessage( null, message, options );
 	}
 
 	@Override

--- a/hibernate-search-engine/src/main/java/org/hibernate/search/backend/impl/jgroups/JGroupsBackendQueueProcessor.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/backend/impl/jgroups/JGroupsBackendQueueProcessor.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.locks.Lock;
 
+import org.hibernate.search.backend.BackendFactory;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.backend.impl.lucene.LuceneBackendQueueProcessor;
@@ -80,7 +81,8 @@ public class JGroupsBackendQueueProcessor implements BackendQueueProcessor {
 		NodeSelectorStrategyHolder masterNodeSelector = serviceManager.requestService( MasterSelectorServiceProvider.class, context );
 		masterNodeSelector.setNodeSelectorStrategy( indexName, selectionStrategy );
 		selectionStrategy.viewAccepted( messageSender.getView() ); // set current view?
-		jgroupsProcessor = new JGroupsBackendQueueTask( this, indexManager, masterNodeSelector );
+		final boolean sync = BackendFactory.isConfiguredAsSync( props );
+		jgroupsProcessor = new JGroupsBackendQueueTask( this, indexManager, masterNodeSelector, sync );
 		luceneBackendQueueProcessor = new LuceneBackendQueueProcessor();
 		luceneBackendQueueProcessor.initialize( props, context, indexManager );
 	}
@@ -149,5 +151,9 @@ public class JGroupsBackendQueueProcessor implements BackendQueueProcessor {
 				|| jgroupsCfg.containsKey( "clusterName" ) ) {
 			throw log.legacyJGroupsConfigurationDefined( indexName );
 		}
+	}
+
+	public boolean isSynch() {
+		return jgroupsProcessor.isSynch();
 	}
 }

--- a/hibernate-search-engine/src/main/java/org/hibernate/search/backend/impl/jgroups/JGroupsBackendQueueTask.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/backend/impl/jgroups/JGroupsBackendQueueTask.java
@@ -49,10 +49,13 @@ public class JGroupsBackendQueueTask {
 	private final String indexName;
 	private final IndexManager indexManager;
 	private final NodeSelectorStrategy masterNodeSelector;
+	private final boolean sync; //true if this backend is synchronous
 
-	public JGroupsBackendQueueTask(JGroupsBackendQueueProcessor factory, IndexManager indexManager, NodeSelectorStrategyHolder masterNodeSelector) {
+	public JGroupsBackendQueueTask(JGroupsBackendQueueProcessor factory, IndexManager indexManager,
+			NodeSelectorStrategyHolder masterNodeSelector, boolean sync) {
 		this.factory = factory;
 		this.indexManager = indexManager;
+		this.sync = sync;
 		this.indexName = indexManager.getIndexName();
 		this.masterNodeSelector = masterNodeSelector.getMasterNodeSelector( indexName );
 	}
@@ -88,7 +91,7 @@ public class JGroupsBackendQueueTask {
 
 		try {
 			Message message =  masterNodeSelector.createMessage( data );
-			factory.getMessageSender().send( message );
+			factory.getMessageSender().send( message, sync );
 			if ( trace ) {
 				log.tracef( "Lucene works have been sent from slave %s to master node.", factory.getAddress() );
 			}
@@ -96,6 +99,10 @@ public class JGroupsBackendQueueTask {
 		catch ( Exception e ) {
 			throw log.unableToSendWorkViaJGroups( e );
 		}
+	}
+
+	public boolean isSynch() {
+		return sync;
 	}
 
 }

--- a/hibernate-search-engine/src/main/java/org/hibernate/search/backend/impl/jgroups/JGroupsMasterMessageListener.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/backend/impl/jgroups/JGroupsMasterMessageListener.java
@@ -67,7 +67,8 @@ public class JGroupsMasterMessageListener implements Receiver {
 		final String indexName = MessageSerializationHelper.extractIndexName( rawBuffer );
 		final NodeSelectorStrategy nodeSelector = selector.getMasterNodeSelector( indexName );
 		try {
-			if ( nodeSelector.isIndexOwnerLocal() ) {
+			//nodeSelector can be null if we receive the message during shutdown
+			if ( nodeSelector != null && nodeSelector.isIndexOwnerLocal() ) {
 				byte[] serializedQueue = MessageSerializationHelper.extractSerializedQueue( rawBuffer );
 				final IndexManager indexManager = context.getAllIndexesManager().getIndexManager( indexName );
 				if ( indexManager != null ) {

--- a/hibernate-search-engine/src/main/java/org/hibernate/search/backend/impl/jgroups/MessageSender.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/backend/impl/jgroups/MessageSender.java
@@ -50,9 +50,10 @@ public interface MessageSender {
 	 * Send message.
 	 *
 	 * @param message the JGroups message
+	 * @param synchronous set to true if we need to block until an ACK is received
 	 * @throws java.lang.Exception for any error
 	 */
-	void send(Message message) throws Exception;
+	void send(Message message, boolean synchronous) throws Exception;
 
 	/**
 	 * Get sender's address.

--- a/hibernate-search-engine/src/main/java/org/hibernate/search/backend/impl/jgroups/NodeSelectorStrategyHolderImplementation.java
+++ b/hibernate-search-engine/src/main/java/org/hibernate/search/backend/impl/jgroups/NodeSelectorStrategyHolderImplementation.java
@@ -35,7 +35,7 @@ import org.jgroups.View;
  */
 final class NodeSelectorStrategyHolderImplementation implements NodeSelectorStrategyHolder {
 
-	private ConcurrentHashMap<String,NodeSelectorStrategy> register = new ConcurrentHashMap<String,NodeSelectorStrategy>( 16, 0.75f, 2 );
+	private final ConcurrentHashMap<String,NodeSelectorStrategy> register = new ConcurrentHashMap<String,NodeSelectorStrategy>( 16, 0.75f, 2 );
 	private Address address;
 	private View view;
 

--- a/hibernate-search-engine/src/test/java/org/hibernate/search/test/backends/jgroups/JGroupsReceivingMockBackend.java
+++ b/hibernate-search-engine/src/test/java/org/hibernate/search/test/backends/jgroups/JGroupsReceivingMockBackend.java
@@ -1,0 +1,79 @@
+/* 
+ * Hibernate, Relational Persistence for Idiomatic Java
+ * 
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.hibernate.search.test.backends.jgroups;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.hibernate.search.backend.IndexingMonitor;
+import org.hibernate.search.backend.LuceneWork;
+import org.hibernate.search.backend.impl.jgroups.JGroupsBackendQueueProcessor;
+import org.hibernate.search.backend.impl.jgroups.MasterNodeSelector;
+import org.hibernate.search.backend.spi.BackendQueueProcessor;
+
+
+/**
+ * JGroupsReceivingMockBackend; a JGroups based BackendQueueProcessor useful to verify
+ * receiver state from tests.
+ *
+ * @author Sanne Grinovero <sanne@hibernate.org> (C) 2013 Red Hat Inc.
+ * @since 4.3
+ */
+public class JGroupsReceivingMockBackend extends JGroupsBackendQueueProcessor implements BackendQueueProcessor {
+
+	private static volatile CountDownLatch threadTrap;
+
+	public JGroupsReceivingMockBackend() {
+		super( new MasterNodeSelector() );
+	}
+
+	@Override
+	public void applyWork(List<LuceneWork> workList, IndexingMonitor monitor) {
+		countDownAndJoin();
+	}
+
+	@Override
+	public void applyStreamWork(LuceneWork singleOperation, IndexingMonitor monitor) {
+		//Unused
+		countDownAndJoin();
+	}
+
+	public static void resetThreadTrap() {
+		threadTrap = new CountDownLatch( 2 );
+	}
+
+	public static void countDownAndJoin() {
+		try {
+			threadTrap.countDown();
+			//Basically we want to wait forever untile we are awoken; we
+			//cap the definition of "forever" to 2 minutes to abort the test
+			//but this should not be necessary.
+			//The main test thread will release us ASAP so a large timeout should not
+			//affect the actual test duration.
+			threadTrap.await( 2, TimeUnit.MINUTES );
+		}
+		catch ( InterruptedException e ) {
+			Thread.currentThread().interrupt();
+		}
+	}
+
+}

--- a/hibernate-search-engine/src/test/java/org/hibernate/search/test/backends/jgroups/SyncJGroupsBackendTest.java
+++ b/hibernate-search-engine/src/test/java/org/hibernate/search/test/backends/jgroups/SyncJGroupsBackendTest.java
@@ -1,0 +1,148 @@
+/* 
+ * Hibernate, Relational Persistence for Idiomatic Java
+ * 
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.hibernate.search.test.backends.jgroups;
+
+import java.io.Serializable;
+
+import junit.framework.Assert;
+
+import org.hibernate.search.SearchException;
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.backend.impl.jgroups.JGroupsBackendQueueProcessor;
+import org.hibernate.search.backend.impl.jgroups.JGroupsChannelProvider;
+import org.hibernate.search.backend.spi.BackendQueueProcessor;
+import org.hibernate.search.backend.spi.Work;
+import org.hibernate.search.backend.spi.WorkType;
+import org.hibernate.search.indexes.impl.DirectoryBasedIndexManager;
+import org.hibernate.search.indexes.spi.IndexManager;
+import org.hibernate.search.test.programmaticmapping.TestingSearchFactoryHolder;
+import org.hibernate.search.test.util.ManualTransactionContext;
+import org.hibernate.search.test.util.TestForIssue;
+import org.jgroups.TimeoutException;
+import org.junit.Rule;
+import org.junit.Test;
+
+
+/**
+ * Verifies sync / async guarantees of the JGroups backend.
+ * The JGroups stack used needs to have the RSVP protocol with ack_on_delivery enabled
+ * (the default configuration we use does).
+ *
+ * @author Sanne Grinovero <sanne@hibernate.org> (C) 2013 Red Hat Inc.
+ * @since 4.3
+ */
+@TestForIssue(jiraKey = "HSEARCH-1296")
+public class SyncJGroupsBackendTest {
+
+	@Rule
+	public TestingSearchFactoryHolder slaveNode = new TestingSearchFactoryHolder( Dvd.class, Book.class )
+		.withProperty( "hibernate.search.default.worker.backend", "jgroupsSlave" )
+		.withProperty( "hibernate.search.dvds.worker.execution", "sync" )
+		.withProperty( "hibernate.search.books.worker.execution", "async" )
+		.withProperty( JGroupsChannelProvider.CONFIGURATION_FILE, "jgroups-testing-udp.xml" )
+		;
+
+	@Rule
+	public TestingSearchFactoryHolder masterNode = new TestingSearchFactoryHolder( Dvd.class, Book.class )
+		.withProperty( "hibernate.search.default.worker.backend", JGroupsReceivingMockBackend.class.getName() )
+		.withProperty( JGroupsChannelProvider.CONFIGURATION_FILE, "jgroups-testing-udp.xml" )
+		;
+
+	@Test
+	public void testSynchAsConfigured() {
+		JGroupsBackendQueueProcessor dvdsBackend = extractJGroupsBackend( "dvds" );
+		Assert.assertTrue( "dvds index was configured with a syncronous JGroups backend", dvdsBackend.isSynch() );
+		JGroupsBackendQueueProcessor booksBackend = extractJGroupsBackend( "books" );
+		Assert.assertFalse( "books index was configured with an asyncronous JGroups backend", booksBackend.isSynch() );
+
+		JGroupsReceivingMockBackend.resetThreadTrap();
+		boolean timeoutTriggered = false;
+		try {
+			//DVDs are sync operations so they will timeout:
+			storeDvd( 1, "Hibernate Search in Action" );
+		}
+		catch (SearchException se) {
+			//Expected: we're inducing the RPC into timeout by blocking receiver processing
+			Throwable cause = se.getCause();
+			Assert.assertTrue( cause instanceof TimeoutException );
+			timeoutTriggered = true;
+		}
+		finally {
+			//release the receiver
+			JGroupsReceivingMockBackend.countDownAndJoin();
+		}
+		Assert.assertTrue( timeoutTriggered );
+
+		JGroupsReceivingMockBackend.resetThreadTrap();
+		//Books are async so they should not timeout
+		storeBook( 1, "Hibernate Search in Action" );
+
+		//Block our own thread awaiting for the receiver.
+		//If we raced past it we would release the receiver, not bad either
+		//as it would also proof we are async.
+		JGroupsReceivingMockBackend.countDownAndJoin();
+	}
+
+	private JGroupsBackendQueueProcessor extractJGroupsBackend(String indexName) {
+		IndexManager indexManager = slaveNode.getSearchFactory().getAllIndexesManager().getIndexManager( indexName );
+		Assert.assertNotNull( indexManager );
+		DirectoryBasedIndexManager dbi = (DirectoryBasedIndexManager) indexManager;
+		BackendQueueProcessor backendQueueProcessor = dbi.getBackendQueueProcessor();
+		Assert.assertTrue( "Backend not using JGroups!", backendQueueProcessor instanceof JGroupsBackendQueueProcessor );
+		return (JGroupsBackendQueueProcessor) backendQueueProcessor;
+	}
+
+	private void storeBook(int id, String string) {
+		Book book = new Book();
+		book.id = id;
+		book.title = string;
+		storeObject( book, id );
+	}
+
+	private void storeDvd(int id, String dvdTitle) {
+		Dvd dvd1 = new Dvd();
+		dvd1.id = id;
+		dvd1.title = dvdTitle;
+		storeObject( dvd1, id );
+	}
+
+	private void storeObject(Object entity, Serializable id) {
+		Work work = new Work( entity, id, WorkType.UPDATE, false );
+		ManualTransactionContext tc = new ManualTransactionContext();
+		slaveNode.getSearchFactory().getWorker().performWork( work, tc );
+		tc.end();
+	}
+
+	@Indexed(index="dvds")
+	public static final class Dvd {
+		@DocumentId long id;
+		@Field String title;
+	}
+
+	@Indexed(index="books")
+	public static final class Book {
+		@DocumentId long id;
+		@Field String title;
+	}
+
+}

--- a/hibernate-search-engine/src/test/resources/jgroups-testing-udp.xml
+++ b/hibernate-search-engine/src/test/resources/jgroups-testing-udp.xml
@@ -1,0 +1,84 @@
+
+<!--
+  Inspired by the default configuration: udp.xml as distributed in JGroups v. 3.2.7.Final
+  - disabled diagnostics
+  - set ttl to 1
+  - RSVP timeouts set very low to speedup timeout-inducing tests
+  - PING discovery set to 2 nodes and aggressive timeouts
+  - UDP buffers set very low
+-->
+
+<config xmlns="urn:org:jgroups"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.1.xsd">
+    <UDP
+         mcast_port="${jgroups.udp.mcast_port:45588}"
+         tos="8"
+         ucast_recv_buf_size="20K"
+         ucast_send_buf_size="20K"
+         mcast_recv_buf_size="20K"
+         mcast_send_buf_size="20K"
+         loopback="true"
+         max_bundle_size="64K"
+         max_bundle_timeout="30"
+         ip_ttl="1"
+         enable_bundling="true"
+         enable_diagnostics="false"
+         thread_naming_pattern="cl"
+
+         timer_type="old"
+         timer.min_threads="4"
+         timer.max_threads="10"
+         timer.keep_alive_time="3000"
+         timer.queue_max_size="500"
+
+         thread_pool.enabled="true"
+         thread_pool.min_threads="2"
+         thread_pool.max_threads="8"
+         thread_pool.keep_alive_time="5000"
+         thread_pool.queue_enabled="true"
+         thread_pool.queue_max_size="10000"
+         thread_pool.rejection_policy="discard"
+
+         oob_thread_pool.enabled="true"
+         oob_thread_pool.min_threads="1"
+         oob_thread_pool.max_threads="8"
+         oob_thread_pool.keep_alive_time="5000"
+         oob_thread_pool.queue_enabled="false"
+         oob_thread_pool.queue_max_size="100"
+         oob_thread_pool.rejection_policy="Run"/>
+
+    <PING timeout="200"
+            num_initial_members="2"/>
+    <MERGE2 max_interval="30000"
+            min_interval="10000"/>
+    <FD_SOCK/>
+    <FD_ALL/>
+    <VERIFY_SUSPECT timeout="1500"  />
+    <BARRIER />
+    <pbcast.NAKACK2 xmit_interval="1000"
+                    xmit_table_num_rows="100"
+                    xmit_table_msgs_per_row="2000"
+                    xmit_table_max_compaction_time="30000"
+                    max_msg_batch_size="500"
+                    use_mcast_xmit="false"
+                    discard_delivered_msgs="true"/>
+    <UNICAST  xmit_interval="2000"
+              xmit_table_num_rows="100"
+              xmit_table_msgs_per_row="2000"
+              xmit_table_max_compaction_time="60000"
+              conn_expiry_timeout="60000"
+              max_msg_batch_size="500"/>
+    <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000"
+                   max_bytes="4M"/>
+    <pbcast.GMS print_local_addr="true" join_timeout="3000"
+                view_bundling="true"/>
+    <UFC max_credits="2M"
+         min_threshold="0.4"/>
+    <MFC max_credits="2M"
+         min_threshold="0.4"/>
+    <FRAG2 frag_size="60K"  />
+    <RSVP resend_interval="20" timeout="500"/>
+    <pbcast.STATE_TRANSFER />
+    <!-- pbcast.FLUSH  /-->
+</config>


### PR DESCRIPTION
@alesj : careful as the code change won't be effective without configuration changes.
It turns out JGroups needs to have the RSVP protocol with ack_on_delivery=true .
According to @danberindei you should not enable this option on the JGroups stack used for Infinispan: make sure you have two separate channels or have him explain alternatives?
