### PR TITLE
HSEARCH-2061 Update javadoc that refers to Elasticsearch as a backend

### DIFF
--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -17,7 +17,7 @@
 
     <artifactId>hibernate-search-elasticsearch</artifactId>
 
-    <name>Hibernate Search Elasticsearch Backend</name>
+    <name>Hibernate Search Elasticsearch</name>
     <description>Hibernate Search backend which has indexing operations forwarded to Elasticsearch</description>
 
     <dependencies>

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/ElasticsearchProjectionConstants.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/ElasticsearchProjectionConstants.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.elasticsearch;
 
 /**
- * Projection constants specific to the Elasticsearch backend.
+ * Projection constants specific to the Elasticsearch.
  * <p>
  * Implementator's note: When adding new constants, be sure to add them to
  * {@code ElasticsearchHSQueryImpl#SUPPORTED_PROJECTION_CONSTANTS}, too.

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/ElasticsearchQueries.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/ElasticsearchQueries.java
@@ -12,7 +12,7 @@ import org.hibernate.search.elasticsearch.impl.JsonBuilder;
 import org.hibernate.search.query.engine.spi.QueryDescriptor;
 
 /**
- * Creates queries to be used with the Elasticsearch backend.
+ * Creates queries to be used with Elasticsearch.
  *
  * @author Gunnar Morling
  */

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/ElasticsearchEnvironment.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/ElasticsearchEnvironment.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.elasticsearch.cfg;
 
 /**
- * Configuration properties of the ES backend.
+ * Configuration properties for Elasticsearch,
  *
  * @author Gunnar Morling
  */


### PR DESCRIPTION
A follow up commit to https://github.com/hibernate/hibernate-search/pull/1107

It removes the term backend when Elasticsearch is mentioned.

Feel free to ignore this if it does not make much sense 