### PR TITLE
HSEARCH-2287 Clear the cached results when the sort order is changed

### DIFF
--- a/engine/src/main/java/org/hibernate/search/query/engine/impl/AbstractHSQuery.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/impl/AbstractHSQuery.java
@@ -120,6 +120,7 @@ public abstract class AbstractHSQuery implements HSQuery, Serializable {
 
 	@Override
 	public HSQuery sort(Sort sort) {
+		clearCachedResults();
 		this.sort = sort;
 		return this;
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2287

Clear the cache results when sort order is changed. It's especially important when using Elasticsearch because we cache much more things.