### PR TITLE
HSEARCH-1792 Multi-tenancy support

### DIFF
--- a/documentation/src/main/asciidoc/advanced-features.asciidoc
+++ b/documentation/src/main/asciidoc/advanced-features.asciidoc
@@ -428,3 +428,33 @@ occurrences. In this case your custom implementation of the method `tf(float fre
 ====
 When two entities share the same index they must declare the same Similarity implementation.
 ====
+
+[[section-multi-tenancy]]
+=== Multi-tenancy
+
+Hibernate Search supports multi-tenancy on top of Hibernate ORM, it stores the tenant identifier in
+the document and automatically filters the query results.
+
+You can find more details about multi-tenancy in the
+link:$$http://hibernate.org/orm/documentation/$$[Hibernate ORM documentation].
+
+.Bind the session to a tenant
+====
+[source, JAVA]
+----
+Session session = getSessionFactory()
+                      .withOptions()
+                          .tenantIdentifier( "YOUR_TENANT_ID" )
+                  .openSession();
+
+FullTextSession session = Search.getFullTextSession( session );
+----
+====
+
+The use of a tenant identifier will have the following effects:
+
+1. Every document saved or updated in the index will have an additional field `__HSearch_TenantId`
+   containing the tenant identifier.
+2. Every search will be filtered using the tenant identifier.
+
+Note that not using a tenant will return all the matching results for all the tenants in the index.

--- a/engine/src/main/java/org/hibernate/search/backend/AddLuceneWork.java
+++ b/engine/src/main/java/org/hibernate/search/backend/AddLuceneWork.java
@@ -23,11 +23,19 @@ public class AddLuceneWork extends LuceneWork {
 	private final Map<String, String> fieldToAnalyzerMap;
 
 	public AddLuceneWork(Serializable id, String idInString, Class<?> entity, Document document) {
-		this( id, idInString, entity, document, null );
+		this( null, id, idInString, entity, document, null );
+	}
+
+	public AddLuceneWork(String tenantId, Serializable id, String idInString, Class<?> entity, Document document) {
+		this( tenantId, id, idInString, entity, document, null );
 	}
 
 	public AddLuceneWork(Serializable id, String idInString, Class<?> entity, Document document, Map<String, String> fieldToAnalyzerMap) {
-		super( id, idInString, entity, document );
+		this( null, id, idInString, entity, document, fieldToAnalyzerMap );
+	}
+
+	public AddLuceneWork(String tenantId, Serializable id, String idInString, Class<?> entity, Document document, Map<String, String> fieldToAnalyzerMap) {
+		super( tenantId, id, idInString, entity, document );
 		this.fieldToAnalyzerMap = fieldToAnalyzerMap;
 	}
 
@@ -43,7 +51,8 @@ public class AddLuceneWork extends LuceneWork {
 
 	@Override
 	public String toString() {
-		return "AddLuceneWork: " + this.getEntityClass().getName() + "#" + this.getIdInString();
+		String tenant = getTenantId() == null ? "" : " [" + getTenantId() + "] ";
+		return "AddLuceneWork" + tenant + ": " + this.getEntityClass().getName() + "#" + this.getIdInString();
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/search/backend/DeleteByQueryLuceneWork.java
+++ b/engine/src/main/java/org/hibernate/search/backend/DeleteByQueryLuceneWork.java
@@ -19,7 +19,11 @@ public class DeleteByQueryLuceneWork extends LuceneWork {
 	private final DeletionQuery deletionQuery;
 
 	public DeleteByQueryLuceneWork(Class<?> entity, DeletionQuery deletionQuery) {
-		super( null, null, entity );
+		this( null, entity, deletionQuery );
+	}
+
+	public DeleteByQueryLuceneWork(String tenantId, Class<?> entity, DeletionQuery deletionQuery) {
+		super( tenantId, null, null, entity );
 		this.deletionQuery = deletionQuery;
 	}
 

--- a/engine/src/main/java/org/hibernate/search/backend/DeleteLuceneWork.java
+++ b/engine/src/main/java/org/hibernate/search/backend/DeleteLuceneWork.java
@@ -18,7 +18,11 @@ public class DeleteLuceneWork extends LuceneWork {
 	private static final long serialVersionUID = -854604138119230246L;
 
 	public DeleteLuceneWork(Serializable id, String idInString, Class<?> entity) {
-		super( id, idInString, entity );
+		this( null, id, idInString, entity );
+	}
+
+	public DeleteLuceneWork(String tenantId, Serializable id, String idInString, Class<?> entity) {
+		super( tenantId, id, idInString, entity );
 	}
 
 	@Override
@@ -28,7 +32,8 @@ public class DeleteLuceneWork extends LuceneWork {
 
 	@Override
 	public String toString() {
-		return "DeleteLuceneWork: " + this.getEntityClass().getName() + "#" + this.getIdInString();
+		String tenant = getTenantId() == null ? "" : " [" + getTenantId() + "] ";
+		return "DeleteLuceneWork" + tenant + ": " + this.getEntityClass().getName() + "#" + this.getIdInString();
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/search/backend/FlushLuceneWork.java
+++ b/engine/src/main/java/org/hibernate/search/backend/FlushLuceneWork.java
@@ -24,15 +24,15 @@ public class FlushLuceneWork extends LuceneWork {
 	 *
 	 * @param entity the entity type for which to flush the index
 	 */
-	public FlushLuceneWork(Class<?> entity) {
-		super( null, null, entity );
+	public FlushLuceneWork(String tenantId, Class<?> entity) {
+		super( tenantId, null, null, entity );
 	}
 
 	/**
 	 * Flushes all index operations
 	 */
 	private FlushLuceneWork() {
-		super( null, null, null );
+		super( null, null, null, null );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/backend/LuceneWork.java
+++ b/engine/src/main/java/org/hibernate/search/backend/LuceneWork.java
@@ -10,7 +10,6 @@ import java.io.Serializable;
 import java.util.Map;
 
 import org.apache.lucene.document.Document;
-
 import org.hibernate.search.backend.impl.WorkVisitor;
 
 /**
@@ -31,14 +30,16 @@ public abstract class LuceneWork {
 
 	private final Document document;
 	private final Class<?> entityClass;
+	private final String tenantId;
 	private final Serializable id;
 	private final String idInString;
 
-	public LuceneWork(Serializable id, String idInString, Class<?> entity) {
-		this( id, idInString, entity, null );
+	public LuceneWork(String tenantId, Serializable id, String idInString, Class<?> entity) {
+		this( tenantId, id, idInString, entity, null );
 	}
 
-	public LuceneWork(Serializable id, String idInString, Class<?> entity, Document document) {
+	public LuceneWork(String tenantId, Serializable id, String idInString, Class<?> entity, Document document) {
+		this.tenantId = tenantId;
 		this.id = id;
 		this.idInString = idInString;
 		this.entityClass = entity;
@@ -61,10 +62,13 @@ public abstract class LuceneWork {
 		return idInString;
 	}
 
+	public String getTenantId() {
+		return tenantId;
+	}
+
 	public abstract <T> T getWorkDelegate(WorkVisitor<T> visitor);
 
 	public Map<String, String> getFieldToAnalyzerMap() {
 		return null;
 	}
-
 }

--- a/engine/src/main/java/org/hibernate/search/backend/OptimizeLuceneWork.java
+++ b/engine/src/main/java/org/hibernate/search/backend/OptimizeLuceneWork.java
@@ -25,14 +25,14 @@ public class OptimizeLuceneWork extends LuceneWork {
 	 * @param entity
 	 */
 	public OptimizeLuceneWork(Class<?> entity) {
-		super( null, null, entity );
+		super( null, null, null, entity );
 	}
 
 	/**
 	 * Optimizes any index
 	 */
 	private OptimizeLuceneWork() {
-		super( null, null, null );
+		super( null, null, null, null );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/backend/PurgeAllLuceneWork.java
+++ b/engine/src/main/java/org/hibernate/search/backend/PurgeAllLuceneWork.java
@@ -18,7 +18,11 @@ public class PurgeAllLuceneWork extends LuceneWork {
 	private static final long serialVersionUID = 8124091288284011715L;
 
 	public PurgeAllLuceneWork(Class<?> entity) {
-		super( null, null, entity, null );
+		this( null, entity );
+	}
+
+	public PurgeAllLuceneWork(String tenantId, Class<?> entity) {
+		super( tenantId, null, null, entity, null );
 	}
 
 	@Override
@@ -28,7 +32,8 @@ public class PurgeAllLuceneWork extends LuceneWork {
 
 	@Override
 	public String toString() {
-		return "PurgeAllLuceneWork: " + this.getEntityClass().getName();
+		String tenant = getTenantId() == null ? "" : " [" + getTenantId() + "] ";
+		return "PurgeAllLuceneWork" + tenant + ": " + this.getEntityClass().getName();
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/search/backend/UpdateLuceneWork.java
+++ b/engine/src/main/java/org/hibernate/search/backend/UpdateLuceneWork.java
@@ -11,7 +11,6 @@ import java.io.Serializable;
 import java.util.Map;
 
 import org.apache.lucene.document.Document;
-
 import org.hibernate.search.backend.impl.WorkVisitor;
 
 /**
@@ -27,11 +26,19 @@ public class UpdateLuceneWork extends LuceneWork {
 	private final Map<String, String> fieldToAnalyzerMap;
 
 	public UpdateLuceneWork(Serializable id, String idInString, Class<?> entity, Document document) {
-		this( id, idInString, entity, document, null );
+		this( null, id, idInString, entity, document, null );
+	}
+
+	public UpdateLuceneWork(String tenantId, Serializable id, String idInString, Class<?> entity, Document document) {
+		this( tenantId, id, idInString, entity, document, null );
 	}
 
 	public UpdateLuceneWork(Serializable id, String idInString, Class<?> entity, Document document, Map<String, String> fieldToAnalyzerMap) {
-		super( id, idInString, entity, document );
+		this( null, id, idInString, entity, document );
+	}
+
+	public UpdateLuceneWork(String tenantId, Serializable id, String idInString, Class<?> entity, Document document, Map<String, String> fieldToAnalyzerMap) {
+		super( tenantId, id, idInString, entity, document );
 		this.fieldToAnalyzerMap = fieldToAnalyzerMap;
 	}
 
@@ -47,7 +54,8 @@ public class UpdateLuceneWork extends LuceneWork {
 
 	@Override
 	public String toString() {
-		return "UpdateLuceneWork: " + this.getEntityClass().getName() + "#" + this.getIdInString();
+		String tenant = getTenantId() == null ? "" : " [" + getTenantId() + "] ";
+		return "UpdateLuceneWork" + tenant + ": " + this.getEntityClass().getName() + "#" + this.getIdInString();
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/search/backend/impl/TransactionalWorker.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/TransactionalWorker.java
@@ -128,13 +128,13 @@ public class TransactionalWorker implements Worker {
 				log.forceSkipIndexOperationViaInterception( entityClass, work.getType() );
 				break;
 			case UPDATE:
-				result = new Work( work.getEntity(), work.getId(), WorkType.UPDATE );
+				result = new Work( work.getTenantIdentifier(), work.getEntity(), work.getId(), WorkType.UPDATE );
 				log.forceUpdateOnIndexOperationViaInterception( entityClass, work.getType() );
 				break;
 			case REMOVE:
 				//This works because other Work constructors are never used from WorkType ADD, UPDATE, REMOVE, COLLECTION
 				//TODO should we force isIdentifierRollback to false if the operation is not a delete?
-				result = new Work( work.getEntity(), work.getId(), WorkType.DELETE, work.isIdentifierWasRolledBack() );
+				result = new Work( work.getTenantIdentifier(), work.getEntity(), work.getId(), WorkType.DELETE, work.isIdentifierWasRolledBack() );
 				log.forceRemoveOnIndexOperationViaInterception( entityClass, work.getType() );
 				break;
 			default:

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/ByTermDeleteWorkDelegate.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/ByTermDeleteWorkDelegate.java
@@ -10,11 +10,15 @@ import java.io.Serializable;
 
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.Term;
-
+import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.bridge.util.impl.NumericFieldUtils;
+import org.hibernate.search.engine.ProjectionConstants;
 import org.hibernate.search.engine.spi.DocumentBuilderIndexedEntity;
 import org.hibernate.search.store.Workspace;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
@@ -39,17 +43,25 @@ public final class ByTermDeleteWorkDelegate extends DeleteWorkDelegate {
 	@Override
 	public void performWork(LuceneWork work, IndexWriter writer, IndexingMonitor monitor) {
 		final Class<?> managedType = work.getEntityClass();
+		final String tenantId = work.getTenantId();
 		DocumentBuilderIndexedEntity builder = workspace.getDocumentBuilder( managedType );
 		Serializable id = work.getId();
 		log.tracef( "Removing %s#%s by id using an IndexWriter.", managedType, id );
 		try {
+			BooleanQuery termDeleteQuery = new BooleanQuery();
+			if ( tenantId != null ) {
+				TermQuery tenantTermQuery = new TermQuery( new Term( ProjectionConstants.TENANT_ID, tenantId ) );
+				termDeleteQuery.add( tenantTermQuery, Occur.MUST );
+			}
 			if ( isIdNumeric( builder ) ) {
-				writer.deleteDocuments( NumericFieldUtils.createExactMatchQuery( builder.getIdKeywordName(), id ) );
+				Query exactMatchQuery = NumericFieldUtils.createExactMatchQuery( builder.getIdKeywordName(), id );
+				termDeleteQuery.add( exactMatchQuery, Occur.MUST );
 			}
 			else {
 				Term idTerm = new Term( builder.getIdKeywordName(), work.getIdInString() );
-				writer.deleteDocuments( idTerm );
+				termDeleteQuery.add( new TermQuery( idTerm ), Occur.MUST );
 			}
+			writer.deleteDocuments( termDeleteQuery );
 			workspace.notifyWorkApplied( work );
 		}
 		catch (Exception e) {

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/DeleteByQueryWorkDelegate.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/DeleteByQueryWorkDelegate.java
@@ -68,6 +68,8 @@ class DeleteByQueryWorkDelegate implements LuceneWorkDelegate {
 		TermQuery classNameQuery = new TermQuery( classNameQueryTerm );
 		entityDeletionQuery.add( classNameQuery, BooleanClause.Occur.MUST );
 
+		addTenantQueryTerm( work.getTenantId(), entityDeletionQuery );
+
 		try {
 			writer.deleteDocuments( entityDeletionQuery );
 		}
@@ -79,4 +81,10 @@ class DeleteByQueryWorkDelegate implements LuceneWorkDelegate {
 
 	}
 
+	private void addTenantQueryTerm(final String tenantId, BooleanQuery entityDeletionQuery) {
+		if ( tenantId != null ) {
+			Term tenantTerm = new Term( ProjectionConstants.TENANT_ID, tenantId );
+			entityDeletionQuery.add( new TermQuery( tenantTerm ), BooleanClause.Occur.MUST );
+		}
+	}
 }

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/DeleteWorkDelegate.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/DeleteWorkDelegate.java
@@ -14,7 +14,6 @@ import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
-
 import org.hibernate.search.engine.ProjectionConstants;
 import org.hibernate.search.bridge.TwoWayFieldBridge;
 import org.hibernate.search.bridge.builtin.NumericFieldBridge;
@@ -22,7 +21,6 @@ import org.hibernate.search.bridge.util.impl.NumericFieldUtils;
 import org.hibernate.search.engine.spi.DocumentBuilderIndexedEntity;
 import org.hibernate.search.store.Workspace;
 import org.hibernate.search.util.logging.impl.Log;
-
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
@@ -70,6 +68,8 @@ class DeleteWorkDelegate implements LuceneWorkDelegate {
 		TermQuery classNameQuery = new TermQuery( classNameQueryTerm );
 		entityDeletionQuery.add( classNameQuery, BooleanClause.Occur.MUST );
 
+		addTenantQueryTerm( work.getTenantId(), entityDeletionQuery );
+
 		try {
 			writer.deleteDocuments( entityDeletionQuery );
 		}
@@ -78,6 +78,13 @@ class DeleteWorkDelegate implements LuceneWorkDelegate {
 			throw new SearchException( message, e );
 		}
 		workspace.notifyWorkApplied( work );
+	}
+
+	private void addTenantQueryTerm(final String tenantId, BooleanQuery entityDeletionQuery) {
+		if ( tenantId != null ) {
+			Term tenantTerm = new Term( ProjectionConstants.TENANT_ID, tenantId );
+			entityDeletionQuery.add( new TermQuery( tenantTerm ), BooleanClause.Occur.MUST );
+		}
 	}
 
 	protected static boolean isIdNumeric(DocumentBuilderIndexedEntity documentBuilder) {

--- a/engine/src/main/java/org/hibernate/search/backend/spi/DeleteByQueryWork.java
+++ b/engine/src/main/java/org/hibernate/search/backend/spi/DeleteByQueryWork.java
@@ -22,15 +22,20 @@ public class DeleteByQueryWork extends Work {
 
 	private final DeletionQuery deleteByQuery;
 
+	public DeleteByQueryWork(Class<?> entityType, DeletionQuery deletionQuery) {
+		this( null, entityType, deletionQuery );
+	}
+
 	/**
 	 * Creates a DeleteByWork
 	 *
+	 * @param tenantId the tenant identifier
 	 * @param entityType the class to operate on
 	 * @param deleteByQuery the query to delete by
 	 * @throws IllegalArgumentException if a unsupported SerializableQuery is passed
 	 */
-	public DeleteByQueryWork(Class<?> entityType, DeletionQuery deletionQuery) {
-		super( entityType, null, WorkType.DELETE_BY_QUERY );
+	public DeleteByQueryWork(String tenantId, Class<?> entityType, DeletionQuery deletionQuery) {
+		super( tenantId, entityType, null, WorkType.DELETE_BY_QUERY );
 		if ( entityType == null ) {
 			throw new IllegalArgumentException( "entityType must not be null" );
 		}

--- a/engine/src/main/java/org/hibernate/search/backend/spi/Work.java
+++ b/engine/src/main/java/org/hibernate/search/backend/spi/Work.java
@@ -20,34 +20,56 @@ public class Work {
 	private final Serializable id;
 	private final WorkType type;
 	private final boolean identifierWasRolledBack;
+	private final String tenantIdentifier;
 
 	public Work(Object entity, Serializable id, WorkType type) {
-		this( entity, null, id, type, false );
+		this( null, entity, null, id, type, false );
 	}
 
 	public Work(Object entity, Serializable id, WorkType type, boolean identifierRollbackEnabled) {
-		this( entity, null, id, type, identifierRollbackEnabled );
+		this( null, entity, null, id, type, identifierRollbackEnabled );
 	}
 
 	public Work(Class<?> entityType, Serializable id, WorkType type) {
-		this( null, entityType, id, type, false );
+		this( null, null, entityType, id, type, false );
 	}
 
 	public Work(Object entity, WorkType type) {
-		this( entity, null, null, type, false );
+		this( null, entity, null, null, type, false );
 	}
 
-	private Work(Object entity, Class<?> entityClass, Serializable id,
+	public Work(String tenantId, Object entity, Serializable id, WorkType type) {
+		this( tenantId, entity, null, id, type, false );
+	}
+
+	public Work(String tenantId, Object entity, Serializable id, WorkType type, boolean identifierRollbackEnabled) {
+		this( tenantId, entity, null, id, type, identifierRollbackEnabled );
+	}
+
+	public Work(String tenantId, Class<?> entityType, Serializable id, WorkType type) {
+		this( tenantId, null, entityType, id, type, false );
+	}
+
+	public Work(String tenantId, Object entity, WorkType type) {
+		this( tenantId, entity, null, null, type, false );
+	}
+
+	private Work(String tenantId, Object entity, Class<?> entityClass, Serializable id,
 			WorkType type, boolean identifierWasRolledBack) {
 		this.entity = entity;
 		this.entityClass = entityClass;
 		this.id = id;
 		this.type = type;
 		this.identifierWasRolledBack = identifierWasRolledBack;
+		this.tenantIdentifier = tenantId;
 	}
 
 	public Class<?> getEntityClass() {
 		return entityClass;
+	}
+
+	public String getTenantIdentifier() {
+		return tenantIdentifier;
 	}
 
 	public Object getEntity() {
@@ -70,6 +92,7 @@ public class Work {
 	public String toString() {
 		final StringBuilder sb = new StringBuilder( "Work{" );
 		sb.append( "entityClass=" ).append( entityClass );
+		sb.append( ", tenantId=" ).append( tenantIdentifier );
 		sb.append( ", id=" ).append( id );
 		sb.append( ", type=" ).append( type );
 		sb.append( '}' );

--- a/engine/src/main/java/org/hibernate/search/engine/ProjectionConstants.java
+++ b/engine/src/main/java/org/hibernate/search/engine/ProjectionConstants.java
@@ -33,6 +33,11 @@ public interface ProjectionConstants {
 	String ID = "__HSearch_id";
 
 	/**
+	 * The tenant identifier
+	 */
+	String TENANT_ID = "__HSearch_TenantId";
+
+	/**
 	 * Lucene Document id.
 	 * <p/>
 	 * Expert: Lucene document id can change overtime between 2 different IndexReader opening.

--- a/engine/src/main/java/org/hibernate/search/engine/spi/DocumentBuilderContainedEntity.java
+++ b/engine/src/main/java/org/hibernate/search/engine/spi/DocumentBuilderContainedEntity.java
@@ -51,7 +51,9 @@ public class DocumentBuilderContainedEntity extends AbstractDocumentBuilder {
 	}
 
 	@Override
-	public void addWorkToQueue(Class<?> entityClass,
+	public void addWorkToQueue(
+			String tenantId,
+			Class<?> entityClass,
 			Object entity,
 			Serializable id,
 			boolean delete,

--- a/engine/src/main/java/org/hibernate/search/engine/spi/DocumentBuilderIndexedEntity.java
+++ b/engine/src/main/java/org/hibernate/search/engine/spi/DocumentBuilderIndexedEntity.java
@@ -211,15 +211,16 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 	}
 
 	@Override
-	public void addWorkToQueue(Class<?> entityClass, Object entity, Serializable id, boolean delete, boolean add, List<LuceneWork> queue, ConversionContext contextualBridge) {
+	public void addWorkToQueue(String tenantId, Class<?> entityClass, Object entity, Serializable id, boolean delete, boolean add, List<LuceneWork> queue, ConversionContext contextualBridge) {
 		DocumentFieldMetadata idFieldMetadata = idPropertyMetadata.getFieldMetadata( idFieldName );
 		String idInString = objectToString( getIdBridge(), idFieldMetadata.getName(), id, contextualBridge );
 		if ( delete && !add ) {
-			queue.add( new DeleteLuceneWork( id, idInString, entityClass ) );
+			queue.add( new DeleteLuceneWork( tenantId, id, idInString, entityClass ) );
 		}
 		else if ( add && !delete ) {
 			queue.add(
 					createAddWork(
+							tenantId,
 							entityClass,
 							entity,
 							id,
@@ -232,6 +233,7 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 		else if ( add && delete ) {
 			queue.add(
 					createUpdateWork(
+							tenantId,
 							entityClass,
 							entity,
 							id,
@@ -273,28 +275,28 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 		return stringValue;
 	}
 
-	public AddLuceneWork createAddWork(Class<?> entityClass, Object entity, Serializable id, String idInString, InstanceInitializer sessionInitializer, ConversionContext conversionContext) {
+	public AddLuceneWork createAddWork(String tenantId, Class<?> entityClass, Object entity, Serializable id, String idInString, InstanceInitializer sessionInitializer, ConversionContext conversionContext) {
 		Map<String, String> fieldToAnalyzerMap = new HashMap<String, String>();
-		Document doc = getDocument( entity, id, fieldToAnalyzerMap, sessionInitializer, conversionContext, null );
+		Document doc = getDocument( tenantId, entity, id, fieldToAnalyzerMap, sessionInitializer, conversionContext, null );
 		final AddLuceneWork addWork;
 		if ( fieldToAnalyzerMap.isEmpty() ) {
-			addWork = new AddLuceneWork( id, idInString, entityClass, doc );
+			addWork = new AddLuceneWork( tenantId, id, idInString, entityClass, doc );
 		}
 		else {
-			addWork = new AddLuceneWork( id, idInString, entityClass, doc, fieldToAnalyzerMap );
+			addWork = new AddLuceneWork( tenantId, id, idInString, entityClass, doc, fieldToAnalyzerMap );
 		}
 		return addWork;
 	}
 
-	public UpdateLuceneWork createUpdateWork(Class entityClass, Object entity, Serializable id, String idInString, InstanceInitializer sessionInitializer, ConversionContext contextualBridge) {
+	public UpdateLuceneWork createUpdateWork(String tenantId, Class entityClass, Object entity, Serializable id, String idInString, InstanceInitializer sessionInitializer, ConversionContext contextualBridge) {
 		Map<String, String> fieldToAnalyzerMap = new HashMap<String, String>();
-		Document doc = getDocument( entity, id, fieldToAnalyzerMap, sessionInitializer, contextualBridge, null );
+		Document doc = getDocument( tenantId, entity, id, fieldToAnalyzerMap, sessionInitializer, contextualBridge, null );
 		final UpdateLuceneWork addWork;
 		if ( fieldToAnalyzerMap.isEmpty() ) {
-			addWork = new UpdateLuceneWork( id, idInString, entityClass, doc );
+			addWork = new UpdateLuceneWork( tenantId, id, idInString, entityClass, doc );
 		}
 		else {
-			addWork = new UpdateLuceneWork( id, idInString, entityClass, doc, fieldToAnalyzerMap );
+			addWork = new UpdateLuceneWork( tenantId, id, idInString, entityClass, doc, fieldToAnalyzerMap );
 		}
 		return addWork;
 	}
@@ -312,7 +314,7 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 	 *
 	 * @return The Lucene <code>Document</code> for the specified entity.
 	 */
-	public Document getDocument(Object instance, Serializable id, Map<String, String> fieldToAnalyzerMap, InstanceInitializer objectInitializer, ConversionContext conversionContext, String[] includedFieldNames) {
+	public Document getDocument(String tenantId, Object instance, Serializable id, Map<String, String> fieldToAnalyzerMap, InstanceInitializer objectInitializer, ConversionContext conversionContext, String[] includedFieldNames) {
 		// TODO as it is, includedFieldNames is not generally useful as we don't know if a fieldbridge creates specific fields or not
 		// TODO only used at the moment to filter the id field and the class field
 
@@ -340,6 +342,8 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 					);
 			doc.add( classField );
 		}
+
+		addTenantIdIfRequired( tenantId, doc );
 
 		// now add the entity id to the document
 		if ( containsFieldName( idFieldName, includedFieldNames ) ) {
@@ -370,6 +374,18 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 				documentLevelBoost
 		);
 		return doc;
+	}
+
+	private void addTenantIdIfRequired(String tenantId, Document doc) {
+		if ( tenantId != null ) {
+			Field tenantIdField = new Field(
+					ProjectionConstants.TENANT_ID,
+					tenantId,
+					Field.Store.YES,
+					Field.Index.NOT_ANALYZED_NO_NORMS,
+					Field.TermVector.NO );
+			doc.add( tenantIdField );
+		}
 	}
 
 	private void buildDocumentFields(Object instance,

--- a/engine/src/main/java/org/hibernate/search/query/dsl/impl/MoreLikeThisBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/impl/MoreLikeThisBuilder.java
@@ -316,7 +316,7 @@ public class MoreLikeThisBuilder<T> {
 			//TODO should we keep the fieldToAnalyzerMap around to pass to the analyzer?
 			Map<String,String> fieldToAnalyzerMap = new HashMap<String, String>( );
 			//FIXME by calling documentBuilder we don't honor .comparingField("foo").ignoreFieldBridge(): probably not a problem in practice though
-			maybeDocument = documentBuilder.getDocument( input, null, fieldToAnalyzerMap, null, new ContextualExceptionBridgeHelper(), fieldNames );
+			maybeDocument = documentBuilder.getDocument( null, input, null, fieldToAnalyzerMap, null, new ContextualExceptionBridgeHelper(), fieldNames );
 			vectors = null;
 		}
 		else {

--- a/engine/src/main/java/org/hibernate/search/query/engine/spi/HSQuery.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/spi/HSQuery.java
@@ -60,6 +60,8 @@ public interface HSQuery extends ProjectionConstants {
 	 */
 	HSQuery luceneQuery(Query query);
 
+	HSQuery tenantIdentifier(String tenantId);
+
 	/**
 	 * Defines the targeted entities. This helps to reduce the number of targeted indexes.
 	 *

--- a/orm/src/main/java/org/hibernate/search/batchindexing/impl/BatchCoordinator.java
+++ b/orm/src/main/java/org/hibernate/search/batchindexing/impl/BatchCoordinator.java
@@ -165,7 +165,7 @@ public class BatchCoordinator extends ErrorHandledRunnable {
 			Set<Class<?>> targetedClasses = extendedIntegrator.getIndexedTypesPolymorphic( rootEntities );
 			for ( Class<?> clazz : targetedClasses ) {
 				//needs do be in-sync work to make sure we wait for the end of it.
-				backend.doWorkInSync( new PurgeAllLuceneWork( clazz ) );
+				backend.doWorkInSync( new PurgeAllLuceneWork( tenantId, clazz ) );
 			}
 			if ( this.optimizeAfterPurge ) {
 				backend.optimize( targetedClasses );

--- a/orm/src/main/java/org/hibernate/search/query/hibernate/impl/FullTextQueryImpl.java
+++ b/orm/src/main/java/org/hibernate/search/query/hibernate/impl/FullTextQueryImpl.java
@@ -15,7 +15,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.Sort;
-
 import org.hibernate.Criteria;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
@@ -24,7 +23,6 @@ import org.hibernate.QueryTimeoutException;
 import org.hibernate.ScrollMode;
 import org.hibernate.ScrollableResults;
 import org.hibernate.Session;
-
 import org.hibernate.engine.query.spi.ParameterMetadata;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.internal.AbstractQueryImpl;
@@ -87,6 +85,7 @@ public class FullTextQueryImpl extends AbstractQueryImpl implements FullTextQuer
 		hSearchQuery
 				.luceneQuery( query )
 				.timeoutExceptionFactory( exceptionFactory )
+				.tenantIdentifier( session.getTenantIdentifier() )
 				.targetedEntities( Arrays.asList( classes ) );
 	}
 

--- a/orm/src/test/java/org/hibernate/search/test/batchindexing/Clock.java
+++ b/orm/src/test/java/org/hibernate/search/test/batchindexing/Clock.java
@@ -59,4 +59,35 @@ public class Clock {
 		builder.append( "]" );
 		return builder.toString();
 	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ( ( brand == null ) ? 0 : brand.hashCode() );
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ( this == obj ) {
+			return true;
+		}
+		if ( obj == null ) {
+			return false;
+		}
+		if ( getClass() != obj.getClass() ) {
+			return false;
+		}
+		Clock other = (Clock) obj;
+		if ( brand == null ) {
+			if ( other.brand != null ) {
+				return false;
+			}
+		}
+		else if ( !brand.equals( other.brand ) ) {
+			return false;
+		}
+		return true;
+	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-1792

This patch will add support for multi-tenancy to hibernate search by keeping track of the tenant id in the `Work` class and storing it in the index,

Documentaitno is currently missing but I will add it if the solution make sense.

@Sanne what do you think?