### PR TITLE
Improve directory creation and validation, enable performance tests again

### DIFF
--- a/engine/src/main/java/org/hibernate/search/store/impl/DirectoryProviderHelper.java
+++ b/engine/src/main/java/org/hibernate/search/store/impl/DirectoryProviderHelper.java
@@ -86,13 +86,13 @@ public final class DirectoryProviderHelper {
 			log.debug( "No root directory, go with relative " + relative );
 			sourceDirectory = FileSystems.getDefault().getPath( relative );
 			if ( Files.notExists( sourceDirectory ) ) {
-				throw new SearchException( "Source directory does not exist: " + relative );
+				throw log.sourceDirectoryNotExisting( relative );
 			}
 			else if ( ! Files.isReadable( sourceDirectory ) ) {
-				throw new SearchException( "Unable to read source directory: " + relative );
+				throw log.directoryIsNotReadable( relative );
 			}
 			else if ( ! Files.isDirectory( sourceDirectory ) ) {
-				throw new SearchException( "Path does not point to a directory: " + relative );
+				throw log.fileIsADirectory( relative );
 			}
 			//else keep source as it
 		}

--- a/engine/src/main/java/org/hibernate/search/store/spi/DirectoryHelper.java
+++ b/engine/src/main/java/org/hibernate/search/store/spi/DirectoryHelper.java
@@ -8,6 +8,8 @@ package org.hibernate.search.store.spi;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
 import java.util.Properties;
 
 import org.apache.lucene.analysis.core.SimpleAnalyzer;
@@ -79,16 +81,25 @@ public class DirectoryHelper {
 	 * @param annotatedIndexName The index name declared on the @Indexed annotation
 	 * @param properties The properties may override the indexname.
 	 * @param verifyIsWritable Verify the directory is writable
-	 * @return the File representing the Index Directory
+	 * @return the Path representing the Index Directory
 	 * @throws SearchException if any.
 	 */
-	public static File getVerifiedIndexDir(String annotatedIndexName, Properties properties, boolean verifyIsWritable) {
+	public static Path getVerifiedIndexPath(String annotatedIndexName, Properties properties, boolean verifyIsWritable) {
 		String indexBase = properties.getProperty( Environment.INDEX_BASE_PROP_NAME, "." );
 		String indexName = properties.getProperty( Environment.INDEX_NAME_PROP_NAME, annotatedIndexName );
-		File baseIndexDir = new File( indexBase );
+		Path baseIndexDir = FileSystems.getDefault().getPath( indexBase );
 		DirectoryProviderHelper.makeSanityCheckedDirectory( baseIndexDir, indexName, verifyIsWritable );
-		File indexDir = new File( baseIndexDir, indexName );
+		Path indexDir = baseIndexDir.resolve( indexName );
 		DirectoryProviderHelper.makeSanityCheckedDirectory( indexDir, indexName, verifyIsWritable );
 		return indexDir;
 	}
+
+	/**
+	 * @deprecated use getVerifiedIndexPath
+	 */
+	@Deprecated
+	public static File getVerifiedIndexDir(String annotatedIndexName, Properties properties, boolean verifyIsWritable) {
+		return getVerifiedIndexPath( annotatedIndexName, properties, verifyIsWritable ).toFile();
+	}
+
 }

--- a/engine/src/main/java/org/hibernate/search/util/impl/FileHelper.java
+++ b/engine/src/main/java/org/hibernate/search/util/impl/FileHelper.java
@@ -177,6 +177,7 @@ public class FileHelper {
 		}
 	}
 
+	@Deprecated
 	public static void delete(File file) throws IOException {
 		delete( file.toPath() );
 	}
@@ -193,7 +194,7 @@ public class FileHelper {
 			throw new IllegalArgumentException();
 		}
 
-		if ( !Files.exists( path ) ) {
+		if ( Files.notExists( path ) ) {
 			return;
 		}
 

--- a/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
@@ -842,4 +842,10 @@ public interface Log extends BasicLogger {
 	@Message(id = 279, value = "Unable to load the UTF-8 Charset!")
 	AssertionFailure assertionNotLoadingUTF8Charset(@Cause UnsupportedEncodingException e);
 
+	@Message(id = 280, value = "Source directory does not exist: '%1$s")
+	SearchException sourceDirectoryNotExisting(String directory);
+
+	@Message(id = 281, value = "Unable to read directory: '%1$s")
+	SearchException directoryIsNotReadable(String directory);
+
 }

--- a/integrationtest/performance/pom.xml
+++ b/integrationtest/performance/pom.xml
@@ -30,6 +30,8 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- We override the version of ShrinkWrap Maven Resolver from Arquillian BOM:
+             this section must be declared before the Arquillian bom import -->
             <dependency>
                 <groupId>org.jboss.shrinkwrap.resolver</groupId>
                 <artifactId>shrinkwrap-resolver-bom</artifactId>
@@ -37,43 +39,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- Imports compatible versions for each Arquillian module -->
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
                 <version>${arquillianVersion}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <!-- Override imported versions to satisfy the dependency-convergence -->
-            <dependency>
-                <groupId>org.jboss.sasl</groupId>
-                <artifactId>jboss-sasl</artifactId>
-                <version>1.0.4.Final</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.marshalling</groupId>
-                <artifactId>jboss-marshalling</artifactId>
-                <version>1.4.4.Final</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.remoting</groupId>
-                <artifactId>jboss-remoting</artifactId>
-                <version>4.0.2.Final</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.xnio</groupId>
-                <artifactId>xnio-api</artifactId>
-                <version>3.2.1.Final</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.marshalling</groupId>
-                <artifactId>jboss-marshalling-river</artifactId>
-                <version>1.4.4.Final</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.xnio</groupId>
-                <artifactId>xnio-nio</artifactId>
-                <version>3.2.1.Final</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -92,6 +64,8 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+
+        <!-- test -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -103,11 +77,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.shrinkwrap.descriptors</groupId>
-            <artifactId>shrinkwrap-descriptors-impl-javaee</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-depchain</artifactId>
             <scope>test</scope>
@@ -116,7 +85,28 @@
         <dependency>
             <groupId>org.wildfly.arquillian</groupId>
             <artifactId>wildfly-arquillian-container-managed</artifactId>
-            <version>1.0.0.Alpha5</version>
+            <version>1.0.0.Final</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.logmanager</groupId>
+                    <artifactId>jboss-logmanager</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.logmanager</groupId>
+                    <artifactId>log4j-jboss-logmanager</artifactId>
+                </exclusion>
+                <!-- This exclusion is needed to be able to setup the project in Windows:
+                     it otherwise includes transitive dependency to the JDK JConsole -->
+                <exclusion>
+                    <artifactId>wildfly-patching</artifactId>
+                    <groupId>org.wildfly</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+            <artifactId>shrinkwrap-descriptors-impl-javaee</artifactId>
             <scope>test</scope>
             <exclusions>
                 <!-- This exclusion is needed to be able to setup the project in Windows:
@@ -151,14 +141,12 @@
     </dependencies>
 
     <build>
-
         <testResources>
             <testResource>
                 <filtering>true</filtering>
                 <directory>src/test/resources</directory>
             </testResource>
         </testResources>
-
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -186,8 +174,8 @@
                                     <groupId>org.wildfly</groupId>
                                     <artifactId>wildfly-dist</artifactId>
                                     <version>${wildflyVersion}</version>
-                                    <type>tar.gz</type>
-                                    <overWrite>false</overWrite>
+                                    <type>zip</type>
+                                    <overWrite>true</overWrite>
                                     <outputDirectory>${project.build.directory}</outputDirectory>
                                 </artifactItem>
                             </artifactItems>

--- a/integrationtest/performance/pom.xml
+++ b/integrationtest/performance/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>org.wildfly.arquillian</groupId>
             <artifactId>wildfly-arquillian-container-managed</artifactId>
-            <version>1.0.0.Final</version>
+            <version>${arquillianContainerVersion}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/TestRunnerArquillian.java
+++ b/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/TestRunnerArquillian.java
@@ -55,6 +55,7 @@ public class TestRunnerArquillian {
 				.addClass( TestConstants.class )
 				.addAsResource( createPersistenceXml(), "META-INF/persistence.xml" )
 				.addAsLibraries( PackagerHelper.hibernateSearchLibraries() )
+				.addAsLibraries( PackagerHelper.hibernateSearchTestingLibraries() )
 				.addAsWebInfResource( EmptyAsset.INSTANCE, "beans.xml" )
 				.add( manifest(), "META-INF/MANIFEST.MF" )
 				.addAsWebInfResource( reportsOutputDirectory(), "classes/" + RUNNER_PROPERTIES );

--- a/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/TestRunnerArquillian.java
+++ b/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/TestRunnerArquillian.java
@@ -83,8 +83,6 @@ public class TestRunnerArquillian {
 				.jtaDataSource( System.getProperty( "datasource", "java:jboss/datasources/ExampleDS" ) );
 
 		Properties properties = scenario.getHibernateProperties();
-		properties.setProperty( "hibernate.transaction.factory_class", "org.hibernate.engine.transaction.internal.jta.JtaTransactionFactory" );
-
 		for ( Entry<Object, Object> property : properties.entrySet() ) {
 			pu.getOrCreateProperties().
 					createProperty().

--- a/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/scenario/TestReporter.java
+++ b/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/scenario/TestReporter.java
@@ -18,13 +18,17 @@ import static org.hibernate.search.test.performance.scenario.TestContext.THREADS
 import static org.hibernate.search.test.performance.scenario.TestContext.VERBOSE;
 import static org.hibernate.search.test.performance.util.Util.runGarbageCollectorAndWait;
 
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
 import java.util.Date;
 import java.util.Map.Entry;
 import java.util.Properties;
@@ -47,9 +51,10 @@ public class TestReporter {
 	private TestReporter() {
 	}
 
-	public static void printReport(TestContext ctx) {
+	public static void printReport(TestContext ctx) throws UnsupportedEncodingException {
 		PrintStream outStream = createOutputStream( ctx.scenario.getClass().getSimpleName() );
-		PrintWriter outWriter = new PrintWriter( outStream );
+		PrintWriter outWriter = new PrintWriter(
+				new BufferedWriter( new OutputStreamWriter( outStream, "UTF-8" ) ), false );
 
 		outWriter.println( "==================================================================" );
 		outWriter.println( "HIBERNATE SEARCH PERFORMANCE TEST REPORT" );
@@ -63,6 +68,7 @@ public class TestReporter {
 		CheckerUncaughtExceptions.printUncaughtExceptions( ctx, outWriter );
 
 		outWriter.close();
+		outStream.close();
 	}
 
 	private static void printSummary(TestContext ctx, PrintWriter out) {
@@ -158,7 +164,7 @@ public class TestReporter {
 			File reportFile = new File( targetDir, "report-" + testScenarioName + "-" + DateFormatUtils.format( new Date(), "yyyy-MM-dd-HH'h'mm'm'" ) + ".txt" );
 
 			final OutputStream std = System.out;
-			final OutputStream file = new PrintStream( reportFile );
+			final OutputStream file = new PrintStream( new FileOutputStream( reportFile ), true, "UTF-8" );
 			final OutputStream stream = new OutputStream() {
 
 				@Override
@@ -178,10 +184,9 @@ public class TestReporter {
 					file.close();
 				}
 			};
-			PrintStream ps = new PrintStream( stream );
-			return ps;
+			return new PrintStream( stream, false, "UTF-8" );
 		}
-		catch (FileNotFoundException e) {
+		catch (FileNotFoundException|UnsupportedEncodingException e) {
 			throw new RuntimeException( e );
 		}
 	}

--- a/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/scenario/TestScenario.java
+++ b/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/scenario/TestScenario.java
@@ -12,6 +12,7 @@ import static org.hibernate.search.test.performance.task.InsertBookTask.SUMMARIE
 import static org.hibernate.search.test.performance.util.CheckerUncaughtExceptions.initUncaughtExceptionHandler;
 import static org.hibernate.search.test.performance.util.Util.log;
 
+import java.io.UnsupportedEncodingException;
 import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -190,7 +191,12 @@ public abstract class TestScenario {
 		TestContext ctx = new TestContext( this, sf );
 		scheduleTasksAndStart( ctx, measuredCyclesCount );
 
-		TestReporter.printReport( ctx );
+		try {
+			TestReporter.printReport( ctx );
+		}
+		catch (UnsupportedEncodingException e) {
+			throw new RuntimeException( e );
+		}
 	}
 
 	protected void scheduleTasksAndStart(TestContext ctx, long cyclesCount) {

--- a/integrationtest/performance/src/test/resources/arquillian.xml
+++ b/integrationtest/performance/src/test/resources/arquillian.xml
@@ -10,13 +10,18 @@
     xsi:schemaLocation="http://jboss.org/schema/arquillian
         http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
-    <engine>
-        <property name="deploymentExportPath">target/</property>
-    </engine>
+    <defaultProtocol type="Servlet 3.0" />
 
-    <container qualifier="jboss" default="true">
+    <!-- Uncomment in order to inspect deployments -->
+    <!--
+    <engine>
+        <property name="deploymentExportPath">target/deployments</property>
+    </engine>
+    -->
+
+    <container qualifier="wildfly" default="true">
         <configuration>
-            <property name="jbossHome">${basedir}/target/wildfly-${wildflyVersion}</property>
+            <property name="jbossHome">${project.build.directory}/wildfly-${wildflyVersion}</property>
             <property name="javaVmArguments">-Xmx512m -Djava.net.preferIPv4Stack=true -Djgroups.bind_addr=127.0.0.1 -XX:+IgnoreUnrecognizedVMOptions</property>
         </configuration>
     </container>

--- a/integrationtest/performance/src/test/resources/arquillian.xml
+++ b/integrationtest/performance/src/test/resources/arquillian.xml
@@ -22,7 +22,7 @@
     <container qualifier="wildfly" default="true">
         <configuration>
             <property name="jbossHome">${project.build.directory}/wildfly-${wildflyVersion}</property>
-            <property name="javaVmArguments">-Xmx512m -Djava.net.preferIPv4Stack=true -Djgroups.bind_addr=127.0.0.1 -XX:+IgnoreUnrecognizedVMOptions</property>
+            <property name="javaVmArguments">-Xmx512m -Djava.net.preferIPv4Stack=true -Djgroups.bind_addr=127.0.0.1</property>
         </configuration>
     </container>
 

--- a/integrationtest/wildfly/pom.xml
+++ b/integrationtest/wildfly/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>org.wildfly.arquillian</groupId>
             <artifactId>wildfly-arquillian-container-managed</artifactId>
-            <version>1.0.0.Final</version>
+            <version>${arquillianContainerVersion}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/wildfly/PackagerHelper.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/wildfly/PackagerHelper.java
@@ -27,6 +27,23 @@ public class PackagerHelper {
 	}
 
 	/**
+	 * Packages which are never included among transitive dependencies of the below methods.
+	 */
+	private static String[] exclusions = new String[] {
+		"org.hibernate:hibernate-core",
+		"org.hibernate.javax.persistence:hibernate-jpa-2.1-api",
+		"org.jboss.logging:jboss-logging",
+		"org.jboss.logging:jboss-logging-processor",
+		"dom4j:dom4j",
+		"xml-apis:xml-apis",
+		"org.jboss:jandex",
+		"antlr:antlr",
+		"org.apache.geronimo.specs:geronimo-jta_1.1_spec",
+		"org.javassist:javassist",
+		"org.jboss.jdeparser:jdeparser"
+	};
+
+	/**
 	 * Returns the set of dependencies defined as org.hibernate:hibernate-search-orm at
 	 * the version being built. We use transitive dependencies to include the version
 	 * of hibernate-search-engine and Apache Lucene at the currently built version, but
@@ -39,22 +56,19 @@ public class PackagerHelper {
 		String currentVersion = Version.getVersionString();
 		return Maven.resolver()
 			.resolve( "org.hibernate:hibernate-search-orm:" + currentVersion )
-			.using( new RejectDependenciesStrategy(
-				false, //we need some dependencies at the right version: Lucene, search-engine, etc..
-				"org.hibernate:hibernate-core",
-				"org.hibernate.javax.persistence:hibernate-jpa-2.1-api",
-				"org.jboss.logging:jboss-logging",
-				"org.jboss.logging:jboss-logging-processor",
-				"dom4j:dom4j",
-				"xml-apis:xml-apis",
-				"org.jboss:jandex",
-				"antlr:antlr",
-				"org.apache.geronimo.specs:geronimo-jta_1.1_spec",
-				"org.javassist:javassist",
-				"org.jboss.jdeparser:jdeparser" ) )
+			// we need some dependencies at the right version: Lucene, search-engine, etc..
+			.using( new RejectDependenciesStrategy( false, exclusions ) )
 			.as( JavaArchive.class );
 		// To debug dependencies, have it dump a zip export:
 		//archive.as( ZipExporter.class ).exportTo( new File("test-app.war"), true );
+	}
+
+	public static JavaArchive[] hibernateSearchTestingLibraries() {
+		String currentVersion = Version.getVersionString();
+		return Maven.resolver()
+			.resolve( "org.hibernate:hibernate-search-testing:" + currentVersion )
+			.using( new RejectDependenciesStrategy( false, exclusions ) )
+			.as( JavaArchive.class );
 	}
 
 }

--- a/integrationtest/wildfly/src/test/resources/arquillian.xml
+++ b/integrationtest/wildfly/src/test/resources/arquillian.xml
@@ -25,9 +25,9 @@
                 <property name="jbossHome">${project.build.directory}/node1/wildfly-${wildflyVersion}</property>
                 <!-- Needed for JMS tests -->
                 <property name="serverConfig">standalone-full-testqueues.xml</property>
-                <property name="javaVmArguments">-javaagent:${byteman.agent.path}=script:${byteman.script.path} -Xmx512m -XX:MaxPermSize=196m -Djava.net.preferIPv4Stack=true -Djgroups.bind_addr=127.0.0.1 -XX:+IgnoreUnrecognizedVMOptions</property>
+                <property name="javaVmArguments">-javaagent:${byteman.agent.path}=script:${byteman.script.path} -Xmx512m -Djava.net.preferIPv4Stack=true -Djgroups.bind_addr=127.0.0.1</property>
                 <!-- To debug the Arquillian managed application server: -->
-                <!-- property name="javaVmArguments">-javaagent:${byteman.agent.path}=script:${byteman.script.path} -Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y -Xmx512m -XX:MaxPermSize=128m -Dorg.jboss.remoting-jmx.timeout=300  -Djava.net.preferIPv4Stack=true -Djgroups.bind_addr=127.0.0.1</property -->
+                <!-- property name="javaVmArguments">-javaagent:${byteman.agent.path}=script:${byteman.script.path} -Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y -Xmx512m -Dorg.jboss.remoting-jmx.timeout=300  -Djava.net.preferIPv4Stack=true -Djgroups.bind_addr=127.0.0.1</property -->
             </configuration>
         </container>
         <!-- Copy of the above, except a port offset is applied and running from a different copy -->
@@ -36,7 +36,7 @@
                 <property name="jbossHome">${project.build.directory}/node2/wildfly-${wildflyVersion}</property>
                 <!-- Needed for JMS tests -->
                 <property name="serverConfig">standalone-full-testqueues.xml</property>
-                <property name="javaVmArguments">-Djboss.socket.binding.port-offset=10000 -Xmx512m -XX:MaxPermSize=196m  -Djava.net.preferIPv4Stack=true -Djgroups.bind_addr=127.0.0.1 -XX:+IgnoreUnrecognizedVMOptions</property>
+                <property name="javaVmArguments">-Djboss.socket.binding.port-offset=10000 -Xmx512m -Djava.net.preferIPv4Stack=true -Djgroups.bind_addr=127.0.0.1</property>
                 <property name="managementPort">19990</property>
             </configuration>
         </container>

--- a/pom.xml
+++ b/pom.xml
@@ -33,10 +33,10 @@
         <module>integrationtest/jms</module>
         <module>integrationtest/narayana</module>
         <module>integrationtest/spring</module>
-        <!-- <module>integrationtest/wildfly</module>  -->
-        <!-- <module>integrationtest/performance</module> -->
+        <!-- <module>integrationtest/wildfly</module> Enabled by profiles: requires JDK8 -->
+        <!-- <module>integrationtest/performance</module> Requires the integrationtest/wildfly module -->
         <module>integrationtest/osgi/karaf-features</module>
-        <!-- <module>integrationtest/sandbox</module> -->
+        <module>integrationtest/sandbox</module>
     </modules>
 
     <issueManagement>
@@ -1173,6 +1173,7 @@
             </activation>
             <modules>
                 <module>integrationtest/wildfly</module>
+                <module>integrationtest/performance</module>
             </modules>
         </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -164,8 +164,9 @@
 
         <!-- Integration tests -->
         <arquillianVersion>1.1.8.Final</arquillianVersion>
+        <arquillianContainerVersion>1.0.0.Final</arquillianContainerVersion>
         <shrinkwrapResolverVersion>2.0.0</shrinkwrapResolverVersion>
-        <wildflyVersion>10.0.0.Alpha5</wildflyVersion>
+        <wildflyVersion>10.0.0.Alpha6</wildflyVersion>
 
         <!-- character encoding -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
 - https://hibernate.atlassian.net/browse/HSEARCH-1932
 - https://hibernate.atlassian.net/browse/HSEARCH-1945

I didn't figure out a way to unit test the "." path resolution which wouldn't simply test that we use the API which we use.. a more reliable test is the fact that we re-enable the performance tests, which would previously fail because of the same "." resolution issue.

See https://github.com/hibernate/hibernate-search/pull/869 for the failure.