### PR TITLE
HSEARCH-1936 do not force storeTermVectorPayloads flag when termVector is YES

### DIFF
--- a/engine/src/main/java/org/hibernate/search/indexes/serialization/impl/LuceneWorkHydrator.java
+++ b/engine/src/main/java/org/hibernate/search/indexes/serialization/impl/LuceneWorkHydrator.java
@@ -420,7 +420,6 @@ public class LuceneWorkHydrator implements LuceneWorksBuilder {
 		type.setTokenized( analyzed );
 		type.setStoreTermVectors( termVector != SerializableTermVector.NO );
 		type.setStoreTermVectorOffsets( termVector == SerializableTermVector.WITH_OFFSETS || termVector == SerializableTermVector.WITH_POSITIONS_OFFSETS );
-		type.setStoreTermVectorPayloads( termVector == SerializableTermVector.YES );
 		type.setStoreTermVectorPositions( termVector == SerializableTermVector.WITH_POSITIONS || termVector == SerializableTermVector.WITH_POSITIONS_OFFSETS );
 		type.setOmitNorms( omitNorms );
 		type.setIndexOptions( omitTermFreqAndPositions ? IndexOptions.DOCS_ONLY : IndexOptions.DOCS_AND_FREQS_AND_POSITIONS );

--- a/serialization/avro/src/test/java/org/hibernate/search/test/serialization/SerializationTest.java
+++ b/serialization/avro/src/test/java/org/hibernate/search/test/serialization/SerializationTest.java
@@ -156,6 +156,16 @@ public class SerializationTest {
 		field = new Field( "tokenstream", tokenStream, Field.TermVector.WITH_POSITIONS_OFFSETS );
 		field.setBoost( 3f );
 		doc.add( field );
+
+		field = new Field(
+				"StringF3",
+				"String field 3",
+				Store.YES,
+				Field.Index.ANALYZED,
+				Field.TermVector.YES
+		);
+		doc.add( field );
+
 		return doc;
 	}
 


### PR DESCRIPTION
@Sanne here is a pull request to fix HSEARCH-1936 I created recently. Not sure this fix won't create regressions but all unit tests still pass after the change.