### PR TITLE
HSEARCH-2241 Clarify deprecation of setFilter() method on FullTextQuery

### DIFF
--- a/orm/src/main/java/org/hibernate/search/FullTextQuery.java
+++ b/orm/src/main/java/org/hibernate/search/FullTextQuery.java
@@ -44,13 +44,17 @@ public interface FullTextQuery extends Query, ProjectionConstants {
 	FullTextQuery setSort(Sort sort);
 
 	/**
-	 * Allows to use lucene filters.
-	 * Semi-deprecated? a preferred way is to use the @FullTextFilterDef approach
+	 * Allows to set a single Lucene filter.
+	 * @deprecated: use the {@link org.hibernate.search.annotations.FullTextFilterDef} approach,
+	 *     or use a {@link org.apache.lucene.search.BooleanQuery} and add a clause using
+	 *     {@link org.apache.lucene.search.BooleanClause.Occur#FILTER}.
 	 *
-	 * @param filter The lucene filter.
+	 * @param filter The Lucene filter.
 	 *
 	 * @return this for method chaining
+	 * @see org.apache.lucene.search.Filter
 	 */
+	@Deprecated
 	FullTextQuery setFilter(Filter filter);
 
 	/**

--- a/orm/src/main/java/org/hibernate/search/jpa/FullTextQuery.java
+++ b/orm/src/main/java/org/hibernate/search/jpa/FullTextQuery.java
@@ -46,13 +46,17 @@ public interface FullTextQuery extends Query, ProjectionConstants {
 	FullTextQuery setSort(Sort sort);
 
 	/**
-	 * Allows to use lucene filters.
-	 * Semi-deprecated? a preferred way is to use the @FullTextFilterDef approach
+	 * Allows to set a single Lucene filter.
+	 * @deprecated: use the {@link org.hibernate.search.annotations.FullTextFilterDef} approach,
+	 *     or use a {@link org.apache.lucene.search.BooleanQuery} and add a clause using
+	 *     {@link org.apache.lucene.search.BooleanClause.Occur#FILTER}.
 	 *
-	 * @param filter The lucene filter.
+	 * @param filter The Lucene filter.
 	 *
-	 * @return {@code this} for method chaining
+	 * @return this for method chaining
+	 * @see org.apache.lucene.search.Filter
 	 */
+	@Deprecated
 	FullTextQuery setFilter(Filter filter);
 
 	/**


### PR DESCRIPTION
Public API references to `org.apache.lucene.search.Filter` have to be removed.

This is an easy first step, as the javadoc already mentioned it to be "semi-deprecated".

Let's apply it to 5.5 as well as it just makes things clearer.

 - https://hibernate.atlassian.net/browse/HSEARCH-2241
