### PR TITLE
HSEARCH-1515 NPE because of inverted boolean check in IdentifierConsumer...

### DIFF
--- a/orm/src/main/java/org/hibernate/search/batchindexing/impl/IdentifierConsumerDocumentProducer.java
+++ b/orm/src/main/java/org/hibernate/search/batchindexing/impl/IdentifierConsumerDocumentProducer.java
@@ -179,7 +179,7 @@ public class IdentifierConsumerDocumentProducer implements SessionAwareRunnable 
 	private void indexAllQueue(Session session, List<?> entities, InstanceInitializer sessionInitializer) {
 		try {
 			ConversionContext contextualBridge = new ContextualExceptionBridgeHelper();
-				if ( entities == null && entities.isEmpty() ) {
+				if ( entities == null || entities.isEmpty() ) {
 					return;
 				}
 				else {


### PR DESCRIPTION
...DocumentProducer

https://hibernate.atlassian.net/browse/HSEARCH-1515
