### PR TITLE
HSEARCH-2170 Convert the GsonHolder to a Service to ensure cleanup

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/ElasticsearchQueries.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/ElasticsearchQueries.java
@@ -7,9 +7,10 @@
 package org.hibernate.search.elasticsearch;
 
 import org.hibernate.search.elasticsearch.impl.ElasticsearchJsonQueryDescriptor;
-import org.hibernate.search.elasticsearch.impl.GsonHolder;
 import org.hibernate.search.elasticsearch.impl.JsonBuilder;
 import org.hibernate.search.query.engine.spi.QueryDescriptor;
+
+import com.google.gson.JsonParser;
 
 /**
  * Creates queries to be used with Elasticsearch.
@@ -17,6 +18,8 @@ import org.hibernate.search.query.engine.spi.QueryDescriptor;
  * @author Gunnar Morling
  */
 public class ElasticsearchQueries {
+
+	private static final JsonParser PARSER = new JsonParser();
 
 	private ElasticsearchQueries() {
 	}
@@ -27,7 +30,7 @@ public class ElasticsearchQueries {
 	 * documentation</a> for the complete query syntax.
 	 */
 	public static QueryDescriptor fromJson(String jsonQuery) {
-		return new ElasticsearchJsonQueryDescriptor( GsonHolder.PARSER.parse( jsonQuery ).getAsJsonObject() );
+		return new ElasticsearchJsonQueryDescriptor( PARSER.parse( jsonQuery ).getAsJsonObject() );
 	}
 
 	/**

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/DefaultGsonService.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/DefaultGsonService.java
@@ -8,25 +8,21 @@ package org.hibernate.search.elasticsearch.impl;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonParser;
 
 import io.searchbox.client.AbstractJestClient;
 
 /**
- * Centralizes the configuration of the Gson object.
- *
  * @author Guillaume Smet
  */
-public class GsonHolder {
+public class DefaultGsonService implements GsonService {
 
-	private GsonHolder() {
-	}
-
-	public static final Gson GSON = new GsonBuilder()
+	private final Gson gson = new GsonBuilder()
 			.setDateFormat( AbstractJestClient.ELASTIC_SEARCH_DATE_FORMAT )
 			.serializeNulls()
 			.create();
 
-	public static final JsonParser PARSER = new JsonParser();
+	public Gson getGson() {
+		return gson;
+	}
 
 }

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchHSQueryImpl.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchHSQueryImpl.java
@@ -73,6 +73,7 @@ import org.hibernate.search.util.logging.impl.LoggerFactory;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.google.gson.JsonPrimitive;
 
 import io.searchbox.core.DocumentResult;
@@ -88,6 +89,8 @@ import io.searchbox.core.search.sort.Sort.Sorting;
  * @author Gunnar Morling
  */
 public class ElasticsearchHSQueryImpl extends AbstractHSQuery {
+
+	private static final JsonParser JSON_PARSER = new JsonParser();
 
 	private static final Log LOG = LoggerFactory.make( Log.class );
 
@@ -821,7 +824,8 @@ public class ElasticsearchHSQueryImpl extends AbstractHSQuery {
 					jsonFilter = ToElasticsearch.fromLuceneFilter( (Filter) candidateFilter );
 				}
 				else if ( candidateFilter instanceof ElasticsearchFilter ) {
-					jsonFilter = GsonHolder.PARSER.parse( ( (ElasticsearchFilter) candidateFilter ).getJsonFilter() ).getAsJsonObject();
+					jsonFilter = JSON_PARSER.parse( ( (ElasticsearchFilter) candidateFilter ).getJsonFilter() )
+							.getAsJsonObject();
 				}
 				else {
 					throw new SearchException(
@@ -841,7 +845,7 @@ public class ElasticsearchHSQueryImpl extends AbstractHSQuery {
 				jsonFilter = ToElasticsearch.fromLuceneFilter( (Filter) filterOrFactory );
 			}
 			else if ( filterOrFactory instanceof ElasticsearchFilter ) {
-				jsonFilter = GsonHolder.PARSER.parse( ( (ElasticsearchFilter) filterOrFactory ).getJsonFilter() ).getAsJsonObject();
+				jsonFilter = JSON_PARSER.parse( ( (ElasticsearchFilter) filterOrFactory ).getJsonFilter() ).getAsJsonObject();
 			}
 			else {
 				throw new SearchException(

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/GsonService.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/GsonService.java
@@ -1,0 +1,22 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.impl;
+
+import org.hibernate.search.engine.service.spi.Service;
+
+import com.google.gson.Gson;
+
+/**
+ * Centralizes the configuration of the Gson object.
+ *
+ * @author Guillaume Smet
+ */
+public interface GsonService extends Service {
+
+	Gson getGson();
+
+}

--- a/elasticsearch/src/main/resources/META-INF/services/org.hibernate.search.elasticsearch.impl.GsonService
+++ b/elasticsearch/src/main/resources/META-INF/services/org.hibernate.search.elasticsearch.impl.GsonService
@@ -1,0 +1,1 @@
+org.hibernate.search.elasticsearch.impl.DefaultGsonService


### PR DESCRIPTION
Mainly because Gson holds references to ThreadLocals, so having it stored in a static variable is not desirable.
JsonParser has been moved to private static variables, though, since it does not contain any data.

https://hibernate.atlassian.net/browse/HSEARCH-2170