### PR TITLE
HSEARCH-1674 OSGi integration tests shouldn't be deployed to Maven repos...

### DIFF
--- a/integrationtest/osgi/karaf-features/pom.xml
+++ b/integrationtest/osgi/karaf-features/pom.xml
@@ -71,6 +71,15 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/integrationtest/osgi/karaf-it/pom.xml
+++ b/integrationtest/osgi/karaf-it/pom.xml
@@ -174,6 +174,14 @@
                 </executions>
             </plugin>
 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 


### PR DESCRIPTION
...itories during release
- https://hibernate.atlassian.net/browse/HSEARCH-1674
