### PR TITLE
HSERACH-1947 Bridge for classes in java.time

### DIFF
--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/DurationBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/DurationBridge.java
@@ -1,0 +1,63 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.bridge.builtin.time.impl;
+
+import java.time.Duration;
+import java.util.Locale;
+
+import org.hibernate.search.bridge.TwoWayStringBridge;
+import org.hibernate.search.util.logging.impl.Log;
+import org.hibernate.search.util.logging.impl.LoggerFactory;
+
+/**
+ * Converts a {@link Duration} to a {@link String}.
+ * <p>
+ * The string is obtained concatenating the number of seconds with the nano of seconds.
+ * The values are padded with 0 to allow field sorting.
+ *
+ * @author Davide D'Alto
+ */
+public class DurationBridge implements TwoWayStringBridge {
+
+	private static final Log log = LoggerFactory.make();
+	private static final int SECONDS_PADDING = 20;
+	private static final int NANOS_PADDING = 9;
+	private static final String FORMAT = "%+0" + SECONDS_PADDING + "d%0" + NANOS_PADDING + "d";
+
+	public static final DurationBridge INSTANCE = new DurationBridge();
+
+	private DurationBridge() {
+	}
+
+	@Override
+	public String objectToString(Object object) {
+		if ( object == null ) {
+			return null;
+		}
+
+		Duration duration = (Duration) object;
+		long seconds = duration.getSeconds();
+		int nano = duration.getNano();
+		return String.format( Locale.ROOT, FORMAT, seconds, nano );
+	}
+
+	@Override
+	public Object stringToObject(String stringValue) {
+		if ( stringValue == null ) {
+			return null;
+		}
+
+		try {
+			long seconds = Long.parseLong( stringValue.substring( 0, SECONDS_PADDING ) );
+			int nano = Integer.parseInt( stringValue.substring( SECONDS_PADDING ) );
+			return Duration.ofSeconds( seconds, nano );
+		}
+		catch (NumberFormatException e) {
+			throw log.parseException( stringValue, Duration.class, e );
+		}
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/InstantBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/InstantBridge.java
@@ -1,0 +1,47 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.bridge.builtin.time.impl;
+
+import static java.time.temporal.ChronoField.INSTANT_SECONDS;
+import static java.time.temporal.ChronoField.NANO_OF_SECOND;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.format.SignStyle;
+
+/**
+ * Converts a {@link Instant} to a {@link String}.
+ * <p>
+ * The string is obtained concatenating the number of seconds from Epoch with the nano of seconds.
+ * The values are padded with 0 to allow field sorting.
+ *
+ * @author Davide D'Alto
+ */
+public class InstantBridge extends TemporalAccessorStringBridge<Instant> {
+
+	private static final int SECONDS_PADDING = 17;
+
+	private static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
+			.appendValue( INSTANT_SECONDS, SECONDS_PADDING, SECONDS_PADDING, SignStyle.ALWAYS )
+			.appendValue( NANO_OF_SECOND, 9 )
+			.toFormatter();
+
+	public static final InstantBridge INSTANCE = new InstantBridge();
+
+	private InstantBridge() {
+		super( FORMATTER, Instant.class );
+	}
+
+	@Override
+	Instant parse(String stringValue) throws DateTimeParseException {
+		long seconds = Long.parseLong( stringValue.substring( 0, SECONDS_PADDING + 1 ) );
+		long nanos = Integer.parseInt( stringValue.substring( SECONDS_PADDING + 1 ) );
+		return Instant.ofEpochSecond( seconds, nanos );
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/LocalDateBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/LocalDateBridge.java
@@ -1,0 +1,46 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.bridge.builtin.time.impl;
+
+import static java.time.temporal.ChronoField.DAY_OF_MONTH;
+import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
+import static java.time.temporal.ChronoField.YEAR;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.format.SignStyle;
+
+/**
+ * Converts a {@link LocalDate} to a {@link String}.
+ * <p>
+ * A {@code LocalDate} 2012-12-31 becomes the string {@code +0000020121231}.
+ * <p>
+ * The sign is always present for the year and the string is padded with 0 to allow field sorting.
+ *
+ * @author Davide D'Alto
+ */
+public class LocalDateBridge extends TemporalAccessorStringBridge<LocalDate> {
+
+	static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
+			.appendValue( YEAR, 9, 9, SignStyle.ALWAYS )
+			.appendValue( MONTH_OF_YEAR, 2 )
+			.appendValue( DAY_OF_MONTH, 2)
+			.toFormatter();
+
+	public static final LocalDateBridge INSTANCE = new LocalDateBridge();
+
+	private LocalDateBridge() {
+		super( FORMATTER, LocalDate.class );
+	}
+
+	@Override
+	LocalDate parse(String stringValue) throws DateTimeParseException {
+		return LocalDate.parse( stringValue, FORMATTER );
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/LocalDateTimeBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/LocalDateTimeBridge.java
@@ -1,0 +1,40 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.bridge.builtin.time.impl;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+
+/**
+ * Converts a {@link LocalDateTime} to a {@link String}.
+ * <p>
+ * A {@code LocalDateTime} +2012-12-31T23:59:59.999 becomes the string {@code +0000020121231235950000000999}.
+ * <p>
+ * The sign is always present for the year and the string is padded with 0 to allow field sorting.
+ *
+ * @author Davide D'Alto
+ */
+public class LocalDateTimeBridge extends TemporalAccessorStringBridge<LocalDateTime> {
+
+	static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
+			.append( LocalDateBridge.FORMATTER )
+			.append( LocalTimeBridge.FORMATTER )
+			.toFormatter();
+
+	public static final LocalDateTimeBridge INSTANCE = new LocalDateTimeBridge();
+
+	private LocalDateTimeBridge() {
+		super( FORMATTER, LocalDateTime.class );
+	}
+
+	@Override
+	LocalDateTime parse(String stringValue) throws DateTimeParseException {
+		return LocalDateTime.parse( stringValue, FORMATTER );
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/LocalTimeBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/LocalTimeBridge.java
@@ -1,0 +1,47 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.bridge.builtin.time.impl;
+
+import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
+import static java.time.temporal.ChronoField.NANO_OF_SECOND;
+import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+
+/**
+ * Converts a {@link LocalTime} to a {@link String}.
+ * <p>
+ * A {@code LocalDateTime} 23:59:59.999 becomes the string {@code 235950000000999}.
+ * <p>
+ * The sign is always present for the year and the string is padded with 0 to allow field sorting.
+ *
+ * @author Davide D'Alto
+ */
+public class LocalTimeBridge extends TemporalAccessorStringBridge<LocalTime> {
+
+	static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
+			.appendValue( HOUR_OF_DAY, 2 )
+			.appendValue( MINUTE_OF_HOUR, 2 )
+			.appendValue( SECOND_OF_MINUTE, 2)
+			.appendValue( NANO_OF_SECOND, 9 )
+			.toFormatter();
+
+	public static final LocalTimeBridge INSTANCE = new LocalTimeBridge();
+
+	private LocalTimeBridge() {
+		super( FORMATTER, LocalTime.class );
+	}
+
+	@Override
+	LocalTime parse(String stringValue) throws DateTimeParseException {
+		return LocalTime.parse( stringValue, FORMATTER );
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/MonthDayBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/MonthDayBridge.java
@@ -1,0 +1,44 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.bridge.builtin.time.impl;
+
+import static java.time.temporal.ChronoField.DAY_OF_MONTH;
+import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
+
+import java.time.MonthDay;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.format.SignStyle;
+
+/**
+ * Converts a {@link MonthDay} to a {@link String}.
+ * <p>
+ * A {@code MonthDay} 2-31 becomes the string {@code 0231} (pattern: MMdd).
+ * <p>
+ * The values are padded with 0 to allow field sorting.
+ *
+ * @author Davide D'Alto
+ */
+public class MonthDayBridge extends TemporalAccessorStringBridge<MonthDay> {
+
+	private static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
+			.appendValue( MONTH_OF_YEAR, 2, 2, SignStyle.NEVER )
+			.appendValue( DAY_OF_MONTH, 2, 2, SignStyle.NEVER )
+			.toFormatter();
+
+	public static final MonthDayBridge INSTANCE = new MonthDayBridge();
+
+	private MonthDayBridge() {
+		super( FORMATTER, MonthDay.class );
+	}
+
+	@Override
+	MonthDay parse(String stringValue) throws DateTimeParseException {
+		return MonthDay.parse( stringValue, FORMATTER );
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/NumericTimeBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/NumericTimeBridge.java
@@ -1,0 +1,24 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.bridge.builtin.time.impl;
+
+import org.hibernate.search.metadata.NumericFieldSettingsDescriptor.NumericEncodingType;
+
+/**
+ * A bridge that converts a class in the jva.time package to a numeric field.
+ *
+ * @author Davide D'Alto
+ */
+public interface NumericTimeBridge {
+
+	/**
+	 * Define the numeric encoding to use for the brdige.
+	 *
+	 * @return the encoding to use for this bridge
+	 */
+	NumericEncodingType getEncodingType();
+}

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/OffsetDateTimeBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/OffsetDateTimeBridge.java
@@ -1,0 +1,40 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.bridge.builtin.time.impl;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+
+/**
+ * Converts a {@link OffsetDateTime} to a {@link String}.
+ * <p>
+ * A {@code MonthDay} 2-31 becomes the string {@code 0231} (pattern: MMdd).
+ * <p>
+ * The values are padded with 0 to allow field sorting.
+ *
+ * @author Davide D'Alto
+ */
+public class OffsetDateTimeBridge extends TemporalAccessorStringBridge<OffsetDateTime> {
+
+	static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
+			.append( LocalDateTimeBridge.FORMATTER )
+			.appendOffsetId()
+			.toFormatter();
+
+	public static final OffsetDateTimeBridge INSTANCE = new OffsetDateTimeBridge();
+
+	private OffsetDateTimeBridge() {
+		super( FORMATTER, OffsetDateTime.class );
+	}
+
+	@Override
+	OffsetDateTime parse(String stringValue) throws DateTimeParseException {
+		return OffsetDateTime.parse( stringValue, FORMATTER );
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/OffsetTimeBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/OffsetTimeBridge.java
@@ -1,0 +1,41 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.bridge.builtin.time.impl;
+
+import java.time.OffsetTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+
+/**
+ * Converts a {@link OffsetTime} to a {@link String}.
+ * <p>
+ * A {@code OffsetTime} 3:45.30.789+02:00 Europe/Paris becomes the string
+ * {@code 034530000000789+02:00}.
+ * <p>
+ * The sign is always present for the year and the string is padded with 0 to allow field sorting.
+ *
+ * @author Davide D'Alto
+ */
+public class OffsetTimeBridge extends TemporalAccessorStringBridge<OffsetTime> {
+
+	private static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
+			.append( LocalTimeBridge.FORMATTER )
+			.appendOffsetId()
+			.toFormatter();
+
+	public static final OffsetTimeBridge INSTANCE = new OffsetTimeBridge();
+
+	private OffsetTimeBridge() {
+		super( FORMATTER, OffsetTime.class );
+	}
+
+	@Override
+	OffsetTime parse(String stringValue) throws DateTimeParseException {
+		return OffsetTime.parse( stringValue, FORMATTER );
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/PeriodBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/PeriodBridge.java
@@ -1,0 +1,64 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.bridge.builtin.time.impl;
+
+import java.time.Duration;
+import java.time.Period;
+import java.util.Locale;
+
+import org.hibernate.search.bridge.TwoWayStringBridge;
+import org.hibernate.search.util.logging.impl.Log;
+import org.hibernate.search.util.logging.impl.LoggerFactory;
+
+/**
+ * Converts a {@link Period} to a {@link String} concatenating year, months and days.
+ * <p>
+ * The sign is always present for the year and the string is padded with 0 to allow field sorting.
+ *
+ * @author Davide D'Alto
+ */
+public class PeriodBridge implements TwoWayStringBridge {
+
+	private static final Log log = LoggerFactory.make();
+	private static final int PADDING = 11;
+	private static final String FORMAT = "%+0" + PADDING + "d%+0" + PADDING + "d%+0" + PADDING + "d";
+
+	public static final PeriodBridge INSTANCE = new PeriodBridge();
+
+	private PeriodBridge() {
+	}
+
+	@Override
+	public String objectToString(Object object) {
+		if ( object == null ) {
+			return null;
+		}
+
+		Period period = (Period) object;
+		int years = period.getYears();
+		int months = period.getMonths();
+		int days = period.getDays();
+		return String.format( Locale.ROOT, FORMAT, years, months, days );
+	}
+
+	@Override
+	public Object stringToObject(String stringValue) {
+		if ( stringValue == null ) {
+			return null;
+		}
+
+		try {
+			int years = Integer.parseInt( stringValue.substring( 0, PADDING ) );
+			int months = Integer.parseInt( stringValue.substring( PADDING, 2 * PADDING ) );
+			int days = Integer.parseInt( stringValue.substring( 2 * PADDING ) );
+			return Period.of( years, months, days );
+		}
+		catch (NumberFormatException e) {
+			throw log.parseException( stringValue, Duration.class, e );
+		}
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/TemporalAccessorStringBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/TemporalAccessorStringBridge.java
@@ -1,0 +1,59 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.bridge.builtin.time.impl;
+
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
+
+import org.hibernate.search.bridge.TwoWayStringBridge;
+import org.hibernate.search.util.logging.impl.Log;
+import org.hibernate.search.util.logging.impl.LoggerFactory;
+
+/**
+ * Base class for the conversion of {@link TemporalAccessor} to {@link String}.
+ *
+ * @author Davide D'Alto
+ */
+public abstract class TemporalAccessorStringBridge<T extends TemporalAccessor> implements TwoWayStringBridge {
+
+	private static final Log log = LoggerFactory.make();
+
+	private final DateTimeFormatter formatter;
+
+	private final Class<T> type;
+
+	public TemporalAccessorStringBridge(DateTimeFormatter formatter, Class<T> type) {
+		this.formatter = formatter;
+		this.type = type;
+	}
+
+	@Override
+	public String objectToString(Object object) {
+		if ( object == null ) {
+			return null;
+		}
+		@SuppressWarnings("unchecked")
+		String formatted = formatter.format( (T) object );
+		return formatted;
+	}
+
+	@Override
+	public Object stringToObject(String stringValue) {
+		if ( stringValue == null ) {
+			return null;
+		}
+
+		try {
+			return parse( stringValue );
+		}
+		catch (Exception e) {
+			throw log.parseException( stringValue, type, e );
+		}
+	}
+
+	abstract T parse(String stringValue) throws Exception;
+}

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/YearBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/YearBridge.java
@@ -1,0 +1,41 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.bridge.builtin.time.impl;
+
+import static java.time.temporal.ChronoField.YEAR;
+
+import java.time.Year;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.SignStyle;
+
+/**
+ * Converts a {@link Year} to a {@link String}.
+ * <p>
+ * A {@code Year} 2 becomes the string {@code +000000002}.
+ * <p>
+ * The sign is always present and the values are padded with 0 to allow field sorting.
+ *
+ * @author Davide D'Alto
+ */
+public class YearBridge extends TemporalAccessorStringBridge<Year> {
+
+	static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
+			.appendValue( YEAR, 9, 9, SignStyle.ALWAYS )
+			.toFormatter();
+
+	public static final YearBridge INSTANCE = new YearBridge();
+
+	private YearBridge() {
+		super( FORMATTER, Year.class );
+	}
+
+	@Override
+	Year parse(String stringValue) throws Exception {
+		return Year.parse( stringValue, FORMATTER );
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/YearBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/YearBridge.java
@@ -6,36 +6,47 @@
  */
 package org.hibernate.search.bridge.builtin.time.impl;
 
-import static java.time.temporal.ChronoField.YEAR;
-
 import java.time.Year;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
-import java.time.format.SignStyle;
+
+import org.apache.lucene.document.Document;
+import org.hibernate.search.bridge.LuceneOptions;
+import org.hibernate.search.bridge.TwoWayFieldBridge;
+import org.hibernate.search.metadata.NumericFieldSettingsDescriptor.NumericEncodingType;
 
 /**
- * Converts a {@link Year} to a {@link String}.
- * <p>
- * A {@code Year} 2 becomes the string {@code +000000002}.
- * <p>
- * The sign is always present and the values are padded with 0 to allow field sorting.
+ * Converts a {@link Year} to a {@link Integer}.
  *
  * @author Davide D'Alto
  */
-public class YearBridge extends TemporalAccessorStringBridge<Year> {
-
-	static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
-			.appendValue( YEAR, 9, 9, SignStyle.ALWAYS )
-			.toFormatter();
+public class YearBridge implements NumericTimeBridge, TwoWayFieldBridge {
 
 	public static final YearBridge INSTANCE = new YearBridge();
 
-	private YearBridge() {
-		super( FORMATTER, Year.class );
+	@Override
+	public void set(String name, Object value, Document document, LuceneOptions luceneOptions) {
+		if ( value != null ) {
+			int isoYear = ( (Year) value ).getValue();
+			luceneOptions.addNumericFieldToDocument( name, isoYear, document );
+		}
 	}
 
 	@Override
-	Year parse(String stringValue) throws Exception {
-		return Year.parse( stringValue, FORMATTER );
+	public Object get(String name, Document document) {
+		Integer isoYear = (Integer) document.getField( name ).numericValue();
+		return Year.of( isoYear );
 	}
+
+	@Override
+	public String objectToString(Object object) {
+		if ( object == null ) {
+			return null;
+		}
+		return String.valueOf( ( (Year) object ).getValue() );
+	}
+
+	@Override
+	public NumericEncodingType getEncodingType() {
+		return NumericEncodingType.INTEGER;
+	}
+
 }

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/YearMonthBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/YearMonthBridge.java
@@ -1,0 +1,46 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.bridge.builtin.time.impl;
+
+import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
+import static java.time.temporal.ChronoField.YEAR;
+
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.format.SignStyle;
+
+/**
+ * Converts a {@link YearMonth} to a {@link String}.
+ * <p>
+ * A {@code YearMonth} 12345-1 becomes the string {@code +00001234501}.
+ * <p>
+ * THe signn is alway present and the values are padded with 0 to allow field sorting.
+ *
+ * @author Davide D'Alto
+ */
+public class YearMonthBridge extends TemporalAccessorStringBridge<YearMonth> {
+
+	static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
+			.parseCaseInsensitive()
+			.parseStrict()
+			.appendValue( YEAR, 9, 9, SignStyle.ALWAYS )
+			.appendValue( MONTH_OF_YEAR, 2 )
+			.toFormatter();
+
+	public static final YearMonthBridge INSTANCE = new YearMonthBridge();
+
+	private YearMonthBridge() {
+		super( FORMATTER, YearMonth.class );
+	}
+
+	@Override
+	YearMonth parse(String stringValue) throws DateTimeParseException {
+		return YearMonth.parse( stringValue, FORMATTER );
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/ZoneIdBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/ZoneIdBridge.java
@@ -1,0 +1,46 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.bridge.builtin.time.impl;
+
+import java.time.ZoneId;
+
+import org.hibernate.search.bridge.TwoWayStringBridge;
+import org.hibernate.search.util.StringHelper;
+
+/**
+ * Converts a {@link ZoneId} to a {@link String}.
+ *
+ * @see ZoneId#getId()
+ * @see ZoneId#of(String)
+ * @author Davide D'Alto
+ */
+public class ZoneIdBridge implements TwoWayStringBridge {
+
+	public static final ZoneIdBridge INSTANCE = new ZoneIdBridge();
+
+	private ZoneIdBridge() {
+	}
+
+	@Override
+	public String objectToString(Object object) {
+		if ( object == null ) {
+			return null;
+		}
+
+		ZoneId zoneId = (ZoneId) object;
+		return zoneId.getId();
+	}
+
+	@Override
+	public Object stringToObject(String stringValue) {
+		if ( StringHelper.isEmpty( stringValue ) ) {
+			return null;
+		}
+
+		return ZoneId.of( stringValue );
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/ZoneOffsetBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/ZoneOffsetBridge.java
@@ -1,0 +1,47 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.bridge.builtin.time.impl;
+
+import java.time.ZoneOffset;
+
+import org.hibernate.search.bridge.TwoWayStringBridge;
+import org.hibernate.search.util.StringHelper;
+
+/**
+ * Converts a {@link ZoneOffset} to a {@link String}.
+ *
+ * @see ZoneOffset#getId()
+ * @see ZoneOffset#of(String)
+ * @author Davide D'Alto
+ */
+public class ZoneOffsetBridge implements TwoWayStringBridge {
+
+	public static final ZoneOffsetBridge INSTANCE = new ZoneOffsetBridge();
+
+	private ZoneOffsetBridge() {
+	}
+
+	@Override
+	public String objectToString(Object object) {
+		if ( object == null ) {
+			return null;
+		}
+
+		ZoneOffset offSet = (ZoneOffset) object;
+		return offSet.getId();
+	}
+
+	@Override
+	public Object stringToObject(String stringValue) {
+		if ( StringHelper.isEmpty( stringValue ) ) {
+			return null;
+		}
+
+		return ZoneOffset.of( stringValue );
+	}
+
+}

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/ZonedDateTimeBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/ZonedDateTimeBridge.java
@@ -1,0 +1,41 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.bridge.builtin.time.impl;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+
+/**
+ * Converts a {@link ZonedDateTime} to a {@link String}.
+ * <p>
+ * A {@code ZonedDateTime} 2012-12-31T23:59:59.999 Europe/Paris becomes the string
+ * {@code +0000020121231235959000000999Europe/Paris}.
+ * <p>
+ * The sign is always present for the year and the string is padded with 0 to allow field sorting.
+ *
+ * @author Davide D'Alto
+ */
+public class ZonedDateTimeBridge extends TemporalAccessorStringBridge<ZonedDateTime> {
+
+	static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
+			.append( LocalDateTimeBridge.FORMATTER )
+			.appendZoneId()
+			.toFormatter();
+
+	public static final ZonedDateTimeBridge INSTANCE = new ZonedDateTimeBridge();
+
+	private ZonedDateTimeBridge() {
+		super( FORMATTER, ZonedDateTime.class );
+	}
+
+	@Override
+	ZonedDateTime parse(String stringValue) throws DateTimeParseException {
+		return ZonedDateTime.parse( stringValue, FORMATTER );
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/package-info.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+/**
+ * This package contains all the bridges to store the temporal classes provided since java 8.
+ */
+package org.hibernate.search.bridge.builtin.time.impl;

--- a/engine/src/main/java/org/hibernate/search/bridge/impl/BridgeFactory.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/impl/BridgeFactory.java
@@ -59,6 +59,7 @@ public final class BridgeFactory {
 
 		ClassLoaderService classLoaderService = serviceManager.requestService( ClassLoaderService.class );
 		try {
+			provideJavaTimeBridges( classLoaderService );
 			for ( BridgeProvider provider : classLoaderService.loadJavaServices( BridgeProvider.class ) ) {
 				regularProviders.add( provider );
 			}
@@ -68,6 +69,13 @@ public final class BridgeFactory {
 		}
 		regularProviders.add( new EnumBridgeProvider() );
 		regularProviders.add( new BasicJDKTypesBridgeProvider( serviceManager ) );
+	}
+
+	private void provideJavaTimeBridges(ClassLoaderService classLoaderService) {
+		JavaTimeBridgeProvider javaTimeBridgeProvider = new JavaTimeBridgeProvider( classLoaderService );
+		if ( javaTimeBridgeProvider.hasFoundSomeJavaTimeTypes() ) {
+			annotationBasedProviders.add( javaTimeBridgeProvider );
+		}
 	}
 
 	/**

--- a/engine/src/main/java/org/hibernate/search/bridge/impl/JavaTimeBridgeProvider.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/impl/JavaTimeBridgeProvider.java
@@ -1,0 +1,140 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+package org.hibernate.search.bridge.impl;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.MonthDay;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Period;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hibernate.search.bridge.FieldBridge;
+import org.hibernate.search.bridge.builtin.impl.TwoWayString2FieldBridgeAdaptor;
+import org.hibernate.search.bridge.builtin.time.impl.DurationBridge;
+import org.hibernate.search.bridge.builtin.time.impl.InstantBridge;
+import org.hibernate.search.bridge.builtin.time.impl.LocalDateBridge;
+import org.hibernate.search.bridge.builtin.time.impl.LocalDateTimeBridge;
+import org.hibernate.search.bridge.builtin.time.impl.LocalTimeBridge;
+import org.hibernate.search.bridge.builtin.time.impl.MonthDayBridge;
+import org.hibernate.search.bridge.builtin.time.impl.OffsetDateTimeBridge;
+import org.hibernate.search.bridge.builtin.time.impl.OffsetTimeBridge;
+import org.hibernate.search.bridge.builtin.time.impl.PeriodBridge;
+import org.hibernate.search.bridge.builtin.time.impl.YearBridge;
+import org.hibernate.search.bridge.builtin.time.impl.YearMonthBridge;
+import org.hibernate.search.bridge.builtin.time.impl.ZoneIdBridge;
+import org.hibernate.search.bridge.builtin.time.impl.ZoneOffsetBridge;
+import org.hibernate.search.bridge.builtin.time.impl.ZonedDateTimeBridge;
+import org.hibernate.search.bridge.spi.BridgeProvider;
+import org.hibernate.search.engine.service.classloading.spi.ClassLoaderService;
+import org.hibernate.search.util.logging.impl.Log;
+import org.hibernate.search.util.logging.impl.LoggerFactory;
+
+/**
+ * {@link BridgeProvider} for the classes in java.time.*
+ * <p>
+ * The bridge for a specific type is created only if the type get found using a {@link ClassLoaderService}.
+ *
+ * @author Davide D'Alto
+ */
+class JavaTimeBridgeProvider implements BridgeProvider {
+
+	private static final Log LOG = LoggerFactory.make();
+
+	private final Map<String, FieldBridge> builtInBridges;
+
+	JavaTimeBridgeProvider(ClassLoaderService classLoaderService) {
+		Map<String, FieldBridge> bridges = populateBridgeMap( classLoaderService );
+		this.builtInBridges = bridges;
+	}
+
+	private static Map<String, FieldBridge> populateBridgeMap(ClassLoaderService classLoaderService) {
+		Map<String, FieldBridge> bridges = new HashMap<String, FieldBridge>( 12 );
+		if ( classExists( classLoaderService, "java.time.Year" ) ) {
+			bridges.put( Year.class.getName(), new TwoWayString2FieldBridgeAdaptor( YearBridge.INSTANCE ) );
+		}
+		if ( classExists( classLoaderService, "java.time.YearMonth" ) ) {
+			bridges.put( YearMonth.class.getName(), new TwoWayString2FieldBridgeAdaptor( YearMonthBridge.INSTANCE ) );
+		}
+		if ( classExists( classLoaderService, "java.time.MonthDay" ) ) {
+			bridges.put( MonthDay.class.getName(), new TwoWayString2FieldBridgeAdaptor( MonthDayBridge.INSTANCE ) );
+		}
+		if ( classExists( classLoaderService, "java.time.LocalDateTime" ) ) {
+			bridges.put( LocalDateTime.class.getName(), new TwoWayString2FieldBridgeAdaptor( LocalDateTimeBridge.INSTANCE ) );
+		}
+		if ( classExists( classLoaderService, "java.time.LocalDate" ) ) {
+			bridges.put( LocalDate.class.getName(), new TwoWayString2FieldBridgeAdaptor( LocalDateBridge.INSTANCE ) );
+		}
+		if ( classExists( classLoaderService, "java.time.LocalTime" ) ) {
+			bridges.put( LocalTime.class.getName(), new TwoWayString2FieldBridgeAdaptor( LocalTimeBridge.INSTANCE ) );
+		}
+		if ( classExists( classLoaderService, "java.time.OffsetDateTime" ) ) {
+			bridges.put( OffsetDateTime.class.getName(), new TwoWayString2FieldBridgeAdaptor( OffsetDateTimeBridge.INSTANCE ) );
+		}
+		if ( classExists( classLoaderService, "java.time.OffsetTime" ) ) {
+			bridges.put( OffsetTime.class.getName(), new TwoWayString2FieldBridgeAdaptor( OffsetTimeBridge.INSTANCE ) );
+		}
+		if ( classExists( classLoaderService, "java.time.ZonedDateTime" ) ) {
+			bridges.put( ZonedDateTime.class.getName(), new TwoWayString2FieldBridgeAdaptor( ZonedDateTimeBridge.INSTANCE ) );
+		}
+		if ( classExists( classLoaderService, "java.time.ZoneOffset" ) ) {
+			bridges.put( ZoneOffset.class.getName(), new TwoWayString2FieldBridgeAdaptor( ZoneOffsetBridge.INSTANCE ) );
+		}
+		if ( classExists( classLoaderService, "java.time.ZoneId" ) ) {
+			bridges.put( ZoneId.class.getName(), new TwoWayString2FieldBridgeAdaptor( ZoneIdBridge.INSTANCE ) );
+		}
+		if ( classExists( classLoaderService, "java.time.Period" ) ) {
+			bridges.put( Period.class.getName(), new TwoWayString2FieldBridgeAdaptor( PeriodBridge.INSTANCE ) );
+		}
+		if ( classExists( classLoaderService, "java.time.Duration" ) ) {
+			bridges.put( Duration.class.getName(), new TwoWayString2FieldBridgeAdaptor( DurationBridge.INSTANCE ) );
+		}
+		if ( classExists( classLoaderService, "java.time.Instant" ) ) {
+			bridges.put( Instant.class.getName(), new TwoWayString2FieldBridgeAdaptor( InstantBridge.INSTANCE ) );
+		}
+		if ( bridges.isEmpty() ) {
+			bridges = Collections.emptyMap();
+		}
+		return bridges;
+	}
+
+	/**
+	 * @return {@code true} if at least one of the supported classes in the package java.time exists on the classpath,
+	 * {@code false} otherwise.
+	 */
+	public boolean hasFoundSomeJavaTimeTypes() {
+		return !builtInBridges.isEmpty();
+	}
+
+	private static boolean classExists(ClassLoaderService classLoaderService, String className) {
+		try {
+			classLoaderService.classForName( className );
+			return true;
+		}
+		catch (org.hibernate.search.engine.service.classloading.spi.ClassLoadingException e) {
+			LOG.javaTimeBridgeWontBeAdded( className );
+			return false;
+		}
+	}
+
+	@Override
+	public FieldBridge provideFieldBridge(BridgeProviderContext bridgeProviderContext) {
+		return builtInBridges.get( bridgeProviderContext.getReturnType().getName() );
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/bridge/impl/JavaTimeBridgeProvider.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/impl/JavaTimeBridgeProvider.java
@@ -67,7 +67,7 @@ class JavaTimeBridgeProvider implements BridgeProvider {
 	private static Map<String, FieldBridge> populateBridgeMap(ClassLoaderService classLoaderService) {
 		Map<String, FieldBridge> bridges = new HashMap<String, FieldBridge>( 12 );
 		if ( classExists( classLoaderService, "java.time.Year" ) ) {
-			bridges.put( Year.class.getName(), new TwoWayString2FieldBridgeAdaptor( YearBridge.INSTANCE ) );
+			bridges.put( Year.class.getName(), YearBridge.INSTANCE );
 		}
 		if ( classExists( classLoaderService, "java.time.YearMonth" ) ) {
 			bridges.put( YearMonth.class.getName(), new TwoWayString2FieldBridgeAdaptor( YearMonthBridge.INSTANCE ) );
@@ -103,7 +103,7 @@ class JavaTimeBridgeProvider implements BridgeProvider {
 			bridges.put( Period.class.getName(), new TwoWayString2FieldBridgeAdaptor( PeriodBridge.INSTANCE ) );
 		}
 		if ( classExists( classLoaderService, "java.time.Duration" ) ) {
-			bridges.put( Duration.class.getName(), new TwoWayString2FieldBridgeAdaptor( DurationBridge.INSTANCE ) );
+			bridges.put( Duration.class.getName(), DurationBridge.INSTANCE );
 		}
 		if ( classExists( classLoaderService, "java.time.Instant" ) ) {
 			bridges.put( Instant.class.getName(), new TwoWayString2FieldBridgeAdaptor( InstantBridge.INSTANCE ) );

--- a/engine/src/main/java/org/hibernate/search/bridge/impl/JavaTimeBridgeProvider.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/impl/JavaTimeBridgeProvider.java
@@ -106,7 +106,7 @@ class JavaTimeBridgeProvider implements BridgeProvider {
 			bridges.put( Duration.class.getName(), DurationBridge.INSTANCE );
 		}
 		if ( classExists( classLoaderService, "java.time.Instant" ) ) {
-			bridges.put( Instant.class.getName(), new TwoWayString2FieldBridgeAdaptor( InstantBridge.INSTANCE ) );
+			bridges.put( Instant.class.getName(), InstantBridge.INSTANCE );
 		}
 		if ( bridges.isEmpty() ) {
 			bridges = Collections.emptyMap();

--- a/engine/src/main/java/org/hibernate/search/bridge/util/impl/NumericFieldUtils.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/util/impl/NumericFieldUtils.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.bridge.util.impl;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.time.Year;
 import java.util.Calendar;
 import java.util.Date;
@@ -26,6 +27,7 @@ public final class NumericFieldUtils {
 
 	private static final String JAVA_TIME_DURATION = "java.time.Duration";
 	private static final String JAVA_TIME_YEAR = "java.time.Year";
+	private static final String JAVA_TIME_INSTANT = "java.time.Instant";
 
 	private static final Log log = LoggerFactory.make();
 
@@ -86,6 +88,11 @@ public final class NumericFieldUtils {
 			Integer toValue = to != null ? ( (Year) to ).getValue() : null;
 			return NumericRangeQuery.newIntRange( fieldName, fromValue, toValue, includeLower, includeUpper );
 		}
+		if ( isAssignableFrom( numericClass, JAVA_TIME_INSTANT ) ) {
+			Long fromValue = from != null ? ( (Instant) from ).toEpochMilli() : null;
+			Long toValue = to != null ? ( (Instant) to ).toEpochMilli() : null;
+			return NumericRangeQuery.newLongRange( fieldName, fromValue, toValue, includeLower, includeUpper );
+		}
 
 		throw log.numericRangeQueryWithNonNumericToAndFromValues( fieldName );
 	}
@@ -130,6 +137,7 @@ public final class NumericFieldUtils {
 				numericClass.isAssignableFrom( Integer.class ) ||
 				numericClass.isAssignableFrom( Float.class ) ||
 				numericClass.isAssignableFrom( Calendar.class ) ||
+				isAssignableFrom( numericClass, JAVA_TIME_INSTANT ) ||
 				isAssignableFrom( numericClass, JAVA_TIME_YEAR ) ||
 				isAssignableFrom( numericClass, JAVA_TIME_DURATION );
 	}

--- a/engine/src/main/java/org/hibernate/search/bridge/util/impl/NumericFieldUtils.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/util/impl/NumericFieldUtils.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.bridge.util.impl;
 
+import java.time.Duration;
+import java.time.Year;
 import java.util.Calendar;
 import java.util.Date;
 
@@ -21,6 +23,9 @@ import org.hibernate.search.util.logging.impl.LoggerFactory;
  * @author Hardy Ferentschik
  */
 public final class NumericFieldUtils {
+
+	private static final String JAVA_TIME_DURATION = "java.time.Duration";
+	private static final String JAVA_TIME_YEAR = "java.time.Year";
 
 	private static final Log log = LoggerFactory.make();
 
@@ -71,8 +76,28 @@ public final class NumericFieldUtils {
 			Long toValue = to != null ? ((Calendar) to).getTime().getTime() : null;
 			return NumericRangeQuery.newLongRange( fieldName, fromValue, toValue, includeLower, includeUpper );
 		}
+		if ( isAssignableFrom( numericClass, JAVA_TIME_DURATION ) ) {
+			Long fromValue = from != null ? ( (Duration) from ).toNanos() : null;
+			Long toValue = to != null ? ( (Duration) to ).toNanos() : null;
+			return NumericRangeQuery.newLongRange( fieldName, fromValue, toValue, includeLower, includeUpper );
+		}
+		if ( isAssignableFrom( numericClass, JAVA_TIME_YEAR ) ) {
+			Integer fromValue = from != null ? ( (Year) from ).getValue() : null;
+			Integer toValue = to != null ? ( (Year) to ).getValue() : null;
+			return NumericRangeQuery.newIntRange( fieldName, fromValue, toValue, includeLower, includeUpper );
+		}
 
 		throw log.numericRangeQueryWithNonNumericToAndFromValues( fieldName );
+	}
+
+	private static boolean isAssignableFrom(Class<?> numericClass, String className) {
+		try {
+			Class<?> clazz = Class.forName( className );
+			return numericClass.isAssignableFrom( clazz );
+		}
+		catch (ClassNotFoundException e) {
+			return false;
+		}
 	}
 
 	/**
@@ -104,6 +129,8 @@ public final class NumericFieldUtils {
 				numericClass.isAssignableFrom( Long.class ) ||
 				numericClass.isAssignableFrom( Integer.class ) ||
 				numericClass.isAssignableFrom( Float.class ) ||
-				numericClass.isAssignableFrom( Calendar.class );
+				numericClass.isAssignableFrom( Calendar.class ) ||
+				isAssignableFrom( numericClass, JAVA_TIME_YEAR ) ||
+				isAssignableFrom( numericClass, JAVA_TIME_DURATION );
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
@@ -69,6 +69,7 @@ import org.hibernate.search.bridge.builtin.NumericFieldBridge;
 import org.hibernate.search.bridge.builtin.impl.NullEncodingFieldBridge;
 import org.hibernate.search.bridge.builtin.impl.NullEncodingTwoWayFieldBridge;
 import org.hibernate.search.bridge.builtin.impl.TwoWayString2FieldBridgeAdaptor;
+import org.hibernate.search.bridge.builtin.time.impl.NumericTimeBridge;
 import org.hibernate.search.bridge.impl.BridgeFactory;
 import org.hibernate.search.engine.BoostStrategy;
 import org.hibernate.search.engine.impl.AnnotationProcessingHelper;
@@ -1067,7 +1068,10 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 
 		// either @NumericField is specified explicitly or we are dealing with a implicit numeric value encoded via a numeric
 		// field bridge
-		return numericFieldAnnotation != null || fieldBridge instanceof NumericFieldBridge || fieldBridge instanceof NumericEncodingDateBridge;
+		return numericFieldAnnotation != null
+				|| fieldBridge instanceof NumericFieldBridge
+				|| fieldBridge instanceof NumericEncodingDateBridge
+				|| fieldBridge instanceof NumericTimeBridge;
 	}
 
 	private NumericEncodingType determineNumericFieldEncoding(FieldBridge fieldBridge) {
@@ -1100,6 +1104,10 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 
 		if ( fieldBridge instanceof NumericEncodingDateBridge ) {
 			return NumericEncodingType.LONG;
+		}
+
+		if ( fieldBridge instanceof NumericTimeBridge ) {
+			return ( (NumericTimeBridge) fieldBridge ).getEncodingType();
 		}
 
 		return NumericEncodingType.UNKNOWN;

--- a/engine/src/main/java/org/hibernate/search/query/dsl/impl/ConnectedMultiFieldsTermQueryBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/impl/ConnectedMultiFieldsTermQueryBuilder.java
@@ -22,6 +22,7 @@ import org.apache.lucene.search.WildcardQuery;
 import org.hibernate.search.bridge.FieldBridge;
 import org.hibernate.search.bridge.builtin.NumericFieldBridge;
 import org.hibernate.search.bridge.builtin.impl.NullEncodingTwoWayFieldBridge;
+import org.hibernate.search.bridge.builtin.time.impl.NumericTimeBridge;
 import org.hibernate.search.bridge.spi.ConversionContext;
 import org.hibernate.search.bridge.util.impl.ContextualExceptionBridgeHelper;
 import org.hibernate.search.bridge.util.impl.NumericFieldUtils;
@@ -85,7 +86,7 @@ public class ConnectedMultiFieldsTermQueryBuilder implements TermTermination {
 			if ( fieldBridge instanceof NullEncodingTwoWayFieldBridge ) {
 				fieldBridge = ( (NullEncodingTwoWayFieldBridge) fieldBridge ).unwrap();
 			}
-			if ( fieldBridge instanceof NumericFieldBridge ) {
+			if ( fieldBridge instanceof NumericFieldBridge || fieldBridge instanceof NumericTimeBridge ) {
 				return NumericFieldUtils.createExactMatchQuery( fieldContext.getField(), value );
 			}
 		}

--- a/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
@@ -874,4 +874,6 @@ public interface Log extends BasicLogger {
 	@Message(id = 288, value = "The configuration property '%s' no longer applies and will be ignored." )
 	void deprecatedConfigurationPropertyIsIgnored(String string);
 
+	@Message(id = 289, value = "String '$1%s' cannot be parsed into a '$2%s'")
+	SearchException parseException(String text, @FormatWith(ClassFormatter.class) Class<?> readerClass, @Cause Exception e);
 }

--- a/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
@@ -880,4 +880,7 @@ public interface Log extends BasicLogger {
 	@LogMessage(level = Level.DEBUG)
 	@Message(id = 290, value = "%s not found on the classpath; the built-in bridge won't be available")
 	void javaTimeBridgeWontBeAdded(String string);
+
+	@Message(id = 291, value = " Value of '%2$s' for type '%1$s' is too big for the conversion")
+	SearchException valueTooLargeForConvertionException(@FormatWith(ClassFormatter.class) Class<?> type, Object duration, @Cause Exception ae);
 }

--- a/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
@@ -876,4 +876,8 @@ public interface Log extends BasicLogger {
 
 	@Message(id = 289, value = "String '$1%s' cannot be parsed into a '$2%s'")
 	SearchException parseException(String text, @FormatWith(ClassFormatter.class) Class<?> readerClass, @Cause Exception e);
+
+	@LogMessage(level = Level.DEBUG)
+	@Message(id = 290, value = "%s not found on the classpath; the built-in bridge won't be available")
+	void javaTimeBridgeWontBeAdded(String string);
 }

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/DurationBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/DurationBridgeTest.java
@@ -1,0 +1,72 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.bridge.time;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.hibernate.search.bridge.builtin.time.impl.DurationBridge;
+import org.junit.Test;
+
+/**
+ * @author Davide D'Alto
+ */
+public class DurationBridgeTest {
+
+	private static final DurationBridge BRIDGE = DurationBridge.INSTANCE;
+
+	private static final Duration MAX_DURATION = Duration.ofSeconds( Long.MAX_VALUE, 999_999_999 );
+	private static final Duration MIN_DURATION = Duration.ofSeconds( Long.MIN_VALUE, 0 );
+	private static final Duration CUSTOM_DURATION = Duration.ofSeconds( -5807L, 10 );
+	private static final Duration ZERO_DURATION = Duration.ZERO;
+
+	private static final String MAX = "+9223372036854775807" + "999999999";
+	private static final String MIN = "-9223372036854775808" + "000000000";
+	private static final String CST = "-0000000000000005807" + "000000010";
+	private static final String ZER = "+0000000000000000000" + "000000000";
+
+	@Test
+	public void testMaxObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( MAX_DURATION ) ).isEqualTo( MAX );
+	}
+
+	@Test
+	public void testMinObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( MIN_DURATION ) ).isEqualTo( MIN );
+	}
+
+	@Test
+	public void testPaddingObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( CUSTOM_DURATION ) ).isEqualTo( CST );
+	}
+
+	@Test
+	public void testZeroObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( ZERO_DURATION ) ).isEqualTo( ZER );
+	}
+
+	@Test
+	public void testMaxStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( MAX ) ).isEqualTo( MAX_DURATION );
+	}
+
+	@Test
+	public void testMinStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( MIN ) ).isEqualTo( MIN_DURATION );
+	}
+
+	@Test
+	public void testPaddingStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( CST ) ).isEqualTo( CUSTOM_DURATION );
+	}
+
+	@Test
+	public void testZeroStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( ZER ) ).isEqualTo( ZERO_DURATION );
+	}
+}

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/InstantBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/InstantBridgeTest.java
@@ -1,0 +1,65 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.bridge.time;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.time.Instant;
+
+import org.hibernate.search.bridge.builtin.time.impl.InstantBridge;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * @author Davide D'Alto
+ */
+public class InstantBridgeTest {
+
+	private static final InstantBridge BRIDGE = InstantBridge.INSTANCE;
+
+	private static final String MAX = "+" + String.valueOf( Instant.MAX.getEpochSecond() ) + String.valueOf( Instant.MAX.getNano() );
+	private static final String MIN = String.valueOf( Instant.MIN.getEpochSecond() ) + "000000000";
+	private static final String CUSTOM = "+00000000000012345" + "000000001";
+
+	private static final Instant MAX_INSTANT = Instant.MAX;
+	private static final Instant MIN_INSTANT = Instant.MIN;
+	private static final Instant CUSTOM_INSTANT = Instant.ofEpochSecond( 12345, 1 );
+
+	@Rule
+	public final ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void testMaxObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( MAX_INSTANT ) ).isEqualTo( MAX );
+	}
+
+	@Test
+	public void testMinObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( MIN_INSTANT ) ).isEqualTo( MIN );
+	}
+
+	@Test
+	public void testPaddingObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( CUSTOM_INSTANT ) ).isEqualTo( CUSTOM );
+	}
+
+	@Test
+	public void testMaxStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( MAX ) ).isEqualTo( MAX_INSTANT );
+	}
+
+	@Test
+	public void testMinStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( MIN ) ).isEqualTo( MIN_INSTANT );
+	}
+
+	@Test
+	public void testPaddingStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( CUSTOM ) ).isEqualTo( CUSTOM_INSTANT );
+	}
+}

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/InstantBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/InstantBridgeTest.java
@@ -11,6 +11,7 @@ import static org.fest.assertions.Assertions.assertThat;
 import java.time.Instant;
 
 import org.hibernate.search.bridge.builtin.time.impl.InstantBridge;
+import org.hibernate.search.exception.SearchException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -22,12 +23,7 @@ public class InstantBridgeTest {
 
 	private static final InstantBridge BRIDGE = InstantBridge.INSTANCE;
 
-	private static final String MAX = "+" + String.valueOf( Instant.MAX.getEpochSecond() ) + String.valueOf( Instant.MAX.getNano() );
-	private static final String MIN = String.valueOf( Instant.MIN.getEpochSecond() ) + "000000000";
-	private static final String CUSTOM = "+00000000000012345" + "000000001";
-
-	private static final Instant MAX_INSTANT = Instant.MAX;
-	private static final Instant MIN_INSTANT = Instant.MIN;
+	private static final Instant MAX_INSTANT = Instant.ofEpochMilli( Long.MAX_VALUE );
 	private static final Instant CUSTOM_INSTANT = Instant.ofEpochSecond( 12345, 1 );
 
 	@Rule
@@ -35,31 +31,19 @@ public class InstantBridgeTest {
 
 	@Test
 	public void testMaxObjectToString() throws Exception {
-		assertThat( BRIDGE.objectToString( MAX_INSTANT ) ).isEqualTo( MAX );
-	}
-
-	@Test
-	public void testMinObjectToString() throws Exception {
-		assertThat( BRIDGE.objectToString( MIN_INSTANT ) ).isEqualTo( MIN );
+		assertThat( BRIDGE.objectToString( MAX_INSTANT ) ).isEqualTo( String.valueOf( MAX_INSTANT.toEpochMilli() ) );
 	}
 
 	@Test
 	public void testPaddingObjectToString() throws Exception {
-		assertThat( BRIDGE.objectToString( CUSTOM_INSTANT ) ).isEqualTo( CUSTOM );
+		assertThat( BRIDGE.objectToString( CUSTOM_INSTANT ) ).isEqualTo( String.valueOf( CUSTOM_INSTANT.toEpochMilli() ) );
 	}
 
 	@Test
-	public void testMaxStringToObject() throws Exception {
-		assertThat( BRIDGE.stringToObject( MAX ) ).isEqualTo( MAX_INSTANT );
-	}
+	public void testTooLargeValueException() {
+		thrown.expect( SearchException.class );
+		thrown.expectMessage( "HSEARCH000291" );
 
-	@Test
-	public void testMinStringToObject() throws Exception {
-		assertThat( BRIDGE.stringToObject( MIN ) ).isEqualTo( MIN_INSTANT );
-	}
-
-	@Test
-	public void testPaddingStringToObject() throws Exception {
-		assertThat( BRIDGE.stringToObject( CUSTOM ) ).isEqualTo( CUSTOM_INSTANT );
+		BRIDGE.objectToString( Instant.MAX );
 	}
 }

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/LocalDateBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/LocalDateBridgeTest.java
@@ -1,0 +1,52 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.bridge.time;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.time.LocalDate;
+
+import org.hibernate.search.bridge.builtin.time.impl.LocalDateBridge;
+import org.junit.Test;
+
+/**
+ * @author Davide D'Alto
+ */
+public class LocalDateBridgeTest {
+
+	private static final LocalDateBridge BRIDGE = LocalDateBridge.INSTANCE;
+
+	@Test
+	public void testMaxObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( LocalDate.MAX ) ).isEqualTo( "+9999999991231" );
+	}
+
+	@Test
+	public void testMinObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( LocalDate.MIN ) ).isEqualTo( "-9999999990101" );
+	}
+
+	@Test
+	public void testPaddingObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( LocalDate.of( 1, 2, 3 ) ) ).isEqualTo( "+0000000010203" );
+	}
+
+	@Test
+	public void testMaxStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( "+9999999991231" ) ).isEqualTo( LocalDate.MAX );
+	}
+
+	@Test
+	public void testMinStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( "-9999999990101" ) ).isEqualTo( LocalDate.MIN );
+	}
+
+	@Test
+	public void testPaddingStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( "+0000000010203" ) ).isEqualTo( LocalDate.of( 1, 2, 3 ) );
+	}
+}

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/LocalDateTimeBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/LocalDateTimeBridgeTest.java
@@ -1,0 +1,63 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.bridge.time;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import org.hibernate.search.bridge.builtin.time.impl.LocalDateTimeBridge;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * @author Davide D'Alto
+ */
+public class LocalDateTimeBridgeTest {
+
+	private static final LocalDateTimeBridge BRIDGE = LocalDateTimeBridge.INSTANCE;
+
+	@Rule
+	public final ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void testMaxObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( LocalDateTime.MAX ) ).isEqualTo( "+9999999991231235959999999999" );
+	}
+
+	@Test
+	public void testMinObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( LocalDateTime.MIN ) ).isEqualTo( "-9999999990101000000000000000" );
+	}
+
+	@Test
+	public void testPaddingObjectToString() throws Exception {
+		LocalDate date = LocalDate.of( 1, 2, 3 );
+		LocalTime time = LocalTime.of( 4, 5, 6, 7 );
+		assertThat( BRIDGE.objectToString( LocalDateTime.of( date, time ) ) ).isEqualTo( "+0000000010203040506000000007" );
+	}
+
+	@Test
+	public void testMaxStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( "+9999999991231235959999999999" ) ).isEqualTo( LocalDateTime.MAX );
+	}
+
+	@Test
+	public void testMinStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( "-9999999990101000000000000000" ) ).isEqualTo( LocalDateTime.MIN );
+	}
+
+	@Test
+	public void testPaddingStringToObject() throws Exception {
+		LocalDate date = LocalDate.of( 1, 2, 3 );
+		LocalTime time = LocalTime.of( 4, 5, 6, 7 );
+		assertThat( BRIDGE.stringToObject( "+0000000010203040506000000007" ) ).isEqualTo( LocalDateTime.of( date, time ) );
+	}
+}

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/LocalTimeBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/LocalTimeBridgeTest.java
@@ -1,0 +1,59 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.bridge.time;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.time.LocalTime;
+
+import org.hibernate.search.bridge.builtin.time.impl.LocalTimeBridge;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * @author Davide D'Alto
+ */
+public class LocalTimeBridgeTest {
+
+	private static final LocalTimeBridge BRIDGE = LocalTimeBridge.INSTANCE;
+	private static final String MAX = "235959999999999";
+	private static final String MIN = "000000000000000";
+
+	@Rule
+	public final ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void testMaxObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( LocalTime.MAX ) ).isEqualTo( MAX );
+	}
+
+	@Test
+	public void testMinObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( LocalTime.MIN ) ).isEqualTo( MIN );
+	}
+
+	@Test
+	public void testPaddingObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( LocalTime.of( 4, 5, 6, 7 ) ) ).isEqualTo( "040506000000007" );
+	}
+
+	@Test
+	public void testMaxStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( MAX ) ).isEqualTo( LocalTime.MAX );
+	}
+
+	@Test
+	public void testMinStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( MIN ) ).isEqualTo( LocalTime.MIN );
+	}
+
+	@Test
+	public void testPaddingStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( "040506000000007" ) ).isEqualTo( LocalTime.of( 4, 5, 6, 7 ) );
+	}
+}

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/MonthDayBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/MonthDayBridgeTest.java
@@ -1,0 +1,59 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.bridge.time;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.time.MonthDay;
+
+import org.hibernate.search.bridge.builtin.time.impl.MonthDayBridge;
+import org.junit.Test;
+
+/**
+ * @author Davide D'Alto
+ */
+public class MonthDayBridgeTest {
+	private static final MonthDayBridge BRIDGE = MonthDayBridge.INSTANCE;
+
+	private static final MonthDay MAX_VALUE = MonthDay.of( 12, 31);
+	private static final MonthDay MIN_VALUE = MonthDay.of( 1, 1 );
+	private static final MonthDay CUSTOM_VALUE = MonthDay.of( 1, 4 );
+
+	private static final String MAX = "1231";
+	private static final String MIN = "0101";
+	private static final String CST = "0104";
+
+	@Test
+	public void testMaxObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( MAX_VALUE ) ).isEqualTo( MAX );
+	}
+
+	@Test
+	public void testMinObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( MIN_VALUE ) ).isEqualTo( MIN );
+	}
+
+	@Test
+	public void testPaddingObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( CUSTOM_VALUE ) ).isEqualTo( CST );
+	}
+
+	@Test
+	public void testMaxStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( MAX ) ).isEqualTo( MAX_VALUE );
+	}
+
+	@Test
+	public void testMinStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( MIN ) ).isEqualTo( MIN_VALUE );
+	}
+
+	@Test
+	public void testPaddingStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( CST ) ).isEqualTo( CUSTOM_VALUE );
+	}
+}

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/OffsetDateTimeBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/OffsetDateTimeBridgeTest.java
@@ -1,0 +1,69 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.bridge.time;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.time.OffsetDateTime;
+
+import org.hibernate.search.bridge.builtin.time.impl.OffsetDateTimeBridge;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * @author Davide D'Alto
+ */
+public class OffsetDateTimeBridgeTest {
+
+	private static final OffsetDateTimeBridge BRIDGE = OffsetDateTimeBridge.INSTANCE;
+
+	private static final String MAX = "+9999999991231235959999999999+18:00";
+	private static final String MIN = "-9999999990101000000000000000-18:00";
+	private static final String CUSTOM = "-0000000010203040506000000007+08:00";
+
+	private static final OffsetDateTime MAX_DATE_TIME = OffsetDateTime.of( LocalDateTime.MAX, ZoneOffset.MAX );
+	private static final OffsetDateTime MIN_DATE_TIME = OffsetDateTime.of( LocalDateTime.MIN, ZoneOffset.MIN );
+	private static final OffsetDateTime CUSTOM_DATE_TIME = OffsetDateTime.of( LocalDate.of( -1, 2, 3 ), LocalTime.of( 4, 5, 6, 7 ), ZoneOffset.ofHours( 8 ) );
+
+	@Rule
+	public final ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void testMaxObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( MAX_DATE_TIME ) ).isEqualTo( MAX );
+	}
+
+	@Test
+	public void testMinObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( MIN_DATE_TIME ) ).isEqualTo( MIN );
+	}
+
+	@Test
+	public void testPaddingObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( CUSTOM_DATE_TIME ) ).isEqualTo( CUSTOM );
+	}
+
+	@Test
+	public void testMaxStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( MAX ) ).isEqualTo( MAX_DATE_TIME );
+	}
+
+	@Test
+	public void testMinStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( MIN ) ).isEqualTo( MIN_DATE_TIME );
+	}
+
+	@Test
+	public void testPaddingStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( CUSTOM ) ).isEqualTo( CUSTOM_DATE_TIME );
+	}
+}

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/OffsetTimeBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/OffsetTimeBridgeTest.java
@@ -1,0 +1,67 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.bridge.time;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.time.LocalTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+
+import org.hibernate.search.bridge.builtin.time.impl.OffsetTimeBridge;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * @author Davide D'Alto
+ */
+public class OffsetTimeBridgeTest {
+
+	private static final OffsetTimeBridge BRIDGE = OffsetTimeBridge.INSTANCE;
+
+	private static final String MAX = "235959999999999+18:00";
+	private static final String MIN = "000000000000000-18:00";
+	private static final String CUSTOM = "040506000000007+08:00";
+
+	private static final OffsetTime MAX_UTC = OffsetTime.of( LocalTime.MAX, ZoneOffset.MAX );
+	private static final OffsetTime MIN_UTC = OffsetTime.of( LocalTime.MIN, ZoneOffset.MIN );
+	private static final OffsetTime CUSTOM_UTC = OffsetTime.of( LocalTime.of( 4, 5, 6, 7 ), ZoneOffset.ofHours( 8 ) );
+
+	@Rule
+	public final ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void testMaxObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( MAX_UTC ) ).isEqualTo( MAX );
+	}
+
+	@Test
+	public void testMinObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( MIN_UTC ) ).isEqualTo( MIN );
+	}
+
+	@Test
+	public void testPaddingObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( CUSTOM_UTC ) ).isEqualTo( CUSTOM );
+	}
+
+	@Test
+	public void testMaxStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( MAX ) ).isEqualTo( MAX_UTC );
+	}
+
+	@Test
+	public void testMinStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( MIN ) ).isEqualTo( MIN_UTC );
+	}
+
+	@Test
+	public void testPaddingStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( CUSTOM ) ).isEqualTo( CUSTOM_UTC );
+	}
+}

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/PeriodBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/PeriodBridgeTest.java
@@ -1,0 +1,77 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.bridge.time;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.time.Period;
+
+import org.hibernate.search.bridge.builtin.time.impl.PeriodBridge;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * @author Davide D'Alto
+ */
+public class PeriodBridgeTest {
+
+	private static final PeriodBridge BRIDGE = PeriodBridge.INSTANCE;
+
+	private static final Period MAX_PERIOD = Period.of( Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE );
+	private static final Period MIN_PERIOD = Period.of( Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MIN_VALUE );
+	private static final Period ZERO_PERIOD = Period.ZERO;
+	private static final Period CUSTOM_PERIOD = Period.of( 100, -20, 3 );
+
+	private static final String MAX = "+2147483647" + "+2147483647" + "+2147483647";
+	private static final String MIN = "-2147483648" + "-2147483648" + "-2147483648";
+	private static final String ZER = "+0000000000" + "+0000000000" + "+0000000000";
+	private static final String CST = "+0000000100" + "-0000000020" + "+0000000003";
+
+	@Rule
+	public final ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void testMaxObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( MAX_PERIOD ) ).isEqualTo( MAX );
+	}
+
+	@Test
+	public void testMinObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( MIN_PERIOD ) ).isEqualTo( MIN );
+	}
+
+	@Test
+	public void testPaddingObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( CUSTOM_PERIOD ) ).isEqualTo( CST );
+	}
+
+	@Test
+	public void testZeroObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( ZERO_PERIOD ) ).isEqualTo( ZER );
+	}
+
+	@Test
+	public void testMaxStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( MAX ) ).isEqualTo( MAX_PERIOD );
+	}
+
+	@Test
+	public void testMinStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( MIN ) ).isEqualTo( MIN_PERIOD );
+	}
+
+	@Test
+	public void testPaddingStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( CST ) ).isEqualTo( CUSTOM_PERIOD );
+	}
+
+	@Test
+	public void testZeroStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( ZER ) ).isEqualTo( ZERO_PERIOD );
+	}
+}

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/YearBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/YearBridgeTest.java
@@ -1,0 +1,71 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.bridge.time;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.time.Year;
+
+import org.hibernate.search.bridge.builtin.time.impl.YearBridge;
+import org.junit.Test;
+
+/**
+ * @author Davide D'Alto
+ */
+public class YearBridgeTest {
+	private static final YearBridge BRIDGE = YearBridge.INSTANCE;
+
+	private static final Year MAX_VALUE = Year.of( Year.MAX_VALUE );
+	private static final Year MIN_VALUE = Year.of( Year.MIN_VALUE );
+	private static final Year CUSTOM_VALUE = Year.of( 12434 );
+	private static final Year ZERO_VALUE = Year.of( 0 );
+
+	private static final String MAX = "+999999999";
+	private static final String MIN = "-999999999";
+	private static final String CST = "+000012434";
+	private static final String ZER = "+000000000";
+
+	@Test
+	public void testMaxObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( MAX_VALUE ) ).isEqualTo( MAX );
+	}
+
+	@Test
+	public void testMinObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( MIN_VALUE ) ).isEqualTo( MIN );
+	}
+
+	@Test
+	public void testPaddingObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( CUSTOM_VALUE ) ).isEqualTo( CST );
+	}
+
+	@Test
+	public void testZeroObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( ZERO_VALUE ) ).isEqualTo( ZER );
+	}
+
+	@Test
+	public void testMaxStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( MAX ) ).isEqualTo( MAX_VALUE );
+	}
+
+	@Test
+	public void testMinStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( MIN ) ).isEqualTo( MIN_VALUE );
+	}
+
+	@Test
+	public void testPaddingStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( CST ) ).isEqualTo( CUSTOM_VALUE );
+	}
+
+	@Test
+	public void testZeroStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( ZER ) ).isEqualTo( ZERO_VALUE );
+	}
+}

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/YearBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/YearBridgeTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
  * @author Davide D'Alto
  */
 public class YearBridgeTest {
+
 	private static final YearBridge BRIDGE = YearBridge.INSTANCE;
 
 	private static final Year MAX_VALUE = Year.of( Year.MAX_VALUE );
@@ -24,48 +25,23 @@ public class YearBridgeTest {
 	private static final Year CUSTOM_VALUE = Year.of( 12434 );
 	private static final Year ZERO_VALUE = Year.of( 0 );
 
-	private static final String MAX = "+999999999";
-	private static final String MIN = "-999999999";
-	private static final String CST = "+000012434";
-	private static final String ZER = "+000000000";
-
 	@Test
 	public void testMaxObjectToString() throws Exception {
-		assertThat( BRIDGE.objectToString( MAX_VALUE ) ).isEqualTo( MAX );
+		assertThat( BRIDGE.objectToString( MAX_VALUE ) ).isEqualTo( String.valueOf( MAX_VALUE.getValue() ) );
 	}
 
 	@Test
 	public void testMinObjectToString() throws Exception {
-		assertThat( BRIDGE.objectToString( MIN_VALUE ) ).isEqualTo( MIN );
+		assertThat( BRIDGE.objectToString( MIN_VALUE ) ).isEqualTo( String.valueOf( MIN_VALUE.getValue() ) );
 	}
 
 	@Test
 	public void testPaddingObjectToString() throws Exception {
-		assertThat( BRIDGE.objectToString( CUSTOM_VALUE ) ).isEqualTo( CST );
+		assertThat( BRIDGE.objectToString( CUSTOM_VALUE ) ).isEqualTo( String.valueOf( CUSTOM_VALUE.getValue() ) );
 	}
 
 	@Test
 	public void testZeroObjectToString() throws Exception {
-		assertThat( BRIDGE.objectToString( ZERO_VALUE ) ).isEqualTo( ZER );
-	}
-
-	@Test
-	public void testMaxStringToObject() throws Exception {
-		assertThat( BRIDGE.stringToObject( MAX ) ).isEqualTo( MAX_VALUE );
-	}
-
-	@Test
-	public void testMinStringToObject() throws Exception {
-		assertThat( BRIDGE.stringToObject( MIN ) ).isEqualTo( MIN_VALUE );
-	}
-
-	@Test
-	public void testPaddingStringToObject() throws Exception {
-		assertThat( BRIDGE.stringToObject( CST ) ).isEqualTo( CUSTOM_VALUE );
-	}
-
-	@Test
-	public void testZeroStringToObject() throws Exception {
-		assertThat( BRIDGE.stringToObject( ZER ) ).isEqualTo( ZERO_VALUE );
+		assertThat( BRIDGE.objectToString( ZERO_VALUE ) ).isEqualTo( String.valueOf( ZERO_VALUE.getValue() ) );
 	}
 }

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/YearMonthBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/YearMonthBridgeTest.java
@@ -1,0 +1,60 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.bridge.time;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.time.Year;
+import java.time.YearMonth;
+
+import org.hibernate.search.bridge.builtin.time.impl.YearMonthBridge;
+import org.junit.Test;
+
+/**
+ * @author Davide D'Alto
+ */
+public class YearMonthBridgeTest {
+	private static final YearMonthBridge BRIDGE = YearMonthBridge.INSTANCE;
+
+	private static final YearMonth MAX_VALUE = YearMonth.of( Year.MAX_VALUE, 12 );
+	private static final YearMonth MIN_VALUE = YearMonth.of( Year.MIN_VALUE, 12 );
+	private static final YearMonth CUSTOM_VALUE = YearMonth.of( -12434, 1 );
+
+	private static final String MAX = "+99999999912";
+	private static final String MIN = "-99999999912";
+	private static final String CST = "-00001243401";
+
+	@Test
+	public void testMaxObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( MAX_VALUE ) ).isEqualTo( MAX );
+	}
+
+	@Test
+	public void testMinObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( MIN_VALUE ) ).isEqualTo( MIN );
+	}
+
+	@Test
+	public void testPaddingObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( CUSTOM_VALUE ) ).isEqualTo( CST );
+	}
+
+	@Test
+	public void testMaxStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( MAX ) ).isEqualTo( MAX_VALUE );
+	}
+
+	@Test
+	public void testMinStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( MIN ) ).isEqualTo( MIN_VALUE );
+	}
+
+	@Test
+	public void testPaddingStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( CST ) ).isEqualTo( CUSTOM_VALUE );
+	}
+}

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/ZoneIdBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/ZoneIdBridgeTest.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.bridge.time;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.time.ZoneId;
+
+import org.hibernate.search.bridge.builtin.time.impl.ZoneIdBridge;
+import org.junit.Test;
+
+/**
+ * @author Davide D'Alto
+ */
+public class ZoneIdBridgeTest {
+
+	private static final ZoneIdBridge BRIDGE = ZoneIdBridge.INSTANCE;
+
+	private static final ZoneId VALUE_EXPECTED = ZoneId.of( "UTC" );
+	private static final String STRING_EXPECTED = "UTC";
+
+	@Test
+	public void testPaddingObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( VALUE_EXPECTED ) ).isEqualTo( STRING_EXPECTED );
+	}
+
+	public void testPaddingStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( STRING_EXPECTED ) ).isEqualTo( VALUE_EXPECTED );
+	}
+}

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/ZoneOffsetBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/ZoneOffsetBridgeTest.java
@@ -1,0 +1,59 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.bridge.time;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.time.ZoneOffset;
+
+import org.hibernate.search.bridge.builtin.time.impl.ZoneOffsetBridge;
+import org.junit.Test;
+
+/**
+ * @author Davide D'Alto
+ */
+public class ZoneOffsetBridgeTest {
+	private static final ZoneOffsetBridge BRIDGE = ZoneOffsetBridge.INSTANCE;
+
+	private static final ZoneOffset MAX_VALUE = ZoneOffset.MAX;
+	private static final ZoneOffset MIN_VALUE = ZoneOffset.MIN;
+	private static final ZoneOffset CUSTOM_VALUE = ZoneOffset.UTC;
+
+	private static final String MAX = "+18:00";
+	private static final String MIN = "-18:00";
+	private static final String CST = "Z";
+
+	@Test
+	public void testMaxObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( MAX_VALUE ) ).isEqualTo( MAX );
+	}
+
+	@Test
+	public void testMinObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( MIN_VALUE ) ).isEqualTo( MIN );
+	}
+
+	@Test
+	public void testPaddingObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( CUSTOM_VALUE ) ).isEqualTo( CST );
+	}
+
+	@Test
+	public void testMaxStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( MAX ) ).isEqualTo( MAX_VALUE );
+	}
+
+	@Test
+	public void testMinStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( MIN ) ).isEqualTo( MIN_VALUE );
+	}
+
+	@Test
+	public void testPaddingStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( CST ) ).isEqualTo( CUSTOM_VALUE );
+	}
+}

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/ZonedDateTimeBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/ZonedDateTimeBridgeTest.java
@@ -1,0 +1,70 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.bridge.time;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import org.hibernate.search.bridge.builtin.time.impl.ZonedDateTimeBridge;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * @author Davide D'Alto
+ */
+public class ZonedDateTimeBridgeTest {
+
+	private static final ZonedDateTimeBridge BRIDGE = ZonedDateTimeBridge.INSTANCE;
+
+	private static final String MAX = "+9999999991231235959999999999+18:00";
+	private static final String MIN = "-9999999990101000000000000000-18:00";
+	private static final String CUSTOM = "-0000000010203040506000000007Europe/Paris";
+
+	private static final ZonedDateTime MAX_VALUE = ZonedDateTime.of( LocalDateTime.MAX, ZoneOffset.MAX );
+	private static final ZonedDateTime MIN_VALUE = ZonedDateTime.of( LocalDateTime.MIN, ZoneOffset.MIN );
+	private static final ZonedDateTime CUSTOM_UTC = ZonedDateTime.of( LocalDate.of( -1, 2, 3 ), LocalTime.of( 4, 5, 6, 7 ), ZoneId.of( "Europe/Paris" ) );
+
+	@Rule
+	public final ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void testMaxObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( MAX_VALUE ) ).isEqualTo( MAX );
+	}
+
+	@Test
+	public void testMinObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( MIN_VALUE ) ).isEqualTo( MIN );
+	}
+
+	@Test
+	public void testPaddingObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( CUSTOM_UTC ) ).isEqualTo( CUSTOM );
+	}
+
+	@Test
+	public void testMaxStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( MAX ) ).isEqualTo( MAX_VALUE );
+	}
+
+	@Test
+	public void testMinStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( MIN ) ).isEqualTo( MIN_VALUE );
+	}
+
+	@Test
+	public void testPaddingStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( CUSTOM ) ).isEqualTo( CUSTOM_UTC );
+	}
+}

--- a/orm/src/test/java/org/hibernate/search/test/bridge/time/JavaTimeTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/time/JavaTimeTest.java
@@ -1,0 +1,282 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.bridge.time;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Month;
+import java.time.MonthDay;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Period;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.apache.lucene.search.Query;
+import org.hibernate.Transaction;
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.Search;
+import org.hibernate.search.annotations.Analyze;
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.Store;
+import org.hibernate.search.query.dsl.QueryBuilder;
+import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.testsupport.TestForIssue;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * @author Davide D'Alto
+ */
+@TestForIssue(jiraKey = "HSEARCH-1947")
+public class JavaTimeTest extends SearchTestBase {
+
+	@After
+	public void deleteEntity() {
+		try (org.hibernate.Session s = openSession()) {
+			Transaction tx = s.beginTransaction();
+			s.delete( s.load( Sample.class, 1L ) );
+			s.flush();
+			tx.commit();
+		}
+	}
+
+	@Test
+	public void testLocalDate() throws Exception {
+		LocalDate date = LocalDate.of( 2012, Month.DECEMBER, 30 );
+		Sample sample = new Sample( 1L, "LocalDate example" );
+		sample.localDate = date;
+
+		assertThatFieldIsIndexed( "localDate", date, sample );
+	}
+
+	@Test
+	public void testLocalTime() throws Exception {
+		LocalTime time = LocalTime.of( 13, 15, 55, 7 );
+
+		Sample sample = new Sample( 1L, "LocalTime example" );
+		sample.localTime = time;
+
+		assertThatFieldIsIndexed( "localTime", time, sample );
+	}
+
+	@Test
+	public void testLocalDateTime() throws Exception {
+		LocalDate date = LocalDate.of( 1998, Month.FEBRUARY, 12 );
+		LocalTime time = LocalTime.of( 13, 05, 33 );
+		LocalDateTime dateTime = LocalDateTime.of( date, time );
+
+		Sample sample = new Sample( 1L, "LocalDateTime example" );
+		sample.localDateTime = dateTime;
+
+		assertThatFieldIsIndexed( "localDateTime", dateTime, sample );
+	}
+
+	@Test
+	public void testInstant() throws Exception {
+		LocalDate date = LocalDate.of( 1998, Month.FEBRUARY, 12 );
+		LocalTime time = LocalTime.of( 13, 05, 33, 5 * 1000_000 );
+		LocalDateTime dateTime = LocalDateTime.of( date, time );
+		Instant instant = dateTime.toInstant( ZoneOffset.UTC );
+
+		Sample sample = new Sample( 1L, "Instant example" );
+		sample.instant = instant;
+
+		assertThatFieldIsIndexed( "instant", instant, sample );
+	}
+
+	@Test
+	public void testDuration() throws Exception {
+		Duration value = Duration.ZERO;
+
+		Sample sample = new Sample( 1L, "Duration example" );
+		sample.duration = value;
+
+		assertThatFieldIsIndexed( "duration", value, sample );
+	}
+
+	@Test
+	public void testPeriod() throws Exception {
+		Period value = Period.ZERO;
+
+		Sample sample = new Sample( 1L, "Period example" );
+		sample.period = value;
+
+		assertThatFieldIsIndexed( "period", value, sample );
+	}
+
+	@Test
+	public void testZoneOffset() throws Exception {
+		ZoneOffset value = ZoneOffset.MAX;
+
+		Sample sample = new Sample( 1L, "zoneOffset example" );
+		sample.zoneOffset = value;
+
+		assertThatFieldIsIndexed( "zoneOffset", value, sample );
+	}
+
+	@Test
+	public void testZoneId() throws Exception {
+		ZoneId value = ZoneId.of( "GMT" );
+
+		Sample sample = new Sample( 1L, "ZoneId example" );
+		sample.zoneId = value;
+
+		assertThatFieldIsIndexed( "zoneId", value, sample );
+	}
+
+	@Test
+	public void testOffsetDateTime() throws Exception {
+		OffsetDateTime value = OffsetDateTime.MIN;
+
+		Sample sample = new Sample( 1L, "OffsetDateTime example" );
+		sample.offsetDateTime = value;
+
+		assertThatFieldIsIndexed( "offsetDateTime", value, sample );
+	}
+
+	@Test
+	public void testOffsetTime() throws Exception {
+		OffsetTime value = OffsetTime.MIN;
+
+		Sample sample = new Sample( 1L, "OffsetTime example" );
+		sample.offsetTime = value;
+
+		assertThatFieldIsIndexed( "offsetTime", value, sample );
+	}
+
+	@Test
+	public void testYear() throws Exception {
+		Year value = Year.of( Year.MAX_VALUE );
+
+		Sample sample = new Sample( 1L, "Year example" );
+		sample.year = value;
+
+		assertThatFieldIsIndexed( "year", value, sample );
+	}
+
+	@Test
+	public void testYearMonth() throws Exception {
+		YearMonth value = YearMonth.of( 124, 12 );
+
+		Sample sample = new Sample( 1L, "YearMonth example" );
+		sample.yearMonth = value;
+
+		assertThatFieldIsIndexed( "yearMonth", value, sample );
+	}
+
+	@Test
+	public void testMonthDay() throws Exception {
+		MonthDay value = MonthDay.of( 12, 1 );
+
+		Sample sample = new Sample( 1L, "MonthDay example" );
+		sample.monthDay = value;
+
+		assertThatFieldIsIndexed( "monthDay", value, sample );
+	}
+
+	private void assertThatFieldIsIndexed(String field, Object expectedValue, Sample sample) {
+		try (org.hibernate.Session s = openSession()) {
+			Transaction tx = s.beginTransaction();
+			s.persist( sample );
+			s.flush();
+			tx.commit();
+
+			tx = s.beginTransaction();
+			final FullTextSession session = Search.getFullTextSession( s );
+
+			Query query = queryBuilder( session ).keyword().onField( field ).ignoreAnalyzer().matching( expectedValue ).createQuery();
+			Object[] result = (Object[]) session.createFullTextQuery( query ).setProjection( field ).uniqueResult();
+
+			assertThat( result ).as( "Indexed value for field '" + field + "' not found" ).containsOnly( expectedValue );
+
+			tx.commit();
+		}
+	}
+
+	@Field(analyze = Analyze.NO, store = Store.YES)
+	private QueryBuilder queryBuilder(final FullTextSession session) {
+		QueryBuilder builder = session.getSearchFactory().buildQueryBuilder().forEntity( Sample.class ).get();
+		return builder;
+	}
+
+	@Entity
+	@Indexed
+	static class Sample {
+
+		public Sample() {
+		}
+
+		public Sample(long id, String description) {
+			this.id = id;
+			this.description = description;
+		}
+
+		@Id
+		@DocumentId
+		long id;
+
+		@Field(analyze = Analyze.NO, store = Store.YES)
+		String description;
+
+		@Field(analyze = Analyze.NO, store = Store.YES)
+		private LocalDate localDate;
+
+		@Field(analyze = Analyze.NO, store = Store.YES)
+		private LocalTime localTime;
+
+		@Field(analyze = Analyze.NO, store = Store.YES)
+		private LocalDateTime localDateTime;
+
+		@Field(analyze = Analyze.NO, store = Store.YES)
+		private Instant instant;
+
+		@Field(analyze = Analyze.NO, store = Store.YES)
+		private Duration duration;
+
+		@Field(analyze = Analyze.NO, store = Store.YES)
+		private Period period;
+
+		@Field(analyze = Analyze.NO, store = Store.YES)
+		private ZoneOffset zoneOffset;
+
+		@Field(analyze = Analyze.NO, store = Store.YES)
+		private ZoneId zoneId;
+
+		@Field(analyze = Analyze.NO, store = Store.YES)
+		private OffsetDateTime offsetDateTime;
+
+		@Field(analyze = Analyze.NO, store = Store.YES)
+		private OffsetTime offsetTime;
+
+		@Field(analyze = Analyze.NO, store = Store.YES)
+		private Year year;
+
+		@Field(analyze = Analyze.NO, store = Store.YES)
+		private YearMonth yearMonth;
+
+		@Field(analyze = Analyze.NO, store = Store.YES)
+		private MonthDay monthDay;
+	}
+
+	@Override
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { Sample.class };
+	}
+}

--- a/orm/src/test/java/org/hibernate/search/test/bridge/time/JavaTimeTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/time/JavaTimeTest.java
@@ -103,7 +103,7 @@ public class JavaTimeTest extends SearchTestBase {
 
 	@Test
 	public void testDuration() throws Exception {
-		Duration value = Duration.ZERO;
+		Duration value = Duration.ofNanos( Long.MAX_VALUE );
 
 		Sample sample = new Sample( 1L, "Duration example" );
 		sample.duration = value;

--- a/orm/src/test/java/org/hibernate/search/test/configuration/integration/HibernateSearchIntegratorTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/integration/HibernateSearchIntegratorTest.java
@@ -18,6 +18,7 @@ import org.unitils.easymock.annotation.Mock;
 import org.hibernate.SessionFactoryObserver;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
+import org.hibernate.boot.registry.classloading.spi.ClassLoadingException;
 import org.hibernate.engine.config.internal.ConfigurationServiceImpl;
 import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -33,6 +34,7 @@ import org.hibernate.service.spi.SessionFactoryServiceRegistry;
 import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.isA;
+import static org.easymock.EasyMock.startsWith;
 
 /**
  * @author Sanne Grinovero
@@ -139,6 +141,10 @@ public class HibernateSearchIntegratorTest extends UnitilsJUnit4 {
 
 		expect( mockClassLoaderService.loadJavaServices( BridgeProvider.class ) )
 			.andReturn( Collections.<BridgeProvider>emptySet() );
+
+		expect( mockClassLoaderService.classForName( startsWith( "java.time" ) ) )
+			.andThrow( new ClassLoadingException( "Called by JavaTimeBridgeProvider; we assume the classes in java.time are not on the ORM class loader" ) )
+			.anyTimes();
 
 		expect( mockMetadata.getEntityBindings() )
 			.andReturn( Collections.EMPTY_SET )


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-1947

The bridges are now going to convert the objects to string padded with zero to allow the sorting.
The provider will check for the types on the classpath instead of checking for the jdk version

By the way, do I need to use the ClassLoader  service to check for the presence of a class or can I use the Class.forName(,..)? I'm asking because in NumericFieldUtils I don't have access to the ClassLoaderService at the moment.

Previous pull request: https://github.com/hibernate/hibernate-search/pull/887


 
