### PR TITLE
HSEARCH-2256 Don't add a tenant ID field in ES if unnecessary

### DIFF
--- a/engine/src/main/java/org/hibernate/search/cfg/spi/SearchConfiguration.java
+++ b/engine/src/main/java/org/hibernate/search/cfg/spi/SearchConfiguration.java
@@ -14,6 +14,7 @@ import org.hibernate.annotations.common.reflection.ReflectionManager;
 import org.hibernate.search.cfg.SearchMapping;
 import org.hibernate.search.engine.service.classloading.spi.ClassLoaderService;
 import org.hibernate.search.engine.service.spi.Service;
+import org.hibernate.search.engine.spi.DocumentBuilderIndexedEntity;
 import org.hibernate.search.spi.InstanceInitializer;
 
 /**
@@ -117,6 +118,12 @@ public interface SearchConfiguration {
 	 * with a {@link org.hibernate.search.annotations.ProvidedId}, if no other Id is specified.
 	 */
 	boolean isIdProvidedImplicit();
+
+	/**
+	 * @return {@code true} if {@link DocumentBuilderIndexedEntity#TENANT_ID_FIELDNAME multitenancy}
+	 * should be enabled. When in doubt, this should return {@code true}.
+	 */
+	boolean isMultitenancyEnabled();
 
 	/**
 	 * @return Returns a classloader service for this configuration of Search. Access to the service is via the

--- a/engine/src/main/java/org/hibernate/search/cfg/spi/SearchConfigurationBase.java
+++ b/engine/src/main/java/org/hibernate/search/cfg/spi/SearchConfigurationBase.java
@@ -55,4 +55,9 @@ public abstract class SearchConfigurationBase implements SearchConfiguration {
 	public boolean isIdProvidedImplicit() {
 		return false;
 	}
+
+	@Override
+	public boolean isMultitenancyEnabled() {
+		return true;
+	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/impl/ImmutableSearchFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/ImmutableSearchFactory.java
@@ -108,6 +108,7 @@ public class ImmutableSearchFactory implements ExtendedSearchIntegratorWithShare
 	private final boolean indexMetadataIsComplete;
 	private final boolean isDeleteByTermEnforced;
 	private final boolean isIdProvidedImplicit;
+	private final boolean isMultitenancyEnabled;
 	private final String statisticsMBeanName;
 	private final IndexManagerFactory indexManagerFactory;
 	private final ObjectLookupMethod defaultObjectLookupMethod;
@@ -148,6 +149,7 @@ public class ImmutableSearchFactory implements ExtendedSearchIntegratorWithShare
 		this.indexMetadataIsComplete = state.isIndexMetadataComplete();
 		this.isDeleteByTermEnforced = state.isDeleteByTermEnforced();
 		this.isIdProvidedImplicit = state.isIdProvidedImplicit();
+		this.isMultitenancyEnabled = state.isMultitenancyEnabled();
 		this.indexManagerFactory = state.getIndexManagerFactory();
 
 		this.enableDirtyChecks = ConfigurationParseHelper.getBooleanValue(
@@ -549,6 +551,11 @@ public class ImmutableSearchFactory implements ExtendedSearchIntegratorWithShare
 	@Override
 	public boolean isIdProvidedImplicit() {
 		return isIdProvidedImplicit;
+	}
+
+	@Override
+	public boolean isMultitenancyEnabled() {
+		return isMultitenancyEnabled;
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/impl/IncrementalSearchConfiguration.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/IncrementalSearchConfiguration.java
@@ -17,7 +17,7 @@ import java.util.Properties;
 import org.hibernate.annotations.common.reflection.ReflectionManager;
 import org.hibernate.annotations.common.reflection.java.JavaReflectionManager;
 import org.hibernate.search.cfg.SearchMapping;
-import org.hibernate.search.cfg.spi.SearchConfiguration;
+import org.hibernate.search.cfg.spi.SearchConfigurationBase;
 import org.hibernate.search.engine.service.classloading.spi.ClassLoaderService;
 import org.hibernate.search.engine.service.spi.Service;
 import org.hibernate.search.spi.InstanceInitializer;
@@ -26,7 +26,7 @@ import org.hibernate.search.spi.impl.SearchFactoryState;
 /**
  * @author Emmanuel Bernard
  */
-public class IncrementalSearchConfiguration implements SearchConfiguration {
+public class IncrementalSearchConfiguration extends SearchConfigurationBase {
 	private final List<Class<?>> classes;
 	private final Map<String, Class<?>> classesByName = new HashMap<String, Class<?>>();
 	private final SearchFactoryState searchFactoryState;

--- a/engine/src/main/java/org/hibernate/search/engine/impl/MutableSearchFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/MutableSearchFactory.java
@@ -330,6 +330,11 @@ public class MutableSearchFactory implements ExtendedSearchIntegratorWithShareab
 	}
 
 	@Override
+	public boolean isMultitenancyEnabled() {
+		return delegate.isMultitenancyEnabled();
+	}
+
+	@Override
 	public IndexManagerFactory getIndexManagerFactory() {
 		return delegate.getIndexManagerFactory();
 	}

--- a/engine/src/main/java/org/hibernate/search/engine/impl/MutableSearchFactoryState.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/MutableSearchFactoryState.java
@@ -62,6 +62,7 @@ public class MutableSearchFactoryState implements SearchFactoryState {
 	private boolean indexMetadataIsComplete;
 	private boolean deleteByTermEnforced;
 	private boolean isIdProvidedImplicit;
+	private boolean isMultitenancyEnabled;
 	private IndexManagerFactory indexManagerFactory;
 	private boolean enlistWorkerInTransaction;
 	private Statistics statistics;
@@ -88,6 +89,7 @@ public class MutableSearchFactoryState implements SearchFactoryState {
 		indexMetadataIsComplete = oldFactoryState.isIndexMetadataComplete();
 		deleteByTermEnforced = oldFactoryState.isDeleteByTermEnforced();
 		isIdProvidedImplicit = oldFactoryState.isIdProvidedImplicit();
+		isMultitenancyEnabled = oldFactoryState.isMultitenancyEnabled();
 		indexManagerFactory = oldFactoryState.getIndexManagerFactory();
 		enlistWorkerInTransaction = oldFactoryState.enlistWorkerInTransaction();
 		statistics = oldFactoryState.getStatistics();
@@ -299,6 +301,15 @@ public class MutableSearchFactoryState implements SearchFactoryState {
 
 	public void setIdProvidedImplicit(boolean idProvidedImplicit) {
 		this.isIdProvidedImplicit = idProvidedImplicit;
+	}
+
+	@Override
+	public boolean isMultitenancyEnabled() {
+		return isMultitenancyEnabled;
+	}
+
+	public void setMultitenancyEnabled(boolean isMultitenancyEnabled) {
+		this.isMultitenancyEnabled = isMultitenancyEnabled;
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/impl/ReflectionReplacingSearchConfiguration.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/ReflectionReplacingSearchConfiguration.java
@@ -13,6 +13,7 @@ import java.util.Properties;
 import org.hibernate.annotations.common.reflection.ReflectionManager;
 import org.hibernate.search.cfg.SearchMapping;
 import org.hibernate.search.cfg.spi.SearchConfiguration;
+import org.hibernate.search.cfg.spi.SearchConfigurationBase;
 import org.hibernate.search.engine.service.classloading.spi.ClassLoaderService;
 import org.hibernate.search.engine.service.spi.Service;
 import org.hibernate.search.spi.InstanceInitializer;
@@ -23,7 +24,7 @@ import org.hibernate.search.spi.InstanceInitializer;
  * @author Sanne Grinovero
  * @since 4.1
  */
-public final class ReflectionReplacingSearchConfiguration implements SearchConfiguration {
+public final class ReflectionReplacingSearchConfiguration extends SearchConfigurationBase {
 
 	private final ReflectionManager reflectionManager;
 	private final SearchConfiguration searchConfiguration;

--- a/engine/src/main/java/org/hibernate/search/spi/SearchIntegratorBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/spi/SearchIntegratorBuilder.java
@@ -294,6 +294,7 @@ public class SearchIntegratorBuilder {
 			factoryState.setTransactionManagerExpected( cfg.isTransactionManagerExpected() );
 			factoryState.setDeleteByTermEnforced( cfg.isDeleteByTermEnforced() );
 			factoryState.setIdProvidedImplicit( cfg.isIdProvidedImplicit() );
+			factoryState.setMultitenancyEnabled( cfg.isMultitenancyEnabled() );
 		}
 	}
 
@@ -590,6 +591,11 @@ public class SearchIntegratorBuilder {
 		@Override
 		public ServiceManager getServiceManager() {
 			return factoryState.getServiceManager();
+		}
+
+		@Override
+		public boolean isMultitenancyEnabled() {
+			return factoryState.isMultitenancyEnabled();
 		}
 
 	}

--- a/engine/src/main/java/org/hibernate/search/spi/WorkerBuildContext.java
+++ b/engine/src/main/java/org/hibernate/search/spi/WorkerBuildContext.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.spi;
 
+import org.hibernate.search.engine.spi.DocumentBuilderIndexedEntity;
+
 /**
  * Build context for the worker and other backend
  * Available after all index, entity metadata are built.
@@ -40,6 +42,12 @@ public interface WorkerBuildContext extends BuildContext {
 	 * @return An instance of the {@code InstanceInitializer} interface.
 	 */
 	InstanceInitializer getInstanceInitializer();
+
+	/**
+	 * @return {@code true} if {@link DocumentBuilderIndexedEntity#TENANT_ID_FIELDNAME multitenancy}
+	 * should be enabled. When in doubt, this should return {@code true}.
+	 */
+	boolean isMultitenancyEnabled();
 
 	/**
 	 * @return {@code true} if the worker and the backend enlist their work in the current transaction;

--- a/engine/src/main/java/org/hibernate/search/spi/impl/SearchFactoryState.java
+++ b/engine/src/main/java/org/hibernate/search/spi/impl/SearchFactoryState.java
@@ -75,6 +75,8 @@ public interface SearchFactoryState {
 
 	boolean isIdProvidedImplicit();
 
+	boolean isMultitenancyEnabled();
+
 	IndexManagerFactory getIndexManagerFactory();
 
 	boolean enlistWorkerInTransaction();

--- a/engine/src/test/java/org/hibernate/search/testsupport/setup/WorkerBuildContextForTest.java
+++ b/engine/src/test/java/org/hibernate/search/testsupport/setup/WorkerBuildContextForTest.java
@@ -38,6 +38,11 @@ public class WorkerBuildContextForTest extends BuildContextForTest implements Wo
 	}
 
 	@Override
+	public boolean isMultitenancyEnabled() {
+		return true;
+	}
+
+	@Override
 	public InstanceInitializer getInstanceInitializer() {
 		return DefaultInstanceInitializer.DEFAULT_INITIALIZER;
 	}

--- a/orm/src/main/java/org/hibernate/search/cfg/impl/SearchConfigurationFromHibernateCore.java
+++ b/orm/src/main/java/org/hibernate/search/cfg/impl/SearchConfigurationFromHibernateCore.java
@@ -14,6 +14,7 @@ import java.util.NoSuchElementException;
 import java.util.Properties;
 import java.util.Set;
 
+import org.hibernate.MultiTenancyStrategy;
 import org.hibernate.annotations.common.reflection.ReflectionManager;
 import org.hibernate.annotations.common.reflection.java.JavaReflectionManager;
 import org.hibernate.boot.Metadata;
@@ -42,6 +43,7 @@ public class SearchConfigurationFromHibernateCore extends SearchConfigurationBas
 	private final Map<Class<? extends Service>, Object> providedServices;
 	private final Metadata metadata;
 	private final Properties legacyConfigurationProperties;//For compatibility reasons only. Should be removed? See HSEARCH-1890
+	private final boolean multitenancyEnabled;
 
 	private ReflectionManager reflectionManager;
 
@@ -65,6 +67,10 @@ public class SearchConfigurationFromHibernateCore extends SearchConfigurationBas
 		providedServices.put( HibernateSessionFactoryService.class, sessionService );
 		this.providedServices = Collections.unmodifiableMap( providedServices );
 		this.legacyConfigurationProperties = extractProperties( configurationService );
+
+		MultiTenancyStrategy multitenancyStrategy =
+				sessionService.getSessionFactory().getSessionFactoryOptions().getMultiTenancyStrategy();
+		this.multitenancyEnabled = !MultiTenancyStrategy.NONE.equals( multitenancyStrategy );
 	}
 
 	@Override
@@ -121,6 +127,11 @@ public class SearchConfigurationFromHibernateCore extends SearchConfigurationBas
 	@Override
 	public boolean isIndexMetadataComplete() {
 		return true;
+	}
+
+	@Override
+	public boolean isMultitenancyEnabled() {
+		return multitenancyEnabled;
 	}
 
 	@Override

--- a/orm/src/test/java/org/hibernate/search/test/configuration/integration/HibernateSearchIntegratorTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/integration/HibernateSearchIntegratorTest.java
@@ -16,10 +16,12 @@ import java.util.HashMap;
 
 import org.easymock.Capture;
 import org.easymock.EasyMock;
+import org.hibernate.MultiTenancyStrategy;
 import org.hibernate.SessionFactoryObserver;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.registry.classloading.spi.ClassLoadingException;
+import org.hibernate.boot.spi.SessionFactoryOptions;
 import org.hibernate.engine.config.internal.ConfigurationServiceImpl;
 import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -60,6 +62,9 @@ public class HibernateSearchIntegratorTest extends UnitilsJUnit4 {
 	private ClassLoaderService mockClassLoaderService;
 
 	@Mock
+	private SessionFactoryOptions mockSessionFactoryOptions;
+
+	@Mock
 	private Metadata mockMetadata;
 
 	@Test
@@ -92,6 +97,14 @@ public class HibernateSearchIntegratorTest extends UnitilsJUnit4 {
 						EasyMock.capture( capturedSessionFactoryObserver ),
 						isA( SessionFactoryObserver.class )
 				)
+		);
+
+		expect( mockSessionFactoryImplementor.getSessionFactoryOptions() ).andReturn(
+				mockSessionFactoryOptions
+		);
+
+		expect( mockSessionFactoryOptions.getMultiTenancyStrategy() ).andReturn(
+				MultiTenancyStrategy.NONE
 		);
 
 		expect( mockSessionFactoryServiceRegistry.getService( EventListenerRegistry.class ) ).andReturn(


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2256

The path I took may seem needlessly complicated, but it has to be this way because the Elasticsearch module does not depend on ORM,only on Engine. Thus it cannot reference the multitenancy strategy directly.

This solution may not prevent unneeded tenant ID fields in every case. In particular, when users choose to implement `SearchConfiguration` themselves, they will not benefit from multitenancy autodetection. But it's arguably their choice, as they do choose to drop our default implementation.

There is an SPI break in this solution: I had to add a method to `SearchConfiguration`. It seems the most common way of implementing `SearchConfiguration` is to extend `SearchConfigurationBase`, though, and I added a default implementation to the latter. I checked the Infinispan HS module, and they do extend `SearchConfigurationBase`, so no trouble here. As for other SPI implementors, unfortunately I cannot tell...