### PR TITLE
HSEARCH-2146 Waiting until ES indexes have become green

### DIFF
--- a/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
+++ b/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
@@ -65,11 +65,12 @@ you will need the new `hibernate-search-backend-elasticsearch` jar.
 
 ==== Configuration
 
-Just three new configuration properties have been introduced so far:
+Just a few new configuration properties have been introduced so far:
 
 Hostname and port for Elasticsearch:: `hibernate.search.elasticsearch.host \http://127.0.0.1:9200`
 Define which indexes should use it:: `hibernate.search.default.indexmanager elasticsearch`
 Decide who manages the index creation:: `hibernate.search.elasticsearch.index_management_strategy CREATE_DELETE`
+Timeout in ms when waiting for indexes to become available after creation:: `hibernate.search.elasticsearch.index_management_wait_timeout 10000`
 
 Other options for the `hibernate.search.elasticsearch.index_management_strategy` property are:
 

--- a/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchEnvironment.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchEnvironment.java
@@ -13,8 +13,18 @@ package org.hibernate.search.backend.elasticsearch.cfg;
  */
 public final class ElasticsearchEnvironment {
 
+	public static final class Defaults {
+		public static final int INDEX_MANAGEMENT_WAIT_TIMEOUT = 10_000;
+	}
+
 	public static final String SERVER_URI = "hibernate.search.elasticsearch.host";
 	public static final String INDEX_MANAGEMENT_STRATEGY = "hibernate.search.elasticsearch.index_management_strategy";
+
+	/**
+	 * Property for specifying the timeout for index management operations (index creation etc.) in milli-seconds.
+	 * Defaults to {@link Defaults#INDEX_MANAGEMENT_WAIT_TIMEOUT} ms.
+	 */
+	public static final String INDEX_MANAGEMENT_WAIT_TIMEOUT = "hibernate.search.elasticsearch.index_management_wait_timeout";
 
 	private ElasticsearchEnvironment() {
 	}

--- a/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchEnvironment.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchEnvironment.java
@@ -13,15 +13,39 @@ package org.hibernate.search.backend.elasticsearch.cfg;
  */
 public final class ElasticsearchEnvironment {
 
+	/**
+	 * Default values for the different settings if no values are given.
+	 */
 	public static final class Defaults {
+		public static final String SERVER_URI = "http://localhost:9200";
+		public static final IndexManagementStrategy INDEX_MANAGEMENT_STRATEGY = IndexManagementStrategy.NONE;
 		public static final int INDEX_MANAGEMENT_WAIT_TIMEOUT = 10_000;
 	}
 
+	/**
+	 * Property for specifying the host name of the Elasticsearch server to connect to. Only a single server (i.e. no
+	 * clusters) is supported at this point.
+	 * <p>
+	 * An URI such as http://myeshost.com:9200 is expected.
+	 * <p>
+	 * Defaults to {@link Defaults#SERVER_URI}.
+	 */
 	public static final String SERVER_URI = "hibernate.search.elasticsearch.host";
+
+	/**
+	 * Property for specifying the strategy for maintaining the Elasticsearch index.
+	 * <p>
+	 * The name of one of the {@link IndexManagementStrategy} constants is expected, e.g. MERGE.
+	 * <p>
+	 *
+	 */
 	public static final String INDEX_MANAGEMENT_STRATEGY = "hibernate.search.elasticsearch.index_management_strategy";
 
 	/**
 	 * Property for specifying the timeout for index management operations (index creation etc.) in milli-seconds.
+	 * <p>
+	 * A numeric value such as 1000 is expected.
+	 * <p>
 	 * Defaults to {@link Defaults#INDEX_MANAGEMENT_WAIT_TIMEOUT} ms.
 	 */
 	public static final String INDEX_MANAGEMENT_WAIT_TIMEOUT = "hibernate.search.elasticsearch.index_management_wait_timeout";

--- a/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/impl/JestClient.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/impl/JestClient.java
@@ -37,7 +37,9 @@ public class JestClient implements Service, Startable, Stoppable {
 		JestClientFactory factory = new JestClientFactory();
 
 		String serverUri = ConfigurationParseHelper.getString(
-				properties, ElasticsearchEnvironment.SERVER_URI, "http://localhost:9200"
+				properties,
+				ElasticsearchEnvironment.SERVER_URI,
+				ElasticsearchEnvironment.Defaults.SERVER_URI
 		);
 
 		// TODO HSEARCH-2062 Make timeouts configurable

--- a/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/impl/JestClient.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/impl/JestClient.java
@@ -40,10 +40,11 @@ public class JestClient implements Service, Startable, Stoppable {
 				properties, ElasticsearchEnvironment.SERVER_URI, "http://localhost:9200"
 		);
 
+		// TODO HSEARCH-2062 Make timeouts configurable
 		factory.setHttpClientConfig(
 			new HttpClientConfig.Builder( serverUri )
 				.multiThreaded( true )
-				.readTimeout( 2000 )
+				.readTimeout( 60000 )
 				.connTimeout( 2000 )
 				.gson( GsonBuilderHolder.BUILDER )
 				.build()

--- a/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchIndexManager.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchIndexManager.java
@@ -103,7 +103,7 @@ public class ElasticsearchIndexManager implements IndexManager {
 
 	private IndexManagementStrategy getIndexManagementStrategy(Properties properties) {
 		String strategy = properties.getProperty( ElasticsearchEnvironment.INDEX_MANAGEMENT_STRATEGY );
-		return strategy != null ? IndexManagementStrategy.valueOf( strategy ) : IndexManagementStrategy.NONE;
+		return strategy != null ? IndexManagementStrategy.valueOf( strategy ) : ElasticsearchEnvironment.Defaults.INDEX_MANAGEMENT_STRATEGY;
 	}
 
 	private String getIndexManagementWaitTimeout(Properties properties) {

--- a/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/ElasticsearchConfigurationValuesSpecifiedIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/ElasticsearchConfigurationValuesSpecifiedIT.java
@@ -1,0 +1,92 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.Search;
+import org.hibernate.search.backend.elasticsearch.ElasticsearchQueries;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchEnvironment;
+import org.hibernate.search.query.engine.spi.QueryDescriptor;
+import org.hibernate.search.test.SearchTestBase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Basic smoke test to make sure the different configuration settings can be overridden.
+ *
+ * @author Gunnar Morling
+ */
+public class ElasticsearchConfigurationValuesSpecifiedIT extends SearchTestBase {
+
+	@Before
+	public void setupTestData() {
+		Session s = openSession();
+		Transaction tx = s.beginTransaction();
+
+		GolfPlayer hergesheimer = new GolfPlayer.Builder()
+			.firstName( "Klaus" )
+			.lastName( "Hergesheimer" )
+			.build();
+
+		s.persist( hergesheimer );
+
+		tx.commit();
+		s.close();
+	}
+
+	@After
+	public void deleteTestData() {
+		Session s = openSession();
+		FullTextSession session = Search.getFullTextSession( s );
+		Transaction tx = s.beginTransaction();
+
+		QueryDescriptor query = ElasticsearchQueries.fromJson( "{ 'query': { 'match_all' : {} } }" );
+		List<?> result = session.createFullTextQuery( query ).list();
+
+		for ( Object entity : result ) {
+			session.delete( entity );
+		}
+
+		tx.commit();
+		s.close();
+	}
+
+	@Test
+	public void canQueryEntityWithConfigurationValuesGiven() throws Exception {
+		Session s = openSession();
+		FullTextSession session = Search.getFullTextSession( s );
+		Transaction tx = s.beginTransaction();
+
+		QueryDescriptor query = ElasticsearchQueries.fromJson( "{ 'query': { 'match_all' : {} } }" );
+		List<?> result = session.createFullTextQuery( query, GolfPlayer.class ).list();
+
+		assertThat( result ).onProperty( "firstName" ).containsOnly( "Klaus" );
+
+		tx.commit();
+		s.close();
+	}
+
+	@Override
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class[] { GolfPlayer.class, GolfCourse.class, Hole.class };
+	}
+
+	@Override
+	public void configure(Map<String, Object> settings) {
+		settings.put( ElasticsearchEnvironment.SERVER_URI, "http://127.0.0.1:9200" );
+		settings.put( ElasticsearchEnvironment.INDEX_MANAGEMENT_WAIT_TIMEOUT, 5_000 );
+		settings.put( ElasticsearchEnvironment.INDEX_MANAGEMENT_STRATEGY, "CREATE" );
+	}
+}

--- a/elasticsearch/src/test/resources/hibernate.properties
+++ b/elasticsearch/src/test/resources/hibernate.properties
@@ -24,3 +24,4 @@ hibernate.cache.provider_class org.hibernate.cache.HashtableCacheProvider
 hibernate.search.elasticsearch.host http://127.0.0.1:9200
 hibernate.search.default.indexmanager elasticsearch
 hibernate.search.elasticsearch.index_management_strategy CREATE_DELETE
+hibernate.search.elasticsearch.index_management_wait_timeout 1000

--- a/elasticsearch/src/test/resources/hibernate.properties
+++ b/elasticsearch/src/test/resources/hibernate.properties
@@ -21,7 +21,5 @@ hibernate.max_fetch_depth 5
 hibernate.cache.region_prefix hibernate.test
 hibernate.cache.provider_class org.hibernate.cache.HashtableCacheProvider
 
-hibernate.search.elasticsearch.host http://127.0.0.1:9200
 hibernate.search.default.indexmanager elasticsearch
 hibernate.search.elasticsearch.index_management_strategy CREATE_DELETE
-hibernate.search.elasticsearch.index_management_wait_timeout 1000


### PR DESCRIPTION
The second commit aims at parallelizing index creation. While it works it feels a bit ad-hoc-ish. Let me know what you think. It cuts down test execution time a bit more, but of obviously the effect will be larger if there are more indexes involved.

Note that I'm handling (index creation + mapping creation) as one execution unit, one could think about splitting these two up, too. This wouldn't improve the end-to-end time, but it'd free threads when waiting for index creation to finish. I don't think it's needed right now.