### PR TITLE
HSEARCH-2235 Added the ability to configure multiple Elasticsearch hosts

### DIFF
--- a/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
+++ b/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
@@ -102,6 +102,12 @@ Add them to your `persistence.xml` or where you put the rest of your Hibernate S
 
 Select Elasticsearch as the backend:: `hibernate.search.default.indexmanager elasticsearch`
 Hostname and port for Elasticsearch:: `hibernate.search.default.elasticsearch.host \http://127.0.0.1:9200` (default)
++
+You may also select multiple hosts (separated by whitespace characters), so that they are assigned requests in turns (load balancing):
++
+`hibernate.search.default.elasticsearch.host \http://es1.mycompany.com:9200 \http://es2.mycompany.com:9200`
++
+In the example above, the first request will go to `es1`, the second to `es2`, the third to `es1`, and so on.
 Selects the index creation strategy::
 `hibernate.search.default.elasticsearch.index_schema_management_strategy CREATE` (default)
 +
@@ -536,3 +542,4 @@ Please check with JIRA and the mailing lists for updates, but at the time of wri
 * Hibernate Search does not make use of nested objects nor parent child relationship mapping https://hibernate.atlassian.net/browse/HSEARCH-2263[HSEARCH-2263].
   This is largely mitigated by the fact that Hibernate Search does the denormalization itself and maintain data consistency when nested objects are updated.
 * There is room for improvements in the performances of the MassIndexer implementation
+* There is no failover to the next host when multiple hosts are configured and one host happens to fail: https://hibernate.atlassian.net/browse/HSEARCH-2469[HSEARCH-2469]

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/ElasticsearchEnvironment.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/ElasticsearchEnvironment.java
@@ -29,12 +29,14 @@ public final class ElasticsearchEnvironment {
 	}
 
 	/**
-	 * Property for specifying the host name of the Elasticsearch server to connect to. Only a single server (which may
-	 * be part of a cluster) is supported at this point.
+	 * Property for specifying the host names and HTTP ports of the Elasticsearch servers to connect to.
 	 * <p>
-	 * An URI such as http://myeshost.com:9200 is expected.
+	 * URIs such as http://myeshost.com:9200 are expected, separated by whitespace characters.
 	 * <p>
 	 * Defaults to {@link Defaults#SERVER_URI}.
+	 * <p>
+	 * Multiple servers may be specified for load-balancing: requests will be assigned to each host in turns.
+	 * Failover is not supported yet.
 	 * <p>
 	 * Can only be given <b>globally</b> (e.g.
 	 * {@code hibernate.search.default.elasticsearch.host=http://myeshost.com:9200}), i.e. only a single Elasticsearch

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/JestClient.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/JestClient.java
@@ -8,6 +8,8 @@ package org.hibernate.search.elasticsearch.client.impl;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -74,15 +76,17 @@ public class JestClient implements Service, Startable, Stoppable {
 
 		JestClientFactory factory = new JestClientFactory();
 
-		String serverUri = ConfigurationParseHelper.getString(
+		String serverUrisString = ConfigurationParseHelper.getString(
 				properties,
 				SERVER_URI_PROP_PREFIX + ElasticsearchEnvironment.SERVER_URI,
 				ElasticsearchEnvironment.Defaults.SERVER_URI
 		);
 
+		Collection<String> serverUris = Arrays.asList( serverUrisString.trim().split( "\\s" ) );
+
 		// TODO HSEARCH-2062 Make timeouts configurable
 		factory.setHttpClientConfig(
-			new HttpClientConfig.Builder( serverUri )
+			new HttpClientConfig.Builder( serverUris )
 				.multiThreaded( true )
 				.readTimeout( 60000 )
 				.connTimeout( 2000 )


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2235

Unfortunately Jest does not handle failover out of the box. So I created [HSEARCH-2469](https://hibernate.atlassian.net/browse/HSEARCH-2469) as a follow-up.

The tests are far from perfect, but right now the elasticsearch-maven-plugin doesn't allow launching multiple Elasticsearch nodes in a single cluster, so we can't do much better.