### PR TITLE
HSEARCH-1724 Simplify access to ClassLoaderService

### DIFF
--- a/engine/src/main/java/org/hibernate/search/backend/impl/WorkerFactory.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/WorkerFactory.java
@@ -12,7 +12,6 @@ import java.util.Properties;
 import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.backend.spi.Worker;
 import org.hibernate.search.cfg.spi.SearchConfiguration;
-import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.spi.WorkerBuildContext;
 import org.hibernate.search.util.StringHelper;
 import org.hibernate.search.util.impl.ClassLoaderHelper;
@@ -39,12 +38,11 @@ public abstract class WorkerFactory {
 	}
 
 	private static Worker instantiateExplicitlyConfiguredWorker(WorkerBuildContext buildContext, String workerImplClassName) {
-		ServiceManager serviceManager = buildContext.getServiceManager();
 		return ClassLoaderHelper.instanceFromName(
 				Worker.class,
 				workerImplClassName,
 				"worker",
-				serviceManager
+				buildContext.getClassLoaderService()
 		);
 	}
 

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/ClassBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/ClassBridge.java
@@ -6,12 +6,11 @@
  */
 package org.hibernate.search.bridge.builtin;
 
+import org.hibernate.search.engine.service.classloading.spi.ClassLoaderService;
 import org.hibernate.search.engine.service.classloading.spi.ClassLoadingException;
-import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.util.StringHelper;
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.bridge.TwoWayStringBridge;
-import org.hibernate.search.util.impl.ClassLoaderHelper;
 
 /**
  * Convert a Class back and forth
@@ -20,10 +19,10 @@ import org.hibernate.search.util.impl.ClassLoaderHelper;
  */
 public class ClassBridge implements TwoWayStringBridge {
 
-	private final ServiceManager serviceManager;
+	private final ClassLoaderService classLoaderService;
 
-	public ClassBridge(ServiceManager serviceManager) {
-		this.serviceManager = serviceManager;
+	public ClassBridge(ClassLoaderService classLoaderService) {
+		this.classLoaderService = classLoaderService;
 	}
 
 	@Override
@@ -33,7 +32,7 @@ public class ClassBridge implements TwoWayStringBridge {
 		}
 		else {
 			try {
-				return ClassLoaderHelper.classForName( stringValue, serviceManager );
+				return classLoaderService.classForName( stringValue );
 			}
 			catch (ClassLoadingException e) {
 				throw new SearchException( "Unable to deserialize Class: " + stringValue, e );

--- a/engine/src/main/java/org/hibernate/search/bridge/impl/BasicJDKTypesBridgeProvider.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/impl/BasicJDKTypesBridgeProvider.java
@@ -34,7 +34,7 @@ import org.hibernate.search.bridge.builtin.UriBridge;
 import org.hibernate.search.bridge.builtin.UrlBridge;
 import org.hibernate.search.bridge.builtin.impl.TwoWayString2FieldBridgeAdaptor;
 import org.hibernate.search.bridge.spi.BridgeProvider;
-import org.hibernate.search.engine.service.spi.ServiceManager;
+import org.hibernate.search.engine.service.classloading.spi.ClassLoaderService;
 
 /**
  * Support all the default types of the JDK.
@@ -62,8 +62,8 @@ class BasicJDKTypesBridgeProvider implements BridgeProvider {
 
 	private final Map<String, FieldBridge> builtInBridges;
 
-	BasicJDKTypesBridgeProvider(ServiceManager serviceManager) {
-		this.clazz = new TwoWayString2FieldBridgeAdaptor( new org.hibernate.search.bridge.builtin.ClassBridge( serviceManager ) );
+	BasicJDKTypesBridgeProvider(ClassLoaderService classLoaderService) {
+		this.clazz = new TwoWayString2FieldBridgeAdaptor( new org.hibernate.search.bridge.builtin.ClassBridge( classLoaderService ) );
 		Map<String, FieldBridge> bridges = new HashMap<String, FieldBridge>();
 		bridges.put( Character.class.getName(), CHARACTER );
 		bridges.put( char.class.getName(), CHARACTER );

--- a/engine/src/main/java/org/hibernate/search/bridge/impl/TikaBridgeProvider.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/impl/TikaBridgeProvider.java
@@ -14,9 +14,7 @@ import java.sql.Blob;
 
 import org.hibernate.search.annotations.TikaBridge;
 import org.hibernate.search.bridge.FieldBridge;
-import org.hibernate.search.engine.service.classloading.spi.ClassLoadingException;
-import org.hibernate.search.engine.service.spi.ServiceManager;
-import org.hibernate.search.exception.AssertionFailure;
+import org.hibernate.search.engine.service.classloading.spi.ClassLoaderService;
 import org.hibernate.search.util.impl.ClassLoaderHelper;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
@@ -44,21 +42,16 @@ class TikaBridgeProvider extends ExtendedBridgeProvider {
 				throw LOG.unsupportedTikaBridgeType( returnType );
 			}
 			TikaBridge tikaAnnotation = annotatedElement.getAnnotation( TikaBridge.class );
-			return createTikaBridge( tikaAnnotation, context.getServiceManager() );
+			return createTikaBridge( tikaAnnotation, context.getClassLoaderService() );
 		}
 		return null;
 	}
 
-	private FieldBridge createTikaBridge(org.hibernate.search.annotations.TikaBridge annotation, ServiceManager serviceManager) {
+	private FieldBridge createTikaBridge(org.hibernate.search.annotations.TikaBridge annotation, ClassLoaderService classLoaderService) {
 		Class<?> tikaBridgeClass;
 		FieldBridge tikaBridge;
-		try {
-			tikaBridgeClass = ClassLoaderHelper.classForName( TIKA_BRIDGE_NAME, serviceManager );
-			tikaBridge = ClassLoaderHelper.instanceFromClass( FieldBridge.class, tikaBridgeClass, "Tika bridge" );
-		}
-		catch (ClassLoadingException e) {
-			throw new AssertionFailure( "Unable to find Tika bridge class: " + TIKA_BRIDGE_NAME );
-		}
+		tikaBridgeClass = classLoaderService.classForName( TIKA_BRIDGE_NAME );
+		tikaBridge = ClassLoaderHelper.instanceFromClass( FieldBridge.class, tikaBridgeClass, "Tika bridge" );
 
 		Class<?> tikaMetadataProcessorClass = annotation.metadataProcessor();
 		if ( tikaMetadataProcessorClass != void.class ) {

--- a/engine/src/main/java/org/hibernate/search/bridge/impl/XMemberBridgeProviderContext.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/impl/XMemberBridgeProviderContext.java
@@ -12,7 +12,7 @@ import java.lang.reflect.AnnotatedElement;
 import org.hibernate.annotations.common.reflection.ReflectionManager;
 import org.hibernate.annotations.common.reflection.XMember;
 import org.hibernate.search.annotations.NumericField;
-import org.hibernate.search.engine.service.spi.ServiceManager;
+import org.hibernate.search.engine.service.classloading.spi.ClassLoaderService;
 
 /**
  * Offer a {@code XMember} based {@code BridgeProviderContext}.
@@ -24,15 +24,15 @@ class XMemberBridgeProviderContext implements ExtendedBridgeProvider.ExtendedBri
 	private final AnnotatedElement annotatedElement;
 	private final Class<?> returnTypeElement;
 	private final String memberName;
-	private final ServiceManager serviceManager;
+	private final ClassLoaderService classLoaderService;
 	private final NumericField numericField;
 
-	public XMemberBridgeProviderContext(XMember member, NumericField numericField, ReflectionManager reflectionManager, ServiceManager serviceManager) {
+	public XMemberBridgeProviderContext(XMember member, NumericField numericField, ReflectionManager reflectionManager, ClassLoaderService classLoaderService) {
 		this.annotatedElement = new XMemberToAnnotatedElementAdaptor( member );
 		// For arrays and collection, return the type of the contained elements
 		this.returnTypeElement = reflectionManager.toClass( member.getElementClass() );
 		this.memberName = member.getName();
-		this.serviceManager = serviceManager;
+		this.classLoaderService = classLoaderService;
 		this.numericField = numericField;
 	}
 
@@ -57,8 +57,8 @@ class XMemberBridgeProviderContext implements ExtendedBridgeProvider.ExtendedBri
 	}
 
 	@Override
-	public ServiceManager getServiceManager() {
-		return serviceManager;
+	public ClassLoaderService getClassLoaderService() {
+		return classLoaderService;
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/search/bridge/spi/BridgeProvider.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/spi/BridgeProvider.java
@@ -8,7 +8,7 @@
 package org.hibernate.search.bridge.spi;
 
 import org.hibernate.search.bridge.FieldBridge;
-import org.hibernate.search.engine.service.spi.ServiceManager;
+import org.hibernate.search.engine.service.classloading.spi.ClassLoaderService;
 
 /**
  * Service interface to implement to allow custom bridges to be
@@ -39,9 +39,8 @@ public interface BridgeProvider {
 		Class<?> getReturnType();
 
 		/**
-		 * Provides access to the {@code ServiceManager} and gives access to
-		 * Hibernate Search services like the {@code ClassLoaderService}.
+		 * Provides access to the {@code ClassLoaderService}.
 		 */
-		ServiceManager getServiceManager();
+		ClassLoaderService getClassLoaderService();
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/impl/DocumentBuilderHelper.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/DocumentBuilderHelper.java
@@ -25,12 +25,11 @@ import org.hibernate.search.engine.metadata.impl.DocumentFieldMetadata;
 import org.hibernate.search.engine.metadata.impl.EmbeddedTypeMetadata;
 import org.hibernate.search.engine.metadata.impl.PropertyMetadata;
 import org.hibernate.search.engine.metadata.impl.TypeMetadata;
+import org.hibernate.search.engine.service.classloading.spi.ClassLoaderService;
 import org.hibernate.search.engine.service.classloading.spi.ClassLoadingException;
-import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.engine.spi.DocumentBuilderIndexedEntity;
 import org.hibernate.search.engine.spi.EntityIndexBinding;
 import org.hibernate.search.engine.spi.SearchFactoryImplementor;
-import org.hibernate.search.util.impl.ClassLoaderHelper;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
@@ -46,9 +45,9 @@ public final class DocumentBuilderHelper {
 	private DocumentBuilderHelper() {
 	}
 
-	public static Class<?> getDocumentClass(String className, ServiceManager serviceManager) {
+	public static Class<?> getDocumentClass(String className, ClassLoaderService classloaderService) {
 		try {
-			return ClassLoaderHelper.classForName( className, serviceManager );
+			return classloaderService.classForName( className );
 		}
 		catch (ClassLoadingException e) {
 			throw new SearchException( "Unable to load indexed class: " + className, e );

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
@@ -86,7 +86,7 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 	public AnnotationMetadataProvider(ReflectionManager reflectionManager, ConfigContext configContext) {
 		this.reflectionManager = reflectionManager;
 		this.configContext = configContext;
-		this.bridgeFactory = new BridgeFactory( configContext.getServiceManager() );
+		this.bridgeFactory = new BridgeFactory( configContext );
 	}
 
 	@Override
@@ -163,7 +163,7 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 				null,
 				member,
 				reflectionManager,
-				configContext.getServiceManager()
+				configContext.getClassLoaderService()
 		);
 
 		DocumentFieldMetadata fieldMetadata =
@@ -219,7 +219,7 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 				numericFieldAnn,
 				member,
 				reflectionManager,
-				configContext.getServiceManager()
+				configContext.getClassLoaderService()
 		);
 		if ( !( idBridge instanceof TwoWayFieldBridge ) ) {
 			throw new SearchException(
@@ -269,8 +269,7 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 			Annotation jpaId;
 			try {
 				@SuppressWarnings("unchecked")
-				Class<? extends Annotation> jpaIdClass =
-						ClassLoaderHelper.classForName( "javax.persistence.Id", configContext.getServiceManager() );
+				Class<? extends Annotation> jpaIdClass = configContext.getClassLoaderService().classForName( "javax.persistence.Id" );
 				jpaId = member.getAnnotation( jpaIdClass );
 			}
 			catch (ClassLoadingException e) {
@@ -567,7 +566,7 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 				null,
 				member,
 				reflectionManager,
-				configContext.getServiceManager()
+				configContext.getClassLoaderService()
 		);
 
 		DocumentFieldMetadata fieldMetadata = new DocumentFieldMetadata.Builder( fieldName, store, index, termVector )
@@ -873,7 +872,7 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 				numericFieldAnnotation,
 				member,
 				reflectionManager,
-				configContext.getServiceManager()
+				configContext.getClassLoaderService()
 		);
 
 		String nullToken = determineNullToken( fieldAnnotation, configContext );
@@ -956,11 +955,7 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 			Annotation transientAnnotation;
 			try {
 				@SuppressWarnings("unchecked")
-				Class<? extends Annotation> transientAnnotationClass =
-						ClassLoaderHelper.classForName(
-								"javax.persistence.Transient",
-								configContext.getServiceManager()
-						);
+				Class<? extends Annotation> transientAnnotationClass = configContext.getClassLoaderService().classForName( "javax.persistence.Transient" );
 				transientAnnotation = member.getAnnotation( transientAnnotationClass );
 			}
 			catch (ClassLoadingException e) {

--- a/engine/src/main/java/org/hibernate/search/engine/service/impl/StandardServiceManager.java
+++ b/engine/src/main/java/org/hibernate/search/engine/service/impl/StandardServiceManager.java
@@ -40,8 +40,10 @@ public class StandardServiceManager implements ServiceManager {
 	private final ConcurrentHashMap<Class<?>, ServiceWrapper<?>> cachedServices = new ConcurrentHashMap<Class<?>, ServiceWrapper<?>>();
 	private final Map<Class<? extends Service>, Object> providedServices;
 	private final Map<Class<? extends Service>, String> defaultServices;
+	private final ClassLoaderService classLoaderService;
 
 	private volatile boolean allServicesReleased = false;
+
 
 	public StandardServiceManager(SearchConfiguration searchConfiguration, BuildContext buildContext) {
 		this( searchConfiguration, buildContext, Collections.<Class<? extends Service>, String>emptyMap() );
@@ -54,6 +56,7 @@ public class StandardServiceManager implements ServiceManager {
 		this.properties = searchConfiguration.getProperties();
 		this.providedServices = createProvidedServices( searchConfiguration );
 		this.defaultServices = defaultServices;
+		this.classLoaderService = searchConfiguration.getClassLoaderService();
 	}
 
 	@Override
@@ -167,7 +170,7 @@ public class StandardServiceManager implements ServiceManager {
 					serviceRole,
 					defaultServices.get( serviceRole ),
 					"default service",
-					this
+					classLoaderService
 			);
 			services.add( service );
 		}

--- a/engine/src/main/java/org/hibernate/search/engine/spi/SearchFactoryImplementor.java
+++ b/engine/src/main/java/org/hibernate/search/engine/spi/SearchFactoryImplementor.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import org.hibernate.search.backend.impl.batch.BatchBackend;
 import org.hibernate.search.batchindexing.MassIndexerProgressMonitor;
 import org.hibernate.search.engine.impl.FilterDef;
+import org.hibernate.search.engine.service.classloading.spi.ClassLoaderService;
 import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.filter.FilterCachingStrategy;
 import org.hibernate.search.indexes.impl.IndexManagerHolder;
@@ -110,4 +111,10 @@ public interface SearchFactoryImplementor extends SearchFactoryIntegrator {
 	 * @return returns the default {@code OBJECT_LOOKUP_METHOD}.
 	 */
 	ObjectLookupMethod getDefaultObjectLookupMethod();
+
+	/**
+	 * This specific service has a direct accessor as it's both essential
+	 * and a performance hotspot.
+	 */
+	ClassLoaderService getClassLoaderService();
 }

--- a/engine/src/main/java/org/hibernate/search/impl/ImmutableSearchFactory.java
+++ b/engine/src/main/java/org/hibernate/search/impl/ImmutableSearchFactory.java
@@ -22,6 +22,7 @@ import org.hibernate.search.cfg.SearchMapping;
 import org.hibernate.search.cfg.spi.IndexManagerFactory;
 import org.hibernate.search.engine.Version;
 import org.hibernate.search.engine.impl.FilterDef;
+import org.hibernate.search.engine.service.classloading.spi.ClassLoaderService;
 import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.engine.spi.AbstractDocumentBuilder;
 import org.hibernate.search.engine.spi.DocumentBuilderContainedEntity;
@@ -107,8 +108,10 @@ public class ImmutableSearchFactory implements SearchFactoryImplementorWithShare
 	private final IndexManagerFactory indexManagerFactory;
 	private final ObjectLookupMethod defaultObjectLookupMethod;
 	private final DatabaseRetrievalMethod defaultDatabaseRetrievalMethod;
+	private final ClassLoaderService classLoaderService;
 
 	public ImmutableSearchFactory(SearchFactoryState state) {
+		this.classLoaderService = state.getClassLoaderService();
 		this.analyzers = state.getAnalyzers();
 		this.cacheBitResultsSize = state.getCacheBitResultsSize();
 		this.configurationProperties = state.getConfigurationProperties();
@@ -514,6 +517,11 @@ public class ImmutableSearchFactory implements SearchFactoryImplementorWithShare
 		else {
 			throw new SearchException( "Can not unwrap an ImmutableSearchFactory into a '" + cls + "'" );
 		}
+	}
+
+	@Override
+	public ClassLoaderService getClassLoaderService() {
+		return classLoaderService;
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/search/impl/IncrementalSearchConfiguration.java
+++ b/engine/src/main/java/org/hibernate/search/impl/IncrementalSearchConfiguration.java
@@ -99,6 +99,6 @@ public class IncrementalSearchConfiguration implements SearchConfiguration {
 
 	@Override
 	public ClassLoaderService getClassLoaderService() {
-		return searchFactoryState.getServiceManager().requestService( ClassLoaderService.class );
+		return searchFactoryState.getClassLoaderService();
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/impl/MutableSearchFactory.java
+++ b/engine/src/main/java/org/hibernate/search/impl/MutableSearchFactory.java
@@ -19,6 +19,7 @@ import org.hibernate.search.batchindexing.MassIndexerProgressMonitor;
 import org.hibernate.search.cfg.SearchMapping;
 import org.hibernate.search.cfg.spi.IndexManagerFactory;
 import org.hibernate.search.engine.impl.FilterDef;
+import org.hibernate.search.engine.service.classloading.spi.ClassLoaderService;
 import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.engine.spi.DocumentBuilderContainedEntity;
 import org.hibernate.search.engine.spi.EntityIndexBinding;
@@ -306,6 +307,11 @@ public class MutableSearchFactory implements SearchFactoryImplementorWithShareab
 	@Override
 	public IndexManagerFactory getIndexManagerFactory() {
 		return delegate.getIndexManagerFactory();
+	}
+
+	@Override
+	public ClassLoaderService getClassLoaderService() {
+		return delegate.getClassLoaderService();
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/impl/MutableSearchFactoryState.java
+++ b/engine/src/main/java/org/hibernate/search/impl/MutableSearchFactoryState.java
@@ -16,6 +16,7 @@ import org.hibernate.search.backend.spi.Worker;
 import org.hibernate.search.cfg.SearchMapping;
 import org.hibernate.search.cfg.spi.IndexManagerFactory;
 import org.hibernate.search.engine.impl.FilterDef;
+import org.hibernate.search.engine.service.classloading.spi.ClassLoaderService;
 import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.engine.spi.DocumentBuilderContainedEntity;
 import org.hibernate.search.engine.spi.EntityIndexBinding;
@@ -58,6 +59,7 @@ public class MutableSearchFactoryState implements SearchFactoryState {
 	private boolean indexMetadataIsComplete;
 	private boolean isIdProvidedImplicit;
 	private IndexManagerFactory indexManagerFactory;
+	private ClassLoaderService classLoaderService;
 
 	public void copyStateFromOldFactory(SearchFactoryState oldFactoryState) {
 		indexingStrategy = oldFactoryState.getIndexingStrategy();
@@ -81,6 +83,7 @@ public class MutableSearchFactoryState implements SearchFactoryState {
 		indexMetadataIsComplete = oldFactoryState.isIndexMetadataComplete();
 		isIdProvidedImplicit = oldFactoryState.isIdProvidedImplicit();
 		indexManagerFactory = oldFactoryState.getIndexManagerFactory();
+		classLoaderService = oldFactoryState.getClassLoaderService();
 	}
 
 	@Override
@@ -286,6 +289,15 @@ public class MutableSearchFactoryState implements SearchFactoryState {
 
 	public void setIndexManagerFactory(IndexManagerFactory indexManagerFactory) {
 		this.indexManagerFactory = indexManagerFactory;
+	}
+
+	@Override
+	public ClassLoaderService getClassLoaderService() {
+		return classLoaderService;
+	}
+
+	public void setClassLoaderService(ClassLoaderService classLoaderService) {
+		this.classLoaderService = classLoaderService;
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/search/impl/SolrAnalyzerBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/impl/SolrAnalyzerBuilder.java
@@ -22,7 +22,7 @@ import org.hibernate.search.annotations.CharFilterDef;
 import org.hibernate.search.annotations.Parameter;
 import org.hibernate.search.annotations.TokenFilterDef;
 import org.hibernate.search.annotations.TokenizerDef;
-import org.hibernate.search.engine.service.spi.ServiceManager;
+import org.hibernate.search.engine.service.classloading.spi.ClassLoaderService;
 import org.hibernate.search.util.impl.HibernateSearchResourceLoader;
 
 import static org.hibernate.search.util.impl.ClassLoaderHelper.instanceFromClass;
@@ -49,8 +49,8 @@ final class SolrAnalyzerBuilder {
 	 */
 	public static Analyzer buildAnalyzer(AnalyzerDef analyzerDef,
 			Version luceneMatchVersion,
-			ServiceManager serviceManager) throws IOException {
-		ResourceLoader defaultResourceLoader = new HibernateSearchResourceLoader( serviceManager );
+			ClassLoaderService classLoaderService) throws IOException {
+		ResourceLoader defaultResourceLoader = new HibernateSearchResourceLoader( classLoaderService );
 		TokenizerDef token = analyzerDef.tokenizer();
 		final Map<String, String> tokenMapsOfParameters = getMapOfParameters( token.params(), luceneMatchVersion );
 		TokenizerFactory tokenFactory = instanceFromClass(

--- a/engine/src/main/java/org/hibernate/search/indexes/impl/IndexManagerHolder.java
+++ b/engine/src/main/java/org/hibernate/search/indexes/impl/IndexManagerHolder.java
@@ -346,12 +346,11 @@ public class IndexManagerHolder {
 	private ShardIdentifierProvider createShardIdentifierProvider(WorkerBuildContext buildContext, Properties indexProperty) {
 		ShardIdentifierProvider shardIdentifierProvider;
 		String shardIdentityProviderName = indexProperty.getProperty( SHARDING_STRATEGY );
-		ServiceManager serviceManager = buildContext.getServiceManager();
 		shardIdentifierProvider = ClassLoaderHelper.instanceFromName(
 				ShardIdentifierProvider.class,
 				shardIdentityProviderName,
 				"ShardIdentifierProvider",
-				serviceManager
+				buildContext.getClassLoaderService()
 		);
 
 		shardIdentifierProvider.initialize( new MaskedProperty( indexProperty, SHARDING_STRATEGY ), buildContext );
@@ -408,12 +407,11 @@ public class IndexManagerHolder {
 			return DEFAULT_SIMILARITY;
 		}
 		else {
-			ServiceManager serviceManager = buildContext.getServiceManager();
 			return ClassLoaderHelper.instanceFromName(
 					Similarity.class,
 					defaultSimilarityClassName,
 					"default similarity",
-					serviceManager
+					buildContext.getClassLoaderService()
 			);
 
 		}
@@ -423,12 +421,11 @@ public class IndexManagerHolder {
 		Similarity configLevelSimilarity = null;
 		String similarityClassName = indexProperties.getProperty( Environment.SIMILARITY_CLASS_PER_INDEX );
 		if ( similarityClassName != null ) {
-			ServiceManager serviceManager = buildContext.getServiceManager();
 			configLevelSimilarity = ClassLoaderHelper.instanceFromName(
 					Similarity.class,
 					similarityClassName,
 					"Similarity class for index " + directoryProviderName,
-					serviceManager
+					buildContext.getClassLoaderService()
 			);
 		}
 		return configLevelSimilarity;
@@ -455,7 +452,7 @@ public class IndexManagerHolder {
 					IndexShardingStrategy.class,
 					shardingStrategyName,
 					"IndexShardingStrategy",
-					serviceManager
+					buildContext.getClassLoaderService()
 			);
 		}
 		shardingStrategy.initialize(
@@ -532,10 +529,7 @@ public class IndexManagerHolder {
 
 		Class<?> shardingStrategy;
 		try {
-			shardingStrategy = ClassLoaderHelper.classForName(
-					shardingStrategyName,
-					buildContext.getServiceManager()
-			);
+			shardingStrategy = buildContext.getClassLoaderService().classForName( shardingStrategyName );
 		}
 		catch (ClassLoadingException e) {
 			throw log.getUnableToLoadShardingStrategyClassException( shardingStrategyName );

--- a/engine/src/main/java/org/hibernate/search/indexes/impl/PropertiesParseHelper.java
+++ b/engine/src/main/java/org/hibernate/search/indexes/impl/PropertiesParseHelper.java
@@ -13,7 +13,6 @@ import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.backend.spi.LuceneIndexingParameters;
 import org.hibernate.search.util.impl.Executors;
-import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.indexes.spi.DirectoryBasedReaderProvider;
 import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.spi.WorkerBuildContext;
@@ -100,12 +99,11 @@ public class PropertiesParseHelper {
 		MaskedProperty maskedProperty = new MaskedProperty( indexProperties, "optimizer" );
 		String optimizerImplClassName = maskedProperty.getProperty( "implementation" );
 		if ( optimizerImplClassName != null && ( !"default".equalsIgnoreCase( optimizerImplClassName ) ) ) {
-			ServiceManager serviceManager = buildContext.getServiceManager();
 			return ClassLoaderHelper.instanceFromName(
 					OptimizerStrategy.class,
 					optimizerImplClassName,
 					"Optimizer Strategy",
-					serviceManager
+					buildContext.getClassLoaderService()
 			);
 		}
 		else {
@@ -157,12 +155,11 @@ public class PropertiesParseHelper {
 			readerProvider = new SharingBufferReaderProvider();
 		}
 		else {
-			ServiceManager serviceManager = buildContext.getServiceManager();
 			readerProvider = ClassLoaderHelper.instanceFromName(
 					DirectoryBasedReaderProvider.class,
 					readerProviderImplName,
 					"readerProvider",
-					serviceManager
+					buildContext.getClassLoaderService()
 			);
 		}
 		readerProvider.initialize( indexManager, maskedProperties );

--- a/engine/src/main/java/org/hibernate/search/indexes/serialization/impl/LuceneWorkHydrator.java
+++ b/engine/src/main/java/org/hibernate/search/indexes/serialization/impl/LuceneWorkHydrator.java
@@ -92,7 +92,7 @@ public class LuceneWorkHydrator implements LuceneWorksBuilder {
 		Class<?> entityClass = ClassLoaderHelper.classForName(
 				entityClassName,
 				"entity class",
-				searchFactory.getServiceManager()
+				searchFactory.getClassLoaderService()
 		);
 		results.add( new PurgeAllLuceneWork( entityClass ) );
 	}
@@ -112,7 +112,7 @@ public class LuceneWorkHydrator implements LuceneWorksBuilder {
 		Class<?> entityClass = ClassLoaderHelper.classForName(
 				entityClassName,
 				"entity class",
-				searchFactory.getServiceManager()
+				searchFactory.getClassLoaderService()
 		);
 		LuceneWork result = new DeleteLuceneWork(
 				id,
@@ -125,11 +125,7 @@ public class LuceneWorkHydrator implements LuceneWorksBuilder {
 
 	@Override
 	public void addAddLuceneWork(String entityClassName, Map<String, String> fieldToAnalyzerMap, ConversionContext conversionContext) {
-		Class<?> entityClass = ClassLoaderHelper.classForName(
-				entityClassName,
-				"entity class",
-				searchFactory.getServiceManager()
-		);
+		Class<?> entityClass = ClassLoaderHelper.classForName( entityClassName, "entity class", searchFactory.getClassLoaderService() );
 		LuceneWork result = new AddLuceneWork(
 				id,
 				objectIdInString( entityClass, id, conversionContext ),
@@ -147,7 +143,7 @@ public class LuceneWorkHydrator implements LuceneWorksBuilder {
 		Class<?> entityClass = ClassLoaderHelper.classForName(
 				entityClassName,
 				"entity class",
-				searchFactory.getServiceManager()
+				searchFactory.getClassLoaderService()
 		);
 		LuceneWork result = new UpdateLuceneWork(
 				id,

--- a/engine/src/main/java/org/hibernate/search/query/engine/impl/DocumentExtractorImpl.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/impl/DocumentExtractorImpl.java
@@ -212,7 +212,7 @@ public class DocumentExtractorImpl implements DocumentExtractor {
 			return clazz;
 		}
 		else {
-			return DocumentBuilderHelper.getDocumentClass( className, searchFactoryImplementor.getServiceManager() );
+			return DocumentBuilderHelper.getDocumentClass( className, searchFactoryImplementor.getClassLoaderService() );
 		}
 	}
 

--- a/engine/src/main/java/org/hibernate/search/spi/BuildContext.java
+++ b/engine/src/main/java/org/hibernate/search/spi/BuildContext.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.spi;
 
+import org.hibernate.search.engine.service.classloading.spi.ClassLoaderService;
 import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.engine.spi.SearchFactoryImplementor;
 import org.hibernate.search.exception.ErrorHandler;
@@ -71,4 +72,6 @@ public interface BuildContext {
 	 * @return the configured {@code ErrorHandler}
 	 */
 	ErrorHandler getErrorHandler();
+
+	ClassLoaderService getClassLoaderService();
 }

--- a/engine/src/main/java/org/hibernate/search/spi/SearchFactoryBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/spi/SearchFactoryBuilder.java
@@ -44,6 +44,7 @@ import org.hibernate.search.engine.impl.FilterDef;
 import org.hibernate.search.engine.impl.MutableEntityIndexBinding;
 import org.hibernate.search.engine.metadata.impl.AnnotationMetadataProvider;
 import org.hibernate.search.engine.metadata.impl.TypeMetadata;
+import org.hibernate.search.engine.service.classloading.spi.ClassLoaderService;
 import org.hibernate.search.engine.service.impl.StandardServiceManager;
 import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.engine.spi.DocumentBuilderContainedEntity;
@@ -224,6 +225,7 @@ public class SearchFactoryBuilder {
 				cfg.getProperties()
 		);
 		// build worker and back end components
+		factoryState.setClassLoaderService( cfg.getClassLoaderService() );
 		factoryState.setWorker( WorkerFactory.createWorker( cfg, buildContext, queueingProcessor ) );
 		factoryState.setFilterCachingStrategy( buildFilterCachingStrategy( cfg ) );
 		factoryState.setCacheBitResultsSize(
@@ -282,6 +284,7 @@ public class SearchFactoryBuilder {
 		if ( rootFactory == null ) {
 			//set the mutable structure of factory state
 			rootFactory = new MutableSearchFactory();
+			factoryState.setClassLoaderService( cfg.getClassLoaderService() );
 			factoryState.setDocumentBuildersIndexedEntities( new ConcurrentHashMap<Class<?>, EntityIndexBinding>() );
 			factoryState.setDocumentBuildersContainedEntities( new ConcurrentHashMap<Class<?>, DocumentBuilderContainedEntity>() );
 			factoryState.setFilterDefinitions( new ConcurrentHashMap<String, FilterDef>() );
@@ -637,6 +640,11 @@ public class SearchFactoryBuilder {
 		@Override
 		public ServiceManager getServiceManager() {
 			return factoryState.getServiceManager();
+		}
+
+		@Override
+		public ClassLoaderService getClassLoaderService() {
+			return factoryState.getClassLoaderService();
 		}
 
 	}

--- a/engine/src/main/java/org/hibernate/search/spi/impl/SearchFactoryState.java
+++ b/engine/src/main/java/org/hibernate/search/spi/impl/SearchFactoryState.java
@@ -15,6 +15,7 @@ import org.hibernate.search.backend.spi.Worker;
 import org.hibernate.search.cfg.SearchMapping;
 import org.hibernate.search.cfg.spi.IndexManagerFactory;
 import org.hibernate.search.engine.impl.FilterDef;
+import org.hibernate.search.engine.service.classloading.spi.ClassLoaderService;
 import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.engine.spi.DocumentBuilderContainedEntity;
 import org.hibernate.search.engine.spi.EntityIndexBinding;
@@ -72,4 +73,6 @@ public interface SearchFactoryState {
 	boolean isIdProvidedImplicit();
 
 	IndexManagerFactory getIndexManagerFactory();
+
+	ClassLoaderService getClassLoaderService();
 }

--- a/engine/src/main/java/org/hibernate/search/stat/impl/StatisticsImpl.java
+++ b/engine/src/main/java/org/hibernate/search/stat/impl/StatisticsImpl.java
@@ -32,7 +32,6 @@ import org.hibernate.search.engine.service.classloading.spi.ClassLoadingExceptio
 import org.hibernate.search.engine.spi.SearchFactoryImplementor;
 import org.hibernate.search.stat.Statistics;
 import org.hibernate.search.stat.spi.StatisticsImplementor;
-import org.hibernate.search.util.impl.ClassLoaderHelper;
 
 /**
  * A concurrent implementation of the {@code Statistics} interface.
@@ -240,10 +239,10 @@ public class StatisticsImpl implements Statistics, StatisticsImplementor {
 	private Class<?> getEntityClass(String entity) {
 		Class<?> clazz;
 		try {
-			clazz = ClassLoaderHelper.classForName( entity, searchFactoryImplementor.getServiceManager() );
+			clazz = searchFactoryImplementor.getClassLoaderService().classForName( entity );
 		}
 		catch (ClassLoadingException e) {
-			throw new IllegalArgumentException( entity + "not a indexed entity" );
+			throw new IllegalArgumentException( entity + "not an indexed entity" );
 		}
 		return clazz;
 	}

--- a/engine/src/main/java/org/hibernate/search/store/impl/DirectoryProviderFactory.java
+++ b/engine/src/main/java/org/hibernate/search/store/impl/DirectoryProviderFactory.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.hibernate.search.exception.SearchException;
-import org.hibernate.search.engine.service.spi.ServiceManager;
+import org.hibernate.search.engine.service.classloading.spi.ClassLoaderService;
 import org.hibernate.search.spi.WorkerBuildContext;
 import org.hibernate.search.store.DirectoryProvider;
 import org.hibernate.search.util.impl.ClassLoaderHelper;
@@ -54,9 +54,9 @@ public final class DirectoryProviderFactory {
 	public static DirectoryProvider<?> createDirectoryProvider(String directoryProviderName, Properties indexProps, WorkerBuildContext context) {
 		String className = indexProps.getProperty( "directory_provider", "" );
 		String maybeShortCut = className.toLowerCase();
+		ClassLoaderService classLoaderService = context.getClassLoaderService();
 
 		DirectoryProvider<?> provider;
-		ServiceManager serviceManager = context.getServiceManager();
 		//try and use the built-in shortcuts before loading the provider as a fully qualified class name
 		if ( defaultProviderClasses.containsKey( maybeShortCut ) ) {
 			String fullClassName = defaultProviderClasses.get( maybeShortCut );
@@ -64,7 +64,7 @@ public final class DirectoryProviderFactory {
 					DirectoryProvider.class,
 					fullClassName,
 					"directory provider",
-					serviceManager
+					classLoaderService
 			);
 		}
 		else {
@@ -72,7 +72,7 @@ public final class DirectoryProviderFactory {
 					DirectoryProvider.class,
 					className,
 					"directory provider",
-					serviceManager
+					classLoaderService
 			);
 		}
 		try {

--- a/engine/src/main/java/org/hibernate/search/store/impl/DirectoryProviderHelper.java
+++ b/engine/src/main/java/org/hibernate/search/store/impl/DirectoryProviderHelper.java
@@ -29,9 +29,9 @@ import org.apache.lucene.store.SimpleFSDirectory;
 import org.apache.lucene.store.SimpleFSLockFactory;
 import org.apache.lucene.store.SingleInstanceLockFactory;
 import org.apache.lucene.util.Version;
-import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.util.StringHelper;
 import org.hibernate.search.cfg.Environment;
+import org.hibernate.search.engine.service.classloading.spi.ClassLoaderService;
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.store.LockFactoryProvider;
 import org.hibernate.search.util.configuration.impl.ConfigurationParseHelper;
@@ -113,8 +113,8 @@ public final class DirectoryProviderHelper {
 	 * @return the created {@code FSDirectory} instance
 	 * @throws java.io.IOException if an error
 	 */
-	public static FSDirectory createFSIndex(File indexDir, Properties properties, ServiceManager serviceManager) throws IOException {
-		LockFactory lockFactory = createLockFactory( indexDir, properties, serviceManager );
+	public static FSDirectory createFSIndex(File indexDir, Properties properties, ClassLoaderService classLoaderService) throws IOException {
+		LockFactory lockFactory = createLockFactory( indexDir, properties, classLoaderService );
 		FSDirectoryType fsDirectoryType = FSDirectoryType.getType( properties );
 		FSDirectory fsDirectory = fsDirectoryType.getDirectory( indexDir, null );
 
@@ -171,7 +171,7 @@ public final class DirectoryProviderHelper {
 	 * @return the LockFactory as configured, or a SimpleFSLockFactory
 	 *         in case of configuration errors or as a default.
 	 */
-	public static LockFactory createLockFactory(File indexDir, Properties dirConfiguration, ServiceManager serviceManager) {
+	public static LockFactory createLockFactory(File indexDir, Properties dirConfiguration, ClassLoaderService classLoaderService) {
 		//For FS-based indexes default to "native", default to "single" otherwise.
 		String defaultStrategy = indexDir == null ? "single" : "native";
 		String lockFactoryName = dirConfiguration.getProperty( LOCKING_STRATEGY_PROP_NAME, defaultStrategy );
@@ -198,7 +198,7 @@ public final class DirectoryProviderHelper {
 					LockFactoryProvider.class,
 					lockFactoryName,
 					LOCKING_STRATEGY_PROP_NAME,
-					serviceManager
+					classLoaderService
 			);
 			return lockFactoryFactory.createLockFactory( indexDir, dirConfiguration );
 		}

--- a/engine/src/main/java/org/hibernate/search/store/impl/FSDirectoryProvider.java
+++ b/engine/src/main/java/org/hibernate/search/store/impl/FSDirectoryProvider.java
@@ -50,7 +50,7 @@ public class FSDirectoryProvider implements DirectoryProvider<FSDirectory> {
 		try {
 			indexName = indexDir.getCanonicalPath();
 			//this is cheap so it's not done in start()
-			directory = DirectoryProviderHelper.createFSIndex( indexDir, properties, context.getServiceManager() );
+			directory = DirectoryProviderHelper.createFSIndex( indexDir, properties, context.getClassLoaderService() );
 		}
 		catch (IOException e) {
 			throw new SearchException( "Unable to initialize index: " + directoryProviderName, e );

--- a/engine/src/main/java/org/hibernate/search/store/impl/FSMasterDirectoryProvider.java
+++ b/engine/src/main/java/org/hibernate/search/store/impl/FSMasterDirectoryProvider.java
@@ -76,7 +76,7 @@ public class FSMasterDirectoryProvider implements DirectoryProvider<FSDirectory>
 		log.debugf( "Index directory: %s", indexDir.getPath() );
 		try {
 			indexName = indexDir.getCanonicalPath();
-			directory = DirectoryProviderHelper.createFSIndex( indexDir, properties, context.getServiceManager() );
+			directory = DirectoryProviderHelper.createFSIndex( indexDir, properties, context.getClassLoaderService() );
 		}
 		catch (IOException e) {
 			throw new SearchException( "Unable to initialize index: " + directoryProviderName, e );

--- a/engine/src/main/java/org/hibernate/search/store/impl/FSSlaveDirectoryProvider.java
+++ b/engine/src/main/java/org/hibernate/search/store/impl/FSSlaveDirectoryProvider.java
@@ -19,15 +19,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.store.RAMDirectory;
-
-import org.hibernate.search.engine.service.spi.ServiceManager;
+import org.hibernate.search.engine.service.classloading.spi.ClassLoaderService;
 import org.hibernate.search.indexes.impl.DirectoryBasedIndexManager;
 import org.hibernate.search.spi.BuildContext;
 import org.hibernate.search.store.DirectoryProvider;
 import org.hibernate.search.util.configuration.impl.ConfigurationParseHelper;
 import org.hibernate.search.util.impl.FileHelper;
 import org.hibernate.search.util.logging.impl.Log;
-
 import org.hibernate.search.exception.AssertionFailure;
 import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.exception.SearchException;
@@ -69,13 +67,13 @@ public class FSSlaveDirectoryProvider implements DirectoryProvider<Directory> {
 	private String directoryProviderName;
 	private Properties properties;
 	private UpdateTask updateTask;
-	private ServiceManager serviceManager;
+	private ClassLoaderService classLoaderService;
 
 	@Override
 	public void initialize(String directoryProviderName, Properties properties, BuildContext context) {
 		this.properties = properties;
 		this.directoryProviderName = directoryProviderName;
-		this.serviceManager = context.getServiceManager();
+		this.classLoaderService = context.getClassLoaderService();
 		//source guessing
 		sourceIndexDir = DirectoryProviderHelper.getSourceDirectory( directoryProviderName, properties, false );
 		log.debugf( "Source directory: %s", sourceIndexDir.getPath() );
@@ -139,8 +137,8 @@ public class FSSlaveDirectoryProvider implements DirectoryProvider<Directory> {
 		int readCurrentState = current; //Unneeded value, but ensure visibility of state protected by memory barrier
 		int currentToBe = 0;
 		try {
-			directory1 = DirectoryProviderHelper.createFSIndex( new File( indexDir, "1" ), properties, serviceManager );
-			directory2 = DirectoryProviderHelper.createFSIndex( new File( indexDir, "2" ), properties, serviceManager );
+			directory1 = DirectoryProviderHelper.createFSIndex( new File( indexDir, "1" ), properties, classLoaderService );
+			directory2 = DirectoryProviderHelper.createFSIndex( new File( indexDir, "2" ), properties, classLoaderService );
 			File currentMarker = new File( indexDir, "current1" );
 			File current2Marker = new File( indexDir, "current2" );
 			if ( currentMarker.exists() ) {

--- a/engine/src/main/java/org/hibernate/search/store/impl/RAMDirectoryProvider.java
+++ b/engine/src/main/java/org/hibernate/search/store/impl/RAMDirectoryProvider.java
@@ -35,18 +35,18 @@ public class RAMDirectoryProvider implements DirectoryProvider<RAMDirectory> {
 		this.indexName = directoryProviderName;
 		this.properties = properties;
 		this.serviceManager = context.getServiceManager();
-	}
-
-	@Override
-	public void start(DirectoryBasedIndexManager indexManager) {
 		try {
-			directory.setLockFactory( DirectoryProviderHelper.createLockFactory( null, properties, serviceManager ) );
-			properties = null;
-			DirectoryProviderHelper.initializeIndexIfNeeded( directory );
+			this.directory.setLockFactory( DirectoryProviderHelper.createLockFactory( null, properties, context.getClassLoaderService() ) );
 		}
 		catch (IOException e) {
 			throw new SearchException( "Unable to initialize index: " + indexName, e );
 		}
+	}
+
+	@Override
+	public void start(DirectoryBasedIndexManager indexManager) {
+		properties = null;
+		DirectoryProviderHelper.initializeIndexIfNeeded( directory );
 	}
 
 

--- a/engine/src/main/java/org/hibernate/search/util/impl/HibernateSearchResourceLoader.java
+++ b/engine/src/main/java/org/hibernate/search/util/impl/HibernateSearchResourceLoader.java
@@ -11,7 +11,6 @@ import java.io.InputStream;
 
 import org.apache.lucene.analysis.util.ResourceLoader;
 import org.hibernate.search.engine.service.classloading.spi.ClassLoaderService;
-import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
@@ -23,24 +22,18 @@ import org.hibernate.search.util.logging.impl.LoggerFactory;
  * @author Hardy Ferentschik
  */
 public class HibernateSearchResourceLoader implements ResourceLoader {
-	private static final Log log = LoggerFactory.make();
-	private final ServiceManager serviceManager;
 
-	public HibernateSearchResourceLoader(ServiceManager serviceManager) {
-		this.serviceManager = serviceManager;
+	private static final Log log = LoggerFactory.make();
+
+	private final ClassLoaderService classLoaderService;
+
+	public HibernateSearchResourceLoader(ClassLoaderService classLoaderService) {
+		this.classLoaderService = classLoaderService;
 	}
 
 	@Override
 	public InputStream openResource(String resource) throws IOException {
-		ClassLoaderService classLoaderService = serviceManager.requestService( ClassLoaderService.class );
-		InputStream inputStream;
-		try {
-			inputStream = classLoaderService.locateResourceStream( resource );
-		}
-		finally {
-			serviceManager.releaseService( ClassLoaderService.class );
-		}
-
+		InputStream inputStream = classLoaderService.locateResourceStream( resource );
 		if ( inputStream == null ) {
 			throw log.unableToLoadResource( resource );
 		}
@@ -55,7 +48,7 @@ public class HibernateSearchResourceLoader implements ResourceLoader {
 				expectedType,
 				className,
 				describeComponent( className ),
-				serviceManager
+				classLoaderService
 		);
 	}
 
@@ -65,7 +58,7 @@ public class HibernateSearchResourceLoader implements ResourceLoader {
 				expectedType,
 				className,
 				describeComponent( className ),
-				serviceManager
+				classLoaderService
 		);
 	}
 

--- a/engine/src/test/java/org/hibernate/search/test/engine/service/StandardServiceManagerTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/engine/service/StandardServiceManagerTest.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.test.engine.service;
 
 import org.hibernate.search.exception.SearchException;
+import org.hibernate.search.engine.service.classloading.spi.ClassLoaderService;
 import org.hibernate.search.engine.service.impl.StandardServiceManager;
 import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.engine.spi.SearchFactoryImplementor;
@@ -213,6 +214,11 @@ public class StandardServiceManagerTest {
 
 		@Override
 		public ErrorHandler getErrorHandler() {
+			return null;
+		}
+
+		@Override
+		public ClassLoaderService getClassLoaderService() {
 			return null;
 		}
 	}

--- a/engine/src/test/java/org/hibernate/search/test/util/impl/HibernateSearchResourceLoaderTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/util/impl/HibernateSearchResourceLoaderTest.java
@@ -9,8 +9,6 @@ package org.hibernate.search.test.util.impl;
 import java.io.InputStream;
 
 import org.hibernate.search.cfg.spi.SearchConfiguration;
-import org.hibernate.search.engine.service.impl.StandardServiceManager;
-import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.spi.BuildContext;
 import org.hibernate.search.testsupport.setup.BuildContextForTest;
@@ -35,8 +33,7 @@ public class HibernateSearchResourceLoaderTest {
 	public void setUp() {
 		SearchConfiguration searchConfiguration = new SearchConfigurationForTest();
 		BuildContext buildContext = new BuildContextForTest( searchConfiguration );
-		ServiceManager serviceManager = new StandardServiceManager( searchConfiguration, buildContext );
-		resourceLoader = new HibernateSearchResourceLoader( serviceManager );
+		resourceLoader = new HibernateSearchResourceLoader( buildContext.getClassLoaderService() );
 	}
 
 	@Test

--- a/engine/src/test/java/org/hibernate/search/testsupport/setup/BuildContextForTest.java
+++ b/engine/src/test/java/org/hibernate/search/testsupport/setup/BuildContextForTest.java
@@ -8,6 +8,7 @@ package org.hibernate.search.testsupport.setup;
 
 import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.cfg.spi.SearchConfiguration;
+import org.hibernate.search.engine.service.classloading.spi.ClassLoaderService;
 import org.hibernate.search.engine.service.impl.StandardServiceManager;
 import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.engine.spi.SearchFactoryImplementor;
@@ -52,6 +53,11 @@ public class BuildContextForTest implements BuildContext {
 	@Override
 	public ErrorHandler getErrorHandler() {
 		return new LogErrorHandler();
+	}
+
+	@Override
+	public ClassLoaderService getClassLoaderService() {
+		return searchConfiguration.getClassLoaderService();
 	}
 }
 

--- a/infinispan/src/main/java/org/hibernate/search/infinispan/DefaultCacheManagerService.java
+++ b/infinispan/src/main/java/org/hibernate/search/infinispan/DefaultCacheManagerService.java
@@ -14,7 +14,6 @@ import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
 import org.hibernate.search.exception.SearchException;
-import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.engine.service.spi.Startable;
 import org.hibernate.search.engine.service.spi.Stoppable;
 import org.hibernate.search.infinispan.impl.InfinispanConfigurationParser;
@@ -75,7 +74,6 @@ public class DefaultCacheManagerService implements CacheManagerService, Startabl
 
 	@Override
 	public void start(Properties properties, BuildContext context) {
-		ServiceManager serviceManager = context.getServiceManager();
 		String name = ConfigurationParseHelper.getString( properties, CACHE_MANAGER_RESOURCE_PROP, null );
 		if ( name == null ) {
 			// No JNDI lookup configured: start the CacheManager
@@ -86,7 +84,7 @@ public class DefaultCacheManagerService implements CacheManagerService, Startabl
 			final String transportOverrideResource = properties.getProperty( INFINISPAN_TRANSPORT_OVERRIDE_RESOURCENAME );
 			try {
 				InfinispanConfigurationParser ispnConfiguration = new InfinispanConfigurationParser();
-				ConfigurationBuilderHolder configurationBuilderHolder = ispnConfiguration.parseFile( cfgName, transportOverrideResource, serviceManager );
+				ConfigurationBuilderHolder configurationBuilderHolder = ispnConfiguration.parseFile( cfgName, transportOverrideResource, context );
 				cacheManager = new DefaultCacheManager( configurationBuilderHolder, true );
 				manageCacheManager = true;
 			}

--- a/infinispan/src/main/java/org/hibernate/search/infinispan/impl/InfinispanConfigurationParser.java
+++ b/infinispan/src/main/java/org/hibernate/search/infinispan/impl/InfinispanConfigurationParser.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.hibernate.search.engine.service.classloading.spi.ClassLoaderService;
-import org.hibernate.search.engine.service.spi.ServiceManager;
+import org.hibernate.search.spi.BuildContext;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
 import org.infinispan.configuration.parsing.ParserRegistry;
@@ -40,18 +40,13 @@ public class InfinispanConfigurationParser {
 	 *
 	 * @param filename Infinispan configuration resource name
 	 * @param transportOverrideResource An alternative JGroups configuration file to be injected
-	 * @param serviceManager the ServiceManager to load resources
+	 * @param context of the SearchFactory initialization
 	 * @throws IOException
 	 * @return
 	 */
-	public ConfigurationBuilderHolder parseFile(String filename, String transportOverrideResource, ServiceManager serviceManager) throws IOException {
-		ClassLoaderService classLoaderService = serviceManager.requestService( ClassLoaderService.class );
-		try {
-			return parseFile( classLoaderService, filename, transportOverrideResource );
-		}
-		finally {
-			serviceManager.releaseService( ClassLoaderService.class );
-		}
+	public ConfigurationBuilderHolder parseFile(String filename, String transportOverrideResource, BuildContext context) throws IOException {
+		ClassLoaderService classLoaderService = context.getClassLoaderService();
+		return parseFile( classLoaderService, filename, transportOverrideResource );
 	}
 
 	private ConfigurationBuilderHolder parseFile(ClassLoaderService classLoaderService, String filename, String transportOverrideResource) {

--- a/orm/src/main/java/org/hibernate/search/impl/FullTextSessionImpl.java
+++ b/orm/src/main/java/org/hibernate/search/impl/FullTextSessionImpl.java
@@ -24,7 +24,7 @@ import org.hibernate.search.backend.TransactionContext;
 import org.hibernate.search.backend.impl.EventSourceTransactionContext;
 import org.hibernate.search.backend.spi.Work;
 import org.hibernate.search.backend.spi.WorkType;
-import org.hibernate.search.engine.service.spi.ServiceManager;
+import org.hibernate.search.engine.service.classloading.spi.ClassLoaderService;
 import org.hibernate.search.engine.spi.SearchFactoryImplementor;
 import org.hibernate.search.query.hibernate.impl.FullTextQueryImpl;
 import org.hibernate.search.batchindexing.spi.MassIndexerFactory;
@@ -178,10 +178,8 @@ public class FullTextSessionImpl extends SessionDelegatorBaseImpl implements Ful
 
 		if ( factoryClassName != null ) {
 			SearchFactoryImplementor searchFactoryImplementor = getSearchFactoryImplementor();
-			ServiceManager serviceManager = searchFactoryImplementor.getServiceManager();
-			factory = ClassLoaderHelper.instanceFromName(
-					MassIndexerFactory.class, factoryClassName, "Mass indexer factory", serviceManager
-			);
+			ClassLoaderService classLoaderService = searchFactoryImplementor.getClassLoaderService();
+			factory = ClassLoaderHelper.instanceFromName( MassIndexerFactory.class, factoryClassName, "Mass indexer factory", classLoaderService );
 		}
 		else {
 			factory = new DefaultMassIndexerFactory();

--- a/orm/src/main/java/org/hibernate/search/query/hibernate/impl/ObjectLoaderBuilder.java
+++ b/orm/src/main/java/org/hibernate/search/query/hibernate/impl/ObjectLoaderBuilder.java
@@ -17,7 +17,6 @@ import org.hibernate.internal.CriteriaImpl;
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.engine.service.classloading.spi.ClassLoaderService;
 import org.hibernate.search.engine.service.classloading.spi.ClassLoadingException;
-import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.engine.spi.SearchFactoryImplementor;
 import org.hibernate.search.exception.AssertionFailure;
 import org.hibernate.search.query.DatabaseRetrievalMethod;
@@ -94,16 +93,12 @@ public class ObjectLoaderBuilder {
 		if ( criteria instanceof CriteriaImpl ) {
 			String targetEntity = ( (CriteriaImpl) criteria ).getEntityOrClassName();
 			if ( entityType == null ) {
-				ServiceManager serviceManager = searchFactoryImplementor.getServiceManager();
 				try {
-					ClassLoaderService classLoaderService = serviceManager.requestService( ClassLoaderService.class );
+					ClassLoaderService classLoaderService = searchFactoryImplementor.getClassLoaderService();
 					entityType = classLoaderService.classForName( targetEntity );
 				}
 				catch (ClassLoadingException e) {
 					throw new SearchException( "Unable to load entity class from criteria: " + targetEntity, e );
-				}
-				finally {
-					serviceManager.releaseService( ClassLoaderService.class );
 				}
 			}
 			else {

--- a/orm/src/test/java/org/hibernate/search/test/directoryProvider/CustomLockProviderTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/directoryProvider/CustomLockProviderTest.java
@@ -56,7 +56,7 @@ public class CustomLockProviderTest {
 			fail();
 		}
 		catch (SearchException e) {
-			assertEquals( "Unable to find locking_strategy implementation class: org.hibernate.NotExistingFactory", e.getCause().getMessage() );
+			assertEquals( "Unable to find locking_strategy implementation class: org.hibernate.NotExistingFactory", e.getCause().getCause().getMessage() );
 		}
 	}
 

--- a/orm/src/test/java/org/hibernate/search/test/reader/functionality/ExtendedSharingBufferReaderProvider.java
+++ b/orm/src/test/java/org/hibernate/search/test/reader/functionality/ExtendedSharingBufferReaderProvider.java
@@ -64,7 +64,7 @@ public class ExtendedSharingBufferReaderProvider extends SharingBufferReaderProv
 		private final RAMDirectoryProvider dp = new RAMDirectoryProvider();
 
 		TestManipulatorPerDP(int seed) {
-			dp.initialize( String.valueOf( seed ), null, new BuildContextForTest( new SearchConfigurationForTest() ) );
+			dp.initialize( String.valueOf( seed ), new Properties(), new BuildContextForTest( new SearchConfigurationForTest() ) );
 		}
 
 		public void setIndexChanged() {


### PR DESCRIPTION
This is needed for the boot refactoring, the SearchFactory uncoupling from its SPI, and also avoids some map lookups during Query execution.
- https://hibernate.atlassian.net/browse/HSEARCH-1724
