### PR TITLE
HSEARCH-2207 Treat BooleanQuery as an immutable Query

### DIFF
--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/ByTermDeleteWorkExecutor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/ByTermDeleteWorkExecutor.java
@@ -63,17 +63,18 @@ public final class ByTermDeleteWorkExecutor extends DeleteWorkExecutor {
 	}
 
 	private void deleteWithTenant(LuceneWork work, IndexWriterDelegate delegate, final String tenantId, DocumentBuilderIndexedEntity builder, Serializable id) throws IOException {
-		BooleanQuery termDeleteQuery = new BooleanQuery();
+		BooleanQuery.Builder termDeleteQueryBuilder = new BooleanQuery.Builder();
 		TermQuery tenantTermQuery = new TermQuery( new Term( DocumentBuilderIndexedEntity.TENANT_ID_FIELDNAME, tenantId ) );
-		termDeleteQuery.add( tenantTermQuery, Occur.FILTER );
+		termDeleteQueryBuilder.add( tenantTermQuery, Occur.FILTER );
 		if ( isIdNumeric( builder ) ) {
 			Query exactMatchQuery = NumericFieldUtils.createExactMatchQuery( builder.getIdKeywordName(), id );
-			termDeleteQuery.add( exactMatchQuery, Occur.FILTER );
+			termDeleteQueryBuilder.add( exactMatchQuery, Occur.FILTER );
 		}
 		else {
 			Term idTerm = new Term( builder.getIdKeywordName(), work.getIdInString() );
-			termDeleteQuery.add( new TermQuery( idTerm ), Occur.FILTER );
+			termDeleteQueryBuilder.add( new TermQuery( idTerm ), Occur.FILTER );
 		}
+		BooleanQuery termDeleteQuery = termDeleteQueryBuilder.build();
 		delegate.deleteDocuments( termDeleteQuery );
 	}
 

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/ByTermUpdateWorkExecutor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/ByTermUpdateWorkExecutor.java
@@ -61,13 +61,13 @@ public final class ByTermUpdateWorkExecutor extends UpdateWorkExecutor {
 						id
 				);
 				Query exactMatchQuery = NumericFieldUtils.createExactMatchQuery( builder.getIdKeywordName(), id );
-				BooleanQuery deleteDocumentsQuery = new BooleanQuery();
-				deleteDocumentsQuery.add( exactMatchQuery, Occur.FILTER );
+				BooleanQuery.Builder deleteDocumentsQueryBuilder = new BooleanQuery.Builder();
+				deleteDocumentsQueryBuilder.add( exactMatchQuery, Occur.FILTER );
 				if ( tenantId != null ) {
 					TermQuery tenantTermQuery = new TermQuery( new Term( DocumentBuilderIndexedEntity.TENANT_ID_FIELDNAME, tenantId ) );
-					deleteDocumentsQuery.add( tenantTermQuery, Occur.FILTER );
+					deleteDocumentsQueryBuilder.add( tenantTermQuery, Occur.FILTER );
 				}
-				delegate.deleteDocuments( deleteDocumentsQuery );
+				delegate.deleteDocuments( deleteDocumentsQueryBuilder.build() );
 				// no need to log the Add operation as we'll log in the delegate
 				this.addDelegate.performWork( work, delegate, monitor );
 			}

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/DeleteByQueryWorkExecutor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/DeleteByQueryWorkExecutor.java
@@ -55,7 +55,7 @@ class DeleteByQueryWorkExecutor implements LuceneWorkExecutor {
 			log.tracef( "Removing all %s matching Query: %s", entityType.toString(), query.toString() );
 		}
 
-		BooleanQuery.Builder entityDeletionBuilder = new BooleanQuery.Builder();
+		BooleanQuery.Builder entityDeletionQueryBuilder = new BooleanQuery.Builder();
 
 		{
 			ScopedAnalyzerReference analyzer = this.workspace.getDocumentBuilder( entityType ).getAnalyzer();
@@ -63,17 +63,17 @@ class DeleteByQueryWorkExecutor implements LuceneWorkExecutor {
 
 			Query queryToDelete = query.toLuceneQuery( scopeAnalyzer );
 
-			entityDeletionBuilder.add( queryToDelete, BooleanClause.Occur.FILTER );
+			entityDeletionQueryBuilder.add( queryToDelete, BooleanClause.Occur.FILTER );
 		}
 
 		Term classNameQueryTerm = new Term( ProjectionConstants.OBJECT_CLASS, entityType.getName() );
 		TermQuery classNameQuery = new TermQuery( classNameQueryTerm );
-		entityDeletionBuilder.add( classNameQuery, BooleanClause.Occur.FILTER );
+		entityDeletionQueryBuilder.add( classNameQuery, BooleanClause.Occur.FILTER );
 
-		addTenantQueryTerm( work.getTenantId(), entityDeletionBuilder );
+		addTenantQueryTerm( work.getTenantId(), entityDeletionQueryBuilder );
 
 		try {
-			BooleanQuery entityDeletionQuery = entityDeletionBuilder.build();
+			BooleanQuery entityDeletionQuery = entityDeletionQueryBuilder.build();
 			delegate.deleteDocuments( entityDeletionQuery );
 		}
 		catch (IOException e) {

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/PurgeAllWorkExecutor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/PurgeAllWorkExecutor.java
@@ -51,9 +51,10 @@ class PurgeAllWorkExecutor implements LuceneWorkExecutor {
 			else {
 				log.tracef( "purgeAll Lucene index using IndexWriter for type $1%s and tenant $2%s", entityType, tenantId );
 				Term tenantIdTerm = tenantId == null ? null : new Term( DocumentBuilderIndexedEntity.TENANT_ID_FIELDNAME, tenantId );
-				BooleanQuery deleteDocumentsQuery = new BooleanQuery();
-				deleteDocumentsQuery.add( new TermQuery( entityTypeTerm ), Occur.FILTER );
-				deleteDocumentsQuery.add( new TermQuery( tenantIdTerm ), Occur.FILTER );
+				BooleanQuery deleteDocumentsQuery = new BooleanQuery.Builder()
+						.add( new TermQuery( entityTypeTerm ), Occur.FILTER )
+						.add( new TermQuery( tenantIdTerm ), Occur.FILTER )
+						.build();
 				delegate.deleteDocuments( deleteDocumentsQuery );
 			}
 		}

--- a/engine/src/main/java/org/hibernate/search/backend/spi/SingularTermDeletionQuery.java
+++ b/engine/src/main/java/org/hibernate/search/backend/spi/SingularTermDeletionQuery.java
@@ -91,12 +91,15 @@ public final class SingularTermDeletionQuery implements DeletionQuery {
 				TokenStream tokenStream = analyzerForEntity.tokenStream( this.getFieldName(), (String) this.getValue() );
 				tokenStream.reset();
 				try {
-					BooleanQuery booleanQuery = new BooleanQuery();
+					BooleanQuery.Builder booleanQueryBuilder = new BooleanQuery.Builder();
 					while ( tokenStream.incrementToken() ) {
 						String value = tokenStream.getAttribute( CharTermAttribute.class ).toString();
-						booleanQuery.add( new TermQuery( new Term( this.getFieldName(), value ) ), Occur.FILTER );
+						booleanQueryBuilder.add(
+								new TermQuery( new Term( this.getFieldName(), value ) ),
+								Occur.FILTER
+						);
 					}
-					return booleanQuery;
+					return booleanQueryBuilder.build(); // BooleanQuery
 				}
 				finally {
 					tokenStream.close();

--- a/engine/src/main/java/org/hibernate/search/query/dsl/impl/ConnectedAllContext.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/impl/ConnectedAllContext.java
@@ -38,11 +38,11 @@ public class ConnectedAllContext implements AllContext {
 			query = clauses.get( 0 ).getQuery();
 		}
 		else {
-			BooleanQuery booleanQuery = new BooleanQuery( );
+			BooleanQuery.Builder builder = new BooleanQuery.Builder();
 			for ( BooleanClause clause : clauses ) {
-				booleanQuery.add( clause );
+				builder.add( clause );
 			}
-			query = booleanQuery;
+			query = builder.build();
 		}
 		return queryCustomizer.setWrappedQuery( query ).createQuery();
 	}

--- a/engine/src/main/java/org/hibernate/search/query/dsl/impl/ConnectedAllContext.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/impl/ConnectedAllContext.java
@@ -38,11 +38,11 @@ public class ConnectedAllContext implements AllContext {
 			query = clauses.get( 0 ).getQuery();
 		}
 		else {
-			BooleanQuery.Builder builder = new BooleanQuery.Builder();
+			BooleanQuery.Builder booleanQueryBuilder = new BooleanQuery.Builder();
 			for ( BooleanClause clause : clauses ) {
-				builder.add( clause );
+				booleanQueryBuilder.add( clause );
 			}
-			query = builder.build();
+			query = booleanQueryBuilder.build();
 		}
 		return queryCustomizer.setWrappedQuery( query ).createQuery();
 	}

--- a/engine/src/main/java/org/hibernate/search/query/dsl/impl/ConnectedMultiFieldsPhraseQueryBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/impl/ConnectedMultiFieldsPhraseQueryBuilder.java
@@ -53,12 +53,11 @@ public class ConnectedMultiFieldsPhraseQueryBuilder implements PhraseTermination
 			return queryCustomizer.setWrappedQuery( createQuery( fieldContexts.get( 0 ) ) ).createQuery();
 		}
 		else {
-			// aggregated fields query builder
-			BooleanQuery.Builder builder = new BooleanQuery.Builder();
+			BooleanQuery.Builder aggregatedFieldsQueryBuilder = new BooleanQuery.Builder();
 			for ( FieldContext fieldContext : fieldContexts ) {
-				builder.add( createQuery( fieldContext ), BooleanClause.Occur.SHOULD );
+				aggregatedFieldsQueryBuilder.add( createQuery( fieldContext ), BooleanClause.Occur.SHOULD );
 			}
-			BooleanQuery aggregatedFieldsQuery = builder.build();
+			BooleanQuery aggregatedFieldsQuery = aggregatedFieldsQueryBuilder.build();
 			return queryCustomizer.setWrappedQuery( aggregatedFieldsQuery ).createQuery();
 		}
 	}

--- a/engine/src/main/java/org/hibernate/search/query/dsl/impl/ConnectedMultiFieldsPhraseQueryBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/impl/ConnectedMultiFieldsPhraseQueryBuilder.java
@@ -53,10 +53,12 @@ public class ConnectedMultiFieldsPhraseQueryBuilder implements PhraseTermination
 			return queryCustomizer.setWrappedQuery( createQuery( fieldContexts.get( 0 ) ) ).createQuery();
 		}
 		else {
-			BooleanQuery aggregatedFieldsQuery = new BooleanQuery( );
+			// aggregated fields query builder
+			BooleanQuery.Builder builder = new BooleanQuery.Builder();
 			for ( FieldContext fieldContext : fieldContexts ) {
-				aggregatedFieldsQuery.add( createQuery( fieldContext ), BooleanClause.Occur.SHOULD );
+				builder.add( createQuery( fieldContext ), BooleanClause.Occur.SHOULD );
 			}
+			BooleanQuery aggregatedFieldsQuery = builder.build();
 			return queryCustomizer.setWrappedQuery( aggregatedFieldsQuery ).createQuery();
 		}
 	}
@@ -127,7 +129,7 @@ public class ConnectedMultiFieldsPhraseQueryBuilder implements PhraseTermination
 		 */
 		final int size = termsPerPosition.size();
 		if ( size == 0 ) {
-			perFieldQuery = new BooleanQuery( );
+			perFieldQuery = new BooleanQuery.Builder().build();
 		}
 		else if ( size <= 1 ) {
 			final List<Term> terms = termsPerPosition.values().iterator().next();
@@ -135,11 +137,11 @@ public class ConnectedMultiFieldsPhraseQueryBuilder implements PhraseTermination
 				perFieldQuery = new TermQuery( terms.get( 0 ) );
 			}
 			else {
-				BooleanQuery query = new BooleanQuery( );
+				BooleanQuery.Builder booleanQueryBuilder = new BooleanQuery.Builder();
 				for ( Term term : terms ) {
-					query.add( new TermQuery(term), BooleanClause.Occur.SHOULD );
+					booleanQueryBuilder.add( new TermQuery(term), BooleanClause.Occur.SHOULD );
 				}
-				perFieldQuery = query;
+				perFieldQuery = booleanQueryBuilder.build();
 			}
 		}
 		else {

--- a/engine/src/main/java/org/hibernate/search/query/dsl/impl/ConnectedMultiFieldsRangeQueryBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/impl/ConnectedMultiFieldsRangeQueryBuilder.java
@@ -67,11 +67,11 @@ public class ConnectedMultiFieldsRangeQueryBuilder implements RangeTerminationEx
 			return queryCustomizer.setWrappedQuery( createQuery( fieldContexts.get( 0 ), conversionContext ) ).createQuery();
 		}
 		else {
-			BooleanQuery.Builder builder = new BooleanQuery.Builder();
+			BooleanQuery.Builder aggregatedFieldsQueryBuilder = new BooleanQuery.Builder();
 			for ( FieldContext fieldContext : fieldContexts ) {
-				builder.add( createQuery( fieldContext, conversionContext ), BooleanClause.Occur.SHOULD );
+				aggregatedFieldsQueryBuilder.add( createQuery( fieldContext, conversionContext ), BooleanClause.Occur.SHOULD );
 			}
-			return queryCustomizer.setWrappedQuery( builder.build() ).createQuery();
+			return queryCustomizer.setWrappedQuery( aggregatedFieldsQueryBuilder.build() ).createQuery();
 		}
 	}
 

--- a/engine/src/main/java/org/hibernate/search/query/dsl/impl/ConnectedMultiFieldsRangeQueryBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/impl/ConnectedMultiFieldsRangeQueryBuilder.java
@@ -67,11 +67,11 @@ public class ConnectedMultiFieldsRangeQueryBuilder implements RangeTerminationEx
 			return queryCustomizer.setWrappedQuery( createQuery( fieldContexts.get( 0 ), conversionContext ) ).createQuery();
 		}
 		else {
-			BooleanQuery aggregatedFieldsQuery = new BooleanQuery();
+			BooleanQuery.Builder builder = new BooleanQuery.Builder();
 			for ( FieldContext fieldContext : fieldContexts ) {
-				aggregatedFieldsQuery.add( createQuery( fieldContext, conversionContext ), BooleanClause.Occur.SHOULD );
+				builder.add( createQuery( fieldContext, conversionContext ), BooleanClause.Occur.SHOULD );
 			}
-			return queryCustomizer.setWrappedQuery( aggregatedFieldsQuery ).createQuery();
+			return queryCustomizer.setWrappedQuery( builder.build() ).createQuery();
 		}
 	}
 

--- a/engine/src/main/java/org/hibernate/search/query/dsl/impl/ConnectedMultiFieldsRangeQueryBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/impl/ConnectedMultiFieldsRangeQueryBuilder.java
@@ -67,7 +67,7 @@ public class ConnectedMultiFieldsRangeQueryBuilder implements RangeTerminationEx
 			return queryCustomizer.setWrappedQuery( createQuery( fieldContexts.get( 0 ), conversionContext ) ).createQuery();
 		}
 		else {
-			BooleanQuery aggregatedFieldsQuery = new BooleanQuery( );
+			BooleanQuery aggregatedFieldsQuery = new BooleanQuery();
 			for ( FieldContext fieldContext : fieldContexts ) {
 				aggregatedFieldsQuery.add( createQuery( fieldContext, conversionContext ), BooleanClause.Occur.SHOULD );
 			}

--- a/engine/src/main/java/org/hibernate/search/query/dsl/impl/ConnectedMultiFieldsTermQueryBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/impl/ConnectedMultiFieldsTermQueryBuilder.java
@@ -67,10 +67,14 @@ public class ConnectedMultiFieldsTermQueryBuilder implements TermTermination {
 			return queryCustomizer.setWrappedQuery( createQuery( fieldsContext.getFirst(), conversionContext ) ).createQuery();
 		}
 		else {
-			BooleanQuery aggregatedFieldsQuery = new BooleanQuery();
+			BooleanQuery.Builder aggregatedFieldsQueryBuilder = new BooleanQuery.Builder();
 			for ( FieldContext fieldContext : fieldsContext ) {
-				aggregatedFieldsQuery.add( createQuery( fieldContext, conversionContext ), BooleanClause.Occur.SHOULD );
+				aggregatedFieldsQueryBuilder.add(
+					createQuery( fieldContext, conversionContext ),
+					BooleanClause.Occur.SHOULD
+				);
 			}
+			BooleanQuery aggregatedFieldsQuery = aggregatedFieldsQueryBuilder.build();
 			return queryCustomizer.setWrappedQuery( aggregatedFieldsQuery ).createQuery();
 		}
 	}
@@ -118,12 +122,12 @@ public class ConnectedMultiFieldsTermQueryBuilder implements TermTermination {
 				perFieldQuery = createTermQuery( fieldContext, terms.get( 0 ) );
 			}
 			else {
-				BooleanQuery booleanQuery = new BooleanQuery();
+				BooleanQuery.Builder booleanQueryBuilder = new BooleanQuery.Builder();
 				for ( String localTerm : terms ) {
 					Query termQuery = createTermQuery( fieldContext, localTerm );
-					booleanQuery.add( termQuery, BooleanClause.Occur.SHOULD );
+					booleanQueryBuilder.add( termQuery, BooleanClause.Occur.SHOULD );
 				}
-				perFieldQuery = booleanQuery;
+				perFieldQuery = booleanQueryBuilder.build();
 			}
 		}
 		return fieldContext.getFieldCustomizer().setWrappedQuery( perFieldQuery ).createQuery();

--- a/engine/src/main/java/org/hibernate/search/query/dsl/impl/MoreLikeThisBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/impl/MoreLikeThisBuilder.java
@@ -213,18 +213,18 @@ public class MoreLikeThisBuilder<T> {
 			return createQuery( q.get( 0 ), fieldsContext.getFirst() );
 		}
 		else {
-			BooleanQuery.Builder builder = new BooleanQuery.Builder();
+			BooleanQuery.Builder queryBuilder = new BooleanQuery.Builder();
 			//the fieldsContext indexes are aligned with the priority queue's
 			Iterator<FieldContext> fieldsContextIterator = fieldsContext.iterator();
 			for ( PriorityQueue<Object[]> queue : q ) {
 				try {
-					builder.add( createQuery( queue, fieldsContextIterator.next() ), BooleanClause.Occur.SHOULD );
+					queryBuilder.add( createQuery( queue, fieldsContextIterator.next() ), BooleanClause.Occur.SHOULD );
 				}
 				catch (BooleanQuery.TooManyClauses ignore) {
 					break;
 				}
 			}
-			return builder.build();
+			return queryBuilder.build();
 		}
 	}
 

--- a/engine/src/main/java/org/hibernate/search/query/dsl/impl/MoreLikeThisBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/impl/MoreLikeThisBuilder.java
@@ -188,18 +188,11 @@ public class MoreLikeThisBuilder<T> {
 		// but at this stage we could have documents reordered and thus with a different id
 		// Maybe a Filter would be more efficient?
 		if ( excludeEntityCompared && documentNumber != null ) {
-			BooleanQuery booleanQuery;
-			if ( ! ( query instanceof BooleanQuery ) ) {
-				booleanQuery = new BooleanQuery();
-				booleanQuery.add( query, BooleanClause.Occur.MUST );
-			}
-			else {
-				booleanQuery = (BooleanQuery) query;
-			}
-			booleanQuery.add(
-					new ConstantScoreQuery( findById ),
-					BooleanClause.Occur.MUST_NOT );
-			return booleanQuery;
+			return new BooleanQuery.Builder()
+					.add( query, BooleanClause.Occur.MUST )
+					.add( new ConstantScoreQuery( findById ),
+							BooleanClause.Occur.MUST_NOT )
+					.build();
 		}
 		else {
 			return query;
@@ -220,18 +213,18 @@ public class MoreLikeThisBuilder<T> {
 			return createQuery( q.get( 0 ), fieldsContext.getFirst() );
 		}
 		else {
-			BooleanQuery query = new BooleanQuery();
+			BooleanQuery.Builder builder = new BooleanQuery.Builder();
 			//the fieldsContext indexes are aligned with the priority queue's
 			Iterator<FieldContext> fieldsContextIterator = fieldsContext.iterator();
 			for ( PriorityQueue<Object[]> queue : q ) {
 				try {
-					query.add( createQuery( queue, fieldsContextIterator.next() ), BooleanClause.Occur.SHOULD );
+					builder.add( createQuery( queue, fieldsContextIterator.next() ), BooleanClause.Occur.SHOULD );
 				}
 				catch (BooleanQuery.TooManyClauses ignore) {
 					break;
 				}
 			}
-			return query;
+			return builder.build();
 		}
 	}
 

--- a/engine/src/main/java/org/hibernate/search/query/engine/impl/FacetManagerImpl.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/impl/FacetManagerImpl.java
@@ -135,13 +135,14 @@ public class FacetManagerImpl implements FacetManager {
 
 	public Filter getFacetFilter() {
 		if ( facetFilter == null ) {
-			BooleanQuery boolQuery = new BooleanQuery();
+			BooleanQuery.Builder builder = new BooleanQuery.Builder();
 			for ( FacetSelectionImpl selection : facetSelection.values() ) {
 				if ( !selection.getFacetList().isEmpty() ) {
 					Query selectionGroupQuery = createSelectionGroupQuery( selection );
-					boolQuery.add( selectionGroupQuery, BooleanClause.Occur.MUST );
+					builder.add( selectionGroupQuery, BooleanClause.Occur.MUST );
 				}
 			}
+			BooleanQuery boolQuery = builder.build();
 			if ( boolQuery.getClauses().length > 0 ) {
 				this.facetFilter = new QueryWrapperFilter( boolQuery );
 			}
@@ -150,10 +151,11 @@ public class FacetManagerImpl implements FacetManager {
 	}
 
 	private Query createSelectionGroupQuery(FacetSelectionImpl selection) {
-		BooleanQuery boolQuery = new BooleanQuery();
+		BooleanQuery.Builder builder = new BooleanQuery.Builder();
 		for ( Facet facet : selection.getFacetList() ) {
-			boolQuery.add( facet.getFacetQuery(), selection.getOccurType() );
+			builder.add( facet.getFacetQuery(), selection.getOccurType() );
 		}
+		BooleanQuery boolQuery = builder.build();
 		return boolQuery;
 	}
 

--- a/engine/src/main/java/org/hibernate/search/query/engine/impl/FacetManagerImpl.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/impl/FacetManagerImpl.java
@@ -135,14 +135,14 @@ public class FacetManagerImpl implements FacetManager {
 
 	public Filter getFacetFilter() {
 		if ( facetFilter == null ) {
-			BooleanQuery.Builder builder = new BooleanQuery.Builder();
+			BooleanQuery.Builder boolQueryBuilder = new BooleanQuery.Builder();
 			for ( FacetSelectionImpl selection : facetSelection.values() ) {
 				if ( !selection.getFacetList().isEmpty() ) {
 					Query selectionGroupQuery = createSelectionGroupQuery( selection );
-					builder.add( selectionGroupQuery, BooleanClause.Occur.MUST );
+					boolQueryBuilder.add( selectionGroupQuery, BooleanClause.Occur.MUST );
 				}
 			}
-			BooleanQuery boolQuery = builder.build();
+			BooleanQuery boolQuery = boolQueryBuilder.build();
 			if ( boolQuery.getClauses().length > 0 ) {
 				this.facetFilter = new QueryWrapperFilter( boolQuery );
 			}

--- a/engine/src/main/java/org/hibernate/search/spatial/impl/SpatialQueryBuilderFromCoordinates.java
+++ b/engine/src/main/java/org/hibernate/search/spatial/impl/SpatialQueryBuilderFromCoordinates.java
@@ -172,16 +172,18 @@ public abstract class SpatialQueryBuilderFromCoordinates {
 					boundingBox.getUpperRight().getLongitude(), true, true );
 		}
 		else {
-			longQuery = new BooleanQuery();
-			( (BooleanQuery) longQuery).add( NumericRangeQuery.newDoubleRange( longitudeFieldName, boundingBox.getLowerLeft().getLongitude(),
-					180.0, true, true ), BooleanClause.Occur.SHOULD );
-			( (BooleanQuery) longQuery).add( NumericRangeQuery.newDoubleRange( longitudeFieldName, -180.0,
-					boundingBox.getUpperRight().getLongitude(), true, true ), BooleanClause.Occur.SHOULD );
+			longQuery = new BooleanQuery.Builder()
+					.add( NumericRangeQuery.newDoubleRange( longitudeFieldName, boundingBox.getLowerLeft().getLongitude(),
+						180.0, true, true ), BooleanClause.Occur.SHOULD )
+					.add( NumericRangeQuery.newDoubleRange( longitudeFieldName, -180.0,
+						boundingBox.getUpperRight().getLongitude(), true, true ), BooleanClause.Occur.SHOULD )
+					.build();
 		}
 
-		BooleanQuery boxQuery = new BooleanQuery();
-		boxQuery.add( latQuery, BooleanClause.Occur.FILTER );
-		boxQuery.add( longQuery, BooleanClause.Occur.FILTER );
+		BooleanQuery boxQuery = new BooleanQuery.Builder()
+				.add( latQuery, BooleanClause.Occur.FILTER )
+				.add( longQuery, BooleanClause.Occur.FILTER )
+				.build();
 
 		return new FilteredQuery(
 				new MatchAllDocsQuery(),

--- a/engine/src/main/java/org/hibernate/search/stat/impl/StatisticsImpl.java
+++ b/engine/src/main/java/org/hibernate/search/stat/impl/StatisticsImpl.java
@@ -210,11 +210,11 @@ public class StatisticsImpl implements Statistics, StatisticsImplementor {
 		IndexReader indexReader = extendedIntegrator.getIndexReaderAccessor().open( clazz );
 		try {
 			IndexSearcher searcher = new IndexSearcher( indexReader );
-			BooleanQuery boolQuery = new BooleanQuery();
-			boolQuery.add( new MatchAllDocsQuery(), BooleanClause.Occur.FILTER );
-			boolQuery.add(
-					new TermQuery( new Term( ProjectionConstants.OBJECT_CLASS, entity ) ), BooleanClause.Occur.FILTER
-			);
+			BooleanQuery boolQuery = new BooleanQuery.Builder()
+					.add( new MatchAllDocsQuery(), BooleanClause.Occur.FILTER )
+					.add( new TermQuery( new Term( ProjectionConstants.OBJECT_CLASS, entity ) ),
+							BooleanClause.Occur.FILTER)
+					.build();
 			try {
 				TopDocs topdocs = searcher.search( boolQuery, 1 );
 				return topdocs.totalHits;

--- a/engine/src/test/java/org/hibernate/search/test/query/engine/FieldNameCollectorTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/query/engine/FieldNameCollectorTest.java
@@ -134,18 +134,18 @@ public class FieldNameCollectorTest {
 
 	@Test
 	public void testNestedBooleanQuery() {
-		BooleanQuery.Builder builder = new BooleanQuery.Builder();
+		BooleanQuery.Builder booleanQueryBuilder = new BooleanQuery.Builder();
 
 		TermQuery termQuery = new TermQuery( new Term( "stringField", "foobar" ) );
-		builder.add( termQuery, BooleanClause.Occur.MUST );
+		booleanQueryBuilder.add( termQuery, BooleanClause.Occur.MUST );
 
 		BooleanQuery.Builder nestedBuilder = new BooleanQuery.Builder();
 		NumericRangeQuery numericRangeQuery = NumericRangeQuery.newIntRange( "intField", 0, 0, true, true );
 		nestedBuilder.add( numericRangeQuery, BooleanClause.Occur.SHOULD );
 		BooleanQuery nestedBooleanQuery = nestedBuilder.build();
-		builder.add( nestedBooleanQuery, BooleanClause.Occur.MUST );
+		booleanQueryBuilder.add( nestedBooleanQuery, BooleanClause.Occur.MUST );
 
-		BooleanQuery booleanQuery = builder.build();
+		BooleanQuery booleanQuery = booleanQueryBuilder.build();
 
 		assertFieldNames( booleanQuery, FieldType.NUMBER, "intField" );
 		assertFieldNames( booleanQuery, FieldType.STRING, "stringField" );

--- a/engine/src/test/java/org/hibernate/search/test/query/engine/FieldNameCollectorTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/query/engine/FieldNameCollectorTest.java
@@ -118,13 +118,15 @@ public class FieldNameCollectorTest {
 
 	@Test
 	public void testBooleanQuery() {
-		BooleanQuery booleanQuery = new BooleanQuery();
+		BooleanQuery.Builder booleanQueryBuilder = new BooleanQuery.Builder();
 
 		TermQuery termQuery = new TermQuery( new Term( "stringField", "foobar" ) );
-		booleanQuery.add( termQuery, BooleanClause.Occur.MUST );
+		booleanQueryBuilder.add( termQuery, BooleanClause.Occur.MUST );
 
 		NumericRangeQuery numericRangeQuery = NumericRangeQuery.newIntRange( "intField", 0, 0, true, true );
-		booleanQuery.add( numericRangeQuery, BooleanClause.Occur.SHOULD );
+		booleanQueryBuilder.add( numericRangeQuery, BooleanClause.Occur.SHOULD );
+
+		BooleanQuery booleanQuery = booleanQueryBuilder.build();
 
 		assertFieldNames( booleanQuery, FieldType.NUMBER, "intField" );
 		assertFieldNames( booleanQuery, FieldType.STRING, "stringField" );
@@ -132,15 +134,18 @@ public class FieldNameCollectorTest {
 
 	@Test
 	public void testNestedBooleanQuery() {
-		BooleanQuery booleanQuery = new BooleanQuery();
+		BooleanQuery.Builder builder = new BooleanQuery.Builder();
 
 		TermQuery termQuery = new TermQuery( new Term( "stringField", "foobar" ) );
-		booleanQuery.add( termQuery, BooleanClause.Occur.MUST );
+		builder.add( termQuery, BooleanClause.Occur.MUST );
 
-		BooleanQuery nestedBooleanQuery = new BooleanQuery();
+		BooleanQuery.Builder nestedBuilder = new BooleanQuery.Builder();
 		NumericRangeQuery numericRangeQuery = NumericRangeQuery.newIntRange( "intField", 0, 0, true, true );
-		nestedBooleanQuery.add( numericRangeQuery, BooleanClause.Occur.SHOULD );
-		booleanQuery.add( nestedBooleanQuery, BooleanClause.Occur.MUST );
+		nestedBuilder.add( numericRangeQuery, BooleanClause.Occur.SHOULD );
+		BooleanQuery nestedBooleanQuery = nestedBuilder.build();
+		builder.add( nestedBooleanQuery, BooleanClause.Occur.MUST );
+
+		BooleanQuery booleanQuery = builder.build();
 
 		assertFieldNames( booleanQuery, FieldType.NUMBER, "intField" );
 		assertFieldNames( booleanQuery, FieldType.STRING, "stringField" );

--- a/orm/src/test/java/org/hibernate/search/test/bridge/BridgeTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/BridgeTest.java
@@ -83,22 +83,25 @@ public class BridgeTest extends SearchTestBase {
 		Query query;
 		List result;
 
-		BooleanQuery booleanQuery = new BooleanQuery();
-		booleanQuery.add( NumericRangeQuery.newDoubleRange( "double2", 2.1, 2.1, true, true ), BooleanClause.Occur.MUST );
-		booleanQuery.add( NumericRangeQuery.newFloatRange( "float2", 2.1f, 2.1f, true, true ), BooleanClause.Occur.MUST );
-		booleanQuery.add( NumericRangeQuery.newIntRange( "integerv2", 2, 3, true, true ), BooleanClause.Occur.MUST );
-		booleanQuery.add( NumericRangeQuery.newLongRange( "long2", 2l, 3l, true, true ), BooleanClause.Occur.MUST );
-		booleanQuery.add( new TermQuery(new Term("type", "dog")), BooleanClause.Occur.MUST );
-		booleanQuery.add( new TermQuery(new Term("storm", "false")), BooleanClause.Occur.MUST );
+		BooleanQuery booleanQuery = new BooleanQuery.Builder()
+				.add( NumericRangeQuery.newDoubleRange( "double2", 2.1, 2.1, true, true ), BooleanClause.Occur.MUST )
+				.add( NumericRangeQuery.newFloatRange( "float2", 2.1f, 2.1f, true, true ), BooleanClause.Occur.MUST )
+				.add( NumericRangeQuery.newIntRange( "integerv2", 2, 3, true, true ), BooleanClause.Occur.MUST )
+				.add( NumericRangeQuery.newLongRange( "long2", 2l, 3l, true, true ), BooleanClause.Occur.MUST )
+				.add( new TermQuery(new Term("type", "dog")), BooleanClause.Occur.MUST )
+				.add( new TermQuery(new Term("storm", "false")), BooleanClause.Occur.MUST )
+				.build();
 
 		result = session.createFullTextQuery( booleanQuery ).list();
 		assertEquals( "find primitives and do not fail on null", 1, result.size() );
 
-		booleanQuery = new BooleanQuery();
-		booleanQuery.add( NumericRangeQuery.newDoubleRange( "double1", 2.1, 2.1, true, true ), BooleanClause.Occur.MUST );
-		booleanQuery.add( NumericRangeQuery.newFloatRange( "float1", 2.1f, 2.1f, true, true ), BooleanClause.Occur.MUST );
-		booleanQuery.add( NumericRangeQuery.newIntRange( "integerv1", 2, 3, true, true ), BooleanClause.Occur.MUST );
-		booleanQuery.add( NumericRangeQuery.newLongRange( "long1", 2l, 3l, true, true ), BooleanClause.Occur.MUST );
+		booleanQuery = new BooleanQuery.Builder()
+				.add( NumericRangeQuery.newDoubleRange( "double1", 2.1, 2.1, true, true ), BooleanClause.Occur.MUST )
+				.add( NumericRangeQuery.newFloatRange( "float1", 2.1f, 2.1f, true, true ), BooleanClause.Occur.MUST )
+				.add( NumericRangeQuery.newIntRange( "integerv1", 2, 3, true, true ), BooleanClause.Occur.MUST )
+				.add( NumericRangeQuery.newLongRange( "long1", 2l, 3l, true, true ), BooleanClause.Occur.MUST )
+				.build();
+
 		result = session.createFullTextQuery( booleanQuery ).list();
 		assertEquals( "null elements should not be stored", 0, result.size() ); //the query is dumb because restrictive
 
@@ -115,15 +118,17 @@ public class BridgeTest extends SearchTestBase {
 				( (Class) ( (Object[]) result.get( 0 ) )[0] ).getName()
 		);
 
-		BooleanQuery bQuery = new BooleanQuery();
-		bQuery.add( new TermQuery( new Term( "uri", "http://www.hibernate.org" ) ), BooleanClause.Occur.MUST );
-		bQuery.add( new TermQuery( new Term( "url", "http://www.hibernate.org" ) ), BooleanClause.Occur.MUST );
+		BooleanQuery bQuery = new BooleanQuery.Builder()
+				.add( new TermQuery( new Term( "uri", "http://www.hibernate.org" ) ), BooleanClause.Occur.MUST )
+				.add( new TermQuery( new Term( "url", "http://www.hibernate.org" ) ), BooleanClause.Occur.MUST )
+				.build();
 
 		result = session.createFullTextQuery( bQuery ).setProjection( "clazz" ).list();
 		assertEquals( "Clazz projection works", 1, result.size() );
 
-		bQuery = new BooleanQuery();
-		bQuery.add( new TermQuery( new Term( "uuid", "f49c6ba8-8d7f-417a-a255-d594dddf729f" ) ), BooleanClause.Occur.MUST );
+		bQuery = new BooleanQuery.Builder()
+				.add( new TermQuery( new Term( "uuid", "f49c6ba8-8d7f-417a-a255-d594dddf729f" ) ), BooleanClause.Occur.MUST )
+				.build();
 
 		result = session.createFullTextQuery( bQuery ).setProjection( "clazz" ).list();
 		assertEquals( "Clazz projection works", 1, result.size() );
@@ -200,56 +205,57 @@ public class BridgeTest extends SearchTestBase {
 		tx = s.beginTransaction();
 		FullTextSession session = Search.getFullTextSession( s );
 
-		BooleanQuery booleanQuery = new BooleanQuery();
+		BooleanQuery.Builder booleanQueryBuilder = new BooleanQuery.Builder();
 
 		Date myDate = DateTools.round( date, DateTools.Resolution.MILLISECOND );
 		NumericRangeQuery numericRangeQuery = NumericRangeQuery.newLongRange(
 				"myDate", myDate.getTime(), myDate.getTime(), true, true
 		);
-		booleanQuery.add( numericRangeQuery, BooleanClause.Occur.MUST );
+		booleanQueryBuilder.add( numericRangeQuery, BooleanClause.Occur.MUST );
 
 		Date dateDay = DateTools.round( date, DateTools.Resolution.DAY );
 		numericRangeQuery = NumericRangeQuery.newLongRange(
 				"dateDay", dateDay.getTime(), dateDay.getTime(), true, true
 		);
-		booleanQuery.add( numericRangeQuery, BooleanClause.Occur.MUST );
+		booleanQueryBuilder.add( numericRangeQuery, BooleanClause.Occur.MUST );
 
 		Date dateMonth = DateTools.round( date, DateTools.Resolution.MONTH );
 		numericRangeQuery = NumericRangeQuery.newLongRange(
 				"dateMonth", dateMonth.getTime(), dateMonth.getTime(), true, true
 		);
-		booleanQuery.add( numericRangeQuery, BooleanClause.Occur.MUST );
+		booleanQueryBuilder.add( numericRangeQuery, BooleanClause.Occur.MUST );
 
 		Date dateYear = DateTools.round( date, DateTools.Resolution.YEAR );
 		numericRangeQuery = NumericRangeQuery.newLongRange(
 				"dateYear", dateYear.getTime(), dateYear.getTime(), true, true
 		);
-		booleanQuery.add( numericRangeQuery, BooleanClause.Occur.MUST );
+		booleanQueryBuilder.add( numericRangeQuery, BooleanClause.Occur.MUST );
 
 		Date dateHour = DateTools.round( date, DateTools.Resolution.HOUR );
 		numericRangeQuery = NumericRangeQuery.newLongRange(
 				"dateHour", dateHour.getTime(), dateHour.getTime(), true, true
 		);
-		booleanQuery.add( numericRangeQuery, BooleanClause.Occur.MUST );
+		booleanQueryBuilder.add( numericRangeQuery, BooleanClause.Occur.MUST );
 
 		Date dateMinute = DateTools.round( date, DateTools.Resolution.MINUTE );
 		numericRangeQuery = NumericRangeQuery.newLongRange(
 				"dateMinute", dateMinute.getTime(), dateMinute.getTime(), true, true
 		);
-		booleanQuery.add( numericRangeQuery, BooleanClause.Occur.MUST );
+		booleanQueryBuilder.add( numericRangeQuery, BooleanClause.Occur.MUST );
 
 		Date dateSecond = DateTools.round( date, DateTools.Resolution.SECOND );
 		numericRangeQuery = NumericRangeQuery.newLongRange(
 				"dateSecond", dateSecond.getTime(), dateSecond.getTime(), true, true
 		);
-		booleanQuery.add( numericRangeQuery, BooleanClause.Occur.MUST );
+		booleanQueryBuilder.add( numericRangeQuery, BooleanClause.Occur.MUST );
 
 		Date dateMillisecond = DateTools.round( date, DateTools.Resolution.MILLISECOND );
 		numericRangeQuery = NumericRangeQuery.newLongRange(
 				"dateMillisecond", dateMillisecond.getTime(), dateMillisecond.getTime(), true, true
 		);
-		booleanQuery.add( numericRangeQuery, BooleanClause.Occur.MUST );
+		booleanQueryBuilder.add( numericRangeQuery, BooleanClause.Occur.MUST );
 
+		BooleanQuery booleanQuery = booleanQueryBuilder.build();
 		List result = session.createFullTextQuery( booleanQuery ).list();
 		assertEquals( "Date not found or not property truncated", 1, result.size() );
 
@@ -284,55 +290,56 @@ public class BridgeTest extends SearchTestBase {
 		FullTextSession session = Search.getFullTextSession( s );
 
 		Date date = calendar.getTime();
-		BooleanQuery booleanQuery = new BooleanQuery();
+		BooleanQuery.Builder booleanQueryBuilder = new BooleanQuery.Builder();
 		Date myDate = DateTools.round( date, DateTools.Resolution.MILLISECOND );
 		NumericRangeQuery numericRangeQuery = NumericRangeQuery.newLongRange(
 				"myCalendar", myDate.getTime(), myDate.getTime(), true, true
 		);
-		booleanQuery.add( numericRangeQuery, BooleanClause.Occur.MUST );
+		booleanQueryBuilder.add( numericRangeQuery, BooleanClause.Occur.MUST );
 
 		Date dateDay = DateTools.round( date, DateTools.Resolution.DAY );
 		numericRangeQuery = NumericRangeQuery.newLongRange(
 				"calendarDay", dateDay.getTime(), dateDay.getTime(), true, true
 		);
-		booleanQuery.add( numericRangeQuery, BooleanClause.Occur.MUST );
+		booleanQueryBuilder.add( numericRangeQuery, BooleanClause.Occur.MUST );
 
 		Date dateMonth = DateTools.round( date, DateTools.Resolution.MONTH );
 		numericRangeQuery = NumericRangeQuery.newLongRange(
 				"calendarMonth", dateMonth.getTime(), dateMonth.getTime(), true, true
 		);
-		booleanQuery.add( numericRangeQuery, BooleanClause.Occur.MUST );
+		booleanQueryBuilder.add( numericRangeQuery, BooleanClause.Occur.MUST );
 
 		Date dateYear = DateTools.round( date, DateTools.Resolution.YEAR );
 		numericRangeQuery = NumericRangeQuery.newLongRange(
 				"calendarYear", dateYear.getTime(), dateYear.getTime(), true, true
 		);
-		booleanQuery.add( numericRangeQuery, BooleanClause.Occur.MUST );
+		booleanQueryBuilder.add( numericRangeQuery, BooleanClause.Occur.MUST );
 
 		Date dateHour = DateTools.round( date, DateTools.Resolution.HOUR );
 		numericRangeQuery = NumericRangeQuery.newLongRange(
 				"calendarHour", dateHour.getTime(), dateHour.getTime(), true, true
 		);
-		booleanQuery.add( numericRangeQuery, BooleanClause.Occur.MUST );
+		booleanQueryBuilder.add( numericRangeQuery, BooleanClause.Occur.MUST );
 
 		Date dateMinute = DateTools.round( date, DateTools.Resolution.MINUTE );
 		numericRangeQuery = NumericRangeQuery.newLongRange(
 				"calendarMinute", dateMinute.getTime(), dateMinute.getTime(), true, true
 		);
-		booleanQuery.add( numericRangeQuery, BooleanClause.Occur.MUST );
+		booleanQueryBuilder.add( numericRangeQuery, BooleanClause.Occur.MUST );
 
 		Date dateSecond = DateTools.round( date, DateTools.Resolution.SECOND );
 		numericRangeQuery = NumericRangeQuery.newLongRange(
 				"calendarSecond", dateSecond.getTime(), dateSecond.getTime(), true, true
 		);
-		booleanQuery.add( numericRangeQuery, BooleanClause.Occur.MUST );
+		booleanQueryBuilder.add( numericRangeQuery, BooleanClause.Occur.MUST );
 
 		Date dateMillisecond = DateTools.round( date, DateTools.Resolution.MILLISECOND );
 		numericRangeQuery = NumericRangeQuery.newLongRange(
 				"calendarMillisecond", dateMillisecond.getTime(), dateMillisecond.getTime(), true, true
 		);
-		booleanQuery.add( numericRangeQuery, BooleanClause.Occur.MUST );
+		booleanQueryBuilder.add( numericRangeQuery, BooleanClause.Occur.MUST );
 
+		BooleanQuery booleanQuery = booleanQueryBuilder.build();
 		List result = session.createFullTextQuery( booleanQuery ).list();
 		assertEquals( "Calendar not found or not property truncated", 1, result.size() );
 

--- a/orm/src/test/java/org/hibernate/search/test/configuration/ProgrammaticMappingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/ProgrammaticMappingTest.java
@@ -350,19 +350,19 @@ public class ProgrammaticMappingTest extends SearchTestBase {
 		tx = s.beginTransaction();
 
 		long searchTimeStamp = DateTools.round( date.getTime(), DateTools.Resolution.DAY );
-		BooleanQuery booleanQuery = new BooleanQuery();
-		booleanQuery.add(
+		BooleanQuery.Builder booleanQueryBuilder = new BooleanQuery.Builder();
+		booleanQueryBuilder.add(
 				NumericRangeQuery.newLongRange(
 						"date-created", searchTimeStamp, searchTimeStamp, true, true
 				), BooleanClause.Occur.SHOULD
 		);
-		booleanQuery.add(
+		booleanQueryBuilder.add(
 				NumericRangeQuery.newLongRange(
 						"blog-entry-created", searchTimeStamp, searchTimeStamp, true, true
 				), BooleanClause.Occur.SHOULD
 		);
 
-		FullTextQuery query = s.createFullTextQuery( booleanQuery )
+		FullTextQuery query = s.createFullTextQuery( booleanQueryBuilder.build() )
 				.setProjection( FullTextQuery.THIS, FullTextQuery.SCORE );
 		assertEquals( "expecting 3 results", 3, query.getResultSize() );
 

--- a/orm/src/test/java/org/hibernate/search/test/filter/FilterTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/filter/FilterTest.java
@@ -387,10 +387,10 @@ public class FilterTest extends SearchTestBase {
 	}
 
 	private BooleanQuery createQuery() {
-		BooleanQuery query = new BooleanQuery();
-		query.add( new TermQuery( new Term( "teacher", "andre" ) ), BooleanClause.Occur.SHOULD );
-		query.add( new TermQuery( new Term( "teacher", "max" ) ), BooleanClause.Occur.SHOULD );
-		query.add( new TermQuery( new Term( "teacher", "aaron" ) ), BooleanClause.Occur.SHOULD );
-		return query;
+		return new BooleanQuery.Builder()
+				.add( new TermQuery( new Term( "teacher", "andre" ) ), BooleanClause.Occur.SHOULD )
+				.add( new TermQuery( new Term( "teacher", "max" ) ), BooleanClause.Occur.SHOULD )
+				.add( new TermQuery( new Term( "teacher", "aaron" ) ), BooleanClause.Occur.SHOULD )
+				.build();
 	}
 }

--- a/orm/src/test/java/org/hibernate/search/test/query/boost/FieldBoostTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/boost/FieldBoostTest.java
@@ -43,9 +43,10 @@ public class FieldBoostTest extends SearchTestBase {
 		Query author = authorParser.parse( "Wells" );
 		Query desc = descParser.parse( "martians" );
 
-		BooleanQuery query = new BooleanQuery();
-		query.add( author, BooleanClause.Occur.SHOULD );
-		query.add( desc, BooleanClause.Occur.SHOULD );
+		BooleanQuery query = new BooleanQuery.Builder()
+				.add( author, BooleanClause.Occur.SHOULD )
+				.add( desc, BooleanClause.Occur.SHOULD )
+				.build();
 		log.debug( query.toString() );
 
 		org.hibernate.search.FullTextQuery hibQuery =
@@ -82,9 +83,10 @@ public class FieldBoostTest extends SearchTestBase {
 		Query author = authorParser.parse( "Wells" );
 		Query desc = descParser.parse( "martians" );
 
-		BooleanQuery query = new BooleanQuery();
-		query.add( author, BooleanClause.Occur.SHOULD );
-		query.add( desc, BooleanClause.Occur.SHOULD );
+		BooleanQuery query = new BooleanQuery.Builder()
+				.add( author, BooleanClause.Occur.SHOULD )
+				.add( desc, BooleanClause.Occur.SHOULD )
+				.build();
 		log.debug( query.toString() );
 
 		org.hibernate.search.FullTextQuery hibQuery =
@@ -121,9 +123,10 @@ public class FieldBoostTest extends SearchTestBase {
 		Query author = authorParser.parse( "Wells" );
 		Query desc = descParser.parse( "martians" );
 
-		BooleanQuery query = new BooleanQuery();
-		query.add( author, BooleanClause.Occur.SHOULD );
-		query.add( desc, BooleanClause.Occur.SHOULD );
+		BooleanQuery query = new BooleanQuery.Builder()
+				.add( author, BooleanClause.Occur.SHOULD )
+				.add( desc, BooleanClause.Occur.SHOULD )
+				.build();
 		log.debug( query.toString() );
 
 		org.hibernate.search.FullTextQuery hibQuery =


### PR DESCRIPTION
`BooleanQuery` has been used traditionally like this:

> ```java
BooleanQuery q = new BooleanQuery();
q.add( otherQuery, Occur.SOMETHING );
```

But now the no-arguments constructor is deprecated, and adding clauses to the instance is deprecated too.
All our code needs to be updated to use `org.apache.lucene.search.BooleanQuery.Builder` instead, as in Lucene 6 all queries become immutable. `BooleanQuery` is used in many areas, including tests.

This merge contains most of the classes in which `BooleanQuery` is used, except the following : 
* [engine/src/main/java/org/hibernate/search/query/dsl/impl/ConnectedMultiFieldsRangeQueryBuilder.java](https://github.com/hibernate/hibernate-search/blob/master/engine/src/main/java/org/hibernate/search/query/dsl/impl/ConnectedMultiFieldsRangeQueryBuilder.java)
* [engine/src/main/java/org/hibernate/search/query/dsl/impl/MoreLikeThisBuilder.java](https://github.com/hibernate/hibernate-search/blob/master/engine/src/main/java/org/hibernate/search/query/dsl/impl/MoreLikeThisBuilder.java)
* [engine/src/main/java/org/hibernate/search/query/engine/impl/FieldNameCollector.java](https://github.com/hibernate/hibernate-search/blob/master/engine/src/main/java/org/hibernate/search/query/engine/impl/FieldNameCollector.java)

Because I don't know how to modify them correctly.