### PR TITLE
HSEARCH-1393 new getIndexBindingForEntity(Class) implementation doesn't ...

### DIFF
--- a/engine/src/main/java/org/hibernate/search/impl/ImmutableSearchFactory.java
+++ b/engine/src/main/java/org/hibernate/search/impl/ImmutableSearchFactory.java
@@ -235,7 +235,13 @@ public class ImmutableSearchFactory implements SearchFactoryImplementorWithShare
 
 	@Override
 	public EntityIndexBinder getIndexBindingForEntity(Class<?> entityType) {
-		return new EntityIndexBindingWrapper( indexBindingForEntities.get( entityType ) );
+		final EntityIndexBinding entityIndexBinding = indexBindingForEntities.get( entityType );
+		if ( entityIndexBinding == null ) {
+			return null;
+		}
+		else {
+			return new EntityIndexBindingWrapper( entityIndexBinding );
+		}
 	}
 
 	@Override


### PR DESCRIPTION
...deal with non-indexed entities

https://hibernate.atlassian.net/browse/HSEARCH-1393
