### PR TITLE
HSEARCH-2171 Don't use analyzers by default on non-string types

### DIFF
--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchDSLIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchDSLIT.java
@@ -8,6 +8,11 @@ package org.hibernate.search.elasticsearch.test;
 
 import static org.hibernate.search.elasticsearch.testutil.JsonHelper.assertJsonEquals;
 
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
@@ -18,8 +23,10 @@ import org.hibernate.search.FullTextQuery;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
 import org.hibernate.search.annotations.Analyzer;
+import org.hibernate.search.annotations.DateBridge;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.Resolution;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.test.SearchTestBase;
 import org.junit.Test;
@@ -104,6 +111,86 @@ public class ElasticsearchDSLIT extends SearchTestBase {
 	}
 
 	@Test
+	public void testDSLKeywordBoolean() throws Exception {
+		try ( Session session = openSession() ) {
+			FullTextSession fullTextSession = Search.getFullTextSession( session );
+			final QueryBuilder queryBuilder = queryBuilder( fullTextSession );
+
+			Query query = queryBuilder
+					.keyword()
+						.onField( "personal" )
+						.matching( true )
+					.createQuery();
+
+			FullTextQuery fullTextQuery = fullTextSession.createFullTextQuery( query, Letter.class );
+			String queryString = fullTextQuery.getQueryString();
+			assertJsonEquals( "{'query':{'term':{'personal':{'value':'true','boost':1.0}}}}", queryString );
+		}
+	}
+
+	@Test
+	public void testDSLKeywordFloat() throws Exception {
+		try ( Session session = openSession() ) {
+			FullTextSession fullTextSession = Search.getFullTextSession( session );
+			final QueryBuilder queryBuilder = queryBuilder( fullTextSession );
+
+			Query query = queryBuilder
+					.keyword()
+						.onField( "shippingCost" )
+						.matching( 0.40f )
+					.createQuery();
+
+			FullTextQuery fullTextQuery = fullTextSession.createFullTextQuery( query, Letter.class );
+			String queryString = fullTextQuery.getQueryString();
+			assertJsonEquals( "{'query':{'range':{'shippingCost':{'gte':0.4,'lte':0.4,'boost':1.0}}}}", queryString );
+		}
+	}
+
+	@Test
+	public void testDSLKeywordDate() throws Exception {
+		try ( Session session = openSession() ) {
+			FullTextSession fullTextSession = Search.getFullTextSession( session );
+			final QueryBuilder queryBuilder = queryBuilder( fullTextSession );
+
+			Calendar date = Calendar.getInstance( TimeZone.getTimeZone( "UTC" ), Locale.ENGLISH );
+			date.set( 1958, 3, 7, 5, 5, 5 );
+			date.set( Calendar.MILLISECOND, 0 );
+
+			Query query = queryBuilder
+					.keyword()
+						.onField( "dateWritten" )
+						.matching( date.getTime() )
+					.createQuery();
+
+			FullTextQuery fullTextQuery = fullTextSession.createFullTextQuery( query, Letter.class );
+			String queryString = fullTextQuery.getQueryString();
+			assertJsonEquals( "{'query':{'term':{'dateWritten':{'value':'1958-04-07T00:00:00Z','boost':1.0}}}}", queryString );
+		}
+	}
+
+	@Test
+	public void testDSLKeywordCalendar() throws Exception {
+		try ( Session session = openSession() ) {
+			FullTextSession fullTextSession = Search.getFullTextSession( session );
+			final QueryBuilder queryBuilder = queryBuilder( fullTextSession );
+
+			Calendar calendar = Calendar.getInstance( TimeZone.getTimeZone( "UTC" ), Locale.ENGLISH );
+			calendar.set( 1958, 3, 7, 5, 5, 5 );
+			calendar.set( Calendar.MILLISECOND, 0 );
+
+			Query query = queryBuilder
+					.keyword()
+						.onField( "dateSent" )
+						.matching( calendar )
+					.createQuery();
+
+			FullTextQuery fullTextQuery = fullTextSession.createFullTextQuery( query, Letter.class );
+			String queryString = fullTextQuery.getQueryString();
+			assertJsonEquals( "{'query':{'term':{'dateSent':{'value':'1958-04-07T00:00:00Z','boost':1.0}}}}", queryString );
+		}
+	}
+
+	@Test
 	public void testDSLPhraseQueryWithoutAnalyzer() {
 		try ( Session session = openSession() ) {
 			FullTextSession fullTextSession = Search.getFullTextSession( session );
@@ -147,6 +234,20 @@ public class ElasticsearchDSLIT extends SearchTestBase {
 		@Field
 		private String signature;
 
+		@Field
+		@DateBridge(resolution = Resolution.DAY)
+		private Date dateWritten;
+
+		@Field
+		@DateBridge(resolution = Resolution.DAY)
+		private Calendar dateSent;
+
+		@Field
+		private boolean personal;
+
+		@Field
+		private float shippingCost;
+
 		public Integer getId() {
 			return id;
 		}
@@ -170,5 +271,26 @@ public class ElasticsearchDSLIT extends SearchTestBase {
 		public void setSignature(String signature) {
 			this.signature = signature;
 		}
+
+
+		public Date getDateWritten() {
+			return dateWritten;
+		}
+
+
+		public void setDateWritten(Date dateWritten) {
+			this.dateWritten = dateWritten;
+		}
+
+
+		public Calendar getDateSent() {
+			return dateSent;
+		}
+
+
+		public void setDateSent(Calendar dateSent) {
+			this.dateSent = dateSent;
+		}
+
 	}
 }

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIT.java
@@ -636,6 +636,26 @@ public class ElasticsearchIT extends SearchTestBase {
 		s.close();
 	}
 
+	@Test
+	public void testBooleanProperty() throws Exception {
+		Session s = openSession();
+		FullTextSession session = Search.getFullTextSession( s );
+		Transaction tx = s.beginTransaction();
+
+		QueryDescriptor query = ElasticsearchQueries.fromJson( "{ 'query': { 'term' : { 'active' : 'true' } } }" );
+		List<?> result = session.createFullTextQuery( query, GolfPlayer.class )
+				.setProjection( ElasticsearchProjectionConstants.ID )
+				.list();
+
+		assertThat( result ).hasSize( 1 );
+		Object[] projection = (Object[]) result.iterator().next();
+
+		assertThat( projection[0] ).isEqualTo( 1L );
+
+		tx.commit();
+		s.close();
+	}
+
 	@Override
 	public Class<?>[] getAnnotatedClasses() {
 		return new Class[] { ScientificArticle.class, Tower.class, Address.class, Country.class, State.class, StateCandidate.class, ResearchPaper.class,

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/BooleanBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/BooleanBridge.java
@@ -6,15 +6,16 @@
  */
 package org.hibernate.search.bridge.builtin;
 
-import org.hibernate.search.util.StringHelper;
 import org.hibernate.search.bridge.TwoWayStringBridge;
+import org.hibernate.search.bridge.spi.IgnoreAnalyzerBridge;
+import org.hibernate.search.util.StringHelper;
 
 /**
  * Bridge a boolean field to a {@link String}.
  *
  * @author Sylvain Vieujot
  */
-public class BooleanBridge implements TwoWayStringBridge {
+public class BooleanBridge implements TwoWayStringBridge, IgnoreAnalyzerBridge {
 
 	@Override
 	public Boolean stringToObject(String stringValue) {

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/NumberBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/NumberBridge.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.bridge.builtin;
 
 import org.hibernate.search.bridge.TwoWayStringBridge;
+import org.hibernate.search.bridge.spi.IgnoreAnalyzerBridge;
 
 /**
  * Base class used to bridge numbers (integer, double, etc.) as strings.
@@ -16,7 +17,7 @@ import org.hibernate.search.bridge.TwoWayStringBridge;
  * @see NumericFieldBridge
  * @author Emmanuel Bernard
  */
-public abstract class NumberBridge implements TwoWayStringBridge {
+public abstract class NumberBridge implements TwoWayStringBridge, IgnoreAnalyzerBridge {
 	@Override
 	public String objectToString(Object object) {
 		return object != null ?

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/UUIDBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/UUIDBridge.java
@@ -9,13 +9,14 @@ package org.hibernate.search.bridge.builtin;
 import java.util.UUID;
 
 import org.hibernate.search.bridge.TwoWayStringBridge;
+import org.hibernate.search.bridge.spi.IgnoreAnalyzerBridge;
 
 /**
  * Bridge a {@link UUID} to a {@link String}.
  *
  * @author Davide D'Alto
  */
-public class UUIDBridge implements TwoWayStringBridge {
+public class UUIDBridge implements TwoWayStringBridge, IgnoreAnalyzerBridge {
 
 	@Override
 	public String objectToString(Object object) {

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/UriBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/UriBridge.java
@@ -12,13 +12,14 @@ import java.net.URISyntaxException;
 import org.hibernate.search.util.StringHelper;
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.bridge.TwoWayStringBridge;
+import org.hibernate.search.bridge.spi.IgnoreAnalyzerBridge;
 
 /**
  * Bridge a {@link URI} to a {@link String}.
  *
  * @author Emmanuel Bernard
  */
-public class UriBridge implements TwoWayStringBridge {
+public class UriBridge implements TwoWayStringBridge, IgnoreAnalyzerBridge {
 	@Override
 	public Object stringToObject(String stringValue) {
 		if ( StringHelper.isEmpty( stringValue ) ) {

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/UrlBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/UrlBridge.java
@@ -11,6 +11,7 @@ import java.net.MalformedURLException;
 
 import org.hibernate.search.util.StringHelper;
 import org.hibernate.search.bridge.TwoWayStringBridge;
+import org.hibernate.search.bridge.spi.IgnoreAnalyzerBridge;
 import org.hibernate.search.exception.SearchException;
 
 /**
@@ -18,7 +19,7 @@ import org.hibernate.search.exception.SearchException;
  *
  * @author Emmanuel Bernard
  */
-public class UrlBridge implements TwoWayStringBridge {
+public class UrlBridge implements TwoWayStringBridge, IgnoreAnalyzerBridge {
 	@Override
 	public Object stringToObject(String stringValue) {
 		if ( StringHelper.isEmpty( stringValue ) ) {

--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/impl/TwoWayString2FieldBridgeIgnoreAnalyzerAdaptor.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/impl/TwoWayString2FieldBridgeIgnoreAnalyzerAdaptor.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.bridge.builtin.impl;
+
+import org.hibernate.search.bridge.TwoWayStringBridge;
+import org.hibernate.search.bridge.spi.IgnoreAnalyzerBridge;
+
+
+/**
+ * @author Yoann Rodiere
+ */
+public class TwoWayString2FieldBridgeIgnoreAnalyzerAdaptor extends TwoWayString2FieldBridgeAdaptor implements IgnoreAnalyzerBridge {
+
+	public <T extends TwoWayStringBridge & IgnoreAnalyzerBridge>
+			TwoWayString2FieldBridgeIgnoreAnalyzerAdaptor(T stringBridge) {
+		super( stringBridge );
+	}
+
+}

--- a/engine/src/main/java/org/hibernate/search/bridge/impl/BasicJDKTypesBridgeProvider.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/impl/BasicJDKTypesBridgeProvider.java
@@ -54,9 +54,9 @@ class BasicJDKTypesBridgeProvider implements BridgeProvider {
 	private static final TwoWayFieldBridge BIG_DECIMAL = new TwoWayString2FieldBridgeIgnoreAnalyzerAdaptor( new BigDecimalBridge() );
 	private static final TwoWayFieldBridge STRING = new TwoWayString2FieldBridgeAdaptor( new StringBridge() );
 	private static final TwoWayFieldBridge BOOLEAN = new TwoWayString2FieldBridgeIgnoreAnalyzerAdaptor( new BooleanBridge() );
-	private static final TwoWayFieldBridge Url = new TwoWayString2FieldBridgeAdaptor( new UrlBridge() );
-	private static final TwoWayFieldBridge Uri = new TwoWayString2FieldBridgeAdaptor( new UriBridge() );
-	private static final TwoWayFieldBridge UUID = new TwoWayString2FieldBridgeAdaptor( new UUIDBridge() );
+	private static final TwoWayFieldBridge Url = new TwoWayString2FieldBridgeIgnoreAnalyzerAdaptor( new UrlBridge() );
+	private static final TwoWayFieldBridge Uri = new TwoWayString2FieldBridgeIgnoreAnalyzerAdaptor( new UriBridge() );
+	private static final TwoWayFieldBridge UUID = new TwoWayString2FieldBridgeIgnoreAnalyzerAdaptor( new UUIDBridge() );
 
 	//Not static as it depends on the application's classloader
 	private final TwoWayFieldBridge clazz;

--- a/engine/src/main/java/org/hibernate/search/bridge/impl/BasicJDKTypesBridgeProvider.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/impl/BasicJDKTypesBridgeProvider.java
@@ -44,14 +44,14 @@ import org.hibernate.search.engine.service.spi.ServiceManager;
 class BasicJDKTypesBridgeProvider implements BridgeProvider {
 
 	private static final TwoWayFieldBridge CHARACTER = new TwoWayString2FieldBridgeAdaptor( new CharacterBridge() );
-	private static final TwoWayFieldBridge DOUBLE = new TwoWayString2FieldBridgeAdaptor( new DoubleBridge() );
-	private static final TwoWayFieldBridge FLOAT = new TwoWayString2FieldBridgeAdaptor( new FloatBridge() );
-	private static final TwoWayFieldBridge BYTE = new TwoWayString2FieldBridgeAdaptor( new ByteBridge() );
-	private static final TwoWayFieldBridge SHORT = new TwoWayString2FieldBridgeAdaptor( new ShortBridge() );
-	private static final TwoWayFieldBridge INTEGER = new TwoWayString2FieldBridgeAdaptor( new IntegerBridge() );
-	private static final TwoWayFieldBridge LONG = new TwoWayString2FieldBridgeAdaptor( new LongBridge() );
-	private static final TwoWayFieldBridge BIG_INTEGER = new TwoWayString2FieldBridgeAdaptor( new BigIntegerBridge() );
-	private static final TwoWayFieldBridge BIG_DECIMAL = new TwoWayString2FieldBridgeAdaptor( new BigDecimalBridge() );
+	private static final TwoWayFieldBridge DOUBLE = new TwoWayString2FieldBridgeIgnoreAnalyzerAdaptor( new DoubleBridge() );
+	private static final TwoWayFieldBridge FLOAT = new TwoWayString2FieldBridgeIgnoreAnalyzerAdaptor( new FloatBridge() );
+	private static final TwoWayFieldBridge BYTE = new TwoWayString2FieldBridgeIgnoreAnalyzerAdaptor( new ByteBridge() );
+	private static final TwoWayFieldBridge SHORT = new TwoWayString2FieldBridgeIgnoreAnalyzerAdaptor( new ShortBridge() );
+	private static final TwoWayFieldBridge INTEGER = new TwoWayString2FieldBridgeIgnoreAnalyzerAdaptor( new IntegerBridge() );
+	private static final TwoWayFieldBridge LONG = new TwoWayString2FieldBridgeIgnoreAnalyzerAdaptor( new LongBridge() );
+	private static final TwoWayFieldBridge BIG_INTEGER = new TwoWayString2FieldBridgeIgnoreAnalyzerAdaptor( new BigIntegerBridge() );
+	private static final TwoWayFieldBridge BIG_DECIMAL = new TwoWayString2FieldBridgeIgnoreAnalyzerAdaptor( new BigDecimalBridge() );
 	private static final TwoWayFieldBridge STRING = new TwoWayString2FieldBridgeAdaptor( new StringBridge() );
 	private static final TwoWayFieldBridge BOOLEAN = new TwoWayString2FieldBridgeIgnoreAnalyzerAdaptor( new BooleanBridge() );
 	private static final TwoWayFieldBridge Url = new TwoWayString2FieldBridgeAdaptor( new UrlBridge() );

--- a/engine/src/main/java/org/hibernate/search/bridge/impl/BasicJDKTypesBridgeProvider.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/impl/BasicJDKTypesBridgeProvider.java
@@ -32,6 +32,7 @@ import org.hibernate.search.bridge.builtin.UUIDBridge;
 import org.hibernate.search.bridge.builtin.UriBridge;
 import org.hibernate.search.bridge.builtin.UrlBridge;
 import org.hibernate.search.bridge.builtin.impl.TwoWayString2FieldBridgeAdaptor;
+import org.hibernate.search.bridge.builtin.impl.TwoWayString2FieldBridgeIgnoreAnalyzerAdaptor;
 import org.hibernate.search.bridge.spi.BridgeProvider;
 import org.hibernate.search.engine.service.spi.ServiceManager;
 
@@ -52,7 +53,7 @@ class BasicJDKTypesBridgeProvider implements BridgeProvider {
 	private static final TwoWayFieldBridge BIG_INTEGER = new TwoWayString2FieldBridgeAdaptor( new BigIntegerBridge() );
 	private static final TwoWayFieldBridge BIG_DECIMAL = new TwoWayString2FieldBridgeAdaptor( new BigDecimalBridge() );
 	private static final TwoWayFieldBridge STRING = new TwoWayString2FieldBridgeAdaptor( new StringBridge() );
-	private static final TwoWayFieldBridge BOOLEAN = new TwoWayString2FieldBridgeAdaptor( new BooleanBridge() );
+	private static final TwoWayFieldBridge BOOLEAN = new TwoWayString2FieldBridgeIgnoreAnalyzerAdaptor( new BooleanBridge() );
 	private static final TwoWayFieldBridge Url = new TwoWayString2FieldBridgeAdaptor( new UrlBridge() );
 	private static final TwoWayFieldBridge Uri = new TwoWayString2FieldBridgeAdaptor( new UriBridge() );
 	private static final TwoWayFieldBridge UUID = new TwoWayString2FieldBridgeAdaptor( new UUIDBridge() );


### PR DESCRIPTION
Here is a fix for [HSEARCH-2171](https://hibernate.atlassian.net/browse/HSEARCH-2171) , which mainly expresses concerns about how non-string values (booleans, dates, ...) are converted to ES query values.
It turns out the problem has already been addressed **for dates** as part of [HSEARCH-2246](https://hibernate.atlassian.net/browse/HSEARCH-2246) (commit d820d1f0791743c02e62366e3ee254d92c44d5ea). **But** one part of the issue, the fact that some types should not see their string value analyzed, has not been addressed for other types (booleans, longs, ...). That's the purpose of this PR.

Note that this may break some existing user code. Because we don't analyze values for these types, this kind of code won't work anymore:

```
			Query query = queryBuilder
					.keyword()
						.onField( "myNumericFieldStoredAsString" )
						.matching( "12 13" ) // Will match 12 or 13
					.createQuery();
```

That's true for the types we address in this PR as well as for dates, addressed in d820d1f0791743c02e62366e3ee254d92c44d5ea.
I'm not sure it was expected behavior, though. This requires overriding the default analyzer, in particular, since the default in Hibernate Search is to use a `LowerCaseTokenizer`, which ignores digits. 

On the other hand, users with custom default analyzers may have had surprises in the past, especially when tokenizing on "." (searching for "12.2" may have matched "12" or "2" but not "12.2").

So, the question is: is the current behavior (number, boolean and URL fields are analyzed) something we want to preserve, or is it a bug? If it's a bug, this PR should be reviewed and merged, otherwise we can put it straight to the trash bin. 