### PR TITLE
ORM 5.2 upgrade PREVIEW

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Hibernate Search is using [Apache Lucene](http://lucene.apache.org/) under the c
 
 This version of Hibernate Search requires:
 
+* Java SE 8
 * Hibernate ORM 5.2.x
 * Apache Lucene 5.5.x
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hibernate Search
 
-*Version: 5.6.0.Beta2 - 05-09-2016*
+*Version: 5.7.0-SNAPSHOT*
 
 ## Description
 
@@ -19,7 +19,7 @@ Hibernate Search is using [Apache Lucene](http://lucene.apache.org/) under the c
 
 This version of Hibernate Search requires:
 
-* Hibernate ORM 5.0.x or 5.1.x
+* Hibernate ORM 5.2.x
 * Apache Lucene 5.5.x
 
 ## Instructions
@@ -31,7 +31,7 @@ Include the following to your dependency list:
     <dependency>
        <groupId>org.hibernate</groupId>
        <artifactId>hibernate-search-orm</artifactId>
-       <version>5.6.0.Beta2</version>
+       <version>5.7.0-SNAPSHOT</version>
     </dependency>
 
 ### Sourceforge Bundle

--- a/backends/jgroups/pom.xml
+++ b/backends/jgroups/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>hibernate-search-parent</artifactId>
         <groupId>org.hibernate</groupId>
-        <version>5.6.0-SNAPSHOT</version>
+        <version>5.7.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/backends/jms/pom.xml
+++ b/backends/jms/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>hibernate-search-parent</artifactId>
         <groupId>org.hibernate</groupId>
-        <version>5.6.0-SNAPSHOT</version>
+        <version>5.7.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/build-config/pom.xml
+++ b/build-config/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-search-parent</artifactId>
-        <version>5.6.0-SNAPSHOT</version>
+        <version>5.7.0-SNAPSHOT</version>
     </parent>
     <artifactId>hibernate-search-build-config</artifactId>
 

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>hibernate-search-parent</artifactId>
         <groupId>org.hibernate</groupId>
-        <version>5.6.0-SNAPSHOT</version>
+        <version>5.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -46,10 +46,6 @@
 
         <!-- Need to list out optional/provided dependencies here again in order to include them via assembly dependency set -->
         <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-entitymanager</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-parsers</artifactId>
         </dependency>

--- a/distribution/src/main/assembly/dist.xml
+++ b/distribution/src/main/assembly/dist.xml
@@ -54,20 +54,6 @@
         </dependencySet>
 
         <dependencySet>
-            <outputDirectory>dist/lib/optional/jpa</outputDirectory>
-            <scope>runtime</scope>
-            <useTransitiveDependencies>true</useTransitiveDependencies>
-            <useTransitiveFiltering>true</useTransitiveFiltering>
-            <includes>
-                <include>org.hibernate:hibernate-entitymanager</include>
-            </includes>
-            <excludes>
-                <exclude>dom4j:*</exclude>
-                <exclude>javassist:javassist</exclude>
-            </excludes>
-        </dependencySet>
-
-        <dependencySet>
             <outputDirectory>dist/lib/optional/analyzers</outputDirectory>
             <scope>runtime</scope>
             <useTransitiveDependencies>true</useTransitiveDependencies>

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>hibernate-search-parent</artifactId>
         <groupId>org.hibernate</groupId>
-        <version>5.6.0-SNAPSHOT</version>
+        <version>5.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/documentation/src/main/asciidoc/getting-started.asciidoc
+++ b/documentation/src/main/asciidoc/getting-started.asciidoc
@@ -68,12 +68,6 @@ All you have to add to your pom.xml is:
 ====
 [source, XML]
 [subs="verbatim,attributes"]
-<!-- If using JPA, add: -->
-<dependency>
-   <groupId>org.hibernate</groupId>
-   <artifactId>hibernate-entitymanager</artifactId>
-   <version>{hibernateVersion}</version>
-</dependency>
 <!-- Infinispan integration: -->
 <dependency>
    <groupId>org.infinispan</groupId>
@@ -82,8 +76,8 @@ All you have to add to your pom.xml is:
 </dependency>
 ====
 
-Only the _hibernate-search-orm_ dependency is mandatory. _hibernate-entitymanager_ is only required
-if you want to use Hibernate Search in conjunction with JPA.
+Only the _hibernate-search-orm_ dependency is mandatory. _infinispan-directory-provider_ is only required
+if you want to use Infinispan to store the Lucene indexes.
 
 ==== Manual library management
 

--- a/documentation/src/main/asciidoc/getting-started.asciidoc
+++ b/documentation/src/main/asciidoc/getting-started.asciidoc
@@ -10,7 +10,7 @@ Hibernate new timer we recommend you start link:http://hibernate.org/quick-start
 .System requirements
 
 |===============
-|Java Runtime|Requires Java version _7_ or greater. You
+|Java Runtime|Requires Java version _8_ or greater. You
             can download a Java Runtime for Windows/Linux/Solaris link:http://www.oracle.com/technetwork/java/javase/downloads/index.html[here].
 |Hibernate Search| `hibernate-search-{hibernateSearchVersion}.jar` and all
             runtime dependencies. You can get the jar artifacts either from

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>hibernate-search-parent</artifactId>
         <groupId>org.hibernate</groupId>
-        <version>5.6.0-SNAPSHOT</version>
+        <version>5.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -55,11 +55,6 @@
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-entitymanager</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
             <artifactId>hibernate-search-orm</artifactId>
             <type>test-jar</type>
             <scope>test</scope>

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchHSQueryImpl.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchHSQueryImpl.java
@@ -936,4 +936,10 @@ public class ElasticsearchHSQueryImpl extends AbstractHSQuery {
 			}
 		}
 	}
+
+	@Override
+	public String getQueryString() {
+		return jsonQuery.toString();
+	}
+
 }

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>hibernate-search-parent</artifactId>
         <groupId>org.hibernate</groupId>
-        <version>5.6.0-SNAPSHOT</version>
+        <version>5.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/engine/src/main/java/org/hibernate/search/query/engine/impl/LuceneHSQuery.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/impl/LuceneHSQuery.java
@@ -846,4 +846,10 @@ public class LuceneHSQuery extends AbstractHSQuery implements HSQuery {
 					totalHits - 1;
 		}
 	}
+
+	@Override
+	public String getQueryString() {
+		return String.valueOf( luceneQuery );
+	}
+
 }

--- a/engine/src/main/java/org/hibernate/search/query/engine/spi/HSQuery.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/spi/HSQuery.java
@@ -248,4 +248,10 @@ public interface HSQuery extends ProjectionConstants {
 	 * @return {@code this}  to allow for method chaining
 	 */
 	HSQuery setSpatialParameters(Coordinates center, String fieldName);
+
+	/**
+	 * @return a human readable representation of the Query in String format
+	 */
+	String getQueryString();
+
 }

--- a/infinispan/pom.xml
+++ b/infinispan/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>hibernate-search-parent</artifactId>
         <groupId>org.hibernate</groupId>
-        <version>5.6.0-SNAPSHOT</version>
+        <version>5.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integrationtest/engine-performance/pom.xml
+++ b/integrationtest/engine-performance/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-search-parent</artifactId>
-        <version>5.6.0-SNAPSHOT</version>
+        <version>5.7.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/integrationtest/jms/pom.xml
+++ b/integrationtest/jms/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <artifactId>hibernate-search-parent</artifactId>
         <groupId>org.hibernate</groupId>
-        <version>5.6.0-SNAPSHOT</version>
+        <version>5.7.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/integrationtest/narayana/pom.xml
+++ b/integrationtest/narayana/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <artifactId>hibernate-search-parent</artifactId>
         <groupId>org.hibernate</groupId>
-        <version>5.6.0-SNAPSHOT</version>
+        <version>5.7.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/integrationtest/osgi/karaf-features/pom.xml
+++ b/integrationtest/osgi/karaf-features/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <artifactId>hibernate-search-parent</artifactId>
         <groupId>org.hibernate</groupId>
-        <version>5.6.0-SNAPSHOT</version>
+        <version>5.7.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/integrationtest/osgi/karaf-features/src/main/features/features.xml
+++ b/integrationtest/osgi/karaf-features/src/main/features/features.xml
@@ -63,7 +63,6 @@
 
         <!-- Hibernate ORM -->
         <bundle>mvn:org.hibernate/hibernate-core/${hibernateVersion}</bundle>
-        <bundle>mvn:org.hibernate/hibernate-entitymanager/${hibernateVersion}</bundle>
         <bundle>mvn:org.hibernate/hibernate-osgi/${hibernateVersion}</bundle>
     </feature>
 </features>

--- a/integrationtest/osgi/karaf-it/pom.xml
+++ b/integrationtest/osgi/karaf-it/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <artifactId>hibernate-search-parent</artifactId>
         <groupId>org.hibernate</groupId>
-        <version>5.6.0-SNAPSHOT</version>
+        <version>5.7.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/integrationtest/performance/pom.xml
+++ b/integrationtest/performance/pom.xml
@@ -183,6 +183,24 @@
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${project.build.directory}</outputDirectory>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.hibernate</groupId>
+                                    <artifactId>hibernate-search-modules</artifactId>
+                                    <version>${project.version}</version>
+                                    <classifier>wildfly-10-dist</classifier>
+                                    <type>zip</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/wildfly-${wildflyVersion}/modules</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.hibernate</groupId>
+                                    <artifactId>hibernate-orm-modules</artifactId>
+                                    <version>${hibernateVersion}</version>
+                                    <classifier>wildfly-10-dist</classifier>
+                                    <type>zip</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}/wildfly-${wildflyVersion}/modules</outputDirectory>
+                                </artifactItem>
                             </artifactItems>
                         </configuration>
                     </execution>

--- a/integrationtest/performance/pom.xml
+++ b/integrationtest/performance/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <artifactId>hibernate-search-parent</artifactId>
         <groupId>org.hibernate</groupId>
-        <version>5.6.0-SNAPSHOT</version>
+        <version>5.7.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/TestRunnerArquillian.java
+++ b/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/TestRunnerArquillian.java
@@ -6,6 +6,9 @@
  */
 package org.hibernate.search.test.performance;
 
+import static org.hibernate.search.test.integration.VersionTestHelper.getHibernateORMModuleName;
+import static org.hibernate.search.test.integration.VersionTestHelper.getWildFlyModuleIdentifier;
+
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.file.Path;
@@ -55,8 +58,6 @@ public class TestRunnerArquillian {
 				.addPackages( true, TestRunnerArquillian.class.getPackage() )
 				.addClass( TestConstants.class )
 				.addAsResource( createPersistenceXml(), "META-INF/persistence.xml" )
-				.addAsWebInfResource( "jboss-deployment-structure-hcann.xml", "/jboss-deployment-structure.xml" )
-				.addAsLibraries( PackagerHelper.hibernateSearchLibraries() )
 				.addAsLibraries( PackagerHelper.hibernateSearchTestingLibraries() )
 				.addAsWebInfResource( EmptyAsset.INSTANCE, "beans.xml" )
 				.add( manifest(), "META-INF/MANIFEST.MF" )
@@ -91,7 +92,11 @@ public class TestRunnerArquillian {
 					name( property.getKey().toString() ).
 					value( property.getValue().toString() );
 		}
-
+		//Additional properties:
+		pu.getOrCreateProperties()
+			.createProperty().name( "jboss.as.jpa.providerModule" ).value( getHibernateORMModuleName() ).up()
+			.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( getWildFlyModuleIdentifier() ).up()
+			;
 		return new StringAsset( pd.exportAsString() );
 	}
 

--- a/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/scenario/TestReporter.java
+++ b/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/scenario/TestReporter.java
@@ -19,6 +19,7 @@ import java.io.UnsupportedEncodingException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Date;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
@@ -141,8 +142,8 @@ public class TestReporter {
 
 		out.println( "" );
 		out.println( "HIBERNATE SEARCH PROPERTIES" );
-		Properties properties = ( (SessionFactoryImplementor) ctx.sf ).getProperties();
-		for ( Entry<Object, Object> e : properties.entrySet() ) {
+		Map<String, Object> properties = ( (SessionFactoryImplementor) ctx.sf ).getProperties();
+		for ( Entry<String, Object> e : properties.entrySet() ) {
 			if ( e.getKey().toString().startsWith( "hibernate.search" ) ) {
 				out.println( "    " + e.getKey() + " = " + e.getValue() );
 			}

--- a/integrationtest/sandbox/pom.xml
+++ b/integrationtest/sandbox/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <artifactId>hibernate-search-parent</artifactId>
         <groupId>org.hibernate</groupId>
-        <version>5.6.0-SNAPSHOT</version>
+        <version>5.7.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/integrationtest/spring/pom.xml
+++ b/integrationtest/spring/pom.xml
@@ -51,11 +51,6 @@
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-entitymanager</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
             <artifactId>hibernate-testing</artifactId>
             <scope>test</scope>
         </dependency>

--- a/integrationtest/spring/pom.xml
+++ b/integrationtest/spring/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <artifactId>hibernate-search-parent</artifactId>
         <groupId>org.hibernate</groupId>
-        <version>5.6.0-SNAPSHOT</version>
+        <version>5.7.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/integrationtest/wildfly/pom.xml
+++ b/integrationtest/wildfly/pom.xml
@@ -314,6 +314,24 @@
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${project.build.directory}/node2/wildfly-${wildflyVersion}/modules</outputDirectory>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.hibernate</groupId>
+                                    <artifactId>hibernate-orm-modules</artifactId>
+                                    <version>${hibernateVersion}</version>
+                                    <classifier>wildfly-10-dist</classifier>
+                                    <type>zip</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}/node1/wildfly-${wildflyVersion}/modules</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.hibernate</groupId>
+                                    <artifactId>hibernate-orm-modules</artifactId>
+                                    <version>${hibernateVersion}</version>
+                                    <classifier>wildfly-10-dist</classifier>
+                                    <type>zip</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}/node2/wildfly-${wildflyVersion}/modules</outputDirectory>
+                                </artifactItem>
                             </artifactItems>
                         </configuration>
                     </execution>

--- a/integrationtest/wildfly/pom.xml
+++ b/integrationtest/wildfly/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <artifactId>hibernate-search-parent</artifactId>
         <groupId>org.hibernate</groupId>
-        <version>5.6.0-SNAPSHOT</version>
+        <version>5.7.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/VersionTestHelper.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/VersionTestHelper.java
@@ -25,6 +25,7 @@ public class VersionTestHelper {
 
 	private static String hibernateSearchVersion = null;
 	private static String hibernateSearchModuleSlot = null;
+	private static String hibernateOrmModuleName = null;
 	private static String luceneFullVersion = null;
 	private static String hibernateAnnotationsFullVersion = null;
 
@@ -49,6 +50,13 @@ public class VersionTestHelper {
 			hibernateSearchVersion = injectVariables( "${dependency.version.HibernateSearch}" );
 		}
 		return hibernateSearchVersion;
+	}
+
+	public static synchronized String getHibernateORMModuleName() {
+		if ( hibernateOrmModuleName == null ) {
+			hibernateOrmModuleName = "org.hibernate:" + injectVariables( "${hibernate-orm.module.slot}" );
+		}
+		return hibernateOrmModuleName;
 	}
 
 	public static synchronized String getDependencyVersionLucene() {

--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/cmp/ContainerManagedPersistenceWithMassIndexerIT.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/cmp/ContainerManagedPersistenceWithMassIndexerIT.java
@@ -28,6 +28,7 @@ import org.junit.runner.RunWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.hibernate.search.test.integration.VersionTestHelper.getHibernateORMModuleName;
 import static org.hibernate.search.test.integration.VersionTestHelper.getWildFlyModuleIdentifier;
 
 /**
@@ -74,6 +75,7 @@ public class ContainerManagedPersistenceWithMassIndexerIT {
 					.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
 					.createProperty().name( "hibernate.search.indexing_strategy" ).value( "manual" ).up()
 					.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( getWildFlyModuleIdentifier() ).up()
+					.createProperty().name( "jboss.as.jpa.providerModule" ).value( getHibernateORMModuleName() ).up()
 				.up().up()
 				.exportAsString();
 		return new StringAsset( persistenceXml );

--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/elasticsearch/ElasticsearchModuleMemberRegistrationIT.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/elasticsearch/ElasticsearchModuleMemberRegistrationIT.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.test.integration.elasticsearch;
 
+import static org.hibernate.search.test.integration.VersionTestHelper.getHibernateORMModuleName;
 import static org.hibernate.search.test.integration.VersionTestHelper.getWildFlyModuleIdentifier;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -80,6 +81,7 @@ public class ElasticsearchModuleMemberRegistrationIT {
 					.createProperty().name( "hibernate.search.default.lucene_version" ).value( "LUCENE_CURRENT" ).up()
 					.createProperty().name( "hibernate.search.default.indexmanager" ).value( "elasticsearch" ).up()
 					.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( getWildFlyModuleIdentifier() ).up()
+					.createProperty().name( "jboss.as.jpa.providerModule" ).value( getHibernateORMModuleName() ).up()
 					.createProperty().name( "hibernate.search.default." + ElasticsearchEnvironment.INDEX_SCHEMA_MANAGEMENT_STRATEGY ).value( "CREATE_DELETE" ).up()
 					.createProperty().name( "hibernate.search.default.elasticsearch.refresh_after_write" ).value( "true" ).up()
 				.up().up()

--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/jgroups/JGroupsDeploymentHelper.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/jgroups/JGroupsDeploymentHelper.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.test.integration.jgroups;
 
+import static org.hibernate.search.test.integration.VersionTestHelper.getHibernateORMModuleName;
 import static org.hibernate.search.test.integration.VersionTestHelper.getWildFlyModuleIdentifier;
 
 import java.io.File;
@@ -89,6 +90,10 @@ public class JGroupsDeploymentHelper {
 						.createProperty()
 							.name( "wildfly.jpa.hibernate.search.module" )
 							.value( getWildFlyModuleIdentifier() )
+							.up()
+						.createProperty()
+							.name( "jboss.as.jpa.providerModule" )
+							.value( getHibernateORMModuleName() )
 							.up()
 						.createProperty()
 							.name( "hibernate.search.services.jgroups.configurationFile" )

--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/jms/DeploymentJmsMasterSlave.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/jms/DeploymentJmsMasterSlave.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.test.integration.jms;
 
+import static org.hibernate.search.test.integration.VersionTestHelper.getHibernateORMModuleName;
 import static org.hibernate.search.test.integration.VersionTestHelper.getWildFlyModuleIdentifier;
 
 import java.io.File;
@@ -122,6 +123,10 @@ public final class DeploymentJmsMasterSlave {
 						.createProperty()
 							.name( "wildfly.jpa.hibernate.search.module" )
 							.value( getWildFlyModuleIdentifier() )
+							.up()
+						.createProperty()
+							.name( "jboss.as.jpa.providerModule" )
+							.value( getHibernateORMModuleName() )
 							.up()
 						.createProperty()
 							.name( "hibernate.hbm2ddl.auto" )

--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/wildfly/MemberRegistrationEarArchiveIT.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/wildfly/MemberRegistrationEarArchiveIT.java
@@ -11,6 +11,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import static org.hibernate.search.test.integration.VersionTestHelper.getHibernateORMModuleName;
+import static org.hibernate.search.test.integration.VersionTestHelper.getWildFlyModuleIdentifier;
+
 import java.util.List;
 
 import javax.inject.Inject;
@@ -73,7 +76,8 @@ public class MemberRegistrationEarArchiveIT {
 					.createProperty().name( "hibernate.hbm2ddl.auto" ).value( "create-drop" ).up()
 					.createProperty().name( "hibernate.search.default.lucene_version" ).value( "LUCENE_CURRENT" ).up()
 					.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
-					.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( "none" ).up()
+					.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( getWildFlyModuleIdentifier() ).up()
+					.createProperty().name( "jboss.as.jpa.providerModule" ).value( getHibernateORMModuleName() ).up()
 				.up().up()
 			.exportAsString();
 		return new StringAsset( persistenceXml );

--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/wildfly/MemberRegistrationIT.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/wildfly/MemberRegistrationIT.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.test.integration.wildfly;
 
+import static org.hibernate.search.test.integration.VersionTestHelper.getHibernateORMModuleName;
+import static org.hibernate.search.test.integration.VersionTestHelper.getWildFlyModuleIdentifier;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -64,7 +66,8 @@ public class MemberRegistrationIT {
 					.createProperty().name( "hibernate.hbm2ddl.auto" ).value( "create-drop" ).up()
 					.createProperty().name( "hibernate.search.default.lucene_version" ).value( "LUCENE_CURRENT" ).up()
 					.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
-					.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( "none" ).up()
+					.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( getWildFlyModuleIdentifier() ).up()
+					.createProperty().name( "jboss.as.jpa.providerModule" ).value( getHibernateORMModuleName() ).up()
 				.up().up()
 			.exportAsString();
 		return new StringAsset( persistenceXml );

--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/wildfly/ModuleMemberRegistrationEarArchiveIT.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/wildfly/ModuleMemberRegistrationEarArchiveIT.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.test.integration.wildfly;
 
+import static org.hibernate.search.test.integration.VersionTestHelper.getHibernateORMModuleName;
 import static org.hibernate.search.test.integration.VersionTestHelper.getWildFlyModuleIdentifier;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -73,6 +74,7 @@ public class ModuleMemberRegistrationEarArchiveIT {
 					.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
 					.createProperty().name( "hibernate.search.default.lucene_version" ).value( "LUCENE_CURRENT" ).up()
 					.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( getWildFlyModuleIdentifier() ).up()
+					.createProperty().name( "jboss.as.jpa.providerModule" ).value( getHibernateORMModuleName() ).up()
 				.up().up()
 			.exportAsString();
 		return new StringAsset( persistenceXml );

--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/wildfly/ModuleMemberRegistrationEarArchiveWithJbossDeploymentIT.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/wildfly/ModuleMemberRegistrationEarArchiveWithJbossDeploymentIT.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.test.integration.wildfly;
 
+import static org.hibernate.search.test.integration.VersionTestHelper.getHibernateORMModuleName;
+import static org.hibernate.search.test.integration.VersionTestHelper.getWildFlyModuleIdentifier;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -113,7 +115,8 @@ public class ModuleMemberRegistrationEarArchiveWithJbossDeploymentIT {
 					.createProperty().name( "hibernate.hbm2ddl.auto" ).value( "create-drop" ).up()
 					.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
 					.createProperty().name( "hibernate.search.default.lucene_version" ).value( "LUCENE_CURRENT" ).up()
-					.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( "none" ).up()
+					.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( getWildFlyModuleIdentifier() ).up()
+					.createProperty().name( "jboss.as.jpa.providerModule" ).value( getHibernateORMModuleName() ).up()
 				.up().up()
 			.exportAsString();
 		return new StringAsset( persistenceXml );

--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/wildfly/ModuleMemberRegistrationIT.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/wildfly/ModuleMemberRegistrationIT.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.test.integration.wildfly;
 
+import static org.hibernate.search.test.integration.VersionTestHelper.getHibernateORMModuleName;
 import static org.hibernate.search.test.integration.VersionTestHelper.getWildFlyModuleIdentifier;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -79,6 +80,7 @@ public class ModuleMemberRegistrationIT {
 					.createProperty().name( "hibernate.search.default.lucene_version" ).value( "LUCENE_CURRENT" ).up()
 					.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
 					.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( getWildFlyModuleIdentifier() ).up()
+					.createProperty().name( "jboss.as.jpa.providerModule" ).value( getHibernateORMModuleName() ).up()
 				.up().up()
 			.exportAsString();
 		return new StringAsset( persistenceXml );

--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/wildfly/massindexing/MassIndexingTimeoutIT.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/wildfly/massindexing/MassIndexingTimeoutIT.java
@@ -29,6 +29,7 @@ import org.jboss.shrinkwrap.descriptor.api.persistence20.PersistenceDescriptor;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.hibernate.search.test.integration.VersionTestHelper.getHibernateORMModuleName;
 import static org.hibernate.search.test.integration.VersionTestHelper.getWildFlyModuleIdentifier;
 import static org.junit.Assert.assertEquals;
 
@@ -67,6 +68,7 @@ public class MassIndexingTimeoutIT {
 					.createProperty().name( "hibernate.search.indexing_strategy" ).value( "manual" ).up()
 					.createProperty().name( "hibernate.jdbc.batch_size" ).value( "50" ).up()
 					.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( getWildFlyModuleIdentifier() ).up()
+					.createProperty().name( "jboss.as.jpa.providerModule" ).value( getHibernateORMModuleName() ).up()
 				.up().up()
 			.exportAsString();
 		return new StringAsset( persistenceXml );

--- a/integrationtest/wildfly/src/test/resources/module-versions.properties
+++ b/integrationtest/wildfly/src/test/resources/module-versions.properties
@@ -2,3 +2,4 @@
 dependency.version.HibernateSearch = ${project.version}
 dependency.version.Lucene = ${luceneVersion}
 dependency.version.hcann = ${hibernateCommonsAnnotationVersion}
+hibernate-orm.module.slot = ${hibernate-orm.module.slot}

--- a/legacy/pom.xml
+++ b/legacy/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>hibernate-search-parent</artifactId>
         <groupId>org.hibernate</groupId>
-        <version>5.6.0-SNAPSHOT</version>
+        <version>5.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-search-parent</artifactId>
-        <version>5.6.0-SNAPSHOT</version>
+        <version>5.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>hibernate-search-modules</artifactId>

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -46,10 +46,6 @@
             <exclusions>
                 <exclusion>
                     <groupId>org.hibernate</groupId>
-                    <artifactId>hibernate-entitymanager</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.hibernate</groupId>
                     <artifactId>hibernate-core</artifactId>
                 </exclusion>
                 <exclusion>

--- a/modules/src/main/modules/search/orm/module.xml
+++ b/modules/src/main/modules/search/orm/module.xml
@@ -11,7 +11,7 @@
     </resources>
     <dependencies>
         <module name="javax.transaction.api" />
-        <module name="org.hibernate" />
+        <module name="org.hibernate" slot="${hibernate-orm.module.slot}" />
         <module name="org.hibernate.commons-annotations" />
         <module name="org.hibernate.search.engine" export="true" services="import" slot="${hibernate.search.version}" />
         <module name="org.jboss.logging" />

--- a/orm/pom.xml
+++ b/orm/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>hibernate-search-parent</artifactId>
         <groupId>org.hibernate</groupId>
-        <version>5.6.0-SNAPSHOT</version>
+        <version>5.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/orm/pom.xml
+++ b/orm/pom.xml
@@ -62,11 +62,6 @@
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-entitymanager</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
             <artifactId>hibernate-envers</artifactId>
             <scope>test</scope>
         </dependency>

--- a/orm/src/main/java/org/hibernate/search/FullTextQuery.java
+++ b/orm/src/main/java/org/hibernate/search/FullTextQuery.java
@@ -29,7 +29,7 @@ import org.hibernate.transform.ResultTransformer;
  * @author Hardy Ferentschik
  * @author Emmanuel Bernard
  */
-public interface FullTextQuery extends Query, ProjectionConstants, QueryImplementor {
+public interface FullTextQuery<R> extends Query<R>, ProjectionConstants, QueryImplementor<R> {
 
 	/**
 	 * Allows to let lucene sort the results. This is useful when you have

--- a/orm/src/main/java/org/hibernate/search/FullTextQuery.java
+++ b/orm/src/main/java/org/hibernate/search/FullTextQuery.java
@@ -14,7 +14,7 @@ import org.apache.lucene.search.Sort;
 
 import org.hibernate.Criteria;
 import org.hibernate.Query;
-
+import org.hibernate.query.spi.QueryImplementor;
 import org.hibernate.search.engine.ProjectionConstants;
 import org.hibernate.search.filter.FullTextFilter;
 import org.hibernate.search.query.DatabaseRetrievalMethod;
@@ -29,7 +29,7 @@ import org.hibernate.transform.ResultTransformer;
  * @author Hardy Ferentschik
  * @author Emmanuel Bernard
  */
-public interface FullTextQuery extends Query, ProjectionConstants {
+public interface FullTextQuery extends Query, ProjectionConstants, QueryImplementor {
 
 	/**
 	 * Allows to let lucene sort the results. This is useful when you have

--- a/orm/src/main/java/org/hibernate/search/backend/impl/EventSourceTransactionContext.java
+++ b/orm/src/main/java/org/hibernate/search/backend/impl/EventSourceTransactionContext.java
@@ -59,7 +59,7 @@ public class EventSourceTransactionContext implements TransactionContext, Serial
 	@Override
 	public Object getTransactionIdentifier() {
 		if ( isRealTransactionInProgress() ) {
-			return eventSource.getTransaction();
+			return eventSource.accessTransaction();
 		}
 		else {
 			return eventSource;
@@ -90,7 +90,7 @@ public class EventSourceTransactionContext implements TransactionContext, Serial
 			else {
 				//TODO could we remove the action queue registration in this case?
 				actionQueue.registerProcess( new DelegateToSynchronizationOnBeforeTx( synchronization ) );
-				eventSource.getTransaction().registerSynchronization(
+				eventSource.accessTransaction().registerSynchronization(
 						new BeforeCommitSynchronizationDelegator( synchronization )
 				);
 			}

--- a/orm/src/main/java/org/hibernate/search/backend/impl/EventSourceTransactionContext.java
+++ b/orm/src/main/java/org/hibernate/search/backend/impl/EventSourceTransactionContext.java
@@ -16,6 +16,7 @@ import org.hibernate.action.spi.AfterTransactionCompletionProcess;
 import org.hibernate.action.spi.BeforeTransactionCompletionProcess;
 import org.hibernate.engine.spi.ActionQueue;
 import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventSource;
 import org.hibernate.event.spi.EventType;
@@ -182,7 +183,7 @@ public class EventSourceTransactionContext implements TransactionContext, Serial
 		}
 
 		@Override
-		public void doAfterTransactionCompletion(boolean success, SessionImplementor sessionImplementor) {
+		public void doAfterTransactionCompletion(boolean success, SharedSessionContractImplementor sessionImplementor) {
 			try {
 				synchronization.afterCompletion( success ? Status.STATUS_COMMITTED : Status.STATUS_ROLLEDBACK );
 			}

--- a/orm/src/main/java/org/hibernate/search/batchindexing/impl/BatchTransactionalContext.java
+++ b/orm/src/main/java/org/hibernate/search/batchindexing/impl/BatchTransactionalContext.java
@@ -12,7 +12,7 @@ import javax.transaction.TransactionManager;
 
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.transaction.jta.platform.spi.JtaPlatform;
-import org.hibernate.resource.transaction.TransactionCoordinatorBuilder;
+import org.hibernate.resource.transaction.spi.TransactionCoordinatorBuilder;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.exception.ErrorHandler;
 import org.hibernate.search.util.logging.impl.Log;

--- a/orm/src/main/java/org/hibernate/search/batchindexing/impl/IdentifierConsumerDocumentProducer.java
+++ b/orm/src/main/java/org/hibernate/search/batchindexing/impl/IdentifierConsumerDocumentProducer.java
@@ -106,11 +106,11 @@ public class IdentifierConsumerDocumentProducer implements Runnable {
 	@Override
 	public void run() {
 		log.trace( "started" );
-		Session session = sessionFactory
+		SessionImplementor session = (SessionImplementor) sessionFactory
 				.withOptions()
 				.tenantIdentifier( tenantId )
 				.openSession();
-		session.setFlushMode( FlushMode.MANUAL );
+		session.setHibernateFlushMode( FlushMode.MANUAL );
 		session.setCacheMode( cacheMode );
 		session.setDefaultReadOnly( true );
 		try {
@@ -126,11 +126,8 @@ public class IdentifierConsumerDocumentProducer implements Runnable {
 		log.trace( "finished" );
 	}
 
-	private void loadAllFromQueue(Session session) throws Exception {
-		final InstanceInitializer sessionInitializer = new HibernateSessionLoadingInitializer(
-				(SessionImplementor) session
-		);
-
+	private void loadAllFromQueue(SessionImplementor session) throws Exception {
+		final InstanceInitializer sessionInitializer = new HibernateSessionLoadingInitializer( session );
 		try {
 			List<Serializable> idList;
 			do {
@@ -159,7 +156,7 @@ public class IdentifierConsumerDocumentProducer implements Runnable {
 	 *
 	 * @throws InterruptedException
 	 */
-	private void loadList(List<Serializable> listIds, Session session, InstanceInitializer sessionInitializer) throws Exception {
+	private void loadList(List<Serializable> listIds, SessionImplementor session, InstanceInitializer sessionInitializer) throws Exception {
 		try {
 			beginTransaction( session );
 
@@ -196,13 +193,13 @@ public class IdentifierConsumerDocumentProducer implements Runnable {
 		}
 	}
 
-	private void rollbackTransaction(Session session) throws Exception {
+	private void rollbackTransaction(SessionImplementor session) throws Exception {
 		try {
 			if ( transactionManager != null ) {
 				transactionManager.rollback();
 			}
 			else {
-				session.getTransaction().rollback();
+				session.accessTransaction().rollback();
 			}
 		}
 		catch (Exception e) {

--- a/orm/src/main/java/org/hibernate/search/batchindexing/impl/IdentifierProducer.java
+++ b/orm/src/main/java/org/hibernate/search/batchindexing/impl/IdentifierProducer.java
@@ -17,7 +17,7 @@ import org.hibernate.SessionFactory;
 import org.hibernate.StatelessSession;
 import org.hibernate.Transaction;
 import org.hibernate.criterion.Projections;
-import org.hibernate.resource.transaction.spi.TransactionStatus;
+import org.hibernate.internal.StatelessSessionImpl;
 import org.hibernate.search.batchindexing.MassIndexerProgressMonitor;
 import org.hibernate.search.exception.ErrorHandler;
 import org.hibernate.search.util.logging.impl.Log;
@@ -82,7 +82,7 @@ public class IdentifierProducer implements StatelessSessionAwareRunnable {
 	public void run(StatelessSession upperSession) throws Exception {
 		log.trace( "started" );
 		try {
-			inTransactionWrapper( upperSession );
+			inTransactionWrapper( (StatelessSessionImpl) upperSession );
 		}
 		catch (Exception exception) {
 			errorHandler.handleException( log.massIndexerExceptionWhileFetchingIds(), exception );
@@ -93,18 +93,18 @@ public class IdentifierProducer implements StatelessSessionAwareRunnable {
 		log.trace( "finished" );
 	}
 
-	private void inTransactionWrapper(StatelessSession upperSession) throws Exception {
-		StatelessSession session = upperSession;
+	private void inTransactionWrapper(StatelessSessionImpl upperSession) throws Exception {
+		StatelessSessionImpl session = upperSession;
 		if ( upperSession == null ) {
 			if ( tenantId == null ) {
-				session = sessionFactory.openStatelessSession();
+				session = (StatelessSessionImpl) sessionFactory.openStatelessSession();
 			}
 			else {
-				session = sessionFactory.withStatelessOptions().tenantIdentifier( tenantId ).openStatelessSession();
+				session = (StatelessSessionImpl) sessionFactory.withStatelessOptions().tenantIdentifier( tenantId ).openStatelessSession();
 			}
 		}
 		try {
-			Transaction transaction = session.getTransaction();
+			Transaction transaction = session.accessTransaction();
 			transaction.begin();
 			loadAllIdentifiers( session );
 			transaction.commit();
@@ -151,7 +151,8 @@ public class IdentifierProducer implements StatelessSessionAwareRunnable {
 				if ( destinationList.size() == batchSize ) {
 					// Explicitly checking whether the TX is still open; Depending on the driver implementation new ids
 					// might be produced otherwise if the driver fetches all rows up-front
-					if ( session.getTransaction().getStatus() != TransactionStatus.ACTIVE ) {
+					StatelessSessionImpl sessionImpl = (StatelessSessionImpl) session;
+					if ( sessionImpl.isTransactionInProgress() == false ) {
 						throw log.transactionNotActiveWhileProducingIdsForBatchIndexing( indexedType );
 					}
 

--- a/orm/src/main/java/org/hibernate/search/batchindexing/impl/IdentifierProducer.java
+++ b/orm/src/main/java/org/hibernate/search/batchindexing/impl/IdentifierProducer.java
@@ -105,9 +105,18 @@ public class IdentifierProducer implements StatelessSessionAwareRunnable {
 		}
 		try {
 			Transaction transaction = session.accessTransaction();
-			transaction.begin();
-			loadAllIdentifiers( session );
-			transaction.commit();
+			final boolean controlTransactions = ! transaction.isActive();
+			if ( controlTransactions ) {
+				transaction.begin();
+			}
+			try {
+				loadAllIdentifiers( session );
+			}
+			finally {
+				if ( controlTransactions ) {
+					transaction.commit();
+				}
+			}
 		}
 		catch (InterruptedException e) {
 			// just quit

--- a/orm/src/main/java/org/hibernate/search/impl/FullTextSharedSessionBuilderDelegator.java
+++ b/orm/src/main/java/org/hibernate/search/impl/FullTextSharedSessionBuilderDelegator.java
@@ -9,9 +9,11 @@ package org.hibernate.search.impl;
 import java.sql.Connection;
 
 import org.hibernate.ConnectionReleaseMode;
+import org.hibernate.FlushMode;
 import org.hibernate.Interceptor;
 import org.hibernate.SessionEventListener;
 import org.hibernate.SharedSessionBuilder;
+import org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode;
 import org.hibernate.resource.jdbc.spi.StatementInspector;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.FullTextSharedSessionBuilder;
@@ -138,6 +140,36 @@ class FullTextSharedSessionBuilderDelegator implements FullTextSharedSessionBuil
 	@Override
 	public FullTextSharedSessionBuilder statementInspector(StatementInspector statementInspector) {
 		builder.statementInspector( statementInspector );
+		return this;
+	}
+
+	@Override
+	public FullTextSharedSessionBuilder connectionHandlingMode() {
+		builder.connectionHandlingMode();
+		return this;
+	}
+
+	@Override
+	public FullTextSharedSessionBuilder flushMode() {
+		builder.flushMode();
+		return this;
+	}
+
+	@Override
+	public FullTextSharedSessionBuilder connectionHandlingMode(PhysicalConnectionHandlingMode mode) {
+		builder.connectionHandlingMode( mode );
+		return this;
+	}
+
+	@Override
+	public FullTextSharedSessionBuilder autoClear(boolean autoClear) {
+		builder.autoClear( autoClear );
+		return this;
+	}
+
+	@Override
+	public FullTextSharedSessionBuilder flushMode(FlushMode flushMode) {
+		builder.flushMode( flushMode );
 		return this;
 	}
 }

--- a/orm/src/main/java/org/hibernate/search/jpa/impl/FullTextQueryImpl.java
+++ b/orm/src/main/java/org/hibernate/search/jpa/impl/FullTextQueryImpl.java
@@ -530,7 +530,7 @@ final class FullTextQueryImpl implements FullTextQuery {
 	public <T> T unwrap(Class<T> type) {
 		//I've purposely decided not to return the underlying Hibernate FullTextQuery
 		//as I see this as an implementation detail that should not be exposed.
-		return query.unwrap( type );
+		return (T) query.unwrap( type );
 	}
 
 }

--- a/orm/src/main/java/org/hibernate/search/query/hibernate/impl/FullTextQueryImpl.java
+++ b/orm/src/main/java/org/hibernate/search/query/hibernate/impl/FullTextQueryImpl.java
@@ -21,11 +21,10 @@ import org.hibernate.LockOptions;
 import org.hibernate.Query;
 import org.hibernate.QueryTimeoutException;
 import org.hibernate.ScrollMode;
-import org.hibernate.ScrollableResults;
 import org.hibernate.Session;
 import org.hibernate.query.ParameterMetadata;
 import org.hibernate.engine.spi.SessionImplementor;
-import org.hibernate.query.internal.QueryImpl;
+import org.hibernate.query.internal.AbstractProducedQuery;
 import org.hibernate.query.spi.QueryImplementor;
 import org.hibernate.query.spi.ScrollableResultsImplementor;
 import org.hibernate.search.FullTextQuery;
@@ -46,6 +45,7 @@ import org.hibernate.search.spatial.impl.Point;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 import org.hibernate.transform.ResultTransformer;
+import org.hibernate.type.Type;
 
 /**
  * Implementation of {@link org.hibernate.search.FullTextQuery}.
@@ -53,7 +53,7 @@ import org.hibernate.transform.ResultTransformer;
  * @author Emmanuel Bernard
  * @author Hardy Ferentschik
  */
-public class FullTextQueryImpl extends QueryImpl implements FullTextQuery {
+public class FullTextQueryImpl<R> extends AbstractProducedQuery<R> implements FullTextQuery<R> {
 
 	private static final Log log = LoggerFactory.make();
 
@@ -80,7 +80,7 @@ public class FullTextQueryImpl extends QueryImpl implements FullTextQuery {
 			SessionImplementor session,
 			ParameterMetadata parameterMetadata) {
 		//TODO handle flushMode
-		super( session, parameterMetadata, query.toString() );
+		super( session, parameterMetadata );
 		this.session = session;
 		ExtendedSearchIntegrator extendedIntegrator = getExtendedSearchIntegrator();
 		this.objectLookupMethod = extendedIntegrator.getDefaultObjectLookupMethod();
@@ -103,6 +103,11 @@ public class FullTextQueryImpl extends QueryImpl implements FullTextQuery {
 	public FullTextQuery setFilter(Filter filter) {
 		hSearchQuery.filter( filter );
 		return this;
+	}
+
+	@Override
+	public List<R> getResultList() {
+		return list();
 	}
 
 	/**
@@ -176,7 +181,7 @@ public class FullTextQueryImpl extends QueryImpl implements FullTextQuery {
 	}
 
 	@Override
-	public ScrollableResultsImplementor scroll() {
+	public ScrollableResultsImpl scroll() {
 		//keep the searcher open until the resultset is closed
 
 		hSearchQuery.getTimeoutManager().start();
@@ -367,6 +372,41 @@ public class FullTextQueryImpl extends QueryImpl implements FullTextQuery {
 
 	private ExtendedSearchIntegrator getExtendedSearchIntegrator() {
 		return ContextHelper.getSearchIntegratorBySessionImplementor( session );
+	}
+
+	@Override
+	public String getQueryString() {
+		return hSearchQuery.getQueryString();
+	}
+
+	@Override
+	protected boolean isNativeQuery() {
+		return false;
+	}
+
+	@Override
+	public Type[] getReturnTypes() {
+		throw new UnsupportedOperationException( "getReturnTypes() is not implemented in Hibernate Search queries" );
+	}
+
+	@Override
+	public String[] getReturnAliases() {
+		throw new UnsupportedOperationException( "getReturnAliases() is not implemented in Hibernate Search queries" );
+	}
+
+	@Override
+	public Query setEntity(int position, Object val) {
+		throw new UnsupportedOperationException( "setEntity(int,Object) is not implemented in Hibernate Search queries" );
+	}
+
+	@Override
+	public Query setEntity(String name, Object val) {
+		throw new UnsupportedOperationException( "setEntity(String,Object) is not implemented in Hibernate Search queries" );
+	}
+
+	@Override
+	public String toString() {
+		return "FullTextQueryImpl(" + getQueryString() + ")";
 	}
 
 	private static final Loader noLoader = new Loader() {

--- a/orm/src/main/java/org/hibernate/search/query/hibernate/impl/FullTextQueryImpl.java
+++ b/orm/src/main/java/org/hibernate/search/query/hibernate/impl/FullTextQueryImpl.java
@@ -25,7 +25,9 @@ import org.hibernate.ScrollableResults;
 import org.hibernate.Session;
 import org.hibernate.engine.query.spi.ParameterMetadata;
 import org.hibernate.engine.spi.SessionImplementor;
-import org.hibernate.internal.AbstractQueryImpl;
+import org.hibernate.query.internal.QueryImpl;
+import org.hibernate.query.spi.QueryImplementor;
+import org.hibernate.query.spi.ScrollableResultsImplementor;
 import org.hibernate.search.FullTextQuery;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.filter.FullTextFilter;
@@ -51,7 +53,7 @@ import org.hibernate.transform.ResultTransformer;
  * @author Emmanuel Bernard
  * @author Hardy Ferentschik
  */
-public class FullTextQueryImpl extends AbstractQueryImpl implements FullTextQuery {
+public class FullTextQueryImpl extends QueryImpl implements FullTextQuery {
 
 	private static final Log log = LoggerFactory.make();
 
@@ -62,6 +64,7 @@ public class FullTextQueryImpl extends AbstractQueryImpl implements FullTextQuer
 	private ResultTransformer resultTransformer;
 	private int fetchSize = 1;
 	private final HSQuery hSearchQuery;
+	private final SessionImplementor session;
 
 
 	/**
@@ -77,8 +80,8 @@ public class FullTextQueryImpl extends AbstractQueryImpl implements FullTextQuer
 			SessionImplementor session,
 			ParameterMetadata parameterMetadata) {
 		//TODO handle flushMode
-		super( query.toString(), null, session, parameterMetadata );
-
+		super( session, parameterMetadata, query.toString() );
+		this.session = session;
 		ExtendedSearchIntegrator extendedIntegrator = getExtendedSearchIntegrator();
 		this.objectLookupMethod = extendedIntegrator.getDefaultObjectLookupMethod();
 		this.databaseRetrievalMethod = extendedIntegrator.getDefaultDatabaseRetrievalMethod();
@@ -173,7 +176,7 @@ public class FullTextQueryImpl extends AbstractQueryImpl implements FullTextQuer
 	}
 
 	@Override
-	public ScrollableResults scroll() {
+	public ScrollableResultsImplementor scroll() {
 		//keep the searcher open until the resultset is closed
 
 		hSearchQuery.getTimeoutManager().start();
@@ -191,7 +194,7 @@ public class FullTextQueryImpl extends AbstractQueryImpl implements FullTextQuer
 	}
 
 	@Override
-	public ScrollableResults scroll(ScrollMode scrollMode) {
+	public ScrollableResultsImplementor scroll(ScrollMode scrollMode) {
 		//TODO think about this scrollmode
 		return scroll();
 	}
@@ -276,7 +279,7 @@ public class FullTextQueryImpl extends AbstractQueryImpl implements FullTextQuer
 	}
 
 	@Override
-	public Query setLockOptions(LockOptions lockOptions) {
+	public QueryImplementor setLockOptions(LockOptions lockOptions) {
 		throw new UnsupportedOperationException( "Lock options are not implemented in Hibernate Search queries" );
 	}
 
@@ -307,7 +310,7 @@ public class FullTextQueryImpl extends AbstractQueryImpl implements FullTextQuer
 	}
 
 	@Override
-	public Query setLockMode(String alias, LockMode lockMode) {
+	public QueryImplementor setLockMode(String alias, LockMode lockMode) {
 		throw new UnsupportedOperationException( "Lock options are not implemented in Hibernate Search queries" );
 	}
 

--- a/orm/src/main/java/org/hibernate/search/query/hibernate/impl/FullTextQueryImpl.java
+++ b/orm/src/main/java/org/hibernate/search/query/hibernate/impl/FullTextQueryImpl.java
@@ -23,7 +23,7 @@ import org.hibernate.QueryTimeoutException;
 import org.hibernate.ScrollMode;
 import org.hibernate.ScrollableResults;
 import org.hibernate.Session;
-import org.hibernate.engine.query.spi.ParameterMetadata;
+import org.hibernate.query.ParameterMetadata;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.query.internal.QueryImpl;
 import org.hibernate.query.spi.QueryImplementor;

--- a/orm/src/main/java/org/hibernate/search/query/hibernate/impl/ScrollableResultsImpl.java
+++ b/orm/src/main/java/org/hibernate/search/query/hibernate/impl/ScrollableResultsImpl.java
@@ -24,6 +24,7 @@ import org.hibernate.search.util.logging.impl.Log;
 
 import org.hibernate.ScrollableResults;
 import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.query.spi.ScrollableResultsImplementor;
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.query.engine.spi.DocumentExtractor;
 import org.hibernate.search.query.engine.spi.EntityInfo;
@@ -53,7 +54,7 @@ import org.hibernate.type.Type;
  * @author John Griffin
  * @author Sanne Grinovero
  */
-public class ScrollableResultsImpl implements ScrollableResults {
+public class ScrollableResultsImpl implements ScrollableResults, ScrollableResultsImplementor {
 
 	private static final Log log = LoggerFactory.make();
 
@@ -72,6 +73,8 @@ public class ScrollableResultsImpl implements ScrollableResults {
 	private final LoadedObject[] resultsContext;
 
 	private int current;
+
+	private boolean closed = false;
 
 	public ScrollableResultsImpl(int fetchSize, DocumentExtractor extractor,
 			Loader loader, SessionImplementor sessionImplementor,
@@ -210,6 +213,7 @@ public class ScrollableResultsImpl implements ScrollableResults {
 
 	@Override
 	public void close() {
+		closed = true;
 		try {
 			documentExtractor.close();
 		}
@@ -507,6 +511,11 @@ public class ScrollableResultsImpl implements ScrollableResults {
 		else {
 			return hibSession.contains( objects[0] );
 		}
+	}
+
+	@Override
+	public boolean isClosed() {
+		return closed;
 	}
 
 }

--- a/orm/src/main/java/org/hibernate/search/query/hibernate/impl/ScrollableResultsImpl.java
+++ b/orm/src/main/java/org/hibernate/search/query/hibernate/impl/ScrollableResultsImpl.java
@@ -426,6 +426,15 @@ public class ScrollableResultsImpl implements ScrollableResults, ScrollableResul
 		throw new UnsupportedOperationException( "Lucene does not work on columns" );
 	}
 
+	/**
+	 * This method is not supported on Lucene based queries
+	 * @throws UnsupportedOperationException always thrown
+	 */
+	@Override
+	public int getNumberOfTypes() {
+		throw new UnsupportedOperationException( "Not implemented for Lucene query results" );
+	}
+
 	@Override
 	public int getRowNumber() {
 		if ( max < first ) {

--- a/orm/src/test/java/org/hibernate/search/test/engine/LazyCollectionsUpdatingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/engine/LazyCollectionsUpdatingTest.java
@@ -151,6 +151,7 @@ public class LazyCollectionsUpdatingTest extends SearchTestBase {
 	// Test setup options - SessionFactory Properties
 	@Override
 	public void configure(Map<String,Object> cfg) {
+		cfg.put( "hibernate.allow_update_outside_transaction", "true" );
 		cfg.put( "hibernate.search.default." + Environment.READER_STRATEGY, FieldSelectorLeakingReaderProvider.class.getName() );
 		cfg.put( Environment.ANALYZER_CLASS, SimpleAnalyzer.class.getName() );
 	}

--- a/orm/src/test/java/org/hibernate/search/test/engine/TransactionTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/engine/TransactionTest.java
@@ -9,6 +9,7 @@ package org.hibernate.search.test.engine;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Map;
 
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
@@ -91,4 +92,10 @@ public class TransactionTest extends SearchTestBase {
 	public Class<?>[] getAnnotatedClasses() {
 		return new Class[] { Document.class };
 	}
+
+	@Override
+	public void configure(Map<String,Object> cfg) {
+		cfg.put( "hibernate.allow_update_outside_transaction", "true" );
+	}
+
 }

--- a/orm/src/test/java/org/hibernate/search/test/interceptor/IndexingActionInterceptorTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/interceptor/IndexingActionInterceptorTest.java
@@ -16,6 +16,7 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.TermQuery;
 import org.hibernate.Transaction;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.resource.transaction.spi.TransactionStatus;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
@@ -46,7 +47,7 @@ public class IndexingActionInterceptorTest extends SearchTestBase {
 	@Override
 	@After
 	public void tearDown() throws Exception {
-		if ( fullTextSession.getTransaction().getStatus() != TransactionStatus.ACTIVE ) {
+		if ( getTransactionStatus( fullTextSession ) != TransactionStatus.ACTIVE ) {
 			Transaction tx = fullTextSession.beginTransaction();
 			blog = (Blog) fullTextSession.get( Blog.class, blog.getId() );
 			fullTextSession.delete( blog );
@@ -58,6 +59,11 @@ public class IndexingActionInterceptorTest extends SearchTestBase {
 		}
 		fullTextSession.close();
 		super.tearDown();
+	}
+
+	private static TransactionStatus getTransactionStatus(FullTextSession fullTextSession) {
+		SharedSessionContractImplementor actualSession = (SharedSessionContractImplementor) fullTextSession;
+		return actualSession.accessTransaction().getStatus();
 	}
 
 	@Test

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.hibernate</groupId>
     <artifactId>hibernate-search-parent</artifactId>
-    <version>5.6.0-SNAPSHOT</version>
+    <version>5.7.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Hibernate Search Aggregator</name>

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,7 @@
 
         <!-- Slot definitions for JBoss Modules (both generated and consumed modules) -->
         <lucene.module.slot>5.5</lucene.module.slot>
+        <hibernate-orm.module.slot>5.2</hibernate-orm.module.slot>
 
         <!-- Dependency versions -->
         <slf4jVersion>1.6.4</slf4jVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -1026,7 +1026,14 @@
                                      </bundledSignatures>
                                      <failOnMissingClasses>false</failOnMissingClasses>
                                      <failOnUnresolvableSignatures>false</failOnUnresolvableSignatures>
+                                     <!--
+                                     The method SharedSessionContract#getTransaction() should never be used
+                                     as it is only reliable in certain configurations.
+                                     The banned Logger methods are the ones which avoid autoboxing, to allow backwards
+                                     compatibility with containers using an older JBoss Logger versions.
+                                      -->
                                      <signatures>
+org.hibernate.SharedSessionContract#getTransaction()
 org.jboss.logging.BasicLogger#tracef(java.lang.String, int)
 org.jboss.logging.BasicLogger#tracef(java.lang.String, int ,int)
 org.jboss.logging.BasicLogger#tracef(java.lang.String, int, java.lang.Object)

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
     </prerequisites>
 
     <properties>
-        <!-- JDK version required for the build; we still create 1.7 byte code -->
+        <!-- JDK version required for the build; we target 1.8 since Hibernate ORM 5.2 requires Java 8 -->
         <minJdkVersion>1.8</minJdkVersion>
 
         <!-- Slot definitions for JBoss Modules (both generated and consumed modules) -->
@@ -688,8 +688,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <showWarnings>true</showWarnings>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <encoding>UTF-8</encoding>
                     <!-- needed because of compiler bug: http://bugs.sun.com/view_bug.do?bug_id=6512707 -->
                     <proc>none</proc>
@@ -782,7 +782,7 @@
                 <configuration>
                     <rules>
                         <requireJavaVersion>
-                            <!-- require JDK 1.7 to run the build -->
+                            <!-- require JDK 1.8 to run the build -->
                             <version>[${minJdkVersion},)</version>
                         </requireJavaVersion>
                         <requireMavenVersion>
@@ -1014,7 +1014,7 @@
                         <execution>
                             <id>verify-forbidden-apis</id>
                                 <configuration>
-                                     <targetVersion>1.7</targetVersion>
+                                     <targetVersion>1.8</targetVersion>
                                      <!-- disallow undocumented classes like sun.misc.Unsafe: -->
                                      <internalRuntimeForbidden>true</internalRuntimeForbidden>
                                      <!-- if the used Java version is too new, don't fail, just do nothing: -->
@@ -1089,7 +1089,7 @@ org.jboss.logging.BasicLogger#debugf(java.lang.Throwable, java.lang.String, long
                          <execution>
                              <id>verify-forbidden-test-apis</id>
                              <configuration>
-                                 <targetVersion>1.7</targetVersion>
+                                 <targetVersion>1.8</targetVersion>
                                  <!-- disallow undocumented classes like sun.misc.Unsafe: -->
                                  <internalRuntimeForbidden>true</internalRuntimeForbidden>
                                  <!-- if the used Java version is too new, don't fail, just do nothing: -->
@@ -1392,7 +1392,7 @@ org.jboss.logging.BasicLogger#debugf(java.lang.Throwable, java.lang.String, long
             <id>non-jigsaw</id>
             <activation>
                 <!-- Asciidoctor, Karaf and WildFly won't work on JDK9 yet  -->
-                <jdk>[1.7,1.8]</jdk>
+                <jdk>1.8</jdk>
             </activation>
             <modules>
                 <module>documentation</module>

--- a/pom.xml
+++ b/pom.xml
@@ -493,11 +493,6 @@
             </dependency>
             <dependency>
                 <groupId>org.hibernate</groupId>
-                <artifactId>hibernate-entitymanager</artifactId>
-                <version>${hibernateVersion}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-envers</artifactId>
                 <version>${hibernateVersion}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
         <jgroupsVersion>3.6.10.Final</jgroupsVersion>
 
         <!-- ORM and transitive deps; Make sure to match ORM's set of versions when updating -->
-        <hibernateVersion>5.1.0.Final</hibernateVersion>
+        <hibernateVersion>5.2.1.Final</hibernateVersion>
         <hibernateCommonsAnnotationVersion>5.0.1.Final</hibernateCommonsAnnotationVersion>
         <jandexVersion>2.0.0.Final</jandexVersion>
         <classMateVersion>1.3.1</classMateVersion>
@@ -161,7 +161,7 @@
             exact versions in this pom are being tested.
             Essentially we allow older versions when we know no changes were necessary when we upgraded the dependency. -->
         <luceneOsgiRangeVersion>[5.3.0,5.6.0)</luceneOsgiRangeVersion>
-        <hibernateOrmOsgiRangeVersion>[5.0.0,5.2.0)</hibernateOrmOsgiRangeVersion>
+        <hibernateOrmOsgiRangeVersion>[5.2.0,5.3.0)</hibernateOrmOsgiRangeVersion>
         <hibernateHcannOsgiRangeVersion>[5,6)</hibernateHcannOsgiRangeVersion>
         <jGroupsOsgiRangeVersion>[3.6.0,4)</jGroupsOsgiRangeVersion>
         <jbossLoggingOsgiRangeVersion>[3.3,4.0.0)</jbossLoggingOsgiRangeVersion>

--- a/serialization/avro/pom.xml
+++ b/serialization/avro/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>hibernate-search-parent</artifactId>
         <groupId>org.hibernate</groupId>
-        <version>5.6.0-SNAPSHOT</version>
+        <version>5.7.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/sharedtestresources/pom.xml
+++ b/sharedtestresources/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-search-parent</artifactId>
-        <version>5.6.0-SNAPSHOT</version>
+        <version>5.7.0-SNAPSHOT</version>
     </parent>
     <artifactId>hibernate-search-sharedtestresources</artifactId>
 

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -41,10 +41,6 @@
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-entitymanager</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
             <artifactId>hibernate-testing</artifactId>
         </dependency>
         <dependency>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>hibernate-search-parent</artifactId>
         <groupId>org.hibernate</groupId>
-        <version>5.6.0-SNAPSHOT</version>
+        <version>5.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
This is a PREVIEW not to be merged in master: master is still aiming at Hibernate ORM `5.0.x` and `5.1.x` compatibility.

Still, I'd appreciate an early review: a couple of changes in ORM made this more complex than usual.
Among these:
 - the class hierarchy: Session now implementing EntityManager, with all its consequences on Query, etc..
 - stricter on what is allowed in CMT vs non-CMT transaction modes

Since it includes a version switch to `5.7.0-SNAPSHOT`, I'll also deploy a snapshot on Nexus for the sake of testing volunteers.

Needs still:

- [ ] to avoid using the old Criteria API, as it generates logged warnings
- [ ] check for other usage of deprecated APIs from ORM
- [ ] see if we can incorporate our JPA wrappers into the Session ones (i.e. unify things such as `org.hibernate.search.jpa.FullTextQuery` and `org.hibernate.search.FullTextQuery<R>`
- [ ] Clarify this ORM update effectively gets us to require Java 8