### PR TITLE
HSEARCH-2422 Always compute scores when projecting on the score in Elasticsearch

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchHSQueryImpl.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchHSQueryImpl.java
@@ -334,6 +334,16 @@ public class ElasticsearchHSQueryImpl extends AbstractHSQuery {
 				completeQuery.add( "aggregations", facets );
 			}
 
+			if ( projectedFields != null ) {
+				for ( String field : projectedFields ) {
+					if ( ElasticsearchProjectionConstants.SCORE.equals( field ) ) {
+						// Make sure to compute scores even if we don't sort by relevance
+						completeQuery.addProperty( "track_scores", true );
+						break;
+					}
+				}
+			}
+
 			// Initialize the sortByDistanceIndex to detect if the results are sorted by distance and the position
 			// of the sort
 			sortByDistanceIndex = getSortByDistanceIndex();

--- a/orm/src/test/java/org/hibernate/search/test/query/ProjectionQueryTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/ProjectionQueryTest.java
@@ -425,7 +425,6 @@ public class ProjectionQueryTest extends SearchTestBase {
 	}
 
 	@Test
-	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2422 Error when projecting on the score while not sorting by relevance
 	public void testProjectionOnScoreWithoutRelevanceSort() throws Exception {
 		FullTextSession s = Search.getFullTextSession( openSession() );
 		prepEmployeeIndex( s );


### PR DESCRIPTION
This PR is based on #1197 (HSEARCH-2393), so we'll have to merge that one first.

Relevant JIRA ticket: https://hibernate.atlassian.net/browse/HSEARCH-2422