### PR TITLE
HSEARCH-2437 Prepare the support for Elasticsearch 5 (+ HSEARCH-2439)

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/ElasticsearchQueries.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/ElasticsearchQueries.java
@@ -47,7 +47,7 @@ public class ElasticsearchQueries {
 		// { "query" : { "query_string" : { "query" : "abstract:Hibernate" } } }
 
 		JsonBuilder.Object query = JsonBuilder.object().add( "query",
-				JsonBuilder.object().add( "queryString",
+				JsonBuilder.object().add( "query_string",
 						JsonBuilder.object().addProperty( "query", queryStringQuery ) ) );
 
 		return new ElasticsearchJsonQueryDescriptor( query.build() );

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchHSQueryImpl.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchHSQueryImpl.java
@@ -506,12 +506,15 @@ public class ElasticsearchHSQueryImpl extends AbstractHSQuery {
 				// the results. If we don't sort by distance, we need to request for the distance using a script_field.
 				query.add( "script_fields",
 						JsonBuilder.object().add( SPATIAL_DISTANCE_FIELD, JsonBuilder.object()
+							.add( "script", JsonBuilder.object()
 								.add( "params",
 										JsonBuilder.object()
 												.addProperty( "lat", spatialSearchCenter.getLatitude() )
 												.addProperty( "lon", spatialSearchCenter.getLongitude() )
 								)
-								.addProperty( "script", "doc[\u0027" + spatialFieldName + "\u0027].arcDistanceInKm(lat,lon)" )
+								.addProperty( "inline", "doc['" + spatialFieldName + "'].arcDistanceInKm(lat,lon)" )
+								.addProperty( "lang", "groovy" )
+							)
 						)
 				);
 				// in this case, the _source field is not present in the Elasticsearch results

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchIndexManager.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchIndexManager.java
@@ -509,7 +509,7 @@ public class ElasticsearchIndexManager implements IndexManager, RemoteAnalyzerPr
 		}
 		field.addProperty( "index", elasticsearchIndex );
 
-		if ( NOT_INDEXED.equals( elasticsearchIndex ) && FieldHelper.isSortableField( sourceProperty, fieldName ) ) {
+		if ( NOT_INDEXED.equals( elasticsearchIndex ) && FieldHelper.isSortableField( mappingBuilder.getMetadata(), sourceProperty, fieldName ) ) {
 			// We must use doc values in order to enable sorting on non-indexed fields
 			field.addProperty( "doc_values", true );
 		}

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchIndexWorkVisitor.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchIndexWorkVisitor.java
@@ -152,13 +152,13 @@ class ElasticsearchIndexWorkVisitor implements IndexWorkVisitor<Void, BackendReq
 		if ( work.getTenantId() != null ) {
 			query = JsonBuilder.object()
 				.add( "query", JsonBuilder.object()
-					.add( "filtered", JsonBuilder.object()
+					.add( "bool", JsonBuilder.object()
 						.add( "filter", JsonBuilder.object()
 							.add( "term", JsonBuilder.object()
 								.addProperty( DocumentBuilderIndexedEntity.TENANT_ID_FIELDNAME, work.getTenantId() )
 							)
 						)
-						.add( "query", convertedQuery )
+						.add( "must", convertedQuery )
 					)
 				)
 				.build();

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/FieldHelper.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/FieldHelper.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.elasticsearch.impl;
 
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.Date;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -19,6 +20,7 @@ import org.hibernate.search.engine.metadata.impl.BridgeDefinedField;
 import org.hibernate.search.engine.metadata.impl.DocumentFieldMetadata;
 import org.hibernate.search.engine.metadata.impl.PropertyMetadata;
 import org.hibernate.search.engine.metadata.impl.SortableFieldMetadata;
+import org.hibernate.search.engine.metadata.impl.TypeMetadata;
 import org.hibernate.search.engine.spi.EntityIndexBinding;
 import org.hibernate.search.metadata.NumericFieldSettingsDescriptor.NumericEncodingType;
 
@@ -250,8 +252,10 @@ class FieldHelper {
 		return null;
 	}
 
-	public static boolean isSortableField(PropertyMetadata sourceProperty, String fieldName) {
-		for ( SortableFieldMetadata sortableField : sourceProperty.getSortableFieldMetadata() ) {
+	public static boolean isSortableField(TypeMetadata sourceType, PropertyMetadata sourceProperty, String fieldName) {
+		Collection<SortableFieldMetadata> sortableFields = sourceProperty != null ? sourceProperty.getSortableFieldMetadata()
+				: sourceType.getClassBridgeSortableFieldMetadata();
+		for ( SortableFieldMetadata sortableField : sortableFields ) {
 			if ( fieldName.equals( sortableField.getFieldName() ) ) {
 				return true;
 			}

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ToElasticsearch.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ToElasticsearch.java
@@ -64,7 +64,7 @@ public class ToElasticsearch {
 			JsonObject termsJsonQuery = JsonBuilder.object().add( "terms",
 					JsonBuilder.object()
 							.addProperty( "field", fieldName )
-							.addProperty( "size", facetingRequest.getMaxNumberOfFacets() == -1 ? 0 : facetingRequest.getMaxNumberOfFacets() )
+							.addProperty( "size", facetingRequest.getMaxNumberOfFacets() == -1 ? Integer.MAX_VALUE : facetingRequest.getMaxNumberOfFacets() )
 							.add( "order", fromFacetSortOrder( facetingRequest.getSort() ) )
 							.addProperty( "min_doc_count", facetingRequest.hasZeroCountsIncluded() ? 0 : 1 )
 					).build();

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ToElasticsearch.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ToElasticsearch.java
@@ -425,9 +425,9 @@ public class ToElasticsearch {
 
 	private static JsonObject convertFilteredQuery(FilteredQuery query) {
 		JsonObject filteredQuery = JsonBuilder.object()
-				.add( "filtered",
+				.add( "bool",
 						JsonBuilder.object()
-								.add( "query", fromLuceneQuery( query.getQuery() ) )
+								.add( "must", fromLuceneQuery( query.getQuery() ) )
 								.add( "filter", fromLuceneQuery( query.getFilter() ) )
 								.append( boostAppender( query ) )
 				).build();
@@ -455,8 +455,8 @@ public class ToElasticsearch {
 		Filter previousFilter = filter.getPreviousFilter();
 		if ( previousFilter instanceof SpatialHashFilter ) {
 			distanceQuery = JsonBuilder.object()
-					.add( "filtered", JsonBuilder.object()
-							.add( "query", distanceQuery )
+					.add( "bool", JsonBuilder.object()
+							.add( "must", distanceQuery )
 							.add( "filter", convertSpatialHashFilter( (SpatialHashFilter) previousFilter ) )
 					).build();
 		}

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIndexMappingIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIndexMappingIT.java
@@ -178,6 +178,11 @@ public class ElasticsearchIndexMappingIT extends SearchTestBase {
 						"'fullName':{" +
 							"'type':'string'" +
 						"}," +
+						"'fullNameStored':{" +
+							"'type':'string'," +
+							"'index':'no'," +
+							"'store':true" +
+						"}," +
 						"'handicap':{" +
 							"'type':'double'" +
 						"}," +
@@ -453,7 +458,8 @@ public class ElasticsearchIndexMappingIT extends SearchTestBase {
 					"\"handicap\": 0.0," + // not nullable
 					"\"puttingStrength\": \"0.0\"," + // not nullable
 					"\"lastName\": \"Kidd\"," +
-					"\"fullName\": \"Kidd\"" +
+					"\"fullName\": \"Kidd\"," +
+					"\"fullNameStored\": \"Kidd\"" +
 					// ranking.value is null but indexNullAs() has not been given, so it's
 					// not present in the index at all
 					// "\"ranking\": {" +

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/GolfPlayer.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/GolfPlayer.java
@@ -28,9 +28,11 @@ import org.hibernate.search.annotations.DateBridge;
 import org.hibernate.search.annotations.DocumentId;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.FieldBridge;
+import org.hibernate.search.annotations.Index;
 import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.annotations.IndexedEmbedded;
 import org.hibernate.search.annotations.Resolution;
+import org.hibernate.search.annotations.Store;
 import org.hibernate.search.bridge.builtin.DoubleBridge;
 
 /**
@@ -40,6 +42,7 @@ import org.hibernate.search.bridge.builtin.DoubleBridge;
 @Indexed(index = "golfplayer")
 @ClassBridges({
 		@ClassBridge(name = "fullName", impl = NameConcatenationBridge.class),
+		@ClassBridge(name = "fullNameStored", index = Index.NO, store = Store.YES, impl = NameConcatenationBridge.class),
 		@ClassBridge(name = "age", impl = AgeBridge.class)
 })
 public class GolfPlayer {


### PR DESCRIPTION
Relevant tickets:

 * https://hibernate.atlassian.net/browse/HSEARCH-2437
 * https://hibernate.atlassian.net/browse/HSEARCH-2439 (it's linked because I only spotted the bug when trying out ES 5)

A few changes that would facilitate the ES 5 support, and yet do not break 2.x compatibility.
