### PR TITLE
HSEARCH-1499

### DIFF
--- a/engine/src/main/java/org/hibernate/search/spatial/impl/DistanceCollector.java
+++ b/engine/src/main/java/org/hibernate/search/spatial/impl/DistanceCollector.java
@@ -21,6 +21,7 @@
 package org.hibernate.search.spatial.impl;
 
 import java.io.IOException;
+import java.util.ArrayList;
 
 import org.apache.lucene.index.AtomicReader;
 import org.apache.lucene.index.AtomicReaderContext;
@@ -28,19 +29,19 @@ import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.FieldCache;
 import org.apache.lucene.search.FieldCache.Doubles;
 import org.apache.lucene.search.Scorer;
-import org.apache.lucene.facet.collections.IntToDoubleMap;
+import org.hibernate.search.SearchException;
 import org.hibernate.search.spatial.Coordinates;
 
 public class DistanceCollector extends Collector {
 
-	private Collector delegate;
-	private boolean acceptsDocsOutOfOrder;
+	private final Point center;
+	private final boolean acceptsDocsOutOfOrder;
+	private final Collector delegate;
+	private final SpatialResultsCollector distances;
+	private final String latitudeField;
+	private final String longitudeField;
 
-	private Point center;
-	private String latitudeField;
-	private String longitudeField;
 	private int docBase = 0;
-	private IntToDoubleMap distances;
 	private Doubles unbasedLatitudeValues;
 	private Doubles unbasedLongitudeValues;
 
@@ -48,7 +49,7 @@ public class DistanceCollector extends Collector {
 		this.delegate = delegate;
 		this.acceptsDocsOutOfOrder = delegate.acceptsDocsOutOfOrder();
 		this.center = Point.fromCoordinates( centerCoordinates );
-		this.distances = new IntToDoubleMap( hitsCount );
+		this.distances = new SpatialResultsCollector( hitsCount );
 		this.latitudeField = SpatialHelper.formatLatitude( fieldname );
 		this.longitudeField = SpatialHelper.formatLongitude( fieldname );
 	}
@@ -62,7 +63,7 @@ public class DistanceCollector extends Collector {
 	public void collect(final int doc) throws IOException {
 		delegate.collect( doc );
 		final int absolute = docBase + doc;
-		distances.put( absolute, center.getDistanceTo( unbasedLatitudeValues.get( doc ), unbasedLongitudeValues.get( doc ) ) );
+		distances.put( absolute, unbasedLatitudeValues.get( doc ), unbasedLongitudeValues.get( doc ) );
 	}
 
 	@Override
@@ -80,6 +81,76 @@ public class DistanceCollector extends Collector {
 	}
 
 	public double getDistance(final int index) {
-		return distances.get( index );
+		return distances.get( index, center );
 	}
+
+	/**
+	 * We'll store matching hits in HitEntry instances so to allow retrieving results
+	 * in a second phase after the Collector has run.
+	 * Also take the opportunity to lazily calculate the actual distance: only store
+	 * latitude and longitude coordinates.
+	 */
+	private static class HitEntry {
+		int documentId;
+		double latitude;
+		double longitude;
+		private HitEntry(int documentId, double latitude, double longitude) {
+			this.documentId = documentId;
+			this.latitude = latitude;
+			this.longitude = longitude;
+		}
+		double getDistance(final Point center) {
+			return center.getDistanceTo( latitude, longitude );
+		}
+	}
+
+	/**
+	 * A custom structure to store all HitEntry instances.
+	 * Based on an array, as in most cases we'll append sequentially and iterate the
+	 * results in the same order too. The size is well known in most situations so we can
+	 * also guess an appropriate allocation size.
+	 *
+	 * Iteration of the results will in practice follow a monotonic index, unless a non natural
+	 * Sort is specified. So by keeping track of the position in the array of the last request,
+	 * and look from that pointer first, the cost of get operations is O(1) in most common use
+	 * cases.
+	 *
+	 * @author Sanne Grinovero
+	 * @since 5.0
+	 */
+	private static class SpatialResultsCollector {
+		final ArrayList<HitEntry> orderedEntries;
+		int currentIterator = 0;
+		private SpatialResultsCollector(int size) {
+			orderedEntries = new ArrayList<HitEntry>( size );
+		}
+		public double get(int index, Point center) {
+			//Optimize for an iteration having a monotonic index:
+			int startingPoint = currentIterator;
+			for ( ; currentIterator < orderedEntries.size(); currentIterator++ ) {
+				HitEntry currentEntry = orderedEntries.get( currentIterator );
+				if ( currentEntry == null ) {
+					break;
+				}
+				if ( currentEntry.documentId == index ) {
+					return currentEntry.getDistance( center );
+				}
+			}
+			//No match yet! scan the remaining section from the beginning:
+			for ( currentIterator = 0; currentIterator < startingPoint; currentIterator++ ) {
+				HitEntry currentEntry = orderedEntries.get( currentIterator );
+				if ( currentEntry == null ) {
+					break;
+				}
+				if ( currentEntry.documentId == index ) {
+					return currentEntry.getDistance( center );
+				}
+			}
+			throw new SearchException( "Unexpected index: this documentId was not collected" );
+		}
+		void put(int documentId, double latitude, double longitude) {
+			orderedEntries.add( new HitEntry( documentId, latitude, longitude ) );
+		}
+	}
+
 }


### PR DESCRIPTION
Besides improving the DistanceCollector's memory consumption, this removes usage of `org.apache.lucene.facet.collections.IntToDoubleMap` which is no longer available in Lucene.

https://hibernate.atlassian.net/browse/HSEARCH-1499
