### PR TITLE
HSEARCH-1970 Untangling IndexManager and BackendQueueProcessor contracts

### DIFF
--- a/backends/jgroups/src/main/java/org/hibernate/search/backend/jgroups/impl/DispatchMessageSender.java
+++ b/backends/jgroups/src/main/java/org/hibernate/search/backend/jgroups/impl/DispatchMessageSender.java
@@ -13,6 +13,7 @@ import org.hibernate.search.backend.jgroups.logging.impl.Log;
 import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.engine.service.spi.Startable;
 import org.hibernate.search.engine.service.spi.Stoppable;
+import org.hibernate.search.indexes.serialization.spi.LuceneWorkSerializer;
 import org.hibernate.search.spi.BuildContext;
 import org.hibernate.search.util.configuration.impl.ConfigurationParseHelper;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
@@ -104,7 +105,8 @@ public final class DispatchMessageSender implements MessageSenderService, Starta
 		channelContainer.start();
 
 		NodeSelectorService masterNodeSelector = serviceManager.requestService( NodeSelectorService.class );
-		JGroupsMasterMessageListener listener = new JGroupsMasterMessageListener( context, masterNodeSelector );
+		LuceneWorkSerializer luceneWorkSerializer = serviceManager.requestService( LuceneWorkSerializer.class );
+		JGroupsMasterMessageListener listener = new JGroupsMasterMessageListener( context, masterNodeSelector, luceneWorkSerializer );
 
 		JChannel channel = channelContainer.getChannel();
 
@@ -143,6 +145,7 @@ public final class DispatchMessageSender implements MessageSenderService, Starta
 	@Override
 	public void stop() {
 		serviceManager.releaseService( NodeSelectorService.class );
+		serviceManager.releaseService( LuceneWorkSerializer.class );
 		serviceManager = null;
 		dispatcher.stop();
 		try {

--- a/backends/jgroups/src/main/java/org/hibernate/search/backend/jgroups/impl/JGroupsBackendQueueProcessor.java
+++ b/backends/jgroups/src/main/java/org/hibernate/search/backend/jgroups/impl/JGroupsBackendQueueProcessor.java
@@ -111,7 +111,7 @@ public class JGroupsBackendQueueProcessor implements BackendQueueProcessor {
 
 		jgroupsProcessor = new JGroupsBackendQueueTask( this, indexManager, masterNodeSelector, luceneWorkSerializer, block, messageTimeout );
 
-		String backend = ConfigurationParseHelper.getString( jgroupsProperties, DELEGATE_BACKEND, "lucene" );
+		String backend = ConfigurationParseHelper.getString( jgroupsProperties, DELEGATE_BACKEND, "local" );
 		delegatedBackend = BackendFactory.createBackend( backend, indexManager, context, props );
 	}
 

--- a/backends/jgroups/src/main/java/org/hibernate/search/backend/jgroups/impl/JGroupsBackendQueueProcessor.java
+++ b/backends/jgroups/src/main/java/org/hibernate/search/backend/jgroups/impl/JGroupsBackendQueueProcessor.java
@@ -17,7 +17,7 @@ import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.backend.jgroups.logging.impl.Log;
 import org.hibernate.search.backend.spi.BackendQueueProcessor;
 import org.hibernate.search.engine.service.spi.ServiceManager;
-import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
+import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.spi.WorkerBuildContext;
 import org.hibernate.search.util.configuration.impl.ConfigurationParseHelper;
 import org.hibernate.search.util.configuration.impl.MaskedProperty;
@@ -79,7 +79,7 @@ public class JGroupsBackendQueueProcessor implements BackendQueueProcessor {
 
 	protected MessageSenderService messageSender;
 	protected String indexName;
-	protected DirectoryBasedIndexManager indexManager;
+	protected IndexManager indexManager;
 
 	private Address address;
 	private ServiceManager serviceManager;
@@ -92,7 +92,7 @@ public class JGroupsBackendQueueProcessor implements BackendQueueProcessor {
 	}
 
 	@Override
-	public void initialize(Properties props, WorkerBuildContext context, DirectoryBasedIndexManager indexManager) {
+	public void initialize(Properties props, WorkerBuildContext context, IndexManager indexManager) {
 		this.indexManager = indexManager;
 		this.indexName = indexManager.getIndexName();
 		assertLegacyOptionsNotUsed( props, indexName );

--- a/backends/jgroups/src/main/java/org/hibernate/search/backend/jgroups/impl/JGroupsBackendQueueProcessor.java
+++ b/backends/jgroups/src/main/java/org/hibernate/search/backend/jgroups/impl/JGroupsBackendQueueProcessor.java
@@ -9,7 +9,6 @@ package org.hibernate.search.backend.jgroups.impl;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
-import java.util.concurrent.locks.Lock;
 
 import org.hibernate.search.backend.BackendFactory;
 import org.hibernate.search.backend.IndexingMonitor;
@@ -139,11 +138,6 @@ public class JGroupsBackendQueueProcessor implements BackendQueueProcessor {
 	}
 
 	@Override
-	public void indexMappingChanged() {
-		// no-op
-	}
-
-	@Override
 	public void applyWork(List<LuceneWork> workList, IndexingMonitor monitor) {
 		if ( selectionStrategy.isIndexOwnerLocal() ) {
 			delegatedBackend.applyWork( workList, monitor );
@@ -165,11 +159,6 @@ public class JGroupsBackendQueueProcessor implements BackendQueueProcessor {
 			//TODO optimize for single operation?
 			jgroupsProcessor.sendLuceneWorkList( Collections.singletonList( singleOperation ) );
 		}
-	}
-
-	@Override
-	public Lock getExclusiveWriteLock() {
-		return delegatedBackend.getExclusiveWriteLock();
 	}
 
 	private static void assertLegacyOptionsNotUsed(Properties props, String indexName) {

--- a/backends/jgroups/src/main/java/org/hibernate/search/backend/jgroups/impl/JGroupsBackendQueueProcessor.java
+++ b/backends/jgroups/src/main/java/org/hibernate/search/backend/jgroups/impl/JGroupsBackendQueueProcessor.java
@@ -16,6 +16,7 @@ import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.backend.jgroups.logging.impl.Log;
 import org.hibernate.search.backend.spi.BackendQueueProcessor;
 import org.hibernate.search.engine.service.spi.ServiceManager;
+import org.hibernate.search.indexes.serialization.spi.LuceneWorkSerializer;
 import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.spi.WorkerBuildContext;
 import org.hibernate.search.util.configuration.impl.ConfigurationParseHelper;
@@ -78,7 +79,6 @@ public class JGroupsBackendQueueProcessor implements BackendQueueProcessor {
 
 	protected MessageSenderService messageSender;
 	protected String indexName;
-	protected IndexManager indexManager;
 
 	private Address address;
 	private ServiceManager serviceManager;
@@ -92,7 +92,6 @@ public class JGroupsBackendQueueProcessor implements BackendQueueProcessor {
 
 	@Override
 	public void initialize(Properties props, WorkerBuildContext context, IndexManager indexManager) {
-		this.indexManager = indexManager;
 		this.indexName = indexManager.getIndexName();
 		assertLegacyOptionsNotUsed( props, indexName );
 		serviceManager = context.getServiceManager();
@@ -108,7 +107,9 @@ public class JGroupsBackendQueueProcessor implements BackendQueueProcessor {
 		final long messageTimeout = ConfigurationParseHelper.getLongValue( jgroupsProperties, MESSAGE_TIMEOUT_MS, DEFAULT_MESSAGE_TIMEOUT );
 
 		log.jgroupsBlockWaitingForAck( indexName, block );
-		jgroupsProcessor = new JGroupsBackendQueueTask( this, indexManager, masterNodeSelector, block, messageTimeout );
+		LuceneWorkSerializer luceneWorkSerializer = serviceManager.requestService( LuceneWorkSerializer.class );
+
+		jgroupsProcessor = new JGroupsBackendQueueTask( this, indexManager, masterNodeSelector, luceneWorkSerializer, block, messageTimeout );
 
 		String backend = ConfigurationParseHelper.getString( jgroupsProperties, DELEGATE_BACKEND, "lucene" );
 		delegatedBackend = BackendFactory.createBackend( backend, indexManager, context, props );
@@ -118,6 +119,7 @@ public class JGroupsBackendQueueProcessor implements BackendQueueProcessor {
 	public void close() {
 		serviceManager.releaseService( NodeSelectorService.class );
 		serviceManager.releaseService( MessageSenderService.class );
+		serviceManager.releaseService( LuceneWorkSerializer.class );
 		delegatedBackend.close();
 	}
 

--- a/backends/jgroups/src/main/java/org/hibernate/search/backend/jgroups/impl/JGroupsMasterMessageListener.java
+++ b/backends/jgroups/src/main/java/org/hibernate/search/backend/jgroups/impl/JGroupsMasterMessageListener.java
@@ -14,7 +14,7 @@ import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.backend.jgroups.logging.impl.Log;
 import org.hibernate.search.backend.spi.BackendQueueProcessor;
 import org.hibernate.search.exception.SearchException;
-import org.hibernate.search.indexes.spi.IndexManager;
+import org.hibernate.search.indexes.serialization.spi.LuceneWorkSerializer;
 import org.hibernate.search.spi.BuildContext;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 import org.jgroups.Address;
@@ -40,10 +40,12 @@ public class JGroupsMasterMessageListener implements Receiver {
 
 	private final BuildContext context;
 	private final NodeSelectorService selector;
+	private final LuceneWorkSerializer luceneWorkSerializer;
 
-	public JGroupsMasterMessageListener(BuildContext context, NodeSelectorService masterNodeSelector) {
+	public JGroupsMasterMessageListener(BuildContext context, NodeSelectorService masterNodeSelector, LuceneWorkSerializer luceneWorkSerializer) {
 		this.context = context;
 		this.selector = masterNodeSelector;
+		this.luceneWorkSerializer = luceneWorkSerializer;
 	}
 
 	@Override
@@ -57,10 +59,9 @@ public class JGroupsMasterMessageListener implements Receiver {
 			//nodeSelector can be null if we receive the message during shutdown
 			if ( nodeSelector != null && nodeSelector.isIndexOwnerLocal() ) {
 				byte[] serializedQueue = MessageSerializationHelper.extractSerializedQueue( offset, bufferLength, rawBuffer );
-				final IndexManager indexManager = context.getAllIndexesManager().getIndexManager( indexName );
 				final BackendQueueProcessor backendQueueProcessor = context.getAllIndexesManager().getBackendQueueProcessor( indexName );
 				if ( backendQueueProcessor != null ) {
-					final List<LuceneWork> queue = indexManager.getSerializer().toLuceneWorks( serializedQueue );
+					final List<LuceneWork> queue = luceneWorkSerializer.toLuceneWorks( serializedQueue );
 					applyLuceneWorkLocally( queue, backendQueueProcessor, message );
 				}
 				else {

--- a/backends/jgroups/src/main/java/org/hibernate/search/backend/jgroups/impl/JGroupsMasterMessageListener.java
+++ b/backends/jgroups/src/main/java/org/hibernate/search/backend/jgroups/impl/JGroupsMasterMessageListener.java
@@ -58,7 +58,7 @@ public class JGroupsMasterMessageListener implements Receiver {
 			if ( nodeSelector != null && nodeSelector.isIndexOwnerLocal() ) {
 				byte[] serializedQueue = MessageSerializationHelper.extractSerializedQueue( offset, bufferLength, rawBuffer );
 				final IndexManager indexManager = context.getAllIndexesManager().getIndexManager( indexName );
-				final BackendQueueProcessor backendQueueProcessor = indexManager.getBackendQueueProcessor();
+				final BackendQueueProcessor backendQueueProcessor = context.getAllIndexesManager().getBackendQueueProcessor( indexName );
 				if ( backendQueueProcessor != null ) {
 					final List<LuceneWork> queue = indexManager.getSerializer().toLuceneWorks( serializedQueue );
 					applyLuceneWorkLocally( queue, backendQueueProcessor, message );

--- a/backends/jgroups/src/test/java/org/hibernate/search/backend/jgroups/impl/JGroupsConfigurationTest.java
+++ b/backends/jgroups/src/test/java/org/hibernate/search/backend/jgroups/impl/JGroupsConfigurationTest.java
@@ -6,12 +6,12 @@
  */
 package org.hibernate.search.backend.jgroups.impl;
 
-import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.annotations.DocumentId;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
-import org.hibernate.search.spi.SearchIntegratorBuilder;
+import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.spi.SearchIntegrator;
+import org.hibernate.search.spi.SearchIntegratorBuilder;
 import org.hibernate.search.testsupport.setup.SearchConfigurationForTest;
 import org.junit.Rule;
 import org.junit.Test;
@@ -73,11 +73,6 @@ public class JGroupsConfigurationTest {
 		SearchIntegrator searchIntegrator = null;
 		try {
 			searchIntegrator = new SearchIntegratorBuilder().configuration( cfg ).buildSearchIntegrator();
-		}
-		catch (SearchException se) {
-			//we know we're getting a generic failure, but we want to make assert on the details message of
-			// the cause:
-			throw se.getCause();
 		}
 		finally {
 			if ( searchIntegrator != null ) {

--- a/backends/jgroups/src/test/java/org/hibernate/search/backend/jgroups/impl/SyncJGroupsBackendTest.java
+++ b/backends/jgroups/src/test/java/org/hibernate/search/backend/jgroups/impl/SyncJGroupsBackendTest.java
@@ -9,7 +9,6 @@ package org.hibernate.search.backend.jgroups.impl;
 import java.io.Serializable;
 import java.util.concurrent.TimeUnit;
 
-import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.annotations.DocumentId;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
@@ -17,18 +16,16 @@ import org.hibernate.search.backend.impl.blackhole.BlackHoleBackendQueueProcesso
 import org.hibernate.search.backend.spi.BackendQueueProcessor;
 import org.hibernate.search.backend.spi.Work;
 import org.hibernate.search.backend.spi.WorkType;
-import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
-import org.hibernate.search.indexes.spi.IndexManager;
+import org.hibernate.search.exception.SearchException;
+import org.hibernate.search.testsupport.TestForIssue;
 import org.hibernate.search.testsupport.junit.SearchFactoryHolder;
 import org.hibernate.search.testsupport.setup.TransactionContextForTest;
-import org.hibernate.search.testsupport.TestForIssue;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 import org.jgroups.TimeoutException;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.Assert;
-
 
 /**
  * Verifies sync / async guarantees of the JGroups backend.
@@ -151,10 +148,7 @@ public class SyncJGroupsBackendTest {
 	}
 
 	private static BackendQueueProcessor extractBackendQueue(SearchFactoryHolder node, String indexName) {
-		IndexManager indexManager = node.getSearchFactory().getIndexManagerHolder().getIndexManager( indexName );
-		Assert.assertNotNull( indexManager );
-		DirectoryBasedIndexManager dbi = (DirectoryBasedIndexManager) indexManager;
-		return dbi.getBackendQueueProcessor();
+		return node.getSearchFactory().getIndexManagerHolder().getBackendQueueProcessor( indexName );
 	}
 
 	private void storeBook(int id, String string) {

--- a/backends/jms/src/main/java/org/hibernate/search/backend/jms/impl/JmsBackendQueueProcessor.java
+++ b/backends/jms/src/main/java/org/hibernate/search/backend/jms/impl/JmsBackendQueueProcessor.java
@@ -17,11 +17,10 @@ import javax.jms.Queue;
 import javax.jms.QueueConnection;
 import javax.jms.QueueConnectionFactory;
 
-import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.backend.spi.BackendQueueProcessor;
-import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
+import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.spi.SearchIntegrator;
 import org.hibernate.search.spi.WorkerBuildContext;
@@ -60,7 +59,7 @@ public abstract class JmsBackendQueueProcessor implements BackendQueueProcessor,
 	private boolean isTransactional;
 
 	@Override
-	public void initialize(Properties props, WorkerBuildContext context, DirectoryBasedIndexManager indexManager) {
+	public void initialize(Properties props, WorkerBuildContext context, IndexManager indexManager) {
 		this.props = props;
 		this.isTransactional = context.enlistWorkerInTransaction();
 		this.indexManager = indexManager;

--- a/backends/jms/src/main/java/org/hibernate/search/backend/jms/impl/JmsBackendQueueProcessor.java
+++ b/backends/jms/src/main/java/org/hibernate/search/backend/jms/impl/JmsBackendQueueProcessor.java
@@ -9,8 +9,6 @@ package org.hibernate.search.backend.jms.impl;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 
 import javax.jms.JMSException;
 import javax.jms.Queue;
@@ -109,17 +107,6 @@ public abstract class JmsBackendQueueProcessor implements BackendQueueProcessor,
 	@Override
 	public void applyStreamWork(LuceneWork singleOperation, IndexingMonitor monitor) {
 		applyWork( Collections.singletonList( singleOperation ), monitor );
-	}
-
-	@Override
-	public Lock getExclusiveWriteLock() {
-		log.warnSuspiciousBackendDirectoryCombination( indexName );
-		return new ReentrantLock(); // keep the invoker happy, still it's useless
-	}
-
-	@Override
-	public void indexMappingChanged() {
-		// no-op
 	}
 
 	public QueueConnection getJMSConnection() {

--- a/backends/jms/src/main/java/org/hibernate/search/backend/jms/impl/JmsBackendQueueTask.java
+++ b/backends/jms/src/main/java/org/hibernate/search/backend/jms/impl/JmsBackendQueueTask.java
@@ -18,12 +18,11 @@ import javax.jms.QueueSender;
 import javax.jms.QueueSession;
 import javax.jms.Session;
 
-import org.hibernate.search.cfg.Environment;
-import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.backend.OptimizeLuceneWork;
+import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.indexes.serialization.spi.LuceneWorkSerializer;
-import org.hibernate.search.indexes.spi.IndexManager;
+import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
 /**
@@ -38,14 +37,14 @@ public class JmsBackendQueueTask implements Runnable {
 	private final Collection<LuceneWork> queue;
 	private final JmsBackendQueueProcessor processor;
 	private final String indexName;
-	private final IndexManager indexManager;
+	private final LuceneWorkSerializer luceneWorkSerializer;
 
-	public JmsBackendQueueTask(String indexName, Collection<LuceneWork> queue, IndexManager indexManager,
-					JmsBackendQueueProcessor jmsBackendQueueProcessor) {
+	public JmsBackendQueueTask(String indexName, Collection<LuceneWork> queue,
+			JmsBackendQueueProcessor jmsBackendQueueProcessor, LuceneWorkSerializer luceneWorkSerializer) {
 		this.indexName = indexName;
 		this.queue = queue;
-		this.indexManager = indexManager;
 		this.processor = jmsBackendQueueProcessor;
+		this.luceneWorkSerializer = luceneWorkSerializer;
 	}
 
 	@Override
@@ -60,8 +59,7 @@ public class JmsBackendQueueTask implements Runnable {
 		if ( filteredQueue.size() == 0 ) {
 			return;
 		}
-		LuceneWorkSerializer serializer = indexManager.getSerializer();
-		byte[] data = serializer.toSerializedModel( filteredQueue );
+		byte[] data = luceneWorkSerializer.toSerializedModel( filteredQueue );
 		QueueSender sender;
 		QueueSession session = null;
 		QueueConnection connection = null;

--- a/engine/src/main/java/org/hibernate/search/backend/BackendFactory.java
+++ b/engine/src/main/java/org/hibernate/search/backend/BackendFactory.java
@@ -9,12 +9,13 @@ package org.hibernate.search.backend;
 import java.lang.reflect.Constructor;
 import java.util.Properties;
 
-import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.backend.impl.blackhole.BlackHoleBackendQueueProcessor;
 import org.hibernate.search.backend.impl.lucene.LuceneBackendQueueProcessor;
 import org.hibernate.search.backend.spi.BackendQueueProcessor;
+import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.engine.service.spi.ServiceManager;
-import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
+import org.hibernate.search.exception.SearchException;
+import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.spi.BuildContext;
 import org.hibernate.search.spi.WorkerBuildContext;
 import org.hibernate.search.util.StringHelper;
@@ -44,13 +45,13 @@ public final class BackendFactory {
 		//not allowed
 	}
 
-	public static BackendQueueProcessor createBackend(DirectoryBasedIndexManager indexManager, WorkerBuildContext buildContext, Properties properties) {
+	public static BackendQueueProcessor createBackend(IndexManager indexManager, WorkerBuildContext buildContext, Properties properties) {
 		String backend = properties.getProperty( Environment.WORKER_BACKEND );
 		return createBackend( backend, indexManager, buildContext, properties );
 	}
 
 	public static BackendQueueProcessor createBackend(String backend,
-			DirectoryBasedIndexManager indexManager,
+			IndexManager indexManager,
 			WorkerBuildContext buildContext,
 			Properties properties) {
 		final BackendQueueProcessor backendQueueProcessor;

--- a/engine/src/main/java/org/hibernate/search/backend/BackendFactory.java
+++ b/engine/src/main/java/org/hibernate/search/backend/BackendFactory.java
@@ -9,12 +9,11 @@ package org.hibernate.search.backend;
 import java.lang.reflect.Constructor;
 import java.util.Properties;
 
+import org.hibernate.search.backend.impl.LocalBackendQueueProcessor;
 import org.hibernate.search.backend.impl.blackhole.BlackHoleBackendQueueProcessor;
-import org.hibernate.search.backend.impl.lucene.LuceneBackendQueueProcessor;
 import org.hibernate.search.backend.spi.BackendQueueProcessor;
 import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.engine.service.spi.ServiceManager;
-import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.spi.BuildContext;
 import org.hibernate.search.spi.WorkerBuildContext;
@@ -57,7 +56,7 @@ public final class BackendFactory {
 		final BackendQueueProcessor backendQueueProcessor;
 
 		if ( StringHelper.isEmpty( backend ) || "lucene".equalsIgnoreCase( backend ) ) {
-			backendQueueProcessor = new LuceneBackendQueueProcessor();
+			backendQueueProcessor = new LocalBackendQueueProcessor();
 		}
 		else if ( "jms".equalsIgnoreCase( backend ) ) {
 			backendQueueProcessor = ClassLoaderHelper.instanceFromName(

--- a/engine/src/main/java/org/hibernate/search/backend/BackendFactory.java
+++ b/engine/src/main/java/org/hibernate/search/backend/BackendFactory.java
@@ -56,7 +56,11 @@ public final class BackendFactory {
 			Properties properties) {
 		final BackendQueueProcessor backendQueueProcessor;
 
-		if ( StringHelper.isEmpty( backend ) || "lucene".equalsIgnoreCase( backend ) ) {
+		if ( StringHelper.isEmpty( backend ) || "local".equalsIgnoreCase( backend ) ) {
+			backendQueueProcessor = new LocalBackendQueueProcessor();
+		}
+		else if ( "lucene".equalsIgnoreCase( backend ) ) {
+			log.deprecatedBackendName();
 			backendQueueProcessor = new LocalBackendQueueProcessor();
 		}
 		else if ( "jms".equalsIgnoreCase( backend ) ) {

--- a/engine/src/main/java/org/hibernate/search/backend/impl/LocalBackendQueueProcessor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/LocalBackendQueueProcessor.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.backend.impl.blackhole;
+package org.hibernate.search.backend.impl;
 
 import java.util.List;
 import java.util.Properties;
@@ -14,43 +14,32 @@ import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.backend.spi.BackendQueueProcessor;
 import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.spi.WorkerBuildContext;
-import org.hibernate.search.util.logging.impl.Log;
-import org.hibernate.search.util.logging.impl.LoggerFactory;
 
 /**
- * This backend does not do anything: the Documents are not
- * sent to any index but are discarded.
- * Useful to identify the bottleneck in indexing performance problems,
- * fully disabling the backend system but still building the Documents
- * needed to update an index (loading data from DB).
+ * A {@link BackendQueueProcessor} which applies given index changes locally to the corresponding {@link IndexManager}.
  *
- * @author Sanne Grinovero
+ * @author Gunnar Morling
  */
-public class BlackHoleBackendQueueProcessor implements BackendQueueProcessor {
+public class LocalBackendQueueProcessor implements BackendQueueProcessor {
 
-	private static final Log log = LoggerFactory.make();
+	private IndexManager indexManager;
 
 	@Override
 	public void initialize(Properties props, WorkerBuildContext context, IndexManager indexManager) {
-		// no-op
-		log.initializedBlackholeBackend();
+		this.indexManager = indexManager;
 	}
 
 	@Override
 	public void close() {
-		// no-op
-		log.closedBlackholeBackend();
 	}
 
 	@Override
 	public void applyWork(List<LuceneWork> workList, IndexingMonitor monitor) {
-		// no-op
-		log.debug( "Discarding a list of LuceneWork" );
+		indexManager.performOperations( workList, monitor );
 	}
 
 	@Override
 	public void applyStreamWork(LuceneWork singleOperation, IndexingMonitor monitor) {
-		// no-op
-		log.debug( "Discarding a single LuceneWork" );
+		indexManager.performStreamOperation( singleOperation, monitor, false );
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/backend/impl/WorkQueuePerIndexSplitter.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/WorkQueuePerIndexSplitter.java
@@ -13,7 +13,7 @@ import java.util.List;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.backend.spi.BackendQueueProcessor;
-import org.hibernate.search.indexes.spi.IndexManager;
+import org.hibernate.search.indexes.impl.IndexManagerHolder;
 
 /**
  * Used by {@link org.hibernate.search.backend.impl.TransactionalOperationExecutor} to split a list of operations
@@ -25,11 +25,10 @@ public class WorkQueuePerIndexSplitter {
 
 	private final HashMap<String,WorkPlan> queues = new HashMap<String,WorkPlan>();
 
-	public List<LuceneWork> getIndexManagerQueue(final IndexManager indexManager) {
-		final String indexName = indexManager.getIndexName();
+	public List<LuceneWork> getIndexManagerQueue(String indexName, IndexManagerHolder indexManagerHolder) {
 		WorkPlan plan = queues.get( indexName );
 		if ( plan == null ) {
-			plan = new WorkPlan( indexManager.getBackendQueueProcessor() );
+			plan = new WorkPlan( indexManagerHolder.getBackendQueueProcessor( indexName ) );
 			queues.put( indexName, plan );
 		}
 		return plan.queue;

--- a/engine/src/main/java/org/hibernate/search/backend/impl/batch/DefaultBatchBackend.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/batch/DefaultBatchBackend.java
@@ -20,9 +20,9 @@ import org.hibernate.search.backend.impl.TransactionalOperationExecutorSelector;
 import org.hibernate.search.backend.impl.WorkQueuePerIndexSplitter;
 import org.hibernate.search.backend.spi.BatchBackend;
 import org.hibernate.search.batchindexing.MassIndexerProgressMonitor;
+import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.engine.spi.EntityIndexBinding;
 import org.hibernate.search.indexes.spi.IndexManager;
-import org.hibernate.search.spi.SearchIntegrator;
 import org.hibernate.search.store.IndexShardingStrategy;
 
 /**
@@ -35,10 +35,10 @@ import org.hibernate.search.store.IndexShardingStrategy;
  */
 public class DefaultBatchBackend implements BatchBackend {
 
-	private final SearchIntegrator integrator;
+	private final ExtendedSearchIntegrator integrator;
 	private final MassIndexerProgressMonitor progressMonitor;
 
-	public DefaultBatchBackend(SearchIntegrator integrator, MassIndexerProgressMonitor progressMonitor) {
+	public DefaultBatchBackend(ExtendedSearchIntegrator integrator, MassIndexerProgressMonitor progressMonitor) {
 		this.integrator = integrator;
 		this.progressMonitor = progressMonitor;
 	}
@@ -63,7 +63,7 @@ public class DefaultBatchBackend implements BatchBackend {
 		}
 		else {
 			WorkQueuePerIndexSplitter workContext = new WorkQueuePerIndexSplitter();
-			TransactionalOperationExecutor executor = work.acceptIndexWorkVisitor( TransactionalOperationExecutorSelector.INSTANCE, null );
+			TransactionalOperationExecutor executor = work.acceptIndexWorkVisitor( new TransactionalOperationExecutorSelector( integrator.getIndexManagerHolder() ), null );
 			executor.performOperation( work, shardingStrategy, workContext );
 			workContext.commitOperations( progressMonitor ); //FIXME I need a "Force sync" actually for when using PurgeAll before the indexing starts
 		}

--- a/engine/src/main/java/org/hibernate/search/backend/impl/blackhole/BlackHoleBackendQueueProcessor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/blackhole/BlackHoleBackendQueueProcessor.java
@@ -11,11 +11,11 @@ import java.util.Properties;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import org.hibernate.search.spi.WorkerBuildContext;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.backend.spi.BackendQueueProcessor;
-import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
+import org.hibernate.search.indexes.spi.IndexManager;
+import org.hibernate.search.spi.WorkerBuildContext;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
@@ -35,7 +35,7 @@ public class BlackHoleBackendQueueProcessor implements BackendQueueProcessor {
 	private final ReentrantLock backendLock = new ReentrantLock();
 
 	@Override
-	public void initialize(Properties props, WorkerBuildContext context, DirectoryBasedIndexManager indexManager) {
+	public void initialize(Properties props, WorkerBuildContext context, IndexManager indexManager) {
 		// no-op
 		log.initializedBlackholeBackend();
 	}

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/LuceneBackendQueueProcessor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/LuceneBackendQueueProcessor.java
@@ -15,6 +15,7 @@ import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.backend.spi.BackendQueueProcessor;
 import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
+import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.spi.WorkerBuildContext;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
@@ -40,14 +41,14 @@ public class LuceneBackendQueueProcessor implements BackendQueueProcessor {
 	private WorkProcessor workProcessor;
 
 	@Override
-	public void initialize(Properties props, WorkerBuildContext context, DirectoryBasedIndexManager indexManager) {
+	public void initialize(Properties props, WorkerBuildContext context, IndexManager indexManager) {
 		sync = BackendFactory.isConfiguredAsSync( props );
 		if ( workspaceOverride == null ) {
 			workspaceOverride = WorkspaceFactory.createWorkspace(
-					indexManager, context, props
+					(DirectoryBasedIndexManager) indexManager, context, props
 			);
 		}
-		resources = new LuceneBackendResources( context, indexManager, props, workspaceOverride );
+		resources = new LuceneBackendResources( context, (DirectoryBasedIndexManager) indexManager, props, workspaceOverride );
 		streamWorker = new LuceneBackendTaskStreamer( resources );
 		String indexName = indexManager.getIndexName();
 		if ( sync ) {

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/WorkspaceHolder.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/WorkspaceHolder.java
@@ -13,7 +13,6 @@ import java.util.concurrent.locks.Lock;
 import org.hibernate.search.backend.BackendFactory;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
-import org.hibernate.search.backend.spi.BackendQueueProcessor;
 import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
 import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.spi.WorkerBuildContext;
@@ -30,7 +29,7 @@ import org.hibernate.search.util.logging.impl.LoggerFactory;
  * @author Emmanuel Bernard
  * @author Sanne Grinovero
  */
-public class LuceneBackendQueueProcessor implements BackendQueueProcessor {
+public class WorkspaceHolder {
 
 	private static final Log log = LoggerFactory.make();
 
@@ -40,7 +39,6 @@ public class LuceneBackendQueueProcessor implements BackendQueueProcessor {
 	private LuceneBackendTaskStreamer streamWorker;
 	private WorkProcessor workProcessor;
 
-	@Override
 	public void initialize(Properties props, WorkerBuildContext context, IndexManager indexManager) {
 		sync = BackendFactory.isConfiguredAsSync( props );
 		if ( workspaceOverride == null ) {
@@ -63,13 +61,11 @@ public class LuceneBackendQueueProcessor implements BackendQueueProcessor {
 		}
 	}
 
-	@Override
 	public void close() {
 		resources.shutdown();
 		workProcessor.shutdown();
 	}
 
-	@Override
 	public void applyStreamWork(LuceneWork singleOperation, IndexingMonitor monitor) {
 		if ( singleOperation == null ) {
 			throw new IllegalArgumentException( "singleOperation should not be null" );
@@ -77,7 +73,6 @@ public class LuceneBackendQueueProcessor implements BackendQueueProcessor {
 		streamWorker.doWork( singleOperation, monitor );
 	}
 
-	@Override
 	public void applyWork(List<LuceneWork> workList, IndexingMonitor monitor) {
 		if ( workList == null ) {
 			throw new IllegalArgumentException( "workList should not be null" );
@@ -85,7 +80,6 @@ public class LuceneBackendQueueProcessor implements BackendQueueProcessor {
 		workProcessor.submit( workList, monitor );
 	}
 
-	@Override
 	public Lock getExclusiveWriteLock() {
 		return resources.getExclusiveModificationLock();
 	}
@@ -104,7 +98,6 @@ public class LuceneBackendQueueProcessor implements BackendQueueProcessor {
 		this.workspaceOverride = workspace;
 	}
 
-	@Override
 	public void indexMappingChanged() {
 		resources = resources.onTheFlyRebuild();
 		workProcessor.updateResources( resources );

--- a/engine/src/main/java/org/hibernate/search/backend/spi/BackendQueueProcessor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/spi/BackendQueueProcessor.java
@@ -12,7 +12,7 @@ import java.util.concurrent.locks.Lock;
 
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
-import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
+import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.spi.WorkerBuildContext;
 
 /**
@@ -30,7 +30,7 @@ public interface BackendQueueProcessor {
 	 * @param context context giving access to required meta data
 	 * @param indexManager the index it is related to.
 	 */
-	void initialize(Properties props, WorkerBuildContext context, DirectoryBasedIndexManager indexManager);
+	void initialize(Properties props, WorkerBuildContext context, IndexManager indexManager);
 
 	/**
 	 * Used to shutdown and eventually release resources.

--- a/engine/src/main/java/org/hibernate/search/backend/spi/BackendQueueProcessor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/spi/BackendQueueProcessor.java
@@ -8,7 +8,6 @@ package org.hibernate.search.backend.spi;
 
 import java.util.List;
 import java.util.Properties;
-import java.util.concurrent.locks.Lock;
 
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
@@ -58,17 +57,6 @@ public interface BackendQueueProcessor {
 	 * @param monitor a {@link org.hibernate.search.backend.IndexingMonitor} object.
 	 */
 	void applyStreamWork(LuceneWork singleOperation, IndexingMonitor monitor);
-
-	/**
-	 * @return a Lock instance which will block index modifications when acquired
-	 */
-	Lock getExclusiveWriteLock();
-
-	/**
-	 * Used to notify the backend that the number or type of indexed entities being indexed
-	 * in this backend changed. This could trigger some needed reconfiguration.
-	 */
-	void indexMappingChanged();
 
 	/**
 	 * Marker insterface describing a backend processor that is transactional

--- a/engine/src/main/java/org/hibernate/search/indexes/impl/NRTIndexManager.java
+++ b/engine/src/main/java/org/hibernate/search/indexes/impl/NRTIndexManager.java
@@ -8,10 +8,9 @@ package org.hibernate.search.indexes.impl;
 
 import java.util.Properties;
 
-import org.hibernate.search.cfg.Environment;
-import org.hibernate.search.backend.impl.lucene.LuceneBackendQueueProcessor;
 import org.hibernate.search.backend.impl.lucene.NRTWorkspaceImpl;
-import org.hibernate.search.backend.spi.BackendQueueProcessor;
+import org.hibernate.search.backend.impl.lucene.WorkspaceHolder;
+import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
 import org.hibernate.search.indexes.spi.DirectoryBasedReaderProvider;
 import org.hibernate.search.spi.WorkerBuildContext;
@@ -41,12 +40,12 @@ public class NRTIndexManager extends DirectoryBasedIndexManager {
 	private NRTWorkspaceImpl nrtWorkspace;
 
 	@Override
-	protected BackendQueueProcessor createBackend(String indexName, Properties cfg, WorkerBuildContext buildContext) {
+	protected WorkspaceHolder createWorkspaceHolder(String indexName, Properties cfg, WorkerBuildContext buildContext) {
 		String backend = cfg.getProperty( Environment.WORKER_BACKEND );
 		if ( backend != null ) {
 			log.ignoringBackendOptionForIndex( indexName, "near-real-time" );
 		}
-		LuceneBackendQueueProcessor backendQueueProcessor = new LuceneBackendQueueProcessor();
+		WorkspaceHolder backendQueueProcessor = new WorkspaceHolder();
 		nrtWorkspace = new NRTWorkspaceImpl( this, buildContext, cfg );
 		backendQueueProcessor.setCustomWorkspace( nrtWorkspace );
 		backendQueueProcessor.initialize( cfg, buildContext, this );

--- a/engine/src/main/java/org/hibernate/search/indexes/serialization/spi/LuceneWorkSerializer.java
+++ b/engine/src/main/java/org/hibernate/search/indexes/serialization/spi/LuceneWorkSerializer.java
@@ -9,6 +9,7 @@ package org.hibernate.search.indexes.serialization.spi;
 import java.util.List;
 
 import org.hibernate.search.backend.LuceneWork;
+import org.hibernate.search.engine.service.spi.Service;
 
 /**
  * Serialize {@code LuceneWork} instances.
@@ -21,7 +22,7 @@ import org.hibernate.search.backend.LuceneWork;
  *
  * @author Sanne Grinovero &lt;sanne@hibernate.org&gt; (C) 2011 Red Hat Inc.
  */
-public interface LuceneWorkSerializer {
+public interface LuceneWorkSerializer extends Service {
 
 	/**
 	 * Convert a List of LuceneWork into a byte[].

--- a/engine/src/main/java/org/hibernate/search/indexes/spi/DirectoryBasedIndexManager.java
+++ b/engine/src/main/java/org/hibernate/search/indexes/spi/DirectoryBasedIndexManager.java
@@ -23,9 +23,7 @@ import org.hibernate.search.cfg.spi.DirectoryProviderService;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.engine.spi.EntityIndexBinding;
-import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.indexes.impl.PropertiesParseHelper;
-import org.hibernate.search.indexes.serialization.impl.LuceneWorkSerializerImpl;
 import org.hibernate.search.indexes.serialization.spi.LuceneWorkSerializer;
 import org.hibernate.search.indexes.serialization.spi.SerializationProvider;
 import org.hibernate.search.spi.WorkerBuildContext;
@@ -141,25 +139,6 @@ public class DirectoryBasedIndexManager implements IndexManager {
 	@Override
 	public void optimize() {
 		performStreamOperation( OptimizeLuceneWork.INSTANCE, null, false );
-	}
-
-	@Override
-	public LuceneWorkSerializer getSerializer() {
-		if ( serializer == null ) {
-			serializationProvider = requestSerializationProvider();
-			serializer = new LuceneWorkSerializerImpl( serializationProvider, boundSearchIntegrator );
-			log.indexManagerUsesSerializationService( this.indexName, this.serializer.describeSerializer() );
-		}
-		return serializer;
-	}
-
-	private SerializationProvider requestSerializationProvider() {
-		try {
-			return serviceManager.requestService( SerializationProvider.class );
-		}
-		catch (SearchException se) {
-			throw log.serializationProviderNotFoundException( se );
-		}
 	}
 
 	//Not exposed on the IndexManager interface

--- a/engine/src/main/java/org/hibernate/search/indexes/spi/DirectoryBasedIndexManager.java
+++ b/engine/src/main/java/org/hibernate/search/indexes/spi/DirectoryBasedIndexManager.java
@@ -14,11 +14,11 @@ import java.util.concurrent.locks.Lock;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.similarities.Similarity;
-
 import org.hibernate.search.backend.BackendFactory;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.backend.OptimizeLuceneWork;
+import org.hibernate.search.backend.impl.lucene.WorkspaceHolder;
 import org.hibernate.search.backend.spi.BackendQueueProcessor;
 import org.hibernate.search.backend.spi.LuceneIndexingParameters;
 import org.hibernate.search.cfg.Environment;
@@ -52,7 +52,7 @@ public class DirectoryBasedIndexManager implements IndexManager {
 	private String indexName;
 	private DirectoryProvider<?> directoryProvider;
 	private Similarity similarity;
-	private BackendQueueProcessor backend;
+	private WorkspaceHolder workspaceHolder;
 	private OptimizerStrategy optimizer;
 	private LuceneIndexingParameters indexingParameters;
 	private final Set<Class<?>> containedEntityTypes = new HashSet<Class<?>>();
@@ -61,6 +61,7 @@ public class DirectoryBasedIndexManager implements IndexManager {
 	private ExtendedSearchIntegrator boundSearchIntegrator = null;
 	private DirectoryBasedReaderProvider readers = null;
 	private ServiceManager serviceManager;
+	private BackendQueueProcessor backendQueueProcessor;
 
 	@Override
 	public String getIndexName() {
@@ -75,7 +76,7 @@ public class DirectoryBasedIndexManager implements IndexManager {
 	@Override
 	public void destroy() {
 		readers.stop();
-		backend.close();
+		workspaceHolder.close();
 		directoryProvider.stop();
 		if ( serializationProvider != null ) {
 			serviceManager.releaseService( SerializationProvider.class );
@@ -90,13 +91,14 @@ public class DirectoryBasedIndexManager implements IndexManager {
 		this.directoryProvider = createDirectoryProvider( indexName, properties, buildContext );
 		this.indexingParameters = PropertiesParseHelper.extractIndexingPerformanceOptions( properties );
 		this.optimizer = PropertiesParseHelper.getOptimizerStrategy( this, properties, buildContext );
-		this.backend = createBackend( indexName, properties, buildContext );
+		this.workspaceHolder = createWorkspaceHolder( indexName, properties, buildContext );
+		this.backendQueueProcessor = BackendFactory.createBackend( this, buildContext, properties );
 		boolean enlistInTransaction = ConfigurationParseHelper.getBooleanValue(
 				properties,
 				Environment.WORKER_ENLIST_IN_TRANSACTION,
 				false
 		);
-		if ( enlistInTransaction && ! ( backend instanceof BackendQueueProcessor.Transactional ) ) {
+		if ( enlistInTransaction && ! ( backendQueueProcessor instanceof BackendQueueProcessor.Transactional ) ) {
 			// We are expecting to use a transactional worker but the backend is not
 			// this is war!
 			// TODO would be better to have this check in the indexManager factory but we need access to the backend
@@ -122,15 +124,15 @@ public class DirectoryBasedIndexManager implements IndexManager {
 	@Override
 	public void performStreamOperation(LuceneWork singleOperation, IndexingMonitor monitor, boolean forceAsync) {
 		//TODO implement async
-		backend.applyStreamWork( singleOperation, monitor );
+		workspaceHolder.applyStreamWork( singleOperation, monitor );
 	}
 
 	@Override
 	public void performOperations(List<LuceneWork> workList, IndexingMonitor monitor) {
 		if ( log.isDebugEnabled() ) {
-			log.debug( "Sending work to backend of type " + backend.getClass() );
+			log.debug( "Applying work via workspace holder of type " + workspaceHolder.getClass() );
 		}
-		backend.applyWork( workList, monitor );
+		workspaceHolder.applyWork( workList, monitor );
 	}
 
 	@Override
@@ -180,9 +182,14 @@ public class DirectoryBasedIndexManager implements IndexManager {
 		}
 	}
 
-	//Not exposed on the IndexManager interface
+	@Override
 	public BackendQueueProcessor getBackendQueueProcessor() {
-		return backend;
+		return backendQueueProcessor;
+	}
+
+	//Not exposed on the IndexManager interface
+	public WorkspaceHolder getWorkspaceHolder() {
+		return workspaceHolder;
 	}
 
 	//Not exposed on the IndexManager interface
@@ -192,7 +199,7 @@ public class DirectoryBasedIndexManager implements IndexManager {
 
 	//Not exposed on the IndexManager interface
 	public Lock getDirectoryModificationLock() {
-		return backend.getExclusiveWriteLock();
+		return workspaceHolder.getExclusiveWriteLock();
 	}
 
 	//Not exposed on the interface
@@ -212,12 +219,14 @@ public class DirectoryBasedIndexManager implements IndexManager {
 
 	private void triggerWorkspaceReconfiguration() {
 		if ( boundSearchIntegrator != null ) { //otherwise it's too early
-			backend.indexMappingChanged();
+			workspaceHolder.indexMappingChanged();
 		}
 	}
 
-	protected BackendQueueProcessor createBackend(String indexName, Properties cfg, WorkerBuildContext buildContext) {
-		return BackendFactory.createBackend( this, buildContext, cfg );
+	protected WorkspaceHolder createWorkspaceHolder(String indexName, Properties cfg, WorkerBuildContext buildContext) {
+		WorkspaceHolder backend = new WorkspaceHolder();
+		backend.initialize( cfg, buildContext, this );
+		return backend;
 	}
 
 	protected DirectoryBasedReaderProvider createIndexReader(String indexName, Properties cfg, WorkerBuildContext buildContext) {

--- a/engine/src/main/java/org/hibernate/search/indexes/spi/IndexManager.java
+++ b/engine/src/main/java/org/hibernate/search/indexes/spi/IndexManager.java
@@ -12,9 +12,9 @@ import java.util.Set;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.similarities.Similarity;
-
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
+import org.hibernate.search.backend.spi.BackendQueueProcessor;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.indexes.serialization.spi.LuceneWorkSerializer;
 import org.hibernate.search.spi.WorkerBuildContext;
@@ -125,4 +125,6 @@ public interface IndexManager {
 	 */
 	LuceneWorkSerializer getSerializer();
 
+	// TODO: Temporary, remove
+	BackendQueueProcessor getBackendQueueProcessor();
 }

--- a/engine/src/main/java/org/hibernate/search/indexes/spi/IndexManager.java
+++ b/engine/src/main/java/org/hibernate/search/indexes/spi/IndexManager.java
@@ -14,7 +14,6 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.similarities.Similarity;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
-import org.hibernate.search.backend.spi.BackendQueueProcessor;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.indexes.serialization.spi.LuceneWorkSerializer;
 import org.hibernate.search.spi.WorkerBuildContext;
@@ -124,7 +123,4 @@ public interface IndexManager {
 	 * @return the Serializer implementation used for this IndexManager
 	 */
 	LuceneWorkSerializer getSerializer();
-
-	// TODO: Temporary, remove
-	BackendQueueProcessor getBackendQueueProcessor();
 }

--- a/engine/src/main/java/org/hibernate/search/indexes/spi/IndexManager.java
+++ b/engine/src/main/java/org/hibernate/search/indexes/spi/IndexManager.java
@@ -15,7 +15,6 @@ import org.apache.lucene.search.similarities.Similarity;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
-import org.hibernate.search.indexes.serialization.spi.LuceneWorkSerializer;
 import org.hibernate.search.spi.WorkerBuildContext;
 
 /**
@@ -118,9 +117,4 @@ public interface IndexManager {
 	 * To optimize the underlying index. Some implementations might ignore the request, if it doesn't apply to them.
 	 */
 	void optimize();
-
-	/**
-	 * @return the Serializer implementation used for this IndexManager
-	 */
-	LuceneWorkSerializer getSerializer();
 }

--- a/engine/src/main/java/org/hibernate/search/spi/SearchIntegratorBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/spi/SearchIntegratorBuilder.java
@@ -212,7 +212,8 @@ public class SearchIntegratorBuilder {
 
 		QueueingProcessor queueingProcessor = new BatchedQueueingProcessor(
 				documentBuildersIndexedEntities,
-				cfg.getProperties()
+				cfg.getProperties(),
+				buildContext.getAllIndexesManager()
 		);
 		// build worker and back end components
 		factoryState.setWorker( WorkerFactory.createWorker( cfg, buildContext, queueingProcessor ) );

--- a/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
@@ -7,12 +7,6 @@
 
 package org.hibernate.search.util.logging.impl;
 
-import static org.jboss.logging.Logger.Level.DEBUG;
-import static org.jboss.logging.Logger.Level.ERROR;
-import static org.jboss.logging.Logger.Level.INFO;
-import static org.jboss.logging.Logger.Level.TRACE;
-import static org.jboss.logging.Logger.Level.WARN;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -39,6 +33,12 @@ import org.jboss.logging.annotations.FormatWith;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
+
+import static org.jboss.logging.Logger.Level.DEBUG;
+import static org.jboss.logging.Logger.Level.ERROR;
+import static org.jboss.logging.Logger.Level.INFO;
+import static org.jboss.logging.Logger.Level.TRACE;
+import static org.jboss.logging.Logger.Level.WARN;
 
 /**
  * Log abstraction layer for Hibernate Search on top of JBoss Logging.
@@ -521,8 +521,8 @@ public interface Log extends BasicLogger {
 	SearchException duplicateDocumentIdFound(String beanXClassName);
 
 	@LogMessage(level = Level.INFO)
-	@Message(id = 168, value = "Serialization service %2$s being used for index '%1$s'")
-	void indexManagerUsesSerializationService(String indexName, String serializerDescription);
+	@Message(id = 168, value = "Using serialization service %1$s")
+	void usingSerializationService(String serializerDescription);
 
 	@Message(id = 169, value = "FieldBridge '%1$s' does not have a objectToString method: field '%2$s' in '%3$s'" +
 			" The FieldBridge must be a TwoWayFieldBridge or you have to enable the ignoreFieldBridge option when defining a Query")

--- a/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
@@ -874,4 +874,8 @@ public interface Log extends BasicLogger {
 	@Message(id = 288, value = "The configuration property '%s' no longer applies and will be ignored." )
 	void deprecatedConfigurationPropertyIsIgnored(String string);
 
+
+	@LogMessage(level = Level.WARN)
+	@Message(id = 289, value = "The backend name 'lucene' is deprecated. Use 'local' instead")
+	void deprecatedBackendName();
 }

--- a/engine/src/main/resources/META-INF/services/org.hibernate.search.indexes.serialization.spi.LuceneWorkSerializer
+++ b/engine/src/main/resources/META-INF/services/org.hibernate.search.indexes.serialization.spi.LuceneWorkSerializer
@@ -1,0 +1,1 @@
+org.hibernate.search.indexes.serialization.impl.LuceneWorkSerializerImpl

--- a/engine/src/test/java/org/hibernate/search/test/backend/BackendQueueProcessorTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/backend/BackendQueueProcessorTest.java
@@ -6,11 +6,15 @@
  */
 package org.hibernate.search.test.backend;
 
-import org.junit.Test;
+import java.util.Properties;
 
+import org.easymock.classextension.EasyMock;
+import org.hibernate.search.backend.impl.LocalBackendQueueProcessor;
 import org.hibernate.search.backend.impl.blackhole.BlackHoleBackendQueueProcessor;
-import org.hibernate.search.backend.impl.lucene.LuceneBackendQueueProcessor;
 import org.hibernate.search.backend.spi.BackendQueueProcessor;
+import org.hibernate.search.indexes.spi.IndexManager;
+import org.hibernate.search.spi.WorkerBuildContext;
+import org.junit.Test;
 
 /**
  * @author Sanne Grinovero (C) 2011 Red Hat Inc.
@@ -19,12 +23,15 @@ public class BackendQueueProcessorTest {
 
 	@Test
 	public void testCheckingForNullWork() {
-		checkBackendBehaviour( new LuceneBackendQueueProcessor() );
+		checkBackendBehaviour( new LocalBackendQueueProcessor() );
 		checkBackendBehaviour( new BlackHoleBackendQueueProcessor() );
 	}
 
 	private void checkBackendBehaviour(BackendQueueProcessor backend) {
 		try {
+			WorkerBuildContext context = EasyMock.createNiceMock( WorkerBuildContext.class );
+			IndexManager indexManager = EasyMock.createNiceMock( IndexManager.class );
+			backend.initialize( new Properties(), context, indexManager );
 			backend.applyWork( null, null );
 		}
 		catch (IllegalArgumentException e) {

--- a/engine/src/test/java/org/hibernate/search/test/backend/serialization/SerializationProviderMissingTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/backend/serialization/SerializationProviderMissingTest.java
@@ -11,7 +11,7 @@ import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.exception.SearchException;
-import org.hibernate.search.indexes.spi.IndexManager;
+import org.hibernate.search.indexes.serialization.spi.LuceneWorkSerializer;
 import org.hibernate.search.testsupport.TestForIssue;
 import org.hibernate.search.testsupport.junit.SearchFactoryHolder;
 import org.junit.Rule;
@@ -40,8 +40,7 @@ public class SerializationProviderMissingTest {
 		thrown.expectMessage( "hibernate-search-serialization-avro" );
 
 		ExtendedSearchIntegrator searchFactory = factoryHolder.getSearchFactory();
-		IndexManager indexManager = searchFactory.getIndexManagerHolder().getIndexManager( "books" );
-		indexManager.getSerializer();
+		searchFactory.getServiceManager().requestService( LuceneWorkSerializer.class );
 	}
 
 	@Indexed(index = "books")

--- a/engine/src/test/java/org/hibernate/search/test/configuration/BaseConfigurationTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/configuration/BaseConfigurationTest.java
@@ -12,7 +12,7 @@ import org.hibernate.search.annotations.DocumentId;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.backend.impl.lucene.AbstractWorkspaceImpl;
-import org.hibernate.search.backend.impl.lucene.LuceneBackendQueueProcessor;
+import org.hibernate.search.backend.impl.lucene.WorkspaceHolder;
 import org.hibernate.search.cfg.SearchMapping;
 import org.hibernate.search.engine.impl.MutableSearchFactory;
 import org.hibernate.search.engine.spi.EntityIndexBinding;
@@ -28,7 +28,7 @@ public class BaseConfigurationTest {
 	protected static AbstractWorkspaceImpl extractWorkspace(MutableSearchFactory sf, Class<?> type) {
 		EntityIndexBinding indexBindingForEntity = sf.getIndexBinding( type );
 		DirectoryBasedIndexManager indexManager = (DirectoryBasedIndexManager) indexBindingForEntity.getIndexManagers()[0];
-		LuceneBackendQueueProcessor backend = (LuceneBackendQueueProcessor) indexManager.getBackendQueueProcessor();
+		WorkspaceHolder backend = (WorkspaceHolder) indexManager.getWorkspaceHolder();
 		return backend.getIndexResources().getWorkspace();
 	}
 

--- a/engine/src/test/java/org/hibernate/search/test/metadata/DummyIndexManager.java
+++ b/engine/src/test/java/org/hibernate/search/test/metadata/DummyIndexManager.java
@@ -16,7 +16,6 @@ import org.apache.lucene.search.similarities.Similarity;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
-import org.hibernate.search.indexes.serialization.spi.LuceneWorkSerializer;
 import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.indexes.spi.ReaderProvider;
 import org.hibernate.search.spi.WorkerBuildContext;
@@ -88,11 +87,6 @@ class DummyIndexManager implements IndexManager {
 
 	@Override
 	public void optimize() {
-		throw new UnsupportedOperationException( "Not supported in dummy index manager" );
-	}
-
-	@Override
-	public LuceneWorkSerializer getSerializer() {
 		throw new UnsupportedOperationException( "Not supported in dummy index manager" );
 	}
 }

--- a/engine/src/test/java/org/hibernate/search/test/metadata/DummyIndexManager.java
+++ b/engine/src/test/java/org/hibernate/search/test/metadata/DummyIndexManager.java
@@ -15,7 +15,6 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.similarities.Similarity;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
-import org.hibernate.search.backend.spi.BackendQueueProcessor;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.indexes.serialization.spi.LuceneWorkSerializer;
 import org.hibernate.search.indexes.spi.IndexManager;
@@ -94,11 +93,6 @@ class DummyIndexManager implements IndexManager {
 
 	@Override
 	public LuceneWorkSerializer getSerializer() {
-		throw new UnsupportedOperationException( "Not supported in dummy index manager" );
-	}
-
-	@Override
-	public BackendQueueProcessor getBackendQueueProcessor() {
 		throw new UnsupportedOperationException( "Not supported in dummy index manager" );
 	}
 }

--- a/engine/src/test/java/org/hibernate/search/test/metadata/DummyIndexManager.java
+++ b/engine/src/test/java/org/hibernate/search/test/metadata/DummyIndexManager.java
@@ -15,6 +15,7 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.similarities.Similarity;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
+import org.hibernate.search.backend.spi.BackendQueueProcessor;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.indexes.serialization.spi.LuceneWorkSerializer;
 import org.hibernate.search.indexes.spi.IndexManager;
@@ -95,6 +96,9 @@ class DummyIndexManager implements IndexManager {
 	public LuceneWorkSerializer getSerializer() {
 		throw new UnsupportedOperationException( "Not supported in dummy index manager" );
 	}
+
+	@Override
+	public BackendQueueProcessor getBackendQueueProcessor() {
+		throw new UnsupportedOperationException( "Not supported in dummy index manager" );
+	}
 }
-
-

--- a/engine/src/test/java/org/hibernate/search/test/util/impl/LoggingCreationTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/util/impl/LoggingCreationTest.java
@@ -7,7 +7,8 @@
 package org.hibernate.search.test.util.impl;
 
 import org.hibernate.search.exception.AssertionFailure;
-import org.hibernate.search.indexes.serialization.impl.LuceneWorkSerializerImpl;
+import org.hibernate.search.util.logging.impl.Log;
+import org.hibernate.search.util.logging.impl.LoggerFactory;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -23,8 +24,20 @@ public class LoggingCreationTest {
 	@Test
 	public void verifyNullAssertionFailure() {
 		thrown.expect( AssertionFailure.class );
-		thrown.expectMessage( "HSEARCH000224: Non optional parameter named 'provider' was null" );
-		LuceneWorkSerializerImpl serializerImpl = new LuceneWorkSerializerImpl( null, null );
+		thrown.expectMessage( "HSEARCH000224: Non optional parameter named 'bar' was null" );
+
+		new Foo( null );
+	}
+
+	private static class Foo {
+
+		private static Log log = LoggerFactory.make();
+
+		Foo(String bar) {
+			if ( bar == null ) {
+				throw log.parametersShouldNotBeNull( "bar" );
+			}
+		}
 	}
 
 }

--- a/engine/src/test/java/org/hibernate/search/testsupport/backend/GatedLuceneBackend.java
+++ b/engine/src/test/java/org/hibernate/search/testsupport/backend/GatedLuceneBackend.java
@@ -20,7 +20,7 @@ import org.hibernate.search.backend.LuceneWork;
  *
  * @author Sanne Grinovero (C) 2011 Red Hat Inc.
  */
-public class GatedLuceneBackend extends LeakingLuceneBackend {
+public class GatedLuceneBackend extends LeakingLocalBackend {
 
 	public static final AtomicBoolean open = new AtomicBoolean( true );
 

--- a/engine/src/test/java/org/hibernate/search/testsupport/backend/LeakingLocalBackend.java
+++ b/engine/src/test/java/org/hibernate/search/testsupport/backend/LeakingLocalBackend.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
-import org.hibernate.search.backend.impl.lucene.LuceneBackendQueueProcessor;
+import org.hibernate.search.backend.impl.LocalBackendQueueProcessor;
 
 /**
  * This backend wraps the default Lucene backend to leak out the last performed list of work for testing purposes: tests
@@ -20,7 +20,7 @@ import org.hibernate.search.backend.impl.lucene.LuceneBackendQueueProcessor;
  * @author Sanne Grinovero
  *
  */
-public class LeakingLuceneBackend extends LuceneBackendQueueProcessor {
+public class LeakingLocalBackend extends LocalBackendQueueProcessor {
 
 	private static volatile List<LuceneWork> lastProcessedQueue = new ArrayList<LuceneWork>();
 

--- a/engine/src/test/java/org/hibernate/search/testsupport/junit/SearchFactoryHolder.java
+++ b/engine/src/test/java/org/hibernate/search/testsupport/junit/SearchFactoryHolder.java
@@ -13,7 +13,7 @@ import java.util.Properties;
 
 import org.junit.Assert;
 import org.hibernate.search.backend.impl.lucene.AbstractWorkspaceImpl;
-import org.hibernate.search.backend.impl.lucene.LuceneBackendQueueProcessor;
+import org.hibernate.search.backend.impl.lucene.WorkspaceHolder;
 import org.hibernate.search.cfg.SearchMapping;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.engine.service.spi.Service;
@@ -101,7 +101,7 @@ public class SearchFactoryHolder extends ExternalResource {
 	public AbstractWorkspaceImpl extractWorkspace(Class indexedType) {
 		EntityIndexBinding indexBindingForEntity = getSearchFactory().getIndexBinding( indexedType );
 		DirectoryBasedIndexManager indexManager = (DirectoryBasedIndexManager) indexBindingForEntity.getIndexManagers()[0];
-		LuceneBackendQueueProcessor backend = (LuceneBackendQueueProcessor) indexManager.getBackendQueueProcessor();
+		WorkspaceHolder backend = (WorkspaceHolder) indexManager.getWorkspaceHolder();
 		return backend.getIndexResources().getWorkspace();
 	}
 

--- a/integrationtest/jms/src/test/java/org/hibernate/search/test/jms/master/JMSMasterTest.java
+++ b/integrationtest/jms/src/test/java/org/hibernate/search/test/jms/master/JMSMasterTest.java
@@ -40,7 +40,7 @@ import org.hibernate.search.backend.spi.DeleteByQueryLuceneWork;
 import org.hibernate.search.backend.spi.SingularTermDeletionQuery;
 import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.engine.ProjectionConstants;
-import org.hibernate.search.indexes.spi.IndexManager;
+import org.hibernate.search.indexes.serialization.spi.LuceneWorkSerializer;
 import org.hibernate.search.query.engine.spi.HSQuery;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.testsupport.TestConstants;
@@ -161,11 +161,17 @@ public class JMSMasterTest extends SearchTestBase {
 		message.setStringProperty(
 				Environment.INDEX_NAME_JMS_PROPERTY,
 				indexName );
-		IndexManager indexManager = getExtendedSearchIntegrator().getIndexManagerHolder().getIndexManager( indexName );
-		byte[] data = indexManager.getSerializer().toSerializedModel( queue );
-		message.setObject( data );
-		QueueSender sender = getQueueSession().createSender( getMessageQueue() );
-		sender.send( message );
+
+		try {
+			LuceneWorkSerializer luceneWorkSerializer = getExtendedSearchIntegrator().getServiceManager().requestService( LuceneWorkSerializer.class );
+			byte[] data = luceneWorkSerializer.toSerializedModel( queue );
+			message.setObject( data );
+			QueueSender sender = getQueueSession().createSender( getMessageQueue() );
+			sender.send( message );
+		}
+		finally {
+			getExtendedSearchIntegrator().getServiceManager().releaseService( LuceneWorkSerializer.class );
+		}
 	}
 
 	private Queue getMessageQueue() throws Exception {

--- a/integrationtest/jms/src/test/java/org/hibernate/search/test/jms/master/JMSMasterTest.java
+++ b/integrationtest/jms/src/test/java/org/hibernate/search/test/jms/master/JMSMasterTest.java
@@ -288,8 +288,8 @@ public class JMSMasterTest extends SearchTestBase {
 
 	@Override
 	public void configure(Map<String,Object> cfg) {
-		// explicitly set the backend even though lucene is default.
-		cfg.put( "hibernate.search.default." + Environment.WORKER_BACKEND, "lucene" );
+		// explicitly set the backend even though local is default.
+		cfg.put( "hibernate.search.default." + Environment.WORKER_BACKEND, "local" );
 	}
 
 	@Override

--- a/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/util/CheckerLuceneIndex.java
+++ b/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/util/CheckerLuceneIndex.java
@@ -16,7 +16,7 @@ import org.apache.lucene.store.Directory;
 import org.hibernate.Session;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
-import org.hibernate.search.backend.impl.lucene.LuceneBackendQueueProcessor;
+import org.hibernate.search.backend.impl.lucene.WorkspaceHolder;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
 import org.hibernate.search.indexes.spi.IndexManager;
@@ -81,7 +81,7 @@ public class CheckerLuceneIndex {
 	 * might not be graceful (the shutdown is not designed to be recoverable).
 	 */
 	private static void stopBackend(DirectoryBasedIndexManager directoryBasedIndexManager) {
-		LuceneBackendQueueProcessor backendQueueProcessor = (LuceneBackendQueueProcessor) directoryBasedIndexManager.getBackendQueueProcessor();
+		WorkspaceHolder backendQueueProcessor = (WorkspaceHolder) directoryBasedIndexManager.getWorkspaceHolder();
 		backendQueueProcessor.getIndexResources().shutdown();
 	}
 

--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/jms/controller/RegistrationController.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/jms/controller/RegistrationController.java
@@ -20,10 +20,9 @@ import javax.persistence.PersistenceContext;
 
 import org.apache.lucene.search.Query;
 import org.hibernate.search.backend.spi.BackendQueueProcessor;
-import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
+import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.jpa.FullTextEntityManager;
 import org.hibernate.search.jpa.Search;
-import org.hibernate.search.spi.SearchIntegrator;
 import org.hibernate.search.test.integration.jms.DeploymentJmsMasterSlave;
 import org.hibernate.search.test.integration.jms.model.RegisteredMember;
 import org.hibernate.search.util.logging.impl.Log;
@@ -119,9 +118,8 @@ public class RegistrationController {
 		}
 
 		// Check the running backend type
-		SearchIntegrator searchIntegrator = Search.getFullTextEntityManager( em ).getSearchFactory().unwrap( SearchIntegrator.class );
-		DirectoryBasedIndexManager indexManager = (DirectoryBasedIndexManager) searchIntegrator.getIndexManager( "membersIndex" );
-		BackendQueueProcessor backendQueueProcessor = indexManager.getBackendQueueProcessor();
+		ExtendedSearchIntegrator searchIntegrator = Search.getFullTextEntityManager( em ).getSearchFactory().unwrap( ExtendedSearchIntegrator.class );
+		BackendQueueProcessor backendQueueProcessor = searchIntegrator.getIndexManagerHolder().getBackendQueueProcessor( "membersIndex" );
 		final String backendName = backendQueueProcessor.getClass().getName();
 		if ( ! backendName.equals( expectedBackendImplementation ) ) {
 			throw new IllegalStateException( "Not running the expected backend '" + expectedBackendImplementation + "' but running '" + backendName + "'" );

--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/jms/transaction/TransactionalJmsMasterSlave.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/jms/transaction/TransactionalJmsMasterSlave.java
@@ -11,14 +11,14 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import org.hibernate.search.backend.impl.LocalBackendQueueProcessor;
+import org.hibernate.search.backend.jms.impl.JndiJMSBackendQueueProcessor;
+import org.hibernate.search.test.integration.jms.controller.RegistrationController;
+import org.hibernate.search.test.integration.jms.model.RegisteredMember;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.InSequence;
 import org.junit.Assert;
 import org.junit.Test;
-import org.hibernate.search.backend.impl.lucene.LuceneBackendQueueProcessor;
-import org.hibernate.search.backend.jms.impl.JndiJMSBackendQueueProcessor;
-import org.hibernate.search.test.integration.jms.controller.RegistrationController;
-import org.hibernate.search.test.integration.jms.model.RegisteredMember;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -58,7 +58,7 @@ public abstract class TransactionalJmsMasterSlave {
 	@InSequence(0)
 	@OperateOnDeployment("master")
 	public void deleteExistingMembers() throws Exception {
-		memberRegistration.assertConfiguration( "Test Sequence 0", "master", LuceneBackendQueueProcessor.class.getName() );
+		memberRegistration.assertConfiguration( "Test Sequence 0", "master", LocalBackendQueueProcessor.class.getName() );
 		int deletedMembers = memberRegistration.deleteAllMembers();
 		assertEquals( "At the start of the test there should be no members", 0, deletedMembers );
 	}
@@ -97,7 +97,7 @@ public abstract class TransactionalJmsMasterSlave {
 	@InSequence(3)
 	@OperateOnDeployment("master")
 	public void registerNewMemberOnMaster() throws Exception {
-		memberRegistration.assertConfiguration( "Test Sequence 3", "master", LuceneBackendQueueProcessor.class.getName() );
+		memberRegistration.assertConfiguration( "Test Sequence 3", "master", LocalBackendQueueProcessor.class.getName() );
 		RegisteredMember newMember = memberRegistration.getNewMember();
 		assertNull( "A non registered member should have null ID", newMember.getId() );
 
@@ -132,7 +132,7 @@ public abstract class TransactionalJmsMasterSlave {
 	@InSequence(6)
 	@OperateOnDeployment("master")
 	public void searchNewMembersAfterSynchronizationOnMaster() throws Exception {
-		memberRegistration.assertConfiguration( "Test Sequence 6", "master", LuceneBackendQueueProcessor.class.getName() );
+		memberRegistration.assertConfiguration( "Test Sequence 6", "master", LocalBackendQueueProcessor.class.getName() );
 		assertSearchResult( "Davide D'Alto", findAtLeastOneEntity( "Davide" ) );
 		assertSearchResult( "Peter O'Tall", findAtLeastOneEntity( "Peter" ) );
 		assertSearchResult( "Richard Mayhew", findAtLeastOneEntity( "Richard" ) );

--- a/orm/src/test/java/org/hibernate/search/test/backend/WorkQueueLengthConfiguredTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/backend/WorkQueueLengthConfiguredTest.java
@@ -9,7 +9,7 @@ package org.hibernate.search.test.backend;
 
 import java.util.Map;
 
-import org.hibernate.search.backend.impl.lucene.LuceneBackendQueueProcessor;
+import org.hibernate.search.backend.impl.lucene.WorkspaceHolder;
 import org.hibernate.search.engine.spi.EntityIndexBinding;
 import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
 import org.hibernate.search.indexes.spi.IndexManager;
@@ -39,7 +39,7 @@ public class WorkQueueLengthConfiguredTest extends SearchTestBase {
 		IndexManager[] indexManagers = indexBindingForEntity.getIndexManagers();
 		assertEquals( 1, indexManagers.length );
 		DirectoryBasedIndexManager indexManager = (DirectoryBasedIndexManager) indexManagers[0];
-		LuceneBackendQueueProcessor backend = (LuceneBackendQueueProcessor) indexManager.getBackendQueueProcessor();
+		WorkspaceHolder backend = (WorkspaceHolder) indexManager.getWorkspaceHolder();
 		assertEquals( 5, backend.getIndexResources().getMaxQueueLength() );
 	}
 

--- a/orm/src/test/java/org/hibernate/search/test/concurrency/ConcurrentFlushTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/concurrency/ConcurrentFlushTest.java
@@ -25,7 +25,7 @@ import org.hibernate.Transaction;
 import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
-import org.hibernate.search.backend.impl.lucene.LuceneBackendQueueProcessor;
+import org.hibernate.search.backend.impl.LocalBackendQueueProcessor;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.testsupport.TestForIssue;
 import org.junit.Assert;
@@ -46,6 +46,7 @@ public class ConcurrentFlushTest extends SearchTestBase {
 			this.jobNumber = jobNumber;
 		}
 
+		@Override
 		public void run() {
 			Session session = sessionFactory.openSession();
 			try {
@@ -100,7 +101,7 @@ public class ConcurrentFlushTest extends SearchTestBase {
 
 	}
 
-	public static class SlowCountingBackend extends LuceneBackendQueueProcessor {
+	public static class SlowCountingBackend extends LocalBackendQueueProcessor {
 		@Override
 		public void applyWork(List<LuceneWork> workList, IndexingMonitor monitor) {
 			// Increment counter

--- a/orm/src/test/java/org/hibernate/search/test/configuration/CustomBackendTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/CustomBackendTest.java
@@ -41,7 +41,7 @@ public class CustomBackendTest {
 		ftSession.close();
 		IndexManagerHolder allIndexesManager = integrator.getIndexManagerHolder();
 		DirectoryBasedIndexManager indexManager = (DirectoryBasedIndexManager) allIndexesManager.getIndexManager( "org.hibernate.search.test.configuration.BlogEntry" );
-		BackendQueueProcessor backendQueueProcessor = indexManager.getBackendQueueProcessor();
+		BackendQueueProcessor backendQueueProcessor = allIndexesManager.getBackendQueueProcessor( indexManager.getIndexName() );
 		assertEquals( backendType, backendQueueProcessor.getClass() );
 		builder.close();
 	}

--- a/orm/src/test/java/org/hibernate/search/test/configuration/CustomBackendTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/CustomBackendTest.java
@@ -7,9 +7,9 @@
 package org.hibernate.search.test.configuration;
 
 import org.hibernate.search.FullTextSession;
-import org.hibernate.search.backend.spi.BackendQueueProcessor;
+import org.hibernate.search.backend.impl.LocalBackendQueueProcessor;
 import org.hibernate.search.backend.impl.blackhole.BlackHoleBackendQueueProcessor;
-import org.hibernate.search.backend.impl.lucene.LuceneBackendQueueProcessor;
+import org.hibernate.search.backend.spi.BackendQueueProcessor;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.indexes.impl.IndexManagerHolder;
 import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
@@ -26,9 +26,9 @@ public class CustomBackendTest {
 	@Test
 	public void test() {
 		verifyBackendUsage( "blackhole", BlackHoleBackendQueueProcessor.class );
-		verifyBackendUsage( "lucene", LuceneBackendQueueProcessor.class );
+		verifyBackendUsage( "lucene", LocalBackendQueueProcessor.class );
 		verifyBackendUsage( BlackHoleBackendQueueProcessor.class );
-		verifyBackendUsage( LuceneBackendQueueProcessor.class );
+		verifyBackendUsage( LocalBackendQueueProcessor.class );
 	}
 
 	private void verifyBackendUsage(String name, Class<? extends BackendQueueProcessor> backendType) {

--- a/orm/src/test/java/org/hibernate/search/test/configuration/CustomBackendTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/CustomBackendTest.java
@@ -26,6 +26,7 @@ public class CustomBackendTest {
 	@Test
 	public void test() {
 		verifyBackendUsage( "blackhole", BlackHoleBackendQueueProcessor.class );
+		verifyBackendUsage( "local", LocalBackendQueueProcessor.class );
 		verifyBackendUsage( "lucene", LocalBackendQueueProcessor.class );
 		verifyBackendUsage( BlackHoleBackendQueueProcessor.class );
 		verifyBackendUsage( LocalBackendQueueProcessor.class );

--- a/orm/src/test/java/org/hibernate/search/test/configuration/ExclusiveIndexTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/ExclusiveIndexTest.java
@@ -10,20 +10,19 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
-import static org.junit.Assert.assertEquals;
-
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.backend.impl.lucene.AbstractWorkspaceImpl;
 import org.hibernate.search.backend.impl.lucene.ExclusiveIndexWorkspaceImpl;
-import org.hibernate.search.backend.impl.lucene.LuceneBackendQueueProcessor;
 import org.hibernate.search.backend.impl.lucene.SharedIndexWorkspaceImpl;
-import org.hibernate.search.backend.spi.BackendQueueProcessor;
+import org.hibernate.search.backend.impl.lucene.WorkspaceHolder;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.indexes.impl.IndexManagerHolder;
 import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
 import org.hibernate.search.test.util.FullTextSessionBuilder;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Verifies the property exclusive_index_use is properly applied to the backend
@@ -60,10 +59,8 @@ public class ExclusiveIndexTest {
 
 	private void assertExclusiveIsEnabled(IndexManagerHolder allIndexesManager, String indexName, boolean expectExclusive) {
 		DirectoryBasedIndexManager indexManager = (DirectoryBasedIndexManager) allIndexesManager.getIndexManager( indexName );
-		BackendQueueProcessor backendQueueProcessor = indexManager.getBackendQueueProcessor();
-		assertEquals( LuceneBackendQueueProcessor.class, backendQueueProcessor.getClass() );
-		LuceneBackendQueueProcessor backend = (LuceneBackendQueueProcessor) backendQueueProcessor;
-		AbstractWorkspaceImpl workspace = backend.getIndexResources().getWorkspace();
+		WorkspaceHolder workspaceHolder = indexManager.getWorkspaceHolder();
+		AbstractWorkspaceImpl workspace = workspaceHolder.getIndexResources().getWorkspace();
 		if ( expectExclusive ) {
 			assertEquals( ExclusiveIndexWorkspaceImpl.class, workspace.getClass() );
 		}

--- a/orm/src/test/java/org/hibernate/search/test/configuration/norms/StoreNormsTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/norms/StoreNormsTest.java
@@ -26,7 +26,7 @@ import org.hibernate.search.annotations.Store;
 import org.hibernate.search.backend.AddLuceneWork;
 import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.test.SearchTestBase;
-import org.hibernate.search.testsupport.backend.LeakingLuceneBackend;
+import org.hibernate.search.testsupport.backend.LeakingLocalBackend;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
@@ -51,7 +51,7 @@ public class StoreNormsTest extends SearchTestBase {
 		fullTextSession.save( test );
 		tx.commit();
 
-		List<LuceneWork> processedQueue = LeakingLuceneBackend.getLastProcessedQueue();
+		List<LuceneWork> processedQueue = LeakingLocalBackend.getLastProcessedQueue();
 		assertTrue( processedQueue.size() == 1 );
 		AddLuceneWork addLuceneWork = (AddLuceneWork) processedQueue.get( 0 );
 		Document doc = addLuceneWork.getDocument();
@@ -73,7 +73,7 @@ public class StoreNormsTest extends SearchTestBase {
 
 	@Override
 	public void configure(Map<String,Object> cfg) {
-		cfg.put( "hibernate.search.default.worker.backend", LeakingLuceneBackend.class.getName() );
+		cfg.put( "hibernate.search.default.worker.backend", LeakingLocalBackend.class.getName() );
 	}
 
 	@Entity

--- a/orm/src/test/java/org/hibernate/search/test/embedded/depth/DocumentIdContainedInTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/embedded/depth/DocumentIdContainedInTest.java
@@ -14,7 +14,7 @@ import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.search.backend.AddLuceneWork;
 import org.hibernate.search.backend.LuceneWork;
-import org.hibernate.search.testsupport.backend.LeakingLuceneBackend;
+import org.hibernate.search.testsupport.backend.LeakingLocalBackend;
 
 /**
  * @author Sanne Grinovero
@@ -33,7 +33,7 @@ public class DocumentIdContainedInTest extends RecursiveGraphTest {
 		finally {
 			session.close();
 		}
-		List<LuceneWork> processedQueue = LeakingLuceneBackend.getLastProcessedQueue();
+		List<LuceneWork> processedQueue = LeakingLocalBackend.getLastProcessedQueue();
 		// as they resolve to the same Lucene id only one instance will make it to the backend.
 		// (which one is undefined, nobody should use a constant as id)
 		Assert.assertEquals( 1, processedQueue.size() );

--- a/orm/src/test/java/org/hibernate/search/test/embedded/depth/RecursiveGraphTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/embedded/depth/RecursiveGraphTest.java
@@ -23,7 +23,7 @@ import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.spi.SearchIntegratorBuilder;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.test.util.HibernateManualConfiguration;
-import org.hibernate.search.testsupport.backend.LeakingLuceneBackend;
+import org.hibernate.search.testsupport.backend.LeakingLocalBackend;
 import org.hibernate.search.testsupport.setup.SearchConfigurationForTest;
 import org.junit.Test;
 
@@ -50,17 +50,17 @@ public class RecursiveGraphTest extends SearchTestBase {
 		verifyMatchExistsWithName( 2L, "parents.parents.name", "Fulk V of Anjou" );
 		verifyNoMatchExists( "parents.parents.parents.name", "Fulk V of Anjou" );
 
-		LeakingLuceneBackend.reset();
+		LeakingLocalBackend.reset();
 		renamePerson( 1L, "John Lackland" );
 		assertEquals( 1, countWorksDoneOnPerson( 1L ) );
 		assertEquals( 0, countWorksDoneOnPerson( 2L ) );
 
-		LeakingLuceneBackend.reset();
+		LeakingLocalBackend.reset();
 		renamePerson( 2L, "Henry II of New England" );
 		assertEquals( 1, countWorksDoneOnPerson( 1L ) );
 		assertEquals( 1, countWorksDoneOnPerson( 2L ) );
 
-		LeakingLuceneBackend.reset();
+		LeakingLocalBackend.reset();
 		renamePerson( 16L, "Fulk 4th of Anjou" );
 		assertEquals( 1, countWorksDoneOnPerson( 16L ) );
 		assertEquals( 0, countWorksDoneOnPerson( 17L ) );
@@ -179,7 +179,7 @@ public class RecursiveGraphTest extends SearchTestBase {
 	}
 
 	private int countWorksDoneOnPerson(Long pk) {
-		List<LuceneWork> processedQueue = LeakingLuceneBackend.getLastProcessedQueue();
+		List<LuceneWork> processedQueue = LeakingLocalBackend.getLastProcessedQueue();
 		int count = 0;
 		for ( LuceneWork luceneWork : processedQueue ) {
 			Serializable id = luceneWork.getId();
@@ -197,7 +197,7 @@ public class RecursiveGraphTest extends SearchTestBase {
 
 	@Override
 	public void configure(Map<String,Object> cfg) {
-		cfg.put( "hibernate.search.default.worker.backend", LeakingLuceneBackend.class.getName() );
+		cfg.put( "hibernate.search.default.worker.backend", LeakingLocalBackend.class.getName() );
 	}
 
 }

--- a/orm/src/test/java/org/hibernate/search/test/embedded/depth/WorkDoneOnEntitiesTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/embedded/depth/WorkDoneOnEntitiesTest.java
@@ -23,7 +23,7 @@ import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.indexes.IndexReaderAccessor;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.test.SearchTestBase;
-import org.hibernate.search.testsupport.backend.LeakingLuceneBackend;
+import org.hibernate.search.testsupport.backend.LeakingLocalBackend;
 import org.hibernate.testing.SkipForDialect;
 import org.junit.After;
 import org.junit.Before;
@@ -247,13 +247,13 @@ public class WorkDoneOnEntitiesTest extends SearchTestBase {
 			session.save( ps[i] );
 		}
 		transaction.commit();
-		LeakingLuceneBackend.reset();
+		LeakingLocalBackend.reset();
 	}
 
 	@Override
 	@After
 	public void tearDown() throws Exception {
-		LeakingLuceneBackend.reset();
+		LeakingLocalBackend.reset();
 		super.tearDown();
 	}
 
@@ -280,7 +280,7 @@ public class WorkDoneOnEntitiesTest extends SearchTestBase {
 	}
 
 	private int countWorksDoneOnPersonId(Integer pk) {
-		List<LuceneWork> processedQueue = LeakingLuceneBackend.getLastProcessedQueue();
+		List<LuceneWork> processedQueue = LeakingLocalBackend.getLastProcessedQueue();
 		int count = 0;
 		for ( LuceneWork luceneWork : processedQueue ) {
 			Serializable id = luceneWork.getId();
@@ -298,7 +298,7 @@ public class WorkDoneOnEntitiesTest extends SearchTestBase {
 
 	@Override
 	public void configure(Map<String,Object> cfg) {
-		cfg.put( "hibernate.search.default.worker.backend", LeakingLuceneBackend.class.getName() );
+		cfg.put( "hibernate.search.default.worker.backend", LeakingLocalBackend.class.getName() );
 	}
 
 }

--- a/orm/src/test/java/org/hibernate/search/test/engine/SkipIndexingWorkForUnaffectingChangesTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/engine/SkipIndexingWorkForUnaffectingChangesTest.java
@@ -14,7 +14,7 @@ import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
 import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.test.SearchTestBase;
-import org.hibernate.search.testsupport.backend.LeakingLuceneBackend;
+import org.hibernate.search.testsupport.backend.LeakingLocalBackend;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -39,8 +39,8 @@ public class SkipIndexingWorkForUnaffectingChangesTest extends SearchTestBase {
 		getSession().persist( line1 );
 		tx.commit();
 
-		Assert.assertEquals( 1, LeakingLuceneBackend.getLastProcessedQueue().size() );
-		LeakingLuceneBackend.reset();
+		Assert.assertEquals( 1, LeakingLocalBackend.getLastProcessedQueue().size() );
+		LeakingLocalBackend.reset();
 		fullTextSession.clear();
 
 		// now change the BusLine in some way which does not affect the index:
@@ -52,32 +52,32 @@ public class SkipIndexingWorkForUnaffectingChangesTest extends SearchTestBase {
 		busStop.setServiceComments( "please clean the garbage after the football match" );
 		tx.commit();
 		if ( isDirtyCheckEnabled() ) {
-			Assert.assertEquals( 0, LeakingLuceneBackend.getLastProcessedQueue().size() );
+			Assert.assertEquals( 0, LeakingLocalBackend.getLastProcessedQueue().size() );
 		}
 		else {
-			Assert.assertEquals( 1, LeakingLuceneBackend.getLastProcessedQueue().size() );
+			Assert.assertEquals( 1, LeakingLocalBackend.getLastProcessedQueue().size() );
 		}
 
 		// now we make an indexing affecting change in the embedded object only,
 		// parent should still be updated
-		LeakingLuceneBackend.reset();
+		LeakingLocalBackend.reset();
 		fullTextSession.clear();
 		tx = fullTextSession.beginTransaction();
 		busStop = (BusStop) fullTextSession.load( BusStop.class, busStop.getId() );
 		busStop.setRoadName( "Mill Road" );
 		tx.commit();
-		Assert.assertEquals( 1, LeakingLuceneBackend.getLastProcessedQueue().size() );
+		Assert.assertEquals( 1, LeakingLocalBackend.getLastProcessedQueue().size() );
 
-		LeakingLuceneBackend.reset();
+		LeakingLocalBackend.reset();
 		fullTextSession.clear();
 		tx = fullTextSession.beginTransaction();
 		busStop = (BusStop) fullTextSession.load( BusStop.class, busStop.getId() );
 		//verify mutable property dirty-ness:
 		busStop.getStartingDate().setTime( 0L );
 		tx.commit();
-		Assert.assertEquals( 1, LeakingLuceneBackend.getLastProcessedQueue().size() );
+		Assert.assertEquals( 1, LeakingLocalBackend.getLastProcessedQueue().size() );
 
-		LeakingLuceneBackend.reset();
+		LeakingLocalBackend.reset();
 		fullTextSession.close();
 	}
 
@@ -91,7 +91,7 @@ public class SkipIndexingWorkForUnaffectingChangesTest extends SearchTestBase {
 	@Override
 	public void configure(Map<String,Object> cfg) {
 		cfg.put( Environment.ANALYZER_CLASS, SimpleAnalyzer.class.getName() );
-		cfg.put( "hibernate.search.default.worker.backend", LeakingLuceneBackend.class.getName() );
+		cfg.put( "hibernate.search.default.worker.backend", LeakingLocalBackend.class.getName() );
 	}
 
 	protected boolean isDirtyCheckEnabled() {

--- a/orm/src/test/java/org/hibernate/search/test/engine/UsingIdentifierRollbackTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/engine/UsingIdentifierRollbackTest.java
@@ -17,7 +17,7 @@ import org.hibernate.search.test.Document;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.test.embedded.depth.PersonWithBrokenSocialSecurityNumber;
 import org.hibernate.search.test.errorhandling.MockErrorHandler;
-import org.hibernate.search.testsupport.backend.LeakingLuceneBackend;
+import org.hibernate.search.testsupport.backend.LeakingLocalBackend;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -71,7 +71,7 @@ public class UsingIdentifierRollbackTest extends SearchTestBase {
 		s.getTransaction().commit();
 		s.close();
 		Assert.assertNull( "unexpected exception detected", errorHandler.getLastException() );
-		List<LuceneWork> processedQueue = LeakingLuceneBackend.getLastProcessedQueue();
+		List<LuceneWork> processedQueue = LeakingLocalBackend.getLastProcessedQueue();
 		Assert.assertEquals( 1, processedQueue.size() );
 		LuceneWork luceneWork = processedQueue.get( 0 );
 		Assert.assertEquals( "100", luceneWork.getIdInString() );
@@ -87,14 +87,14 @@ public class UsingIdentifierRollbackTest extends SearchTestBase {
 		super.configure( cfg );
 		cfg.put( "hibernate.use_identifier_rollback", "true" );
 		cfg.put( Environment.ERROR_HANDLER, MockErrorHandler.class.getName() );
-		cfg.put( "hibernate.search.default.worker.backend", LeakingLuceneBackend.class.getName() );
+		cfg.put( "hibernate.search.default.worker.backend", LeakingLocalBackend.class.getName() );
 	}
 
 	@Override
 	@After
 	public void tearDown() throws Exception {
 		super.tearDown();
-		LeakingLuceneBackend.reset();
+		LeakingLocalBackend.reset();
 	}
 
 }

--- a/orm/src/test/java/org/hibernate/search/test/engine/optimizations/CollectionUpdateEventsSecondTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/engine/optimizations/CollectionUpdateEventsSecondTest.java
@@ -20,7 +20,7 @@ import org.hibernate.event.spi.LoadEventListener;
 import org.hibernate.search.FullTextQuery;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.backend.LuceneWork;
-import org.hibernate.search.testsupport.backend.LeakingLuceneBackend;
+import org.hibernate.search.testsupport.backend.LeakingLocalBackend;
 import org.hibernate.search.test.util.FullTextSessionBuilder;
 
 import org.junit.Test;
@@ -98,16 +98,16 @@ public class CollectionUpdateEventsSecondTest {
 	 * Counter is reset after invocation.
 	 */
 	private void assertOperationsPerformed(int expectedOperationCount) {
-		List<LuceneWork> lastProcessedQueue = LeakingLuceneBackend.getLastProcessedQueue();
+		List<LuceneWork> lastProcessedQueue = LeakingLocalBackend.getLastProcessedQueue();
 		Assert.assertEquals( expectedOperationCount, lastProcessedQueue.size() );
-		LeakingLuceneBackend.reset();
+		LeakingLocalBackend.reset();
 	}
 
 	private FullTextSessionBuilder createSearchFactory() {
 		loadCountListener = new LoadCountingListener();
 		FullTextSessionBuilder builder = new FullTextSessionBuilder()
 				.setProperty( "hibernate.search.default.worker.backend",
-						LeakingLuceneBackend.class.getName() )
+						LeakingLocalBackend.class.getName() )
 				.addAnnotatedClass( LocationGroup.class )
 				.addAnnotatedClass( Location.class )
 				.addLoadEventListener( loadCountListener );

--- a/orm/src/test/java/org/hibernate/search/test/engine/optimizations/UpdateOperationsTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/engine/optimizations/UpdateOperationsTest.java
@@ -16,7 +16,7 @@ import org.hibernate.Transaction;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.test.Document;
 import org.hibernate.search.test.util.FullTextSessionBuilder;
-import org.hibernate.search.testsupport.backend.LeakingLuceneBackend;
+import org.hibernate.search.testsupport.backend.LeakingLocalBackend;
 import org.hibernate.search.testsupport.optimizer.LeakingOptimizer;
 import org.junit.Test;
 
@@ -39,7 +39,7 @@ public class UpdateOperationsTest {
 		FullTextSessionBuilder fullTextSessionBuilder = createSearchFactory( indexMetadataIsComplete );
 		try {
 			LeakingOptimizer.reset();
-			LeakingLuceneBackend.reset();
+			LeakingLocalBackend.reset();
 			FullTextSession session = fullTextSessionBuilder.openFullTextSession();
 			Assert.assertEquals( 0, LeakingOptimizer.getTotalOperations() );
 
@@ -48,7 +48,7 @@ public class UpdateOperationsTest {
 			tx.commit();
 
 			Assert.assertEquals( 1, LeakingOptimizer.getTotalOperations() );
-			Assert.assertEquals( 1, LeakingLuceneBackend.getLastProcessedQueue().size() );
+			Assert.assertEquals( 1, LeakingLocalBackend.getLastProcessedQueue().size() );
 
 			tx = session.beginTransaction();
 			List list = session.createFullTextQuery( new MatchAllDocsQuery() ).list();
@@ -56,7 +56,7 @@ public class UpdateOperationsTest {
 			doc.setSummary( "Example of what was used in ancient times to read" );
 			tx.commit();
 
-			Assert.assertEquals( 1, LeakingLuceneBackend.getLastProcessedQueue().size() );
+			Assert.assertEquals( 1, LeakingLocalBackend.getLastProcessedQueue().size() );
 			Assert.assertEquals( expectedBackendOperations, LeakingOptimizer.getTotalOperations() );
 		}
 		finally {
@@ -66,7 +66,7 @@ public class UpdateOperationsTest {
 
 	private static FullTextSessionBuilder createSearchFactory(boolean indexMetadataIsComplete) {
 		FullTextSessionBuilder builder = new FullTextSessionBuilder()
-				.setProperty( "hibernate.search.default.worker.backend", LeakingLuceneBackend.class.getName() )
+				.setProperty( "hibernate.search.default.worker.backend", LeakingLocalBackend.class.getName() )
 				.setProperty( "hibernate.search.default.optimizer.implementation", LeakingOptimizer.class.getCanonicalName() )
 				.addAnnotatedClass( Document.class );
 		if ( !indexMetadataIsComplete ) {

--- a/orm/src/test/java/org/hibernate/search/test/engine/optimizations/deletebyterm/DeleteByTermTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/engine/optimizations/deletebyterm/DeleteByTermTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
-import org.hibernate.search.backend.impl.lucene.LuceneBackendQueueProcessor;
+import org.hibernate.search.backend.impl.lucene.WorkspaceHolder;
 import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
 import org.hibernate.search.spi.SearchIntegrator;
 import org.hibernate.search.test.util.FullTextSessionBuilder;
@@ -59,7 +59,7 @@ public class DeleteByTermTest {
 
 		// add a document that matches the entity a identifier to see if it is removed when the entity is removed
 		DirectoryBasedIndexManager indexManager = (DirectoryBasedIndexManager) fts.getSearchFactory().unwrap( SearchIntegrator.class ).getIndexManager( "index1" );
-		LuceneBackendQueueProcessor backendProcessor = (LuceneBackendQueueProcessor) indexManager.getBackendQueueProcessor();
+		WorkspaceHolder backendProcessor = (WorkspaceHolder) indexManager.getWorkspaceHolder();
 		IndexWriter writer = backendProcessor.getIndexResources().getWorkspace().getIndexWriter();
 		Document document = new Document();
 		document.add( new StringField( "id", "1", org.apache.lucene.document.Field.Store.NO ) );
@@ -111,7 +111,7 @@ public class DeleteByTermTest {
 
 		// add a document that matches the entity a identifier to see if it is removed when the entity is removed
 		DirectoryBasedIndexManager indexManager = (DirectoryBasedIndexManager) fts.getSearchFactory().unwrap( SearchIntegrator.class ).getIndexManager( "index1" );
-		LuceneBackendQueueProcessor backendProcessor = (LuceneBackendQueueProcessor) indexManager.getBackendQueueProcessor();
+		WorkspaceHolder backendProcessor = (WorkspaceHolder) indexManager.getWorkspaceHolder();
 		IndexWriter writer = backendProcessor.getIndexResources().getWorkspace().getIndexWriter();
 		Document document = new Document();
 		document.add( new StringField( "id", "1", org.apache.lucene.document.Field.Store.NO ) );

--- a/orm/src/test/java/org/hibernate/search/test/id/EmbeddedIdWithDocumentIdTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/id/EmbeddedIdWithDocumentIdTest.java
@@ -16,7 +16,7 @@ import org.hibernate.search.Search;
 import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.test.SearchTestBase;
-import org.hibernate.search.testsupport.backend.LeakingLuceneBackend;
+import org.hibernate.search.testsupport.backend.LeakingLocalBackend;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -31,7 +31,7 @@ public class EmbeddedIdWithDocumentIdTest extends SearchTestBase {
 
 	@Test
 	public void testFieldBridge() throws Exception {
-		LeakingLuceneBackend.reset();
+		LeakingLocalBackend.reset();
 
 		PersonPK johnDoePk = new PersonPK();
 		johnDoePk.setFirstName( "John" );
@@ -47,7 +47,7 @@ public class EmbeddedIdWithDocumentIdTest extends SearchTestBase {
 		tx.commit();
 		s.clear();
 
-		List<LuceneWork> lastProcessedQueue = LeakingLuceneBackend.getLastProcessedQueue();
+		List<LuceneWork> lastProcessedQueue = LeakingLocalBackend.getLastProcessedQueue();
 		assertEquals( 1, lastProcessedQueue.size() );
 		LuceneWork luceneWork = lastProcessedQueue.get( 0 );
 		assertEquals( "AB123", luceneWork.getIdInString() );
@@ -81,7 +81,7 @@ public class EmbeddedIdWithDocumentIdTest extends SearchTestBase {
 
 	@Override
 	public void configure(Map<String,Object> cfg) {
-		cfg.put( "hibernate.search.default.worker.backend", LeakingLuceneBackend.class.getName() );
+		cfg.put( "hibernate.search.default.worker.backend", LeakingLocalBackend.class.getName() );
 	}
 
 }

--- a/serialization/avro/src/test/java/org/hibernate/search/test/serialization/ConcurrentServiceTest.java
+++ b/serialization/avro/src/test/java/org/hibernate/search/test/serialization/ConcurrentServiceTest.java
@@ -10,9 +10,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.lucene.document.Document;
-import org.junit.Rule;
-import org.junit.Test;
-
 import org.hibernate.search.backend.AddLuceneWork;
 import org.hibernate.search.backend.DeleteLuceneWork;
 import org.hibernate.search.backend.LuceneWork;
@@ -23,6 +20,8 @@ import org.hibernate.search.testsupport.TestForIssue;
 import org.hibernate.search.testsupport.concurrency.ConcurrentRunner;
 import org.hibernate.search.testsupport.concurrency.ConcurrentRunner.TaskFactory;
 import org.hibernate.search.testsupport.junit.SearchFactoryHolder;
+import org.junit.Rule;
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
@@ -68,9 +67,8 @@ public class ConcurrentServiceTest {
 
 	private LuceneWorkSerializer extractSerializer() {
 		return searchFactoryHolder.getSearchFactory()
-				.getIndexManagerHolder()
-				.getIndexManager( RemoteEntity.class.getName() )
-				.getSerializer();
+				.getServiceManager()
+				.requestService( LuceneWorkSerializer.class );
 	}
 
 	private static class SerializingThread implements Runnable {

--- a/serialization/avro/src/test/java/org/hibernate/search/test/serialization/DocValuesSerializationTest.java
+++ b/serialization/avro/src/test/java/org/hibernate/search/test/serialization/DocValuesSerializationTest.java
@@ -15,21 +15,20 @@ import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.util.BytesRef;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-
 import org.hibernate.search.backend.AddLuceneWork;
 import org.hibernate.search.backend.LuceneWork;
+import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.engine.service.impl.StandardServiceManager;
 import org.hibernate.search.engine.service.spi.ServiceManager;
-import org.hibernate.search.indexes.serialization.impl.LuceneWorkSerializerImpl;
 import org.hibernate.search.indexes.serialization.spi.LuceneWorkSerializer;
-import org.hibernate.search.indexes.serialization.spi.SerializationProvider;
 import org.hibernate.search.test.util.SerializationTestHelper;
 import org.hibernate.search.testsupport.TestForIssue;
 import org.hibernate.search.testsupport.junit.SearchFactoryHolder;
+import org.hibernate.search.testsupport.setup.BuildContextForTest;
 import org.hibernate.search.testsupport.setup.SearchConfigurationForTest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * @author Hardy Ferentschik
@@ -44,14 +43,21 @@ public class DocValuesSerializationTest {
 
 	@Before
 	public void setUp() {
-		ServiceManager serviceManager = new StandardServiceManager(
+		ServiceManager serviceManager = getTestServiceManager();
+		workSerializer = serviceManager.requestService( LuceneWorkSerializer.class );
+	}
+
+	private ServiceManager getTestServiceManager() {
+		SearchConfigurationForTest searchConfiguration = new SearchConfigurationForTest();
+		return new StandardServiceManager(
 				new SearchConfigurationForTest(),
-				null
-		);
-		SerializationProvider serializationProvider = serviceManager.requestService( SerializationProvider.class );
-		workSerializer = new LuceneWorkSerializerImpl(
-				serializationProvider,
-				searchFactoryHolder.getSearchFactory()
+				new BuildContextForTest( searchConfiguration ) {
+
+					@Override
+					public ExtendedSearchIntegrator getUninitializedSearchIntegrator() {
+						return searchFactoryHolder.getSearchFactory();
+					};
+				}
 		);
 	}
 

--- a/serialization/avro/src/test/java/org/hibernate/search/test/serialization/ProtocolBackwardCompatibilityTest.java
+++ b/serialization/avro/src/test/java/org/hibernate/search/test/serialization/ProtocolBackwardCompatibilityTest.java
@@ -33,10 +33,6 @@ import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.util.AttributeImpl;
 import org.apache.lucene.util.BytesRef;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-
 import org.hibernate.search.backend.AddLuceneWork;
 import org.hibernate.search.backend.DeleteLuceneWork;
 import org.hibernate.search.backend.FlushLuceneWork;
@@ -44,17 +40,20 @@ import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.backend.OptimizeLuceneWork;
 import org.hibernate.search.backend.PurgeAllLuceneWork;
 import org.hibernate.search.backend.UpdateLuceneWork;
+import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.engine.service.impl.StandardServiceManager;
 import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.indexes.serialization.avro.impl.KnownProtocols;
 import org.hibernate.search.indexes.serialization.impl.CopyTokenStream;
-import org.hibernate.search.indexes.serialization.impl.LuceneWorkSerializerImpl;
 import org.hibernate.search.indexes.serialization.spi.LuceneWorkSerializer;
-import org.hibernate.search.indexes.serialization.spi.SerializationProvider;
 import org.hibernate.search.test.util.SerializationTestHelper;
 import org.hibernate.search.testsupport.TestConstants;
 import org.hibernate.search.testsupport.junit.SearchFactoryHolder;
+import org.hibernate.search.testsupport.setup.BuildContextForTest;
 import org.hibernate.search.testsupport.setup.SearchConfigurationForTest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * This tests backwards compatibility between Avro protocol versions.
@@ -72,16 +71,8 @@ public class ProtocolBackwardCompatibilityTest {
 
 	@Before
 	public void setUp() throws Exception {
-		ServiceManager serviceManager = new StandardServiceManager(
-				new SearchConfigurationForTest(),
-				null
-		);
-		SerializationProvider serializationProvider = serviceManager.requestService( SerializationProvider.class );
-
-		luceneWorkSerializer = new LuceneWorkSerializerImpl(
-				serializationProvider,
-				searchFactoryHolder.getSearchFactory()
-		);
+		ServiceManager serviceManager = getTestServiceManager();
+		luceneWorkSerializer = serviceManager.requestService( LuceneWorkSerializer.class );
 
 		// check target directory -
 		// we always write out a serialized version of a work list supported by the latest protocol
@@ -91,6 +82,20 @@ public class ProtocolBackwardCompatibilityTest {
 		workList.addAll( buildV11Works() );
 		workList.addAll( buildV12Works() );
 		serializeWithAvro( workList );
+	}
+
+	private ServiceManager getTestServiceManager() {
+		SearchConfigurationForTest searchConfiguration = new SearchConfigurationForTest();
+		return new StandardServiceManager(
+				new SearchConfigurationForTest(),
+				new BuildContextForTest( searchConfiguration ) {
+
+					@Override
+					public ExtendedSearchIntegrator getUninitializedSearchIntegrator() {
+						return searchFactoryHolder.getSearchFactory();
+					};
+				}
+		);
 	}
 
 	@Test


### PR DESCRIPTION
@Sanne, @hferentschik This PR does the untangling of `(DirectoryBased)IndexManager` and `BackendQueueProcessor` we discussed. Responsibilities are much nicer defined that way and it will e.g. allow to use the ES index manager via JMS without further changes in the new ES index manager being required.

On a tangent this change also allowed to remove some methods from `BQP` which did not really make sense there (lock handling).

Of course it's a braking change to existing `IndexManager` and `BackendQueueProcessor` implementations. Not sure how much that is in reality as I'd expect those contracts only to be implemented by rather advanced integrators?

Anyways, let me know what you think. Maybe it's not as overwhelming as the ES PR :)