### PR TITLE
HSEARCH-2432 Entity Ids containing underscore lost when querying

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/DocumentIdHelper.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/DocumentIdHelper.java
@@ -21,8 +21,8 @@ public class DocumentIdHelper {
 		return work.getTenantId() == null ? work.getIdInString() : work.getTenantId() + "_" + work.getIdInString();
 	}
 
-	static String getEntityId(String documentId) {
-		if ( documentId.contains( "_" ) ) {
+	static String getEntityId(String documentId, String tenantId) {
+		if ( tenantId != null && documentId.contains( "_" ) ) {
 			documentId = documentId.substring( documentId.indexOf( "_" ) + 1 );
 		}
 

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchHSQueryImpl.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchHSQueryImpl.java
@@ -683,7 +683,7 @@ public class ElasticsearchHSQueryImpl extends AbstractHSQuery {
 
 		private Object getId(JsonObject hit, EntityIndexBinding binding, ConversionContext conversionContext) {
 			Document tmp = new Document();
-			tmp.add( new StringField( "id", DocumentIdHelper.getEntityId( hit.get( "_id" ).getAsString() ), Store.NO ) );
+			tmp.add( new StringField( "id", DocumentIdHelper.getEntityId( hit.get( "_id" ).getAsString(), tenantId ), Store.NO ) );
 
 			addIdBridgeDefinedFields( hit, binding, tmp, conversionContext );
 

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchImplicitProvidedIdIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchImplicitProvidedIdIT.java
@@ -6,56 +6,80 @@
  */
 package org.hibernate.search.elasticsearch.test;
 
+import java.io.Serializable;
 import java.util.List;
 
 import org.hibernate.search.backend.spi.Work;
 import org.hibernate.search.backend.spi.WorkType;
 import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.elasticsearch.cfg.ElasticsearchEnvironment;
+import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.query.engine.spi.EntityInfo;
 import org.hibernate.search.spi.SearchIntegrator;
-import org.hibernate.search.spi.SearchIntegratorBuilder;
 import org.hibernate.search.testsupport.TestForIssue;
-import org.hibernate.search.testsupport.setup.SearchConfigurationForTest;
+import org.hibernate.search.testsupport.junit.SearchFactoryHolder;
 import org.hibernate.search.testsupport.setup.TransactionContextForTest;
 
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
 
 import org.apache.lucene.search.Query;
 
 public class ElasticsearchImplicitProvidedIdIT {
 
+	@Rule
+	public SearchFactoryHolder sfHolder = new SearchFactoryHolder( User.class )
+			.withProperty( "hibernate.search.default." + Environment.INDEX_MANAGER_IMPL_NAME, "elasticsearch" )
+			.withProperty( "hibernate.search.default." + ElasticsearchEnvironment.REFRESH_AFTER_WRITE, "true" )
+			.withIdProvidedImplicit( true );
+
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-2431")
 	public void testWithProjection() throws Exception {
-		SearchConfigurationForTest cfg = new SearchConfigurationForTest()
-				.addProperty( "hibernate.search.default." + Environment.INDEX_MANAGER_IMPL_NAME, "elasticsearch" )
-				.addProperty( "hibernate.search.default." + ElasticsearchEnvironment.REFRESH_AFTER_WRITE, "true" )
-				.addClass( User.class )
-				.setIdProvidedImplicit( true );
+		ExtendedSearchIntegrator searchIntegrator = sfHolder.getSearchFactory();
+		User user = new User();
+		user.setId( 1 );
+		user.setSurname( "Smith" );
 
-		SearchIntegratorBuilder searchIntegratorBuilder = new SearchIntegratorBuilder().configuration( cfg );
+		indexUser( user, "S:1", searchIntegrator );
 
-		try (SearchIntegrator searchIntegrator = searchIntegratorBuilder.buildSearchIntegrator();) {
-			User user = new User();
-			user.setId( 1 );
-			user.setSurname( "Smith" );
+		QueryBuilder queryBuilder = searchIntegrator.buildQueryBuilder().forEntity( User.class ).get();
+		Query query = queryBuilder.keyword().onField( "surname" ).matching( "smith" ).createQuery();
 
-			Work work = new Work( user, "S:1", WorkType.ADD, false );
-			TransactionContextForTest tc = new TransactionContextForTest();
-			searchIntegrator.getWorker().performWork( work, tc );
-			tc.end();
+		List<EntityInfo> entityInfoList = searchIntegrator.createHSQuery( query, User.class )
+				.projection( "surname" )
+				.queryEntityInfos();
 
-			QueryBuilder queryBuilder = searchIntegrator.buildQueryBuilder().forEntity( User.class ).get();
-			Query query = queryBuilder.keyword().onField( "surname" ).matching( "smith" ).createQuery();
+		Assert.assertEquals( 1, entityInfoList.size() );
+	}
 
-			List<EntityInfo> entityInfoList = searchIntegrator.createHSQuery( query, User.class )
-					.projection( "surname" )
-					.queryEntityInfos();
+	private void indexUser(User user, Serializable id, SearchIntegrator searchIntegrator) {
+		Work work = new Work( user, id, WorkType.ADD, false );
+		TransactionContextForTest tc = new TransactionContextForTest();
+		searchIntegrator.getWorker().performWork( work, tc );
+		tc.end();
+	}
 
-			Assert.assertEquals( 1, entityInfoList.size() );
-		}
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-2432")
+	public void testWithCustomId() throws Exception {
+		ExtendedSearchIntegrator searchIntegrator = sfHolder.getSearchFactory();
+		User user = new User();
+		user.setId( 325 );
+		user.setSurname( "Lee" );
+
+		Serializable customId = "S:custom_id_325";
+
+		indexUser( user, customId, searchIntegrator );
+
+		QueryBuilder queryBuilder = searchIntegrator.buildQueryBuilder().forEntity( User.class ).get();
+		Query query = queryBuilder.keyword().onField( "surname" ).matching( "Lee" ).createQuery();
+
+		List<EntityInfo> entityInfoList = searchIntegrator.createHSQuery( query, User.class ).queryEntityInfos();
+
+		Assert.assertEquals( 1, entityInfoList.size() );
+		Assert.assertEquals( customId, entityInfoList.iterator().next().getId() );
 	}
 }

--- a/engine/src/test/java/org/hibernate/search/testsupport/junit/SearchFactoryHolder.java
+++ b/engine/src/test/java/org/hibernate/search/testsupport/junit/SearchFactoryHolder.java
@@ -40,6 +40,7 @@ public class SearchFactoryHolder extends ExternalResource {
 
 	private SearchIntegrator[] searchIntegrator;
 	private int numberOfSessionFactories = 1;
+	private boolean idProvidedImplicit = false;
 
 	public SearchFactoryHolder(Class<?>... entities) {
 		this( null, entities );
@@ -75,6 +76,7 @@ public class SearchFactoryHolder extends ExternalResource {
 		for ( Class<?> c : entities ) {
 			cfg.addClass( c );
 		}
+		cfg.setIdProvidedImplicit( idProvidedImplicit );
 		return new SearchIntegratorBuilder().configuration( cfg ).buildSearchIntegrator();
 	}
 
@@ -90,6 +92,11 @@ public class SearchFactoryHolder extends ExternalResource {
 	public SearchFactoryHolder withProperty(String key, Object value) {
 		Assert.assertNull( "SearchIntegrator already initialized", searchIntegrator );
 		configuration.put( key, value );
+		return this;
+	}
+
+	public SearchFactoryHolder withIdProvidedImplicit(boolean value) {
+		this.idProvidedImplicit = value;
 		return this;
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2432