### PR TITLE
HSEARCH-2365 HostCanBeConfiguredIT.shouldApplyConfiguredElasticsearch…

### DIFF
--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/HostCanBeConfiguredIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/HostCanBeConfiguredIT.java
@@ -45,7 +45,9 @@ public class HostCanBeConfiguredIT {
 
 			Throwable rootCause = getRootCause( e );
 			assertThat( rootCause ).isInstanceOf( ConnectException.class );
-			assertThat( rootCause ).hasMessage( "Connection refused" );
+			//N.B. the exact message is different on Windows vs Linux so
+			//we only check for it to contain this string:
+			assertThat( rootCause.getMessage() ).contains( "Connection refused" );
 		}
 
 	}


### PR DESCRIPTION
…Host should expect a different message when testing on Windows

- https://hibernate.atlassian.net/browse/HSEARCH-2365