### PR TITLE
Maintenance release of 5.1

### DIFF
--- a/engine/src/main/java/org/hibernate/search/engine/integration/impl/ExtendedSearchIntegrator.java
+++ b/engine/src/main/java/org/hibernate/search/engine/integration/impl/ExtendedSearchIntegrator.java
@@ -44,6 +44,9 @@ public interface ExtendedSearchIntegrator extends SearchIntegrator {
 
 	FilterDef getFilterDefinition(String name);
 
+	@Deprecated
+	String getIndexingStrategy();
+
 	int getFilterCacheBitResultsSize();
 
 	Set<Class<?>> getIndexedTypesPolymorphic(Class<?>[] classes);

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -26,6 +26,12 @@
         <!-- Needs to match the SLOT being used by Infinispan -->
         <infinispan.integration.slot>${infinispan.module.slot}</infinispan.integration.slot>
 
+        <!--
+          Needs to match the SLOT being used by the Hibernate Search version on which Infinispan depends on
+          This is sometimes essential when Infinispan upgrades major Hibernate Search versions.
+        -->
+        <infinispan.integration.slot.previous>${infinispan.module.slot.previous}</infinispan.integration.slot.previous>
+
         <!-- Needs to match the SLOT being used by Infinispan -->
         <jgroups.integration.slot>${jgroups.module.slot}</jgroups.integration.slot>
 

--- a/modules/src/main/aliases/search/infinispan-storage/module.xml
+++ b/modules/src/main/aliases/search/infinispan-storage/module.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate Search, full-text search for your domain model
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<module-alias xmlns="urn:jboss:module:1.1"
+    name="org.hibernate.search.infinispan-storage" slot="${infinispan.integration.slot.previous}"
+    target-name="org.hibernate.search.infinispan-storage" target-slot="${infinispan.integration.slot}" />

--- a/modules/src/main/assembly/dist.xml
+++ b/modules/src/main/assembly/dist.xml
@@ -31,6 +31,11 @@
             <filtered>true</filtered>
         </file>
         <file>
+            <source>${aliases.xml.basedir}/search/infinispan-storage/module.xml</source>
+            <outputDirectory>/org/hibernate/search/infinispan-storage/${infinispan.module.slot.previous}</outputDirectory>
+            <filtered>true</filtered>
+        </file>
+        <file>
             <source>${module.xml.basedir}/search/orm/module.xml</source>
             <outputDirectory>/org/hibernate/search/orm/${hibernate.search.version}</outputDirectory>
             <filtered>true</filtered>

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,7 @@
         <!-- Slot definitions for JBoss Modules (both generated and consumed modules) -->
         <hibernate.search.module.slot>5.1</hibernate.search.module.slot>
         <infinispan.module.slot>ispn-7.1</infinispan.module.slot>
+        <infinispan.module.slot.previous>ispn-7.0</infinispan.module.slot.previous>
         <lucene.module.slot>4.10</lucene.module.slot>
         <jgroups.module.slot>ispn-7.1</jgroups.module.slot>
 


### PR DESCRIPTION

I've applies some backports already. These two are new, and meant for 5.1 only:

 - https://hibernate.atlassian.net/browse/HSEARCH-1859
 - https://hibernate.atlassian.net/browse/HSEARCH-1860