### PR TITLE
HSEARCH-2393 Remove dependency to Lucene in tests for features common to Lucene and Elasticsearch

### DIFF
--- a/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
+++ b/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
@@ -531,6 +531,7 @@ Please check with JIRA and the mailing lists for updates, but at the time of wri
 * MoreLikeThis queries: https://hibernate.atlassian.net/browse/HSEARCH-2395[HSEARCH-2395]
 * `@IndexedEmbedded.indexNullAs`: https://hibernate.atlassian.net/browse/HSEARCH-2389[HSEARCH-2389]
 * <<search-monitoring,Statistics>>: https://hibernate.atlassian.net/browse/HSEARCH-2421[HSEARCH-2421]
+* `@AnalyzerDiscriminator`: https://hibernate.atlassian.net/browse/HSEARCH-2428[HSEARCH-2428]
 * Mixing Lucene based indexes and Elasticsearch based indexes (partial support is here though)
 * Hibernate Search does not make use of nested objects nor parent child relationship mapping https://hibernate.atlassian.net/browse/HSEARCH-2263[HSEARCH-2263].
   This is largely mitigated by the fact that Hibernate Search does the denormalization itself and maintain data consistency when nested objects are updated.

--- a/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
+++ b/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
@@ -173,6 +173,10 @@ In order for your value to be understood by Hibernate Search (and Elasticsearch)
  * For booleans, use either `true` or `false`.
  * For dates, use the ISO-8601 format (`yyyy-MM-dd'T'HH:mm:ssZ`, for instance `2016-08-26T16:41:00+01:00`). The time and time zone may be omitted (if omitted, the time zone will be interpreted as the default JVM time zone).
 
+===== Dynamic boosting
+
+The `org.hibernate.search.annotations.DynamicBoost` annotation is not (and cannot be) supported with Elasticsearch, because the platform lacks per-document, index-time boosting capabilities. Static boosts (`@Boost`) are, however, supported.
+
 ==== [[elasticsearch-mapping-analyzer]] Analyzers
 
 WARNING: Analyzers are treated differently than in Lucene embedded mode.

--- a/elasticsearch/elasticsearchconfiguration/elasticsearch.yml
+++ b/elasticsearch/elasticsearchconfiguration/elasticsearch.yml
@@ -72,6 +72,26 @@ index.analysis:
       tokenizer: standard
       filter: [lowercase]
       char_filter: htmlStrip
+    org_hibernate_search_test_configuration_BlogEntry_en:
+      type: custom
+      tokenizer: standard
+      filter: [lowercase, snowballEnglish]
+    org_hibernate_search_test_configuration_BlogEntry_de:
+      type: custom
+      tokenizer: standard
+      filter: [lowercase, stemGerman]
+    org_hibernate_search_test_configuration_ProgrammaticSearchMappingFactory_ngram:
+      type: custom
+      tokenizer: standard
+      filter: [lowercase, ngram3]
+    org_hibernate_search_test_configuration_ProgrammaticSearchMappingFactory_english:
+      type: custom
+      tokenizer: standard
+      filter: [lowercase, snowballEnglish]
+    org_hibernate_search_test_configuration_ProgrammaticSearchMappingFactory_deutsch:
+      type: custom
+      tokenizer: standard
+      filter: [lowercase, stemGerman]
   filter:
     custom-filter:
       type : stop
@@ -87,6 +107,9 @@ index.analysis:
     snowballEnglish:
       type: snowball
       language: 'English'
+    stemGerman:
+      type : stemmer
+      name : 'german'
   char_filter:
     htmlStrip:
       type: html_strip

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -234,8 +234,6 @@
                                 
                                 <!-- HSEARCH-2393 Remove depencies to Lucene in tests for features common to Lucene and Elasticsearch -->
                                 <exclude>**/ProgrammaticMappingTest.java</exclude><!-- Analyzers -->
-                                <exclude>**/IndexAndQueryNullTest.java</exclude><!-- Projection constant __HSearch_Document -->
-                                <exclude>**/ProgrammaticIndexAndQueryNullTest.java</exclude><!-- Projection constant __HSearch_Document -->
                                 <exclude>**/ProjectionQueryTest.java</exclude><!-- Projection constant __HSearch_Document -->
                                 <exclude>**/SortUsingEntityManagerTest.java</exclude><!-- Sort type LONG instead of STRING? -->
                                 <exclude>**/LazyCollectionsUpdatingTest.java</exclude><!-- Use of TermQuery? -->

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -234,7 +234,6 @@
                                 
                                 <!-- HSEARCH-2393 Remove depencies to Lucene in tests for features common to Lucene and Elasticsearch -->
                                 <exclude>**/ProgrammaticMappingTest.java</exclude><!-- Analyzers -->
-                                <exclude>**/TransactionTest.java</exclude><!-- Directory -->
                                 <exclude>**/IndexingActionInterceptorTest.java</exclude><!-- Queries on the object's class -->
                                 <exclude>**/ToStringTest.java</exclude><!-- Relies on the lucene query's toString(), should be the HSQuery's getQueryString? -->
                                 <exclude>**/DynamicBoostingTest.java</exclude><!-- Projection constant __HSearch_Explanation -->

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -234,7 +234,6 @@
                                 
                                 <!-- HSEARCH-2393 Remove depencies to Lucene in tests for features common to Lucene and Elasticsearch -->
                                 <exclude>**/ProgrammaticMappingTest.java</exclude><!-- Analyzers -->
-                                <exclude>**/SortUsingEntityManagerTest.java</exclude><!-- Sort type LONG instead of STRING? -->
                                 <exclude>**/LazyCollectionsUpdatingTest.java</exclude><!-- Use of TermQuery? -->
                                 <exclude>**/LuceneErrorHandlingTest.java</exclude><!-- LuceneErrorHandlingTest$NoOpLuceneWorkDelegate cannot be cast ... -->
                                 <exclude>**/SyncWorkerTest.java</exclude><!-- Use of QueryParser? -->

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -234,7 +234,6 @@
                                 
                                 <!-- HSEARCH-2393 Remove depencies to Lucene in tests for features common to Lucene and Elasticsearch -->
                                 <exclude>**/ProgrammaticMappingTest.java</exclude><!-- Analyzers -->
-                                <exclude>**/LazyCollectionsUpdatingTest.java</exclude><!-- Use of TermQuery? -->
                                 <exclude>**/LuceneErrorHandlingTest.java</exclude><!-- LuceneErrorHandlingTest$NoOpLuceneWorkDelegate cannot be cast ... -->
                                 <exclude>**/SyncWorkerTest.java</exclude><!-- Use of QueryParser? -->
                                 <exclude>**/WorkerTestCase.java</exclude><!-- Use of QueryParser? -->

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -234,7 +234,6 @@
                                 
                                 <!-- HSEARCH-2393 Remove depencies to Lucene in tests for features common to Lucene and Elasticsearch -->
                                 <exclude>**/ProgrammaticMappingTest.java</exclude><!-- Analyzers -->
-                                <exclude>**/IndexingActionInterceptorTest.java</exclude><!-- Queries on the object's class -->
                                 <exclude>**/ToStringTest.java</exclude><!-- Relies on the lucene query's toString(), should be the HSQuery's getQueryString? -->
                                 <exclude>**/DynamicBoostingTest.java</exclude><!-- Projection constant __HSearch_Explanation -->
                                 <exclude>**/IndexAndQueryNullTest.java</exclude><!-- Projection constant __HSearch_Document -->

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -235,7 +235,6 @@
                                 <!-- HSEARCH-2393 Remove depencies to Lucene in tests for features common to Lucene and Elasticsearch -->
                                 <exclude>**/ProgrammaticMappingTest.java</exclude><!-- Analyzers -->
                                 <exclude>**/LuceneErrorHandlingTest.java</exclude><!-- LuceneErrorHandlingTest$NoOpLuceneWorkDelegate cannot be cast ... -->
-                                <exclude>**/NumericFieldTest.java</exclude><!-- Missing field metadata (should use MetadataProvidingFieldBridge) -->
                                 <exclude>**/SortOnFieldsFromCustomBridgeTest.java</exclude><!-- Missing field metadata (should use MetadataProvidingFieldBridge) -->
                                 <exclude>**/DirectoryProviderForQueryTest.java</exclude><!-- Full text filters must implement ElasticsearchFilter -->
                                 

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -233,7 +233,6 @@
                                 <exclude>**/BridgeProviderTest.java</exclude>
                                 
                                 <!-- HSEARCH-2393 Remove depencies to Lucene in tests for features common to Lucene and Elasticsearch -->
-                                <exclude>**/ClassBridgeTest.java</exclude><!-- QueryParser -->
                                 <exclude>**/ProgrammaticMappingTest.java</exclude><!-- Analyzers -->
                                 <exclude>**/WorkDoneOnEntitiesTest.java</exclude><!-- IndexReader -->
                                 <exclude>**/DeleteByTermTest.java</exclude><!-- WorkspaceHolder -->

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -234,7 +234,6 @@
                                 
                                 <!-- HSEARCH-2393 Remove depencies to Lucene in tests for features common to Lucene and Elasticsearch -->
                                 <exclude>**/ProgrammaticMappingTest.java</exclude><!-- Analyzers -->
-                                <exclude>**/DeleteByTermTest.java</exclude><!-- WorkspaceHolder -->
                                 <exclude>**/UpdateOperationsTest.java</exclude><!-- LeakingOptimizer -->
                                 <exclude>**/TransactionTest.java</exclude><!-- Directory -->
                                 <exclude>**/IndexingActionInterceptorTest.java</exclude><!-- Queries on the object's class -->

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -235,7 +235,6 @@
                                 <!-- HSEARCH-2393 Remove depencies to Lucene in tests for features common to Lucene and Elasticsearch -->
                                 <exclude>**/ProgrammaticMappingTest.java</exclude><!-- Analyzers -->
                                 <exclude>**/LuceneErrorHandlingTest.java</exclude><!-- LuceneErrorHandlingTest$NoOpLuceneWorkDelegate cannot be cast ... -->
-                                <exclude>**/DirectoryProviderForQueryTest.java</exclude><!-- Full text filters must implement ElasticsearchFilter -->
                                 
                                 <!-- HSEARCH-2395 Support MoreLikeThisQueries with the Elasticsearch backend -->
                                 <exclude>**/MoreLikeThisTest.java</exclude>
@@ -254,6 +253,12 @@
                                 
                                 <!-- HSEARCH-2400 Support IndexingMonitor for the Elasticsearch backend -->
                                 <exclude>**/ProgressMonitorTest.java</exclude>
+                                
+                                <!-- HSEARCH-2426 Remote analyzer initialization fails when using dynamic sharding on Elasticsearch -->
+                                <exclude>**/DirectoryProviderForQueryTest.java</exclude>
+                                <exclude>**/CustomerShardingStrategyTest.java</exclude>
+                                <exclude>**/DynamicShardingTest.java</exclude>
+                                <exclude>**/IdShardingStrategyTest.java</exclude>
                                 
                                 <!-- HSEARCH-2404 Enable CollectionUpdateEventTest for Elasticsearch -->
                                 <exclude>**/CollectionUpdateEventTest.java</exclude><!-- Only fails on CI (Travis) -->

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -239,7 +239,6 @@
                                 <exclude>**/UpdateOperationsTest.java</exclude><!-- LeakingOptimizer -->
                                 <exclude>**/TransactionTest.java</exclude><!-- Directory -->
                                 <exclude>**/IndexingActionInterceptorTest.java</exclude><!-- Queries on the object's class -->
-                                <exclude>**/IndexControlMBeanTest.java</exclude><!-- IndexReader -->
                                 <exclude>**/ToStringTest.java</exclude><!-- Relies on the lucene query's toString(), should be the HSQuery's getQueryString? -->
                                 <exclude>**/DynamicBoostingTest.java</exclude><!-- Projection constant __HSearch_Explanation -->
                                 <exclude>**/IndexAndQueryNullTest.java</exclude><!-- Projection constant __HSearch_Document -->

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -234,7 +234,6 @@
                                 
                                 <!-- HSEARCH-2393 Remove depencies to Lucene in tests for features common to Lucene and Elasticsearch -->
                                 <exclude>**/ProgrammaticMappingTest.java</exclude><!-- Analyzers -->
-                                <exclude>**/ProjectionQueryTest.java</exclude><!-- Projection constant __HSearch_Document -->
                                 <exclude>**/SortUsingEntityManagerTest.java</exclude><!-- Sort type LONG instead of STRING? -->
                                 <exclude>**/LazyCollectionsUpdatingTest.java</exclude><!-- Use of TermQuery? -->
                                 <exclude>**/LuceneErrorHandlingTest.java</exclude><!-- LuceneErrorHandlingTest$NoOpLuceneWorkDelegate cannot be cast ... -->

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -235,7 +235,6 @@
                                 <!-- HSEARCH-2393 Remove depencies to Lucene in tests for features common to Lucene and Elasticsearch -->
                                 <exclude>**/ProgrammaticMappingTest.java</exclude><!-- Analyzers -->
                                 <exclude>**/LuceneErrorHandlingTest.java</exclude><!-- LuceneErrorHandlingTest$NoOpLuceneWorkDelegate cannot be cast ... -->
-                                <exclude>**/SortOnFieldsFromCustomBridgeTest.java</exclude><!-- Missing field metadata (should use MetadataProvidingFieldBridge) -->
                                 <exclude>**/DirectoryProviderForQueryTest.java</exclude><!-- Full text filters must implement ElasticsearchFilter -->
                                 
                                 <!-- HSEARCH-2395 Support MoreLikeThisQueries with the Elasticsearch backend -->

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -234,7 +234,6 @@
                                 
                                 <!-- HSEARCH-2393 Remove depencies to Lucene in tests for features common to Lucene and Elasticsearch -->
                                 <exclude>**/ProgrammaticMappingTest.java</exclude><!-- Analyzers -->
-                                <exclude>**/ToStringTest.java</exclude><!-- Relies on the lucene query's toString(), should be the HSQuery's getQueryString? -->
                                 <exclude>**/IndexAndQueryNullTest.java</exclude><!-- Projection constant __HSearch_Document -->
                                 <exclude>**/ProgrammaticIndexAndQueryNullTest.java</exclude><!-- Projection constant __HSearch_Document -->
                                 <exclude>**/ProjectionQueryTest.java</exclude><!-- Projection constant __HSearch_Document -->

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -234,7 +234,6 @@
                                 
                                 <!-- HSEARCH-2393 Remove depencies to Lucene in tests for features common to Lucene and Elasticsearch -->
                                 <exclude>**/ProgrammaticMappingTest.java</exclude><!-- Analyzers -->
-                                <exclude>**/WorkDoneOnEntitiesTest.java</exclude><!-- IndexReader -->
                                 <exclude>**/DeleteByTermTest.java</exclude><!-- WorkspaceHolder -->
                                 <exclude>**/UpdateOperationsTest.java</exclude><!-- LeakingOptimizer -->
                                 <exclude>**/TransactionTest.java</exclude><!-- Directory -->

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -232,9 +232,6 @@
                                 <!-- HSEARCH-2392 Enable BridgeProviderTest for Elasticsearch -->
                                 <exclude>**/BridgeProviderTest.java</exclude>
                                 
-                                <!-- HSEARCH-2393 Remove depencies to Lucene in tests for features common to Lucene and Elasticsearch -->
-                                <exclude>**/ProgrammaticMappingTest.java</exclude><!-- Analyzers -->
-                                
                                 <!-- HSEARCH-2395 Support MoreLikeThisQueries with the Elasticsearch backend -->
                                 <exclude>**/MoreLikeThisTest.java</exclude>
                                 

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -235,7 +235,6 @@
                                 <!-- HSEARCH-2393 Remove depencies to Lucene in tests for features common to Lucene and Elasticsearch -->
                                 <exclude>**/ProgrammaticMappingTest.java</exclude><!-- Analyzers -->
                                 <exclude>**/ToStringTest.java</exclude><!-- Relies on the lucene query's toString(), should be the HSQuery's getQueryString? -->
-                                <exclude>**/DynamicBoostingTest.java</exclude><!-- Projection constant __HSearch_Explanation -->
                                 <exclude>**/IndexAndQueryNullTest.java</exclude><!-- Projection constant __HSearch_Document -->
                                 <exclude>**/ProgrammaticIndexAndQueryNullTest.java</exclude><!-- Projection constant __HSearch_Document -->
                                 <exclude>**/ProjectionQueryTest.java</exclude><!-- Projection constant __HSearch_Document -->

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -234,7 +234,6 @@
                                 
                                 <!-- HSEARCH-2393 Remove depencies to Lucene in tests for features common to Lucene and Elasticsearch -->
                                 <exclude>**/ProgrammaticMappingTest.java</exclude><!-- Analyzers -->
-                                <exclude>**/UpdateOperationsTest.java</exclude><!-- LeakingOptimizer -->
                                 <exclude>**/TransactionTest.java</exclude><!-- Directory -->
                                 <exclude>**/IndexingActionInterceptorTest.java</exclude><!-- Queries on the object's class -->
                                 <exclude>**/ToStringTest.java</exclude><!-- Relies on the lucene query's toString(), should be the HSQuery's getQueryString? -->

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -235,8 +235,6 @@
                                 <!-- HSEARCH-2393 Remove depencies to Lucene in tests for features common to Lucene and Elasticsearch -->
                                 <exclude>**/ProgrammaticMappingTest.java</exclude><!-- Analyzers -->
                                 <exclude>**/LuceneErrorHandlingTest.java</exclude><!-- LuceneErrorHandlingTest$NoOpLuceneWorkDelegate cannot be cast ... -->
-                                <exclude>**/SyncWorkerTest.java</exclude><!-- Use of QueryParser? -->
-                                <exclude>**/WorkerTestCase.java</exclude><!-- Use of QueryParser? -->
                                 <exclude>**/NumericFieldTest.java</exclude><!-- Missing field metadata (should use MetadataProvidingFieldBridge) -->
                                 <exclude>**/SortOnFieldsFromCustomBridgeTest.java</exclude><!-- Missing field metadata (should use MetadataProvidingFieldBridge) -->
                                 <exclude>**/DirectoryProviderForQueryTest.java</exclude><!-- Full text filters must implement ElasticsearchFilter -->

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -234,7 +234,6 @@
                                 
                                 <!-- HSEARCH-2393 Remove depencies to Lucene in tests for features common to Lucene and Elasticsearch -->
                                 <exclude>**/ProgrammaticMappingTest.java</exclude><!-- Analyzers -->
-                                <exclude>**/LuceneErrorHandlingTest.java</exclude><!-- LuceneErrorHandlingTest$NoOpLuceneWorkDelegate cannot be cast ... -->
                                 
                                 <!-- HSEARCH-2395 Support MoreLikeThisQueries with the Elasticsearch backend -->
                                 <exclude>**/MoreLikeThisTest.java</exclude>

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ToElasticsearch.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ToElasticsearch.java
@@ -572,6 +572,9 @@ public class ToElasticsearch {
 		else if ( luceneFilter instanceof CachingWrapperFilter ) {
 			return fromLuceneFilter( ( (CachingWrapperFilter) luceneFilter ).getCachedFilter() );
 		}
+		else if ( luceneFilter instanceof org.apache.lucene.search.CachingWrapperFilter ) {
+			return fromLuceneFilter( ( (org.apache.lucene.search.CachingWrapperFilter) luceneFilter ).getFilter() );
+		}
 		throw LOG.cannotTransformLuceneFilterIntoEsQuery( luceneFilter );
 	}
 

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
@@ -183,4 +183,10 @@ public interface Log extends org.hibernate.search.util.logging.impl.Log {
 	)
 	SearchException backtrackingWindowOverflow(int backtrackingLimit, int windowStartIndex, int requestedIndex);
 
+	@LogMessage(level = Level.WARN)
+	@Message(id = ES_BACKEND_MESSAGES_START_ID + 32,
+			value = "@DynamicBoost is not supported with Elasticsearch. Ignoring boost strategy '%1$s' for entity '%2$s' (field path '%3$s')."
+	)
+	void unsupportedDynamicBoost(Class<?> boostStrategyType, Class<?> entityType, String fieldPath);
+
 }

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIndexNullAsTypeCheckingIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIndexNullAsTypeCheckingIT.java
@@ -6,10 +6,7 @@
  */
 package org.hibernate.search.elasticsearch.test;
 
-import java.util.Collections;
 import java.util.Date;
-import java.util.Map;
-import java.util.Set;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -17,118 +14,62 @@ import javax.persistence.Id;
 import org.hibernate.search.annotations.DocumentId;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
-import org.hibernate.search.elasticsearch.cfg.ElasticsearchEnvironment;
-import org.hibernate.search.elasticsearch.cfg.IndexSchemaManagementStrategy;
 import org.hibernate.search.elasticsearch.impl.ElasticsearchIndexManager;
 import org.hibernate.search.exception.SearchException;
-import org.hibernate.search.test.DefaultTestResourceManager;
-import org.hibernate.search.test.util.TestConfiguration;
+import org.hibernate.search.test.SearchInitializationTestBase;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
 
 /**
- * Unit tests for {@link ElasticsearchIndexManager}'s indexNullAs type checking.
+ * Tests for {@link ElasticsearchIndexManager}'s indexNullAs type checking.
  *
  * @author Yoann Rodiere
  */
-@RunWith(Suite.class)
-@SuiteClasses(value = {
-		ElasticsearchIndexNullAsTypeCheckingIT.BooleanFailureTest.class,
-		ElasticsearchIndexNullAsTypeCheckingIT.DateFailureTest.class
-})
-public class ElasticsearchIndexNullAsTypeCheckingIT {
+public class ElasticsearchIndexNullAsTypeCheckingIT extends SearchInitializationTestBase {
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
 
-	protected abstract static class AbstractIndexNullAsFailureTest implements TestConfiguration {
-		@Rule
-		public ExpectedException thrown = ExpectedException.none();
+	@Test
+	public void indexNullAs_invalid_boolean() {
+		thrown.expect( SearchException.class );
+		thrown.expectMessage( "HSEARCH400027" );
+		thrown.expectMessage( "Boolean" );
+		thrown.expectMessage( "myField" );
 
-		private DefaultTestResourceManager testResourceManager;
-
-		protected void init() {
-			getTestResourceManager().openSessionFactory();
-		}
-
-		// synchronized due to lazy initialization (source: SearchTestBase.java)
-		private synchronized DefaultTestResourceManager getTestResourceManager() {
-			if ( testResourceManager == null ) {
-				testResourceManager = new DefaultTestResourceManager( this, this.getClass() );
-			}
-			return testResourceManager;
-		}
-
-		@Override
-		public void configure(Map<String, Object> settings) {
-			settings.put(
-					ElasticsearchEnvironment.INDEX_SCHEMA_MANAGEMENT_STRATEGY,
-					IndexSchemaManagementStrategy.RECREATE
-					);
-		}
-
-		@Override
-		public Set<String> multiTenantIds() {
-			// Empty by default; specify more than one tenant to enable multi-tenancy
-			return Collections.emptySet();
-		}
+		init( BooleanFailureTestEntity.class );
 	}
 
-	public static class BooleanFailureTest extends AbstractIndexNullAsFailureTest {
-		@Test
-		public void indexNullAs_invalid_boolean() {
-			thrown.expect( SearchException.class );
-			thrown.expectMessage( "HSEARCH400027" );
-			thrown.expectMessage( "Boolean" );
-			thrown.expectMessage( "myField" );
+	@Indexed
+	@Entity
+	public static class BooleanFailureTestEntity {
+		@DocumentId
+		@Id
+		Long id;
 
-			init();
-		}
-
-		@Override
-		public Class<?>[] getAnnotatedClasses() {
-			return new Class[] { BooleanFailureTestEntity.class };
-		}
-
-		@Indexed
-		@Entity
-		public static class BooleanFailureTestEntity {
-			@DocumentId
-			@Id
-			Long id;
-
-			@Field(indexNullAs = "foo")
-			boolean myField;
-		}
+		@Field(indexNullAs = "foo")
+		boolean myField;
 	}
 
-	public static class DateFailureTest extends AbstractIndexNullAsFailureTest {
-		@Test
-		public void indexNullAs_invalid_boolean() {
-			thrown.expect( SearchException.class );
-			thrown.expectMessage( "HSEARCH400028" );
-			thrown.expectMessage( "Date" );
-			thrown.expectMessage( "myField" );
+	@Test
+	public void indexNullAs_invalid_date() {
+		thrown.expect( SearchException.class );
+		thrown.expectMessage( "HSEARCH400028" );
+		thrown.expectMessage( "Date" );
+		thrown.expectMessage( "myField" );
 
-			init();
-		}
+		init( DateFailureTestEntity.class );
+	}
 
-		@Override
-		public Class<?>[] getAnnotatedClasses() {
-			return new Class[] { DateFailureTestEntity.class };
-		}
+	@Indexed
+	@Entity
+	public static class DateFailureTestEntity {
+		@DocumentId
+		@Id
+		Long id;
 
-		@Indexed
-		@Entity
-		public static class DateFailureTestEntity {
-			@DocumentId
-			@Id
-			Long id;
-
-			@Field(indexNullAs = "01/01/2013") // Expected format is ISO-8601 (yyyy-MM-dd'T'HH:mm:ssZ)
-			Date myField;
-		}
+		@Field(indexNullAs = "01/01/2013") // Expected format is ISO-8601 (yyyy-MM-dd'T'HH:mm:ssZ)
+		Date myField;
 	}
 
 }

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchUnsupportedFeaturesIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchUnsupportedFeaturesIT.java
@@ -1,0 +1,82 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.test;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import org.hibernate.search.annotations.DynamicBoost;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.engine.BoostStrategy;
+import org.hibernate.search.test.SearchInitializationTestBase;
+import org.hibernate.search.test.util.impl.ExpectedLog4jLog;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Test that users attempting to use unsupported features are duly warned.
+ *
+ * @author Yoann Rodiere
+ */
+public class ElasticsearchUnsupportedFeaturesIT extends SearchInitializationTestBase {
+
+	@Rule
+	public ExpectedLog4jLog logged = ExpectedLog4jLog.create();
+
+	@Test
+	public void dynamicBoosting() throws Exception {
+		logged.expectMessage( "HSEARCH400032", "@DynamicBoost", DynamicBoostingEntity.class.getSimpleName() );
+
+		init( DynamicBoostingEntity.class );
+	}
+
+	@Indexed
+	@Entity
+	@DynamicBoost(impl = CustomBoostStrategy.class)
+	public static class DynamicBoostingEntity {
+		@Id
+		@GeneratedValue
+		private Integer id;
+
+		private Float boost;
+
+		@Field
+		private String data;
+
+		public Integer getId() {
+			return id;
+		}
+
+		public Float getBoost() {
+			return boost;
+		}
+
+		public void setBoost(Float boost) {
+			this.boost = boost;
+		}
+
+		public String getData() {
+			return data;
+		}
+
+		public void setData(String data) {
+			this.data = data;
+		}
+
+	}
+
+	public static class CustomBoostStrategy implements BoostStrategy {
+		@Override
+		public float defineBoost(Object value) {
+			DynamicBoostingEntity entity = (DynamicBoostingEntity) value;
+			return entity.getBoost();
+		}
+	}
+
+}

--- a/engine/src/test/java/org/hibernate/search/test/util/impl/ExpectedLog4jLog.java
+++ b/engine/src/test/java/org/hibernate/search/test/util/impl/ExpectedLog4jLog.java
@@ -1,0 +1,168 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.util.impl;
+
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.Logger;
+import org.apache.log4j.spi.LoggingEvent;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.StringDescription;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.rules.TestRule;
+import org.junit.runners.model.Statement;
+
+/**
+ * @author Yoann Rodiere
+ */
+public class ExpectedLog4jLog implements TestRule {
+
+	/**
+	 * Returns a {@linkplain TestRule rule} that does not mandate any particular log to be produced (identical to
+	 * behavior without this rule).
+	 */
+	public static ExpectedLog4jLog create() {
+		return new ExpectedLog4jLog();
+	}
+
+	private List<Matcher<?>> expectations = new ArrayList<>();
+
+	private ExpectedLog4jLog() {
+	}
+
+	@Override
+	public Statement apply(Statement base, org.junit.runner.Description description) {
+		return new ExpectedLogStatement( base );
+	}
+
+	/**
+	 * Verify that your code produces a log event matching the given matcher.
+	 */
+	public void expectEvent(Matcher<? extends LoggingEvent> matcher) {
+		expectations.add( matcher );
+	}
+
+	/**
+	 * Verify that your code produces a log message containing the given string.
+	 */
+	public void expectMessage(String containedString) {
+		expectMessage( CoreMatchers.containsString( containedString ) );
+	}
+
+	/**
+	 * Verify that your code produces a log message containing all of the given string.
+	 */
+	public void expectMessage(String containedString, String... otherContainedStrings) {
+		Collection<Matcher<? super String>> matchers = new ArrayList<>();
+		matchers.add( CoreMatchers.containsString( containedString ) );
+		for ( String otherContainedString : otherContainedStrings ) {
+			matchers.add( CoreMatchers.containsString( otherContainedString ) );
+		}
+		expectMessage( CoreMatchers.<String>allOf( matchers ) );
+	}
+
+	/**
+	 * Verify that your code produces a log message matches the given Hamcrest matcher.
+	 *
+	 * @return An expectation setter, for specifying the number of expected matching events (if different from one).
+	 */
+	public void expectMessage(Matcher<String> matcher) {
+		expectEvent( eventMessageMatcher( matcher ) );
+	}
+
+	private Matcher<LoggingEvent> eventMessageMatcher(final Matcher<String> messageMatcher) {
+		return new TypeSafeMatcher<LoggingEvent>() {
+
+			@Override
+			public void describeTo(Description description) {
+				description.appendText( "a LoggingEvent with message matching " );
+				messageMatcher.describeTo( description );
+			}
+
+			@Override
+			protected boolean matchesSafely(LoggingEvent item) {
+				return messageMatcher.matches( item.getMessage() );
+			}
+		};
+	}
+
+	private class TestAppender extends AppenderSkeleton {
+		private final Set<Matcher<?>> expectationsMet = new HashSet<>();
+
+		@Override
+		public void close() {
+		}
+
+		@Override
+		public boolean requiresLayout() {
+			return false;
+		}
+
+		@Override
+		protected void append(LoggingEvent event) {
+			for ( Matcher<?> expectation : ExpectedLog4jLog.this.expectations ) {
+				if ( !expectationsMet.contains( expectation ) && expectation.matches( event ) ) {
+					expectationsMet.add( expectation );
+				}
+			}
+		}
+
+		public Set<Matcher<?>> getExpectationsNotMet() {
+			Set<Matcher<?>> expectationsNotMet = new HashSet<>();
+			expectationsNotMet.addAll( expectations );
+			expectationsNotMet.removeAll( expectationsMet );
+			return expectationsNotMet;
+		}
+
+	}
+
+	private class ExpectedLogStatement extends Statement {
+
+		private final Statement next;
+
+		public ExpectedLogStatement(Statement base) {
+			next = base;
+		}
+
+		@Override
+		public void evaluate() throws Throwable {
+			final Logger logger = Logger.getRootLogger();
+			TestAppender appender = new TestAppender();
+			logger.addAppender( appender );
+			try {
+				next.evaluate();
+			}
+			finally {
+				logger.removeAppender( appender );
+			}
+			Set<Matcher<?>> expectationsNotMet = appender.getExpectationsNotMet();
+			if ( !expectationsNotMet.isEmpty() ) {
+				fail( buildFailureMessage( expectationsNotMet ) );
+			}
+		}
+	}
+
+	private static String buildFailureMessage(Set<Matcher<?>> expectationsNotMet) {
+		Description description = new StringDescription();
+		description.appendText( "Some logs were missing:" );
+		for ( Matcher<?> expectationNotMet : expectationsNotMet ) {
+			description.appendText( "\n" );
+			expectationNotMet.describeTo( description );
+		}
+		return description.toString();
+	}
+
+}

--- a/orm/src/test/java/org/hibernate/search/test/DefaultTestResourceManager.java
+++ b/orm/src/test/java/org/hibernate/search/test/DefaultTestResourceManager.java
@@ -16,7 +16,6 @@ import java.util.Map;
 import java.util.UUID;
 
 import org.apache.lucene.analysis.core.StopAnalyzer;
-import org.apache.lucene.store.Directory;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.boot.Metadata;
@@ -30,8 +29,6 @@ import org.hibernate.search.SearchFactory;
 import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.hcore.util.impl.ContextHelper;
-import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
-import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.test.util.MultitenancyTestHelper;
 import org.hibernate.search.test.util.TestConfiguration;
 import org.hibernate.search.testsupport.TestConstants;
@@ -158,14 +155,6 @@ public final class DefaultTestResourceManager implements TestResourceManager {
 			throw new IllegalStateException( "SessionFactory should be already defined at this point" );
 		}
 		return sessionFactory;
-	}
-
-	@Override
-	public Directory getDirectory(Class<?> clazz) {
-		ExtendedSearchIntegrator integrator = ContextHelper.getSearchIntegratorBySFI( sessionFactory );
-		IndexManager[] indexManagers = integrator.getIndexBinding( clazz ).getIndexManagers();
-		DirectoryBasedIndexManager indexManager = (DirectoryBasedIndexManager) indexManagers[0];
-		return indexManager.getDirectoryProvider().getDirectory();
 	}
 
 	@Override

--- a/orm/src/test/java/org/hibernate/search/test/SearchInitializationTestBase.java
+++ b/orm/src/test/java/org/hibernate/search/test/SearchInitializationTestBase.java
@@ -1,0 +1,68 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hibernate.search.test.util.ImmutableTestConfiguration;
+import org.hibernate.search.test.util.TestConfiguration;
+import org.junit.After;
+
+/**
+ * A base class for tests of the initialization process.
+ *
+ * <p>The main difference with {@link SearchTestBase} is that the test itself does not implement
+ * {@link TestConfiguration}, which enables using different configurations for different test methods.
+ * <p>When subclassing this class, Hibernate Search initialization must be triggered manually by calling
+ * {@link #init(TestConfiguration)}.
+ * <p>This is most commonly used to assert exceptions are thrown in specific cases.
+ *
+ * @author Yoann Rodiere
+ */
+public abstract class SearchInitializationTestBase {
+
+	private DefaultTestResourceManager testResourceManager;
+
+	/**
+	 * @param configuration The test configuration to use when initializing.
+	 * @see ImmutableTestConfiguration
+	 */
+	protected void init(TestConfiguration configuration) {
+		if ( testResourceManager == null ) {
+			testResourceManager = new DefaultTestResourceManager( configuration, this.getClass() );
+		}
+		testResourceManager.openSessionFactory();
+	}
+
+	/**
+	 * Initialize with no particular settings
+	 * @param annotatedClasses The classes to search for annotations
+	 */
+	protected void init(Class<?>... annotatedClasses) {
+		Map<String, Object> settings = new HashMap<>();
+		init( new ImmutableTestConfiguration( settings, annotatedClasses ) );
+	}
+
+	/**
+	 * @return the testResourceManager, or null if there isn't any (i.e. if {@link #init(TestConfiguration)}
+	 * hasn't been called yet or if {@link #tearDown()} has been called)
+	 */
+	protected TestResourceManager getTestResourceManager() {
+		return testResourceManager;
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		try {
+			testResourceManager.defaultTearDown();
+		}
+		finally {
+			testResourceManager = null;
+		}
+	}
+}

--- a/orm/src/test/java/org/hibernate/search/test/SearchTestBase.java
+++ b/orm/src/test/java/org/hibernate/search/test/SearchTestBase.java
@@ -12,7 +12,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.lucene.store.Directory;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.search.SearchFactory;
@@ -94,11 +93,6 @@ public abstract class SearchTestBase implements TestResourceManager, TestConfigu
 	@Override
 	public Path getBaseIndexDir() {
 		return getTestResourceManager().getBaseIndexDir();
-	}
-
-	@Override
-	public Directory getDirectory(Class<?> clazz) {
-		return getTestResourceManager().getDirectory( clazz );
 	}
 
 	@Override

--- a/orm/src/test/java/org/hibernate/search/test/TestResourceManager.java
+++ b/orm/src/test/java/org/hibernate/search/test/TestResourceManager.java
@@ -14,7 +14,7 @@ import org.apache.lucene.store.Directory;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.search.SearchFactory;
-import org.hibernate.search.spi.SearchIntegrator;
+import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 
 /**
  * Interface defining ORM and Search infrastructure methods a test base class needs to offer.
@@ -35,7 +35,7 @@ public interface TestResourceManager {
 
 	SearchFactory getSearchFactory();
 
-	SearchIntegrator getExtendedSearchIntegrator();
+	ExtendedSearchIntegrator getExtendedSearchIntegrator();
 
 	Directory getDirectory(Class<?> clazz);
 

--- a/orm/src/test/java/org/hibernate/search/test/TestResourceManager.java
+++ b/orm/src/test/java/org/hibernate/search/test/TestResourceManager.java
@@ -10,7 +10,6 @@ package org.hibernate.search.test;
 import java.io.IOException;
 import java.nio.file.Path;
 
-import org.apache.lucene.store.Directory;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.search.SearchFactory;
@@ -36,8 +35,6 @@ public interface TestResourceManager {
 	SearchFactory getSearchFactory();
 
 	ExtendedSearchIntegrator getExtendedSearchIntegrator();
-
-	Directory getDirectory(Class<?> clazz);
 
 	void ensureIndexesAreEmpty() throws IOException;
 

--- a/orm/src/test/java/org/hibernate/search/test/bridge/CatDeptsFieldsClassBridge.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/CatDeptsFieldsClassBridge.java
@@ -9,14 +9,14 @@ package org.hibernate.search.test.bridge;
 import java.util.Map;
 
 import org.apache.lucene.document.Document;
-import org.hibernate.search.bridge.FieldBridge;
 import org.hibernate.search.bridge.LuceneOptions;
 import org.hibernate.search.bridge.ParameterizedBridge;
+import org.hibernate.search.bridge.TwoWayFieldBridge;
 
 /**
  * @author John Griffin
  */
-public class CatDeptsFieldsClassBridge implements FieldBridge, ParameterizedBridge {
+public class CatDeptsFieldsClassBridge implements TwoWayFieldBridge, ParameterizedBridge {
 
 	private String sepChar;
 
@@ -31,6 +31,20 @@ public class CatDeptsFieldsClassBridge implements FieldBridge, ParameterizedBrid
 		// from the name field of the ClassBridge Annotation. This is not
 		// a requirement. It just works that way in this instance. The
 		// actual name could be supplied by hard coding it below.
+
+		String indexedString = objectToString( value );
+		if ( !indexedString.isEmpty() ) {
+			luceneOptions.addFieldToDocument( name, indexedString, document );
+		}
+	}
+
+	@Override
+	public Object get(String name, Document document) {
+		return document.get( name );
+	}
+
+	@Override
+	public String objectToString(Object value) {
 		Departments dep = (Departments) value;
 		String fieldValue1 = dep.getBranch();
 		if ( fieldValue1 == null ) {
@@ -40,7 +54,6 @@ public class CatDeptsFieldsClassBridge implements FieldBridge, ParameterizedBrid
 		if ( fieldValue2 == null ) {
 			fieldValue2 = "";
 		}
-		String indexedString = fieldValue1 + sepChar + fieldValue2;
-		luceneOptions.addFieldToDocument( name, indexedString, document );
+		return fieldValue1 + sepChar + fieldValue2;
 	}
 }

--- a/orm/src/test/java/org/hibernate/search/test/bridge/DateSplitBridge.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/DateSplitBridge.java
@@ -15,6 +15,9 @@ import java.util.TimeZone;
 import org.apache.lucene.document.Document;
 import org.hibernate.search.bridge.FieldBridge;
 import org.hibernate.search.bridge.LuceneOptions;
+import org.hibernate.search.bridge.MetadataProvidingFieldBridge;
+import org.hibernate.search.bridge.spi.FieldMetadataBuilder;
+import org.hibernate.search.bridge.spi.FieldType;
 
 /**
  * Store the date in 3 different fields - year, month, day - to ease Range Query per
@@ -22,9 +25,20 @@ import org.hibernate.search.bridge.LuceneOptions;
  *
  * @author Emmanuel Bernard
  */
-public class DateSplitBridge implements FieldBridge {
+public class DateSplitBridge implements FieldBridge, MetadataProvidingFieldBridge {
 
 	private static final TimeZone GMT = TimeZone.getTimeZone( "GMT" );
+
+	private static final String YEAR_SUFFIX = "_year";
+	private static final String MONTH_SUFFIX = "_month";
+	private static final String DAY_SUFFIX = "_day";
+
+	@Override
+	public void configureFieldMetadata(String name, FieldMetadataBuilder builder) {
+		builder.field( name + YEAR_SUFFIX, FieldType.STRING )
+				.field( name + MONTH_SUFFIX, FieldType.STRING )
+				.field( name + DAY_SUFFIX, FieldType.STRING );
+	}
 
 	@Override
 	public void set(String name, Object value, Document document, LuceneOptions luceneOptions) {
@@ -36,14 +50,14 @@ public class DateSplitBridge implements FieldBridge {
 		int day = cal.get( Calendar.DAY_OF_MONTH );
 
 		// set year
-		luceneOptions.addFieldToDocument( name + ".year", String.valueOf( year ), document );
+		luceneOptions.addFieldToDocument( name + YEAR_SUFFIX, String.valueOf( year ), document );
 
 		// set month and pad it if needed
-		luceneOptions.addFieldToDocument( name + ".month",
+		luceneOptions.addFieldToDocument( name + MONTH_SUFFIX,
 				month < 10 ? "0" : "" + String.valueOf( month ), document );
 
 		// set day and pad it if needed
-		luceneOptions.addFieldToDocument( name + ".day",
+		luceneOptions.addFieldToDocument( name + DAY_SUFFIX,
 				day < 10 ? "0" : "" + String.valueOf( day ), document );
 	}
 }

--- a/orm/src/test/java/org/hibernate/search/test/bridge/EquipmentType.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/EquipmentType.java
@@ -10,14 +10,14 @@ import java.util.Map;
 
 import org.apache.lucene.document.Document;
 
-import org.hibernate.search.bridge.FieldBridge;
 import org.hibernate.search.bridge.LuceneOptions;
 import org.hibernate.search.bridge.ParameterizedBridge;
+import org.hibernate.search.bridge.TwoWayFieldBridge;
 
 /**
  * @author John Griffin
  */
-public class EquipmentType implements FieldBridge, ParameterizedBridge {
+public class EquipmentType implements TwoWayFieldBridge, ParameterizedBridge {
 
 	private Map<String,String> equips;
 
@@ -33,12 +33,31 @@ public class EquipmentType implements FieldBridge, ParameterizedBridge {
 		// from the name field of the ClassBridge Annotation. This is not
 		// a requirement. It just works that way in this instance. The
 		// actual name could be supplied by hard coding it below.
-		Departments deps = (Departments) value;
-		String fieldValue1 = deps.getManufacturer();
 
-		if ( fieldValue1 != null ) {
-			String indexedString = equips.get( fieldValue1 );
+		String indexedString = objectToString( value );
+		if ( !indexedString.isEmpty() ) {
 			luceneOptions.addFieldToDocument( name, indexedString, document );
 		}
+	}
+
+	@Override
+	public Object get(String name, Document document) {
+		return document.get( name );
+	}
+
+	@Override
+	public String objectToString(Object value) {
+		Departments deps = (Departments) value;
+		String fieldValue1 = deps.getManufacturer();
+		String result = null;
+
+		if ( fieldValue1 != null ) {
+			result = equips.get( fieldValue1 );
+		}
+		if ( result == null ) {
+			result = "";
+		}
+
+		return result;
 	}
 }

--- a/orm/src/test/java/org/hibernate/search/test/configuration/LuceneProgrammaticMappingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/LuceneProgrammaticMappingTest.java
@@ -1,0 +1,87 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.configuration;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.search.Query;
+import org.hibernate.Transaction;
+import org.hibernate.search.FullTextQuery;
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.Search;
+import org.hibernate.search.cfg.Environment;
+import org.hibernate.search.engine.ProjectionConstants;
+import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * @author Emmanuel Bernard
+ */
+@Category(SkipOnElasticsearch.class) // This test is Lucene-specific. The generic equivalent is ProgrammaticMappingTest.
+public class LuceneProgrammaticMappingTest extends SearchTestBase {
+
+	@Test
+	public void testNumeric() throws Exception {
+		Item item = new Item();
+		item.setId( 1 );
+		item.setPrice( (short) 3454 );
+
+		FullTextSession s = Search.getFullTextSession( openSession() );
+		Transaction tx = s.beginTransaction();
+		s.persist( item );
+		tx.commit();
+		s.clear();
+
+		tx = s.beginTransaction();
+
+		Query q = s.getSearchFactory().buildQueryBuilder().forEntity( Item.class ).get().all().createQuery();
+		FullTextQuery query = s.createFullTextQuery( q, Item.class );
+
+		@SuppressWarnings("unchecked")
+		List<Object[]> result = query.setProjection( ProjectionConstants.DOCUMENT, ProjectionConstants.THIS )
+				.list();
+
+		assertEquals( "Numeric field via programmatic config", 1, query.getResultSize() );
+
+		Object[] row = result.iterator().next();
+		Document document = (Document) row[0];
+
+		IndexableField priceNumeric = document.getField( "price" );
+		assertThat( priceNumeric.numericValue() ).isEqualTo( 3454 );
+
+		IndexableField priceString = document.getField( "price_string" );
+		assertThat( priceString.numericValue() ).isNull();
+		assertThat( priceString.stringValue() ).isEqualTo( "3454" );
+
+		s.delete( row[1] );
+
+		tx.commit();
+		s.close();
+	}
+
+	@Override
+	public void configure(Map<String,Object> cfg) {
+		cfg.put( Environment.MODEL_MAPPING, ProgrammaticSearchMappingFactory.class.getName() );
+	}
+
+	@Override
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] {
+				ProductCatalog.class,
+				Item.class,
+				BlogEntry.class
+		};
+	}
+}

--- a/orm/src/test/java/org/hibernate/search/test/configuration/ProgrammaticMappingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/ProgrammaticMappingTest.java
@@ -475,10 +475,11 @@ public class ProgrammaticMappingTest extends SearchTestBase {
 		s.persist( address );
 
 		address = new Address();
+
 		address.setStreet1( "Peachtnot Rd NE" );
 		address.setStreet2( "Peachtree Rd NE" );
 		address.setLastUpdated( c );
-		address.setOwner( "test2" );
+		address.setOwner( "testowner" );
 		s.persist( address );
 
 		tx.commit();
@@ -490,7 +491,7 @@ public class ProgrammaticMappingTest extends SearchTestBase {
 		QueryParser parser = new QueryParser( "id", TestConstants.standardAnalyzer );
 		org.apache.lucene.search.Query luceneQuery = parser.parse( "street1:Peachtnot" );
 		FullTextQuery query = s.createFullTextQuery( luceneQuery ).setProjection( FullTextQuery.THIS, FullTextQuery.SCORE );
-		query.enableFullTextFilter( "security" ).setParameter( "ownerName", "test" );
+		query.enableFullTextFilter( "security" ).setParameter( "ownerName", "testowner" );
 		assertEquals( "expecting 1 results", 1, query.getResultSize() );
 
 		@SuppressWarnings( "unchecked" )

--- a/orm/src/test/java/org/hibernate/search/test/configuration/ProgrammaticMappingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/ProgrammaticMappingTest.java
@@ -852,6 +852,7 @@ public class ProgrammaticMappingTest extends SearchTestBase {
 	}
 
 	@Test
+	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2429 Analyzers on ClassBridge are being ignored with Elasticsearch
 	public void testClassBridgeInstanceMapping() throws Exception {
 		OrderLine orderLine = new OrderLine();
 		orderLine.setName( "Sequoia" );

--- a/orm/src/test/java/org/hibernate/search/test/configuration/ProgrammaticMappingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/ProgrammaticMappingTest.java
@@ -46,10 +46,12 @@ import org.hibernate.search.spatial.SpatialQueryBuilder;
 import org.hibernate.search.spi.SearchIntegrator;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.testsupport.TestConstants;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
 import org.hibernate.search.testsupport.setup.TransactionContextForTest;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -671,6 +673,7 @@ public class ProgrammaticMappingTest extends SearchTestBase {
 	}
 
 	@Test
+	@Category(SkipOnElasticsearch.class) // Dynamic boosting is not supported on Elasticsearch
 	public void testDynamicBoosts() throws Exception {
 
 		Session session = openSession();

--- a/orm/src/test/java/org/hibernate/search/test/configuration/ProgrammaticMappingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/ProgrammaticMappingTest.java
@@ -47,6 +47,7 @@ import org.hibernate.search.spi.SearchIntegrator;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.testsupport.TestConstants;
 import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
+import org.hibernate.search.testsupport.junit.ElasticsearchSupportInProgress;
 import org.hibernate.search.testsupport.setup.TransactionContextForTest;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
@@ -281,6 +282,7 @@ public class ProgrammaticMappingTest extends SearchTestBase {
 	}
 
 	@Test
+	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2428 Provide an alternative to org.hibernate.search.analyzer.Discriminator for Elasticsearch?
 	public void testAnalyzerDiscriminator() throws Exception {
 		FullTextSession s = Search.getFullTextSession( openSession() );
 		Transaction tx = s.beginTransaction();

--- a/orm/src/test/java/org/hibernate/search/test/configuration/ProgrammaticSearchMappingFactory.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/ProgrammaticSearchMappingFactory.java
@@ -26,31 +26,46 @@ import org.hibernate.search.cfg.SearchMapping;
 
 public class ProgrammaticSearchMappingFactory {
 
+	private static final String EN_ANALYZER_NAME = BlogEntry.EN_ANALYZER_NAME;
+	private static final String ENGLISH_ANALYZER_NAME =
+			"org_hibernate_search_test_configuration_ProgrammaticSearchMappingFactory" + "_english";
+	private static final String DEUTSCH_ANALYZER_NAME =
+			"org_hibernate_search_test_configuration_ProgrammaticSearchMappingFactory" + "_deutsch";
+	private static final String NGRAM_ANALYZER_NAME =
+			"org_hibernate_search_test_configuration_ProgrammaticSearchMappingFactory" + "_ngram";
+
 	@Factory
 	public SearchMapping build() {
 		SearchMapping mapping = new SearchMapping();
 
 		mapping.fullTextFilterDef( "security", SecurityFilterFactory.class ).cache( FilterCacheModeType.INSTANCE_ONLY )
-				.analyzerDef( "ngram", StandardTokenizerFactory.class )
+				/*
+				 * CAUTION: those analyzer definitions are duplicated in the elasticsearch.yml for test with Elasticsearch.
+				 * Any update here should be reflected there.
+				 */
+				.analyzerDef( NGRAM_ANALYZER_NAME, StandardTokenizerFactory.class )
 					.filter( LowerCaseFilterFactory.class )
 					.filter( NGramFilterFactory.class )
 						.param( "minGramSize", "3" )
 						.param( "maxGramSize", "3" )
-				.analyzerDef( "english", StandardTokenizerFactory.class )
+				.analyzerDef( ENGLISH_ANALYZER_NAME, StandardTokenizerFactory.class )
 					.filter( LowerCaseFilterFactory.class )
 					.filter( SnowballPorterFilterFactory.class )
-				.analyzerDef( "deutsch", StandardTokenizerFactory.class )
+				.analyzerDef( DEUTSCH_ANALYZER_NAME, StandardTokenizerFactory.class )
 					.filter( LowerCaseFilterFactory.class )
 					.filter( GermanStemFilterFactory.class )
+				/*
+				 * End of analyzer definitions that are duplicated in the elasticsearch.yml for test with Elasticsearch.
+				 */
 				.entity( Address.class )
 					.indexed()
 					.boost( 2 )
 					.classBridge( AddressClassBridge.class )
-					.analyzer( "english" )
+					.analyzer( ENGLISH_ANALYZER_NAME )
 					.property( "addressId", ElementType.FIELD ).documentId().name( "id" )
 					.property( "lastUpdated", ElementType.FIELD )
 						.field().name( "last-updated" )
-								.analyzer( "en" ).store( Store.YES )
+								.analyzer( EN_ANALYZER_NAME ).store( Store.YES )
 								.calendarBridge( Resolution.DAY )
 					.property( "dateCreated", ElementType.FIELD )
 						.field().name( "date-created" ).index( Index.YES )
@@ -60,7 +75,7 @@ public class ProgrammaticSearchMappingFactory {
 						.field()
 					.property( "street1", ElementType.FIELD )
 						.field()
-						.field().name( "street1_ngram" ).analyzer( "ngram" )
+						.field().name( "street1_ngram" ).analyzer( NGRAM_ANALYZER_NAME )
 						.field()
 							.name( "street1_abridged" )
 							.bridge( ConcatStringBridge.class ).param( ConcatStringBridge.SIZE, "4" )
@@ -69,16 +84,16 @@ public class ProgrammaticSearchMappingFactory {
 				.entity( ProvidedIdEntry.class ).indexed()
 						.providedId().name( "providedidentry" ).bridge( LongBridge.class )
 						.property( "name", ElementType.FIELD )
-							.field().name( "providedidentry.name" ).analyzer( "en" ).index( Index.YES ).store( Store.YES )
+							.field().name( "providedidentry.name" ).analyzer( EN_ANALYZER_NAME ).index( Index.YES ).store( Store.YES )
 						.property( "blurb", ElementType.FIELD )
-							.field().name( "providedidentry.blurb" ).analyzer( "en" ).index( Index.YES ).store( Store.YES )
+							.field().name( "providedidentry.blurb" ).analyzer( EN_ANALYZER_NAME ).index( Index.YES ).store( Store.YES )
 						.property( "age", ElementType.FIELD )
-							.field().name( "providedidentry.age" ).analyzer( "en" ).index( Index.YES ).store( Store.YES )
+							.field().name( "providedidentry.age" ).analyzer( EN_ANALYZER_NAME ).index( Index.YES ).store( Store.YES )
 				.entity( ProductCatalog.class ).indexed()
 					.boost( 2 )
 					.property( "id", ElementType.FIELD ).documentId().name( "id" )
 					.property( "name", ElementType.FIELD )
-						.field().name( "productCatalogName" ).index( Index.YES ).analyzer( "en" ).store( Store.YES )
+						.field().name( "productCatalogName" ).index( Index.YES ).analyzer( EN_ANALYZER_NAME ).store( Store.YES )
 					.property( "items", ElementType.FIELD )
 						.indexEmbedded()
 							.includeEmbeddedObjectId( true )
@@ -88,7 +103,7 @@ public class ProgrammaticSearchMappingFactory {
 						.documentId()
 							.sortableField()
 					.property( "description", ElementType.FIELD )
-						.field().name( "description" ).analyzer( "en" ).index( Index.YES ).store( Store.YES )
+						.field().name( "description" ).analyzer( EN_ANALYZER_NAME ).index( Index.YES ).store( Store.YES )
 					.property( "productCatalog", ElementType.FIELD )
 						.containedIn()
 					.property( "price", ElementType.FIELD )
@@ -163,7 +178,7 @@ public class ProgrammaticSearchMappingFactory {
 					.classBridgeInstance( new OrderLineClassBridge( "orderLineName" ) )
 					.classBridgeInstance( new OrderLineClassBridge( null ) )
 						.name( "orderLineName_ngram" )
-						.analyzer( "ngram" )
+						.analyzer( NGRAM_ANALYZER_NAME )
 					.classBridgeInstance( new OrderLineClassBridge( null ) )
 						.param( "fieldName", "orderLineNameViaParam" )
 		;

--- a/orm/src/test/java/org/hibernate/search/test/configuration/ProgrammaticSearchMappingFactory.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/ProgrammaticSearchMappingFactory.java
@@ -82,7 +82,7 @@ public class ProgrammaticSearchMappingFactory {
 					.property( "street2", ElementType.METHOD )
 						.field().name( "idx_street2" ).store( Store.YES ).boost( 2 )
 				.entity( ProvidedIdEntry.class ).indexed()
-						.providedId().name( "providedidentry" ).bridge( LongBridge.class )
+						.providedId().name( "providedidentry.providedid" ).bridge( LongBridge.class )
 						.property( "name", ElementType.FIELD )
 							.field().name( "providedidentry.name" ).analyzer( EN_ANALYZER_NAME ).index( Index.YES ).store( Store.YES )
 						.property( "blurb", ElementType.FIELD )

--- a/orm/src/test/java/org/hibernate/search/test/directoryProvider/RamDirectoryTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/directoryProvider/RamDirectoryTest.java
@@ -6,15 +6,13 @@
  */
 package org.hibernate.search.test.directoryProvider;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.List;
 
-import org.apache.lucene.index.DirectoryReader;
-import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.TermQuery;
-
 import org.hibernate.Session;
-
 import org.hibernate.search.Search;
 import org.hibernate.search.test.AlternateDocument;
 import org.hibernate.search.test.Document;
@@ -22,8 +20,6 @@ import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * @author Emmanuel Bernard
@@ -80,13 +76,7 @@ public class RamDirectoryTest extends SearchTestBase {
 	}
 
 	private int getDocumentNbr() throws Exception {
-		IndexReader reader = DirectoryReader.open( getDirectory( Document.class ) );
-		try {
-			return reader.numDocs();
-		}
-		finally {
-			reader.close();
-		}
+		return getNumberOfDocumentsInIndex( Document.class );
 	}
 
 	@Override

--- a/orm/src/test/java/org/hibernate/search/test/engine/LuceneNumericFieldTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/engine/LuceneNumericFieldTest.java
@@ -1,0 +1,194 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.engine;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.search.Query;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.Search;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.IndexedEmbedded;
+import org.hibernate.search.annotations.NumericField;
+import org.hibernate.search.annotations.Store;
+import org.hibernate.search.engine.ProjectionConstants;
+import org.hibernate.search.query.dsl.QueryContextBuilder;
+import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.testsupport.TestForIssue;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+@Category(SkipOnElasticsearch.class) // This test is Lucene-specific. The generic equivalent is NumericFieldTest.
+public class LuceneNumericFieldTest extends SearchTestBase {
+
+	@Override
+	@Before
+	public void setUp() throws Exception {
+		super.setUp();
+		prepareData();
+	}
+
+	@Override
+	@After
+	public void tearDown() throws Exception {
+		cleanData();
+		super.tearDown();
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-1987")
+	public void testOneOfSeveralFieldsIsNumeric() {
+		try ( Session session = openSession() ) {
+			FullTextSession fullTextSession = Search.getFullTextSession( session );
+			Transaction tx = fullTextSession.beginTransaction();
+
+			QueryContextBuilder queryBuilder = fullTextSession.getSearchFactory().buildQueryBuilder();
+			Query query = queryBuilder.forEntity( TouristAttraction.class ).get().all().createQuery();
+
+			@SuppressWarnings("unchecked")
+			List<Object[]> list = fullTextSession.createFullTextQuery( query, TouristAttraction.class )
+					.setProjection( ProjectionConstants.DOCUMENT )
+					.list();
+
+			assertEquals( 1, list.size() );
+			Document document = (Document) list.iterator().next()[0];
+
+			IndexableField scoreNumeric = document.getField( "scoreNumeric" );
+			assertThat( scoreNumeric.numericValue() ).isEqualTo( 23 );
+
+			IndexableField scoreString = document.getField( "scoreString" );
+			assertThat( scoreString.numericValue() ).isNull();
+			assertThat( scoreString.stringValue() ).isEqualTo( "23" );
+
+			tx.commit();
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-1987")
+	public void testNumericMappingOfEmbeddedFields() {
+		try ( Session session = openSession() ) {
+			FullTextSession fullTextSession = Search.getFullTextSession( session );
+			Transaction tx = fullTextSession.beginTransaction();
+
+			QueryContextBuilder queryBuilder = fullTextSession.getSearchFactory().buildQueryBuilder();
+			Query query = queryBuilder.forEntity( ScoreBoard.class ).get().all().createQuery();
+
+			@SuppressWarnings("unchecked")
+			List<Object[]> list = fullTextSession.createFullTextQuery( query, ScoreBoard.class )
+					.setProjection( ProjectionConstants.DOCUMENT )
+					.list();
+
+			assertEquals( 1, list.size() );
+			Document document = (Document) list.iterator().next()[0];
+
+			IndexableField scoreNumeric = document.getField( "score_id" );
+			assertThat( scoreNumeric.numericValue() ).isEqualTo( 1 );
+
+			IndexableField beta = document.getField( "score_beta" );
+			assertThat( beta.numericValue() ).isEqualTo( 100 );
+
+			tx.commit();
+		}
+	}
+
+	@Override
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[]{ TouristAttraction.class, ScoreBoard.class, Score.class };
+	}
+
+	private void prepareData() {
+		try ( Session session = openSession() ) {
+			FullTextSession fullTextSession = Search.getFullTextSession( session );
+			Transaction tx = fullTextSession.beginTransaction();
+
+			TouristAttraction attraction = new TouristAttraction( 1, (short) 23, (short) 46L );
+			fullTextSession.save( attraction );
+
+			Score score1 = new Score();
+			score1.id = 1;
+			score1.subscore = 100;
+
+			fullTextSession.save( score1 );
+
+			ScoreBoard scoreboard = new ScoreBoard();
+			scoreboard.id = 1l;
+			scoreboard.scores.add( score1 );
+
+			fullTextSession.save( scoreboard );
+
+			tx.commit();
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private void cleanData() {
+		try ( Session session = openSession() ) {
+			FullTextSession fullTextSession = Search.getFullTextSession( session );
+			Transaction tx = fullTextSession.beginTransaction();
+
+			List<TouristAttraction> attractions = fullTextSession.createCriteria( TouristAttraction.class ).list();
+			for ( TouristAttraction attraction : attractions ) {
+				fullTextSession.delete( attraction );
+			}
+
+			List<ScoreBoard> scoreboards = fullTextSession.createCriteria( ScoreBoard.class ).list();
+			for ( ScoreBoard scoreboard : scoreboards ) {
+				fullTextSession.delete( scoreboard );
+			}
+
+			List<Score> scores = fullTextSession.createCriteria( Score.class ).list();
+			for ( Score score : scores ) {
+				fullTextSession.delete( score );
+			}
+
+			tx.commit();
+		}
+	}
+
+	@Indexed
+	@Entity
+	static class ScoreBoard {
+
+		@Id
+		Long id;
+
+		@IndexedEmbedded(includeEmbeddedObjectId = true, prefix = "score_")
+		@OneToMany
+		Set<Score> scores = new HashSet<Score>();
+
+	}
+
+	@Indexed
+	@Entity
+	static class Score {
+
+		@Id
+		@NumericField
+		Integer id;
+
+		@Field(name = "beta", store = Store.YES)
+		Integer subscore;
+	}
+}

--- a/orm/src/test/java/org/hibernate/search/test/engine/TouristAttraction.java
+++ b/orm/src/test/java/org/hibernate/search/test/engine/TouristAttraction.java
@@ -24,14 +24,14 @@ import org.hibernate.search.annotations.Store;
 public class TouristAttraction {
 
 	@Id
-	final int id;
+	int id;
 
 	@Fields({
 			@Field(name = "scoreNumeric", store = Store.YES),
 			@Field(name = "scoreString", store = Store.YES)
 	})
 	@NumericField(forField = "scoreNumeric")
-	final short score;
+	short score;
 
 	@Fields({
 			@Field(name = "ratingNumericPrecision1", store = Store.YES),
@@ -42,7 +42,11 @@ public class TouristAttraction {
 			@NumericField(forField = "ratingNumericPrecision1", precisionStep = 1),
 			@NumericField(forField = "ratingNumericPrecision2", precisionStep = 2)
 	})
-	final short rating;
+	short rating;
+
+	TouristAttraction() {
+		// empty
+	}
 
 	TouristAttraction(int id, short score, short rating) {
 		this.id = id;

--- a/orm/src/test/java/org/hibernate/search/test/engine/TransactionTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/engine/TransactionTest.java
@@ -6,21 +6,17 @@
  */
 package org.hibernate.search.test.engine;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
 
-import org.apache.lucene.index.DirectoryReader;
-import org.apache.lucene.index.IndexReader;
-
 import org.hibernate.Session;
-
 import org.hibernate.jdbc.Work;
 import org.hibernate.search.test.Document;
 import org.hibernate.search.test.SearchTestBase;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * @author Emmanuel Bernard
@@ -78,13 +74,7 @@ public class TransactionTest extends SearchTestBase {
 	}
 
 	private int getDocumentNumber() throws IOException {
-		IndexReader reader = DirectoryReader.open( getDirectory( Document.class ) );
-		try {
-			return reader.numDocs();
-		}
-		finally {
-			reader.close();
-		}
+		return getNumberOfDocumentsInIndex( Document.class );
 	}
 
 	@Override

--- a/orm/src/test/java/org/hibernate/search/test/engine/optimizations/UpdateOperationsTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/engine/optimizations/UpdateOperationsTest.java
@@ -11,16 +11,24 @@ import java.util.List;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.hibernate.Transaction;
 import org.hibernate.search.FullTextSession;
+import org.hibernate.search.backend.impl.lucene.AbstractWorkspaceImpl;
 import org.hibernate.search.test.Document;
 import org.hibernate.search.test.util.FullTextSessionBuilder;
 import org.hibernate.search.testsupport.backend.LeakingLocalBackend;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
 import org.hibernate.search.testsupport.optimizer.LeakingOptimizer;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
+ * Test that {@link AbstractWorkspaceImpl} uses
+ * {@link org.apache.lucene.index.IndexWriter#updateDocument(Term, Iterable<? extends IndexableField>)}
+ * for updating documents when possible.
+ *
  * @author Sanne Grinovero (C) 2012 Red Hat Inc.
  */
+@Category( SkipOnElasticsearch.class ) // This optimization is specific to the Lucene backend
 public class UpdateOperationsTest {
 
 	@Test

--- a/orm/src/test/java/org/hibernate/search/test/engine/optimizations/deletebyterm/DeleteByTermTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/engine/optimizations/deletebyterm/DeleteByTermTest.java
@@ -16,7 +16,7 @@ import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.junit.Test;
-
+import org.junit.experimental.categories.Category;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
@@ -24,12 +24,14 @@ import org.hibernate.search.backend.impl.lucene.WorkspaceHolder;
 import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
 import org.hibernate.search.spi.SearchIntegrator;
 import org.hibernate.search.test.util.FullTextSessionBuilder;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
 
 import static org.fest.assertions.Assertions.assertThat;
 
 /**
  * @author Emmanuel Bernard &lt;emmanuel@hibernate.org&gt;
  */
+@Category(SkipOnElasticsearch.class) // This optimization is specific to the Lucene backend
 public class DeleteByTermTest {
 
 	@Test

--- a/orm/src/test/java/org/hibernate/search/test/engine/worker/WorkerTestCase.java
+++ b/orm/src/test/java/org/hibernate/search/test/engine/worker/WorkerTestCase.java
@@ -11,16 +11,15 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.apache.lucene.queryparser.classic.ParseException;
-import org.apache.lucene.queryparser.classic.QueryParser;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
 import org.hibernate.resource.transaction.spi.TransactionStatus;
 import org.hibernate.search.Search;
 import org.hibernate.search.test.SearchTestBase;
-import org.hibernate.search.testsupport.TestConstants;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -86,26 +85,19 @@ public class WorkerTestCase extends SearchTestBase {
 				s = sf.openSession();
 				tx = s.beginTransaction();
 				ee = (Employee) s.get( Employee.class, ee.getId() );
-				ee.setName( "Emmanuel2" );
+				ee.setName( "John" );
 				tx.commit();
 				s.close();
 				s = sf.openSession();
 				tx = s.beginTransaction();
 				er = (Employer) s.get( Employer.class, er.getId() );
-				er.setName( "RH2" );
+				er.setName( "JBoss" );
 				tx.commit();
 				s.close();
 
 				s = sf.openSession();
 				tx = s.beginTransaction();
-				QueryParser parser = new QueryParser( "id", TestConstants.stopAnalyzer );
-				Query query;
-				try {
-					query = parser.parse( "name:emmanuel2" );
-				}
-				catch (ParseException e) {
-					throw new RuntimeException( e );
-				}
+				Query query = new TermQuery( new Term( "name", "john" ) );
 				boolean results = Search.getFullTextSession( s ).createFullTextQuery( query ).list().size() > 0;
 				// don't test because in case of async, it query happens before
 				// actual saving

--- a/orm/src/test/java/org/hibernate/search/test/errorhandling/LuceneErrorHandlingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/errorhandling/LuceneErrorHandlingTest.java
@@ -27,8 +27,10 @@ import org.hibernate.search.exception.impl.LogErrorHandler;
 import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.spi.SearchIntegrator;
 import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Test to verify the configured ErrorHandler is used in the Lucene
@@ -39,6 +41,7 @@ import org.junit.Test;
  * @author Sanne Grinovero
  * @since 3.2
  */
+@Category(SkipOnElasticsearch.class) // This test is Lucene-specific. The equivalent for Elasticsearch is ElasticsearchExceptionHandlingIT
 public class LuceneErrorHandlingTest extends SearchTestBase {
 
 	static final AtomicInteger WORK_COUNTER = new AtomicInteger();

--- a/orm/src/test/java/org/hibernate/search/test/interceptor/Blog.java
+++ b/orm/src/test/java/org/hibernate/search/test/interceptor/Blog.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.test.interceptor;
 
+import java.util.Objects;
+
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
@@ -27,6 +29,18 @@ public class Blog {
 
 	public void setId(Integer id) {
 		this.id = id;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return getClass().equals( obj.getClass() )
+				&& id != null
+				&& Objects.equals( id, ((Blog) obj).id );
+	}
+
+	@Override
+	public int hashCode() {
+		return getClass().hashCode();
 	}
 
 	private Integer id;

--- a/orm/src/test/java/org/hibernate/search/test/jmx/IndexControlMBeanTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/jmx/IndexControlMBeanTest.java
@@ -32,9 +32,11 @@ import org.hibernate.search.Search;
 import org.hibernate.search.jmx.IndexControlMBean;
 import org.hibernate.search.jmx.StatisticsInfoMBean;
 import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.testsupport.junit.ElasticsearchSupportInProgress;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.osjava.sj.memory.MemoryContext;
 
 import static org.junit.Assert.assertEquals;
@@ -81,6 +83,7 @@ public class IndexControlMBeanTest extends SearchTestBase {
 	}
 
 	@Test
+	@Category( ElasticsearchSupportInProgress.class ) // HSEARCH-2421 Support statistics with Elasticsearch
 	public void testIndexAndPurge() throws Exception {
 		FullTextSession s = Search.getFullTextSession( openSession() );
 		Transaction tx = s.beginTransaction();

--- a/orm/src/test/java/org/hibernate/search/test/jpa/ToStringTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/jpa/ToStringTest.java
@@ -6,24 +6,25 @@
  */
 package org.hibernate.search.test.jpa;
 
+import static org.junit.Assert.assertThat;
+
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 
 import org.apache.lucene.search.Query;
-import org.junit.Before;
-import org.junit.Test;
-
+import org.hamcrest.CoreMatchers;
 import org.hibernate.Session;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.hcore.util.impl.ContextHelper;
 import org.hibernate.search.jpa.FullTextEntityManager;
 import org.hibernate.search.jpa.Search;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.testsupport.TestForIssue;
-
-import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * @author Hardy Ferentschik
@@ -66,16 +67,16 @@ public class ToStringTest extends JPATestCase {
 	}
 
 	@Override
-	public Class[] getAnnotatedClasses() {
+	public Class<?>[] getAnnotatedClasses() {
 		return new Class<?>[] { Foo.class };
 	}
 
-	private void assertToStringContainsLuceneQueryInformation(String fullTextQueryString) {
-		assertEquals(
-				"Unexpected toString implementation. The string should contain Lucene query information",
-				"FullTextQueryImpl(fubar:snafu)",
-				fullTextQueryString
-		);
+	private void assertToStringContainsLuceneQueryInformation(String fullTextQueryToString) {
+		String queryString = ContextHelper.getSearchIntegrator( fullTextSession )
+				.createHSQuery( luceneQuery, Foo.class )
+				.getQueryString();
+		assertThat( "Unexpected toString implementation. The string should contain a string representation of the internal query.",
+				fullTextQueryToString, CoreMatchers.containsString( queryString ) );
 	}
 
 	@Entity

--- a/orm/src/test/java/org/hibernate/search/test/query/LuceneProjectionQueryTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/LuceneProjectionQueryTest.java
@@ -1,0 +1,283 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.query;
+
+import static org.hibernate.search.testsupport.readerprovider.FieldSelectorLeakingReaderProvider.assertFieldSelectorDisabled;
+import static org.hibernate.search.testsupport.readerprovider.FieldSelectorLeakingReaderProvider.assertFieldSelectorEnabled;
+import static org.hibernate.search.testsupport.readerprovider.FieldSelectorLeakingReaderProvider.resetFieldSelector;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.queryparser.classic.QueryParser;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.search.FullTextQuery;
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.Search;
+import org.hibernate.search.cfg.Environment;
+import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.testsupport.TestConstants;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
+import org.hibernate.search.testsupport.readerprovider.FieldSelectorLeakingReaderProvider;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Tests aspects of projection that are specific to the Lucene Backend.
+ *
+ * @author Emmanuel Bernard
+ * @author John Griffin
+ * @author Hardy Ferentschik
+ */
+@Category(SkipOnElasticsearch.class) // This test is specific to the Lucene backend
+public class LuceneProjectionQueryTest extends SearchTestBase {
+
+	@Override
+	public void configure(Map<String,Object> cfg) {
+		cfg.put( "hibernate.search.default.directory_provider", "ram" );
+		cfg.put( "hibernate.search.default." + Environment.READER_STRATEGY, FieldSelectorLeakingReaderProvider.class.getName() );
+	}
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+		Session s = openSession();
+		Transaction tx = s.beginTransaction();
+
+		Employee e1 = new Employee( 1000, "Griffin", "ITech" );
+		s.save( e1 );
+		Employee e2 = new Employee( 1001, "Jackson", "Accounting" );
+		e2.setHireDate( new Date() );
+		s.save( e2 );
+		Employee e3 = new Employee( 1002, "Jimenez", "ITech" );
+		s.save( e3 );
+		Employee e4 = new Employee( 1003, "Stejskal", "ITech" );
+		s.save( e4 );
+		Employee e5 = new Employee( 1004, "Whetbrook", "ITech" );
+		s.save( e5 );
+
+		s.persist( new CalendarDay().setDayFromItalianString( "01/04/2011" ) );
+		s.persist( new CalendarDay().setDayFromItalianString( "02/04/2011" ) );
+
+		tx.commit();
+		s.clear();
+	}
+
+	@After
+	@Override
+	public void tearDown() throws Exception {
+		Session s = getSession(); // Opened during setup
+		try {
+			Transaction tx = s.beginTransaction();
+			for ( Object element : s.createQuery( "from " + Employee.class.getName() ).list() ) {
+				s.delete( element );
+			}
+			tx.commit();
+		}
+		finally {
+			s.close();
+		}
+		super.tearDown();
+	}
+
+	@Test
+	public void testProjectionOfThisFieldSelector() throws Exception {
+		FullTextSession s = Search.getFullTextSession( getSession() );
+		Transaction tx = s.beginTransaction();
+
+		QueryParser parser = new QueryParser( "dept", TestConstants.standardAnalyzer );
+		Query query = parser.parse( "dept:ITech" );
+		org.hibernate.search.FullTextQuery hibQuery = s.createFullTextQuery( query, Employee.class );
+		hibQuery.setProjection( FullTextQuery.THIS );
+
+		resetFieldSelector();
+		List<?> result = hibQuery.list();
+		assertNotNull( result );
+		assertFalse( result.isEmpty() );
+		assertFieldSelectorEnabled( "id" );
+
+		tx.commit();
+	}
+
+	@Test
+	public void testClassProjectionFieldSelector() throws Exception {
+		FullTextSession s = Search.getFullTextSession( getSession() );
+		Transaction tx = s.beginTransaction();
+
+		QueryParser parser = new QueryParser( "dept", TestConstants.standardAnalyzer );
+		Query query = parser.parse( "dept:ITech" );
+		org.hibernate.search.FullTextQuery hibQuery = s.createFullTextQuery( query, Employee.class );
+		hibQuery.setProjection( FullTextQuery.OBJECT_CLASS );
+
+		resetFieldSelector();
+		List<?> result = hibQuery.list();
+		assertNotNull( result );
+		assertFalse( result.isEmpty() );
+		assertFieldSelectorEnabled( ); // empty!
+
+		tx.commit();
+	}
+
+	@Test
+	public void testStoredFieldProjectionFieldSelector() throws Exception {
+		FullTextSession s = Search.getFullTextSession( getSession() );
+		Transaction tx = s.beginTransaction();
+
+		QueryParser parser = new QueryParser( "dept", TestConstants.standardAnalyzer );
+		Query query = parser.parse( "dept:ITech" );
+		org.hibernate.search.FullTextQuery hibQuery = s.createFullTextQuery( query, Employee.class );
+		hibQuery.setProjection( "id", "lastname", "dept" );
+
+		resetFieldSelector();
+		List<?> result = hibQuery.list();
+		assertNotNull( result );
+		assertFalse( result.isEmpty() );
+		assertFieldSelectorEnabled( "lastname", "dept", "id" );
+
+		tx.commit();
+	}
+
+	@Test
+	public void testLuceneDocumentProjection() throws Exception {
+		FullTextSession s = Search.getFullTextSession( getSession() );
+		Transaction tx = s.beginTransaction();
+
+		QueryParser parser = new QueryParser( "dept", TestConstants.standardAnalyzer );
+		Query query = parser.parse( "dept:Accounting" );
+		org.hibernate.search.FullTextQuery hibQuery = s.createFullTextQuery( query, Employee.class );
+		hibQuery.setProjection( FullTextQuery.DOCUMENT );
+
+		List<?> result = hibQuery.list();
+		assertNotNull( result );
+		Object[] projection = (Object[]) result.get( 0 );
+		assertTrue( "DOCUMENT incorrect", projection[0] instanceof Document );
+		assertEquals( "DOCUMENT size incorrect", 5, ( (Document) projection[0] ).getFields().size() );
+
+		tx.commit();
+	}
+
+	@Test
+	public void testLuceneDocumentProjectionFieldSelector() throws Exception {
+		FullTextSession s = Search.getFullTextSession( getSession() );
+		Transaction tx = s.beginTransaction();
+
+		QueryParser parser = new QueryParser( "dept", TestConstants.standardAnalyzer );
+		Query query = parser.parse( "dept:Accounting" );
+		org.hibernate.search.FullTextQuery hibQuery = s.createFullTextQuery( query, Employee.class );
+		hibQuery.setProjection( FullTextQuery.DOCUMENT );
+
+		resetFieldSelector();
+		List<?> result = hibQuery.list();
+		assertNotNull( result );
+		assertFalse( result.isEmpty() );
+		assertFieldSelectorDisabled(); //because of DOCUMENT being projected
+
+		tx.commit();
+	}
+
+	@Test
+	public void testLuceneDocumentIdProjection() throws Exception {
+		FullTextSession s = Search.getFullTextSession( getSession() );
+		Transaction tx = s.beginTransaction();
+
+		QueryParser parser = new QueryParser( "dept", TestConstants.standardAnalyzer );
+		Query query = parser.parse( "dept:ITech" );
+		org.hibernate.search.FullTextQuery hibQuery = s.createFullTextQuery( query, Employee.class );
+		hibQuery.setProjection( FullTextQuery.DOCUMENT_ID );
+
+		List<?> result = hibQuery.list();
+		assertNotNull( result );
+		Object[] projection = (Object[]) result.get( 0 );
+		assertTrue( "DOCUMENT_ID incorrect", projection[0] instanceof Integer );
+
+		tx.commit();
+	}
+
+	@Test
+	public void testLuceneDocumentIdProjectionFieldSelector() throws Exception {
+		FullTextSession s = Search.getFullTextSession( getSession() );
+		Transaction tx = s.beginTransaction();
+
+		QueryParser parser = new QueryParser( "dept", TestConstants.standardAnalyzer );
+		Query query = parser.parse( "dept:ITech" );
+		org.hibernate.search.FullTextQuery hibQuery = s.createFullTextQuery( query, Employee.class );
+		hibQuery.setProjection( FullTextQuery.DOCUMENT_ID );
+
+		resetFieldSelector();
+		List<?> result = hibQuery.list();
+		assertNotNull( result );
+		assertFalse( result.isEmpty() );
+		assertFieldSelectorDisabled(); //because of only DOCUMENT_ID being projected
+
+		tx.commit();
+	}
+
+	@Test
+	public void testLuceneDocumentProjectionNonLoadedFieldOptimization() throws Exception {
+		FullTextSession s = Search.getFullTextSession( getSession() );
+		Transaction tx = s.beginTransaction();
+
+		QueryParser parser = new QueryParser( "dept", TestConstants.standardAnalyzer );
+		Query query = parser.parse( "dept:Accounting" );
+		org.hibernate.search.FullTextQuery hibQuery = s.createFullTextQuery( query, Employee.class );
+		hibQuery.setProjection( FullTextQuery.ID, FullTextQuery.DOCUMENT );
+
+		List<?> result = hibQuery.list();
+		assertNotNull( result );
+
+		Object[] projection = (Object[]) result.get( 0 );
+		assertNotNull( projection );
+		assertEquals( "id field name not projected", 1001, projection[0] );
+		assertEquals(
+				"Document fields should not be lazy on DOCUMENT projection",
+				"Jackson", ( (Document) projection[1] ).getField( "lastname" ).stringValue()
+		);
+		assertEquals( "DOCUMENT size incorrect", 5, ( (Document) projection[1] ).getFields().size() );
+
+		tx.commit();
+	}
+
+	@Test
+	public void testProjectionUnmappedFieldValues() throws ParseException, IOException {
+		FullTextSession s = Search.getFullTextSession( getSession() );
+		Transaction tx = s.beginTransaction();
+
+		org.hibernate.search.FullTextQuery hibQuery = s.createFullTextQuery( new MatchAllDocsQuery(), CalendarDay.class );
+		hibQuery.setProjection( "day.year" );
+
+		resetFieldSelector();
+		List<?> result = hibQuery.list();
+		assertFieldSelectorEnabled( ); //empty: can't use one as the bridge we use mandates optimisations to be disabled
+		assertNotNull( result );
+		assertFalse( result.isEmpty() );
+
+		tx.commit();
+	}
+
+	@Override
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class[] {
+				Employee.class,
+				CalendarDay.class
+		};
+	}
+
+}

--- a/orm/src/test/java/org/hibernate/search/test/query/boost/DynamicBoostingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/boost/DynamicBoostingTest.java
@@ -18,13 +18,16 @@ import org.hibernate.search.FullTextSession;
 import org.hibernate.search.engine.ProjectionConstants;
 import org.hibernate.search.Search;
 import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+@Category(SkipOnElasticsearch.class) // Dynamic boosting is not supported on Elasticsearch
 public class DynamicBoostingTest extends SearchTestBase {
 
 	private static final Log log = LoggerFactory.make();

--- a/orm/src/test/java/org/hibernate/search/test/query/dsl/DSLTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/dsl/DSLTest.java
@@ -49,7 +49,6 @@ import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.query.dsl.impl.ConnectedTermMatchingContext;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.testsupport.TestForIssue;
-import org.hibernate.search.testsupport.junit.ElasticsearchSupportInProgress;
 import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
@@ -486,7 +485,7 @@ public class DSLTest extends SearchTestBase {
 	}
 
 	@Test
-	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2393 Remove dependency to Lucene in tests for features common to Lucene and Elasticsearch
+	@Category(SkipOnElasticsearch.class) // This only works because of a Lucene-specific hack in org.hibernate.search.bridge.util.impl.NumericFieldUtils.createNumericRangeQuery
 	public void testRangeQueryFromToIgnoreFieldBridge() throws Exception {
 		Transaction transaction = fullTextSession.beginTransaction();
 		final QueryBuilder monthQb = fullTextSession.getSearchFactory()
@@ -551,7 +550,7 @@ public class DSLTest extends SearchTestBase {
 	}
 
 	@Test
-	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2393 Remove dependency to Lucene in tests for features common to Lucene and Elasticsearch
+	@Category(SkipOnElasticsearch.class) // This only works because of a Lucene-specific hack in org.hibernate.search.bridge.util.impl.NumericFieldUtils.createNumericRangeQuery
 	public void testRangeQueryBelowIgnoreFieldBridge() throws Exception {
 		Transaction transaction = fullTextSession.beginTransaction();
 		final QueryBuilder monthQb = fullTextSession.getSearchFactory()
@@ -632,7 +631,7 @@ public class DSLTest extends SearchTestBase {
 	}
 
 	@Test
-	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2393 Remove dependency to Lucene in tests for features common to Lucene and Elasticsearch
+	@Category(SkipOnElasticsearch.class) // This only works because of a Lucene-specific hack in org.hibernate.search.bridge.util.impl.NumericFieldUtils.createNumericRangeQuery
 	public void testRangeQueryAboveIgnoreFieldBridge() throws Exception {
 		Transaction transaction = fullTextSession.beginTransaction();
 		final QueryBuilder monthQb = fullTextSession.getSearchFactory()

--- a/orm/src/test/java/org/hibernate/search/test/query/nullValues/IndexAndQueryNullTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/nullValues/IndexAndQueryNullTest.java
@@ -7,13 +7,15 @@
 
 package org.hibernate.search.test.query.nullValues;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.List;
 import java.util.Map;
 
-import org.apache.lucene.document.Document;
 import org.apache.lucene.index.Term;
-import org.apache.lucene.queryparser.classic.ParseException;
-import org.apache.lucene.queryparser.classic.QueryParser;
+import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.hibernate.Transaction;
@@ -24,19 +26,15 @@ import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.test.query.ProjectionToMapResultTransformer;
-import org.hibernate.search.testsupport.TestConstants;
+import org.hibernate.search.testsupport.TestForIssue;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 /**
- * Tests for indexing and querying {@code null} values. See HSEARCH-115
+ * Tests for indexing and querying {@code null} values.
  *
  * @author Hardy Ferentschik
  */
+@TestForIssue(jiraKey = "HSEARCH-115")
 public class IndexAndQueryNullTest extends SearchTestBase {
 
 	@Test
@@ -53,30 +51,8 @@ public class IndexAndQueryNullTest extends SearchTestBase {
 		fullTextSession.clear();
 		tx = fullTextSession.beginTransaction();
 
-		searchKeywordWithExpectedNumberOfResults( fullTextSession, "foo", 1 );
-		searchKeywordWithExpectedNumberOfResults( fullTextSession, "_custom_token_", 1 );
-
-		tx.commit();
-		fullTextSession.close();
-	}
-
-	@Test
-	public void testLuceneDocumentContainsNullToken() throws Exception {
-		Value nullValue = new Value( null );
-
-		FullTextSession fullTextSession = Search.getFullTextSession( openSession() );
-		Transaction tx = fullTextSession.beginTransaction();
-		getSession().save( nullValue );
-		tx.commit();
-
-		fullTextSession.clear();
-		tx = fullTextSession.beginTransaction();
-
-		Document document = getSingleIndexedDocument( fullTextSession, QueryType.USE_LUCENE_QUERY );
-
-		String indexedNullString = document.get( "value" );
-		String expectedString = "_custom_token_";
-		assertEquals( "The null value should be indexed as " + expectedString, expectedString, indexedNullString );
+		searchKeywordWithExpectedNumberOfResults( fullTextSession, "value", "foo", 1 );
+		searchKeywordWithExpectedNumberOfResults( fullTextSession, "value", "_custom_token_", 1 );
 
 		tx.commit();
 		fullTextSession.close();
@@ -84,37 +60,34 @@ public class IndexAndQueryNullTest extends SearchTestBase {
 
 	@Test
 	public void testNullIndexingWithDSLQuery() throws Exception {
+		Value fooValue = new Value( "foo" );
 		Value nullValue = new Value( null );
 
 		FullTextSession fullTextSession = Search.getFullTextSession( openSession() );
 		Transaction tx = fullTextSession.beginTransaction();
+		getSession().save( fooValue );
 		getSession().save( nullValue );
 		tx.commit();
 
 		fullTextSession.clear();
 		tx = fullTextSession.beginTransaction();
 
-		Document document = getSingleIndexedDocument( fullTextSession, QueryType.USE_DSL_QUERY );
+		QueryBuilder queryBuilder = getSearchFactory().buildQueryBuilder().forEntity( Value.class ).get();
+		Query query = queryBuilder.keyword().onField( "value" ).matching( null ).createQuery();
+		FullTextQuery fullTextQuery = fullTextSession.createFullTextQuery( query, Value.class );
 
-		String indexedNullString = document.get( "value" );
-
-		String expectedString = "_custom_token_";
-		assertEquals( "The null value should be indexed as " + expectedString, expectedString, indexedNullString );
+		@SuppressWarnings("unchecked")
+		List<Value> valueList = fullTextQuery.list();
+		assertEquals( "Wrong number of results", 1, valueList.size() );
 
 		tx.commit();
 		fullTextSession.close();
 	}
 
-	@Test
+	@Test(expected = SearchException.class)
 	public void testNullIndexingWithDSLQueryIgnoringFieldBridge() throws Exception {
-		try {
-			QueryBuilder queryBuilder = getSearchFactory().buildQueryBuilder().forEntity( Value.class ).get();
-			queryBuilder.keyword().onField( "value" ).ignoreFieldBridge().matching( null ).createQuery();
-			fail();
-		}
-		catch (SearchException e) {
-			// success
-		}
+		QueryBuilder queryBuilder = getSearchFactory().buildQueryBuilder().forEntity( Value.class ).get();
+		queryBuilder.keyword().onField( "value" ).ignoreFieldBridge().matching( null ).createQuery();
 	}
 
 	@Test
@@ -129,17 +102,17 @@ public class IndexAndQueryNullTest extends SearchTestBase {
 		fullTextSession.clear();
 		tx = fullTextSession.beginTransaction();
 
-		Query query = createLuceneQuery();
+		Query query = new MatchAllDocsQuery();
 		FullTextQuery fullTextQuery = fullTextSession.createFullTextQuery( query, Value.class );
 		fullTextQuery.setProjection(
 				"id",
 				"value"
 		);
 		fullTextQuery.setResultTransformer( new ProjectionToMapResultTransformer() );
-		List mappedResults = fullTextQuery.list();
+		List<?> mappedResults = fullTextQuery.list();
 		assertTrue( "Wrong result size", mappedResults.size() == 1 );
 
-		Map map = (Map) mappedResults.get( 0 );
+		Map<?, ?> map = (Map<?, ?>) mappedResults.get( 0 );
 		Integer id = (Integer) map.get( "id" );
 		assertNotNull( id );
 
@@ -150,90 +123,56 @@ public class IndexAndQueryNullTest extends SearchTestBase {
 		fullTextSession.close();
 	}
 
-
 	@Test
-	public void testConfiguredDefaultNullToken() throws Exception {
-		Value nullValue = new Value( null );
+	public void testIndexAndSearchConfiguredDefaultNullToken() throws Exception {
+		Value fooValue = new Value( "foo" );
+		fooValue.setFallback( "foo" );
+		Value nullValue = new Value( "bar" );
+		nullValue.setFallback( null );
 
 		FullTextSession fullTextSession = Search.getFullTextSession( openSession() );
 		Transaction tx = fullTextSession.beginTransaction();
+		getSession().save( fooValue );
 		getSession().save( nullValue );
 		tx.commit();
 
 		fullTextSession.clear();
 		tx = fullTextSession.beginTransaction();
 
-		Document document = getSingleIndexedDocument( fullTextSession, QueryType.USE_LUCENE_QUERY );
-
-		String indexedNullString = document.get( "fallback" );
-
-		String expectedString = "fubar";
-		assertEquals( "The null value should be indexed as " + expectedString, expectedString, indexedNullString );
+		searchKeywordWithExpectedNumberOfResults( fullTextSession, "fallback", "foo", 1 );
+		searchKeywordWithExpectedNumberOfResults( fullTextSession, "fallback", "fubar", 1 );
 
 		tx.commit();
 		fullTextSession.close();
 	}
 
+
 	@Test
-	public void testNullIndexingWithCustomFieldBridge() throws Exception {
-		Value nullValue = new Value( null );
+	public void testIndexAndSearchWithCustomFieldBridge() throws Exception {
+		Value fooValue = new Value( "foo" );
+		fooValue.setDummy( "foo" );
+		Value nullValue = new Value( "bar" );
+		nullValue.setDummy( null );
 
 		FullTextSession fullTextSession = Search.getFullTextSession( openSession() );
 		Transaction tx = fullTextSession.beginTransaction();
+		getSession().save( fooValue );
 		getSession().save( nullValue );
 		tx.commit();
 
 		fullTextSession.clear();
 		tx = fullTextSession.beginTransaction();
 
-		Document document = getSingleIndexedDocument( fullTextSession, QueryType.USE_LUCENE_QUERY );
-
-		String indexedNullString = document.get( "dummy" );
-
-		String expectedString = "_dummy_";
-		assertEquals( "The null value should be indexed as " + expectedString, expectedString, indexedNullString );
+		searchKeywordWithExpectedNumberOfResults( fullTextSession, "dummy", "foo", 1 );
+		searchKeywordWithExpectedNumberOfResults( fullTextSession, "dummy", "_dummy_", 1 );
 
 		tx.commit();
 		fullTextSession.close();
 	}
 
-	private Document getSingleIndexedDocument(FullTextSession fullTextSession, QueryType type) throws ParseException {
-		Query query;
-		if ( QueryType.USE_LUCENE_QUERY.equals( type ) ) {
-			query = createLuceneQuery();
-		}
-		else {
-			query = createDSLQuery();
-		}
-
-		FullTextQuery fullTextQuery = fullTextSession.createFullTextQuery( query, Value.class );
-		fullTextQuery.setProjection(
-				FullTextQuery.DOCUMENT
-		);
-		fullTextQuery.setResultTransformer( new ProjectionToMapResultTransformer() );
-		List mappedResults = fullTextQuery.list();
-		assertTrue( "Wrong result size", mappedResults.size() == 1 );
-
-		Map map = (Map) mappedResults.get( 0 );
-		Document document = (Document) map.get( FullTextQuery.DOCUMENT );
-		assertNotNull( document );
-		return document;
-	}
-
-	private Query createLuceneQuery() throws ParseException {
-		QueryParser parser = new QueryParser( "id", TestConstants.standardAnalyzer );
-		parser.setAllowLeadingWildcard( true );
-		return parser.parse( "*" );
-	}
-
-	private Query createDSLQuery() {
-		QueryBuilder queryBuilder = getSearchFactory().buildQueryBuilder().forEntity( Value.class ).get();
-		return queryBuilder.keyword().onField( "value" ).matching( null ).createQuery();
-	}
-
-	private void searchKeywordWithExpectedNumberOfResults(FullTextSession fullTextSession, String queryString, int expectedNumberOfResults)
+	private void searchKeywordWithExpectedNumberOfResults(FullTextSession fullTextSession, String fieldName, String termValue, int expectedNumberOfResults)
 			throws Exception {
-		TermQuery query = new TermQuery( new Term( "value", queryString ) );
+		TermQuery query = new TermQuery( new Term( fieldName, termValue ) );
 		FullTextQuery fullTextQuery = fullTextSession.createFullTextQuery( query, Value.class );
 		@SuppressWarnings("unchecked")
 		List<Value> valueList = fullTextQuery.list();

--- a/orm/src/test/java/org/hibernate/search/test/query/nullValues/IndexNullLuceneDocumentContentTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/nullValues/IndexNullLuceneDocumentContentTest.java
@@ -1,0 +1,146 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+package org.hibernate.search.test.query.nullValues;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.queryparser.classic.ParseException;
+import org.apache.lucene.queryparser.classic.QueryParser;
+import org.apache.lucene.search.Query;
+import org.hibernate.Transaction;
+import org.hibernate.search.FullTextQuery;
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.Search;
+import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.test.query.ProjectionToMapResultTransformer;
+import org.hibernate.search.testsupport.TestConstants;
+import org.hibernate.search.testsupport.TestForIssue;
+import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Tests for indexing {@code null} values, asserting the actual document content.
+ *
+ * This is just for extra safety, there already are index/query tests in {@link IndexAndQueryNullTest}.
+ *
+ * @author Hardy Ferentschik
+ */
+@TestForIssue(jiraKey = "HSEARCH-115")
+@Category(SkipOnElasticsearch.class) // Lucene documents cannot be accessed on Elasticsearch
+public class IndexNullLuceneDocumentContentTest extends SearchTestBase {
+
+	@Test
+	public void testLuceneDocumentContainsNullToken() throws Exception {
+		Value nullValue = new Value( null );
+
+		FullTextSession fullTextSession = Search.getFullTextSession( openSession() );
+		Transaction tx = fullTextSession.beginTransaction();
+		getSession().save( nullValue );
+		tx.commit();
+
+		fullTextSession.clear();
+		tx = fullTextSession.beginTransaction();
+
+		Document document = getSingleIndexedDocument( fullTextSession );
+
+		String indexedNullString = document.get( "value" );
+		String expectedString = "_custom_token_";
+		assertEquals( "The null value should be indexed as " + expectedString, expectedString, indexedNullString );
+
+		tx.commit();
+		fullTextSession.close();
+	}
+
+	@Test
+	public void testConfiguredDefaultNullToken() throws Exception {
+		Value nullValue = new Value( null );
+
+		FullTextSession fullTextSession = Search.getFullTextSession( openSession() );
+		Transaction tx = fullTextSession.beginTransaction();
+		getSession().save( nullValue );
+		tx.commit();
+
+		fullTextSession.clear();
+		tx = fullTextSession.beginTransaction();
+
+		Document document = getSingleIndexedDocument( fullTextSession );
+
+		String indexedNullString = document.get( "fallback" );
+
+		String expectedString = "fubar";
+		assertEquals( "The null value should be indexed as " + expectedString, expectedString, indexedNullString );
+
+		tx.commit();
+		fullTextSession.close();
+	}
+
+	@Test
+	public void testNullIndexingWithCustomFieldBridge() throws Exception {
+		Value nullValue = new Value( null );
+
+		FullTextSession fullTextSession = Search.getFullTextSession( openSession() );
+		Transaction tx = fullTextSession.beginTransaction();
+		getSession().save( nullValue );
+		tx.commit();
+
+		fullTextSession.clear();
+		tx = fullTextSession.beginTransaction();
+
+		Document document = getSingleIndexedDocument( fullTextSession );
+
+		String indexedNullString = document.get( "dummy" );
+
+		String expectedString = "_dummy_";
+		assertEquals( "The null value should be indexed as " + expectedString, expectedString, indexedNullString );
+
+		tx.commit();
+		fullTextSession.close();
+	}
+
+	private Document getSingleIndexedDocument(FullTextSession fullTextSession) throws ParseException {
+		Query query = createLuceneQuery();
+
+		FullTextQuery fullTextQuery = fullTextSession.createFullTextQuery( query, Value.class );
+		fullTextQuery.setProjection(
+				FullTextQuery.DOCUMENT
+		);
+		fullTextQuery.setResultTransformer( new ProjectionToMapResultTransformer() );
+		List<?> mappedResults = fullTextQuery.list();
+		assertTrue( "Wrong result size", mappedResults.size() == 1 );
+
+		Map<?, ?> map = (Map<?, ?>) mappedResults.get( 0 );
+		Document document = (Document) map.get( FullTextQuery.DOCUMENT );
+		assertNotNull( document );
+		return document;
+	}
+
+	private Query createLuceneQuery() throws ParseException {
+		QueryParser parser = new QueryParser( "id", TestConstants.standardAnalyzer );
+		parser.setAllowLeadingWildcard( true );
+		return parser.parse( "*" );
+	}
+
+	@Override
+	public void configure(Map<String,Object> cfg) {
+		cfg.put( "hibernate.search.default_null_token", "fubar" );
+	}
+
+	@Override
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class[] {
+				Value.class,
+		};
+	}
+}

--- a/orm/src/test/java/org/hibernate/search/test/query/sorting/Explorer.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/sorting/Explorer.java
@@ -50,9 +50,12 @@ public class Explorer {
 
 	@ManyToOne
 	@IndexedEmbedded
-	@Field(bridge = @FieldBridge(impl = Territory.IdFieldBridge.class))
-	@NumericField
-	@SortableField
+	/*
+	 * Don't store the id in "favoriteTerritory" directly as this could conflict
+	 * with the @IndexedEmbedded with the Elasticsearch backend
+	 */
+	@Field(name = "favoriteTerritory.idFromBridge", bridge = @FieldBridge(impl = Territory.IdFieldBridge.class))
+	@NumericField(forField = "favoriteTerritory.idFromBridge")
 	private Territory favoriteTerritory;
 
 	public Explorer() {

--- a/orm/src/test/java/org/hibernate/search/test/query/sorting/SortOnFieldsFromCustomBridgeTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/sorting/SortOnFieldsFromCustomBridgeTest.java
@@ -143,7 +143,7 @@ public class SortOnFieldsFromCustomBridgeTest extends SearchTestBase {
 		List<Book> result = fullTextSession.createFullTextQuery( new MatchAllDocsQuery(), Explorer.class )
 			.setSort(
 					new Sort(
-							new SortField( "favoriteTerritory", SortField.Type.INT )
+							new SortField( "favoriteTerritory.idFromBridge", SortField.Type.INT )
 					)
 			)
 			.list();
@@ -162,7 +162,7 @@ public class SortOnFieldsFromCustomBridgeTest extends SearchTestBase {
 
 		@SuppressWarnings("unchecked")
 		List<Book> result = fullTextSession.createFullTextQuery( new MatchAllDocsQuery(), Explorer.class )
-			.setSort( new Sort( new SortField( "territoryName", SortField.Type.STRING ) ) )
+			.setSort( new Sort( new SortField( "favoriteTerritory.territoryName", SortField.Type.STRING ) ) )
 			.list();
 
 		assertNotNull( result );

--- a/orm/src/test/java/org/hibernate/search/test/util/BackendTestHelper.java
+++ b/orm/src/test/java/org/hibernate/search/test/util/BackendTestHelper.java
@@ -16,8 +16,12 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.WildcardQuery;
+import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
+import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.indexes.IndexReaderAccessor;
+import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
+import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.test.TestResourceManager;
 
 /**
@@ -72,9 +76,16 @@ public abstract class BackendTestHelper {
 			this.resourceManager = resourceManager;
 		}
 
+		public Directory getDirectory(Class<?> entityType) {
+			ExtendedSearchIntegrator integrator = resourceManager.getExtendedSearchIntegrator();
+			IndexManager[] indexManagers = integrator.getIndexBinding( entityType ).getIndexManagers();
+			DirectoryBasedIndexManager indexManager = (DirectoryBasedIndexManager) indexManagers[0];
+			return indexManager.getDirectoryProvider().getDirectory();
+		}
+
 		@Override
 		public int getNumberOfDocumentsInIndex(Class<?> entityType) {
-			try ( IndexReader reader = DirectoryReader.open( resourceManager.getDirectory( entityType ) ) ) {
+			try ( IndexReader reader = DirectoryReader.open( getDirectory( entityType ) ) ) {
 				return reader.numDocs();
 			}
 			catch (IOException e) {


### PR DESCRIPTION
This PR is based on HSEARCH-2296, we'll have to review and merge the PR ( #1192) first.

Related JIRA ticket: https://hibernate.atlassian.net/browse/HSEARCH-2393

The purpose of this PR is to make tests currently ignored in `elasticsearch/pom.xml` work with Elasticsearch, so that we can enable them.
