### PR TITLE
HSEARCH-2479: Changed Hashmap in ConnectedMultiFieldsPhraseQueryBuild…

### DIFF
--- a/engine/src/main/java/org/hibernate/search/query/dsl/impl/ConnectedMultiFieldsPhraseQueryBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/impl/ConnectedMultiFieldsPhraseQueryBuilder.java
@@ -11,9 +11,9 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
@@ -82,7 +82,7 @@ public class ConnectedMultiFieldsPhraseQueryBuilder implements PhraseTermination
 			 */
 			TokenStream stream = null;
 			boolean isMultiPhrase = false;
-			Map<Integer, List<Term>> termsPerPosition = new HashMap<Integer, List<Term>>();
+			Map<Integer, List<Term>> termsPerPosition = new TreeMap<Integer, List<Term>>();
 			try {
 				Reader reader = new StringReader( sentence );
 				stream = analyzer.tokenStream( fieldName, reader );

--- a/orm/src/test/java/org/hibernate/search/test/query/dsl/DSLTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/dsl/DSLTest.java
@@ -744,6 +744,25 @@ public class DSLTest extends SearchTestBase {
 
 		transaction.commit();
 	}
+	
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-2479")
+	public void testPhraseQueryTermCreation() throws Exception {
+		String testCaseText = "Test the Test test of your test test to test test test of test and Test budgeting.";
+		Transaction transaction = fullTextSession.beginTransaction();
+		final QueryBuilder monthQb = fullTextSession.getSearchFactory()
+				.buildQueryBuilder().forEntity( Month.class ).get();
+
+		Query query = monthQb
+				.phrase()
+					.onField( "mythology" )
+					.sentence( testCaseText )
+					.createQuery();
+
+		assertEquals( "test term ordering", 0, fullTextSession.createFullTextQuery( query, Month.class ).getResultSize() );
+		
+		transaction.commit();
+	}
 
 	@Test
 	public void testPhraseQueryWithStopWords() throws Exception {

--- a/orm/src/test/java/org/hibernate/search/test/query/dsl/DSLTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/dsl/DSLTest.java
@@ -760,7 +760,7 @@ public class DSLTest extends SearchTestBase {
 					.createQuery();
 
 		assertEquals( "test term ordering", 0, fullTextSession.createFullTextQuery( query, Month.class ).getResultSize() );
-		
+
 		transaction.commit();
 	}
 

--- a/orm/src/test/java/org/hibernate/search/test/query/dsl/DSLTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/dsl/DSLTest.java
@@ -744,7 +744,7 @@ public class DSLTest extends SearchTestBase {
 
 		transaction.commit();
 	}
-	
+
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-2479")
 	public void testPhraseQueryTermCreation() throws Exception {


### PR DESCRIPTION
…er to TreeMap to keep the correct order of search terms.