### PR TITLE
HSEARCH-2021 et al.: Allowing to sort on fields contributed by custom bridges

### DIFF
--- a/documentation/src/main/asciidoc/mapping.asciidoc
+++ b/documentation/src/main/asciidoc/mapping.asciidoc
@@ -316,25 +316,40 @@ required doc value fields, in addition to the document fields it adds. Furthermo
 the sortable fields created by this bridge:
 
 [[example-adding-docvaluefield]]
-.Adding a sortable field via a custom field bridge
+.Adding sortable fields via a custom field bridge
 ====
 [source, JAVA]
 ----
+/***
+  * Custom field bridge for a Map property which creates sortable fields with the values
+  * of two keys from the map.
+  */
 public class MyClassBridge implements MetadataProvidingFieldBridge {
 
     @Override
     public void set(
             String name, Object value, Document document, LuceneOptions luceneOptions) {
 
-        // add other document field(s)
-        // ...
+        Map<String, String> map = (Map<String, String>) value;
 
-        // add doc value field
-        document.add( new NumericDocValuesField( "myField", 311 );
+        String firstName = map.get( "firstName" );
+        String lastName = map.get( "lastName" );
+
+        // add regular document fields
+        luceneOptions.addFieldToDocument( name + "_firstName", lastName, document );
+        luceneOptions.addFieldToDocument( name + "_lastName", lastName, document );
+
+        // add doc value fields to allow for sorting
+        document.add( new SortedDocValuesField( name + "_firstName", new BytesRef( firstName ) ) );
+        document.add( new SortedDocValuesField( name + "_lastName", new BytesRef( lastName ) ) );
     }
 
-    Set<String> getSortableFieldNames(String name) {
-        return Collections.singleton( "myField" );
+    public Set<String> getSortableFieldNames(String name) {
+        Set<String> sortableFields = new HashSet<>();
+        sortableFields.add( name + "_firstName" );
+        sortableFields.add( name + "_lastName" );
+
+        return sortableFields;
     }
 }
 ----

--- a/documentation/src/main/asciidoc/mapping.asciidoc
+++ b/documentation/src/main/asciidoc/mapping.asciidoc
@@ -350,6 +350,26 @@ The `MetadataProvidingFieldBridge` contract is under active development and cons
 may be altered in future revisions, e.g. by adding further methods, thus breaking existing implementations.
 ====
 
+[[flagging-uncovered-sorts]]
+====== Flagging uncovered sorts
+By default Hibernate Search will transparently create an uninverting index reader when running a query with sorts not
+covered by the sortable fields configured as described above. While this allows to execute the query, relying on index
+uninverting negatively impacts performance.
+
+You thus can optionally advice Hibernate Search to raise an exception when detecting uncovered sorts. To do so, specify
+the following option:
+
+.Disabling automatic index uninverting for uncovered sorts
+====
+[source]
+----
+hibernate.search.index_uninverting_allowed = false
+----
+====
+
+You e.g. may set this to "false" during testing to identify the sortable fields required for your queries and set it to
+"true" in production environments to fall back to index uninverting for uncovered sorts accidentally left over.
+
 [[id-annotation]]
 ===== @Id
 

--- a/documentation/src/main/asciidoc/mapping.asciidoc
+++ b/documentation/src/main/asciidoc/mapping.asciidoc
@@ -309,6 +309,47 @@ Should you want to make a property sortable but not searchable, still an `@Field
 bridge configuration can be inherited). It can be marked with `store = Store.NO` and `index = Index.NO`, causing
 only the doc value field required for sorting to be added, but not a regular index field.
 
+Fields added through class-level bridges or custom field-level bridges (when not using the default field name) cannot
+be marked as sortable by means of the `@SortableField` annotation. Instead the field bridge itself has to add the
+required doc value fields, in addition to the document fields it adds. Furthermore such bridge needs to implement the
+`MetadataProvidingFieldBridge` interface which defines a method `getSortableFieldNames()` for returning the names of
+the sortable fields created by this bridge:
+
+[[example-adding-docvaluefield]]
+.Adding a sortable field via a custom field bridge
+====
+[source, JAVA]
+----
+public class MyClassBridge implements MetadataProvidingFieldBridge {
+
+    @Override
+    public void set(
+            String name, Object value, Document document, LuceneOptions luceneOptions) {
+
+        // add other document field(s)
+        // ...
+
+        // add doc value field
+        document.add( new NumericDocValuesField( "myField", 311 );
+    }
+
+    Set<String> getSortableFieldNames(String name) {
+        return Collections.singleton( "myField" );
+    }
+}
+----
+====
+
+The names returned from `getSortableFieldNames()` will be used for sort validation upon query execution. The name
+passed to the method is the default field name also passed to `set()`. It needs to be used consistently with `set()`,
+e.g. as a prefix for all custom fields added.
+
+[NOTE]
+====
+The `MetadataProvidingFieldBridge` contract is under active development and considered experimental at this time. It
+may be altered in future revisions, e.g. by adding further methods, thus breaking existing implementations.
+====
+
 [[id-annotation]]
 ===== @Id
 

--- a/engine/src/main/java/org/hibernate/search/bridge/MetadataProvidingFieldBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/MetadataProvidingFieldBridge.java
@@ -20,6 +20,10 @@ public interface MetadataProvidingFieldBridge extends FieldBridge {
 
 	/**
 	 * Returns the names of the sortable fields created by this field bridge.
+	 *
+	 * @param name The default field name; Should be used consistently with
+	 * {@link FieldBridge#set(String, Object, org.apache.lucene.document.Document, LuceneOptions)}.
+	 * @return The names of the sortable fields created by this field bridge. Never {@code null}.
 	 */
-	Set<String> getSortableFieldNames();
+	Set<String> getSortableFieldNames(String name);
 }

--- a/engine/src/main/java/org/hibernate/search/bridge/MetadataProvidingFieldBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/MetadataProvidingFieldBridge.java
@@ -1,0 +1,25 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.bridge;
+
+import java.util.Set;
+
+/**
+ * Optional contract to be implemented by {@link FieldBridge} implementations wishing to expose meta-data related to the
+ * fields they create.
+ *
+ * @author Gunnar Morling
+ * @hsearch.experimental This contract is currently under active development and may be altered in future releases,
+ * breaking existing implementations.
+ */
+public interface MetadataProvidingFieldBridge extends FieldBridge {
+
+	/**
+	 * Returns the names of the sortable fields created by this field bridge.
+	 */
+	Set<String> getSortableFieldNames();
+}

--- a/engine/src/main/java/org/hibernate/search/cfg/Environment.java
+++ b/engine/src/main/java/org/hibernate/search/cfg/Environment.java
@@ -260,6 +260,17 @@ public final class Environment {
 	 */
 	public static final String INDEX_NAME_PROP_NAME = "indexName";
 
+	/**
+	 * Option for allowing or disallowing index uninverting when sorting on fields not covered by doc value fields. If
+	 * disallowed and and uncovered sort is detected, an exception will be raised, otherwise only a warning will be
+	 * logged.
+	 * <p>
+	 * Allowed values are "true" and "false". Defaults to "true".
+	 *
+	 * @see org.hibernate.search.annotations.SortableField
+	 */
+	public static final String INDEX_UNINVERTING_ALLOWED = "hibernate.search.index_uninverting_allowed";
+
 	public static final Map<Class<? extends Service>, String> DEFAULT_SERVICES_MAP;
 	// TODO for now we hard code the default services. This could/should be made configurable (HF)
 	static

--- a/engine/src/main/java/org/hibernate/search/engine/impl/ImmutableSearchFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/ImmutableSearchFactory.java
@@ -110,6 +110,7 @@ public class ImmutableSearchFactory implements ExtendedSearchIntegratorWithShare
 	private final ObjectLookupMethod defaultObjectLookupMethod;
 	private final DatabaseRetrievalMethod defaultDatabaseRetrievalMethod;
 	private final boolean enlistWorkerInTransaction;
+	private final boolean indexUninvertingAllowed;
 
 	public ImmutableSearchFactory(SearchFactoryState state) {
 		this.analyzers = state.getAnalyzers();
@@ -158,6 +159,10 @@ public class ImmutableSearchFactory implements ExtendedSearchIntegratorWithShare
 		this.defaultDatabaseRetrievalMethod = determineDefaultDatabaseRetrievalMethod();
 		this.enlistWorkerInTransaction = ConfigurationParseHelper.getBooleanValue(
 				configurationProperties, Environment.WORKER_ENLIST_IN_TRANSACTION, false
+		);
+
+		this.indexUninvertingAllowed = ConfigurationParseHelper.getBooleanValue(
+				configurationProperties, Environment.INDEX_UNINVERTING_ALLOWED, true
 		);
 	}
 
@@ -531,6 +536,11 @@ public class ImmutableSearchFactory implements ExtendedSearchIntegratorWithShare
 	@Override
 	public IndexManager getIndexManager(String indexName) {
 		return getIndexManagerHolder().getIndexManager( indexName );
+	}
+
+	@Override
+	public boolean isIndexUninvertingAllowed() {
+		return indexUninvertingAllowed;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/engine/src/main/java/org/hibernate/search/engine/impl/MutableSearchFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/MutableSearchFactory.java
@@ -333,6 +333,11 @@ public class MutableSearchFactory implements ExtendedSearchIntegratorWithShareab
 	}
 
 	@Override
+	public boolean isIndexUninvertingAllowed() {
+		return delegate.isIndexUninvertingAllowed();
+	}
+
+	@Override
 	public <T> T unwrap(Class<T> cls) {
 		if ( SearchIntegrator.class.equals( cls ) || ExtendedSearchIntegrator.class.equals( cls ) || MutableSearchFactory.class.equals( cls ) ) {
 			return (T) this;

--- a/engine/src/main/java/org/hibernate/search/engine/integration/impl/ExtendedSearchIntegrator.java
+++ b/engine/src/main/java/org/hibernate/search/engine/integration/impl/ExtendedSearchIntegrator.java
@@ -119,4 +119,10 @@ public interface ExtendedSearchIntegrator extends SearchIntegrator {
 	 * @return returns the default {@code OBJECT_LOOKUP_METHOD}.
 	 */
 	ObjectLookupMethod getDefaultObjectLookupMethod();
+
+	/**
+	 * Whether index uninverting should be done when running queries with sorts not covered by the configured sortable
+	 * fields. If not allowed, an exception will be raised in this situation.
+	 */
+	boolean isIndexUninvertingAllowed();
 }

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
@@ -691,6 +691,11 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 
 		typeMetadataBuilder.addClassBridgeField( fieldMetadata );
 
+		if ( spatialBridge instanceof MetadataProvidingFieldBridge ) {
+			MetadataProvidingFieldBridge metadataProvidingFieldBridge = (MetadataProvidingFieldBridge) spatialBridge;
+			typeMetadataBuilder.addClassBridgeSortableFields( metadataProvidingFieldBridge.getSortableFieldNames( fieldName ) );
+		}
+
 		Analyzer analyzer = typeMetadataBuilder.getAnalyzer();
 		if ( analyzer == null ) {
 			throw new AssertionFailure( "Analyzer should not be undefined" );

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
@@ -59,6 +59,7 @@ import org.hibernate.search.annotations.Store;
 import org.hibernate.search.annotations.TermVector;
 import org.hibernate.search.bridge.ContainerBridge;
 import org.hibernate.search.bridge.FieldBridge;
+import org.hibernate.search.bridge.MetadataProvidingFieldBridge;
 import org.hibernate.search.bridge.StringBridge;
 import org.hibernate.search.bridge.TwoWayFieldBridge;
 import org.hibernate.search.bridge.builtin.DefaultStringBridge;
@@ -615,6 +616,9 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 
 		typeMetadataBuilder.addClassBridgeField( fieldMetadata );
 
+		if ( fieldBridge instanceof MetadataProvidingFieldBridge ) {
+			typeMetadataBuilder.addClassBridgeSortableFields( ( (MetadataProvidingFieldBridge) fieldBridge).getSortableFieldNames() );
+		}
 		Analyzer analyzer = AnnotationProcessingHelper.getAnalyzer( classBridgeAnnotation.analyzer(), configContext );
 		typeMetadataBuilder.addToScopedAnalyzer( fieldName, analyzer, index );
 	}
@@ -1035,6 +1039,15 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 				reflectionManager,
 				configContext.getServiceManager()
 		);
+
+		if ( fieldBridge instanceof MetadataProvidingFieldBridge ) {
+			for ( String sortableField : ( (MetadataProvidingFieldBridge) fieldBridge).getSortableFieldNames() ) {
+				SortableFieldMetadata sortableFieldMetadata = new SortableFieldMetadata.Builder()
+					.fieldName( sortableField )
+					.build();
+				propertyMetadataBuilder.addSortableField( sortableFieldMetadata );
+			}
+		}
 
 		final NumericEncodingType numericEncodingType = determineNumericFieldEncoding( fieldBridge );
 		final NullMarkerCodec nullTokenCodec = determineNullMarkerCodec( fieldAnnotation, configContext, numericEncodingType, fieldName );

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
@@ -617,7 +617,8 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 		typeMetadataBuilder.addClassBridgeField( fieldMetadata );
 
 		if ( fieldBridge instanceof MetadataProvidingFieldBridge ) {
-			typeMetadataBuilder.addClassBridgeSortableFields( ( (MetadataProvidingFieldBridge) fieldBridge).getSortableFieldNames() );
+			MetadataProvidingFieldBridge metadataProvidingFieldBridge = (MetadataProvidingFieldBridge) fieldBridge;
+			typeMetadataBuilder.addClassBridgeSortableFields( metadataProvidingFieldBridge.getSortableFieldNames( fieldName ) );
 		}
 		Analyzer analyzer = AnnotationProcessingHelper.getAnalyzer( classBridgeAnnotation.analyzer(), configContext );
 		typeMetadataBuilder.addToScopedAnalyzer( fieldName, analyzer, index );
@@ -1041,7 +1042,9 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 		);
 
 		if ( fieldBridge instanceof MetadataProvidingFieldBridge ) {
-			for ( String sortableField : ( (MetadataProvidingFieldBridge) fieldBridge).getSortableFieldNames() ) {
+			MetadataProvidingFieldBridge metadataProvidingFieldBridge = (MetadataProvidingFieldBridge) fieldBridge;
+
+			for ( String sortableField : metadataProvidingFieldBridge.getSortableFieldNames( fieldName ) ) {
 				SortableFieldMetadata sortableFieldMetadata = new SortableFieldMetadata.Builder()
 					.fieldName( sortableField )
 					.build();

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/TypeMetadata.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/TypeMetadata.java
@@ -136,6 +136,8 @@ public class TypeMetadata {
 	// TODO - would be nice to not need this in TypeMetadata (HF)
 	private final Set<XClass> optimizationBlackList;
 
+	private final Set<SortableFieldMetadata> classBridgeSortableFieldMetadata;
+
 	protected TypeMetadata(Builder builder) {
 		this.indexedType = builder.indexedType;
 		this.boost = builder.boost;
@@ -156,6 +158,7 @@ public class TypeMetadata {
 		this.propertyGetterNameToPropertyMetadata = keyPropertyMetadata( builder.propertyMetadataSet );
 		this.documentFieldNameToFieldMetadata = keyFieldMetadata( builder.propertyMetadataSet );
 		this.classBridgeFieldNameToDocumentFieldMetadata = copyClassBridgeMetadata( builder.classBridgeFields );
+		this.classBridgeSortableFieldMetadata = Collections.unmodifiableSet( builder.classBridgeSortableFieldMetadata );
 	}
 
 	public Class<?> getType() {
@@ -176,6 +179,10 @@ public class TypeMetadata {
 
 	public Set<DocumentFieldMetadata> getClassBridgeMetadata() {
 		return classBridgeFields;
+	}
+
+	public Set<SortableFieldMetadata> getClassBridgeSortableFieldMetadata() {
+		return classBridgeSortableFieldMetadata;
 	}
 
 	public DocumentFieldMetadata getDocumentFieldMetadataFor(String fieldName) {
@@ -403,6 +410,7 @@ public class TypeMetadata {
 		private final Set<String> collectionRoles = new TreeSet<String>();
 		private PropertyMetadata idPropertyMetadata;
 		private XProperty jpaProperty;
+		private final Set<SortableFieldMetadata> classBridgeSortableFieldMetadata = new HashSet<>();
 
 		public Builder(Class<?> indexedType, ConfigContext configContext) {
 			this( indexedType, new ScopedAnalyzer( configContext.getDefaultAnalyzer() ) );
@@ -546,6 +554,12 @@ public class TypeMetadata {
 		@Override
 		public String toString() {
 			return "TypeMetadata.Builder{indexedType=" + indexedType + "}";
+		}
+
+		public void addClassBridgeSortableFields(Iterable<String> sortableFieldNames) {
+			for ( String sortableFieldName : sortableFieldNames ) {
+				classBridgeSortableFieldMetadata.add( new SortableFieldMetadata.Builder().fieldName( sortableFieldName ).build() );
+			}
 		}
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/spi/DocumentBuilderIndexedEntity.java
+++ b/engine/src/main/java/org/hibernate/search/engine/spi/DocumentBuilderIndexedEntity.java
@@ -703,6 +703,13 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 	private void addSortFieldDocValues(Document document, PropertyMetadata propertyMetadata, float documentBoost, Object propertyValue) {
 		for ( SortableFieldMetadata sortField : propertyMetadata.getSortableFieldMetadata() ) {
 			DocumentFieldMetadata fieldMetaData = propertyMetadata.getFieldMetadata( sortField.getFieldName() );
+
+			// field marked as sortable by custom bridge to allow sort field validation pass, but that bridge itself is
+			// in charge of adding the required field
+			if ( fieldMetaData == null ) {
+				continue;
+			}
+
 			IndexableField field;
 
 			// A non-stored, non-indexed field will not be added to the actual document; in that case retrieve

--- a/engine/src/main/java/org/hibernate/search/query/engine/impl/LuceneHSQuery.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/impl/LuceneHSQuery.java
@@ -562,6 +562,8 @@ public class LuceneHSQuery extends AbstractHSQuery implements HSQuery, Serializa
 	}
 
 	private void collectSortableFields(SortConfigurations.Builder sortConfigurations, EmbeddedTypeMetadata embeddedTypeMetadata) {
+		sortConfigurations.addSortableFields( embeddedTypeMetadata.getClassBridgeSortableFieldMetadata() );
+
 		for ( PropertyMetadata property : embeddedTypeMetadata.getAllPropertyMetadata() ) {
 			sortConfigurations.addSortableFields( property.getSortableFieldMetadata() );
 		}

--- a/engine/src/main/java/org/hibernate/search/query/engine/impl/LuceneHSQuery.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/impl/LuceneHSQuery.java
@@ -464,6 +464,10 @@ public class LuceneHSQuery extends AbstractHSQuery implements HSQuery, Serializa
 			this.classesAndSubclasses = extendedIntegrator.getIndexedTypes();
 		}
 
+		if ( this.sort != null ) {
+			validateSortFields( extendedIntegrator );
+		}
+
 		//set up the searcher
 		final IndexManager[] indexManagers = targetedIndexes.toArray(
 				new IndexManager[targetedIndexes.size()]
@@ -502,7 +506,6 @@ public class LuceneHSQuery extends AbstractHSQuery implements HSQuery, Serializa
 			);
 		}
 		else if ( this.sort != null ) {
-			validateSortFields( extendedIntegrator );
 			if ( projection != null ) {
 				boolean activate = false;
 				for ( String field : projection ) {

--- a/engine/src/main/java/org/hibernate/search/query/engine/impl/LuceneHSQuery.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/impl/LuceneHSQuery.java
@@ -545,6 +545,7 @@ public class LuceneHSQuery extends AbstractHSQuery implements HSQuery, Serializa
 			sortConfigurations.setIndex( indexManager.getIndexName() );
 			sortConfigurations.setEntityType( typeMetadata.getType() );
 
+			sortConfigurations.addSortableFields( typeMetadata.getClassBridgeSortableFieldMetadata() );
 			sortConfigurations.addSortableFields( typeMetadata.getIdPropertyMetadata().getSortableFieldMetadata() );
 
 			for ( PropertyMetadata property : typeMetadata.getAllPropertyMetadata() ) {

--- a/engine/src/main/java/org/hibernate/search/query/engine/impl/LuceneHSQuery.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/impl/LuceneHSQuery.java
@@ -469,7 +469,12 @@ public class LuceneHSQuery extends AbstractHSQuery implements HSQuery, Serializa
 				new IndexManager[targetedIndexes.size()]
 		);
 
-		final IndexReader compoundReader = MultiReaderFactory.openReader( sortConfigurations.build(), sort, indexManagers );
+		final IndexReader compoundReader = MultiReaderFactory.openReader(
+				sortConfigurations.build(),
+				sort,
+				indexManagers,
+				extendedIntegrator.isIndexUninvertingAllowed()
+		);
 
 		final Query filteredQuery = filterQueryByTenantId( filterQueryByClasses( luceneQuery ) );
 

--- a/engine/src/main/java/org/hibernate/search/query/engine/impl/SortConfigurations.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/impl/SortConfigurations.java
@@ -67,7 +67,7 @@ public class SortConfigurations implements Iterable<SortConfigurations.SortConfi
 
 			for ( SortField sortField : sort.getSort() ) {
 				// no doc value field needed for these
-				if ( sortField.getType() == SortField.Type.DOC && sortField.getType() == SortField.Type.SCORE ) {
+				if ( sortField.getType() == SortField.Type.DOC || sortField.getType() == SortField.Type.SCORE ) {
 					continue;
 				}
 

--- a/engine/src/main/java/org/hibernate/search/reader/impl/MultiReaderFactory.java
+++ b/engine/src/main/java/org/hibernate/search/reader/impl/MultiReaderFactory.java
@@ -29,17 +29,17 @@ public final class MultiReaderFactory {
 	}
 
 	public static IndexReader openReader(IndexManager... indexManagers) {
-		return openReader( null, null, indexManagers );
+		return openReader( null, null, indexManagers, true );
 	}
 
-	public static IndexReader openReader(SortConfigurations configuredSorts, Sort sort, IndexManager[] indexManagers) {
+	public static IndexReader openReader(SortConfigurations configuredSorts, Sort sort, IndexManager[] indexManagers, boolean indexUninvertingAllowed) {
 		if ( indexManagers.length == 0 ) {
 			return null;
 		}
 		else {
 			//everything should be the same so wrap in an MultiReader
 			try {
-				return ManagedMultiReader.createInstance( indexManagers, configuredSorts, sort );
+				return ManagedMultiReader.createInstance( indexManagers, configuredSorts, sort, indexUninvertingAllowed );
 			}
 			catch (IOException e) {
 				throw log.ioExceptionOnMultiReaderRefresh( e );

--- a/engine/src/main/java/org/hibernate/search/spatial/SpatialFieldBridge.java
+++ b/engine/src/main/java/org/hibernate/search/spatial/SpatialFieldBridge.java
@@ -11,16 +11,18 @@ import java.beans.PropertyDescriptor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import org.apache.lucene.document.Document;
+import java.util.Collections;
+import java.util.Set;
 
-import org.hibernate.search.bridge.FieldBridge;
+import org.apache.lucene.document.Document;
 import org.hibernate.search.bridge.LuceneOptions;
+import org.hibernate.search.bridge.MetadataProvidingFieldBridge;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
 import static java.util.Locale.ENGLISH;
 
-public abstract class SpatialFieldBridge implements FieldBridge {
+public abstract class SpatialFieldBridge implements MetadataProvidingFieldBridge {
 
 	private static final Log LOG = LoggerFactory.make();
 
@@ -43,6 +45,11 @@ public abstract class SpatialFieldBridge implements FieldBridge {
 				throw LOG.cannotExtractCoordinateFromObject( value.getClass().getName() );
 			}
 		}
+	}
+
+	@Override
+	public Set<String> getSortableFieldNames(String name) {
+		return Collections.singleton( name );
 	}
 
 	private Double getCoordinateFromField(String coordinateField, Object value) {

--- a/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
@@ -915,4 +915,7 @@ public interface Log extends BasicLogger {
 
 	@Message(id = 300, value = "Several @NumericField annotations used on %1$s#%2$s refer to the same field")
 	SearchException severalNumericFieldAnnotationsForSameField(@FormatWith(ClassFormatter.class) Class<?> entityClass, String memberName);
+
+	@Message(id = 301, value = "Requested sort field(s) %3$s are not configured for entity type %1$s mapped to index %2$s, thus an uninverting reader must be created. You should declare the missing sort fields using @SortableField." )
+	SearchException uncoveredSortsRequestedWithUninvertingNotAllowed(@FormatWith(ClassFormatter.class) Class<?> entityType, String indexName, String uncoveredSorts);
 }

--- a/engine/src/test/java/org/hibernate/search/test/sorting/ManagedMultiReaderTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/sorting/ManagedMultiReaderTest.java
@@ -64,7 +64,7 @@ public class ManagedMultiReaderTest {
 			.build();
 
 
-		try ( ManagedMultiReader reader = (ManagedMultiReader) MultiReaderFactory.openReader( configuredSorts, sort, indexManagers ) ) {
+		try ( ManagedMultiReader reader = (ManagedMultiReader) MultiReaderFactory.openReader( configuredSorts, sort, indexManagers, false ) ) {
 			List<? extends IndexReader> actualReaders = reader.getSubReaders();
 			assertThat( actualReaders ).hasSize( 1 );
 			assertThat( actualReaders.get( 0 ).getClass().getSimpleName() ).isEqualTo( "StandardDirectoryReader" );
@@ -93,7 +93,7 @@ public class ManagedMultiReaderTest {
 			)
 			.build();
 
-		try ( ManagedMultiReader reader = (ManagedMultiReader) MultiReaderFactory.openReader( configuredSorts, sort, indexManagers ) ) {
+		try ( ManagedMultiReader reader = (ManagedMultiReader) MultiReaderFactory.openReader( configuredSorts, sort, indexManagers, true ) ) {
 			List<? extends IndexReader> actualReaders = reader.getSubReaders();
 			assertThat( actualReaders ).hasSize( 1 );
 			assertThat( actualReaders.get( 0 ).getClass().getSimpleName() ).isEqualTo( "UninvertingDirectoryReader" );
@@ -131,7 +131,11 @@ public class ManagedMultiReaderTest {
 					)
 			.build();
 
-		try ( ManagedMultiReader reader = (ManagedMultiReader) MultiReaderFactory.openReader( configuredSorts, sort, indexManagers.toArray( new IndexManager[indexManagers.size()] ) ) ) {
+		try ( ManagedMultiReader reader = (ManagedMultiReader) MultiReaderFactory.openReader(
+				configuredSorts,
+				sort,
+				indexManagers.toArray( new IndexManager[indexManagers.size()] ),
+				true) ) {
 			List<? extends IndexReader> actualReaders = reader.getSubReaders();
 			assertThat( actualReaders ).hasSize( 2 );
 			assertThat( actualReaders.get( 0 ).getClass().getSimpleName() ).isEqualTo( "UninvertingDirectoryReader" );

--- a/orm/src/test/java/org/hibernate/search/test/query/Book.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/Book.java
@@ -105,6 +105,7 @@ public class Book {
 			@Field(store = Store.YES),
 			@Field(name = "summary_forSort", analyze = Analyze.NO, store = Store.YES)
 	})
+	@SortableField(forField = "summary_forSort")
 	public String getSummary() {
 		return summary;
 	}

--- a/orm/src/test/java/org/hibernate/search/test/query/sorting/Explorer.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/sorting/Explorer.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.ManyToOne;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.SortedDocValuesField;
@@ -23,6 +24,7 @@ import org.hibernate.search.annotations.ClassBridge;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.FieldBridge;
 import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.IndexedEmbedded;
 import org.hibernate.search.annotations.SortableField;
 import org.hibernate.search.bridge.LuceneOptions;
 import org.hibernate.search.bridge.MetadataProvidingFieldBridge;
@@ -46,6 +48,10 @@ public class Explorer {
 	@ElementCollection
 	private final Map<String, String> nameParts = new HashMap<>();
 
+	@ManyToOne
+	@IndexedEmbedded
+	private Territory favoriteTerritory;
+
 	public Explorer() {
 	}
 
@@ -53,10 +59,12 @@ public class Explorer {
 		this.id = id;
 	}
 
-	public Explorer(int id, int exploredCountries, String firstName, String middleName, String lastName) {
+	public Explorer(int id, int exploredCountries, Territory favoriteTerritory, String firstName, String middleName, String lastName) {
 		this.id = id;
 
 		this.exploredCountries = exploredCountries;
+		this.favoriteTerritory = favoriteTerritory;
+
 		nameParts.put( "firstName", firstName );
 		nameParts.put( "middleName", middleName );
 		nameParts.put( "lastName", lastName );
@@ -72,6 +80,10 @@ public class Explorer {
 
 	public Map<String, String> getNameParts() {
 		return nameParts;
+	}
+
+	public Territory getFavoriteTerritory() {
+		return favoriteTerritory;
 	}
 
 	/**

--- a/orm/src/test/java/org/hibernate/search/test/query/sorting/Explorer.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/sorting/Explorer.java
@@ -1,0 +1,122 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.query.sorting;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.util.BytesRef;
+import org.hibernate.search.annotations.ClassBridge;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.FieldBridge;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.SortableField;
+import org.hibernate.search.bridge.LuceneOptions;
+import org.hibernate.search.bridge.MetadataProvidingFieldBridge;
+
+@Entity
+@Indexed
+@ClassBridge(impl = Explorer.FirstAndMiddleNamesFieldBridge.class)
+public class Explorer {
+
+	@Id
+	private int id;
+
+	@Field
+	@SortableField
+	private int exploredCountries;
+
+	@Field(bridge = @FieldBridge(impl = Explorer.LastNameFieldBridge.class))
+	@ElementCollection
+	private final Map<String, String> nameParts = new HashMap<>();
+
+	public Explorer() {
+	}
+
+	public Explorer(int id) {
+		this.id = id;
+	}
+
+	public Explorer(int id, int exploredCountries, String firstName, String middleName, String lastName) {
+		this.id = id;
+
+		this.exploredCountries = exploredCountries;
+		nameParts.put( "firstName", firstName );
+		nameParts.put( "middleName", middleName );
+		nameParts.put( "lastName", lastName );
+	}
+
+	public int getId() {
+		return id;
+	}
+
+	public int getExploredCountries() {
+		return exploredCountries;
+	}
+
+	public Map<String, String> getNameParts() {
+		return nameParts;
+	}
+
+	/**
+	 * Used as class-level bridge for creating the "firstName" and "middleName" document and doc value fields.
+	 */
+	public static class FirstAndMiddleNamesFieldBridge implements MetadataProvidingFieldBridge {
+
+		@Override
+		public void set(String name, Object value, Document document, LuceneOptions luceneOptions) {
+			Explorer explorer = (Explorer) value;
+
+			String firstName = explorer.getNameParts().get( "firstName" );
+			luceneOptions.addFieldToDocument( "firstName", firstName, document );
+			document.add( new SortedDocValuesField( "firstName", new BytesRef( firstName ) ) );
+
+			String middleName = explorer.getNameParts().get( "middleName" );
+			luceneOptions.addFieldToDocument( "middleName", middleName, document );
+			document.add( new SortedDocValuesField( "middleName", new BytesRef( middleName ) ) );
+		}
+
+		@Override
+		public Set<String> getSortableFieldNames() {
+			Set<String> sortableFields = new HashSet<>();
+			sortableFields.add( "firstName" );
+			sortableFields.add( "middleName" );
+
+			return sortableFields;
+		}
+	}
+
+	/**
+	 * Used as field-level bridge for creating the "lastName" document and doc value fields.
+	 */
+	public static class LastNameFieldBridge implements MetadataProvidingFieldBridge {
+
+		@Override
+		public void set(String name, Object value, Document document, LuceneOptions luceneOptions) {
+			@SuppressWarnings("unchecked")
+			Map<String, String> nameParts = (Map<String, String>) value;
+			String lastName = nameParts.get( "lastName" );
+
+			luceneOptions.addFieldToDocument( "lastName", lastName, document );
+			document.add( new SortedDocValuesField( "lastName", new BytesRef( lastName ) ) );
+		}
+
+		@Override
+		public Set<String> getSortableFieldNames() {
+			return Collections.singleton( "lastName" );
+		}
+	}
+}

--- a/orm/src/test/java/org/hibernate/search/test/query/sorting/Explorer.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/sorting/Explorer.java
@@ -29,7 +29,10 @@ import org.hibernate.search.bridge.MetadataProvidingFieldBridge;
 
 @Entity
 @Indexed
-@ClassBridge(impl = Explorer.FirstAndMiddleNamesFieldBridge.class)
+@ClassBridge(
+		name = "fn",
+		impl = Explorer.FirstAndMiddleNamesFieldBridge.class
+)
 public class Explorer {
 
 	@Id
@@ -81,19 +84,19 @@ public class Explorer {
 			Explorer explorer = (Explorer) value;
 
 			String firstName = explorer.getNameParts().get( "firstName" );
-			luceneOptions.addFieldToDocument( "firstName", firstName, document );
-			document.add( new SortedDocValuesField( "firstName", new BytesRef( firstName ) ) );
+			luceneOptions.addFieldToDocument( name + "_firstName", firstName, document );
+			document.add( new SortedDocValuesField( name + "_firstName", new BytesRef( firstName ) ) );
 
 			String middleName = explorer.getNameParts().get( "middleName" );
-			luceneOptions.addFieldToDocument( "middleName", middleName, document );
-			document.add( new SortedDocValuesField( "middleName", new BytesRef( middleName ) ) );
+			luceneOptions.addFieldToDocument( name + "_middleName", middleName, document );
+			document.add( new SortedDocValuesField( name + "_middleName", new BytesRef( middleName ) ) );
 		}
 
 		@Override
-		public Set<String> getSortableFieldNames() {
+		public Set<String> getSortableFieldNames(String fieldName) {
 			Set<String> sortableFields = new HashSet<>();
-			sortableFields.add( "firstName" );
-			sortableFields.add( "middleName" );
+			sortableFields.add( fieldName + "_firstName" );
+			sortableFields.add( fieldName + "_middleName" );
 
 			return sortableFields;
 		}
@@ -110,13 +113,13 @@ public class Explorer {
 			Map<String, String> nameParts = (Map<String, String>) value;
 			String lastName = nameParts.get( "lastName" );
 
-			luceneOptions.addFieldToDocument( "lastName", lastName, document );
-			document.add( new SortedDocValuesField( "lastName", new BytesRef( lastName ) ) );
+			luceneOptions.addFieldToDocument( name + "_lastName", lastName, document );
+			document.add( new SortedDocValuesField( name + "_lastName", new BytesRef( lastName ) ) );
 		}
 
 		@Override
-		public Set<String> getSortableFieldNames() {
-			return Collections.singleton( "lastName" );
+		public Set<String> getSortableFieldNames(String fieldName) {
+			return Collections.singleton( fieldName + "_lastName" );
 		}
 	}
 }

--- a/orm/src/test/java/org/hibernate/search/test/query/sorting/SortOnFieldsFromCustomBridgeTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/sorting/SortOnFieldsFromCustomBridgeTest.java
@@ -70,8 +70,8 @@ public class SortOnFieldsFromCustomBridgeTest extends SearchTestBase {
 		List<Book> result = fullTextSession.createFullTextQuery( new MatchAllDocsQuery(), Explorer.class )
 			.setSort(
 					new Sort(
-							new SortField( "firstName", SortField.Type.STRING ),
-							new SortField( "middleName", SortField.Type.STRING )
+							new SortField( "fn_firstName", SortField.Type.STRING ),
+							new SortField( "fn_middleName", SortField.Type.STRING )
 					)
 			)
 			.list();
@@ -90,7 +90,7 @@ public class SortOnFieldsFromCustomBridgeTest extends SearchTestBase {
 
 		@SuppressWarnings("unchecked")
 		List<Book> result = fullTextSession.createFullTextQuery( new MatchAllDocsQuery(), Explorer.class )
-			.setSort( new Sort( new SortField( "lastName", SortField.Type.STRING ) ) )
+			.setSort( new Sort( new SortField( "nameParts_lastName", SortField.Type.STRING ) ) )
 			.list();
 
 		assertNotNull( result );
@@ -111,7 +111,7 @@ public class SortOnFieldsFromCustomBridgeTest extends SearchTestBase {
 			.setSort(
 					new Sort(
 							new SortField( "exploredCountries", SortField.Type.INT ),
-							new SortField( "lastName", SortField.Type.STRING )
+							new SortField( "nameParts_lastName", SortField.Type.STRING )
 					)
 			)
 			.list();

--- a/orm/src/test/java/org/hibernate/search/test/query/sorting/SortTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/sorting/SortTest.java
@@ -468,7 +468,7 @@ public class SortTest extends SearchTestBase {
 		}
 
 		@Override
-		public Set<String> getSortableFieldNames() {
+		public Set<String> getSortableFieldNames(String fieldName) {
 			return Collections.singleton( "sum" );
 		}
 	}

--- a/orm/src/test/java/org/hibernate/search/test/query/sorting/SortWithIndexUninvertingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/sorting/SortWithIndexUninvertingTest.java
@@ -1,0 +1,149 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.query.sorting;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.lucene.queryparser.classic.QueryParser;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+import org.hibernate.Transaction;
+import org.hibernate.resource.transaction.spi.TransactionStatus;
+import org.hibernate.search.FullTextQuery;
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.Search;
+import org.hibernate.search.cfg.Environment;
+import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.test.query.Book;
+import org.hibernate.search.testsupport.TestConstants;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+/**
+ * Test for sorting on fields which are not added as doc value fields and thus require index uninverting.
+ *
+ * @author Gunnar Morling
+ */
+public class SortWithIndexUninvertingTest extends SearchTestBase {
+
+	private static FullTextSession fullTextSession;
+	private static QueryParser queryParser;
+
+	@Override
+	@Before
+	public void setUp() throws Exception {
+		super.setUp();
+		fullTextSession = Search.getFullTextSession( openSession() );
+		queryParser = new QueryParser(
+				"title",
+				TestConstants.stopAnalyzer
+		);
+
+		createTestContractors();
+	}
+
+	@Override
+	@After
+	public void tearDown() throws Exception {
+		// check for ongoing transaction which is an indicator that something went wrong
+		// don't call the cleanup methods in this case. Otherwise the original error get swallowed
+		if ( fullTextSession.getTransaction().getStatus() != TransactionStatus.ACTIVE ) {
+			deleteTestContractors();
+			fullTextSession.close();
+		}
+		super.tearDown();
+	}
+
+
+	@Test
+	public void testCombinedQueryOnIndexWithSortFieldAndIndexToBeUninverted() throws Exception {
+		Transaction tx = fullTextSession.beginTransaction();
+
+		Query query = queryParser.parse( "name:Bill" );
+		FullTextQuery hibQuery = fullTextSession.createFullTextQuery( query, Plumber.class, BrickLayer.class );
+		Sort sort = new Sort( new SortField( "sortName", SortField.Type.STRING ) ); //ASC
+		hibQuery.setSort( sort );
+
+		@SuppressWarnings("unchecked")
+		List<Book> result = hibQuery.list();
+		assertNotNull( result );
+		assertThat( result ).onProperty( "name" )
+			.describedAs( "Expecting results from index with sort field and uninverted index in the correct sort order" )
+			.containsExactly( "Bill the brick layer", "Bill the plumber" );
+
+		tx.commit();
+	}
+
+	/**
+	 * The index is shared by two entities. One declares the required sorts, the other does not. As this would require
+	 * uninverting the index for one entity but not the other, that situation is considered inconsistent and an
+	 * exception is expected.
+	 */
+	@Test
+	public void testQueryOnIndexSharedByEntityWithRequiredSortFieldAndEntityWithoutRaisesException() throws Exception {
+		Transaction tx = fullTextSession.beginTransaction();
+
+		Query query = queryParser.parse( "name:Bill" );
+		FullTextQuery hibQuery = fullTextSession.createFullTextQuery( query, Thatcher.class, BrickLayer.class );
+		Sort sort = new Sort( new SortField( "sortName", SortField.Type.STRING ) ); //ASC
+		hibQuery.setSort( sort );
+
+		try {
+			hibQuery.list();
+			fail( "Expected exception was not raised" );
+		}
+		catch (Exception e) {
+			assertThat( e.getMessage() ).contains( "HSEARCH000298" );
+		}
+
+		tx.commit();
+	}
+
+	private void createTestContractors() {
+		Transaction tx = fullTextSession.beginTransaction();
+
+		fullTextSession.save( new Plumber( 1, "Bill the plumber" ) );
+		fullTextSession.save( new BrickLayer( 2, "Bill the brick layer", "Johnson" ) );
+		fullTextSession.save( new BrickLayer( 4, "Barny the brick layer", "Johnson" ) );
+		fullTextSession.save( new BrickLayer( 5, "Bart the brick layer", "Higgins" ) );
+		fullTextSession.save( new BrickLayer( 6, "Barny the brick layer", "Higgins" ) );
+		fullTextSession.save( new Thatcher( 3, "Bill the thatcher" ) );
+
+		tx.commit();
+		fullTextSession.clear();
+	}
+
+	private void deleteTestContractors() {
+		Transaction tx = fullTextSession.beginTransaction();
+		fullTextSession.createQuery( "delete " + Plumber.class.getName() ).executeUpdate();
+		fullTextSession.createQuery( "delete " + BrickLayer.class.getName() ).executeUpdate();
+		fullTextSession.createQuery( "delete " + Thatcher.class.getName() ).executeUpdate();
+		tx.commit();
+		fullTextSession.clear();
+	}
+
+	@Override
+	public void configure(Map<String, Object> settings) {
+		settings.put( Environment.INDEX_UNINVERTING_ALLOWED, "true" );
+	}
+
+	@Override
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class[] {
+				Plumber.class,
+				BrickLayer.class,
+				Thatcher.class
+		};
+	}
+}

--- a/orm/src/test/java/org/hibernate/search/test/query/sorting/Territory.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/sorting/Territory.java
@@ -1,0 +1,80 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.query.sorting;
+
+import java.util.Collections;
+import java.util.Set;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.util.BytesRef;
+import org.hibernate.search.annotations.ClassBridge;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.bridge.LuceneOptions;
+import org.hibernate.search.bridge.MetadataProvidingFieldBridge;
+
+/**
+ * @author Gunnar Morling
+ */
+@Entity
+@Indexed
+@ClassBridge(impl = Territory.NameFieldBridge.class)
+public class Territory {
+
+	@Id
+	private int id;
+
+	private String name;
+
+	Territory() {
+	}
+
+	public Territory(int id) {
+		this.id = id;
+	}
+
+	public Territory(int id, String name) {
+		this.id = id;
+		this.name = name;
+	}
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public static class NameFieldBridge implements MetadataProvidingFieldBridge {
+
+		@Override
+		public void set(String name, Object value, Document document, LuceneOptions luceneOptions) {
+			Territory territory = (Territory) value;
+
+			String territoryName = territory.getName();
+			luceneOptions.addFieldToDocument( "territoryName", territoryName, document );
+			document.add( new SortedDocValuesField( "territoryName", new BytesRef( territoryName ) ) );
+		}
+
+		@Override
+		public Set<String> getSortableFieldNames(String fieldName) {
+			return Collections.singleton( "territoryName" );
+		}
+	}
+}

--- a/orm/src/test/java/org/hibernate/search/test/spatial/POI.java
+++ b/orm/src/test/java/org/hibernate/search/test/spatial/POI.java
@@ -15,7 +15,6 @@ import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.FieldBridge;
 import org.hibernate.search.annotations.Index;
 import org.hibernate.search.annotations.Indexed;
-import org.hibernate.search.annotations.SortableField;
 import org.hibernate.search.annotations.Store;
 import org.hibernate.search.spatial.Coordinates;
 import org.hibernate.search.spatial.SpatialFieldBridgeByHash;
@@ -45,7 +44,6 @@ public class POI {
 
 	@Field(store = Store.YES, index = Index.YES, analyze = Analyze.NO)
 	@FieldBridge(impl = SpatialFieldBridgeByHash.class)
-	@SortableField
 	@Embedded
 	public Coordinates getLocation() {
 		return new Coordinates() {

--- a/orm/src/test/java/org/hibernate/search/test/spatial/POI.java
+++ b/orm/src/test/java/org/hibernate/search/test/spatial/POI.java
@@ -6,18 +6,19 @@
  */
 package org.hibernate.search.test.spatial;
 
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
 import org.hibernate.search.annotations.Analyze;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.FieldBridge;
 import org.hibernate.search.annotations.Index;
 import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.SortableField;
 import org.hibernate.search.annotations.Store;
-import org.hibernate.search.spatial.SpatialFieldBridgeByHash;
 import org.hibernate.search.spatial.Coordinates;
-
-import javax.persistence.Embedded;
-import javax.persistence.Entity;
-import javax.persistence.Id;
+import org.hibernate.search.spatial.SpatialFieldBridgeByHash;
 
 /**
  * Hibernate Search spatial : Point Of Interest test entity
@@ -44,6 +45,7 @@ public class POI {
 
 	@Field(store = Store.YES, index = Index.YES, analyze = Analyze.NO)
 	@FieldBridge(impl = SpatialFieldBridgeByHash.class)
+	@SortableField
 	@Embedded
 	public Coordinates getLocation() {
 		return new Coordinates() {

--- a/orm/src/test/java/org/hibernate/search/test/spatial/SpatialSearchSortByDistanceAndPagingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/spatial/SpatialSearchSortByDistanceAndPagingTest.java
@@ -20,9 +20,7 @@ import javax.persistence.Id;
 import javax.persistence.Transient;
 
 import org.apache.lucene.search.Sort;
-
 import org.hibernate.Session;
-
 import org.hibernate.search.FullTextQuery;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
@@ -32,6 +30,7 @@ import org.hibernate.search.annotations.Latitude;
 import org.hibernate.search.annotations.Longitude;
 import org.hibernate.search.annotations.Spatial;
 import org.hibernate.search.annotations.SpatialMode;
+import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.query.dsl.Unit;
 import org.hibernate.search.spatial.DistanceSortField;
@@ -205,6 +204,12 @@ public class SpatialSearchSortByDistanceAndPagingTest extends SearchTestBase {
 		return new Class<?>[] {
 				GeoEntity.class
 		};
+	}
+
+	@Override
+	public void configure(Map<String, Object> settings) {
+		// TODO HSEARCH-2044 Atm. sorting on spatial fields is only possible w/ index uninverting
+		settings.put( Environment.INDEX_UNINVERTING_ALLOWED, "true" );
 	}
 
 	@Entity

--- a/orm/src/test/java/org/hibernate/search/test/spatial/SpatialSearchSortByDistanceAndPagingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/spatial/SpatialSearchSortByDistanceAndPagingTest.java
@@ -30,7 +30,6 @@ import org.hibernate.search.annotations.Latitude;
 import org.hibernate.search.annotations.Longitude;
 import org.hibernate.search.annotations.Spatial;
 import org.hibernate.search.annotations.SpatialMode;
-import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.query.dsl.Unit;
 import org.hibernate.search.spatial.DistanceSortField;
@@ -204,12 +203,6 @@ public class SpatialSearchSortByDistanceAndPagingTest extends SearchTestBase {
 		return new Class<?>[] {
 				GeoEntity.class
 		};
-	}
-
-	@Override
-	public void configure(Map<String, Object> settings) {
-		// TODO HSEARCH-2044 Atm. sorting on spatial fields is only possible w/ index uninverting
-		settings.put( Environment.INDEX_UNINVERTING_ALLOWED, "true" );
 	}
 
 	@Entity

--- a/orm/src/test/resources/hibernate.properties
+++ b/orm/src/test/resources/hibernate.properties
@@ -20,3 +20,6 @@ hibernate.max_fetch_depth 5
 
 hibernate.cache.region_prefix hibernate.test
 hibernate.cache.provider_class org.hibernate.cache.HashtableCacheProvider
+
+# Uncovered sorts should fail a test by default; Specific tests for uninverting may alter this setting
+hibernate.search.index_uninverting_allowed false


### PR DESCRIPTION
HSEARCH-2021: Adds a new optional `FieldBridge` sub-contract which allows implementations to expose the names of the sortable fields they created; Experimental, to be evolved into more complete means of exposing related meta-data down the road

HSEARCH-2043: Adding option to fail upon uncovered sorts which is useful for testing (by users and us); Defaults to not fail atm. which may be altered later on if we want to encourage users more actively to configure all sorts

HSEARCH-2042: Minor en-passant fix which avoids index uninverting in some cases