### PR TITLE
HSEARCH-2105 Several improvements around ES embeddable mapping

### DIFF
--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -299,6 +299,7 @@
                                 <exclude>**/SortWithIndexUninvertingTest.java</exclude>
                                 <exclude>**/SortOnFieldsFromCustomBridgeTest.java</exclude>
                                 <exclude>**/RollbackTransactionTest.java</exclude>
+                                <exclude>**/PrefixedEmbeddedCaseInPathTest.java</exclude>
 
                                 <!-- Specific to other backends -->
                                 <exclude>**/CustomBackendTest.java</exclude>

--- a/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchHSQueryImpl.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchHSQueryImpl.java
@@ -629,8 +629,9 @@ public class ElasticsearchHSQueryImpl extends AbstractHSQuery {
 		if ( aggregation == null ) {
 			return Collections.emptyList();
 		}
+
 		// deal with nested aggregation for nested documents
-		if ( FieldHelper.isEmbeddedField( facetRequest.getFieldName() ) ) {
+		if ( isNested( facetRequest ) ) {
 			aggregation = aggregation.getAsJsonObject().get( facetRequest.getFacetingName() );
 		}
 		if ( aggregation == null ) {
@@ -644,6 +645,12 @@ public class ElasticsearchHSQueryImpl extends AbstractHSQuery {
 					bucket.getAsJsonObject().get( "doc_count" ).getAsInt() ) );
 		}
 		return facets;
+	}
+
+	private boolean isNested(DiscreteFacetRequest facetRequest) {
+		//TODO Drive through meta-data
+//		return FieldHelper.isEmbeddedField( facetRequest.getFieldName() );
+		return false;
 	}
 
 	// TODO: Investigate scrolling API:

--- a/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchHSQueryImpl.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchHSQueryImpl.java
@@ -533,6 +533,11 @@ public class ElasticsearchHSQueryImpl extends AbstractHSQuery {
 			}
 			// Should only be the case for custom bridges
 			else {
+				// TODO: should we do it?
+				if ( !value.isJsonPrimitive() ) {
+					throw new SearchException( "Projection of non-JSON-primitive field values is not supported: " + value );
+				}
+
 				JsonPrimitive primitive = value.getAsJsonPrimitive();
 
 				if ( primitive.isBoolean() ) {

--- a/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchIndexManager.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchIndexManager.java
@@ -398,7 +398,13 @@ public class ElasticsearchIndexManager implements IndexManager {
 			JsonObject property = parentProperties.getAsJsonObject( part );
 			if ( property == null ) {
 				property = new JsonObject();
-				property.addProperty( "type", "nested" );
+
+				// TODO enable nested mapping as needed:
+				// * only needed for embedded *-to-many with more than one field
+				// * for these, the user should be able to opt out (nested would be the safe default mapping in this
+				// case, but they could want to opt out when only ever querying on single fields of the embeddable)
+
+//				property.addProperty( "type", "nested" );
 
 				JsonObject properties = new JsonObject();
 				property.add( "properties", properties );
@@ -508,5 +514,10 @@ public class ElasticsearchIndexManager implements IndexManager {
 	@Override
 	public void optimize() {
 		// TODO Is there such thing for ES?
+	}
+
+	@Override
+	public String toString() {
+		return "ElasticsearchIndexManager [actualIndexName=" + actualIndexName + "]";
 	}
 }

--- a/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchNestingContextFactoryProvider.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchNestingContextFactoryProvider.java
@@ -1,0 +1,155 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.impl;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field.Store;
+import org.apache.lucene.document.TextField;
+import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
+import org.hibernate.search.engine.metadata.impl.EmbeddedTypeMetadata.Container;
+import org.hibernate.search.engine.nesting.impl.NestingContext;
+import org.hibernate.search.engine.nesting.impl.NestingContextFactory;
+import org.hibernate.search.engine.nesting.impl.NestingContextFactoryProvider;
+import org.hibernate.search.engine.nesting.impl.NoOpNestingContext;
+import org.hibernate.search.engine.service.spi.Startable;
+import org.hibernate.search.engine.spi.EntityIndexBinding;
+import org.hibernate.search.indexes.spi.IndexManager;
+import org.hibernate.search.spi.BuildContext;
+import org.hibernate.search.util.StringHelper;
+
+public class ElasticsearchNestingContextFactoryProvider implements NestingContextFactoryProvider, Startable {
+
+	private ElasticsearchNestingContextFactory factory;
+
+	@Override
+	public void start(Properties properties, BuildContext context) {
+		factory = new ElasticsearchNestingContextFactory( context.getUninitializedSearchIntegrator() );
+	}
+
+	@Override
+	public NestingContextFactory getNestingContextFactory() {
+		return factory;
+	}
+
+	private static class ElasticsearchNestingContextFactory implements NestingContextFactory {
+
+		private final ConcurrentMap<String, ContextCreationStratey> strategies = new ConcurrentHashMap<>();
+		private ExtendedSearchIntegrator searchIntegrator;
+
+		public ElasticsearchNestingContextFactory(ExtendedSearchIntegrator searchIntegrator) {
+			this.searchIntegrator = searchIntegrator;
+		}
+
+		@Override
+		public NestingContext createNestingContext(Class<?> indexedEntityType) {
+			ContextCreationStratey strategy = strategies.get( indexedEntityType.getName() );
+
+			if ( strategy == null ) {
+				strategy = isMappedToElasticsearch( indexedEntityType ) ? ContextCreationStratey.ES : ContextCreationStratey.NO_OP;
+				strategies.putIfAbsent( indexedEntityType.getName(), strategy );
+			}
+
+			return strategy.create();
+		}
+
+		private boolean isMappedToElasticsearch(Class<?> entityType) {
+			Set<Class<?>> queriedEntityTypesWithSubTypes = searchIntegrator.getIndexedTypesPolymorphic( new Class<?>[] { entityType } );
+
+			for ( Class<?> queriedEntityType : queriedEntityTypesWithSubTypes ) {
+				EntityIndexBinding binding = searchIntegrator.getIndexBinding( queriedEntityType );
+				IndexManager[] indexManagers = binding.getIndexManagers();
+
+				for ( IndexManager indexManager : indexManagers ) {
+					if ( indexManager instanceof ElasticsearchIndexManager ) {
+						return true;
+					}
+				}
+			}
+
+			return false;
+		}
+	}
+
+	private enum ContextCreationStratey {
+		NO_OP {
+			@Override
+			NestingContext create() {
+				return NoOpNestingContext.INSTANCE;
+			}
+		},
+		ES {
+			@Override
+			NestingContext create() {
+				return new ElasticsearchNestingContext();
+			}
+		};
+
+		abstract NestingContext create();
+	}
+
+	private static class ElasticsearchNestingContext implements NestingContext {
+
+		private Deque<NestingStackElement> path = new ArrayDeque<>();
+
+		@Override
+		public void push(String fieldName, Container containerType) {
+			path.push(
+					new NestingStackElement(
+							fieldName,
+							containerType == Container.OBJECT ? null : 0
+					)
+			);
+		}
+
+		@Override
+		public void mark(Document document) {
+			String currentPath = StringHelper.join( path.descendingIterator(), "." );
+			document.add( new TextField( "$nesting", currentPath, Store.NO ) );
+		}
+
+		@Override
+		public void incrementCollectionIndex() {
+			path.peek().increment();
+		}
+
+		@Override
+		public void pop() {
+			path.pop();
+		}
+	}
+
+	private static class NestingStackElement {
+		String field;
+		Integer index;
+
+		public NestingStackElement(String fieldName, Integer index) {
+			this.field = fieldName;
+			this.index = index;
+		}
+
+		@Override
+		public String toString() {
+			if ( index == null ) {
+				return field;
+			}
+			else {
+				return field + "[" + index + "]";
+			}
+		}
+
+		void increment() {
+			index = index + 1;
+		}
+	}
+}

--- a/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchNestingContextFactoryProvider.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchNestingContextFactoryProvider.java
@@ -44,7 +44,7 @@ public class ElasticsearchNestingContextFactoryProvider implements NestingContex
 
 	private static class ElasticsearchNestingContextFactory implements NestingContextFactory {
 
-		private final ConcurrentMap<String, ContextCreationStratey> strategies = new ConcurrentHashMap<>();
+		private final ConcurrentMap<String, ContextCreationStrategy> strategies = new ConcurrentHashMap<>();
 		private ExtendedSearchIntegrator searchIntegrator;
 
 		public ElasticsearchNestingContextFactory(ExtendedSearchIntegrator searchIntegrator) {
@@ -53,10 +53,10 @@ public class ElasticsearchNestingContextFactoryProvider implements NestingContex
 
 		@Override
 		public NestingContext createNestingContext(Class<?> indexedEntityType) {
-			ContextCreationStratey strategy = strategies.get( indexedEntityType.getName() );
+			ContextCreationStrategy strategy = strategies.get( indexedEntityType.getName() );
 
 			if ( strategy == null ) {
-				strategy = isMappedToElasticsearch( indexedEntityType ) ? ContextCreationStratey.ES : ContextCreationStratey.NO_OP;
+				strategy = isMappedToElasticsearch( indexedEntityType ) ? ContextCreationStrategy.ES : ContextCreationStrategy.NO_OP;
 				strategies.putIfAbsent( indexedEntityType.getName(), strategy );
 			}
 
@@ -81,7 +81,7 @@ public class ElasticsearchNestingContextFactoryProvider implements NestingContex
 		}
 	}
 
-	private enum ContextCreationStratey {
+	private enum ContextCreationStrategy {
 		NO_OP {
 			@Override
 			NestingContext create() {

--- a/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ToElasticsearch.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ToElasticsearch.java
@@ -51,7 +51,7 @@ public class ToElasticsearch {
 							.addProperty( "min_doc_count", facetingRequest.hasZeroCountsIncluded() ? 0 : 1 )
 					).build();
 
-			if ( FieldHelper.isEmbeddedField( fieldName ) ) {
+			if ( isNested( fieldName ) ) {
 				JsonBuilder.Object facetJsonQuery = JsonBuilder.object();
 				facetJsonQuery.add( "nested", JsonBuilder.object()
 								.addProperty( "path", FieldHelper.getEmbeddedFieldPath( fieldName ) ) );
@@ -257,7 +257,7 @@ public class ToElasticsearch {
 	}
 
 	private static JsonObject wrapQueryForNestedIfRequired(String field, JsonObject query) {
-		if ( !FieldHelper.isEmbeddedField( field ) ) {
+		if ( !isNested( field ) ) {
 			return query;
 		}
 		String path = FieldHelper.getEmbeddedFieldPath( field );
@@ -267,6 +267,12 @@ public class ToElasticsearch {
 						.addProperty( "path", path )
 						.add( "query", query ) )
 				.build();
+	}
+
+	private static boolean isNested(String field) {
+		//TODO Drive through meta-data
+//		return FieldHelper.isEmbeddedField( field );
+		return false;
 	}
 
 	public static JsonObject fromLuceneFilter(Filter luceneFilter) {

--- a/elasticsearch/src/main/resources/META-INF/services/org.hibernate.search.engine.nesting.impl.NestingContextFactoryProvider
+++ b/elasticsearch/src/main/resources/META-INF/services/org.hibernate.search.engine.nesting.impl.NestingContextFactoryProvider
@@ -1,0 +1,1 @@
+org.hibernate.search.backend.elasticsearch.impl.ElasticsearchNestingContextFactoryProvider

--- a/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/ElasticsearchClassBridgeIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/ElasticsearchClassBridgeIT.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.backend.elasticsearch.test;
 
+import static org.fest.assertions.Assertions.assertThat;
+
 import java.util.Calendar;
 import java.util.List;
 import java.util.Locale;
@@ -21,8 +23,6 @@ import org.hibernate.search.test.SearchTestBase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.fest.assertions.Assertions.assertThat;
 
 /**
  * @author Gunnar Morling
@@ -116,6 +116,6 @@ public class ElasticsearchClassBridgeIT extends SearchTestBase {
 
 	@Override
 	public Class<?>[] getAnnotatedClasses() {
-		return new Class[]{ GolfPlayer.class };
+		return new Class[]{ GolfPlayer.class, GolfCourse.class, Hole.class };
 	}
 }

--- a/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/ElasticsearchIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/ElasticsearchIT.java
@@ -638,8 +638,7 @@ public class ElasticsearchIT extends SearchTestBase {
 
 	@Override
 	public Class<?>[] getAnnotatedClasses() {
-		return new Class[]{
-				ScientificArticle.class, Tower.class, Address.class, Country.class, State.class, StateCandidate.class, ResearchPaper.class, BachelorThesis.class, MasterThesis.class, GolfPlayer.class
-		};
+		return new Class[] { ScientificArticle.class, Tower.class, Address.class, Country.class, State.class, StateCandidate.class, ResearchPaper.class,
+				BachelorThesis.class, MasterThesis.class, GolfPlayer.class, GolfCourse.class, Hole.class };
 	}
 }

--- a/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/ElasticsearchIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/ElasticsearchIT.java
@@ -27,15 +27,15 @@ import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
 import org.hibernate.search.backend.elasticsearch.ElasticsearchQueries;
 import org.hibernate.search.backend.elasticsearch.ProjectionConstants;
+import org.hibernate.search.backend.elasticsearch.test.model.Address;
+import org.hibernate.search.backend.elasticsearch.test.model.Country;
+import org.hibernate.search.backend.elasticsearch.test.model.Owner;
+import org.hibernate.search.backend.elasticsearch.test.model.Person;
+import org.hibernate.search.backend.elasticsearch.test.model.State;
+import org.hibernate.search.backend.elasticsearch.test.model.StateCandidate;
+import org.hibernate.search.backend.elasticsearch.test.model.Tower;
 import org.hibernate.search.query.engine.spi.QueryDescriptor;
 import org.hibernate.search.test.SearchTestBase;
-import org.hibernate.search.test.embedded.Address;
-import org.hibernate.search.test.embedded.Country;
-import org.hibernate.search.test.embedded.Owner;
-import org.hibernate.search.test.embedded.Person;
-import org.hibernate.search.test.embedded.State;
-import org.hibernate.search.test.embedded.StateCandidate;
-import org.hibernate.search.test.embedded.Tower;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -226,7 +226,7 @@ public class ElasticsearchIT extends SearchTestBase {
 				"{" +
 					"'query' : { " +
 						"'match' : { " +
-							"'address.ownedBy_name' : 'renting'" +
+							"'address.ownedBy.name' : 'renting'" +
 						" }" +
 					" }" +
 				" }"
@@ -273,7 +273,7 @@ public class ElasticsearchIT extends SearchTestBase {
 				"{" +
 					"'query' : { " +
 						"'match' : { " +
-							"'address.ownedBy_name' : 'buckhead'" +
+							"'address.ownedBy.name' : 'buckhead'" +
 						" }" +
 					" }" +
 				" }"

--- a/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/ElasticsearchIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/ElasticsearchIT.java
@@ -210,13 +210,8 @@ public class ElasticsearchIT extends SearchTestBase {
 		query = ElasticsearchQueries.fromJson(
 				"{" +
 					"'query' : { " +
-						"'nested' : { " +
-							"'path' : 'address'," +
-							" 'query': { " +
-								"'match' : { " +
-									"'address.street' : 'place'" +
-								" }" +
-							" }" +
+						"'match' : { " +
+							"'address.street' : 'place'" +
 						" }" +
 					" }" +
 				" }"
@@ -227,13 +222,8 @@ public class ElasticsearchIT extends SearchTestBase {
 		query = ElasticsearchQueries.fromJson(
 				"{" +
 					"'query' : { " +
-						"'nested' : { " +
-							"'path' : 'address'," +
-							" 'query': { " +
-								"'match' : { " +
-									"'address.ownedBy_name' : 'renting'" +
-								" }" +
-							" }" +
+						"'match' : { " +
+							"'address.ownedBy_name' : 'renting'" +
 						" }" +
 					" }" +
 				" }"
@@ -244,13 +234,8 @@ public class ElasticsearchIT extends SearchTestBase {
 		query = ElasticsearchQueries.fromJson(
 				"{" +
 					"'query' : { " +
-						"'nested' : { " +
-							"'path' : 'address'," +
-							" 'query': { " +
-								"'match' : { " +
-									"'address.id' : " + a.getId() +
-								" }" +
-							" }" +
+						"'match' : { " +
+							"'address.id' : " + a.getId() +
 						" }" +
 					" }" +
 				" }"
@@ -261,13 +246,8 @@ public class ElasticsearchIT extends SearchTestBase {
 		query = ElasticsearchQueries.fromJson(
 				"{" +
 					"'query' : { " +
-						"'nested' : { " +
-							"'path' : 'address.country'," +
-							" 'query': { " +
-								"'match' : { " +
-									"'address.country.name' : 'France'" +
-								" }" +
-							" }" +
+						"'match' : { " +
+							"'address.country.name' : 'France'" +
 						" }" +
 					" }" +
 				" }"
@@ -289,13 +269,8 @@ public class ElasticsearchIT extends SearchTestBase {
 		query = ElasticsearchQueries.fromJson(
 				"{" +
 					"'query' : { " +
-						"'nested' : { " +
-							"'path' : 'address'," +
-							" 'query': { " +
-								"'match' : { " +
-									"'address.ownedBy_name' : 'buckhead'" +
-								" }" +
-							" }" +
+						"'match' : { " +
+							"'address.ownedBy_name' : 'buckhead'" +
 						" }" +
 					" }" +
 				" }"
@@ -562,7 +537,7 @@ public class ElasticsearchIT extends SearchTestBase {
 		Object[] projection = (Object[]) result.iterator().next();
 		assertThat( projection[0] ).describedAs( "id" ).isEqualTo( 1L );
 		assertThat( projection[1] ).describedAs( "object class" ).isEqualTo( GolfPlayer.class );
-		assertThat( projection[2] ).describedAs( "score" ).isEqualTo( 1.0F );
+		assertThat( projection[2] ).describedAs( "score" ).isEqualTo( 0.30685282F );
 		assertThat( projection[3] ).describedAs( "this" ).isInstanceOf( GolfPlayer.class );
 		assertThat( ( (GolfPlayer) projection[3] ).getId() ).isEqualTo( 1L );
 		assertThat( projection[4] ).describedAs( "firstName" ).isEqualTo( "Klaus" );

--- a/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/ElasticsearchIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/ElasticsearchIT.java
@@ -125,6 +125,9 @@ public class ElasticsearchIT extends SearchTestBase {
 			.puttingStrength( 2.5 )
 			.driveWidth( 285 )
 			.ranking( 311 )
+			.strength( "precision" )
+			.strength( "willingness" )
+			.strength( "stamina" )
 			.build();
 		s.persist( hergesheimer );
 
@@ -284,6 +287,31 @@ public class ElasticsearchIT extends SearchTestBase {
 		s.delete( s.get( Tower.class, tower.getId() ) );
 		tx.commit();
 
+		s.close();
+	}
+
+	@Test
+	public void testEmbeddedIndexingOfElementCollection() throws Exception {
+		Session s = openSession();
+		Transaction tx = s.beginTransaction();
+
+		FullTextSession session = Search.getFullTextSession( s );
+		QueryDescriptor query;
+		List<?> result;
+
+		query = ElasticsearchQueries.fromJson(
+				"{" +
+					"'query' : { " +
+						"'match' : { " +
+							"'strengths' : 'willingness'" +
+						" }" +
+					" }" +
+				" }"
+		);
+		result = session.createFullTextQuery( query, GolfPlayer.class ).list();
+		assertEquals( "unable to find property in embedded element collection", 1, result.size() );
+
+		tx.commit();
 		s.close();
 	}
 

--- a/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/ElasticsearchNullValueIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/ElasticsearchNullValueIT.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.backend.elasticsearch.test;
 
+import static org.fest.assertions.Assertions.assertThat;
+
 import java.util.Calendar;
 import java.util.List;
 import java.util.Locale;
@@ -21,8 +23,6 @@ import org.hibernate.search.test.SearchTestBase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.fest.assertions.Assertions.assertThat;
 
 /**
  * @author Gunnar Morling
@@ -140,6 +140,6 @@ public class ElasticsearchNullValueIT extends SearchTestBase {
 
 	@Override
 	public Class<?>[] getAnnotatedClasses() {
-		return new Class[]{ GolfPlayer.class };
+		return new Class[]{ GolfPlayer.class, GolfCourse.class, Hole.class };
 	}
 }

--- a/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/GolfCourse.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/GolfCourse.java
@@ -1,0 +1,110 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToMany;
+import javax.persistence.OneToMany;
+import javax.persistence.OrderColumn;
+import javax.persistence.SequenceGenerator;
+
+import org.hibernate.search.annotations.ContainedIn;
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.IndexedEmbedded;
+
+/**
+ * @author Gunnar Morling
+ */
+@Entity
+@Indexed
+public class GolfCourse {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "GOLF_COURSE_SEQ")
+	@SequenceGenerator(name = "GOLF_COURSE_SEQ", sequenceName = "golfcourse_sequence", allocationSize = 20)
+	@DocumentId
+	private Long id;
+
+	@Field
+	private String name;
+
+	@Field
+	private double rating;
+
+	@ContainedIn
+	@ManyToMany
+	private Set<GolfPlayer> playedBy = new HashSet<>();
+
+	@OneToMany(cascade = CascadeType.ALL)
+	@IndexedEmbedded
+	@OrderColumn
+	private List<Hole> holes = new ArrayList<>();
+
+	GolfCourse() {
+	}
+
+	GolfCourse(String name, double rating, Hole... holes) {
+		this.name = name;
+		this.rating = rating;
+		if ( holes != null ) {
+			for ( Hole hole : holes ) {
+				this.holes.add( hole );
+			}
+		}
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public double getRating() {
+		return rating;
+	}
+
+	public void setRating(double rating) {
+		this.rating = rating;
+	}
+
+	public Set<GolfPlayer> getPlayedBy() {
+		return playedBy;
+	}
+
+	public void setPlayedBy(Set<GolfPlayer> playedBy) {
+		this.playedBy = playedBy;
+	}
+
+	public List<Hole> getHoles() {
+		return holes;
+	}
+
+	public void setHoles(List<Hole> holes) {
+		this.holes = holes;
+	}
+}

--- a/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/GolfPlayer.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/GolfPlayer.java
@@ -8,7 +8,10 @@ package org.hibernate.search.backend.elasticsearch.test;
 
 import java.math.BigInteger;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 
+import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -68,6 +71,11 @@ public class GolfPlayer {
 
 	@IndexedEmbedded
 	private Ranking ranking;
+
+	@ElementCollection
+	@Field
+	@IndexedEmbedded
+	private Set<String> strengths;
 
 	GolfPlayer() {
 	}
@@ -144,6 +152,15 @@ public class GolfPlayer {
 		this.ranking = ranking;
 	}
 
+	public Set<String> getStrengths() {
+		return strengths;
+	}
+
+
+	public void setStrengths(Set<String> strengths) {
+		this.strengths = strengths;
+	}
+
 	public static class Builder {
 
 		private String firstName;
@@ -154,6 +171,7 @@ public class GolfPlayer {
 		private double puttingStrength;
 		private Integer driveWidth;
 		private Integer ranking;
+		private Set<String> strengths = new HashSet<>();
 
 		public Builder firstName(String firstName) {
 			this.firstName = firstName;
@@ -195,6 +213,11 @@ public class GolfPlayer {
 			return this;
 		}
 
+		public Builder strength(String strength) {
+			this.strengths.add( strength );
+			return this;
+		}
+
 		GolfPlayer build() {
 			GolfPlayer player = new GolfPlayer();
 
@@ -208,6 +231,7 @@ public class GolfPlayer {
 			if ( ranking != null ) {
 				player.setRanking( new Ranking( BigInteger.valueOf( ranking ) ) );
 			}
+			player.setStrengths( strengths );
 			return player;
 		}
 	}

--- a/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/GolfPlayer.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/GolfPlayer.java
@@ -16,6 +16,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.ManyToMany;
 import javax.persistence.SequenceGenerator;
 
 import org.hibernate.search.annotations.ClassBridge;
@@ -76,6 +77,10 @@ public class GolfPlayer {
 	@Field
 	@IndexedEmbedded
 	private Set<String> strengths;
+
+	@ManyToMany
+	@IndexedEmbedded
+	private Set<GolfCourse> playedCourses;
 
 	GolfPlayer() {
 	}
@@ -156,9 +161,16 @@ public class GolfPlayer {
 		return strengths;
 	}
 
-
 	public void setStrengths(Set<String> strengths) {
 		this.strengths = strengths;
+	}
+
+	public Set<GolfCourse> getPlayedCourses() {
+		return playedCourses;
+	}
+
+	public void setPlayedCourses(Set<GolfCourse> playedCourses) {
+		this.playedCourses = playedCourses;
 	}
 
 	public static class Builder {
@@ -172,6 +184,7 @@ public class GolfPlayer {
 		private Integer driveWidth;
 		private Integer ranking;
 		private Set<String> strengths = new HashSet<>();
+		private final Set<GolfCourse> playedCourses = new HashSet<>();
 
 		public Builder firstName(String firstName) {
 			this.firstName = firstName;
@@ -218,6 +231,14 @@ public class GolfPlayer {
 			return this;
 		}
 
+		public Builder playedCourses(GolfCourse... courses) {
+			for ( GolfCourse course : courses ) {
+				this.playedCourses.add( course );
+			}
+
+			return this;
+		}
+
 		GolfPlayer build() {
 			GolfPlayer player = new GolfPlayer();
 
@@ -232,6 +253,9 @@ public class GolfPlayer {
 				player.setRanking( new Ranking( BigInteger.valueOf( ranking ) ) );
 			}
 			player.setStrengths( strengths );
+			if ( !playedCourses.isEmpty() ) {
+				player.setPlayedCourses( playedCourses );
+			}
 			return player;
 		}
 	}

--- a/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/Hole.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/Hole.java
@@ -1,0 +1,61 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.test;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.NumericField;
+
+@Entity
+public class Hole {
+
+	@Id
+	@GeneratedValue
+	private long id;
+
+	@Field
+	private int length;
+
+	@NumericField
+	@Field
+	private byte par;
+
+	Hole() {
+	}
+
+	public Hole(int length, byte par) {
+		this.length = length;
+		this.par = par;
+	}
+
+	public long getId() {
+		return id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	public int getLength() {
+		return length;
+	}
+
+	public void setLength(int length) {
+		this.length = length;
+	}
+
+	public byte getPar() {
+		return par;
+	}
+
+	public void setPar(byte par) {
+		this.par = par;
+	}
+}

--- a/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/model/Address.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/model/Address.java
@@ -1,0 +1,91 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.test.model;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+
+import org.hibernate.annotations.Target;
+import org.hibernate.search.annotations.ContainedIn;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.IndexedEmbedded;
+
+/**
+ * @author Emmanuel Bernard
+ */
+
+@Entity
+@Indexed
+public class Address {
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	@Field
+	private String street;
+
+	@IndexedEmbedded(depth = 1, targetElement = Owner.class)
+	@Target(Owner.class)
+	private Person ownedBy;
+
+	@OneToMany(mappedBy = "address")
+	@ContainedIn
+	private Set<Tower> towers = new HashSet<Tower>();
+
+	@ManyToOne(cascade = CascadeType.ALL)
+	@IndexedEmbedded
+	private Country country;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getStreet() {
+		return street;
+	}
+
+	public void setStreet(String street) {
+		this.street = street;
+	}
+
+	public Person getOwnedBy() {
+		return ownedBy;
+	}
+
+	public void setOwnedBy(Person ownedBy) {
+		this.ownedBy = ownedBy;
+	}
+
+
+	public Set<Tower> getTowers() {
+		return towers;
+	}
+
+	public void setTowers(Set<Tower> towers) {
+		this.towers = towers;
+	}
+
+	public Country getCountry() {
+		return country;
+	}
+
+	public void setCountry(Country country) {
+		this.country = country;
+	}
+}

--- a/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/model/Country.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/model/Country.java
@@ -1,0 +1,67 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.test.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+
+import org.hibernate.annotations.IndexColumn;
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.IndexedEmbedded;
+
+/**
+ * @author Emmanuel Bernard
+ */
+@Entity
+@Indexed
+public class Country {
+	@Id
+	@GeneratedValue
+	@DocumentId
+	private Integer id;
+
+	@Field
+	private String name;
+
+	@OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+	//FIXME with JPA 2, move to @OrderColumn
+	@IndexColumn(name = "list_position")
+	@IndexedEmbedded
+	private List<State> states = new ArrayList<State>();
+
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public List<State> getStates() {
+		return states;
+	}
+
+	public void setStates(List<State> states) {
+		this.states = states;
+	}
+}

--- a/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/model/Owner.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/model/Owner.java
@@ -1,0 +1,47 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.test.model;
+
+import javax.persistence.Embeddable;
+
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.IndexedEmbedded;
+import org.hibernate.annotations.Parent;
+
+/**
+ * @author Emmanuel Bernard
+ */
+@Embeddable
+public class Owner implements Person {
+	@Field
+	private String name;
+
+	@Parent
+	@IndexedEmbedded //play the lunatic user
+	private Address address;
+
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@Override
+	public Address getAddress() {
+		return address;
+	}
+
+	@Override
+	public void setAddress(Address address) {
+		this.address = address;
+	}
+}

--- a/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/model/Person.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/model/Person.java
@@ -1,0 +1,22 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.test.model;
+
+/**
+ * @author Emmanuel Bernard
+ */
+public interface Person {
+
+	String getName();
+
+	void setName(String name);
+
+	Address getAddress();
+
+	void setAddress(Address address);
+
+}

--- a/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/model/State.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/model/State.java
@@ -1,0 +1,59 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.test.model;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+
+import org.hibernate.search.annotations.ContainedIn;
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+
+/**
+ * @author Hardy Ferentschik
+ */
+@Entity
+public class State {
+	@Id
+	@DocumentId
+	@GeneratedValue
+	private Integer id;
+
+	@Field
+	private String name;
+
+	@ContainedIn
+	@OneToOne(mappedBy = "state", cascade = CascadeType.ALL)
+	private StateCandidate candidate;
+
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public StateCandidate getCandidate() {
+		return candidate;
+	}
+
+	public void setCandidate( StateCandidate candidate ) {
+		this.candidate = candidate;
+	}
+}

--- a/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/model/StateCandidate.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/model/StateCandidate.java
@@ -1,0 +1,78 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.test.model;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.IndexedEmbedded;
+
+/**
+ *
+ * @author Hardy Ferentschik
+ */
+@Entity
+@Indexed
+public class StateCandidate implements Person {
+
+	@Id @GeneratedValue
+	@DocumentId
+	private int id;
+
+	@Field
+	private String name;
+
+	@OneToOne(cascade = CascadeType.ALL)
+	private Address address;
+
+	@IndexedEmbedded
+	@OneToOne(cascade = CascadeType.ALL)
+	private State state;
+
+	public State getState() {
+		return state;
+	}
+
+	public void setState( State state ) {
+		this.state = state;
+	}
+
+	@Override
+	public Address getAddress() {
+		return address;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public void setAddress( Address address ) {
+		this.address = address;
+
+	}
+
+	@Override
+	public void setName( String name ) {
+		this.name = name;
+	}
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId( int id ) {
+		this.id = id;
+	}
+}

--- a/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/model/Tower.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/model/Tower.java
@@ -1,0 +1,62 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.test.model;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.IndexedEmbedded;
+
+/**
+ * @author Emmanuel Bernard
+ */
+@Entity
+@Indexed
+public class Tower {
+	@Id
+	@GeneratedValue
+	@DocumentId
+	private Long id;
+
+	@Field
+	private String name;
+
+	@ManyToOne(cascade = CascadeType.ALL)
+	@IndexedEmbedded(includeEmbeddedObjectId = true)
+	private Address address;
+
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Address getAddress() {
+		return address;
+	}
+
+	public void setAddress(Address address) {
+		this.address = address;
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/engine/nesting/impl/DefaultNestingContextFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/nesting/impl/DefaultNestingContextFactory.java
@@ -1,0 +1,22 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.nesting.impl;
+
+/**
+ * Always returns the no-op context.
+ *
+ * @author Gunnar Morling
+ */
+public class DefaultNestingContextFactory implements NestingContextFactory {
+
+	public static final NestingContextFactory INSTANCE = new DefaultNestingContextFactory();
+
+	@Override
+	public NestingContext createNestingContext(Class<?> indexedEntityType) {
+		return NoOpNestingContext.INSTANCE;
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/engine/nesting/impl/NestingContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/nesting/impl/NestingContext.java
@@ -1,0 +1,29 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.nesting.impl;
+
+import org.apache.lucene.document.Document;
+import org.hibernate.search.engine.metadata.impl.EmbeddedTypeMetadata.Container;
+
+/**
+ * Allows backends to insert "marker" fields representing the current nesting in case of index embedded associations.
+ * <p>
+ * Experimental, non-exposed work-around to facilitate creating proper ES document structures until we'll have migrated
+ * off using Lucene {@code Document} objects as the one and only document representation.
+ *
+ * @author Gunnar Morling
+ */
+public interface NestingContext {
+
+	void push(String fieldName, Container containerType);
+
+	void pop();
+
+	void mark(Document document);
+
+	void incrementCollectionIndex();
+}

--- a/engine/src/main/java/org/hibernate/search/engine/nesting/impl/NestingContextFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/nesting/impl/NestingContextFactory.java
@@ -1,0 +1,17 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.nesting.impl;
+
+/**
+ * Factory for creating {@link NestingContext}s.
+ *
+ * @author Gunnar Morling
+ */
+public interface NestingContextFactory {
+
+	NestingContext createNestingContext(Class<?> indexedEntityType);
+}

--- a/engine/src/main/java/org/hibernate/search/engine/nesting/impl/NestingContextFactoryProvider.java
+++ b/engine/src/main/java/org/hibernate/search/engine/nesting/impl/NestingContextFactoryProvider.java
@@ -1,0 +1,19 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.nesting.impl;
+
+import org.hibernate.search.engine.service.spi.Service;
+
+/**
+ * Service for obtaining {@link NestingContextFactory} implementations.
+ *
+ * @author Gunnar Morling
+ */
+public interface NestingContextFactoryProvider extends Service {
+
+	NestingContextFactory getNestingContextFactory();
+}

--- a/engine/src/main/java/org/hibernate/search/engine/nesting/impl/NoOpNestingContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/nesting/impl/NoOpNestingContext.java
@@ -1,0 +1,36 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.nesting.impl;
+
+import org.apache.lucene.document.Document;
+import org.hibernate.search.engine.metadata.impl.EmbeddedTypeMetadata.Container;
+
+/**
+ * No-op {@link NestingContext}.
+ *
+ * @author Gunnar Morling
+ */
+public class NoOpNestingContext implements NestingContext {
+
+	public static final NestingContext INSTANCE = new NoOpNestingContext();
+
+	@Override
+	public void push(String fieldName, Container containerType) {
+	}
+
+	@Override
+	public void pop() {
+	}
+
+	@Override
+	public void mark(Document document) {
+	}
+
+	@Override
+	public void incrementCollectionIndex() {
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/util/StringHelper.java
+++ b/engine/src/main/java/org/hibernate/search/util/StringHelper.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.util;
 
 import java.util.Arrays;
+import java.util.Iterator;
 
 /**
  * Inspired from {@code org.hibernate.util.StringHelper}, but removing
@@ -79,6 +80,37 @@ public final class StringHelper {
 			}
 
 			sb.append( object );
+		}
+
+		return sb.toString();
+	}
+
+	/**
+	 * Joins the elements of the given iterable to a string, separated by the given separator string.
+	 *
+	 * @param iterable the iterable to join
+	 * @param separator the separator string
+	 *
+	 * @return a string made up of the string representations of the given iterable members, separated by the given separator
+	 *         string
+	 */
+	public static String join(Iterator<?> iterator, String separator) {
+		if ( iterator == null ) {
+			return null;
+		}
+
+		StringBuilder sb = new StringBuilder();
+		boolean isFirst = true;
+
+		while ( iterator.hasNext() ) {
+			if ( !isFirst ) {
+				sb.append( separator );
+			}
+			else {
+				isFirst = false;
+			}
+
+			sb.append( iterator.next() );
 		}
 
 		return sb.toString();


### PR DESCRIPTION
Hey @Sanne can you quickly check out this PR, specifically the last three commits of it (I based this on @gsmet's not yet merged faceting work).

It does two things:

* Don't use nested mappings by default with ES for now (as discussed, we can make nested the default for index-embedded collections with more than one field and/or make it user-configurable eventually)
* Ensures that for index-embedded collections those fields that belong to one collection element are mapped to the same array element in the resulting ES JSON array (again, that's not a real nested mapping with sub-docs, i.e. the index looks essentially the same as with plain HS+Lucene, but the field should be correctly correlated in the JSON array, otherwise users will hate it).

For the second issue I came up with a hack which I think is acceptable but I'd like your feedback before driving it further. The idea is to insert "marker fields" which denote the array index of the subsequent document fields. This allows to restore the properly structured JSON by examining the "flattened" document. Note that this only happens in the ES case (I service-yified this part, only ES plugs in a proper impl, whereas in plain Lucene it's no-ops).

To give an example, say I have an association from `GolfPlayer` to a collection of `GolfCourse` which is index-embedded. That's the relevant parts of the document as built for ES:

    $nesting=playedCourses[0] // marker field
    playedCourses.name=Purbeck
    playedCourses.rating=127.3
    $nesting=playedCourses[1]
    playedCourses.name=Mount Maja
    playedCourses.rating=111.9

The marker fields themselves won't be added to the JSON document of course, they are only info used to asemble the required structure.

It's hacky but it does the trick and IMHO is good enough for the time being. Pushing potentially wrongly structured data to ES is very bad, hence I'd go with that solution for now. In the next step we should look into abandoning using plain Lucene `Document`s as the actual datastructure which will make all that unneeded. ~~Note that there are two test failures I still need to sort out.~~

Please let me know what you think.