### PR TITLE
HSEARCH-2390 Investigate and label test exclusions in the ES module

### DIFF
--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -198,99 +198,99 @@
                                 <include>**/*.java</include>
                             </includes>
                             <excludes>
-                                <!-- Unknown cause failures (to be explored still) -->
-                                <exclude>**/EmbeddedSortableIdFieldTest.java</exclude>
-                                <exclude>**/CollectionUpdateEventTest.java</exclude>
-
-                                <!-- Analyzers -->
+                                <!-- HSEARCH-2391 Support -orm/-engine analyzer-related tests in -elasticsearch -->
                                 <exclude>**/CustomAnalyzerInClassBridgeTest.java</exclude>
                                 <exclude>**/SolrAnalyzerTest.java</exclude>
-
-                                <!-- Bridges -->
+                                <exclude>**/AnalyzerTest.java</exclude>
+                                <exclude>**/DoubleAnalyzerTest.java</exclude>
+                                <exclude>**/AnalyzerInheritanceTest.java</exclude>
+                                
+                                <!-- HSEARCH-2389 Support indexNullAs for @IndexedEmbedded applied on objects with Elasticsearch -->
+                                <exclude>**/IndexEmbeddedProgrammaticallyMappedTest.java</exclude>
+                                <!-- Also, parts of NullEmbeddedTest -->
+                                
+                                <!-- HSEARCH-2271 Enable ArrayBridgeTest (and similar) for Elasticsearch -->
                                 <exclude>**/ArrayBridgeTest.java</exclude>
-                                <exclude>**/BridgeTest.java</exclude>
-                                <exclude>**/ClassBridgeTest.java</exclude>
                                 <exclude>**/IterableBridgeTest.java</exclude>
                                 <exclude>**/MapBridgeTest.java</exclude>
+                                
+                                <!-- HSEARCH-2402 Elasticsearch backend mistakes @DateBridge for @CalendarBridge -->
+                                <exclude>**/BridgeTest.java</exclude>
+                                <exclude>**/NumericEncodingQueriesTest.java</exclude>
+                                
+                                <!-- HSEARCH-2403 TwoWayFieldBridge exceptions are not wrapped properly when retrieving ES projection values -->
+                                <exclude>**/BridgeTest.java</exclude>
+                                
+                                <!-- HSEARCH-2392 Enable BridgeProviderTest for Elasticsearch -->
                                 <exclude>**/BridgeProviderTest.java</exclude>
+                                
+                                <!-- HSEARCH-2386 TikaMetadataProcessor cannot add sortable fields (or fields usable in Elasticsearch) -->
                                 <exclude>**/TikaBridgeBlobSupportTest.java</exclude>
                                 <exclude>**/TikaBridgeTest.java</exclude>
-
-                                <exclude>**/HibernateSearchIntegratorTest.java</exclude>
-                                <exclude>**/OptimizationTriggerTest.java</exclude>
-                                <exclude>**/WorkQueueLengthConfiguredTest.java</exclude>
-                                <exclude>**/CompressionTest.java</exclude>
-                                <exclude>**/IndexEmbeddedProgrammaticallyMappedTest.java</exclude>
-                                <exclude>**/ProgrammaticMappingTest.java</exclude>
-                                <exclude>**/ShardsConfigurationTest.java</exclude>
-                                <exclude>**/WorkDoneOnEntitiesTest.java</exclude>
-                                <exclude>**/NumericFieldTest.java</exclude>
-                                <exclude>**/DeleteByTermTest.java</exclude>
-                                <exclude>**/UpdateOperationsTest.java</exclude>
-                                <exclude>**/TransactionTest.java</exclude>
-                                <exclude>**/SearchAndEnversIntegrationTest.java</exclude>
-                                <exclude>**/IndexingActionInterceptorTest.java</exclude>
-                                <exclude>**/IndexControlMBeanTest.java</exclude>
-                                <exclude>**/ToStringTest.java</exclude>
-                                <exclude>**/DynamicBoostingTest.java</exclude>
+                                
+                                <!-- HSEARCH-2393 Remove depencies to Lucene in tests for features common to Lucene and Elasticsearch -->
+                                <exclude>**/ClassBridgeTest.java</exclude><!-- QueryParser -->
+                                <exclude>**/ProgrammaticMappingTest.java</exclude><!-- Analyzers -->
+                                <exclude>**/WorkDoneOnEntitiesTest.java</exclude><!-- IndexReader -->
+                                <exclude>**/DeleteByTermTest.java</exclude><!-- WorkspaceHolder -->
+                                <exclude>**/UpdateOperationsTest.java</exclude><!-- LeakingOptimizer -->
+                                <exclude>**/TransactionTest.java</exclude><!-- Directory -->
+                                <exclude>**/IndexingActionInterceptorTest.java</exclude><!-- Queries on the object's class -->
+                                <exclude>**/IndexControlMBeanTest.java</exclude><!-- IndexReader -->
+                                <exclude>**/ToStringTest.java</exclude><!-- Relies on the lucene query's toString(), should be the HSQuery's getQueryString? -->
+                                <exclude>**/DynamicBoostingTest.java</exclude><!-- Projection constant __HSearch_Explanation -->
+                                <exclude>**/IndexAndQueryNullTest.java</exclude><!-- Projection constant __HSearch_Document -->
+                                <exclude>**/ProgrammaticIndexAndQueryNullTest.java</exclude><!-- Projection constant __HSearch_Document -->
+                                <exclude>**/ProjectionQueryTest.java</exclude><!-- Projection constant __HSearch_Document -->
+                                <exclude>**/SortUsingEntityManagerTest.java</exclude><!-- Sort type LONG instead of STRING? -->
+                                <exclude>**/LazyM2OContainedInTest.java</exclude><!-- Use of TermQuery? -->
+                                <exclude>**/SearchAfterUninitializedProxyEntityLoadingTest.java</exclude><!-- Use of TermQuery? -->
+                                <exclude>**/LazyCollectionsUpdatingTest.java</exclude><!-- Use of TermQuery? -->
+                                <exclude>**/LuceneErrorHandlingTest.java</exclude><!-- LuceneErrorHandlingTest$NoOpLuceneWorkDelegate cannot be cast ... -->
+                                <exclude>**/SyncWorkerTest.java</exclude><!-- Use of QueryParser? -->
+                                <exclude>**/WorkerTestCase.java</exclude><!-- Use of QueryParser? -->
+                                <exclude>**/NumericFieldTest.java</exclude><!-- Missing field metadata (should use MetadataProvidingFieldBridge) -->
+                                <exclude>**/SortOnFieldsFromCustomBridgeTest.java</exclude><!-- Missing field metadata (should use MetadataProvidingFieldBridge) -->
+                                <exclude>**/DirectoryProviderForQueryTest.java</exclude><!-- Full text filters must implement ElasticsearchFilter -->
+                                
+                                <!-- HSEARCH-2394 Fix dependency issues for tests that are re-used in Elasticsearch -->
+                                <exclude>**/SearchAndEnversIntegrationTest.java</exclude><!-- Envers -->
+                                <exclude>**/HibernateSearchIntegratorTest.java</exclude><!-- Unitils -->
+                                
+                                <!-- HSEARCH-2395 Support MoreLikeThisQueries with the Elasticsearch backend -->
                                 <exclude>**/MoreLikeThisTest.java</exclude>
-                                <exclude>**/NumericEncodingQueriesTest.java</exclude>
+                                
+                                <!-- HSEARCH-2137 Translate core Lucene Queries to Elasticsearch queries -->
                                 <exclude>**/ExplanationTest.java</exclude>
 
-                                <!-- Embedded ids -->
+                                <!-- HSEARCH-2396 Support EmbeddedIds with the Elasticsearch backend -->
                                 <exclude>**/EmbeddedIdTest.java</exclude>
                                 <exclude>**/EmbeddedIdWithDocumentIdTest.java</exclude>
                                 <exclude>**/ProgrammaticEmbeddedItTest.java</exclude>
                                 <exclude>**/CollectionInitializeTest.java</exclude>
-
-                                <!-- Needs range queries on nested fields -->
+                                <exclude>**/EmbeddedSortableIdFieldTest.java</exclude>
+                                
+                                <!-- HSEARCH-2397 The Elasticsearch backend doesn't support embeddeds prefixes properly -->
                                 <exclude>**/DslEmbeddedSearchTest.java</exclude>
-
-                                <!-- Faceting -->
-                                <exclude>**/FacetUnknownFieldFailureTest.java</exclude>
-
-                                <exclude>**/IndexAndQueryNullTest.java</exclude>
-                                <exclude>**/ProgrammaticIndexAndQueryNullTest.java</exclude>
-                                <exclude>**/ProjectionQueryTest.java</exclude>
-                                <exclude>**/SortUsingEntityManagerTest.java</exclude>
-                                <exclude>**/SortUsingEntityManagerTest.java</exclude>
-                                <exclude>**/TermVectorTest.java</exclude>
-                                <exclude>**/JPATimeoutTest.java</exclude>
-                                <exclude>**/DirectoryProviderForQueryTest.java</exclude>
-                                <exclude>**/DirectorySelectionTest.java</exclude>
-                                <exclude>**/AnalyzerTest.java</exclude>
-                                <exclude>**/DoubleAnalyzerTest.java</exclude>
-                                <exclude>**/AnalyzerInheritanceTest.java</exclude>
-                                <exclude>**/ProgressMonitorTest.java</exclude>
-                                <exclude>**/RetryInitializeTest.java</exclude>
-                                <exclude>**/LazyM2OContainedInTest.java</exclude>
-                                <exclude>**/SearchAfterUninitializedProxyEntityLoadingTest.java</exclude>
-                                <exclude>**/LazyCollectionsUpdatingTest.java</exclude>
-                                <exclude>**/SyncWorkerTest.java</exclude>
-                                <exclude>**/WorkerTestCase.java</exclude>
-                                <exclude>**/ConcurrentMergeErrorHandledTest.java</exclude>
-                                <exclude>**/LuceneErrorHandlingTest.java</exclude>
-                                <exclude>**/EmbeddedFieldBoostTest.java</exclude>
-                                <exclude>**/TimeoutTest.java</exclude>
-                                <exclude>**/QueryValidationTest.java</exclude>
-                                <exclude>**/SimilarityTest.java</exclude>
-                                <exclude>**/SortWithIndexUninvertingTest.java</exclude>
-                                <exclude>**/SortOnFieldsFromCustomBridgeTest.java</exclude>
                                 <exclude>**/PrefixedEmbeddedCaseInPathTest.java</exclude>
-
-                                <!-- Specific to other backends -->
-                                <exclude>**/CustomBackendTest.java</exclude>
-                                <exclude>**/FSDirectorySelectionTest.java</exclude>
-                                <exclude>**/FSDirectoryTest.java</exclude>
-                                <exclude>**/RamDirectoryTest.java</exclude>
-                                <exclude>**/ExclusiveIndexTest.java</exclude>
-                                <exclude>**/IndexManagerOverrideTest.java</exclude>
-                                <exclude>**/CustomLockProviderTest.java</exclude>
-                                <exclude>**/DirectoryLifecycleTest.java</exclude>
-                                <exclude>**/ScheduledCommitPolicyTest.java</exclude>
-                                <exclude>**/FSSlaveAndMasterDPTest.java</exclude>
-                                <exclude>**/IndexReaderSeeOptimizedIndexTest.java</exclude>
-                                <exclude>**/LuceneIndexingParametersTest.java</exclude>
+                                
+                                <!-- HSEARCH-2398 Improve field name/type validation when querying the Elasticsearch backend -->
+                                <exclude>**/FacetUnknownFieldFailureTest.java</exclude><!-- The elasticsearch backend seems too lenient for unknown field names. -->
+                                <exclude>**/QueryValidationTest.java</exclude><!-- testTargetNumericEncodedFieldWithStringQueryThrowsException: The Elasticsearch backend throws an exception, but not exactly the one we expect -->
+                                <exclude>**/QueryValidationTest.java</exclude><!-- testTargetStringEncodedFieldWithNumericRangeQueryThrowsException: The Elasticsearch backend seems to accept numeric range queries on string fields...? (it even seems to match) -->
+                                
+                                <!-- HSEARCH-2399 Implement timeouts for the Elasticsearch backend -->
+                                <exclude>**/JPATimeoutTest.java</exclude>
+                                <exclude>**/TimeoutTest.java</exclude>
+                                
+                                <!-- HSEARCH-2400 Support IndexingMonitor for the Elasticsearch backend -->
+                                <exclude>**/ProgressMonitorTest.java</exclude>
+                                
+                                <!-- HSEARCH-2401 Boosts are (erroneously) not applied to IndexedEmbeddeds -->
+                                <exclude>**/EmbeddedFieldBoostTest.java</exclude>
+                                
+                                <!-- HSEARCH-2404 Enable CollectionUpdateEventTest for Elasticsearch -->
+                                <exclude>**/CollectionUpdateEventTest.java</exclude><!-- Only fails on CI (Travis) -->
                             </excludes>
                             <excludedGroups>org.hibernate.search.testsupport.junit.SkipOnElasticsearch,org.hibernate.search.testsupport.junit.ElasticsearchSupportInProgress</excludedGroups>
                         </configuration>

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -220,7 +220,6 @@
                                 <exclude>**/OptimizationTriggerTest.java</exclude>
                                 <exclude>**/WorkQueueLengthConfiguredTest.java</exclude>
                                 <exclude>**/CompressionTest.java</exclude>
-                                <exclude>**/ConcurrentFlushTest.java</exclude>
                                 <exclude>**/IndexEmbeddedProgrammaticallyMappedTest.java</exclude>
                                 <exclude>**/ProgrammaticMappingTest.java</exclude>
                                 <exclude>**/ShardsConfigurationTest.java</exclude>
@@ -248,7 +247,6 @@
                                 <exclude>**/DslEmbeddedSearchTest.java</exclude>
 
                                 <!-- Faceting -->
-                                <exclude>**/FacetIndexingFailureTest.java</exclude>
                                 <exclude>**/FacetUnknownFieldFailureTest.java</exclude>
 
                                 <exclude>**/IndexAndQueryNullTest.java</exclude>
@@ -271,11 +269,8 @@
                                 <exclude>**/SyncWorkerTest.java</exclude>
                                 <exclude>**/WorkerTestCase.java</exclude>
                                 <exclude>**/ConcurrentMergeErrorHandledTest.java</exclude>
-                                <exclude>**/ErrorHandlingDuringDocumentCreationTest.java</exclude>
                                 <exclude>**/LuceneErrorHandlingTest.java</exclude>
-                                <exclude>**/ManualIndexingOnlyInterceptorTest.java</exclude>
                                 <exclude>**/EmbeddedFieldBoostTest.java</exclude>
-                                <exclude>**/MultiClassesQueryLoaderTest.java</exclude>
                                 <exclude>**/TimeoutTest.java</exclude>
                                 <exclude>**/QueryValidationTest.java</exclude>
                                 <exclude>**/SimilarityTest.java</exclude>

--- a/engine/src/test/java/org/hibernate/search/test/backend/lucene/ScheduledCommitPolicyTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/backend/lucene/ScheduledCommitPolicyTest.java
@@ -15,12 +15,14 @@ import org.hibernate.search.backend.spi.WorkType;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.query.engine.spi.HSQuery;
 import org.hibernate.search.testsupport.junit.SearchFactoryHolder;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
 import org.hibernate.search.testsupport.setup.CountingErrorHandler;
 import org.hibernate.search.testsupport.setup.TransactionContextForTest;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
@@ -35,6 +37,7 @@ import static org.junit.Assert.assertTrue;
  * @author gustavonalle
  */
 @RunWith(BMUnitRunner.class)
+@Category(SkipOnElasticsearch.class) // Commit policies are specific to the Lucene backend
 public class ScheduledCommitPolicyTest {
 
 	private static final int NUMBER_ENTITIES = 1000;

--- a/orm/src/test/java/org/hibernate/search/test/backend/OptimizationTriggerTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/backend/OptimizationTriggerTest.java
@@ -21,14 +21,17 @@ import org.hibernate.search.spi.SearchIntegrator;
 import org.hibernate.search.store.optimization.OptimizerStrategy;
 import org.hibernate.search.store.optimization.impl.IncrementalOptimizerStrategy;
 import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static org.junit.Assert.assertEquals;
 
 /**
  * @author Sanne Grinovero (C) 2011 Red Hat Inc.
  */
+@Category(SkipOnElasticsearch.class) // Optimizer strategies are specific to the Lucene backend
 public class OptimizationTriggerTest extends SearchTestBase {
 
 	@Test

--- a/orm/src/test/java/org/hibernate/search/test/backend/WorkQueueLengthConfiguredTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/backend/WorkQueueLengthConfiguredTest.java
@@ -15,7 +15,9 @@ import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
 import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.spi.SearchIntegrator;
 import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static org.junit.Assert.assertEquals;
 
@@ -25,6 +27,7 @@ import static org.junit.Assert.assertEquals;
  *
  * @author Sanne Grinovero (C) 2011 Red Hat Inc.
  */
+@Category(SkipOnElasticsearch.class) // The "max_queue_length" parameter is specific to the Lucene backend
 public class WorkQueueLengthConfiguredTest extends SearchTestBase {
 
 	@Override

--- a/orm/src/test/java/org/hibernate/search/test/compression/CompressionTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/compression/CompressionTest.java
@@ -26,9 +26,11 @@ import org.hibernate.search.FullTextQuery;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
 import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -39,6 +41,7 @@ import static org.junit.Assert.assertTrue;
  * @author Sanne Grinovero
  * @author Hardy Ferentschik
  */
+@Category(SkipOnElasticsearch.class) // Compression is specific to the Lucene backend
 public class CompressionTest extends SearchTestBase {
 
 	/**

--- a/orm/src/test/java/org/hibernate/search/test/configuration/CustomBackendTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/CustomBackendTest.java
@@ -14,13 +14,16 @@ import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.indexes.impl.IndexManagerHolder;
 import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
 import org.hibernate.search.test.util.FullTextSessionBuilder;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static org.junit.Assert.assertEquals;
 
 /**
  * @author Sanne Grinovero
  */
+@Category(SkipOnElasticsearch.class) // Worker backends are specific to the Lucene backend
 public class CustomBackendTest {
 
 	@Test

--- a/orm/src/test/java/org/hibernate/search/test/configuration/ExclusiveIndexTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/ExclusiveIndexTest.java
@@ -22,13 +22,16 @@ import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.indexes.impl.IndexManagerHolder;
 import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
 import org.hibernate.search.test.util.FullTextSessionBuilder;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Verifies the property exclusive_index_use is properly applied to the backend
  *
  * @author Sanne Grinovero (C) 2011 Red Hat Inc.
  */
+@Category(SkipOnElasticsearch.class) // The "exclusive_index_use" parameter is specific to the Lucene backend
 public class ExclusiveIndexTest {
 
 	@Test

--- a/orm/src/test/java/org/hibernate/search/test/configuration/IndexManagerOverrideTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/IndexManagerOverrideTest.java
@@ -17,14 +17,17 @@ import org.hibernate.search.indexes.impl.IndexManagerHolder;
 import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
 import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.test.util.FullTextSessionBuilder;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Verifies the configured IndexManager implementation is used for each index .
  *
  * @author Sanne Grinovero (C) 2011 Red Hat Inc.
  */
+@Category(SkipOnElasticsearch.class) // This test does not actually use backends
 public class IndexManagerOverrideTest {
 
 	public static class FooIndexManager extends DirectoryBasedIndexManager {

--- a/orm/src/test/java/org/hibernate/search/test/configuration/LuceneIndexingParametersTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/LuceneIndexingParametersTest.java
@@ -14,8 +14,10 @@ import org.hibernate.search.backend.spi.LuceneIndexingParameters;
 import org.hibernate.search.test.Document;
 import org.hibernate.search.test.query.Author;
 import org.hibernate.search.test.query.Book;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
 import org.hibernate.search.testsupport.serialization.SerializationTestHelper;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static org.hibernate.search.backend.configuration.impl.IndexWriterSetting.MAX_BUFFERED_DOCS;
 import static org.hibernate.search.backend.configuration.impl.IndexWriterSetting.MAX_MERGE_DOCS;
@@ -28,6 +30,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * @author Sanne Grinovero
  */
+@Category(SkipOnElasticsearch.class) // These parameters are specific to the Lucene backend
 public class LuceneIndexingParametersTest extends ConfigurationReadTestCase {
 
 	@Override

--- a/orm/src/test/java/org/hibernate/search/test/configuration/ShardsConfigurationTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/ShardsConfigurationTest.java
@@ -18,7 +18,9 @@ import org.hibernate.search.store.impl.RAMDirectoryProvider;
 import org.hibernate.search.test.Document;
 import org.hibernate.search.test.query.Author;
 import org.hibernate.search.test.query.Book;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static org.hibernate.search.backend.configuration.impl.IndexWriterSetting.MAX_BUFFERED_DOCS;
 import static org.hibernate.search.backend.configuration.impl.IndexWriterSetting.MAX_MERGE_DOCS;
@@ -79,6 +81,7 @@ public class ShardsConfigurationTest extends ConfigurationReadTestCase {
 	}
 
 	@Test
+	@Category(SkipOnElasticsearch.class) // DirectoryProviders and IndexWriterSettings are specific to the Lucene backend
 	public void testShardingSettingsInherited() {
 		IndexManager[] indexManagers = getExtendedSearchIntegrator().getIndexBindings().get( Document.class ).getIndexManagers();
 		assertTrue( getDirectoryProvider( indexManagers[0] ) instanceof RAMDirectoryProvider );
@@ -89,6 +92,7 @@ public class ShardsConfigurationTest extends ConfigurationReadTestCase {
 	}
 
 	@Test
+	@Category(SkipOnElasticsearch.class) // IndexWriterSettings are specific to the Lucene backend
 	public void testShardN2UsesDefaults() {
 		assertValueIsSet( Document.class, 2, MAX_BUFFERED_DOCS, 4 );
 		assertValueIsSet( Document.class, 2, MERGE_FACTOR, 100 );
@@ -99,6 +103,7 @@ public class ShardsConfigurationTest extends ConfigurationReadTestCase {
 	}
 
 	@Test
+	@Category(SkipOnElasticsearch.class) // IndexWriterSettings are specific to the Lucene backend
 	public void testShardN1_ExplicitParams() {
 		assertValueIsSet( Document.class, 1, MAX_BUFFERED_DOCS, 12 );
 		assertValueIsSet( Document.class, 1, MAX_MERGE_DOCS, 11 );

--- a/orm/src/test/java/org/hibernate/search/test/directoryProvider/CustomLockProviderTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/directoryProvider/CustomLockProviderTest.java
@@ -14,7 +14,9 @@ import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
 import org.hibernate.search.spi.SearchIntegrator;
 import org.hibernate.search.store.DirectoryProvider;
 import org.hibernate.search.test.util.FullTextSessionBuilder;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -25,6 +27,7 @@ import java.io.IOException;
 /**
  * @author Sanne Grinovero
  */
+@Category(SkipOnElasticsearch.class) // Locking parameters are specific to the Lucene backend
 public class CustomLockProviderTest {
 
 	private static final String SINGLE_INSTANCE_LOCK_FQN = "org.apache.lucene.store.SingleInstanceLockFactory$SingleInstanceLock";

--- a/orm/src/test/java/org/hibernate/search/test/directoryProvider/DirectoryLifecycleTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/directoryProvider/DirectoryLifecycleTest.java
@@ -14,11 +14,14 @@ import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
 import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.spi.SearchIntegrator;
 import org.hibernate.search.test.util.FullTextSessionBuilder;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * @author Sanne Grinovero (C) 2011 Red Hat Inc.
  */
+@Category(SkipOnElasticsearch.class) // Directory providers are specific to the Lucene backend
 public class DirectoryLifecycleTest {
 
 	@Test

--- a/orm/src/test/java/org/hibernate/search/test/directoryProvider/FSDirectorySelectionTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/directoryProvider/FSDirectorySelectionTest.java
@@ -23,7 +23,9 @@ import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.spi.SearchIntegrator;
 import org.hibernate.search.store.impl.FSDirectoryProvider;
 import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -32,6 +34,7 @@ import static org.junit.Assert.fail;
 /**
  * @author Hardy Ferentschik
  */
+@Category(SkipOnElasticsearch.class) // Directories are specific to the Lucene backend
 public class FSDirectorySelectionTest extends SearchTestBase {
 
 	@Test

--- a/orm/src/test/java/org/hibernate/search/test/directoryProvider/FSDirectoryTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/directoryProvider/FSDirectoryTest.java
@@ -27,9 +27,11 @@ import org.hibernate.Session;
 import org.hibernate.search.test.Document;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.testsupport.TestConstants;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
 import org.hibernate.search.util.impl.FileHelper;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -38,6 +40,7 @@ import static org.junit.Assert.assertTrue;
  * @author Gavin King
  * @author Sanne Grinovero
  */
+@Category(SkipOnElasticsearch.class) // Directories are specific to the Lucene backend
 public class FSDirectoryTest extends SearchTestBase {
 
 	@Test

--- a/orm/src/test/java/org/hibernate/search/test/directoryProvider/FSSlaveAndMasterDPTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/directoryProvider/FSSlaveAndMasterDPTest.java
@@ -21,9 +21,11 @@ import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.testsupport.TestConstants;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
 import org.hibernate.search.util.impl.FileHelper;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
+import org.junit.experimental.categories.Category;
 
 /**
  * Test case for master/slave directories.
@@ -31,6 +33,7 @@ import org.hibernate.search.util.logging.impl.LoggerFactory;
  * @author Emmanuel Bernard
  * @author Hardy Ferentschik
  */
+@Category(SkipOnElasticsearch.class) // Directories are specific to the Lucene backend
 public class FSSlaveAndMasterDPTest extends MultipleSFTestCase {
 
 	private static final Log log = LoggerFactory.make();

--- a/orm/src/test/java/org/hibernate/search/test/directoryProvider/RamDirectoryTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/directoryProvider/RamDirectoryTest.java
@@ -19,13 +19,16 @@ import org.hibernate.search.Search;
 import org.hibernate.search.test.AlternateDocument;
 import org.hibernate.search.test.Document;
 import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static org.junit.Assert.assertEquals;
 
 /**
  * @author Emmanuel Bernard
  */
+@Category(SkipOnElasticsearch.class) // Directories are specific to the Lucene backend
 public class RamDirectoryTest extends SearchTestBase {
 
 	@Test

--- a/orm/src/test/java/org/hibernate/search/test/directoryProvider/RetryInitializeTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/directoryProvider/RetryInitializeTest.java
@@ -24,9 +24,11 @@ import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
 import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.spi.SearchIntegrator;
 import org.hibernate.search.test.util.FullTextSessionBuilder;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Verifies basic behavior of FSSlaveDirectoryProvider around
@@ -35,6 +37,7 @@ import org.junit.Test;
  *
  * @author Sanne Grinovero (C) 2011 Red Hat Inc.
  */
+@Category(SkipOnElasticsearch.class) // Directory providers are specific to the Lucene backend
 public class RetryInitializeTest {
 
 	private FullTextSessionBuilder slave;

--- a/orm/src/test/java/org/hibernate/search/test/embedded/EmbeddedTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/embedded/EmbeddedTest.java
@@ -34,8 +34,7 @@ import org.junit.experimental.categories.Category;
 public class EmbeddedTest extends SearchTestBase {
 
 	@Test
-	// other separators than "." not supported for now
-	@Category(ElasticsearchSupportInProgress.class)
+	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2397 The Elasticsearch backend doesn't support embeddeds prefixes properly
 	public void testEmbeddedIndexing() throws Exception {
 		Tower tower = new Tower();
 		tower.setName( "JBoss tower" );
@@ -135,8 +134,7 @@ public class EmbeddedTest extends SearchTestBase {
 	}
 
 	@Test
-	// other separators than "." not supported for now
-	@Category(ElasticsearchSupportInProgress.class)
+	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2397 The Elasticsearch backend doesn't support embeddeds prefixes properly
 	public void testContainedIn() throws Exception {
 		Tower tower = new Tower();
 		tower.setName( "JBoss tower" );

--- a/orm/src/test/java/org/hibernate/search/test/embedded/nullindexed/NullEmbeddedTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/embedded/nullindexed/NullEmbeddedTest.java
@@ -78,9 +78,7 @@ public class NullEmbeddedTest extends SearchTestBase {
 	}
 
 	@Test
-	// "IS NULL" for intermediary element in the graph (pet) needs to be mapped to missing filter:
-	// https://www.elastic.co/guide/en/elasticsearch/guide/current/_dealing_with_null_values.html
-	@Category(ElasticsearchSupportInProgress.class)
+	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2389 Support indexNullAs for @IndexedEmbedded applied on objects with Elasticsearch
 	public void testNestedEmebeddedNullIndexing() throws Exception {
 		Man withPet = new Man( "Davide" );
 
@@ -126,9 +124,7 @@ public class NullEmbeddedTest extends SearchTestBase {
 	}
 
 	@Test
-	// "IS NULL" for intermediary element in the graph (pet) needs to be mapped to missing filter:
-	// https://www.elastic.co/guide/en/elasticsearch/guide/current/_dealing_with_null_values.html
-	@Category(ElasticsearchSupportInProgress.class)
+	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2389 Support indexNullAs for @IndexedEmbedded applied on objects with Elasticsearch
 	public void testEmbeddedNullIndexing() throws Exception {
 		Man me = new Man( "Davide" );
 		Pet dog = new Pet( "dog" );

--- a/orm/src/test/java/org/hibernate/search/test/engine/optimizations/IndexReaderSeeOptimizedIndexTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/engine/optimizations/IndexReaderSeeOptimizedIndexTest.java
@@ -19,9 +19,11 @@ import org.hibernate.search.Search;
 import org.hibernate.search.SearchFactory;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.testsupport.TestForIssue;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Test that the IndexReader can see an optmized index before the factory is closed.
@@ -29,6 +31,7 @@ import org.junit.Test;
  * @author Davide D'Alto
  */
 @TestForIssue(jiraKey = "HSEARCH-1681")
+@Category(SkipOnElasticsearch.class) // IndexReaders are specific to the Lucene backend
 public class IndexReaderSeeOptimizedIndexTest extends SearchTestBase {
 
 	private String indexBasePath;

--- a/orm/src/test/java/org/hibernate/search/test/errorhandling/ConcurrentMergeErrorHandledTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/errorhandling/ConcurrentMergeErrorHandledTest.java
@@ -15,10 +15,12 @@ import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.exception.ErrorHandler;
 import org.hibernate.search.spi.SearchIntegrator;
 import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -37,6 +39,7 @@ import org.junit.runner.RunWith;
  * @see Environment#ERROR_HANDLER
  */
 @RunWith(BMUnitRunner.class)
+@Category(SkipOnElasticsearch.class) // Merge schedulers are specific to the Lucene backend
 public class ConcurrentMergeErrorHandledTest extends SearchTestBase {
 
 	@Test

--- a/orm/src/test/java/org/hibernate/search/test/filter/FilterTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/filter/FilterTest.java
@@ -73,9 +73,7 @@ public class FilterTest extends SearchTestBase {
 	}
 
 	@Test
-	@Category(ElasticsearchSupportInProgress.class)
-	// For now, the Elasticsearch backend does not support caching of the Filter instances as the caching API is based
-	// on Lucene filters.
+	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2405 Support caching for filters with Elasticsearch
 	// Moreover the Elasticsearch backend does not support custom Lucene filters.
 	public void testCache() {
 		InstanceBasedExcludeAllFilter.assertConstructorInvoked( 1 ); // SearchFactory tests filter construction once
@@ -114,9 +112,7 @@ public class FilterTest extends SearchTestBase {
 
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-295")
-	@Category(SkipOnElasticsearch.class)
-	// For now, the Elasticsearch backend does not support caching of the Filter instances as the caching API is based
-	// on Lucene filters.
+	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2405 Support caching for filters with Elasticsearch
 	// Moreover the Elasticsearch backend does not support custom Lucene filters.
 	public void testFiltersCreatedByFactoryWithoutKeyMethodShouldBeCachedByAllParameterNamesAndValues() {
 		assertEquals( 0, FieldConstraintFilterFactoryWithoutKeyMethod.getBuiltFilters().size() );

--- a/orm/src/test/java/org/hibernate/search/test/query/TermVectorTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/TermVectorTest.java
@@ -16,7 +16,9 @@ import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
 import org.hibernate.search.SearchFactory;
 import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -27,6 +29,7 @@ import static org.junit.Assert.assertNull;
  * @author John Griffin
  * @author Sanne Grinovero
  */
+@Category(SkipOnElasticsearch.class) // IndexReaders (which provide access to term vectors) are specific to the Lucene backend
 public class TermVectorTest extends SearchTestBase {
 
 	@Test

--- a/orm/src/test/java/org/hibernate/search/test/query/dsl/DSLTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/dsl/DSLTest.java
@@ -486,8 +486,7 @@ public class DSLTest extends SearchTestBase {
 	}
 
 	@Test
-	@Category(ElasticsearchSupportInProgress.class)
-	// The resolution is not yet supported for the date bridges
+	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2393 Remove dependency to Lucene in tests for features common to Lucene and Elasticsearch
 	public void testRangeQueryFromToIgnoreFieldBridge() throws Exception {
 		Transaction transaction = fullTextSession.beginTransaction();
 		final QueryBuilder monthQb = fullTextSession.getSearchFactory()
@@ -552,8 +551,7 @@ public class DSLTest extends SearchTestBase {
 	}
 
 	@Test
-	@Category(ElasticsearchSupportInProgress.class)
-	// The resolution is not yet supported for the date bridges
+	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2393 Remove dependency to Lucene in tests for features common to Lucene and Elasticsearch
 	public void testRangeQueryBelowIgnoreFieldBridge() throws Exception {
 		Transaction transaction = fullTextSession.beginTransaction();
 		final QueryBuilder monthQb = fullTextSession.getSearchFactory()
@@ -634,8 +632,7 @@ public class DSLTest extends SearchTestBase {
 	}
 
 	@Test
-	@Category(ElasticsearchSupportInProgress.class)
-	// The resolution is not yet supported for the date bridges
+	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2393 Remove dependency to Lucene in tests for features common to Lucene and Elasticsearch
 	public void testRangeQueryAboveIgnoreFieldBridge() throws Exception {
 		Transaction transaction = fullTextSession.beginTransaction();
 		final QueryBuilder monthQb = fullTextSession.getSearchFactory()

--- a/orm/src/test/java/org/hibernate/search/test/query/sorting/SortWithIndexUninvertingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/sorting/SortWithIndexUninvertingTest.java
@@ -22,9 +22,11 @@ import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.test.query.Book;
 import org.hibernate.search.testsupport.TestConstants;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
@@ -91,6 +93,7 @@ public class SortWithIndexUninvertingTest extends SearchTestBase {
 	 * exception is expected.
 	 */
 	@Test
+	@Category(SkipOnElasticsearch.class) // This problem does not affect the Elasticsearch backend
 	public void testQueryOnIndexSharedByEntityWithRequiredSortFieldAndEntityWithoutRaisesException() throws Exception {
 		Transaction tx = fullTextSession.beginTransaction();
 

--- a/orm/src/test/java/org/hibernate/search/test/shards/DirectorySelectionTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/shards/DirectorySelectionTest.java
@@ -16,15 +16,18 @@ import org.hibernate.search.Search;
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.indexes.IndexReaderAccessor;
 import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Test to retrieve specific IndexReader instances by index name.
  *
  * @author Sanne Grinovero (C) 2011 Red Hat Inc.
  */
+@Category(SkipOnElasticsearch.class) // Directories are specific to the Lucene backend
 public class DirectorySelectionTest extends SearchTestBase {
 	private IndexReaderAccessor indexReaderAccessor;
 

--- a/orm/src/test/java/org/hibernate/search/test/similarity/SimilarityTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/similarity/SimilarityTest.java
@@ -18,7 +18,9 @@ import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
 import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -26,6 +28,7 @@ import static org.junit.Assert.assertFalse;
 /**
  * @author Emmanuel Bernard
  */
+@Category(SkipOnElasticsearch.class) // Similarity tuning is specific to the Lucene backend
 public class SimilarityTest extends SearchTestBase {
 
 	@Test


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2390

Just a PR to reorganize test exclusions and match them with the tickets I just created. Most of those tickets identify the actual issue.
I also enabled some tests that happened to pass anyway.

The patch of the pom file is a bit unreadable, sorry about that... But I guess there's no other way.