### PR TITLE
HSEARCH-1646 Custom AssertionError should no longer extend the Assertion...

### DIFF
--- a/engine/src/main/java/org/hibernate/search/exception/AssertionFailure.java
+++ b/engine/src/main/java/org/hibernate/search/exception/AssertionFailure.java
@@ -6,18 +6,27 @@
  */
 package org.hibernate.search.exception;
 
-/**
- * Temporarily extending org.hibernate.annotations.common.AssertionFailure
- * for backwards compatibility. The parent class is going to be removed!
- */
-public class AssertionFailure extends org.hibernate.annotations.common.AssertionFailure {
+import org.hibernate.search.util.logging.impl.Log;
+import org.hibernate.search.util.logging.impl.LoggerFactory;
 
-	public AssertionFailure(String s, Throwable t) {
-		super( s, t );
-	}
+/**
+ * Indicates failure of an assertion: a possible bug in Hibernate Search.
+ *
+ * @author Gavin King
+ * @auhor Emmanuel Bernard
+ */
+public class AssertionFailure extends RuntimeException {
+
+	private static final Log log = LoggerFactory.make();
 
 	public AssertionFailure(String s) {
 		super( s );
+		log.assertionFailure( this );
+	}
+
+	public AssertionFailure(String s, Throwable t) {
+		super( s, t );
+		log.assertionFailure( this );
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
@@ -661,4 +661,8 @@ public interface Log extends BasicLogger {
 	@Message(id = 224, value = "Non optional parameter named '%s' was null" )
 	AssertionFailure parametersShouldNotBeNull(String parameterName);
 
+	@LogMessage(level = Level.ERROR)
+	@Message(id = 225, value = "An assertion failure occurred (this may indicate a bug in Hibernate)" )
+	void assertionFailure(@Cause Throwable assertionFailure);
+
 }


### PR DESCRIPTION
...Error from HCANN (API change)

Should we also remove the logging statements in AssertionFailure ?
Those are copied from the parent class, so it doesn't actually change the semantics.
I feel like these are going to log errors twice and I don't think that will make things easier to understand.
- https://hibernate.atlassian.net/browse/HSEARCH-1646
