### PR TITLE
HSEARCH-2408 @IndexedEmbedded.prefix, .depth, etc. don't work on @ElementCollection anymore

### DIFF
--- a/documentation/src/main/asciidoc/mapping.asciidoc
+++ b/documentation/src/main/asciidoc/mapping.asciidoc
@@ -145,7 +145,7 @@ you can specify a string which will be inserted as token for the null value. Per
 is set to `org.hibernate.search.annotations.Field.DO_NOT_INDEX_NULL` indicating that null values
 should not be indexed. You can set this value to `DEFAULT_NULL_TOKEN` to indicate that a default null
 token should be used. This default null token can be specified in the configuration using
-`hibernate.search.default_null_token`. If this property is not set the string "_null_" will
+`hibernate.search.default_null_token`. If this property is not set the string `\_null_` will
 be used as default.
 When the field is of a Numeric Type (see <<numeric-field-annotation>>), the token will be encoded as the
 respective numeric type: the `indexNullAs` value needs to be set to a value which can be parsed into
@@ -836,6 +836,24 @@ You can explicitly include the id of the embedded object using `includePath`, fo
 Having explicit control of the indexed paths might be easier if you're designing your application by
 defining the needed queries first, as at that point you might know exactly which fields you need,
 and which other fields are unnecessary to implement your use case.
+====
+
+
+===== Indexing null embeddeds
+Per default null values are ignored and not indexed. However, using `indexNullAs` you can specify that a field should be added when the embedded is null, with a value of your choice.
+
+Per default `indexNullAs` is set to `org.hibernate.search.annotations.IndexedEmbedded.DO_NOT_INDEX_NULL`, indicating that null values should not be indexed. You can set this value to `IndexedEmbedded.DEFAULT_NULL_TOKEN` to indicate that a default null token should be used. This default null token can be specified in the configuration using `hibernate.search.default_null_token`. If this property is not set the string `\_null_` will be used as default.
+
+The field name used when indexing null values depend on the `prefix`:
+
+ * if the `prefix` is not set, the field name will be the Java property name
+ * if the `prefix` is set, the field name will be the prefix with the trailing dot (if any) removed.
+   For instance with the prefix `my_embedded.`, the null field name will be `my_embedded` (without dot).
+
+[NOTE]
+====
+When `indexNullAs` is used, it is important to use the chosen null token in search queries (see
+<<search-query>>) in order to find null values.
 ====
 
 ==== Associated objects: building a dependency graph with @ContainedIn

--- a/engine/src/main/java/org/hibernate/search/annotations/IndexedEmbedded.java
+++ b/engine/src/main/java/org/hibernate/search/annotations/IndexedEmbedded.java
@@ -77,6 +77,12 @@ public @interface IndexedEmbedded {
 	Class<?> targetElement() default void.class;
 
 	/**
+	 * By default, null values are not indexed. Use {@link #indexNullAs()} if you want
+	 * null values to be indexed.
+	 * <p>If this property is set to something different from the default, null values
+	 * will be indexed in a field named after the {@link #prefix() prefix}, with the
+	 * trailing dot (if any) removed.
+	 *
 	 * @return Returns the value to be used for indexing {@code null}. Per default
 	 *         {@code IndexedEmbedded.DO_NOT_INDEX_NULL} is
 	 *         returned indicating that null values are not indexed.

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
@@ -1710,16 +1710,10 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 			return;
 		}
 
-		boolean elementCollection = isElementCollection( member );
-		if ( elementCollection ) {
-			// @IndexEmbedded used with @ElementCollection
-			logWarnings( member, indexedEmbeddedAnnotation );
-		}
-
 		parseContext.collectUnqualifiedCollectionRole( member.getName() );
 
 		int oldMaxLevel = parseContext.getMaxLevel();
-		int potentialLevel = elementCollection ? INFINITE_DEPTH : potentialLevel( parseContext, indexedEmbeddedAnnotation, member );
+		int potentialLevel = potentialLevel( parseContext, indexedEmbeddedAnnotation, member );
 		// HSEARCH-1442 recreating the behaviour prior to PropertiesMetadata refactoring
 		// not sure whether this is algorithmically correct though. @IndexedEmbedded processing should be refactored (HF)
 		if ( potentialLevel < oldMaxLevel ) {
@@ -1727,10 +1721,10 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 		}
 		parseContext.incrementLevel();
 
-		XClass elementClass = elementCollection ? returnedType( member ) : elementClass( member, indexedEmbeddedAnnotation );
-		String localPrefix = elementCollection ? defaultPrefix( member ) : buildEmbeddedPrefix( indexedEmbeddedAnnotation, member );
+		XClass elementClass = elementClass( member, indexedEmbeddedAnnotation );
+		String localPrefix = buildEmbeddedPrefix( indexedEmbeddedAnnotation, member );
 		String fullPrefix = prefix + localPrefix;
-		boolean includeEmbeddedObjectId = elementCollection ? false : indexedEmbeddedAnnotation.includeEmbeddedObjectId();
+		boolean includeEmbeddedObjectId = indexedEmbeddedAnnotation.includeEmbeddedObjectId();
 
 		if ( parseContext.getMaxLevel() == INFINITE_DEPTH
 				&& parseContext.hasBeenProcessed( elementClass ) ) {
@@ -1833,21 +1827,6 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 		}
 	}
 
-	private void logWarnings(XProperty member, IndexedEmbedded indexedEmbeddedAnnotation) {
-		if ( isDepthSet( indexedEmbeddedAnnotation ) ) {
-			log.indexEmbeddedValueIgnored( member.getName(), "depth" );
-		}
-		if ( void.class != indexedEmbeddedAnnotation.targetElement() ) {
-			log.indexEmbeddedValueIgnored( member.getName(), "targetElement" );
-		}
-		if ( !isDefaultPrefix( indexedEmbeddedAnnotation ) ) {
-			log.indexEmbeddedValueIgnored( member.getName(), "prefix" );
-		}
-		if ( indexedEmbeddedAnnotation.includeEmbeddedObjectId() ) {
-			log.indexEmbeddedValueIgnored( member.getName(), "includeEmbeddedObjectId" );
-		}
-	}
-
 	private int potentialLevel(ParseContext parseContext, IndexedEmbedded indexedEmbeddedAnnotation, XProperty member) {
 		int potentialLevel = depth( indexedEmbeddedAnnotation ) + parseContext.getLevel();
 		// This is really catching a possible int overflow. depth() can return Integer.MAX_VALUE, which then can
@@ -1869,18 +1848,6 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 
 	private XClass returnedType(XProperty member) {
 		return member.getElementClass();
-	}
-
-	private boolean isElementCollection(XProperty member) {
-		Annotation[] annotations = member.getAnnotations();
-		for ( Annotation annotation : annotations ) {
-			String type = annotation.annotationType().getName();
-			// Using String because the annotation class might not be on the classpath
-			if ( "javax.persistence.ElementCollection".equals( type ) ) {
-				return true;
-			}
-		}
-		return false;
 	}
 
 	private int depth(IndexedEmbedded embeddedAnn) {

--- a/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
@@ -970,10 +970,6 @@ public interface Log extends BasicLogger {
 	@Message(id = 315, value = "Lazy remote analyzer %1$s is not initialized.")
 	SearchException lazyRemoteAnalyzerNotInitialized(LazyRemoteAnalyzer analyzer);
 
-	@LogMessage(level = Level.WARN)
-	@Message(id = 316, value = "The value for @IndexEmbedded#%2$s() on the property `%1$s` is ignored when the annotation is used with @ElementCollection")
-	void indexEmbeddedValueIgnored(String propertyName, String indexEmbeddedAttribute);
-
 	@Message(id = 317, value = "Projection constant '%s' is not supported for this query.")
 	SearchException unexpectedProjectionConstant(String constantName);
 

--- a/orm/src/test/java/org/hibernate/search/test/bridge/ArrayBridgeTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/ArrayBridgeTest.java
@@ -13,7 +13,7 @@ import org.apache.lucene.document.DateTools;
 import org.apache.lucene.search.Query;
 import org.junit.Before;
 import org.junit.Test;
-
+import org.junit.experimental.categories.Category;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 
@@ -24,6 +24,7 @@ import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.query.dsl.TermMatchingContext;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.test.bridge.ArrayBridgeTestEntity.Language;
+import org.hibernate.search.testsupport.junit.ElasticsearchSupportInProgress;
 
 import static org.hibernate.search.test.bridge.ArrayBridgeTestEntity.Language.ENGLISH;
 import static org.hibernate.search.test.bridge.ArrayBridgeTestEntity.Language.ITALIAN;
@@ -93,6 +94,7 @@ public class ArrayBridgeTest extends SearchTestBase {
 	}
 
 	@Test
+	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2389 Support indexNullAs for @IndexedEmbedded applied on objects with Elasticsearch
 	public void testSearchNullEmbedded() throws Exception {
 		List<ArrayBridgeTestEntity> results = findEmbeddedNullResults( "nullIndexed", ArrayBridgeTestEntity.NULL_EMBEDDED, true );
 
@@ -102,9 +104,10 @@ public class ArrayBridgeTest extends SearchTestBase {
 	}
 
 	@Test
+	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2389 Support indexNullAs for @IndexedEmbedded applied on objects with Elasticsearch
 	public void testSearchNullNumericEmbedded() throws Exception {
 		List<ArrayBridgeTestEntity> results =
-				findEmbeddedNullResults( "numericNullIndexed", ArrayBridgeTestEntity.NULL_EMBEDDED_NUMERIC, true );
+				findEmbeddedNullResults( "embeddedNum", ArrayBridgeTestEntity.NULL_EMBEDDED_NUMERIC, true );
 
 		assertNotNull( "No result found for an indexed collection", results );
 		assertEquals( "Unexpected number of results in a collection", 1, results.size() );

--- a/orm/src/test/java/org/hibernate/search/test/bridge/ArrayBridgeTestEntity.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/ArrayBridgeTestEntity.java
@@ -76,6 +76,10 @@ public class ArrayBridgeTestEntity {
 
 	@Field(indexNullAs = NULL_TOKEN, analyze = Analyze.NO)
 	@ElementCollection
+	/*
+	 * This will only have an effect for null maps, since the type for the map values
+	 * does not contain any @Field annotation (which means there is nothing to embed).
+	 */
 	@IndexedEmbedded(indexNullAs = NULL_EMBEDDED)
 	@OrderColumn
 	@CollectionTable(name = "NullIndexed", joinColumns = @JoinColumn(name = "array_id"))
@@ -90,8 +94,11 @@ public class ArrayBridgeTestEntity {
 
 	@Field(store = Store.YES, indexNullAs = NULL_NUMERIC_TOKEN, analyze = Analyze.NO)
 	@ElementCollection
-	// The attribute prefix should be ignored; It does not make much sense in the context of a collection
-	@IndexedEmbedded(prefix = "embeddedNum", indexNullAs = NULL_EMBEDDED_NUMERIC)
+	/*
+	 * This will only have an effect for null maps, since the type for the map values
+	 * does not contain any @Field annotation (which means there is nothing to embed).
+	 */
+	@IndexedEmbedded(prefix = "embeddedNum.", indexNullAs = NULL_EMBEDDED_NUMERIC)
 	@OrderColumn
 	@CollectionTable(name = "NumericNullIndexed", joinColumns = @JoinColumn(name = "array_id"))
 	@Column(name = "numericNullIndexed")

--- a/orm/src/test/java/org/hibernate/search/test/bridge/IterableBridgeTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/IterableBridgeTest.java
@@ -21,8 +21,10 @@ import org.hibernate.search.bridge.util.impl.NumericFieldUtils;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.query.dsl.TermMatchingContext;
 import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.testsupport.junit.ElasticsearchSupportInProgress;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static org.hibernate.search.test.bridge.IterableBridgeTestEntity.Language.ENGLISH;
 import static org.hibernate.search.test.bridge.IterableBridgeTestEntity.Language.ITALIAN;
@@ -102,6 +104,7 @@ public class IterableBridgeTest extends SearchTestBase {
 	}
 
 	@Test
+	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2389 Support indexNullAs for @IndexedEmbedded applied on objects with Elasticsearch
 	public void testSearchNullEmbedded() throws Exception {
 		List<IterableBridgeTestEntity> results = findEmbeddedNullResults( "nullIndexed", IterableBridgeTestEntity.NULL_EMBEDDED, true );
 
@@ -111,9 +114,10 @@ public class IterableBridgeTest extends SearchTestBase {
 	}
 
 	@Test
+	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2389 Support indexNullAs for @IndexedEmbedded applied on objects with Elasticsearch
 	public void testSearchNullNumericEmbedded() throws Exception {
 		List<IterableBridgeTestEntity> results =
-				findEmbeddedNullResults( "numericNullIndexed", IterableBridgeTestEntity.NULL_EMBEDDED_NUMERIC, true );
+				findEmbeddedNullResults( "embeddedNum", IterableBridgeTestEntity.NULL_EMBEDDED_NUMERIC, true );
 
 		assertNotNull( "No result found for an indexed collection", results );
 		assertEquals( "Unexpected number of results in a collection", 1, results.size() );

--- a/orm/src/test/java/org/hibernate/search/test/bridge/IterableBridgeTestEntity.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/IterableBridgeTestEntity.java
@@ -77,6 +77,10 @@ public class IterableBridgeTestEntity {
 
 	@Field(indexNullAs = NULL_TOKEN, analyze = Analyze.NO)
 	@ElementCollection
+	/*
+	 * This will only have an effect for null maps, since the type for the map values
+	 * does not contain any @Field annotation (which means there is nothing to embed).
+	 */
 	@IndexedEmbedded(indexNullAs = NULL_EMBEDDED)
 	@CollectionTable(name = "NullIndexed", joinColumns = @JoinColumn(name = "iterable_id"))
 	@Column(name = "nullIndexed")
@@ -94,8 +98,11 @@ public class IterableBridgeTestEntity {
 
 	@Field(store = Store.YES, indexNullAs = NULL_NUMERIC_TOKEN, analyze = Analyze.NO)
 	@ElementCollection
-	// The attribute prefix should be ignored; It does not make much sense in the context of a collection
-	@IndexedEmbedded(prefix = "embeddedNum", indexNullAs = NULL_EMBEDDED_NUMERIC)
+	/*
+	 * This will only have an effect for null maps, since the type for the map values
+	 * does not contain any @Field annotation (which means there is nothing to embed).
+	 */
+	@IndexedEmbedded(prefix = "embeddedNum.", indexNullAs = NULL_EMBEDDED_NUMERIC)
 	@CollectionTable(name = "NumericNullIndexed", joinColumns = @JoinColumn(name = "iterable_id"))
 	@Column(name = "numericNullIndexed")
 	public Set<Integer> getNumericNullIndexed() {

--- a/orm/src/test/java/org/hibernate/search/test/bridge/MapBridgeTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/MapBridgeTest.java
@@ -21,8 +21,10 @@ import org.hibernate.search.bridge.util.impl.NumericFieldUtils;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.query.dsl.TermMatchingContext;
 import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.testsupport.junit.ElasticsearchSupportInProgress;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static org.hibernate.search.test.bridge.MapBridgeTestEntity.Language.ENGLISH;
 import static org.hibernate.search.test.bridge.MapBridgeTestEntity.Language.ITALIAN;
@@ -100,6 +102,7 @@ public class MapBridgeTest extends SearchTestBase {
 	}
 
 	@Test
+	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2389 Support indexNullAs for @IndexedEmbedded applied on objects with Elasticsearch
 	public void testSearchNullEmbedded() throws Exception {
 		List<MapBridgeTestEntity> results = findEmbeddedNullResults( "nullIndexed", MapBridgeTestEntity.NULL_EMBEDDED, true );
 
@@ -109,9 +112,10 @@ public class MapBridgeTest extends SearchTestBase {
 	}
 
 	@Test
+	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2389 Support indexNullAs for @IndexedEmbedded applied on objects with Elasticsearch
 	public void testSearchNullNumericEmbedded() throws Exception {
 		List<MapBridgeTestEntity> results =
-				findEmbeddedNullResults( "numericNullIndexed", MapBridgeTestEntity.NULL_EMBEDDED_NUMERIC, true );
+				findEmbeddedNullResults( "embeddedNum", MapBridgeTestEntity.NULL_EMBEDDED_NUMERIC, true );
 
 		assertNotNull( "No result found for an indexed collection", results );
 		assertEquals( "Unexpected number of results in a collection", 1, results.size() );

--- a/orm/src/test/java/org/hibernate/search/test/bridge/MapBridgeTestEntity.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/MapBridgeTestEntity.java
@@ -76,6 +76,10 @@ public class MapBridgeTestEntity {
 
 	@Field(indexNullAs = NULL_TOKEN, analyze = Analyze.NO)
 	@ElementCollection
+	/*
+	 * This will only have an effect for null maps, since the type for the map values
+	 * does not contain any @Field annotation (which means there is nothing to embed).
+	 */
 	@IndexedEmbedded(indexNullAs = NULL_EMBEDDED)
 	@CollectionTable(name = "NullIndexed", joinColumns = @JoinColumn(name = "iterable_id"))
 	@Column(name = "nullIndexed")
@@ -94,8 +98,11 @@ public class MapBridgeTestEntity {
 
 	@Field(store = Store.YES, indexNullAs = NULL_NUMERIC_TOKEN, analyze = Analyze.NO)
 	@ElementCollection
-	// The attribute prefix should be ignored; It does not make much sense in the context of a collection
-	@IndexedEmbedded(prefix = "embeddedNum", indexNullAs = NULL_EMBEDDED_NUMERIC)
+	/*
+	 * This will only have an effect for null maps, since the type for the map values
+	 * does not contain any @Field annotation (which means there is nothing to embed).
+	 */
+	@IndexedEmbedded(prefix = "embeddedNum.", indexNullAs = NULL_EMBEDDED_NUMERIC)
 	@CollectionTable(name = "NumericNullIndexed", joinColumns = @JoinColumn(name = "iterable_id"))
 	@Column(name = "numericNullIndexed")
 	@MapKeyColumn(nullable = false)

--- a/orm/src/test/java/org/hibernate/search/test/embedded/Address.java
+++ b/orm/src/test/java/org/hibernate/search/test/embedded/Address.java
@@ -29,6 +29,7 @@ import org.hibernate.search.annotations.IndexedEmbedded;
 @Entity
 @Indexed
 public class Address {
+
 	@Id
 	@GeneratedValue
 	private Long id;
@@ -41,7 +42,7 @@ public class Address {
 	private Person ownedBy;
 
 	@ElementCollection
-	@IndexedEmbedded
+	@IndexedEmbedded( prefix = "inhabitants." )
 	private Set<Resident> residents = new HashSet<Resident>();
 
 	@OneToMany(mappedBy = "address")

--- a/orm/src/test/java/org/hibernate/search/test/embedded/EmbeddedTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/embedded/EmbeddedTest.java
@@ -161,7 +161,7 @@ public class EmbeddedTest extends SearchTestBase {
 		Query query;
 		List<?> result;
 
-		query = parser.parse( "address.residents.name:Smith" );
+		query = parser.parse( "address.inhabitants.name:Smith" );
 		result = session.createFullTextQuery( query ).list();
 		assertEquals( "unable to find property in embedded @ElementCollection", 1, result.size() );
 		s.close();

--- a/orm/src/test/java/org/hibernate/search/test/embedded/nullindexed/Pet.java
+++ b/orm/src/test/java/org/hibernate/search/test/embedded/nullindexed/Pet.java
@@ -10,6 +10,7 @@ package org.hibernate.search.test.embedded.nullindexed;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
@@ -34,8 +35,12 @@ public class Pet {
 	private String name;
 
 	@OneToMany
-	@IndexedEmbedded ( indexNullAs = IndexedEmbedded.DEFAULT_NULL_TOKEN )
+	@IndexedEmbedded( prefix = "pups.", indexNullAs = IndexedEmbedded.DEFAULT_NULL_TOKEN )
 	private List<Puppy> puppies = new ArrayList<Puppy>();
+
+	@ElementCollection
+	@IndexedEmbedded( prefix = "tricks_", indexNullAs = IndexedEmbedded.DEFAULT_NULL_TOKEN )
+	private List<Trick> tricks = new ArrayList<Trick>();
 
 	public Pet() {
 	}
@@ -70,6 +75,19 @@ public class Pet {
 
 	public Pet addPuppy(Puppy puppy) {
 		this.puppies.add( puppy );
+		return this;
+	}
+
+	public List<Trick> getTricks() {
+		return tricks;
+	}
+
+	public void setTricks(List<Trick> tricks) {
+		this.tricks = tricks;
+	}
+
+	public Pet addTrick(Trick trick) {
+		this.tricks.add( trick );
 		return this;
 	}
 

--- a/orm/src/test/java/org/hibernate/search/test/embedded/nullindexed/Trick.java
+++ b/orm/src/test/java/org/hibernate/search/test/embedded/nullindexed/Trick.java
@@ -1,0 +1,50 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+package org.hibernate.search.test.embedded.nullindexed;
+
+import javax.persistence.Embeddable;
+
+import org.hibernate.search.annotations.Field;
+
+/**
+ * @author Yoann Rodiere
+ */
+@Embeddable
+public class Trick {
+
+	@Field
+	private String name;
+
+	@Field
+	private String reward;
+
+	public Trick() {
+	}
+
+	public Trick(String name, String reward) {
+		this.name = name;
+		this.reward = reward;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getReward() {
+		return reward;
+	}
+
+	public void setReward(String reward) {
+		this.reward = reward;
+	}
+
+}


### PR DESCRIPTION
This PR is based on HSEARCH-2397, we'll have to review and merge the PR ( #1188) first.

Related JIRA ticket: https://hibernate.atlassian.net/browse/HSEARCH-2408

There are details on what's being done in the commit comments.
