### PR TITLE
HSEARCH-2189 Elasticsearch Scroll API

### DIFF
--- a/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
+++ b/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
@@ -313,7 +313,7 @@ If your result set is bigger, you may take advantage of scrolling by using the `
 Limitations:
 
 * This method is not available in `org.hibernate.search.jpa.FullTextQuery`.
-* The Elasticsearch implementation does not allow defining an offset (i.e. calling `setFirstResult(int)` on the query before calling `scroll()`): the scrolling will always start with the first result, and using `setFirstResult(int)` will result in a `UnsupportedOperationException` being thrown.
+* The Elasticsearch implementation has poor performance when an offset has been defined (i.e. `setFirstResult(int)` has been called on the query before calling `scroll()`). This is because Elasticsearch does not provide such feature, thus Hibernate Search has to scroll through every previous result under the hood.
 * The Elasticsearch implementation allows only limited backtracking. Calling `scrollableResylts.setRowNumber(4)` when currently positioned at index `1006`, for example, may result in a `SearchException` being thrown, because only 1000 previous elements had been kept in memory. You may work this around by tweaking the property: `hibernate.search.elasticsearch.scroll_backtracking_window_size` (see <<elasticsearch-integration-configuration>>).
 * The `ScrollableResults` will become stale and unusable after a given period of time spent without fetching results from Elasticsearch. You may work this around by tweaking two properties: `hibernate.search.elasticsearch.scroll_timeout` and `hibernate.search.elasticsearch.scroll_fetch_size` (see <<elasticsearch-integration-configuration>>). Typically, you will solve timeout issues by reducing the fetch size and/or increasing the timeout limit, but this will also increase the performance hit on Elasticsearch.
 

--- a/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
+++ b/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
@@ -99,6 +99,7 @@ Selects the index creation strategy:: `hibernate.search.default.elasticsearch.in
 Maximum time to wait for the indexes to become available before failing (in ms):: `hibernate.search.default.elasticsearch.index_management_wait_timeout 10000`
 Status an index must at least have in order for Hibernate Search to work with it (one of "green", "yellow" or "red"):: `hibernate.search.default.elasticsearch.required_index_status green`
 Whether to perform an explicit refresh after a set of operations has been executed against a specific index (`true` or `false`):: `hibernate.search.default.elasticsearch.refresh_after_write false`
+When <<elasticsearch-scrolling,scrolling>>, the minimum number of previous results kept in memory at any time:: `hibernate.search.elasticsearch.scroll_backtracking_window_size`
 When <<elasticsearch-scrolling,scrolling>>, the number of results fetched by each Elasticsearch call:: `hibernate.search.elasticsearch.scroll_fetch_size`
 When <<elasticsearch-scrolling,scrolling>>, the maximum duration `ScrollableResults` will be usable if no other results are fetched from Elasticsearch, in seconds::
 `hibernate.search.elasticsearch.scroll_timeout`
@@ -313,7 +314,7 @@ Limitations:
 
 * This method is not available in `org.hibernate.search.jpa.FullTextQuery`.
 * The Elasticsearch implementation does not allow defining an offset (i.e. calling `setFirstResult(int)` on the query before calling `scroll()`): the scrolling will always start with the first result, and using `setFirstResult(int)` will result in a `UnsupportedOperationException` being thrown.
-* The Elasticsearch implementation is forward-only. Calling `scrollableResylts.setRowNumber(5)` when currently positioned at index `1000`, for example, will result in a `UnsupportedOperationException` being thrown.
+* The Elasticsearch implementation allows only limited backtracking. Calling `scrollableResylts.setRowNumber(4)` when currently positioned at index `1006`, for example, may result in a `SearchException` being thrown, because only 1000 previous elements had been kept in memory. You may work this around by tweaking the property: `hibernate.search.elasticsearch.scroll_backtracking_window_size` (see <<elasticsearch-integration-configuration>>).
 * The `ScrollableResults` will become stale and unusable after a given period of time spent without fetching results from Elasticsearch. You may work this around by tweaking two properties: `hibernate.search.elasticsearch.scroll_timeout` and `hibernate.search.elasticsearch.scroll_fetch_size` (see <<elasticsearch-integration-configuration>>). Typically, you will solve timeout issues by reducing the fetch size and/or increasing the timeout limit, but this will also increase the performance hit on Elasticsearch.
 
 ==== Projections

--- a/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
+++ b/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
@@ -88,7 +88,7 @@ you will need the new `hibernate-search-elasticsearch` jar.
 ----
 ====
 
-==== Configuration
+==== [[elasticsearch-integration-configuration]] Configuration
 
 Configuration is minimal.
 Add them to your `persistence.xml` or where you put the rest of your Hibernate Search configuration.
@@ -99,6 +99,9 @@ Selects the index creation strategy:: `hibernate.search.default.elasticsearch.in
 Maximum time to wait for the indexes to become available before failing (in ms):: `hibernate.search.default.elasticsearch.index_management_wait_timeout 10000`
 Status an index must at least have in order for Hibernate Search to work with it (one of "green", "yellow" or "red"):: `hibernate.search.default.elasticsearch.required_index_status green`
 Whether to perform an explicit refresh after a set of operations has been executed against a specific index (`true` or `false`):: `hibernate.search.default.elasticsearch.refresh_after_write false`
+When <<elasticsearch-scrolling,scrolling>>, the number of results fetched by each Elasticsearch call:: `hibernate.search.elasticsearch.scroll_fetch_size`
+When <<elasticsearch-scrolling,scrolling>>, the maximum duration `ScrollableResults` will be usable if no other results are fetched from Elasticsearch, in seconds::
+`hibernate.search.elasticsearch.scroll_timeout`
 
 Let's see the options for the `index_schema_management_strategy` property:
 
@@ -111,7 +114,7 @@ Let's see the options for the `index_schema_management_strategy` property:
 |CREATE_DELETE|Similarly to 'CREATE' but will also delete the index at shutdown. Commonly used for tests.
 |===============
 
-Note that all properties besides `host` can be given globally as shown above and/or be given for specific indexes:
+Note that all properties prefixed with `hibernate.search.default` (besides `host`) can be given globally as shown above and/or be given for specific indexes:
 `hibernate.search.someindex.elasticsearch.index_schema_management_strategy MERGE`.
 
 ===== Elasticsearch configuration
@@ -125,6 +128,7 @@ However there are a few features that would benefit from a few changes:
   see <<elasticsearch-query-spatial>>
 * if you want to be able to use the purge all Hibernate Search command,
   install the link:https://www.elastic.co/guide/en/elasticsearch/plugins/current/plugins-delete-by-query.html[`delete-by-query`] plugin
+* if you want to use paging (as opposed to <<elasticsearch-scrolling,scrolling>>) on result sets larger than 10000 elements (for instance access the 10001st result), you may increase the value of the `index.max_result_window` property (default is 10000).
 
 === Mapping and indexing
 
@@ -295,6 +299,23 @@ you need to enable the Groovy plugin by adding the following snippet to your Ela
 script.engine.groovy.inline.search: on
 ----
 
+==== [[elasticsearch-scrolling]] Paging and scrolling
+
+You may handle large result sets in two different ways, with different limitations.
+
+For (relatively) smaller result sets, you may use the traditional offset/limit querying provided by the `FullTextQuery` interfaces: `setFirstResult(int)` and `setMaxResults(int)`.
+Limitations:
+
+* This will only get you as far as the 10000 first documents, i.e. when requesting a window that includes documents beyond the 10000th result, Elasticsearch will return an error. If you want to raise this limit, see the `index.max_result_window` property in https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#dynamic-index-settings[Elasticsearch's settings].
+
+If your result set is bigger, you may take advantage of scrolling by using the `scroll` method on `org.hibernate.search.FullTextQuery`.
+Limitations:
+
+* This method is not available in `org.hibernate.search.jpa.FullTextQuery`.
+* The Elasticsearch implementation does not allow defining an offset (i.e. calling `setFirstResult(int)` on the query before calling `scroll()`): the scrolling will always start with the first result, and using `setFirstResult(int)` will result in a `UnsupportedOperationException` being thrown.
+* The Elasticsearch implementation is forward-only. Calling `scrollableResylts.setRowNumber(5)` when currently positioned at index `1000`, for example, will result in a `UnsupportedOperationException` being thrown.
+* The `ScrollableResults` will become stale and unusable after a given period of time spent without fetching results from Elasticsearch. You may work this around by tweaking two properties: `hibernate.search.elasticsearch.scroll_timeout` and `hibernate.search.elasticsearch.scroll_fetch_size` (see <<elasticsearch-integration-configuration>>). Typically, you will solve timeout issues by reducing the fetch size and/or increasing the timeout limit, but this will also increase the performance hit on Elasticsearch.
+
 ==== Projections
 
 All fields are stored by Elasticsearch in the JSON document it indexes,
@@ -407,9 +428,6 @@ Please check with JIRA and the mailing lists for updates, but at the time of wri
 
 * Defining analyzers with `@AnalyzerDef`, analyzers have to be defined in the Elasticsearch configuration
 * Query timeouts
-* Pagination is limited to the 10000 first documents (configurable in Elasticsearch)
-** better support through the scrolling API is planned
-* Scrolling on large results
 * MoreLikeThis queries
 * Mixing Lucene based indexes and Elasticsearch based indexes (partial support is here though)
 * There is room for improvements in the performances of the MassIndexer implementation

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/ElasticsearchEnvironment.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/ElasticsearchEnvironment.java
@@ -23,6 +23,8 @@ public final class ElasticsearchEnvironment {
 		public static final int INDEX_MANAGEMENT_WAIT_TIMEOUT = 10_000;
 		public static final String REQUIRED_INDEX_STATUS = "green";
 		public static final boolean REFRESH_AFTER_WRITE = false;
+		public static final int SCROLL_FETCH_SIZE = 1_000;
+		public static final int SCROLL_TIMEOUT = 60;
 	}
 
 	/**
@@ -87,6 +89,31 @@ public final class ElasticsearchEnvironment {
 	 * specific indexes (e.g. {@code hibernate.search.someindex.elasticsearch.refresh_after_write=true}).
 	 */
 	public static final String REFRESH_AFTER_WRITE = "elasticsearch.refresh_after_write";
+
+	/**
+	 * Property for specifying the the number of results fetched by each Elasticsearch call when scrolling.
+	 * <p>
+	 * A strictly positive value is expected.
+	 * <p>
+	 * Defaults to {@link Defaults#SCROLL_FETCH_SIZE}.
+	 * <p>
+	 * Can only be given <b>globally</b> (e.g.
+	 * {@code hibernate.search.elasticsearch.scroll_fetch_size=1000}).
+	 */
+	public static final String SCROLL_FETCH_SIZE = "elasticsearch.scroll_fetch_size";
+
+	/**
+	 * Property for specifying the maximum duration {@code ScrollableResults} will be usable if no
+	 * other results are fetched from Elasticsearch, in seconds.
+	 * <p>
+	 * A strictly positive value is expected.
+	 * <p>
+	 * Defaults to {@link Defaults#SCROLL_TIMEOUT}.
+	 * <p>
+	 * Can only be given <b>globally</b> (e.g.
+	 * {@code hibernate.search.elasticsearch.scroll_timeout=60}).
+	 */
+	public static final String SCROLL_TIMEOUT = "elasticsearch.scroll_timeout";
 
 	private ElasticsearchEnvironment() {
 	}

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/ElasticsearchEnvironment.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/ElasticsearchEnvironment.java
@@ -23,6 +23,7 @@ public final class ElasticsearchEnvironment {
 		public static final int INDEX_MANAGEMENT_WAIT_TIMEOUT = 10_000;
 		public static final String REQUIRED_INDEX_STATUS = "green";
 		public static final boolean REFRESH_AFTER_WRITE = false;
+		public static final int SCROLL_BACKTRACKING_WINDOW_SIZE = 10_000;
 		public static final int SCROLL_FETCH_SIZE = 1_000;
 		public static final int SCROLL_TIMEOUT = 60;
 	}
@@ -89,6 +90,21 @@ public final class ElasticsearchEnvironment {
 	 * specific indexes (e.g. {@code hibernate.search.someindex.elasticsearch.refresh_after_write=true}).
 	 */
 	public static final String REFRESH_AFTER_WRITE = "elasticsearch.refresh_after_write";
+
+	/**
+	 * Property for specifying the the minimum number of previous results kept in memory at any time when scrolling.
+	 * <p>
+	 * This determines the number of positions one will be able to scroll backward (<em>backtracking</em>) without
+	 * starting over the scrolling.
+	 * <p>
+	 * A strictly positive value is expected.
+	 * <p>
+	 * Defaults to {@link Defaults#SCROLL_BACKTRACKING_WINDOW_SIZE}.
+	 * <p>
+	 * Can only be given <b>globally</b> (e.g.
+	 * {@code hibernate.search.elasticsearch.scroll_backtracking_window_size=10000}).
+	 */
+	public static final String SCROLL_BACKTRACKING_WINDOW_SIZE = "elasticsearch.scroll_backtracking_window_size";
 
 	/**
 	 * Property for specifying the the number of results fetched by each Elasticsearch call when scrolling.

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
@@ -159,11 +159,6 @@ public interface Log extends org.hibernate.search.util.logging.impl.Log {
 	SearchException facetingRequestHasUnsupportedType(String facetingRequestType);
 
 	@Message(id = ES_BACKEND_MESSAGES_START_ID + 27,
-			value = "Cannot use an offset ('from', 'firstResult') when scrolling through Elasticsearch results"
-	)
-	UnsupportedOperationException unsupportedOffsettedScrolling();
-
-	@Message(id = ES_BACKEND_MESSAGES_START_ID + 28,
 			value = "Cannot scroll backward more than %1$s positions through Elasticsearch results. First index still in memory is %2$s, requested index is %3$s."
 	)
 	SearchException backtrackingWindowOverflow(int backtrackingLimit, int windowStartIndex, int requestedIndex);

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
@@ -164,7 +164,7 @@ public interface Log extends org.hibernate.search.util.logging.impl.Log {
 	UnsupportedOperationException unsupportedOffsettedScrolling();
 
 	@Message(id = ES_BACKEND_MESSAGES_START_ID + 28,
-			value = "Cannot scroll backward through Elasticsearch results. Previously accessed index was %1$s, requested index is %2$s."
+			value = "Cannot scroll backward more than %1$s positions through Elasticsearch results. First index still in memory is %2$s, requested index is %3$s."
 	)
-	UnsupportedOperationException unsupportedBackwardTraversal(int lastRequestedIndex, int index);
+	SearchException backtrackingWindowOverflow(int backtrackingLimit, int windowStartIndex, int requestedIndex);
 }

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
@@ -157,4 +157,14 @@ public interface Log extends org.hibernate.search.util.logging.impl.Log {
 			value = "Faceting request of type %1$s not supported"
 	)
 	SearchException facetingRequestHasUnsupportedType(String facetingRequestType);
+
+	@Message(id = ES_BACKEND_MESSAGES_START_ID + 27,
+			value = "Cannot use an offset ('from', 'firstResult') when scrolling through Elasticsearch results"
+	)
+	UnsupportedOperationException unsupportedOffsettedScrolling();
+
+	@Message(id = ES_BACKEND_MESSAGES_START_ID + 28,
+			value = "Cannot scroll backward through Elasticsearch results. Previously accessed index was %1$s, requested index is %2$s."
+	)
+	UnsupportedOperationException unsupportedBackwardTraversal(int lastRequestedIndex, int index);
 }

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/Window.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/Window.java
@@ -1,0 +1,143 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.util.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A fixed-size, random-access collection that removes the first element when it becomes full.
+ *
+ * <p>The indices accepted by this container are within a bounded range. This range may start at any
+ * positive integer value, i.e. the container may not allow access to element at index {@code 0}, but
+ * only indices {@code 102-134} for instance. The range will advance automatically as the window gets full
+ * and more elements are added.
+ *
+ * @author Yoann Rodiere
+ */
+public class Window<E> {
+	/**
+	 * The external index of the first element in this window, i.e. the index that will give
+	 * access to the first element when given to {@link #get(int)}.
+	 * <p>If the window is empty, this will be the index of the next added element.
+	 */
+	private int externalStartIndex;
+
+	/**
+	 * The number of elements that can be added before the first element gets automatically erased.
+	 */
+	private int capacity;
+
+	/**
+	 * The initial value of {@link #externalStartIndex}, for use in {@link #clear()}.
+	 */
+	private final int initialExternalStartIndex;
+
+	/**
+	 * The actual data.
+	 */
+	private final List<E> elementData;
+
+	/**
+	 * The position where the first element in this window is stored within {{@link #elementData}.
+	 * <p>If the window is empty, this will be the index of the next added element.
+	 */
+	private int internalStartIndex;
+
+	/**
+	 * The number of elements in this window.
+	 */
+	private int size;
+
+	/**
+	 * @param initialIndex The index of the first added element.
+	 * @param capacity The number of elements that can be added before the first element gets automatically erased.
+	 */
+	public Window(int initialIndex, int capacity) {
+		if ( capacity <= 0 ) {
+			throw new IllegalArgumentException( "capacity must be at least 1" );
+		}
+		this.initialExternalStartIndex = initialIndex;
+		this.capacity = capacity;
+		externalStartIndex = initialIndex;
+		elementData = new ArrayList<>(); // Take advantage of ArrayList's "smart" growth and O(1) random access
+		internalStartIndex = 0;
+		size = 0;
+	}
+
+	public int start() {
+		return externalStartIndex;
+	}
+
+	/**
+	 * @return The number of elements in this element container.
+	 */
+	public int size() {
+		return size;
+	}
+
+	public boolean isEmpty() {
+		return size == 0;
+	}
+
+	/**
+	 * @return The maximum number of element that can fit this window.
+	 */
+	public int capacity() {
+		return capacity;
+	}
+
+	public E get(int externalIndex) {
+		rangeCheck( externalIndex );
+		int internalIndex = ( externalIndex - externalStartIndex + internalStartIndex ) % capacity;
+		return elementData.get( internalIndex );
+	}
+
+	private void rangeCheck(int externalIndex) {
+		int start = start();
+		if ( externalIndex < start || start + size() <= externalIndex ) {
+			throw new IndexOutOfBoundsException();
+		}
+	}
+
+	/**
+	 * Add an element, removing the first element if it's necessary in order to respect the size limit.
+	 *
+	 * @param element The element to add.
+	 * @return {@code true} to indicate the element has been added.
+	 */
+	public boolean add(E element) {
+		int newElementIndex = ( internalStartIndex + size ) % capacity;
+		if ( size == capacity ) {
+			// Overflow: drop the first element
+			internalStartIndex = ( internalStartIndex + 1 ) % capacity;
+			++externalStartIndex;
+		}
+		else {
+			++size;
+		}
+		if ( newElementIndex == elementData.size() ) {
+			elementData.add( element );
+		}
+		else {
+			elementData.set( newElementIndex, element );
+		}
+		return true;
+	}
+
+	public void clear() {
+		this.externalStartIndex = initialExternalStartIndex;
+
+		// Clear references for the GC
+		for ( int i = 0; i < size; i++ ) {
+			elementData.set( (internalStartIndex + i ) % capacity, null );
+		}
+
+		this.internalStartIndex = 0;
+		this.size = 0;
+	}
+}

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIT.java
@@ -391,7 +391,7 @@ public class ElasticsearchIT extends SearchTestBase {
 		assertEquals( -1, scrollableResults.getRowNumber() );
 		assertTrue( scrollableResults.last() );
 		assertEquals( 3, scrollableResults.getRowNumber() );
-		scrollableResults.beforeFirst();
+		scrollableResults.beforeFirst(); // Won't fail even if we're going backward, because we didn't actually fetch the last result
 
 		List<ScientificArticle> articles = new ArrayList<>();
 		while ( scrollableResults.next() ) {
@@ -406,32 +406,29 @@ public class ElasticsearchIT extends SearchTestBase {
 				"ORM modelling"
 		);
 
-		fullTextQuery = session.createFullTextQuery( query, ScientificArticle.class )
-				.setSort( new Sort( new SortField( "id", SortField.Type.STRING, false ) ) );
-
-		scrollableResults = fullTextQuery
-				.setFirstResult( 1 )
-				.setMaxResults( 2 )
-				.scroll();
-
-		assertEquals( -1, scrollableResults.getRowNumber() );
-		assertTrue( scrollableResults.last() );
-		assertEquals( 1, scrollableResults.getRowNumber() );
-		scrollableResults.beforeFirst();
-
-		articles = new ArrayList<>();
-		while ( scrollableResults.next() ) {
-			articles.add( (ScientificArticle) scrollableResults.get()[0] );
-		}
-		scrollableResults.close();
-
-		assertThat( articles ).onProperty( "title" ).containsExactly(
-				"Latest in ORM",
-				"High-performance ORM"
-		);
-
 		tx.commit();
 		s.close();
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testScrollWithOffset() throws Exception {
+		Session s = openSession();
+		FullTextSession session = Search.getFullTextSession( s );
+		Transaction tx = s.beginTransaction();
+		try {
+			QueryDescriptor query = ElasticsearchQueries.fromJson( "{ 'query': { 'match' : { 'abstract' : 'Hibernate' } } }" );
+			FullTextQuery fullTextQuery = session.createFullTextQuery( query, ScientificArticle.class )
+					.setSort( new Sort( new SortField( "id", SortField.Type.STRING, false ) ) );
+
+			fullTextQuery
+					.setFirstResult( 1 )
+					.setMaxResults( 2 )
+					.scroll();
+		}
+		finally {
+			tx.commit();
+			s.close();
+		}
 	}
 
 	@Test

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchScrollingIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchScrollingIT.java
@@ -109,15 +109,22 @@ public class ElasticsearchScrollingIT {
 		assertEquals( 500, info.getId() );
 	}
 
-	@Test(expected = UnsupportedOperationException.class)
+	@Test
 	public void scrollBackward() throws Exception {
-		generateData( 0, 3 );
+		generateData( 0, 1001 );
 
 		Query query = builder().all().createQuery();
 		DocumentExtractor extractor = getQuery( query )
 				.queryDocumentExtractor();
-		extractor.extract( 1 );
-		extractor.extract( 0 );
+
+		EntityInfo info = extractor.extract( 1000 );
+		assertNotNull( info );
+		assertEquals( 1000, info.getId() );
+
+		// Backtrack exactly 1000 positions
+		info = extractor.extract( 0 );
+		assertNotNull( info );
+		assertEquals( 0, info.getId() );
 	}
 
 	private QueryBuilder builder() {

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchScrollingIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchScrollingIT.java
@@ -1,0 +1,170 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.SortableField;
+import org.hibernate.search.backend.spi.Work;
+import org.hibernate.search.backend.spi.WorkType;
+import org.hibernate.search.cfg.Environment;
+import org.hibernate.search.elasticsearch.cfg.ElasticsearchEnvironment;
+import org.hibernate.search.elasticsearch.cfg.IndexSchemaManagementStrategy;
+import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
+import org.hibernate.search.exception.SearchException;
+import org.hibernate.search.query.dsl.QueryBuilder;
+import org.hibernate.search.query.engine.spi.DocumentExtractor;
+import org.hibernate.search.query.engine.spi.EntityInfo;
+import org.hibernate.search.query.engine.spi.HSQuery;
+import org.hibernate.search.testsupport.TestForIssue;
+import org.hibernate.search.testsupport.junit.SearchFactoryHolder;
+import org.hibernate.search.testsupport.setup.TransactionContextForTest;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Yoann Rodiere
+ */
+@TestForIssue( jiraKey = "HSEARCH-2189" )
+public class ElasticsearchScrollingIT {
+
+	/**
+	 * The default value for the index.max_result_window setting in Elasticsearch.
+	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/2.4/breaking_21_search_changes.html#_from_size_limits
+	 */
+	private static final int DEFAULT_MAX_RESULT_WINDOW = 10000;
+
+	@Rule
+	public SearchFactoryHolder sfHolder = new SearchFactoryHolder( IndexedObject.class )
+			.withProperty(
+					"hibernate.search.default." + ElasticsearchEnvironment.INDEX_SCHEMA_MANAGEMENT_STRATEGY,
+					IndexSchemaManagementStrategy.CREATE_DELETE.name()
+					)
+			.withProperty( "hibernate.search.default." + Environment.INDEX_MANAGER_IMPL_NAME, "elasticsearch" );
+
+	@Test
+	public void searchBeforeMaxResultWindow() throws Exception {
+		generateData( 0, DEFAULT_MAX_RESULT_WINDOW + 10 );
+
+		Query query = builder().all().createQuery();
+		List<EntityInfo> results = getQuery( query )
+				.firstResult( DEFAULT_MAX_RESULT_WINDOW - 5 ).maxResults( 5 )
+				.queryEntityInfos();
+		assertEquals( 5, results.size() );
+		assertEquals( DEFAULT_MAX_RESULT_WINDOW - 5, results.get( 0 ).getId() );
+	}
+
+	@Test(expected = SearchException.class)
+	public void searchBeyondMaxResultWindow() throws Exception {
+		generateData( 0, DEFAULT_MAX_RESULT_WINDOW + 10 );
+
+		Query query = builder().all().createQuery();
+		getQuery( query )
+				.firstResult( DEFAULT_MAX_RESULT_WINDOW + 1 ).maxResults( 5 )
+				.queryEntityInfos();
+	}
+
+	@Test
+	public void scrollBeyondMaxResultWindow() throws Exception {
+		generateData( 0, DEFAULT_MAX_RESULT_WINDOW + 10 );
+
+		Query query = builder().all().createQuery();
+		DocumentExtractor extractor = getQuery( query )
+				.queryDocumentExtractor();
+		for ( int i = 0; i < DEFAULT_MAX_RESULT_WINDOW + 10; ++i ) {
+			EntityInfo info = extractor.extract(i);
+			assertNotNull( info );
+			assertEquals( i, info.getId() );
+		}
+	}
+
+	@Test
+	public void scrollForwardToArbitraryPosition() throws Exception {
+		generateData( 0, 1000 );
+
+		Query query = builder().all().createQuery();
+		DocumentExtractor extractor = getQuery( query )
+				.queryDocumentExtractor();
+
+		EntityInfo info = extractor.extract( 1 );
+		assertNotNull( info );
+		assertEquals( 1, info.getId() );
+
+		info = extractor.extract( 500 );
+		assertNotNull( info );
+		assertEquals( 500, info.getId() );
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void scrollBackward() throws Exception {
+		generateData( 0, 3 );
+
+		Query query = builder().all().createQuery();
+		DocumentExtractor extractor = getQuery( query )
+				.queryDocumentExtractor();
+		extractor.extract( 1 );
+		extractor.extract( 0 );
+	}
+
+	private QueryBuilder builder() {
+		return sfHolder.getSearchFactory().buildQueryBuilder().forEntity( IndexedObject.class ).get();
+	}
+
+	private HSQuery getQuery(Query luceneQuery) {
+		ExtendedSearchIntegrator sf = sfHolder.getSearchFactory();
+		HSQuery hsQuery = sf.createQueryDescriptor( luceneQuery, IndexedObject.class )
+				.createHSQuery( sf );
+		return hsQuery
+				.targetedEntities( Arrays.asList( new Class<?>[] { IndexedObject.class } ) )
+				.projection( "id" )
+				.sort( new Sort( new SortField( "idSort", SortField.Type.INT )) );
+	}
+
+	private void generateData(int firstId, int count) throws Exception {
+		TransactionContextForTest tc = new TransactionContextForTest();
+		for ( int id = firstId; id < firstId + count; ++id ) {
+			Work work = new Work( new IndexedObject( id ), id, WorkType.ADD, false );
+			sfHolder.getSearchFactory().getWorker().performWork( work, tc );
+		}
+		tc.end();
+
+		// Wait for Elasticsearch to make everything available
+		Thread.sleep( 1000 );
+	}
+
+	@Indexed
+	public static class IndexedObject {
+		@DocumentId
+		@Field(name = "idSort")
+		@SortableField(forField = "idSort")
+		private Integer id;
+
+		public IndexedObject(Integer id) {
+			super();
+			this.id = id;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+	}
+}

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/WindowTest.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/WindowTest.java
@@ -1,0 +1,102 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.hibernate.search.elasticsearch.util.impl.Window;
+import org.junit.Test;
+
+/**
+ * @author Yoann Rodiere
+ */
+public class WindowTest {
+
+	@Test
+	public void add_withinBounds() {
+		Window<Integer> window = new Window<>( 4100, 100 );
+		window.add( 1 );
+		assertEquals( Integer.valueOf( 1 ), window.get( 4100 ) );
+		assertEquals( 4100, window.start() );
+		assertEquals( 1, window.size() );
+		assertFalse( window.isEmpty() );
+		assertEquals( 100, window.capacity() );
+
+		window.add( 2 );
+		assertEquals( Integer.valueOf( 1 ), window.get( 4100 ) );
+		assertEquals( Integer.valueOf( 2 ), window.get( 4101 ) );
+		assertEquals( 4100, window.start() );
+		assertEquals( 2, window.size() );
+		assertFalse( window.isEmpty() );
+		assertEquals( 100, window.capacity() );
+	}
+
+	@Test(expected = IndexOutOfBoundsException.class)
+	public void add_outOfBounds_after() {
+		Window<Integer> window = new Window<>( 4100, 10 );
+		window.add( 1 );
+		window.add( 2 );
+
+		window.get( 3 );
+	}
+
+	@Test(expected = IndexOutOfBoundsException.class)
+	public void add_outOfBounds_before() {
+		Window<Integer> window = new Window<>( 4100, 10 );
+		window.add( 1 );
+		window.add( 2 );
+
+		window.get( 0 );
+	}
+
+	@Test
+	public void add_overflow() {
+		Window<Integer> window = new Window<>( 10_000, 4 );
+		window.add( 1 );
+		window.add( 2 );
+		window.add( 3 );
+		window.add( 4 );
+		assertEquals( Integer.valueOf( 1 ), window.get( 10_000 ) );
+		assertEquals( Integer.valueOf( 2 ), window.get( 10_001 ) );
+		assertEquals( Integer.valueOf( 3 ), window.get( 10_002 ) );
+		assertEquals( Integer.valueOf( 4 ), window.get( 10_003 ) );
+		assertEquals( 10_000, window.start() );
+		assertEquals( 4, window.size() );
+		assertFalse( window.isEmpty() );
+		assertEquals( 4, window.capacity() );
+
+		window.add( 5 );
+		assertEquals( Integer.valueOf( 2 ), window.get( 10_001 ) );
+		assertEquals( Integer.valueOf( 3 ), window.get( 10_002 ) );
+		assertEquals( Integer.valueOf( 4 ), window.get( 10_003 ) );
+		assertEquals( Integer.valueOf( 5 ), window.get( 10_004 ) );
+		assertEquals( 10_001, window.start() );
+		assertEquals( 4, window.size() );
+		assertFalse( window.isEmpty() );
+		assertEquals( 4, window.capacity() );
+	}
+
+	@Test
+	public void clear() {
+		Window<Integer> window = new Window<>( 12, 10 );
+		window.add( 1 );
+		window.add( 2 );
+		assertEquals( 2, window.size() );
+		assertFalse( window.isEmpty() );
+		assertEquals( 12, window.start() );
+		assertEquals( 10, window.capacity() );
+
+		window.clear();
+		assertEquals( 0, window.size() );
+		assertTrue( window.isEmpty() );
+		assertEquals( 12, window.start() );
+		assertEquals( 10, window.capacity() );
+	}
+
+}

--- a/engine/src/main/java/org/hibernate/search/query/engine/spi/DocumentExtractor.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/spi/DocumentExtractor.java
@@ -26,6 +26,13 @@ import org.apache.lucene.search.TopDocs;
  */
 public interface DocumentExtractor extends Closeable {
 
+	/**
+	 * Retrieves entity information for the result at the given index.
+	 *
+	 * @param index The requested result index.
+	 * @return The entity information for the requested result.
+	 * @throws IOException
+	 */
 	EntityInfo extract(int index) throws IOException;
 
 	int getFirstIndex();


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2189

There were features I didn't want to provide because they would be no efficient way to implement them. I implemented them anyway, because of -engine/-orm tests that were failing when ran against Elasticsearch. The details about inefficiencies are provided in the documentation.

The commits should probably be squashed together before merging. I just kept them separate in case we end up not providing those features.