### PR TITLE
HSEARCH-2108 Support Elasticsearch custom and Built-in analyzers

### DIFF
--- a/elasticsearch/elasticsearchconfiguration/elasticsearch.yml
+++ b/elasticsearch/elasticsearchconfiguration/elasticsearch.yml
@@ -49,4 +49,10 @@ node.local: true
 index.number_of_shards: 1
 index.number_of_replicas: 0
 
+# Custom analyzer used in tests
+index.analysis.analyzer.custom-analyzer:
+  type: custom
+  tokenizer: standard
+  filter: standard, lowercase
+
 

--- a/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/analyzer/impl/ElasticsearchAnalyzer.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/analyzer/impl/ElasticsearchAnalyzer.java
@@ -1,0 +1,32 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.analyzer.impl;
+
+import org.apache.lucene.analysis.Analyzer;
+
+/**
+ * Wraps analyzer implementations defined on Elasticsearch.
+ *
+ * @author Davide D'Alto
+ */
+public class ElasticsearchAnalyzer extends Analyzer {
+
+	private final String name;
+
+	public ElasticsearchAnalyzer(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	protected TokenStreamComponents createComponents(String fieldName) {
+		return null;
+	}
+}

--- a/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/ElasticsearchAnalyzerIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/ElasticsearchAnalyzerIT.java
@@ -1,0 +1,153 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.util.List;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.TermQuery;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.Search;
+import org.hibernate.search.annotations.Analyzer;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.test.SearchTestBase;
+import org.junit.Test;
+
+/**
+ * Test the the use of ELasticsearch built-in and custom analyzers.
+ *
+ * @author Davide D'Alto
+ */
+public class ElasticsearchAnalyzerIT extends SearchTestBase {
+
+	@Test
+	public void testEnglishBuiltInAnalyzer() throws Exception {
+		try ( Session session = openSession() ) {
+			FullTextSession fullTextSession = Search.getFullTextSession( session );
+			Transaction tx = session.beginTransaction();
+			Tweet tweet = new Tweet();
+			tweet.setEnglishTweet( "Fox" );
+			session.persist( tweet );
+			tx.commit();
+			session.clear();
+
+			TermQuery query = new TermQuery( new Term( "englishTweet", "foxes" ) );
+			@SuppressWarnings("unchecked")
+			List<Tweet> list = fullTextSession.createFullTextQuery( query ).list();
+			assertThat( list ).onProperty( "englishTweet" ).containsExactly( tweet.getEnglishTweet() );
+		}
+	}
+
+	@Test
+	public void testWhitespaceBuiltInAnalyzer() throws Exception {
+		try ( Session session = openSession() ) {
+			FullTextSession fullTextSession = Search.getFullTextSession( session );
+			Transaction tx = session.beginTransaction();
+			Tweet tweet = new Tweet();
+			tweet.setWhitespaceTweet( "What does the fox say?" );
+			session.persist( tweet );
+			tx.commit();
+			session.clear();
+
+			TermQuery query = new TermQuery( new Term( "whitespaceTweet", "fox      say" ) );
+			@SuppressWarnings("unchecked")
+			List<Tweet> list = fullTextSession.createFullTextQuery( query, Tweet.class ).list();
+			assertThat( list ).onProperty( "whitespaceTweet" ).containsExactly( tweet.getWhitespaceTweet() );
+		}
+	}
+
+	@Test
+	public void testCustomAnalyzer() throws Exception {
+		try ( Session session = openSession() ) {
+			FullTextSession fullTextSession = Search.getFullTextSession( session );
+			Transaction tx = session.beginTransaction();
+			Tweet tweet = new Tweet();
+			tweet.setCustomTweet( "Custom" );
+			session.persist( tweet );
+			tx.commit();
+			session.clear();
+
+			TermQuery query = new TermQuery( new Term( "customTweet", "Custom" ) );
+			@SuppressWarnings("unchecked")
+			List<Tweet> list = fullTextSession.createFullTextQuery( query, Tweet.class ).list();
+			assertThat( list ).onProperty( "customTweet" ).containsExactly( tweet.getCustomTweet() );
+		}
+	}
+
+	@Entity
+	@Indexed(index = "tweet")
+	public static class Tweet {
+
+		@Id
+		@GeneratedValue
+		private Integer id;
+
+		@Field
+		@Analyzer(definition = "english")
+		private String englishTweet;
+
+		@Field
+		@Analyzer(definition = "whitespace")
+		private String whitespaceTweet;
+
+		@Field
+		// Defined in the elasticsearch.yml configuration file
+		@Analyzer(definition = "custom-analyzer")
+		private String customTweet;
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getEnglishTweet() {
+			return englishTweet;
+		}
+
+		public void setEnglishTweet(String englishTweet) {
+			this.englishTweet = englishTweet;
+		}
+
+		public String getWhitespaceTweet() {
+			return whitespaceTweet;
+		}
+
+		public void setWhitespaceTweet(String whitespaceTweet) {
+			this.whitespaceTweet = whitespaceTweet;
+		}
+
+		public String getCustomTweet() {
+			return customTweet;
+		}
+
+		public void setCustomTweet(String customTweet) {
+			this.customTweet = customTweet;
+		}
+
+		@Override
+		public String toString() {
+			return "[" + englishTweet + ", " + whitespaceTweet + "]";
+		}
+	}
+
+	@Override
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[]{ Tweet.class };
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/analyzer/spi/AnalyzerDefiner.java
+++ b/engine/src/main/java/org/hibernate/search/analyzer/spi/AnalyzerDefiner.java
@@ -1,0 +1,35 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.analyzer.spi;
+
+import org.apache.lucene.analysis.Analyzer;
+
+/**
+ * Applies to index managers that are bound to backends supporting built-in analyzer definitions.
+ * <p>
+ * For example, Elasticsearch comes with whitespace and languages analyzers without definition defined in
+ * the classpath.
+ *
+ * @author Davide D'Alto
+ */
+public interface AnalyzerDefiner {
+
+	/**
+	 * Checks if the index manager can managed additional analyzer
+	 *
+	 * @return true if it supports additional analyzers without the need of an analyzer defintion
+	 */
+	boolean supportsAdditionalAnalyzer();
+
+	/**
+	 * Creates an analyzer for the provided definition.
+	 *
+	 * @param definitionName the name of the analyzer deifinition
+	 * @return an {@link Analyzer} instance the can be used
+	 */
+	Analyzer createAnalyzer(String definitionName);
+}

--- a/engine/src/main/java/org/hibernate/search/spi/SearchIntegratorBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/spi/SearchIntegratorBuilder.java
@@ -393,7 +393,7 @@ public class SearchIntegratorBuilder {
 		);
 
 		factoryState.addFilterDefinitions( configContext.initFilters() );
-		factoryState.addAnalyzers( configContext.initLazyAnalyzers() );
+		factoryState.addAnalyzers( configContext.initLazyAnalyzers( indexesFactory ) );
 	}
 
 	/**

--- a/engine/src/main/java/org/hibernate/search/util/impl/DelegateNamedAnalyzer.java
+++ b/engine/src/main/java/org/hibernate/search/util/impl/DelegateNamedAnalyzer.java
@@ -42,7 +42,7 @@ public final class DelegateNamedAnalyzer extends AnalyzerWrapper {
 	}
 
 	@Override
-	protected Analyzer getWrappedAnalyzer(String fieldName) {
+	public Analyzer getWrappedAnalyzer(String fieldName) {
 		return delegate;
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2108

With this patch if Elasticsearch is used as IndexManager the check on the analyzer defintions is cancelled. 
If there is a wrong definition name in the code an error is thrown during the craetion of the index. Sadly I couldn't find any reliable way to check if an analyzer definition exists in on elasticsearch.

The catch is that it is not possible to use different indexmanagers with the elasticsearch one

