### PR TITLE
Testsuite leaks and windows build problems

### DIFF
--- a/backends/jgroups/src/test/java/org/hibernate/search/test/jgroups/common/MultipleSessionsSearchTestCase.java
+++ b/backends/jgroups/src/test/java/org/hibernate/search/test/jgroups/common/MultipleSessionsSearchTestCase.java
@@ -94,7 +94,7 @@ public abstract class MultipleSessionsSearchTestCase extends SearchTestBase {
 		HashMap<String, Object> slaveConfiguration = new HashMap<String,Object>();
 		configureSlave( slaveConfiguration );
 		TestConfiguration slaveTestConfiguration = new ImmutableTestConfiguration( slaveConfiguration, getAnnotatedClasses() );
-		slaveResources = new DefaultTestResourceManager( slaveTestConfiguration );
+		slaveResources = new DefaultTestResourceManager( slaveTestConfiguration, this.getClass() );
 		slaveResources.openSessionFactory();
 	}
 

--- a/engine/src/test/java/org/hibernate/search/test/jmx/MultipleStatisticsMBeanTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/jmx/MultipleStatisticsMBeanTest.java
@@ -6,8 +6,10 @@
  */
 package org.hibernate.search.test.jmx;
 
-import java.io.File;
+import java.io.IOException;
 import java.lang.management.ManagementFactory;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanServer;
@@ -36,20 +38,30 @@ import static org.junit.Assert.fail;
  */
 @TestForIssue(jiraKey = "HSEARCH-1026")
 public class MultipleStatisticsMBeanTest {
-	private static File simpleJndiDir;
+	private static Path simpleJndiDir;
 	private static MBeanServer mbeanServer;
 
 	@BeforeClass
 	public static void beforeClass() {
-		File targetDir = TestConstants.getTargetDir( MultipleStatisticsMBeanTest.class );
-		simpleJndiDir = new File( targetDir, "simpleJndi" );
-		simpleJndiDir.mkdir();
+		Path targetDir = TestConstants.getTargetDir( MultipleStatisticsMBeanTest.class );
+		simpleJndiDir = targetDir.resolve( "simpleJndi" );
+		try {
+			Files.createDirectory( simpleJndiDir );
+		}
+		catch (IOException e) {
+			throw new RuntimeException( e );
+		}
 		mbeanServer = ManagementFactory.getPlatformMBeanServer();
 	}
 
 	@AfterClass
 	public static void afterClass() {
-		simpleJndiDir.delete();
+		try {
+			Files.delete( simpleJndiDir );
+		}
+		catch (IOException e) {
+			throw new RuntimeException( e );
+		}
 	}
 
 	@Test
@@ -117,7 +129,7 @@ public class MultipleStatisticsMBeanTest {
 		SearchConfigurationForTest configuration = new SearchConfigurationForTest()
 				.addProperty( "hibernate.session_factory_name", "java:comp/SessionFactory" )
 				.addProperty( "hibernate.jndi.class", "org.osjava.sj.SimpleContextFactory" )
-				.addProperty( "hibernate.jndi.org.osjava.sj.root", simpleJndiDir.getAbsolutePath() )
+				.addProperty( "hibernate.jndi.org.osjava.sj.root", simpleJndiDir.toAbsolutePath().toString() )
 				.addProperty( "hibernate.jndi.org.osjava.sj.jndi.shared", "true" )
 				.addProperty( Environment.JMX_ENABLED, "true" );
 

--- a/engine/src/test/java/org/hibernate/search/test/jmx/MultipleStatisticsMBeanTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/jmx/MultipleStatisticsMBeanTest.java
@@ -26,7 +26,6 @@ import org.hibernate.search.jmx.StatisticsInfoMBean;
 import org.hibernate.search.jmx.impl.JMXRegistrar;
 import org.hibernate.search.spi.SearchIntegratorBuilder;
 import org.hibernate.search.spi.SearchIntegrator;
-import org.hibernate.search.testsupport.TestConstants;
 import org.hibernate.search.testsupport.TestForIssue;
 
 import static org.junit.Assert.assertEquals;
@@ -43,14 +42,7 @@ public class MultipleStatisticsMBeanTest {
 
 	@BeforeClass
 	public static void beforeClass() {
-		Path targetDir = TestConstants.getTargetDir( MultipleStatisticsMBeanTest.class );
-		simpleJndiDir = targetDir.resolve( "simpleJndi" );
-		try {
-			Files.createDirectory( simpleJndiDir );
-		}
-		catch (IOException e) {
-			throw new RuntimeException( e );
-		}
+		simpleJndiDir = SimpleJNDIHelper.makeTestingJndiDirectory( MultipleStatisticsMBeanTest.class );
 		mbeanServer = ManagementFactory.getPlatformMBeanServer();
 	}
 
@@ -114,7 +106,6 @@ public class MultipleStatisticsMBeanTest {
 		String objectName = JMXRegistrar.buildMBeanName( StatisticsInfoMBean.STATISTICS_MBEAN_OBJECT_NAME, suffix );
 		ObjectName statisticsBeanObjectName = new ObjectName( objectName );
 
-
 		ObjectInstance mBean = null;
 		try {
 			mBean = mbeanServer.getObjectInstance( statisticsBeanObjectName );
@@ -127,11 +118,9 @@ public class MultipleStatisticsMBeanTest {
 
 	private SearchIntegrator createSearchIntegratorUsingJndiPrefix(String suffix) {
 		SearchConfigurationForTest configuration = new SearchConfigurationForTest()
-				.addProperty( "hibernate.session_factory_name", "java:comp/SessionFactory" )
-				.addProperty( "hibernate.jndi.class", "org.osjava.sj.SimpleContextFactory" )
-				.addProperty( "hibernate.jndi.org.osjava.sj.root", simpleJndiDir.toAbsolutePath().toString() )
-				.addProperty( "hibernate.jndi.org.osjava.sj.jndi.shared", "true" )
-				.addProperty( Environment.JMX_ENABLED, "true" );
+				.addProperty( Environment.JMX_ENABLED, "true" )
+				.addProperty( "hibernate.session_factory_name", "java:comp/SessionFactory" );
+		SimpleJNDIHelper.enableSimpleJndi( configuration, simpleJndiDir );
 
 		if ( suffix != null ) {
 			configuration.addProperty( Environment.JMX_BEAN_SUFFIX, suffix );

--- a/engine/src/test/java/org/hibernate/search/test/jmx/SimpleJNDIHelper.java
+++ b/engine/src/test/java/org/hibernate/search/test/jmx/SimpleJNDIHelper.java
@@ -1,0 +1,58 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.jmx;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Properties;
+
+import org.hibernate.search.cfg.spi.SearchConfiguration;
+import org.hibernate.search.testsupport.TestConstants;
+
+/**
+ * A common place for helper methods useful for all tests using SimpleJNDI
+ * @author Sanne Grinovero
+ */
+class SimpleJNDIHelper {
+
+	private SimpleJNDIHelper() {
+		//not to be constructed
+	}
+
+	/**
+	 * @param testClass the current test class is needed to define were to best store the temporary data
+	 * @return the Path for SimpleJNDI to store its data
+	 */
+	public static Path makeTestingJndiDirectory(Class<?> testClass) {
+		Path targetDir = TestConstants.getTargetDir( testClass );
+		Path simpleJndiDir = targetDir.resolve( "simpleJndi" );
+		if ( ! Files.exists( simpleJndiDir) ) {
+			try {
+				Files.createDirectory( simpleJndiDir );
+			}
+			catch (IOException e) {
+				throw new RuntimeException( e );
+			}
+		}
+		return simpleJndiDir;
+	}
+
+	public static void enableSimpleJndi(SearchConfiguration configuration, Path jndiStorage) {
+		Properties p = configuration.getProperties();
+		enableSimpleJndi( p, jndiStorage );
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	public static void enableSimpleJndi(Map p, Path jndiStorage) {
+		p.put( "hibernate.jndi.class", "org.osjava.sj.SimpleContextFactory" );
+		p.put( "hibernate.jndi.org.osjava.sj.root", jndiStorage.toAbsolutePath().toString() );
+		p.put( "hibernate.jndi.org.osjava.sj.jndi.shared", "true" );
+	}
+
+}

--- a/integrationtest/narayana/src/test/java/org/hibernate/search/test/integration/jbossjta/JBossTSIT.java
+++ b/integrationtest/narayana/src/test/java/org/hibernate/search/test/integration/jbossjta/JBossTSIT.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.test.integration.jbossjta;
 
-import java.io.File;
 import java.util.HashMap;
 import java.util.List;
 
@@ -30,8 +29,6 @@ import org.hibernate.search.jpa.Search;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.test.integration.jbossjta.infra.JBossTADataSourceBuilder;
 import org.hibernate.search.test.integration.jbossjta.infra.PersistenceUnitInfoBuilder;
-import org.hibernate.search.testsupport.TestConstants;
-import org.hibernate.search.util.impl.FileHelper;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -46,15 +43,12 @@ import com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionManagerImpl
 public class JBossTSIT {
 
 	private static EntityManagerFactory factory;
-	public static File tempDirectory = new File( TestConstants.getTargetDir( JBossTSIT.class ) + "/h2" );
 
 	@BeforeClass
 	public static void setUp() throws Exception {
-		FileHelper.delete( tempDirectory );
-		tempDirectory.mkdir();
 
 		//DataSource configuration
-		final String url = "jdbc:h2:file:" + tempDirectory.getAbsolutePath() + "/h2db";
+		final String url = "jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1";
 		final String user = "sa";
 		final String password = "";
 
@@ -101,7 +95,6 @@ public class JBossTSIT {
 		if ( factory != null ) {
 			factory.close();
 		}
-		FileHelper.delete( tempDirectory );
 	}
 
 	@Test

--- a/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/TestRunnerArquillian.java
+++ b/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/TestRunnerArquillian.java
@@ -6,9 +6,9 @@
  */
 package org.hibernate.search.test.performance;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.nio.file.Path;
 import java.util.Map.Entry;
 import java.util.Properties;
 
@@ -64,8 +64,8 @@ public class TestRunnerArquillian {
 	}
 
 	private static StringAsset reportsOutputDirectory() throws IOException {
-		File path = TestConstants.getTargetDir( TestRunnerArquillian.class );
-		String absolutePath = path.getAbsolutePath();
+		Path path = TestConstants.getTargetDir( TestRunnerArquillian.class );
+		String absolutePath = path.toAbsolutePath().toString();
 		//Use Properties to make sure we encode the output correctly,
 		//especially tricky to deal with escaping of paths:
 		Properties runnerProperties = new Properties();

--- a/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/scenario/TestReporter.java
+++ b/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/scenario/TestReporter.java
@@ -19,7 +19,6 @@ import static org.hibernate.search.test.performance.scenario.TestContext.VERBOSE
 import static org.hibernate.search.test.performance.util.Util.runGarbageCollectorAndWait;
 
 import java.io.BufferedWriter;
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -29,6 +28,8 @@ import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Date;
 import java.util.Map.Entry;
 import java.util.Properties;
@@ -160,11 +161,12 @@ public class TestReporter {
 
 	private static PrintStream createOutputStream(String testScenarioName) {
 		try {
-			File targetDir = getTargetDir();
-			File reportFile = new File( targetDir, "report-" + testScenarioName + "-" + DateFormatUtils.format( new Date(), "yyyy-MM-dd-HH'h'mm'm'" ) + ".txt" );
+			Path targetDir = getTargetDir();
+			String reportFileName = "report-" + testScenarioName + "-" + DateFormatUtils.format( new Date(), "yyyy-MM-dd-HH'h'mm'm'" ) + ".txt";
+			Path reportFile = targetDir.resolve( reportFileName );
 
 			final OutputStream std = System.out;
-			final OutputStream file = new PrintStream( new FileOutputStream( reportFile ), true, "UTF-8" );
+			final OutputStream file = new PrintStream( new FileOutputStream( reportFile.toFile() ), true, "UTF-8" );
 			final OutputStream stream = new OutputStream() {
 
 				@Override
@@ -191,7 +193,7 @@ public class TestReporter {
 		}
 	}
 
-	private static File getTargetDir() {
+	private static Path getTargetDir() {
 		InputStream runnerPropertiesStream = TestReporter.class.getResourceAsStream( "/" + RUNNER_PROPERTIES );
 		if ( runnerPropertiesStream != null ) {
 			Properties runnerProperties = new Properties();
@@ -201,7 +203,7 @@ public class TestReporter {
 			catch (IOException e) {
 				throw new RuntimeException( e );
 			}
-			return new File( runnerProperties.getProperty( TARGET_DIR_KEY ) );
+			return Paths.get( runnerProperties.getProperty( TARGET_DIR_KEY ) );
 		}
 		else {
 			return TestConstants.getTargetDir( TestReporter.class );

--- a/integrationtest/sandbox/src/test/java/org/hibernate/search/test/performance/reader/ReaderPerformanceTestCase.java
+++ b/integrationtest/sandbox/src/test/java/org/hibernate/search/test/performance/reader/ReaderPerformanceTestCase.java
@@ -64,7 +64,7 @@ public abstract class ReaderPerformanceTestCase extends SearchTestBase {
 	@After
 	public void tearDown() throws Exception {
 		super.tearDown();
-		String indexBase = TestConstants.getIndexDirectory( SearchTestBase.class );
+		String indexBase = TestConstants.getIndexDirectory( ReaderPerformanceTestCase.class );
 		File indexDir = new File(indexBase);
 		FileHelper.delete( indexDir );
 	}

--- a/orm/src/test/java/org/hibernate/search/test/DefaultTestResourceManager.java
+++ b/orm/src/test/java/org/hibernate/search/test/DefaultTestResourceManager.java
@@ -65,9 +65,9 @@ public final class DefaultTestResourceManager implements TestResourceManager {
 	private SearchFactory searchFactory;
 	private Map<String,Object> configurationSettings;
 
-	public DefaultTestResourceManager(TestConfiguration test) {
+	public DefaultTestResourceManager(TestConfiguration test, Class currentTestModuleClass) {
 		this.test = test;
-		this.baseIndexDir = createBaseIndexDir();
+		this.baseIndexDir = createBaseIndexDir( currentTestModuleClass );
 	}
 
 	@Override
@@ -217,13 +217,13 @@ public final class DefaultTestResourceManager implements TestResourceManager {
 		searchFactory = null;
 	}
 
-	private Path createBaseIndexDir() {
+	private Path createBaseIndexDir(Class currentTestModuleClass) {
 		// Make sure no directory is ever reused across the test suite as Windows might not be able
 		// to delete the files after usage. See also
 		// http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4715154
-		String shortTestName = this.getClass().getSimpleName() + "-" + UUID.randomUUID().toString().substring( 0, 8 );
+		String shortTestName = currentTestModuleClass.getSimpleName() + "-" + UUID.randomUUID().toString().substring( 0, 8 );
 
-		return Paths.get( TestConstants.getIndexDirectory( this.getClass() ), shortTestName );
+		return Paths.get( TestConstants.getIndexDirectory( currentTestModuleClass ), shortTestName );
 	}
 
 	private static class RollbackWork implements Work {

--- a/orm/src/test/java/org/hibernate/search/test/DefaultTestResourceManager.java
+++ b/orm/src/test/java/org/hibernate/search/test/DefaultTestResourceManager.java
@@ -6,9 +6,9 @@
  */
 package org.hibernate.search.test;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.HashMap;
@@ -56,7 +56,7 @@ public final class DefaultTestResourceManager implements TestResourceManager {
 	private static final Log log = LoggerFactory.make();
 
 	private final TestConfiguration test;
-	private final File baseIndexDir;
+	private final Path baseIndexDir;
 
 	/* Each of the following fields needs to be cleaned up on close */
 	private SessionFactoryImplementor sessionFactory;
@@ -193,7 +193,7 @@ public final class DefaultTestResourceManager implements TestResourceManager {
 
 	@Override
 	public Path getBaseIndexDir() {
-		return baseIndexDir.toPath();
+		return baseIndexDir;
 	}
 
 	public void defaultTearDown() throws Exception {
@@ -217,16 +217,13 @@ public final class DefaultTestResourceManager implements TestResourceManager {
 		searchFactory = null;
 	}
 
-	private File createBaseIndexDir() {
+	private Path createBaseIndexDir() {
 		// Make sure no directory is ever reused across the test suite as Windows might not be able
 		// to delete the files after usage. See also
 		// http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4715154
 		String shortTestName = this.getClass().getSimpleName() + "-" + UUID.randomUUID().toString().substring( 0, 8 );
 
-		// the constructor File(File, String) is broken too, see :
-		// http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=5066567
-		// So make sure to use File(String, String) in this case as TestConstants works with absolute paths!
-		return new File( TestConstants.getIndexDirectory( this.getClass() ), shortTestName );
+		return Paths.get( TestConstants.getIndexDirectory( this.getClass() ), shortTestName );
 	}
 
 	private static class RollbackWork implements Work {

--- a/orm/src/test/java/org/hibernate/search/test/SearchTestBase.java
+++ b/orm/src/test/java/org/hibernate/search/test/SearchTestBase.java
@@ -111,7 +111,7 @@ public abstract class SearchTestBase implements TestResourceManager, TestConfigu
 	// synchronized due to lazy initialization
 	private synchronized DefaultTestResourceManager getTestResourceManager() {
 		if ( testResourceManager == null ) {
-			testResourceManager = new DefaultTestResourceManager( this );
+			testResourceManager = new DefaultTestResourceManager( this, this.getClass() );
 		}
 		return testResourceManager;
 	}

--- a/orm/src/test/java/org/hibernate/search/test/jmx/IndexControlMBeanTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/jmx/IndexControlMBeanTest.java
@@ -6,9 +6,7 @@
  */
 package org.hibernate.search.test.jmx;
 
-import java.io.IOException;
 import java.lang.management.ManagementFactory;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Hashtable;
@@ -34,7 +32,6 @@ import org.hibernate.search.Search;
 import org.hibernate.search.jmx.IndexControlMBean;
 import org.hibernate.search.jmx.StatisticsInfoMBean;
 import org.hibernate.search.test.SearchTestBase;
-import org.hibernate.search.testsupport.TestConstants;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -136,23 +133,10 @@ public class IndexControlMBeanTest extends SearchTestBase {
 
 	@Override
 	public void configure(Map<String,Object> cfg) {
-		Path targetDir = TestConstants.getTargetDir( IndexControlMBeanTest.class );
-		Path simpleJndiDir = targetDir.resolve( "simpleJndi" );
-		if ( ! Files.exists( simpleJndiDir) ) {
-			try {
-				Files.createDirectory( simpleJndiDir );
-			}
-			catch (IOException e) {
-				throw new RuntimeException( e );
-			}
-		}
-
+		Path simpleJndiDir = SimpleJNDIHelper.makeTestingJndiDirectory( IndexControlMBeanTest.class );
+		SimpleJNDIHelper.enableSimpleJndi( cfg, simpleJndiDir );
 		cfg.put( "hibernate.session_factory_name", "java:comp/SessionFactory" );
-		cfg.put( "hibernate.jndi.class", "org.osjava.sj.SimpleContextFactory" );
 		cfg.put( "hibernate.jndi.org.osjava.sj.factory", "org.hibernate.search.test.jmx.IndexControlMBeanTest$CustomContextFactory" );
-		cfg.put( "hibernate.jndi.org.osjava.sj.root", simpleJndiDir.toAbsolutePath().toString() );
-		cfg.put( "hibernate.jndi.org.osjava.sj.jndi.shared", "true" );
-
 		cfg.put( "hibernate.search.indexing_strategy", "manual" );
 		cfg.put( Environment.JMX_ENABLED, "true" );
 	}

--- a/orm/src/test/java/org/hibernate/search/test/jmx/IndexControlMBeanTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/jmx/IndexControlMBeanTest.java
@@ -6,8 +6,10 @@
  */
 package org.hibernate.search.test.jmx;
 
-import java.io.File;
+import java.io.IOException;
 import java.lang.management.ManagementFactory;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Map;
@@ -134,14 +136,21 @@ public class IndexControlMBeanTest extends SearchTestBase {
 
 	@Override
 	public void configure(Map<String,Object> cfg) {
-		File targetDir = TestConstants.getTargetDir( IndexControlMBeanTest.class );
-		File simpleJndiDir = new File( targetDir, "simpleJndi" );
-		simpleJndiDir.mkdir();
+		Path targetDir = TestConstants.getTargetDir( IndexControlMBeanTest.class );
+		Path simpleJndiDir = targetDir.resolve( "simpleJndi" );
+		if ( ! Files.exists( simpleJndiDir) ) {
+			try {
+				Files.createDirectory( simpleJndiDir );
+			}
+			catch (IOException e) {
+				throw new RuntimeException( e );
+			}
+		}
 
 		cfg.put( "hibernate.session_factory_name", "java:comp/SessionFactory" );
 		cfg.put( "hibernate.jndi.class", "org.osjava.sj.SimpleContextFactory" );
 		cfg.put( "hibernate.jndi.org.osjava.sj.factory", "org.hibernate.search.test.jmx.IndexControlMBeanTest$CustomContextFactory" );
-		cfg.put( "hibernate.jndi.org.osjava.sj.root", simpleJndiDir.getAbsolutePath() );
+		cfg.put( "hibernate.jndi.org.osjava.sj.root", simpleJndiDir.toAbsolutePath().toString() );
 		cfg.put( "hibernate.jndi.org.osjava.sj.jndi.shared", "true" );
 
 		cfg.put( "hibernate.search.indexing_strategy", "manual" );

--- a/orm/src/test/java/org/hibernate/search/test/jmx/IndexControlMBeanWithSuffixTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/jmx/IndexControlMBeanWithSuffixTest.java
@@ -6,8 +6,10 @@
  */
 package org.hibernate.search.test.jmx;
 
-import java.io.File;
+import java.io.IOException;
 import java.lang.management.ManagementFactory;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 
 import javax.management.MBeanServer;
@@ -70,14 +72,21 @@ public class IndexControlMBeanWithSuffixTest extends SearchTestBase {
 
 	@Override
 	public void configure(Map<String,Object> cfg) {
-		File targetDir = TestConstants.getTargetDir( IndexControlMBeanWithSuffixTest.class );
-		File simpleJndiDir = new File( targetDir, "simpleJndi" );
-		simpleJndiDir.mkdir();
+		Path targetDir = TestConstants.getTargetDir( IndexControlMBeanWithSuffixTest.class );
+		Path simpleJndiDir = targetDir.resolve( "simpleJndi" );
+		if ( ! Files.exists( simpleJndiDir) ) {
+			try {
+				Files.createDirectory( simpleJndiDir );
+			}
+			catch (IOException e) {
+				throw new RuntimeException( e );
+			}
+		}
 
 		cfg.put( "hibernate.session_factory_name", "java:comp/SessionFactory" );
 		cfg.put( "hibernate.jndi.class", "org.osjava.sj.SimpleContextFactory" );
 		cfg.put( "hibernate.jndi.org.osjava.sj.factory", "org.hibernate.search.test.jmx.IndexControlMBeanTest$CustomContextFactory" );
-		cfg.put( "hibernate.jndi.org.osjava.sj.root", simpleJndiDir.getAbsolutePath() );
+		cfg.put( "hibernate.jndi.org.osjava.sj.root", simpleJndiDir.toAbsolutePath().toString() );
 		cfg.put( "hibernate.jndi.org.osjava.sj.jndi.shared", "true" );
 
 		cfg.put( "hibernate.search.indexing_strategy", "manual" );

--- a/orm/src/test/java/org/hibernate/search/test/jmx/IndexControlMBeanWithSuffixTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/jmx/IndexControlMBeanWithSuffixTest.java
@@ -6,9 +6,7 @@
  */
 package org.hibernate.search.test.jmx;
 
-import java.io.IOException;
 import java.lang.management.ManagementFactory;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 
@@ -19,7 +17,6 @@ import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.jmx.IndexControlMBean;
 import org.hibernate.search.jmx.impl.JMXRegistrar;
 import org.hibernate.search.test.SearchTestBase;
-import org.hibernate.search.testsupport.TestConstants;
 import org.hibernate.search.testsupport.TestForIssue;
 import org.junit.After;
 import org.junit.Before;
@@ -72,23 +69,10 @@ public class IndexControlMBeanWithSuffixTest extends SearchTestBase {
 
 	@Override
 	public void configure(Map<String,Object> cfg) {
-		Path targetDir = TestConstants.getTargetDir( IndexControlMBeanWithSuffixTest.class );
-		Path simpleJndiDir = targetDir.resolve( "simpleJndi" );
-		if ( ! Files.exists( simpleJndiDir) ) {
-			try {
-				Files.createDirectory( simpleJndiDir );
-			}
-			catch (IOException e) {
-				throw new RuntimeException( e );
-			}
-		}
-
+		Path jndiStorage = SimpleJNDIHelper.makeTestingJndiDirectory( IndexControlMBeanWithSuffixTest.class );
+		SimpleJNDIHelper.enableSimpleJndi( cfg, jndiStorage );
 		cfg.put( "hibernate.session_factory_name", "java:comp/SessionFactory" );
-		cfg.put( "hibernate.jndi.class", "org.osjava.sj.SimpleContextFactory" );
 		cfg.put( "hibernate.jndi.org.osjava.sj.factory", "org.hibernate.search.test.jmx.IndexControlMBeanTest$CustomContextFactory" );
-		cfg.put( "hibernate.jndi.org.osjava.sj.root", simpleJndiDir.toAbsolutePath().toString() );
-		cfg.put( "hibernate.jndi.org.osjava.sj.jndi.shared", "true" );
-
 		cfg.put( "hibernate.search.indexing_strategy", "manual" );
 		cfg.put( Environment.JMX_ENABLED, "true" );
 		cfg.put( Environment.JMX_BEAN_SUFFIX, JNDI_APP_SUFFIX );

--- a/orm/src/test/java/org/hibernate/search/test/jmx/MutableSearchFactoryAndJMXTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/jmx/MutableSearchFactoryAndJMXTest.java
@@ -6,13 +6,10 @@
  */
 package org.hibernate.search.test.jmx;
 
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.spi.SearchIntegratorBuilder;
-import org.hibernate.search.testsupport.TestConstants;
 import org.hibernate.search.test.util.HibernateManualConfiguration;
 import org.hibernate.search.testsupport.setup.SearchConfigurationForTest;
 
@@ -25,29 +22,18 @@ public class MutableSearchFactoryAndJMXTest {
 
 	@Test
 	public void testRebuildFactory() {
-		Path targetDir = TestConstants.getTargetDir( MutableSearchFactoryAndJMXTest.class );
-		Path simpleJndiDir = targetDir.resolve( "simpleJndi" );
-		if ( ! Files.exists( simpleJndiDir) ) {
-			try {
-				Files.createDirectory( simpleJndiDir );
-			}
-			catch (IOException e) {
-				throw new RuntimeException( e );
-			}
-		}
+		Path jndiStorage = SimpleJNDIHelper.makeTestingJndiDirectory( MutableSearchFactoryAndJMXTest.class );
 
 		SearchConfigurationForTest configuration = new HibernateManualConfiguration()
 				.addProperty( "hibernate.session_factory_name", "java:comp/SessionFactory" )
-				.addProperty( "hibernate.jndi.class", "org.osjava.sj.SimpleContextFactory" )
-				.addProperty( "hibernate.jndi.org.osjava.sj.root", simpleJndiDir.toAbsolutePath().toString() )
-				.addProperty( "hibernate.jndi.org.osjava.sj.jndi.shared", "true" )
 				.addProperty( Environment.JMX_ENABLED, "true" );
+		SimpleJNDIHelper.enableSimpleJndi( configuration, jndiStorage );
 
 		new SearchIntegratorBuilder().configuration( configuration ).buildSearchIntegrator();
 
 		// if there are problems with the JMX registration there will be an exception when the new factory is build
 		new SearchIntegratorBuilder().configuration( configuration ).buildSearchIntegrator();
 	}
-}
 
+}
 

--- a/orm/src/test/java/org/hibernate/search/test/jmx/MutableSearchFactoryAndJMXTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/jmx/MutableSearchFactoryAndJMXTest.java
@@ -6,7 +6,9 @@
  */
 package org.hibernate.search.test.jmx;
 
-import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.spi.SearchIntegratorBuilder;
@@ -23,14 +25,21 @@ public class MutableSearchFactoryAndJMXTest {
 
 	@Test
 	public void testRebuildFactory() {
-		File targetDir = TestConstants.getTargetDir( MutableSearchFactoryAndJMXTest.class );
-		File simpleJndiDir = new File( targetDir, "simpleJndi" );
-		simpleJndiDir.mkdir();
+		Path targetDir = TestConstants.getTargetDir( MutableSearchFactoryAndJMXTest.class );
+		Path simpleJndiDir = targetDir.resolve( "simpleJndi" );
+		if ( ! Files.exists( simpleJndiDir) ) {
+			try {
+				Files.createDirectory( simpleJndiDir );
+			}
+			catch (IOException e) {
+				throw new RuntimeException( e );
+			}
+		}
 
 		SearchConfigurationForTest configuration = new HibernateManualConfiguration()
 				.addProperty( "hibernate.session_factory_name", "java:comp/SessionFactory" )
 				.addProperty( "hibernate.jndi.class", "org.osjava.sj.SimpleContextFactory" )
-				.addProperty( "hibernate.jndi.org.osjava.sj.root", simpleJndiDir.getAbsolutePath() )
+				.addProperty( "hibernate.jndi.org.osjava.sj.root", simpleJndiDir.toAbsolutePath().toString() )
 				.addProperty( "hibernate.jndi.org.osjava.sj.jndi.shared", "true" )
 				.addProperty( Environment.JMX_ENABLED, "true" );
 

--- a/orm/src/test/java/org/hibernate/search/test/jmx/NoMBeansEnabledTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/jmx/NoMBeansEnabledTest.java
@@ -6,8 +6,10 @@
  */
 package org.hibernate.search.test.jmx;
 
-import java.io.File;
+import java.io.IOException;
 import java.lang.management.ManagementFactory;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 
 import javax.management.MBeanServer;
@@ -49,13 +51,20 @@ public class NoMBeansEnabledTest extends SearchTestBase {
 
 	@Override
 	public void configure(Map<String,Object> cfg) {
-		File targetDir = TestConstants.getTargetDir( NoMBeansEnabledTest.class );
-		File simpleJndiDir = new File( targetDir, "simpleJndi" );
-		simpleJndiDir.mkdir();
+		Path targetDir = TestConstants.getTargetDir( NoMBeansEnabledTest.class );
+		Path simpleJndiDir = targetDir.resolve( "simpleJndi" );
+		if ( ! Files.exists( simpleJndiDir) ) {
+			try {
+				Files.createDirectory( simpleJndiDir );
+			}
+			catch (IOException e) {
+				throw new RuntimeException( e );
+			}
+		}
 
 		cfg.put( "hibernate.session_factory_name", "java:comp/SessionFactory" );
 		cfg.put( "hibernate.jndi.class", "org.osjava.sj.SimpleContextFactory" );
-		cfg.put( "hibernate.jndi.org.osjava.sj.root", simpleJndiDir.getAbsolutePath() );
+		cfg.put( "hibernate.jndi.org.osjava.sj.root", simpleJndiDir.toAbsolutePath().toString() );
 		cfg.put( "hibernate.jndi.org.osjava.sj.jndi.shared", "true" );
 		// not setting the property is effectively the same as setting is explicitly to false
 		// cfg.setProperty( Environment.JMX_ENABLED, "false" );

--- a/orm/src/test/java/org/hibernate/search/test/jmx/NoMBeansEnabledTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/jmx/NoMBeansEnabledTest.java
@@ -6,9 +6,7 @@
  */
 package org.hibernate.search.test.jmx;
 
-import java.io.IOException;
 import java.lang.management.ManagementFactory;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 
@@ -19,7 +17,6 @@ import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.jmx.IndexControlMBean;
 import org.hibernate.search.jmx.StatisticsInfoMBean;
 import org.hibernate.search.test.SearchTestBase;
-import org.hibernate.search.testsupport.TestConstants;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -51,21 +48,9 @@ public class NoMBeansEnabledTest extends SearchTestBase {
 
 	@Override
 	public void configure(Map<String,Object> cfg) {
-		Path targetDir = TestConstants.getTargetDir( NoMBeansEnabledTest.class );
-		Path simpleJndiDir = targetDir.resolve( "simpleJndi" );
-		if ( ! Files.exists( simpleJndiDir) ) {
-			try {
-				Files.createDirectory( simpleJndiDir );
-			}
-			catch (IOException e) {
-				throw new RuntimeException( e );
-			}
-		}
-
+		Path simpleJndiDir = SimpleJNDIHelper.makeTestingJndiDirectory( NoMBeansEnabledTest.class );
+		SimpleJNDIHelper.enableSimpleJndi( cfg, simpleJndiDir );
 		cfg.put( "hibernate.session_factory_name", "java:comp/SessionFactory" );
-		cfg.put( "hibernate.jndi.class", "org.osjava.sj.SimpleContextFactory" );
-		cfg.put( "hibernate.jndi.org.osjava.sj.root", simpleJndiDir.toAbsolutePath().toString() );
-		cfg.put( "hibernate.jndi.org.osjava.sj.jndi.shared", "true" );
 		// not setting the property is effectively the same as setting is explicitly to false
 		// cfg.setProperty( Environment.JMX_ENABLED, "false" );
 	}

--- a/serialization/avro/src/test/java/org/hibernate/search/test/serialization/ProtocolBackwardCompatibilityTest.java
+++ b/serialization/avro/src/test/java/org/hibernate/search/test/serialization/ProtocolBackwardCompatibilityTest.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.test.serialization;
 
-import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -219,11 +218,9 @@ public class ProtocolBackwardCompatibilityTest {
 	}
 
 	private void storeSerializedForm(byte[] out, int major, int minor) throws IOException {
-		File file = new File(
-				TestConstants.getTargetDir( ProtocolBackwardCompatibilityTest.class ),
-				RESOURCE_BASE_NAME + major + "." + minor
-		);
-		try (OutputStream outputStream = new FileOutputStream( file )) {
+		Path targetDir = TestConstants.getTargetDir( ProtocolBackwardCompatibilityTest.class );
+		Path outputFilePath = targetDir.resolve( RESOURCE_BASE_NAME + major + "." + minor );
+		try (OutputStream outputStream = new FileOutputStream( outputFilePath.toFile() )) {
 			outputStream.write( out );
 			outputStream.flush();
 		}


### PR DESCRIPTION
 - https://hibernate.atlassian.net/browse/HSEARCH-2033

Several tests leak files on Windows, in particular the JGroups tests fail as they attempt to generate an invalid path.

The useage of H2 in the Narayana integration tests leads to an attempt to delete in-use files during teardown.