### PR TITLE
HSEARCH-1769 Fix NoSuchElementException error in SyncWorkProcessor

### DIFF
--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/SyncWorkProcessor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/SyncWorkProcessor.java
@@ -28,6 +28,8 @@ import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.List;
 import java.util.concurrent.locks.LockSupport;
 
@@ -82,6 +84,18 @@ final class SyncWorkProcessor implements WorkProcessor {
 	 * @param monitor for statistics collection
 	 */
 	public void submit(List<LuceneWork> workList, IndexingMonitor monitor) {
+		//avoid empty work lists as workaround for HSEARCH-1769
+		if ( workList.isEmpty() ) {
+			// only log this error at trace level until we properly fix HSEARCH-1769
+			if ( log.isTraceEnabled() ) {
+				StringWriter stackTraceStringWriter = new StringWriter();
+				PrintWriter stackTracePrintWriter = new PrintWriter( stackTraceStringWriter );
+				new Throwable().printStackTrace( stackTracePrintWriter );
+				log.workListShouldNeverBeEmpty( stackTraceStringWriter.toString() );
+			}
+			// skip that work
+			return;
+		}
 		Changeset changeset = new Changeset( workList, Thread.currentThread(), monitor );
 		transferQueue.add( changeset );
 		wakeUpConsumer();

--- a/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
@@ -789,4 +789,8 @@ public interface Log extends BasicLogger {
 	@LogMessage(level = Level.DEBUG)
 	@Message(id = 233, value = "Backend for index '%s' started: using an Asynchronous backend with periodic commits." )
 	void luceneBackendInitializedAsynchronously(String indexName);
+
+	@LogMessage(level = Level.TRACE)
+	@Message(id = 234, value = "WorkList should never be empty. Stacktrace below \n %s" )
+	void workListShouldNeverBeEmpty(String stackTrace);
 }


### PR DESCRIPTION
@gustavonalle (cc @Sanne) here is the fix I am thinking of.

I don't know how to properly test that situation. I walked the code for 1.5 hours and I cannot find the reason why an empty List<LuceneWork> arrives here. It *might* be due to a different problem?
To further track this down, I also added a log to be able to detect empty lists before they go to a different thread.

My changes pass the test suite. Not sure how much of that feature was covered though.

We can apply to master when you guys are happy.