### PR TITLE
HSEARCH-1480 newArrayList helper should mandate a size hint

### DIFF
--- a/engine/src/main/java/org/hibernate/search/query/collector/impl/FacetCollector.java
+++ b/engine/src/main/java/org/hibernate/search/query/collector/impl/FacetCollector.java
@@ -143,7 +143,7 @@ public class FacetCollector extends Collector {
 			}
 		}
 		else {
-			List<Map.Entry<String, IntegerWrapper>> countEntryList = newArrayList();
+			List<Map.Entry<String, IntegerWrapper>> countEntryList = newArrayList( counter.getCounts().size() );
 			for ( Entry<String, IntegerWrapper> stringIntegerEntry : counter.getCounts().entrySet() ) {
 				countEntryList.add( stringIntegerEntry );
 			}
@@ -156,7 +156,7 @@ public class FacetCollector extends Collector {
 	}
 
 	private List<Facet> createRangeFacetList(Collection<Entry<String, IntegerWrapper>> countEntryList, FacetingRequestImpl request, int count) {
-		List<Facet> facetList = newArrayList();
+		List<Facet> facetList = newArrayList( countEntryList.size() );
 		int includedFacetCount = 0;
 		for ( Map.Entry<String, IntegerWrapper> countEntry : countEntryList ) {
 			Facet facet = request.createFacet( countEntry.getKey(), countEntry.getValue().getCount() );

--- a/engine/src/main/java/org/hibernate/search/query/dsl/impl/FacetBuildingContext.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/impl/FacetBuildingContext.java
@@ -43,7 +43,7 @@ class FacetBuildingContext<T> {
 	/**
 	 * The list of types which are supported for range faceting
 	 */
-	private static final List<Class<?>> allowedRangeTypes = newArrayList();
+	private static final List<Class<?>> allowedRangeTypes = newArrayList( 6 );
 
 	static {
 		allowedRangeTypes.add( String.class );

--- a/engine/src/main/java/org/hibernate/search/util/impl/CollectionHelper.java
+++ b/engine/src/main/java/org/hibernate/search/util/impl/CollectionHelper.java
@@ -63,6 +63,10 @@ public final class CollectionHelper {
 		return new ArrayList<T>();
 	}
 
+	public static <T> ArrayList<T> newArrayList(final int size) {
+		return new ArrayList<T>( size );
+	}
+
 	public static <T> Set<T> asSet(T... ts) {
 		return new HashSet<T>( Arrays.asList( ts ) );
 	}


### PR DESCRIPTION
I'd prefer to have exclusively

```
newArrayList(final int size);
```

as to encourage _thinking_ about a reasonable value, but since we couldn't agree on that I'm just adding this method on top of the existing one. Still I hope we'll all keep in mind to use the one with a size argument when it's possible.

https://hibernate.atlassian.net/browse/HSEARCH-1480
