### PR TITLE
HSEARCH-2274 Making sure ES host can be specified using property "hib…

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/impl/JestClient.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/impl/JestClient.java
@@ -47,7 +47,17 @@ public class JestClient implements Service, Startable, Stoppable {
 
 	private static final Log LOG = LoggerFactory.make( Log.class );
 
+	/**
+	 * HTTP response code for a request timed out.
+	 */
 	private static final int TIME_OUT = 408;
+
+	/**
+	 * Prefix for accessing the {@link ElasticsearchEnvironment#SERVER_URI} variable. That's currently needed as we
+	 * don't access this one in the context of a specific index manager. The prefix is used to have the property name
+	 * inline with the other index-related property names, it cannot be overridden per moment, though.
+	 */
+	private static final String SERVER_URI_PROP_PREFIX = "hibernate.search.default.";
 
 	private io.searchbox.client.JestClient client;
 
@@ -57,7 +67,7 @@ public class JestClient implements Service, Startable, Stoppable {
 
 		String serverUri = ConfigurationParseHelper.getString(
 				properties,
-				ElasticsearchEnvironment.SERVER_URI,
+				SERVER_URI_PROP_PREFIX + ElasticsearchEnvironment.SERVER_URI,
 				ElasticsearchEnvironment.Defaults.SERVER_URI
 		);
 

--- a/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/HostCanBeConfiguredIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/test/HostCanBeConfiguredIT.java
@@ -1,0 +1,62 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.test;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+import java.net.ConnectException;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.search.exception.SearchException;
+import org.hibernate.search.testsupport.TestForIssue;
+import org.junit.Test;
+
+/**
+ * Test to make sure that the ES host can be configured and not the default is applied unconditionally. To test it, the
+ * host is set to a non-available URL, and the assertion is based on the resulting exception.
+ *
+ * @author Gunnar Morling
+ */
+@TestForIssue(jiraKey = "HSEARCH-2274")
+public class HostCanBeConfiguredIT {
+
+	@Test
+	public void shouldApplyConfiguredElasticsearchHost() {
+		StandardServiceRegistryBuilder srb = new StandardServiceRegistryBuilder()
+				.applySetting( "hibernate.search.default.elasticsearch.host", "http://localhost:9201" );
+
+		Metadata metadata = new MetadataSources( srb.build() )
+				.addAnnotatedClass( MasterThesis.class )
+				.buildMetadata();
+
+		try {
+			metadata.buildSessionFactory();
+			fail( "Expecting exception due to unavailable ES host" );
+		}
+		catch (SearchException e) {
+			assertThat( e.getMessage() ).startsWith( "HSEARCH400007" );
+
+			Throwable rootCause = getRootCause( e );
+			assertThat( rootCause ).isInstanceOf( ConnectException.class );
+			assertThat( rootCause ).hasMessage( "Connection refused" );
+		}
+
+	}
+
+	private Throwable getRootCause(Throwable throwable) {
+		while ( true ) {
+			Throwable cause = throwable.getCause();
+			if ( cause == null ) {
+				return throwable;
+			}
+			throwable = cause;
+		}
+	}
+}


### PR DESCRIPTION
…ernate.search.default.elasticsearch.host"