### PR TITLE
HSEARCH-2448 (+ HSEARCH-2419) Throw exceptions with clear messages when there are field type conflicts with Elasticsearch	

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/JsonElementType.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/JsonElementType.java
@@ -8,7 +8,9 @@ package org.hibernate.search.elasticsearch.impl;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 
 abstract class JsonElementType<T extends JsonElement> {
 
@@ -53,6 +55,50 @@ abstract class JsonElementType<T extends JsonElement> {
 		@Override
 		public String toString() {
 			return JsonArray.class.getSimpleName();
+		}
+	};
+
+	public static final JsonElementType<JsonPrimitive> PRIMITIVE = new JsonElementType<JsonPrimitive>() {
+		@Override
+		public JsonPrimitive newInstance() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public JsonPrimitive cast(JsonElement element) {
+			return element == null || element.isJsonNull() ? null : element.getAsJsonPrimitive();
+		}
+
+		@Override
+		public boolean isInstance(JsonElement element) {
+			return element != null && element.isJsonPrimitive();
+		}
+
+		@Override
+		public String toString() {
+			return JsonPrimitive.class.getSimpleName();
+		}
+	};
+
+	public static final JsonElementType<JsonNull> NULL = new JsonElementType<JsonNull>() {
+		@Override
+		public JsonNull newInstance() {
+			return JsonNull.INSTANCE;
+		}
+
+		@Override
+		public JsonNull cast(JsonElement element) {
+			return element == null ? null : element.getAsJsonNull();
+		}
+
+		@Override
+		public boolean isInstance(JsonElement element) {
+			return element != null && element.isJsonNull();
+		}
+
+		@Override
+		public String toString() {
+			return JsonNull.class.getSimpleName();
 		}
 	};
 

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/UnexpectedJsonElementTypeException.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/UnexpectedJsonElementTypeException.java
@@ -1,0 +1,52 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.impl;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import com.google.gson.JsonElement;
+
+/**
+ * @author Yoann Rodiere
+ */
+public class UnexpectedJsonElementTypeException extends Exception /** Non-runtime */ {
+
+	private final JsonAccessor accessor;
+	private final List<JsonElementType<?>> expectedTypes;
+	private final JsonElement actualElement;
+
+	public UnexpectedJsonElementTypeException(JsonAccessor accessor, JsonElementType<?> expectedType, JsonElement actualElement) {
+		this( accessor, Arrays.asList( expectedType ), actualElement );
+	}
+
+	public UnexpectedJsonElementTypeException(JsonAccessor accessor, List<? extends JsonElementType<?>> expectedTypes, JsonElement actualElement) {
+		this.accessor = accessor;
+		this.expectedTypes = Collections.unmodifiableList( new ArrayList<>( expectedTypes ) );
+		this.actualElement = actualElement;
+	}
+
+	@Override
+	public String getMessage() {
+		return "Unexpected type at '" + accessor + "'. Expected one of " + expectedTypes + ", got '" + actualElement + "'";
+	}
+
+	public JsonAccessor getAccessor() {
+		return accessor;
+	}
+
+	public List<JsonElementType<?>> getExpectedTypes() {
+		return expectedTypes;
+	}
+
+	public JsonElement getActualElement() {
+		return actualElement;
+	}
+
+}

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
@@ -204,4 +204,15 @@ public interface Log extends org.hibernate.search.util.logging.impl.Log {
 	)
 	SearchException schemaMergeFailed(String indexName, @Cause Exception cause);
 
+	@Message(id = ES_BACKEND_MESSAGES_START_ID + 36,
+			value = "Mapping conflict detected for field '%2$s' on entity '%1$s'."
+					+ " The current mapping would require the field to be mapped to  both a composite field"
+					+ " ('object' datatype) and a \"concrete\" field ('integer', 'date', etc.) holding a value,"
+					+ " which Elasticsearch does not allow. If you're seeing this issue, you probably added both"
+					+ " an @IndexedEmbedded annotation and a @Field (or similar) annotation on the same property:"
+					+ " if that's the case, please set either @IndexedEmbedded.prefix or @Field.name to a custom value"
+					+ " different from the default to resolve the conflict."
+	)
+	SearchException fieldIsBothCompositeAndConcrete(Class<?> entityType, String fieldPath);
+
 }

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/schema/impl/DefaultElasticsearchSchemaTranslator.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/schema/impl/DefaultElasticsearchSchemaTranslator.java
@@ -77,14 +77,16 @@ public class DefaultElasticsearchSchemaTranslator implements ElasticsearchSchema
 
 		root.setDynamic( DynamicType.STRICT );
 
+		ElasticsearchMappingBuilder builder = new ElasticsearchMappingBuilder( descriptor, root );
+
 		if ( executionOptions.isMultitenancyEnabled() ) {
 			PropertyMapping tenantId = new PropertyMapping();
 			tenantId.setType( DataType.STRING );
 			tenantId.setIndex( IndexType.NOT_ANALYZED );
-			root.addProperty( DocumentBuilderIndexedEntity.TENANT_ID_FIELDNAME, tenantId );
+			builder.setPropertyAbsolute( DocumentBuilderIndexedEntity.TENANT_ID_FIELDNAME, tenantId );
 		}
 
-		addMappings( new ElasticsearchMappingBuilder( descriptor, root ) );
+		addMappings( builder );
 
 		return root;
 	}

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/schema/impl/model/DataType.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/schema/impl/model/DataType.java
@@ -18,7 +18,12 @@ import com.google.gson.annotations.SerializedName;
 public enum DataType {
 
 	@SerializedName("object")
-	OBJECT,
+	OBJECT {
+		@Override
+		public boolean isComposite() {
+			return true;
+		}
+	},
 	@SerializedName("string")
 	STRING,
 	@SerializedName("long")
@@ -36,4 +41,8 @@ public enum DataType {
 	@SerializedName("geo_point")
 	GEO_POINT
 	;
+
+	public boolean isComposite() {
+		return false;
+	}
 }

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/PathComponentExtractor.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/PathComponentExtractor.java
@@ -88,6 +88,14 @@ public class PathComponentExtractor implements Cloneable {
 		currentIndexInPath = 0;
 	}
 
+	/**
+	 * @return The absolute path of the last non-null path component returned by {@link #next(ConsumptionLimit)},
+	 * or {@code null} if {@link #next(ConsumptionLimit)} hasn't returned such a component yet.
+	 */
+	public String getLastComponentAbsolutePath() {
+		return currentIndexInPath == 0 ? null : path.substring( 0, currentIndexInPath - 1 );
+	}
+
 	@Override
 	public PathComponentExtractor clone() {
 		try {

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchSchemaNamingConflictIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchSchemaNamingConflictIT.java
@@ -1,0 +1,230 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.test;
+
+import static org.hibernate.search.test.util.impl.ExceptionMatcherBuilder.isException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.persistence.Embeddable;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import org.apache.lucene.document.Document;
+import org.hibernate.AssertionFailure;
+import org.hibernate.HibernateException;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.FieldBridge;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.IndexedEmbedded;
+import org.hibernate.search.bridge.LuceneOptions;
+import org.hibernate.search.bridge.MetadataProvidingFieldBridge;
+import org.hibernate.search.bridge.spi.FieldMetadataBuilder;
+import org.hibernate.search.bridge.spi.FieldType;
+import org.hibernate.search.elasticsearch.cfg.ElasticsearchEnvironment;
+import org.hibernate.search.elasticsearch.cfg.IndexSchemaManagementStrategy;
+import org.hibernate.search.elasticsearch.testutil.TestElasticsearchClient;
+import org.hibernate.search.exception.SearchException;
+import org.hibernate.search.test.SearchInitializationTestBase;
+import org.hibernate.search.test.util.ImmutableTestConfiguration;
+import org.hibernate.testing.TestForIssue;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * Tests for conflict detection when generating the Elasticsearch schema.
+ *
+ * @author Yoann Rodiere
+ */
+@RunWith(Parameterized.class)
+@TestForIssue(jiraKey = "HSEARCH-2448")
+public class ElasticsearchSchemaNamingConflictIT extends SearchInitializationTestBase {
+
+	private static final String COMPOSITE_CONCRETE_CONFLICT_MESSAGE_ID = "HSEARCH400036";
+
+	private static final String CONFLICTING_FIELD_NAME = "conflictingFieldName";
+
+	@Parameters(name = "With strategy {0}")
+	public static IndexSchemaManagementStrategy[] strategies() {
+		return IndexSchemaManagementStrategy.values();
+	}
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Rule
+	public TestElasticsearchClient elasticSearchClient = new TestElasticsearchClient();
+
+	private IndexSchemaManagementStrategy strategy;
+
+	public ElasticsearchSchemaNamingConflictIT(IndexSchemaManagementStrategy strategy) {
+		super();
+		this.strategy = strategy;
+	}
+
+	@Test
+	public void detectConflict_schemaGeneration_compositeOnConcrete() throws Exception {
+		testDetectConflictDuringSchemaGeneration( CompositeOnConcreteEntity.class );
+	}
+
+	@Test
+	public void detectConflict_schemaGeneration_concreteOnComposite() throws Exception {
+		testDetectConflictDuringSchemaGeneration( ConcreteOnCompositeEntity.class );
+	}
+
+	private void testDetectConflictDuringSchemaGeneration(Class<?> entityClass) {
+		Assume.assumeTrue( "The strategy " + strategy + " does not involve schema generation."
+				+ " No point running this test.",
+				generatesSchema( strategy ) );
+
+		thrown.expect(
+				isException( SearchException.class )
+						.withMessage( COMPOSITE_CONCRETE_CONFLICT_MESSAGE_ID )
+						.withMessage( CONFLICTING_FIELD_NAME + "'" )
+						.withMessage( entityClass.getName() )
+				.build()
+		);
+
+		elasticSearchClient.registerForCleanup( entityClass );
+		init( strategy, entityClass );
+	}
+
+	@Test
+	public void detectConflict_indexing_compositeOnConcrete() throws Exception {
+		testDetectConflictDuringIndexing( CompositeOnConcreteEntity.class );
+	}
+
+	@Test
+	public void detectConflict_indexing_concreteOnComposite() throws Exception {
+		testDetectConflictDuringIndexing( ConcreteOnCompositeEntity.class );
+	}
+
+	private void testDetectConflictDuringIndexing(Class<?> entityClass) throws Exception {
+		Assume.assumeFalse( "The strategy " + strategy + " involves schema generation,"
+				+ " which means conflicts prevent search factory initialization"
+				+ " and thus prevent indexing. No point running this test.",
+				generatesSchema( strategy ) );
+
+		elasticSearchClient.deleteAndCreateIndex( entityClass );
+		init( strategy, entityClass );
+
+		thrown.expect(
+				isException( AssertionFailure.class )
+				.causedBy( HibernateException.class )
+				.causedBy( SearchException.class )
+						.withMessage( COMPOSITE_CONCRETE_CONFLICT_MESSAGE_ID )
+						.withMessage( CONFLICTING_FIELD_NAME + "'" )
+						.withMessage( entityClass.getName() )
+				.build()
+		);
+
+		Object newEntity = entityClass.newInstance();
+		try ( Session session = getTestResourceManager().openSession() ) {
+			Transaction tx = session.beginTransaction();
+			session.save( newEntity );
+			tx.commit();
+		}
+	}
+
+	private boolean generatesSchema(IndexSchemaManagementStrategy strategy) {
+		return !IndexSchemaManagementStrategy.NONE.equals( strategy );
+	}
+
+	private void init(IndexSchemaManagementStrategy strategy, Class<?> ... entityClasses) {
+		Map<String, Object> settings = new HashMap<>();
+		settings.put(
+				"hibernate.search.default." + ElasticsearchEnvironment.INDEX_SCHEMA_MANAGEMENT_STRATEGY,
+				strategy.name()
+		);
+
+		init( new ImmutableTestConfiguration( settings, entityClasses ) );
+	}
+
+	@Embeddable
+	public static class EmbeddedTypeWithNonConflictingField {
+		@Field
+		int nonConflictingField = 0;
+	}
+
+	@Embeddable
+	public static class EmbeddedTypeWithConflictingField {
+		@Field(name = CONFLICTING_FIELD_NAME)
+		int conflictingField = 0;
+	}
+
+	/**
+	 * A class for which Hibernate Search will first handle the mapping for the "concrete"
+	 * (non-composite) field, and then the mapping for the composite field.
+	 */
+	@Entity
+	@Indexed
+	public static class CompositeOnConcreteEntity {
+		@DocumentId
+		@Id
+		@GeneratedValue
+		Long id;
+
+		@IndexedEmbedded(prefix = CONFLICTING_FIELD_NAME + ".")
+		@Field(name = CONFLICTING_FIELD_NAME, bridge = @FieldBridge(impl = SimpleToStringBridge.class))
+		@Embedded
+		EmbeddedTypeWithNonConflictingField embedded =
+				new EmbeddedTypeWithNonConflictingField();
+
+		public static class SimpleToStringBridge implements MetadataProvidingFieldBridge {
+
+			@Override
+			public void set(String name, Object value, Document document, LuceneOptions luceneOptions) {
+				luceneOptions.addFieldToDocument( name, String.valueOf( value ), document );
+			}
+
+			@Override
+			public void configureFieldMetadata(String name, FieldMetadataBuilder builder) {
+				builder.field( name, FieldType.STRING );
+			}
+		}
+	}
+
+	/**
+	 * A class for which Hibernate Search will first handle the mapping for the composite
+	 * field, and then the mapping for the "concrete" (non-composite) field.
+	 */
+	@Entity
+	@Indexed
+	public static class ConcreteOnCompositeEntity {
+		@DocumentId
+		@Id
+		@GeneratedValue
+		Long id;
+
+		@Embedded
+		EmbeddedTypeWithNonConflictingField embedded =
+				new EmbeddedTypeWithNonConflictingField();
+
+		// Hack: methods are handled first, so take advantage of that.
+		@IndexedEmbedded(prefix = CONFLICTING_FIELD_NAME + ".")
+		public EmbeddedTypeWithNonConflictingField getEmbedded() {
+			return embedded;
+		}
+
+		@IndexedEmbedded(prefix = "")
+		@Embedded
+		EmbeddedTypeWithConflictingField otherEmbedded =
+				new EmbeddedTypeWithConflictingField();
+	}
+
+}

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/GolfPlayer.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/GolfPlayer.java
@@ -88,7 +88,6 @@ public class GolfPlayer {
 
 	@ElementCollection
 	@Field
-	@IndexedEmbedded
 	private Set<String> strengths;
 
 	@ManyToMany

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/testutil/TestElasticsearchClient.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/testutil/TestElasticsearchClient.java
@@ -53,6 +53,10 @@ public class TestElasticsearchClient extends ExternalResource {
 		deleteAndCreateIndex( IndexNameNormalizer.getElasticsearchIndexName( rootClass.getName() ) );
 	}
 
+	public void registerForCleanup(Class<?> rootClass) {
+		createdIndicesNames.add( IndexNameNormalizer.getElasticsearchIndexName( rootClass.getName() ) );
+	}
+
 	public void putMapping(Class<?> mappedAndRootClass, String mappingJson) throws IOException {
 		putMapping( mappedAndRootClass, mappedAndRootClass, mappingJson );
 	}
@@ -82,12 +86,16 @@ public class TestElasticsearchClient extends ExternalResource {
 		tryDeleteESIndex( indexName );
 
 		JestResult result = client.execute( new CreateIndex.Builder( indexName ).build() );
-		createdIndicesNames.add( indexName );
+		registerForCleanup( indexName );
 		if ( !result.isSucceeded() ) {
 			throw new AssertionFailure( "Error while creating index '" + indexName + "' for tests:" + result.getErrorMessage() );
 		}
 
 		waitForIndexCreation( indexName );
+	}
+
+	public void registerForCleanup(String indexName) {
+		createdIndicesNames.add( indexName );
 	}
 
 	private void waitForIndexCreation(final String indexNameToWaitFor) throws IOException {

--- a/engine/src/main/java/org/hibernate/search/bridge/impl/BridgeFactory.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/impl/BridgeFactory.java
@@ -19,7 +19,6 @@ import org.hibernate.annotations.common.reflection.XClass;
 import org.hibernate.annotations.common.reflection.XMember;
 import org.hibernate.search.annotations.ClassBridge;
 import org.hibernate.search.annotations.Field;
-import org.hibernate.search.annotations.IndexedEmbedded;
 import org.hibernate.search.annotations.Parameter;
 import org.hibernate.search.annotations.Spatial;
 import org.hibernate.search.bridge.AppliedOnTypeAwareBridge;
@@ -275,9 +274,6 @@ public final class BridgeFactory {
 	}
 
 	private ContainerType getContainerType(XMember member, ReflectionManager reflectionManager) {
-		if ( ! member.isAnnotationPresent( IndexedEmbedded.class ) ) {
-			return ContainerType.SINGLE;
-		}
 		if ( member.isArray() ) {
 			return ContainerType.ARRAY;
 		}
@@ -288,8 +284,6 @@ public final class BridgeFactory {
 		if ( member.isCollection() && Map.class.equals( member.getCollectionClass() ) ) {
 			return ContainerType.MAP;
 		}
-		// marked @IndexedEmbedded but not a container
-		// => probably a @Field @IndexedEmbedded Foo foo;
 		return ContainerType.SINGLE;
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
@@ -15,8 +15,8 @@ import java.lang.reflect.Method;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -1133,7 +1133,7 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 			String prefix,
 			PathsContext pathsContext,
 			ParseContext parseContext) {
-		Map<String, NumericField> fieldsMarkedAsNumeric = new HashMap<>();
+		Map<String, NumericField> fieldsMarkedAsNumeric = new LinkedHashMap<>();
 
 		NumericField numericFieldAnnotation = member.getAnnotation( NumericField.class );
 		if ( numericFieldAnnotation != null ) {
@@ -1205,7 +1205,7 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 			return Collections.emptySet();
 		}
 
-		Set<Facet> matchingFacetAnnotations = new HashSet<>( 1 );
+		Set<Facet> matchingFacetAnnotations = new LinkedHashSet<>( 1 );
 
 		if ( facetAnnotation != null && facetAnnotation.forField().equals( fieldName ) ) {
 			matchingFacetAnnotations.add( facetAnnotation );

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/DocumentFieldMetadata.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/DocumentFieldMetadata.java
@@ -7,8 +7,8 @@
 package org.hibernate.search.engine.metadata.impl;
 
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -233,8 +233,8 @@ public class DocumentFieldMetadata {
 			this.store = store;
 			this.index = index;
 			this.termVector = termVector;
-			this.facetMetadata = new HashSet<>( 1 ); // the most common case is a single facet
-			this.bridgeDefinedFields = new HashMap<>();
+			this.facetMetadata = new LinkedHashSet<>( 1 ); // the most common case is a single facet
+			this.bridgeDefinedFields = new LinkedHashMap<>();
 		}
 
 		public String getAbsoluteName() {

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/FieldMetadataBuilderImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/FieldMetadataBuilderImpl.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.engine.metadata.impl;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.hibernate.search.bridge.spi.FieldMetadataBuilder;
@@ -20,8 +20,8 @@ import org.hibernate.search.bridge.spi.FieldType;
  */
 class FieldMetadataBuilderImpl implements FieldMetadataBuilder {
 
-	private final Set<String> sortableFieldsAbsoluteNames = new HashSet<>();
-	private final Set<BridgeDefinedField> bridgeDefinedFields = new HashSet<>();
+	private final Set<String> sortableFieldsAbsoluteNames = new LinkedHashSet<>();
+	private final Set<BridgeDefinedField> bridgeDefinedFields = new LinkedHashSet<>();
 	private final BackReference<DocumentFieldMetadata> fieldMetadata;
 
 	public FieldMetadataBuilderImpl(BackReference<DocumentFieldMetadata> fieldMetadata) {

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/NumericFieldsConfiguration.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/NumericFieldsConfiguration.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.engine.metadata.impl;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -27,7 +27,7 @@ class NumericFieldsConfiguration {
 	private final Class<?> indexedType;
 	private final XProperty member;
 	private final Map<String, NumericField> fieldsMarkedAsNumeric;
-	private final Set<String> fieldsOfProperty = new HashSet<>();
+	private final Set<String> fieldsOfProperty = new LinkedHashSet<>();
 
 	NumericFieldsConfiguration(Class<?> indexedType, XProperty member, Map<String, NumericField> fieldsMarkedAsNumeric) {
 		this.indexedType = indexedType;

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/ParseContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/ParseContext.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.engine.metadata.impl;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -20,9 +20,9 @@ import org.hibernate.search.indexes.spi.IndexManagerType;
  * @author Hardy Ferentschik
  */
 public class ParseContext {
-	private final Set<XClass> processedClasses = new HashSet<>();
+	private final Set<XClass> processedClasses = new LinkedHashSet<>();
 	private final Set<String> spatialNames = new TreeSet<>();
-	private final Set<String> unqualifiedCollectedCollectionRoles = new HashSet<>();
+	private final Set<String> unqualifiedCollectedCollectionRoles = new LinkedHashSet<>();
 
 	private IndexManagerType indexManagerType;
 	private XClass currentClass;

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/PathsContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/PathsContext.java
@@ -6,8 +6,8 @@
  */
 package org.hibernate.search.engine.metadata.impl;
 
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -18,7 +18,7 @@ import java.util.Set;
  */
 public class PathsContext {
 
-	private final Map<String, Boolean> pathsEncounteredState = new HashMap<>();
+	private final Map<String, Boolean> pathsEncounteredState = new LinkedHashMap<>();
 
 	public void addIncludedPath(String path) {
 		pathsEncounteredState.put( path, Boolean.FALSE );
@@ -37,7 +37,7 @@ public class PathsContext {
 	}
 
 	public Set<String> getUnEncounteredPaths() {
-		Set<String> unEncounteredPaths = new HashSet<>();
+		Set<String> unEncounteredPaths = new LinkedHashSet<>();
 		for ( String path : pathsEncounteredState.keySet() ) {
 			if ( notEncountered( path ) ) {
 				unEncounteredPaths.add( path );

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/PropertyMetadata.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/PropertyMetadata.java
@@ -8,8 +8,8 @@ package org.hibernate.search.engine.metadata.impl;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -53,7 +53,7 @@ public class PropertyMetadata {
 	}
 
 	private Map<String, DocumentFieldMetadata> createDocumentFieldMetadataMap(Set<DocumentFieldMetadata> fieldMetadataSet) {
-		Map<String, DocumentFieldMetadata> tmpMap = new HashMap<>();
+		Map<String, DocumentFieldMetadata> tmpMap = new LinkedHashMap<>();
 		for ( DocumentFieldMetadata documentFieldMetadata : fieldMetadataSet ) {
 			tmpMap.put( documentFieldMetadata.getAbsoluteName(), documentFieldMetadata );
 		}
@@ -129,8 +129,8 @@ public class PropertyMetadata {
 			}
 			this.propertyAccessor = propertyAccessor;
 			this.propertyClass = propertyClass;
-			this.fieldMetadataSet = new HashSet<>();
-			this.sortableFieldMetadata = new HashSet<>();
+			this.fieldMetadataSet = new LinkedHashSet<>();
+			this.sortableFieldMetadata = new LinkedHashSet<>();
 		}
 
 		public Builder dynamicBoostStrategy(BoostStrategy boostStrategy) {

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/TypeMetadata.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/TypeMetadata.java
@@ -9,8 +9,7 @@ package org.hibernate.search.engine.metadata.impl;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -400,7 +399,7 @@ public class TypeMetadata {
 	}
 
 	private Map<String, PropertyMetadata> buildPropertyMetadataMap(Set<PropertyMetadata> propertyMetadataSet) {
-		Map<String, PropertyMetadata> tmpMap = new HashMap<String, PropertyMetadata>();
+		Map<String, PropertyMetadata> tmpMap = new LinkedHashMap<String, PropertyMetadata>();
 		for ( PropertyMetadata propertyMetadata : propertyMetadataSet ) {
 			tmpMap.put( propertyMetadata.getPropertyAccessorName(), propertyMetadata );
 		}
@@ -430,7 +429,7 @@ public class TypeMetadata {
 	}
 
 	private Map<String, DocumentFieldMetadata> buildFieldMetadataMap(Set<DocumentFieldMetadata> documentFieldMetadataSet) {
-		Map<String, DocumentFieldMetadata> tmpMap = new HashMap<String, DocumentFieldMetadata>();
+		Map<String, DocumentFieldMetadata> tmpMap = new LinkedHashMap<String, DocumentFieldMetadata>();
 		for ( DocumentFieldMetadata documentFieldMetadata : documentFieldMetadataSet ) {
 			String name = documentFieldMetadata.getAbsoluteName();
 			if ( StringHelper.isEmpty( name ) ) {
@@ -452,7 +451,7 @@ public class TypeMetadata {
 	}
 
 	private Map<String, FacetMetadata> buildFacetMetadataMap(Collection<DocumentFieldMetadata> documentFieldMetadataCollection) {
-		Map<String, FacetMetadata> tmpMap = new HashMap<String, FacetMetadata>();
+		Map<String, FacetMetadata> tmpMap = new LinkedHashMap<String, FacetMetadata>();
 		for ( DocumentFieldMetadata documentFieldMetadata : documentFieldMetadataCollection ) {
 			for ( FacetMetadata facetMetadata : documentFieldMetadata.getFacetMetadata() ) {
 				tmpMap.put( facetMetadata.getAbsoluteName(), facetMetadata );
@@ -463,7 +462,7 @@ public class TypeMetadata {
 	}
 
 	private Map<String, BridgeDefinedField> buildBridgeDefinedFieldMetadataMap(Collection<DocumentFieldMetadata> documentFieldMetadataCollection) {
-		Map<String, BridgeDefinedField> tmpMap = new HashMap<String, BridgeDefinedField>();
+		Map<String, BridgeDefinedField> tmpMap = new LinkedHashMap<String, BridgeDefinedField>();
 		for ( DocumentFieldMetadata documentFieldMetadata : documentFieldMetadataCollection ) {
 			for ( BridgeDefinedField bridgeDefinedField : documentFieldMetadata.getBridgeDefinedFields().values() ) {
 				tmpMap.put( bridgeDefinedField.getAbsoluteName(), bridgeDefinedField );
@@ -474,7 +473,7 @@ public class TypeMetadata {
 	}
 
 	private Map<String, DocumentFieldMetadata> copyClassBridgeMetadata(Set<DocumentFieldMetadata> classBridgeFields) {
-		Map<String, DocumentFieldMetadata> tmpMap = new HashMap<String, DocumentFieldMetadata>();
+		Map<String, DocumentFieldMetadata> tmpMap = new LinkedHashMap<String, DocumentFieldMetadata>();
 		for ( DocumentFieldMetadata fieldMetadata : classBridgeFields ) {
 			tmpMap.put( fieldMetadata.getAbsoluteName(), fieldMetadata );
 		}
@@ -495,15 +494,15 @@ public class TypeMetadata {
 		private Discriminator discriminator;
 		private XMember discriminatorGetter;
 		private boolean stateInspectionOptimizationsEnabled = true;
-		private final Set<PropertyMetadata> propertyMetadataSet = new HashSet<>();
-		private final Set<DocumentFieldMetadata> classBridgeFields = new HashSet<DocumentFieldMetadata>();
-		private final Set<EmbeddedTypeMetadata> embeddedTypeMetadata = new HashSet<EmbeddedTypeMetadata>();
-		private final Set<ContainedInMetadata> containedInMetadata = new HashSet<ContainedInMetadata>();
-		private final Set<XClass> optimizationClassList = new HashSet<XClass>();
+		private final Set<PropertyMetadata> propertyMetadataSet = new LinkedHashSet<>();
+		private final Set<DocumentFieldMetadata> classBridgeFields = new LinkedHashSet<DocumentFieldMetadata>();
+		private final Set<EmbeddedTypeMetadata> embeddedTypeMetadata = new LinkedHashSet<EmbeddedTypeMetadata>();
+		private final Set<ContainedInMetadata> containedInMetadata = new LinkedHashSet<ContainedInMetadata>();
+		private final Set<XClass> optimizationClassList = new LinkedHashSet<XClass>();
 		private final Set<String> collectionRoles = new TreeSet<String>();
 		private PropertyMetadata idPropertyMetadata;
 		private XProperty jpaProperty;
-		private final Set<SortableFieldMetadata> classBridgeSortableFieldMetadata = new HashSet<>();
+		private final Set<SortableFieldMetadata> classBridgeSortableFieldMetadata = new LinkedHashSet<>();
 
 		public Builder(Class<?> indexedType, IndexManagerType indexManagerType, ConfigContext configContext) {
 			this( indexedType, buildScopedAnalyzerReferenceBuilder( indexManagerType, configContext ) );

--- a/orm/src/test/java/org/hibernate/search/test/SearchInitializationTestBase.java
+++ b/orm/src/test/java/org/hibernate/search/test/SearchInitializationTestBase.java
@@ -59,7 +59,9 @@ public abstract class SearchInitializationTestBase {
 	@After
 	public void tearDown() throws Exception {
 		try {
-			testResourceManager.defaultTearDown();
+			if ( testResourceManager != null ) {
+				testResourceManager.defaultTearDown();
+			}
 		}
 		finally {
 			testResourceManager = null;

--- a/orm/src/test/java/org/hibernate/search/test/bridge/ArrayBridgeNullEmbeddedTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/ArrayBridgeNullEmbeddedTest.java
@@ -1,0 +1,202 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.bridge;
+
+import java.util.List;
+
+import org.apache.lucene.search.Query;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.Search;
+import org.hibernate.search.bridge.util.impl.NumericFieldUtils;
+import org.hibernate.search.query.dsl.QueryBuilder;
+import org.hibernate.search.query.dsl.TermMatchingContext;
+import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.test.bridge.ArrayBridgeNullEmbeddedTestEntity.Language;
+import org.hibernate.search.testsupport.junit.ElasticsearchSupportInProgress;
+
+import static org.hibernate.search.test.bridge.ArrayBridgeNullEmbeddedTestEntity.Language.ENGLISH;
+import static org.hibernate.search.test.bridge.ArrayBridgeNullEmbeddedTestEntity.Language.ITALIAN;
+import static org.hibernate.search.test.bridge.ArrayBridgeNullEmbeddedTestEntity.Language.KLINGON;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Test indexing of {@link javax.persistence.ElementCollection} annotated arrays when
+ * there also is an @IndexedEmbedded annotation using {@code indexNullAs} on the same property.
+ *
+ * @author Davide D'Alto
+ */
+@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2389 Support indexNullAs for @IndexedEmbedded applied on objects with Elasticsearch
+public class ArrayBridgeNullEmbeddedTest extends SearchTestBase {
+
+	private FullTextSession fullTextSession;
+	private ArrayBridgeNullEmbeddedTestEntity withoutNull;
+	private ArrayBridgeNullEmbeddedTestEntity withNullEntry;
+	private ArrayBridgeNullEmbeddedTestEntity withNullEmbedded;
+
+	@Override
+	@Before
+	public void setUp() throws Exception {
+		super.setUp();
+		Session session = openSession();
+		fullTextSession = Search.getFullTextSession( session );
+		prepareData();
+	}
+
+	private void prepareData() {
+		Transaction tx = fullTextSession.beginTransaction();
+
+		withoutNull = persistEntity( fullTextSession, "Davide D'Alto" );
+		withoutNull.setNullIndexed( new Language[] { ITALIAN, ENGLISH } );
+		withoutNull.setNumericNullIndexed( new Integer[] { 1, 2 } );
+
+		withNullEntry = persistEntity( fullTextSession, "Worf" );
+		withNullEntry.setNullIndexed( new Language[] { KLINGON, ENGLISH, null } );
+		withNullEntry.setNumericNullIndexed( new Integer[] { 11, null } );
+
+		withNullEmbedded = persistEntity( fullTextSession, "Mime" );
+		withNullEmbedded.setNumericNullIndexed( null );
+		withNullEmbedded.setNullIndexed( null );
+
+		tx.commit();
+	}
+
+	@Test
+	public void testSearchNullEntry() throws Exception {
+		List<ArrayBridgeNullEmbeddedTestEntity> results = findResults( "nullIndexed", ArrayBridgeNullEmbeddedTestEntity.NULL_TOKEN, true );
+
+		assertNotNull( "No result found for an indexed collection", results );
+		assertEquals( "Unexpected number of results in a collection", 1, results.size() );
+		assertEquals( "Wrong result returned looking for a null in a collection", withNullEntry.getName(), results.get( 0 ).getName() );
+	}
+
+	@Test
+	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2389 Support indexNullAs for @IndexedEmbedded applied on objects with Elasticsearch
+	public void testSearchNullEmbedded() throws Exception {
+		List<ArrayBridgeNullEmbeddedTestEntity> results = findEmbeddedNullResults( "nullIndexed", ArrayBridgeNullEmbeddedTestEntity.NULL_EMBEDDED, true );
+
+		assertNotNull( "No result found for an indexed collection", results );
+		assertEquals( "Unexpected number of results in a collection", 1, results.size() );
+		assertEquals( "Wrong result returned looking for a null in a collection", withNullEmbedded.getName(), results.get( 0 ).getName() );
+	}
+
+	@Test
+	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2389 Support indexNullAs for @IndexedEmbedded applied on objects with Elasticsearch
+	public void testSearchNullNumericEmbedded() throws Exception {
+		List<ArrayBridgeNullEmbeddedTestEntity> results =
+				findEmbeddedNullResults( "embeddedNum", ArrayBridgeNullEmbeddedTestEntity.NULL_EMBEDDED_NUMERIC, true );
+
+		assertNotNull( "No result found for an indexed collection", results );
+		assertEquals( "Unexpected number of results in a collection", 1, results.size() );
+		assertEquals( "Wrong result returned looking for a null collection", withNullEmbedded.getName(), results.get( 0 ).getName() );
+	}
+
+	@Test
+	public void testSearchNullNumericEntry() throws Exception {
+		List<ArrayBridgeNullEmbeddedTestEntity> results =
+				findResults( "numericNullIndexed", ArrayBridgeNullEmbeddedTestEntity.NULL_NUMERIC_TOKEN, true );
+
+		assertNotNull( "No result found for an indexed collection", results );
+		assertEquals( "Unexpected number of results in a collection", 1, results.size() );
+		assertEquals( "Wrong result returned looking for a null in a collection of numeric", withNullEntry.getName(), results.get( 0 ).getName() );
+	}
+
+	@Test
+	public void testSearchNotNullEntry() throws Exception {
+		{
+			List<ArrayBridgeNullEmbeddedTestEntity> results = findResults( "nullIndexed", KLINGON, false );
+
+			assertNotNull( "No result found for an indexed collection", results );
+			assertEquals( "Wrong number of results returned for an indexed collection", 1, results.size() );
+			assertEquals( "Wrong result returned from an indexed collection", withNullEntry.getName(), results.get( 0 )
+					.getName() );
+		}
+		{
+			List<ArrayBridgeNullEmbeddedTestEntity> results = findResults( "nullIndexed", ITALIAN, false );
+
+			assertNotNull( "No result found for an indexed collection", results );
+			assertEquals( "Wrong number of results returned for an indexed collection", 1, results.size() );
+			assertEquals( "Wrong result returned from an indexed collection", withoutNull.getName(), results.get( 0 )
+					.getName() );
+		}
+		{
+			List<ArrayBridgeNullEmbeddedTestEntity> results = findResults( "nullIndexed", ENGLISH, false );
+
+			assertNotNull( "No result found for an indexed collection", results );
+			assertEquals( "Wrong number of results returned for an indexed collection", 2, results.size() );
+		}
+	}
+
+	@Test
+	public void testSearchNotNullNumeric() throws Exception {
+		{
+			List<ArrayBridgeNullEmbeddedTestEntity> results = findNumericResults( "numericNullIndexed", 1 );
+
+			assertNotNull( "No result found for an indexed collection", results );
+			assertEquals( "Wrong number of results returned for an indexed collection", 1, results.size() );
+			assertEquals( "Wrong result returned from an indexed collection", withoutNull.getName(), results.get( 0 )
+					.getName() );
+		}
+		{
+			List<ArrayBridgeNullEmbeddedTestEntity> results = findNumericResults( "numericNullIndexed", 11 );
+
+			assertNotNull( "No result found for an indexed collection", results );
+			assertEquals( "Wrong number of results returned for an indexed collection", 1, results.size() );
+			assertEquals( "Wrong result returned from an indexed collection", withNullEntry.getName(), results.get( 0 )
+					.getName() );
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private List<ArrayBridgeNullEmbeddedTestEntity> findEmbeddedNullResults(String fieldName, Object value, boolean checkNullToken) {
+		QueryBuilder queryBuilder = fullTextSession.getSearchFactory().buildQueryBuilder()
+				.forEntity( ArrayBridgeNullEmbeddedTestEntity.class ).get();
+		TermMatchingContext termMatchingContext = queryBuilder.keyword().onField( fieldName );
+		if ( checkNullToken ) {
+			termMatchingContext.ignoreFieldBridge();
+		}
+		Query query = termMatchingContext.ignoreAnalyzer().matching( value ).createQuery();
+		return fullTextSession.createFullTextQuery( query, ArrayBridgeNullEmbeddedTestEntity.class ).list();
+	}
+
+	@SuppressWarnings("unchecked")
+	private List<ArrayBridgeNullEmbeddedTestEntity> findResults(String fieldName, Object value, boolean checkNullToken) {
+		QueryBuilder queryBuilder = fullTextSession.getSearchFactory().buildQueryBuilder()
+				.forEntity( ArrayBridgeNullEmbeddedTestEntity.class ).get();
+		TermMatchingContext termMatchingContext = queryBuilder.keyword().onField( fieldName );
+		if ( checkNullToken ) {
+			termMatchingContext.ignoreFieldBridge();
+			termMatchingContext.ignoreAnalyzer();
+		}
+		Query query = termMatchingContext.matching( value ).createQuery();
+		return fullTextSession.createFullTextQuery( query, ArrayBridgeNullEmbeddedTestEntity.class ).list();
+	}
+
+	@SuppressWarnings("unchecked")
+	private List<ArrayBridgeNullEmbeddedTestEntity> findNumericResults(String fieldName, Object number) {
+		Query query = NumericFieldUtils.createNumericRangeQuery( fieldName, number, number, true, true );
+		return fullTextSession.createFullTextQuery( query, ArrayBridgeNullEmbeddedTestEntity.class ).list();
+	}
+
+	private ArrayBridgeNullEmbeddedTestEntity persistEntity(Session s, String name) {
+		ArrayBridgeNullEmbeddedTestEntity boy = new ArrayBridgeNullEmbeddedTestEntity();
+		boy.setName( name );
+		s.persist( boy );
+		return boy;
+	}
+
+	@Override
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { ArrayBridgeNullEmbeddedTestEntity.class, };
+	}
+}

--- a/orm/src/test/java/org/hibernate/search/test/bridge/ArrayBridgeNullEmbeddedTestEntity.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/ArrayBridgeNullEmbeddedTestEntity.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.search.test.bridge;
 
-import java.util.Date;
-
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
@@ -19,10 +17,9 @@ import javax.persistence.OrderColumn;
 import javax.persistence.Table;
 
 import org.hibernate.search.annotations.Analyze;
-import org.hibernate.search.annotations.DateBridge;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
-import org.hibernate.search.annotations.Resolution;
+import org.hibernate.search.annotations.IndexedEmbedded;
 import org.hibernate.search.annotations.Store;
 
 /**
@@ -31,19 +28,18 @@ import org.hibernate.search.annotations.Store;
 @Entity
 @Indexed
 @Table(name = "ABT_Entity")
-public class ArrayBridgeTestEntity {
+public class ArrayBridgeNullEmbeddedTestEntity {
 
 	static final String NULL_TOKEN = "NULL_MARKER";
 	static final String NULL_NUMERIC_TOKEN = "-555";
+	static final String NULL_EMBEDDED = "EMBEDDED_NULL";
+
+	static final String NULL_EMBEDDED_NUMERIC = "-666";
 
 	private Long id;
 	private String name;
 	private Language[] nullIndexed = new Language[0];
-	private String[] nullNotIndexed = new String[0];
 	private Integer[] numericNullIndexed = new Integer[0];
-	private Long[] numericNullNotIndexed = new Long[0];
-
-	private Date[] dates = new Date[0];
 
 	public enum Language {
 		ITALIAN, ENGLISH, PIRATE, KLINGON
@@ -72,6 +68,11 @@ public class ArrayBridgeTestEntity {
 
 	@Field(indexNullAs = NULL_TOKEN, analyze = Analyze.NO)
 	@ElementCollection
+	/*
+	 * This will only have an effect for null maps, since the type for the map values
+	 * does not contain any @Field annotation (which means there is nothing to embed).
+	 */
+	@IndexedEmbedded(indexNullAs = NULL_EMBEDDED)
 	@OrderColumn
 	@CollectionTable(name = "NullIndexed", joinColumns = @JoinColumn(name = "array_id"))
 	@Column(name = "nullIndexed")
@@ -85,6 +86,11 @@ public class ArrayBridgeTestEntity {
 
 	@Field(store = Store.YES, indexNullAs = NULL_NUMERIC_TOKEN, analyze = Analyze.NO)
 	@ElementCollection
+	/*
+	 * This will only have an effect for null maps, since the type for the map values
+	 * does not contain any @Field annotation (which means there is nothing to embed).
+	 */
+	@IndexedEmbedded(prefix = "embeddedNum.", indexNullAs = NULL_EMBEDDED_NUMERIC)
 	@OrderColumn
 	@CollectionTable(name = "NumericNullIndexed", joinColumns = @JoinColumn(name = "array_id"))
 	@Column(name = "numericNullIndexed")
@@ -96,49 +102,9 @@ public class ArrayBridgeTestEntity {
 		this.numericNullIndexed = phoneNumbers;
 	}
 
-	@Field(store = Store.YES)
-	@ElementCollection
-	@OrderColumn
-	@CollectionTable(name = "NullNotIndexed", joinColumns = @JoinColumn(name = "array_id"))
-	@Column(name = "nullNotIndexed")
-	public String[] getNullNotIndexed() {
-		return nullNotIndexed;
-	}
-
-	public void setNullNotIndexed(String[] skipNullCollection) {
-		this.nullNotIndexed = skipNullCollection;
-	}
-
-	@Field(store = Store.YES)
-	@ElementCollection
-	@OrderColumn
-	@CollectionTable(name = "NumericNullNotIndexed", joinColumns = @JoinColumn(name = "array_id"))
-	@Column(name = "numericNullNotIndexed")
-	public Long[] getNumericNullNotIndexed() {
-		return numericNullNotIndexed;
-	}
-
-	public void setNumericNullNotIndexed(Long[] numericSkipNullCollection) {
-		this.numericNullNotIndexed = numericSkipNullCollection;
-	}
-
-	@Field(analyze = Analyze.NO, store = Store.YES)
-	@ElementCollection
-	@DateBridge(resolution = Resolution.SECOND)
-	@OrderColumn
-	@CollectionTable(name = "Dates", joinColumns = @JoinColumn(name = "array_id"))
-	@Column(name = "dates")
-	public Date[] getDates() {
-		return dates;
-	}
-
-	public void setDates(Date[] dates) {
-		this.dates = dates;
-	}
-
 	@Override
 	public String toString() {
-		return ArrayBridgeTestEntity.class.getSimpleName() + "[id=" + id + ", name=" + name + "]";
+		return ArrayBridgeNullEmbeddedTestEntity.class.getSimpleName() + "[id=" + id + ", name=" + name + "]";
 	}
 
 }

--- a/orm/src/test/java/org/hibernate/search/test/bridge/ArrayBridgeTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/ArrayBridgeTest.java
@@ -13,7 +13,6 @@ import org.apache.lucene.document.DateTools;
 import org.apache.lucene.search.Query;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 
@@ -24,7 +23,6 @@ import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.query.dsl.TermMatchingContext;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.test.bridge.ArrayBridgeTestEntity.Language;
-import org.hibernate.search.testsupport.junit.ElasticsearchSupportInProgress;
 
 import static org.hibernate.search.test.bridge.ArrayBridgeTestEntity.Language.ENGLISH;
 import static org.hibernate.search.test.bridge.ArrayBridgeTestEntity.Language.ITALIAN;
@@ -33,7 +31,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 /**
- * Test indexing of {@link javax.persistence.ElementCollection} annotated elements.
+ * Test indexing of {@link javax.persistence.ElementCollection} annotated arrays.
  *
  * @author Davide D'Alto
  */
@@ -91,27 +89,6 @@ public class ArrayBridgeTest extends SearchTestBase {
 		assertNotNull( "No result found for an indexed collection", results );
 		assertEquals( "Unexpected number of results in a collection", 1, results.size() );
 		assertEquals( "Wrong result returned looking for a null in a collection", withNullEntry.getName(), results.get( 0 ).getName() );
-	}
-
-	@Test
-	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2389 Support indexNullAs for @IndexedEmbedded applied on objects with Elasticsearch
-	public void testSearchNullEmbedded() throws Exception {
-		List<ArrayBridgeTestEntity> results = findEmbeddedNullResults( "nullIndexed", ArrayBridgeTestEntity.NULL_EMBEDDED, true );
-
-		assertNotNull( "No result found for an indexed collection", results );
-		assertEquals( "Unexpected number of results in a collection", 1, results.size() );
-		assertEquals( "Wrong result returned looking for a null in a collection", withNullEmbedded.getName(), results.get( 0 ).getName() );
-	}
-
-	@Test
-	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2389 Support indexNullAs for @IndexedEmbedded applied on objects with Elasticsearch
-	public void testSearchNullNumericEmbedded() throws Exception {
-		List<ArrayBridgeTestEntity> results =
-				findEmbeddedNullResults( "embeddedNum", ArrayBridgeTestEntity.NULL_EMBEDDED_NUMERIC, true );
-
-		assertNotNull( "No result found for an indexed collection", results );
-		assertEquals( "Unexpected number of results in a collection", 1, results.size() );
-		assertEquals( "Wrong result returned looking for a null collection", withNullEmbedded.getName(), results.get( 0 ).getName() );
 	}
 
 	@Test
@@ -223,18 +200,6 @@ public class ArrayBridgeTest extends SearchTestBase {
 				"Wrong result returned from a collection of Date", withoutNull.getName(), results.get( 0 )
 						.getName()
 		);
-	}
-
-	@SuppressWarnings("unchecked")
-	private List<ArrayBridgeTestEntity> findEmbeddedNullResults(String fieldName, Object value, boolean checkNullToken) {
-		QueryBuilder queryBuilder = fullTextSession.getSearchFactory().buildQueryBuilder()
-				.forEntity( ArrayBridgeTestEntity.class ).get();
-		TermMatchingContext termMatchingContext = queryBuilder.keyword().onField( fieldName );
-		if ( checkNullToken ) {
-			termMatchingContext.ignoreFieldBridge();
-		}
-		Query query = termMatchingContext.ignoreAnalyzer().matching( value ).createQuery();
-		return fullTextSession.createFullTextQuery( query, ArrayBridgeTestEntity.class ).list();
 	}
 
 	@SuppressWarnings("unchecked")

--- a/orm/src/test/java/org/hibernate/search/test/bridge/IterableBridgeNullEmbeddedTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/IterableBridgeNullEmbeddedTest.java
@@ -1,0 +1,208 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.bridge;
+
+import java.util.List;
+
+import org.apache.lucene.search.Query;
+
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.Search;
+import org.hibernate.search.bridge.util.impl.NumericFieldUtils;
+import org.hibernate.search.query.dsl.QueryBuilder;
+import org.hibernate.search.query.dsl.TermMatchingContext;
+import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.testsupport.junit.ElasticsearchSupportInProgress;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.hibernate.search.test.bridge.IterableBridgeNullEmbeddedTestEntity.Language.ENGLISH;
+import static org.hibernate.search.test.bridge.IterableBridgeNullEmbeddedTestEntity.Language.ITALIAN;
+import static org.hibernate.search.test.bridge.IterableBridgeNullEmbeddedTestEntity.Language.KLINGON;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Test indexing of {@link javax.persistence.ElementCollection} annotated iterables when
+ * there also is an @IndexedEmbedded annotation using {@code indexNullAs} on the same property.
+ *
+ * @author Davide D'Alto
+ */
+@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2389 Support indexNullAs for @IndexedEmbedded applied on objects with Elasticsearch
+public class IterableBridgeNullEmbeddedTest extends SearchTestBase {
+
+	private FullTextSession fullTextSession;
+	private IterableBridgeNullEmbeddedTestEntity withoutNull;
+	private IterableBridgeNullEmbeddedTestEntity withNullEntry;
+	private IterableBridgeNullEmbeddedTestEntity withNullEmbedded;
+
+	@Override
+	@Before
+	public void setUp() throws Exception {
+		super.setUp();
+		Session session = openSession();
+		fullTextSession = Search.getFullTextSession( session );
+		prepareData();
+	}
+
+	private void prepareData() {
+		Transaction tx = fullTextSession.beginTransaction();
+
+		withoutNull = persistEntity( fullTextSession, "Davide D'Alto" );
+		withoutNull.addNullIndexed( ITALIAN );
+		withoutNull.addNullIndexed( ENGLISH );
+		withoutNull.addNumericNullIndexed( 1 );
+		withoutNull.addNumericNullIndexed( 2 );
+
+		withNullEntry = persistEntity( fullTextSession, "Worf" );
+		withNullEntry.addNullIndexed( KLINGON );
+		withNullEntry.addNullIndexed( ENGLISH );
+		withNullEntry.addNullIndexed( null );
+		withNullEntry.addNumericNullIndexed( 11 );
+		withNullEntry.addNumericNullIndexed( null );
+
+		withNullEmbedded = persistEntity( fullTextSession, "Mime" );
+		withNullEmbedded.setNumericNullIndexed( null );
+		withNullEmbedded.setNullIndexed( null );
+
+		tx.commit();
+	}
+
+	@Test
+	public void testSearchNullEntry() throws Exception {
+		{
+			List<IterableBridgeNullEmbeddedTestEntity> results = findResults( "nullIndexed", IterableBridgeNullEmbeddedTestEntity.NULL_TOKEN, true );
+
+			assertNotNull( "No result found for an indexed collection", results );
+			assertEquals( "Unexpected number of results in a collection", 1, results.size() );
+			assertEquals( "Wrong result returned looking for a null in a collection", withNullEntry.getName(), results.get( 0 ).getName() );
+		}
+	}
+
+	@Test
+	public void testSearchNullEmbedded() throws Exception {
+		List<IterableBridgeNullEmbeddedTestEntity> results = findEmbeddedNullResults( "nullIndexed", IterableBridgeNullEmbeddedTestEntity.NULL_EMBEDDED, true );
+
+		assertNotNull( "No result found for an indexed collection", results );
+		assertEquals( "Unexpected number of results in a collection", 1, results.size() );
+		assertEquals( "Wrong result returned looking for a null in a collection", withNullEmbedded.getName(), results.get( 0 ).getName() );
+	}
+
+	@Test
+	public void testSearchNullNumericEmbedded() throws Exception {
+		List<IterableBridgeNullEmbeddedTestEntity> results =
+				findEmbeddedNullResults( "embeddedNum", IterableBridgeNullEmbeddedTestEntity.NULL_EMBEDDED_NUMERIC, true );
+
+		assertNotNull( "No result found for an indexed collection", results );
+		assertEquals( "Unexpected number of results in a collection", 1, results.size() );
+		assertEquals( "Wrong result returned looking for a null in a collection of numeric", withNullEmbedded.getName(), results.get( 0 ).getName() );
+	}
+
+	@Test
+	public void testSearchNullNumericEntry() throws Exception {
+		List<IterableBridgeNullEmbeddedTestEntity> results = findResults( "numericNullIndexed", IterableBridgeNullEmbeddedTestEntity.NULL_NUMERIC_TOKEN, true );
+
+		assertNotNull( "No result found for an indexed collection", results );
+		assertEquals( "Unexpected number of results in a collection", 1, results.size() );
+		assertEquals( "Wrong result returned looking for a null in a collection of numeric", withNullEntry.getName(), results.get( 0 ).getName() );
+	}
+
+	@Test
+	public void testSearchNotNullEntry() throws Exception {
+		{
+			List<IterableBridgeNullEmbeddedTestEntity> results = findResults( "nullIndexed", KLINGON, false );
+
+			assertNotNull( "No result found for an indexed collection", results );
+			assertEquals( "Wrong number of results returned for an indexed collection", 1, results.size() );
+			assertEquals( "Wrong result returned from an indexed collection", withNullEntry.getName(), results.get( 0 )
+					.getName() );
+		}
+		{
+			List<IterableBridgeNullEmbeddedTestEntity> results = findResults( "nullIndexed", ITALIAN, false );
+
+			assertNotNull( "No result found for an indexed collection", results );
+			assertEquals( "Wrong number of results returned for an indexed collection", 1, results.size() );
+			assertEquals( "Wrong result returned from an indexed collection", withoutNull.getName(), results.get( 0 )
+					.getName() );
+		}
+		{
+			List<IterableBridgeNullEmbeddedTestEntity> results = findResults( "nullIndexed", ENGLISH, false );
+
+			assertNotNull( "No result found for an indexed collection", results );
+			assertEquals( "Wrong number of results returned for an indexed collection", 2, results.size() );
+		}
+	}
+
+	@Test
+	public void testSearchNotNullNumeric() throws Exception {
+		{
+			List<IterableBridgeNullEmbeddedTestEntity> results = findNumericResults( "numericNullIndexed", 1 );
+
+			assertNotNull( "No result found for an indexed collection", results );
+			assertEquals( "Wrong number of results returned for an indexed collection", 1, results.size() );
+			assertEquals( "Wrong result returned from an indexed collection", withoutNull.getName(), results.get( 0 )
+					.getName() );
+		}
+		{
+			List<IterableBridgeNullEmbeddedTestEntity> results = findNumericResults( "numericNullIndexed", 11 );
+
+			assertNotNull( "No result found for an indexed collection", results );
+			assertEquals( "Wrong number of results returned for an indexed collection", 1, results.size() );
+			assertEquals( "Wrong result returned from an indexed collection", withNullEntry.getName(), results.get( 0 )
+					.getName() );
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private List<IterableBridgeNullEmbeddedTestEntity> findEmbeddedNullResults(String fieldName, Object value, boolean checkForNullToken) {
+		QueryBuilder queryBuilder = fullTextSession.getSearchFactory().buildQueryBuilder()
+				.forEntity( IterableBridgeNullEmbeddedTestEntity.class ).get();
+		TermMatchingContext termMatchingContext = queryBuilder.keyword().onField( fieldName );
+		if ( checkForNullToken ) {
+			termMatchingContext.ignoreFieldBridge();
+		}
+		Query query = termMatchingContext
+				.ignoreAnalyzer()
+				.matching( value ).createQuery();
+		return fullTextSession.createFullTextQuery( query, IterableBridgeNullEmbeddedTestEntity.class ).list();
+	}
+
+	@SuppressWarnings("unchecked")
+	private List<IterableBridgeNullEmbeddedTestEntity> findResults( String fieldName, Object value, boolean checkRawValue) {
+		QueryBuilder queryBuilder = fullTextSession.getSearchFactory().buildQueryBuilder()
+				.forEntity( IterableBridgeNullEmbeddedTestEntity.class ).get();
+		TermMatchingContext termMatchingContext = queryBuilder.keyword().onField( fieldName );
+		if ( checkRawValue ) {
+			termMatchingContext.ignoreFieldBridge();
+			termMatchingContext.ignoreAnalyzer();
+		}
+		Query query = termMatchingContext.matching( value ).createQuery();
+		return fullTextSession.createFullTextQuery( query, IterableBridgeNullEmbeddedTestEntity.class ).list();
+	}
+
+	@SuppressWarnings("unchecked")
+	private List<IterableBridgeNullEmbeddedTestEntity> findNumericResults( String fieldName, Object number) {
+		Query query = NumericFieldUtils.createNumericRangeQuery( fieldName, number, number, true, true );
+		return fullTextSession.createFullTextQuery( query, IterableBridgeNullEmbeddedTestEntity.class ).list();
+	}
+
+	private IterableBridgeNullEmbeddedTestEntity persistEntity(Session s, String name) {
+		IterableBridgeNullEmbeddedTestEntity boy = new IterableBridgeNullEmbeddedTestEntity();
+		boy.setName( name );
+		s.persist( boy );
+		return boy;
+	}
+
+	@Override
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { IterableBridgeNullEmbeddedTestEntity.class, };
+	}
+}

--- a/orm/src/test/java/org/hibernate/search/test/bridge/IterableBridgeNullEmbeddedTestEntity.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/IterableBridgeNullEmbeddedTestEntity.java
@@ -6,12 +6,8 @@
  */
 package org.hibernate.search.test.bridge;
 
-import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
-
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
@@ -22,10 +18,9 @@ import javax.persistence.JoinColumn;
 import javax.persistence.Table;
 
 import org.hibernate.search.annotations.Analyze;
-import org.hibernate.search.annotations.DateBridge;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
-import org.hibernate.search.annotations.Resolution;
+import org.hibernate.search.annotations.IndexedEmbedded;
 import org.hibernate.search.annotations.Store;
 
 /**
@@ -34,19 +29,17 @@ import org.hibernate.search.annotations.Store;
 @Entity
 @Indexed
 @Table(name = "IBT_Entity")
-public class IterableBridgeTestEntity {
+public class IterableBridgeNullEmbeddedTestEntity {
 
 	static final String NULL_TOKEN = "NULL_MARKER";
 	static final String NULL_NUMERIC_TOKEN = "-555";
+	static final String NULL_EMBEDDED = "EMBEDDED_NULL";
+	static final String NULL_EMBEDDED_NUMERIC = "-666";
 
 	private Long id;
 	private String name;
 	private Set<Language> nullIndexed = new HashSet<Language>();
-	private List<String> nullNotIndexed = new ArrayList<String>();
 	private Set<Integer> numericNullIndexed = new HashSet<Integer>();
-	private List<Long> numericNullNotIndexed = new ArrayList<Long>();
-
-	private List<Date> dates = new ArrayList<Date>();
 
 	public enum Language {
 		ITALIAN, ENGLISH, PIRATE, KLINGON
@@ -75,6 +68,11 @@ public class IterableBridgeTestEntity {
 
 	@Field(indexNullAs = NULL_TOKEN, analyze = Analyze.NO)
 	@ElementCollection
+	/*
+	 * This will only have an effect for null maps, since the type for the map values
+	 * does not contain any @Field annotation (which means there is nothing to embed).
+	 */
+	@IndexedEmbedded(indexNullAs = NULL_EMBEDDED)
 	@CollectionTable(name = "NullIndexed", joinColumns = @JoinColumn(name = "iterable_id"))
 	@Column(name = "nullIndexed")
 	public Set<Language> getNullIndexed() {
@@ -91,6 +89,11 @@ public class IterableBridgeTestEntity {
 
 	@Field(store = Store.YES, indexNullAs = NULL_NUMERIC_TOKEN, analyze = Analyze.NO)
 	@ElementCollection
+	/*
+	 * This will only have an effect for null maps, since the type for the map values
+	 * does not contain any @Field annotation (which means there is nothing to embed).
+	 */
+	@IndexedEmbedded(prefix = "embeddedNum.", indexNullAs = NULL_EMBEDDED_NUMERIC)
 	@CollectionTable(name = "NumericNullIndexed", joinColumns = @JoinColumn(name = "iterable_id"))
 	@Column(name = "numericNullIndexed")
 	public Set<Integer> getNumericNullIndexed() {
@@ -105,58 +108,9 @@ public class IterableBridgeTestEntity {
 		this.numericNullIndexed.add( number );
 	}
 
-	@Field(store = Store.YES)
-	@ElementCollection
-	@CollectionTable(name = "NullNotIndexed", joinColumns = @JoinColumn(name = "iterable_id"))
-	@Column(name = "nullNotIndexed")
-	public List<String> getNullNotIndexed() {
-		return nullNotIndexed;
-	}
-
-	public void setNullNotIndexed(List<String> skipNullCollection) {
-		this.nullNotIndexed = skipNullCollection;
-	}
-
-	public void addNullNotIndexed(String value) {
-		this.nullNotIndexed.add( value );
-	}
-
-	@Field(store = Store.YES)
-	@ElementCollection
-	@CollectionTable(name = "NumericNullNotIndexed", joinColumns = @JoinColumn(name = "iterable_id"))
-	@Column(name = "numericNullNotIndexed")
-	public List<Long> getNumericNullNotIndexed() {
-		return numericNullNotIndexed;
-	}
-
-	public void setNumericNullNotIndexed(List<Long> numericSkipNullCollection) {
-		this.numericNullNotIndexed = numericSkipNullCollection;
-	}
-
-	public void addNumericNullNotIndexed(Long value) {
-		this.numericNullNotIndexed.add( value );
-	}
-
-	@Field(analyze = Analyze.NO, store = Store.YES)
-	@ElementCollection
-	@DateBridge(resolution = Resolution.SECOND)
-	@CollectionTable(name = "Dates", joinColumns = @JoinColumn(name = "iterable_id"))
-	@Column(name = "dates")
-	public List<Date> getDates() {
-		return dates;
-	}
-
-	public void setDates(List<Date> dates) {
-		this.dates = dates;
-	}
-
-	public void addDate(Date value) {
-		this.dates.add( value );
-	}
-
 	@Override
 	public String toString() {
-		return IterableBridgeTestEntity.class.getSimpleName() + "[id=" + id + ", name=" + name + "]";
+		return IterableBridgeNullEmbeddedTestEntity.class.getSimpleName() + "[id=" + id + ", name=" + name + "]";
 	}
 
 }

--- a/orm/src/test/java/org/hibernate/search/test/bridge/IterableBridgeTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/IterableBridgeTest.java
@@ -21,10 +21,8 @@ import org.hibernate.search.bridge.util.impl.NumericFieldUtils;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.query.dsl.TermMatchingContext;
 import org.hibernate.search.test.SearchTestBase;
-import org.hibernate.search.testsupport.junit.ElasticsearchSupportInProgress;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
 import static org.hibernate.search.test.bridge.IterableBridgeTestEntity.Language.ENGLISH;
 import static org.hibernate.search.test.bridge.IterableBridgeTestEntity.Language.ITALIAN;
@@ -33,7 +31,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 /**
- * Test indexing of {@link javax.persistence.ElementCollection} annotated elements.
+ * Test indexing of {@link javax.persistence.ElementCollection} annotated iterables.
  *
  * @author Davide D'Alto
  */
@@ -101,27 +99,6 @@ public class IterableBridgeTest extends SearchTestBase {
 			assertEquals( "Unexpected number of results in a collection", 1, results.size() );
 			assertEquals( "Wrong result returned looking for a null in a collection", withNullEntry.getName(), results.get( 0 ).getName() );
 		}
-	}
-
-	@Test
-	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2389 Support indexNullAs for @IndexedEmbedded applied on objects with Elasticsearch
-	public void testSearchNullEmbedded() throws Exception {
-		List<IterableBridgeTestEntity> results = findEmbeddedNullResults( "nullIndexed", IterableBridgeTestEntity.NULL_EMBEDDED, true );
-
-		assertNotNull( "No result found for an indexed collection", results );
-		assertEquals( "Unexpected number of results in a collection", 1, results.size() );
-		assertEquals( "Wrong result returned looking for a null in a collection", withNullEmbedded.getName(), results.get( 0 ).getName() );
-	}
-
-	@Test
-	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2389 Support indexNullAs for @IndexedEmbedded applied on objects with Elasticsearch
-	public void testSearchNullNumericEmbedded() throws Exception {
-		List<IterableBridgeTestEntity> results =
-				findEmbeddedNullResults( "embeddedNum", IterableBridgeTestEntity.NULL_EMBEDDED_NUMERIC, true );
-
-		assertNotNull( "No result found for an indexed collection", results );
-		assertEquals( "Unexpected number of results in a collection", 1, results.size() );
-		assertEquals( "Wrong result returned looking for a null in a collection of numeric", withNullEmbedded.getName(), results.get( 0 ).getName() );
 	}
 
 	@Test
@@ -230,20 +207,6 @@ public class IterableBridgeTest extends SearchTestBase {
 		assertEquals( "Wrong number of results returned for an indexed collection", 1, results.size() );
 		assertEquals( "Wrong result returned from a collection of Date", withoutNull.getName(), results.get( 0 )
 				.getName() );
-	}
-
-	@SuppressWarnings("unchecked")
-	private List<IterableBridgeTestEntity> findEmbeddedNullResults(String fieldName, Object value, boolean checkForNullToken) {
-		QueryBuilder queryBuilder = fullTextSession.getSearchFactory().buildQueryBuilder()
-				.forEntity( IterableBridgeTestEntity.class ).get();
-		TermMatchingContext termMatchingContext = queryBuilder.keyword().onField( fieldName );
-		if ( checkForNullToken ) {
-			termMatchingContext.ignoreFieldBridge();
-		}
-		Query query = termMatchingContext
-				.ignoreAnalyzer()
-				.matching( value ).createQuery();
-		return fullTextSession.createFullTextQuery( query, IterableBridgeTestEntity.class ).list();
 	}
 
 	@SuppressWarnings("unchecked")

--- a/orm/src/test/java/org/hibernate/search/test/bridge/MapBridgeNullEmbeddedTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/MapBridgeNullEmbeddedTest.java
@@ -1,0 +1,207 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.bridge;
+
+import java.util.List;
+
+import org.apache.lucene.search.Query;
+
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.Search;
+import org.hibernate.search.bridge.util.impl.NumericFieldUtils;
+import org.hibernate.search.query.dsl.QueryBuilder;
+import org.hibernate.search.query.dsl.TermMatchingContext;
+import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.testsupport.junit.ElasticsearchSupportInProgress;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.hibernate.search.test.bridge.MapBridgeNullEmbeddedTestEntity.Language.ENGLISH;
+import static org.hibernate.search.test.bridge.MapBridgeNullEmbeddedTestEntity.Language.ITALIAN;
+import static org.hibernate.search.test.bridge.MapBridgeNullEmbeddedTestEntity.Language.KLINGON;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Test indexing of {@link javax.persistence.ElementCollection} annotated maps when
+ * there also is an @IndexedEmbedded annotation using {@code indexNullAs} on the same property.
+ *
+ * @author Davide D'Alto
+ */
+@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2389 Support indexNullAs for @IndexedEmbedded applied on objects with Elasticsearch
+public class MapBridgeNullEmbeddedTest extends SearchTestBase {
+
+	private FullTextSession fullTextSession;
+	private MapBridgeNullEmbeddedTestEntity withoutNull;
+	private MapBridgeNullEmbeddedTestEntity withNullEntry;
+	private MapBridgeNullEmbeddedTestEntity withNullEmbedded;
+
+	@Override
+	@Before
+	public void setUp() throws Exception {
+		super.setUp();
+		Session session = openSession();
+		fullTextSession = Search.getFullTextSession( session );
+		prepareData();
+	}
+
+	private void prepareData() {
+		Transaction tx = fullTextSession.beginTransaction();
+
+		withoutNull = persistEntity( fullTextSession, "Davide D'Alto" );
+		withoutNull.addNullIndexed( 1, ITALIAN );
+		withoutNull.addNullIndexed( 2, ENGLISH );
+		withoutNull.addNumericNullIndexed( 1, 1 );
+		withoutNull.addNumericNullIndexed( 2, 2 );
+
+		withNullEntry = persistEntity( fullTextSession, "Worf" );
+		withNullEntry.addNullIndexed( 1, KLINGON );
+		withNullEntry.addNullIndexed( 2, ENGLISH );
+		withNullEntry.addNullIndexed( 3, null );
+		withNullEntry.addNumericNullIndexed( 1, 11 );
+		withNullEntry.addNumericNullIndexed( 2, null );
+
+		withNullEmbedded = persistEntity( fullTextSession, "Mime" );
+		withNullEmbedded.setNumericNullIndexed( null );
+		withNullEmbedded.setNullIndexed( null );
+
+		tx.commit();
+	}
+
+	@Test
+	public void testSearchNullEntry() throws Exception {
+		List<MapBridgeNullEmbeddedTestEntity> results = findResults( "nullIndexed", MapBridgeNullEmbeddedTestEntity.NULL_TOKEN, true );
+
+		assertNotNull( "No result found for an indexed collection", results );
+		assertEquals( "Unexpected number of results in a collection", 1, results.size() );
+		assertEquals( "Wrong result returned looking for a null in a collection", withNullEntry.getName(), results.get( 0 ).getName() );
+	}
+
+	@Test
+	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2389 Support indexNullAs for @IndexedEmbedded applied on objects with Elasticsearch
+	public void testSearchNullEmbedded() throws Exception {
+		List<MapBridgeNullEmbeddedTestEntity> results = findEmbeddedNullResults( "nullIndexed", MapBridgeNullEmbeddedTestEntity.NULL_EMBEDDED, true );
+
+		assertNotNull( "No result found for an indexed collection", results );
+		assertEquals( "Unexpected number of results in a collection", 1, results.size() );
+		assertEquals( "Wrong result returned looking for a null in a collection", withNullEmbedded.getName(), results.get( 0 ).getName() );
+	}
+
+	@Test
+	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2389 Support indexNullAs for @IndexedEmbedded applied on objects with Elasticsearch
+	public void testSearchNullNumericEmbedded() throws Exception {
+		List<MapBridgeNullEmbeddedTestEntity> results =
+				findEmbeddedNullResults( "embeddedNum", MapBridgeNullEmbeddedTestEntity.NULL_EMBEDDED_NUMERIC, true );
+
+		assertNotNull( "No result found for an indexed collection", results );
+		assertEquals( "Unexpected number of results in a collection", 1, results.size() );
+		assertEquals( "Wrong result returned looking for a null in a collection of numeric", withNullEmbedded.getName(), results.get( 0 ).getName() );
+	}
+
+	@Test
+	public void testSearchNullNumericEntry() throws Exception {
+		List<MapBridgeNullEmbeddedTestEntity> results =
+				findResults( "numericNullIndexed", MapBridgeNullEmbeddedTestEntity.NULL_NUMERIC_TOKEN, false );
+
+		assertNotNull( "No result found for an indexed collection", results );
+		assertEquals( "Unexpected number of results in a collection", 1, results.size() );
+		assertEquals( "Wrong result returned looking for a null in a collection of numeric", withNullEntry.getName(), results.get( 0 ).getName() );
+	}
+
+	@Test
+	public void testSearchNotNullEntry() throws Exception {
+		{
+			List<MapBridgeNullEmbeddedTestEntity> results = findResults( "nullIndexed", KLINGON, false );
+
+			assertNotNull( "No result found for an indexed collection", results );
+			assertEquals( "Wrong number of results returned for an indexed collection", 1, results.size() );
+			assertEquals( "Wrong result returned from an indexed collection", withNullEntry.getName(), results.get( 0 )
+					.getName() );
+		}
+		{
+			List<MapBridgeNullEmbeddedTestEntity> results = findResults( "nullIndexed", ITALIAN, false );
+
+			assertNotNull( "No result found for an indexed collection", results );
+			assertEquals( "Wrong number of results returned for an indexed collection", 1, results.size() );
+			assertEquals( "Wrong result returned from an indexed collection", withoutNull.getName(), results.get( 0 )
+					.getName() );
+		}
+		{
+			List<MapBridgeNullEmbeddedTestEntity> results = findResults( "nullIndexed", ENGLISH, false );
+
+			assertNotNull( "No result found for an indexed collection", results );
+			assertEquals( "Wrong number of results returned for an indexed collection", 2, results.size() );
+		}
+	}
+
+	@Test
+	public void testSearchNotNullNumeric() throws Exception {
+		{
+			List<MapBridgeNullEmbeddedTestEntity> results = findNumericResults( "numericNullIndexed", 1 );
+
+			assertNotNull( "No result found for an indexed collection", results );
+			assertEquals( "Wrong number of results returned for an indexed collection", 1, results.size() );
+			assertEquals( "Wrong result returned from an indexed collection", withoutNull.getName(), results.get( 0 )
+					.getName() );
+		}
+		{
+			List<MapBridgeNullEmbeddedTestEntity> results = findNumericResults( "numericNullIndexed", 11 );
+
+			assertNotNull( "No result found for an indexed collection", results );
+			assertEquals( "Wrong number of results returned for an indexed collection", 1, results.size() );
+			assertEquals( "Wrong result returned from an indexed collection", withNullEntry.getName(), results.get( 0 )
+					.getName() );
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private List<MapBridgeNullEmbeddedTestEntity> findEmbeddedNullResults(String fieldName, Object value, boolean checkNullToken) {
+		QueryBuilder queryBuilder = fullTextSession.getSearchFactory().buildQueryBuilder()
+				.forEntity( MapBridgeNullEmbeddedTestEntity.class ).get();
+		TermMatchingContext termMatchingContext = queryBuilder.keyword().onField( fieldName );
+		if ( checkNullToken ) {
+			termMatchingContext.ignoreFieldBridge();
+		}
+		Query query = termMatchingContext.ignoreAnalyzer().matching( value ).createQuery();
+		return fullTextSession.createFullTextQuery( query, MapBridgeNullEmbeddedTestEntity.class ).list();
+	}
+
+	@SuppressWarnings("unchecked")
+	private List<MapBridgeNullEmbeddedTestEntity> findResults(String fieldName, Object value, boolean checkNullToken) {
+		QueryBuilder queryBuilder = fullTextSession.getSearchFactory().buildQueryBuilder()
+				.forEntity( MapBridgeNullEmbeddedTestEntity.class ).get();
+		TermMatchingContext termMatchingContext = queryBuilder.keyword().onField( fieldName );
+		if ( checkNullToken ) {
+			termMatchingContext.ignoreFieldBridge();
+			termMatchingContext.ignoreAnalyzer();
+		}
+		Query query = termMatchingContext.matching( value ).createQuery();
+		return fullTextSession.createFullTextQuery( query, MapBridgeNullEmbeddedTestEntity.class ).list();
+	}
+
+	@SuppressWarnings("unchecked")
+	private List<MapBridgeNullEmbeddedTestEntity> findNumericResults(String fieldName, Object number) {
+		Query query = NumericFieldUtils.createNumericRangeQuery( fieldName, number, number, true, true );
+		return fullTextSession.createFullTextQuery( query, MapBridgeNullEmbeddedTestEntity.class ).list();
+	}
+
+	private MapBridgeNullEmbeddedTestEntity persistEntity(Session s, String name) {
+		MapBridgeNullEmbeddedTestEntity boy = new MapBridgeNullEmbeddedTestEntity();
+		boy.setName( name );
+		s.persist( boy );
+		return boy;
+	}
+
+	@Override
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { MapBridgeNullEmbeddedTestEntity.class, };
+	}
+}

--- a/orm/src/test/java/org/hibernate/search/test/bridge/MapBridgeNullEmbeddedTestEntity.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/MapBridgeNullEmbeddedTestEntity.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.test.bridge;
 
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import javax.persistence.CollectionTable;
@@ -20,10 +19,9 @@ import javax.persistence.MapKeyColumn;
 import javax.persistence.Table;
 
 import org.hibernate.search.annotations.Analyze;
-import org.hibernate.search.annotations.DateBridge;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
-import org.hibernate.search.annotations.Resolution;
+import org.hibernate.search.annotations.IndexedEmbedded;
 import org.hibernate.search.annotations.Store;
 
 /**
@@ -32,19 +30,17 @@ import org.hibernate.search.annotations.Store;
 @Entity
 @Indexed
 @Table(name = "IBT_Entity")
-public class MapBridgeTestEntity {
+public class MapBridgeNullEmbeddedTestEntity {
 
 	static final String NULL_TOKEN = "NULL_MARKER";
 	static final String NULL_NUMERIC_TOKEN = "-7777";
+	static final String NULL_EMBEDDED = "EMBEDDED_NULL";
+	static final String NULL_EMBEDDED_NUMERIC = "-4444";
 
 	private Long id;
 	private String name;
 	private Map<Integer, Language> nullIndexed = new HashMap<Integer, Language>();
-	private Map<Integer, String> nullNotIndexed = new HashMap<Integer, String>();
 	private Map<Integer, Integer> numericNullIndexed = new HashMap<Integer, Integer>();
-	private Map<Integer, Long> numericNullNotIndexed = new HashMap<Integer, Long>();
-
-	private Map<Integer, Date> dates = new HashMap<Integer, Date>();
 
 	public enum Language {
 		ITALIAN, ENGLISH, PIRATE, KLINGON
@@ -73,6 +69,11 @@ public class MapBridgeTestEntity {
 
 	@Field(indexNullAs = NULL_TOKEN, analyze = Analyze.NO)
 	@ElementCollection
+	/*
+	 * This will only have an effect for null maps, since the type for the map values
+	 * does not contain any @Field annotation (which means there is nothing to embed).
+	 */
+	@IndexedEmbedded(indexNullAs = NULL_EMBEDDED)
 	@CollectionTable(name = "NullIndexed", joinColumns = @JoinColumn(name = "iterable_id"))
 	@Column(name = "nullIndexed")
 	@MapKeyColumn(nullable = false)
@@ -90,6 +91,11 @@ public class MapBridgeTestEntity {
 
 	@Field(store = Store.YES, indexNullAs = NULL_NUMERIC_TOKEN, analyze = Analyze.NO)
 	@ElementCollection
+	/*
+	 * This will only have an effect for null maps, since the type for the map values
+	 * does not contain any @Field annotation (which means there is nothing to embed).
+	 */
+	@IndexedEmbedded(prefix = "embeddedNum.", indexNullAs = NULL_EMBEDDED_NUMERIC)
 	@CollectionTable(name = "NumericNullIndexed", joinColumns = @JoinColumn(name = "iterable_id"))
 	@Column(name = "numericNullIndexed")
 	@MapKeyColumn(nullable = false)
@@ -105,60 +111,8 @@ public class MapBridgeTestEntity {
 		this.numericNullIndexed.put( key, number );
 	}
 
-	@Field(store = Store.YES)
-	@ElementCollection
-	@CollectionTable(name = "NullNotIndexed", joinColumns = @JoinColumn(name = "iterable_id"))
-	@Column(name = "nullNotIndexed")
-	@MapKeyColumn(nullable = false)
-	public Map<Integer, String> getNullNotIndexed() {
-		return nullNotIndexed;
-	}
-
-	public void setNullNotIndexed(Map<Integer, String> nullNotIndexed) {
-		this.nullNotIndexed = nullNotIndexed;
-	}
-
-	public void addNullNotIndexed(Integer key, String value) {
-		this.nullNotIndexed.put( key, value );
-	}
-
-	@Field(store = Store.YES)
-	@ElementCollection
-	@CollectionTable(name = "NumericNullNotIndexed", joinColumns = @JoinColumn(name = "iterable_id"))
-	@Column(name = "numericNullNotIndexed")
-	@MapKeyColumn(nullable = false)
-	public Map<Integer, Long> getNumericNullNotIndexed() {
-		return numericNullNotIndexed;
-	}
-
-	public void setNumericNullNotIndexed(Map<Integer, Long> numericSkipNullCollection) {
-		this.numericNullNotIndexed = numericSkipNullCollection;
-	}
-
-	public void addNumericNullNotIndexed(Integer key, Long value) {
-		this.numericNullNotIndexed.put( key, value );
-	}
-
-	@Field(analyze = Analyze.NO, store = Store.YES)
-	@ElementCollection
-	@DateBridge(resolution = Resolution.SECOND)
-	@CollectionTable(name = "Dates", joinColumns = @JoinColumn(name = "iterable_id"))
-	@Column(name = "dates")
-	@MapKeyColumn(nullable = false)
-	public Map<Integer, Date> getDates() {
-		return dates;
-	}
-
-	public void setDates(Map<Integer, Date> dates) {
-		this.dates = dates;
-	}
-
-	public void addDate(Integer key, Date value) {
-		this.dates.put( key, value );
-	}
-
 	@Override
 	public String toString() {
-		return MapBridgeTestEntity.class.getSimpleName() + "[id=" + id + ", name=" + name + "]";
+		return MapBridgeNullEmbeddedTestEntity.class.getSimpleName() + "[id=" + id + ", name=" + name + "]";
 	}
 }

--- a/orm/src/test/java/org/hibernate/search/test/bridge/MapBridgeTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/MapBridgeTest.java
@@ -21,10 +21,8 @@ import org.hibernate.search.bridge.util.impl.NumericFieldUtils;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.query.dsl.TermMatchingContext;
 import org.hibernate.search.test.SearchTestBase;
-import org.hibernate.search.testsupport.junit.ElasticsearchSupportInProgress;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
 import static org.hibernate.search.test.bridge.MapBridgeTestEntity.Language.ENGLISH;
 import static org.hibernate.search.test.bridge.MapBridgeTestEntity.Language.ITALIAN;
@@ -33,7 +31,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 /**
- * Test indexing of {@link javax.persistence.ElementCollection} annotated elements.
+ * Test indexing of {@link javax.persistence.ElementCollection} annotated maps.
  *
  * @author Davide D'Alto
  */
@@ -99,27 +97,6 @@ public class MapBridgeTest extends SearchTestBase {
 		assertNotNull( "No result found for an indexed collection", results );
 		assertEquals( "Unexpected number of results in a collection", 1, results.size() );
 		assertEquals( "Wrong result returned looking for a null in a collection", withNullEntry.getName(), results.get( 0 ).getName() );
-	}
-
-	@Test
-	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2389 Support indexNullAs for @IndexedEmbedded applied on objects with Elasticsearch
-	public void testSearchNullEmbedded() throws Exception {
-		List<MapBridgeTestEntity> results = findEmbeddedNullResults( "nullIndexed", MapBridgeTestEntity.NULL_EMBEDDED, true );
-
-		assertNotNull( "No result found for an indexed collection", results );
-		assertEquals( "Unexpected number of results in a collection", 1, results.size() );
-		assertEquals( "Wrong result returned looking for a null in a collection", withNullEmbedded.getName(), results.get( 0 ).getName() );
-	}
-
-	@Test
-	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2389 Support indexNullAs for @IndexedEmbedded applied on objects with Elasticsearch
-	public void testSearchNullNumericEmbedded() throws Exception {
-		List<MapBridgeTestEntity> results =
-				findEmbeddedNullResults( "embeddedNum", MapBridgeTestEntity.NULL_EMBEDDED_NUMERIC, true );
-
-		assertNotNull( "No result found for an indexed collection", results );
-		assertEquals( "Unexpected number of results in a collection", 1, results.size() );
-		assertEquals( "Wrong result returned looking for a null in a collection of numeric", withNullEmbedded.getName(), results.get( 0 ).getName() );
 	}
 
 	@Test
@@ -229,18 +206,6 @@ public class MapBridgeTest extends SearchTestBase {
 		assertEquals( "Wrong number of results returned for an indexed collection", 1, results.size() );
 		assertEquals( "Wrong result returned from a collection of Date", withoutNull.getName(), results.get( 0 )
 				.getName() );
-	}
-
-	@SuppressWarnings("unchecked")
-	private List<MapBridgeTestEntity> findEmbeddedNullResults(String fieldName, Object value, boolean checkNullToken) {
-		QueryBuilder queryBuilder = fullTextSession.getSearchFactory().buildQueryBuilder()
-				.forEntity( MapBridgeTestEntity.class ).get();
-		TermMatchingContext termMatchingContext = queryBuilder.keyword().onField( fieldName );
-		if ( checkNullToken ) {
-			termMatchingContext.ignoreFieldBridge();
-		}
-		Query query = termMatchingContext.ignoreAnalyzer().matching( value ).createQuery();
-		return fullTextSession.createFullTextQuery( query, MapBridgeTestEntity.class ).list();
 	}
 
 	@SuppressWarnings("unchecked")

--- a/orm/src/test/java/org/hibernate/search/test/event/autoindexembeddable/EmbeddableCategories.java
+++ b/orm/src/test/java/org/hibernate/search/test/event/autoindexembeddable/EmbeddableCategories.java
@@ -15,7 +15,6 @@ import javax.persistence.MapKeyColumn;
 
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.FieldBridge;
-import org.hibernate.search.annotations.IndexedEmbedded;
 
 /**
  * @author Hardy Ferentschik
@@ -26,7 +25,6 @@ public class EmbeddableCategories {
 	private Map<Long, String> categories;
 
 	@ElementCollection
-	@IndexedEmbedded
 	@MapKeyColumn
 	@Field(bridge = @FieldBridge(impl = CategoriesBridge.class))
 	public Map<Long, String> getCategories() {


### PR DESCRIPTION
Relevant tickets:

 1. https://hibernate.atlassian.net/browse/HSEARCH-2448: Throw exceptions with clear messages when there are field type conflicts with Elasticsearch
 2. https://hibernate.atlassian.net/browse/HSEARCH-2419 Using array/iterable/map field bridges requires the @IndexedEmbedded annotation

About the second ticket: we used to force users to use `@IndexedEmbedded` along with `@Field` to correctly index containers (iterables, maps, arrays) of primitive types. On top of being weird (we're not really embedding another `@Indexed` type in that case), this started to not work at all once we fixed the first ticket, which was (more or less) about preventing that kind of use (`@IndexedEmbedded` + `@Field` on the same property).

Please note that the second commit is not just here to ease up debugging: without it, some tests cannot be written at all, because metadata order is not predictable.