### PR TITLE
HSEARCH-2138 Not refreshing indexes by default

### DIFF
--- a/backends/jgroups/src/test/resources/hibernate.properties
+++ b/backends/jgroups/src/test/resources/hibernate.properties
@@ -23,3 +23,4 @@ hibernate.cache.provider_class org.hibernate.cache.HashtableCacheProvider
 
 hibernate.search.default.elasticsearch.host http://127.0.0.1:9200
 hibernate.search.default.elasticsearch.index_management_strategy CREATE_DELETE
+hibernate.search.default.elasticsearch.refresh_after_write true

--- a/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
+++ b/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
@@ -98,6 +98,7 @@ Hostname and port for Elasticsearch:: `hibernate.search.default.elasticsearch.ho
 Selects the index creation strategy:: `hibernate.search.default.elasticsearch.index_management_strategy CREATE_DELETE`
 Maximum time to wait for the indexes to become available before failing (in ms):: `hibernate.search.default.elasticsearch.index_management_wait_timeout 10000`
 Status an index must at least have in order for Hibernate Search to work with it (one of "green", "yellow" or "red"):: `hibernate.search.default.elasticsearch.required_index_status green`
+Whether to perform an explicit refresh after a set of operations has been executed against a specific index (`true` or `false`):: `hibernate.search.default.elasticsearch.refresh_after_write false`
 
 Let's see the options for the `index_management_strategy` property:
 

--- a/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchEnvironment.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchEnvironment.java
@@ -22,6 +22,7 @@ public final class ElasticsearchEnvironment {
 		public static final IndexManagementStrategy INDEX_MANAGEMENT_STRATEGY = IndexManagementStrategy.NONE;
 		public static final int INDEX_MANAGEMENT_WAIT_TIMEOUT = 10_000;
 		public static final String REQUIRED_INDEX_STATUS = "green";
+		public static final boolean REFRESH_AFTER_WRITE = false;
 	}
 
 	/**
@@ -73,6 +74,19 @@ public final class ElasticsearchEnvironment {
 	 * specific indexes (e.g. {@code hibernate.search.someindex.elasticsearch.required_index_status=yellow}).
 	 */
 	public static final String REQUIRED_INDEX_STATUS = "elasticsearch.required_index_status";
+
+	/**
+	 * Property for specifying whether an explicit index refresh should be issued after a set of operations targeting a
+	 * given index has been executed or not.
+	 * <p>
+	 * A boolean value (true, false) is expected.
+	 * <p>
+	 * Defaults to {@link Defaults#REFRESH_AFTER_WRITE}.
+	 * <p>
+	 * Can be given globally (e.g. {@code hibernate.search.default.elasticsearch.refresh_after_write=false}) or for
+	 * specific indexes (e.g. {@code hibernate.search.someindex.elasticsearch.refresh_after_write=true}).
+	 */
+	public static final String REFRESH_AFTER_WRITE = "elasticsearch.refresh_after_write";
 
 	private ElasticsearchEnvironment() {
 	}

--- a/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/impl/BackendRequest.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/impl/BackendRequest.java
@@ -28,11 +28,13 @@ public class BackendRequest<T extends JestResult> {
 	private final Set<Integer> ignoredErrorStatuses;
 	private final LuceneWork luceneWork;
 	private final String indexName;
+	private final boolean refreshAfterWrite;
 
-	public BackendRequest(Action<T> action, LuceneWork luceneWork, String indexName, int... ignoredErrorStatuses) {
+	public BackendRequest(Action<T> action, LuceneWork luceneWork, String indexName, boolean refreshAfterWrite, int... ignoredErrorStatuses) {
 		this.action = action;
 		this.luceneWork = luceneWork;
 		this.indexName = indexName;
+		this.refreshAfterWrite = refreshAfterWrite;
 		this.ignoredErrorStatuses = asSet( ignoredErrorStatuses );
 	}
 
@@ -67,6 +69,13 @@ public class BackendRequest<T extends JestResult> {
 
 	public String getIndexName() {
 		return indexName;
+	}
+
+	/**
+	 * Whether performing an explicit index refresh after executing this action is needed or not.
+	 */
+	public boolean needsRefreshAfterWrite() {
+		return refreshAfterWrite;
 	}
 
 	public Set<Integer> getIgnoredErrorStatuses() {

--- a/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/impl/BulkRequest.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/impl/BulkRequest.java
@@ -23,14 +23,27 @@ public class BulkRequest implements ExecutableRequest {
 	private final JestClient jestClient;
 	private final ErrorHandler errorHandler;
 	private final List<BackendRequest<?>> requests;
+
+	/**
+	 * Whether to perform a refresh in the course of executing this bulk or not. Note that this will refresh all indexes
+	 * touched by this bulk, not only those given via {@link #indexesNeedingRefresh}. That's acceptable.
+	 * <p>
+	 * If {@code true}, no explicit refresh of the concerned indexes is needed afterwards.
+	 */
 	private final boolean refresh;
 	private final Set<String> indexNames;
 
-	public BulkRequest(JestClient jestClient, ErrorHandler errorHandler, List<BackendRequest<?>> requests, Set<String> indexNames, boolean refresh) {
+	/**
+	 * Names of those indexes to be refreshed after executing this bulk
+	 */
+	private final Set<String> indexesNeedingRefresh;
+
+	public BulkRequest(JestClient jestClient, ErrorHandler errorHandler, List<BackendRequest<?>> requests, Set<String> indexNames, Set<String> indexesNeedingRefresh, boolean refresh) {
 		this.jestClient = jestClient;
 		this.errorHandler = errorHandler;
 		this.requests = requests;
 		this.indexNames = indexNames;
+		this.indexesNeedingRefresh = indexesNeedingRefresh;
 		this.refresh = refresh;
 	}
 
@@ -71,12 +84,12 @@ public class BulkRequest implements ExecutableRequest {
 	}
 
 	@Override
-	public Set<String> getRefreshedIndexes() {
+	public Set<String> getIndexesNeedingRefresh() {
 		if ( refresh ) {
-			return indexNames;
+			return Collections.emptySet();
 		}
 		else {
-			return Collections.emptySet();
+			return indexesNeedingRefresh;
 		}
 	}
 
@@ -87,6 +100,7 @@ public class BulkRequest implements ExecutableRequest {
 
 	@Override
 	public String toString() {
-		return "BulkRequest [size=" + requests.size() + ", refresh=" + refresh + ", indexNames=" + indexNames + "]";
+		return "BulkRequest [size=" + requests.size() + ", refresh=" + refresh + ", indexNames=" + indexNames + ", indexesNeedingRefresh=" + indexesNeedingRefresh
+				+ "]";
 	}
 }

--- a/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/impl/ExecutableRequest.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/impl/ExecutableRequest.java
@@ -22,7 +22,7 @@ public interface ExecutableRequest {
 	Set<String> getTouchedIndexes();
 
 	/**
-	 * Returns the names of the indexes which got refreshed during executing this request, i.e. no subsequent refresh is needed.
+	 * Returns the names of the indexes which need refreshing after executing this request.
 	 */
-	Set<String> getRefreshedIndexes();
+	Set<String> getIndexesNeedingRefresh();
 }

--- a/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/impl/SingleRequest.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/impl/SingleRequest.java
@@ -51,8 +51,8 @@ public class SingleRequest implements ExecutableRequest {
 	}
 
 	@Override
-	public Set<String> getRefreshedIndexes() {
-		return Collections.emptySet();
+	public Set<String> getIndexesNeedingRefresh() {
+		return request.needsRefreshAfterWrite() ? Collections.singleton( request.getIndexName() ) : Collections.<String>emptySet();
 	}
 
 	@Override

--- a/elasticsearch/src/test/resources/hibernate.properties
+++ b/elasticsearch/src/test/resources/hibernate.properties
@@ -23,3 +23,4 @@ hibernate.cache.provider_class org.hibernate.cache.HashtableCacheProvider
 
 hibernate.search.default.indexmanager elasticsearch
 hibernate.search.default.elasticsearch.index_management_strategy CREATE_DELETE
+hibernate.search.default.elasticsearch.refresh_after_write true

--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/elasticsearch/ElasticsearchModuleMemberRegistrationIT.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/elasticsearch/ElasticsearchModuleMemberRegistrationIT.java
@@ -80,6 +80,7 @@ public class ElasticsearchModuleMemberRegistrationIT {
 					.createProperty().name( "hibernate.search.default.indexmanager" ).value( "elasticsearch" ).up()
 					.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( getWildFlyModuleIdentifier() ).up()
 					.createProperty().name( "hibernate.search.default.elasticsearch.index_management_strategy" ).value( "CREATE_DELETE" ).up()
+					.createProperty().name( "hibernate.search.default.elasticsearch.refresh_after_write" ).value( "true" ).up()
 				.up().up()
 			.exportAsString();
 		return new StringAsset( persistenceXml );


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2138

~~Based on top of #1096 (only https://github.com/hibernate/hibernate-search/commit/d55e5176def9704440e8611f300f961ee0f02bf4 is the meat of this change).~~

ES refreshes indexes by default every second, making index changes visible almost immediately. That should be fine for most production purposes, but during our testing it's not enough.

Until now, we always enforced a refresh after writes towards an index in order to make the test suite run reliable. This change makes this an option, which is disabled by default and only enabled during our tests. While not perfect, it should be a good compromise between offering proper speed in practice and making our test suite run reliable.