### PR TITLE
HSEARCH-1649 Massindexer in multi-tenancy

### DIFF
--- a/documentation/src/main/asciidoc/architecture.asciidoc
+++ b/documentation/src/main/asciidoc/architecture.asciidoc
@@ -160,3 +160,45 @@ The name of this strategy is `not-shared`.
 You can write your own reader strategy that suits your application needs by implementing
 org.hibernate.search.reader.ReaderProvider. The implementation must be thread safe.
 
+[[search-architecture-multitenancy]]
+=== Multi-tenancy
+
+==== What is multi-tenancy?
+
+The term multi-tenancy in general is applied to software development to indicate anarchitecture in 
+which a single running instance of an application simultaneously serves multiple clients (tenants).
+This is highly common in SaaS solutions.
+Isolating information (data, customizations, etc) pertaining to the various tenants is a particular
+challenge in these systems.
+This includes the data owned by each tenant stored in the database.
+You will find more details on how to enable multi-tenancy in the
+link:$$http://docs.jboss.org/hibernate/orm/4.3/devguide/en-US/html/ch16.html$$[Hibernate ORM developer's guide].
+
+You can create a full-text search session in the following way:
+
+.Create a FullTextSession with a tenant identifier
+====
+[cource, JAVA]
+----
+Session session = sessionFactory.withOptions().tenantIdentifier("client-A").openSession();
+FullTextSession fullTextSession = Search.getFullTextSession(session);
+----
+====
+
+The FullTextSession will be bound to the specific tenant ("client-A" in the example)
+and the mass indexer will only index the entities associated to that tenant identifier.
+
+==== Limitations
+
+Integration of full automatic support for multi-tenancy has not been implemented yet.
+You will need to take some limitations into account:
+
+1. Queries won't be filtered automatically per tenant.
+   Hibernate Search will run the query on all the entries in the index.
+   If you need to filter per tenant you need to store the tenant identifier for each
+   document and filter on it.
+
+2. The purge operation won't consider the tenant,
+   it will delete all the documents in the index of the specific type,
+   ignoring the tenant identifier in the session.
+

--- a/orm/src/main/java/org/hibernate/search/batchindexing/impl/BatchCoordinator.java
+++ b/orm/src/main/java/org/hibernate/search/batchindexing/impl/BatchCoordinator.java
@@ -44,6 +44,7 @@ public class BatchCoordinator extends ErrorHandledRunnable {
 	private final MassIndexerProgressMonitor monitor;
 	private final long objectsLimit;
 	private final int idFetchSize;
+	private final String tenantId;
 
 	public BatchCoordinator(Set<Class<?>> rootEntities,
 							ExtendedSearchIntegrator extendedIntegrator,
@@ -57,9 +58,11 @@ public class BatchCoordinator extends ErrorHandledRunnable {
 							boolean purgeAtStart,
 							boolean optimizeAfterPurge,
 							MassIndexerProgressMonitor monitor,
-							int idFetchSize) {
+							int idFetchSize,
+							String tenantId) {
 		super( extendedIntegrator );
 		this.idFetchSize = idFetchSize;
+		this.tenantId = tenantId;
 		this.rootEntities = rootEntities.toArray( new Class<?>[rootEntities.size()] );
 		this.sessionFactory = sessionFactory;
 		this.typesToIndexInParallel = typesToIndexInParallel;
@@ -106,7 +109,7 @@ public class BatchCoordinator extends ErrorHandledRunnable {
 							extendedIntegrator, sessionFactory, type,
 							documentBuilderThreads,
 							cacheMode, objectLoadingBatchSize, endAllSignal,
-							monitor, backend, objectsLimit, idFetchSize
+							monitor, backend, objectsLimit, idFetchSize, tenantId
 					)
 			);
 		}

--- a/orm/src/main/java/org/hibernate/search/batchindexing/impl/BatchIndexingWorkspace.java
+++ b/orm/src/main/java/org/hibernate/search/batchindexing/impl/BatchIndexingWorkspace.java
@@ -57,6 +57,8 @@ public class BatchIndexingWorkspace extends ErrorHandledRunnable {
 
 	private final int idFetchSize;
 
+	private final String tenantId;
+
 	public BatchIndexingWorkspace(ExtendedSearchIntegrator extendedIntegrator,
 								SessionFactoryImplementor sessionFactory,
 								Class<?> entityType,
@@ -67,10 +69,12 @@ public class BatchIndexingWorkspace extends ErrorHandledRunnable {
 								MassIndexerProgressMonitor monitor,
 								BatchBackend backend,
 								long objectsLimit,
-								int idFetchSize) {
+								int idFetchSize,
+								String tenantId) {
 		super( extendedIntegrator );
 		this.indexedType = entityType;
 		this.idFetchSize = idFetchSize;
+		this.tenantId = tenantId;
 		this.idNameOfIndexedType = extendedIntegrator.getIndexBinding( entityType )
 				.getDocumentBuilder()
 				.getIdentifierName();
@@ -99,7 +103,7 @@ public class BatchIndexingWorkspace extends ErrorHandledRunnable {
 	public void runWithErrorHandler() {
 		try {
 			final ErrorHandler errorHandler = extendedIntegrator.getErrorHandler();
-			final BatchTransactionalContext transactionalContext = new BatchTransactionalContext( extendedIntegrator, sessionFactory, errorHandler );
+			final BatchTransactionalContext transactionalContext = new BatchTransactionalContext( extendedIntegrator, sessionFactory, errorHandler, tenantId );
 			//first start the consumers, then the producers (reverse order):
 			//from primary keys to LuceneWork ADD operations:
 			startTransformationToLuceneWork( transactionalContext, errorHandler );
@@ -125,8 +129,10 @@ public class BatchIndexingWorkspace extends ErrorHandledRunnable {
 				new IdentifierProducer(
 						primaryKeyStream, sessionFactory,
 						objectLoadingBatchSize, indexedType, monitor,
-						objectsLimit, errorHandler, idFetchSize
-				));
+						objectsLimit, errorHandler, idFetchSize,
+						tenantId
+				),
+				tenantId);
 		//execIdentifiersLoader has size 1 and is not configurable: ensures the list is consistent as produced by one transaction
 		final ThreadPoolExecutor execIdentifiersLoader = Executors.newFixedThreadPool( 1, "identifierloader" );
 		try {
@@ -142,8 +148,10 @@ public class BatchIndexingWorkspace extends ErrorHandledRunnable {
 				new IdentifierConsumerDocumentProducer(
 						primaryKeyStream, monitor, sessionFactory, producerEndSignal,
 						cacheMode, indexedType, extendedIntegrator,
-						idNameOfIndexedType, backend, errorHandler
-				));
+						idNameOfIndexedType, backend, errorHandler,
+						tenantId
+				),
+				tenantId);
 		final ThreadPoolExecutor execFirstLoader = Executors.newFixedThreadPool( documentBuilderThreads, "entityloader" );
 		try {
 			for ( int i = 0; i < documentBuilderThreads; i++ ) {

--- a/orm/src/main/java/org/hibernate/search/batchindexing/impl/BatchTransactionalContext.java
+++ b/orm/src/main/java/org/hibernate/search/batchindexing/impl/BatchTransactionalContext.java
@@ -36,11 +36,11 @@ public class BatchTransactionalContext {
 	final TransactionFactory<?> transactionFactory;
 	final ExtendedSearchIntegrator extendedIntegrator;
 
-	public BatchTransactionalContext(ExtendedSearchIntegrator extendedIntegrator, SessionFactoryImplementor sessionFactory, ErrorHandler errorHandler) {
+	public BatchTransactionalContext(ExtendedSearchIntegrator extendedIntegrator, SessionFactoryImplementor sessionFactory, ErrorHandler errorHandler, String tenantId) {
 		this.extendedIntegrator = extendedIntegrator;
 		this.factory = sessionFactory;
 		this.errorHandler = errorHandler;
-		this.transactionManager = lookupTransactionManager( factory );
+		this.transactionManager = lookupTransactionManager( factory, tenantId );
 		this.transactionFactory = lookupTransactionFactory( factory );
 	}
 
@@ -48,8 +48,10 @@ public class BatchTransactionalContext {
 		return sessionFactory.getServiceRegistry().getService( TransactionFactory.class );
 	}
 
-	private static TransactionManager lookupTransactionManager(SessionFactoryImplementor sessionFactory) {
-		final Session session = sessionFactory.openSession();
+	private static TransactionManager lookupTransactionManager(SessionFactoryImplementor sessionFactory, String tenantId) {
+		final Session session = tenantId == null
+				? sessionFactory.openSession()
+				: sessionFactory.withOptions().tenantIdentifier( tenantId ).openSession();
 		try {
 			EventSource eventSource = (EventSource)session;
 			return eventSource

--- a/orm/src/main/java/org/hibernate/search/batchindexing/impl/IdentifierConsumerDocumentProducer.java
+++ b/orm/src/main/java/org/hibernate/search/batchindexing/impl/IdentifierConsumerDocumentProducer.java
@@ -18,7 +18,6 @@ import org.hibernate.LockMode;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
-
 import org.hibernate.criterion.CriteriaSpecification;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.engine.spi.SessionImplementor;
@@ -63,6 +62,7 @@ public class IdentifierConsumerDocumentProducer implements SessionAwareRunnable 
 	private final ErrorHandler errorHandler;
 	private final BatchBackend backend;
 	private final CountDownLatch producerEndSignal;
+	private final String tenantId;
 
 	public IdentifierConsumerDocumentProducer(
 			ProducerConsumerQueue<List<Serializable>> fromIdentifierListToEntities,
@@ -71,7 +71,8 @@ public class IdentifierConsumerDocumentProducer implements SessionAwareRunnable 
 			CountDownLatch producerEndSignal,
 			CacheMode cacheMode, Class<?> type,
 			ExtendedSearchIntegrator searchFactory,
-			String idName, BatchBackend backend, ErrorHandler errorHandler) {
+			String idName, BatchBackend backend, ErrorHandler errorHandler,
+			String tenantId) {
 		this.source = fromIdentifierListToEntities;
 		this.monitor = monitor;
 		this.sessionFactory = sessionFactory;
@@ -82,6 +83,7 @@ public class IdentifierConsumerDocumentProducer implements SessionAwareRunnable 
 		this.errorHandler = errorHandler;
 		this.producerEndSignal = producerEndSignal;
 		this.entityIndexBindings = searchFactory.getIndexBindings();
+		this.tenantId = tenantId;
 		log.trace( "created" );
 	}
 
@@ -90,7 +92,12 @@ public class IdentifierConsumerDocumentProducer implements SessionAwareRunnable 
 		log.trace( "started" );
 		Session session = upperSession;
 		if ( upperSession == null ) {
-			session = sessionFactory.openSession();
+			if ( tenantId == null ) {
+				session = sessionFactory.openSession();
+			}
+			else {
+				session = sessionFactory.withOptions().tenantIdentifier( tenantId ).openSession();
+			}
 		}
 		session.setFlushMode( FlushMode.MANUAL );
 		session.setCacheMode( cacheMode );

--- a/orm/src/main/java/org/hibernate/search/batchindexing/spi/MassIndexerWithTenant.java
+++ b/orm/src/main/java/org/hibernate/search/batchindexing/spi/MassIndexerWithTenant.java
@@ -1,0 +1,25 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.batchindexing.spi;
+
+import org.hibernate.search.MassIndexer;
+
+/**
+ * A {@link MassIndexer} that can be assigned to a tenant in architectures with multi-tenancy.
+ *
+ * @author Davide D'Alto
+ */
+public interface MassIndexerWithTenant extends MassIndexer {
+
+	/**
+	 * Set the tenant that is associated to this {@link MassIndexer}.
+	 *
+	 * @param tenantIdentifier the identifier of the tenant associated this {@link MassIndexer}
+	 * @return <tt>this</tt> for method chaining
+	 */
+	MassIndexerWithTenant tenantIdentifier(String tenantIdentifier);
+}

--- a/orm/src/main/java/org/hibernate/search/impl/FullTextSessionImpl.java
+++ b/orm/src/main/java/org/hibernate/search/impl/FullTextSessionImpl.java
@@ -28,6 +28,7 @@ import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.query.hibernate.impl.FullTextQueryImpl;
 import org.hibernate.search.batchindexing.spi.MassIndexerFactory;
+import org.hibernate.search.batchindexing.spi.MassIndexerWithTenant;
 import org.hibernate.search.util.impl.ClassLoaderHelper;
 import org.hibernate.search.hcore.util.impl.ContextHelper;
 import org.hibernate.search.hcore.util.impl.HibernateHelper;
@@ -154,7 +155,11 @@ final class FullTextSessionImpl extends SessionDelegatorBaseImpl implements Full
 	@Override
 	public MassIndexer createIndexer(Class<?>... types) {
 		MassIndexerFactory massIndexerFactory = createMassIndexerFactory();
-		return massIndexerFactory.createMassIndexer( getSearchIntegrator(), getFactory(), types );
+		MassIndexer massIndexer = massIndexerFactory.createMassIndexer( getSearchIntegrator(), getFactory(), types );
+		if ( massIndexer instanceof MassIndexerWithTenant ) {
+			( (MassIndexerWithTenant) massIndexer ).tenantIdentifier( getTenantIdentifier() );
+		}
+		return massIndexer;
 	}
 
 	@Override

--- a/orm/src/test/java/org/hibernate/search/test/batchindexing/Clock.java
+++ b/orm/src/test/java/org/hibernate/search/test/batchindexing/Clock.java
@@ -48,4 +48,15 @@ public class Clock {
 	public void setId(Integer id) {
 		this.id = id;
 	}
+
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append( "[" );
+		builder.append( id );
+		builder.append( "," );
+		builder.append( brand );
+		builder.append( "]" );
+		return builder.toString();
+	}
 }

--- a/orm/src/test/java/org/hibernate/search/test/batchindexing/DatabaseMultitenancyTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/batchindexing/DatabaseMultitenancyTest.java
@@ -1,0 +1,287 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.batchindexing;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.lucene.search.Query;
+import org.h2.Driver;
+import org.hibernate.HibernateException;
+import org.hibernate.MultiTenancyStrategy;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.H2Dialect;
+import org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionProviderImpl;
+import org.hibernate.engine.jdbc.connections.spi.AbstractMultiTenantConnectionProvider;
+import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.Search;
+import org.hibernate.search.query.dsl.QueryBuilder;
+import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.testsupport.TestForIssue;
+import org.hibernate.testing.RequiresDialect;
+import org.hibernate.tool.hbm2ddl.ConnectionHelper;
+import org.hibernate.tool.hbm2ddl.SchemaExport;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * This is a test class to check that search can be used with ORM in multi-tenancy.
+ * <p>
+ * The test will create one database for each tenant identifier.
+ * The two tenant identifiers are: metamec and geochron.
+ *
+ * @author Davide D'Alto
+ */
+@RequiresDialect(
+	comment = "The connection provider for this test requires H2",
+	strictMatching = true,
+	value = org.hibernate.dialect.H2Dialect.class
+)
+public class DatabaseMultitenancyTest extends SearchTestBase {
+
+	public static final Dialect DIALECT = new H2Dialect();
+
+	/**
+	 * Metamec tenant identifier
+	 */
+	private static final String METAMEC_TID = "metamec";
+
+	/**
+	 * Geochron tenant identifier
+	 */
+	private static final String GEOCHRON_TID = "geochron";
+
+	private static String[] METAMEC_MODELS = { "Metamec - Model A850", "Metamec - Model 4562" };
+	private static String[] GEOCHRON_MODELS = { "Geochron - Model The Original Kilburg", "Geochron - Model The Boardroom" };
+
+	@Override
+	protected void configure(Configuration cfg) {
+		super.configure( cfg );
+		cfg.setProperty( AvailableSettings.MULTI_TENANT, MultiTenancyStrategy.DATABASE.name() );
+		cfg.setProperty( AvailableSettings.MULTI_TENANT_CONNECTION_PROVIDER, ClockMultitenantConnectionProvider.class.getName() );
+		cfg.setProperty( "hibernate.search.default.directory_provider", "ram" );
+
+		// Multi-tenancy does not work well with SchemaExport
+		cfg.getProperties().remove( AvailableSettings.HBM2DDL_AUTO );
+	}
+
+	@Override
+	@Before
+	public void setUp() throws Exception {
+		super.setUp();
+
+		exportSchema( ClockMultitenantConnectionProvider.GEOCHRON_PROVIDER, getCfg() );
+		exportSchema( ClockMultitenantConnectionProvider.METAMEC_PROVIDER, getCfg() );
+
+		Session sessionMetamec = openSessionWithTenantId( METAMEC_TID );
+		persist( sessionMetamec, METAMEC_MODELS );
+		sessionMetamec.close();
+
+		Session sessionGeochron = openSessionWithTenantId( GEOCHRON_TID );
+		persist( sessionGeochron, GEOCHRON_MODELS );
+		sessionGeochron.close();
+	}
+
+	@Test
+	public void shouldOnlyFindMetamecModels() throws Exception {
+		List<Clock> list = searchAll( METAMEC_TID );
+		assertThat( list ).onProperty( "brand" ).containsOnly( METAMEC_MODELS );
+	}
+
+	@Test
+	public void shouldOnlyFindGeochronModels() throws Exception {
+		List<Clock> list = searchAll( GEOCHRON_TID );
+		assertThat( list ).onProperty( "brand" ).containsOnly( GEOCHRON_MODELS );
+	}
+
+	@Test
+	public void shouldBePossibleToRunAQuery() throws Exception {
+		List<Clock> list = searchModel( "model", GEOCHRON_TID );
+		assertThat( list ).onProperty( "brand" ).containsOnly( GEOCHRON_MODELS );
+	}
+
+	@Test
+	public void shouldBeAbleToPurgeTheIndex() {
+		purgeAll( Clock.class, GEOCHRON_TID );
+
+		List<Clock> list = searchAll( GEOCHRON_TID );
+		assertThat( list ).isEmpty();
+	}
+
+	@Test
+	public void shouldBeAbleToRebuildTheIndexForTheTenantId() throws Exception {
+		purgeAll( Clock.class, GEOCHRON_TID );
+		purgeAll( Clock.class, METAMEC_TID );
+		rebuildIndexWithMassIndexer( Clock.class, GEOCHRON_TID );
+
+		List<Clock> list = searchAll( GEOCHRON_TID );
+		assertThat( list ).onProperty( "brand" ).containsOnly( GEOCHRON_MODELS );
+	}
+
+	private List<Clock> searchModel(String searchString, String tenantId) {
+		FullTextSession session = Search.getFullTextSession( openSessionWithTenantId( tenantId ) );
+		QueryBuilder queryBuilder = session.getSearchFactory().buildQueryBuilder().forEntity( Clock.class ).get();
+		Query luceneQuery = queryBuilder.keyword().wildcard().onField( "brand" ).matching( searchString ).createQuery();
+		Transaction transaction = session.beginTransaction();
+		@SuppressWarnings("unchecked")
+		List<Clock> list = session.createFullTextQuery( luceneQuery ).list();
+		transaction.commit();
+		session.clear();
+		session.close();
+		return list;
+	}
+
+	private List<Clock> searchAll(String tenantId) {
+		FullTextSession session = Search.getFullTextSession( openSessionWithTenantId( tenantId ) );
+		QueryBuilder queryBuilder = session.getSearchFactory().buildQueryBuilder().forEntity( Clock.class ).get();
+		Query luceneQuery = queryBuilder.all().createQuery();
+		Transaction transaction = session.beginTransaction();
+		@SuppressWarnings("unchecked")
+		List<Clock> list = session.createFullTextQuery( luceneQuery ).list();
+		transaction.commit();
+		session.clear();
+		session.close();
+		return list;
+	}
+
+	private void rebuildIndexWithMassIndexer(Class<?> entityType, String tenantId) throws Exception {
+		FullTextSession session = Search.getFullTextSession( openSessionWithTenantId( tenantId ) );
+		session.createIndexer( entityType ).purgeAllOnStart( true ).startAndWait();
+		int numDocs = session.getSearchFactory().getIndexReaderAccessor().open( entityType ).numDocs();
+		session.close();
+		assertThat( numDocs ).isGreaterThan( 0 );
+	}
+
+	private void purgeAll(Class<?> entityType, String tenantId) {
+		FullTextSession session = Search.getFullTextSession( openSessionWithTenantId( tenantId ) );
+		session.purgeAll( entityType );
+		session.flushToIndexes();
+		int numDocs = session.getSearchFactory().getIndexReaderAccessor().open( entityType ).numDocs();
+		session.close();
+		assertThat( numDocs ).isEqualTo( 0 );
+	}
+
+	private Session openSessionWithTenantId(String tenantId) {
+		return getSessionFactory().withOptions().tenantIdentifier( tenantId ).openSession();
+	}
+
+	@Override
+	protected Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { Clock.class };
+	}
+
+	private void persist(Session session, String... models) {
+		session.beginTransaction();
+		for ( int i = 0; i < models.length; i++ ) {
+			session.persist( new Clock( i + 1, models[i] ) );
+		}
+		session.getTransaction().commit();
+		session.clear();
+	}
+
+	@After
+	public void deleteEntities() throws Exception {
+		Session session = openSessionWithTenantId( METAMEC_TID );
+		deleteClocks( session );
+		session.close();
+
+		session = openSessionWithTenantId( GEOCHRON_TID );
+		deleteClocks( session );
+		session.close();
+	}
+
+	private void deleteClocks(Session session) {
+		session.beginTransaction();
+		@SuppressWarnings("unchecked")
+		List<Clock> clocks = session.createCriteria( Clock.class ).list();
+		for ( Clock clock : clocks ) {
+			session.delete( clock );
+		}
+		session.getTransaction().commit();
+		session.clear();
+	}
+
+	/*
+	 * Hibernate does not generate the schema when using multi-tenancy.
+	 * We have to call the SchemaExport class explicitly.
+	 */
+	private void exportSchema(final ConnectionProvider provider, Configuration cfg) {
+		String[] generateDropSchemaScript = cfg.generateDropSchemaScript( DIALECT );
+		String[] generateSchemaCreationScript = cfg.generateSchemaCreationScript( DIALECT );
+		new SchemaExport( new ConnectionHelper() {
+
+			private Connection connection;
+
+			@Override
+			public void prepare(boolean needsAutoCommit) throws SQLException {
+				connection = provider.getConnection();
+			}
+
+			@Override
+			public Connection getConnection() throws SQLException {
+				return connection;
+			}
+
+			@Override
+			public void release() throws SQLException {
+				provider.closeConnection( connection );
+			}
+		},
+
+		generateDropSchemaScript, generateSchemaCreationScript ).execute( false, true, false, false );
+	}
+
+	public static class ClockMultitenantConnectionProvider extends AbstractMultiTenantConnectionProvider {
+
+		private static final ConnectionProvider METAMEC_PROVIDER = buildConnectionProvider( METAMEC_TID );
+		private static final ConnectionProvider GEOCHRON_PROVIDER = buildConnectionProvider( GEOCHRON_TID );
+
+		@Override
+		protected ConnectionProvider getAnyConnectionProvider() {
+			return GEOCHRON_PROVIDER;
+		}
+
+		@Override
+		protected ConnectionProvider selectConnectionProvider(String tenantIdentifier) {
+			if ( METAMEC_TID.equals( tenantIdentifier ) ) {
+				return METAMEC_PROVIDER;
+			}
+			else if ( GEOCHRON_TID.equals( tenantIdentifier ) ) {
+				return GEOCHRON_PROVIDER;
+			}
+			throw new HibernateException( "Unknown tenant identifier: " + tenantIdentifier );
+		}
+
+		private static DriverManagerConnectionProviderImpl buildConnectionProvider(String tenantId) {
+			DriverManagerConnectionProviderImpl connectionProvider = new DriverManagerConnectionProviderImpl();
+			connectionProvider.configure( getConnectionProviderProperties( tenantId + "-db" ) );
+			return connectionProvider;
+		}
+
+		public static Properties getConnectionProviderProperties(String dbName) {
+			Properties props = new Properties( null );
+			props.put( Environment.DRIVER, Driver.class.getName() );
+			props.put( Environment.URL, String.format( "jdbc:h2:mem:%s;DB_CLOSE_DELAY=-1;MVCC=TRUE", dbName) );
+			props.put( Environment.USER, "sa" );
+			props.put( Environment.PASS, "" );
+			return props;
+		}
+	}
+
+}

--- a/orm/src/test/java/org/hibernate/search/test/batchindexing/DatabaseMultitenancyTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/batchindexing/DatabaseMultitenancyTest.java
@@ -134,6 +134,40 @@ public class DatabaseMultitenancyTest extends SearchTestBase {
 		assertThat( list ).onProperty( "brand" ).containsOnly( GEOCHRON_MODELS );
 	}
 
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-1792")
+	@Ignore
+	public void shouldOnlyPurgeTheEntitiesOfTheSelecedTenant() {
+		purgeAll( Clock.class, GEOCHRON_TID );
+
+		List<Clock> list = searchAll( METAMEC_TID );
+		assertThat( list ).onProperty( "brand" ).containsOnly( METAMEC_MODELS );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-1792")
+	@Ignore
+	public void shouldOnlyReturnResultsOfTheSpecificTenant() throws Exception {
+		purgeAll( Clock.class, GEOCHRON_TID );
+		purgeAll( Clock.class, METAMEC_TID );
+		rebuildIndexWithMassIndexer( Clock.class, GEOCHRON_TID );
+
+		List<Clock> list = searchAll( METAMEC_TID );
+		assertThat( list ).isEmpty();
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-1792")
+	@Ignore
+	public void shouldSearchOtherTenantsDocuments() throws Exception {
+		purgeAll( Clock.class, GEOCHRON_TID );
+		purgeAll( Clock.class, METAMEC_TID );
+		rebuildIndexWithMassIndexer( Clock.class, GEOCHRON_TID );
+
+		List<Clock> list = searchModel( "geochron", METAMEC_TID );
+		assertThat( list ).isEmpty();
+	}
+
 	private List<Clock> searchModel(String searchString, String tenantId) {
 		FullTextSession session = Search.getFullTextSession( openSessionWithTenantId( tenantId ) );
 		QueryBuilder queryBuilder = session.getSearchFactory().buildQueryBuilder().forEntity( Clock.class ).get();


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-1649

This patch will make the massindexer work when using multi-tenancy.

It adds an interface MassIndexerWithTenant that allows to store the tenant identifier of the session used to create the mass indexer.

I've updated the documentation and it should explain the issues of using Hibernate Search in a multi-tenancy architecture.

There is also a commit for [HSEARCH-1792](https://hibernate.atlassian.net/browse/HSEARCH-1792) containing the tests that shuold pass to fix that issue.
