### PR TITLE
HSEARCH-2436 Reference a ZonedDateTime bug with ES 2.4.1/5.0.0 in the Elasticsearch doc

### DIFF
--- a/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
+++ b/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
@@ -490,6 +490,7 @@ Here is a list of known limitations.
 
 Please check with JIRA and the mailing lists for updates, but at the time of writing this at least the following features are known to not work yet:
 
+* Mapping `java.time.ZonedDateTime` won't work with Elasticsearch 2.4.1 and 5.0.0 because of https://github.com/elastic/elasticsearch/issues/20911[a pending bug in Elasticsearch]: https://hibernate.atlassian.net/browse/HSEARCH-2414[HSEARCH-2414]. A temporary workaround would be to index a `java.time.OffsetDateTime` instead (if it's enough for your needs) or to use an earlier version of Elasticsearch.
 * Defining analyzers with `@AnalyzerDef`, analyzers have to be defined in the Elasticsearch configuration: https://hibernate.atlassian.net/browse/HSEARCH-2417[HSEARCH-2417]
 * Query timeouts: https://hibernate.atlassian.net/browse/HSEARCH-2399[HSEARCH-2399]
 * MoreLikeThis queries: https://hibernate.atlassian.net/browse/HSEARCH-2395[HSEARCH-2395]


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2436