### PR TITLE
HSEARCH-2262 In the Elasticsearch mapping, validate the type of the null_value/indexNullAs property

### DIFF
--- a/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
+++ b/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
@@ -135,6 +135,19 @@ Simply use familiar annotations from <<search-mapping>>.
 The name of the index will be the lowercased name provided to `@Indexed` (non qualified class name by default).
 Hibernate Search will map the fully qualified class name to the Elasticsearch type.
 
+==== Annotation specificities
+
+===== Field.indexNullAs
+
+The `org.hibernate.search.annotations.Field` annotation allows you to provide a replacement value for null properties through the `indexNullAs` attribute (see <<field-annotation>>), but this value must be provided as a string.
+
+In order for your value to be understood by Hibernate Search (and Elasticsearch), the provided string must follow one of those formats:
+
+ * For string values, no particular format is required.
+ * For numeric values, use formats accepted by `Double.parseDouble`, `Integer.parseInteger`, etc., depending on the actual type of your field.
+ * For booleans, use either `true` or `false`.
+ * For dates, use the ISO-8601 format (`yyyy-MM-dd'T'HH:mm:ssZ`, for instance `2016-08-26T16:41:00+01:00`). The time and time zone may be omitted (if omitted, the time zone will be interpreted as the default JVM time zone).
+
 ==== [[elasticsearch-mapping-analyzer]] Analyzers
 
 CAUTION: Analyzers are treated differently than in Lucene embedded mode.

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticSearchIndexNullAsHelper.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticSearchIndexNullAsHelper.java
@@ -1,0 +1,106 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.impl;
+
+import java.util.Date;
+
+import org.hibernate.search.elasticsearch.logging.impl.Log;
+import org.hibernate.search.elasticsearch.util.impl.ElasticsearchDateHelper;
+import org.hibernate.search.exception.AssertionFailure;
+import org.hibernate.search.util.logging.impl.LoggerFactory;
+
+/**
+ * @author Sanne Grinovero
+ * @author Yoann Rodiere
+ */
+class ElasticSearchIndexNullAsHelper {
+
+	private static final Log LOG = LoggerFactory.make( Log.class );
+
+	private ElasticSearchIndexNullAsHelper() {
+		// not to be instantiated
+	}
+
+	public static Object getNullValue(String fieldName, ElasticsearchFieldType dataType, String indexNullAs) {
+		switch ( dataType ) {
+			case STRING:
+				return indexNullAs;
+			case DOUBLE:
+				return toDouble( indexNullAs, fieldName );
+			case FLOAT:
+				return toFloat( indexNullAs, fieldName );
+			case INTEGER:
+				return toInteger( indexNullAs, fieldName );
+			case LONG:
+				return toLong( indexNullAs, fieldName );
+			case DATE:
+				return toDate( indexNullAs, fieldName );
+			case BOOLEAN:
+				return toBoolean( indexNullAs, fieldName );
+			default:
+				throw new AssertionFailure( "Unexpected Elasticsearch datatype: " + dataType );
+		}
+	}
+
+	private static Long toLong(String proposedTokenValue, String fieldName) {
+		try {
+			return Long.parseLong( proposedTokenValue );
+		}
+		catch (NumberFormatException nfe) {
+			throw LOG.nullMarkerNeedsToRepresentALongNumber( proposedTokenValue, fieldName );
+		}
+	}
+
+	private static Integer toInteger(String proposedTokenValue, String fieldName) {
+		try {
+			return Integer.parseInt( proposedTokenValue );
+		}
+		catch (NumberFormatException nfe) {
+			throw LOG.nullMarkerNeedsToRepresentAnIntegerNumber( proposedTokenValue, fieldName );
+		}
+	}
+
+	private static Float toFloat(String proposedTokenValue, String fieldName) {
+		try {
+			return Float.parseFloat( proposedTokenValue );
+		}
+		catch (NumberFormatException nfe) {
+			throw LOG.nullMarkerNeedsToRepresentAFloatNumber( proposedTokenValue, fieldName );
+		}
+	}
+
+	private static Double toDouble(String proposedTokenValue, String fieldName) {
+		try {
+			return Double.parseDouble( proposedTokenValue );
+		}
+		catch (NumberFormatException nfe) {
+			throw LOG.nullMarkerNeedsToRepresentADoubleNumber( proposedTokenValue, fieldName );
+		}
+	}
+
+	private static Boolean toBoolean(String indexNullAs, String fieldName) {
+		if ( Boolean.TRUE.toString().equals( indexNullAs ) ) {
+			return Boolean.TRUE;
+		}
+		else if ( Boolean.FALSE.toString().equals( indexNullAs ) ) {
+			return Boolean.FALSE;
+		}
+		else {
+			throw LOG.nullMarkerNeedsToRepresentABoolean( indexNullAs, fieldName );
+		}
+	}
+
+	private static Date toDate(String indexNullAs, String fieldName) {
+		try {
+			return ElasticsearchDateHelper.stringToDate( indexNullAs );
+		}
+		catch (IllegalArgumentException e) {
+			throw LOG.nullMarkerNeedsToRepresentADate( indexNullAs, fieldName );
+		}
+	}
+
+}

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchFieldType.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchFieldType.java
@@ -1,0 +1,41 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.impl;
+
+/**
+ * An enum representation of Elasticsearch field datatypes.
+ *
+ * <p>Only those types that are supported by Hibernate Search are listed.
+ *
+ * @author Yoann Rodiere
+ */
+enum ElasticsearchFieldType {
+
+	STRING("string"),
+	LONG("long"),
+	INTEGER("integer"),
+	DOUBLE("double"),
+	FLOAT("float"),
+	DATE("date"),
+	BOOLEAN("boolean"),
+
+	GEO_POINT("geo_point");
+
+	private final String elasticsearchString;
+
+	private ElasticsearchFieldType(String elasticsearchString) {
+		this.elasticsearchString = elasticsearchString;
+	}
+
+	/**
+	 * @return the Elasticsearch name for this type.
+	 */
+	public String getElasticsearchString() {
+		return elasticsearchString;
+	};
+
+}

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
@@ -157,4 +157,14 @@ public interface Log extends org.hibernate.search.util.logging.impl.Log {
 			value = "Faceting request of type %1$s not supported"
 	)
 	SearchException facetingRequestHasUnsupportedType(String facetingRequestType);
+
+	@Message(id = ES_BACKEND_MESSAGES_START_ID + 27,
+			value = "The 'indexNullAs' property for field '%2$s' needs to represent a Boolean to match the field type of the index. "
+					+ "Please change value from '%1$s' to represent a Boolean." )
+	SearchException nullMarkerNeedsToRepresentABoolean(String proposedTokenValue, String fieldName);
+
+	@Message(id = ES_BACKEND_MESSAGES_START_ID + 28,
+			value = "The 'indexNullAs' property for field '%2$s' needs to represent a Date to match the field type of the index. "
+					+ "Please change value from '%1$s' to represent a Date." )
+	SearchException nullMarkerNeedsToRepresentADate(String proposedTokenValue, String fieldName);
 }

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIndexNullAsTypeCheckingIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIndexNullAsTypeCheckingIT.java
@@ -1,0 +1,134 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.test;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+import java.util.Set;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.elasticsearch.cfg.ElasticsearchEnvironment;
+import org.hibernate.search.elasticsearch.cfg.IndexSchemaManagementStrategy;
+import org.hibernate.search.elasticsearch.impl.ElasticsearchIndexManager;
+import org.hibernate.search.exception.SearchException;
+import org.hibernate.search.test.DefaultTestResourceManager;
+import org.hibernate.search.test.util.TestConfiguration;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+/**
+ * Unit tests for {@link ElasticsearchIndexManager}'s indexNullAs type checking.
+ *
+ * @author Yoann Rodiere
+ */
+@RunWith(Suite.class)
+@SuiteClasses(value = {
+		ElasticsearchIndexNullAsTypeCheckingIT.BooleanFailureTest.class,
+		ElasticsearchIndexNullAsTypeCheckingIT.DateFailureTest.class
+})
+public class ElasticsearchIndexNullAsTypeCheckingIT {
+
+	protected abstract static class AbstractIndexNullAsFailureTest implements TestConfiguration {
+		@Rule
+		public ExpectedException thrown = ExpectedException.none();
+
+		private DefaultTestResourceManager testResourceManager;
+
+		protected void init() {
+			getTestResourceManager().openSessionFactory();
+		}
+
+		// synchronized due to lazy initialization (source: SearchTestBase.java)
+		private synchronized DefaultTestResourceManager getTestResourceManager() {
+			if ( testResourceManager == null ) {
+				testResourceManager = new DefaultTestResourceManager( this, this.getClass() );
+			}
+			return testResourceManager;
+		}
+
+		@Override
+		public void configure(Map<String, Object> settings) {
+			settings.put(
+					ElasticsearchEnvironment.INDEX_SCHEMA_MANAGEMENT_STRATEGY,
+					IndexSchemaManagementStrategy.CREATE
+					);
+		}
+
+		@Override
+		public Set<String> multiTenantIds() {
+			// Empty by default; specify more than one tenant to enable multi-tenancy
+			return Collections.emptySet();
+		}
+	}
+
+	public static class BooleanFailureTest extends AbstractIndexNullAsFailureTest {
+		@Test
+		public void indexNullAs_invalid_boolean() {
+			thrown.expect( SearchException.class );
+			thrown.expectMessage( "HSEARCH400027" );
+			thrown.expectMessage( "Boolean" );
+			thrown.expectMessage( "myField" );
+
+			init();
+		}
+
+		@Override
+		public Class<?>[] getAnnotatedClasses() {
+			return new Class[] { BooleanFailureTestEntity.class };
+		}
+
+		@Indexed
+		@Entity
+		public static class BooleanFailureTestEntity {
+			@DocumentId
+			@Id
+			Long id;
+
+			@Field(indexNullAs = "foo")
+			boolean myField;
+		}
+	}
+
+	public static class DateFailureTest extends AbstractIndexNullAsFailureTest {
+		@Test
+		public void indexNullAs_invalid_boolean() {
+			thrown.expect( SearchException.class );
+			thrown.expectMessage( "HSEARCH400028" );
+			thrown.expectMessage( "Date" );
+			thrown.expectMessage( "myField" );
+
+			init();
+		}
+
+		@Override
+		public Class<?>[] getAnnotatedClasses() {
+			return new Class[] { DateFailureTestEntity.class };
+		}
+
+		@Indexed
+		@Entity
+		public static class DateFailureTestEntity {
+			@DocumentId
+			@Id
+			Long id;
+
+			@Field(indexNullAs = "01/01/2013") // Expected format is ISO-8601 (yyyy-MM-dd'T'HH:mm:ssZ)
+			Date myField;
+		}
+	}
+
+}

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/GolfPlayer.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/GolfPlayer.java
@@ -61,11 +61,11 @@ public class GolfPlayer {
 	@Field(indexNullAs = "false")
 	private Boolean active;
 
-	@Field(indexNullAs = "1970-01-01")
+	@Field(indexNullAs = "1970-01-01+00:00")
 	@DateBridge(resolution = Resolution.DAY)
 	private Date dateOfBirth;
 
-	@Field(indexNullAs = "1970-01-01")
+	@Field(indexNullAs = "1970-01-01+00:00")
 	@DateBridge(resolution = Resolution.DAY)
 	private Calendar subscriptionEndDate;
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2262

~~This currenly only works when running on JVMs with UTC timezone, and will fail miserably on JVMs with GMT+1 default timezone for instance. Either we fix [HSEARCH-2335](https://hibernate.atlassian.net/browse/HSEARCH-2335) and this PR will work as is, or we decide not to, and this PR will need some work.~~ Fixed, see comments.