### PR TITLE
Speedup integration tests

### DIFF
--- a/integrationtest/wildfly/pom.xml
+++ b/integrationtest/wildfly/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>org.wildfly.arquillian</groupId>
             <artifactId>wildfly-arquillian-container-managed</artifactId>
-            <version>1.0.0.Alpha5</version>
+            <version>1.0.0.Final</version>
             <scope>test</scope>
             <exclusions>
                 <!-- This exclusion is needed to be able to setup the project in Windows:

--- a/integrationtest/wildfly/pom.xml
+++ b/integrationtest/wildfly/pom.xml
@@ -98,6 +98,14 @@
                 <!-- This exclusion is needed to be able to setup the project in Windows:
                      it otherwise includes transitive dependency to the JDK JConsole -->
                 <exclusion>
+                    <groupId>org.jboss.logmanager</groupId>
+                    <artifactId>jboss-logmanager</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.logmanager</groupId>
+                    <artifactId>log4j-jboss-logmanager</artifactId>
+                </exclusion>
+                <exclusion>
                     <artifactId>wildfly-patching</artifactId>
                     <groupId>org.wildfly</groupId>
                 </exclusion>

--- a/integrationtest/wildfly/src/test/resources/arquillian.xml
+++ b/integrationtest/wildfly/src/test/resources/arquillian.xml
@@ -10,8 +10,10 @@
     xsi:schemaLocation="http://jboss.org/schema/arquillian
         http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
+    <defaultProtocol type="jmx-as7" />
+
     <group qualifier="Grid" default="true">
-        <container qualifier="container.active-1" default="true">
+        <container qualifier="container.active-1" mode="suite" default="true">
             <configuration>
                 <property name="jbossHome">${project.build.directory}/node1/wildfly-${wildflyVersion}</property>
                 <!-- Needed for JMS tests -->
@@ -22,7 +24,7 @@
             </configuration>
         </container>
         <!-- Copy of the above, except a port offset is applied and running from a different copy -->
-        <container qualifier="container.active-2">
+        <container qualifier="container.active-2" mode="suite">
             <configuration>
                 <property name="jbossHome">${project.build.directory}/node2/wildfly-${wildflyVersion}</property>
                 <!-- Needed for JMS tests -->

--- a/pom.xml
+++ b/pom.xml
@@ -163,9 +163,9 @@
         <commonsLangVersion>2.6</commonsLangVersion>
 
         <!-- Integration tests -->
-        <arquillianVersion>1.1.2.Final</arquillianVersion>
+        <arquillianVersion>1.1.8.Final</arquillianVersion>
         <shrinkwrapResolverVersion>2.0.0</shrinkwrapResolverVersion>
-        <wildflyVersion>9.0.0.CR1</wildflyVersion>
+        <wildflyVersion>9.0.0.CR2</wildflyVersion>
 
         <!-- character encoding -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
The only purpose for this change is to reduce the execution time of wildfly tests.

revised/simplified version of PR #843