### PR TITLE
HSEARCH-2213 Cryptic error

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchIndexManager.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchIndexManager.java
@@ -176,7 +176,7 @@ public class ElasticsearchIndexManager implements IndexManager, RemoteAnalyzerPr
 
 	private void waitForIndexCreation() {
 		Builder healthBuilder = new Health.Builder()
-				.setParameter( "wait_for_status", "green" )
+				.setParameter( "wait_for_status", "yellow" )
 				.setParameter( "timeout", indexManagementWaitTimeout );
 
 		Health health = new Health( healthBuilder ) {
@@ -190,6 +190,12 @@ public class ElasticsearchIndexManager implements IndexManager, RemoteAnalyzerPr
 
 		if ( !result.isSucceeded() ) {
 			throw new SearchException( "Index " + actualIndexName + " wasn't created in time; Reason: " + result.getErrorMessage() );
+		}
+
+		String status = result.getJsonObject().get( "status" ).getAsString();
+
+		if ( ! "green".equals( status ) ) {
+			LOG.warnf( "Index '%s' is in state 'yellow'. Check the replica configuration in Elasticsearch if the status doesn't change to 'green' after a while.", actualIndexName );
 		}
 	}
 

--- a/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
@@ -71,4 +71,8 @@ public interface Log extends org.hibernate.search.util.logging.impl.Log {
 	@Message(id = ES_BACKEND_MESSAGES_START_ID + 9,
 			value = "'%1$s' is not a remote analyzer. It will be ignored")
 	void analyzerIsNotRemote(String name);
+
+	@Message(id = ES_BACKEND_MESSAGES_START_ID + 10,
+			value = "Elasticsearch connection time-out; check that the cluster status is at least `yellow`;\n Request:\n========\n%1$sResponse:\n=========\n%2$s" )
+	SearchException elasticsearchRequestTimeout(String request, String response);
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2213

Built on top of https://github.com/hibernate/hibernate-search/pull/1069

Not sure how to test it now that we have relaxed the status to yellow.
But the error message now explains that you should check the status of the cluster.
It also shows the status at the time of the request