### PR TITLE
HSEARCH-1849 Using Path instead of File in tests to simplify migration

### DIFF
--- a/engine/src/test/java/org/hibernate/search/test/store/DirectoryHelperTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/store/DirectoryHelperTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertTrue;
 public class DirectoryHelperTest {
 
 	@Test
-	public void testMkdirsDetermineIndex() {
+	public void testMkdirsDetermineIndex() throws Exception {
 		String root = "./testDir/dir1/dir2";
 		String relative = "dir3";
 

--- a/infinispan/src/test/java/org/hibernate/search/infinispan/StoredIndexTest.java
+++ b/infinispan/src/test/java/org/hibernate/search/infinispan/StoredIndexTest.java
@@ -9,18 +9,18 @@ package org.hibernate.search.infinispan;
 import java.io.File;
 import java.util.List;
 
-import org.infinispan.hibernate.search.impl.DefaultCacheManagerService;
-import org.junit.Assert;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.TermQuery;
 import org.hibernate.Transaction;
 import org.hibernate.cfg.Environment;
 import org.hibernate.search.FullTextQuery;
 import org.hibernate.search.FullTextSession;
-import org.hibernate.search.testsupport.TestConstants;
 import org.hibernate.search.test.util.FullTextSessionBuilder;
+import org.hibernate.search.testsupport.TestConstants;
 import org.hibernate.search.util.impl.FileHelper;
+import org.infinispan.hibernate.search.impl.DefaultCacheManagerService;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -174,7 +174,7 @@ public class StoredIndexTest {
 	 * as the binary format is not necessarily compatible across releases.
 	 */
 	@AfterClass
-	public static void removeFileSystemStoredIndexes() {
+	public static void removeFileSystemStoredIndexes() throws Exception {
 		File targetDir = TestConstants.getTargetDir( StoredIndexTest.class );
 		FileHelper.delete( new File( targetDir, "LuceneIndexesData" ) );
 		FileHelper.delete( new File( targetDir, "LuceneIndexesMetaData" ) );

--- a/integrationtest/narayana/src/test/java/org/hibernate/search/test/integration/jbossjta/JBossTSIT.java
+++ b/integrationtest/narayana/src/test/java/org/hibernate/search/test/integration/jbossjta/JBossTSIT.java
@@ -18,14 +18,8 @@ import javax.persistence.spi.PersistenceUnitInfo;
 import javax.persistence.spi.PersistenceUnitTransactionType;
 import javax.sql.DataSource;
 
-import com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionManagerImple;
-
 import org.apache.lucene.search.Query;
 import org.h2.jdbcx.JdbcDataSource;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
 import org.hibernate.ConnectionReleaseMode;
 import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.H2Dialect;
@@ -34,10 +28,16 @@ import org.hibernate.engine.transaction.jta.platform.internal.JBossStandAloneJta
 import org.hibernate.search.jpa.FullTextEntityManager;
 import org.hibernate.search.jpa.Search;
 import org.hibernate.search.query.dsl.QueryBuilder;
-import org.hibernate.search.testsupport.TestConstants;
 import org.hibernate.search.test.integration.jbossjta.infra.JBossTADataSourceBuilder;
 import org.hibernate.search.test.integration.jbossjta.infra.PersistenceUnitInfoBuilder;
+import org.hibernate.search.testsupport.TestConstants;
 import org.hibernate.search.util.impl.FileHelper;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionManagerImple;
 
 /**
  * @author Emmanuel Bernard
@@ -97,7 +97,7 @@ public class JBossTSIT {
 	}
 
 	@AfterClass
-	public static void tearDown() {
+	public static void tearDown() throws Exception {
 		if ( factory != null ) {
 			factory.close();
 		}

--- a/orm/src/test/java/org/hibernate/search/test/SearchTestBase.java
+++ b/orm/src/test/java/org/hibernate/search/test/SearchTestBase.java
@@ -6,7 +6,8 @@
  */
 package org.hibernate.search.test;
 
-import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -82,12 +83,12 @@ public abstract class SearchTestBase implements TestResourceManager, TestConfigu
 	}
 
 	@Override
-	public void ensureIndexesAreEmpty() {
+	public void ensureIndexesAreEmpty() throws IOException {
 		getTestResourceManager().ensureIndexesAreEmpty();
 	}
 
 	@Override
-	public File getBaseIndexDir() {
+	public Path getBaseIndexDir() {
 		return getTestResourceManager().getBaseIndexDir();
 	}
 

--- a/orm/src/test/java/org/hibernate/search/test/TestResourceManager.java
+++ b/orm/src/test/java/org/hibernate/search/test/TestResourceManager.java
@@ -7,7 +7,8 @@
 
 package org.hibernate.search.test;
 
-import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
 
 import org.apache.lucene.store.Directory;
 import org.hibernate.Session;
@@ -38,8 +39,8 @@ public interface TestResourceManager {
 
 	Directory getDirectory(Class<?> clazz);
 
-	void ensureIndexesAreEmpty();
+	void ensureIndexesAreEmpty() throws IOException;
 
-	File getBaseIndexDir();
+	Path getBaseIndexDir();
 
 }

--- a/orm/src/test/java/org/hibernate/search/test/configuration/ConfigurationReadTestCase.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/ConfigurationReadTestCase.java
@@ -12,10 +12,10 @@ import org.hibernate.HibernateException;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
-import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.backend.configuration.impl.IndexWriterSetting;
 import org.hibernate.search.backend.spi.LuceneIndexingParameters;
 import org.hibernate.search.engine.spi.EntityIndexBinding;
+import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
 import org.hibernate.search.test.SearchTestBase;
 import org.junit.Before;
@@ -73,7 +73,7 @@ public abstract class ConfigurationReadTestCase extends SearchTestBase {
 
 	@Override
 	public void configure(Map<String,Object> cfg) {
-		cfg.put( "hibernate.search.default.indexBase", getBaseIndexDir().getAbsolutePath() );
+		cfg.put( "hibernate.search.default.indexBase", getBaseIndexDir().toAbsolutePath().toString() );
 	}
 
 	public static void assertCfgIsInvalid(Configuration configuration, Class[] mapping) {

--- a/orm/src/test/java/org/hibernate/search/test/directoryProvider/DirectoryProviderHelperTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/directoryProvider/DirectoryProviderHelperTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertTrue;
 public class DirectoryProviderHelperTest {
 
 	@Test
-	public void testMkdirsGetSource() {
+	public void testMkdirsGetSource() throws Exception {
 		String root = "./testDir";
 		String relative = "dir1/dir2/dir3";
 

--- a/orm/src/test/java/org/hibernate/search/test/directoryProvider/FSDirectorySelectionTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/directoryProvider/FSDirectorySelectionTest.java
@@ -16,8 +16,8 @@ import org.hibernate.SessionFactory;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
-import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.engine.spi.EntityIndexBinding;
+import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
 import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.spi.SearchIntegrator;
@@ -81,7 +81,7 @@ public class FSDirectorySelectionTest extends SearchTestBase {
 	private SessionFactory createSessionFactoryUsingDirectoryType(String directoryType) {
 		Configuration config = new Configuration();
 		config.addAnnotatedClass( SnowStorm.class );
-		config.setProperty( "hibernate.search.default.indexBase", getBaseIndexDir().getAbsolutePath() );
+		config.setProperty( "hibernate.search.default.indexBase", getBaseIndexDir().toAbsolutePath().toString() );
 		config.setProperty( "hibernate.search.default.directory_provider", FSDirectoryProvider.class.getName() );
 		config.setProperty( "hibernate.search.default.filesystem_access_type", directoryType );
 		return config.buildSessionFactory();

--- a/orm/src/test/java/org/hibernate/search/test/directoryProvider/FSDirectoryTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/directoryProvider/FSDirectoryTest.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.test.directoryProvider;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -51,7 +50,7 @@ public class FSDirectoryTest extends SearchTestBase {
 		s.getTransaction().commit();
 		s.close();
 
-		Directory dir = FSDirectory.open( new File( getBaseIndexDir().toString(), "Documents" ) );
+		Directory dir = FSDirectory.open( getBaseIndexDir().resolve( "Documents" ).toFile() );
 		try {
 			IndexReader reader = DirectoryReader.open( dir );
 			try {
@@ -68,7 +67,7 @@ public class FSDirectoryTest extends SearchTestBase {
 
 			s = getSessionFactory().openSession();
 			s.getTransaction().begin();
-			Document entity = (Document) s.get( Document.class, Long.valueOf( 1 ) );
+			Document entity = s.get( Document.class, Long.valueOf( 1 ) );
 			entity.setSummary( "Object/relational mapping with EJB3" );
 			s.persist( new Document( "Seam in Action", "", "blah blah blah blah" ) );
 			s.getTransaction().commit();
@@ -146,7 +145,7 @@ public class FSDirectoryTest extends SearchTestBase {
 		s.getTransaction().commit();
 		s.close();
 
-		FSDirectory dir = FSDirectory.open( new File( getBaseIndexDir(), "Documents" ) );
+		FSDirectory dir = FSDirectory.open( getBaseIndexDir().resolve( "Documents" ).toFile() );
 		IndexReader indexReader = DirectoryReader.open( dir );
 		IndexSearcher searcher = new IndexSearcher( indexReader );
 		try {
@@ -182,7 +181,7 @@ public class FSDirectoryTest extends SearchTestBase {
 		s.getTransaction().commit();
 		s.close();
 
-		Directory dir = FSDirectory.open( new File( getBaseIndexDir(), "Documents" ) );
+		Directory dir = FSDirectory.open( getBaseIndexDir().resolve( "Documents" ).toFile() );
 		IndexReader indexReader = DirectoryReader.open( dir );
 		IndexSearcher searcher = new IndexSearcher( indexReader );
 		// deleting before search, but after IndexSearcher creation:

--- a/orm/src/test/java/org/hibernate/search/test/directoryProvider/FSSlaveAndMasterDPTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/directoryProvider/FSSlaveAndMasterDPTest.java
@@ -7,15 +7,15 @@
 package org.hibernate.search.test.directoryProvider;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.lucene.queryparser.classic.QueryParser;
-
+import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
-import org.hibernate.HibernateException;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
@@ -155,7 +155,7 @@ public class FSSlaveAndMasterDPTest extends MultipleSFTestCase {
 		return getSessionFactories()[1].openSession();
 	}
 
-	static File prepareDirectories(String testId) {
+	static File prepareDirectories(String testId) throws IOException {
 
 		String superRootPath = TestConstants.getIndexDirectory( FSSlaveAndMasterDPTest.class );
 		File root = new File( superRootPath, testId );
@@ -203,7 +203,7 @@ public class FSSlaveAndMasterDPTest extends MultipleSFTestCase {
 		cleanupDirectories( root );
 	}
 
-	static void cleanupDirectories( File root ) {
+	static void cleanupDirectories( File root ) throws IOException {
 		log.debugf( "Deleting test directory %s ", root.getAbsolutePath() );
 		FileHelper.delete( root );
 	}

--- a/orm/src/test/java/org/hibernate/search/test/shards/DynamicShardingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/shards/DynamicShardingTest.java
@@ -6,12 +6,9 @@
  */
 package org.hibernate.search.test.shards;
 
-import static org.fest.assertions.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-
-import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -42,6 +39,9 @@ import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.testsupport.TestConstants;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Emmanuel Bernard <emmanuel@hibernate.org>
@@ -131,8 +131,8 @@ public class DynamicShardingTest extends SearchTestBase {
 
 		// use filesystem based directory provider to be able to assert against index
 		cfg.put( "hibernate.search.default.directory_provider", "filesystem" );
-		File sub = getBaseIndexDir();
-		cfg.put( "hibernate.search.default.indexBase", sub.getAbsolutePath() );
+		Path sub = getBaseIndexDir();
+		cfg.put( "hibernate.search.default.indexBase", sub.toAbsolutePath().toString() );
 	}
 
 	@Override
@@ -143,7 +143,7 @@ public class DynamicShardingTest extends SearchTestBase {
 	}
 
 	private void assertNumberOfEntitiesInIndex(String indexName, int expectedCount) throws IOException {
-		FSDirectory fsDirectory = FSDirectory.open( new File( getBaseIndexDir(), indexName ) );
+		FSDirectory fsDirectory = FSDirectory.open( getBaseIndexDir().resolve( indexName ).toFile() );
 		try {
 			IndexReader reader = DirectoryReader.open( fsDirectory );
 			try {
@@ -180,8 +180,8 @@ public class DynamicShardingTest extends SearchTestBase {
 
 		// use filesystem based directory provider to be able to assert against index
 		config.setProperty( "hibernate.search.default.directory_provider", "filesystem" );
-		File sub = getBaseIndexDir();
-		config.setProperty( "hibernate.search.default.indexBase", sub.getAbsolutePath() );
+		Path sub = getBaseIndexDir();
+		config.setProperty( "hibernate.search.default.indexBase", sub.toAbsolutePath().toString() );
 
 		config.addAnnotatedClass( Animal.class );
 

--- a/orm/src/test/java/org/hibernate/search/test/shards/ShardsTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/shards/ShardsTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.shards;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
@@ -18,9 +18,9 @@ import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.store.FSDirectory;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
-import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
+import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.store.impl.IdHashShardingStrategy;
 import org.hibernate.search.test.SearchTestBase;
@@ -39,8 +39,8 @@ public class ShardsTest extends SearchTestBase {
 	@Override
 	public void configure(Map<String,Object> cfg) {
 		cfg.put( "hibernate.search.default.directory_provider", "filesystem" );
-		File sub = getBaseIndexDir();
-		cfg.put( "hibernate.search.default.indexBase", sub.getAbsolutePath() );
+		Path sub = getBaseIndexDir();
+		cfg.put( "hibernate.search.default.indexBase", sub.toAbsolutePath().toString() );
 		cfg.put( Environment.ANALYZER_CLASS, StopAnalyzer.class.getName() );
 		//is the default when multiple shards are set up
 		//cfg.setProperty( "hibernate.search.Animal.sharding_strategy", IdHashShardingStrategy.class );
@@ -76,7 +76,7 @@ public class ShardsTest extends SearchTestBase {
 		s.clear();
 
 		tx = s.beginTransaction();
-		a = (Animal) s.get( Animal.class, 1 );
+		a = s.get( Animal.class, 1 );
 		a.setName( "Mouse" );
 		Furniture fur = new Furniture();
 		fur.setColor( "dark blue" );
@@ -119,7 +119,7 @@ public class ShardsTest extends SearchTestBase {
 
 		s.clear();
 
-		FSDirectory animal00Directory = FSDirectory.open( new File( getBaseIndexDir(), "Animal00" ) );
+		FSDirectory animal00Directory = FSDirectory.open( getBaseIndexDir().resolve( "Animal00" ).toFile() );
 		try {
 			IndexReader reader = DirectoryReader.open( animal00Directory );
 			try {
@@ -134,7 +134,7 @@ public class ShardsTest extends SearchTestBase {
 			animal00Directory.close();
 		}
 
-		FSDirectory animal01Directory = FSDirectory.open( new File( getBaseIndexDir(), "Animal.1" ) );
+		FSDirectory animal01Directory = FSDirectory.open( getBaseIndexDir().resolve( "Animal.1" ).toFile() );
 		try {
 			IndexReader reader = DirectoryReader.open( animal01Directory );
 			try {
@@ -150,13 +150,13 @@ public class ShardsTest extends SearchTestBase {
 		}
 
 		tx = s.beginTransaction();
-		a = (Animal) s.get( Animal.class, 1 );
+		a = s.get( Animal.class, 1 );
 		a.setName( "Mouse" );
 		tx.commit();
 
 		s.clear();
 
-		animal01Directory = FSDirectory.open( new File( getBaseIndexDir(), "Animal.1" ) );
+		animal01Directory = FSDirectory.open( getBaseIndexDir().resolve( "Animal.1" ).toFile() );
 		try {
 			IndexReader reader = DirectoryReader.open( animal01Directory );
 			try {

--- a/orm/src/test/java/org/hibernate/search/test/util/FullTextSessionBuilder.java
+++ b/orm/src/test/java/org/hibernate/search/test/util/FullTextSessionBuilder.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.test.util;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -149,7 +150,12 @@ public class FullTextSessionBuilder implements AutoCloseable, TestRule {
 		}
 		finally {
 			if ( usingFileSystem ) {
-				cleanupFilesystem();
+				try {
+					cleanupFilesystem();
+				}
+				catch (IOException e) {
+					throw new RuntimeException( e );
+				}
 			}
 		}
 		sessionFactory = null;
@@ -220,7 +226,7 @@ public class FullTextSessionBuilder implements AutoCloseable, TestRule {
 		return mapping;
 	}
 
-	public void cleanupFilesystem() {
+	public void cleanupFilesystem() throws IOException {
 		FileHelper.delete( indexRootDirectory );
 	}
 


### PR DESCRIPTION
Adapts some test infra to use JDK 7 `Path` instead of `File`. This can be integrated to master, it will simplify migration to Lucene 5 later on.