### PR TITLE
HSEARCH-1346 Make Facet.count not part of Facet equality

### DIFF
--- a/engine/src/main/java/org/hibernate/search/query/dsl/impl/AbstractFacet.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/impl/AbstractFacet.java
@@ -75,9 +75,6 @@ public abstract class AbstractFacet implements Facet {
 
 		AbstractFacet that = (AbstractFacet) o;
 
-		if ( count != that.count ) {
-			return false;
-		}
 		if ( facetingName != null ? !facetingName.equals( that.facetingName ) : that.facetingName != null ) {
 			return false;
 		}
@@ -96,7 +93,6 @@ public abstract class AbstractFacet implements Facet {
 		int result = facetingName != null ? facetingName.hashCode() : 0;
 		result = 31 * result + ( fieldName != null ? fieldName.hashCode() : 0 );
 		result = 31 * result + ( value != null ? value.hashCode() : 0 );
-		result = 31 * result + count;
 		return result;
 	}
 

--- a/orm/src/test/java/org/hibernate/search/test/query/facet/FacetFilteringTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/facet/FacetFilteringTest.java
@@ -106,6 +106,18 @@ public class FacetFilteringTest extends AbstractFacetTest {
 		assertFacetCounts( facetManager.getFacets( colorFacetName ), new int[] { 4, 0, 0, 0, 0 } );
 		assertFacetCounts( facetManager.getFacets( ccsFacetName ), new int[] { 4, 0, 0, 0 } );
 
+		assertEquals(
+				"Facets should not take count in equality",
+				colorFacet,
+				facetManager.getFacets( colorFacetName ).get( 0 )
+		);
+		assertTrue(
+				"We should be able to find facets amongst the selected ones",
+				facetManager.getFacetGroup( colorFacetName ).getSelectedFacets().contains(
+						facetManager.getFacets( colorFacetName ).get( 0 )
+				)
+		);
+
 		facetManager.getFacetGroup( colorFacetName ).clearSelectedFacets();
 		facetManager.getFacetGroup( ccsFacetName ).clearSelectedFacets();
 		assertFacetCounts( facetManager.getFacets( colorFacetName ), new int[] { 12, 12, 12, 12, 2 } );


### PR DESCRIPTION
Faciliates FacetManager.getSelectedFacets() / .getFacets() mixed usage

See https://hibernate.atlassian.net/browse/HSEARCH-1346, I went for relaxing count as part of the `Facet` equality.
