### PR TITLE
HSEARCH-2367 (+ others) QueryDescriptor API/SPI improvements

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/ElasticsearchQueries.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/ElasticsearchQueries.java
@@ -15,6 +15,9 @@ import com.google.gson.JsonParser;
 /**
  * Creates queries to be used with Elasticsearch.
  *
+ * <p>Methods in this class return {@link QueryDescriptor}s. See {@code QueryDescriptor}'s
+ * javadoc for more information about how to use it.
+ *
  * @author Gunnar Morling
  */
 public class ElasticsearchQueries {

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchHSQueryImpl.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchHSQueryImpl.java
@@ -159,6 +159,11 @@ public class ElasticsearchHSQueryImpl extends AbstractHSQuery {
 	}
 
 	@Override
+	public String getQueryString() {
+		return jsonQuery.toString();
+	}
+
+	@Override
 	public DocumentExtractor queryDocumentExtractor() {
 		return new ElasticsearchScrollAPIDocumentExtractor();
 	}

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchJsonQueryDescriptor.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchJsonQueryDescriptor.java
@@ -9,6 +9,7 @@ package org.hibernate.search.elasticsearch.impl;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.query.engine.spi.HSQuery;
 import org.hibernate.search.query.engine.spi.QueryDescriptor;
+import org.hibernate.search.spi.SearchIntegrator;
 
 import com.google.gson.JsonObject;
 
@@ -26,8 +27,8 @@ public class ElasticsearchJsonQueryDescriptor implements QueryDescriptor {
 	}
 
 	@Override
-	public HSQuery createHSQuery(ExtendedSearchIntegrator extendedIntegrator) {
-		return new ElasticsearchHSQueryImpl( jsonQuery, extendedIntegrator );
+	public HSQuery createHSQuery(SearchIntegrator searchIntegrator) {
+		return new ElasticsearchHSQueryImpl( jsonQuery, searchIntegrator.unwrap( ExtendedSearchIntegrator.class ) );
 	}
 
 	@Override

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchScrollingIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchScrollingIT.java
@@ -9,7 +9,6 @@ package org.hibernate.search.elasticsearch.test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.apache.lucene.search.Query;
@@ -134,10 +133,8 @@ public class ElasticsearchScrollingIT {
 
 	private HSQuery getQuery(Query luceneQuery) {
 		ExtendedSearchIntegrator sf = sfHolder.getSearchFactory();
-		HSQuery hsQuery = sf.createQueryDescriptor( luceneQuery, IndexedObject.class )
-				.createHSQuery( sf );
+		HSQuery hsQuery = sf.createHSQuery( luceneQuery, IndexedObject.class );
 		return hsQuery
-				.targetedEntities( Arrays.asList( new Class<?>[] { IndexedObject.class } ) )
 				.projection( "id" )
 				.sort( new Sort( new SortField( "idSort", SortField.Type.INT ) ) );
 	}

--- a/engine/src/main/java/org/hibernate/search/engine/impl/ImmutableSearchFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/ImmutableSearchFactory.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.engine.impl;
 
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
@@ -281,7 +282,7 @@ public class ImmutableSearchFactory implements ExtendedSearchIntegratorWithShare
 	}
 
 	@Override
-	public QueryDescriptor createQueryDescriptor(Query luceneQuery, Class<?>... entities) {
+	public HSQuery createHSQuery(Query luceneQuery, Class<?>... entities) {
 		QueryDescriptor descriptor = null;
 
 		if ( queryTranslatorPresent ) {
@@ -293,7 +294,11 @@ public class ImmutableSearchFactory implements ExtendedSearchIntegratorWithShare
 			}
 		}
 
-		return descriptor != null ? descriptor : new LuceneQueryDescriptor( luceneQuery );
+		if ( descriptor == null ) {
+			descriptor = new LuceneQueryDescriptor( luceneQuery );
+		}
+
+		return descriptor.createHSQuery( this ).targetedEntities( Arrays.asList( entities ) );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/impl/LuceneQueryDescriptor.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/LuceneQueryDescriptor.java
@@ -7,9 +7,9 @@
 package org.hibernate.search.engine.impl;
 
 import org.apache.lucene.search.Query;
-import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.query.engine.spi.HSQuery;
 import org.hibernate.search.query.engine.spi.QueryDescriptor;
+import org.hibernate.search.spi.SearchIntegrator;
 
 /**
  * A {@link QueryDescriptor} for a Lucene query.
@@ -25,7 +25,7 @@ public class LuceneQueryDescriptor implements QueryDescriptor {
 	}
 
 	@Override
-	public HSQuery createHSQuery(ExtendedSearchIntegrator extendedIntegrator) {
+	public HSQuery createHSQuery(SearchIntegrator extendedIntegrator) {
 		HSQuery hsQuery = extendedIntegrator.createHSQuery();
 		hsQuery.luceneQuery( luceneQuery );
 

--- a/engine/src/main/java/org/hibernate/search/engine/impl/MutableSearchFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/MutableSearchFactory.java
@@ -36,7 +36,6 @@ import org.hibernate.search.query.DatabaseRetrievalMethod;
 import org.hibernate.search.query.ObjectLookupMethod;
 import org.hibernate.search.query.dsl.QueryContextBuilder;
 import org.hibernate.search.query.engine.spi.HSQuery;
-import org.hibernate.search.query.engine.spi.QueryDescriptor;
 import org.hibernate.search.query.engine.spi.TimeoutExceptionFactory;
 import org.hibernate.search.spi.IndexingMode;
 import org.hibernate.search.spi.InstanceInitializer;
@@ -147,8 +146,8 @@ public class MutableSearchFactory implements ExtendedSearchIntegratorWithShareab
 	}
 
 	@Override
-	public QueryDescriptor createQueryDescriptor(Query luceneQuery, Class<?>... entities) {
-		return delegate.createQueryDescriptor( luceneQuery, entities );
+	public HSQuery createHSQuery(Query luceneQuery, Class<?>... entities) {
+		return delegate.createHSQuery( luceneQuery, entities );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/query/dsl/impl/MoreLikeThisBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/impl/MoreLikeThisBuilder.java
@@ -163,15 +163,10 @@ public class MoreLikeThisBuilder<T> {
 			return null;
 		}
 		findById = new TermQuery( new Term( documentBuilder.getIdKeywordName(), id ) );
-		HSQuery query = queryContext.getFactory().createHSQuery();
-		//can't use Arrays.asList for some obscure capture reason
-		List<Class<?>> classes = new ArrayList<Class<?>>( 1 );
-		classes.add( queryContext.getEntityType() );
+		HSQuery query = queryContext.getFactory().createHSQuery( findById, queryContext.getEntityType() );
 		List<EntityInfo> entityInfos = query
-				.luceneQuery( findById )
 				.maxResults( 1 )
 				.projection( HSQuery.DOCUMENT_ID )
-				.targetedEntities( classes )
 				.queryEntityInfos();
 		if ( entityInfos.size() == 0 ) {
 			if ( inputType == ID ) {

--- a/engine/src/main/java/org/hibernate/search/query/engine/impl/LuceneHSQuery.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/impl/LuceneHSQuery.java
@@ -134,6 +134,11 @@ public class LuceneHSQuery extends AbstractHSQuery implements HSQuery {
 	}
 
 	@Override
+	public String getQueryString() {
+		return getLuceneQuery().toString();
+	}
+
+	@Override
 	public List<EntityInfo> queryEntityInfos() {
 		LazyQueryState searcher = buildSearcher();
 		if ( searcher == null ) {

--- a/engine/src/main/java/org/hibernate/search/query/engine/spi/HSQuery.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/spi/HSQuery.java
@@ -65,6 +65,10 @@ public interface HSQuery extends ProjectionConstants {
 	/**
 	 * Defines the targeted entities. This helps to reduce the number of targeted indexes.
 	 *
+	 * <p><strong>Note:</strong> calling this method is not necessary if you obtained the HSQuery through
+	 * {@link SearchIntegrator#createHSQuery(Query, Class...)}, unless you want to change the targeted
+	 * entities.
+	 *
 	 * @param classes the list of classes (indexes) targeted by this query
 	 * @return {@code this} to allow for method chaining
 	 */
@@ -165,9 +169,14 @@ public interface HSQuery extends ProjectionConstants {
 	FacetManager getFacetManager();
 
 	/**
-	 * @return the underlying Lucene query
+	 * @return the underlying Lucene query (if any)
 	 */
 	Query getLuceneQuery();
+
+	/**
+	 * @return a String representation of the underlying query
+	 */
+	String getQueryString();
 
 	/**
 	 * Execute the Lucene query and return the list of {@code EntityInfo}s populated with

--- a/engine/src/main/java/org/hibernate/search/query/engine/spi/QueryDescriptor.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/spi/QueryDescriptor.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.query.engine.spi;
 
-import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
+import org.hibernate.search.spi.SearchIntegrator;
 
 /**
  * An index query which is able to create a corresponding {@link HSQuery} object.
@@ -15,5 +15,5 @@ import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
  */
 public interface QueryDescriptor {
 
-	HSQuery createHSQuery(ExtendedSearchIntegrator extendedIntegrator);
+	HSQuery createHSQuery(SearchIntegrator searchIntegrator);
 }

--- a/engine/src/main/java/org/hibernate/search/query/engine/spi/QueryDescriptor.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/spi/QueryDescriptor.java
@@ -11,6 +11,10 @@ import org.hibernate.search.spi.SearchIntegrator;
 /**
  * An index query which is able to create a corresponding {@link HSQuery} object.
  *
+ * <p><strong>Note:</strong>In the Hibernate-Search-ORM module, you may pass query descriptors to
+ * {@code org.hibernate.search.FullTextSession.createFullTextQuery(QueryDescriptor, Class<?>...)}
+ * to create a FullTextQuery.
+ *
  * @author Gunnar Morling
  */
 public interface QueryDescriptor {

--- a/engine/src/main/java/org/hibernate/search/spi/SearchIntegrator.java
+++ b/engine/src/main/java/org/hibernate/search/spi/SearchIntegrator.java
@@ -22,7 +22,6 @@ import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.metadata.IndexedTypeDescriptor;
 import org.hibernate.search.query.dsl.QueryContextBuilder;
 import org.hibernate.search.query.engine.spi.HSQuery;
-import org.hibernate.search.query.engine.spi.QueryDescriptor;
 import org.hibernate.search.query.engine.spi.TimeoutExceptionFactory;
 import org.hibernate.search.stat.Statistics;
 
@@ -71,16 +70,17 @@ public interface SearchIntegrator extends AutoCloseable {
 	HSQuery createHSQuery();
 
 	/**
-	 * Return an Hibernate Search query descriptor.
-	 * <p>This method supports non-Lucene backends (e.g. Elasticsearch).
-	 * <p>The returned object allows for the creation of an {@link HSQuery} supported
-	 * by the relevant backend.
+	 * Return an Hibernate Search query object.
+	 * This method DOES support non-Lucene backends (e.g. Elasticsearch).
+	 * The returned object uses fluent APIs to define additional query settings.
 	 * <p>Be aware that some backends may not implement {@link HSQuery#luceneQuery(Query)},
 	 * in which case the query provided here cannot be overridden.
+	 * <p>Calling {@link HSQuery#targetedEntities(java.util.List)} on the resulting query
+	 * is not necessary, unless you later decide to target a subset of {@code entities}.
 	 *
-	 * @return an Hibernate Search query descriptor
+	 * @return an Hibernate Search query object
 	 */
-	QueryDescriptor createQueryDescriptor(Query luceneQuery, Class<?>... entities);
+	HSQuery createHSQuery(Query luceneQuery, Class<?>... entities);
 
 	/**
 	 * @return true if the SearchIntegrator was stopped

--- a/engine/src/test/java/org/hibernate/search/test/backend/DeleteByQueryTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/backend/DeleteByQueryTest.java
@@ -217,10 +217,7 @@ public class DeleteByQueryTest {
 	private void assertCount(Class<?> entityType, int count, ExtendedSearchIntegrator integrator) {
 		{
 			Query query = integrator.buildQueryBuilder().forEntity( Book.class ).get().all().createQuery();
-			HSQuery hsQuery = integrator.createHSQuery().luceneQuery( query );
-			List<Class<?>> l = new ArrayList<>();
-			l.add( entityType );
-			hsQuery.targetedEntities( l );
+			HSQuery hsQuery = integrator.createHSQuery( query, entityType );
 			assertEquals( count, hsQuery.queryResultSize() );
 		}
 	}

--- a/engine/src/test/java/org/hibernate/search/test/backend/lucene/AsyncBackendFlushTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/backend/lucene/AsyncBackendFlushTest.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.search.test.backend.lucene;
 
-import java.util.Collections;
-
 import org.hibernate.search.backend.spi.Work;
 import org.hibernate.search.backend.spi.WorkType;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
@@ -51,8 +49,7 @@ public class AsyncBackendFlushTest {
 
 	private void assertDocumentsIndexed(int number) {
 		ExtendedSearchIntegrator searchFactory = sfHolder.getSearchFactory();
-		HSQuery hsQuery = searchFactory.createHSQuery().luceneQuery( new MatchAllDocsQuery() )
-				.targetedEntities( Collections.<Class<?>>singletonList( Quote.class ) );
+		HSQuery hsQuery = searchFactory.createHSQuery( new MatchAllDocsQuery(), Quote.class );
 		assertEquals( number, hsQuery.queryResultSize() );
 	}
 

--- a/engine/src/test/java/org/hibernate/search/test/backend/lucene/ScheduledCommitPolicyTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/backend/lucene/ScheduledCommitPolicyTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 import static org.hibernate.search.test.backend.lucene.Conditions.assertConditionMet;
@@ -121,9 +120,7 @@ public class ScheduledCommitPolicyTest {
 
 		private HSQuery matchAllQuery() {
 			return searchFactory
-					.createHSQuery()
-					.luceneQuery( new MatchAllDocsQuery() )
-					.targetedEntities( Arrays.<Class<?>>asList( Quote.class ) );
+					.createHSQuery( new MatchAllDocsQuery(), Quote.class );
 		}
 
 		@Override

--- a/engine/src/test/java/org/hibernate/search/test/bridge/PropertiesExampleBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/PropertiesExampleBridgeTest.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.test.bridge;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Assert;
@@ -52,8 +51,7 @@ public class PropertiesExampleBridgeTest {
 
 		Query queryAllGuests = guestQueryBuilder.all().createQuery();
 
-		List<EntityInfo> queryEntityInfos = searchFactory.createHSQuery().luceneQuery( queryAllGuests )
-				.targetedEntities( Arrays.asList( new Class<?>[] { DynamicIndexedValueHolder.class } ) )
+		List<EntityInfo> queryEntityInfos = searchFactory.createHSQuery( queryAllGuests, DynamicIndexedValueHolder.class )
 				.projection( "value.surname" )
 				.queryEntityInfos();
 

--- a/engine/src/test/java/org/hibernate/search/test/bridge/builtin/NullEncodingTwoWayFieldBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/builtin/NullEncodingTwoWayFieldBridgeTest.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.test.bridge.builtin;
 
-import java.util.Arrays;
 import java.util.Date;
 
 import org.apache.lucene.search.Query;
@@ -56,9 +55,7 @@ public class NullEncodingTwoWayFieldBridgeTest {
 
 		Query termQuery = NumericFieldUtils.createExactMatchQuery( "deletionDate", Long.parseLong( "-1" ) );
 		int queryResultSize = searchFactory
-					.createHSQuery()
-					.targetedEntities( Arrays.asList( new Class<?>[] { Sample.class } ) )
-					.luceneQuery( termQuery )
+					.createHSQuery( termQuery, Sample.class )
 					.queryResultSize();
 		Assert.assertEquals( 1, queryResultSize );
 	}

--- a/engine/src/test/java/org/hibernate/search/test/configuration/ImplicitProvidedIdTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/configuration/ImplicitProvidedIdTest.java
@@ -7,7 +7,6 @@
 package org.hibernate.search.test.configuration;
 
 import java.lang.annotation.ElementType;
-import java.util.Arrays;
 
 import org.junit.Assert;
 import org.apache.lucene.search.Query;
@@ -166,9 +165,7 @@ public class ImplicitProvidedIdTest {
 				.matching( matchTitle ? book.title : isbn )
 				.createQuery();
 
-			int queryResultSize = searchIntegrator.createHSQuery()
-					.luceneQuery( query )
-					.targetedEntities( Arrays.asList( new Class<?>[]{ Book.class } ) )
+			int queryResultSize = searchIntegrator.createHSQuery( query, Book.class )
 					.queryResultSize();
 			Assert.assertEquals( 1, queryResultSize );
 		}

--- a/engine/src/test/java/org/hibernate/search/test/configuration/mutablefactory/MutableFactoryTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/configuration/mutablefactory/MutableFactoryTest.java
@@ -175,11 +175,7 @@ public class MutableFactoryTest {
 		QueryParser parser = new QueryParser( "name", TestConstants.standardAnalyzer );
 		Query luceneQuery = parser.parse( "Emmanuel" );
 
-		HSQuery hsQuery = sf.createHSQuery().luceneQuery( luceneQuery );
-		List<Class<?>> l = new ArrayList<>();
-		l.add( A.class );
-
-		hsQuery.targetedEntities( l );
+		HSQuery hsQuery = sf.createHSQuery( luceneQuery, A.class );
 
 		hsQuery.getTimeoutManager().start();
 
@@ -201,11 +197,7 @@ public class MutableFactoryTest {
 
 		luceneQuery = parser.parse( "Noel" );
 
-		hsQuery = sf.createHSQuery().luceneQuery( luceneQuery );
-		l.add( B.class );
-		l.add( C.class );
-
-		hsQuery.targetedEntities( l );
+		hsQuery = sf.createHSQuery( luceneQuery, A.class, B.class, C.class );
 
 		hsQuery.getTimeoutManager().start();
 
@@ -218,8 +210,7 @@ public class MutableFactoryTest {
 
 		luceneQuery = parser.parse( "Vincent" );
 
-		hsQuery = sf.createHSQuery().luceneQuery( luceneQuery );
-		hsQuery.targetedEntities( l );
+		hsQuery = sf.createHSQuery( luceneQuery, A.class, B.class, C.class );
 
 		hsQuery.getTimeoutManager().start();
 

--- a/engine/src/test/java/org/hibernate/search/test/dsl/NumericTypeGuessedTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/dsl/NumericTypeGuessedTest.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.test.dsl;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.apache.lucene.document.Document;
@@ -60,8 +59,7 @@ public class NumericTypeGuessedTest {
 						.to( 3 ).excludeLimit()
 						.createQuery();
 
-		List<EntityInfo> queryEntityInfos = searchFactory.createHSQuery().luceneQuery( query )
-				.targetedEntities( Arrays.asList( new Class<?>[] { CustomBridgedNumbers.class } ) )
+		List<EntityInfo> queryEntityInfos = searchFactory.createHSQuery( query, CustomBridgedNumbers.class )
 				.projection( "title" )
 				.queryEntityInfos();
 

--- a/engine/src/test/java/org/hibernate/search/test/dsl/NumericTypeWithNullEncodingTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/dsl/NumericTypeWithNullEncodingTest.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.test.dsl;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.apache.lucene.search.NumericRangeQuery;
@@ -117,8 +116,7 @@ public class NumericTypeWithNullEncodingTest {
 	private List<EntityInfo> runProjection(Query query, String fieldName) {
 		return sfHolder
 				.getSearchFactory()
-				.createHSQuery().luceneQuery( query )
-				.targetedEntities( Arrays.asList( new Class<?>[] { SomeEntity.class } ) )
+				.createHSQuery( query, SomeEntity.class )
 				.projection( fieldName )
 				.queryEntityInfos();
 	}

--- a/engine/src/test/java/org/hibernate/search/test/dsl/SortDSLTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/dsl/SortDSLTest.java
@@ -629,10 +629,8 @@ public class SortDSLTest {
 
 	private List<EntityInfo> query(Query luceneQuery, Sort sort) {
 		ExtendedSearchIntegrator sf = sfHolder.getSearchFactory();
-		HSQuery hsQuery = sf.createQueryDescriptor( luceneQuery, IndexedEntry.class )
-				.createHSQuery( sf );
+		HSQuery hsQuery = sf.createHSQuery( luceneQuery, IndexedEntry.class );
 		return hsQuery
-				.targetedEntities( Arrays.asList( new Class<?>[] { IndexedEntry.class } ) )
 				.projection( "id" )
 				.sort( sort )
 				.queryEntityInfos();

--- a/engine/src/test/java/org/hibernate/search/test/fileleaks/AllFilesClosedTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/fileleaks/AllFilesClosedTest.java
@@ -7,7 +7,6 @@
 package org.hibernate.search.test.fileleaks;
 
 import java.io.Serializable;
-import java.util.Arrays;
 
 import org.junit.Assert;
 import org.apache.lucene.search.MatchAllDocsQuery;
@@ -118,10 +117,7 @@ public class AllFilesClosedTest {
 	 * @param expected number of elements found in the index
 	 */
 	private void assertElementsInIndex(int expected) {
-		HSQuery hsQuery = searchIntegrator.createHSQuery();
-		hsQuery
-			.luceneQuery( new MatchAllDocsQuery() )
-			.targetedEntities( Arrays.asList( new Class<?>[]{ Book.class, Dvd.class } ) );
+		HSQuery hsQuery = searchIntegrator.createHSQuery( new MatchAllDocsQuery(), Book.class, Dvd.class );
 		int resultSize = hsQuery.queryResultSize();
 		Assert.assertEquals( expected, resultSize );
 	}

--- a/engine/src/test/java/org/hibernate/search/test/filters/FreshReadersProvidedTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/filters/FreshReadersProvidedTest.java
@@ -78,18 +78,14 @@ public class FreshReadersProvidedTest {
 
 		Query queryAllGuests = guestQueryBuilder.all().createQuery();
 
-		List<EntityInfo> queryEntityInfos = searchFactory.createHSQuery()
-			.luceneQuery( queryAllGuests )
-			.targetedEntities( Arrays.asList( new Class<?>[]{ Guest.class } ) )
+		List<EntityInfo> queryEntityInfos = searchFactory.createHSQuery( queryAllGuests, Guest.class )
 			.queryEntityInfos();
 
 		Assert.assertEquals( 1, queryEntityInfos.size() );
 		Assert.assertEquals( 13L, queryEntityInfos.get( 0 ).getId() );
 
 		RecordingFilter filter = new RecordingFilter( "name" );
-		List<EntityInfo> filteredQueryEntityInfos = searchFactory.createHSQuery()
-				.luceneQuery( queryAllGuests )
-				.targetedEntities( Arrays.asList( new Class<?>[]{ Guest.class } ) )
+		List<EntityInfo> filteredQueryEntityInfos = searchFactory.createHSQuery( queryAllGuests, Guest.class )
 				.filter( filter )
 				.queryEntityInfos();
 
@@ -109,9 +105,7 @@ public class FreshReadersProvidedTest {
 			tc.end();
 		}
 
-		List<EntityInfo> queryEntityInfosAgain = searchFactory.createHSQuery()
-			.luceneQuery( queryAllGuests )
-			.targetedEntities( Arrays.asList( new Class<?>[]{ Guest.class } ) )
+		List<EntityInfo> queryEntityInfosAgain = searchFactory.createHSQuery( queryAllGuests, Guest.class )
 			.queryEntityInfos();
 
 		Assert.assertEquals( 2, queryEntityInfosAgain.size() );
@@ -119,9 +113,7 @@ public class FreshReadersProvidedTest {
 		Assert.assertEquals( 7L, queryEntityInfosAgain.get( 1 ).getId() );
 
 		RecordingFilter secondFilter = new RecordingFilter( "name" );
-		List<EntityInfo> secondFilteredQueryEntityInfos = searchFactory.createHSQuery()
-				.luceneQuery( queryAllGuests )
-				.targetedEntities( Arrays.asList( new Class<?>[]{ Guest.class } ) )
+		List<EntityInfo> secondFilteredQueryEntityInfos = searchFactory.createHSQuery( queryAllGuests, Guest.class )
 				.filter( secondFilter )
 				.queryEntityInfos();
 

--- a/engine/src/test/java/org/hibernate/search/test/id/NumericIdEncodingTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/id/NumericIdEncodingTest.java
@@ -8,7 +8,6 @@ package org.hibernate.search.test.id;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.apache.lucene.search.NumericRangeQuery;
@@ -53,9 +52,7 @@ public class NumericIdEncodingTest {
 	}
 
 	private void expectedProjections(NumericRangeQuery<Long> numericRangeQuery, String... expectedProjections) {
-		HSQuery hsQuery = factoryHolder.getSearchFactory().createHSQuery()
-				.luceneQuery( numericRangeQuery )
-				.targetedEntities( Arrays.<Class<?>>asList( Staff.class ) )
+		HSQuery hsQuery = factoryHolder.getSearchFactory().createHSQuery( numericRangeQuery, Staff.class )
 				.projection( "name" );
 		List<EntityInfo> result = hsQuery.queryEntityInfos();
 		assertEquals( expectedProjections.length, result.size() );

--- a/engine/src/test/java/org/hibernate/search/test/projection/ProjectionConversionTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/projection/ProjectionConversionTest.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.test.projection;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
@@ -173,8 +172,7 @@ public class ProjectionConversionTest {
 		ExtendedSearchIntegrator searchFactory = sfHolder.getSearchFactory();
 		QueryBuilder queryBuilder = searchFactory.buildQueryBuilder().forEntity( ExampleEntity.class ).get();
 		Query queryAllGuests = queryBuilder.all().createQuery();
-		List<EntityInfo> queryEntityInfos = searchFactory.createHSQuery().luceneQuery( queryAllGuests )
-				.targetedEntities( Arrays.asList( new Class<?>[] { ExampleEntity.class } ) )
+		List<EntityInfo> queryEntityInfos = searchFactory.createHSQuery( queryAllGuests, ExampleEntity.class )
 				.projection( projectionField )
 				.queryEntityInfos();
 

--- a/engine/src/test/java/org/hibernate/search/test/query/serialization/QuerySerializationTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/query/serialization/QuerySerializationTest.java
@@ -7,7 +7,6 @@
 package org.hibernate.search.test.query.serialization;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 
 import org.apache.lucene.search.Query;
@@ -55,8 +54,7 @@ public class QuerySerializationTest {
 		QueryBuilder queryBuilder = integrator.buildQueryBuilder().forEntity( Book.class ).get();
 
 		Query luceneQuery = queryBuilder.keyword().onField( "text" ).matching( "art" ).createQuery();
-		HSQuery hsQuery = integrator.createHSQuery().luceneQuery( luceneQuery );
-		hsQuery.targetedEntities( Arrays.<Class<?>>asList( Book.class ) );
+		HSQuery hsQuery = integrator.createHSQuery( luceneQuery, Book.class );
 		//Lucene Queries are not serializable: who's using LuceneHSQuery will need to
 		//encode the query separately and set it again.
 		hsQuery.luceneQuery( null );

--- a/engine/src/test/java/org/hibernate/search/test/sharding/LogRotationExampleTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/sharding/LogRotationExampleTest.java
@@ -7,7 +7,6 @@
 package org.hibernate.search.test.sharding;
 
 import java.io.Serializable;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.HashSet;
@@ -106,9 +105,7 @@ public class LogRotationExampleTest {
 
 	private int queryAndFilter(Query luceneQuery, int fromHour, int toHour) {
 		ExtendedSearchIntegrator searchFactory = sfHolder.getSearchFactory();
-		HSQuery hsQuery = searchFactory.createHSQuery()
-			.luceneQuery( luceneQuery )
-			.targetedEntities( Arrays.asList( new Class<?>[]{ LogMessage.class } ) );
+		HSQuery hsQuery = searchFactory.createHSQuery( luceneQuery, LogMessage.class );
 		hsQuery
 			.enableFullTextFilter( "timeRange" )
 				.setParameter( "from", Integer.valueOf( fromHour ) )

--- a/engine/src/test/java/org/hibernate/search/test/sorting/SortingTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/sorting/SortingTest.java
@@ -176,8 +176,8 @@ public class SortingTest {
 				.createQuery();
 
 		Sort sort = new Sort( new SortField( "description", SortField.Type.DOUBLE ) );
-		HSQuery hsQuery = integrator.createHSQuery().luceneQuery( query );
-		hsQuery.targetedEntities( Arrays.<Class<?>>asList( entityType ) ).sort( sort );
+		HSQuery hsQuery = integrator.createHSQuery( query, entityType );
+		hsQuery.sort( sort );
 		hsQuery.queryEntityInfos().size();
 	}
 
@@ -198,8 +198,8 @@ public class SortingTest {
 				.createQuery();
 
 		Sort sort = new Sort( new SortField( "longValue", SortField.Type.STRING ) );
-		HSQuery hsQuery = integrator.createHSQuery().luceneQuery( query );
-		hsQuery.targetedEntities( Arrays.<Class<?>>asList( entityType ) ).sort( sort );
+		HSQuery hsQuery = integrator.createHSQuery( query, entityType );
+		hsQuery.sort( sort );
 		hsQuery.queryEntityInfos().size();
 	}
 
@@ -220,8 +220,8 @@ public class SortingTest {
 				.createQuery();
 
 		Sort sort = new Sort( new SortField( "longValue", SortField.Type.INT ) );
-		HSQuery hsQuery = integrator.createHSQuery().luceneQuery( query );
-		hsQuery.targetedEntities( Arrays.<Class<?>>asList( entityType ) ).sort( sort );
+		HSQuery hsQuery = integrator.createHSQuery( query, entityType );
+		hsQuery.sort( sort );
 		hsQuery.queryEntityInfos().size();
 	}
 
@@ -240,8 +240,7 @@ public class SortingTest {
 
 	private void assertNumberOfResults(int expectedResultsNumber, Query query, Sort sort) {
 		ExtendedSearchIntegrator integrator = factoryHolder.getSearchFactory();
-		HSQuery hsQuery = integrator.createHSQuery().luceneQuery( query );
-		hsQuery.targetedEntities( Arrays.<Class<?>>asList( Person.class ) );
+		HSQuery hsQuery = integrator.createHSQuery( query, Person.class );
 		if ( sort != null ) {
 			hsQuery.sort( sort );
 		}
@@ -281,8 +280,7 @@ public class SortingTest {
 
 	private void assertSortedResults(Query query, Sort sort, int... expectedIds) {
 		ExtendedSearchIntegrator integrator = factoryHolder.getSearchFactory();
-		HSQuery hsQuery = integrator.createHSQuery().luceneQuery( query );
-		hsQuery.targetedEntities( Arrays.<Class<?>>asList( Person.class ) );
+		HSQuery hsQuery = integrator.createHSQuery( query, Person.class );
 		if ( sort != null ) {
 			hsQuery.sort( sort );
 		}
@@ -305,9 +303,9 @@ public class SortingTest {
 				.matching( null )
 				.createQuery();
 
-		HSQuery hsQuery = integrator.createHSQuery().luceneQuery( query );
+		HSQuery hsQuery = integrator.createHSQuery( query, Person.class );
 		Sort sort = new Sort( new SortField( fieldName, sortType ) );
-		hsQuery.targetedEntities( Arrays.<Class<?>>asList( Person.class ) ).sort( sort );
+		hsQuery.sort( sort );
 		return hsQuery;
 	}
 

--- a/integrationtest/jms/src/test/java/org/hibernate/search/test/jms/master/JMSMasterTest.java
+++ b/integrationtest/jms/src/test/java/org/hibernate/search/test/jms/master/JMSMasterTest.java
@@ -140,11 +140,10 @@ public class JMSMasterTest extends SearchTestBase {
 			Thread.sleep( 1000 );
 
 			{
-				HSQuery hsQuery = this.getExtendedSearchIntegrator().createHSQuery()
-						.luceneQuery( this.getExtendedSearchIntegrator().buildQueryBuilder().forEntity( TShirt.class ).get().all().createQuery() );
-				List<Class<?>> l = new ArrayList<>( 1 );
-				l.add( TShirt.class );
-				hsQuery.targetedEntities( l );
+				HSQuery hsQuery = this.getExtendedSearchIntegrator().createHSQuery(
+						this.getExtendedSearchIntegrator().buildQueryBuilder().forEntity( TShirt.class ).get().all().createQuery(),
+						TShirt.class
+						);
 				assertEquals( 0, hsQuery.queryResultSize() );
 			}
 		}

--- a/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/backend/BackendStressTest.java
+++ b/integrationtest/performance/src/test/java/org/hibernate/search/test/performance/backend/BackendStressTest.java
@@ -203,9 +203,7 @@ public class BackendStressTest {
 		@Override
 		public boolean evaluate() {
 			int size = integrator
-					.createHSQuery()
-					.luceneQuery( new MatchAllDocsQuery() )
-					.targetedEntities( Arrays.<Class<?>>asList( Quote.class ) )
+					.createHSQuery( new MatchAllDocsQuery(), Quote.class )
 					.queryResultSize();
 			System.out.println( "Index size=" + size + ", expected=" + expectedSize );
 			return size >= expectedSize;

--- a/integrationtest/sandbox/src/test/java/org/hibernate/search/test/performance/nrt/ReadWriteParallelismTest.java
+++ b/integrationtest/sandbox/src/test/java/org/hibernate/search/test/performance/nrt/ReadWriteParallelismTest.java
@@ -7,7 +7,6 @@
 
 package org.hibernate.search.test.performance.nrt;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -105,9 +104,7 @@ public class ReadWriteParallelismTest {
 	}
 
 	private static void verifyMatches(SearchIntegrator searchIntegrator, int expectedMatches, Query query) {
-		List<EntityInfo> queryEntityInfos = searchIntegrator.createHSQuery()
-				.luceneQuery( query )
-				.targetedEntities( Arrays.asList( new Class<?>[]{ Book.class } ) )
+		List<EntityInfo> queryEntityInfos = searchIntegrator.createHSQuery( query, Book.class )
 				.queryEntityInfos();
 		Assert.assertEquals( expectedMatches, queryEntityInfos.size() );
 	}

--- a/orm/src/main/java/org/hibernate/search/impl/FullTextSessionImpl.java
+++ b/orm/src/main/java/org/hibernate/search/impl/FullTextSessionImpl.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.impl;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.Properties;
 import java.util.Set;
 
@@ -31,6 +32,7 @@ import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.hcore.util.impl.ContextHelper;
 import org.hibernate.search.hcore.util.impl.HibernateHelper;
+import org.hibernate.search.query.engine.spi.HSQuery;
 import org.hibernate.search.query.engine.spi.QueryDescriptor;
 import org.hibernate.search.query.hibernate.impl.FullTextQueryImpl;
 import org.hibernate.search.util.impl.ClassLoaderHelper;
@@ -69,15 +71,20 @@ final class FullTextSessionImpl extends SessionDelegatorBaseImpl implements Full
 	 */
 	@Override
 	public FullTextQuery createFullTextQuery(org.apache.lucene.search.Query luceneQuery, Class<?>... entities) {
-		QueryDescriptor queryDescriptor = getSearchIntegrator().createQueryDescriptor( luceneQuery, entities );
-		return createFullTextQuery( queryDescriptor, entities );
+		HSQuery hsQuery = getSearchIntegrator().createHSQuery( luceneQuery, entities );
+		return createFullTextQuery( hsQuery );
 	}
 
 	@Override
 	public FullTextQuery createFullTextQuery(QueryDescriptor queryDescriptor, Class<?>... entities) {
+		HSQuery hsQuery = queryDescriptor.createHSQuery( getSearchIntegrator() )
+				.targetedEntities( Arrays.asList( entities ) );
+		return createFullTextQuery( hsQuery );
+	}
+
+	private FullTextQuery createFullTextQuery(HSQuery hsQuery, Class<?>... entities) {
 		return new FullTextQueryImpl(
-				queryDescriptor,
-				entities,
+				hsQuery,
 				sessionImplementor,
 				new ParameterMetadata( null, null )
 		);

--- a/orm/src/main/java/org/hibernate/search/query/hibernate/impl/FullTextQueryImpl.java
+++ b/orm/src/main/java/org/hibernate/search/query/hibernate/impl/FullTextQueryImpl.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.query.hibernate.impl;
 
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -36,7 +35,6 @@ import org.hibernate.search.query.engine.spi.DocumentExtractor;
 import org.hibernate.search.query.engine.spi.EntityInfo;
 import org.hibernate.search.query.engine.spi.FacetManager;
 import org.hibernate.search.query.engine.spi.HSQuery;
-import org.hibernate.search.query.engine.spi.QueryDescriptor;
 import org.hibernate.search.query.engine.spi.TimeoutExceptionFactory;
 import org.hibernate.search.query.engine.spi.TimeoutManager;
 import org.hibernate.search.spatial.Coordinates;
@@ -67,27 +65,24 @@ public class FullTextQueryImpl extends AbstractQueryImpl implements FullTextQuer
 	/**
 	 * Constructs a  <code>FullTextQueryImpl</code> instance.
 	 *
-	 * @param query The query.
-	 * @param classes Array of classes (must be immutable) used to filter the results to the given class types.
+	 * @param hSearchQuery The query, with the {@link HSQuery#targetedEntities(List) targeted entities} already set if necessary.
 	 * @param session Access to the Hibernate session.
 	 * @param parameterMetadata Additional query metadata.
 	 */
-	public FullTextQueryImpl(QueryDescriptor query,
-			Class<?>[] classes,
+	public FullTextQueryImpl(HSQuery hSearchQuery,
 			SessionImplementor session,
 			ParameterMetadata parameterMetadata) {
 		//TODO handle flushMode
-		super( query.toString(), null, session, parameterMetadata );
+		super( hSearchQuery.getQueryString(), null, session, parameterMetadata );
 
 		ExtendedSearchIntegrator extendedIntegrator = getExtendedSearchIntegrator();
 		this.objectLookupMethod = extendedIntegrator.getDefaultObjectLookupMethod();
 		this.databaseRetrievalMethod = extendedIntegrator.getDefaultDatabaseRetrievalMethod();
 
-		hSearchQuery = query.createHSQuery( extendedIntegrator );
-		hSearchQuery
+		this.hSearchQuery = hSearchQuery;
+		this.hSearchQuery
 				.timeoutExceptionFactory( exceptionFactory )
-				.tenantIdentifier( session.getTenantIdentifier() )
-				.targetedEntities( Arrays.asList( classes ) );
+				.tenantIdentifier( session.getTenantIdentifier() );
 	}
 
 	@Override


### PR DESCRIPTION
This is an attempt to fix:

 * [HSEARCH-2367 QueryDescriptors ignore targetEntities](https://hibernate.atlassian.net/browse/HSEARCH-2367) (first and foremost)
 * [HSEARCH-2372 QueryDescriptor creates an implementation leak](https://hibernate.atlassian.net/browse/HSEARCH-2372) (a related, easy-to-fix issue since we're at it)
 * [HSEARCH-2370 Document how to use QueryDescriptor](https://hibernate.atlassian.net/browse/HSEARCH-2370) (a related, easy-to-fix issue since we're at it)

This also happens to fix [HSEARCH-2371 Using a SearchIntegrator-provided QueryDescriptor will require passing the targeted entities twice](https://hibernate.atlassian.net/browse/HSEARCH-2371)

On the bright side, this fixes the issues with only a few changes. Most additions/deletions in this PR are not strictly required, but were added to ease up test maintenance in 59e14ea .

On the not-so-bright side, I had to change the `SearchIntegrator` interface and to add a method to `HSQuery`. **But** I think it's okay for the following reasons:

 * The changes to `SearchIntegrator` only affect methods added in version 5.6, which is still in beta.
 * The new method in `HSQuery` is fairly simple (`getQueryString`), and I don't think we provide a way for service providers to provide their own `HSQuery`. This contract is about a service we provide to service provider, more than about a service that service providers provide to us. So adding a requirement mainly affects us.

I checked the Infinispan integration and didn't find an implementation of `HSQuery`, so I think we're fine on this side. Plus, HSEARCH-2367 was opened by an Infinispan maintainer trying to port it to the next version of Hibernate Search, so I think they at least might understand.

To reviewers: I'd recommend reviewing the commits individually, since 59e14ea , the commit with the most additions/deletions, also happen to be the least relevant to this PR (mostly boilerplate code).