### PR TITLE
HSEARCH-2360 and others: fixes around projections

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchHSQueryImpl.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchHSQueryImpl.java
@@ -242,6 +242,7 @@ public class ElasticsearchHSQueryImpl extends AbstractHSQuery {
 
 	@Override
 	protected void clearCachedResults() {
+		searcher = null;
 		searchResult = null;
 		resultSize = null;
 	}

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
@@ -123,11 +123,6 @@ public interface Log extends org.hibernate.search.util.logging.impl.Log {
 	)
 	SearchException unexpectedNumericEncodingType(String fieldType, String fieldName);
 
-	@Message(id = ES_BACKEND_MESSAGES_START_ID + 19,
-			value = "Cannot project field '%2$s' for entity %1$s: unknown field"
-	)
-	SearchException unknownFieldForProjection(String entityType, String fieldName);
-
 	@Message(id = ES_BACKEND_MESSAGES_START_ID + 20,
 			value = "Could not create mapping for entity type %1$s"
 	)

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/FieldHelper.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/FieldHelper.java
@@ -131,6 +131,12 @@ public class FieldHelper {
 	}
 
 	public static ExtendedFieldType getType(DocumentFieldMetadata fieldMetadata) {
+		// Always use user-provided type in priority
+		BridgeDefinedField overriddenField = fieldMetadata.getBridgeDefinedFields().get( fieldMetadata.getAbsoluteName() );
+		if ( overriddenField != null ) {
+			return getType( overriddenField );
+		}
+
 		PropertyMetadata propertyMetata = fieldMetadata.getSourceProperty();
 		Class<?> propertyClass = propertyMetata == null ? null : propertyMetata.getPropertyClass();
 		if ( propertyClass == null ) {

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchClassBridgeIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchClassBridgeIT.java
@@ -114,7 +114,7 @@ public class ElasticsearchClassBridgeIT extends SearchTestBase {
 
 		Object[] projection = (Object[]) result.iterator().next();
 		assertThat( projection[0] ).describedAs( "fullName" ).isEqualTo( "Klaus Hergesheimer" );
-		assertThat( ( (Number) projection[1] ).intValue() ).describedAs( "age" ).isEqualTo( 34 );
+		assertThat( (Integer) projection[1] ).describedAs( "age" ).isEqualTo( 34 );
 
 		tx.commit();
 		s.close();

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIndexMappingIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIndexMappingIT.java
@@ -160,7 +160,7 @@ public class ElasticsearchIndexMappingIT extends SearchTestBase {
 							"'null_value':false" +
 						"}," +
 						"'age':{" +
-							"'type':'string'" +
+							"'type':'integer'" +
 						"}," +
 						"'dateOfBirth':{" +
 							"'type':'date'," +

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/NameConcatenationBridge.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/NameConcatenationBridge.java
@@ -7,18 +7,27 @@
 package org.hibernate.search.elasticsearch.test;
 
 import org.apache.lucene.document.Document;
-import org.hibernate.search.bridge.FieldBridge;
 import org.hibernate.search.bridge.LuceneOptions;
+import org.hibernate.search.bridge.TwoWayFieldBridge;
 
 /**
  * @author Gunnar Morling
  */
-public class NameConcatenationBridge implements FieldBridge {
+public class NameConcatenationBridge implements TwoWayFieldBridge {
 
 	@Override
 	public void set(String name, Object value, Document document, LuceneOptions luceneOptions) {
-		GolfPlayer player = (GolfPlayer) value;
+		luceneOptions.addFieldToDocument( name, objectToString( value ), document );
+	}
 
+	@Override
+	public Object get(String name, Document document) {
+		return document.get( name );
+	}
+
+	@Override
+	public String objectToString(Object object) {
+		GolfPlayer player = (GolfPlayer) object;
 		StringBuilder names = new StringBuilder();
 		if ( player.getFirstName() != null ) {
 			names.append( player.getFirstName() ).append( " " );
@@ -26,7 +35,6 @@ public class NameConcatenationBridge implements FieldBridge {
 		if ( player.getLastName() != null ) {
 			names.append( player.getLastName() );
 		}
-
-		luceneOptions.addFieldToDocument( name, names.toString(), document );
+		return names.toString();
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/impl/DocumentBuilderHelper.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/DocumentBuilderHelper.java
@@ -129,10 +129,10 @@ public final class DocumentBuilderHelper {
 		}
 		else {
 			if ( store == Store.NO ) {
-				throw new SearchException( "Projecting an unstored field: " + fieldName );
+				throw log.projectingNonStoredField( fieldName );
 			}
 			else {
-				throw new SearchException( "FieldBridge is not a TwoWayFieldBridge: " + fieldBridge.getClass() );
+				throw log.projectingFieldWithoutTwoWayFieldBridge( fieldName, fieldBridge.getClass() );
 			}
 		}
 	}

--- a/engine/src/main/java/org/hibernate/search/query/engine/impl/AbstractHSQuery.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/impl/AbstractHSQuery.java
@@ -156,6 +156,7 @@ public abstract class AbstractHSQuery implements HSQuery, Serializable {
 			}
 			this.hasThisProjection = hasThis;
 		}
+		clearCachedResults();
 		return this;
 	}
 

--- a/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
@@ -994,4 +994,10 @@ public interface Log extends BasicLogger {
 			+ "gracefully for index '%s'.")
 	void timedOutWaitingShutdownOfReaderProvider(String indexName);
 
+	@Message(id = 323, value = "The field '%1$s' is not stored.")
+	SearchException projectingNonStoredField(String fieldName);
+
+	@Message(id = 324, value = "The fieldBridge for field '%1$s' is an instance of '%2$s', which does not implement TwoWayFieldBridge. Projected fields must have a TwoWayFieldBridge.")
+	SearchException projectingFieldWithoutTwoWayFieldBridge(String fieldName, Class<?> fieldBridgeClass);
+
 }


### PR DESCRIPTION
~This PR is based on #1217 (HSEARCH-2451), so we'll have to wait for that one to be merged first.~ => Done!

The purpose of this PR is:

 1. to use source filtering when projecting: [HSEARCH-2360](https://hibernate.atlassian.net/browse/HSEARCH-2360)
 2. to add support for projection on fields that are not mapped in Elasticsearch (aligning the behavior on the Lucene indexing service): [HSEARCH-2471](https://hibernate.atlassian.net/browse/HSEARCH-2471)
 3. to drop support for projection on fields that have only one-way bridges (aligning the behavior on the Lucene indexing service): [HSEARCH-2470](https://hibernate.atlassian.net/browse/HSEARCH-2470)

The main change is that, because of 1., metadata inspection for projections is now executed when building the query, and is not executed anymore when converting JSON hits to Java objects: the initial metadata inspection produces objects responsible for later data conversion that already take metadata into account.
The exact reason for this change is to avoid code duplication: since we now have to inspect metadata before running the query (to build the source filtering parameter), we may as well make the most of it.
One side-effect is that now, we only inspect metadata once for each field and for each queried type, whereas we used to inspect metadata once for each field and for each result. Which is not perfect, but arguably better.