### PR TITLE
HSEARCH-2034

### DIFF
--- a/engine/src/main/java/org/hibernate/search/query/dsl/MustJunction.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/MustJunction.java
@@ -11,13 +11,23 @@ package org.hibernate.search.query.dsl;
  * Represents the context in which a must clause is described.
  *
  * @author Emmanuel Bernard
+ * @author Sanne Grinovero
  */
 public interface MustJunction extends BooleanJunction<MustJunction> {
 	/**
 	 * Negate the must clause.
 	 * Results of the boolean query do NOT match the subquery.
+	 * A negated must clause always disables scoring on the subquery.
 	 *
-	 * @return a {@link BooleanJunction}
+	 * @return the same {@link BooleanJunction} for method chaining.
 	 */
 	BooleanJunction not();
+
+	/**
+	 * Disables scoring on the subquery.
+	 * If you are only interested to use this clause as a filtering criteria
+	 * and don't need it to affect result scoring, this might improve performance.
+	 * @return the same {@link BooleanJunction} for method chaining.
+	 */
+	BooleanJunction disableScoring();
 }

--- a/engine/src/main/java/org/hibernate/search/query/dsl/impl/BooleanQueryBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/impl/BooleanQueryBuilder.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanClause.Occur;
-import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BooleanQuery.Builder;
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
@@ -109,11 +109,11 @@ class BooleanQueryBuilder implements MustJunction {
 			}
 		}
 
-		BooleanQuery query = new BooleanQuery();
+		Builder builder = new org.apache.lucene.search.BooleanQuery.Builder();
 		for ( BooleanClause clause : clauses ) {
-			query.add( clause );
+			builder.add( clause );
 		}
-		return queryCustomizer.setWrappedQuery( query ).createQuery();
+		return queryCustomizer.setWrappedQuery( builder.build() ).createQuery();
 	}
 
 	@Override


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HSEARCH-2034

Allow users of the Query DSL to disable scoring, to improve performance when the intent is just to filter by some criteria.

