### PR TITLE
HSEARCH-1725 Improve allocation rate of the new Lucene synchronous batch backend

### DIFF
--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/BatchSyncProcessor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/BatchSyncProcessor.java
@@ -11,10 +11,7 @@ import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
-import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.locks.LockSupport;
 
 /**
@@ -35,7 +32,8 @@ public class BatchSyncProcessor {
 
 	private static final Log log = LoggerFactory.make();
 
-	private final BlockingQueue<Changeset> transferQueue = new LinkedBlockingDeque<>();
+	private final MultiWriteDrainableLinkedList<Changeset> transferQueue = new MultiWriteDrainableLinkedList<>();
+
 	private volatile LuceneBackendResources resources;
 	private final String indexName;
 	private volatile boolean stop = false;
@@ -72,7 +70,7 @@ public class BatchSyncProcessor {
 		wakeUpConsumer();
 		boolean interrupted = false;
 		while ( ! changeset.isProcessed() && ! interrupted ) {
-			LockSupport.park();
+			parkCurrentThread();
 			if ( Thread.interrupted() ) {
 				interrupted = true;
 			}
@@ -111,26 +109,36 @@ public class BatchSyncProcessor {
 	private class Consumer implements Runnable {
 		@Override
 		public void run() {
+			Iterable<Changeset> changesets;
 			while ( ! stop ) {
-				while ( transferQueue.isEmpty() && ! stop ) {
+				changesets = transferQueue.drainToDetachedIterable();
+				while ( changesets == null && ! stop ) {
 					// Avoid busy wait
-					LockSupport.park();
+					parkCurrentThread();
+					changesets = transferQueue.drainToDetachedIterable();
 				}
-				if ( ! transferQueue.isEmpty() ) {
-					List<Changeset> changesets = new LinkedList<>();
-					transferQueue.drainTo( changesets );
-					ChangesetList changesetList = new ChangesetList( changesets );
-					try {
-						LuceneBackendQueueTask luceneBackendQueueTask = new LuceneBackendQueueTask( changesetList.getWork(), resources, null );
-						luceneBackendQueueTask.run();
-					}
-					finally {
-						changesetList.markProcessed();
-					}
+				if ( changesets != null ) {
+					applyChangesets( changesets );
 				}
 			}
 			log.stoppingSyncConsumerThread( indexName );
 		}
+
+		private void applyChangesets(Iterable<Changeset> changesets) {
+			ChangesetList changesetList = new ChangesetList( changesets );
+			try {
+				LuceneBackendQueueTask luceneBackendQueueTask = new LuceneBackendQueueTask( changesetList, resources, null );
+				luceneBackendQueueTask.run();
+			}
+			finally {
+				changesetList.markProcessed();
+			}
+		}
+	}
+
+	private void parkCurrentThread() {
+		//Always use some safety margin when parking threads:
+		LockSupport.parkNanos( 1_000_000_000 );
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/Changeset.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/Changeset.java
@@ -9,6 +9,7 @@ package org.hibernate.search.backend.impl.lucene;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.locks.LockSupport;
 
@@ -30,8 +31,8 @@ final class Changeset {
 		this.monitor = monitor;
 	}
 
-	List<LuceneWork> getWorkList() {
-		return workList;
+	Iterator<LuceneWork> getWorkListIterator() {
+		return workList.iterator();
 	}
 
 	IndexingMonitor getMonitor() {

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/ChangesetList.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/ChangesetList.java
@@ -6,36 +6,72 @@
  */
 package org.hibernate.search.backend.impl.lucene;
 
-import org.hibernate.search.backend.LuceneWork;
+import java.util.Collections;
+import java.util.Iterator;
 
-import java.util.ArrayList;
-import java.util.List;
+import org.hibernate.search.backend.LuceneWork;
 
 /**
  * Aggregator for {@link org.hibernate.search.backend.impl.lucene.Changeset}
  *
  * @author gustavonalle
  */
-final class ChangesetList {
+final class ChangesetList implements Iterable<LuceneWork> {
 
-	private final List<Changeset> changesets;
+	private final Iterable<Changeset> changesets;
 
-	ChangesetList(List<Changeset> changesets) {
+	ChangesetList(Iterable<Changeset> changesets) {
 		this.changesets = changesets;
-	}
-
-	List<LuceneWork> getWork() {
-		ArrayList<LuceneWork> luceneWorks = new ArrayList<>();
-		for ( Changeset changeset : changesets ) {
-			luceneWorks.addAll( changeset.getWorkList() );
-		}
-		return luceneWorks;
 	}
 
 	void markProcessed() {
 		for ( Changeset changeset : changesets ) {
 			changeset.markProcessed();
 		}
+	}
+
+	@Override
+	public Iterator<LuceneWork> iterator() {
+		return new WorkIterator( changesets.iterator() );
+	}
+
+	/**
+	 * A shallow iterator on all LuceneWork which avoids collection copies.
+	 * Optimized as this code area is very hot at runtime.
+	 */
+	private static class WorkIterator implements Iterator<LuceneWork> {
+
+		private Iterator<Changeset> outerIterator;
+		private Iterator<LuceneWork> current = Collections.<LuceneWork>emptyIterator();
+
+		public WorkIterator(Iterator<Changeset> iterator) {
+			this.outerIterator = iterator;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return current.hasNext() || outerIterator.hasNext();
+		}
+
+		@Override
+		public LuceneWork next() {
+			if ( current.hasNext() ) {
+				//advance the inner loop only
+				return current.next();
+			}
+			else {
+				//advance outer loop first
+				Changeset next = outerIterator.next();
+				current = next.getWorkListIterator();
+				return current.next();
+			}
+		}
+
+		@Override
+		public void remove() {
+			throw new UnsupportedOperationException( "This iterator is unable to remove elements" );
+		}
+
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/LuceneBackendQueueTask.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/LuceneBackendQueueTask.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.backend.impl.lucene;
 
-import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.locks.Lock;
 
@@ -31,10 +30,10 @@ final class LuceneBackendQueueTask implements Runnable {
 
 	private final Lock modificationLock;
 	private final LuceneBackendResources resources;
-	private final List<LuceneWork> workList;
+	private final Iterable<LuceneWork> workList;
 	private final IndexingMonitor monitor;
 
-	LuceneBackendQueueTask(List<LuceneWork> workList, LuceneBackendResources resources, IndexingMonitor monitor) {
+	LuceneBackendQueueTask(Iterable<LuceneWork> workList, LuceneBackendResources resources, IndexingMonitor monitor) {
 		this.workList = workList;
 		this.resources = resources;
 		this.monitor = monitor;

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/MultiWriteDrainableLinkedList.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/MultiWriteDrainableLinkedList.java
@@ -1,0 +1,139 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.impl.lucene;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.concurrent.locks.ReentrantLock;
+
+
+/**
+ * A custom structure similar to a concurrent linked list.
+ *
+ * This could be functionally replaced by a LinkedBlockingDeque, but we only
+ * need a specific subset of its functionality.
+ * Specifically, we need to maintain the order of elements being added, but on
+ * a drain we'll only ever need to iterate the list sequentially, and the
+ * drain needs to atomically reset the queue.
+ *
+ * @author Sanne Grinovero <sanne@hibernate.org> (C) 2014 Red Hat Inc.
+ * @since 5.0
+ */
+final class MultiWriteDrainableLinkedList<T> {
+
+	private final ReentrantLock lock = new ReentrantLock();
+
+	//Guarded by lock
+	private Node<T> first = null;
+
+	//Guarded by lock
+	private Node<T> last = null;
+
+	/**
+	 * Adds a new entry to this list.
+	 */
+	void add(T element) {
+		final Node<T> newnode = new Node<T>( element );
+		final ReentrantLock lock = this.lock;
+		lock.lock();
+		try {
+			if ( first == null ) {
+				first = newnode;
+				last = newnode;
+			}
+			else {
+				last.next = newnode;
+				last = newnode;
+			}
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+	/**
+	 * Returns an Iterable over all results added so far, but
+	 * atomically clears the structure as well.
+	 * The returned iterable will be the only entry point to
+	 * read the previously appended data.
+	 * @return an Iterable, or null if there is no data.
+	 */
+	Iterable<T> drainToDetachedIterable() {
+		final Node<T> head;
+		final ReentrantLock lock = this.lock;
+		lock.lock();
+		try {
+			head = first;
+			first = null;
+			last = null;
+		}
+		finally {
+			lock.unlock();
+		}
+		if ( head != null ) {
+			return new DetachedNodeIterable<T>( head );
+		}
+		else {
+			//The choice to return null rather than an empty iterator
+			//allows the client to not need an isEmpty() method, which would
+			//need a different level of lock granularity.
+			return null;
+		}
+	}
+
+	static final class Node<T> {
+		T value;
+		Node<T> next;
+		Node(T x) {
+			value = x;
+		}
+	}
+
+	static final class DetachedNodeIterable<T> implements Iterable<T> {
+
+		private Node<T> head;
+
+		public DetachedNodeIterable(Node<T> head) {
+			this.head = head;
+		}
+
+		@Override
+		public Iterator<T> iterator() {
+			return new DetachedNodeIterator<T>( head );
+		}
+	}
+
+	static final class DetachedNodeIterator<T> implements Iterator<T> {
+
+		private Node<T> current;
+
+		DetachedNodeIterator(Node head) {
+			this.current = head;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return current != null;
+		}
+
+		@Override
+		public T next() {
+			if ( current == null ) {
+				throw new NoSuchElementException();
+			}
+			T v = current.value;
+			current = current.next;
+			return v;
+		}
+
+		@Override
+		public void remove() {
+			throw new UnsupportedOperationException( "This iterator is unable to remove elements" );
+		}
+	}
+
+}

--- a/engine/src/main/java/org/hibernate/search/exception/impl/ErrorContextBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/exception/impl/ErrorContextBuilder.java
@@ -20,7 +20,7 @@ import org.hibernate.search.exception.ErrorContext;
 public class ErrorContextBuilder {
 
 	private Throwable th;
-	private List<LuceneWork> workToBeDone;
+	private Iterable<LuceneWork> workToBeDone;
 	private List<LuceneWork> failingOperations;
 	private List<LuceneWork> operationsThatWorked;
 
@@ -45,8 +45,8 @@ public class ErrorContextBuilder {
 
 	}
 
-	public ErrorContextBuilder allWorkToBeDone(List<LuceneWork> workOnWriter) {
-		this.workToBeDone = new ArrayList<LuceneWork>( workOnWriter );
+	public ErrorContextBuilder allWorkToBeDone(Iterable<LuceneWork> workOnWriter) {
+		this.workToBeDone = workOnWriter;
 		return this;
 	}
 
@@ -57,7 +57,10 @@ public class ErrorContextBuilder {
 
 		// for situation when there is a primary failure
 		if ( workToBeDone != null ) {
-			List<LuceneWork> workLeft = new ArrayList<LuceneWork>( workToBeDone );
+			List<LuceneWork> workLeft = new ArrayList<LuceneWork>();
+			for ( LuceneWork work : workToBeDone ) {
+				workLeft.add( work );
+			}
 			if ( operationsThatWorked != null ) {
 				workLeft.removeAll( operationsThatWorked );
 			}


### PR DESCRIPTION
When testing low-scale I couldn't detect any performance improvement, still this has a lower contention point on the work queue and keeps the allocation rate of objects much lower.

Also improves the allocation rate for the garbage created by the `ErrorHandler`, at cost of being slightly less efficient in the case there actually is an error (which is hopefully a great bargain).
- https://hibernate.atlassian.net/browse/HSEARCH-1725
