### PR TITLE
HSEARCH-1547 Clarify the intent of SearchManager.releaseAllServices

### DIFF
--- a/engine/src/main/java/org/hibernate/search/engine/service/spi/ServiceManager.java
+++ b/engine/src/main/java/org/hibernate/search/engine/service/spi/ServiceManager.java
@@ -56,7 +56,10 @@ public interface ServiceManager {
 	<S extends Service> void releaseService(Class<S> serviceRole);
 
 	/**
-	 * Stops all services.
+	 * Stops all (non provided) services even if they have not been properly released.
+	 *
+	 * Called by Hibernate Search when the {@link org.hibernate.search.SearchFactory} is closed.
+	 * At this stage, services should no longer be requested. The behavior is undefined.
 	 */
 	void releaseAllServices();
 }


### PR DESCRIPTION
Proposal.
I don't think we need to overthink this. It is just a private hook that the SearchFactory needs to call. If it was not leading to additional interface for nothing, we could make an interface hosting this method and move it to `impl`.
