### PR TITLE
java.lang.IllegalStateException: Not a JSON Object: null

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchIndexWorkVisitor.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchIndexWorkVisitor.java
@@ -68,7 +68,7 @@ class ElasticsearchIndexWorkVisitor implements IndexWorkVisitor<Void, BackendReq
 	private static final Log LOG = LoggerFactory.make();
 
 	private static final Pattern DOT = Pattern.compile( "\\." );
-	private static final Pattern NAME_AND_INDEX = Pattern.compile( "(.+?)(\\[([0-9])+\\])?" );
+	private static final Pattern NAME_AND_INDEX = Pattern.compile( "(.+?)(\\[([0-9]+)\\])?" );
 
 	private static final String DELETE_ALL_QUERY = "{ \"query\" : { \"constant_score\" : { \"filter\" : { \"match_all\" : { } } } } }";
 	private static final String DELETE_ALL_FOR_TENANT_QUERY = "{ \"query\" : { \"constant_score\" : { \"filter\" : { \"term\" : { \"" + DocumentBuilderIndexedEntity.TENANT_ID_FIELDNAME + "\" : \"%s\" } } } } }";


### PR DESCRIPTION
Hi,

Recenetly, I guess, I have found the bug in regular expression in ElasticsearchIndexWorkVisitor causing the error in the following stacktrace:

```
org.springframework.transaction.TransactionSystemException: Could not commit JPA transaction; nested exception is javax.persistence.RollbackException: Error while committing the transaction
	at org.springframework.orm.jpa.JpaTransactionManager.doCommit(JpaTransactionManager.java:526)
	at org.springframework.transaction.support.AbstractPlatformTransactionManager.processCommit(AbstractPlatformTransactionManager.java:761)
	at org.springframework.transaction.support.AbstractPlatformTransactionManager.commit(AbstractPlatformTransactionManager.java:730)
	at org.springframework.transaction.interceptor.TransactionAspectSupport.commitTransactionAfterReturning(TransactionAspectSupport.java:485)
	at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:291)
	at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:96)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179)
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:655)
	at com.momega.hsearchbug.service.ParentService$$EnhancerBySpringCGLIB$$80455dc8.inputData(<generated>)
	at hsearchbug.SimpleTest.test(SimpleTest.java:24)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:50)
	at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:38)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:459)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:675)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:382)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:192)
Caused by: javax.persistence.RollbackException: Error while committing the transaction
	at org.hibernate.jpa.internal.TransactionImpl.commit(TransactionImpl.java:87)
	at org.springframework.orm.jpa.JpaTransactionManager.doCommit(JpaTransactionManager.java:517)
	... 32 more
Caused by: org.hibernate.AssertionFailure: Exception releasing cache locks
	at org.hibernate.engine.spi.ActionQueue$AfterTransactionCompletionProcessQueue.afterTransactionCompletion(ActionQueue.java:935)
	at org.hibernate.engine.spi.ActionQueue.afterTransactionCompletion(ActionQueue.java:469)
	at org.hibernate.internal.SessionImpl.afterTransactionCompletion(SessionImpl.java:2356)
	at org.hibernate.engine.jdbc.internal.JdbcCoordinatorImpl.afterTransactionCompletion(JdbcCoordinatorImpl.java:491)
	at org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorImpl.afterCompletionCallback(JdbcResourceLocalTransactionCoordinatorImpl.java:167)
	at org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorImpl.access$200(JdbcResourceLocalTransactionCoordinatorImpl.java:38)
	at org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorImpl$TransactionDriverControlImpl.commit(JdbcResourceLocalTransactionCoordinatorImpl.java:233)
	at org.hibernate.engine.transaction.internal.TransactionImpl.commit(TransactionImpl.java:65)
	at org.hibernate.jpa.internal.TransactionImpl.commit(TransactionImpl.java:61)
	... 33 more
Caused by: org.hibernate.HibernateException: Error while indexing in Hibernate Search (after transaction completion)
	at org.hibernate.search.backend.impl.EventSourceTransactionContext$DelegateToSynchronizationOnAfterTx.doAfterTransactionCompletion(EventSourceTransactionContext.java:190)
	at org.hibernate.engine.spi.ActionQueue$AfterTransactionCompletionProcessQueue.afterTransactionCompletion(ActionQueue.java:928)
	... 41 more
Caused by: java.lang.IllegalStateException: Not a JSON Object: null
	at com.google.gson.JsonElement.getAsJsonObject(JsonElement.java:90)
	at org.hibernate.search.elasticsearch.impl.ElasticsearchIndexWorkVisitor.getOrCreateDocumentTree(ElasticsearchIndexWorkVisitor.java:408)
	at org.hibernate.search.elasticsearch.impl.ElasticsearchIndexWorkVisitor.convertToJson(ElasticsearchIndexWorkVisitor.java:207)
	at org.hibernate.search.elasticsearch.impl.ElasticsearchIndexWorkVisitor.indexDocument(ElasticsearchIndexWorkVisitor.java:178)
	at org.hibernate.search.elasticsearch.impl.ElasticsearchIndexWorkVisitor.visitAddWork(ElasticsearchIndexWorkVisitor.java:88)
	at org.hibernate.search.elasticsearch.impl.ElasticsearchIndexWorkVisitor.visitAddWork(ElasticsearchIndexWorkVisitor.java:1)
	at org.hibernate.search.backend.AddLuceneWork.acceptIndexWorkVisitor(AddLuceneWork.java:47)
	at org.hibernate.search.elasticsearch.impl.ElasticsearchIndexManager.performOperations(ElasticsearchIndexManager.java:692)
	at org.hibernate.search.backend.impl.LocalBackendQueueProcessor.applyWork(LocalBackendQueueProcessor.java:38)
	at org.hibernate.search.backend.impl.WorkQueuePerIndexSplitter.commitOperations(WorkQueuePerIndexSplitter.java:46)
	at org.hibernate.search.backend.impl.BatchedQueueingProcessor.performWorks(BatchedQueueingProcessor.java:83)
	at org.hibernate.search.backend.impl.PostTransactionWorkQueueSynchronization.afterCompletion(PostTransactionWorkQueueSynchronization.java:74)
	at org.hibernate.search.backend.impl.EventSourceTransactionContext$DelegateToSynchronizationOnAfterTx.doAfterTransactionCompletion(EventSourceTransactionContext.java:187)
	... 42 more

```

I have also writen the simple application showing the problem.
It can be found here: https://github.com/momega/hsearchbug

According my analysis regular expression in ElasticsearchIndexWorkVisitor.NAME_AND_INDEX is wrong and has to be changed to my version. Original expression may get invalid element from the array. For example: when tries to obtain element at index 19, it gets element ant index 9. It leads to error above.

I hope it helps.

Best regards,
Martin
