### PR TITLE
HSEARCH-2336 Upgrade Unitils to 3.4.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -547,12 +547,12 @@
             <dependency>
                 <groupId>org.easymock</groupId>
                 <artifactId>easymock</artifactId>
-                <version>2.4</version>
+                <version>3.2</version>
             </dependency>
             <dependency>
                 <groupId>org.unitils</groupId>
                 <artifactId>unitils-easymock</artifactId>
-                <version>3.3</version>
+                <version>3.4.3</version>
             </dependency>
             <dependency>
                 <groupId>simple-jndi</groupId>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2336

The main thing to check is: is it okay to upgrade to another major version of Easymock, even though we may expose this version through the `hibernate-search-testing` module?

The release notes of EasyMock 3 are available at the bottom of this page: http://easymock.sourceforge.net/EasyMock3_0_Documentation.html
From the release notes, it doesn't seem there's been a major overhaul on 3.x, and the build passes without changing anything other than the versions in the POM.