### PR TITLE
HSEARCH-2237 ScopedAnalyzerReference shouldn't close the underlying analyzer references

### DIFF
--- a/engine/src/main/java/org/hibernate/search/util/impl/ScopedAnalyzerReference.java
+++ b/engine/src/main/java/org/hibernate/search/util/impl/ScopedAnalyzerReference.java
@@ -91,12 +91,9 @@ public final class ScopedAnalyzerReference implements AnalyzerReference {
 
 	@Override
 	public void close() {
-		if ( globalAnalyzer != null ) {
-			globalAnalyzer.close();
-		}
-		for ( AnalyzerReference entry : analyzers.values() ) {
-			entry.close();
-		}
+		// we don't close the underlying {@code AnalyzerReference}s as they might be used by other
+		// {@code ScopedAnalyzerReference}. It is especially true for the reference to the
+		// PassThroughAnalyzer which is shared statically.
 	}
 
 	/**


### PR DESCRIPTION
This one was well hidden and was triggered by my work generalizing the usage of analyzer references.