### PR TITLE
HSEARCH-2257 Add Elasticsearch-specific TOOK and TIMED_OUT projections

### DIFF
--- a/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
+++ b/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
@@ -318,6 +318,28 @@ query = ftem.createFullTextQuery(
 projection = (Object[]) query.getSingleResult();
 --
 
+If you're looking for information about execution time, you may also use `org.hibernate.search.elasticsearch.ElasticsearchProjectionConstants.TOOK` and `org.hibernate.search.elasticsearch.ElasticsearchProjectionConstants.TIMED_OUT`: 
+
+[source,java]
+--
+query = ftem.createFullTextQuery(
+                    qb.keyword()
+                    .onField( "tags" )
+                    .matching( "round-based" )
+                    .createQuery(),
+                    VideoGame.class
+            )
+            .setProjection(
+                    ElasticsearchProjectionConstants.SOURCE,
+                    ElasticsearchProjectionConstants.TOOK,
+                    ElasticsearchProjectionConstants.TIMED_OUT 
+            );
+
+projection = (Object[]) query.getSingleResult();
+Integer took = (Integer) projection[1]; // Execution time (milliseconds)
+Boolean timedOut = (Boolean) projection[2]; // Whether the query timed out
+--
+
 ==== Filters
 
 The Elasticsearch integration supports the definition of full text filters.

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/ElasticsearchProjectionConstants.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/ElasticsearchProjectionConstants.java
@@ -49,5 +49,17 @@ public interface ElasticsearchProjectionConstants {
 	 */
 	String SOURCE = "__HSearch_Source";
 
-	// TODO HSEARCH-2257 add "took" etc.?
+	/**
+	 * The time Elasticsearch took to execute the search, in milliseconds and as an {@code Integer}.
+	 * <p>The time is computed on the server side.
+	 */
+	String TOOK = "__HSearch_Took";
+
+	/**
+	 * Whether the search timed out on the Elasticsearch server or not, as a {@code Boolean}.
+	 * <p>Note that a timed-out search may still return results, they are just incomplete.
+	 * <p>This does not translate a network timeout while reaching out to the Elasticsearch server,
+	 * but a timeout internal to Elasticsearch itself.
+	 */
+	String TIMED_OUT = "__HSearch_TimedOut";
 }

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchHSQueryImpl.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchHSQueryImpl.java
@@ -107,7 +107,9 @@ public class ElasticsearchHSQueryImpl extends AbstractHSQuery {
 					ElasticsearchProjectionConstants.SCORE,
 					ElasticsearchProjectionConstants.SOURCE,
 					ElasticsearchProjectionConstants.SPATIAL_DISTANCE,
-					ElasticsearchProjectionConstants.THIS
+					ElasticsearchProjectionConstants.THIS,
+					ElasticsearchProjectionConstants.TOOK,
+					ElasticsearchProjectionConstants.TIMED_OUT
 			)
 	);
 
@@ -238,10 +240,11 @@ public class ElasticsearchHSQueryImpl extends AbstractHSQuery {
 		}
 
 		List<EntityInfo> results = new ArrayList<>( searchResult.getTotal() );
-		JsonArray hits = searchResult.getJsonObject().get( "hits" ).getAsJsonObject().get( "hits" ).getAsJsonArray();
+		JsonObject searchResultJsonObject = searchResult.getJsonObject();
+		JsonArray hits = searchResultJsonObject.get( "hits" ).getAsJsonObject().get( "hits" ).getAsJsonArray();
 
 		for ( JsonElement hit : hits ) {
-			EntityInfo entityInfo = searcher.convertQueryHit( hit.getAsJsonObject() );
+			EntityInfo entityInfo = searcher.convertQueryHit( searchResultJsonObject, hit.getAsJsonObject() );
 			if ( entityInfo != null ) {
 				results.add( entityInfo );
 			}
@@ -504,7 +507,7 @@ public class ElasticsearchHSQueryImpl extends AbstractHSQuery {
 			}
 		}
 
-		EntityInfo convertQueryHit(JsonObject hit) {
+		EntityInfo convertQueryHit(JsonObject searchResult, JsonObject hit) {
 			String type = hit.get( "_type" ).getAsString();
 			Class<?> clazz = entityTypesByName.get( type );
 
@@ -548,6 +551,12 @@ public class ElasticsearchHSQueryImpl extends AbstractHSQuery {
 							else {
 								projections[i] = hit.getAsJsonObject().get( "fields" ).getAsJsonObject().get( SPATIAL_DISTANCE_FIELD ).getAsDouble();
 							}
+							break;
+						case ElasticsearchProjectionConstants.TOOK:
+							projections[i] = searchResult.get( "took" ).getAsInt();
+							break;
+						case ElasticsearchProjectionConstants.TIMED_OUT:
+							projections[i] = searchResult.get( "timed_out" ).getAsBoolean();
 							break;
 						case ElasticsearchProjectionConstants.THIS:
 							// Use EntityInfo.ENTITY_PLACEHOLDER as placeholder.
@@ -917,11 +926,12 @@ public class ElasticsearchHSQueryImpl extends AbstractHSQuery {
 
 		private void runSearch() {
 			SearchResult searchResult = searcher.runSearch();
-			JsonArray hits = searchResult.getJsonObject().get( "hits" ).getAsJsonObject().get( "hits" ).getAsJsonArray();
+			JsonObject searchResultJsonObject = searchResult.getJsonObject();
+			JsonArray hits = searchResultJsonObject.get( "hits" ).getAsJsonObject().get( "hits" ).getAsJsonArray();
 			results = new ArrayList<>( searchResult.getTotal() );
 
 			for ( JsonElement hit : hits ) {
-				EntityInfo converted = searcher.convertQueryHit( hit.getAsJsonObject() );
+				EntityInfo converted = searcher.convertQueryHit( searchResultJsonObject, hit.getAsJsonObject() );
 				if ( converted != null ) {
 					results.add( converted );
 				}

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIT.java
@@ -552,7 +552,9 @@ public class ElasticsearchIT extends SearchTestBase {
 						"dateOfBirth",
 						"handicap",
 						"driveWidth",
-						"ranking.value"
+						"ranking.value",
+						ElasticsearchProjectionConstants.TOOK,
+						ElasticsearchProjectionConstants.TIMED_OUT
 				)
 				.list();
 
@@ -575,6 +577,9 @@ public class ElasticsearchIT extends SearchTestBase {
 		assertThat( projection[8] ).describedAs( "handicap" ).isEqualTo( 3.4D );
 		assertThat( projection[9] ).describedAs( "driveWidth" ).isEqualTo( 285 );
 		assertThat( projection[10] ).describedAs( "ranking value" ).isEqualTo( BigInteger.valueOf( 311 ) );
+		assertThat( projection[11] ).describedAs( "took" ).isInstanceOf( Integer.class );
+		assertThat( (Integer) projection[11] ).describedAs( "took" ).isGreaterThanOrEqualTo( 0 );
+		assertThat( projection[12] ).describedAs( "timeout" ).isEqualTo( Boolean.FALSE );
 
 		tx.commit();
 		s.close();


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2257

@gsmet suggested in the original ticket that maybe only "took" and "timed_out" are strictly necessary, implying "_shards" may be unnecessary (["_shards"](https://www.elastic.co/guide/en/elasticsearch/reference/current/_the_search_api.html) tells us how many shards were searched, as well as a count of the successful/failed searched shards). I tend to agree with that as it seems like advanced usage to me, and I think HS 6.0 would be a better time for introducing advanced query metadata.
Let me know if I'm mistaken, though.