### PR TITLE
HSEARCH-1683 Bundled JBoss Modules being generated for Apache Lucene use...

### DIFF
--- a/modules/src/main/assembly/dist.xml
+++ b/modules/src/main/assembly/dist.xml
@@ -16,7 +16,7 @@
     <files>
         <file>
             <source>${module.xml.basedir}/lucene/module.xml</source>
-            <outputDirectory>/org/apache/lucene/${luceneVersion}</outputDirectory>
+            <outputDirectory>/org/apache/lucene/${lucene.module.slot}</outputDirectory>
             <filtered>true</filtered>
         </file>
         <file>
@@ -97,7 +97,7 @@
 
         <dependencySet>
             <useProjectArtifact>false</useProjectArtifact>
-            <outputDirectory>org/apache/lucene/${luceneVersion}</outputDirectory>
+            <outputDirectory>org/apache/lucene/${lucene.module.slot}</outputDirectory>
             <useTransitiveFiltering>false</useTransitiveFiltering>
             <unpack>false</unpack>
             <includes>


### PR DESCRIPTION
...s wrong slot name

Reminder: the modules we generate for Hibernate Search depend on slot {lucene.module.slot}, not on the {luceneVersion} so this was working by chance.
