### PR TITLE
HSEARCH-1908 Avoid the need to dynamically override the Analyzer to fieldname mapping

### DIFF
--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/AbstractWorkspaceImpl.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/AbstractWorkspaceImpl.java
@@ -193,4 +193,27 @@ public abstract class AbstractWorkspaceImpl implements Workspace {
 	public String getIndexName() {
 		return this.indexManager.getIndexName();
 	}
+
+	public IndexWriterDelegate getIndexWriterDelegate(ErrorContextBuilder errorContextBuilder) {
+		IndexWriter indexWriter = getIndexWriter( errorContextBuilder );
+		//This to respect the existing semantics of returning null on failure of IW opening
+		if ( indexWriter != null ) {
+			return new IndexWriterDelegate( indexWriter );
+		}
+		else {
+			return null;
+		}
+	}
+
+	public IndexWriterDelegate getIndexWriterDelegate() {
+		IndexWriter indexWriter = getIndexWriter();
+		//This to respect the existing semantics of returning null on failure of IW opening
+		if ( indexWriter != null ) {
+			return new IndexWriterDelegate( indexWriter );
+		}
+		else {
+			return null;
+		}
+	}
+
 }

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/IndexWriterDelegate.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/IndexWriterDelegate.java
@@ -7,11 +7,15 @@
 package org.hibernate.search.backend.impl.lucene;
 
 import java.io.IOException;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
+import org.hibernate.search.backend.impl.lucene.analysis.ConcurrentlyMutableAnalyzer;
 import org.hibernate.search.util.impl.ScopedAnalyzer;
 
 /**
@@ -23,10 +27,17 @@ import org.hibernate.search.util.impl.ScopedAnalyzer;
  */
 public final class IndexWriterDelegate {
 
-	final IndexWriter indexWriter;
+	private final IndexWriter indexWriter;
+	private final ConcurrentlyMutableAnalyzer mutableAnalyzer;
+	private final Lock readLock;
+	private final Lock writeLock;
 
 	public IndexWriterDelegate(final IndexWriter indexWriter) {
 		this.indexWriter = indexWriter;
+		this.mutableAnalyzer = (ConcurrentlyMutableAnalyzer) indexWriter.getAnalyzer();
+		ReadWriteLock lock = new ReentrantReadWriteLock();
+		this.readLock = lock.readLock();
+		this.writeLock = lock.writeLock();
 	}
 
 	public void deleteDocuments(final Query termDeleteQuery) throws IOException {
@@ -43,7 +54,29 @@ public final class IndexWriterDelegate {
 	}
 
 	public void updateDocument(final Term idTerm, final Document document, final ScopedAnalyzer analyzer) throws IOException {
-		indexWriter.updateDocument( idTerm, document, analyzer );
+		// Try being optimistic first:
+		final boolean applyWithinReadLock;
+		readLock.lock();
+		try {
+			applyWithinReadLock = mutableAnalyzer.isCompatibleWith( analyzer );
+			if ( applyWithinReadLock ) {
+				indexWriter.updateDocument( idTerm, document );
+			}
+		}
+		finally {
+			readLock.unlock();
+		}
+		// If that failed, take the pessimistic lock:
+		if ( ! applyWithinReadLock ) {
+			writeLock.lock();
+			try {
+				mutableAnalyzer.updateAnalyzer( analyzer );
+				indexWriter.updateDocument( idTerm, document );
+			}
+			finally {
+				writeLock.unlock();
+			}
+		}
 	}
 
 	/**

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/IndexWriterDelegate.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/IndexWriterDelegate.java
@@ -38,7 +38,8 @@ public final class IndexWriterDelegate {
 	}
 
 	public void addDocument(final Document document, final ScopedAnalyzer analyzer) throws IOException {
-		indexWriter.addDocument( document, analyzer );
+		//This is now equivalent to the old "addDocument" method:
+		updateDocument( null, document, analyzer );
 	}
 
 	public void updateDocument(final Term idTerm, final Document document, final ScopedAnalyzer analyzer) throws IOException {

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/IndexWriterDelegate.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/IndexWriterDelegate.java
@@ -1,0 +1,57 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.impl.lucene;
+
+import java.io.IOException;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
+import org.hibernate.search.util.impl.ScopedAnalyzer;
+
+/**
+ * Encapsulates various operations to be performed on a single IndexWriter.
+ * Avoid using {@link org.hibernate.search.store.Workspace#getIndexWriter()} directly as it bypasses lifecycle
+ * management of the IndexWriter such as reference counting, potentially leading to leaks.
+ *
+ * @author Sanne Grinovero <sanne@hibernate.org> (C) 2015 Red Hat Inc.
+ */
+public final class IndexWriterDelegate {
+
+	final IndexWriter indexWriter;
+
+	public IndexWriterDelegate(final IndexWriter indexWriter) {
+		this.indexWriter = indexWriter;
+	}
+
+	public void deleteDocuments(final Query termDeleteQuery) throws IOException {
+		indexWriter.deleteDocuments( termDeleteQuery );
+	}
+
+	public void deleteDocuments(final Term idTerm) throws IOException {
+		indexWriter.deleteDocuments( idTerm );
+	}
+
+	public void addDocument(final Document document, final ScopedAnalyzer analyzer) throws IOException {
+		indexWriter.addDocument( document, analyzer );
+	}
+
+	public void updateDocument(final Term idTerm, final Document document, final ScopedAnalyzer analyzer) throws IOException {
+		indexWriter.updateDocument( idTerm, document, analyzer );
+	}
+
+	/**
+	 * This method should not be used: created only to avoid changes in public API.
+	 * @deprecated
+	 */
+	@Deprecated
+	public IndexWriter getIndexWriter() {
+		return indexWriter;
+	}
+
+}

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/LuceneBackendQueueTask.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/LuceneBackendQueueTask.java
@@ -9,7 +9,6 @@ package org.hibernate.search.backend.impl.lucene;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.locks.Lock;
 
-import org.apache.lucene.index.IndexWriter;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.exception.impl.ErrorContextBuilder;
@@ -78,8 +77,8 @@ final class LuceneBackendQueueTask implements Runnable {
 		ErrorContextBuilder errorContextBuilder = new ErrorContextBuilder();
 		errorContextBuilder.allWorkToBeDone( workList );
 
-		IndexWriter indexWriter = workspace.getIndexWriter( errorContextBuilder );
-		if ( indexWriter == null ) {
+		IndexWriterDelegate delegate = workspace.getIndexWriterDelegate( errorContextBuilder );
+		if ( delegate == null ) {
 			log.cannotOpenIndexWriterCausePreviousError();
 			return;
 		}
@@ -89,7 +88,7 @@ final class LuceneBackendQueueTask implements Runnable {
 		try {
 			for ( LuceneWork luceneWork : workList ) {
 				currentOperation = luceneWork;
-				performWork( luceneWork, resources, indexWriter, monitor );
+				performWork( luceneWork, resources, delegate, monitor );
 				errorContextBuilder.workCompleted( currentOperation );
 			}
 			currentOperation = null;
@@ -107,7 +106,8 @@ final class LuceneBackendQueueTask implements Runnable {
 		}
 	}
 
-	static void performWork(final LuceneWork work, final LuceneBackendResources resources, final IndexWriter indexWriter, final IndexingMonitor monitor) {
-		work.acceptIndexWorkVisitor( resources.getWorkVisitor(), null ).performWork( work, indexWriter, monitor );
+	static void performWork(final LuceneWork work, final LuceneBackendResources resources, final IndexWriterDelegate delegate, final IndexingMonitor monitor) {
+		work.acceptIndexWorkVisitor( resources.getWorkVisitor(), null ).performWork( work, delegate, monitor );
 	}
+
 }

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/LuceneBackendTaskStreamer.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/LuceneBackendTaskStreamer.java
@@ -8,7 +8,6 @@ package org.hibernate.search.backend.impl.lucene;
 
 import java.util.concurrent.locks.Lock;
 
-import org.apache.lucene.index.IndexWriter;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.backend.impl.lucene.works.LuceneWorkExecutor;
@@ -42,15 +41,15 @@ final class LuceneBackendTaskStreamer {
 	public void doWork(final LuceneWork work, final IndexingMonitor monitor) {
 		modificationLock.lock();
 		try {
-			IndexWriter indexWriter = workspace.getIndexWriter();
-			if ( indexWriter == null ) {
+			IndexWriterDelegate delegate = workspace.getIndexWriterDelegate();
+			if ( delegate == null ) {
 				log.cannotOpenIndexWriterCausePreviousError();
 				return;
 			}
 			boolean errors = true;
 			try {
 				LuceneWorkExecutor executor = work.acceptIndexWorkVisitor( resources.getWorkVisitor(), null );
-				executor.performWork( work, indexWriter, monitor );
+				executor.performWork( work, delegate, monitor );
 				errors = false;
 			}
 			finally {

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/analysis/ConcurrentlyMutableAnalyzer.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/analysis/ConcurrentlyMutableAnalyzer.java
@@ -1,0 +1,89 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.impl.lucene.analysis;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.DelegatingAnalyzerWrapper;
+import org.hibernate.search.exception.AssertionFailure;
+import org.hibernate.search.util.impl.ScopedAnalyzer;
+
+/**
+ * An Analyzer implementation which can dynamically be reconfigured. We use this as temporary solution to workaround
+ * LUCENE-6212, until a better solution is found.
+ *
+ * @author Sanne Grinovero <sanne@hibernate.org> (C) 2015 Red Hat Inc.
+ */
+public final class ConcurrentlyMutableAnalyzer extends DelegatingAnalyzerWrapper {
+
+	private final AtomicReference<ScopedAnalyzer> current = new AtomicReference<>();
+
+	public ConcurrentlyMutableAnalyzer(Analyzer initialAnalyzer) {
+		super( new ResettableReuseStrategy() );
+		if ( initialAnalyzer instanceof ScopedAnalyzer ) {
+			current.set( (ScopedAnalyzer) initialAnalyzer );
+		}
+		else {
+			current.set( new ScopedAnalyzer( initialAnalyzer ) );
+		}
+	}
+
+	@Override
+	protected Analyzer getWrappedAnalyzer(String fieldName) {
+		return current.get();
+	}
+
+	/**
+	 * Checks if the currently set Analyzer is the same as the
+	 * proposed one, in which case there is no need for
+	 * replacements or locking.
+	 * Correct concurrency control requires external locking!
+	 * @param analyzer
+	 * @return
+	 */
+	public boolean isCompatibleWith(ScopedAnalyzer analyzer) {
+		// TODO Optimise this
+		return false;
+	}
+
+	/**
+	 * Correct concurrency control requires external locking!
+	 * @param analyzer
+	 */
+	public void updateAnalyzer(ScopedAnalyzer analyzer) {
+		current.set( analyzer );
+	}
+
+	private static final class ResettableReuseStrategy extends ReuseStrategy {
+
+		@Override
+		public TokenStreamComponents getReusableComponents(Analyzer analyzer, String fieldName) {
+			if ( analyzer instanceof ConcurrentlyMutableAnalyzer ) {
+				ConcurrentlyMutableAnalyzer cma = (ConcurrentlyMutableAnalyzer) analyzer;
+				final Analyzer wrappedAnalyzer = cma.getWrappedAnalyzer( fieldName );
+				return wrappedAnalyzer.getReuseStrategy().getReusableComponents( wrappedAnalyzer, fieldName );
+			}
+			else {
+				throw new AssertionFailure( "This ReuseStrategy should only be applied to a ConcurrentlyMutableAnalyzer " );
+			}
+		}
+
+		@Override
+		public void setReusableComponents(Analyzer analyzer, String fieldName, TokenStreamComponents components) {
+			if ( analyzer instanceof ConcurrentlyMutableAnalyzer ) {
+				ConcurrentlyMutableAnalyzer cma = (ConcurrentlyMutableAnalyzer) analyzer;
+				final Analyzer wrappedAnalyzer = cma.getWrappedAnalyzer( fieldName );
+				wrappedAnalyzer.getReuseStrategy().setReusableComponents( analyzer, fieldName, components );
+			}
+			else {
+				throw new AssertionFailure( "This ReuseStrategy should only be applied to a ConcurrentlyMutableAnalyzer " );
+			}
+		}
+	};
+
+}

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/analysis/ConcurrentlyMutableAnalyzer.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/analysis/ConcurrentlyMutableAnalyzer.java
@@ -44,11 +44,11 @@ public final class ConcurrentlyMutableAnalyzer extends DelegatingAnalyzerWrapper
 	 * replacements or locking.
 	 * Correct concurrency control requires external locking!
 	 * @param analyzer
-	 * @return
+	 * @return true if there is no need to replace the current Analyzer
 	 */
 	public boolean isCompatibleWith(ScopedAnalyzer analyzer) {
-		// TODO Optimise this
-		return false;
+		ScopedAnalyzer currentAnalyzer = current.get();
+		return currentAnalyzer.isCompositeOfSameInstances( analyzer );
 	}
 
 	/**

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/AddWorkExecutor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/AddWorkExecutor.java
@@ -10,11 +10,11 @@ import java.io.IOException;
 import java.util.Map;
 
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.index.IndexWriter;
 
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
+import org.hibernate.search.backend.impl.lucene.IndexWriterDelegate;
 import org.hibernate.search.engine.spi.DocumentBuilderIndexedEntity;
 import org.hibernate.search.store.Workspace;
 import org.hibernate.search.util.impl.ScopedAnalyzer;
@@ -41,7 +41,7 @@ class AddWorkExecutor implements LuceneWorkExecutor {
 	}
 
 	@Override
-	public void performWork(LuceneWork work, IndexWriter writer, IndexingMonitor monitor) {
+	public void performWork(LuceneWork work, IndexWriterDelegate delegate, IndexingMonitor monitor) {
 		final Class<?> entityType = work.getEntityClass();
 		DocumentBuilderIndexedEntity documentBuilder = workspace.getDocumentBuilder( entityType );
 		Map<String, String> fieldToAnalyzerMap = work.getFieldToAnalyzerMap();
@@ -51,7 +51,7 @@ class AddWorkExecutor implements LuceneWorkExecutor {
 			log.trace( "add to Lucene index: " + entityType + "#" + work.getId() + ":" + work.getDocument() );
 		}
 		try {
-			writer.addDocument( work.getDocument(), analyzer );
+			delegate.addDocument( work.getDocument(), analyzer );
 			workspace.notifyWorkApplied( work );
 		}
 		catch (IOException e) {

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/ByTermDeleteWorkExecutor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/ByTermDeleteWorkExecutor.java
@@ -9,7 +9,6 @@ package org.hibernate.search.backend.impl.lucene.works;
 import java.io.IOException;
 import java.io.Serializable;
 
-import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
@@ -18,6 +17,7 @@ import org.apache.lucene.search.TermQuery;
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
+import org.hibernate.search.backend.impl.lucene.IndexWriterDelegate;
 import org.hibernate.search.bridge.util.impl.NumericFieldUtils;
 import org.hibernate.search.engine.spi.DocumentBuilderIndexedEntity;
 import org.hibernate.search.store.Workspace;
@@ -41,7 +41,7 @@ public final class ByTermDeleteWorkExecutor extends DeleteWorkExecutor {
 	}
 
 	@Override
-	public void performWork(LuceneWork work, IndexWriter writer, IndexingMonitor monitor) {
+	public void performWork(LuceneWork work, IndexWriterDelegate delegate, IndexingMonitor monitor) {
 		final Class<?> managedType = work.getEntityClass();
 		final String tenantId = work.getTenantId();
 		DocumentBuilderIndexedEntity builder = workspace.getDocumentBuilder( managedType );
@@ -49,10 +49,10 @@ public final class ByTermDeleteWorkExecutor extends DeleteWorkExecutor {
 		log.tracef( "Removing %s#%s by id using an IndexWriter.", managedType, id );
 		try {
 			if ( tenantId == null ) {
-				deleteWithoutTenant( work, writer, builder, id );
+				deleteWithoutTenant( work, delegate, builder, id );
 			}
 			else {
-				deleteWithTenant( work, writer, tenantId, builder, id );
+				deleteWithTenant( work, delegate, tenantId, builder, id );
 			}
 			workspace.notifyWorkApplied( work );
 		}
@@ -62,7 +62,7 @@ public final class ByTermDeleteWorkExecutor extends DeleteWorkExecutor {
 		}
 	}
 
-	private void deleteWithTenant(LuceneWork work, IndexWriter writer, final String tenantId, DocumentBuilderIndexedEntity builder, Serializable id) throws IOException {
+	private void deleteWithTenant(LuceneWork work, IndexWriterDelegate delegate, final String tenantId, DocumentBuilderIndexedEntity builder, Serializable id) throws IOException {
 		BooleanQuery termDeleteQuery = new BooleanQuery();
 		TermQuery tenantTermQuery = new TermQuery( new Term( DocumentBuilderIndexedEntity.TENANT_ID_FIELDNAME, tenantId ) );
 		termDeleteQuery.add( tenantTermQuery, Occur.MUST );
@@ -74,17 +74,17 @@ public final class ByTermDeleteWorkExecutor extends DeleteWorkExecutor {
 			Term idTerm = new Term( builder.getIdKeywordName(), work.getIdInString() );
 			termDeleteQuery.add( new TermQuery( idTerm ), Occur.MUST );
 		}
-		writer.deleteDocuments( termDeleteQuery );
+		delegate.deleteDocuments( termDeleteQuery );
 	}
 
-	private void deleteWithoutTenant(LuceneWork work, IndexWriter writer, DocumentBuilderIndexedEntity builder, Serializable id) throws IOException {
+	private void deleteWithoutTenant(LuceneWork work, IndexWriterDelegate delegate, DocumentBuilderIndexedEntity builder, Serializable id) throws IOException {
 		if ( isIdNumeric( builder ) ) {
-			writer.deleteDocuments( NumericFieldUtils.createExactMatchQuery( builder.getIdKeywordName(), id ) );
+			delegate.deleteDocuments( NumericFieldUtils.createExactMatchQuery( builder.getIdKeywordName(), id ) );
 		}
 		else {
 			Term idTerm = new Term( builder.getIdKeywordName(), work.getIdInString() );
 			//The point to this class is to avoid using a Query to perform the delete operation!
-			writer.deleteDocuments( idTerm );
+			delegate.deleteDocuments( idTerm );
 		}
 	}
 

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/ByTermUpdateWorkExecutor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/ByTermUpdateWorkExecutor.java
@@ -10,7 +10,6 @@ package org.hibernate.search.backend.impl.lucene.works;
 import java.io.Serializable;
 import java.util.Map;
 
-import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
@@ -19,6 +18,7 @@ import org.apache.lucene.search.BooleanClause.Occur;
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
+import org.hibernate.search.backend.impl.lucene.IndexWriterDelegate;
 import org.hibernate.search.bridge.util.impl.NumericFieldUtils;
 import org.hibernate.search.engine.spi.DocumentBuilderIndexedEntity;
 import org.hibernate.search.store.Workspace;
@@ -48,7 +48,7 @@ public final class ByTermUpdateWorkExecutor extends UpdateWorkExecutor {
 	}
 
 	@Override
-	public void performWork(LuceneWork work, IndexWriter writer, IndexingMonitor monitor) {
+	public void performWork(LuceneWork work, IndexWriterDelegate delegate, IndexingMonitor monitor) {
 		final Serializable id = work.getId();
 		final String tenantId = work.getTenantId();
 		final Class<?> managedType = work.getEntityClass();
@@ -67,9 +67,9 @@ public final class ByTermUpdateWorkExecutor extends UpdateWorkExecutor {
 					TermQuery tenantTermQuery = new TermQuery( new Term( DocumentBuilderIndexedEntity.TENANT_ID_FIELDNAME, tenantId ) );
 					deleteDocumentsQuery.add( tenantTermQuery, Occur.MUST );
 				}
-				writer.deleteDocuments( deleteDocumentsQuery );
+				delegate.deleteDocuments( deleteDocumentsQuery );
 				// no need to log the Add operation as we'll log in the delegate
-				this.addDelegate.performWork( work, writer, monitor );
+				this.addDelegate.performWork( work, delegate, monitor );
 			}
 			else {
 				log.tracef( "Updating %s#%s by id using an IndexWriter#updateDocument.", managedType, id );
@@ -77,7 +77,7 @@ public final class ByTermUpdateWorkExecutor extends UpdateWorkExecutor {
 				Map<String, String> fieldToAnalyzerMap = work.getFieldToAnalyzerMap();
 				ScopedAnalyzer analyzer = builder.getAnalyzer();
 				analyzer = AddWorkExecutor.updateAnalyzerMappings( workspace, analyzer, fieldToAnalyzerMap );
-				writer.updateDocument( idTerm, work.getDocument(), analyzer );
+				delegate.updateDocument( idTerm, work.getDocument(), analyzer );
 			}
 			workspace.notifyWorkApplied( work );
 		}

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/DeleteByQueryWorkExecutor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/DeleteByQueryWorkExecutor.java
@@ -8,7 +8,6 @@ package org.hibernate.search.backend.impl.lucene.works;
 
 import java.io.IOException;
 
-import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
@@ -16,6 +15,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
+import org.hibernate.search.backend.impl.lucene.IndexWriterDelegate;
 import org.hibernate.search.backend.spi.DeleteByQueryLuceneWork;
 import org.hibernate.search.backend.spi.DeletionQuery;
 import org.hibernate.search.engine.ProjectionConstants;
@@ -43,7 +43,7 @@ class DeleteByQueryWorkExecutor implements LuceneWorkExecutor {
 	}
 
 	@Override
-	public void performWork(LuceneWork work, IndexWriter writer, IndexingMonitor monitor) {
+	public void performWork(LuceneWork work, IndexWriterDelegate delegate, IndexingMonitor monitor) {
 		DeleteByQueryLuceneWork deleteWork = (DeleteByQueryLuceneWork) work;
 
 		final Class<?> entityType = work.getEntityClass();
@@ -56,7 +56,6 @@ class DeleteByQueryWorkExecutor implements LuceneWorkExecutor {
 		BooleanQuery entityDeletionQuery = new BooleanQuery();
 
 		{
-
 			ScopedAnalyzer analyzer = this.workspace.getDocumentBuilder( entityType ).getAnalyzer();
 			Query queryToDelete = query.toLuceneQuery( analyzer );
 
@@ -70,14 +69,13 @@ class DeleteByQueryWorkExecutor implements LuceneWorkExecutor {
 		addTenantQueryTerm( work.getTenantId(), entityDeletionQuery );
 
 		try {
-			writer.deleteDocuments( entityDeletionQuery );
+			delegate.deleteDocuments( entityDeletionQuery );
 		}
 		catch (IOException e) {
 			SearchException ex = log.unableToDeleteByQuery( entityType, query, e );
 			throw ex;
 		}
 		this.workspace.notifyWorkApplied( work );
-
 	}
 
 	private void addTenantQueryTerm(final String tenantId, BooleanQuery entityDeletionQuery) {

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/DeleteExtWorkExecutor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/DeleteExtWorkExecutor.java
@@ -8,12 +8,12 @@ package org.hibernate.search.backend.impl.lucene.works;
 
 import java.io.Serializable;
 
-import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.Term;
 import org.hibernate.search.exception.AssertionFailure;
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
+import org.hibernate.search.backend.impl.lucene.IndexWriterDelegate;
 import org.hibernate.search.bridge.util.impl.NumericFieldUtils;
 import org.hibernate.search.engine.spi.DocumentBuilderIndexedEntity;
 import org.hibernate.search.store.Workspace;
@@ -43,17 +43,17 @@ public final class DeleteExtWorkExecutor extends DeleteWorkExecutor {
 	}
 
 	@Override
-	public void performWork(LuceneWork work, IndexWriter writer, IndexingMonitor monitor) {
+	public void performWork(LuceneWork work, IndexWriterDelegate delegate, IndexingMonitor monitor) {
 		checkType( work );
 		Serializable id = work.getId();
 		log.tracef( "Removing %s#%s by id using an IndexWriter.", managedType, id );
 		try {
 			if ( idIsNumeric ) {
-				writer.deleteDocuments( NumericFieldUtils.createExactMatchQuery( builder.getIdKeywordName(), id ) );
+				delegate.deleteDocuments( NumericFieldUtils.createExactMatchQuery( builder.getIdKeywordName(), id ) );
 			}
 			else {
 				Term idTerm = new Term( builder.getIdKeywordName(), work.getIdInString() );
-				writer.deleteDocuments( idTerm );
+				delegate.deleteDocuments( idTerm );
 			}
 			workspace.notifyWorkApplied( work );
 		}

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/DeleteWorkExecutor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/DeleteWorkExecutor.java
@@ -8,7 +8,6 @@ package org.hibernate.search.backend.impl.lucene.works;
 
 import java.io.Serializable;
 
-import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
@@ -24,6 +23,7 @@ import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
+import org.hibernate.search.backend.impl.lucene.IndexWriterDelegate;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
 /**
@@ -46,7 +46,7 @@ class DeleteWorkExecutor implements LuceneWorkExecutor {
 	}
 
 	@Override
-	public void performWork(LuceneWork work, IndexWriter writer, IndexingMonitor monitor) {
+	public void performWork(LuceneWork work, IndexWriterDelegate delegate, IndexingMonitor monitor) {
 		final Class<?> entityType = work.getEntityClass();
 		final Serializable id = work.getId();
 		log.tracef( "Removing %s#%s by query.", entityType, id );
@@ -71,7 +71,7 @@ class DeleteWorkExecutor implements LuceneWorkExecutor {
 		addTenantQueryTerm( work.getTenantId(), entityDeletionQuery );
 
 		try {
-			writer.deleteDocuments( entityDeletionQuery );
+			delegate.deleteDocuments( entityDeletionQuery );
 		}
 		catch (Exception e) {
 			String message = "Unable to remove " + entityType + "#" + id + " from index.";

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/FlushWorkExecutor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/FlushWorkExecutor.java
@@ -6,10 +6,9 @@
  */
 package org.hibernate.search.backend.impl.lucene.works;
 
-import org.apache.lucene.index.IndexWriter;
-
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
+import org.hibernate.search.backend.impl.lucene.IndexWriterDelegate;
 import org.hibernate.search.store.Workspace;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
@@ -33,7 +32,7 @@ class FlushWorkExecutor implements LuceneWorkExecutor {
 	}
 
 	@Override
-	public void performWork(LuceneWork work, IndexWriter writer, IndexingMonitor monitor) {
+	public void performWork(LuceneWork work, IndexWriterDelegate delegate, IndexingMonitor monitor) {
 		log.debug( "performing FlushWorkDelegate" );
 		workspace.flush();
 	}

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/LuceneWorkExecutor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/LuceneWorkExecutor.java
@@ -6,9 +6,9 @@
  */
 package org.hibernate.search.backend.impl.lucene.works;
 
-import org.apache.lucene.index.IndexWriter;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
+import org.hibernate.search.backend.impl.lucene.IndexWriterDelegate;
 
 /**
  * <p>LuceneWorkDelegate interface.</p>
@@ -21,10 +21,10 @@ public interface LuceneWorkExecutor {
 	 * Will perform work on an IndexWriter.
 	 *
 	 * @param work the LuceneWork to apply to the IndexWriter.
-	 * @param writer the IndexWriter to use.
+	 * @param delegate the IndexWriterDelegate to use.
 	 * @param monitor will be notified of performed operations
 	 * @throws java.lang.UnsupportedOperationException when the work is not compatible with an IndexWriter.
 	 */
-	void performWork(LuceneWork work, IndexWriter writer, IndexingMonitor monitor);
+	void performWork(LuceneWork work, IndexWriterDelegate delegate, IndexingMonitor monitor);
 
 }

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/OptimizeWorkExecutor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/OptimizeWorkExecutor.java
@@ -6,12 +6,11 @@
  */
 package org.hibernate.search.backend.impl.lucene.works;
 
-import org.apache.lucene.index.IndexWriter;
 import org.hibernate.search.store.Workspace;
 import org.hibernate.search.util.logging.impl.Log;
-
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
+import org.hibernate.search.backend.impl.lucene.IndexWriterDelegate;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
 /**
@@ -35,10 +34,10 @@ class OptimizeWorkExecutor implements LuceneWorkExecutor {
 	}
 
 	@Override
-	public void performWork(LuceneWork work, IndexWriter writer, IndexingMonitor monitor) {
+	public void performWork(LuceneWork work, IndexWriterDelegate delegate, IndexingMonitor monitor) {
 		final Class<?> entityType = work.getEntityClass();
 		log.tracef( "optimize Lucene index: %s", entityType );
-		workspace.performOptimization( writer );
+		workspace.performOptimization( delegate.getIndexWriter() );
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/PurgeAllWorkExecutor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/PurgeAllWorkExecutor.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.backend.impl.lucene.works;
 
-import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
@@ -18,6 +17,7 @@ import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
+import org.hibernate.search.backend.impl.lucene.IndexWriterDelegate;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
 /**
@@ -39,14 +39,14 @@ class PurgeAllWorkExecutor implements LuceneWorkExecutor {
 	}
 
 	@Override
-	public void performWork(LuceneWork work, IndexWriter writer, IndexingMonitor monitor) {
+	public void performWork(LuceneWork work, IndexWriterDelegate delegate, IndexingMonitor monitor) {
 		final Class<?> entityType = work.getEntityClass();
 		final String tenantId = work.getTenantId();
 		try {
 			Term entityTypeTerm = new Term( ProjectionConstants.OBJECT_CLASS, entityType.getName() );
 			if ( tenantId == null ) {
 				log.tracef( "purgeAll Lucene index using IndexWriter for type: %s", entityType );
-				writer.deleteDocuments( entityTypeTerm );
+				delegate.deleteDocuments( entityTypeTerm );
 			}
 			else {
 				log.tracef( "purgeAll Lucene index using IndexWriter for type $1%s and tenant $2%s", entityType, tenantId );
@@ -54,7 +54,7 @@ class PurgeAllWorkExecutor implements LuceneWorkExecutor {
 				BooleanQuery deleteDocumentsQuery = new BooleanQuery();
 				deleteDocumentsQuery.add( new TermQuery( entityTypeTerm ), Occur.MUST );
 				deleteDocumentsQuery.add( new TermQuery( tenantIdTerm ), Occur.MUST );
-				writer.deleteDocuments( deleteDocumentsQuery );
+				delegate.deleteDocuments( deleteDocumentsQuery );
 			}
 		}
 		catch (Exception e) {

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/UpdateWorkExecutor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/UpdateWorkExecutor.java
@@ -7,9 +7,9 @@
 
 package org.hibernate.search.backend.impl.lucene.works;
 
-import org.apache.lucene.index.IndexWriter;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
+import org.hibernate.search.backend.impl.lucene.IndexWriterDelegate;
 
 /**
  * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
@@ -25,11 +25,11 @@ public class UpdateWorkExecutor implements LuceneWorkExecutor {
 	}
 
 	@Override
-	public void performWork(final LuceneWork work, final IndexWriter writer, final IndexingMonitor monitor) {
+	public void performWork(final LuceneWork work, IndexWriterDelegate delegate, final IndexingMonitor monitor) {
 		// This is the slowest implementation, needing to remove and then add to the index;
 		// see also org.hibernate.search.backend.impl.lucene.works.UpdateExtWorkDelegate
-		this.deleteDelegate.performWork( work, writer, monitor );
-		this.addDelegate.performWork( work, writer, monitor );
+		this.deleteDelegate.performWork( work, delegate, monitor );
+		this.addDelegate.performWork( work, delegate, monitor );
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/search/store/Workspace.java
+++ b/engine/src/main/java/org/hibernate/search/store/Workspace.java
@@ -15,8 +15,11 @@ import org.hibernate.search.backend.impl.CommitPolicy;
 import org.hibernate.search.engine.spi.DocumentBuilderIndexedEntity;
 
 /**
+ * @deprecated This interface will be moved and should be considered non-public API [HSEARCH-1915]
+ *
  * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
  */
+@Deprecated
 public interface Workspace {
 
 	DocumentBuilderIndexedEntity getDocumentBuilder(Class<?> entity);

--- a/engine/src/main/java/org/hibernate/search/util/impl/ScopedAnalyzer.java
+++ b/engine/src/main/java/org/hibernate/search/util/impl/ScopedAnalyzer.java
@@ -47,6 +47,28 @@ public final class ScopedAnalyzer extends AnalyzerWrapper {
 		scopedAnalyzers.put( scope, scopedAnalyzer );
 	}
 
+	/**
+	 * Compares the references of the global analyzer backing this ScopedAnalyzer
+	 * and each scoped analyzer.
+	 * @param other ScopedAnalyzer to compare to
+	 * @return true if and only if the same instance of global analyzer is being used
+	 * and all scoped analyzers also match, by reference.
+	 */
+	public boolean isCompositeOfSameInstances(ScopedAnalyzer other) {
+		if ( this.globalAnalyzer != other.globalAnalyzer ) {
+			return false;
+		}
+		if ( this.scopedAnalyzers.size() != other.scopedAnalyzers.size() ) {
+			return false;
+		}
+		for ( String fieldname : scopedAnalyzers.keySet() ) {
+			if ( this.scopedAnalyzers.get( fieldname ) != other.scopedAnalyzers.get( fieldname ) ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
 	@Override
 	protected Analyzer getWrappedAnalyzer(String fieldName) {
 		final Analyzer analyzer = scopedAnalyzers.get( fieldName );

--- a/orm/src/test/java/org/hibernate/search/test/errorhandling/LuceneErrorHandlingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/errorhandling/LuceneErrorHandlingTest.java
@@ -11,12 +11,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.lucene.index.IndexWriter;
 import org.hibernate.search.backend.DeleteLuceneWork;
 import org.hibernate.search.backend.IndexWorkVisitor;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.backend.impl.StreamingOperationExecutorSelector;
+import org.hibernate.search.backend.impl.lucene.IndexWriterDelegate;
 import org.hibernate.search.backend.impl.lucene.works.LuceneWorkExecutor;
 import org.hibernate.search.batchindexing.MassIndexerProgressMonitor;
 import org.hibernate.search.cfg.Environment;
@@ -138,7 +138,7 @@ public class LuceneErrorHandlingTest extends SearchTestBase {
 		}
 
 		@Override
-		public void performWork(LuceneWork work, IndexWriter writer, IndexingMonitor monitor) {
+		public void performWork(LuceneWork work, IndexWriterDelegate delegate, IndexingMonitor monitor) {
 			WORK_COUNTER.incrementAndGet();
 		}
 
@@ -179,7 +179,7 @@ public class LuceneErrorHandlingTest extends SearchTestBase {
 		}
 
 		@Override
-		public void performWork(LuceneWork work, IndexWriter writer, IndexingMonitor monitor) {
+		public void performWork(LuceneWork work, IndexWriterDelegate delegate, IndexingMonitor monitor) {
 			throw new SearchException( "failed work message" );
 		}
 	}


### PR DESCRIPTION
 - https://hibernate.atlassian.net/browse/HSEARCH-1908

This is all to avoid invoking
 IndexWriter.addDocument( document, analyzer )

as the only option in Lucene 5 is

 IndexWriter.addDocument( document )
