### PR TITLE
HSEARCH-1947 Java 8 Date and Time

### DIFF
--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/DurationNumericBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/DurationNumericBridge.java
@@ -1,0 +1,50 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.bridge.builtin.time.impl;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * Converts an {@link Duration} to the number of milliseconds from the epoch of 1970-01-01T00:00:00Z.
+ * <p>
+ * If the duration is too large to fit in a {@code long} milliseconds, then an
+ * exception is thrown.
+ * <p>
+ * If the duration has greater than millisecond precision, then the conversion will drop any excess precision information
+ * as though the amount in nanoseconds was subject to integer division by one million.
+ * <p>
+ * The biggest instant that can be converted using {@link Long#MAX_VALUE} is w * The biggest instant that can be converted using {@link Long#MAX_VALUE} is 292278994-08-17T07:12:55.807Z.
+ * <p>
+ * The biggest duration that can be converted using {@link Long#MAX_VALUE} is PT2562047788015H12M55.807S.
+ * The smallest duration that can be converted using {@link Long#MIN_VALUE} is PT-2562047788015H-12M-55.808S.
+ *
+ * @author Davide D'Alto
+ */
+public class DurationNumericBridge extends JavaTimeNumericBridge<Duration, Long> {
+
+	public static final DurationNumericBridge INSTANCE = new DurationNumericBridge();
+
+	private DurationNumericBridge() {
+	}
+
+	/**
+	 * @see Duration#toMillis()
+	 */
+	@Override
+	public Long encode(Duration accessor) {
+		return accessor.toMillis();
+	}
+
+	/**
+	 * @see Duration#of(long, java.time.temporal.TemporalUnit)
+	 */
+	@Override
+	public Duration decode(Long value) {
+		return Duration.of( value, ChronoUnit.MILLIS );
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/InstantNumericBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/InstantNumericBridge.java
@@ -1,0 +1,47 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.bridge.builtin.time.impl;
+
+import java.time.Instant;
+
+/**
+ * Converts an {@link Instant} to the number of milliseconds from the epoch of 1970-01-01T00:00:00Z.
+ * <p>
+ * If the instant represents a point on the time-line too far in the future or past to fit in a {@code long}
+ * milliseconds, then an exception is thrown.
+ * <p>
+ * If the instant has greater than millisecond precision, then the conversion will drop any excess precision
+ * information as though the amount in nanoseconds was subject to integer division by one million.
+ * <p>
+ * The biggest instant that can be converted using {@link Long#MAX_VALUE} is 292278994-08-17T07:12:55.807Z.
+ * The smallest instant that can be converted using {@link Long#MIN_VALUE} is -292275055-05-16T16:47:04.192Z.
+ *
+ * @author Davide D'Alto
+ */
+public class InstantNumericBridge extends JavaTimeNumericBridge<Instant, Long> {
+
+	public static final InstantNumericBridge INSTANCE = new InstantNumericBridge();
+
+	private InstantNumericBridge() {
+	}
+
+	/**
+	 * @see Instant#toEpochMilli()
+	 */
+	@Override
+	public Long encode(Instant instant) {
+		return instant.toEpochMilli();
+	}
+
+	/**
+	 * @see Instant#ofEpochMilli(long)
+	 */
+	@Override
+	public Instant decode(Long value) {
+		return Instant.ofEpochMilli( value );
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/JavaTimeNumericBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/JavaTimeNumericBridge.java
@@ -1,0 +1,68 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.bridge.builtin.time.impl;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexableField;
+import org.hibernate.search.bridge.FieldBridge;
+import org.hibernate.search.bridge.LuceneOptions;
+import org.hibernate.search.bridge.TwoWayFieldBridge;
+
+/**
+ * A bridge that converts a temporal type (a class in the package java.time.*) to a number.
+ *
+ * @param T the temporal type
+ * @param N the type of the number resulting from the conversion
+ *
+ * @author Davide D'Alto
+ */
+public abstract class JavaTimeNumericBridge<T, N extends Number> implements FieldBridge, TwoWayFieldBridge {
+
+	/**
+	 * Converts an instance of T to an instance of N.
+	 *
+	 * @param temporal an instance of T. It's never null
+	 * @return an instance of N representing the temporal
+	 */
+	public abstract N encode(T temporal);
+
+	/**
+	 * Converts an instance of N to an instance of T.
+	 *
+	 * @param number an instance of N. It's never null
+	 * @return an instance of T representing the number
+	 */
+	public abstract T decode(N number);
+
+	@Override
+	public void set(String name, Object value, Document document, LuceneOptions luceneOptions) {
+		if ( value != null ) {
+			@SuppressWarnings("unchecked")
+			N encoded = encode( (T) value );
+			luceneOptions.addNumericFieldToDocument( name, encoded, document );
+		}
+	}
+
+	@Override
+	public final String objectToString(final Object object) {
+		@SuppressWarnings("unchecked")
+		N encoded = encode( (T) object );
+		return object == null ? null : String.valueOf( encoded );
+	}
+
+	@Override
+	public Object get(final String name, final Document document) {
+		final IndexableField field = document.getField( name );
+		if ( field == null ) {
+			return null;
+		}
+
+		@SuppressWarnings("unchecked")
+		N numericValue = (N) field.numericValue();
+		return decode( numericValue );
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/LocalDateNumericBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/LocalDateNumericBridge.java
@@ -1,0 +1,52 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.bridge.builtin.time.impl;
+
+import java.time.LocalDate;
+
+/**
+ * Converts a {@link LocalDate} to a {@link Long}.
+ * <p>
+ * The digits of the resulting number will have the following pattern: yyyyMMdd
+ * <p>
+ * For example, the date 2001-3-25 will become the number 20010325.
+ * <p>
+ * The values during encoding and decoding must be between the boundaries of a {@link LocalDate};
+ * if some of the values are out of range, a {@link java.time.DateTimeException} is thrown.
+ *
+ * @author Davide D'Alto
+ */
+public class LocalDateNumericBridge extends JavaTimeNumericBridge<LocalDate, Long> {
+
+	public static final LocalDateNumericBridge INSTANCE = new LocalDateNumericBridge();
+
+	private LocalDateNumericBridge() {
+	}
+
+	@Override
+	public Long encode(LocalDate date) {
+		long year = (long) date.getYear() * 10_000L;
+		long month = (long) date.getMonthValue() * 100L;
+		long day = (long) date.getDayOfMonth();
+
+		return year < 0
+				? year - month - day
+				: year + month + day;
+	}
+
+	@Override
+	public LocalDate decode(Long number) {
+		long absValue = Math.abs( number );
+		int year = (int) ( absValue / 10_000L );
+		int month = (int) ( ( absValue / 100L ) % 100L );
+		int day = (int) ( absValue % 100 );
+
+		return number.longValue() < 0
+				? LocalDate.of( -year, month, day )
+				: LocalDate.of( year, month, day );
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/LocalDateTimeNumericBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/LocalDateTimeNumericBridge.java
@@ -1,0 +1,45 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.bridge.builtin.time.impl;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+/**
+ * Converts a {@link LocalDateTime} to number of millisecond from Epoch using a UTC offset.
+ * <p>
+ * The LocalDateTime is converted to an {@link Instant} using {@link ZoneOffset#UTC}:
+ * <p>
+ * If the instant represents a point on the time-line too far in the future or past to fit in a {@code long}
+ * milliseconds, then an exception is thrown.
+ * <p>
+ * If the instant has greater than millisecond precision, then the conversion will drop any excess precision information
+ * as though the amount in nanoseconds was subject to integer division by one million.
+ * <p>
+ * The biggest date that can be converted using {@link Long#MAX_VALUE} is 292278994-08-17T07:12:55.807.
+ * The smallest date that can be converted using {@link Long#MIN_VALUE} is -292275055-05-16T16:47:04.192.
+ *
+ * @author Davide D'Alto
+ */
+public class LocalDateTimeNumericBridge extends JavaTimeNumericBridge<LocalDateTime, Long> {
+
+	public static final LocalDateTimeNumericBridge INSTANCE = new LocalDateTimeNumericBridge();
+
+	private LocalDateTimeNumericBridge() {
+	}
+
+	@Override
+	public Long encode(LocalDateTime dateTime) {
+		return dateTime.atOffset( ZoneOffset.UTC ).toInstant().toEpochMilli();
+	}
+
+	@Override
+	public LocalDateTime decode(Long value) {
+		return Instant.ofEpochMilli( value ).atOffset( ZoneOffset.UTC ).toLocalDateTime();
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/LocalTimeNumericBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/LocalTimeNumericBridge.java
@@ -1,0 +1,45 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.bridge.builtin.time.impl;
+
+import java.time.LocalTime;
+
+/**
+ * Converts a {@link LocalTime} to a {@link Long}.
+ * <p>
+ * The digits of the resulting number will have the following pattern: hhMMssnnnnnnnnn
+ * <p>
+ * The values during encoding and decoding must be between the boundaries of a {@link LocalTime};
+ * if some of the values are out of range, a {@link java.time.DateTimeException} is thrown.
+ *
+ * @author Davide D'Alto
+ */
+public class LocalTimeNumericBridge extends JavaTimeNumericBridge<LocalTime, Long> {
+
+	public static final LocalTimeNumericBridge INSTANCE = new LocalTimeNumericBridge();
+
+	private LocalTimeNumericBridge() {
+	}
+
+	@Override
+	public Long encode(LocalTime time) {
+		long hour = (long) time.getHour() * 1_00_00_000_000_000L;
+		long min = (long) time.getMinute() * 1_00_000_000_000L;
+		long sec = (long) time.getSecond() * 1_000_000_000L;
+		long nano = (long) time.getNano();
+		return hour + min + sec + nano;
+	}
+
+	@Override
+	public LocalTime decode(Long value) {
+		int hour = (int) ( value / 1_00_00_000_000_000L );
+		int min = (int) ( ( value / 1_00_000_000_000L ) % 100L );
+		int sec = (int) ( ( value / 1_000_000_000L ) % 100L );
+		int nano = (int) ( value % 1_000_000_000L );
+		return LocalTime.of( hour, min, sec, nano );
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/MonthDayNumericBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/MonthDayNumericBridge.java
@@ -1,0 +1,47 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.bridge.builtin.time.impl;
+
+import java.time.MonthDay;
+
+/**
+ * Converts a {@link MonthDay} to an {@link Integer}.
+ * <p>
+ * For example, the date 2000-11 will become the number 200011.
+ *
+ * @author Davide D'Alto
+ */
+public class MonthDayNumericBridge extends JavaTimeNumericBridge<MonthDay, Integer> {
+
+	public static final MonthDayNumericBridge INSTANCE = new MonthDayNumericBridge();
+
+	private MonthDayNumericBridge() {
+	}
+
+	@Override
+	public Integer encode(MonthDay monthDay) {
+		int month = monthDay.getMonthValue() * 100;
+		int day = monthDay.getDayOfMonth();
+		return month + day;
+	}
+
+	/**
+	 * Converts an {@link Integer} to a {@link MonthDay}.
+	 *
+	 * @param value the number representing a {@link MonthDay}
+	 * @return a valid {@link MonthDay}
+	 *
+	 * @see MonthDay#of(java.time.Month, int)
+	 * @throws java.time.DateTimeException if the value does not represents a valid {@link MonthDay}
+	 */
+	@Override
+	public MonthDay decode(Integer value) {
+		int month = value / 100;
+		int day = value % 100;
+		return MonthDay.of( month, day );
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/TemporalStringBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/TemporalStringBridge.java
@@ -1,0 +1,54 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.bridge.builtin.time.impl;
+
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.TemporalAccessor;
+
+import org.hibernate.search.bridge.TwoWayStringBridge;
+import org.hibernate.search.util.logging.impl.Log;
+import org.hibernate.search.util.logging.impl.LoggerFactory;
+
+/**
+ * @author Davide D'Alto
+ */
+public class TemporalStringBridge<T extends TemporalAccessor> implements TwoWayStringBridge {
+
+	private static final Log log = LoggerFactory.make();
+
+	private final DateTimeFormatter formatter;
+
+	public TemporalStringBridge(DateTimeFormatter formatter) {
+		this.formatter = formatter;
+	}
+
+	@Override
+	public String objectToString(Object object) {
+		if ( object == null ) {
+			return null;
+		}
+		@SuppressWarnings("unchecked")
+		String formatted = formatter.format( (T) object );
+		return formatted;
+	}
+
+	@Override
+	public Object stringToObject(String stringValue) {
+		if ( stringValue != null ) {
+			try {
+				return formatter.parse( stringValue );
+			}
+			catch (DateTimeParseException e) {
+				throw log.invalidStringDateFieldInDocument( "", stringValue );
+			}
+		}
+		else {
+			return null;
+		}
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/YearMonthNumericBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/YearMonthNumericBridge.java
@@ -1,0 +1,54 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.bridge.builtin.time.impl;
+
+import java.time.YearMonth;
+
+/**
+ * Converts a {@link YearMonth} to a {@link Long}.
+ * <p>
+ * The digits of the resulting number will have the following pattern: yyyyMM
+ * <p>
+ * For example, the date 2001-3 will become the number 200103.
+ *
+ * @author Davide D'Alto
+ */
+public class YearMonthNumericBridge extends JavaTimeNumericBridge<YearMonth, Long> {
+
+	public static final YearMonthNumericBridge INSTANCE = new YearMonthNumericBridge();
+
+	private YearMonthNumericBridge() {
+	}
+
+	@Override
+	public Long encode(YearMonth yearMonth) {
+		long year = (long) yearMonth.getYear() * 100L;
+		long month = (long) yearMonth.getMonthValue();
+
+		return year < 0
+				? year - month
+				: year + month;
+	}
+
+	/**
+	 * Converts a {@link Long} instance to {@link YearMonth} instance.
+	 *
+	 * @see YearMonth#of(int, int)
+	 * @param value an instance of {@link YearMonth}. It must not be null.
+	 * @return an {@link YearMonth} instance representing the number
+	 * @throws java.time.DateTimeException if the number does not result in a valid {@link YearMonth}
+	 */
+	@Override
+	public YearMonth decode(Long value) {
+		long abs = Math.abs( value );
+		int year = (int) ( abs / 100L );
+		int month = (int) ( abs % 100L );
+		return value < 0
+				? YearMonth.of( -year, month )
+				: YearMonth.of( year, month );
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/YearNumericBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/YearNumericBridge.java
@@ -1,0 +1,38 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.bridge.builtin.time.impl;
+
+import java.time.Year;
+
+/**
+ * Converts a {@link Year} to an {@link Integer}.
+ *
+ * @author Davide D'Alto
+ */
+public class YearNumericBridge extends JavaTimeNumericBridge<Year, Integer> {
+
+	public static final YearNumericBridge INSTANCE = new YearNumericBridge();
+
+	private YearNumericBridge() {
+	}
+
+	/**
+	 * @see Year#getValue()
+	 */
+	@Override
+	public Integer encode(Year year) {
+		return year.getValue();
+	}
+
+	/**
+	 * @see Year#of(int)
+	 */
+	@Override
+	public Year decode(Integer number) {
+		return Year.of( number );
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/ZoneIdStringBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/ZoneIdStringBridge.java
@@ -1,0 +1,41 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.bridge.builtin.time.impl;
+
+import java.time.ZoneId;
+
+import org.hibernate.search.bridge.TwoWayStringBridge;
+import org.hibernate.search.util.StringHelper;
+
+/**
+ * Converts a {@link ZoneId} to a string.
+ *
+ * @see ZoneId#getId()
+ * @see ZoneId#of(String)
+ * @author Davide D'Alto
+ */
+public class ZoneIdStringBridge implements TwoWayStringBridge {
+
+	@Override
+	public String objectToString(Object object) {
+		if ( object == null ) {
+			return null;
+		}
+
+		ZoneId zoneId = (ZoneId) object;
+		return zoneId.getId();
+	}
+
+	@Override
+	public Object stringToObject(String stringValue) {
+		if ( StringHelper.isEmpty( stringValue ) ) {
+			return null;
+		}
+
+		return ZoneId.of( stringValue );
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/ZoneOffseStringBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/ZoneOffseStringBridge.java
@@ -1,0 +1,42 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.bridge.builtin.time.impl;
+
+import java.time.ZoneOffset;
+
+import org.hibernate.search.bridge.TwoWayStringBridge;
+import org.hibernate.search.util.StringHelper;
+
+/**
+ * Converts a {@link ZoneOffset} to a string.
+ *
+ * @see ZoneOffset#getId()
+ * @see ZoneOffset#of(String)
+ * @author Davide D'Alto
+ */
+public class ZoneOffseStringBridge implements TwoWayStringBridge {
+
+	@Override
+	public String objectToString(Object object) {
+		if ( object == null ) {
+			return null;
+		}
+
+		ZoneOffset offSet = (ZoneOffset) object;
+		return offSet.getId();
+	}
+
+	@Override
+	public Object stringToObject(String stringValue) {
+		if ( StringHelper.isEmpty( stringValue ) ) {
+			return null;
+		}
+
+		return ZoneOffset.of( stringValue );
+	}
+
+}

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/package-info.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+/**
+ * This package contains all the bridges to store the temporal classes provided since java 8.
+ */
+package org.hibernate.search.bridge.builtin.time.impl;

--- a/engine/src/main/java/org/hibernate/search/bridge/impl/BridgeFactory.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/impl/BridgeFactory.java
@@ -30,6 +30,7 @@ import org.hibernate.search.bridge.builtin.impl.BuiltinMapBridge;
 import org.hibernate.search.bridge.builtin.impl.String2FieldBridgeAdaptor;
 import org.hibernate.search.bridge.builtin.impl.TwoWayString2FieldBridgeAdaptor;
 import org.hibernate.search.bridge.spi.BridgeProvider;
+import org.hibernate.search.engine.Version;
 import org.hibernate.search.engine.service.classloading.spi.ClassLoaderService;
 import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.exception.AssertionFailure;
@@ -56,6 +57,10 @@ public final class BridgeFactory {
 		annotationBasedProviders.add( new NumericBridgeProvider() );
 		annotationBasedProviders.add( new SpatialBridgeProvider() );
 		annotationBasedProviders.add( new TikaBridgeProvider() );
+
+		if ( Version.getJavaRelease() >= 8 ) {
+			annotationBasedProviders.add( new JavaTimeBridgeProvider() );
+		}
 
 		ClassLoaderService classLoaderService = serviceManager.requestService( ClassLoaderService.class );
 		try {

--- a/engine/src/main/java/org/hibernate/search/bridge/impl/JavaTimeBridgeProvider.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/impl/JavaTimeBridgeProvider.java
@@ -1,0 +1,66 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+package org.hibernate.search.bridge.impl;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.MonthDay;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hibernate.search.bridge.FieldBridge;
+import org.hibernate.search.bridge.TwoWayFieldBridge;
+import org.hibernate.search.bridge.builtin.impl.TwoWayString2FieldBridgeAdaptor;
+import org.hibernate.search.bridge.builtin.time.impl.InstantNumericBridge;
+import org.hibernate.search.bridge.builtin.time.impl.LocalDateNumericBridge;
+import org.hibernate.search.bridge.builtin.time.impl.LocalDateTimeNumericBridge;
+import org.hibernate.search.bridge.builtin.time.impl.LocalTimeNumericBridge;
+import org.hibernate.search.bridge.builtin.time.impl.MonthDayNumericBridge;
+import org.hibernate.search.bridge.builtin.time.impl.YearMonthNumericBridge;
+import org.hibernate.search.bridge.builtin.time.impl.YearNumericBridge;
+import org.hibernate.search.bridge.builtin.time.impl.ZoneIdStringBridge;
+import org.hibernate.search.bridge.builtin.time.impl.ZoneOffseStringBridge;
+import org.hibernate.search.bridge.spi.BridgeProvider;
+
+/**
+ * {@link BridgeProvider} for the classes in java.time.*
+ *
+ * @author Davide D'Alto
+ */
+class JavaTimeBridgeProvider implements BridgeProvider {
+
+	private static final TwoWayFieldBridge ZONE_OFFSET = new TwoWayString2FieldBridgeAdaptor( new ZoneOffseStringBridge() );
+	private static final TwoWayFieldBridge ZONE_ID = new TwoWayString2FieldBridgeAdaptor( new ZoneIdStringBridge() );
+
+	private final Map<String, FieldBridge> builtInBridges;
+
+	JavaTimeBridgeProvider() {
+		Map<String, FieldBridge> bridges = new HashMap<String, FieldBridge>();
+		bridges.put( MonthDay.class.getName(), MonthDayNumericBridge.INSTANCE );
+		bridges.put( Year.class.getName(), YearNumericBridge.INSTANCE );
+		bridges.put( YearMonth.class.getName(), YearMonthNumericBridge.INSTANCE );
+		bridges.put( Instant.class.getName(), InstantNumericBridge.INSTANCE );
+		bridges.put( LocalDate.class.getName(), LocalDateNumericBridge.INSTANCE );
+		bridges.put( LocalDateTime.class.getName(), LocalDateTimeNumericBridge.INSTANCE );
+		bridges.put( LocalTime.class.getName(), LocalTimeNumericBridge.INSTANCE );
+		bridges.put( ZoneOffset.class.getName(), ZONE_OFFSET );
+		bridges.put( ZoneId.class.getName(), ZONE_ID );
+		this.builtInBridges = bridges;
+	}
+
+	@Override
+	public FieldBridge provideFieldBridge(BridgeProviderContext bridgeProviderContext) {
+		return builtInBridges.get( bridgeProviderContext.getReturnType().getName() );
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/engine/Version.java
+++ b/engine/src/main/java/org/hibernate/search/engine/Version.java
@@ -15,7 +15,7 @@ import org.hibernate.search.util.logging.impl.LoggerFactory;
 public final class Version {
 
 	private Version() {
-		//now allowed
+		// now allowed
 	}
 
 	public static String getVersionString() {
@@ -28,4 +28,17 @@ public final class Version {
 
 	public static void touch() {
 	}
+
+	/**
+	 * Returns the Java release for the current runtime
+	 *
+	 * @return the Java release as an integer (e.g. 8 for Java 8)
+	 */
+	public static int getJavaRelease() {
+		// Will return something like 1.8
+		String[] specificationVersion = System.getProperty( "java.specification.version" ).split( "\\." );
+
+		return Integer.parseInt( specificationVersion[1] );
+	}
+
 }

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
@@ -23,9 +23,7 @@ import java.util.Set;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Field;
-
 import org.hibernate.annotations.common.reflection.ClassLoadingException;
-
 import org.hibernate.annotations.common.reflection.ReflectionManager;
 import org.hibernate.annotations.common.reflection.XAnnotatedElement;
 import org.hibernate.annotations.common.reflection.XClass;
@@ -69,8 +67,10 @@ import org.hibernate.search.bridge.builtin.NumericFieldBridge;
 import org.hibernate.search.bridge.builtin.impl.NullEncodingFieldBridge;
 import org.hibernate.search.bridge.builtin.impl.NullEncodingTwoWayFieldBridge;
 import org.hibernate.search.bridge.builtin.impl.TwoWayString2FieldBridgeAdaptor;
+import org.hibernate.search.bridge.builtin.time.impl.JavaTimeNumericBridge;
 import org.hibernate.search.bridge.impl.BridgeFactory;
 import org.hibernate.search.engine.BoostStrategy;
+import org.hibernate.search.engine.Version;
 import org.hibernate.search.engine.impl.AnnotationProcessingHelper;
 import org.hibernate.search.engine.impl.ConfigContext;
 import org.hibernate.search.engine.impl.DefaultBoostStrategy;
@@ -1058,7 +1058,15 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 
 		// either @NumericField is specified explicitly or we are dealing with a implicit numeric value encoded via a numeric
 		// field bridge
-		return numericFieldAnnotation != null || fieldBridge instanceof NumericFieldBridge || fieldBridge instanceof NumericEncodingDateBridge;
+		return numericFieldAnnotation != null
+				|| fieldBridge instanceof NumericFieldBridge
+				|| fieldBridge instanceof NumericEncodingDateBridge
+				|| ( jdk8Compatible()
+						&& fieldBridge instanceof JavaTimeNumericBridge );
+	}
+
+	private static boolean jdk8Compatible() {
+		return Version.getJavaRelease() >= 8;
 	}
 
 	private NumericEncodingType determineNumericFieldEncoding(FieldBridge fieldBridge) {

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/LocalDateBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/LocalDateBridgeTest.java
@@ -1,0 +1,59 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.bridge.time;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.time.LocalDate;
+
+import org.hibernate.search.bridge.builtin.time.impl.LocalDateNumericBridge;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * @author Davide D'Alto
+ */
+public class LocalDateBridgeTest {
+
+	private static final LocalDateNumericBridge BRIDGE = LocalDateNumericBridge.INSTANCE;
+
+	@Rule
+	public final ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void testLocaDateToLong() {
+		LocalDate date = LocalDate.of( 2012, 10, 7 );
+		assertThat( BRIDGE.encode( date ) ).isEqualTo( 20121007L );
+	}
+
+	@Test
+	public void testBiggestLocaDateToLong() {
+		assertThat( BRIDGE.encode( LocalDate.MAX ) ).isEqualTo( 999999999_12_31L );
+	}
+
+	@Test
+	public void testSmallestLocaDateToLong() {
+		assertThat( BRIDGE.encode( LocalDate.MIN ) ).isEqualTo( -9999999990101L );
+	}
+
+	@Test
+	public void testLongToLocaDate() {
+		LocalDate date = LocalDate.of( 2012, 10, 7 );
+		assertThat( BRIDGE.decode( 20121007L ) ).isEqualTo( date );
+	}
+
+	@Test
+	public void testLongToBiggestLocalDate() {
+		assertThat( BRIDGE.decode( 9999999991231L ) ).isEqualTo( LocalDate.MAX );
+	}
+
+	@Test
+	public void testLongToSmallestLocalDate() {
+		assertThat( BRIDGE.decode( -9999999990101L ) ).isEqualTo( LocalDate.MIN );
+	}
+}

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/LocalTimeBridge.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/LocalTimeBridge.java
@@ -1,0 +1,54 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.bridge.time;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.time.LocalTime;
+
+import org.hibernate.search.bridge.builtin.time.impl.LocalTimeNumericBridge;
+import org.junit.Test;
+
+/**
+ * @author Davide D'Alto
+ */
+public class LocalTimeBridge {
+
+	private static final LocalTimeNumericBridge BRIDGE = LocalTimeNumericBridge.INSTANCE;
+
+	@Test
+	public void testLocaTimeToLong() {
+		LocalTime time = LocalTime.of( 16, 1, 59, 678_000_000 );
+		assertThat( BRIDGE.encode( time ) ).isEqualTo( 16_01_59_678_000_000L );
+	}
+
+	@Test
+	public void testBiggestLocaTimeToLong() {
+		assertThat( BRIDGE.encode( LocalTime.MAX ) ).isEqualTo( 23_59_59_999_999_999L );
+	}
+
+	@Test
+	public void testSmallestLocaTimeToLong() {
+		assertThat( BRIDGE.encode( LocalTime.MIN ) ).isEqualTo( 0L );
+	}
+
+	@Test
+	public void testLongToLocalTime() {
+		LocalTime time = LocalTime.of( 16, 1, 59, 678_000_000 );
+		assertThat( BRIDGE.decode( 16_01_59_678_000_000L ) ).isEqualTo( time );
+	}
+
+	@Test
+	public void testLongToBiggestLocalTime() {
+		assertThat( BRIDGE.decode( 23_59_59_999_999_999L ) ).isEqualTo( LocalTime.MAX );
+	}
+
+	@Test
+	public void testIntToSmallestLocalTime() {
+		assertThat( BRIDGE.decode( 0L ) ).isEqualTo( LocalTime.MIN );
+	}
+}

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/MonthDayBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/MonthDayBridgeTest.java
@@ -1,0 +1,52 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.bridge.time;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.time.MonthDay;
+
+import org.hibernate.search.bridge.builtin.time.impl.MonthDayNumericBridge;
+import org.junit.Test;
+
+/**
+ * @author Davide D'Alto
+ */
+public class MonthDayBridgeTest {
+
+	private static final MonthDayNumericBridge BRIDGE = MonthDayNumericBridge.INSTANCE;
+
+	@Test
+	public void testMonthDayToInt() {
+		assertThat( BRIDGE.encode( MonthDay.of( 4, 3 ) ) ).isEqualTo( 403 );
+	}
+
+	@Test
+	public void testBiggestMonthDayToInt() {
+		assertThat( BRIDGE.encode( MonthDay.of( 12, 31 ) ) ).isEqualTo( 1231 );
+	}
+
+	@Test
+	public void testSmallestMonthDayToInt() {
+		assertThat( BRIDGE.encode( MonthDay.of( 1, 1 ) ) ).isEqualTo( 101 );
+	}
+
+	@Test
+	public void testIntToMonthDay() {
+		assertThat( BRIDGE.decode( 102 ) ).isEqualTo( MonthDay.of( 1, 2 ) );
+	}
+
+	@Test
+	public void testIntToBiggestMonthDay() {
+		assertThat( BRIDGE.decode( 1231 ) ).isEqualTo( MonthDay.of( 12, 31 ) );
+	}
+
+	@Test
+	public void testIntToSmallestMonthDay() {
+		assertThat( BRIDGE.decode( 101 ) ).isEqualTo( MonthDay.of( 1, 1 ) );
+	}
+}

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/YearBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/YearBridgeTest.java
@@ -1,0 +1,53 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.bridge.time;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.time.Year;
+
+import org.hibernate.search.bridge.builtin.time.impl.YearNumericBridge;
+import org.junit.Test;
+
+/**
+ * @author Davide D'Alto
+ */
+public class YearBridgeTest {
+
+	private static final YearNumericBridge BRIDGE = YearNumericBridge.INSTANCE;
+
+	@Test
+	public void testYearToInt() {
+		Year year = Year.of( 1 );
+		assertThat( BRIDGE.encode( year ) ).isEqualTo( 1 );
+	}
+
+	@Test
+	public void testBiggestYearToInt() {
+		assertThat( BRIDGE.encode( Year.of( Year.MAX_VALUE ) ) ).isEqualTo( 999_999_999 );
+	}
+
+	@Test
+	public void testSmallestYearToInt() {
+		assertThat( BRIDGE.encode( Year.of( Year.MIN_VALUE ) ) ).isEqualTo( -999_999_999 );
+	}
+
+	@Test
+	public void testIntToYear() {
+		assertThat( BRIDGE.decode( 1 ) ).isEqualTo( Year.of( 1 ) );
+	}
+
+	@Test
+	public void testIntToBiggestYear() {
+		assertThat( BRIDGE.decode( 999_999_999 ) ).isEqualTo( Year.of( Year.MAX_VALUE ) );
+	}
+
+	@Test
+	public void testIntToSmallestYear() {
+		assertThat( BRIDGE.decode( -999_999_999 ) ).isEqualTo( Year.of( Year.MIN_VALUE ) );
+	}
+}

--- a/orm/src/test/java/org/hibernate/search/test/bridge/time/JavaTimeTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/time/JavaTimeTest.java
@@ -1,0 +1,202 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.bridge.time;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Month;
+import java.time.ZoneOffset;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.apache.lucene.search.Query;
+import org.hibernate.Transaction;
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.Search;
+import org.hibernate.search.annotations.Analyze;
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.Store;
+import org.hibernate.search.query.dsl.QueryBuilder;
+import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.testsupport.TestForIssue;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * @author Davide D'Alto
+ */
+@TestForIssue(jiraKey = "HSEARCH-1947")
+public class JavaTimeTest extends SearchTestBase {
+
+	@After
+	public void deleteEntity() {
+		try (org.hibernate.Session s = openSession()) {
+			Transaction tx = s.beginTransaction();
+			s.delete( s.load( Sample.class, 1L ) );
+			s.flush();
+			tx.commit();
+		}
+	}
+
+	@Test
+	public void testLocalDate() throws Exception {
+		LocalDate date = LocalDate.of( 2012, Month.DECEMBER, 30 );
+		Sample sample = new Sample( 1L, "LocalDate example" );
+		sample.localDate = date;
+
+		try (org.hibernate.Session s = openSession()) {
+			Transaction tx = s.beginTransaction();
+			s.persist( sample );
+			s.flush();
+			tx.commit();
+
+			tx = s.beginTransaction();
+			final FullTextSession session = Search.getFullTextSession( s );
+			String field = "localDate";
+
+			Query query = queryBuilder( session ).keyword().onField( field ).ignoreAnalyzer().matching( date ).createQuery();
+			Object[] result = (Object[]) session.createFullTextQuery( query ).setProjection( field ).uniqueResult();
+
+			assertThat( result ).containsOnly( date );
+
+			tx.commit();
+		}
+
+	}
+
+	@Test
+	public void testLocalTime() throws Exception {
+		LocalTime time = LocalTime.of( 13, 15, 55, 7 );
+
+		Sample sample = new Sample( 1L, "Local time example" );
+		sample.localTime = time;
+
+		try (org.hibernate.Session s = openSession()) {
+			Transaction tx = s.beginTransaction();
+			s.persist( sample );
+			s.flush();
+			tx.commit();
+
+			tx = s.beginTransaction();
+			final FullTextSession session = Search.getFullTextSession( s );
+			String field = "localTime";
+
+			Query query = queryBuilder( session ).keyword().onField( field ).ignoreAnalyzer().matching( time ).createQuery();
+			Object[] result = (Object[]) session.createFullTextQuery( query ).setProjection( field ).uniqueResult();
+			assertThat( result ).containsOnly( time );
+
+			tx.commit();
+		}
+	}
+
+	@Test
+	public void testLocalDateTime() throws Exception {
+		LocalDate date = LocalDate.of( 1998, Month.FEBRUARY, 12 );
+		LocalTime time = LocalTime.of( 13, 05, 33 );
+		LocalDateTime dateTime = LocalDateTime.of( date, time );
+
+		Sample sample = new Sample( 1L, "LocalDateTime example" );
+		sample.localDateTime = dateTime;
+
+		try (org.hibernate.Session s = openSession()) {
+			Transaction tx = s.beginTransaction();
+			s.persist( sample );
+			s.flush();
+			tx.commit();
+
+			tx = s.beginTransaction();
+			final FullTextSession session = Search.getFullTextSession( s );
+			String field = "localDateTime";
+
+			Query query = queryBuilder( session ).keyword().onField( field ).ignoreAnalyzer().matching( dateTime ).createQuery();
+			Object[] result = (Object[]) session.createFullTextQuery( query ).setProjection( field ).uniqueResult();
+
+			assertThat( result ).containsOnly( dateTime );
+
+			tx.commit();
+		}
+	}
+
+	@Test
+	public void testInstant() throws Exception {
+		LocalDate date = LocalDate.of( 1998, Month.FEBRUARY, 12 );
+		LocalTime time = LocalTime.of( 13, 05, 33, 5 * 1000_000 );
+		LocalDateTime dateTime = LocalDateTime.of( date, time );
+		Instant instant = dateTime.toInstant( ZoneOffset.UTC );
+
+		Sample sample = new Sample( 1L, "Instant example" );
+		sample.instant = instant;
+
+		try (org.hibernate.Session s = openSession()) {
+			Transaction tx = s.beginTransaction();
+			s.persist( sample );
+			s.flush();
+			tx.commit();
+
+			tx = s.beginTransaction();
+			final FullTextSession session = Search.getFullTextSession( s );
+			String field = "instant";
+
+			Query query = queryBuilder( session ).keyword().onField( field ).ignoreAnalyzer().matching( instant ).createQuery();
+			Object[] result = (Object[]) session.createFullTextQuery( query ).setProjection( field ).uniqueResult();
+
+			assertThat( result ).containsOnly( instant );
+
+			tx.commit();
+		}
+	}
+
+	@Field(analyze = Analyze.NO, store = Store.YES)
+	private QueryBuilder queryBuilder(final FullTextSession session) {
+		QueryBuilder builder = session.getSearchFactory().buildQueryBuilder().forEntity( Sample.class ).get();
+		return builder;
+	}
+
+	@Entity
+	@Indexed
+	static class Sample {
+
+		public Sample() {
+		}
+
+		public Sample(long id, String description) {
+			this.id = id;
+			this.description = description;
+		}
+
+		@Id
+		@DocumentId
+		long id;
+
+		@Field(analyze = Analyze.NO, store = Store.YES)
+		String description;
+
+		@Field(analyze = Analyze.NO, store = Store.YES)
+		private LocalDate localDate;
+
+		@Field(analyze = Analyze.NO, store = Store.YES)
+		private LocalTime localTime;
+
+		@Field(analyze = Analyze.NO, store = Store.YES)
+		private LocalDateTime localDateTime;
+
+		@Field(analyze = Analyze.NO, store = Store.YES)
+		private Instant instant;
+	}
+
+	@Override
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { Sample.class };
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -732,7 +732,7 @@
                     <rules>
                         <requireJavaVersion>
                             <!-- require JDK 1.7 to run the build -->
-                            <version>[1.7,)</version>
+                            <version>[1.8,)</version>
                         </requireJavaVersion>
                         <requireMavenVersion>
                             <version>3.2.3</version>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-1947

This patch will enforce the use of JDK 8 for the build and add the new bridges under the package:
`org.hibernate.search.bridge.builtin.time.impl`

After the discussion on the mailing list ,and off-line with @Sanne I've created bridges for:

* `LocalDate`, `LocalTime`, `Year`, `YearMonth`, `MonthDay`:
  they get stored as numeric fields where the digits represents the year, month or day of the date.
  For example, 2012-12-1 becomes the long 20121201
* `Instant`, `LocalDateTime`: they are stored as number of milliseconds from epoch.
* `Duration`: duration in milliseconds
* `ZoneId` and `ZoneOffset`: they get store as string 

Note that the precision for `Duration`, `LocalDateTime` and `Instant` is the millisecond.
This should cover most cases.

None of this bridges support `@DateBridge`. It seems there  is no real need for the user to select the encoding, and the new java api provides methods and classes for date and time truncation. Maybe it could be useful for the time to have a @TimeBridge annotation to set the resolution using `java.time.temporal.ChronoUnit`. A user can always create a custom bridge or we can add feature if they are requested.

We decided to not create a bridge for OffsetDateTime, OffsetTime, ZonedDateTIme and so on.
Probably the most useful way to store the offset and the zone is in separte fields, but with the current bridges the user can store these information as separate properties of the entity.




