### PR TITLE
HSEARCH-1726 Allow performance validation tests to run on MariaDB

### DIFF
--- a/integrationtest/performance/readme.md
+++ b/integrationtest/performance/readme.md
@@ -37,17 +37,13 @@ A system property enables them:
 
     > mvn clean test -Dtest=TestRunnerStandalone -Dscenario=org.hibernate.search.test.performance.scenario.FileSystemDefaultTestScenario -Dorg.hibernate.search.enable_performance_tests=true
 
-- run tests in standalone mode against specified database (via system properties)
+- run tests in standalone mode against a PostgreSQL database (via system properties)
 
-    > mvn clean test -Ppostgresql84
-                     -Dtest=TestRunnerStandalone 
-                     -Dscenario=org.hibernate.search.test.performance.scenario.FileSystemDefaultTestScenario
-                     -Dhibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
-                     -Dhibernate.connection.driver_class=org.postgresql.Driver
-                     -Dhibernate.connection.url=jdbc:postgresql://localhost:5432/dev
-                     -Dhibernate.connection.username=foo
-                     -Dhibernate.connection.password=foo
-                     -Dorg.hibernate.search.enable_performance_tests=true
+    > mvn clean test -Ppostgresql84 -Dtest=TestRunnerStandalone -Dscenario=org.hibernate.search.test.performance.scenario.FileSystemDefaultTestScenario -Dhibernate.dialect=org.hibernate.dialect.PostgreSQLDialect -Dhibernate.connection.driver_class=org.postgresql.Driver -Dhibernate.connection.url=jdbc:postgresql://localhost:5432/dev -Dhibernate.connection.username=foo -Dhibernate.connection.password=foo -Dorg.hibernate.search.enable_performance_tests=true
+
+- run tests in standalone mode against a MariaDB database (via system properties)
+
+    > mvn clean test -Pmysql51 -Dtest=TestRunnerStandalone -Dscenario=org.hibernate.search.test.performance.scenario.FileSystemDefaultTestScenario -Dhibernate.hikari.dataSourceClassName=com.mysql.jdbc.jdbc2.optional.MysqlDataSource -Dhibernate.dialect=org.hibernate.dialect.MySQL5InnoDBDialect -Dhibernate.hikari.dataSource.url=jdbc:mysql://hostname:3306/hibperf -Dhibernate.hikari.dataSource.user=foo -Dhibernate.hikari.dataSource.password=foo -Dorg.hibernate.search.enable_performance_tests=true
                      
 - run tests in container mode against default data source (java:jboss/datasources/ExampleDS)
 
@@ -55,7 +51,4 @@ A system property enables them:
 
 - run tests in container mode against specified data source (via system property)                     
     
-    > mvn clean test -Dtest=TestRunnerArquillian
-                     -Dscenario=org.hibernate.search.test.performance.scenario.FileSystemDefaultTestScenario 
-                     -Ddatasource=foo
-                     -Dorg.hibernate.search.enable_performance_tests=true
+    > mvn clean test -Dtest=TestRunnerArquillian -Dscenario=org.hibernate.search.test.performance.scenario.FileSystemDefaultTestScenario -Ddatasource=foo -Dorg.hibernate.search.enable_performance_tests=true

--- a/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/model/Author.java
+++ b/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/model/Author.java
@@ -8,6 +8,7 @@ package org.hibernate.search.test.performance.model;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.Table;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.hibernate.search.annotations.Field;
@@ -16,6 +17,7 @@ import org.hibernate.search.annotations.Field;
  * @author Tomas Hradec
  */
 @Entity
+@Table(name = "author")
 public class Author {
 
 	@Id

--- a/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/model/Book.java
+++ b/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/model/Book.java
@@ -16,6 +16,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.ManyToMany;
+import javax.persistence.Table;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.lucene.analysis.core.LowerCaseFilterFactory;
@@ -40,6 +41,7 @@ import org.hibernate.search.annotations.TokenizerDef;
  * @author Tomas Hradec
  */
 @Entity
+@Table(name = "book")
 @Indexed
 @AnalyzerDef(name = "textAnalyzer", tokenizer = @TokenizerDef(factory = StandardTokenizerFactory.class), filters = {
 		@TokenFilterDef(factory = LowerCaseFilterFactory.class),


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HSEARCH-1726

Also reformatting the examples in the readme, as it's otherwise very unpractical to use.
