### PR TITLE
HSEARCH-2113 Improve sort support

### DIFF
--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -263,7 +263,6 @@
                                 <exclude>**/IndexAndQueryNullTest.java</exclude>
                                 <exclude>**/ProgrammaticIndexAndQueryNullTest.java</exclude>
                                 <exclude>**/ProjectionQueryTest.java</exclude>
-                                <exclude>**/SortTest.java</exclude>
                                 <exclude>**/SortUsingEntityManagerTest.java</exclude>
                                 <exclude>**/SortUsingEntityManagerTest.java</exclude>
                                 <exclude>**/TermVectorTest.java</exclude>

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -314,6 +314,7 @@
                                 <exclude>**/FSSlaveAndMasterDPTest.java</exclude>
                                 <exclude>**/IndexReaderSeeOptimizedIndexTest.java</exclude>
                             </excludes>
+                            <excludedGroups>org.hibernate.search.testsupport.junit.SkipOnElasticsearch,org.hibernate.search.testsupport.junit.ElasticsearchSupportInProgress</excludedGroups>
                         </configuration>
                     </execution>
                 </executions>

--- a/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchHSQueryImpl.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchHSQueryImpl.java
@@ -339,8 +339,7 @@ public class ElasticsearchHSQueryImpl extends AbstractHSQuery {
 			// TODO: embedded fields
 			if ( sort != null ) {
 				for ( SortField sortField : sort.getSort() ) {
-					String sortFieldName = sortField.getField().equals( idFieldName ) ? "_uid" : sortField.getField();
-					search.addSort( new Sort( sortFieldName, sortField.getReverse() ? Sorting.DESC : Sorting.ASC ) );
+					search.addSort( getSort( sortField, idFieldName ) );
 				}
 			}
 			this.search = search.build();
@@ -398,6 +397,31 @@ public class ElasticsearchHSQueryImpl extends AbstractHSQuery {
 			else {
 				return indexedTargetedEntities;
 			}
+		}
+
+		private Sort getSort(SortField sortField, String idFieldName) {
+			String sortFieldName;
+			if ( sortField.getField() == null ) {
+				switch (sortField.getType()) {
+					case DOC:
+						sortFieldName = "_uid";
+						break;
+					case SCORE:
+						sortFieldName = "_score";
+						break;
+					default:
+						throw LOG.cannotUseThisSortTypeWithNullSortFieldName( sortField.getType() );
+				}
+			}
+			else {
+				if ( sortField.getField().equals( idFieldName ) ) {
+					sortFieldName = "_uid";
+				}
+				else {
+					sortFieldName = sortField.getField();
+				}
+			}
+			return new Sort( sortFieldName, sortField.getReverse() ? Sorting.DESC : Sorting.ASC );
 		}
 
 		SearchResult runSearch() {

--- a/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
@@ -8,6 +8,7 @@ package org.hibernate.search.backend.elasticsearch.logging.impl;
 
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.SortField;
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.util.logging.impl.ClassFormatter;
 import org.jboss.logging.annotations.FormatWith;
@@ -37,4 +38,8 @@ public interface Log extends org.hibernate.search.util.logging.impl.Log {
 	@Message(id = ES_BACKEND_MESSAGES_START_ID + 4,
 			value = "The sort order RANGE_DEFINITION_ORDER should not be sent to the Elasticsearch backend" )
 	SearchException cannotSendRangeDefinitionOrderToElasticsearchBackend();
+
+	@Message(id = ES_BACKEND_MESSAGES_START_ID + 5,
+			value = "The SortType '%1$s' cannot be used with a null sort field name")
+	SearchException cannotUseThisSortTypeWithNullSortFieldName(SortField.Type sortType);
 }

--- a/engine/src/test/java/org/hibernate/search/testsupport/junit/ElasticsearchSupportInProgress.java
+++ b/engine/src/test/java/org/hibernate/search/testsupport/junit/ElasticsearchSupportInProgress.java
@@ -1,0 +1,16 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.testsupport.junit;
+
+/**
+ * JUnit category marker.
+ *
+ * Used to temporarily ignore tests which are not working yet with the Elasticsearch backend.
+ */
+public interface ElasticsearchSupportInProgress {
+
+}

--- a/engine/src/test/java/org/hibernate/search/testsupport/junit/SkipOnElasticsearch.java
+++ b/engine/src/test/java/org/hibernate/search/testsupport/junit/SkipOnElasticsearch.java
@@ -1,0 +1,16 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.testsupport.junit;
+
+/**
+ * JUnit category marker.
+ *
+ * Used to ignore tests which are not sensible when using the Elasticsearch backend.
+ */
+public interface SkipOnElasticsearch {
+
+}

--- a/orm/src/test/java/org/hibernate/search/test/query/sorting/SortTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/sorting/SortTest.java
@@ -6,6 +6,11 @@
  */
 package org.hibernate.search.test.query.sorting;
 
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.IOException;
 import java.util.Calendar;
 import java.util.List;
@@ -46,14 +51,11 @@ import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.test.query.Author;
 import org.hibernate.search.test.query.Book;
 import org.hibernate.search.testsupport.TestConstants;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.fest.assertions.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import org.junit.experimental.categories.Category;
 
 /**
  * @author Hardy Ferentschik
@@ -126,6 +128,7 @@ public class SortTest extends SearchTestBase {
 
 	@SuppressWarnings("unchecked")
 	@Test
+	@Category(SkipOnElasticsearch.class)
 	public void testResultOrderedByIdAlteringSortStyle() throws Exception {
 		Transaction tx = fullTextSession.beginTransaction();
 
@@ -203,6 +206,7 @@ public class SortTest extends SearchTestBase {
 
 	@SuppressWarnings("unchecked")
 	@Test
+	@Category(SkipOnElasticsearch.class)
 	public void testCustomFieldComparatorAscendingSort() {
 		Transaction tx = fullTextSession.beginTransaction();
 
@@ -225,6 +229,7 @@ public class SortTest extends SearchTestBase {
 
 	@SuppressWarnings("unchecked")
 	@Test
+	@Category(SkipOnElasticsearch.class)
 	public void testCustomFieldComparatorDescendingSort() {
 		Transaction tx = fullTextSession.beginTransaction();
 


### PR DESCRIPTION
In passing, create an infrastructure to be able to ignore specific tests which don't make sense with Elasticsearch.