### PR TITLE
HSEARCH-2414 and HSEARCH-2413: work around buggy ZonedDateTime format support in ES 2.4.1 and upgrade ES test version

### DIFF
--- a/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
+++ b/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
@@ -74,7 +74,7 @@ docker run -p 9200:9200 -d -v "$PWD/plugin_dir":/usr/share/elasticsearch/plugins
 .Elasticsearch version
 --
 Hibernate Search expects an Elasticsearch node version 2.0 at least.
-Hibernate Search internal tests run against Elasticsearch 2.3.
+Hibernate Search internal tests run against Elasticsearch 2.4.
 --
 
 ==== Dependencies in your Java application

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/bridge/builtin/time/impl/ElasticsearchZonedDateTimeBridge.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/bridge/builtin/time/impl/ElasticsearchZonedDateTimeBridge.java
@@ -16,11 +16,13 @@ import java.util.Locale;
 import org.hibernate.search.util.impl.TimeHelper;
 
 /**
- * Converts a {@link ZonedDateTime} to a {@link String} in ISO-8601 extended format (9 digits for the year instead of 4).
+ * Converts a {@link ZonedDateTime} to a {@link String} almost in ISO-8601 extended format (9 digits
+ * for the year instead of 4, and the zone ID is appended after a dash instead of being between squarebrackets).
  *
  * <p>Be aware that this format is <strong>not</strong> the same as {@link DateTimeFormatter#ISO_ZONED_DATE_TIME}
- * (mainly because of the second fraction field, which is at least 3 characters long), nor as Elasticsearch's
- * "strict_date_time" format (since years with more than 4 digits are allowed, and both the zone ID and offset are displayed).
+ * (mainly because of the second fraction field, which is at least 3 characters long, and because of the zone ID),
+ * nor as Elasticsearch's "strict_date_time" format (since years with more than 4 digits are allowed, and both
+ * the zone ID and offset are displayed).
  *
  * @author Yoann Rodiere
  */
@@ -28,10 +30,9 @@ public class ElasticsearchZonedDateTimeBridge extends ElasticsearchTemporalAcces
 
 	private static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
 			.append( ElasticsearchOffsetDateTimeBridge.FORMATTER )
-			.appendLiteral( '[' )
+			.appendLiteral( '-' )
 			.parseCaseSensitive()
 			.appendZoneRegionId()
-			.appendLiteral( ']' )
 			.toFormatter( Locale.ROOT )
 			.withResolverStyle( ResolverStyle.STRICT );
 

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchIndexManager.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchIndexManager.java
@@ -611,8 +611,8 @@ public class ElasticsearchIndexManager implements IndexManager, RemoteAnalyzerPr
 				break;
 			case ZONED_DATE_TIME:
 				elasticsearchType = ElasticsearchFieldType.DATE;
-				formats.add( "yyyy-MM-dd'T'HH:mm:ss.SSSZZ'['ZZZ']'" );
-				formats.add( "yyyyyyyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSZZ'['ZZZ']'" );
+				formats.add( "yyyy-MM-dd'T'HH:mm:ss.SSSZZ-ZZZ" );
+				formats.add( "yyyyyyyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSZZ-ZZZ" );
 				break;
 			case YEAR:
 				elasticsearchType = ElasticsearchFieldType.DATE;

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchJavaTimeIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchJavaTimeIT.java
@@ -202,7 +202,7 @@ public class ElasticsearchJavaTimeIT extends SearchTestBase {
 		sample.zonedDateTime = value;
 
 		// The "fields" attribute only ever contains UTC date/times
-		assertThatFieldIsFormatted( sample, "zonedDateTime", "2011-10-30T02:50:00.007+01:00[CET]", "2011-10-30T01:50:00.007+00:00[UTC]" );
+		assertThatFieldIsFormatted( sample, "zonedDateTime", "2011-10-30T02:50:00.007+01:00-CET", "2011-10-30T01:50:00.007+00:00-UTC" );
 	}
 
 	@Test
@@ -218,7 +218,7 @@ public class ElasticsearchJavaTimeIT extends SearchTestBase {
 
 		// Elasticsearch only has millisecond-precision, so the "fields" value is missing the nanoseconds
 		// Also, the "fields" attribute only ever contains UTC date/times
-		assertThatFieldIsFormatted( sample, "zonedDateTime", "2011-10-30T02:50:00.000000007+01:00[CET]", "2011-10-30T01:50:00.000+00:00[UTC]" );
+		assertThatFieldIsFormatted( sample, "zonedDateTime", "2011-10-30T02:50:00.000000007+01:00-CET", "2011-10-30T01:50:00.000+00:00-UTC" );
 	}
 
 	@Test

--- a/pom.xml
+++ b/pom.xml
@@ -181,14 +181,14 @@
         <commonsLangVersion>2.6</commonsLangVersion>
 
         <!-- Elasticsearch -->
-        <testElasticsearchMavenPluginVersion>2.0</testElasticsearchMavenPluginVersion>
+        <testElasticsearchMavenPluginVersion>2.2</testElasticsearchMavenPluginVersion>
         <!-- In theory we're not coupled to a specific version of Elasticsearch; this property
              controls which version is being used to run integration tests. When updating,
              make sure to use the right JNA version, too
         -->
-        <testElasticsearchVersion>2.3.1</testElasticsearchVersion>
+        <testElasticsearchVersion>2.4.1</testElasticsearchVersion>
         <testElasticsearchJnaVersion>4.1.0</testElasticsearchJnaVersion>
-        <elasticsearchJestVersion>2.0.0</elasticsearchJestVersion>
+        <elasticsearchJestVersion>2.0.3</elasticsearchJestVersion>
         <elasticsearchCommonsLang3Version>3.4</elasticsearchCommonsLang3Version>
         <elasticsearchGsonVersion>2.4</elasticsearchGsonVersion>
 


### PR DESCRIPTION
This PR changes ElasticsearchZonedDateTimeBridge to use a date format that ES 2.4 accepts and upgrades ES test version to 2.4

The downside is we don't use the standard format for ZonedDateTime on ES anymore. But right now ES is buggy (https://github.com/elastic/elasticsearch/issues/20911) so we can't do otherwise.

So we have to choose: either we wait for Joda to release the fix and ES to upgrade on both the 2.4 and 5.0 branches, or we use a non-standard format (and that will probably stay that way a long time because of backward compatibility)