### PR TITLE
HSEARCH-2333 Introduced createQueryDescriptor(Query, Class<?>...)

### DIFF
--- a/engine/src/main/java/org/hibernate/search/engine/impl/LuceneQueryDescriptor.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/LuceneQueryDescriptor.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.query.hibernate.impl;
+package org.hibernate.search.engine.impl;
 
 import org.apache.lucene.search.Query;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;

--- a/engine/src/main/java/org/hibernate/search/engine/impl/MutableSearchFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/MutableSearchFactory.java
@@ -13,6 +13,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.search.Query;
 import org.hibernate.search.analyzer.impl.AnalyzerReference;
 import org.hibernate.search.backend.spi.BatchBackend;
 import org.hibernate.search.backend.spi.Worker;
@@ -35,6 +36,7 @@ import org.hibernate.search.query.DatabaseRetrievalMethod;
 import org.hibernate.search.query.ObjectLookupMethod;
 import org.hibernate.search.query.dsl.QueryContextBuilder;
 import org.hibernate.search.query.engine.spi.HSQuery;
+import org.hibernate.search.query.engine.spi.QueryDescriptor;
 import org.hibernate.search.query.engine.spi.TimeoutExceptionFactory;
 import org.hibernate.search.spi.IndexingMode;
 import org.hibernate.search.spi.InstanceInitializer;
@@ -142,6 +144,11 @@ public class MutableSearchFactory implements ExtendedSearchIntegratorWithShareab
 	@Override
 	public HSQuery createHSQuery() {
 		return delegate.createHSQuery();
+	}
+
+	@Override
+	public QueryDescriptor createQueryDescriptor(Query luceneQuery, Class<?>... entities) {
+		return delegate.createQueryDescriptor( luceneQuery, entities );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/spi/SearchIntegrator.java
+++ b/engine/src/main/java/org/hibernate/search/spi/SearchIntegrator.java
@@ -9,6 +9,7 @@ package org.hibernate.search.spi;
 import java.util.Set;
 
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.search.Query;
 import org.hibernate.search.backend.spi.BatchBackend;
 import org.hibernate.search.backend.spi.Worker;
 import org.hibernate.search.batchindexing.MassIndexerProgressMonitor;
@@ -21,6 +22,7 @@ import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.metadata.IndexedTypeDescriptor;
 import org.hibernate.search.query.dsl.QueryContextBuilder;
 import org.hibernate.search.query.engine.spi.HSQuery;
+import org.hibernate.search.query.engine.spi.QueryDescriptor;
 import org.hibernate.search.query.engine.spi.TimeoutExceptionFactory;
 import org.hibernate.search.stat.Statistics;
 
@@ -57,7 +59,8 @@ public interface SearchIntegrator extends AutoCloseable {
 
 	/**
 	 * Return an Hibernate Search query object.
-	 * This object uses fluent APIs to define the query executed.
+	 * This method does NOT support non-Lucene backends (e.g. Elasticsearch).
+	 * The returned object uses fluent APIs to define the query executed.
 	 * Offers a few execution approaches:
 	 * - return the list of results eagerly
 	 * - return the list of results lazily
@@ -66,6 +69,18 @@ public interface SearchIntegrator extends AutoCloseable {
 	 * @return an Hibernate Search query object
 	 */
 	HSQuery createHSQuery();
+
+	/**
+	 * Return an Hibernate Search query descriptor.
+	 * <p>This method supports non-Lucene backends (e.g. Elasticsearch).
+	 * <p>The returned object allows for the creation of an {@link HSQuery} supported
+	 * by the relevant backend.
+	 * <p>Be aware that some backends may not implement {@link HSQuery#luceneQuery(Query)},
+	 * in which case the query provided here cannot be overridden.
+	 *
+	 * @return an Hibernate Search query descriptor
+	 */
+	QueryDescriptor createQueryDescriptor(Query luceneQuery, Class<?>... entities);
 
 	/**
 	 * @return true if the SearchIntegrator was stopped

--- a/orm/src/test/java/org/hibernate/search/test/configuration/integration/HibernateSearchIntegratorTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/integration/HibernateSearchIntegratorTest.java
@@ -31,6 +31,7 @@ import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.event.impl.FullTextIndexEventListener;
 import org.hibernate.search.hcore.impl.HibernateSearchIntegrator;
 import org.hibernate.search.hcore.impl.SearchFactoryReference;
+import org.hibernate.search.query.engine.impl.LuceneQueryTranslator;
 import org.hibernate.service.spi.SessionFactoryServiceRegistry;
 import org.junit.Test;
 import org.unitils.UnitilsJUnit4;
@@ -144,6 +145,9 @@ public class HibernateSearchIntegratorTest extends UnitilsJUnit4 {
 		expect( mockClassLoaderService.classForName( "javax.persistence.EmbeddedId" ) )
 			.andReturn( Object.class )
 			.anyTimes();
+
+		expect( mockClassLoaderService.loadJavaServices( LuceneQueryTranslator.class ) )
+				.andReturn( Collections.<LuceneQueryTranslator>emptySet() );
 
 		expect( mockClassLoaderService.loadJavaServices( IndexManagerTypeSpecificBridgeProvider.class ) )
 				.andReturn( Collections.<IndexManagerTypeSpecificBridgeProvider>emptySet() );


### PR DESCRIPTION
... in ExtendedSearchIntegrator.
This enables easier backend-independent querying when relying on the ORM module is not an option, e.g. in tests of the -engine module.
In particular, in #1139 we have this code for querying without relying on the ORM module:

```java
private List<EntityInfo> query(Query luceneQuery, Sort sort) {
	HSQuery hsQuery = getHSQuery( luceneQuery );
	return hsQuery
			.targetedEntities( Arrays.asList( new Class<?>[] { IndexedEntry.class } ) )
			.projection( "id" )
			.sort( sort )
			.queryEntityInfos();
}

private HSQuery getHSQuery(Query luceneQuery) {
	ExtendedSearchIntegrator sf = sfHolder.getSearchFactory();
	QueryDescriptor descriptor = null;
	try {
		ServiceReference<LuceneQueryTranslator> translator =
				sf.getServiceManager().requestReference( LuceneQueryTranslator.class );
		if ( translator.get().conversionRequired( IndexedEntry.class ) ) {
			descriptor = translator.get().convertLuceneQuery( luceneQuery );
		}
	}
	catch (SearchException e) {
		// Ignore: no translator found
	}

	if ( descriptor == null ) {
		descriptor = new LuceneQueryDescriptor( luceneQuery );
	}

	return descriptor.createHSQuery( sf );
}
```

It's a bit awkward, because we use service references simply for creating a query. But apparently that's the only way to do it in a backend-independent way.
With this PR, the code above would be much simpler:

```java
private List<EntityInfo> query(Query luceneQuery, Sort sort) {
	ExtendedSearchIntegrator sf = sfHolder.getSearchFactory();
	HSQuery hsQuery = sf.createQueryDescriptor( luceneQuery, IndexedEntry.class ).createHSQuery( sf );
	return hsQuery
			.targetedEntities( Arrays.asList( new Class<?>[] { IndexedEntry.class } ) )
			.projection( "id" )
			.sort( sort )
			.queryEntityInfos();
}
```

Now the accesses to services are hidden.
It still feels a bit weird (especially providing the `ExtendedSearchIntegrator` and the target entities twice), but we can't do much better without bringing substantial changes to QueryDescriptor/HSQuery. I tried not to add anything to these interfaces so as not to break ascending compatibility. HSQuery having been part of the SPI for a very long time, we'd better wait for HS 6.0 before changing it.

See `FullTextSessionImpl#createFullTextQuery(QueryDescriptor, Class<?>...)` for another example of an actual simplification.