### PR TITLE
Add Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,37 @@
+language: java
+jdk:
+  - oraclejdk8
+addons:
+  postgresql: '9.4'
+  mariadb: '10.1'
+  apt:
+    packages:
+      - oracle-java8-installer
+# might be useful to push reports to an S3 bucket
+#  artifacts:
+#    paths:
+#      - $(find $HOME -name surefire-reports | tr "\n" ":")
+#    debug: true
+#  s3_region: 'us-west-2'
+cache:
+  directories:
+    - $HOME/.m2
+env:
+  - DB=h2
+# for now, let's test only with H2
+#  - DB=pgsql
+#  - DB=mariadb
+install:
+  - mvn -v
+  # first run to download all the Maven dependencies without logging
+  - mvn -s settings-example.xml -B -q clean compile -DskipTests=true
+before_script: 
+  - if [[ "$DB" == "pgsql" ]]; then psql -U postgres -f 'travis/pgsql.sql';fi 
+  - if [[ "$DB" == "mariadb" ]]; then mysql -u root < 'travis/mariadb.sql'; fi
+script:
+  # we run checkstyle first to fail fast if there is a styling error
+  - mvn -s settings-example.xml checkstyle:check
+  - if [[ "$DB" == "h2" ]]; then mvn -s settings-example.xml -Ph2 verify;fi 
+  - if [[ "$DB" == "pgsql" ]]; then mvn -s settings-example.xml -Pci-postgresql verify;fi 
+  - if [[ "$DB" == "mariadb" ]]; then mvn -s settings-example.xml -Pci-mariadb verify; fi
+  

--- a/backends/jgroups/src/test/java/org/hibernate/search/backend/jgroups/impl/SyncJGroupsBackendTest.java
+++ b/backends/jgroups/src/test/java/org/hibernate/search/backend/jgroups/impl/SyncJGroupsBackendTest.java
@@ -43,12 +43,13 @@ public class SyncJGroupsBackendTest {
 
 	private static final Log log = LoggerFactory.make();
 	private static final String JGROUPS_CONFIGURATION = "testing-flush-loopback.xml";
+	private static final int JGROUPS_MESSAGES_TIMEOUT = 1000;
 
 	@Rule
 	public SearchFactoryHolder slaveNode = new SearchFactoryHolder( Dvd.class, Book.class, Drink.class, Star.class )
 		.withProperty( "hibernate.search.default.worker.backend", "jgroupsSlave" )
 		.withProperty( "hibernate.search.dvds.worker.execution", "sync" )
-		.withProperty( "hibernate.search.dvds.jgroups.messages_timeout", "200" )
+		.withProperty( "hibernate.search.dvds.jgroups.messages_timeout", JGROUPS_MESSAGES_TIMEOUT )
 		.withProperty( "hibernate.search.books.worker.execution", "async" )
 		.withProperty( "hibernate.search.drinks.jgroups." + JGroupsBackendQueueProcessor.BLOCK_WAITING_ACK, "true" )
 		.withProperty( "hibernate.search.stars.jgroups." + JGroupsBackendQueueProcessor.BLOCK_WAITING_ACK, "false" )
@@ -135,7 +136,7 @@ public class SyncJGroupsBackendTest {
 		BackendQueueProcessor backendQueueProcessor = extractBackendQueue( slaveNode, "dvds" );
 		JGroupsBackendQueueProcessor jgroupsProcessor = (JGroupsBackendQueueProcessor) backendQueueProcessor;
 		long messageTimeout = jgroupsProcessor.getMessageTimeout();
-		Assert.assertEquals( "message timeout configuration property not applied", 200, messageTimeout );
+		Assert.assertEquals( "message timeout configuration property not applied", JGROUPS_MESSAGES_TIMEOUT, messageTimeout );
 	}
 
 	private JGroupsReceivingMockBackend extractMockBackend(String indexName) {

--- a/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/impl/JestClient.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/impl/JestClient.java
@@ -43,8 +43,8 @@ public class JestClient implements Service, Startable, Stoppable {
 		factory.setHttpClientConfig(
 			new HttpClientConfig.Builder( serverUri )
 				.multiThreaded( true )
-				.readTimeout( 2000 )
-				.connTimeout( 2000 )
+				.readTimeout( 10000 )
+				.connTimeout( 10000 )
 				.gson( GsonBuilderHolder.BUILDER )
 				.build()
 		);

--- a/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/TestRunnerStandalone.java
+++ b/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/TestRunnerStandalone.java
@@ -39,10 +39,7 @@ public class TestRunnerStandalone {
 		setDefaultProperty( properties, "hibernate.dialect", "org.hibernate.dialect.H2Dialect" );
 		setDefaultProperty( properties, "hibernate.connection.provider_class", "org.hibernate.hikaricp.internal.HikariCPConnectionProvider" );
 		setDefaultProperty( properties, "hibernate.hikari.maximumPoolSize", "20" );
-		setDefaultProperty( properties, "hibernate.hikari.dataSourceClassName", "org.h2.jdbcx.JdbcDataSource" );
 		setDefaultProperty( properties, "hibernate.hikari.dataSource.url", "jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;MULTI_THREADED=1" );
-		setDefaultProperty( properties, "hibernate.hikari.dataSource.user", "sa" );
-		setDefaultProperty( properties, "hibernate.hikari.dataSource.password", "" );
 		setDefaultProperty( properties, "hibernate.connection.isolation", "TRANSACTION_READ_COMMITTED" );
 		return properties;
 	}

--- a/travis/mariadb.sql
+++ b/travis/mariadb.sql
@@ -1,0 +1,4 @@
+CREATE DATABASE testingdb;
+GRANT ALL ON testingdb.* TO hibernate_user@localhost IDENTIFIED BY 'hibernate_password';
+FLUSH PRIVILEGES;
+SET GLOBAL binlog_format = 'ROW';

--- a/travis/pgsql.sql
+++ b/travis/pgsql.sql
@@ -1,0 +1,2 @@
+CREATE USER hibernate_user WITH PASSWORD 'hibernate_password';
+CREATE DATABASE testingdb WITH OWNER hibernate_user;


### PR DESCRIPTION
Hi!

As mentioned on the list, I think we could give Travis a try for building the PRs.

Note that what is interesting with Travis is that it can also run for our individual forks so we can get our branches tested by the CI before creating the PR.

The .travis.yml build the tests for 3 different RDBMS, maybe we could just build it for PostgreSQL if we only use Travis for the PR tests?

Thoughts?