### PR TITLE
HSEARCH-2071 Support EmbeddedId

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchHSQueryImpl.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchHSQueryImpl.java
@@ -38,7 +38,9 @@ import org.hibernate.search.backend.elasticsearch.logging.impl.Log;
 import org.hibernate.search.bridge.FieldBridge;
 import org.hibernate.search.bridge.TwoWayFieldBridge;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
+import org.hibernate.search.engine.metadata.impl.BridgeDefinedField;
 import org.hibernate.search.engine.metadata.impl.DocumentFieldMetadata;
+import org.hibernate.search.engine.metadata.impl.PropertyMetadata;
 import org.hibernate.search.engine.service.spi.ServiceReference;
 import org.hibernate.search.engine.spi.DocumentBuilderIndexedEntity;
 import org.hibernate.search.engine.spi.EntityIndexBinding;
@@ -256,14 +258,6 @@ public class ElasticsearchHSQueryImpl extends AbstractHSQuery {
 
 		searchResult = searcher.runSearch();
 		resultSize = searchResult.getTotal();
-	}
-
-	private Object getId(JsonObject hit, EntityIndexBinding binding) {
-		Document tmp = new Document();
-		tmp.add( new StringField( "id", DocumentIdHelper.getEntityId( hit.get( "_id" ).getAsString() ), Store.NO) );
-		Object id = binding.getDocumentBuilder().getIdBridge().get( "id", tmp );
-
-		return id;
 	}
 
 	/**
@@ -560,6 +554,25 @@ public class ElasticsearchHSQueryImpl extends AbstractHSQuery {
 			return new EntityInfoImpl( clazz, binding.getDocumentBuilder().getIdentifierName(), (Serializable) id, projections );
 		}
 
+		private Object getId(JsonObject hit, EntityIndexBinding binding) {
+			Document tmp = new Document();
+			tmp.add( new StringField( "id", DocumentIdHelper.getEntityId( hit.get( "_id" ).getAsString() ), Store.NO) );
+
+			addIdBridgeDefinedFields( hit, binding, tmp );
+
+			return binding.getDocumentBuilder().getIdBridge().get( "id", tmp );
+		}
+
+		// Add to the document the additional fields created when indexing the id
+		private void addIdBridgeDefinedFields(JsonObject hit, EntityIndexBinding binding, Document tmp) {
+			Set<BridgeDefinedField> allBridgeDefinedFields = new HashSet<>();
+			allBridgeDefinedFields.addAll( binding.getDocumentBuilder().getMetadata().getIdPropertyMetadata().getBridgeDefinedFields().values() );
+			for ( BridgeDefinedField bridgeDefinedField : allBridgeDefinedFields ) {
+				Object fieldValue = getFieldValue( binding, hit, bridgeDefinedField.getName() );
+				tmp.add( new StringField( bridgeDefinedField.getName(), String.valueOf( fieldValue ), Store.NO ) );
+			}
+		}
+
 		/**
 		 * Returns the value of the given field as retrieved from the ES result and converted using the corresponding
 		 * field bridge. In case this bridge is not a 2-way bridge, the unconverted value will be returned.
@@ -568,13 +581,16 @@ public class ElasticsearchHSQueryImpl extends AbstractHSQuery {
 			DocumentFieldMetadata field = FieldHelper.getFieldMetadata( binding, projectedField );
 
 			if ( field == null ) {
-				throw new IllegalArgumentException( "Unknown field " + projectedField + " for entity "
+				// We check if it is a field created by a field bridge
+				if ( !isBridgeDefinedField( binding, projectedField ) ) {
+					throw new IllegalArgumentException( "Unknown field " + projectedField + " for entity "
 						+ binding.getDocumentBuilder().getMetadata().getType().getName() );
+				}
 			}
 
 			JsonElement value;
 
-			if ( field.isId() ) {
+			if ( field != null && field.isId() ) {
 				value = hit.get( "_id" );
 			}
 			else {
@@ -585,7 +601,27 @@ public class ElasticsearchHSQueryImpl extends AbstractHSQuery {
 				return null;
 			}
 
-			return convertFieldValue( binding, field, value );
+			if ( field != null ) {
+				return convertFieldValue( binding, field, value );
+			}
+			else {
+				return convertPrimitiveValue( value );
+			}
+		}
+
+		private boolean isBridgeDefinedField(EntityIndexBinding binding, String projectedField) {
+			BridgeDefinedField bridgeDefinedField = binding.getDocumentBuilder().getMetadata().getIdPropertyMetadata().getBridgeDefinedFields().get( projectedField );
+			if ( bridgeDefinedField != null ) {
+				return true;
+			}
+			Set<PropertyMetadata> allPropertyMetadata = binding.getDocumentBuilder().getMetadata().getAllPropertyMetadata();
+			for ( PropertyMetadata propertyMetadata : allPropertyMetadata ) {
+				bridgeDefinedField = propertyMetadata.getBridgeDefinedFields().get( projectedField );
+				if ( bridgeDefinedField != null && bridgeDefinedField.getName().equals( projectedField ) ) {
+					return true;
+				}
+			}
+			return false;
 		}
 
 		private Object convertFieldValue(EntityIndexBinding binding, DocumentFieldMetadata field, JsonElement value) {
@@ -626,28 +662,32 @@ public class ElasticsearchHSQueryImpl extends AbstractHSQuery {
 			}
 			// Should only be the case for custom bridges
 			else {
-				// TODO: HSEARCH-2255 should we do it?
-				if ( !value.isJsonPrimitive() ) {
-					throw new SearchException( "Projection of non-JSON-primitive field values is not supported: " + value );
-				}
+				return convertPrimitiveValue( value );
+			}
+		}
 
-				JsonPrimitive primitive = value.getAsJsonPrimitive();
+		private Object convertPrimitiveValue(JsonElement value) {
+			// TODO: HSEARCH-2255 should we do it?
+			if ( !value.isJsonPrimitive() ) {
+				throw LOG.unsupportedProjectionOfNonJsonPrimitiveFields( value );
+			}
 
-				if ( primitive.isBoolean() ) {
-					return primitive.getAsBoolean();
-				}
-				else if ( primitive.isNumber() ) {
-					// TODO HSEARCH-2255 this will expose a Gson-specific Number implementation; Can we somehow return an Integer,
-					// Long... etc. instead?
-					return primitive.getAsNumber();
-				}
-				else if ( primitive.isString() ) {
-					return primitive.getAsString();
-				}
-				else {
-					// TODO HSEARCH-2255 Better raise an exception?
-					return primitive.toString();
-				}
+			JsonPrimitive primitive = value.getAsJsonPrimitive();
+
+			if ( primitive.isBoolean() ) {
+				return primitive.getAsBoolean();
+			}
+			else if ( primitive.isNumber() ) {
+				// TODO HSEARCH-2255 this will expose a Gson-specific Number implementation; Can we somehow return an Integer,
+				// Long... etc. instead?
+				return primitive.getAsNumber();
+			}
+			else if ( primitive.isString() ) {
+				return primitive.getAsString();
+			}
+			else {
+				// TODO HSEARCH-2255 Better raise an exception?
+				return primitive.toString();
 			}
 		}
 

--- a/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchIndexManager.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchIndexManager.java
@@ -74,6 +74,7 @@ public class ElasticsearchIndexManager implements IndexManager, RemoteAnalyzerPr
 	private static final Log LOG = LoggerFactory.make( Log.class );
 
 	private static final String ANALYZED = "analyzed";
+	private static final String NOT_ANALYZED = "not_analyzed";
 
 	private String indexName;
 	private String actualIndexName;
@@ -284,7 +285,7 @@ public class ElasticsearchIndexManager implements IndexManager, RemoteAnalyzerPr
 			// TODO HSEARCH-2256 Should we make this configurable?
 			JsonObject field = new JsonObject();
 			field.addProperty( "type", "string" );
-			field.addProperty( "index", "not_analyzed" );
+			field.addProperty( "index", NOT_ANALYZED );
 			properties.add( DocumentBuilderIndexedEntity.TENANT_ID_FIELDNAME, field );
 
 			// normal document fields
@@ -421,7 +422,7 @@ public class ElasticsearchIndexManager implements IndexManager, RemoteAnalyzerPr
 				// the fields potentially created for the spatial hash queries
 				JsonObject field = new JsonObject();
 				field.addProperty( "type", "string" );
-				field.addProperty( "index", "not_analyzed" );
+				field.addProperty( "index", NOT_ANALYZED );
 
 				getOrCreateProperties( payload, fieldName ).add( fieldName, field );
 			}
@@ -435,7 +436,7 @@ public class ElasticsearchIndexManager implements IndexManager, RemoteAnalyzerPr
 		JsonObject field = new JsonObject();
 		field.addProperty( "type", getFieldType( facetMetadata ) );
 		field.addProperty( "store", false );
-		field.addProperty( "index", "not_analyzed" );
+		field.addProperty( "index", NOT_ANALYZED );
 
 		getOrCreateProperties( payload, fullFieldName).add( simpleFieldName, field );
 		return field;
@@ -447,7 +448,7 @@ public class ElasticsearchIndexManager implements IndexManager, RemoteAnalyzerPr
 		if ( FieldHelper.isBoolean( binding, fieldMetadata.getName() ) ||
 				FieldHelper.isDate( binding, fieldMetadata.getName() ) ||
 				FieldHelper.isNumeric(fieldMetadata) ) {
-			return "not_analyzed";
+			return NOT_ANALYZED;
 		}
 
 		return getIndexValue( fieldMetadata.getIndex() );
@@ -459,7 +460,7 @@ public class ElasticsearchIndexManager implements IndexManager, RemoteAnalyzerPr
 		if ( FieldHelper.isBoolean( bridgeDefinedField )
 				|| FieldHelper.isNumeric( bridgeDefinedField )
 				|| FieldHelper.isDate( bridgeDefinedField ) ) {
-			return "not_analyzed";
+			return NOT_ANALYZED;
 		}
 
 		Field.Index index = bridgeDefinedField.getIndex();
@@ -473,7 +474,7 @@ public class ElasticsearchIndexManager implements IndexManager, RemoteAnalyzerPr
 				return ANALYZED;
 			case NOT_ANALYZED:
 			case NOT_ANALYZED_NO_NORMS:
-				return "not_analyzed";
+				return NOT_ANALYZED;
 			case NO:
 				return "no";
 			default:

--- a/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchIndexManager.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchIndexManager.java
@@ -442,7 +442,6 @@ public class ElasticsearchIndexManager implements IndexManager, RemoteAnalyzerPr
 		return field;
 	}
 
-	@SuppressWarnings("deprecation")
 	private String getIndex(EntityIndexBinding binding, DocumentFieldMetadata fieldMetadata) {
 		// Never analyze boolean, date or numeric
 		if ( FieldHelper.isBoolean( binding, fieldMetadata.getName() ) ||

--- a/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchIndexManager.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchIndexManager.java
@@ -12,6 +12,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.document.Field;
 import org.apache.lucene.search.similarities.Similarity;
 import org.hibernate.search.analyzer.impl.AnalyzerReference;
 import org.hibernate.search.analyzer.impl.RemoteAnalyzer;
@@ -345,11 +346,9 @@ public class ElasticsearchIndexManager implements IndexManager, RemoteAnalyzerPr
 		String index = getIndex( descriptor, fieldMetadata );
 		field.addProperty( "index", index );
 
-		if ( isAnalyzed( index ) && fieldMetadata.getAnalyzerReference() != null ) {
-			String analyzerName = analyzerName( descriptor.getDocumentBuilder().getBeanClass(), fieldMetadata );
-			if ( analyzerName != null ) {
-				field.addProperty( "analyzer", analyzerName );
-			}
+		String analyzerName = getAnalyzerName( descriptor, fieldMetadata, index );
+		if ( analyzerName != null ) {
+			field.addProperty( "analyzer", analyzerName );
 		}
 
 		if ( fieldMetadata.getBoost() != null ) {
@@ -372,6 +371,13 @@ public class ElasticsearchIndexManager implements IndexManager, RemoteAnalyzerPr
 		}
 	}
 
+	private String getAnalyzerName(EntityIndexBinding descriptor, DocumentFieldMetadata fieldMetadata, String index) {
+		if ( isAnalyzed( index ) && fieldMetadata.getAnalyzerReference() != null ) {
+			return analyzerName( descriptor.getDocumentBuilder().getBeanClass(), fieldMetadata );
+		}
+		return null;
+	}
+
 	private boolean isAnalyzed(String index) {
 		return ANALYZED.equals( index );
 	}
@@ -386,7 +392,9 @@ public class ElasticsearchIndexManager implements IndexManager, RemoteAnalyzerPr
 			JsonObject field = new JsonObject();
 
 			field.addProperty( "type", getFieldType( bridgeDefinedField ) );
-			field.addProperty( "index", ANALYZED );
+
+			String index = getIndex( bridgeDefinedField );
+			field.addProperty( "index", index );
 
 			// we don't overwrite already defined fields. Typically, in the case of spatial, the geo_point field
 			// is defined before the double field and we want to keep the geo_point one
@@ -442,7 +450,24 @@ public class ElasticsearchIndexManager implements IndexManager, RemoteAnalyzerPr
 			return "not_analyzed";
 		}
 
-		switch ( fieldMetadata.getIndex() ) {
+		return getIndexValue( fieldMetadata.getIndex() );
+	}
+
+	@SuppressWarnings("deprecation")
+	private String getIndex(BridgeDefinedField bridgeDefinedField) {
+		// Never analyze boolean
+		if ( FieldHelper.isBoolean( bridgeDefinedField )
+				|| FieldHelper.isNumeric( bridgeDefinedField )
+				|| FieldHelper.isDate( bridgeDefinedField ) ) {
+			return "not_analyzed";
+		}
+
+		Field.Index index = bridgeDefinedField.getIndex();
+		return getIndexValue( index );
+	}
+
+	private String getIndexValue(Field.Index index) {
+		switch ( index ) {
 			case ANALYZED:
 			case ANALYZED_NO_NORMS:
 				return ANALYZED;
@@ -452,7 +477,7 @@ public class ElasticsearchIndexManager implements IndexManager, RemoteAnalyzerPr
 			case NO:
 				return "no";
 			default:
-				throw new IllegalArgumentException( "Unexpected index type: " + fieldMetadata.getIndex() );
+				throw new IllegalArgumentException( "Unexpected index type: " + index );
 		}
 	}
 

--- a/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/FieldHelper.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/FieldHelper.java
@@ -19,6 +19,7 @@ import org.hibernate.search.engine.metadata.impl.EmbeddedTypeMetadata;
 import org.hibernate.search.engine.metadata.impl.PropertyMetadata;
 import org.hibernate.search.engine.metadata.impl.TypeMetadata;
 import org.hibernate.search.engine.spi.EntityIndexBinding;
+import org.hibernate.search.exception.AssertionFailure;
 import org.hibernate.search.metadata.NumericFieldSettingsDescriptor.NumericEncodingType;
 
 /**
@@ -74,9 +75,17 @@ class FieldHelper {
 		return "boolean".equals( propertyTypeName ) || "java.lang.Boolean".equals( propertyTypeName );
 	}
 
+	static boolean isBoolean(BridgeDefinedField field) {
+		return FieldType.BOOLEAN == field.getType();
+	}
+
 	static boolean isDate(EntityIndexBinding indexBinding, String fieldName) {
 		String propertyTypeName = getPropertyTypeName( indexBinding, fieldName );
 		return "java.util.Date".equals( propertyTypeName );
+	}
+
+	static boolean isDate(BridgeDefinedField field) {
+		return FieldType.DATE == field.getType();
 	}
 
 	static boolean isNumeric(DocumentFieldMetadata field) {
@@ -91,6 +100,22 @@ class FieldHelper {
 		}
 
 		return false;
+	}
+
+	static boolean isNumeric(BridgeDefinedField field) {
+		switch ( field.getType() ) {
+			case LONG:
+			case INTEGER:
+			case FLOAT:
+			case DOUBLE:
+				return true;
+			case STRING:
+			case BOOLEAN:
+			case DATE:
+				return false;
+			default:
+				throw new AssertionFailure( "Type not recognized: " + field.getType() );
+		}
 	}
 
 	static String[] getFieldNameParts(String fieldName) {

--- a/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
@@ -24,6 +24,8 @@ import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.Param;
 
+import com.google.gson.JsonElement;
+
 import io.searchbox.client.JestResult;
 
 /**
@@ -77,4 +79,7 @@ public interface Log extends org.hibernate.search.util.logging.impl.Log {
 			value = "Elasticsearch connection time-out; check the cluster status, it should be 'green';\n Request:\n========\n%1$sResponse:\n=========\n%2$s" )
 	SearchException elasticsearchRequestTimeout(String request, String response);
 
+	@Message(id = ES_BACKEND_MESSAGES_START_ID + 11,
+			value = "Projection of non-JSON-primitive field values is not supported: '%1$s'")
+	SearchException unsupportedProjectionOfNonJsonPrimitiveFields(JsonElement value);
 }

--- a/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/CheckCustomFieldDefaultsIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/CheckCustomFieldDefaultsIT.java
@@ -1,0 +1,116 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.test;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.search.annotations.Analyze;
+import org.hibernate.search.annotations.Analyzer;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.FieldBridge;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.bridge.MetadataProvidingFieldBridge;
+import org.hibernate.search.test.bridge.CheckCustomFieldDefaultAnalyzer;
+import org.hibernate.search.test.bridge.CheckCustomFieldDefaultsTest;
+
+/**
+ * Test that custom fields created using a {@link MetadataProvidingFieldBridge} use the expected
+ * defaults.
+ *
+ * @see CheckCustomFieldDefaultsTest
+ * @author Davide D'Alto
+ */
+public class CheckCustomFieldDefaultsIT extends CheckCustomFieldDefaultAnalyzer {
+
+	@Override
+	protected Object entity(String id, String code, String result) {
+		Experiment experiment = new Experiment();
+		experiment.id = id;
+		experiment.subject = code;
+		experiment.result = result;
+		return experiment;
+	}
+
+
+	@Override
+	protected Class<?> getEntityType() {
+		return Experiment.class;
+	}
+
+	@Override
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class[]{ Experiment.class };
+	}
+
+	@Entity
+	@Indexed
+	public static class Experiment {
+
+		@Id
+		@FieldBridge(impl = AdditionalFieldBridge.class)
+		public String id;
+
+		@Field(analyze = Analyze.NO)
+		@FieldBridge(impl = AdditionalFieldBridge.class)
+		public String subject;
+
+		@Field(analyze = Analyze.YES)
+		@FieldBridge(impl = AdditionalFieldBridge.class)
+		@Analyzer(definition = "whitespace")
+		public String result;
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + ( ( id == null ) ? 0 : id.hashCode() );
+			result = prime * result + ( ( this.result == null ) ? 0 : this.result.hashCode() );
+			result = prime * result + ( ( subject == null ) ? 0 : subject.hashCode() );
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if ( this == obj ) {
+				return true;
+			}
+			if ( obj == null ) {
+				return false;
+			}
+			if ( getClass() != obj.getClass() ) {
+				return false;
+			}
+			Experiment other = (Experiment) obj;
+			if ( id == null ) {
+				if ( other.id != null ) {
+					return false;
+				}
+			}
+			else if ( !id.equals( other.id ) ) {
+				return false;
+			}
+			if ( result == null ) {
+				if ( other.result != null ) {
+					return false;
+				}
+			}
+			else if ( !result.equals( other.result ) ) {
+				return false;
+			}
+			if ( subject == null ) {
+				if ( other.subject != null ) {
+					return false;
+				}
+			}
+			else if ( !subject.equals( other.subject ) ) {
+				return false;
+			}
+			return true;
+		}
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
@@ -365,7 +365,7 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 		checkForSortableFields( member, typeMetadataBuilder, propertyMetadataBuilder, "", true, null, parseContext );
 
 		if ( idBridge instanceof MetadataProvidingFieldBridge ) {
-			FieldMetadataBuilderImpl bridgeDefinedMetadata = getBridgeContributedFieldMetadata( path, (MetadataProvidingFieldBridge) idBridge );
+			FieldMetadataBuilderImpl bridgeDefinedMetadata = getBridgeContributedFieldMetadata( fieldMetadata, (MetadataProvidingFieldBridge) idBridge );
 
 			for ( BridgeDefinedField bridgeDefinedField : bridgeDefinedMetadata.getFields() ) {
 				propertyMetadataBuilder.addBridgeDefinedField( bridgeDefinedField );
@@ -696,7 +696,7 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 
 		typeMetadataBuilder.addClassBridgeField( fieldMetadata );
 
-		contributeClassBridgeDefinedFields( typeMetadataBuilder, fieldName, fieldBridge );
+		contributeClassBridgeDefinedFields( typeMetadataBuilder, fieldMetadata, fieldBridge );
 
 		if ( !parseContext.skipAnalyzers() ) {
 			AnalyzerReference analyzer = AnnotationProcessingHelper.getAnalyzerReference(
@@ -742,7 +742,7 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 
 		if ( fieldBridge instanceof MetadataProvidingFieldBridge ) {
 			MetadataProvidingFieldBridge metadataProvidingFieldBridge = (MetadataProvidingFieldBridge) fieldBridge;
-			FieldMetadataBuilderImpl bridgeContributedMetadata = getBridgeContributedFieldMetadata( fieldName, metadataProvidingFieldBridge );
+			FieldMetadataBuilderImpl bridgeContributedMetadata = getBridgeContributedFieldMetadata( fieldMetadata, metadataProvidingFieldBridge );
 			for ( BridgeDefinedField field : bridgeContributedMetadata.getFields() ) {
 				propertyMetadataBuilder.addBridgeDefinedField( field );
 			}
@@ -783,7 +783,7 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 
 		typeMetadataBuilder.addClassBridgeField( fieldMetadata );
 
-		contributeClassBridgeDefinedFields( typeMetadataBuilder, fieldName, spatialBridge );
+		contributeClassBridgeDefinedFields( typeMetadataBuilder, fieldMetadata, spatialBridge );
 
 		AnalyzerReference analyzerReference = typeMetadataBuilder.getAnalyzerReference();
 		if ( analyzerReference == null ) {
@@ -791,11 +791,11 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 		}
 	}
 
-	private void contributeClassBridgeDefinedFields(TypeMetadata.Builder typeMetadataBuilder, String fieldName, FieldBridge fieldBridge) {
+	private void contributeClassBridgeDefinedFields(TypeMetadata.Builder typeMetadataBuilder, DocumentFieldMetadata fieldMetadata, FieldBridge fieldBridge) {
 		if ( fieldBridge instanceof MetadataProvidingFieldBridge ) {
 			MetadataProvidingFieldBridge metadataProvidingFieldBridge = (MetadataProvidingFieldBridge) fieldBridge;
 
-			FieldMetadataBuilderImpl classBridgeContributedFieldMetadata = getBridgeContributedFieldMetadata( fieldName, metadataProvidingFieldBridge );
+			FieldMetadataBuilderImpl classBridgeContributedFieldMetadata = getBridgeContributedFieldMetadata( fieldMetadata, metadataProvidingFieldBridge );
 
 			typeMetadataBuilder.addClassBridgeSortableFields( classBridgeContributedFieldMetadata.getSortableFields() );
 			typeMetadataBuilder.addClassBridgeDefinedFields( classBridgeContributedFieldMetadata.getFields() );
@@ -1203,22 +1203,6 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 			);
 		}
 
-		if ( fieldBridge instanceof MetadataProvidingFieldBridge ) {
-			MetadataProvidingFieldBridge metadataProvidingFieldBridge = (MetadataProvidingFieldBridge) fieldBridge;
-			FieldMetadataBuilderImpl bridgeContributedMetadata = getBridgeContributedFieldMetadata( fieldName, metadataProvidingFieldBridge );
-
-			for ( String sortableField : bridgeContributedMetadata.getSortableFields() ) {
-				SortableFieldMetadata sortableFieldMetadata = new SortableFieldMetadata.Builder()
-					.fieldName( sortableField )
-					.build();
-				propertyMetadataBuilder.addSortableField( sortableFieldMetadata );
-			}
-
-			for ( BridgeDefinedField field : bridgeContributedMetadata.getFields() ) {
-				propertyMetadataBuilder.addBridgeDefinedField( field );
-			}
-		}
-
 		final NumericEncodingType numericEncodingType = determineNumericFieldEncoding( fieldBridge );
 		final NullMarkerCodec nullTokenCodec = determineNullMarkerCodec( fieldAnnotation, configContext, numericEncodingType, fieldName );
 		if ( nullTokenCodec != NotEncodingCodec.SINGLETON && fieldBridge instanceof TwoWayFieldBridge ) {
@@ -1285,6 +1269,22 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 
 		DocumentFieldMetadata fieldMetadata = fieldMetadataBuilder.build();
 		propertyMetadataBuilder.addDocumentField( fieldMetadata );
+
+		if ( fieldBridge instanceof MetadataProvidingFieldBridge ) {
+			MetadataProvidingFieldBridge metadataProvidingFieldBridge = (MetadataProvidingFieldBridge) fieldBridge;
+			FieldMetadataBuilderImpl bridgeContributedMetadata = getBridgeContributedFieldMetadata( fieldMetadata, metadataProvidingFieldBridge );
+
+			for ( String sortableField : bridgeContributedMetadata.getSortableFields() ) {
+				SortableFieldMetadata sortableFieldMetadata = new SortableFieldMetadata.Builder()
+					.fieldName( sortableField )
+					.build();
+				propertyMetadataBuilder.addSortableField( sortableFieldMetadata );
+			}
+
+			for ( BridgeDefinedField field : bridgeContributedMetadata.getFields() ) {
+				propertyMetadataBuilder.addBridgeDefinedField( field );
+			}
+		}
 
 		// keep track of collection role names for ORM integration optimization based on collection update events
 		parseContext.collectUnqualifiedCollectionRole( member.getName() );
@@ -1916,9 +1916,9 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 		return true;
 	}
 
-	private FieldMetadataBuilderImpl getBridgeContributedFieldMetadata(String fieldName, MetadataProvidingFieldBridge metadataProvidingFieldBridge) {
-		FieldMetadataBuilderImpl builder = new FieldMetadataBuilderImpl();
-		metadataProvidingFieldBridge.configureFieldMetadata( fieldName, builder );
+	private FieldMetadataBuilderImpl getBridgeContributedFieldMetadata(DocumentFieldMetadata fieldMetadata, MetadataProvidingFieldBridge metadataProvidingFieldBridge) {
+		FieldMetadataBuilderImpl builder = new FieldMetadataBuilderImpl( fieldMetadata );
+		metadataProvidingFieldBridge.configureFieldMetadata( fieldMetadata.getFieldName(), builder );
 		return builder;
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/BridgeDefinedField.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/BridgeDefinedField.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.engine.metadata.impl;
 
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.Field.Index;
 import org.hibernate.search.bridge.spi.FieldType;
 
 /**
@@ -15,12 +17,18 @@ import org.hibernate.search.bridge.spi.FieldType;
  */
 public class BridgeDefinedField {
 
-	private String name;
-	private FieldType type;
+	private final String name;
+	private final FieldType type;
+	private final Index index;
 
-	public BridgeDefinedField(String name, FieldType type) {
+	public BridgeDefinedField(String name, FieldType type, Index index) {
 		this.name = name;
 		this.type = type;
+		this.index = index;
+	}
+
+	public Field.Index getIndex() {
+		return index;
 	}
 
 	public String getName() {

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/FieldMetadataBuilderImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/FieldMetadataBuilderImpl.java
@@ -22,6 +22,11 @@ class FieldMetadataBuilderImpl implements FieldMetadataBuilder {
 
 	private final Set<String> sortableFields = new HashSet<>();
 	private final Set<BridgeDefinedField> fields = new HashSet<>();
+	private final DocumentFieldMetadata fieldMetadata;
+
+	public FieldMetadataBuilderImpl(DocumentFieldMetadata fieldMetadata) {
+		this.fieldMetadata = fieldMetadata;
+	}
 
 	@Override
 	public FieldMetadataCreationContext field(String name, FieldType type) {
@@ -43,7 +48,7 @@ class FieldMetadataBuilderImpl implements FieldMetadataBuilder {
 
 		public FieldMetadataCreationContextImpl(String name, FieldType type) {
 			this.fieldName = name;
-			fields.add( new BridgeDefinedField( name, type ) );
+			fields.add( new BridgeDefinedField( name, type, fieldMetadata.getIndex() ) );
 		}
 
 		@Override

--- a/orm/src/test/java/org/hibernate/search/test/bridge/CheckCustomFieldDefaultAnalyzer.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/CheckCustomFieldDefaultAnalyzer.java
@@ -1,0 +1,169 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.bridge;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.TermQuery;
+import org.fest.assertions.Assertions;
+import org.hibernate.Session;
+import org.hibernate.search.Search;
+import org.hibernate.search.bridge.LuceneOptions;
+import org.hibernate.search.bridge.MetadataProvidingFieldBridge;
+import org.hibernate.search.bridge.TwoWayFieldBridge;
+import org.hibernate.search.bridge.spi.FieldMetadataBuilder;
+import org.hibernate.search.bridge.spi.FieldType;
+import org.hibernate.search.test.SearchTestBase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Groups together tests to check the defaults used when a custom field is created using a
+ * {@link MetadataProvidingFieldBridge}.
+ * <p>
+ * The entity is expected to have three fields: an id, an analyzed field and a not analyzed field.
+ * Each of these fields will have a copy created using {@link AdditionalFieldBridge}.
+ *
+ * @author Davide D'Alto
+ */
+public abstract class CheckCustomFieldDefaultAnalyzer extends SearchTestBase {
+
+	@Before
+	public void before() throws Exception {
+		try ( Session session = openSession() ) {
+			session.beginTransaction();
+			session.persist( entity() );
+			session.getTransaction().commit();
+		}
+	}
+
+	private Object entity() {
+		return entity( "GLaDOS", "CHELL", "WELL DONE. HERE COME THE TEST RESULTS: 'YOU ARE A HORRIBLE PERSON." );
+	}
+
+	protected abstract Object entity(String id, String notAnalyzedField, String analyzedField);
+
+	protected abstract Class<?> getEntityType();
+
+	@After
+	public void after() throws Exception {
+		try ( Session session = openSession() ) {
+			session.beginTransaction();
+			session.delete( entity() );
+			session.getTransaction().commit();
+		}
+	}
+
+	@Test
+	public void shouldBeAbleToFindTheCustomIdField() throws Exception {
+		try ( Session session = openSession() ) {
+			session.beginTransaction();
+			TermQuery termQuery = new TermQuery( new Term( "copy_of_id", "GLaDOS" ) );
+			Object result = Search.getFullTextSession( session ).createFullTextQuery( termQuery, getEntityType() ).uniqueResult();
+			Assertions.assertThat( result ).isEqualTo( entity() );
+			session.getTransaction().commit();
+		}
+	}
+
+	@Test
+	public void shouldNotAnalyzeCustomIdField() throws Exception {
+		try ( Session session = openSession() ) {
+			session.beginTransaction();
+			TermQuery termQuery = new TermQuery( new Term( "copy_of_id", "glados" ) );
+			Object result = Search.getFullTextSession( session ).createFullTextQuery( termQuery, getEntityType() ).uniqueResult();
+			Assertions.assertThat( result ).isNull();
+			session.getTransaction().commit();
+		}
+	}
+
+	@Test
+	public void shouldBeAbleToFindNotAnalyzedCustomField() throws Exception {
+		try ( Session session = openSession() ) {
+			session.beginTransaction();
+			TermQuery termQuery = new TermQuery( new Term( "copy_of_subject", "CHELL" ) );
+			Object result = Search.getFullTextSession( session ).createFullTextQuery( termQuery, getEntityType() ).uniqueResult();
+			Assertions.assertThat( result ).isEqualTo( entity() );
+			session.getTransaction().commit();
+		}
+	}
+
+	@Test
+	public void shouldNotAnalyzeCustomField() throws Exception {
+		try ( Session session = openSession() ) {
+			session.beginTransaction();
+			TermQuery termQuery = new TermQuery( new Term( "copy_of_subject", "chell" ) );
+			Object result = Search.getFullTextSession( session ).createFullTextQuery( termQuery, getEntityType() ).uniqueResult();
+			Assertions.assertThat( result ).isNull();
+			session.getTransaction().commit();
+		}
+	}
+
+	@Test
+	// The analyzer is applied for the annotated field
+	public void shouldBeAbleToFindAnalyzedAnnotatedField() throws Exception {
+		try ( Session session = openSession() ) {
+			session.beginTransaction();
+			TermQuery termQuery = new TermQuery( new Term( "result", "HORRIBLE" ) );
+			Object result = Search.getFullTextSession( session ).createFullTextQuery( termQuery, getEntityType() ).uniqueResult();
+			Assertions.assertThat( result ).isEqualTo( entity() );
+			session.getTransaction().commit();
+		}
+	}
+
+	@Test
+	// The custom field will use the default analyzer instead of the one defined on the field
+	public void shouldNotBeAbleToFindAnalyzedCustomField() throws Exception {
+		try ( Session session = openSession() ) {
+			session.beginTransaction();
+			TermQuery termQuery = new TermQuery( new Term( "copy_of_result", "HORRIBLE" ) );
+			Object result = Search.getFullTextSession( session ).createFullTextQuery( termQuery, getEntityType() ).uniqueResult();
+			Assertions.assertThat( result ).isNull();
+			session.getTransaction().commit();
+		}
+	}
+
+	@Test
+	// THe custom field used the default analyzer instead of the one defined on the field
+	public void shouldBeAbleToFindAnalyzedCustomField() throws Exception {
+		try ( Session session = openSession() ) {
+			session.beginTransaction();
+			TermQuery termQuery = new TermQuery( new Term( "copy_of_result", "horrible" ) );
+			Object result = Search.getFullTextSession( session ).createFullTextQuery( termQuery, getEntityType() ).uniqueResult();
+			Assertions.assertThat( result ).isEqualTo( entity() );
+			session.getTransaction().commit();
+		}
+	}
+
+	public static class AdditionalFieldBridge implements MetadataProvidingFieldBridge, TwoWayFieldBridge {
+
+		@Override
+		public void set(String name, Object value, Document document, LuceneOptions luceneOptions) {
+			luceneOptions.addFieldToDocument( name, (String) value, document );
+			luceneOptions.addFieldToDocument( copyOf( name ), (String) value, document );
+		}
+
+		private String copyOf(String name) {
+			return "copy_of_" + name;
+		}
+
+		@Override
+		public void configureFieldMetadata(String name, FieldMetadataBuilder builder) {
+			builder.field( copyOf( name ), FieldType.STRING );
+		}
+
+		@Override
+		public Object get(String name, Document document) {
+			return document.get( name );
+		}
+
+		@Override
+		public String objectToString(Object object) {
+			return (String) object;
+		}
+	}
+}

--- a/orm/src/test/java/org/hibernate/search/test/bridge/CheckCustomFieldDefaultsTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/CheckCustomFieldDefaultsTest.java
@@ -1,0 +1,115 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.bridge;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
+import org.hibernate.search.annotations.Analyze;
+import org.hibernate.search.annotations.Analyzer;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.FieldBridge;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.bridge.MetadataProvidingFieldBridge;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Test that custom fields created using a {@link MetadataProvidingFieldBridge} use the expected defaults.
+ *
+ * @author Davide D'Alto
+ */
+@Category(SkipOnElasticsearch.class)
+public class CheckCustomFieldDefaultsTest extends CheckCustomFieldDefaultAnalyzer {
+
+	@Override
+	protected Object entity(String id, String code, String result) {
+		Experiment experiment = new Experiment();
+		experiment.id = id;
+		experiment.subject = code;
+		experiment.result = result;
+		return experiment;
+	}
+
+	@Override
+	protected Class<?> getEntityType() {
+		return Experiment.class;
+	}
+
+	@Override
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class[]{ Experiment.class };
+	}
+
+	@Entity
+	@Indexed
+	public static class Experiment {
+
+		@Id
+		@FieldBridge(impl = AdditionalFieldBridge.class)
+		public String id;
+
+		@Field(analyze = Analyze.NO)
+		@FieldBridge(impl = AdditionalFieldBridge.class)
+		public String subject;
+
+		@Field(analyze = Analyze.YES)
+		@FieldBridge(impl = AdditionalFieldBridge.class)
+		@Analyzer(impl = WhitespaceAnalyzer.class)
+		public String result;
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + ( ( id == null ) ? 0 : id.hashCode() );
+			result = prime * result + ( ( this.result == null ) ? 0 : this.result.hashCode() );
+			result = prime * result + ( ( subject == null ) ? 0 : subject.hashCode() );
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if ( this == obj ) {
+				return true;
+			}
+			if ( obj == null ) {
+				return false;
+			}
+			if ( getClass() != obj.getClass() ) {
+				return false;
+			}
+			Experiment other = (Experiment) obj;
+			if ( id == null ) {
+				if ( other.id != null ) {
+					return false;
+				}
+			}
+			else if ( !id.equals( other.id ) ) {
+				return false;
+			}
+			if ( result == null ) {
+				if ( other.result != null ) {
+					return false;
+				}
+			}
+			else if ( !result.equals( other.result ) ) {
+				return false;
+			}
+			if ( subject == null ) {
+				if ( other.subject != null ) {
+					return false;
+				}
+			}
+			else if ( !subject.equals( other.subject ) ) {
+				return false;
+			}
+			return true;
+		}
+	}
+}

--- a/orm/src/test/java/org/hibernate/search/test/id/EmbeddedIdTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/id/EmbeddedIdTest.java
@@ -63,7 +63,7 @@ public class EmbeddedIdTest extends SearchTestBase {
 	}
 
 	/**
-	 * HSEARCH-HSEARCH-306, HSEARCH-248
+	 * HSEARCH-306, HSEARCH-248
 	 *
 	 * @throws Exception throws exception in case the test fails.
 	 */

--- a/orm/src/test/java/org/hibernate/search/test/id/withmeta/EmbeddedIdWithMetadataProvidingBridgeTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/id/withmeta/EmbeddedIdWithMetadataProvidingBridgeTest.java
@@ -1,0 +1,115 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.id.withmeta;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.TermQuery;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.search.Search;
+import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.test.id.EmbeddedIdTest;
+import org.junit.Test;
+
+/**
+ * This test class is a copy of {@link EmbeddedIdTest} with the difference that the fields created by
+ * the bridges won't contain `.`.
+ * <p>
+ * The reason behind it is that Elasticsearch does not allow fields name to contain a `.`.
+ *
+ * @author Davide D'Alto
+ */
+public class EmbeddedIdWithMetadataProvidingBridgeTest extends SearchTestBase {
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testFieldBridge() throws Exception {
+		PersonPK emmanuelPk = new PersonPK();
+		emmanuelPk.setFirstName( "Emmanuel" );
+		emmanuelPk.setLastName( "Bernard" );
+		Person emmanuel = new Person();
+		emmanuel.setFavoriteColor( "Blue" );
+		emmanuel.setId( emmanuelPk );
+
+		Session s = openSession();
+		Transaction tx = s.beginTransaction();
+		s.save( emmanuel );
+		tx.commit();
+		s.clear();
+
+		tx = s.beginTransaction();
+		List<Person> results = Search.getFullTextSession( s ).createFullTextQuery(
+				new TermQuery( new Term( "id_lastName", "Bernard" ) )
+		).list();
+		assertEquals( 1, results.size() );
+		emmanuel = (Person) results.get( 0 );
+		emmanuel.setFavoriteColor( "Red" );
+		tx.commit();
+		s.clear();
+
+		tx = s.beginTransaction();
+		results = Search.getFullTextSession( s ).createFullTextQuery(
+				new TermQuery( new Term( "id_lastName", "Bernard" ) )
+		).list();
+		assertEquals( 1, results.size() );
+		emmanuel = (Person) results.get( 0 );
+		assertEquals( "Red", emmanuel.getFavoriteColor() );
+		s.delete( results.get( 0 ) );
+		tx.commit();
+		s.close();
+	}
+
+	/**
+	 * HSEARCH-306, HSEARCH-248
+	 *
+	 * @throws Exception throws exception in case the test fails.
+	 */
+	@Test
+	public void testSafeFromTupleId() throws Exception {
+		PersonPK emmanuelPk = new PersonPK();
+		emmanuelPk.setFirstName( "Emmanuel" );
+		emmanuelPk.setLastName( "Bernard" );
+		Person emmanuel = new Person();
+		emmanuel.setFavoriteColor( "Blue" );
+		emmanuel.setId( emmanuelPk );
+
+		PersonPK johnPk = new PersonPK();
+		johnPk.setFirstName( "John" );
+		johnPk.setLastName( "Doe" );
+		Person john = new Person();
+		john.setFavoriteColor( "Blue" );
+		john.setId( johnPk );
+
+		Session s = openSession();
+		Transaction tx = s.beginTransaction();
+		s.save( emmanuel );
+		s.save( john );
+		tx.commit();
+		s.clear();
+
+		tx = s.beginTransaction();
+
+		// we need a query which has at least the size of two.
+		List results = Search.getFullTextSession( s ).createFullTextQuery(
+				new TermQuery( new Term( "favoriteColor", "blue" ) )
+		).list();
+		assertEquals( 2, results.size() );
+		tx.commit();
+		s.close();
+	}
+
+	@Override
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class[] {
+				Person.class
+		};
+	}
+}

--- a/orm/src/test/java/org/hibernate/search/test/id/withmeta/Person.java
+++ b/orm/src/test/java/org/hibernate/search/test/id/withmeta/Person.java
@@ -1,0 +1,44 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.id.withmeta;
+
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.FieldBridge;
+import org.hibernate.search.annotations.Indexed;
+
+/**
+ * @author Davide D'Alto
+ */
+@Entity
+@Indexed
+public class Person {
+
+	@EmbeddedId
+	@FieldBridge(impl = PersonPKMetadataProviderBridge.class)
+	private PersonPK id;
+	private String favoriteColor;
+
+	public PersonPK getId() {
+		return id;
+	}
+
+	public void setId(PersonPK id) {
+		this.id = id;
+	}
+
+	@Field
+	public String getFavoriteColor() {
+		return favoriteColor;
+	}
+
+	public void setFavoriteColor(String favoriteColor) {
+		this.favoriteColor = favoriteColor;
+	}
+}

--- a/orm/src/test/java/org/hibernate/search/test/id/withmeta/PersonPK.java
+++ b/orm/src/test/java/org/hibernate/search/test/id/withmeta/PersonPK.java
@@ -1,0 +1,64 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.id.withmeta;
+
+import java.io.Serializable;
+import javax.persistence.Embeddable;
+
+/**
+ * @author Davide D'Alto
+ */
+@SuppressWarnings("serial")
+@Embeddable
+public class PersonPK implements Serializable {
+	private String firstName;
+	private String lastName;
+
+	public String getLastName() {
+		return lastName;
+	}
+
+	public void setLastName(String lastName) {
+		this.lastName = lastName;
+	}
+
+	public String getFirstName() {
+		return firstName;
+	}
+
+	public void setFirstName(String firstName) {
+		this.firstName = firstName;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if ( this == o ) {
+			return true;
+		}
+		if ( !( o instanceof PersonPK ) ) {
+			return false;
+		}
+		PersonPK personPK = (PersonPK) o;
+
+		if ( firstName != null ? !firstName.equals( personPK.firstName ) : personPK.firstName != null ) {
+			return false;
+		}
+		if ( lastName != null ? !lastName.equals( personPK.lastName ) : personPK.lastName != null ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		int result;
+		result = ( firstName != null ? firstName.hashCode() : 0 );
+		result = 31 * result + ( lastName != null ? lastName.hashCode() : 0 );
+		return result;
+	}
+}

--- a/orm/src/test/java/org/hibernate/search/test/id/withmeta/PersonPKMetadataProviderBridge.java
+++ b/orm/src/test/java/org/hibernate/search/test/id/withmeta/PersonPKMetadataProviderBridge.java
@@ -1,0 +1,69 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.id.withmeta;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexableField;
+
+import org.hibernate.search.bridge.LuceneOptions;
+import org.hibernate.search.bridge.MetadataProvidingFieldBridge;
+import org.hibernate.search.bridge.TwoWayFieldBridge;
+import org.hibernate.search.bridge.spi.FieldMetadataBuilder;
+import org.hibernate.search.bridge.spi.FieldType;
+
+/**
+ * @author Davide D'Alto
+ */
+public class PersonPKMetadataProviderBridge implements MetadataProvidingFieldBridge, TwoWayFieldBridge {
+
+	@Override
+	public Object get(String name, Document document) {
+		PersonPK id = new PersonPK();
+		IndexableField field = document.getField( firstName( name ) );
+		id.setFirstName( field.stringValue() );
+		field = document.getField( lastName( name ) );
+		id.setLastName( field.stringValue() );
+		return id;
+	}
+
+	@Override
+	public String objectToString(Object object) {
+		PersonPK id = (PersonPK) object;
+		StringBuilder sb = new StringBuilder();
+		sb.append( id.getFirstName() ).append( " " ).append( id.getLastName() );
+		return sb.toString();
+	}
+
+	@Override
+	public void set(String name, Object value, Document document, LuceneOptions luceneOptions) {
+		PersonPK id = (PersonPK) value;
+
+		//store each property in a unique field
+		luceneOptions.addFieldToDocument( firstName( name ), id.getFirstName(), document );
+
+		luceneOptions.addFieldToDocument( lastName( name ), id.getLastName(), document );
+
+		//store the unique string representation in the named field
+		luceneOptions.addFieldToDocument( name, objectToString( id ), document );
+
+	}
+
+	@Override
+	public void configureFieldMetadata(String name, FieldMetadataBuilder builder) {
+		builder
+			.field( firstName( name ), FieldType.STRING )
+			.field( lastName( name ), FieldType.STRING );
+	}
+
+	private static String lastName(String name) {
+		return name + "_lastName";
+	}
+
+	private static String firstName(String name) {
+		return name + "_firstName";
+	}
+}

--- a/orm/src/test/java/org/hibernate/search/test/id/withmeta/PlainPerson.java
+++ b/orm/src/test/java/org/hibernate/search/test/id/withmeta/PlainPerson.java
@@ -1,0 +1,38 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.id.withmeta;
+
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+
+/**
+ * @author Davide D'Alto
+ */
+@Entity
+public class PlainPerson {
+
+	@EmbeddedId
+	private PersonPK id;
+	private String favoriteColor;
+
+	public PersonPK getId() {
+		return id;
+	}
+
+	public void setId(PersonPK id) {
+		this.id = id;
+	}
+
+	public String getFavoriteColor() {
+		return favoriteColor;
+	}
+
+	public void setFavoriteColor(String favoriteColor) {
+		this.favoriteColor = favoriteColor;
+	}
+
+}

--- a/orm/src/test/java/org/hibernate/search/test/id/withmeta/ProgrammaticEmbeddedItWithMetadataProvidingBridgeTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/id/withmeta/ProgrammaticEmbeddedItWithMetadataProvidingBridgeTest.java
@@ -1,0 +1,86 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.id.withmeta;
+
+import java.lang.annotation.ElementType;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.TermQuery;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.search.cfg.Environment;
+import org.hibernate.search.Search;
+import org.hibernate.search.cfg.SearchMapping;
+import org.hibernate.search.test.SearchTestBase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Davide D'Alto
+ */
+public class ProgrammaticEmbeddedItWithMetadataProvidingBridgeTest extends SearchTestBase {
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testFieldBridge() throws Exception {
+		PersonPK emmanuelPk = new PersonPK();
+		emmanuelPk.setFirstName( "Emmanuel" );
+		emmanuelPk.setLastName( "Bernard" );
+		PlainPerson emmanuel = new PlainPerson();
+		emmanuel.setFavoriteColor( "Blue" );
+		emmanuel.setId( emmanuelPk );
+
+		Session s = openSession();
+		Transaction tx = s.beginTransaction();
+		s.save( emmanuel );
+		tx.commit();
+		s.clear();
+
+		tx = s.beginTransaction();
+		List<PlainPerson> results = Search.getFullTextSession( s ).createFullTextQuery(
+				new TermQuery( new Term( "id_lastName", "Bernard" ) )
+		).list();
+		assertEquals( 1, results.size() );
+		emmanuel = (PlainPerson) results.get( 0 );
+		emmanuel.setFavoriteColor( "Red" );
+		tx.commit();
+		s.clear();
+
+		tx = s.beginTransaction();
+		results = Search.getFullTextSession( s ).createFullTextQuery(
+				new TermQuery( new Term( "id_lastName", "Bernard" ) )
+		).list();
+		assertEquals( 1, results.size() );
+		emmanuel = (PlainPerson) results.get( 0 );
+		assertEquals( "Red", emmanuel.getFavoriteColor() );
+		s.delete( results.get( 0 ) );
+		tx.commit();
+		s.close();
+	}
+
+	@Override
+	public void configure(Map<String,Object> cfg) {
+		SearchMapping mapping = new SearchMapping();
+		mapping
+			.entity( PlainPerson.class )
+				.indexed()
+			.property( "id", ElementType.FIELD )
+				.documentId()
+				.bridge( PersonPKMetadataProviderBridge.class )
+			.property( "", ElementType.FIELD )
+				.field();
+		cfg.put( Environment.MODEL_MAPPING, mapping );
+	}
+
+	@Override
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class[]{ PlainPerson.class };
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/projects/HSEARCH/issues/HSEARCH-2071

I checked the test `EmbeddableIdTest` and `ProgrammaticEmbeddedItTest` and they won't work with elasticsearch for the following reasons:
* the field bridge used for the id is not a `MetadataProvidingFieldBridge`; because of this, the new fields are not defined during the schema creation and this causes some errors when we need to create them;
* the fields name contain a `.` ;

I've created new tests without this limitations and checked that the Lucene and Elasticsearch backend are consistent. This resulted in another test failure because on Lucene a field was store not analyzed while in Elasticsearch was stored analyzed.

I tried to fix the issue by adding some information in the `BridgeDefinedField`. Let me know if it makes sense.