### PR TITLE
Fix a typo in Infinispan documentation.

### DIFF
--- a/documentation/src/main/asciidoc/ch03.asciidoc
+++ b/documentation/src/main/asciidoc/ch03.asciidoc
@@ -337,7 +337,7 @@ To use the Infinispan directory via Maven, add the following dependencies:
 <dependency>
    <groupId>org.hibernate</groupId>
    <artifactId>hibernate-search</artifactId>
-   <version>WORKING</version>
+   <version>{hibernateSearchVersion}</version>
 </dependency>
 <dependency>
    <groupId>org.hibernate</groupId>


### PR DESCRIPTION
Looks like an oversight.
