### PR TITLE
HSEARCH-1760 Projection on "Id" keyword should not be repeated on a matc...

### DIFF
--- a/engine/src/main/java/org/hibernate/search/engine/impl/DocumentBuilderHelper.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/DocumentBuilderHelper.java
@@ -144,7 +144,7 @@ public final class DocumentBuilderHelper {
 			for ( DocumentFieldMetadata fieldMetadata : propertyMetadata.getFieldMetadata() ) {
 				final String fieldName = fieldMetadata.getName();
 				int matchingPosition = getFieldPosition( fields, fieldName );
-				if ( matchingPosition != -1 ) {
+				if ( matchingPosition != -1 && result[matchingPosition] == NOT_SET ) {
 					contextualBridge.pushProperty( fieldName );
 					try {
 						populateResult(
@@ -183,7 +183,7 @@ public final class DocumentBuilderHelper {
 		//process class bridges
 		for ( DocumentFieldMetadata fieldMetadata : typeMetadata.getClassBridgeMetadata() ) {
 			int matchingPosition = getFieldPosition( fields, fieldMetadata.getName() );
-			if ( matchingPosition != -1 ) {
+			if ( matchingPosition != -1 && result[matchingPosition] == NOT_SET ) {
 				populateResult(
 						fieldMetadata.getName(),
 						fieldMetadata.getFieldBridge(),


### PR DESCRIPTION
...hing field name as field projection

https://hibernate.atlassian.net/browse/HSEARCH-1760

@hferentschik this also prevents a projection error on the id field in case of ambiguity, but I'm not adding a test as I think it's going to be outdated by your work on HSEARCH-1759

Still worth applying this from a performance perspective. Also I'm not sure if there might be other ambiguities in metadata mapping, it could prevent some nasty issues.. but since this is hypotetically speaking I'm not sure how I would test for that. Just seems safer.
