### PR TITLE
HSEARCH-1664 Setting up jQAssistant to detect implementation types being...

### DIFF
--- a/jqassistant/rules.xml
+++ b/jqassistant/rules.xml
@@ -1,0 +1,75 @@
+<jqa:jqassistant-rules xmlns:jqa="http://www.buschmais.com/jqassistant/core/analysis/rules/schema/v1.0">
+
+    <constraint id="my-rules:PublicTypesMayNotExtendInternalTypes">
+        <description>API/SPI types must not extend/implement internal types.</description>
+        <cypher><![CDATA[
+            MATCH
+                (clazz)-[:`EXTENDS`]->(supertype)
+            WHERE
+                NOT clazz.fqn =~".*impl.*"
+                AND NOT clazz.fqn =~".*test.*"
+                AND supertype.fqn =~".*impl.*"
+            RETURN
+                clazz
+            UNION ALL
+            MATCH
+                (clazz:`Class`)-[:`IMPLEMENTS`]->(supertype)
+            WHERE NOT
+                clazz.fqn =~".*impl.*"
+                AND NOT clazz.fqn =~".*test.*"
+                AND supertype.fqn =~".*impl.*"
+            RETURN
+                clazz
+        ]]></cypher>
+    </constraint>
+
+    <constraint id="my-rules:PublicMethodsMayNotExposeInternalTypes">
+        <description>API/SPI methods must not expose internal types.</description>
+        <cypher><![CDATA[
+            // return values
+            MATCH
+                (clazz)-[:`DECLARES`]->(method)-[:`RETURNS`]->(returntype)
+            WHERE
+                NOT clazz.fqn =~".*impl.*"
+                AND NOT clazz.fqn =~".*test.*"
+                AND (method.visibility="public" OR method.visibility="protected")
+                AND returntype.fqn =~ ".*impl.*"
+            RETURN
+                method
+
+            // parameters
+            UNION ALL
+            MATCH
+                (clazz)-[:`DECLARES`]->(method)-[:`HAS`]->(parameter)-[:`OF_TYPE`]->(parametertype)
+            WHERE
+                NOT clazz.fqn =~".*impl.*"
+                AND NOT clazz.fqn =~".*test.*"
+                AND (method.visibility="public" OR method.visibility="protected")
+                AND parametertype.fqn =~ ".*impl.*"
+            RETURN
+                method
+        ]]></cypher>
+    </constraint>
+
+    <constraint id="my-rules:PublicFieldsMayNotExposeInternalTypes">
+        <description>API/SPI fields must not expose internal types.</description>
+        <cypher><![CDATA[
+            MATCH
+                (clazz)-[:`DECLARES`]->(field)-[:`OF_TYPE`]->(fieldtype)
+            WHERE
+                NOT clazz.fqn =~".*impl.*"
+                AND NOT clazz.fqn =~".*test.*"
+                AND (field.visibility="public" OR field.visibility="protected")
+                AND fieldtype.fqn =~ ".*impl.*"
+            RETURN
+                field
+        ]]></cypher>
+    </constraint>
+
+    <group id="default">
+        <includeConstraint refId="my-rules:PublicTypesMayNotExtendInternalTypes" />
+        <includeConstraint refId="my-rules:PublicMethodsMayNotExposeInternalTypes" />
+        <includeConstraint refId="my-rules:PublicFieldsMayNotExposeInternalTypes" />
+    </group>
+
+</jqa:jqassistant-rules>

--- a/pom.xml
+++ b/pom.xml
@@ -994,6 +994,11 @@
                         </lifecycleMappingMetadata>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>com.buschmais.jqassistant.scm</groupId>
+                    <artifactId>jqassistant-maven-plugin</artifactId>
+                    <version>1.0.0-M3</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
@@ -1305,6 +1310,31 @@
                 <jdbc.pass>searctru</jdbc.pass>
                 <jdbc.isolation>4096</jdbc.isolation>
             </properties>
+        </profile>
+        <profile>
+            <id>jqassistant</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.buschmais.jqassistant.scm</groupId>
+                        <artifactId>jqassistant-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>scan</id>
+                                <goals>
+                                    <goal>scan</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>analyze</id>
+                                <goals>
+                                    <goal>analyze</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
... exposed in public API/SPI

This uses the [jQAssistant](http://jqassisant.torg) tool to detect any implementation types which are exposed via the public API/SPI. To do so, run

```
mvn clean install -Pjqassistant -DskipTests=true
```

This will fail the build in case any implementation types are exposed through the API/SPI. Technically, the tool loads all the project types, their methods, relationships etc. into a graph database (Neo4j) and which then can be queried. Any queries in `jqassistant/rules.xml` will be executed during the build, and if they return any result, the build will fail and the query results be shown (incorrectly exposed internal types in our case).

Note that by running

```
mvn jqassistant:server
```

a Neo4j server will be spun up at http://localhost:7474/browser/ which allows to query the database in an interactive manner and develop/test queries.
