### PR TITLE
HSEARCH-1278 Spodaric test failure: org.hibernate.search.test.batchindex...

### DIFF
--- a/engine/src/test/java/org/hibernate/search/test/util/BytemanHelper.java
+++ b/engine/src/test/java/org/hibernate/search/test/util/BytemanHelper.java
@@ -53,11 +53,6 @@ public class BytemanHelper extends Helper {
 		}
 	}
 
-	public void throwNPE(String message) {
-		//Needed because of Bug BYTEMAN-173: can't simply inject a NPE from the rule
-		throw new NullPointerException( message );
-	}
-
 	public void assertBooleanValue(boolean actual, boolean expected) {
 		if ( actual != expected ) {
 			fail( "Unexpected boolean value" );

--- a/orm/src/test/java/org/hibernate/search/test/batchindexing/MassIndexerErrorReportingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/batchindexing/MassIndexerErrorReportingTest.java
@@ -43,8 +43,7 @@ public class MassIndexerErrorReportingTest extends SearchTestCase {
 	@Test
 	@BMRule(targetClass = "org.hibernate.search.batchindexing.impl.IdentifierConsumerEntityProducer",
 			targetMethod = "loadList",
-			helper = "org.hibernate.search.test.util.BytemanHelper",
-			action = "throwNPE(\"Byteman created NPE\")",
+			action = "throw new NullPointerException(\"Byteman created NPE\")",
 			name = "testMassIndexerErrorsReported")
 	public void testMassIndexerErrorsReported() throws InterruptedException {
 		SearchFactoryImplementor searchFactory = getSearchFactoryImpl();
@@ -58,7 +57,8 @@ public class MassIndexerErrorReportingTest extends SearchTestCase {
 		String errorMessage = mockErrorHandler.getErrorMessage();
 		Assert.assertEquals( "HSEARCH000116: Unexpected error during MassIndexer operation", errorMessage );
 		Throwable exception = mockErrorHandler.getLastException();
-		Assert.assertTrue( exception instanceof org.jboss.byteman.rule.exception.ExecuteException );
+		Assert.assertTrue( exception instanceof NullPointerException );
+		Assert.assertEquals( "Byteman created NPE", exception.getMessage() );
 	}
 
 	static MockErrorHandler getErrorHandler(SearchFactoryImplementor searchFactory) {


### PR DESCRIPTION
...ing.MassIndexerErrorReportingTest

I _think_ this might solve the occasional test failure, but since I can't reproduce it locally I'd have CI run it several times before merging.

For sure it's a needed cleanup, as we had an ugly workaround in place to compensate for a long solved limitation in Byteman.
