### PR TITLE
HSEARCH-2067 Introduce the notion of backend specific FieldBridges

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchBridgeProvider.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchBridgeProvider.java
@@ -18,6 +18,8 @@ import org.hibernate.search.bridge.FieldBridge;
 import org.hibernate.search.bridge.LuceneOptions;
 import org.hibernate.search.bridge.TwoWayFieldBridge;
 import org.hibernate.search.bridge.impl.ExtendedBridgeProvider;
+import org.hibernate.search.bridge.spi.BackendSpecificBridgeProvider;
+import org.hibernate.search.indexes.spi.IndexManager;
 
 /**
  * Creates bridges specific to ES.
@@ -25,7 +27,12 @@ import org.hibernate.search.bridge.impl.ExtendedBridgeProvider;
  * @author Gunnar Morling
  */
 // TODO Handle Calendar
-public class ElasticsearchBridgeProvider extends ExtendedBridgeProvider {
+public class ElasticsearchBridgeProvider extends ExtendedBridgeProvider implements BackendSpecificBridgeProvider {
+
+	@Override
+	public Class<? extends IndexManager> getBackend() {
+		return ElasticsearchIndexManager.class;
+	}
 
 	@Override
 	public FieldBridge provideFieldBridge(ExtendedBridgeProviderContext bridgeContext) {

--- a/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchNestingContextFactoryProvider.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchNestingContextFactoryProvider.java
@@ -9,7 +9,6 @@ package org.hibernate.search.backend.elasticsearch.impl;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Properties;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -23,8 +22,6 @@ import org.hibernate.search.engine.nesting.impl.NestingContextFactory;
 import org.hibernate.search.engine.nesting.impl.NestingContextFactoryProvider;
 import org.hibernate.search.engine.nesting.impl.NoOpNestingContext;
 import org.hibernate.search.engine.service.spi.Startable;
-import org.hibernate.search.engine.spi.EntityIndexBinding;
-import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.spi.BuildContext;
 import org.hibernate.search.util.StringHelper;
 
@@ -64,20 +61,7 @@ public class ElasticsearchNestingContextFactoryProvider implements NestingContex
 		}
 
 		private boolean isMappedToElasticsearch(Class<?> entityType) {
-			Set<Class<?>> queriedEntityTypesWithSubTypes = searchIntegrator.getIndexedTypesPolymorphic( new Class<?>[] { entityType } );
-
-			for ( Class<?> queriedEntityType : queriedEntityTypesWithSubTypes ) {
-				EntityIndexBinding binding = searchIntegrator.getIndexBinding( queriedEntityType );
-				IndexManager[] indexManagers = binding.getIndexManagers();
-
-				for ( IndexManager indexManager : indexManagers ) {
-					if ( indexManager instanceof ElasticsearchIndexManager ) {
-						return true;
-					}
-				}
-			}
-
-			return false;
+			return searchIntegrator.isManagedBy( entityType, ElasticsearchIndexManager.class );
 		}
 	}
 

--- a/elasticsearch/src/main/resources/META-INF/services/org.hibernate.search.bridge.spi.BackendSpecificBridgeProvider
+++ b/elasticsearch/src/main/resources/META-INF/services/org.hibernate.search.bridge.spi.BackendSpecificBridgeProvider
@@ -1,0 +1,1 @@
+org.hibernate.search.backend.elasticsearch.impl.ElasticsearchBridgeProvider

--- a/engine/src/main/java/org/hibernate/search/bridge/spi/BackendSpecificBridgeProvider.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/spi/BackendSpecificBridgeProvider.java
@@ -1,0 +1,25 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.bridge.spi;
+
+import org.hibernate.search.indexes.spi.IndexManager;
+
+/**
+ * Bridge provider specific to a given backend.
+ *
+ * @author Guillaume Smet
+ */
+public interface BackendSpecificBridgeProvider extends BridgeProvider {
+
+	/**
+	 * Returns the backend for which we register the bridge
+	 *
+	 * @return the backend for which we register the bridge
+	 */
+	Class<? extends IndexManager> getBackend();
+
+}

--- a/engine/src/main/java/org/hibernate/search/cfg/spi/IndexManagerFactory.java
+++ b/engine/src/main/java/org/hibernate/search/cfg/spi/IndexManagerFactory.java
@@ -28,14 +28,14 @@ public interface IndexManagerFactory extends Service {
 	 *
 	 * @return the type chosen
 	 */
-	Class<? extends IndexManager> determineIndexManagerImpl(Class<?> mappedClass, String indexManagerImplementationName);
+	Class<? extends IndexManager> determineIndexManagerType(Class<?> mappedClass, String indexManagerImplementationName);
 
 	/**
 	 * @param mappedClass the mapped entity class
-	 * @param indexManagerImpl a given {@code IndexManager} type
+	 * @param indexManagerType a given {@code IndexManager} type
 	 *
 	 * @return a new {@code IndexManager} instance of the given type
 	 */
-	IndexManager createIndexManager(Class<?> mappedClass, Class<? extends IndexManager> indexManagerImpl);
+	IndexManager createIndexManager(Class<?> mappedClass, Class<? extends IndexManager> indexManagerType);
 
 }

--- a/engine/src/main/java/org/hibernate/search/cfg/spi/IndexManagerFactory.java
+++ b/engine/src/main/java/org/hibernate/search/cfg/spi/IndexManagerFactory.java
@@ -21,21 +21,17 @@ public interface IndexManagerFactory extends Service {
 
 	/**
 	 * Determine the {@code IndexManager} implementation which will be used for this entity type.
-	 *
-	 * @param mappedClass the mapped entity class
 	 * @param indexManagerImplementationName how this is resolved to an {@code IndexManager} type
 	 * is left to the implementor.
 	 *
 	 * @return the type chosen
 	 */
-	Class<? extends IndexManager> determineIndexManagerType(Class<?> mappedClass, String indexManagerImplementationName);
+	Class<? extends IndexManager> determineIndexManagerType(String indexManagerImplementationName);
 
 	/**
-	 * @param mappedClass the mapped entity class
 	 * @param indexManagerType a given {@code IndexManager} type
-	 *
 	 * @return a new {@code IndexManager} instance of the given type
 	 */
-	IndexManager createIndexManager(Class<?> mappedClass, Class<? extends IndexManager> indexManagerType);
+	IndexManager createIndexManager(Class<? extends IndexManager> indexManagerType);
 
 }

--- a/engine/src/main/java/org/hibernate/search/cfg/spi/IndexManagerFactory.java
+++ b/engine/src/main/java/org/hibernate/search/cfg/spi/IndexManagerFactory.java
@@ -15,20 +15,27 @@ import org.hibernate.search.indexes.spi.IndexManager;
  * define new short-hand aliases, change the default implementation.
  *
  * @author Sanne Grinovero (C) 2012 Red Hat Inc.
+ * @author Guillaume Smet
  */
 public interface IndexManagerFactory extends Service {
 
 	/**
-	 * @return a new instance of the default IndexManager
-	 */
-	IndexManager createDefaultIndexManager();
-
-	/**
-	 * @param indexManagerImplementationName how this is resolved to an IndexManager type
+	 * Determine the {@code IndexManager} implementation which will be used for this entity type.
+	 *
+	 * @param mappedClass the mapped entity class
+	 * @param indexManagerImplementationName how this is resolved to an {@code IndexManager} type
 	 * is left to the implementor.
 	 *
-	 * @return a new IndexManager instance of the chosen type
+	 * @return the type chosen
 	 */
-	IndexManager createIndexManagerByName(String indexManagerImplementationName);
+	Class<? extends IndexManager> determineIndexManagerImpl(Class<?> mappedClass, String indexManagerImplementationName);
+
+	/**
+	 * @param mappedClass the mapped entity class
+	 * @param indexManagerImpl a given {@code IndexManager} type
+	 *
+	 * @return a new {@code IndexManager} instance of the given type
+	 */
+	IndexManager createIndexManager(Class<?> mappedClass, Class<? extends IndexManager> indexManagerImpl);
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/impl/DefaultIndexManagerFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/DefaultIndexManagerFactory.java
@@ -47,38 +47,38 @@ public class DefaultIndexManagerFactory implements IndexManagerFactory, Startabl
 	}
 
 	@Override
-	public Class<? extends IndexManager> determineIndexManagerImpl(Class<?> mappedClass, String indexManagerImplementationName) {
+	public Class<? extends IndexManager> determineIndexManagerType(Class<?> mappedClass, String indexManagerImplementationName) {
 		if ( indexManagersPerEntity.containsKey( mappedClass ) ) {
 			return indexManagersPerEntity.get( mappedClass );
 		}
 
-		Class<? extends IndexManager> indexManagerImpl;
+		Class<? extends IndexManager> indexManagerType;
 		if ( StringHelper.isEmpty( indexManagerImplementationName ) ) {
-			indexManagerImpl = getDefaultIndexManagerImpl();
+			indexManagerType = getDefaultIndexManagerType();
 		}
 		else {
 			indexManagerImplementationName = indexManagerImplementationName.trim();
-			indexManagerImpl = fromAlias( indexManagerImplementationName );
-			if ( indexManagerImpl == null ) {
+			indexManagerType = fromAlias( indexManagerImplementationName );
+			if ( indexManagerType == null ) {
 				indexManagerImplementationName = aliasToFQN( indexManagerImplementationName );
-				indexManagerImpl = ClassLoaderHelper.classForName(
+				indexManagerType = ClassLoaderHelper.classForName(
 						IndexManager.class,
 						indexManagerImplementationName,
 						"index manager",
 						serviceManager
 				);
 			}
-			log.indexManagerAliasResolved( indexManagerImplementationName, indexManagerImpl );
+			log.indexManagerAliasResolved( indexManagerImplementationName, indexManagerType );
 		}
-		addMapping( mappedClass, indexManagerImpl );
-		return indexManagerImpl;
+		addMapping( mappedClass, indexManagerType );
+		return indexManagerType;
 	}
 
 	@Override
-	public IndexManager createIndexManager(Class<?> mappedClass, Class<? extends IndexManager> indexManagerImpl) {
+	public IndexManager createIndexManager(Class<?> mappedClass, Class<? extends IndexManager> indexManagerType) {
 		IndexManager indexManager = ClassLoaderHelper.instanceFromClass(
 				IndexManager.class,
-				indexManagerImpl,
+				indexManagerType,
 				"index manager"
 		);
 
@@ -90,7 +90,7 @@ public class DefaultIndexManagerFactory implements IndexManagerFactory, Startabl
 	 *
 	 * @return the default {@code IndexManager} impl
 	 */
-	protected Class<? extends IndexManager> getDefaultIndexManagerImpl() {
+	protected Class<? extends IndexManager> getDefaultIndexManagerType() {
 		return DirectoryBasedIndexManager.class;
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/impl/DefaultMutableEntityIndexBinding.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/DefaultMutableEntityIndexBinding.java
@@ -20,6 +20,7 @@ import org.hibernate.search.store.ShardIdentifierProvider;
  */
 public class DefaultMutableEntityIndexBinding implements MutableEntityIndexBinding {
 
+	private final Class<? extends IndexManager> indexManagerImpl;
 	private final IndexShardingStrategy shardingStrategy;
 	private final Similarity similarityInstance;
 	private DocumentBuilderIndexedEntity documentBuilder;
@@ -27,14 +28,26 @@ public class DefaultMutableEntityIndexBinding implements MutableEntityIndexBindi
 	private final EntityIndexingInterceptor entityIndexingInterceptor;
 
 	public DefaultMutableEntityIndexBinding(
+			Class<? extends IndexManager> indexManagerImpl,
 			IndexShardingStrategy shardingStrategy,
 			Similarity similarityInstance,
 			IndexManager[] providers,
 			EntityIndexingInterceptor entityIndexingInterceptor) {
+				this.indexManagerImpl = indexManagerImpl;
 				this.shardingStrategy = shardingStrategy;
 				this.similarityInstance = similarityInstance;
 				this.indexManagers = providers;
 				this.entityIndexingInterceptor = entityIndexingInterceptor;
+	}
+
+	@Override
+	public Class<? extends IndexManager> getIndexManagerImpl() {
+		return indexManagerImpl;
+	}
+
+	@Override
+	public boolean isManagedBy(Class<? extends IndexManager> indexManager) {
+		return indexManager.isAssignableFrom( indexManagerImpl );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/impl/DefaultMutableEntityIndexBinding.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/DefaultMutableEntityIndexBinding.java
@@ -20,7 +20,7 @@ import org.hibernate.search.store.ShardIdentifierProvider;
  */
 public class DefaultMutableEntityIndexBinding implements MutableEntityIndexBinding {
 
-	private final Class<? extends IndexManager> indexManagerImpl;
+	private final Class<? extends IndexManager> indexManagerType;
 	private final IndexShardingStrategy shardingStrategy;
 	private final Similarity similarityInstance;
 	private DocumentBuilderIndexedEntity documentBuilder;
@@ -28,12 +28,12 @@ public class DefaultMutableEntityIndexBinding implements MutableEntityIndexBindi
 	private final EntityIndexingInterceptor entityIndexingInterceptor;
 
 	public DefaultMutableEntityIndexBinding(
-			Class<? extends IndexManager> indexManagerImpl,
+			Class<? extends IndexManager> indexManagerType,
 			IndexShardingStrategy shardingStrategy,
 			Similarity similarityInstance,
 			IndexManager[] providers,
 			EntityIndexingInterceptor entityIndexingInterceptor) {
-				this.indexManagerImpl = indexManagerImpl;
+				this.indexManagerType = indexManagerType;
 				this.shardingStrategy = shardingStrategy;
 				this.similarityInstance = similarityInstance;
 				this.indexManagers = providers;
@@ -41,13 +41,13 @@ public class DefaultMutableEntityIndexBinding implements MutableEntityIndexBindi
 	}
 
 	@Override
-	public Class<? extends IndexManager> getIndexManagerImpl() {
-		return indexManagerImpl;
+	public Class<? extends IndexManager> getIndexManagerType() {
+		return indexManagerType;
 	}
 
 	@Override
 	public boolean isManagedBy(Class<? extends IndexManager> indexManager) {
-		return indexManager.isAssignableFrom( indexManagerImpl );
+		return indexManager.isAssignableFrom( indexManagerType );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/impl/DynamicShardingEntityIndexBinding.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/DynamicShardingEntityIndexBinding.java
@@ -24,7 +24,7 @@ import org.hibernate.search.store.ShardIdentifierProvider;
  */
 public class DynamicShardingEntityIndexBinding implements MutableEntityIndexBinding {
 
-	private final Class<? extends IndexManager> indexManagerImpl;
+	private final Class<? extends IndexManager> indexManagerType;
 	private final DynamicShardingStrategy shardingStrategy;
 	private final Similarity similarityInstance;
 	private final ShardIdentifierProvider shardIdentityProvider;
@@ -37,7 +37,7 @@ public class DynamicShardingEntityIndexBinding implements MutableEntityIndexBind
 	private IndexManagerFactory indexManagerFactory;
 
 	public DynamicShardingEntityIndexBinding(
-			Class<? extends IndexManager> indexManagerImpl,
+			Class<? extends IndexManager> indexManagerType,
 			ShardIdentifierProvider shardIdentityProvider,
 			Similarity similarityInstance,
 			EntityIndexingInterceptor entityIndexingInterceptor,
@@ -45,7 +45,7 @@ public class DynamicShardingEntityIndexBinding implements MutableEntityIndexBind
 			ExtendedSearchIntegrator extendedIntegrator,
 			IndexManagerHolder indexManagerHolder,
 			String rootDirectoryProviderName) {
-		this.indexManagerImpl = indexManagerImpl;
+		this.indexManagerType = indexManagerType;
 		this.shardIdentityProvider = shardIdentityProvider;
 		this.similarityInstance = similarityInstance;
 		this.entityIndexingInterceptor = entityIndexingInterceptor;
@@ -64,13 +64,13 @@ public class DynamicShardingEntityIndexBinding implements MutableEntityIndexBind
 	}
 
 	@Override
-	public Class<? extends IndexManager> getIndexManagerImpl() {
-		return indexManagerImpl;
+	public Class<? extends IndexManager> getIndexManagerType() {
+		return indexManagerType;
 	}
 
 	@Override
-	public boolean isManagedBy(Class<? extends IndexManager> indexManagerImplCandidate) {
-		return indexManagerImplCandidate.isAssignableFrom( indexManagerImpl );
+	public boolean isManagedBy(Class<? extends IndexManager> indexManagerTypeCandidate) {
+		return indexManagerTypeCandidate.isAssignableFrom( indexManagerType );
 	}
 
 	@Override
@@ -127,7 +127,7 @@ public class DynamicShardingEntityIndexBinding implements MutableEntityIndexBind
 
 	public MutableEntityIndexBinding cloneWithSimilarity(Similarity entitySimilarity) {
 		return new DynamicShardingEntityIndexBinding(
-				indexManagerImpl,
+				indexManagerType,
 				shardIdentityProvider,
 				entitySimilarity,
 				entityIndexingInterceptor,

--- a/engine/src/main/java/org/hibernate/search/engine/impl/DynamicShardingEntityIndexBinding.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/DynamicShardingEntityIndexBinding.java
@@ -24,6 +24,7 @@ import org.hibernate.search.store.ShardIdentifierProvider;
  */
 public class DynamicShardingEntityIndexBinding implements MutableEntityIndexBinding {
 
+	private final Class<? extends IndexManager> indexManagerImpl;
 	private final DynamicShardingStrategy shardingStrategy;
 	private final Similarity similarityInstance;
 	private final ShardIdentifierProvider shardIdentityProvider;
@@ -36,6 +37,7 @@ public class DynamicShardingEntityIndexBinding implements MutableEntityIndexBind
 	private IndexManagerFactory indexManagerFactory;
 
 	public DynamicShardingEntityIndexBinding(
+			Class<? extends IndexManager> indexManagerImpl,
 			ShardIdentifierProvider shardIdentityProvider,
 			Similarity similarityInstance,
 			EntityIndexingInterceptor entityIndexingInterceptor,
@@ -43,6 +45,7 @@ public class DynamicShardingEntityIndexBinding implements MutableEntityIndexBind
 			ExtendedSearchIntegrator extendedIntegrator,
 			IndexManagerHolder indexManagerHolder,
 			String rootDirectoryProviderName) {
+		this.indexManagerImpl = indexManagerImpl;
 		this.shardIdentityProvider = shardIdentityProvider;
 		this.similarityInstance = similarityInstance;
 		this.entityIndexingInterceptor = entityIndexingInterceptor;
@@ -58,6 +61,16 @@ public class DynamicShardingEntityIndexBinding implements MutableEntityIndexBind
 				this,
 				rootDirectoryProviderName
 		);
+	}
+
+	@Override
+	public Class<? extends IndexManager> getIndexManagerImpl() {
+		return indexManagerImpl;
+	}
+
+	@Override
+	public boolean isManagedBy(Class<? extends IndexManager> indexManagerImplCandidate) {
+		return indexManagerImplCandidate.isAssignableFrom( indexManagerImpl );
 	}
 
 	@Override
@@ -114,6 +127,7 @@ public class DynamicShardingEntityIndexBinding implements MutableEntityIndexBind
 
 	public MutableEntityIndexBinding cloneWithSimilarity(Similarity entitySimilarity) {
 		return new DynamicShardingEntityIndexBinding(
+				indexManagerImpl,
 				shardIdentityProvider,
 				entitySimilarity,
 				entityIndexingInterceptor,

--- a/engine/src/main/java/org/hibernate/search/engine/impl/EntityIndexBindingFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/EntityIndexBindingFactory.java
@@ -33,7 +33,7 @@ public final class EntityIndexBindingFactory {
 
 	@SuppressWarnings( "unchecked" )
 	public static MutableEntityIndexBinding buildEntityIndexBinding(Class<?> type,
-			Class<? extends IndexManager> indexManagerImpl,
+			Class<? extends IndexManager> indexManagerType,
 			IndexManager[] providers,
 			IndexShardingStrategy shardingStrategy,
 			ShardIdentifierProvider shardIdentifierProvider,
@@ -50,7 +50,7 @@ public final class EntityIndexBindingFactory {
 		EntityIndexingInterceptor safeInterceptor = interceptor;
 		if ( isDynamicSharding ) {
 			return new DynamicShardingEntityIndexBinding(
-					indexManagerImpl,
+					indexManagerType,
 					shardIdentifierProvider,
 					similarity,
 					safeInterceptor,
@@ -60,7 +60,7 @@ public final class EntityIndexBindingFactory {
 					rootDirectoryProviderName );
 		}
 		else {
-			return new DefaultMutableEntityIndexBinding( indexManagerImpl, shardingStrategy, similarity, providers, interceptor );
+			return new DefaultMutableEntityIndexBinding( indexManagerType, shardingStrategy, similarity, providers, interceptor );
 		}
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/impl/EntityIndexBindingFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/EntityIndexBindingFactory.java
@@ -32,7 +32,9 @@ public final class EntityIndexBindingFactory {
 	}
 
 	@SuppressWarnings( "unchecked" )
-	public static MutableEntityIndexBinding buildEntityIndexBinding(Class<?> type, IndexManager[] providers,
+	public static MutableEntityIndexBinding buildEntityIndexBinding(Class<?> type,
+			Class<? extends IndexManager> indexManagerImpl,
+			IndexManager[] providers,
 			IndexShardingStrategy shardingStrategy,
 			ShardIdentifierProvider shardIdentifierProvider,
 			Similarity similarity,
@@ -47,7 +49,9 @@ public final class EntityIndexBindingFactory {
 		}
 		EntityIndexingInterceptor safeInterceptor = interceptor;
 		if ( isDynamicSharding ) {
-			return new DynamicShardingEntityIndexBinding( shardIdentifierProvider,
+			return new DynamicShardingEntityIndexBinding(
+					indexManagerImpl,
+					shardIdentifierProvider,
 					similarity,
 					safeInterceptor,
 					properties,
@@ -56,7 +60,7 @@ public final class EntityIndexBindingFactory {
 					rootDirectoryProviderName );
 		}
 		else {
-			return new DefaultMutableEntityIndexBinding( shardingStrategy, similarity, providers, interceptor );
+			return new DefaultMutableEntityIndexBinding( indexManagerImpl, shardingStrategy, similarity, providers, interceptor );
 		}
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/impl/ImmutableSearchFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/ImmutableSearchFactory.java
@@ -564,6 +564,19 @@ public class ImmutableSearchFactory implements ExtendedSearchIntegratorWithShare
 		return indexUninvertingAllowed;
 	}
 
+	@Override
+	public boolean isManagedBy(Class<?> mappedClass, Class<? extends IndexManager> indexManagerCandidate) {
+		Set<Class<?>> queriedEntityTypesWithSubTypes = getIndexedTypesPolymorphic( new Class<?>[]{ mappedClass } );
+
+		for ( Class<?> queriedEntityType : queriedEntityTypesWithSubTypes ) {
+			EntityIndexBinding binding = getIndexBinding( queriedEntityType );
+			if ( binding.isManagedBy( indexManagerCandidate ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	@SuppressWarnings("unchecked")
 	@Override
 	public <T> T unwrap(Class<T> cls) {

--- a/engine/src/main/java/org/hibernate/search/engine/impl/ImmutableSearchFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/ImmutableSearchFactory.java
@@ -565,12 +565,12 @@ public class ImmutableSearchFactory implements ExtendedSearchIntegratorWithShare
 	}
 
 	@Override
-	public boolean isManagedBy(Class<?> mappedClass, Class<? extends IndexManager> indexManagerCandidate) {
+	public boolean isManagedBy(Class<?> mappedClass, Class<? extends IndexManager> indexManagerTypeCandidate) {
 		Set<Class<?>> queriedEntityTypesWithSubTypes = getIndexedTypesPolymorphic( new Class<?>[]{ mappedClass } );
 
 		for ( Class<?> queriedEntityType : queriedEntityTypesWithSubTypes ) {
 			EntityIndexBinding binding = getIndexBinding( queriedEntityType );
-			if ( binding.isManagedBy( indexManagerCandidate ) ) {
+			if ( binding.isManagedBy( indexManagerTypeCandidate ) ) {
 				return true;
 			}
 		}

--- a/engine/src/main/java/org/hibernate/search/engine/impl/MutableSearchFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/MutableSearchFactory.java
@@ -344,6 +344,11 @@ public class MutableSearchFactory implements ExtendedSearchIntegratorWithShareab
 	}
 
 	@Override
+	public boolean isManagedBy(Class<?> mappedClass, Class<? extends IndexManager> indexManagerCandidate) {
+		return delegate.isManagedBy( mappedClass, indexManagerCandidate );
+	}
+
+	@Override
 	public <T> T unwrap(Class<T> cls) {
 		if ( SearchIntegrator.class.equals( cls ) || ExtendedSearchIntegrator.class.equals( cls ) || MutableSearchFactory.class.equals( cls ) ) {
 			return (T) this;

--- a/engine/src/main/java/org/hibernate/search/engine/impl/MutableSearchFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/MutableSearchFactory.java
@@ -344,8 +344,8 @@ public class MutableSearchFactory implements ExtendedSearchIntegratorWithShareab
 	}
 
 	@Override
-	public boolean isManagedBy(Class<?> mappedClass, Class<? extends IndexManager> indexManagerCandidate) {
-		return delegate.isManagedBy( mappedClass, indexManagerCandidate );
+	public boolean isManagedBy(Class<?> mappedClass, Class<? extends IndexManager> indexManagerTypeCandidate) {
+		return delegate.isManagedBy( mappedClass, indexManagerTypeCandidate );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/impl/MutableSearchFactoryState.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/MutableSearchFactoryState.java
@@ -327,12 +327,12 @@ public class MutableSearchFactoryState implements SearchFactoryState {
 	}
 
 	@Override
-	public boolean isManagedBy(Class<?> mappedClass, Class<? extends IndexManager> indexManagerCandidate) {
+	public boolean isManagedBy(Class<?> mappedClass, Class<? extends IndexManager> indexManagerTypeCandidate) {
 		Set<Class<?>> queriedEntityTypesWithSubTypes = indexHierarchy.getIndexedClasses( new Class<?>[]{ mappedClass } );
 
 		for ( Class<?> queriedEntityType : queriedEntityTypesWithSubTypes ) {
 			EntityIndexBinding binding = indexBindingForEntities.get( queriedEntityType );
-			if ( binding != null && binding.isManagedBy( indexManagerCandidate ) ) {
+			if ( binding != null && binding.isManagedBy( indexManagerTypeCandidate ) ) {
 				return true;
 			}
 		}

--- a/engine/src/main/java/org/hibernate/search/engine/integration/impl/ExtendedSearchIntegrator.java
+++ b/engine/src/main/java/org/hibernate/search/engine/integration/impl/ExtendedSearchIntegrator.java
@@ -17,6 +17,7 @@ import org.hibernate.search.engine.spi.EntityIndexBinding;
 import org.hibernate.search.engine.spi.TimingSource;
 import org.hibernate.search.filter.FilterCachingStrategy;
 import org.hibernate.search.indexes.impl.IndexManagerHolder;
+import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.query.DatabaseRetrievalMethod;
 import org.hibernate.search.query.ObjectLookupMethod;
 import org.hibernate.search.spi.InstanceInitializer;
@@ -137,4 +138,15 @@ public interface ExtendedSearchIntegrator extends SearchIntegrator {
 	 * @throws org.hibernate.search.exception.SearchException if the definition name is unknown
 	 */
 	AnalyzerReference getAnalyzerReference(String name);
+
+	/**
+	 * Returns whether an entity is managed by a given {@code IndexManager}.
+	 *
+	 * @param mappedClass the entity type
+	 * @param indexManagerCandidate the tested {@code IndexManager} implementation
+	 *
+	 * @return returns whether an entity is managed by a given {@code IndexManager}.
+	 */
+	boolean isManagedBy(Class<?> mappedClass, Class<? extends IndexManager> indexManagerCandidate);
+
 }

--- a/engine/src/main/java/org/hibernate/search/engine/integration/impl/ExtendedSearchIntegrator.java
+++ b/engine/src/main/java/org/hibernate/search/engine/integration/impl/ExtendedSearchIntegrator.java
@@ -143,10 +143,10 @@ public interface ExtendedSearchIntegrator extends SearchIntegrator {
 	 * Returns whether an entity is managed by a given {@code IndexManager}.
 	 *
 	 * @param mappedClass the entity type
-	 * @param indexManagerCandidate the tested {@code IndexManager} implementation
+	 * @param indexManagerTypeCandidate the tested {@code IndexManager} type
 	 *
 	 * @return returns whether an entity is managed by a given {@code IndexManager}.
 	 */
-	boolean isManagedBy(Class<?> mappedClass, Class<? extends IndexManager> indexManagerCandidate);
+	boolean isManagedBy(Class<?> mappedClass, Class<? extends IndexManager> indexManagerTypeCandidate);
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/MetadataProvider.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/MetadataProvider.java
@@ -20,5 +20,21 @@ public interface MetadataProvider {
 	 */
 	TypeMetadata getTypeMetadataFor(Class<?> clazz);
 
+	/**
+	 * Returns the ContainedIn related metadata for the specified type.
+	 *
+	 * The metadata for ContainedIn are not comprehensive: they do not
+	 * contain the information about the FieldBridges. It's of no use
+	 * for ContainedIn resolution and we can't build these information
+	 * because classes only marked with {@code ContainedIn} are not tied
+	 * to an {@code IndexManager}.
+	 *
+	 * @param clazz The type of interest.
+	 *
+	 * @return the {@code ContainedInTypeMetadata} for the specified type
+	 */
+	TypeMetadata getTypeMetadataForContainedIn(Class<?> clazz);
+
 	boolean containsSearchMetadata(Class<?> clazz);
+
 }

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/ParseContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/ParseContext.java
@@ -18,15 +18,33 @@ import org.hibernate.annotations.common.reflection.XClass;
  * @author Hardy Ferentschik
  */
 public class ParseContext {
+	public static final boolean SKIP_FIELD_BRIDGES = true;
+	public static final boolean INCLUDE_FIELD_BRIDGES = false;
+
 	private final Set<XClass> processedClasses = new HashSet<>();
 	private final Set<String> spatialNames = new TreeSet<>();
 	private final Set<String> unqualifiedCollectedCollectionRoles = new HashSet<>();
 
+	private XClass mappedClass;
+	private boolean skipFieldBridges;
 	private XClass currentClass;
 	private int level = 0;
 	private int maxLevel = Integer.MAX_VALUE;
 	private boolean explicitDocumentId = false;
 	private boolean includeEmbeddedObjectId = false;
+
+	public ParseContext(XClass mappedClass, boolean skipFieldBridges) {
+		this.mappedClass = mappedClass;
+		this.skipFieldBridges = skipFieldBridges;
+	}
+
+	public XClass getMappedClass() {
+		return mappedClass;
+	}
+
+	public boolean skipFieldBridges() {
+		return skipFieldBridges;
+	}
 
 	boolean hasBeenProcessed(XClass processedClass) {
 		return processedClasses.contains( processedClass );

--- a/engine/src/main/java/org/hibernate/search/engine/spi/EntityIndexBinding.java
+++ b/engine/src/main/java/org/hibernate/search/engine/spi/EntityIndexBinding.java
@@ -50,6 +50,18 @@ public interface EntityIndexBinding {
 	void postInitialize(Set<Class<?>> indexedClasses);
 
 	/**
+	 * @return the {@code IndexManager} impl used by this entity type
+	 */
+	Class<? extends IndexManager> getIndexManagerImpl();
+
+	/**
+	 * @param indexManagerCandidate the tested {@code IndexManager} implementation
+	 *
+	 * @return whether this entity is managed by the given {@code IndexManager} impl
+	 */
+	boolean isManagedBy(Class<? extends IndexManager> indexManagerCandidate);
+
+	/**
 	 * @return the array of index managers
 	 */
 	IndexManager[] getIndexManagers();

--- a/engine/src/main/java/org/hibernate/search/engine/spi/EntityIndexBinding.java
+++ b/engine/src/main/java/org/hibernate/search/engine/spi/EntityIndexBinding.java
@@ -52,14 +52,14 @@ public interface EntityIndexBinding {
 	/**
 	 * @return the {@code IndexManager} impl used by this entity type
 	 */
-	Class<? extends IndexManager> getIndexManagerImpl();
+	Class<? extends IndexManager> getIndexManagerType();
 
 	/**
-	 * @param indexManagerCandidate the tested {@code IndexManager} implementation
+	 * @param indexManagerTypeCandidate the tested {@code IndexManager} type
 	 *
-	 * @return whether this entity is managed by the given {@code IndexManager} impl
+	 * @return whether this entity is managed by the given {@code IndexManager} type
 	 */
-	boolean isManagedBy(Class<? extends IndexManager> indexManagerCandidate);
+	boolean isManagedBy(Class<? extends IndexManager> indexManagerTypeCandidate);
 
 	/**
 	 * @return the array of index managers

--- a/engine/src/main/java/org/hibernate/search/indexes/impl/IndexManagerHolder.java
+++ b/engine/src/main/java/org/hibernate/search/indexes/impl/IndexManagerHolder.java
@@ -87,10 +87,10 @@ public class IndexManagerHolder {
 
 		ServiceManager serviceManager = buildContext.getServiceManager();
 		IndexManagerFactory indexManagerFactory = serviceManager.requestService( IndexManagerFactory.class );
-		Class<? extends IndexManager> indexManagerImpl;
+		Class<? extends IndexManager> indexManagerType;
 		try {
 			// we consider that all the shards will share the same IndexManager impl
-			indexManagerImpl = indexManagerFactory.determineIndexManagerImpl( mappedClass,
+			indexManagerType = indexManagerFactory.determineIndexManagerType( mappedClass,
 					indexProperties[0].getProperty( Environment.INDEX_MANAGER_IMPL_NAME ) );
 		}
 		finally {
@@ -101,7 +101,7 @@ public class IndexManagerHolder {
 		if ( !isDynamicSharding ) {
 			indexManagers = createIndexManagers(
 					indexName,
-					indexManagerImpl,
+					indexManagerType,
 					mappedClass,
 					similarity,
 					indexProperties,
@@ -125,7 +125,7 @@ public class IndexManagerHolder {
 
 		return EntityIndexBindingFactory.buildEntityIndexBinding(
 				entity.getClass(),
-				indexManagerImpl,
+				indexManagerType,
 				indexManagers,
 				shardingStrategy,
 				shardIdentifierProvider,
@@ -174,7 +174,7 @@ public class IndexManagerHolder {
 
 		indexManager = createIndexManager(
 				indexName,
-				entityIndexBinding.getIndexManagerImpl(),
+				entityIndexBinding.getIndexManagerType(),
 				entityIndexBinding.getDocumentBuilder().getBeanClass(),
 				entityIndexBinding.getSimilarity(),
 				properties,
@@ -243,7 +243,7 @@ public class IndexManagerHolder {
 	}
 
 	private IndexManager doCreateIndexManager(String indexName,
-			Class<? extends IndexManager> indexManagerImpl,
+			Class<? extends IndexManager> indexManagerType,
 			Class<?> mappedClass,
 			Similarity indexSimilarity,
 			Properties properties,
@@ -255,7 +255,7 @@ public class IndexManagerHolder {
 		// create IndexManager instance via the index manager factory
 		final IndexManager manager;
 		try {
-			manager = indexManagerFactory.createIndexManager( mappedClass, indexManagerImpl );
+			manager = indexManagerFactory.createIndexManager( mappedClass, indexManagerType );
 		}
 		finally {
 			serviceManager.releaseService( IndexManagerFactory.class );
@@ -475,7 +475,7 @@ public class IndexManagerHolder {
 	}
 
 	private IndexManager[] createIndexManagers(String indexBaseName,
-			Class<? extends IndexManager> indexManagerImpl,
+			Class<? extends IndexManager> indexManagerType,
 			Class<?> mappedClass,
 			Similarity similarity,
 			Properties[] indexProperties,
@@ -491,7 +491,7 @@ public class IndexManagerHolder {
 			IndexManager indexManager = indexManagersRegistry.get( indexManagerName );
 			if ( indexManager == null ) {
 				indexManager = createIndexManager(
-						indexManagerName, indexManagerImpl, mappedClass, similarity, indexProp, context
+						indexManagerName, indexManagerType, mappedClass, similarity, indexProp, context
 				);
 			}
 			else {
@@ -515,7 +515,7 @@ public class IndexManagerHolder {
 	 * to avoid contention on this synchronized method during dynamic reconfiguration at runtime.
 	 */
 	private synchronized IndexManager createIndexManager(String indexManagerName,
-			Class<? extends IndexManager> indexManagerImpl,
+			Class<? extends IndexManager> indexManagerType,
 			Class<?> mappedClass,
 			Similarity similarity,
 			Properties indexProperties,
@@ -524,7 +524,7 @@ public class IndexManagerHolder {
 		if ( indexManager == null ) {
 			indexManager = doCreateIndexManager(
 					indexManagerName,
-					indexManagerImpl,
+					indexManagerType,
 					mappedClass,
 					similarity,
 					indexProperties,

--- a/engine/src/main/java/org/hibernate/search/indexes/impl/IndexManagerHolder.java
+++ b/engine/src/main/java/org/hibernate/search/indexes/impl/IndexManagerHolder.java
@@ -90,8 +90,7 @@ public class IndexManagerHolder {
 		Class<? extends IndexManager> indexManagerType;
 		try {
 			// we consider that all the shards will share the same IndexManager impl
-			indexManagerType = indexManagerFactory.determineIndexManagerType( mappedClass,
-					indexProperties[0].getProperty( Environment.INDEX_MANAGER_IMPL_NAME ) );
+			indexManagerType = indexManagerFactory.determineIndexManagerType( indexProperties[0].getProperty( Environment.INDEX_MANAGER_IMPL_NAME ) );
 		}
 		finally {
 			serviceManager.releaseService( IndexManagerFactory.class );
@@ -255,7 +254,7 @@ public class IndexManagerHolder {
 		// create IndexManager instance via the index manager factory
 		final IndexManager manager;
 		try {
-			manager = indexManagerFactory.createIndexManager( mappedClass, indexManagerType );
+			manager = indexManagerFactory.createIndexManager( indexManagerType );
 		}
 		finally {
 			serviceManager.releaseService( IndexManagerFactory.class );

--- a/engine/src/main/java/org/hibernate/search/spi/impl/SearchFactoryState.java
+++ b/engine/src/main/java/org/hibernate/search/spi/impl/SearchFactoryState.java
@@ -22,6 +22,7 @@ import org.hibernate.search.engine.spi.TimingSource;
 import org.hibernate.search.exception.ErrorHandler;
 import org.hibernate.search.filter.FilterCachingStrategy;
 import org.hibernate.search.indexes.impl.IndexManagerHolder;
+import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.query.engine.spi.TimeoutExceptionFactory;
 import org.hibernate.search.spi.IndexingMode;
 import org.hibernate.search.spi.InstanceInitializer;
@@ -80,4 +81,6 @@ public interface SearchFactoryState {
 	boolean enlistWorkerInTransaction();
 
 	Statistics getStatistics();
+
+	boolean isManagedBy(Class<?> mappedClass, Class<? extends IndexManager> indexManagerCandidate);
 }

--- a/engine/src/main/java/org/hibernate/search/spi/impl/SearchFactoryState.java
+++ b/engine/src/main/java/org/hibernate/search/spi/impl/SearchFactoryState.java
@@ -82,5 +82,5 @@ public interface SearchFactoryState {
 
 	Statistics getStatistics();
 
-	boolean isManagedBy(Class<?> mappedClass, Class<? extends IndexManager> indexManagerCandidate);
+	boolean isManagedBy(Class<?> mappedClass, Class<? extends IndexManager> indexManagerTypeCandidate);
 }

--- a/engine/src/test/java/org/hibernate/search/test/bridge/DefaultStringBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/DefaultStringBridgeTest.java
@@ -6,10 +6,8 @@
  */
 package org.hibernate.search.test.bridge;
 
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.assertTrue;
 
-import org.hibernate.annotations.common.reflection.java.JavaReflectionManager;
 import org.hibernate.search.annotations.DocumentId;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
@@ -17,35 +15,18 @@ import org.hibernate.search.bridge.FieldBridge;
 import org.hibernate.search.bridge.StringBridge;
 import org.hibernate.search.bridge.builtin.DefaultStringBridge;
 import org.hibernate.search.bridge.builtin.impl.String2FieldBridgeAdaptor;
-import org.hibernate.search.cfg.spi.SearchConfiguration;
-import org.hibernate.search.engine.impl.ConfigContext;
-import org.hibernate.search.engine.metadata.impl.AnnotationMetadataProvider;
 import org.hibernate.search.metadata.FieldDescriptor;
 import org.hibernate.search.metadata.IndexedTypeDescriptor;
 import org.hibernate.search.test.metadata.DescriptorTestHelper;
 import org.hibernate.search.testsupport.TestForIssue;
-import org.hibernate.search.testsupport.setup.BuildContextForTest;
-import org.hibernate.search.testsupport.setup.SearchConfigurationForTest;
-
-import static org.junit.Assert.assertTrue;
+import org.hibernate.search.testsupport.setup.AbstractAnnotationMetadataTest;
+import org.junit.Test;
 
 /**
  * @author Hardy Ferentschik
  */
 @TestForIssue(jiraKey = "HSEARCH-1756")
-public class DefaultStringBridgeTest {
-
-	private AnnotationMetadataProvider metadataProvider;
-
-	@Before
-	public void setUp() {
-		SearchConfiguration searchConfiguration = new SearchConfigurationForTest();
-		ConfigContext configContext = new ConfigContext(
-				searchConfiguration,
-				new BuildContextForTest( searchConfiguration )
-		);
-		metadataProvider = new AnnotationMetadataProvider( new JavaReflectionManager(), configContext );
-	}
+public class DefaultStringBridgeTest extends AbstractAnnotationMetadataTest {
 
 	@Test
 	public void testUsageOfDefaultStringBridgeInFieldBridgeAnnotation() throws Exception {

--- a/engine/src/test/java/org/hibernate/search/test/configuration/IndexManagerFactoryCustomizationTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/configuration/IndexManagerFactoryCustomizationTest.java
@@ -137,7 +137,7 @@ public class IndexManagerFactoryCustomizationTest {
 
 	public static class NRTIndexManagerFactory extends DefaultIndexManagerFactory {
 		@Override
-		public Class<? extends IndexManager> getDefaultIndexManagerImpl() {
+		public Class<? extends IndexManager> getDefaultIndexManagerType() {
 			return NRTIndexManager.class;
 		}
 	}

--- a/engine/src/test/java/org/hibernate/search/test/configuration/IndexManagerFactoryCustomizationTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/configuration/IndexManagerFactoryCustomizationTest.java
@@ -137,8 +137,8 @@ public class IndexManagerFactoryCustomizationTest {
 
 	public static class NRTIndexManagerFactory extends DefaultIndexManagerFactory {
 		@Override
-		public IndexManager createDefaultIndexManager() {
-			return new NRTIndexManager();
+		public Class<? extends IndexManager> getDefaultIndexManagerImpl() {
+			return NRTIndexManager.class;
 		}
 	}
 

--- a/engine/src/test/java/org/hibernate/search/test/configuration/TypeMetadataTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/configuration/TypeMetadataTest.java
@@ -7,9 +7,12 @@
 
 package org.hibernate.search.test.configuration;
 
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 import java.util.Set;
 
-import org.hibernate.annotations.common.reflection.java.JavaReflectionManager;
 import org.hibernate.search.annotations.Analyze;
 import org.hibernate.search.annotations.DocumentId;
 import org.hibernate.search.annotations.Field;
@@ -19,37 +22,16 @@ import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.annotations.SortableField;
 import org.hibernate.search.annotations.SortableFields;
 import org.hibernate.search.bridge.builtin.IntegerBridge;
-import org.hibernate.search.cfg.spi.SearchConfiguration;
-import org.hibernate.search.engine.impl.ConfigContext;
-import org.hibernate.search.engine.metadata.impl.AnnotationMetadataProvider;
 import org.hibernate.search.engine.metadata.impl.SortableFieldMetadata;
 import org.hibernate.search.engine.metadata.impl.TypeMetadata;
 import org.hibernate.search.exception.SearchException;
-import org.hibernate.search.testsupport.setup.BuildContextForTest;
-import org.hibernate.search.testsupport.setup.SearchConfigurationForTest;
-import org.junit.Before;
+import org.hibernate.search.testsupport.setup.AbstractAnnotationMetadataTest;
 import org.junit.Test;
-
-import static org.fest.assertions.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 /**
  * @author Hardy Ferentschik
  */
-public class TypeMetadataTest {
-
-	private AnnotationMetadataProvider metadataProvider;
-
-	@Before
-	public void setUp() {
-		SearchConfiguration searchConfiguration = new SearchConfigurationForTest();
-		ConfigContext configContext = new ConfigContext(
-				searchConfiguration,
-				new BuildContextForTest( searchConfiguration )
-		);
-		metadataProvider = new AnnotationMetadataProvider( new JavaReflectionManager(), configContext );
-	}
+public class TypeMetadataTest extends AbstractAnnotationMetadataTest {
 
 	@Test
 	public void testMultipleDocumentIdsCauseException() {

--- a/engine/src/test/java/org/hibernate/search/test/metadata/DocumentFieldMetadataTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/metadata/DocumentFieldMetadataTest.java
@@ -7,11 +7,14 @@
 
 package org.hibernate.search.test.metadata;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.net.URI;
 import java.util.Date;
 import java.util.Set;
 
-import org.hibernate.annotations.common.reflection.java.JavaReflectionManager;
 import org.hibernate.search.annotations.Analyze;
 import org.hibernate.search.annotations.DocumentId;
 import org.hibernate.search.annotations.Facet;
@@ -22,45 +25,24 @@ import org.hibernate.search.annotations.Fields;
 import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.annotations.NumericField;
 import org.hibernate.search.annotations.NumericFields;
-import org.hibernate.search.cfg.spi.SearchConfiguration;
-import org.hibernate.search.engine.impl.ConfigContext;
-import org.hibernate.search.engine.metadata.impl.AnnotationMetadataProvider;
 import org.hibernate.search.engine.metadata.impl.DocumentFieldMetadata;
 import org.hibernate.search.engine.metadata.impl.FacetMetadata;
 import org.hibernate.search.engine.metadata.impl.TypeMetadata;
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.testsupport.TestForIssue;
-import org.hibernate.search.testsupport.setup.BuildContextForTest;
-import org.hibernate.search.testsupport.setup.SearchConfigurationForTest;
-import org.junit.Before;
+import org.hibernate.search.testsupport.setup.AbstractAnnotationMetadataTest;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * @author Hardy Ferentschik
  */
 @TestForIssue(jiraKey = "HSEARCH-809")
-public class DocumentFieldMetadataTest {
+public class DocumentFieldMetadataTest extends AbstractAnnotationMetadataTest {
 
 	@Rule
 	public ExpectedException expectedException = ExpectedException.none();
-
-	private AnnotationMetadataProvider metadataProvider;
-
-	@Before
-	public void setUp() {
-		SearchConfiguration searchConfiguration = new SearchConfigurationForTest();
-		ConfigContext configContext = new ConfigContext(
-				searchConfiguration,
-				new BuildContextForTest( searchConfiguration )
-		);
-		metadataProvider = new AnnotationMetadataProvider( new JavaReflectionManager(), configContext );
-	}
 
 	@Test
 	public void testStringFieldCanBeCOnfiguredForFaceting() {

--- a/engine/src/test/java/org/hibernate/search/test/metadata/FieldConfigurationTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/metadata/FieldConfigurationTest.java
@@ -6,41 +6,22 @@
  */
 package org.hibernate.search.test.metadata;
 
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-import org.hibernate.annotations.common.reflection.java.JavaReflectionManager;
-import org.hibernate.search.cfg.spi.SearchConfiguration;
-import org.hibernate.search.engine.impl.ConfigContext;
-import org.hibernate.search.engine.metadata.impl.AnnotationMetadataProvider;
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.metadata.IndexedTypeDescriptor;
 import org.hibernate.search.metadata.PropertyDescriptor;
 import org.hibernate.search.testsupport.TestForIssue;
-import org.hibernate.search.testsupport.setup.BuildContextForTest;
-import org.hibernate.search.testsupport.setup.SearchConfigurationForTest;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.hibernate.search.testsupport.setup.AbstractAnnotationMetadataTest;
+import org.junit.Test;
 
 /**
  * @author Hardy Ferentschik
  */
 @TestForIssue(jiraKey = "HSEARCH-1759")
-public class FieldConfigurationTest {
-
-	private AnnotationMetadataProvider metadataProvider;
-
-	@Before
-	public void setUp() {
-		SearchConfiguration searchConfiguration = new SearchConfigurationForTest();
-		ConfigContext configContext = new ConfigContext(
-				searchConfiguration,
-				new BuildContextForTest( searchConfiguration )
-		);
-		metadataProvider = new AnnotationMetadataProvider( new JavaReflectionManager(), configContext );
-	}
+public class FieldConfigurationTest extends AbstractAnnotationMetadataTest {
 
 	@Test
 	public void testFieldAnnotationTargetingSameFieldAsDocumentIdIsNotAllowed() {

--- a/engine/src/test/java/org/hibernate/search/test/metadata/FieldDescriptorTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/metadata/FieldDescriptorTest.java
@@ -7,8 +7,14 @@
 
 package org.hibernate.search.test.metadata;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
-import org.hibernate.annotations.common.reflection.java.JavaReflectionManager;
 import org.hibernate.search.annotations.Analyze;
 import org.hibernate.search.annotations.Index;
 import org.hibernate.search.annotations.Norms;
@@ -16,9 +22,6 @@ import org.hibernate.search.annotations.Store;
 import org.hibernate.search.annotations.TermVector;
 import org.hibernate.search.bridge.StringBridge;
 import org.hibernate.search.bridge.builtin.NumericFieldBridge;
-import org.hibernate.search.cfg.spi.SearchConfiguration;
-import org.hibernate.search.engine.impl.ConfigContext;
-import org.hibernate.search.engine.metadata.impl.AnnotationMetadataProvider;
 import org.hibernate.search.metadata.FieldDescriptor;
 import org.hibernate.search.metadata.FieldSettingsDescriptor;
 import org.hibernate.search.metadata.IndexedTypeDescriptor;
@@ -27,35 +30,14 @@ import org.hibernate.search.metadata.NumericFieldSettingsDescriptor.NumericEncod
 import org.hibernate.search.spatial.SpatialFieldBridge;
 import org.hibernate.search.testsupport.TestForIssue;
 import org.hibernate.search.testsupport.analyzer.FooAnalyzer;
-import org.hibernate.search.testsupport.setup.BuildContextForTest;
-import org.hibernate.search.testsupport.setup.SearchConfigurationForTest;
-import org.junit.Before;
+import org.hibernate.search.testsupport.setup.AbstractAnnotationMetadataTest;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * @author Hardy Ferentschik
  */
 @TestForIssue(jiraKey = "HSEARCH-436")
-public class FieldDescriptorTest {
-
-	private AnnotationMetadataProvider metadataProvider;
-
-	@Before
-	public void setUp() {
-		SearchConfiguration searchConfiguration = new SearchConfigurationForTest();
-		ConfigContext configContext = new ConfigContext(
-				searchConfiguration,
-				new BuildContextForTest( searchConfiguration )
-		);
-		metadataProvider = new AnnotationMetadataProvider( new JavaReflectionManager(), configContext );
-	}
+public class FieldDescriptorTest extends AbstractAnnotationMetadataTest {
 
 	@Test
 	public void testFieldDescriptorLuceneOptions() {

--- a/engine/src/test/java/org/hibernate/search/test/metadata/IndexDescriptorTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/metadata/IndexDescriptorTest.java
@@ -7,41 +7,24 @@
 
 package org.hibernate.search.test.metadata;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Set;
 
-import org.hibernate.annotations.common.reflection.java.JavaReflectionManager;
-import org.hibernate.search.cfg.spi.SearchConfiguration;
-import org.hibernate.search.engine.impl.ConfigContext;
-import org.hibernate.search.engine.metadata.impl.AnnotationMetadataProvider;
 import org.hibernate.search.engine.metadata.impl.TypeMetadata;
 import org.hibernate.search.metadata.IndexDescriptor;
 import org.hibernate.search.metadata.IndexedTypeDescriptor;
 import org.hibernate.search.metadata.impl.IndexedTypeDescriptorImpl;
-import org.hibernate.search.testsupport.setup.BuildContextForTest;
-import org.hibernate.search.testsupport.setup.SearchConfigurationForTest;
 import org.hibernate.search.testsupport.TestForIssue;
-import org.junit.Before;
+import org.hibernate.search.testsupport.setup.AbstractAnnotationMetadataTest;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author Hardy Ferentschik
  */
 @TestForIssue(jiraKey = "HSEARCH-436")
-public class IndexDescriptorTest {
-	private AnnotationMetadataProvider metadataProvider;
-
-	@Before
-	public void setUp() {
-		SearchConfiguration searchConfiguration = new SearchConfigurationForTest();
-		ConfigContext configContext = new ConfigContext(
-				searchConfiguration,
-				new BuildContextForTest( searchConfiguration )
-		);
-		metadataProvider = new AnnotationMetadataProvider( new JavaReflectionManager(), configContext );
-	}
+public class IndexDescriptorTest extends AbstractAnnotationMetadataTest {
 
 	@Test
 	public void testIndexInformation() {

--- a/engine/src/test/java/org/hibernate/search/test/metadata/IndexedEmbeddedWithDepthAndIncludePathTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/metadata/IndexedEmbeddedWithDepthAndIncludePathTest.java
@@ -6,34 +6,16 @@
  */
 package org.hibernate.search.test.metadata;
 
-import org.hibernate.search.cfg.spi.SearchConfiguration;
-import org.hibernate.search.testsupport.setup.BuildContextForTest;
-import org.hibernate.search.testsupport.setup.SearchConfigurationForTest;
-import org.junit.Before;
-import org.junit.Test;
-import org.hibernate.annotations.common.reflection.java.JavaReflectionManager;
-import org.hibernate.search.engine.impl.ConfigContext;
-import org.hibernate.search.engine.metadata.impl.AnnotationMetadataProvider;
+import static org.junit.Assert.assertNotNull;
+
 import org.hibernate.search.engine.metadata.impl.EmbeddedTypeMetadata;
 import org.hibernate.search.engine.metadata.impl.TypeMetadata;
 import org.hibernate.search.testsupport.TestForIssue;
-
-import static org.junit.Assert.assertNotNull;
+import org.hibernate.search.testsupport.setup.AbstractAnnotationMetadataTest;
+import org.junit.Test;
 
 @TestForIssue(jiraKey = "HSEARCH-1442")
-public class IndexedEmbeddedWithDepthAndIncludePathTest {
-
-	private AnnotationMetadataProvider metadataProvider;
-
-	@Before
-	public void setUp() {
-		SearchConfiguration searchConfiguration = new SearchConfigurationForTest();
-		ConfigContext configContext = new ConfigContext(
-				searchConfiguration,
-				new BuildContextForTest( searchConfiguration )
-		);
-		metadataProvider = new AnnotationMetadataProvider( new JavaReflectionManager(), configContext );
-	}
+public class IndexedEmbeddedWithDepthAndIncludePathTest extends AbstractAnnotationMetadataTest {
 
 	@Test
 	public void testDepthIsProperlyHandled() {

--- a/engine/src/test/java/org/hibernate/search/test/metadata/IndexedTypeDescriptorTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/metadata/IndexedTypeDescriptorTest.java
@@ -6,44 +6,26 @@
  */
 package org.hibernate.search.test.metadata;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.util.HashSet;
 import java.util.Set;
 
-import org.hibernate.annotations.common.reflection.java.JavaReflectionManager;
-import org.hibernate.search.cfg.spi.SearchConfiguration;
-import org.hibernate.search.engine.impl.ConfigContext;
 import org.hibernate.search.engine.impl.DefaultBoostStrategy;
-import org.hibernate.search.engine.metadata.impl.AnnotationMetadataProvider;
 import org.hibernate.search.metadata.FieldDescriptor;
 import org.hibernate.search.metadata.IndexedTypeDescriptor;
 import org.hibernate.search.metadata.PropertyDescriptor;
 import org.hibernate.search.testsupport.TestForIssue;
-import org.hibernate.search.testsupport.setup.BuildContextForTest;
-import org.hibernate.search.testsupport.setup.SearchConfigurationForTest;
-import org.junit.Before;
+import org.hibernate.search.testsupport.setup.AbstractAnnotationMetadataTest;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * @author Hardy Ferentschik
  */
 @TestForIssue(jiraKey = "HSEARCH-436")
-public class IndexedTypeDescriptorTest {
-
-	private AnnotationMetadataProvider metadataProvider;
-
-	@Before
-	public void setUp() {
-		SearchConfiguration searchConfiguration = new SearchConfigurationForTest();
-		ConfigContext configContext = new ConfigContext(
-				searchConfiguration,
-				new BuildContextForTest( searchConfiguration )
-		);
-		metadataProvider = new AnnotationMetadataProvider( new JavaReflectionManager(), configContext );
-	}
+public class IndexedTypeDescriptorTest extends AbstractAnnotationMetadataTest {
 
 	@Test
 	public void testIsIndexed() {

--- a/engine/src/test/java/org/hibernate/search/test/metadata/PropertyDescriptorTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/metadata/PropertyDescriptorTest.java
@@ -7,15 +7,14 @@
 
 package org.hibernate.search.test.metadata;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.hibernate.annotations.common.reflection.java.JavaReflectionManager;
-import org.hibernate.search.cfg.spi.SearchConfiguration;
-import org.hibernate.search.engine.impl.ConfigContext;
-import org.hibernate.search.engine.metadata.impl.AnnotationMetadataProvider;
 import org.hibernate.search.engine.metadata.impl.TypeMetadata;
 import org.hibernate.search.metadata.FieldDescriptor;
 import org.hibernate.search.metadata.IndexDescriptor;
@@ -23,34 +22,18 @@ import org.hibernate.search.metadata.IndexedTypeDescriptor;
 import org.hibernate.search.metadata.PropertyDescriptor;
 import org.hibernate.search.metadata.impl.IndexedTypeDescriptorImpl;
 import org.hibernate.search.testsupport.TestForIssue;
-import org.hibernate.search.testsupport.setup.BuildContextForTest;
-import org.hibernate.search.testsupport.setup.SearchConfigurationForTest;
-import org.junit.Before;
+import org.hibernate.search.testsupport.setup.AbstractAnnotationMetadataTest;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author Hardy Ferentschik
  */
 @TestForIssue(jiraKey = "HSEARCH-436")
-public class PropertyDescriptorTest {
+public class PropertyDescriptorTest extends AbstractAnnotationMetadataTest {
 
 	private static final List<String> TEST_INDEX_NAMES = Arrays.asList(
 			"index-0", "index-0", "index-0"
 	);
-	private AnnotationMetadataProvider metadataProvider;
-
-	@Before
-	public void setUp() {
-		SearchConfiguration searchConfiguration = new SearchConfigurationForTest();
-		ConfigContext configContext = new ConfigContext(
-				searchConfiguration,
-				new BuildContextForTest( searchConfiguration )
-		);
-		metadataProvider = new AnnotationMetadataProvider( new JavaReflectionManager(), configContext );
-	}
 
 	@Test
 	public void testIdProperty() {

--- a/engine/src/test/java/org/hibernate/search/testsupport/setup/AbstractAnnotationMetadataTest.java
+++ b/engine/src/test/java/org/hibernate/search/testsupport/setup/AbstractAnnotationMetadataTest.java
@@ -1,0 +1,41 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.testsupport.setup;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.hibernate.annotations.common.reflection.java.JavaReflectionManager;
+import org.hibernate.search.cfg.spi.SearchConfiguration;
+import org.hibernate.search.engine.impl.ConfigContext;
+import org.hibernate.search.engine.impl.MutableSearchFactoryState;
+import org.hibernate.search.engine.metadata.impl.AnnotationMetadataProvider;
+import org.hibernate.search.engine.spi.EntityIndexBinding;
+import org.hibernate.search.spi.impl.PolymorphicIndexHierarchy;
+import org.junit.Before;
+
+/**
+ * @author Guillaume Smet
+ */
+public abstract class AbstractAnnotationMetadataTest {
+
+	protected AnnotationMetadataProvider metadataProvider;
+
+	@Before
+	public void setUp() {
+		SearchConfiguration searchConfiguration = new SearchConfigurationForTest();
+		ConfigContext configContext = new ConfigContext(
+				searchConfiguration,
+				new BuildContextForTest( searchConfiguration ) );
+
+		MutableSearchFactoryState factoryState = new MutableSearchFactoryState();
+		factoryState.setIndexHierarchy( new PolymorphicIndexHierarchy() );
+		factoryState.setDocumentBuildersIndexedEntities( new ConcurrentHashMap<Class<?>, EntityIndexBinding>() );
+
+		metadataProvider = new AnnotationMetadataProvider( new JavaReflectionManager(), configContext, factoryState );
+	}
+
+}

--- a/orm/src/test/java/org/hibernate/search/test/configuration/integration/HibernateSearchIntegratorTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/integration/HibernateSearchIntegratorTest.java
@@ -20,6 +20,7 @@ import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventType;
+import org.hibernate.search.bridge.spi.BackendSpecificBridgeProvider;
 import org.hibernate.search.bridge.spi.BridgeProvider;
 import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.event.impl.FullTextIndexEventListener;
@@ -41,8 +42,6 @@ import static org.easymock.EasyMock.startsWith;
  * @author Hardy Ferentschik
  */
 public class HibernateSearchIntegratorTest extends UnitilsJUnit4 {
-
-	private static final String ELASTICSEARCH_BRIDGE_PROVIDER_CLASS = "org.hibernate.search.backend.elasticsearch.impl.ElasticsearchBridgeProvider";
 
 	private static final Boolean SEARCH_DISABLED = Boolean.FALSE;
 	private static final Boolean SEARCH_ENABLED = Boolean.TRUE;
@@ -146,15 +145,15 @@ public class HibernateSearchIntegratorTest extends UnitilsJUnit4 {
 			.andReturn( Object.class )
 			.anyTimes();
 
+		expect( mockClassLoaderService.loadJavaServices( BackendSpecificBridgeProvider.class ) )
+			.andReturn( Collections.<BackendSpecificBridgeProvider>emptySet() );
+
 		expect( mockClassLoaderService.loadJavaServices( BridgeProvider.class ) )
 			.andReturn( Collections.<BridgeProvider>emptySet() );
 
 		expect( mockClassLoaderService.classForName( startsWith( "java.time" ) ) )
 			.andThrow( new ClassLoadingException( "Called by JavaTimeBridgeProvider; we assume the classes in java.time are not on the ORM class loader" ) )
 			.anyTimes();
-
-		expect( mockClassLoaderService.classForName( ELASTICSEARCH_BRIDGE_PROVIDER_CLASS ) )
-			.andReturn( null );
 
 		expect( mockMetadata.getEntityBindings() )
 			.andReturn( Collections.EMPTY_SET )

--- a/orm/src/test/java/org/hibernate/search/test/embedded/EmbeddedEntityNotIndexedTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/embedded/EmbeddedEntityNotIndexedTest.java
@@ -6,46 +6,29 @@
  */
 package org.hibernate.search.test.embedded;
 
+import static org.junit.Assert.assertNull;
+
 import java.sql.Timestamp;
+
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.OneToOne;
 
-import org.hibernate.annotations.common.reflection.java.JavaReflectionManager;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.annotations.IndexedEmbedded;
-import org.hibernate.search.cfg.spi.SearchConfiguration;
-import org.hibernate.search.engine.impl.ConfigContext;
-import org.hibernate.search.engine.metadata.impl.AnnotationMetadataProvider;
 import org.hibernate.search.engine.metadata.impl.TypeMetadata;
 import org.hibernate.search.testsupport.TestForIssue;
-import org.hibernate.search.testsupport.setup.BuildContextForTest;
-import org.hibernate.search.testsupport.setup.SearchConfigurationForTest;
-import org.junit.Before;
+import org.hibernate.search.testsupport.setup.AbstractAnnotationMetadataTest;
 import org.junit.Test;
-
-import static org.junit.Assert.assertNull;
 
 
 /**
  * @author Hardy Ferentschik
  */
 @TestForIssue(jiraKey = "HSEARCH-1494")
-public class EmbeddedEntityNotIndexedTest {
-
-	private AnnotationMetadataProvider metadataProvider;
-
-	@Before
-	public void setUp() {
-		SearchConfiguration searchConfiguration = new SearchConfigurationForTest();
-		ConfigContext configContext = new ConfigContext(
-				searchConfiguration,
-				new BuildContextForTest( searchConfiguration )
-		);
-		metadataProvider = new AnnotationMetadataProvider( new JavaReflectionManager(), configContext );
-	}
+public class EmbeddedEntityNotIndexedTest extends AbstractAnnotationMetadataTest {
 
 	@Test
 	public void testMultipleDocumentIdsCauseException() {

--- a/orm/src/test/java/org/hibernate/search/test/embedded/EmbeddedObjectIdInclusionTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/embedded/EmbeddedObjectIdInclusionTest.java
@@ -6,47 +6,29 @@
  */
 package org.hibernate.search.test.embedded;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.OneToOne;
 
-import org.hibernate.annotations.common.reflection.java.JavaReflectionManager;
 import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.annotations.IndexedEmbedded;
-import org.hibernate.search.cfg.spi.SearchConfiguration;
-import org.hibernate.search.engine.impl.ConfigContext;
-import org.hibernate.search.engine.metadata.impl.AnnotationMetadataProvider;
 import org.hibernate.search.engine.metadata.impl.EmbeddedTypeMetadata;
 import org.hibernate.search.engine.metadata.impl.PropertyMetadata;
 import org.hibernate.search.engine.metadata.impl.TypeMetadata;
 import org.hibernate.search.testsupport.TestForIssue;
-import org.hibernate.search.testsupport.setup.BuildContextForTest;
-import org.hibernate.search.testsupport.setup.SearchConfigurationForTest;
-import org.junit.Before;
+import org.hibernate.search.testsupport.setup.AbstractAnnotationMetadataTest;
 import org.junit.Test;
-
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author Hardy Ferentschik
  */
 @TestForIssue(jiraKey = "HSEARCH-1494")
-public class EmbeddedObjectIdInclusionTest {
-
-	private AnnotationMetadataProvider metadataProvider;
-
-	@Before
-	public void setUp() {
-		SearchConfiguration searchConfiguration = new SearchConfigurationForTest();
-		ConfigContext configContext = new ConfigContext(
-				searchConfiguration,
-				new BuildContextForTest( searchConfiguration )
-		);
-		metadataProvider = new AnnotationMetadataProvider( new JavaReflectionManager(), configContext );
-	}
+public class EmbeddedObjectIdInclusionTest extends AbstractAnnotationMetadataTest {
 
 	@Test
 	public void testIncludeEmbeddedObjectId() {


### PR DESCRIPTION
So here is the work I did for HSEARCH-2067.

It introduces the notion of backend specific FieldBridges which are only enabled if a type is managed by a given backend.

There are a couple of shortcomings we should probably discuss:

## Building TypeMetadata

As the initialization of FieldBridges now depends on the backend which manages a type, we need to have this information to build them. We can have it when we build the TypeMetadata for an indexed type as it is attached to a backend but we don't have it when we build the TypeMetadata for ContainedIn types as they are not attached to a specific backend (and might even be used by indexed entities managed by 2 different backends).

At first, I tried to implement a ContainedInTypeMetadata with only the relevant information (and I hoped there were only a few of them) but we really need most of them for the dirty checking and optimizations so I ended up implementing a skipFieldBridges method in ParseContext (see AnnotationMetadataProvider).

## Change in SPI

I had to change the IndexManagerFactory SPI to make it a 2 steps process. I'm pretty sure it's going to be subject to discussions (Sanne?).

Maybe it's the good time to also add a method to be able to register new aliases?