### PR TITLE
HSEARCH-2384 Make the Elasticsearch version used for integration tests a build parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ installation directory. Then read the documentation available in *docs/reference
     > cd hibernate-search
     > mvn clean install -s settings-example.xml
 
-#### Build options (profiles)
+#### Build options (profiles and properties)
 
 The documentation is based on [AsciiDoctor](http://asciidoctor.org/). Per default only the html
 output is enabled. To also generate the docbok output and build the documentation from there use:
@@ -59,6 +59,20 @@ To build the distribution bundle run:
 
 You can also build the above mentioned modules directly by changing into these directories and
 executing maven in the module directory.
+
+The Elasticsearch module tests against only one version of Elasticsearch at a time. You may
+redefine the version to use by specifying the right profile and using the
+`testElasticsearchVersion` property:
+
+    > mvn clean install -Pelasticsearch-2.0 -DtestElasticsearchVersion=2.1.0
+
+The following profiles are available:
+
+ * `elasticsearch-2.0` for 2.0.x and 2.1.x
+ * `elasticsearch-2.2` for 2.2.x and later 2.x (the default)
+
+A list of available versions for `testElasticsearchVersion` can be found on
+[Maven Central](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22org.elasticsearch%22%20AND%20a%3A%22elasticsearch%22).
 
 ### Contributing
 

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -85,6 +85,7 @@
                             <hibernateVersion>${hibernateVersion}</hibernateVersion>
                             <luceneVersion>${luceneVersion}</luceneVersion>
                             <infinispanVersion>${infinispanVersion}</infinispanVersion>
+                            <testElasticsearchVersion>${testElasticsearchVersion}</testElasticsearchVersion>
                         </attributes>
                     </configuration>
                 </plugin>

--- a/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
+++ b/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
@@ -73,7 +73,7 @@ docker run -p 9200:9200 -d -v "$PWD/plugin_dir":/usr/share/elasticsearch/plugins
 [NOTE]
 .Elasticsearch version
 --
-Hibernate Search expects an Elasticsearch node version 2.0 at least.
+Hibernate Search expects an Elasticsearch node version 2.0 at least. 5.0 is not supported yet.
 Hibernate Search internal tests run against Elasticsearch {testElasticsearchVersion}.
 --
 

--- a/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
+++ b/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
@@ -74,7 +74,7 @@ docker run -p 9200:9200 -d -v "$PWD/plugin_dir":/usr/share/elasticsearch/plugins
 .Elasticsearch version
 --
 Hibernate Search expects an Elasticsearch node version 2.0 at least.
-Hibernate Search internal tests run against Elasticsearch 2.3.
+Hibernate Search internal tests run against Elasticsearch {testElasticsearchVersion}.
 --
 
 ==== Dependencies in your Java application

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -270,38 +270,6 @@
                 <artifactId>maven-processor-plugin</artifactId>
             </plugin>
             <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>unpack</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>unpack</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.elasticsearch.plugin</groupId>
-                                    <artifactId>delete-by-query</artifactId>
-                                    <version>${testElasticsearchVersion}</version>
-                                    <type>zip</type>
-                                    <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/_ES_PLUGINS_/delete-by-query</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.elasticsearch.module</groupId>
-                                    <artifactId>lang-groovy</artifactId>
-                                    <version>${testElasticsearchVersion}</version>
-                                    <type>zip</type>
-                                    <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/_ES_PLUGINS_/lang-groovy</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>com.github.alexcojocaru</groupId>
                 <artifactId>elasticsearch-maven-plugin</artifactId>
                 <configuration>
@@ -332,4 +300,108 @@
 
         </plugins>
     </build>
+    
+    <profiles>
+        <profile>
+            <id>elasticsearch-2.0</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <!-- Delete-by-query is a plugin in Elasticsearch 2.x -->
+                                        <artifactItem>
+                                            <groupId>org.elasticsearch.plugin</groupId>
+                                            <artifactId>delete-by-query</artifactId>
+                                            <version>${testElasticsearchVersion}</version>
+                                            <type>zip</type>
+                                            <overWrite>true</overWrite>
+                                            <outputDirectory>${project.build.directory}/_ES_PLUGINS_/delete-by-query</outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- We must redeclare this plugin here, otherwise it will start before the plugins above are deployed  -->
+                    <plugin>
+                        <groupId>com.github.alexcojocaru</groupId>
+                        <artifactId>elasticsearch-maven-plugin</artifactId>
+                        <dependencies>
+                            <!-- Groovy is in a core module named "org.elasticsearch:elasticsearch-groovy" in Elasticsearch 2.0.x and 2.1.x
+                                 Also, in ES 2.0/2.1, core modules are not located in the plugin directory as with newer versions, but are
+                                 simply expected to be in the classpath.
+                            -->
+                            <dependency>
+                                <groupId>org.elasticsearch</groupId>
+                                <artifactId>elasticsearch-groovy</artifactId>
+                                <version>${testElasticsearchVersion}</version>
+                                <type>jar</type>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>elasticsearch-2.2</id>
+            <!-- Activation rules are not inherited from the profile definition in the parent, so we must copy them here -->
+            <activation>
+                <property>
+                    <name>!testElasticsearchVersion</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <!-- Delete-by-query is a plugin in Elasticsearch 2.x -->
+                                        <artifactItem>
+                                            <groupId>org.elasticsearch.plugin</groupId>
+                                            <artifactId>delete-by-query</artifactId>
+                                            <version>${testElasticsearchVersion}</version>
+                                            <type>zip</type>
+                                            <overWrite>true</overWrite>
+                                            <outputDirectory>${project.build.directory}/_ES_PLUGINS_/delete-by-query</outputDirectory>
+                                        </artifactItem>
+                                        <!-- Groovy is in a plugin named "org.elasticsearch.module:lang-groovy" in Elasticsearch 2.2+ -->
+                                        <artifactItem>
+                                            <groupId>org.elasticsearch.module</groupId>
+                                            <artifactId>lang-groovy</artifactId>
+                                            <version>${testElasticsearchVersion}</version>
+                                            <type>zip</type>
+                                            <overWrite>true</overWrite>
+                                            <outputDirectory>${project.build.directory}/_ES_PLUGINS_/lang-groovy</outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- We must redeclare this plugin here, otherwise it will start before the plugins above are deployed  -->
+                    <plugin>
+                        <groupId>com.github.alexcojocaru</groupId>
+                        <artifactId>elasticsearch-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -181,11 +181,6 @@
         <commonsLangVersion>2.6</commonsLangVersion>
 
         <!-- Elasticsearch -->
-        <testElasticsearchMavenPluginVersion>2.2</testElasticsearchMavenPluginVersion>
-        <!-- In theory we're not coupled to a specific version of Elasticsearch; this property
-             controls which version is being used to run integration tests.
-        -->
-        <testElasticsearchVersion>2.3.1</testElasticsearchVersion>
         <elasticsearchJestVersion>2.0.0</elasticsearchJestVersion>
         <elasticsearchCommonsLang3Version>3.4</elasticsearchCommonsLang3Version>
         <elasticsearchGsonVersion>2.4</elasticsearchGsonVersion>
@@ -577,6 +572,7 @@
                 <artifactId>slf4j-log4j12</artifactId>
                 <version>${slf4jVersion}</version>
             </dependency>
+            
             <dependency>
                 <groupId>log4j</groupId>
                 <artifactId>log4j</artifactId>
@@ -1259,18 +1255,8 @@ org.jboss.logging.BasicLogger#debugf(java.lang.Throwable, java.lang.String, long
                             <artifactId>elasticsearch</artifactId>
                             <version>${testElasticsearchVersion}</version>
                         </dependency>
-
-                        <!-- The next three are used to get ES log output into the Maven console -->
-                        <dependency>
-                            <groupId>org.slf4j</groupId>
-                            <artifactId>slf4j-api</artifactId>
-                            <version>${slf4jVersion}</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>org.slf4j</groupId>
-                            <artifactId>slf4j-log4j12</artifactId>
-                            <version>${slf4jVersion}</version>
-                        </dependency>
+                        
+                        <!-- The next is used to get ES log output into the Maven console -->
                         <dependency>
                             <groupId>org.hibernate</groupId>
                             <artifactId>hibernate-search-sharedtestresources</artifactId>
@@ -1407,6 +1393,43 @@ org.jboss.logging.BasicLogger#debugf(java.lang.Throwable, java.lang.String, long
             <id>perf</id>
             <properties>
                 <org.hibernate.search.enable_performance_tests>true</org.hibernate.search.enable_performance_tests>
+            </properties>
+        </profile>
+
+        <!-- =============================== -->
+        <!-- Elasticsearch IT profiles       -->
+        <!-- =============================== -->
+        <!--
+             Different profiles are needed to handle the environment setup (which is handled in Maven,
+             on contrary to the various database profiles).
+             
+             To run tests against a different version of Elasticsearch, use the appropriate profile
+             and provide the Elasticsearch version:
+             
+                 mvn clean test -Pelasticsearch5 -DtestElasticsearchVersion=5.0.0
+          -->
+        
+        <!-- Elasticsearch [2.0,2.2) test environment -->
+        <profile>
+            <id>elasticsearch-2.0</id>
+            <properties>
+                <testElasticsearchMavenPluginVersion>2.2</testElasticsearchMavenPluginVersion>
+                <testElasticsearchVersion>2.0.0</testElasticsearchVersion>
+            </properties>
+        </profile>
+        
+        <!-- Elasticsearch 2.2+ test environment (default) -->
+        <profile>
+            <id>elasticsearch-2.2</id>
+            <activation>
+                <!-- Activate by default, i.e. if testElasticsearchVersion has not been defined explicitly -->
+                <property>
+                    <name>!testElasticsearchVersion</name>
+                </property>
+            </activation>
+            <properties>
+                <testElasticsearchMavenPluginVersion>2.2</testElasticsearchMavenPluginVersion>
+                <testElasticsearchVersion>2.3.1</testElasticsearchVersion>
             </properties>
         </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -181,13 +181,11 @@
         <commonsLangVersion>2.6</commonsLangVersion>
 
         <!-- Elasticsearch -->
-        <testElasticsearchMavenPluginVersion>2.0</testElasticsearchMavenPluginVersion>
+        <testElasticsearchMavenPluginVersion>2.2</testElasticsearchMavenPluginVersion>
         <!-- In theory we're not coupled to a specific version of Elasticsearch; this property
-             controls which version is being used to run integration tests. When updating,
-             make sure to use the right JNA version, too
+             controls which version is being used to run integration tests.
         -->
         <testElasticsearchVersion>2.3.1</testElasticsearchVersion>
-        <testElasticsearchJnaVersion>4.1.0</testElasticsearchJnaVersion>
         <elasticsearchJestVersion>2.0.0</elasticsearchJestVersion>
         <elasticsearchCommonsLang3Version>3.4</elasticsearchCommonsLang3Version>
         <elasticsearchGsonVersion>2.4</elasticsearchGsonVersion>
@@ -1277,14 +1275,6 @@ org.jboss.logging.BasicLogger#debugf(java.lang.Throwable, java.lang.String, long
                             <groupId>org.hibernate</groupId>
                             <artifactId>hibernate-search-sharedtestresources</artifactId>
                             <version>${project.version}</version>
-                        </dependency>
-
-                        <!-- JNA isn't part of the ES fat JAR; Adding it so ES doesn't complain 
-                             upon start-up -->
-                        <dependency>
-                            <groupId>net.java.dev.jna</groupId>
-                            <artifactId>jna</artifactId>
-                            <version>${testElasticsearchJnaVersion}</version>
                         </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION
~~This PR is based on HSEARCH-2437, so we need to merge #1206 first.~~ => Merged

Relevant JIRA ticket: https://hibernate.atlassian.net/browse/HSEARCH-2384

Not sure about this one...
Actually, there already was a parameter to test against another Elasticsearch version (kinda): we only need to pass `-DtestElasticsearchVersion=<myVersion>`.
Now, I polished it a bit, notably by including the parameter in the generated doc, but there's not much to do as long as we stay on ES 2.x.

On ES 5.x though, things get a bit tricky.
First thing: we have to use maven profiles, because the plugin configuration itself will change. Most notably, some dependencies are not available in ES 5 (the DeleteQuery plugin), and the elasticsearch-maven-plugin will be in a different version. Also, we need additional dependencies because ES 5 uses log4j2.
But the worst is, there's no support from elasticsearch-maven-plugin for ES 5 yet. So I had to work it around, forking the plugin and building it if needed in the `.travis.yml`. From Jenkins, we can't even build yet, and locally we have to first build the elasticsearch-maven-plugin from my fork and install it in the local Maven repository.

We could keep it that way, temporarily, though I have my doubts about licensing (since we're building a modified version of one of our compile-time dependencies, there may be some legal requirements on our side). Or we can wait and see what happens to my PR (https://github.com/alexcojocaru/elasticsearch-maven-plugin/pull/19). But if it doesn't move, we'll have to do _something_ (either maintain a fork, or setup our build environments differently).


*Update*: I got additional pieces of information, and it seems the future isn't very bright for elasticsearch-maven-plugin, mainly because the Elasticsearch team doesn't support embedded mode and will not publish plugins/modules JARs anymore. So the way to go is probably this: http://david.pilato.fr/blog/2016/10/18/elasticsearch-real-integration-tests-updated-for-ga/