### PR TITLE
HSEARCH-2213 Better error message when time out occurs

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
@@ -71,4 +71,8 @@ public interface Log extends org.hibernate.search.util.logging.impl.Log {
 	@Message(id = ES_BACKEND_MESSAGES_START_ID + 9,
 			value = "'%1$s' is not a remote analyzer. It will be ignored")
 	void analyzerIsNotRemote(String name);
+
+	@Message(id = ES_BACKEND_MESSAGES_START_ID + 10,
+			value = "Elasticsearch connection time-out; check the cluster status, it should be 'green';\n Request:\n========\n%1$sResponse:\n=========\n%2$s" )
+	SearchException elasticsearchRequestTimeout(String request, String response);
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2213

The log error will look something like this
```
org.hibernate.search.exception.SearchException: HSEARCH400010: Elasticsearch connection time-out; check the cluster status, it should be 'green';
 Request:
========
Operation: 
Data:
null
Response:
=========
Status: 408
Error message: 408 Request Timeout
Cluster name: elasticsearch
Cluster status: yellow
```