### PR TITLE
HSEARCH-2205 Upgrade to Elasticsearch 2.3.1: Java9 compatibility and …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
              controls which version is being used to run integration tests. When updating,
              make sure to use the right JNA version, too
         -->
-        <testElasticsearchVersion>2.2.0</testElasticsearchVersion>
+        <testElasticsearchVersion>2.3.1</testElasticsearchVersion>
         <testElasticsearchJnaVersion>4.1.0</testElasticsearchJnaVersion>
         <elasticsearchJestVersion>2.0.0</elasticsearchJestVersion>
         <elasticsearchCommonsLang3Version>3.4</elasticsearchCommonsLang3Version>


### PR DESCRIPTION
…Lucene aligned to 5.5

Seems fine to still use the same version of JNA.