### PR TITLE
HSEARCH-2400 Support IndexingMonitor for the Elasticsearch backend

### DIFF
--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -247,9 +247,6 @@
                                 <exclude>**/JPATimeoutTest.java</exclude>
                                 <exclude>**/TimeoutTest.java</exclude>
                                 
-                                <!-- HSEARCH-2400 Support IndexingMonitor for the Elasticsearch backend -->
-                                <exclude>**/ProgressMonitorTest.java</exclude>
-                                
                                 <!-- HSEARCH-2426 Remote analyzer initialization fails when using dynamic sharding on Elasticsearch -->
                                 <exclude>**/DirectoryProviderForQueryTest.java</exclude>
                                 <exclude>**/CustomerShardingStrategyTest.java</exclude>

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/BackendRequest.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/BackendRequest.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
 
 import io.searchbox.action.Action;
@@ -28,12 +29,18 @@ public class BackendRequest<T extends JestResult> {
 	private final Set<Integer> ignoredErrorStatuses;
 	private final LuceneWork luceneWork;
 	private final String indexName;
+	private final IndexingMonitor indexingMonitor;
+	private final BackendRequestSuccessReporter<? super T> successReporter;
 	private final boolean refreshAfterWrite;
 
-	public BackendRequest(Action<T> action, LuceneWork luceneWork, String indexName, boolean refreshAfterWrite, int... ignoredErrorStatuses) {
+	public BackendRequest(Action<T> action, LuceneWork luceneWork, String indexName,
+			IndexingMonitor indexingMonitor, BackendRequestSuccessReporter<? super T> successReporter,
+			boolean refreshAfterWrite, int... ignoredErrorStatuses) {
 		this.action = action;
 		this.luceneWork = luceneWork;
 		this.indexName = indexName;
+		this.indexingMonitor = indexingMonitor;
+		this.successReporter = successReporter;
 		this.refreshAfterWrite = refreshAfterWrite;
 		this.ignoredErrorStatuses = asSet( ignoredErrorStatuses );
 	}
@@ -69,6 +76,14 @@ public class BackendRequest<T extends JestResult> {
 
 	public String getIndexName() {
 		return indexName;
+	}
+
+	public IndexingMonitor getIndexingMonitor() {
+		return indexingMonitor;
+	}
+
+	public BackendRequestSuccessReporter<? super T> getSuccessReporter() {
+		return successReporter;
 	}
 
 	/**

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/BackendRequestProcessor.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/BackendRequestProcessor.java
@@ -23,6 +23,7 @@ import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.engine.service.spi.Startable;
 import org.hibernate.search.engine.service.spi.Stoppable;
 import org.hibernate.search.exception.ErrorHandler;
+import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.spi.BuildContext;
 import org.hibernate.search.util.impl.Executors;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
@@ -165,8 +166,8 @@ public class BackendRequestProcessor implements Service, Startable, Stoppable {
 		try {
 			jestClient.executeRequest( refreshBuilder.build() );
 		}
-		catch (BulkRequestFailedException brfe) {
-			errorHandler.handleException( "Refresh failed", brfe );
+		catch (SearchException e) {
+			errorHandler.handleException( "Refresh failed", e );
 		}
 	}
 

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/BackendRequestSuccessReporter.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/BackendRequestSuccessReporter.java
@@ -1,0 +1,33 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.client.impl;
+
+import org.hibernate.search.backend.IndexingMonitor;
+
+import io.searchbox.client.JestResult;
+import io.searchbox.core.BulkResult.BulkResultItem;
+
+/**
+ * @author Yoann Rodiere
+ */
+public interface BackendRequestSuccessReporter<T extends JestResult> {
+
+	/**
+	 * Reports the given detailed result to the given monitor.
+	 * @param result The detailed result.
+	 * @param monitor The monitor to report results to.
+	 */
+	void report(T result, IndexingMonitor monitor);
+
+	/**
+	 * Reports the given summary result to the given monitor.
+	 * @param bulkResultItem The summary result.
+	 * @param monitor The monitor to report results to.
+	 */
+	void report(BulkResultItem bulkResultItem, IndexingMonitor monitor);
+
+}

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/BulkRequest.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/BulkRequest.java
@@ -8,12 +8,18 @@ package org.hibernate.search.elasticsearch.client.impl;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
+import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.exception.ErrorHandler;
 import org.hibernate.search.exception.impl.ErrorContextBuilder;
+
+import io.searchbox.core.BulkResult.BulkResultItem;
 
 /**
  * A request group backed by an actual bulk request.
@@ -38,7 +44,8 @@ public class BulkRequest implements ExecutableRequest {
 	 */
 	private final Set<String> indexesNeedingRefresh;
 
-	public BulkRequest(JestClient jestClient, ErrorHandler errorHandler, List<BackendRequest<?>> requests, Set<String> indexNames, Set<String> indexesNeedingRefresh, boolean refresh) {
+	public BulkRequest(JestClient jestClient, ErrorHandler errorHandler, List<BackendRequest<?>> requests,
+			Set<String> indexNames, Set<String> indexesNeedingRefresh, boolean refresh) {
 		this.jestClient = jestClient;
 		this.errorHandler = errorHandler;
 		this.requests = requests;
@@ -49,19 +56,20 @@ public class BulkRequest implements ExecutableRequest {
 
 	@Override
 	public void execute() {
+		Map<BackendRequest<?>, BulkResultItem> results = null;
 		try {
-			jestClient.executeBulkRequest( requests, refresh );
+			results = jestClient.executeBulkRequest( requests, refresh );
+			RuntimeException e = reportResults( results, null );
+			if ( e != null ) {
+				throw e; // Handle the exception below
+			}
 		}
 		catch (BulkRequestFailedException brfe) {
+			// Call the result handler anyway for those requests that succeeded
+			reportResults( brfe.getSuccessfulItems(), brfe );
+
 			ErrorContextBuilder builder = new ErrorContextBuilder();
 			List<LuceneWork> allWork = new ArrayList<>();
-
-			for ( BackendRequest<?> backendRequest : requests ) {
-				allWork.add( backendRequest.getLuceneWork() );
-				if ( !brfe.getErroneousItems().contains( backendRequest ) ) {
-					builder.workCompleted( backendRequest.getLuceneWork() );
-				}
-			}
 
 			builder.allWorkToBeDone( allWork );
 
@@ -76,6 +84,81 @@ public class BulkRequest implements ExecutableRequest {
 		catch (Exception e) {
 			errorHandler.handleException( "Bulk request failed", e );
 		}
+	}
+
+	/**
+	 * Call every result reporter making sure that:<ul>
+	 * <li>calls to indexing monitors are grouped, meaning if 5 results require a call to {@code documentsAdded}
+	 * (for instance), only one call will be done with {@code 5L} as a parameter.
+	 * <li>exceptions are handled properly so that one failing reporter will not prevent others from being called
+	 * </ul>
+	 *
+	 * <p>No locally caught exception will be re-thrown, but the "main" exception will be returned.
+	 * The "main" exception is either the {@code preexistingMainException} parameter (if non-null) or the first
+	 * locally caught exception. Every locally caught exception that is not the "main" exception will be
+	 * added as suppressed to the "main" exception.
+	 *
+	 * @param successfulItems The requests and their results, for calling result reporters.
+	 * @param preexistingMainException The exception to use as a "main" exception (see above), or {@code null}.
+	 * @return The "main" exception (see above), or {@code null} if there isn't any.
+	 */
+	private RuntimeException reportResults(Map<BackendRequest<?>, BulkResultItem> successfulItems, RuntimeException preexistingMainException) {
+		/*
+		 * We use buffers to avoid too many calls to the actual index monitor, which is potentially synchronized
+		 * and hence may be a contention point.
+		 */
+		Map<IndexingMonitor, BufferingIndexMonitor> buffers = new HashMap<>();
+
+		RuntimeException mainException = preexistingMainException;
+		for ( Map.Entry<BackendRequest<?>, BulkResultItem> entry : successfulItems.entrySet() ) {
+			try {
+				reportResult( buffers, entry );
+			}
+			catch (RuntimeException e) {
+				mainException = returnOrSuppressException( mainException, e );
+			}
+		}
+
+		// Flush the buffers
+		for ( BufferingIndexMonitor buffer : buffers.values() ) {
+			try {
+				buffer.flush();
+			}
+			catch (RuntimeException e) {
+				mainException = returnOrSuppressException( mainException, e );
+			}
+		}
+
+		return mainException;
+	}
+
+	private RuntimeException returnOrSuppressException(RuntimeException existingException, RuntimeException newException) {
+		// Do not stop calling handlers just because *one* handler failed, report the error later
+		if ( existingException == null ) {
+			return newException;
+		}
+		else {
+			existingException.addSuppressed( newException );
+			return existingException;
+		}
+	}
+
+	private void reportResult(Map<IndexingMonitor, BufferingIndexMonitor> buffers, Entry<BackendRequest<?>, BulkResultItem> entry) {
+		BackendRequest<?> request = entry.getKey();
+		BulkResultItem result = entry.getValue();
+
+		IndexingMonitor originalMonitor = request.getIndexingMonitor();
+		if ( originalMonitor == null ) {
+			return;
+		}
+
+		BufferingIndexMonitor bufferingMonitor = buffers.get( originalMonitor );
+		if ( bufferingMonitor == null ) {
+			bufferingMonitor = new BufferingIndexMonitor( originalMonitor );
+			buffers.put( originalMonitor, bufferingMonitor );
+		}
+
+		request.getSuccessReporter().report( result, bufferingMonitor );
 	}
 
 	@Override
@@ -102,5 +185,27 @@ public class BulkRequest implements ExecutableRequest {
 	public String toString() {
 		return "BulkRequest [size=" + requests.size() + ", refresh=" + refresh + ", indexNames=" + indexNames + ", indexesNeedingRefresh=" + indexesNeedingRefresh
 				+ "]";
+	}
+
+	private static final class BufferingIndexMonitor implements IndexingMonitor {
+
+		private final IndexingMonitor delegate;
+
+		private long documentsAdded = 0L;
+
+		public BufferingIndexMonitor(IndexingMonitor delegate) {
+			super();
+			this.delegate = delegate;
+		}
+
+		@Override
+		public void documentsAdded(long increment) {
+			documentsAdded += increment;
+		}
+
+		private void flush() {
+			delegate.documentsAdded( documentsAdded );
+			documentsAdded = 0L;
+		}
 	}
 }

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/BulkRequestFailedException.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/BulkRequestFailedException.java
@@ -8,10 +8,12 @@ package org.hibernate.search.elasticsearch.client.impl;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.hibernate.search.exception.SearchException;
 
 import io.searchbox.client.JestResult;
+import io.searchbox.core.BulkResult.BulkResultItem;
 
 /**
  * A failure during applying a bulk of index changes. Provides access to the failed requests and in turn Lucene works.
@@ -20,11 +22,19 @@ import io.searchbox.client.JestResult;
  */
 public class BulkRequestFailedException extends SearchException {
 
+	private final Map<BackendRequest<?>, BulkResultItem> successfulItems;
+
 	private final List<BackendRequest<?>> erroneousItems;
 
-	public BulkRequestFailedException(String message, List<BackendRequest<? extends JestResult>> erroneousItems) {
+	public BulkRequestFailedException(String message, Map<BackendRequest<?>, BulkResultItem> successfulItems,
+			List<BackendRequest<? extends JestResult>> erroneousItems) {
 		super( message );
+		this.successfulItems = Collections.unmodifiableMap( successfulItems );
 		this.erroneousItems = Collections.unmodifiableList( erroneousItems );
+	}
+
+	public Map<BackendRequest<?>, BulkResultItem> getSuccessfulItems() {
+		return successfulItems;
 	}
 
 	public List<BackendRequest<?>> getErroneousItems() {

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/DocumentAddedBackendRequestSuccessReporter.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/DocumentAddedBackendRequestSuccessReporter.java
@@ -1,0 +1,37 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.impl;
+
+import org.hibernate.search.backend.IndexingMonitor;
+import org.hibernate.search.elasticsearch.client.impl.BackendRequestSuccessReporter;
+
+import io.searchbox.core.BulkResult.BulkResultItem;
+import io.searchbox.core.DocumentResult;
+
+
+/**
+ * @author Yoann Rodiere
+ */
+class DocumentAddedBackendRequestSuccessReporter implements BackendRequestSuccessReporter<DocumentResult> {
+
+	public static final DocumentAddedBackendRequestSuccessReporter INSTANCE = new DocumentAddedBackendRequestSuccessReporter();
+
+	private DocumentAddedBackendRequestSuccessReporter() {
+		// Private constructor
+	}
+
+	@Override
+	public void report(DocumentResult result, IndexingMonitor monitor) {
+		monitor.documentsAdded( 1L );
+	}
+
+	@Override
+	public void report(BulkResultItem bulkResultItem, IndexingMonitor monitor) {
+		monitor.documentsAdded( 1L );
+	}
+
+}

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchIndexManager.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchIndexManager.java
@@ -285,7 +285,7 @@ public class ElasticsearchIndexManager implements IndexManager, RemoteAnalyzerPr
 	public void performOperations(List<LuceneWork> workList, IndexingMonitor monitor) {
 		List<BackendRequest<?>> requests = new ArrayList<>( workList.size() );
 		for ( LuceneWork luceneWork : workList ) {
-			requests.add( luceneWork.acceptIndexWorkVisitor( visitor, null ) );
+			requests.add( luceneWork.acceptIndexWorkVisitor( visitor, monitor ) );
 		}
 
 		requestProcessor.executeSync( requests );
@@ -297,7 +297,7 @@ public class ElasticsearchIndexManager implements IndexManager, RemoteAnalyzerPr
 			requestProcessor.awaitAsyncProcessingCompletion();
 		}
 		else {
-			BackendRequest<?> request = singleOperation.acceptIndexWorkVisitor( visitor, null );
+			BackendRequest<?> request = singleOperation.acceptIndexWorkVisitor( visitor, monitor );
 
 			if ( request != null ) {
 				requestProcessor.executeAsync( request );

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchIndexWorkVisitor.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchIndexWorkVisitor.java
@@ -12,10 +12,6 @@ import java.util.Set;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.DoubleDocValuesField;
-import org.apache.lucene.document.DoubleField;
-import org.apache.lucene.document.FloatField;
-import org.apache.lucene.document.IntField;
-import org.apache.lucene.document.LongField;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.facet.FacetsConfig;
@@ -364,10 +360,6 @@ class ElasticsearchIndexWorkVisitor implements IndexWorkVisitor<IndexingMonitor,
 
 	private String getDocumentId(LuceneWork work) {
 		return work.getTenantId() == null ? work.getIdInString() : work.getTenantId() + "_" + work.getIdInString();
-	}
-
-	private boolean isNumeric(IndexableField field) {
-		return field instanceof IntField || field instanceof LongField || field instanceof FloatField || field instanceof DoubleField;
 	}
 
 	private boolean isDocValueField(IndexableField field) {

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/NoopBackendRequestSuccessHandler.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/NoopBackendRequestSuccessHandler.java
@@ -1,0 +1,37 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.impl;
+
+import org.hibernate.search.backend.IndexingMonitor;
+import org.hibernate.search.elasticsearch.client.impl.BackendRequestSuccessReporter;
+
+import io.searchbox.client.JestResult;
+import io.searchbox.core.BulkResult.BulkResultItem;
+
+
+/**
+ * @author Yoann Rodiere
+ */
+public class NoopBackendRequestSuccessHandler implements BackendRequestSuccessReporter<JestResult> {
+
+	public static final NoopBackendRequestSuccessHandler INSTANCE = new NoopBackendRequestSuccessHandler();
+
+	private NoopBackendRequestSuccessHandler() {
+		// Private constructor
+	}
+
+	@Override
+	public void report(JestResult result, IndexingMonitor monitor) {
+		// Do nothing
+	}
+
+	@Override
+	public void report(BulkResultItem bulkResultItem, IndexingMonitor monitor) {
+		// Do nothing
+	}
+
+}

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.elasticsearch.logging.impl;
 
 import java.util.List;
+import java.util.Map;
 
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.Query;
@@ -28,6 +29,7 @@ import org.jboss.logging.annotations.Param;
 import com.google.gson.JsonElement;
 
 import io.searchbox.client.JestResult;
+import io.searchbox.core.BulkResult.BulkResultItem;
 
 /**
  * Hibernate Search log abstraction for the Elasticsearch integration.
@@ -66,10 +68,12 @@ public interface Log extends org.hibernate.search.util.logging.impl.Log {
 	)
 	SearchException elasticsearchRequestFailed(String request, String response, @Cause Exception cause);
 
+	// The bounds on wildcards below are necessary for the logger code generation to work
 	@Message(id = ES_BACKEND_MESSAGES_START_ID + 8,
 			value = "Elasticsearch request failed.\n Request:\n========\n%1$sResponse:\n=========\n%2$s"
 	)
-	BulkRequestFailedException elasticsearchBulkRequestFailed(String request, String response, @Param List<BackendRequest<? extends JestResult>> erroneousItems);
+	BulkRequestFailedException elasticsearchBulkRequestFailed(String request, String response,
+			@Param Map<BackendRequest<? extends JestResult>, BulkResultItem> successfulItems, @Param List<BackendRequest<? extends JestResult>> erroneousItems);
 
 	@LogMessage(level = Level.WARN)
 	@Message(id = ES_BACKEND_MESSAGES_START_ID + 9,


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2400

If you feel like method parameters in `BackendRequestSuccessHandler` are too much, I can remove them: they're not strictly necessary right now, but they're cheap and I think they would come handy if we make the `IndexMonitor` more complex one day.