### PR TITLE
HSEARCH-1461 Statistics copied over during addClasses(..) invocation

### DIFF
--- a/engine/src/main/java/org/hibernate/search/engine/impl/ImmutableSearchFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/ImmutableSearchFactory.java
@@ -131,15 +131,20 @@ public class ImmutableSearchFactory implements ExtendedSearchIntegratorWithShare
 		this.timeoutExceptionFactory = state.getDefaultTimeoutExceptionFactory();
 		this.timingSource = state.getTimingSource();
 		this.mapping = state.getProgrammaticMapping();
-		this.statistics = new StatisticsImpl( this );
+		if ( state.getStatistics() == null ) {
+			this.statistics = new StatisticsImpl( this );
+			boolean statsEnabled = ConfigurationParseHelper.getBooleanValue(
+					configurationProperties, Environment.GENERATE_STATS, false
+			);
+			this.statistics.setStatisticsEnabled( statsEnabled );
+		}
+		else {
+			this.statistics = (StatisticsImpl) state.getStatistics();
+		}
 		this.indexMetadataIsComplete = state.isIndexMetadataComplete();
 		this.isDeleteByTermEnforced = state.isDeleteByTermEnforced();
 		this.isIdProvidedImplicit = state.isIdProvidedImplicit();
 		this.indexManagerFactory = state.getIndexManagerFactory();
-		boolean statsEnabled = ConfigurationParseHelper.getBooleanValue(
-				configurationProperties, Environment.GENERATE_STATS, false
-		);
-		this.statistics.setStatisticsEnabled( statsEnabled );
 
 		this.enableDirtyChecks = ConfigurationParseHelper.getBooleanValue(
 				configurationProperties, Environment.ENABLE_DIRTY_CHECK, true

--- a/engine/src/main/java/org/hibernate/search/engine/impl/MutableSearchFactoryState.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/MutableSearchFactoryState.java
@@ -30,6 +30,7 @@ import org.hibernate.search.spi.InstanceInitializer;
 import org.hibernate.search.spi.impl.ExtendedSearchIntegratorWithShareableState;
 import org.hibernate.search.spi.impl.PolymorphicIndexHierarchy;
 import org.hibernate.search.spi.impl.SearchFactoryState;
+import org.hibernate.search.stat.Statistics;
 import org.hibernate.search.util.configuration.impl.ConfigurationParseHelper;
 
 /**
@@ -63,6 +64,7 @@ public class MutableSearchFactoryState implements SearchFactoryState {
 	private boolean isIdProvidedImplicit;
 	private IndexManagerFactory indexManagerFactory;
 	private boolean enlistWorkerInTransaction;
+	private Statistics statistics;
 
 	public void copyStateFromOldFactory(SearchFactoryState oldFactoryState) {
 		indexingMode = oldFactoryState.getIndexingMode();
@@ -88,6 +90,7 @@ public class MutableSearchFactoryState implements SearchFactoryState {
 		isIdProvidedImplicit = oldFactoryState.isIdProvidedImplicit();
 		indexManagerFactory = oldFactoryState.getIndexManagerFactory();
 		enlistWorkerInTransaction = oldFactoryState.enlistWorkerInTransaction();
+		statistics = oldFactoryState.getStatistics();
 	}
 
 	@Override
@@ -310,6 +313,15 @@ public class MutableSearchFactoryState implements SearchFactoryState {
 
 	public void setIndexManagerFactory(IndexManagerFactory indexManagerFactory) {
 		this.indexManagerFactory = indexManagerFactory;
+	}
+
+	@Override
+	public Statistics getStatistics() {
+		return statistics;
+	}
+
+	public void setStatistics(Statistics statistics) {
+		this.statistics = statistics;
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/search/spi/impl/SearchFactoryState.java
+++ b/engine/src/main/java/org/hibernate/search/spi/impl/SearchFactoryState.java
@@ -25,6 +25,7 @@ import org.hibernate.search.indexes.impl.IndexManagerHolder;
 import org.hibernate.search.query.engine.spi.TimeoutExceptionFactory;
 import org.hibernate.search.spi.IndexingMode;
 import org.hibernate.search.spi.InstanceInitializer;
+import org.hibernate.search.stat.Statistics;
 
 /**
  * Represents the sharable state of a search factory
@@ -77,4 +78,6 @@ public interface SearchFactoryState {
 	IndexManagerFactory getIndexManagerFactory();
 
 	boolean enlistWorkerInTransaction();
+
+	Statistics getStatistics();
 }

--- a/engine/src/test/java/org/hibernate/search/test/configuration/mutablefactory/MutableFactoryTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/configuration/mutablefactory/MutableFactoryTest.java
@@ -34,6 +34,9 @@ import org.hibernate.search.testsupport.TestConstants;
 import org.hibernate.search.test.configuration.mutablefactory.generated.Generated;
 import org.hibernate.search.testsupport.setup.SearchConfigurationForTest;
 import org.hibernate.search.testsupport.setup.TransactionContextForTest;
+import org.hibernate.search.query.engine.spi.HSQuery;
+import org.hibernate.search.query.engine.spi.EntityInfo;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -148,6 +151,84 @@ public class MutableFactoryTest {
 		assertEquals( 1, hits.totalHits );
 
 		sf.getIndexReaderAccessor().close( indexReader );
+
+		sf.close();
+	}
+
+	@Test
+	public void testAddingClassSimpleAPIwithJMX() throws Exception {
+		SearchIntegrator sf = new SearchIntegratorBuilder()
+				.configuration(
+						new SearchConfigurationForTest()
+							.addClass( A.class )
+							.addProperty( "hibernate.search.jmx_enabled" , Boolean.TRUE.toString() )
+							.addProperty( "hibernate.search.generate_statistics", Boolean.TRUE.toString() )
+							.addProperty( "com.sun.management.jmxremote", Boolean.TRUE.toString() ) )
+				.buildSearchIntegrator();
+
+		TransactionContextForTest tc = new TransactionContextForTest();
+
+		doIndexWork( new A( 1, "Emmanuel" ), 1, sf, tc );
+
+		tc.end();
+
+		QueryParser parser = new QueryParser( "name", TestConstants.standardAnalyzer );
+		Query luceneQuery = parser.parse( "Emmanuel" );
+
+		HSQuery hsQuery = sf.createHSQuery().luceneQuery( luceneQuery );
+		List<Class<?>> l = new ArrayList<>();
+		l.add( A.class );
+
+		hsQuery.targetedEntities( l );
+
+		hsQuery.getTimeoutManager().start();
+
+		List<EntityInfo> entityInfos = hsQuery.queryEntityInfos();
+		assertEquals( 1 , entityInfos.size() );
+		assertEquals( 1 , sf.getStatistics().getSearchQueryExecutionCount() );
+		assertEquals( 1 , sf.getStatistics().getIndexedClassNames().size() );
+
+		hsQuery.getTimeoutManager().stop();
+
+		sf.addClasses( B.class, C.class );
+
+		tc = new TransactionContextForTest();
+
+		doIndexWork( new B( 1, "Noel" ), 1, sf, tc );
+		doIndexWork( new C( 1, "Vincent" ), 1, sf, tc );
+
+		tc.end();
+
+		luceneQuery = parser.parse( "Noel" );
+
+		hsQuery = sf.createHSQuery().luceneQuery( luceneQuery );
+		l.add( B.class );
+		l.add( C.class );
+
+		hsQuery.targetedEntities( l );
+
+		hsQuery.getTimeoutManager().start();
+
+		entityInfos = hsQuery.queryEntityInfos();
+		assertEquals( 1 , entityInfos.size() );
+		assertEquals( 2 , sf.getStatistics().getSearchQueryExecutionCount() );
+		assertEquals( 3 , sf.getStatistics().getIndexedClassNames().size() );
+
+		hsQuery.getTimeoutManager().stop();
+
+		luceneQuery = parser.parse( "Vincent" );
+
+		hsQuery = sf.createHSQuery().luceneQuery( luceneQuery );
+		hsQuery.targetedEntities( l );
+
+		hsQuery.getTimeoutManager().start();
+
+		entityInfos = hsQuery.queryEntityInfos();
+		assertEquals( 1 , entityInfos.size() );
+		assertEquals( 3 , sf.getStatistics().getSearchQueryExecutionCount() );
+		assertEquals( 3 , sf.getStatistics().getIndexedClassNames().size() );
+
+		hsQuery.getTimeoutManager().stop();
 
 		sf.close();
 	}


### PR DESCRIPTION
Added `MutableFactoryTest.testAddingClassSimpleAPIwithJMX()` to test that the statistics are still collected after the method `addClasses(Class<?>... classes)` invocation, verifying that the total number of queries (`searchQueryCount`) and the size of the set of the indexed classes (`indexedClasses`) are both updated in the right way.
The JMX console and the statistics generation are both activated.

`SearchFactoryTest` added the method `Statistics getStatistics()` to this interface
`ImmutableSearchFactory` added the code to handle the copy of the previous statistics. The field `isStatisticsEnabled` is setted only in case of new creation.
`MutableSearchFactoryState` added the copy of the statistics and the getter and setter for the Statistics object itself