### PR TITLE
Test case for HSEARCH-2069

### DIFF
--- a/orm/src/test/java/org/hibernate/search/test/embedded/sortablefield/EmbeddedSortableIdFieldTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/embedded/sortablefield/EmbeddedSortableIdFieldTest.java
@@ -1,0 +1,26 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.embedded.sortablefield;
+
+import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.testsupport.TestForIssue;
+import org.junit.Test;
+
+@TestForIssue(jiraKey = "HSEARCH-2069")
+public class EmbeddedSortableIdFieldTest extends SearchTestBase {
+
+	@Test
+	public void test() {
+		// Nothing to do here: if the test fails, it will fail during initialization. 
+	}
+
+	@Override
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class[] { Level1.class, Level2SortableId.class };
+	}
+
+}

--- a/orm/src/test/java/org/hibernate/search/test/embedded/sortablefield/Level1.java
+++ b/orm/src/test/java/org/hibernate/search/test/embedded/sortablefield/Level1.java
@@ -1,0 +1,49 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.embedded.sortablefield;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.IndexedEmbedded;
+
+@Entity
+@Indexed
+class Level1 {
+
+	@Id
+	@DocumentId
+	@Field
+	@GeneratedValue
+	private Integer id;
+
+	@OneToOne(mappedBy = "level1Parent")
+	@IndexedEmbedded(includePaths = "name")
+	private Level2SortableId level2Child;
+
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public Level2SortableId getLevel2Child() {
+		return level2Child;
+	}
+
+	public void setLevel2Child(Level2SortableId level2Child) {
+		this.level2Child = level2Child;
+	}
+
+}

--- a/orm/src/test/java/org/hibernate/search/test/embedded/sortablefield/Level1.java
+++ b/orm/src/test/java/org/hibernate/search/test/embedded/sortablefield/Level1.java
@@ -12,7 +12,6 @@ import javax.persistence.Id;
 import javax.persistence.OneToOne;
 
 import org.hibernate.search.annotations.DocumentId;
-import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.annotations.IndexedEmbedded;
 
@@ -22,7 +21,6 @@ class Level1 {
 
 	@Id
 	@DocumentId
-	@Field
 	@GeneratedValue
 	private Integer id;
 

--- a/orm/src/test/java/org/hibernate/search/test/embedded/sortablefield/Level2SortableId.java
+++ b/orm/src/test/java/org/hibernate/search/test/embedded/sortablefield/Level2SortableId.java
@@ -1,0 +1,61 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.embedded.sortablefield;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+
+import org.hibernate.search.annotations.ContainedIn;
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.SortableField;
+
+@Entity
+@Indexed
+class Level2SortableId {
+
+	@Id
+	@DocumentId
+	@SortableField
+	@GeneratedValue
+	private Integer id;
+
+	@OneToOne
+	@ContainedIn
+	private Level1 level1Parent;
+
+	@Field
+	private String name;
+
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public Level1 getLevel1Parent() {
+		return level1Parent;
+	}
+
+	public void setLevel1Parent(Level1 level1Parent) {
+		this.level1Parent = level1Parent;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+}


### PR DESCRIPTION
Here it is.
I put this test case in the ORM package, because the engine does not depend on JPA, which prevents me from adding the @Id annotation that triggers implicit creation of an "id" field and then the whole issue.