### PR TITLE
HSERCH-1946 left directories after test

### DIFF
--- a/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/TestRunnerStandalone.java
+++ b/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/TestRunnerStandalone.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 /**
  * @author Tomas Hradec
  */
-@SuppressWarnings("deprecation")
 public class TestRunnerStandalone {
 
 	private final TestScenario scenario = TestScenarioFactory.create();

--- a/pom.xml
+++ b/pom.xml
@@ -715,6 +715,7 @@
                             <excludes>
                                 <exclude>**/hibernate.properties</exclude>
                                 <exclude>**/log4j.properties</exclude>
+                                <exclude>**/META-INF/**</exclude>
                             </excludes>
                         </configuration>
                     </execution>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-1946

The problem is caused by some persistence unit that are included in the testing jar.