### PR TITLE
HSEARCH-2039

### DIFF
--- a/backends/jgroups/src/test/java/org/hibernate/search/test/jgroups/common/MultipleSessionsSearchTestCase.java
+++ b/backends/jgroups/src/test/java/org/hibernate/search/test/jgroups/common/MultipleSessionsSearchTestCase.java
@@ -6,6 +6,10 @@
  */
 package org.hibernate.search.test.jgroups.common;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -43,11 +47,11 @@ public abstract class MultipleSessionsSearchTestCase extends SearchTestBase {
 		//master
 		cfg.put(
 				"hibernate.search.default.sourceBase",
-				TestConstants.getIndexDirectory( MultipleSessionsSearchTestCase.class ) + masterCopy
+				TestConstants.getIndexDirectory( getTargetDir() ) + masterCopy
 		);
 		cfg.put(
 				"hibernate.search.default.indexBase",
-				TestConstants.getIndexDirectory( MultipleSessionsSearchTestCase.class ) + masterMain
+				TestConstants.getIndexDirectory( getTargetDir() ) + masterMain
 		);
 		cfg.put( "hibernate.search.default.refresh", "1" );
 		cfg.put(
@@ -59,11 +63,11 @@ public abstract class MultipleSessionsSearchTestCase extends SearchTestBase {
 		//slave(s)
 		cfg.put(
 				"hibernate.search.default.sourceBase",
-				TestConstants.getIndexDirectory( MultipleSessionsSearchTestCase.class ) + masterCopy
+				TestConstants.getIndexDirectory( getTargetDir() ) + masterCopy
 		);
 		cfg.put(
 				"hibernate.search.default.indexBase",
-				TestConstants.getIndexDirectory( MultipleSessionsSearchTestCase.class ) + slave
+				TestConstants.getIndexDirectory( getTargetDir() ) + slave
 		);
 		cfg.put( "hibernate.search.default.refresh", "1" );
 		cfg.put(
@@ -106,4 +110,19 @@ public abstract class MultipleSessionsSearchTestCase extends SearchTestBase {
 		return slaveResources.getSessionFactory();
 	}
 
+	private Path getTargetDir() {
+		URI classesDirUri;
+
+		try {
+			classesDirUri = getClass().getProtectionDomain()
+					.getCodeSource()
+					.getLocation()
+					.toURI();
+		}
+		catch (URISyntaxException e) {
+			throw new RuntimeException( e );
+		}
+
+		return Paths.get( classesDirUri ).getParent();
+	}
 }

--- a/engine/src/test/java/org/hibernate/search/test/jmx/SimpleJNDIHelper.java
+++ b/engine/src/test/java/org/hibernate/search/test/jmx/SimpleJNDIHelper.java
@@ -7,13 +7,15 @@
 package org.hibernate.search.test.jmx;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Properties;
 
 import org.hibernate.search.cfg.spi.SearchConfiguration;
-import org.hibernate.search.testsupport.TestConstants;
 
 /**
  * A common place for helper methods useful for all tests using SimpleJNDI
@@ -30,7 +32,7 @@ class SimpleJNDIHelper {
 	 * @return the Path for SimpleJNDI to store its data
 	 */
 	public static Path makeTestingJndiDirectory(Class<?> testClass) {
-		Path targetDir = TestConstants.getTargetDir( testClass );
+		Path targetDir = getTargetDir();
 		Path simpleJndiDir = targetDir.resolve( "simpleJndi" );
 		if ( ! Files.exists( simpleJndiDir) ) {
 			try {
@@ -55,4 +57,18 @@ class SimpleJNDIHelper {
 		p.put( "hibernate.jndi.org.osjava.sj.jndi.shared", "true" );
 	}
 
+	private static Path getTargetDir() {
+		URI classesDirUri;
+		try {
+			classesDirUri = SimpleJNDIHelper.class.getProtectionDomain()
+					.getCodeSource()
+					.getLocation()
+					.toURI();
+		}
+		catch (URISyntaxException e) {
+			throw new RuntimeException( e );
+		}
+
+		return Paths.get( classesDirUri ).getParent();
+	}
 }

--- a/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/TestRunnerArquillian.java
+++ b/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/TestRunnerArquillian.java
@@ -20,6 +20,7 @@ import org.hibernate.SessionFactory;
 import org.hibernate.search.test.integration.wildfly.PackagerHelper;
 import org.hibernate.search.test.performance.scenario.TestScenario;
 import org.hibernate.search.test.performance.scenario.TestScenarioFactory;
+import org.hibernate.search.test.performance.util.TargetDirHelper;
 import org.hibernate.search.testsupport.TestConstants;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -48,7 +49,7 @@ public class TestRunnerArquillian {
 	public static final String TARGET_DIR_KEY = "target";
 
 	@Deployment
-	public static Archive<?> createTestArchive() throws IOException {
+	public static Archive<?> createTestArchive() throws Exception {
 		WebArchive archive = ShrinkWrap
 				.create( WebArchive.class, TestRunnerArquillian.class.getSimpleName() + ".war" )
 				.addPackages( true, TestRunnerArquillian.class.getPackage() )
@@ -63,8 +64,8 @@ public class TestRunnerArquillian {
 		return archive;
 	}
 
-	private static StringAsset reportsOutputDirectory() throws IOException {
-		Path path = TestConstants.getTargetDir( TestRunnerArquillian.class );
+	private static StringAsset reportsOutputDirectory() throws Exception {
+		Path path = TargetDirHelper.getTargetDir();
 		String absolutePath = path.toAbsolutePath().toString();
 		//Use Properties to make sure we encode the output correctly,
 		//especially tricky to deal with escaping of paths:

--- a/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/scenario/FileSystemDefaultTestScenario.java
+++ b/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/scenario/FileSystemDefaultTestScenario.java
@@ -8,6 +8,7 @@ package org.hibernate.search.test.performance.scenario;
 
 import java.util.Properties;
 
+import org.hibernate.search.test.performance.util.TargetDirHelper;
 import org.hibernate.search.testsupport.TestConstants;
 
 /**
@@ -19,7 +20,7 @@ public class FileSystemDefaultTestScenario extends TestScenario {
 	public Properties getHibernateProperties() {
 		Properties properties = super.getHibernateProperties();
 		properties.setProperty( "hibernate.search.default.directory_provider", "filesystem" );
-		properties.setProperty( "hibernate.search.default.indexBase", TestConstants.getIndexDirectory( FileSystemDefaultTestScenario.class ) );
+		properties.setProperty( "hibernate.search.default.indexBase", TestConstants.getIndexDirectory( TargetDirHelper.getTargetDir() ) );
 		return properties;
 	}
 

--- a/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/scenario/FileSystemNearRealTimeTestScenario.java
+++ b/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/scenario/FileSystemNearRealTimeTestScenario.java
@@ -8,6 +8,7 @@ package org.hibernate.search.test.performance.scenario;
 
 import java.util.Properties;
 
+import org.hibernate.search.test.performance.util.TargetDirHelper;
 import org.hibernate.search.testsupport.TestConstants;
 
 /**
@@ -19,7 +20,7 @@ public class FileSystemNearRealTimeTestScenario extends TestScenario {
 	public Properties getHibernateProperties() {
 		Properties properties = super.getHibernateProperties();
 		properties.setProperty( "hibernate.search.default.directory_provider", "filesystem" );
-		properties.setProperty( "hibernate.search.default.indexBase", TestConstants.getIndexDirectory( FileSystemNearRealTimeTestScenario.class ) );
+		properties.setProperty( "hibernate.search.default.indexBase", TestConstants.getIndexDirectory( TargetDirHelper.getTargetDir() ) );
 		properties.setProperty( "hibernate.search.default.indexmanager", "near-real-time" );
 		return properties;
 	}

--- a/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/scenario/TestReporter.java
+++ b/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/scenario/TestReporter.java
@@ -6,18 +6,6 @@
  */
 package org.hibernate.search.test.performance.scenario;
 
-import static org.apache.commons.lang.StringUtils.leftPad;
-import static org.apache.commons.lang.StringUtils.rightPad;
-import static org.hibernate.search.test.performance.TestRunnerArquillian.RUNNER_PROPERTIES;
-import static org.hibernate.search.test.performance.TestRunnerArquillian.TARGET_DIR_KEY;
-import static org.hibernate.search.test.performance.scenario.TestContext.ASSERT_QUERY_RESULTS;
-import static org.hibernate.search.test.performance.scenario.TestContext.CHECK_INDEX_STATE;
-import static org.hibernate.search.test.performance.scenario.TestContext.MEASURE_MEMORY;
-import static org.hibernate.search.test.performance.scenario.TestContext.MEASURE_TASK_TIME;
-import static org.hibernate.search.test.performance.scenario.TestContext.THREADS_COUNT;
-import static org.hibernate.search.test.performance.scenario.TestContext.VERBOSE;
-import static org.hibernate.search.test.performance.util.Util.runGarbageCollectorAndWait;
-
 import java.io.BufferedWriter;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -38,11 +26,24 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang.time.DateFormatUtils;
 import org.apache.commons.lang.time.DurationFormatUtils;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.search.testsupport.TestConstants;
+import org.hibernate.search.engine.Version;
 import org.hibernate.search.test.performance.task.AbstractTask;
 import org.hibernate.search.test.performance.util.CheckerLuceneIndex;
 import org.hibernate.search.test.performance.util.CheckerUncaughtExceptions;
-import org.hibernate.search.engine.Version;
+import org.hibernate.search.test.performance.util.TargetDirHelper;
+import org.hibernate.search.testsupport.TestConstants;
+
+import static org.apache.commons.lang.StringUtils.leftPad;
+import static org.apache.commons.lang.StringUtils.rightPad;
+import static org.hibernate.search.test.performance.TestRunnerArquillian.RUNNER_PROPERTIES;
+import static org.hibernate.search.test.performance.TestRunnerArquillian.TARGET_DIR_KEY;
+import static org.hibernate.search.test.performance.scenario.TestContext.ASSERT_QUERY_RESULTS;
+import static org.hibernate.search.test.performance.scenario.TestContext.CHECK_INDEX_STATE;
+import static org.hibernate.search.test.performance.scenario.TestContext.MEASURE_MEMORY;
+import static org.hibernate.search.test.performance.scenario.TestContext.MEASURE_TASK_TIME;
+import static org.hibernate.search.test.performance.scenario.TestContext.THREADS_COUNT;
+import static org.hibernate.search.test.performance.scenario.TestContext.VERBOSE;
+import static org.hibernate.search.test.performance.util.Util.runGarbageCollectorAndWait;
 
 /**
  * @author Tomas Hradec
@@ -206,7 +207,7 @@ public class TestReporter {
 			return Paths.get( runnerProperties.getProperty( TARGET_DIR_KEY ) );
 		}
 		else {
-			return TestConstants.getTargetDir( TestReporter.class );
+			return TargetDirHelper.getTargetDir();
 		}
 	}
 

--- a/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/util/TargetDirHelper.java
+++ b/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/util/TargetDirHelper.java
@@ -1,0 +1,41 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.performance.util;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Obtains the target directory of this module.
+ *
+ * @author Gunnar Morling
+ */
+public class TargetDirHelper {
+
+	private TargetDirHelper() {
+	}
+
+	/**
+	 * Returns the target directory of this module.
+	 */
+	public static Path getTargetDir() {
+		URI classesDirUri;
+		try {
+			classesDirUri = TargetDirHelper.class.getProtectionDomain()
+					.getCodeSource()
+					.getLocation()
+					.toURI();
+		}
+		catch (URISyntaxException e) {
+			throw new RuntimeException( e );
+		}
+
+		return Paths.get( classesDirUri ).getParent();
+	}
+}

--- a/integrationtest/sandbox/src/test/java/org/hibernate/search/test/performance/optimizer/OptimizerPerformanceTest.java
+++ b/integrationtest/sandbox/src/test/java/org/hibernate/search/test/performance/optimizer/OptimizerPerformanceTest.java
@@ -24,6 +24,7 @@ import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
 import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.test.util.TargetDirHelper;
 import org.hibernate.search.testsupport.TestConstants;
 import org.hibernate.search.util.impl.FileHelper;
 import org.junit.After;
@@ -37,7 +38,7 @@ public class OptimizerPerformanceTest extends SearchTestBase {
 	@Override
 	@Before
 	public void setUp() throws Exception {
-		String indexBase = TestConstants.getIndexDirectory( OptimizerPerformanceTest.class );
+		String indexBase = TestConstants.getIndexDirectory( TargetDirHelper.getTargetDir() );
 		File indexDir = new File(indexBase);
 		FileHelper.delete( indexDir );
 		indexDir.mkdirs();
@@ -54,7 +55,7 @@ public class OptimizerPerformanceTest extends SearchTestBase {
 	@After
 	public void tearDown() throws Exception {
 		super.tearDown();
-		String indexBase = TestConstants.getIndexDirectory( OptimizerPerformanceTest.class );
+		String indexBase = TestConstants.getIndexDirectory( TargetDirHelper.getTargetDir() );
 		File indexDir = new File(indexBase);
 		FileHelper.delete( indexDir );
 	}
@@ -105,9 +106,9 @@ public class OptimizerPerformanceTest extends SearchTestBase {
 
 				s = sf.openSession();
 				tx = s.beginTransaction();
-				w = (Worker) s.get( Worker.class, w.getId() );
+				w = s.get( Worker.class, w.getId() );
 				w.setName( "Gavin" );
-				c = (Construction) s.get( Construction.class, c.getId() );
+				c = s.get( Construction.class, c.getId() );
 				c.setName( "W Hotel" );
 				tx.commit();
 				s.close();
@@ -138,9 +139,9 @@ public class OptimizerPerformanceTest extends SearchTestBase {
 
 				s = sf.openSession();
 				tx = s.beginTransaction();
-				w = (Worker) s.get( Worker.class, w.getId() );
+				w = s.get( Worker.class, w.getId() );
 				s.delete( w );
-				c = (Construction) s.get( Construction.class, c.getId() );
+				c = s.get( Construction.class, c.getId() );
 				s.delete( c );
 				tx.commit();
 				s.close();
@@ -153,7 +154,7 @@ public class OptimizerPerformanceTest extends SearchTestBase {
 	}
 
 	protected static class ReverseWork implements Runnable {
-		private SessionFactory sf;
+		private final SessionFactory sf;
 
 		public ReverseWork(SessionFactory sf) {
 			this.sf = sf;
@@ -173,18 +174,18 @@ public class OptimizerPerformanceTest extends SearchTestBase {
 
 				s = sf.openSession();
 				tx = s.beginTransaction();
-				w = (Worker) s.get( Worker.class, w.getId() );
+				w = s.get( Worker.class, w.getId() );
 				w.setName( "Remi" );
-				c = (Construction) s.get( Construction.class, c.getId() );
+				c = s.get( Construction.class, c.getId() );
 				c.setName( "Palais des festivals" );
 				tx.commit();
 				s.close();
 
 				s = sf.openSession();
 				tx = s.beginTransaction();
-				w = (Worker) s.get( Worker.class, w.getId() );
+				w = s.get( Worker.class, w.getId() );
 				s.delete( w );
-				c = (Construction) s.get( Construction.class, c.getId() );
+				c = s.get( Construction.class, c.getId() );
 				s.delete( c );
 				tx.commit();
 				s.close();
@@ -197,7 +198,7 @@ public class OptimizerPerformanceTest extends SearchTestBase {
 
 	@Override
 	public void configure(Map<String,Object> cfg) {
-		cfg.put( "hibernate.search.default.indexBase", TestConstants.getIndexDirectory( OptimizerPerformanceTest.class ) );
+		cfg.put( "hibernate.search.default.indexBase", TestConstants.getIndexDirectory( TargetDirHelper.getTargetDir() ) );
 		cfg.put( "hibernate.search.default.directory_provider", "filesystem" );
 		cfg.put( Environment.ANALYZER_CLASS, StopAnalyzer.class.getName() );
 	}

--- a/integrationtest/sandbox/src/test/java/org/hibernate/search/test/performance/reader/BufferSharingReaderPerformanceTest.java
+++ b/integrationtest/sandbox/src/test/java/org/hibernate/search/test/performance/reader/BufferSharingReaderPerformanceTest.java
@@ -21,6 +21,6 @@ public class BufferSharingReaderPerformanceTest extends ReaderPerformance {
 
 	@Override
 	protected String getIndexBaseDir() {
-		return TestConstants.getIndexDirectory( TargetDirHelper.getTargetDir() ) + "BufferSharingReaderPerformanceTest";
+		return TestConstants.getIndexDirectory( TargetDirHelper.getTargetDir() );
 	}
 }

--- a/integrationtest/sandbox/src/test/java/org/hibernate/search/test/performance/reader/BufferSharingReaderPerformanceTest.java
+++ b/integrationtest/sandbox/src/test/java/org/hibernate/search/test/performance/reader/BufferSharingReaderPerformanceTest.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.test.performance.reader;
 
 import org.hibernate.search.indexes.impl.SharingBufferReaderProvider;
+import org.hibernate.search.test.util.TargetDirHelper;
 import org.hibernate.search.testsupport.TestConstants;
 
 /**
@@ -20,6 +21,6 @@ public class BufferSharingReaderPerformanceTest extends ReaderPerformance {
 
 	@Override
 	protected String getIndexBaseDir() {
-		return TestConstants.getIndexDirectory( BufferSharingReaderPerformanceTest.class ) + "BufferSharingReaderPerformanceTest";
+		return TestConstants.getIndexDirectory( TargetDirHelper.getTargetDir() ) + "BufferSharingReaderPerformanceTest";
 	}
 }

--- a/integrationtest/sandbox/src/test/java/org/hibernate/search/test/performance/reader/NotSharedReaderPerformanceTest.java
+++ b/integrationtest/sandbox/src/test/java/org/hibernate/search/test/performance/reader/NotSharedReaderPerformanceTest.java
@@ -21,7 +21,7 @@ public class NotSharedReaderPerformanceTest extends ReaderPerformance {
 
 	@Override
 	protected String getIndexBaseDir() {
-		return TestConstants.getIndexDirectory( TargetDirHelper.getTargetDir() ) + "NotSharedReaderPerformanceTest";
+		return TestConstants.getIndexDirectory( TargetDirHelper.getTargetDir() );
 	}
 
 }

--- a/integrationtest/sandbox/src/test/java/org/hibernate/search/test/performance/reader/NotSharedReaderPerformanceTest.java
+++ b/integrationtest/sandbox/src/test/java/org/hibernate/search/test/performance/reader/NotSharedReaderPerformanceTest.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.test.performance.reader;
 
+import org.hibernate.search.test.util.TargetDirHelper;
 import org.hibernate.search.testsupport.TestConstants;
 
 /**
@@ -20,7 +21,7 @@ public class NotSharedReaderPerformanceTest extends ReaderPerformance {
 
 	@Override
 	protected String getIndexBaseDir() {
-		return TestConstants.getIndexDirectory( NotSharedReaderPerformanceTest.class ) + "NotSharedReaderPerformanceTest";
+		return TestConstants.getIndexDirectory( TargetDirHelper.getTargetDir() ) + "NotSharedReaderPerformanceTest";
 	}
 
 }

--- a/integrationtest/sandbox/src/test/java/org/hibernate/search/test/performance/reader/ReaderPerformanceTestCase.java
+++ b/integrationtest/sandbox/src/test/java/org/hibernate/search/test/performance/reader/ReaderPerformanceTestCase.java
@@ -28,6 +28,7 @@ import org.hibernate.search.FullTextQuery;
 import org.hibernate.search.Search;
 import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.test.util.TargetDirHelper;
 import org.hibernate.search.testsupport.TestConstants;
 import org.hibernate.search.util.impl.FileHelper;
 import org.hibernate.search.util.logging.impl.Log;
@@ -48,7 +49,7 @@ public abstract class ReaderPerformanceTestCase extends SearchTestBase {
 	@Override
 	@Before
 	public void setUp() throws Exception {
-		String indexBase = TestConstants.getIndexDirectory( ReaderPerformanceTestCase.class );
+		String indexBase = TestConstants.getIndexDirectory( TargetDirHelper.getTargetDir() );
 		File indexDir = new File(indexBase);
 		indexDir.mkdir();
 		File[] files = indexDir.listFiles();
@@ -64,7 +65,7 @@ public abstract class ReaderPerformanceTestCase extends SearchTestBase {
 	@After
 	public void tearDown() throws Exception {
 		super.tearDown();
-		String indexBase = TestConstants.getIndexDirectory( ReaderPerformanceTestCase.class );
+		String indexBase = TestConstants.getIndexDirectory( TargetDirHelper.getTargetDir() );
 		File indexDir = new File(indexBase);
 		FileHelper.delete( indexDir );
 	}
@@ -126,8 +127,8 @@ public abstract class ReaderPerformanceTestCase extends SearchTestBase {
 	}
 
 	protected class Work implements Runnable {
-		private Random random = new Random();
-		private SessionFactory sf;
+		private final Random random = new Random();
+		private final SessionFactory sf;
 //		public volatile int count = 0;
 		public AtomicInteger count = new AtomicInteger( 0 );
 
@@ -219,8 +220,8 @@ public abstract class ReaderPerformanceTestCase extends SearchTestBase {
 	}
 
 	protected static class ReverseWork implements Runnable {
-		private SessionFactory sf;
-		private Random random = new Random();
+		private final SessionFactory sf;
+		private final Random random = new Random();
 
 		public ReverseWork(SessionFactory sf) {
 			this.sf = sf;
@@ -274,7 +275,7 @@ public abstract class ReaderPerformanceTestCase extends SearchTestBase {
 
 	@Override
 	public void configure(Map<String,Object> cfg) {
-		cfg.put( "hibernate.search.default.indexBase", TestConstants.getIndexDirectory( ReaderPerformanceTestCase.class ) );
+		cfg.put( "hibernate.search.default.indexBase", TestConstants.getIndexDirectory( TargetDirHelper.getTargetDir() ) );
 		cfg.put( "hibernate.search.default.directory_provider", "filesystem" );
 		cfg.put( Environment.ANALYZER_CLASS, StopAnalyzer.class.getName() );
 	}

--- a/integrationtest/sandbox/src/test/java/org/hibernate/search/test/performance/reader/SharedReaderPerformanceTest.java
+++ b/integrationtest/sandbox/src/test/java/org/hibernate/search/test/performance/reader/SharedReaderPerformanceTest.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.test.performance.reader;
 
+import org.hibernate.search.test.util.TargetDirHelper;
 import org.hibernate.search.testsupport.TestConstants;
 
 /**
@@ -20,6 +21,6 @@ public class SharedReaderPerformanceTest extends ReaderPerformance {
 
 	@Override
 	protected String getIndexBaseDir() {
-		return TestConstants.getIndexDirectory( SharedReaderPerformanceTest.class ) + "SharedReaderPerformanceTest";
+		return TestConstants.getIndexDirectory( TargetDirHelper.getTargetDir() ) + "SharedReaderPerformanceTest";
 	}
 }

--- a/integrationtest/sandbox/src/test/java/org/hibernate/search/test/performance/reader/SharedReaderPerformanceTest.java
+++ b/integrationtest/sandbox/src/test/java/org/hibernate/search/test/performance/reader/SharedReaderPerformanceTest.java
@@ -21,6 +21,6 @@ public class SharedReaderPerformanceTest extends ReaderPerformance {
 
 	@Override
 	protected String getIndexBaseDir() {
-		return TestConstants.getIndexDirectory( TargetDirHelper.getTargetDir() ) + "SharedReaderPerformanceTest";
+		return TestConstants.getIndexDirectory( TargetDirHelper.getTargetDir() );
 	}
 }

--- a/integrationtest/sandbox/src/test/java/org/hibernate/search/test/util/TargetDirHelper.java
+++ b/integrationtest/sandbox/src/test/java/org/hibernate/search/test/util/TargetDirHelper.java
@@ -1,0 +1,41 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.util;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Obtains the target directory of this module.
+ *
+ * @author Gunnar Morling
+ */
+public class TargetDirHelper {
+
+	private TargetDirHelper() {
+	}
+
+	/**
+	 * Returns the target directory of this module.
+	 */
+	public static Path getTargetDir() {
+		URI classesDirUri;
+		try {
+			classesDirUri = TargetDirHelper.class.getProtectionDomain()
+					.getCodeSource()
+					.getLocation()
+					.toURI();
+		}
+		catch (URISyntaxException e) {
+			throw new RuntimeException( e );
+		}
+
+		return Paths.get( classesDirUri ).getParent();
+	}
+}

--- a/orm/src/test/java/org/hibernate/search/test/DefaultTestResourceManager.java
+++ b/orm/src/test/java/org/hibernate/search/test/DefaultTestResourceManager.java
@@ -218,12 +218,13 @@ public final class DefaultTestResourceManager implements TestResourceManager {
 	}
 
 	private Path createBaseIndexDir(Class<?> currentTestModuleClass) {
-		// Make sure no directory is ever reused across the test suite as Windows might not be able
-		// to delete the files after usage. See also
+		// Appending UUID to be extra-sure no directory is ever reused across the test suite as Windows might not be
+		// able to delete the files after usage. See also
 		// http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4715154
-		String shortTestName = currentTestModuleClass.getSimpleName() + "-" + UUID.randomUUID().toString().substring( 0, 8 );
-
-		return Paths.get( TestConstants.getIndexDirectory( TestConstants.getTempTestDataDir() ), shortTestName );
+		return Paths.get(
+				TestConstants.getIndexDirectory( TestConstants.getTempTestDataDir(), currentTestModuleClass ),
+				UUID.randomUUID().toString().substring( 0, 8 )
+		);
 	}
 
 	private static class RollbackWork implements Work {

--- a/orm/src/test/java/org/hibernate/search/test/DefaultTestResourceManager.java
+++ b/orm/src/test/java/org/hibernate/search/test/DefaultTestResourceManager.java
@@ -65,7 +65,7 @@ public final class DefaultTestResourceManager implements TestResourceManager {
 	private SearchFactory searchFactory;
 	private Map<String,Object> configurationSettings;
 
-	public DefaultTestResourceManager(TestConfiguration test, Class currentTestModuleClass) {
+	public DefaultTestResourceManager(TestConfiguration test, Class<?> currentTestModuleClass) {
 		this.test = test;
 		this.baseIndexDir = createBaseIndexDir( currentTestModuleClass );
 	}
@@ -217,13 +217,13 @@ public final class DefaultTestResourceManager implements TestResourceManager {
 		searchFactory = null;
 	}
 
-	private Path createBaseIndexDir(Class currentTestModuleClass) {
+	private Path createBaseIndexDir(Class<?> currentTestModuleClass) {
 		// Make sure no directory is ever reused across the test suite as Windows might not be able
 		// to delete the files after usage. See also
 		// http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4715154
 		String shortTestName = currentTestModuleClass.getSimpleName() + "-" + UUID.randomUUID().toString().substring( 0, 8 );
 
-		return Paths.get( TestConstants.getIndexDirectory( currentTestModuleClass ), shortTestName );
+		return Paths.get( TestConstants.getIndexDirectory( TestConstants.getTempTestDataDir() ), shortTestName );
 	}
 
 	private static class RollbackWork implements Work {

--- a/orm/src/test/java/org/hibernate/search/test/configuration/field/TokenizationTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/field/TokenizationTest.java
@@ -10,19 +10,18 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 
-import org.jboss.byteman.contrib.bmunit.BMRule;
-import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import org.hibernate.cfg.Configuration;
 import org.hibernate.search.annotations.Analyze;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Index;
 import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.annotations.Store;
-import org.hibernate.search.testsupport.TestConstants;
 import org.hibernate.search.testsupport.BytemanHelper;
+import org.hibernate.search.testsupport.TestConstants;
+import org.jboss.byteman.contrib.bmunit.BMRule;
+import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 
@@ -48,7 +47,6 @@ public class TokenizationTest {
 
 		config.setProperty( "hibernate.search.lucene_version", TestConstants.getTargetLuceneVersion().toString() );
 		config.setProperty( "hibernate.search.default.directory_provider", "ram" );
-		config.setProperty( "hibernate.search.default.indexBase", TestConstants.getIndexDirectory( TokenizationTest.class ) );
 
 		config.buildSessionFactory();
 

--- a/orm/src/test/java/org/hibernate/search/test/directoryProvider/FSSlaveAndMasterDPTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/directoryProvider/FSSlaveAndMasterDPTest.java
@@ -157,7 +157,7 @@ public class FSSlaveAndMasterDPTest extends MultipleSFTestCase {
 
 	static File prepareDirectories(String testId) throws IOException {
 
-		String superRootPath = TestConstants.getIndexDirectory( FSSlaveAndMasterDPTest.class );
+		String superRootPath = TestConstants.getIndexDirectory( TestConstants.getTempTestDataDir() );
 		File root = new File( superRootPath, testId );
 
 		if ( root.exists() ) {

--- a/orm/src/test/java/org/hibernate/search/test/util/FullTextSessionBuilder.java
+++ b/orm/src/test/java/org/hibernate/search/test/util/FullTextSessionBuilder.java
@@ -92,7 +92,7 @@ public class FullTextSessionBuilder implements AutoCloseable, TestRule {
 	 * @return the same builder (this).
 	 */
 	public FullTextSessionBuilder useFileSystemDirectoryProvider(Class<?> testClass) {
-		indexRootDirectory = new File( TestConstants.getIndexDirectory( testClass ) );
+		indexRootDirectory = new File( TestConstants.getIndexDirectory( TestConstants.getTempTestDataDir() ) );
 		log.debugf( "Using %s as index directory.", indexRootDirectory.getAbsolutePath() );
 		cfg.setProperty( "hibernate.search.default.directory_provider", "filesystem" );
 		cfg.setProperty( "hibernate.search.default.indexBase", indexRootDirectory.getAbsolutePath() );

--- a/serialization/avro/src/test/java/org/hibernate/search/test/serialization/ProtocolBackwardCompatibilityTest.java
+++ b/serialization/avro/src/test/java/org/hibernate/search/test/serialization/ProtocolBackwardCompatibilityTest.java
@@ -10,6 +10,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -32,10 +33,6 @@ import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.util.AttributeImpl;
 import org.apache.lucene.util.BytesRef;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-
 import org.hibernate.search.backend.AddLuceneWork;
 import org.hibernate.search.backend.DeleteLuceneWork;
 import org.hibernate.search.backend.FlushLuceneWork;
@@ -51,9 +48,11 @@ import org.hibernate.search.indexes.serialization.impl.LuceneWorkSerializerImpl;
 import org.hibernate.search.indexes.serialization.spi.LuceneWorkSerializer;
 import org.hibernate.search.indexes.serialization.spi.SerializationProvider;
 import org.hibernate.search.test.util.SerializationTestHelper;
-import org.hibernate.search.testsupport.TestConstants;
 import org.hibernate.search.testsupport.junit.SearchFactoryHolder;
 import org.hibernate.search.testsupport.setup.SearchConfigurationForTest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * This tests backwards compatibility between Avro protocol versions.
@@ -218,7 +217,7 @@ public class ProtocolBackwardCompatibilityTest {
 	}
 
 	private void storeSerializedForm(byte[] out, int major, int minor) throws IOException {
-		Path targetDir = TestConstants.getTargetDir( ProtocolBackwardCompatibilityTest.class );
+		Path targetDir = getTargetDir();
 		Path outputFilePath = targetDir.resolve( RESOURCE_BASE_NAME + major + "." + minor );
 		try (OutputStream outputStream = new FileOutputStream( outputFilePath.toFile() )) {
 			outputStream.write( out );
@@ -231,5 +230,21 @@ public class ProtocolBackwardCompatibilityTest {
 		URI uri = url.toURI();
 		Path path = Paths.get( uri );
 		return Files.readAllBytes( path );
+	}
+
+	private Path getTargetDir() {
+		URI classesDirUri;
+
+		try {
+			classesDirUri = getClass().getProtectionDomain()
+					.getCodeSource()
+					.getLocation()
+					.toURI();
+		}
+		catch (URISyntaxException e) {
+			throw new RuntimeException( e );
+		}
+
+		return Paths.get( classesDirUri ).getParent();
 	}
 }


### PR DESCRIPTION
Hey @Sanne, this uses temporary directories as index dirs for the tests in "orm".

Other modules I still let use their "target" dir as that's generally safer to clean-up (the temp dirs used in "orm" are deleted upon normal JVM shut-down, but e.g. not when killing a test run). I've pushed the determination of target dirs to the individual modules, as a common re-used helper just seemed to easy to be abused in cases where it shouldn't (tests in "orm").

I'm also adding the caller name to index dirs now so to make it easier to identify tests potentially causing file leaks.