### PR TITLE
HSEARCH-2374 Make the default value of hibernate.search.default.elasticsearch.index_schema_management_strategy less confusing	

### DIFF
--- a/backends/jgroups/src/test/resources/hibernate.properties
+++ b/backends/jgroups/src/test/resources/hibernate.properties
@@ -22,5 +22,5 @@ hibernate.cache.region_prefix hibernate.test
 hibernate.cache.provider_class org.hibernate.cache.HashtableCacheProvider
 
 hibernate.search.default.elasticsearch.host http://127.0.0.1:9200
-hibernate.search.default.elasticsearch.index_schema_management_strategy CREATE_DELETE
+hibernate.search.default.elasticsearch.index_schema_management_strategy RECREATE_DELETE
 hibernate.search.default.elasticsearch.refresh_after_write true

--- a/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
+++ b/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
@@ -95,7 +95,7 @@ Add them to your `persistence.xml` or where you put the rest of your Hibernate S
 
 Select Elasticsearch as the backend:: `hibernate.search.default.indexmanager elasticsearch`
 Hostname and port for Elasticsearch:: `hibernate.search.default.elasticsearch.host \http://127.0.0.1:9200`
-Selects the index creation strategy:: `hibernate.search.default.elasticsearch.index_schema_management_strategy CREATE_DELETE`
+Selects the index creation strategy:: `hibernate.search.default.elasticsearch.index_schema_management_strategy RECREATE_DELETE`
 Maximum time to wait for the indexes to become available before failing (in ms):: `hibernate.search.default.elasticsearch.index_management_wait_timeout 10000`
 Status an index must at least have in order for Hibernate Search to work with it (one of "green", "yellow" or "red"):: `hibernate.search.default.elasticsearch.required_index_status green`
 Whether to perform an explicit refresh after a set of operations has been executed against a specific index (`true` or `false`):: `hibernate.search.default.elasticsearch.refresh_after_write false`
@@ -109,10 +109,10 @@ Let's see the options for the `index_schema_management_strategy` property:
 [options="header"]
 |===============
 |Value|Definition
-|NONE|Indexes will not be created nor deleted.
-|MERGE|Missing indexes and mappings will be created, mappings will be updated if there are no conflicts.
-|CREATE|Indexed will be deleted if existing and then created. This will delete all content from the index!
-|CREATE_DELETE|Similarly to 'CREATE' but will also delete the index at shutdown. Commonly used for tests.
+|`NONE`|Indexes will not be created nor deleted.
+|`MERGE`|Missing indexes and mappings will be created, mappings will be updated if there are no conflicts.
+|`RECREATE`|Indexed will be deleted if existing and then created. This will delete all content from the index!
+|`RECREATE_DELETE`|Similarly to `RECREATE` but will also delete the index at shutdown. Commonly used for tests.
 |===============
 
 Note that all properties prefixed with `hibernate.search.default` (besides `host`) can be given globally as shown above and/or be given for specific indexes:

--- a/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
+++ b/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
@@ -95,7 +95,7 @@ Add them to your `persistence.xml` or where you put the rest of your Hibernate S
 
 Select Elasticsearch as the backend:: `hibernate.search.default.indexmanager elasticsearch`
 Hostname and port for Elasticsearch:: `hibernate.search.default.elasticsearch.host \http://127.0.0.1:9200`
-Selects the index creation strategy:: `hibernate.search.default.elasticsearch.index_schema_management_strategy RECREATE_DELETE`
+Selects the index creation strategy:: `hibernate.search.default.elasticsearch.index_schema_management_strategy CREATE`
 Maximum time to wait for the indexes to become available before failing (in ms):: `hibernate.search.default.elasticsearch.index_management_wait_timeout 10000`
 Status an index must at least have in order for Hibernate Search to work with it (one of "green", "yellow" or "red"):: `hibernate.search.default.elasticsearch.required_index_status green`
 Whether to perform an explicit refresh after a set of operations has been executed against a specific index (`true` or `false`):: `hibernate.search.default.elasticsearch.refresh_after_write false`
@@ -111,6 +111,7 @@ Let's see the options for the `index_schema_management_strategy` property:
 |Value|Definition
 |`NONE`|Indexes will not be created nor deleted.
 |`MERGE`|Missing indexes and mappings will be created, mappings will be updated if there are no conflicts.
+|`CREATE`|**The default**: existing indexes will not be altered, missing indexes will be created.
 |`RECREATE`|Indexed will be deleted if existing and then created. This will delete all content from the index!
 |`RECREATE_DELETE`|Similarly to `RECREATE` but will also delete the index at shutdown. Commonly used for tests.
 |===============

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/ElasticsearchEnvironment.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/ElasticsearchEnvironment.java
@@ -19,7 +19,7 @@ public final class ElasticsearchEnvironment {
 	public static final class Defaults {
 
 		public static final String SERVER_URI = "http://localhost:9200";
-		public static final IndexSchemaManagementStrategy INDEX_SCHEMA_MANAGEMENT_STRATEGY = IndexSchemaManagementStrategy.NONE;
+		public static final IndexSchemaManagementStrategy INDEX_SCHEMA_MANAGEMENT_STRATEGY = IndexSchemaManagementStrategy.CREATE;
 		public static final int INDEX_MANAGEMENT_WAIT_TIMEOUT = 10_000;
 		public static final String REQUIRED_INDEX_STATUS = "green";
 		public static final boolean REFRESH_AFTER_WRITE = false;

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/ElasticsearchEnvironment.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/ElasticsearchEnvironment.java
@@ -50,7 +50,7 @@ public final class ElasticsearchEnvironment {
 	 * The name of one of the {@link IndexSchemaManagementStrategy} constants is expected, e.g. MERGE.
 	 * <p>
 	 * Can be given globally (e.g. {@code hibernate.search.default.elasticsearch.index_schema_management_strategy=MERGE}) or
-	 * for specific indexes (e.g. {@code hibernate.search.someindex.elasticsearch.index_schema_management_strategy=CREATE}).
+	 * for specific indexes (e.g. {@code hibernate.search.someindex.elasticsearch.index_schema_management_strategy=RECREATE}).
 	 */
 	public static final String INDEX_SCHEMA_MANAGEMENT_STRATEGY = "elasticsearch.index_schema_management_strategy";
 

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/IndexSchemaManagementStrategy.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/IndexSchemaManagementStrategy.java
@@ -27,11 +27,11 @@ public enum IndexSchemaManagementStrategy {
 	/**
 	 * Indexes - and all their contents - will be deleted and newly created upon session factory initialization.
 	 */
-	CREATE,
+	RECREATE,
 
 	/**
-	 * The same as {@link #CREATE}, but indexes - and all their contents - will be deleted upon session factory
+	 * The same as {@link #DELETE_CREATE}, but indexes - and all their contents - will be deleted upon session factory
 	 * shut-down as well.
 	 */
-	CREATE_DELETE;
+	RECREATE_DELETE;
 }

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/IndexSchemaManagementStrategy.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/IndexSchemaManagementStrategy.java
@@ -25,12 +25,17 @@ public enum IndexSchemaManagementStrategy {
 	MERGE,
 
 	/**
+	 * Existing indexes will not be altered, missing indexes will be created.
+	 */
+	CREATE,
+
+	/**
 	 * Indexes - and all their contents - will be deleted and newly created upon session factory initialization.
 	 */
 	RECREATE,
 
 	/**
-	 * The same as {@link #DELETE_CREATE}, but indexes - and all their contents - will be deleted upon session factory
+	 * The same as {@link #RECREATE}, but indexes - and all their contents - will be deleted upon session factory
 	 * shut-down as well.
 	 */
 	RECREATE_DELETE;

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchIndexManager.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchIndexManager.java
@@ -201,7 +201,7 @@ public class ElasticsearchIndexManager implements IndexManager, RemoteAnalyzerPr
 
 	@Override
 	public void destroy() {
-		if ( indexManagementStrategy == IndexSchemaManagementStrategy.CREATE_DELETE ) {
+		if ( indexManagementStrategy == IndexSchemaManagementStrategy.RECREATE_DELETE ) {
 			deleteIndexIfExisting();
 		}
 
@@ -225,8 +225,8 @@ public class ElasticsearchIndexManager implements IndexManager, RemoteAnalyzerPr
 		if ( indexManagementStrategy == IndexSchemaManagementStrategy.NONE ) {
 			return;
 		}
-		else if ( indexManagementStrategy == IndexSchemaManagementStrategy.CREATE ||
-				indexManagementStrategy == IndexSchemaManagementStrategy.CREATE_DELETE ) {
+		else if ( indexManagementStrategy == IndexSchemaManagementStrategy.RECREATE ||
+				indexManagementStrategy == IndexSchemaManagementStrategy.RECREATE_DELETE ) {
 
 			deleteIndexIfExisting();
 			createIndex();

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchIndexManager.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchIndexManager.java
@@ -225,9 +225,13 @@ public class ElasticsearchIndexManager implements IndexManager, RemoteAnalyzerPr
 		if ( indexManagementStrategy == IndexSchemaManagementStrategy.NONE ) {
 			return;
 		}
+		else if ( indexManagementStrategy == IndexSchemaManagementStrategy.CREATE ) {
+			if ( createIndexIfNotYetExisting() ) {
+				createIndexMappings();
+			}
+		}
 		else if ( indexManagementStrategy == IndexSchemaManagementStrategy.RECREATE ||
 				indexManagementStrategy == IndexSchemaManagementStrategy.RECREATE_DELETE ) {
-
 			deleteIndexIfExisting();
 			createIndex();
 			createIndexMappings();
@@ -273,12 +277,16 @@ public class ElasticsearchIndexManager implements IndexManager, RemoteAnalyzerPr
 		}
 	}
 
-	private void createIndexIfNotYetExisting() {
+	/**
+	 * @return {@code true} if the index was actually created, {@code false} if it already existed.
+	 */
+	private boolean createIndexIfNotYetExisting() {
 		if ( jestClient.executeRequest( new IndicesExists.Builder( actualIndexName ).build(), 404 ).getResponseCode() == 200 ) {
-			return;
+			return false;
 		}
 
 		jestClient.executeRequest( new CreateIndex.Builder( actualIndexName ).build() );
+		return true;
 	}
 
 	private void deleteIndexIfExisting() {

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchIndexManager.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchIndexManager.java
@@ -285,7 +285,15 @@ public class ElasticsearchIndexManager implements IndexManager, RemoteAnalyzerPr
 			return false;
 		}
 
-		jestClient.executeRequest( new CreateIndex.Builder( actualIndexName ).build() );
+		JestResult result = jestClient.executeRequest(
+				new CreateIndex.Builder( actualIndexName ).build(),
+				"index_already_exists_exception"
+				);
+		if ( !result.isSucceeded() ) {
+			// The index was created just after we checked if it existed: just do as if it had been created when we checked.
+			return false;
+		}
+
 		return true;
 	}
 

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIndexNullAsTypeCheckingIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIndexNullAsTypeCheckingIT.java
@@ -64,7 +64,7 @@ public class ElasticsearchIndexNullAsTypeCheckingIT {
 		public void configure(Map<String, Object> settings) {
 			settings.put(
 					ElasticsearchEnvironment.INDEX_SCHEMA_MANAGEMENT_STRATEGY,
-					IndexSchemaManagementStrategy.CREATE
+					IndexSchemaManagementStrategy.RECREATE
 					);
 		}
 

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchScrollingIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchScrollingIT.java
@@ -51,7 +51,7 @@ public class ElasticsearchScrollingIT {
 	public SearchFactoryHolder sfHolder = new SearchFactoryHolder( IndexedObject.class )
 			.withProperty(
 					"hibernate.search.default." + ElasticsearchEnvironment.INDEX_SCHEMA_MANAGEMENT_STRATEGY,
-					IndexSchemaManagementStrategy.CREATE_DELETE.name()
+					IndexSchemaManagementStrategy.RECREATE_DELETE.name()
 					)
 			.withProperty( "hibernate.search.default." + Environment.INDEX_MANAGER_IMPL_NAME, "elasticsearch" )
 			.withProperty( "hibernate.search.default." + ElasticsearchEnvironment.REFRESH_AFTER_WRITE, "true" );

--- a/elasticsearch/src/test/resources/hibernate.properties
+++ b/elasticsearch/src/test/resources/hibernate.properties
@@ -22,5 +22,5 @@ hibernate.cache.region_prefix hibernate.test
 hibernate.cache.provider_class org.hibernate.cache.HashtableCacheProvider
 
 hibernate.search.default.indexmanager elasticsearch
-hibernate.search.default.elasticsearch.index_schema_management_strategy CREATE_DELETE
+hibernate.search.default.elasticsearch.index_schema_management_strategy RECREATE_DELETE
 hibernate.search.default.elasticsearch.refresh_after_write true

--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/elasticsearch/ElasticsearchModuleMemberRegistrationIT.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/elasticsearch/ElasticsearchModuleMemberRegistrationIT.java
@@ -18,6 +18,7 @@ import javax.annotation.Resource;
 import javax.inject.Inject;
 
 import org.hibernate.search.elasticsearch.cfg.ElasticsearchEnvironment;
+import org.hibernate.search.elasticsearch.cfg.IndexSchemaManagementStrategy;
 import org.hibernate.search.test.integration.VersionTestHelper;
 import org.hibernate.search.test.integration.wildfly.controller.MemberRegistration;
 import org.hibernate.search.test.integration.wildfly.model.Member;
@@ -80,7 +81,8 @@ public class ElasticsearchModuleMemberRegistrationIT {
 					.createProperty().name( "hibernate.search.default.lucene_version" ).value( "LUCENE_CURRENT" ).up()
 					.createProperty().name( "hibernate.search.default.indexmanager" ).value( "elasticsearch" ).up()
 					.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( getWildFlyModuleIdentifier() ).up()
-					.createProperty().name( "hibernate.search.default." + ElasticsearchEnvironment.INDEX_SCHEMA_MANAGEMENT_STRATEGY ).value( "CREATE_DELETE" ).up()
+					.createProperty().name( "hibernate.search.default." + ElasticsearchEnvironment.INDEX_SCHEMA_MANAGEMENT_STRATEGY )
+						.value( IndexSchemaManagementStrategy.RECREATE_DELETE.name() ).up()
 					.createProperty().name( "hibernate.search.default.elasticsearch.refresh_after_write" ).value( "true" ).up()
 				.up().up()
 			.exportAsString();


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2374

After a bit of thought, I think the `CREATE` strategy added in this PR would probably be a better default than `NONE`. As @gsmet pointed out, users would probably expect a similar behavior irrespective of the backend they use, and the `CREATE` strategy is similar to the behavior when using a local Lucene backend. And it does not harm if you overlook the strategy setting, since this `CREATE` strategy will never alter existing indexes: worst case, you got new, unwanted indexes.

The pre-existing strategies were renamed in order to avoid confusions. It's not strictly necessary, but I think it's better than naming the new strategy `CREATE_ONLY` to distinguish from the pre-existing `CREATE` that also drops the schema...
The breaking of existing configuration should not be bery bad, since the `(RE)CREATE` and `(RE)CREATE_DELETE` can hardly be considered in a production environment. So warning users when we announce the release should do the trick...