### PR TITLE
HSEARCH-1580 Take into account @ContainedIn annotations even if there is...

### DIFF
--- a/documentation/src/main/asciidoc/ch04.asciidoc
+++ b/documentation/src/main/asciidoc/ch04.asciidoc
@@ -592,7 +592,7 @@ public class Person {
       return child;
    }
 
-   // ... other fields omitted</programlisting></example>
+   // ... other fields omitted
 ----
 ====
 
@@ -679,6 +679,14 @@ Having explicit control of the indexed paths might be easier if you're designing
 defining the needed queries first, as at that point you might know exactly which fields you need,
 and which other fields are unnecessary to implement your use case.
 ====
+
+==== Associated objects: building a dependency graph with +@ContainedIn+
+
+While +@ContainedIn+ is often seen as the counterpart of +@IndexedEmbedded+, it can also be used
+on its own to build an indexing dependency graph.
+
+When an entity is reindexed, all the entities pointed by +@ContainedIn+ are also going to be
+reindexed.
 
 === Boosting
 
@@ -2459,7 +2467,7 @@ public class ProductCatalog {
 
 ==== Contained In definition
 
-@ContainedIn can be define as seen in the example below:
+@ContainedIn can be defined as seen in the example below:
 
 .Programmatically defining ContainedIn
 ====

--- a/engine/src/main/java/org/hibernate/search/annotations/ContainedIn.java
+++ b/engine/src/main/java/org/hibernate/search/annotations/ContainedIn.java
@@ -14,13 +14,16 @@ import java.lang.annotation.Documented;
 
 /**
  * Describe the owning entity as being part of the target entity's
- * index (to be more accurate, being part of the indexed object graph).
+ * indexed object graph.
  * <p>
- * Only necessary when an &#64;Indexed class is used as a &#64;IndexedEmbedded
+ * Often used when an &#64;Indexed class is used as a &#64;IndexedEmbedded
  * target class. &#64;ContainedIn must mark the property pointing back
- * to the &#64;IndexedEmbedded owning Entity.
+ * to the &#64;IndexedEmbedded owning Entity (not necessary if the class
+ * is an &#64;Embeddable class).
  * <p>
- * Not necessary if the class is an &#64;Embeddable class.
+ * Also used to trigger a reindex of related entities even if no
+ * &#64;IndexedEmbedded is involved, allowing to define a dependency
+ * graph.
  * <p>
  * <code>
  * &#64;Indexed<br>

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
@@ -734,23 +734,25 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 			return;
 		}
 
-		updateContainedInMaxDepths( member, typeMetadataBuilder );
+		ContainedInMetadataBuilder containedInMetadataBuilder = new ContainedInMetadataBuilder( member );
+		updateContainedInMaxDepths( containedInMetadataBuilder, member );
+		typeMetadataBuilder.addContainedIn( containedInMetadataBuilder.createContainedInMetadata() );
 
 		parseContext.collectUnqualifiedCollectionRole( member.getName() );
 	}
 
-	private void updateContainedInMaxDepths(XProperty member, TypeMetadata.Builder typeMetadataBuilder) {
-		updateContainedInMaxDepth( member, typeMetadataBuilder, XClass.ACCESS_FIELD );
-		updateContainedInMaxDepth( member, typeMetadataBuilder, XClass.ACCESS_PROPERTY );
+	private void updateContainedInMaxDepths(ContainedInMetadataBuilder containedInMetadataBuilder, XProperty member) {
+		updateContainedInMaxDepth( containedInMetadataBuilder, member, XClass.ACCESS_FIELD );
+		updateContainedInMaxDepth( containedInMetadataBuilder, member, XClass.ACCESS_PROPERTY );
 	}
 
-	private void updateContainedInMaxDepth(XMember memberWithContainedIn, TypeMetadata.Builder typeMetadataBuilder, String accessType) {
+	private void updateContainedInMaxDepth(ContainedInMetadataBuilder containedInMetadataBuilder, XMember memberWithContainedIn, String accessType) {
 		XClass memberReturnedType = memberWithContainedIn.getElementClass();
 		String mappedBy = mappedBy( memberWithContainedIn );
 		List<XProperty> returnedTypeProperties = memberReturnedType.getDeclaredProperties( accessType );
 		for ( XProperty property : returnedTypeProperties ) {
 			if ( isCorrespondingIndexedEmbedded( mappedBy, property ) ) {
-				updateDepthProperties( memberWithContainedIn, typeMetadataBuilder, property );
+				updateDepthProperties( containedInMetadataBuilder, property );
 				break;
 			}
 		}
@@ -769,11 +771,8 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 		return false;
 	}
 
-	private void updateDepthProperties(XMember memberWithContainedIn,
-			TypeMetadata.Builder typeMetadataBuilder,
-			XProperty property) {
-		int depth = property.getAnnotation( IndexedEmbedded.class ).depth();
-		typeMetadataBuilder.addContainedIn( new ContainedInMetadata( memberWithContainedIn, depth ) );
+	private void updateDepthProperties(ContainedInMetadataBuilder containedInMetadataBuilder, XProperty property) {
+		containedInMetadataBuilder.maxDepth( property.getAnnotation( IndexedEmbedded.class ).depth() );
 	}
 
 	private String mappedBy(XMember member) {

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/ContainedInMetadataBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/ContainedInMetadataBuilder.java
@@ -1,0 +1,33 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.metadata.impl;
+
+import org.hibernate.annotations.common.reflection.XMember;
+
+/**
+ * @author Guillaume Smet
+ */
+public class ContainedInMetadataBuilder {
+
+	private final XMember containedInMember;
+
+	private Integer maxDepth;
+
+	public ContainedInMetadataBuilder(XMember containedInMember) {
+		this.containedInMember = containedInMember;
+	}
+
+	public ContainedInMetadataBuilder maxDepth(Integer maxDepth) {
+		this.maxDepth = maxDepth;
+		return this;
+	}
+
+	public ContainedInMetadata createContainedInMetadata() {
+		return new ContainedInMetadata( containedInMember, maxDepth );
+	}
+
+}

--- a/orm/src/test/java/org/hibernate/search/test/embedded/update/ContainedInWithoutIndexedEmbeddedReindexPropagationTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/embedded/update/ContainedInWithoutIndexedEmbeddedReindexPropagationTest.java
@@ -1,0 +1,142 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.embedded.update;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.WildcardQuery;
+import org.hibernate.Transaction;
+import org.hibernate.search.FullTextQuery;
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.Search;
+import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.testsupport.TestForIssue;
+import org.junit.Test;
+
+/**
+ * @author Guillaume Smet
+ */
+@TestForIssue(jiraKey = "HSEARCH-1573")
+public class ContainedInWithoutIndexedEmbeddedReindexPropagationTest extends SearchTestBase {
+
+	@Test
+	public void testUpdatingContainedInEntityPropagatesToAllEntitiesSimpleCase() throws Exception {
+		// first operation -> save
+		FullTextSession session = Search.getFullTextSession( openSession() );
+		Transaction tx = session.beginTransaction();
+
+		SimpleParentEntity parent = new SimpleParentEntity( "name1" );
+		session.save( parent );
+
+		SimpleChildEntity child = new SimpleChildEntity( parent );
+		session.save( child );
+
+		parent.setChild( child );
+		session.update( parent );
+
+		tx.commit();
+		session.close();
+
+		// assert that everything got saved correctly
+		session = Search.getFullTextSession( openSession() );
+		tx = session.beginTransaction();
+		assertEquals( 1, getSimpleChildEntitiesFromIndex( session, parent.getName() ).size() );
+		tx.commit();
+		session.close();
+
+		// update the parent name
+		session = Search.getFullTextSession( openSession() );
+		tx = session.beginTransaction();
+		parent.setName( "newname2" );
+		session.update( parent );
+		tx.commit();
+		session.close();
+
+		// check that the SimpleChildEntity has been reindexed correctly
+		session = Search.getFullTextSession( openSession() );
+		tx = session.beginTransaction();
+		assertEquals( 1, getSimpleChildEntitiesFromIndex( session, parent.getName() ).size() );
+		tx.commit();
+		session.close();
+	}
+
+	@Test
+	public void testUpdatingContainedInEntityPropagatesToAllEntitiesBusinessCase() throws Exception {
+		ProductModel model = new ProductModel( "042024N" );
+
+		ProductArticle article1 = new ProductArticle( model, "02" );
+		ProductArticle article2 = new ProductArticle( model, "E3" );
+
+		ProductShootingBrief shootingBrief1 = new ProductShootingBrief( "Shooting brief 1" );
+		ProductShootingBrief shootingBrief2 = new ProductShootingBrief( "Shooting brief 2" );
+
+		// first operation -> save
+		FullTextSession session = Search.getFullTextSession( openSession() );
+		Transaction tx = session.beginTransaction();
+
+		session.save( shootingBrief1 );
+		session.save( shootingBrief2 );
+
+		model.setShootingBrief( shootingBrief1 );
+		article2.setShootingBrief( shootingBrief2 );
+
+		session.save( model );
+		session.save( article1 );
+		session.save( article2 );
+
+		tx.commit();
+		session.close();
+
+		// assert that everything got saved correctly
+		session = Search.getFullTextSession( openSession() );
+		tx = session.beginTransaction();
+		assertEquals( 2, getShootingBriefsFromIndex( session, model.getMainReferenceCode().getRawValue() ).size() );
+		tx.commit();
+		session.close();
+
+		// add a new reference code to the model: this should also trigger a reindex of the ProductShootingBrief
+		// due to the @ContainedIn dependency graph
+		session = Search.getFullTextSession( openSession() );
+		tx = session.beginTransaction();
+		model.getAdditionalReferenceCodes().add( new ProductReferenceCode( model, "NEWREF" ) );
+		session.update( model );
+		tx.commit();
+		session.close();
+
+		// check that the ProductShootingBrief has been reindexed correctly.
+		session = Search.getFullTextSession( openSession() );
+		tx = session.beginTransaction();
+		assertEquals( 1, getShootingBriefsFromIndex( session, "NEWREF" ).size() );
+		tx.commit();
+		session.close();
+	}
+
+	private List<SimpleChildEntity> getSimpleChildEntitiesFromIndex(FullTextSession session, String name) {
+		FullTextQuery q = session.createFullTextQuery( new TermQuery( new Term( "parentName", name ) ), SimpleChildEntity.class );
+		@SuppressWarnings("unchecked")
+		List<SimpleChildEntity> results = q.list();
+		return results;
+	}
+
+	private List<ProductShootingBrief> getShootingBriefsFromIndex(FullTextSession session, String referenceCode) {
+		FullTextQuery q = session.createFullTextQuery( new WildcardQuery( new Term( "referenceCodeCollection", referenceCode.toLowerCase() + "*" ) ),
+				ProductShootingBrief.class );
+		@SuppressWarnings("unchecked")
+		List<ProductShootingBrief> results = q.list();
+		return results;
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class[] { SimpleParentEntity.class, SimpleChildEntity.class, ProductArticle.class, ProductModel.class, ProductReferenceCode.class,
+				ProductShootingBrief.class };
+	}
+}

--- a/orm/src/test/java/org/hibernate/search/test/embedded/update/ProductArticle.java
+++ b/orm/src/test/java/org/hibernate/search/test/embedded/update/ProductArticle.java
@@ -1,0 +1,114 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.embedded.update;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Transient;
+
+import org.hibernate.search.annotations.ContainedIn;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.FieldBridge;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.test.embedded.fieldoncollection.CollectionOfStringsFieldBridge;
+
+@Entity
+@Indexed
+public class ProductArticle {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	private String colorCode;
+
+	@ManyToOne(optional = false)
+	// Note: we have a custom fieldBridge here, that's why there's not @IndexedEmbedded even if we also search on
+	// the ProductModel information
+	private ProductModel model;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@ContainedIn
+	private ProductShootingBrief shootingBrief;
+
+	protected ProductArticle() {
+	}
+
+	public ProductArticle(ProductModel model, String colorCode) {
+		this.model = model;
+		this.colorCode = colorCode;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getColorCode() {
+		return colorCode;
+	}
+
+	public void setColorCode(String colorCode) {
+		this.colorCode = colorCode;
+	}
+
+	public ProductModel getModel() {
+		return model;
+	}
+
+	public void setModel(ProductModel model) {
+		this.model = model;
+	}
+
+	public ProductShootingBrief getShootingBrief() {
+		return shootingBrief;
+	}
+
+	public void setShootingBrief(ProductShootingBrief shootingBrief) {
+		if ( shootingBrief != null ) {
+			shootingBrief.getArticles().add( this );
+		}
+		this.shootingBrief = shootingBrief;
+	}
+
+	@Transient
+	@Field(bridge = @FieldBridge(impl = CollectionOfStringsFieldBridge.class))
+	public Collection<String> getProductReferenceCodeWithColorCollection() {
+		Collection<String> productReferenceCodeWithColorCollection = new ArrayList<String>();
+
+		productReferenceCodeWithColorCollection.add( getProductReferenceCodeWithColor( model.getMainReferenceCode() ) );
+		for ( ProductReferenceCode code : model.getAdditionalReferenceCodes() ) {
+			productReferenceCodeWithColorCollection.add( getProductReferenceCodeWithColor( code ) );
+		}
+
+		return Collections.<String>unmodifiableCollection( productReferenceCodeWithColorCollection );
+	}
+
+	@Transient
+	@ContainedIn
+	private ProductShootingBrief getModelShootingBrief() {
+		return model.getShootingBrief();
+	}
+
+	@Transient
+	private String getProductReferenceCodeWithColor(ProductReferenceCode referenceCode) {
+		StringBuilder sb = new StringBuilder();
+		sb.append( referenceCode.getRawValue() );
+		sb.append( colorCode );
+		return sb.toString();
+	}
+}

--- a/orm/src/test/java/org/hibernate/search/test/embedded/update/ProductModel.java
+++ b/orm/src/test/java/org/hibernate/search/test/embedded/update/ProductModel.java
@@ -1,0 +1,115 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.embedded.update;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+
+import org.hibernate.search.annotations.ContainedIn;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.FieldBridge;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.test.embedded.fieldoncollection.CollectionOfStringsFieldBridge;
+
+@Entity
+@Indexed
+public class ProductModel {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	@OneToOne(cascade = CascadeType.ALL)
+	private ProductReferenceCode mainReferenceCode;
+
+	@OneToMany(mappedBy = "model", cascade = CascadeType.ALL)
+	private List<ProductReferenceCode> additionalReferenceCodes = new ArrayList<ProductReferenceCode>();
+
+	@OneToMany(mappedBy = "model", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+	@ContainedIn
+	private Set<ProductArticle> articles = new HashSet<ProductArticle>();
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@ContainedIn
+	private ProductShootingBrief shootingBrief;
+
+	protected ProductModel() {
+	}
+
+	public ProductModel(String referenceCode) {
+		this.mainReferenceCode = new ProductReferenceCode( this, referenceCode );
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public ProductReferenceCode getMainReferenceCode() {
+		return mainReferenceCode;
+	}
+
+	public void setMainReferenceCode(ProductReferenceCode mainReferenceCode) {
+		this.mainReferenceCode = mainReferenceCode;
+	}
+
+	public List<ProductReferenceCode> getAdditionalReferenceCodes() {
+		return additionalReferenceCodes;
+	}
+
+	public void setAdditionalReferenceCodes(List<ProductReferenceCode> additionalReferenceCodes) {
+		this.additionalReferenceCodes = additionalReferenceCodes;
+	}
+
+	public Set<ProductArticle> getArticles() {
+		return articles;
+	}
+
+	public void setArticles(Set<ProductArticle> articles) {
+		this.articles = articles;
+	}
+
+	public ProductShootingBrief getShootingBrief() {
+		return shootingBrief;
+	}
+
+	public void setShootingBrief(ProductShootingBrief shootingBrief) {
+		if ( shootingBrief != null ) {
+			shootingBrief.getModels().add( this );
+		}
+		this.shootingBrief = shootingBrief;
+	}
+
+	@Field(bridge = @FieldBridge(impl = CollectionOfStringsFieldBridge.class))
+	public Collection<String> getProductReferenceCodeCollection() {
+		Collection<String> productReferenceCodeCollection = new ArrayList<String>();
+
+		productReferenceCodeCollection.add( mainReferenceCode.getRawValue() );
+		for ( ProductReferenceCode code : additionalReferenceCodes ) {
+			productReferenceCodeCollection.add( code.getRawValue() );
+		}
+
+		return Collections.<String>unmodifiableCollection( productReferenceCodeCollection );
+	}
+
+}

--- a/orm/src/test/java/org/hibernate/search/test/embedded/update/ProductReferenceCode.java
+++ b/orm/src/test/java/org/hibernate/search/test/embedded/update/ProductReferenceCode.java
@@ -1,0 +1,60 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.embedded.update;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+@Entity
+public class ProductReferenceCode {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	@ManyToOne(optional = false)
+	private ProductModel model;
+
+	@Column(nullable = false)
+	private String rawValue;
+
+	protected ProductReferenceCode() {
+	}
+
+	public ProductReferenceCode(ProductModel model, String rawValue) {
+		this.model = model;
+		this.rawValue = rawValue;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public ProductModel getModel() {
+		return model;
+	}
+
+	public void setModel(ProductModel model) {
+		this.model = model;
+	}
+
+	public String getRawValue() {
+		return rawValue;
+	}
+
+	public void setRawValue(String rawValue) {
+		this.rawValue = rawValue;
+	}
+
+}

--- a/orm/src/test/java/org/hibernate/search/test/embedded/update/ProductShootingBrief.java
+++ b/orm/src/test/java/org/hibernate/search/test/embedded/update/ProductShootingBrief.java
@@ -1,0 +1,105 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.embedded.update;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.Transient;
+
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.hibernate.search.annotations.Analyzer;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.FieldBridge;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.test.embedded.fieldoncollection.CollectionOfStringsFieldBridge;
+
+@Entity
+@Indexed
+public class ProductShootingBrief {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	private String name;
+
+	@OneToMany(mappedBy = "shootingBrief", fetch = FetchType.LAZY)
+	private Set<ProductArticle> articles = new HashSet<ProductArticle>();
+
+	@OneToMany(mappedBy = "shootingBrief", fetch = FetchType.LAZY)
+	private Set<ProductModel> models = new HashSet<ProductModel>();
+
+	protected ProductShootingBrief() {
+	}
+
+	public ProductShootingBrief(String name) {
+		this.name = name;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Set<ProductArticle> getArticles() {
+		return articles;
+	}
+
+	public void setArticles(Set<ProductArticle> articles) {
+		this.articles = articles;
+	}
+
+	public Set<ProductModel> getModels() {
+		return models;
+	}
+
+	public void setModels(Set<ProductModel> models) {
+		this.models = models;
+	}
+
+	@Transient
+	@Field(bridge = @FieldBridge(impl = CollectionOfStringsFieldBridge.class), analyzer = @Analyzer(impl = StandardAnalyzer.class))
+	public Collection<String> getReferenceCodeCollection() {
+		Collection<String> referenceCodes = new ArrayList<String>();
+
+		for ( ProductArticle article : articles ) {
+			referenceCodes.addAll( article.getProductReferenceCodeWithColorCollection() );
+		}
+		for ( ProductModel model : models ) {
+			referenceCodes.addAll( model.getProductReferenceCodeCollection() );
+
+			for ( ProductArticle article : model.getArticles() ) {
+				if ( article.getShootingBrief() == null ) {
+					referenceCodes.addAll( article.getProductReferenceCodeWithColorCollection() );
+				}
+			}
+		}
+
+		return Collections.unmodifiableCollection( referenceCodes );
+	}
+
+}

--- a/orm/src/test/java/org/hibernate/search/test/embedded/update/SimpleChildEntity.java
+++ b/orm/src/test/java/org/hibernate/search/test/embedded/update/SimpleChildEntity.java
@@ -1,0 +1,40 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.embedded.update;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+
+import org.hibernate.search.annotations.Analyze;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+
+@Entity
+@Indexed
+public class SimpleChildEntity {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	@OneToOne(mappedBy = "child", optional = false)
+	private SimpleParentEntity parent;
+
+	protected SimpleChildEntity() {
+	}
+
+	public SimpleChildEntity(SimpleParentEntity parent) {
+		this.parent = parent;
+	}
+
+	@Field(analyze = Analyze.NO)
+	public String getParentName() {
+		return parent.getName();
+	}
+}

--- a/orm/src/test/java/org/hibernate/search/test/embedded/update/SimpleParentEntity.java
+++ b/orm/src/test/java/org/hibernate/search/test/embedded/update/SimpleParentEntity.java
@@ -1,0 +1,64 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.embedded.update;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+
+import org.hibernate.search.annotations.ContainedIn;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+
+@Entity
+@Indexed
+public class SimpleParentEntity {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	@Field
+	private String name;
+
+	@OneToOne
+	@ContainedIn
+	private SimpleChildEntity child;
+
+	protected SimpleParentEntity() {
+	}
+
+	public SimpleParentEntity(String name) {
+		this.name = name;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public SimpleChildEntity getChild() {
+		return child;
+	}
+
+	public void setChild(SimpleChildEntity child) {
+		this.child = child;
+	}
+
+}


### PR DESCRIPTION
... no corresponding @IndexedEmbedded

This patch brings back the behavior observed before a refactoring committed during the 4.4 cycle and later
fixed in 4.4 and 4.5 - see HSEARCH-1573 for the related history.
