### PR TITLE
HSEARCH-1312 Adding test to show that reported errors are unrelated.

### DIFF
--- a/engine/src/main/java/org/hibernate/search/spi/SearchFactoryBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/spi/SearchFactoryBuilder.java
@@ -25,9 +25,6 @@ import org.hibernate.annotations.common.reflection.MetadataProviderInjector;
 import org.hibernate.annotations.common.reflection.ReflectionManager;
 import org.hibernate.annotations.common.reflection.XClass;
 import org.hibernate.annotations.common.reflection.java.JavaReflectionManager;
-import org.hibernate.search.cfg.Environment;
-import org.hibernate.search.exception.SearchException;
-import org.hibernate.search.engine.Version;
 import org.hibernate.search.annotations.AnalyzerDef;
 import org.hibernate.search.annotations.AnalyzerDefs;
 import org.hibernate.search.annotations.Factory;
@@ -38,8 +35,10 @@ import org.hibernate.search.annotations.Key;
 import org.hibernate.search.backend.impl.BatchedQueueingProcessor;
 import org.hibernate.search.backend.impl.QueueingProcessor;
 import org.hibernate.search.backend.impl.WorkerFactory;
+import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.cfg.SearchMapping;
 import org.hibernate.search.cfg.spi.SearchConfiguration;
+import org.hibernate.search.engine.Version;
 import org.hibernate.search.engine.impl.DefaultTimingSource;
 import org.hibernate.search.engine.impl.FilterDef;
 import org.hibernate.search.engine.impl.MutableEntityIndexBinding;
@@ -53,6 +52,7 @@ import org.hibernate.search.engine.spi.EntityIndexBinding;
 import org.hibernate.search.engine.spi.EntityState;
 import org.hibernate.search.engine.spi.SearchFactoryImplementor;
 import org.hibernate.search.exception.ErrorHandler;
+import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.exception.impl.LogErrorHandler;
 import org.hibernate.search.filter.FilterCachingStrategy;
 import org.hibernate.search.filter.ShardSensitiveOnlyFilter;
@@ -333,7 +333,7 @@ public class SearchFactoryBuilder {
 
 			if ( mappedXClass.isAnnotationPresent( Indexed.class ) ) {
 				if ( mappedXClass.isAbstract() ) {
-					log.abstractClassesCannotInsertDocuments();
+					log.abstractClassesCannotInsertDocuments( mappedXClass.getName() );
 					continue;
 				}
 

--- a/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
@@ -169,8 +169,8 @@ public interface Log extends BasicLogger {
 	void foundCurrentMarker();
 
 	@LogMessage(level = WARN)
-	@Message(id = 44, value = "Abstract classes can never insert index documents. Remove @Indexed.")
-	void abstractClassesCannotInsertDocuments();
+	@Message(id = 44, value = "Abstract classes cannot be indexed directly. Only concrete subclasses can be indexed. @Indexed on '%s' is superfluous and should be removed.")
+	void abstractClassesCannotInsertDocuments(String clazz);
 
 	@LogMessage(level = WARN)
 	@Message(id = 45, value = "@ContainedIn is pointing to an entity having @ProvidedId: %1$s. " +
@@ -633,5 +633,8 @@ public interface Log extends BasicLogger {
 
 	@Message(id = 215, value = "Multiple matching FieldBridges found for %s of return type %s: %s" )
 	SearchException multipleMatchingFieldBridges(XMember member, XClass memberType, String listOfFieldBridges);
+
+	@Message(id = 216, value = "Found invalid @IndexedEmbedded->paths elements configured for member '%s' of class '%s'. The invalid paths are [%s]" )
+	SearchException invalidIncludePathConfiguration(String member, String clazz, String invalidPaths);
 
 }

--- a/engine/src/test/java/org/hibernate/search/test/configuration/indexedembedded/IndexedEmbeddedWithAbstractClassTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/configuration/indexedembedded/IndexedEmbeddedWithAbstractClassTest.java
@@ -1,0 +1,151 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.configuration.indexedembedded;
+
+import java.util.List;
+
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.IndexedEmbedded;
+import org.hibernate.search.exception.SearchException;
+import org.hibernate.search.spi.SearchFactoryBuilder;
+import org.hibernate.search.testsupport.BytemanHelper;
+import org.hibernate.search.testsupport.TestForIssue;
+import org.hibernate.search.testsupport.setup.SearchConfigurationForTest;
+import org.jboss.byteman.contrib.bmunit.BMRule;
+import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Hardy Ferentschik
+ */
+@TestForIssue(jiraKey = "HSEARCH-1312")
+@RunWith(BMUnitRunner.class)
+public class IndexedEmbeddedWithAbstractClassTest {
+
+	@Test
+	@BMRule(targetClass = "org.hibernate.search.util.logging.impl.Log_$logger",
+			targetMethod = "abstractClassesCannotInsertDocuments",
+			helper = "org.hibernate.search.testsupport.BytemanHelper",
+			action = "countInvocation()",
+			name = "testAbstractClassAnnotatedWithIndexedLogsWarning")
+	public void testAbstractClassAnnotatedWithIndexedLogsWarning() {
+		SearchConfigurationForTest configuration = new SearchConfigurationForTest()
+				.addProperty( "hibernate.search.default.directory_provider", "ram" )
+				.addClass( A.class )
+				.addClass( AbstractA.class )
+				.addClass( D.class );
+
+		new SearchFactoryBuilder().configuration( configuration ).buildSearchFactory();
+		Assert.assertEquals( "Wrong invocation count", 1, BytemanHelper.getAndResetInvocationCount() );
+	}
+
+	@Test
+	@BMRule(targetClass = "org.hibernate.search.util.logging.impl.Log_$logger",
+			targetMethod = "abstractClassesCannotInsertDocuments",
+			helper = "org.hibernate.search.testsupport.BytemanHelper",
+			action = "countInvocation()",
+			name = "testAbstractClassAnnotatedWithIndexedLogsWarning")
+	public void testInvalidConfiguredPathThrowsException() {
+		try {
+			SearchConfigurationForTest configuration = new SearchConfigurationForTest()
+					.addProperty( "hibernate.search.default.directory_provider", "ram" )
+					.addClass( B.class )
+					.addClass( AbstractB.class )
+					.addClass( D.class );
+
+			new SearchFactoryBuilder().configuration( configuration ).buildSearchFactory();
+			fail( "Invalid configuration should throw an exception" );
+		}
+		catch (SearchException e) {
+			assertTrue( "Invalid exception code", e.getMessage().startsWith( "HSEARCH000216" ) );
+		}
+		Assert.assertEquals( "Wrong invocation count", 0, BytemanHelper.getAndResetInvocationCount() );
+	}
+
+	@Test
+	@BMRule(targetClass = "org.hibernate.search.util.logging.impl.Log_$logger",
+			targetMethod = "abstractClassesCannotInsertDocuments",
+			helper = "org.hibernate.search.testsupport.BytemanHelper",
+			action = "countInvocation()",
+			name = "testAbstractClassAnnotatedWithIndexedLogsWarning")
+	public void testInvalidConfiguredPathThrowsExceptionAndIndexedAbstractClassLogsWarning() {
+		try {
+			SearchConfigurationForTest configuration = new SearchConfigurationForTest()
+					.addProperty( "hibernate.search.default.directory_provider", "ram" )
+					.addClass( C.class )
+					.addClass( AbstractC.class )
+					.addClass( D.class );
+
+			new SearchFactoryBuilder().configuration( configuration ).buildSearchFactory();
+			fail( "Invalid configuration should throw an exception" );
+		}
+		catch (SearchException e) {
+			assertTrue( "Invalid exception code", e.getMessage().startsWith( "HSEARCH000216" ) );
+		}
+		Assert.assertEquals( "Wrong invocation count", 1, BytemanHelper.getAndResetInvocationCount() );
+	}
+
+	@Indexed
+	public abstract static class AbstractA {
+
+		@DocumentId
+		long id;
+
+		@IndexedEmbedded(includePaths = { "foo" })
+		List<D> list;
+	}
+
+	@Indexed
+	public static final class A extends AbstractA {
+	}
+
+	public abstract static class AbstractB {
+
+		@DocumentId
+		long id;
+
+		@IndexedEmbedded(includePaths = { "snafu", "fubar" })
+		List<D> list;
+	}
+
+	@Indexed
+	public static final class B extends AbstractB {
+	}
+
+	@Indexed
+	public abstract static class AbstractC {
+
+		@DocumentId
+		long id;
+
+		@IndexedEmbedded(includePaths = { "snafu", "fubar" })
+		List<D> list;
+	}
+
+	@Indexed
+	public static final class C extends AbstractC {
+	}
+
+	@Indexed
+	public static class D {
+
+		@DocumentId
+		long id;
+
+		@Field
+		String foo;
+	}
+}
+
+

--- a/orm/src/test/java/org/hibernate/search/test/embedded/path/validation/TestInvalidPaths.java
+++ b/orm/src/test/java/org/hibernate/search/test/embedded/path/validation/TestInvalidPaths.java
@@ -7,13 +7,13 @@
 
 package org.hibernate.search.test.embedded.path.validation;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.test.util.FullTextSessionBuilder;
 import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author zkurey
@@ -50,7 +50,7 @@ public class TestInvalidPaths {
 		}
 		catch (SearchException se) {
 			assertTrue( "Should contain information about invalid path b.c.dne (message: <" + se.getMessage() + ">)" ,
-					se.getMessage().matches( ".*\\sb.c.dne.*" ) );
+					se.getMessage().matches( ".*\\[b.c.dne\\].*" ) );
 			assertFalse( "Should NOT contain information about invalid path prefix: notJustA (message: <" + se.getMessage() + ">)",
 					se.getMessage().contains( "notJustA" ) );
 		}


### PR DESCRIPTION
- Improving error messages and use consistently the Log interface.
- Simplifying NullEncodingFieldBridge creation
