### PR TITLE
HSEARCH-2376 Analyze SortedDocValuesField values

### DIFF
--- a/engine/src/main/java/org/hibernate/search/engine/spi/DocumentBuilderIndexedEntity.java
+++ b/engine/src/main/java/org/hibernate/search/engine/spi/DocumentBuilderIndexedEntity.java
@@ -753,6 +753,8 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 	 * Adds the doc field values to the document required to map the configured sort fields. The value from the
 	 * underlying field will be obtained from the document (it has been written at this point already) and an equivalent
 	 * doc field value will be added.
+	 * For non-numeric fields, if the field value is supposed to be analyzed, the analysis will be performed by
+	 * this method, because Lucene does not analyze SortedDocValuesFields values automatically.
 	 */
 	private void addSortFieldDocValues(Document document, PropertyMetadata propertyMetadata, float documentBoost, Object propertyValue) {
 		for ( SortableFieldMetadata sortField : propertyMetadata.getSortableFieldMetadata() ) {

--- a/engine/src/main/java/org/hibernate/search/util/AnalyzerUtils.java
+++ b/engine/src/main/java/org/hibernate/search/util/AnalyzerUtils.java
@@ -21,7 +21,9 @@ import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
 /**
- * Helper class to test analyzers. Taken and modified from <i>Lucene in Action</i>.
+ * Helper class to hide boilerplate code when using Lucene Analyzers.
+ *
+ * <p>Taken and modified from <i>Lucene in Action</i>.
  *
  * @author Hardy Ferentschik
  */

--- a/engine/src/main/java/org/hibernate/search/util/impl/InternalAnalyzerUtils.java
+++ b/engine/src/main/java/org/hibernate/search/util/impl/InternalAnalyzerUtils.java
@@ -1,0 +1,64 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.impl;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.hibernate.search.exception.SearchException;
+import org.hibernate.search.util.AnalyzerUtils;
+import org.hibernate.search.util.logging.impl.Log;
+import org.hibernate.search.util.logging.impl.LoggerFactory;
+
+/**
+ * Analysis helpers that have no reason to be exposed publicy as {@link AnalyzerUtils} is.
+ *
+ * @author Yoann Rodiere
+ */
+public final class InternalAnalyzerUtils {
+
+	private static final Log log = LoggerFactory.make();
+
+	private InternalAnalyzerUtils() {
+		// Not used
+	}
+
+	/**
+	 * Returns the first token resulting from the analysis, logging a warning if there are more than one token.
+	 * @throws SearchException if a problem occurs when analyzing the sortable field's value.
+	 */
+	public static String analyzeSortableValue(Analyzer analyzer, String fieldName, String text) {
+		final TokenStream stream = analyzer.tokenStream( fieldName, new StringReader( text ) );
+		try {
+			try {
+				String firstToken = null;
+				CharTermAttribute term = stream.addAttribute( CharTermAttribute.class );
+				stream.reset();
+				if ( stream.incrementToken() ) {
+					firstToken = new String( term.buffer(), 0, term.length() );
+					if ( stream.incrementToken() ) {
+						log.multipleTermsInAnalyzedSortableField( fieldName );
+					}
+					else {
+						stream.end();
+					}
+				}
+				return firstToken;
+			}
+			finally {
+				stream.close();
+			}
+		}
+		catch (SearchException | IOException e) {
+			throw log.couldNotAnalyzeSortableField( fieldName, e );
+		}
+	}
+
+}

--- a/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
@@ -985,4 +985,12 @@ public interface Log extends BasicLogger {
 	@Message(id = 319, value = "Using serialization service %1$s")
 	void usingSerializationService(String serializerDescription);
 
+	@Message(id = 320, value = "Could not analyze sortable field '%1$s'.")
+	SearchException couldNotAnalyzeSortableField(String fieldName, @Cause Exception cause);
+
+	@LogMessage(level = Level.WARN)
+	@Message(id = 321, value = "The analysis of field '%1$s' produced multiple tokens. Tokenization or term generation"
+			+ " (synonyms) should not be used on sortable fields. Only the first token will be indexed.")
+	void multipleTermsInAnalyzedSortableField(String fieldName);
+
 }

--- a/engine/src/test/java/org/hibernate/search/test/sorting/SortingTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/sorting/SortingTest.java
@@ -13,10 +13,17 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.lucene.analysis.core.KeywordTokenizerFactory;
+import org.apache.lucene.analysis.core.LowerCaseFilterFactory;
+import org.apache.lucene.analysis.core.WhitespaceTokenizerFactory;
+import org.apache.lucene.analysis.miscellaneous.ASCIIFoldingFilterFactory;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.hibernate.search.annotations.Analyze;
+import org.hibernate.search.annotations.Analyzer;
+import org.hibernate.search.annotations.AnalyzerDef;
+import org.hibernate.search.annotations.AnalyzerDefs;
 import org.hibernate.search.annotations.DocumentId;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.FieldBridge;
@@ -25,6 +32,8 @@ import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.annotations.IndexedEmbedded;
 import org.hibernate.search.annotations.SortableFields;
 import org.hibernate.search.annotations.Store;
+import org.hibernate.search.annotations.TokenFilterDef;
+import org.hibernate.search.annotations.TokenizerDef;
 import org.hibernate.search.backend.spi.Work;
 import org.hibernate.search.backend.spi.WorkType;
 import org.hibernate.search.backend.spi.Worker;
@@ -93,6 +102,65 @@ public class SortingTest {
 		Query query = factoryHolder.getSearchFactory().buildQueryBuilder().forEntity( Person.class ).get().all().createQuery();
 		Sort sortAsString = new Sort( new SortField( "name", SortField.Type.STRING ) );
 		assertSortedResults( query, sortAsString, 3, 2, 1, 0 );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-2376")
+	public void testSortingOnCollatedString() {
+		// Index all testData:
+		storeTestingData(
+				new Person( 0, 3, "Éléonore" ),
+				new Person( 1, 10, "édouard" ),
+				new Person( 2, 9, "Edric" ),
+				new Person( 3, 5, "aaron" ),
+				new Person( 4, 7, " zach" )
+			);
+
+		// Sorting by collated name
+		Query query = factoryHolder.getSearchFactory().buildQueryBuilder().forEntity( Person.class ).get().all().createQuery();
+		Sort sortAsString = new Sort( new SortField( "collatedName", SortField.Type.STRING ) );
+		assertSortedResults( query, sortAsString, 4, 3, 1, 2, 0 );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-2376")
+	public void testAnalyzedSortableStoredField() {
+		Person person = new Person( 0, 3, "Éléonore" );
+
+		// Index all testData:
+		storeTestingData( person );
+
+		/*
+		 * Check the stored value is the value *before* analysis
+		 * This check makes sens mainly because we use DocValues for sorting, and
+		 * so should field value storage.
+		 */
+		Query query = factoryHolder.getSearchFactory().buildQueryBuilder().forEntity( Person.class ).get().keyword()
+				.onField( "id" )
+				.matching( person.id )
+				.createQuery();
+		assertStoredValueEquals( query, "collatedName", person.name );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-2376")
+	public void testSortingOnTokenizedString() {
+		// Index all testData:
+		storeTestingData(
+				new Person( 0, 3, "elizabeth" ),
+				new Person( 1, 10, "zach other" ),
+				new Person( 2, 9, " edric" ),
+				new Person( 3, 5, "bob" ),
+				new Person( 4, 10, "zach Aaron" )
+			);
+
+		// Sorting by tokenized name: ensure only the first token is taken into account
+		Query query = factoryHolder.getSearchFactory().buildQueryBuilder().forEntity( Person.class ).get().all().createQuery();
+		Sort sortAsString = new Sort(
+				new SortField( "tokenizedName", SortField.Type.STRING ),
+				SortField.FIELD_DOC // Stabilize the sort for the two zachs
+				);
+		assertSortedResults( query, sortAsString, 3, 2, 0, 1, 4 );
 	}
 
 	@Test
@@ -294,6 +362,16 @@ public class SortingTest {
 		}
 	}
 
+	private void assertStoredValueEquals(Query query, String fieldName, Object expectedValue) {
+		ExtendedSearchIntegrator integrator = factoryHolder.getSearchFactory();
+		HSQuery hsQuery = integrator.createHSQuery( query, Person.class );
+		hsQuery.projection( fieldName );
+		assertEquals( 1, hsQuery.queryResultSize() );
+		List<EntityInfo> queryEntityInfos = hsQuery.queryEntityInfos();
+		assertEquals( 1, queryEntityInfos.size() );
+		assertEquals( expectedValue, queryEntityInfos.get( 0 ).getProjection()[0] );
+	}
+
 	private HSQuery queryForValueNullAndSorting(String fieldName, SortField.Type sortType) {
 		ExtendedSearchIntegrator integrator = factoryHolder.getSearchFactory();
 		QueryBuilder queryBuilder = integrator.buildQueryBuilder().forEntity( Person.class ).get();
@@ -309,6 +387,20 @@ public class SortingTest {
 		return hsQuery;
 	}
 
+	@AnalyzerDefs({
+		@AnalyzerDef(
+				name = "collatingAnalyzer",
+				tokenizer = @TokenizerDef(factory = KeywordTokenizerFactory.class),
+				filters = {
+						@TokenFilterDef(factory = ASCIIFoldingFilterFactory.class),
+						@TokenFilterDef(factory = LowerCaseFilterFactory.class)
+				}
+		),
+		@AnalyzerDef(
+				name = "tokenizingAnalyzer",
+				tokenizer = @TokenizerDef(factory = WhitespaceTokenizerFactory.class)
+		)
+	})
 	@Indexed
 	private class Person {
 
@@ -326,8 +418,16 @@ public class SortingTest {
 		})
 		final Integer age;
 
-		@org.hibernate.search.annotations.SortableField
-		@Field(store = Store.YES, analyze = Analyze.NO, indexNullAs = Field.DEFAULT_NULL_TOKEN)
+		@SortableFields({
+				@org.hibernate.search.annotations.SortableField(forField = "name"),
+				@org.hibernate.search.annotations.SortableField(forField = "collatedName"),
+				@org.hibernate.search.annotations.SortableField(forField = "tokenizedName")
+		})
+		@Fields({
+				@Field(name = "name", store = Store.YES, analyze = Analyze.NO, indexNullAs = Field.DEFAULT_NULL_TOKEN),
+				@Field(name = "collatedName", store = Store.YES, analyzer = @Analyzer(definition = "collatingAnalyzer")),
+				@Field(name = "tokenizedName", store = Store.YES, analyzer = @Analyzer(definition = "tokenizingAnalyzer"))
+		})
 		final String name;
 
 		@IndexedEmbedded

--- a/orm/src/test/java/org/hibernate/search/test/query/facet/StringFacetingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/facet/StringFacetingTest.java
@@ -47,6 +47,35 @@ public class StringFacetingTest extends AbstractFacetTest {
 		assertFacet( facetList.get( 4 ), "Ford", 1 );
 	}
 
+	/**
+	 * Asserts that a sortable field with collation (whose value is analyzed)
+	 * doesn't conflict with a facet, even if the sortable field and the facet have
+	 * conflicting (identical) names.
+	 *
+	 * This makes sense because both features use DocValues internally, and we'd
+	 * like to make sure Lucene doesn't mix the two.
+	 */
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-2376")
+	public void testStringFacetingWithNameCollision() throws Exception {
+		FacetingRequest request = queryBuilder( Car.class ).facet()
+				.name( "manufacturer" )
+				.onField( "facetNameCollision" )
+				.discrete()
+				.includeZeroCounts( false )
+				.createFacetingRequest();
+		FullTextQuery query = matchAll( request );
+
+		List<Facet> facetList = query.getFacetManager().getFacets( "manufacturer" );
+		assertEquals( "Wrong number of facets", 5, facetList.size() );
+
+		assertFacet( facetList.get( 0 ), "Honda", 13 );
+		assertFacet( facetList.get( 1 ), "BMW", 12 );
+		assertFacet( facetList.get( 2 ), "Mercedes", 12 );
+		assertFacet( facetList.get( 3 ), "Toyota", 12 );
+		assertFacet( facetList.get( 4 ), "Ford", 1 );
+	}
+
 	private void assertFacet(Facet facet, String expectedMake, int expectedCount) {
 		assertEquals( "Wrong facet value", expectedMake, facet.getValue() );
 		assertEquals( "Wrong facet count", expectedCount, facet.getCount() );


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2376

To sum up, `SortedDocValuesField` are not analyzed automatically by lucene as other `Field`s are, so we have to do it manually.

Note: we don't do anything for remote analyzers, because the Elasticsearch module doesn't use docvalues and thus is unaffected by this bug. If one day it does, it will be affected, because fields with docvalues in ES are not analyzed. And then we're gonna have a hard time analyzing values with an analyzer that's not even here...

I'll submit PR for backports once this one is approved.