### PR TITLE
HSEARCH-1948 Missing tools.jar make the performance integration tests…

### DIFF
--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/wildfly/PackagerHelper.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/wildfly/PackagerHelper.java
@@ -40,7 +40,8 @@ public class PackagerHelper {
 		"antlr:antlr",
 		"org.apache.geronimo.specs:geronimo-jta_1.1_spec",
 		"org.javassist:javassist",
-		"org.jboss.jdeparser:jdeparser"
+		"org.jboss.jdeparser:jdeparser",
+		"com.sun:tools" //Always exclude this as it's not available on JDK9
 	};
 
 	/**


### PR DESCRIPTION
… fail on JDK9

 - https://hibernate.atlassian.net/browse/HSEARCH-1948
