### PR TITLE
HSEARCH-2217 Move Travis build to Trusty infrastructure and use Maven wrapper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
+sudo: required
+dist: trusty
 language: java
 jdk:
   - oraclejdk8
 addons:
-  postgresql: '9.4'
-  mariadb: '10.1'
+  # for now, let's test only with H2
+  #postgresql: '9.4'
+  #mariadb: '10.0'
   apt:
     packages:
       - oracle-java8-installer
@@ -11,27 +14,28 @@ addons:
 #  artifacts:
 #    paths:
 #      - $(find $HOME -name surefire-reports | tr "\n" ":")
-#    debug: true
+#      - $(find $HOME -name failsafe-reports | tr "\n" ":")
 #  s3_region: 'us-west-2'
 cache:
   directories:
     - $HOME/.m2
 env:
   - DB=h2
-# for now, let's test only with H2
-#  - DB=pgsql
-#  - DB=mariadb
+  # for now, let's test only with H2
+  #- DB=pgsql
+  #- DB=mariadb
 install:
-  - mvn -v
+  # The Maven install provided by Travis is outdated, use Maven wrapper to get the latest version
+  - mvn -N io.takari:maven:wrapper
+  - ./mvnw -v
   # first run to download all the Maven dependencies without logging
-  - mvn -s settings-example.xml -B -q clean compile -DskipTests=true
+  - ./mvnw -s settings-example.xml -B -q clean install -DskipTests=true
+  # we run checkstyle first to fail fast if there is a styling error
+  - ./mvnw -s settings-example.xml checkstyle:check
 before_script: 
   - if [[ "$DB" == "pgsql" ]]; then psql -U postgres -f 'travis/pgsql.sql';fi 
   - if [[ "$DB" == "mariadb" ]]; then mysql -u root < 'travis/mariadb.sql'; fi
 script:
-  # we run checkstyle first to fail fast if there is a styling error
-  - mvn -s settings-example.xml checkstyle:check
-  - if [[ "$DB" == "h2" ]]; then mvn -s settings-example.xml -Ph2 verify;fi 
-  - if [[ "$DB" == "pgsql" ]]; then mvn -s settings-example.xml -Pci-postgresql verify;fi 
-  - if [[ "$DB" == "mariadb" ]]; then mvn -s settings-example.xml -Pci-mariadb verify; fi
-  
+  - if [[ "$DB" == "h2" ]]; then ./mvnw -s settings-example.xml -Pdocs,docbook,dist clean install;fi 
+  - if [[ "$DB" == "pgsql" ]]; then ./mvnw -s settings-example.xml -Pci-postgresql,docs,docbook,dist clean install;fi 
+  - if [[ "$DB" == "mariadb" ]]; then ./mvnw -s settings-example.xml -Pci-mariadb,docs,docbook,dist clean install; fi


### PR DESCRIPTION
With this commit, we should be able to enable Travis on the main repo with all the integration tests running!