### PR TITLE
HSEARCH-1764: Allowing to set some index embedded related meta-data through the API

### DIFF
--- a/engine/src/main/java/org/hibernate/search/annotations/Factory.java
+++ b/engine/src/main/java/org/hibernate/search/annotations/Factory.java
@@ -6,21 +6,23 @@
  */
 package org.hibernate.search.annotations;
 
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Documented;
 
 /**
- * Marks a method as a factory method for a given type.
- * A factory method is called whenever a new instance of a given
- * type is requested.
- * The factory method is used with a higher priority than a plain no-arg constructor when present
- * <br />
- * <code>&#64;Factory</code> currently works for &#64;FullTextFilterDef.impl classes
+ * Marks a method as a factory method for a given type. A factory method is called whenever a new instance of a given
+ * type is requested. The factory method is used with a higher priority than a plain no-arg constructor when present.
+ * <p>
+ * Factory methods currently are used to instantiate the following classes:
+ * <ul>
+ * <li>{@link org.apache.lucene.search.Filter}; The factory class is to be given via {@link FullTextFilterDef#impl()}</li>
+ * <li>{@link org.hibernate.search.cfg.SearchMapping}; The factory class is to be registered with the bootstrapping
+ * configuration using the {@link org.hibernate.search.cfg.Environment#MODEL_MAPPING} key</li>
+ * </ul>
  *
- * @see org.hibernate.search.annotations.Factory
  * @author Emmanuel Bernard
  */
 @Retention( RetentionPolicy.RUNTIME )

--- a/engine/src/main/java/org/hibernate/search/annotations/Field.java
+++ b/engine/src/main/java/org/hibernate/search/annotations/Field.java
@@ -29,12 +29,14 @@ import java.lang.annotation.Target;
 public @interface Field {
 
 	/**
-	 * Default value for {@link #indexNullAs} parameter. Indicates that {@code null} values should not be indexed.
+	 * Default value for the {@link #indexNullAs} parameter. Indicates that {@code null} values should not be indexed.
 	 */
 	String DO_NOT_INDEX_NULL = "__DO_NOT_INDEX_NULL__";
 
 	/**
-	 * Value for {@link #indexNullAs} parameter indicating that {@code null} values should not indexed using the
+	 * Value for the {@link #indexNullAs} parameter indicating that {@code null} values should be indexed using the null
+	 * token given through the {@link org.hibernate.search.cfg.Environment#DEFAULT_NULL_TOKEN} configuration property.
+	 * If no value is given for that property, the token {@code _null_} will be used.
 	 */
 	String DEFAULT_NULL_TOKEN = "__DEFAULT_NULL_TOKEN__";
 

--- a/engine/src/main/java/org/hibernate/search/annotations/IndexedEmbedded.java
+++ b/engine/src/main/java/org/hibernate/search/annotations/IndexedEmbedded.java
@@ -12,22 +12,24 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Specifies that an association ({@code @*To*}, {@code @Embedded}, {@code @CollectionOfEmbedded}) is to be indexed in
+ * the root entity index. This allows queries involving associated objects properties.
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.FIELD, ElementType.METHOD })
 @Documented
-/**
- * Specifies that an association (@*To*, @Embedded, @CollectionOfEmbedded) is to be indexed* in the root entity index.
- * This allows queries involving associated objects properties.
- */
 public @interface IndexedEmbedded {
 
 	/**
-	 * Default value for {@link #indexNullAs} parameter. Indicates that {@code null} values should not be indexed.
+	 * Default value for the {@link #indexNullAs} parameter. Indicates that {@code null} values should not be indexed.
 	 */
 	String DO_NOT_INDEX_NULL = "__DO_NOT_INDEX_NULL__";
 
 	/**
-	 * Value for {@link #indexNullAs} parameter indicating that {@code null} values should not indexed using the
+	 * Value for the {@link #indexNullAs} parameter indicating that {@code null} values should be indexed using the null
+	 * token given through the {@link org.hibernate.search.cfg.Environment#DEFAULT_NULL_TOKEN} configuration property.
+	 * If no value is given for that property, the token {@code _null_} will be used.
 	 */
 	String DEFAULT_NULL_TOKEN = "__DEFAULT_NULL_TOKEN__";
 

--- a/engine/src/main/java/org/hibernate/search/cfg/IndexEmbeddedMapping.java
+++ b/engine/src/main/java/org/hibernate/search/cfg/IndexEmbeddedMapping.java
@@ -16,8 +16,8 @@ public class IndexEmbeddedMapping {
 
 	private final SearchMapping mapping;
 	private final Map<String,Object> indexEmbedded;
-	private EntityDescriptor entity;
-	private PropertyDescriptor property;
+	private final EntityDescriptor entity;
+	private final PropertyDescriptor property;
 
 	public IndexEmbeddedMapping(SearchMapping mapping, PropertyDescriptor property, EntityDescriptor entity) {
 		this.mapping = mapping;
@@ -39,6 +39,11 @@ public class IndexEmbeddedMapping {
 
 	public IndexEmbeddedMapping depth(int depth) {
 		this.indexEmbedded.put( "depth", depth );
+		return this;
+	}
+
+	public IndexEmbeddedMapping includeEmbeddedObjectId(boolean includeEmbeddedObjectId) {
+		this.indexEmbedded.put( "includeEmbeddedObjectId", includeEmbeddedObjectId );
 		return this;
 	}
 

--- a/engine/src/main/java/org/hibernate/search/cfg/IndexEmbeddedMapping.java
+++ b/engine/src/main/java/org/hibernate/search/cfg/IndexEmbeddedMapping.java
@@ -47,6 +47,11 @@ public class IndexEmbeddedMapping {
 		return this;
 	}
 
+	public IndexEmbeddedMapping indexNullAs(String nullToken) {
+		this.indexEmbedded.put( "indexNullAs", nullToken );
+		return this;
+	}
+
 	public PropertyMapping property(String name, ElementType type) {
 		return new PropertyMapping( name, type, entity, mapping );
 	}
@@ -62,5 +67,4 @@ public class IndexEmbeddedMapping {
 	public FieldMapping field() {
 		return new FieldMapping( property, entity, mapping );
 	}
-
 }

--- a/engine/src/main/java/org/hibernate/search/cfg/IndexEmbeddedMapping.java
+++ b/engine/src/main/java/org/hibernate/search/cfg/IndexEmbeddedMapping.java
@@ -12,6 +12,13 @@ import java.util.Map;
 
 import org.apache.lucene.analysis.util.TokenizerFactory;
 
+/**
+ * Configures index-embedded association.
+ *
+ * @author Emmanuel Bernard
+ * @author Gunnar Morling
+ * @see org.hibernate.search.annotations.IndexedEmbedded
+ */
 public class IndexEmbeddedMapping {
 
 	private final SearchMapping mapping;
@@ -50,6 +57,24 @@ public class IndexEmbeddedMapping {
 	public IndexEmbeddedMapping indexNullAs(String nullToken) {
 		this.indexEmbedded.put( "indexNullAs", nullToken );
 		return this;
+	}
+
+	public IndexEmbeddedMapping includePaths(String firstPath, String... furtherPaths) {
+		this.indexEmbedded.put( "includePaths", merge( firstPath, furtherPaths ) );
+		return this;
+	}
+
+	private String[] merge(String firstPath, String... furtherPaths) {
+		if ( furtherPaths == null ) {
+			return new String[] { firstPath };
+		}
+		else {
+			String[] paths = new String[1 + furtherPaths.length];
+			paths[0] = firstPath;
+			System.arraycopy( furtherPaths, 0, paths, 1, furtherPaths.length );
+
+			return paths;
+		}
 	}
 
 	public PropertyMapping property(String name, ElementType type) {

--- a/engine/src/main/java/org/hibernate/search/cfg/SearchMapping.java
+++ b/engine/src/main/java/org/hibernate/search/cfg/SearchMapping.java
@@ -16,12 +16,17 @@ import java.util.Set;
 import org.apache.lucene.analysis.util.TokenizerFactory;
 
 /**
+ * Allows to configure indexing and search related aspects of a domain model using a fluent Java API. This API can be
+ * used instead of or in conjunction with the annotation based configuration via
+ * {@link org.hibernate.search.annotations.Indexed} etc. In case of conflicts the programmatic configuration for an
+ * element takes precedence over the annotation-based configuration.
+ *
  * @author Emmanuel Bernard
  */
 public class SearchMapping {
-	private Set<Map<String, Object>> analyzerDefs = new HashSet<Map<String, Object>>();
-	private Set<Map<String, Object>> fullTextFilterDefs = new HashSet<Map<String, Object>>();
-	private Map<Class<?>, EntityDescriptor> entities = new HashMap<Class<?>, EntityDescriptor>();
+	private final Set<Map<String, Object>> analyzerDefs = new HashSet<Map<String, Object>>();
+	private final Set<Map<String, Object>> fullTextFilterDefs = new HashSet<Map<String, Object>>();
+	private final Map<Class<?>, EntityDescriptor> entities = new HashMap<Class<?>, EntityDescriptor>();
 
 	public Set<Map<String, Object>> getAnalyzerDefs() {
 		return analyzerDefs;

--- a/orm/src/test/java/org/hibernate/search/test/DefaultTestResourceManager.java
+++ b/orm/src/test/java/org/hibernate/search/test/DefaultTestResourceManager.java
@@ -13,11 +13,9 @@ import java.util.UUID;
 
 import org.apache.lucene.analysis.core.StopAnalyzer;
 import org.apache.lucene.store.Directory;
-
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
-
 import org.hibernate.cfg.Configuration;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.jdbc.Work;
@@ -25,12 +23,12 @@ import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
 import org.hibernate.search.SearchFactory;
 import org.hibernate.search.cfg.Environment;
-import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
+import org.hibernate.search.exception.SearchException;
+import org.hibernate.search.hcore.util.impl.ContextHelper;
 import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
 import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.testsupport.TestConstants;
-import org.hibernate.search.hcore.util.impl.ContextHelper;
 import org.hibernate.search.util.impl.FileHelper;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
@@ -55,7 +53,7 @@ public final class DefaultTestResourceManager implements TestResourceManager {
 	private boolean needsConfigurationRebuild;
 
 	public DefaultTestResourceManager(Class<?>[] annotatedClasses) {
-		this.annotatedClasses = annotatedClasses;
+		this.annotatedClasses = annotatedClasses == null ? new Class<?>[0] : annotatedClasses;
 		this.cfg = new Configuration();
 		this.baseIndexDir = createBaseIndexDir();
 		this.needsConfigurationRebuild = true;

--- a/orm/src/test/java/org/hibernate/search/test/configuration/IndexEmbeddedProgrammaticallyMappedTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/IndexEmbeddedProgrammaticallyMappedTest.java
@@ -15,6 +15,7 @@ import org.hibernate.search.FullTextSession;
 import org.hibernate.search.annotations.IndexedEmbedded;
 import org.hibernate.search.test.util.FullTextSessionBuilder;
 import org.hibernate.search.testsupport.TestConstants;
+import org.hibernate.search.testsupport.TestForIssue;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -24,6 +25,7 @@ import static org.junit.Assert.assertEquals;
  *
  * @author Gunnar Morling
  */
+@TestForIssue(jiraKey = "HSEARCH-1764")
 public class IndexEmbeddedProgrammaticallyMappedTest {
 
 	@Test

--- a/orm/src/test/java/org/hibernate/search/test/configuration/IndexEmbeddedProgrammaticallyMappedTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/IndexEmbeddedProgrammaticallyMappedTest.java
@@ -1,0 +1,87 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.configuration;
+
+import java.lang.annotation.ElementType;
+
+import org.apache.lucene.queryparser.classic.QueryParser;
+import org.hibernate.Transaction;
+import org.hibernate.search.FullTextQuery;
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.test.util.FullTextSessionBuilder;
+import org.hibernate.search.testsupport.TestConstants;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for the programmatic configuration of embedded index elements.
+ *
+ * @author Gunnar Morling
+ */
+public class IndexEmbeddedProgrammaticallyMappedTest {
+
+	@Test
+	public void canSetIncludeEmbeddedObjectIdProgrammatically() throws Exception {
+		try (FullTextSessionBuilder builder = getFullTextSessionBuilder() ) {
+			// given
+			builder.fluentMapping()
+				.entity( Address.class)
+					.indexed()
+					.property( "addressId", ElementType.METHOD )
+						.documentId()
+							.name( "id" )
+					.property( "country", ElementType.METHOD )
+						.indexEmbedded()
+							.includeEmbeddedObjectId( true );
+
+			setupTestData( builder );
+
+			FullTextSession s = builder.openFullTextSession();
+
+			// when
+			QueryParser parser = new QueryParser( "id", TestConstants.standardAnalyzer );
+			org.apache.lucene.search.Query luceneQuery = parser.parse( "country.id:1" );
+
+			Transaction tx = s.beginTransaction();
+
+			// then
+			FullTextQuery query = s.createFullTextQuery( luceneQuery );
+			assertEquals( 1, query.getResultSize() );
+			assertEquals( "Bob McRobb", ( (Address) query.list().iterator().next() ).getOwner() );
+
+			tx.commit();
+			s.close();
+		}
+	}
+
+	@SuppressWarnings("resource")
+	private FullTextSessionBuilder getFullTextSessionBuilder() {
+		return new FullTextSessionBuilder()
+			.addAnnotatedClass( Address.class )
+			.addAnnotatedClass( Country.class );
+	}
+
+	public void setupTestData(FullTextSessionBuilder builder) {
+		FullTextSession s = builder.openFullTextSession();
+		Transaction tx = s.beginTransaction();
+
+		Address bobsPlace = new Address();
+		bobsPlace.setOwner( "Bob McRobb" );
+
+		Country scotland = new Country();
+		scotland.setName( "Scotland" );
+		bobsPlace.setCountry( scotland );
+		scotland.getAddresses().add( bobsPlace );
+
+		s.persist( bobsPlace );
+		s.persist( scotland );
+
+		tx.commit();
+		s.close();
+	}
+}


### PR DESCRIPTION
In addition to `includeEmbeddedObjectId()`, there is also support for `includePaths()` and `indexNullAs()`.