### PR TITLE
HSEARCH-1663

### DIFF
--- a/engine/src/main/java/org/hibernate/search/backend/impl/batch/DefaultBatchBackend.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/batch/DefaultBatchBackend.java
@@ -16,6 +16,7 @@ import org.hibernate.search.backend.OptimizeLuceneWork;
 import org.hibernate.search.backend.impl.StreamingSelectionVisitor;
 import org.hibernate.search.backend.impl.TransactionalSelectionVisitor;
 import org.hibernate.search.backend.impl.WorkQueuePerIndexSplitter;
+import org.hibernate.search.backend.spi.BatchBackend;
 import org.hibernate.search.batchindexing.MassIndexerProgressMonitor;
 import org.hibernate.search.engine.spi.EntityIndexBinding;
 import org.hibernate.search.indexes.spi.IndexManager;

--- a/engine/src/main/java/org/hibernate/search/backend/spi/BatchBackend.java
+++ b/engine/src/main/java/org/hibernate/search/backend/spi/BatchBackend.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.backend.impl.batch;
+package org.hibernate.search.backend.spi;
 
 
 import java.util.Set;

--- a/engine/src/main/java/org/hibernate/search/engine/impl/ImmutableSearchFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/ImmutableSearchFactory.java
@@ -48,11 +48,12 @@ import org.hibernate.search.query.dsl.impl.ConnectedQueryContextBuilder;
 import org.hibernate.search.query.engine.impl.HSQueryImpl;
 import org.hibernate.search.query.engine.spi.HSQuery;
 import org.hibernate.search.query.engine.spi.TimeoutExceptionFactory;
+import org.hibernate.search.spi.IndexingMode;
 import org.hibernate.search.spi.InstanceInitializer;
 import org.hibernate.search.spi.SearchIntegrator;
 import org.hibernate.search.spi.WorkerBuildContext;
-import org.hibernate.search.spi.impl.PolymorphicIndexHierarchy;
 import org.hibernate.search.spi.impl.ExtendedSearchIntegratorWithShareableState;
+import org.hibernate.search.spi.impl.PolymorphicIndexHierarchy;
 import org.hibernate.search.spi.impl.SearchFactoryState;
 import org.hibernate.search.stat.Statistics;
 import org.hibernate.search.stat.impl.StatisticsImpl;
@@ -92,7 +93,7 @@ public class ImmutableSearchFactory implements ExtendedSearchIntegratorWithShare
 	private final boolean transactionManagerExpected;
 	private final IndexManagerHolder allIndexesManager;
 	private final ErrorHandler errorHandler;
-	private final String indexingStrategy;
+	private final IndexingMode indexingMode;
 	private final ServiceManager serviceManager;
 	private final boolean enableDirtyChecks;
 	private final DefaultIndexReaderAccessor indexReaderAccessor;
@@ -117,7 +118,7 @@ public class ImmutableSearchFactory implements ExtendedSearchIntegratorWithShare
 		this.filterCachingStrategy = state.getFilterCachingStrategy();
 		this.filterDefinitions = state.getFilterDefinitions();
 		this.indexHierarchy = state.getIndexHierarchy();
-		this.indexingStrategy = state.getIndexingStrategy();
+		this.indexingMode = state.getIndexingMode();
 		this.worker = state.getWorker();
 		this.serviceManager = state.getServiceManager();
 		this.transactionManagerExpected = state.isTransactionManagerExpected();
@@ -191,8 +192,14 @@ public class ImmutableSearchFactory implements ExtendedSearchIntegratorWithShare
 	}
 
 	@Override
+	@Deprecated
 	public String getIndexingStrategy() {
-		return indexingStrategy;
+		return indexingMode.toExternalRepresentation();
+	}
+
+	@Override
+	public IndexingMode getIndexingMode() {
+		return indexingMode;
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/impl/ImmutableSearchFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/ImmutableSearchFactory.java
@@ -13,8 +13,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.lucene.analysis.Analyzer;
-import org.hibernate.search.backend.impl.batch.BatchBackend;
 import org.hibernate.search.backend.impl.batch.DefaultBatchBackend;
+import org.hibernate.search.backend.spi.BatchBackend;
 import org.hibernate.search.backend.spi.Worker;
 import org.hibernate.search.batchindexing.MassIndexerProgressMonitor;
 import org.hibernate.search.cfg.Environment;

--- a/engine/src/main/java/org/hibernate/search/engine/impl/MutableSearchFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/MutableSearchFactory.java
@@ -34,12 +34,13 @@ import org.hibernate.search.query.ObjectLookupMethod;
 import org.hibernate.search.query.dsl.QueryContextBuilder;
 import org.hibernate.search.query.engine.spi.HSQuery;
 import org.hibernate.search.query.engine.spi.TimeoutExceptionFactory;
+import org.hibernate.search.spi.IndexingMode;
 import org.hibernate.search.spi.InstanceInitializer;
-import org.hibernate.search.spi.SearchIntegratorBuilder;
 import org.hibernate.search.spi.SearchIntegrator;
+import org.hibernate.search.spi.SearchIntegratorBuilder;
 import org.hibernate.search.spi.WorkerBuildContext;
-import org.hibernate.search.spi.impl.PolymorphicIndexHierarchy;
 import org.hibernate.search.spi.impl.ExtendedSearchIntegratorWithShareableState;
+import org.hibernate.search.spi.impl.PolymorphicIndexHierarchy;
 import org.hibernate.search.stat.Statistics;
 import org.hibernate.search.stat.spi.StatisticsImplementor;
 
@@ -120,10 +121,18 @@ public class MutableSearchFactory implements ExtendedSearchIntegratorWithShareab
 		return this;
 	}
 
+	@Override
+	@Deprecated
 	public String getIndexingStrategy() {
-		return delegate.getIndexingStrategy();
+		return delegate.getIndexingMode().toExternalRepresentation();
 	}
 
+	@Override
+	public IndexingMode getIndexingMode() {
+		return delegate.getIndexingMode();
+	}
+
+	@Override
 	public void close() {
 		delegate.close();
 	}

--- a/engine/src/main/java/org/hibernate/search/engine/impl/MutableSearchFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/MutableSearchFactory.java
@@ -13,7 +13,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.lucene.analysis.Analyzer;
-import org.hibernate.search.backend.impl.batch.BatchBackend;
+import org.hibernate.search.backend.spi.BatchBackend;
 import org.hibernate.search.backend.spi.Worker;
 import org.hibernate.search.batchindexing.MassIndexerProgressMonitor;
 import org.hibernate.search.cfg.SearchMapping;

--- a/engine/src/main/java/org/hibernate/search/engine/impl/MutableSearchFactoryState.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/MutableSearchFactoryState.java
@@ -23,9 +23,10 @@ import org.hibernate.search.exception.ErrorHandler;
 import org.hibernate.search.filter.FilterCachingStrategy;
 import org.hibernate.search.indexes.impl.IndexManagerHolder;
 import org.hibernate.search.query.engine.spi.TimeoutExceptionFactory;
+import org.hibernate.search.spi.IndexingMode;
 import org.hibernate.search.spi.InstanceInitializer;
-import org.hibernate.search.spi.impl.PolymorphicIndexHierarchy;
 import org.hibernate.search.spi.impl.ExtendedSearchIntegratorWithShareableState;
+import org.hibernate.search.spi.impl.PolymorphicIndexHierarchy;
 import org.hibernate.search.spi.impl.SearchFactoryState;
 
 /**
@@ -37,7 +38,7 @@ public class MutableSearchFactoryState implements SearchFactoryState {
 
 	private Map<Class<?>, DocumentBuilderContainedEntity> documentBuildersContainedEntities;
 	private Map<Class<?>, EntityIndexBinding> indexBindingsPerEntity;
-	private String indexingStrategy;
+	private IndexingMode indexingMode;
 	private Worker worker;
 	private BackendQueueProcessor backendQueueProcessor;
 	private Map<String, FilterDef> filterDefinitions;
@@ -60,7 +61,7 @@ public class MutableSearchFactoryState implements SearchFactoryState {
 	private IndexManagerFactory indexManagerFactory;
 
 	public void copyStateFromOldFactory(SearchFactoryState oldFactoryState) {
-		indexingStrategy = oldFactoryState.getIndexingStrategy();
+		indexingMode = oldFactoryState.getIndexingMode();
 		indexBindingsPerEntity = oldFactoryState.getIndexBindings();
 		documentBuildersContainedEntities = oldFactoryState.getDocumentBuildersContainedEntities();
 		worker = oldFactoryState.getWorker();
@@ -104,8 +105,8 @@ public class MutableSearchFactoryState implements SearchFactoryState {
 	}
 
 	@Override
-	public String getIndexingStrategy() {
-		return indexingStrategy;
+	public IndexingMode getIndexingMode() {
+		return indexingMode;
 	}
 
 	@Override
@@ -155,8 +156,8 @@ public class MutableSearchFactoryState implements SearchFactoryState {
 		this.indexBindingsPerEntity = documentBuildersIndexedEntities;
 	}
 
-	public void setIndexingStrategy(String indexingStrategy) {
-		this.indexingStrategy = indexingStrategy;
+	public void setIndexingMode(IndexingMode indexingMode) {
+		this.indexingMode = indexingMode;
 	}
 
 	public void setWorker(Worker worker) {

--- a/engine/src/main/java/org/hibernate/search/engine/integration/impl/ExtendedSearchIntegrator.java
+++ b/engine/src/main/java/org/hibernate/search/engine/integration/impl/ExtendedSearchIntegrator.java
@@ -46,8 +46,6 @@ public interface ExtendedSearchIntegrator extends SearchIntegrator {
 
 	FilterDef getFilterDefinition(String name);
 
-	String getIndexingStrategy();
-
 	int getFilterCacheBitResultsSize();
 
 	Set<Class<?>> getIndexedTypesPolymorphic(Class<?>[] classes);

--- a/engine/src/main/java/org/hibernate/search/engine/integration/impl/ExtendedSearchIntegrator.java
+++ b/engine/src/main/java/org/hibernate/search/engine/integration/impl/ExtendedSearchIntegrator.java
@@ -10,8 +10,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
-import org.hibernate.search.backend.impl.batch.BatchBackend;
-import org.hibernate.search.batchindexing.MassIndexerProgressMonitor;
 import org.hibernate.search.engine.impl.FilterDef;
 import org.hibernate.search.engine.spi.DocumentBuilderContainedEntity;
 import org.hibernate.search.engine.spi.EntityIndexBinding;
@@ -49,8 +47,6 @@ public interface ExtendedSearchIntegrator extends SearchIntegrator {
 	int getFilterCacheBitResultsSize();
 
 	Set<Class<?>> getIndexedTypesPolymorphic(Class<?>[] classes);
-
-	BatchBackend makeBatchBackend(MassIndexerProgressMonitor progressMonitor);
 
 	boolean isJMXEnabled();
 

--- a/engine/src/main/java/org/hibernate/search/engine/spi/AbstractDocumentBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/engine/spi/AbstractDocumentBuilder.java
@@ -80,6 +80,9 @@ public abstract class AbstractDocumentBuilder {
 		optimizationBlackList.addAll( typeMetadata.getOptimizationBlackList() );
 	}
 
+	/**
+	 * @param contextualBridge Context used for exception preparation during bridge invocations. May be {@code null}.
+	 */
 	public abstract void addWorkToQueue(Class<?> entityClass,
 			Object entity, Serializable id,
 			boolean delete,

--- a/engine/src/main/java/org/hibernate/search/spi/BuildContext.java
+++ b/engine/src/main/java/org/hibernate/search/spi/BuildContext.java
@@ -44,12 +44,15 @@ public interface BuildContext {
 	ExtendedSearchIntegrator getUninitializedSearchIntegrator();
 
 	/**
-	 * Returns the configured indexing strategy (<i>event</i> vs <i>manual</i>).
-	 *
-	 * @return hte configured indexing strategy
-	 * @see org.hibernate.search.cfg.Environment#INDEXING_STRATEGY
+	 * @deprecated Scheduled for removal. Use {@link #getIndexingMode()} instead.
 	 */
+	@Deprecated
 	String getIndexingStrategy();
+
+	/**
+	 * Returns the current indexing strategy as specified via {@link org.hibernate.search.cfg.Environment#INDEXING_STRATEGY}.
+	 */
+	IndexingMode getIndexingMode();
 
 	/**
 	 * Access the {@code ServiceManager}.

--- a/engine/src/main/java/org/hibernate/search/spi/IndexingMode.java
+++ b/engine/src/main/java/org/hibernate/search/spi/IndexingMode.java
@@ -1,0 +1,60 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.spi;
+
+import org.hibernate.search.util.logging.impl.Log;
+import org.hibernate.search.util.logging.impl.LoggerFactory;
+
+/**
+ * Modes for triggering indexing of entities.
+ *
+ * @author Gunnar Morling
+ */
+public enum IndexingMode {
+
+	/**
+	 * Indexing is triggered automatically upon entity insertion, update etc.
+	 */
+	EVENT("event"),
+
+	/**
+	 * Indexing is triggered explicitly.
+	 */
+	MANUAL("manual");
+
+	private static Log LOG = LoggerFactory.make();
+
+	private String externalRepresentation;
+
+	private IndexingMode(String externalRepresentation) {
+		this.externalRepresentation = externalRepresentation;
+	}
+
+	/**
+	 * Returns the {@link IndexingMode} matching the given external representation as specified via
+	 * {@link org.hibernate.search.cfg.Environment#INDEXING_STRATEGY}
+	 */
+	public static IndexingMode fromExternalRepresentation(String indexingMode) {
+		if ( EVENT.toExternalRepresentation().equals( indexingMode ) ) {
+			return IndexingMode.EVENT;
+		}
+		else if ( MANUAL.toExternalRepresentation().equals( indexingMode ) ) {
+			return IndexingMode.MANUAL;
+		}
+		else {
+			throw LOG.unknownIndexingMode( indexingMode );
+		}
+	}
+
+	/**
+	 * Returns the external representation of this indexing mode. Generally this enumeration itself should preferably be
+	 * used for comparisons etc.
+	 */
+	public String toExternalRepresentation() {
+		return externalRepresentation;
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/spi/SearchIntegrator.java
+++ b/engine/src/main/java/org/hibernate/search/spi/SearchIntegrator.java
@@ -175,8 +175,13 @@ public interface SearchIntegrator extends AutoCloseable {
 	/**
 	 * Shuts down all workers and releases all resources.
 	 */
+	@Override
 	void close();
 
 	IndexManager getIndexManager(String indexName);
 
+	/**
+	 * Returns the current indexing strategy as specified via {@link org.hibernate.search.cfg.Environment#INDEXING_STRATEGY}.
+	 */
+	IndexingMode getIndexingMode();
 }

--- a/engine/src/main/java/org/hibernate/search/spi/SearchIntegrator.java
+++ b/engine/src/main/java/org/hibernate/search/spi/SearchIntegrator.java
@@ -9,7 +9,9 @@ package org.hibernate.search.spi;
 import java.util.Set;
 
 import org.apache.lucene.analysis.Analyzer;
+import org.hibernate.search.backend.spi.BatchBackend;
 import org.hibernate.search.backend.spi.Worker;
+import org.hibernate.search.batchindexing.MassIndexerProgressMonitor;
 import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.engine.spi.EntityIndexBinding;
 import org.hibernate.search.exception.ErrorHandler;
@@ -184,4 +186,6 @@ public interface SearchIntegrator extends AutoCloseable {
 	 * Returns the current indexing strategy as specified via {@link org.hibernate.search.cfg.Environment#INDEXING_STRATEGY}.
 	 */
 	IndexingMode getIndexingMode();
+
+	BatchBackend makeBatchBackend(MassIndexerProgressMonitor progressMonitor);
 }

--- a/engine/src/main/java/org/hibernate/search/spi/SearchIntegratorBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/spi/SearchIntegratorBuilder.java
@@ -195,7 +195,7 @@ public class SearchIntegratorBuilder {
 
 		factoryState.setSearchMapping( mapping ); // might be null if feature is not used
 
-		factoryState.setIndexingStrategy( defineIndexingStrategy( cfg ) );//need to be done before the document builds
+		factoryState.setIndexingMode( defineIndexingMode( cfg ) );//need to be done before the document builds
 		initDocumentBuilders( cfg, buildContext, mapping );
 
 		final Map<Class<?>, EntityIndexBinding> documentBuildersIndexedEntities = factoryState.getIndexBindings();
@@ -486,12 +486,9 @@ public class SearchIntegratorBuilder {
 		return reflectionManager;
 	}
 
-	private static String defineIndexingStrategy(SearchConfiguration cfg) {
-		String indexingStrategy = cfg.getProperties().getProperty( Environment.INDEXING_STRATEGY, "event" );
-		if ( !( "event".equals( indexingStrategy ) || "manual".equals( indexingStrategy ) ) ) {
-			throw new SearchException( Environment.INDEXING_STRATEGY + " unknown: " + indexingStrategy );
-		}
-		return indexingStrategy;
+	private static IndexingMode defineIndexingMode(SearchConfiguration cfg) {
+		String indexingStrategy = cfg.getProperties().getProperty( Environment.INDEXING_STRATEGY, IndexingMode.EVENT.toExternalRepresentation() );
+		return IndexingMode.fromExternalRepresentation( indexingStrategy );
 	}
 
 	private ErrorHandler createErrorHandler(SearchConfiguration searchConfiguration) {
@@ -538,8 +535,14 @@ public class SearchIntegratorBuilder {
 		}
 
 		@Override
+		@Deprecated
 		public String getIndexingStrategy() {
-			return factoryState.getIndexingStrategy();
+			return factoryState.getIndexingMode().name().toLowerCase();
+		}
+
+		@Override
+		public IndexingMode getIndexingMode() {
+			return factoryState.getIndexingMode();
 		}
 
 		@Override

--- a/engine/src/main/java/org/hibernate/search/spi/impl/SearchFactoryState.java
+++ b/engine/src/main/java/org/hibernate/search/spi/impl/SearchFactoryState.java
@@ -23,6 +23,7 @@ import org.hibernate.search.exception.ErrorHandler;
 import org.hibernate.search.filter.FilterCachingStrategy;
 import org.hibernate.search.indexes.impl.IndexManagerHolder;
 import org.hibernate.search.query.engine.spi.TimeoutExceptionFactory;
+import org.hibernate.search.spi.IndexingMode;
 import org.hibernate.search.spi.InstanceInitializer;
 
 /**
@@ -35,7 +36,7 @@ public interface SearchFactoryState {
 
 	Map<Class<?>, EntityIndexBinding> getIndexBindings();
 
-	String getIndexingStrategy();
+	IndexingMode getIndexingMode();
 
 	Worker getWorker();
 

--- a/engine/src/main/java/org/hibernate/search/store/impl/FSDirectoryProvider.java
+++ b/engine/src/main/java/org/hibernate/search/store/impl/FSDirectoryProvider.java
@@ -14,6 +14,7 @@ import org.apache.lucene.store.FSDirectory;
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
 import org.hibernate.search.spi.BuildContext;
+import org.hibernate.search.spi.IndexingMode;
 import org.hibernate.search.store.DirectoryProvider;
 import org.hibernate.search.store.spi.DirectoryHelper;
 import org.hibernate.search.util.logging.impl.Log;
@@ -44,7 +45,7 @@ public class FSDirectoryProvider implements DirectoryProvider<FSDirectory> {
 	@Override
 	public void initialize(String directoryProviderName, Properties properties, BuildContext context) {
 		// on "manual" indexing skip read-write check on index directory
-		boolean manual = "manual".equals( context.getIndexingStrategy() );
+		boolean manual = IndexingMode.MANUAL == context.getIndexingMode();
 		File indexDir = DirectoryHelper.getVerifiedIndexDir( directoryProviderName, properties, !manual );
 		try {
 			indexName = indexDir.getCanonicalPath();

--- a/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
@@ -753,4 +753,7 @@ public interface Log extends BasicLogger {
 
 	@Message(id = 253, value = "To use '%1$s' as a locking strategy, an indexBase path must be set")
 	SearchException indexBasePathRequiredForLockingStrategy(String strategy);
+
+	@Message(id = 254, value = "Unknown indexing mode: %1$s")
+	SearchException unknownIndexingMode(String indexingMode);
 }

--- a/engine/src/test/java/org/hibernate/search/test/engine/service/StandardServiceManagerTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/engine/service/StandardServiceManagerTest.java
@@ -6,13 +6,14 @@
  */
 package org.hibernate.search.test.engine.service;
 
-import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.engine.service.impl.StandardServiceManager;
 import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.exception.ErrorHandler;
+import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.indexes.impl.IndexManagerHolder;
 import org.hibernate.search.spi.BuildContext;
+import org.hibernate.search.spi.IndexingMode;
 import org.hibernate.search.testsupport.TestForIssue;
 import org.hibernate.search.testsupport.junit.SearchFactoryHolder;
 import org.hibernate.search.testsupport.setup.SearchConfigurationForTest;
@@ -197,6 +198,11 @@ public class StandardServiceManagerTest {
 
 		@Override
 		public String getIndexingStrategy() {
+			return null;
+		}
+
+		@Override
+		public IndexingMode getIndexingMode() {
 			return null;
 		}
 

--- a/engine/src/test/java/org/hibernate/search/testsupport/setup/BuildContextForTest.java
+++ b/engine/src/test/java/org/hibernate/search/testsupport/setup/BuildContextForTest.java
@@ -15,6 +15,7 @@ import org.hibernate.search.exception.ErrorHandler;
 import org.hibernate.search.exception.impl.LogErrorHandler;
 import org.hibernate.search.indexes.impl.IndexManagerHolder;
 import org.hibernate.search.spi.BuildContext;
+import org.hibernate.search.spi.IndexingMode;
 
 /**
  * A {@code BuildContext} implementation for running tests.
@@ -22,7 +23,6 @@ import org.hibernate.search.spi.BuildContext;
  * @author Hardy Ferentschik
  */
 public class BuildContextForTest implements BuildContext {
-	private static final String INDEXING_STRATEGY_EVENT = "event";
 	private final SearchConfiguration searchConfiguration;
 
 	public BuildContextForTest(SearchConfiguration searchConfiguration) {
@@ -36,7 +36,12 @@ public class BuildContextForTest implements BuildContext {
 
 	@Override
 	public String getIndexingStrategy() {
-		return INDEXING_STRATEGY_EVENT;
+		return IndexingMode.EVENT.toExternalRepresentation();
+	}
+
+	@Override
+	public IndexingMode getIndexingMode() {
+		return IndexingMode.EVENT;
 	}
 
 	@Override

--- a/orm/src/main/java/org/hibernate/search/batchindexing/impl/BatchCoordinator.java
+++ b/orm/src/main/java/org/hibernate/search/batchindexing/impl/BatchCoordinator.java
@@ -16,7 +16,7 @@ import org.hibernate.search.util.impl.Executors;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.CacheMode;
 import org.hibernate.search.backend.PurgeAllLuceneWork;
-import org.hibernate.search.backend.impl.batch.BatchBackend;
+import org.hibernate.search.backend.spi.BatchBackend;
 import org.hibernate.search.batchindexing.MassIndexerProgressMonitor;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 

--- a/orm/src/main/java/org/hibernate/search/batchindexing/impl/BatchIndexingWorkspace.java
+++ b/orm/src/main/java/org/hibernate/search/batchindexing/impl/BatchIndexingWorkspace.java
@@ -14,7 +14,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import org.hibernate.CacheMode;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.search.exception.SearchException;
-import org.hibernate.search.backend.impl.batch.BatchBackend;
+import org.hibernate.search.backend.spi.BatchBackend;
 import org.hibernate.search.batchindexing.MassIndexerProgressMonitor;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.exception.ErrorHandler;

--- a/orm/src/main/java/org/hibernate/search/batchindexing/impl/IdentifierConsumerDocumentProducer.java
+++ b/orm/src/main/java/org/hibernate/search/batchindexing/impl/IdentifierConsumerDocumentProducer.java
@@ -18,12 +18,11 @@ import org.hibernate.LockMode;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
-
 import org.hibernate.criterion.CriteriaSpecification;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.search.backend.AddLuceneWork;
-import org.hibernate.search.backend.impl.batch.BatchBackend;
+import org.hibernate.search.backend.spi.BatchBackend;
 import org.hibernate.search.batchindexing.MassIndexerProgressMonitor;
 import org.hibernate.search.bridge.TwoWayFieldBridge;
 import org.hibernate.search.bridge.spi.ConversionContext;

--- a/orm/src/main/java/org/hibernate/search/event/impl/FullTextIndexEventListener.java
+++ b/orm/src/main/java/org/hibernate/search/event/impl/FullTextIndexEventListener.java
@@ -43,8 +43,9 @@ import org.hibernate.search.backend.spi.WorkType;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.engine.spi.AbstractDocumentBuilder;
 import org.hibernate.search.engine.spi.EntityIndexBinding;
-import org.hibernate.search.util.impl.ReflectionHelper;
+import org.hibernate.search.spi.IndexingMode;
 import org.hibernate.search.util.impl.Maps;
+import org.hibernate.search.util.impl.ReflectionHelper;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
@@ -66,8 +67,6 @@ public final class FullTextIndexEventListener implements PostDeleteEventListener
 		Serializable {
 
 	private static final Log log = LoggerFactory.make();
-	private static final String INDEXING_STRATEGY_MANUAL = "manual";
-	private static final String INDEXING_STRATEGY_EVENT = "event";
 
 	private boolean disabled;
 	private boolean skipDirtyChecks = true;
@@ -191,11 +190,11 @@ public final class FullTextIndexEventListener implements PostDeleteEventListener
 	 */
 	public void initialize(ExtendedSearchIntegrator extendedIntegrator) {
 		this.extendedIntegrator = extendedIntegrator;
-		String indexingStrategy = extendedIntegrator.getIndexingStrategy();
-		if ( INDEXING_STRATEGY_EVENT.equals( indexingStrategy ) ) {
+
+		if ( extendedIntegrator.getIndexingMode() == IndexingMode.EVENT ) {
 			disabled = extendedIntegrator.getIndexBindings().size() == 0;
 		}
-		else if ( INDEXING_STRATEGY_MANUAL.equals( indexingStrategy ) ) {
+		else if ( extendedIntegrator.getIndexingMode() == IndexingMode.MANUAL ) {
 			disabled = true;
 		}
 


### PR DESCRIPTION
This picks some low-hanging fruits to get rid of several references to HS "impl" classes from ISPN.

The remaining references in "main" code are (going to ignore dependencies in test code for now):

infinispan-query
* SearchableCacheConfiguration
  * org.hibernate.search.engine.service.classloading.impl.DefaultClassLoaderService (there is a TODO already to replace it with something from ISPN)
* LuceneWorkTransformationVisitor
  * org.hibernate.search.backend.impl.WorkVisitor

infinispan-remote-query-server
* IndexingTagHandler
  * org.hibernate.search.engine.impl.LuceneOptionsImpl
  * org.hibernate.search.engine.metadata.impl.DocumentFieldMetadata
* QueryFacadeImpl
  * org.hibernate.search.bridge.builtin.impl.NullEncodingTwoWayFieldBridge
  * org.hibernate.search.bridge.builtin.impl.TwoWayString2FieldBridgeAdaptor

Any ideas for resolving some or all of these are welcome. I guess though we'll need to tackle them at another time, as the HS iteration is nearly over.

