### PR TITLE
HSEARCH-1619 Using TestConstants.getIndexDirectory(Class) to determine t...

### DIFF
--- a/integrationtest/sandbox/src/test/java/org/hibernate/search/test/performance/optimizer/OptimizerPerformanceTest.java
+++ b/integrationtest/sandbox/src/test/java/org/hibernate/search/test/performance/optimizer/OptimizerPerformanceTest.java
@@ -36,10 +36,11 @@ public class OptimizerPerformanceTest extends SearchTestBase {
 	@Before
 	public void setUp() throws Exception {
 		forceConfigurationRebuild();
-		File sub = getBaseIndexDir();
-		FileHelper.delete( sub );
-		sub.mkdirs();
-		File[] files = sub.listFiles();
+		String indexBase = TestConstants.getIndexDirectory( OptimizerPerformanceTest.class );
+		File indexDir = new File(indexBase);
+		FileHelper.delete( indexDir );
+		indexDir.mkdirs();
+		File[] files = indexDir.listFiles();
 		for ( File file : files ) {
 			if ( file.isDirectory() ) {
 				FileHelper.delete( file );
@@ -52,8 +53,9 @@ public class OptimizerPerformanceTest extends SearchTestBase {
 	@After
 	public void tearDown() throws Exception {
 		super.tearDown();
-		File sub = getBaseIndexDir();
-		FileHelper.delete( sub );
+		String indexBase = TestConstants.getIndexDirectory( OptimizerPerformanceTest.class );
+		File indexDir = new File(indexBase);
+		FileHelper.delete( indexDir );
 	}
 
 	@Test
@@ -195,8 +197,7 @@ public class OptimizerPerformanceTest extends SearchTestBase {
 	@Override
 	protected void configure(org.hibernate.cfg.Configuration cfg) {
 		super.configure( cfg );
-		File sub = getBaseIndexDir();
-		cfg.setProperty( "hibernate.search.default.indexBase", sub.getAbsolutePath() );
+		cfg.setProperty( "hibernate.search.default.indexBase", TestConstants.getIndexDirectory( OptimizerPerformanceTest.class ) );
 		cfg.setProperty( "hibernate.search.default.directory_provider", "filesystem" );
 		cfg.setProperty( Environment.ANALYZER_CLASS, StopAnalyzer.class.getName() );
 	}

--- a/integrationtest/sandbox/src/test/java/org/hibernate/search/test/performance/reader/BufferSharingReaderPerformanceTest.java
+++ b/integrationtest/sandbox/src/test/java/org/hibernate/search/test/performance/reader/BufferSharingReaderPerformanceTest.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.test.performance.reader;
 
 import org.hibernate.search.indexes.impl.SharingBufferReaderProvider;
+import org.hibernate.search.testsupport.TestConstants;
 
 /**
  * @author Sanne Grinovero
@@ -15,5 +16,10 @@ public class BufferSharingReaderPerformanceTest extends ReaderPerformance {
 	@Override
 	protected String getReaderStrategyName() {
 		return SharingBufferReaderProvider.class.getName();
+	}
+
+	@Override
+	protected String getIndexBaseDir() {
+		return TestConstants.getIndexDirectory( BufferSharingReaderPerformanceTest.class ) + "BufferSharingReaderPerformanceTest";
 	}
 }

--- a/integrationtest/sandbox/src/test/java/org/hibernate/search/test/performance/reader/NotSharedReaderPerformanceTest.java
+++ b/integrationtest/sandbox/src/test/java/org/hibernate/search/test/performance/reader/NotSharedReaderPerformanceTest.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.test.performance.reader;
 
+import org.hibernate.search.testsupport.TestConstants;
+
 /**
  * @author Sanne Grinovero
  */
@@ -14,6 +16,11 @@ public class NotSharedReaderPerformanceTest extends ReaderPerformance {
 	@Override
 	protected String getReaderStrategyName() {
 		return "not-shared";
+	}
+
+	@Override
+	protected String getIndexBaseDir() {
+		return TestConstants.getIndexDirectory( NotSharedReaderPerformanceTest.class ) + "NotSharedReaderPerformanceTest";
 	}
 
 }

--- a/integrationtest/sandbox/src/test/java/org/hibernate/search/test/performance/reader/ReaderPerformance.java
+++ b/integrationtest/sandbox/src/test/java/org/hibernate/search/test/performance/reader/ReaderPerformance.java
@@ -51,9 +51,10 @@ public abstract class ReaderPerformance extends SearchTestBase {
 	@Before
 	public void setUp() throws Exception {
 		super.setUp();
-		File baseIndexDir = getBaseIndexDir();
-		baseIndexDir.mkdirs();
-		File[] files = baseIndexDir.listFiles();
+		String indexBase = getIndexBaseDir();
+		File indexDir = new File( indexBase );
+		indexDir.mkdirs();
+		File[] files = indexDir.listFiles();
 		for ( File file : files ) {
 			FileHelper.delete( file );
 		}
@@ -63,7 +64,7 @@ public abstract class ReaderPerformance extends SearchTestBase {
 	@After
 	public void tearDown() throws Exception {
 		super.tearDown();
-		FileHelper.delete( getBaseIndexDir() );
+		FileHelper.delete( new File( getIndexBaseDir() ) );
 	}
 
 	@Test
@@ -76,7 +77,10 @@ public abstract class ReaderPerformance extends SearchTestBase {
 
 	private void buildBigIndex() throws InterruptedException, IOException {
 		System.out.println( "Going to create fake index..." );
-		FSDirectory directory = FSDirectory.open( new File( getBaseIndexDir(), Detective.class.getCanonicalName() ) );
+
+		FSDirectory directory = FSDirectory.open(
+				new File( getIndexBaseDir(), Detective.class.getCanonicalName() )
+		);
 		SimpleAnalyzer analyzer = new SimpleAnalyzer( Version.LUCENE_CURRENT );
 		IndexWriterConfig cfg = new IndexWriterConfig(Version.LUCENE_CURRENT, analyzer);
 		IndexWriter iw = new IndexWriter( directory, cfg );
@@ -107,7 +111,7 @@ public abstract class ReaderPerformance extends SearchTestBase {
 	protected void configure(org.hibernate.cfg.Configuration cfg) {
 		super.configure( cfg );
 		cfg.setProperty( "hibernate.search.default.directory_provider", "filesystem" );
-		cfg.setProperty( "hibernate.search.default.indexBase", getBaseIndexDir().getAbsolutePath() );
+		cfg.setProperty( "hibernate.search.default.indexBase", getIndexBaseDir() );
 		cfg.setProperty(
 				"hibernate.search.default.optimizer.transaction_limit.max", "10"
 		); // workaround too many open files
@@ -117,6 +121,8 @@ public abstract class ReaderPerformance extends SearchTestBase {
 	}
 
 	protected abstract String getReaderStrategyName();
+
+	protected abstract String getIndexBaseDir();
 
 	private void timeMs() throws InterruptedException {
 		ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool( WORKER_THREADS );

--- a/integrationtest/sandbox/src/test/java/org/hibernate/search/test/performance/reader/ReaderPerformanceTestCase.java
+++ b/integrationtest/sandbox/src/test/java/org/hibernate/search/test/performance/reader/ReaderPerformanceTestCase.java
@@ -19,9 +19,11 @@ import org.apache.lucene.queryparser.classic.MultiFieldQueryParser;
 import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.search.Query;
+
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
+
 import org.hibernate.search.FullTextQuery;
 import org.hibernate.search.Search;
 import org.hibernate.search.cfg.Environment;
@@ -47,9 +49,10 @@ public abstract class ReaderPerformanceTestCase extends SearchTestBase {
 	@Before
 	public void setUp() throws Exception {
 		forceConfigurationRebuild();
-		File sub = getBaseIndexDir();
-		sub.mkdir();
-		File[] files = sub.listFiles();
+		String indexBase = TestConstants.getIndexDirectory( ReaderPerformanceTestCase.class );
+		File indexDir = new File(indexBase);
+		indexDir.mkdir();
+		File[] files = indexDir.listFiles();
 		for ( File file : files ) {
 			if ( file.isDirectory() ) {
 				FileHelper.delete( file );
@@ -62,8 +65,9 @@ public abstract class ReaderPerformanceTestCase extends SearchTestBase {
 	@After
 	public void tearDown() throws Exception {
 		super.tearDown();
-		File sub = getBaseIndexDir();
-		FileHelper.delete( sub );
+		String indexBase = TestConstants.getIndexDirectory( SearchTestBase.class );
+		File indexDir = new File(indexBase);
+		FileHelper.delete( indexDir );
 	}
 
 	@Override
@@ -274,8 +278,10 @@ public abstract class ReaderPerformanceTestCase extends SearchTestBase {
 	@Override
 	protected void configure(org.hibernate.cfg.Configuration cfg) {
 		super.configure( cfg );
-		File sub = getBaseIndexDir();
-		cfg.setProperty( "hibernate.search.default.indexBase", sub.getAbsolutePath() );
+		cfg.setProperty(
+				"hibernate.search.default.indexBase",
+				TestConstants.getIndexDirectory( ReaderPerformanceTestCase.class )
+		);
 		cfg.setProperty( "hibernate.search.default.directory_provider", "filesystem" );
 		cfg.setProperty( Environment.ANALYZER_CLASS, StopAnalyzer.class.getName() );
 	}

--- a/integrationtest/sandbox/src/test/java/org/hibernate/search/test/performance/reader/SharedReaderPerformanceTest.java
+++ b/integrationtest/sandbox/src/test/java/org/hibernate/search/test/performance/reader/SharedReaderPerformanceTest.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.test.performance.reader;
 
+import org.hibernate.search.testsupport.TestConstants;
+
 /**
  * @author Sanne Grinovero
  */
@@ -13,5 +15,10 @@ public class SharedReaderPerformanceTest extends ReaderPerformance {
 	@Override
 	protected String getReaderStrategyName() {
 		return "shared";
+	}
+
+	@Override
+	protected String getIndexBaseDir() {
+		return TestConstants.getIndexDirectory( SharedReaderPerformanceTest.class ) + "SharedReaderPerformanceTest";
 	}
 }


### PR DESCRIPTION
...he index directory

This is work in progress, but since @Sanne is keen to integrate, I create a first pull request. I am planning to follow up with another pull request which will try to ensure that this is problem is not happening in the future anymore. The main culprit is really _SearchTestBase#getBaseIndexDir_ which is designed to work as part of the compiled sources. It fails, if it is used bundled in the testing jar.
