### PR TITLE
HSEARCH-2330 (+	HSEARCH-2261) Allow MetadataProvidingFieldBridges to override field type 

### DIFF
--- a/engine/src/main/java/org/hibernate/search/engine/spi/DocumentBuilderIndexedEntity.java
+++ b/engine/src/main/java/org/hibernate/search/engine/spi/DocumentBuilderIndexedEntity.java
@@ -766,12 +766,15 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 	 */
 	private void addSortFieldDocValues(Document document, PropertyMetadata propertyMetadata, float documentBoost, Object propertyValue) {
 		for ( SortableFieldMetadata sortField : propertyMetadata.getSortableFieldMetadata() ) {
-			DocumentFieldMetadata fieldMetaData = propertyMetadata.getFieldMetadata( sortField.getFieldName() );
-
 			// field marked as sortable by custom bridge to allow sort field validation pass, but that bridge itself is
 			// in charge of adding the required field
-			if ( fieldMetaData == null ) {
+			if ( propertyMetadata.getBridgeDefinedFields().containsKey( sortField.getFieldName() ) ) {
 				continue;
+			}
+
+			DocumentFieldMetadata fieldMetaData = propertyMetadata.getFieldMetadata( sortField.getFieldName() );
+			if ( fieldMetaData == null ) {
+				throw new AssertionFailure( "A sortable field did not match neither an @Field nor a bridge-defined field" );
 			}
 
 			IndexableField field;

--- a/engine/src/main/java/org/hibernate/search/query/engine/impl/AbstractHSQuery.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/impl/AbstractHSQuery.java
@@ -302,16 +302,16 @@ public abstract class AbstractHSQuery implements HSQuery, Serializable {
 	}
 
 	private void validateCommonSortField(ExtendedSearchIntegrator extendedIntegrator, Iterable<Class<?>> targetedEntities, SortField sortField) {
-		DocumentFieldMetadata metadata = findFieldMetadata( extendedIntegrator, targetedEntities, sortField.getField() );
-		if ( metadata != null ) {
-			validateSortField( sortField, metadata );
+		// Inspect bridge-defined fields first, to allow them to override field metadata
+		BridgeDefinedField bridgeDefinedField = findBridgeDefinedField( extendedIntegrator, targetedEntities, sortField.getField() );
+		if ( bridgeDefinedField != null ) {
+			validateSortField( sortField, bridgeDefinedField );
 		}
 		else {
-			BridgeDefinedField bridgeDefinedField = findBridgeDefinedField( extendedIntegrator, targetedEntities, sortField.getField() );
-			if ( bridgeDefinedField != null ) {
-				validateSortField( sortField, bridgeDefinedField );
+			DocumentFieldMetadata metadata = findFieldMetadata( extendedIntegrator, targetedEntities, sortField.getField() );
+			if ( metadata != null ) {
+				validateSortField( sortField, metadata );
 			}
-			//else the field is not known. Custom fieldbridge? Not throwing an exception to improve backwards compatibility
 		}
 	}
 

--- a/engine/src/test/java/org/hibernate/search/test/dsl/SortDSLTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/dsl/SortDSLTest.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.lucene.document.Document;
+import org.apache.lucene.document.DoubleDocValuesField;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
@@ -23,14 +24,16 @@ import org.hibernate.search.annotations.DocumentId;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.FieldBridge;
 import org.hibernate.search.annotations.Indexed;
-import org.hibernate.search.annotations.NumericField;
 import org.hibernate.search.annotations.SortableField;
 import org.hibernate.search.annotations.Spatial;
 import org.hibernate.search.annotations.SpatialMode;
 import org.hibernate.search.backend.spi.Work;
 import org.hibernate.search.backend.spi.WorkType;
 import org.hibernate.search.bridge.LuceneOptions;
+import org.hibernate.search.bridge.MetadataProvidingFieldBridge;
 import org.hibernate.search.bridge.StringBridge;
+import org.hibernate.search.bridge.spi.FieldMetadataBuilder;
+import org.hibernate.search.bridge.spi.FieldType;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.query.dsl.QueryBuilder;
@@ -652,7 +655,13 @@ public class SortDSLTest {
 		}
 	}
 
-	public static class WrappedDoubleValueFieldBridge implements org.hibernate.search.bridge.FieldBridge, StringBridge {
+	public static class WrappedDoubleValueFieldBridge implements MetadataProvidingFieldBridge, StringBridge {
+
+		@Override
+		public void configureFieldMetadata(String name, FieldMetadataBuilder builder) {
+			builder.field( name, FieldType.DOUBLE )
+					.sortable( true );
+		}
 
 		@Override
 		public String objectToString(Object object) {
@@ -674,6 +683,7 @@ public class SortDSLTest {
 			}
 
 			luceneOptions.addNumericFieldToDocument( name, doubleValue, document );
+			document.add( new DoubleDocValuesField( name, doubleValue ) );
 		}
 
 	}
@@ -734,12 +744,9 @@ public class SortDSLTest {
 		Double uniqueNumericField;
 
 		@Field(bridge = @FieldBridge(impl = WrappedStringValueFieldBridge.class))
-		@SortableField
 		WrappedStringValue fieldBridgedStringField;
 
 		@Field(bridge = @FieldBridge(impl = WrappedDoubleValueFieldBridge.class))
-		@SortableField
-		@NumericField
 		WrappedDoubleValue fieldBridgedNumericField;
 
 		Double latitude;

--- a/orm/src/test/java/org/hibernate/search/test/query/sorting/Explorer.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/sorting/Explorer.java
@@ -22,7 +22,6 @@ import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.FieldBridge;
 import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.annotations.IndexedEmbedded;
-import org.hibernate.search.annotations.NumericField;
 import org.hibernate.search.annotations.SortableField;
 import org.hibernate.search.bridge.LuceneOptions;
 import org.hibernate.search.bridge.MetadataProvidingFieldBridge;
@@ -55,7 +54,6 @@ public class Explorer {
 	 * with the @IndexedEmbedded with the Elasticsearch backend
 	 */
 	@Field(name = "favoriteTerritory.idFromBridge", bridge = @FieldBridge(impl = Territory.IdFieldBridge.class))
-	@NumericField(forField = "favoriteTerritory.idFromBridge")
 	private Territory favoriteTerritory;
 
 	public Explorer() {

--- a/orm/src/test/java/org/hibernate/search/test/query/sorting/Territory.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/sorting/Territory.java
@@ -10,6 +10,7 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 
 import org.apache.lucene.document.Document;
+import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.util.BytesRef;
 import org.hibernate.search.annotations.Analyze;
@@ -56,6 +57,7 @@ public class Territory {
 			}
 			int id = ( (Territory) value ).getId();
 			luceneOptions.addNumericFieldToDocument( name, id, document );
+			document.add( new NumericDocValuesField( name, id ) );
 		}
 
 	}


### PR DESCRIPTION
This PR is based on #1197 (HSEARCH-2393), which will have to be merged first.

Relevant tickets:

 * https://hibernate.atlassian.net/browse/HSEARCH-2330
 * https://hibernate.atlassian.net/browse/HSEARCH-2261

I implemented the solution suggested in my last comment on HSEARCH-2330. By allowing `MetadataProvidingFieldBridge`s to override the field type, we end up removing the need for users to use workarounds, such as adding a @Numeric annotation on non-numeric properties that have a custom field bridge that will generate a numeric field. Now the whole knowledge about the type resides in the custom field bridge, which seems a bit cleaner.