### PR TITLE
HSEARCH-295 Automatically determining filter key based on all parameter names and values

### DIFF
--- a/documentation/src/main/asciidoc/ch05.asciidoc
+++ b/documentation/src/main/asciidoc/ch05.asciidoc
@@ -1283,7 +1283,6 @@ whose score is 5. In this example the specified filter implements the
 If your Filter creation requires additional steps or if the filter you want to use does not have a
 no-arg constructor, you can use the factory pattern:
 
-
 .Creating a filter using the factory pattern
 ====
 [source, JAVA]
@@ -1320,7 +1319,7 @@ fullTextQuery.enableFullTextFilter("security").setParameter("level", 5);
 ----
 ====
 
-Each parameter name should have an associated setter on either the filter or filter factory of the
+Each parameter must have an associated setter on either the filter or filter factory of the
 targeted named filter definition.
 
 .Using parameters in the actual filter implementation
@@ -1337,36 +1336,52 @@ public class SecurityFilterFactory {
         this.level = level;
     }
 
-    @Key
-    public FilterKey getKey() {
-        StandardFilterKey key = new StandardFilterKey();
-        key.addParameter( level );
-        return key;
-    }
-
     @Factory
     public Filter getFilter() {
-        Query query = new TermQuery( new Term("level", level.toString() ) );
+        Query query = new TermQuery( new Term( "level", level.toString() ) );
         return new CachingWrapperFilter( new QueryWrapperFilter(query) );
     }
 }
 ----
 ====
 
-Note the method annotated `@Key` returning a `FilterKey` object. The returned object has a special
-contract: the key object must implement equals() / hashCode() so that 2 keys are equal if and only
+By default filters will be cached once created, based on all their parameter names and values.
+Optionally you can provide a custom filter key implementation, which e.g. may be beneficial in terms of memory consumption.
+To do so, declare a method annotated with `@Key`, returning a `FilterKey` object:
+
+.Providing a custom filter key
+====
+[source, JAVA]
+----
+public class SecurityFilterFactory {
+
+    private Integer level;
+
+    // setLevel(), getFilter() ...
+
+    @Key
+    public FilterKey getKey() {
+        StandardFilterKey key = new StandardFilterKey();
+        key.addParameter( level );
+        return key;
+    }
+}
+----
+====
+
+The returned filter key object must implement equals() / hashCode() so that 2 keys are equal if and only
 if the given Filter types are the same and the set of parameters are the same. In other words, 2
 filter keys are equal if and only if the filters from which the keys are generated can be
 interchanged. The key object is used as a key in the cache mechanism.
 
-`@Key` methods are needed only if:
-
-
-* you enabled the filter caching system (enabled by default)
-* your filter has parameters
-
 In most cases, using the `StandardFilterKey` implementation will be good enough. It delegates the
 `equals()` / `hashCode()` implementation to each of the parameters equals and hashCode methods.
+
+Note that a `@Key` method is generally not needed. You still may consider to add one if the default implementation is not efficient enough.
+No key method is needed at all if
+
+* you disabled the filter caching system (enabled by default)
+* your filter has no parameters
 
 As mentioned before the defined filters are per default cached and the cache uses a combination of
 hard and soft references to allow disposal of memory when needed. The hard reference cache keeps

--- a/engine/src/main/java/org/hibernate/search/annotations/FullTextFilterDef.java
+++ b/engine/src/main/java/org/hibernate/search/annotations/FullTextFilterDef.java
@@ -6,11 +6,11 @@
  */
 package org.hibernate.search.annotations;
 
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Documented;
 
 /**
  * Defines a FullTextFilter that can be optionally applied to
@@ -23,21 +23,30 @@ import java.lang.annotation.Documented;
 @Target( { ElementType.TYPE } )
 @Documented
 public @interface FullTextFilterDef {
+
 	/**
 	 * @return the filter name. Must be unique across all mappings for a given persistence unit
 	 */
 	String name();
 
 	/**
-	 * Either implements {@link org.apache.lucene.search.Filter}
-	 * or contains a <code>@Factory</code> method returning one.
-	 * The generated <code>Filter</code> must be thread-safe.
+	 * The implementation of this filter definition. May be
+	 * <ul>
+	 * <li>a class implementing {@link org.apache.lucene.search.Filter} or</li>
+	 * <li>a filter factory class, defining a method annotated with {@link Factory} which has no parameters and returns
+	 * a {@code Filter} instance.</li>
+	 * </ul>
+	 * The given class must define a no-args constructor and a JavaBeans setter method for each parameter to be passed
+	 * via {@link org.hibernate.search.filter.FullTextFilter#setParameter(String, Object)}.
+	 * <p>
+	 * It may optionally declare a parameterless method annotated with {@link Key} returning the
+	 * {@link org.hibernate.search.filter.FilterKey} to be used for caching the Lucene filters created from this filter
+	 * definition. If no such method exists, a cache key will be built from the names and values of all the filter's
+	 * parameters.
+	 * <p>
+	 * The Lucene filter created by this filter definition must be thread-safe.
 	 *
-	 * If the filter accept parameters, an <code>@Key</code> method must be present as well.
-	 *
-	 * @return a class which either implements <code>Filter</code> directly or contains a method annotated with
-	 * <code>@Factory</code>.
-	 *
+	 * @return A class implementing {@code Filter} or a filter factory class
 	 */
 	Class<?> impl();
 

--- a/engine/src/main/java/org/hibernate/search/engine/impl/FilterDef.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/FilterDef.java
@@ -11,10 +11,12 @@ import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.annotations.FilterCacheModeType;
 import org.hibernate.search.annotations.FullTextFilterDef;
+import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.util.impl.ReflectionHelper;
+import org.hibernate.search.util.logging.impl.Log;
+import org.hibernate.search.util.logging.impl.LoggerFactory;
 
 /**
  * A wrapper class which encapsulates all required information to create a defined filter.
@@ -23,9 +25,12 @@ import org.hibernate.search.util.impl.ReflectionHelper;
  */
 //TODO serialization
 public class FilterDef {
+
+	private static final Log LOG = LoggerFactory.make();
+
 	private Method factoryMethod;
 	private Method keyMethod;
-	private Map<String, Method> setters = new HashMap<String, Method>();
+	private final Map<String, Method> setters = new HashMap<String, Method>();
 	private final FilterCacheModeType cacheMode;
 	private final Class<?> impl;
 	private final String name;
@@ -77,15 +82,15 @@ public class FilterDef {
 		try {
 			method.invoke( filter, parameterValue );
 		}
-		catch (IllegalAccessException e) {
-			throw new SearchException( "Unable to set Filter parameter: " + parameterName + " on filter class: " + this.impl, e );
+		catch (IllegalAccessException | InvocationTargetException | IllegalArgumentException e) {
+			throw LOG.unableToSetFilterParameter( impl, parameterName, e );
 		}
-		catch (InvocationTargetException e) {
-			throw new SearchException( "Unable to set Filter parameter: " + parameterName + " on filter class: " + this.impl, e );
-		}
-		catch (IllegalArgumentException e) {
-			throw new SearchException( "Unable to set Filter parameter: " + parameterName + " on filter class: "
-					+ this.impl + " : " + e.getMessage(), e );
-		}
+	}
+
+	@Override
+	public String toString() {
+		return "FilterDef [name=" + name + ", impl=" + impl + ", cacheMode=" + cacheMode + ", factoryMethod="
+				+ ( factoryMethod != null ? factoryMethod.getName() : null ) + ", keyMethod=" + ( keyMethod != null ? keyMethod.getName() : null )
+				+ ", setters=" + setters.keySet() + "]";
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/filter/StandardFilterKey.java
+++ b/engine/src/main/java/org/hibernate/search/filter/StandardFilterKey.java
@@ -68,4 +68,9 @@ public class StandardFilterKey extends FilterKey {
 		}
 		return true;
 	}
+
+	@Override
+	public String toString() {
+		return "StandardFilterKey [parameters=" + parameters + "]";
+	}
 }

--- a/engine/src/main/java/org/hibernate/search/filter/impl/DefaultFilterKey.java
+++ b/engine/src/main/java/org/hibernate/search/filter/impl/DefaultFilterKey.java
@@ -1,0 +1,75 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.filter.impl;
+
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.hibernate.search.filter.FilterKey;
+
+/**
+ * A {@link FilterKey} based on the name of a filter definition and the name/value pairs passed to a given instantiation
+ * of that definition.
+ *
+ * @author Gunnar Morling
+ */
+public class DefaultFilterKey extends FilterKey {
+
+	private final String filterDefName;
+	private final SortedMap<String, Object> parameters;
+
+	public DefaultFilterKey(String filterDefName, Map<String, Object> parameters) {
+		this.filterDefName = filterDefName;
+		this.parameters = new TreeMap<>( parameters );
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ( ( filterDefName == null ) ? 0 : filterDefName.hashCode() );
+		result = prime * result + ( ( parameters == null ) ? 0 : parameters.hashCode() );
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ( this == obj ) {
+			return true;
+		}
+		if ( obj == null ) {
+			return false;
+		}
+		if ( getClass() != obj.getClass() ) {
+			return false;
+		}
+		DefaultFilterKey other = (DefaultFilterKey) obj;
+		if ( filterDefName == null ) {
+			if ( other.filterDefName != null ) {
+				return false;
+			}
+		}
+		else if ( !filterDefName.equals( other.filterDefName ) ) {
+			return false;
+		}
+		if ( parameters == null ) {
+			if ( other.parameters != null ) {
+				return false;
+			}
+		}
+		else if ( !parameters.equals( other.parameters ) ) {
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "DefaultFilterKey [filterDefName=" + filterDefName + ", parameters=" + parameters + "]";
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/filter/impl/FullTextFilterImpl.java
+++ b/engine/src/main/java/org/hibernate/search/filter/impl/FullTextFilterImpl.java
@@ -42,4 +42,9 @@ public class FullTextFilterImpl implements FullTextFilterImplementor {
 	public Map<String, Object> getParameters() {
 		return parameters;
 	}
+
+	@Override
+	public String toString() {
+		return "FullTextFilterImpl [name=" + name + ", parameters=" + parameters + "]";
+	}
 }

--- a/engine/src/main/java/org/hibernate/search/query/engine/impl/HSQueryImpl.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/impl/HSQueryImpl.java
@@ -786,13 +786,7 @@ public class HSQueryImpl implements HSQuery, Serializable {
 			try {
 				filter = (Filter) def.getFactoryMethod().invoke( instance );
 			}
-			catch (IllegalAccessException e) {
-				throw new SearchException(
-						"Unable to access @Factory method: "
-								+ def.getImpl().getName() + "." + def.getFactoryMethod().getName(), e
-				);
-			}
-			catch (InvocationTargetException e) {
+			catch (IllegalAccessException | InvocationTargetException e) {
 				throw new SearchException(
 						"Unable to access @Factory method: "
 								+ def.getImpl().getName() + "." + def.getFactoryMethod().getName(), e
@@ -800,7 +794,7 @@ public class HSQueryImpl implements HSQuery, Serializable {
 			}
 			catch (ClassCastException e) {
 				throw new SearchException(
-						"@Key method does not return a org.apache.lucene.search.Filter class: "
+						"Factory method does not return a org.apache.lucene.search.Filter class: "
 								+ def.getImpl().getName() + "." + def.getFactoryMethod().getName(), e
 				);
 			}

--- a/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
@@ -743,4 +743,7 @@ public interface Log extends BasicLogger {
 
 	@Message(id = 250, value = "Unsupported value type for configuration property " + Environment.ERROR_HANDLER + ": %1$s")
 	SearchException unsupportedErrorHandlerConfigurationValueType(@FormatWith(ClassFormatter.class) Class<?> errorHandlerValueType);
+
+	@Message(id = 251, value = "Unable to set filter parameter '%2$s' on filter class %1$s")
+	SearchException unableToSetFilterParameter(Class<?> filterClass, String parameterName, @Cause Exception e);
 }

--- a/orm/src/test/java/org/hibernate/search/test/filter/Driver.java
+++ b/orm/src/test/java/org/hibernate/search/test/filter/Driver.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.test.filter;
 
 import java.util.Date;
+
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
@@ -39,12 +40,18 @@ import org.hibernate.search.bridge.builtin.IntegerBridge;
 		@FullTextFilterDef(name = "fieldConstraintFilter-2",
 				impl = FieldConstraintFilterFactory.class,
 				cache = FilterCacheModeType.INSTANCE_AND_DOCIDSETRESULTS),
+		@FullTextFilterDef(name = "cacheinstancewithoutkeymethodtest",
+				impl = FieldConstraintFilterWithoutKeyMethod.class,
+				cache = FilterCacheModeType.INSTANCE_AND_DOCIDSETRESULTS),
 		//Filter factory with parameters
 		@FullTextFilterDef(name = "cacheresultstest",
 				impl = ExcludeAllFilterFactory.class,
 				cache = FilterCacheModeType.INSTANCE_AND_DOCIDSETRESULTS),
 		@FullTextFilterDef(name = "cacheinstancetest",
 				impl = InstanceBasedExcludeAllFilter.class,
+				cache = FilterCacheModeType.INSTANCE_ONLY),
+		@FullTextFilterDef(name = "cacheinstancefromfactorywithoutkeymethodtest",
+				impl = FieldConstraintFilterFactoryWithoutKeyMethod.class,
 				cache = FilterCacheModeType.INSTANCE_ONLY),
 		@FullTextFilterDef(name = "empty",
 				impl = NullReturningEmptyFilter.class,

--- a/orm/src/test/java/org/hibernate/search/test/filter/Driver.java
+++ b/orm/src/test/java/org/hibernate/search/test/filter/Driver.java
@@ -34,10 +34,10 @@ import org.hibernate.search.bridge.builtin.IntegerBridge;
 				impl = SecurityFilterFactory.class,
 				cache = FilterCacheModeType.INSTANCE_AND_DOCIDSETRESULTS),
 		@FullTextFilterDef(name = "fieldConstraintFilter-1",
-				impl = FieldConstraintFilter.class,
+				impl = FieldConstraintFilterFactory.class,
 				cache = FilterCacheModeType.INSTANCE_AND_DOCIDSETRESULTS),
 		@FullTextFilterDef(name = "fieldConstraintFilter-2",
-				impl = FieldConstraintFilter.class,
+				impl = FieldConstraintFilterFactory.class,
 				cache = FilterCacheModeType.INSTANCE_AND_DOCIDSETRESULTS),
 		//Filter factory with parameters
 		@FullTextFilterDef(name = "cacheresultstest",

--- a/orm/src/test/java/org/hibernate/search/test/filter/FieldConstraintFilterFactory.java
+++ b/orm/src/test/java/org/hibernate/search/test/filter/FieldConstraintFilterFactory.java
@@ -11,15 +11,22 @@ import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryWrapperFilter;
 import org.apache.lucene.search.TermQuery;
-
+import org.hibernate.search.annotations.Factory;
+import org.hibernate.search.annotations.Key;
+import org.hibernate.search.filter.FilterKey;
 import org.hibernate.search.filter.StandardFilterKey;
 import org.hibernate.search.filter.impl.CachingWrapperFilter;
 
-public class FieldConstraintFilter {
+/**
+ * Creates a filter for a given field.
+ *
+ * @author Hardy Ferentschik
+ */
+public class FieldConstraintFilterFactory {
 	private String field;
 	private String value;
 
-	@org.hibernate.search.annotations.Factory
+	@Factory
 	public Filter buildFilter() {
 		Query q = new TermQuery( new Term( field, value ) );
 		Filter filter = new QueryWrapperFilter( q );
@@ -35,8 +42,8 @@ public class FieldConstraintFilter {
 		this.value = value;
 	}
 
-	@org.hibernate.search.annotations.Key
-	public org.hibernate.search.filter.FilterKey getKey() {
+	@Key
+	public FilterKey getKey() {
 		StandardFilterKey key = new StandardFilterKey();
 		key.addParameter( field );
 		key.addParameter( value );

--- a/orm/src/test/java/org/hibernate/search/test/filter/FieldConstraintFilterFactoryWithoutKeyMethod.java
+++ b/orm/src/test/java/org/hibernate/search/test/filter/FieldConstraintFilterFactoryWithoutKeyMethod.java
@@ -1,0 +1,122 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.filter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Filter;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryWrapperFilter;
+import org.apache.lucene.search.TermQuery;
+import org.hibernate.search.annotations.Factory;
+import org.hibernate.search.filter.impl.CachingWrapperFilter;
+
+/**
+ * Creates a filter for a given field, providing access to all invocations of {@link #buildFilter()} for testing
+ * purposes.
+ *
+ * @author Hardy Ferentschik
+ * @author Gunnar Morling
+ */
+public class FieldConstraintFilterFactoryWithoutKeyMethod {
+
+	private static List<BuildFilterInvocation> builtFilters = new ArrayList<>();
+
+	private String field;
+	private String value;
+
+	@Factory
+	public Filter buildFilter() {
+		builtFilters.add( new BuildFilterInvocation( field, value ) );
+
+		Query q = new TermQuery( new Term( field, value ) );
+		Filter filter = new QueryWrapperFilter( q );
+		filter = new CachingWrapperFilter( filter );
+
+		return filter;
+	}
+
+	public void setField(String field) {
+		this.field = field;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+
+	static List<BuildFilterInvocation> getBuiltFilters() {
+		return builtFilters;
+	}
+
+	/**
+	 * Represents one invocation of {@link FieldConstraintFilterFactoryWithoutKeyMethod#buildFilter()}.
+	 */
+	static class BuildFilterInvocation {
+		private final String field;
+		private final String value;
+
+		public BuildFilterInvocation(String field, String value) {
+			this.field = field;
+			this.value = value;
+		}
+
+		public String getField() {
+			return field;
+		}
+
+		public String getValue() {
+			return value;
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + ( ( field == null ) ? 0 : field.hashCode() );
+			result = prime * result + ( ( value == null ) ? 0 : value.hashCode() );
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if ( this == obj ) {
+				return true;
+			}
+			if ( obj == null ) {
+				return false;
+			}
+			if ( getClass() != obj.getClass() ) {
+				return false;
+			}
+			BuildFilterInvocation other = (BuildFilterInvocation) obj;
+			if ( field == null ) {
+				if ( other.field != null ) {
+					return false;
+				}
+			}
+			else if ( !field.equals( other.field ) ) {
+				return false;
+			}
+			if ( value == null ) {
+				if ( other.value != null ) {
+					return false;
+				}
+			}
+			else if ( !value.equals( other.value ) ) {
+				return false;
+			}
+			return true;
+		}
+
+		@Override
+		public String toString() {
+			return "BuildFilterInvocation [field=" + field + ", value=" + value + "]";
+		}
+	}
+}

--- a/orm/src/test/java/org/hibernate/search/test/filter/FieldConstraintFilterWithoutKeyMethod.java
+++ b/orm/src/test/java/org/hibernate/search/test/filter/FieldConstraintFilterWithoutKeyMethod.java
@@ -1,0 +1,112 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.filter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.lucene.index.AtomicReaderContext;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.DocIdSet;
+import org.apache.lucene.search.Filter;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryWrapperFilter;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.util.Bits;
+import org.hibernate.search.filter.impl.CachingWrapperFilter;
+
+/**
+ * A filter based on a given value for a given field.
+ *
+ * @author Gunnar Morling
+ */
+public class FieldConstraintFilterWithoutKeyMethod extends Filter {
+
+	private static List<FieldConstraintFilterWithoutKeyMethod> instances = new ArrayList<>();
+
+	private String field;
+	private String value;
+
+	// used by the engine
+	public FieldConstraintFilterWithoutKeyMethod() {
+		instances.add( this );
+	}
+
+	// used for assertions only
+	FieldConstraintFilterWithoutKeyMethod(String field, String value) {
+		this.field = field;
+		this.value = value;
+	}
+
+	public void setField(String field) {
+		this.field = field;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+
+	@Override
+	public DocIdSet getDocIdSet(AtomicReaderContext context, Bits acceptDocs) throws IOException {
+		Query q = new TermQuery( new Term( field, value ) );
+		Filter filter = new QueryWrapperFilter( q );
+		filter = new CachingWrapperFilter( filter );
+
+		return filter.getDocIdSet( context, acceptDocs );
+	}
+
+
+	public static List<FieldConstraintFilterWithoutKeyMethod> getInstances() {
+		return instances;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ( ( field == null ) ? 0 : field.hashCode() );
+		result = prime * result + ( ( value == null ) ? 0 : value.hashCode() );
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ( this == obj ) {
+			return true;
+		}
+		if ( obj == null ) {
+			return false;
+		}
+		if ( getClass() != obj.getClass() ) {
+			return false;
+		}
+		FieldConstraintFilterWithoutKeyMethod other = (FieldConstraintFilterWithoutKeyMethod) obj;
+		if ( field == null ) {
+			if ( other.field != null ) {
+				return false;
+			}
+		}
+		else if ( !field.equals( other.field ) ) {
+			return false;
+		}
+		if ( value == null ) {
+			if ( other.value != null ) {
+				return false;
+			}
+		}
+		else if ( !value.equals( other.value ) ) {
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "FieldConstraintFilterWithoutKeyMethod [field=" + field + ", value=" + value + "]";
+	}
+}

--- a/orm/src/test/java/org/hibernate/search/test/filter/FilterTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/filter/FilterTest.java
@@ -97,7 +97,7 @@ public class FilterTest extends SearchTestBase {
 		ftQuery = fullTextSession.createFullTextQuery( query, Driver.class );
 		ftQuery.enableFullTextFilter( "cacheinstancetest" );
 		ftQuery.getResultSize();
-//		InstanceBasedExcludeAllFilter.assertConstructorInvoked( 2 ); //uncomment this when solving HSEARCH-818
+		InstanceBasedExcludeAllFilter.assertConstructorInvoked( 2 );
 	}
 
 	@Test

--- a/orm/src/test/java/org/hibernate/search/test/filter/FilterTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/filter/FilterTest.java
@@ -15,20 +15,20 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.NumericRangeFilter;
 import org.apache.lucene.search.TermQuery;
-
 import org.hibernate.Session;
-
 import org.hibernate.search.FullTextQuery;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.test.filter.Employee.Role;
+import org.hibernate.search.test.filter.FieldConstraintFilterFactoryWithoutKeyMethod.BuildFilterInvocation;
 import org.hibernate.search.testsupport.TestForIssue;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -98,6 +98,115 @@ public class FilterTest extends SearchTestBase {
 		ftQuery.enableFullTextFilter( "cacheinstancetest" );
 		ftQuery.getResultSize();
 //		InstanceBasedExcludeAllFilter.assertConstructorInvoked( 2 ); //uncomment this when solving HSEARCH-818
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-295")
+	public void testFiltersCreatedByFactoryWithoutKeyMethodShouldBeCachedByAllParameterNamesAndValues() {
+		assertEquals( 0, FieldConstraintFilterFactoryWithoutKeyMethod.getBuiltFilters().size() );
+
+		FullTextQuery ftQuery = fullTextSession.createFullTextQuery( query, Driver.class );
+		assertEquals( "No filter should happen", 3, ftQuery.getResultSize() );
+
+		// 1. Creating one filter
+		ftQuery = fullTextSession.createFullTextQuery( query, Driver.class );
+		ftQuery.enableFullTextFilter( "cacheinstancefromfactorywithoutkeymethodtest" )
+			.setParameter( "field", "teacher" )
+			.setParameter( "value", "andre" );
+
+		assertEquals( 1, ftQuery.getResultSize() );
+		assertThat( FieldConstraintFilterFactoryWithoutKeyMethod.getBuiltFilters() ).containsExactly( new BuildFilterInvocation( "teacher", "andre" ) );
+
+		// 2. Creating another filter with other param value
+		ftQuery = fullTextSession.createFullTextQuery( query, Driver.class );
+		ftQuery.enableFullTextFilter( "cacheinstancefromfactorywithoutkeymethodtest" )
+			.setParameter( "field", "teacher" )
+			.setParameter( "value", "max" );
+
+		assertEquals( 1, ftQuery.getResultSize() );
+		assertThat( FieldConstraintFilterFactoryWithoutKeyMethod.getBuiltFilters() ).containsExactly(
+				new BuildFilterInvocation( "teacher", "andre" ),
+				new BuildFilterInvocation( "teacher", "max" )
+		);
+
+		// 3. Creating the first filter again, should be obtained from cache
+		ftQuery = fullTextSession.createFullTextQuery( query, Driver.class );
+		ftQuery.enableFullTextFilter( "cacheinstancefromfactorywithoutkeymethodtest" )
+			.setParameter( "field", "teacher" )
+			.setParameter( "value", "andre" );
+
+		assertEquals( 1, ftQuery.getResultSize() );
+		assertThat( FieldConstraintFilterFactoryWithoutKeyMethod.getBuiltFilters() ).containsExactly(
+				new BuildFilterInvocation( "teacher", "andre" ),
+				new BuildFilterInvocation( "teacher", "max" )
+		);
+
+		// 4. Creating the first filter again, just using different parameter order, should be obtained from cache
+		ftQuery = fullTextSession.createFullTextQuery( query, Driver.class );
+		ftQuery.enableFullTextFilter( "cacheinstancefromfactorywithoutkeymethodtest" )
+			.setParameter( "value", "andre" )
+			.setParameter( "field", "teacher" );
+
+		assertEquals( 1, ftQuery.getResultSize() );
+		assertThat( FieldConstraintFilterFactoryWithoutKeyMethod.getBuiltFilters() ).containsExactly(
+				new BuildFilterInvocation( "teacher", "andre" ),
+				new BuildFilterInvocation( "teacher", "max" )
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-295")
+	public void testFiltersWithoutKeyMethodShouldBeCachedByAllParameterNamesAndValues() {
+		// TODO HSEARCH-818 Discarding all instantiations stemming from SF bootstrap
+		FieldConstraintFilterWithoutKeyMethod.getInstances().clear();
+
+		FullTextQuery ftQuery = fullTextSession.createFullTextQuery( query, Driver.class );
+		assertEquals( "No filter should happen", 3, ftQuery.getResultSize() );
+
+		// 1. Creating one filter
+		ftQuery = fullTextSession.createFullTextQuery( query, Driver.class );
+		ftQuery.enableFullTextFilter( "cacheinstancewithoutkeymethodtest" )
+			.setParameter( "field", "teacher" )
+			.setParameter( "value", "andre" );
+
+		assertEquals( 1, ftQuery.getResultSize() );
+		assertThat( FieldConstraintFilterWithoutKeyMethod.getInstances() ).containsExactly( new FieldConstraintFilterWithoutKeyMethod( "teacher", "andre" ) );
+
+		// 2. Creating another filter with other param value
+		ftQuery = fullTextSession.createFullTextQuery( query, Driver.class );
+		ftQuery.enableFullTextFilter( "cacheinstancewithoutkeymethodtest" )
+			.setParameter( "field", "teacher" )
+			.setParameter( "value", "max" );
+
+		assertEquals( 1, ftQuery.getResultSize() );
+		assertThat( FieldConstraintFilterWithoutKeyMethod.getInstances() ).containsExactly(
+				new FieldConstraintFilterWithoutKeyMethod( "teacher", "andre" ),
+				new FieldConstraintFilterWithoutKeyMethod( "teacher", "max" )
+		);
+
+		// 3. Creating the first filter again, should be obtained from cache
+		ftQuery = fullTextSession.createFullTextQuery( query, Driver.class );
+		ftQuery.enableFullTextFilter( "cacheinstancewithoutkeymethodtest" )
+			.setParameter( "field", "teacher" )
+			.setParameter( "value", "andre" );
+
+		assertEquals( 1, ftQuery.getResultSize() );
+		assertThat( FieldConstraintFilterWithoutKeyMethod.getInstances() ).containsExactly(
+				new FieldConstraintFilterWithoutKeyMethod( "teacher", "andre" ),
+				new FieldConstraintFilterWithoutKeyMethod( "teacher", "max" )
+		);
+
+		// 4. Creating the first filter again, just using different parameter order, should be obtained from cache
+		ftQuery = fullTextSession.createFullTextQuery( query, Driver.class );
+		ftQuery.enableFullTextFilter( "cacheinstancewithoutkeymethodtest" )
+			.setParameter( "value", "andre" )
+			.setParameter( "field", "teacher" );
+
+		assertEquals( 1, ftQuery.getResultSize() );
+		assertThat( FieldConstraintFilterWithoutKeyMethod.getInstances() ).containsExactly(
+				new FieldConstraintFilterWithoutKeyMethod( "teacher", "andre" ),
+				new FieldConstraintFilterWithoutKeyMethod( "teacher", "max" )
+		);
 	}
 
 	@Test


### PR DESCRIPTION
* The `@Key` method is optional now; By default a `StandardFilterKey` will be used which is based on all presented parameter names and values
* Avoiding filter (factory) instantiation if not needed

@Sanne Is that what you had in mind for [HSEARCH-295](https://hibernate.atlassian.net/browse/HSEARCH-295)?