### PR TITLE
HSEARCH-2162 Use the Hibernate JDBC properties consistently in TestRu…

### DIFF
--- a/integrationtest/performance/readme.md
+++ b/integrationtest/performance/readme.md
@@ -67,10 +67,10 @@ username and password.
         mvn clean test -Pmysql51 -Dtest=TestRunnerStandalone \
         -Dscenario=org.hibernate.search.test.performance.scenario.FileSystemDefaultTestScenario \
         -Dhibernate.dialect=org.hibernate.dialect.MySQL5InnoDBDialect \
-        -Dhibernate.hikari.dataSourceClassName=com.mysql.jdbc.jdbc2.optional.MysqlDataSource \
-        -Dhibernate.hikari.dataSource.url=jdbc:mysql://hostname:3306/hibperf \
-        -Dhibernate.hikari.dataSource.user=foo \
-        -Dhibernate.hikari.dataSource.password=foo \
+        -Dhibernate.connection.driver_class=com.mysql.jdbc.Driver \
+        -Dhibernate.connection.url=jdbc:mysql://hostname:3306/hibperf \
+        -Dhibernate.connection.username=foo \
+        -Dhibernate.connection.password=foo \
         -Dorg.hibernate.search.enable_performance_tests=true
 
 ### In container against a data source

--- a/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/TestRunnerStandalone.java
+++ b/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/TestRunnerStandalone.java
@@ -38,8 +38,11 @@ public class TestRunnerStandalone {
 		Properties properties = scenario.getHibernateProperties();
 		setDefaultProperty( properties, "hibernate.dialect", "org.hibernate.dialect.H2Dialect" );
 		setDefaultProperty( properties, "hibernate.connection.provider_class", "org.hibernate.hikaricp.internal.HikariCPConnectionProvider" );
+		setDefaultProperty( properties, "hibernate.connection.driver_class", "org.h2.Driver" );
+		setDefaultProperty( properties, "hibernate.connection.username", "sa" );
+		setDefaultProperty( properties, "hibernate.connection.password", "" );
+		setDefaultProperty( properties, "hibernate.connection.url", "jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;MULTI_THREADED=1" );
 		setDefaultProperty( properties, "hibernate.hikari.maximumPoolSize", "20" );
-		setDefaultProperty( properties, "hibernate.hikari.dataSource.url", "jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;MULTI_THREADED=1" );
 		setDefaultProperty( properties, "hibernate.connection.isolation", "TRANSACTION_READ_COMMITTED" );
 		return properties;
 	}


### PR DESCRIPTION
…nnerStandalone

Followup of HSEARCH-2149: we can't use a mix of Hibernate and HikariCP properties
as they are merged by HikariCP and two of them conflict.

In Eclipse, HSEARCH-2149 made the test work but probably because the classpath is not clean and it loaded an hibernate.properties. HSEARCH-2149 also made the test work with Maven when a database profile was set.

But with Maven and without a database profile, the test didn't run anymore. This commit fixes it in all cases by using consistently the Hibernate JDBC properties instead of mixing Hibernate properties and HikariCP specific properties: you cannot set a driverClassName and a datasourceClassName and the driverClassName is automatically copied from the Hibernate JDBC properties if defined.