### PR TITLE
Query serialization

### DIFF
--- a/engine/src/main/java/org/hibernate/search/query/engine/impl/AbstractHSQuery.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/impl/AbstractHSQuery.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.query.engine.impl;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -32,7 +33,7 @@ import static org.hibernate.search.util.impl.CollectionHelper.newHashMap;
  *
  * @author Gunnar Morling
  */
-public abstract class AbstractHSQuery implements HSQuery {
+public abstract class AbstractHSQuery implements HSQuery, Serializable {
 
 	private static final Log LOG = LoggerFactory.make();
 

--- a/engine/src/main/java/org/hibernate/search/query/engine/impl/LuceneHSQuery.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/impl/LuceneHSQuery.java
@@ -7,7 +7,6 @@
 package org.hibernate.search.query.engine.impl;
 
 import java.io.IOException;
-import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -66,7 +65,7 @@ import static org.hibernate.search.util.impl.FilterCacheModeTypeHelper.cacheResu
  * @author Emmanuel Bernard
  * @author Hardy Ferentschik
  */
-public class LuceneHSQuery extends AbstractHSQuery implements HSQuery, Serializable {
+public class LuceneHSQuery extends AbstractHSQuery implements HSQuery {
 
 	static final Log log = LoggerFactory.make();
 	private static final FullTextFilterImplementor[] EMPTY_FULL_TEXT_FILTER_IMPLEMENTOR = new FullTextFilterImplementor[0];

--- a/engine/src/test/java/org/hibernate/search/test/query/serialization/QuerySerializationTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/query/serialization/QuerySerializationTest.java
@@ -1,0 +1,81 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.query.serialization;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.lucene.search.Query;
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.backend.spi.Work;
+import org.hibernate.search.backend.spi.WorkType;
+import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
+import org.hibernate.search.query.dsl.QueryBuilder;
+import org.hibernate.search.query.engine.spi.EntityInfo;
+import org.hibernate.search.query.engine.spi.HSQuery;
+import org.hibernate.search.testsupport.junit.SearchFactoryHolder;
+import org.hibernate.search.testsupport.serialization.SerializationTestHelper;
+import org.hibernate.search.testsupport.setup.TransactionContextForTest;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+
+/**
+ * Verifies Serialization of the LuceneHSQuery object.
+ * Infinispan needs to serialize these.
+ *
+ * @author Sanne Grinovero
+ */
+public class QuerySerializationTest {
+
+	@Rule
+	public SearchFactoryHolder sfHolder = new SearchFactoryHolder( Book.class );
+
+	@Test
+	public void verifyExceptionOnNonMeaningfullQueries() throws ClassNotFoundException, IOException {
+		final ExtendedSearchIntegrator integrator = sfHolder.getSearchFactory();
+
+		Book book = new Book();
+		book.title = "Java Serialization";
+		book.text = "The black art of object serialization is full of pitfalls even for experienced developers";
+
+		Work work = new Work( book, book.title, WorkType.ADD, false );
+		TransactionContextForTest tc = new TransactionContextForTest();
+		integrator.getWorker().performWork( work, tc );
+		tc.end();
+
+		QueryBuilder queryBuilder = integrator.buildQueryBuilder().forEntity( Book.class ).get();
+
+		Query luceneQuery = queryBuilder.keyword().onField( "text" ).matching( "art" ).createQuery();
+		HSQuery hsQuery = integrator.createHSQuery().luceneQuery( luceneQuery );
+		hsQuery.targetedEntities( Arrays.<Class<?>>asList( Book.class ) );
+		//Lucene Queries are not serializable: who's using LuceneHSQuery will need to
+		//encode the query separately and set it again.
+		hsQuery.luceneQuery( null );
+
+		HSQuery clonedQuery = SerializationTestHelper.duplicateBySerialization( hsQuery );
+
+		clonedQuery.afterDeserialise( integrator );
+		clonedQuery.luceneQuery( luceneQuery );
+		List<EntityInfo> result = clonedQuery.queryEntityInfos();
+		Assert.assertEquals( 1, result.size() );
+	}
+
+	@Indexed
+	static class Book {
+		@DocumentId
+		String title;
+
+		@Field
+		String text;
+	}
+
+}

--- a/engine/src/test/java/org/hibernate/search/testsupport/serialization/SerializationTestHelper.java
+++ b/engine/src/test/java/org/hibernate/search/testsupport/serialization/SerializationTestHelper.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.test;
+package org.hibernate.search.testsupport.serialization;
 
 import static org.junit.Assert.assertEquals;
 
@@ -16,7 +16,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.hibernate.search.test.SerializationTestHelper.Foo.TestInnerClass;
+import org.hibernate.search.testsupport.serialization.SerializationTestHelper.Foo.TestInnerClass;
 import org.junit.Test;
 
 /**

--- a/orm/src/test/java/org/hibernate/search/test/configuration/LuceneIndexingParametersTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/LuceneIndexingParametersTest.java
@@ -12,9 +12,9 @@ import java.util.Properties;
 
 import org.hibernate.search.backend.spi.LuceneIndexingParameters;
 import org.hibernate.search.test.Document;
-import org.hibernate.search.test.SerializationTestHelper;
 import org.hibernate.search.test.query.Author;
 import org.hibernate.search.test.query.Book;
+import org.hibernate.search.testsupport.serialization.SerializationTestHelper;
 import org.junit.Test;
 
 import static org.hibernate.search.backend.configuration.impl.IndexWriterSetting.MAX_BUFFERED_DOCS;

--- a/orm/src/test/java/org/hibernate/search/test/configuration/MaskedPropertiesTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/MaskedPropertiesTest.java
@@ -9,7 +9,7 @@ package org.hibernate.search.test.configuration;
 import java.io.IOException;
 import java.util.Properties;
 
-import org.hibernate.search.test.SerializationTestHelper;
+import org.hibernate.search.testsupport.serialization.SerializationTestHelper;
 import org.hibernate.search.util.configuration.impl.MaskedProperty;
 import org.junit.Test;
 

--- a/orm/src/test/java/org/hibernate/search/test/engine/EventListenerSerializationTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/engine/EventListenerSerializationTest.java
@@ -9,7 +9,7 @@ package org.hibernate.search.test.engine;
 import java.io.IOException;
 
 import org.hibernate.search.event.impl.FullTextIndexEventListener;
-import org.hibernate.search.test.SerializationTestHelper;
+import org.hibernate.search.testsupport.serialization.SerializationTestHelper;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;

--- a/orm/src/test/java/org/hibernate/search/test/engine/QuerySerializationTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/engine/QuerySerializationTest.java
@@ -24,7 +24,7 @@ import org.hibernate.search.spi.SearchIntegrator;
 import org.hibernate.search.test.AlternateDocument;
 import org.hibernate.search.test.Document;
 import org.hibernate.search.test.SearchTestBase;
-import org.hibernate.search.test.SerializationTestHelper;
+import org.hibernate.search.testsupport.serialization.SerializationTestHelper;
 import org.junit.Ignore;
 import org.junit.Test;
 

--- a/orm/src/test/java/org/hibernate/search/test/jpa/EntityManagerSerializationTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/jpa/EntityManagerSerializationTest.java
@@ -13,9 +13,9 @@ import org.junit.Test;
 
 import org.hibernate.search.jpa.FullTextEntityManager;
 import org.hibernate.search.jpa.Search;
-import org.hibernate.search.test.SerializationTestHelper;
 import org.hibernate.search.testsupport.TestConstants;
 import org.hibernate.search.testsupport.TestForIssue;
+import org.hibernate.search.testsupport.serialization.SerializationTestHelper;
 
 import static org.junit.Assert.assertEquals;
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2073

@gustavonalle your same patch, but adding a unit test to catch Serialization issues on this class in the future.

The Lucene queries are not serializable, so I'm surprised you need this. Does my test model the Infinispan use case closely, i.e. by re-setting the Lucene Query instance?
