### PR TITLE
Facet test that reveals a NullPointerException

### DIFF
--- a/engine/src/main/java/org/hibernate/search/query/engine/impl/QueryHits.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/impl/QueryHits.java
@@ -423,12 +423,13 @@ public class QueryHits {
 			throw log.unknownFieldNameForFaceting( facetRequest.getFacetingName(), facetRequest.getFieldName() );
 		}
 		ArrayList<Facet> facets = new ArrayList<>();
-		for ( LabelAndValue labelAndValue : facetResult.labelValues ) {
-			Facet facet = facetRequest.createFacet( labelAndValue.label, (int) labelAndValue.value );
-			facets.add( facet );
-			termValues.remove( labelAndValue.label );
+		if ( facetResult != null ) {
+			for ( LabelAndValue labelAndValue : facetResult.labelValues ) {
+				Facet facet = facetRequest.createFacet( labelAndValue.label, (int) labelAndValue.value );
+				facets.add( facet );
+				termValues.remove( labelAndValue.label );
+			}
 		}
-
 		for ( String termValue : termValues ) {
 			Facet facet = facetRequest.createFacet( termValue, 0 );
 			facets.add( 0, facet );

--- a/orm/src/test/java/org/hibernate/search/test/query/facet/NoQueryResultsFacetingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/facet/NoQueryResultsFacetingTest.java
@@ -71,8 +71,8 @@ public class NoQueryResultsFacetingTest extends AbstractFacetTest {
 		facetManager.enableFaceting( requestDesc );
 		facetManager.enableFaceting( requestAsc );
 
-		assertFacetCounts( facetManager.getFacets( descendingOrderedFacet ), new int[] { 5, 4, 4, 0 } );
-		assertFacetCounts( facetManager.getFacets( ascendingOrderedFacet ), new int[] { 0, 4, 4, 5 } );
+		assertFacetCounts( facetManager.getFacets( descendingOrderedFacet ), new int[] { 0, 0, 0, 0 } );
+		assertFacetCounts( facetManager.getFacets( ascendingOrderedFacet ), new int[] { 0, 0, 0, 0 } );
 
 		facetManager.disableFaceting( descendingOrderedFacet );
 		assertTrue(
@@ -80,7 +80,7 @@ public class NoQueryResultsFacetingTest extends AbstractFacetTest {
 						descendingOrderedFacet
 				).isEmpty()
 		);
-		assertFacetCounts( facetManager.getFacets( ascendingOrderedFacet ), new int[] { 0, 4, 4, 5 } );
+		assertFacetCounts( facetManager.getFacets( ascendingOrderedFacet ), new int[] { 0, 0, 0, 0 } );
 
 		facetManager.disableFaceting( ascendingOrderedFacet );
 		assertTrue(

--- a/orm/src/test/java/org/hibernate/search/test/query/facet/NoQueryResultsFacetingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/facet/NoQueryResultsFacetingTest.java
@@ -1,0 +1,208 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.query.facet;
+
+import java.util.List;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+
+import org.hibernate.search.FullTextQuery;
+import org.hibernate.search.query.engine.spi.FacetManager;
+import org.hibernate.search.query.facet.Facet;
+import org.hibernate.search.query.facet.FacetSortOrder;
+import org.hibernate.search.query.facet.FacetingRequest;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Hardy Ferentschik
+ */
+public class NoQueryResultsFacetingTest extends AbstractFacetTest {
+	private final String facetFieldName = "cubicCapacity";
+	private final String facetName = "ccs";
+
+	@Test
+	public void testSimpleDiscretFacetingWithNoResultsQuery() throws Exception {
+		FacetingRequest request = queryBuilder( Car.class ).facet()
+				.name( facetName )
+				.onField( facetFieldName )
+				.discrete()
+				.createFacetingRequest();
+		FullTextQuery query = queryHondaNoResultsWithFacet( request );
+
+		List<Facet> facetList = query.getFacetManager().getFacets( facetName );
+		assertEquals( "Wrong number of facets", 0, facetList.size() );
+	}
+
+	@Test
+	public void testMultipleFacetsWithNoResultsQuery() {
+		final String descendingOrderedFacet = "desc";
+		FacetingRequest requestDesc = queryBuilder( Car.class ).facet()
+				.name( descendingOrderedFacet )
+				.onField( facetFieldName )
+				.discrete()
+				.includeZeroCounts( true )
+				.createFacetingRequest();
+
+		final String ascendingOrderedFacet = "asc";
+		FacetingRequest requestAsc = queryBuilder( Car.class ).facet()
+				.name( ascendingOrderedFacet )
+				.onField( facetFieldName )
+				.discrete()
+				.orderedBy( FacetSortOrder.COUNT_ASC )
+				.includeZeroCounts( true )
+				.createFacetingRequest();
+		TermQuery term = new TermQuery( new Term( "make", "nonExistentValue" ) );
+		FullTextQuery query = fullTextSession.createFullTextQuery( term, Car.class );
+		FacetManager facetManager = query.getFacetManager();
+
+		facetManager.enableFaceting( requestDesc );
+		facetManager.enableFaceting( requestAsc );
+
+		assertFacetCounts( facetManager.getFacets( descendingOrderedFacet ), new int[] { 5, 4, 4, 0 } );
+		assertFacetCounts( facetManager.getFacets( ascendingOrderedFacet ), new int[] { 0, 4, 4, 5 } );
+
+		facetManager.disableFaceting( descendingOrderedFacet );
+		assertTrue(
+				"descendingOrderedFacet should be disabled", query.getFacetManager().getFacets(
+						descendingOrderedFacet
+				).isEmpty()
+		);
+		assertFacetCounts( facetManager.getFacets( ascendingOrderedFacet ), new int[] { 0, 4, 4, 5 } );
+
+		facetManager.disableFaceting( ascendingOrderedFacet );
+		assertTrue(
+				"descendingOrderedFacet should be disabled",
+				facetManager.getFacets( descendingOrderedFacet ).isEmpty()
+		);
+		assertTrue(
+				"ascendingOrderedFacet should be disabled",
+				facetManager.getFacets( ascendingOrderedFacet ).isEmpty()
+		);
+	}
+	private FullTextQuery queryHondaNoResultsWithFacet(FacetingRequest request) {
+		Query luceneQuery = queryBuilder( Car.class )
+				.keyword()
+				.onField( "make" )
+				.matching( "nonExistentValue" )
+				.createQuery();
+		FullTextQuery query = fullTextSession.createFullTextQuery( luceneQuery, Car.class );
+		query.getFacetManager().enableFaceting( request );
+		assertEquals( "Wrong number of query matches", 0, query.getResultSize() );
+		return query;
+	}
+	@Test
+	public void testSimpleDiscretFacetingQuery() throws Exception {
+		FacetingRequest request = queryBuilder( Car.class ).facet()
+				.name( facetName )
+				.onField( facetFieldName )
+				.discrete()
+				.createFacetingRequest();
+		FullTextQuery query = queryHondaWithFacet( request );
+
+		List<Facet> facetList = query.getFacetManager().getFacets( facetName );
+		assertEquals( "Wrong number of facets", 3, facetList.size() );
+	}
+
+	@Test
+	public void testMultipleFacetsQuery() {
+		final String descendingOrderedFacet = "desc";
+		FacetingRequest requestDesc = queryBuilder( Car.class ).facet()
+				.name( descendingOrderedFacet )
+				.onField( facetFieldName )
+				.discrete()
+				.includeZeroCounts( true )
+				.createFacetingRequest();
+
+		final String ascendingOrderedFacet = "asc";
+		FacetingRequest requestAsc = queryBuilder( Car.class ).facet()
+				.name( ascendingOrderedFacet )
+				.onField( facetFieldName )
+				.discrete()
+				.orderedBy( FacetSortOrder.COUNT_ASC )
+				.includeZeroCounts( true )
+				.createFacetingRequest();
+		TermQuery term = new TermQuery( new Term( "make", "Honda" ) );
+		FullTextQuery query = fullTextSession.createFullTextQuery( term, Car.class );
+		FacetManager facetManager = query.getFacetManager();
+
+		facetManager.enableFaceting( requestDesc );
+		facetManager.enableFaceting( requestAsc );
+
+		assertFacetCounts( facetManager.getFacets( descendingOrderedFacet ), new int[] { 5, 4, 4, 0 } );
+		assertFacetCounts( facetManager.getFacets( ascendingOrderedFacet ), new int[] { 0, 4, 4, 5 } );
+
+		facetManager.disableFaceting( descendingOrderedFacet );
+		assertTrue(
+				"descendingOrderedFacet should be disabled", query.getFacetManager().getFacets(
+						descendingOrderedFacet
+				).isEmpty()
+		);
+		assertFacetCounts( facetManager.getFacets( ascendingOrderedFacet ), new int[] { 0, 4, 4, 5 } );
+
+		facetManager.disableFaceting( ascendingOrderedFacet );
+		assertTrue(
+				"descendingOrderedFacet should be disabled",
+				facetManager.getFacets( descendingOrderedFacet ).isEmpty()
+		);
+		assertTrue(
+				"ascendingOrderedFacet should be disabled",
+				facetManager.getFacets( ascendingOrderedFacet ).isEmpty()
+		);
+	}
+	private FullTextQuery queryHondaWithFacet(FacetingRequest request) {
+		Query luceneQuery = queryBuilder( Car.class )
+				.keyword()
+				.onField( "make" )
+				.matching( "Honda" )
+				.createQuery();
+		FullTextQuery query = fullTextSession.createFullTextQuery( luceneQuery, Car.class );
+		query.getFacetManager().enableFaceting( request );
+		assertEquals( "Wrong number of query matches", 13, query.getResultSize() );
+		return query;
+	}
+
+	@Override
+	public void loadTestData(Session session) {
+		Transaction tx = session.beginTransaction();
+		for ( String make : makes ) {
+			for ( String color : colors ) {
+				for ( int cc : ccs ) {
+					Car car = new Car( make, color, cc );
+					session.save( car );
+				}
+			}
+		}
+		Car car = new Car( "Honda", "yellow", 2407 );
+		session.save( car );
+
+		car = new Car( "Ford", "yellow", 2500 );
+		session.save( car );
+
+		Fruit apple = new Fruit( "Apple", 3.15 );
+		session.save( apple );
+
+		tx.commit();
+		session.clear();
+	}
+
+	@Override
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class[] {
+				Car.class,
+				Fruit.class
+		};
+	}
+}


### PR DESCRIPTION
This test reveals a NullPointerException where there is no results for the given query.
I am facing this error since I've updated to 5.3+ releases.
It seems to be a bug when there is no results on the search query.

Also I've added correction suggestion in QueryHits.java

Test results:

```
java.lang.NullPointerException:
    at org.hibernate.search.query.engine.impl.QueryHits.updateStringFacets(QueryHits.java:426)
    at org.hibernate.search.query.engine.impl.QueryHits.updateFacets(QueryHits.java:280)
    at org.hibernate.search.query.engine.impl.QueryHits.updateTopDocs(QueryHits.java:265)
    at org.hibernate.search.query.engine.impl.QueryHits.<init>(QueryHits.java:145)
    at org.hibernate.search.query.engine.impl.QueryHits.<init>(QueryHits.java:114)
    at org.hibernate.search.query.engine.impl.HSQueryImpl.getQueryHits(HSQueryImpl.java:447)
    at org.hibernate.search.query.engine.impl.HSQueryImpl.queryDocumentExtractor(HSQueryImpl.java:325)
    at org.hibernate.search.query.engine.impl.FacetManagerImpl.getFacets(FacetManagerImpl.java:97)
    at org.hibernate.search.test.query.facet.NoQueryResultsFacetingTest.testSimpleDiscretFacetingWithNoResultsQuery(NoQueryResultsFacetingTest.java:49)
```