### PR TITLE
HSEARCH-2445 Improve error handling

### DIFF
--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/IndexWriterHolder.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/IndexWriterHolder.java
@@ -27,6 +27,7 @@ import org.hibernate.search.exception.ErrorContext;
 import org.hibernate.search.exception.ErrorHandler;
 import org.hibernate.search.exception.impl.ErrorContextBuilder;
 import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
+import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.store.DirectoryProvider;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
@@ -40,6 +41,7 @@ class IndexWriterHolder {
 	private final ErrorHandler errorHandler;
 	private final ParameterSet indexParameters;
 	private final DirectoryProvider directoryProvider;
+	private final IndexManager indexManager;
 	private final String indexName;
 
 	// variable state:
@@ -64,6 +66,7 @@ class IndexWriterHolder {
 
 	IndexWriterHolder(ErrorHandler errorHandler, DirectoryBasedIndexManager indexManager) {
 		this.errorHandler = errorHandler;
+		this.indexManager = indexManager;
 		this.indexName = indexManager.getIndexName();
 		this.luceneParameters = indexManager.getIndexingParameters();
 		this.indexParameters = luceneParameters.getIndexParameters();
@@ -250,7 +253,7 @@ class IndexWriterHolder {
 		}
 		final ErrorContext errorContext;
 		if ( errorContextBuilder != null ) {
-			errorContext = errorContextBuilder.errorThatOccurred( ioe ).createErrorContext();
+			errorContext = errorContextBuilder.errorThatOccurred( ioe ).indexManager( indexManager ).createErrorContext();
 			this.errorHandler.handle( errorContext );
 		}
 		else {

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/LuceneBackendQueueTask.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/LuceneBackendQueueTask.java
@@ -62,7 +62,7 @@ final class LuceneBackendQueueTask implements Runnable {
 	private void handleException(Exception e) {
 		ErrorContextBuilder builder = new ErrorContextBuilder();
 		builder.allWorkToBeDone( workList );
-		builder.errorThatOccurred( e );
+		builder.errorThatOccurred( e ).indexManager( resources.getIndexManager() );
 		resources.getErrorHandler().handle( builder.createErrorContext() );
 	}
 
@@ -75,6 +75,7 @@ final class LuceneBackendQueueTask implements Runnable {
 		AbstractWorkspaceImpl workspace = resources.getWorkspace();
 
 		ErrorContextBuilder errorContextBuilder = new ErrorContextBuilder();
+		errorContextBuilder.indexManager( resources.getIndexManager() );
 		errorContextBuilder.allWorkToBeDone( workList );
 
 		IndexWriterDelegate delegate = workspace.getIndexWriterDelegate( errorContextBuilder );
@@ -96,7 +97,7 @@ final class LuceneBackendQueueTask implements Runnable {
 			someFailureHappened = false;
 		}
 		catch (RuntimeException re) {
-			errorContextBuilder.errorThatOccurred( re );
+			errorContextBuilder.errorThatOccurred( re ).indexManager( resources.getIndexManager() );
 			if ( currentOperation != null ) {
 				errorContextBuilder.addWorkThatFailed( currentOperation );
 			}

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/LuceneBackendResources.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/LuceneBackendResources.java
@@ -20,6 +20,7 @@ import org.hibernate.search.backend.impl.lucene.works.LuceneWorkExecutor;
 import org.hibernate.search.exception.ErrorHandler;
 import org.hibernate.search.indexes.impl.PropertiesParseHelper;
 import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
+import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.spi.WorkerBuildContext;
 import org.hibernate.search.util.impl.Executors;
 import org.hibernate.search.util.logging.impl.Log;
@@ -40,6 +41,7 @@ public final class LuceneBackendResources {
 	private final ErrorHandler errorHandler;
 	private final int maxQueueLength;
 	private final String indexName;
+	private final IndexManager indexManager;
 
 	private final ReadLock readLock;
 	private final WriteLock writeLock;
@@ -48,6 +50,7 @@ public final class LuceneBackendResources {
 
 	LuceneBackendResources(WorkerBuildContext context, DirectoryBasedIndexManager indexManager, Properties props, AbstractWorkspaceImpl workspace) {
 		this.indexName = indexManager.getIndexName();
+		this.indexManager = indexManager;
 		this.errorHandler = context.getErrorHandler();
 		this.workspace = workspace;
 		this.maxQueueLength = PropertiesParseHelper.extractMaxQueueSize( indexName, props );
@@ -57,6 +60,7 @@ public final class LuceneBackendResources {
 	}
 
 	private LuceneBackendResources(LuceneBackendResources previous) {
+		this.indexManager = previous.indexManager;
 		this.indexName = previous.indexName;
 		this.errorHandler = previous.errorHandler;
 		this.workspace = previous.workspace;
@@ -93,6 +97,10 @@ public final class LuceneBackendResources {
 
 	public String getIndexName() {
 		return indexName;
+	}
+
+	public IndexManager getIndexManager() {
+		return indexManager;
 	}
 
 	public IndexWorkVisitor<Void, LuceneWorkExecutor> getWorkVisitor() {

--- a/engine/src/main/java/org/hibernate/search/exception/ErrorContext.java
+++ b/engine/src/main/java/org/hibernate/search/exception/ErrorContext.java
@@ -9,6 +9,7 @@ package org.hibernate.search.exception;
 import java.util.List;
 
 import org.hibernate.search.backend.LuceneWork;
+import org.hibernate.search.indexes.spi.IndexManager;
 
 /**
  * @author Amin Mohammed-Coleman
@@ -23,5 +24,7 @@ public interface ErrorContext {
 	Throwable getThrowable();
 
 	boolean hasErrors();
+
+	IndexManager getIndexManager();
 
 }

--- a/engine/src/main/java/org/hibernate/search/exception/impl/ErrorContextBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/exception/impl/ErrorContextBuilder.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.exception.ErrorContext;
+import org.hibernate.search.indexes.spi.IndexManager;
 
 /**
  * @author Amin Mohammed-Coleman
@@ -23,6 +24,7 @@ public class ErrorContextBuilder {
 	private Iterable<LuceneWork> workToBeDone;
 	private List<LuceneWork> failingOperations;
 	private List<LuceneWork> operationsThatWorked;
+	private IndexManager indexManager;
 
 	public ErrorContextBuilder errorThatOccurred(Throwable th) {
 		this.th = th;
@@ -43,6 +45,11 @@ public class ErrorContextBuilder {
 		this.getOperationsThatWorked().add( luceneWork );
 		return this;
 
+	}
+
+	public ErrorContextBuilder indexManager(IndexManager indexName) {
+		this.indexManager = indexName;
+		return this;
 	}
 
 	public ErrorContextBuilder allWorkToBeDone(Iterable<LuceneWork> workOnWriter) {
@@ -71,6 +78,7 @@ public class ErrorContextBuilder {
 			}
 		}
 		context.setFailingOperations( getFailingOperations() );
+		context.setIndexManager( indexManager );
 		return context;
 	}
 

--- a/engine/src/main/java/org/hibernate/search/exception/impl/ErrorContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/exception/impl/ErrorContextImpl.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.exception.ErrorContext;
+import org.hibernate.search.indexes.spi.IndexManager;
 
 /**
  * @author Amin Mohammed-Coleman
@@ -23,6 +24,8 @@ class ErrorContextImpl implements ErrorContext {
 	private LuceneWork operationAtFault;
 
 	private Throwable throwable;
+
+	private IndexManager indexManager;
 
 	@Override
 	public List<LuceneWork> getFailingOperations() {
@@ -57,6 +60,15 @@ class ErrorContextImpl implements ErrorContext {
 	@Override
 	public boolean hasErrors() {
 		return failingOperations != null && failingOperations.size() > 0;
+	}
+
+	@Override
+	public IndexManager getIndexManager() {
+		return indexManager;
+	}
+
+	public void setIndexManager(IndexManager indexManager) {
+		this.indexManager = indexManager;
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/search/spi/ErrorHandlerFactory.java
+++ b/engine/src/main/java/org/hibernate/search/spi/ErrorHandlerFactory.java
@@ -1,0 +1,73 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.spi;
+
+import org.hibernate.search.cfg.Environment;
+import org.hibernate.search.cfg.spi.SearchConfiguration;
+import org.hibernate.search.engine.service.classloading.spi.ClassLoaderService;
+import org.hibernate.search.exception.ErrorHandler;
+import org.hibernate.search.exception.impl.LogErrorHandler;
+import org.hibernate.search.util.StringHelper;
+import org.hibernate.search.util.impl.ClassLoaderHelper;
+import org.hibernate.search.util.logging.impl.Log;
+import org.hibernate.search.util.logging.impl.LoggerFactory;
+
+/**
+ * Factory of {@link org.hibernate.search.exception.ErrorHandler}.
+ */
+public class ErrorHandlerFactory {
+
+	private static final Log log = LoggerFactory.make();
+
+	/**
+	 * @return Default ErrorHandler in case none is explicitly configured.
+	 */
+	public ErrorHandler getDefault() {
+		return new LogErrorHandler();
+	}
+
+	/**
+	 * @param searchConfiguration
+	 * @return ErrorHandler specified in the {@link SearchConfiguration} or the default one in case not specified.
+	 */
+	public ErrorHandler createErrorHandler(SearchConfiguration searchConfiguration) {
+		Object configuredErrorHandler = searchConfiguration.getProperties().get( Environment.ERROR_HANDLER );
+
+		if ( configuredErrorHandler == null ) {
+			return getDefault();
+		}
+		if ( configuredErrorHandler instanceof String ) {
+			return createErrorHandlerFromString(
+					(String) configuredErrorHandler,
+					searchConfiguration.getClassLoaderService()
+			);
+		}
+		else if ( configuredErrorHandler instanceof ErrorHandler ) {
+			return (ErrorHandler) configuredErrorHandler;
+		}
+		else {
+			throw log.unsupportedErrorHandlerConfigurationValueType( configuredErrorHandler.getClass() );
+		}
+	}
+
+	private ErrorHandler createErrorHandlerFromString(
+			String errorHandlerClassName,
+			ClassLoaderService classLoaderService) {
+		if ( StringHelper.isEmpty( errorHandlerClassName ) || ErrorHandler.LOG.equals( errorHandlerClassName.trim() ) ) {
+			return getDefault();
+		}
+		else {
+			Class<?> errorHandlerClass = classLoaderService.classForName( errorHandlerClassName );
+			return ClassLoaderHelper.instanceFromClass(
+					ErrorHandler.class,
+					errorHandlerClass,
+					"Error Handler"
+			);
+		}
+	}
+
+}

--- a/orm/src/test/java/org/hibernate/search/test/errorhandling/LuceneErrorHandlingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/errorhandling/LuceneErrorHandlingTest.java
@@ -87,6 +87,7 @@ public class LuceneErrorHandlingTest extends SearchTestBase {
 		Assert.assertEquals( expectedErrorMessage.toString() , errorMessage );
 		Assert.assertTrue( exception instanceof SearchException );
 		Assert.assertEquals( "failed work message", exception.getMessage() );
+		Assert.assertEquals( indexManager, mockErrorHandler.getIndexManager() );
 	}
 
 	private MockErrorHandler getErrorHandlerAndAssertCorrectTypeIsUsed() {

--- a/orm/src/test/java/org/hibernate/search/test/errorhandling/MockErrorHandler.java
+++ b/orm/src/test/java/org/hibernate/search/test/errorhandling/MockErrorHandler.java
@@ -6,7 +6,9 @@
  */
 package org.hibernate.search.test.errorhandling;
 
+import org.hibernate.search.exception.ErrorContext;
 import org.hibernate.search.exception.impl.LogErrorHandler;
+import org.hibernate.search.indexes.spi.IndexManager;
 
 /**
  * This is a LogErrorHandler used for testing only,
@@ -20,6 +22,13 @@ public class MockErrorHandler extends LogErrorHandler {
 
 	private volatile String errorMessage;
 	private volatile Throwable lastException;
+	private IndexManager indexManager;
+
+	@Override
+	public void handle(ErrorContext context) {
+		indexManager = context.getIndexManager();
+		super.handle( context );
+	}
 
 	@Override
 	public void handleException(String errorMsg, Throwable exceptionThatOccurred) {
@@ -33,6 +42,10 @@ public class MockErrorHandler extends LogErrorHandler {
 
 	public Throwable getLastException() {
 		return lastException;
+	}
+
+	public IndexManager getIndexManager() {
+		return indexManager;
 	}
 
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2445

As described in the JIRA, this PR introduces two changes:
* Expose the ```IndexManager``` in the ```ErrorContext```
* Relocate the ```ErrorHandler``` creation to ```Configuration``` level so that it's easier to eventually wrap the default one