### PR TITLE
HSEARCH-2321 Upgrade maven-jdocbook-plugin and pressgang

### DIFF
--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -100,7 +100,7 @@
                                     <pluginExecutionFilter>
                                         <groupId>org.jboss.maven.plugins</groupId>
                                         <artifactId>maven-jdocbook-plugin</artifactId>
-                                        <versionRange>[2.3.5,)</versionRange>
+                                        <versionRange>[2.3.10,)</versionRange>
                                         <goals>
                                             <goal>resources</goal>
                                             <goal>generate</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -913,18 +913,18 @@
                 <plugin>
                     <groupId>org.jboss.maven.plugins</groupId>
                     <artifactId>maven-jdocbook-plugin</artifactId>
-                    <version>2.3.9</version>
+                    <version>2.3.10</version>
                     <extensions>true</extensions>
                     <dependencies>
                         <dependency>
                             <groupId>org.jboss.pressgang</groupId>
                             <artifactId>pressgang-xslt-ns</artifactId>
-                            <version>3.1.3</version>
+                            <version>3.1.4</version>
                         </dependency>
                         <dependency>
                             <groupId>org.hibernate</groupId>
                             <artifactId>hibernate-jdocbook-style</artifactId>
-                            <version>3.0.0</version>
+                            <version>3.0.2</version>
                             <type>jdocbook-style</type>
                         </dependency>
                     </dependencies>


### PR DESCRIPTION
It allows to generate valid HTML5 output and fixes a bug where the user
was not brought to the right place when clicking on an anchor.