### PR TITLE
HSEARCH-2323 Properly ignore hibernate-noorm-release-scripts directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Typically *NIX text editors, by default, append '~' to files on saving to make backups
 *~
 
+# Our build scripts - necessary for our release jobs
+hibernate-noorm-release-scripts
+
 #Checkstyle
 .checkstyle
 

--- a/distribution/src/main/assembly/dist.xml
+++ b/distribution/src/main/assembly/dist.xml
@@ -150,6 +150,10 @@
             <filtered>true</filtered>
         </file>
         <file>
+            <source>../CONTRIBUTING.md</source>
+            <outputDirectory>/</outputDirectory>
+        </file>
+        <file>
             <source>../lgpl.txt</source>
             <outputDirectory>/</outputDirectory>
         </file>
@@ -175,7 +179,20 @@
             <outputDirectory>project</outputDirectory>
             <useDefaultExcludes>true</useDefaultExcludes>
             <excludes>
+                <!-- we already have these files at the top level of the distribution -->
+                <exclude>README.md</exclude>
+                <exclude>CONTRIBUTING.md</exclude>
+                <exclude>changelog.txt</exclude>
+                <exclude>copyright.txt</exclude>
+                <exclude>lgpl.txt</exclude>
+
+                <!-- only needed for documentation and helper scripts, no need to include them -->
+                <exclude>hibernate-noorm-release-scripts/**</exclude>
+
+                <!-- actual files which should be ignored -->
                 <exclude>.git</exclude>
+                <exclude>.travis.yml</exclude>
+                <exclude>travis/**</exclude>
                 <exclude>*.log</exclude>
                 <exclude>*.sh</exclude>
                 <exclude>**/.gitignore</exclude>


### PR DESCRIPTION
And additional cleanup to the distribution.

 * https://hibernate.atlassian.net/browse/HSEARCH-2323