### PR TITLE
HSEARCH-2480 Adding classes to the SearchIntegrator concurrently fails with Elasticsearch

### DIFF
--- a/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
+++ b/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
@@ -118,9 +118,9 @@ Let's see the options for the `index_schema_management_strategy` property:
 |Value|Definition
 |`NONE`|Indexes and their mappings will not be created, deleted nor altered.
 |`VALIDATE`|Existing indexes and mappings will be checked for conflicts with Hibernate Search's metamodel. Indexes and their mappings will not be created, deleted nor altered.
-|`MERGE`|Missing indexes and mappings will be created, mappings will be updated if there are no conflicts.
-|`CREATE`|**The default**: existing indexes will not be altered, missing indexes will be created.
-|`RECREATE`|Indexes will be deleted if existing and then created. This will delete all content from the indexes!
+|`MERGE`|Missing indexes and mappings will be created, existing mappings will be updated if there are no conflicts.
+|`CREATE`|**The default**: existing indexes will not be altered, missing indexes will be created along with their mappings.
+|`RECREATE`|Indexes will be deleted if existing and then created along with their mappings. This will delete all content from the indexes!
 |`RECREATE_DELETE`|Similarly to `RECREATE` but will also delete the index at shutdown. Commonly used for tests.
 |===============
 +

--- a/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
+++ b/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
@@ -120,14 +120,14 @@ Let's see the options for the `index_schema_management_strategy` property:
 |`VALIDATE`|Existing indexes and mappings will be checked for conflicts with Hibernate Search's metamodel. Indexes and their mappings will not be created, deleted nor altered.
 |`MERGE`|Missing indexes and mappings will be created, mappings will be updated if there are no conflicts.
 |`CREATE`|**The default**: existing indexes will not be altered, missing indexes will be created.
-|`RECREATE`|Indexed will be deleted if existing and then created. This will delete all content from the index!
+|`RECREATE`|Indexes will be deleted if existing and then created. This will delete all content from the indexes!
 |`RECREATE_DELETE`|Similarly to `RECREATE` but will also delete the index at shutdown. Commonly used for tests.
 |===============
 +
 [CAUTION]
 .Strategies in production environments
 ====
-It is strongly recommended to use either `NONE` or `VALIDATE` in a production environment. `CREATE` and `CREATE_DELETE` are obviously unsuitable in this context (unless you want to reindex everything upon every startup), and `MERGE` may leave your mapping half-merged in case of conflict.
+It is strongly recommended to use either `NONE` or `VALIDATE` in a production environment. `RECREATE` and `RECREATE_DELETE` are obviously unsuitable in this context (unless you want to reindex everything upon every startup), and `MERGE` may leave your mapping half-merged in case of conflict.
 
 To be precise, if your mapping changed in an incompatible way, such as a field having its type changed, merging may be impossible. In this case, the `MERGE` strategy will prevent Hibernate Search from starting, but it may already have successfully merged another index, making a rollback difficult at best.
 

--- a/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
+++ b/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
@@ -121,6 +121,9 @@ Let's see the options for the `index_schema_management_strategy` property:
 |`MERGE`|Missing indexes and mappings will be created, existing mappings will be updated if there are no conflicts.
 |`CREATE`|**The default**: existing indexes will not be altered, missing indexes will be created along with their mappings.
 |`RECREATE`|Indexes will be deleted if existing and then created along with their mappings. This will delete all content from the indexes!
++
+Note that whenever a search factory is altered after initialization (i.e. new entities are mapped),
+the index will *not* be deleted again: new mappings will simply be added to the index.
 |`RECREATE_DELETE`|Similarly to `RECREATE` but will also delete the index at shutdown. Commonly used for tests.
 |===============
 +

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/IndexSchemaManagementStrategy.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/IndexSchemaManagementStrategy.java
@@ -29,17 +29,19 @@ public enum IndexSchemaManagementStrategy {
 
 	/**
 	 * Upon session factory initialization, index mappings will be merged with existing ones, causing an exception if a
-	 * mapping to be merged is not compatible with the existing one. Missing indexes and mappings will be created.
+	 * mapping to be merged is not compatible with the existing one.
+	 * <p>Missing indexes will be created along with their mappings. Missing mappings on existing indexes will be created.
 	 */
 	MERGE,
 
 	/**
-	 * Existing indexes will not be altered, missing indexes will be created.
+	 * Existing indexes will not be altered, missing indexes will be created along with their mappings.
 	 */
 	CREATE,
 
 	/**
-	 * Indexes - and all their contents - will be deleted and newly created upon session factory initialization.
+	 * Indexes - and all their contents - will be deleted and newly created (along with their mappings) upon
+	 * session factory initialization.
 	 */
 	RECREATE,
 

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/IndexSchemaManagementStrategy.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/IndexSchemaManagementStrategy.java
@@ -42,6 +42,9 @@ public enum IndexSchemaManagementStrategy {
 	/**
 	 * Indexes - and all their contents - will be deleted and newly created (along with their mappings) upon
 	 * session factory initialization.
+	 *
+	 * <p>Note that whenever a search factory is altered after initialization (i.e. new entities are mapped),
+	 * the index will <strong>not</strong> be deleted again: new mappings will simply be added to the index.
 	 */
 	RECREATE,
 

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/schema/impl/DefaultElasticsearchSchemaMigrator.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/schema/impl/DefaultElasticsearchSchemaMigrator.java
@@ -49,12 +49,6 @@ public class DefaultElasticsearchSchemaMigrator implements ElasticsearchSchemaMi
 		String indexName = indexMetadata.getName();
 
 		try {
-			if ( !schemaAccessor.indexExists( indexName ) ) {
-				schemaAccessor.createIndexIfAbsent( indexName, executionOptions );
-			}
-
-			schemaAccessor.waitForIndexStatus( indexName, executionOptions );
-
 			for ( Map.Entry<String, TypeMapping> entry : indexMetadata.getMappings().entrySet() ) {
 				String mappingName = entry.getKey();
 				TypeMapping mapping = entry.getValue();

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/schema/impl/ElasticsearchSchemaCreator.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/schema/impl/ElasticsearchSchemaCreator.java
@@ -11,26 +11,37 @@ import org.hibernate.search.engine.service.spi.Service;
 import org.hibernate.search.exception.SearchException;
 
 /**
- * An object responsible for creating an index based on provided metadata.
+ * An object responsible for creating an index and its mappings based on provided metadata.
  *
  * @author Yoann Rodiere
  */
 public interface ElasticsearchSchemaCreator extends Service {
 
 	/**
-	 * Create an index and populates mappings.
+	 * Create an index.
 	 *
 	 * @param indexMetadata The expected index metadata.
 	 * @throws SearchException If an error occurs.
 	 */
-	void create(IndexMetadata indexMetadata, ExecutionOptions executionOptions);
+	void createIndex(IndexMetadata indexMetadata, ExecutionOptions executionOptions);
 
 	/**
-	 * Create an index and populates mappings, but only if the index doesn't already exist.
+	 * Create an index, but only if the index doesn't already exist.
+	 *
+	 * @param indexMetadata The expected index metadata.
+	 * @return {@code true} if the index had to be created, {@code false} otherwise.
+	 * @throws SearchException If an error occurs.
+	 */
+	boolean createIndexIfAbsent(IndexMetadata indexMetadata, ExecutionOptions executionOptions);
+
+	/**
+	 * Create mappings on a supposedly existing index.
+	 *
+	 * <p>Mappings are supposed to be absent from the index.
 	 *
 	 * @param indexMetadata The expected index metadata.
 	 * @throws SearchException If an error occurs.
 	 */
-	void createIfAbsent(IndexMetadata indexMetadata, ExecutionOptions executionOptions);
+	void createMappings(IndexMetadata indexMetadata, ExecutionOptions executionOptions);
 
 }

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/schema/impl/ElasticsearchSchemaMigrator.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/schema/impl/ElasticsearchSchemaMigrator.java
@@ -18,12 +18,11 @@ import org.hibernate.search.exception.SearchException;
 public interface ElasticsearchSchemaMigrator extends Service {
 
 	/**
-	 * Merge metadata with the existing schema:
-	 * <ul>
-	 * <li>Create the index if it doesn't exist
-	 * <li>For each mapping, merge the existing mapping with the expected one, throwing {@link SearchException}
-	 * if an incompatible attribute is detected.
-	 * </ul>
+	 * Merge metadata with the existing schema: for each mapping, merge the existing mapping
+	 * with the expected one, throwing {@link SearchException} if an incompatible attribute
+	 * is detected.
+	 *
+	 * <p>The index is expected to already exist.
 	 *
 	 * @param indexMetadata The expected index metadata.
 	 * @throws SearchException If an error occurs.

--- a/engine/src/test/java/org/hibernate/search/test/configuration/mutablefactory/MutableFactoryTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/configuration/mutablefactory/MutableFactoryTest.java
@@ -211,7 +211,6 @@ public class MutableFactoryTest {
 	}
 
 	@Test
-	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2480 Adding classes to the SearchIntegrator concurrently fails with Elasticsearch
 	public void testMultiThreadedAddClasses() throws Exception {
 		QueryParser parser = new QueryParser( "name", TestConstants.standardAnalyzer );
 		try ( SearchIntegrator sf = new SearchIntegratorBuilder().configuration( new SearchConfigurationForTest() ).buildSearchIntegrator() ) {

--- a/engine/src/test/java/org/hibernate/search/test/configuration/mutablefactory/MutableFactoryTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/configuration/mutablefactory/MutableFactoryTest.java
@@ -214,8 +214,8 @@ public class MutableFactoryTest {
 	public void testMultiThreadedAddClasses() throws Exception {
 		QueryParser parser = new QueryParser( "name", TestConstants.standardAnalyzer );
 		try ( SearchIntegrator sf = new SearchIntegratorBuilder().configuration( new SearchConfigurationForTest() ).buildSearchIntegrator() ) {
-			int numberOfClasses = 25;
-			int numberOfThreads = 5;
+			int numberOfClasses = 100;
+			int numberOfThreads = 10;
 			new ConcurrentRunner( numberOfClasses, numberOfThreads,
 					new TaskFactory() {
 						@Override


### PR DESCRIPTION
~~This PR is based on #1224 (HSEARCH-2406), which will have to be merged first.~~ => Done

Relevant ticket: https://hibernate.atlassian.net/browse/HSEARCH-2480

It appears that the issue was valid, but my analysis was completely wrong.

The actual issue was that whenever the search factory changed (due to a new class mapping being added), every existing `ElasticsearchIndexManager` would reinitialize as if we were just starting Hibernate Search. Which means in particular that if we had chosen the `RECREATE_DELETE` schema management strategy, every Elasticsearch index would be deleted and re-created. Which includes indexes containing pre-existing entities whose mapping didn't change at all. Which is quite annoying...