### PR TITLE
HSEARCH-2486 Enable @ContainedIn on classes whose only link to Search…

### DIFF
--- a/engine/src/main/java/org/hibernate/search/util/impl/ReflectionHelper.java
+++ b/engine/src/main/java/org/hibernate/search/util/impl/ReflectionHelper.java
@@ -115,13 +115,41 @@ public abstract class ReflectionHelper {
 	}
 
 	/**
-	 * Checks whether the specified class contains any Search specific annotations.
+	 * Checks whether the specified class contains any Search-specific annotations.
+	 *
+	 * <p>This method will return {@code true} if such an annotation is detected
+	 * in the class itself or in one of its superclass, either applied directly on the class,
+	 * on a field, or on a method.
 	 *
 	 * @param mappedClass the {@code XClass} to check for Search annotations
 	 *
 	 * @return Returns {@code true} if the class contains at least one Search annotation, {@code false} otherwise
 	 */
 	public static boolean containsSearchAnnotations(XClass mappedClass) {
+		List<XClass> hierarchy = createXClassHierarchy( mappedClass );
+
+		for ( XClass clazz : hierarchy ) {
+			if ( containsLocalSearchAnnotation( clazz ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Checks whether the specified class contains any locally-declared, Search-specific annotations.
+	 *
+	 * <p>This method will return {@code true} if such an annotation is detected
+	 * in the class itself, either applied directly on the class, on a field, or on a method.
+	 * <p>Only fields and methods declared by the specified class are taken into account:
+	 * inherited fields and methods are ignored.
+	 *
+	 * @param mappedClass the {@code XClass} to check for Search annotations
+	 *
+	 * @return Returns {@code true} if the class contains at least one Search annotation, {@code false} otherwise
+	 */
+	private static boolean containsLocalSearchAnnotation(XClass mappedClass) {
 		// check the type annotations
 		if ( containsSearchAnnotation( mappedClass.getAnnotations() ) ) {
 			return true;

--- a/orm/src/test/java/org/hibernate/search/test/embedded/ContainedInEntityInheritanceTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/embedded/ContainedInEntityInheritanceTest.java
@@ -1,0 +1,122 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.embedded;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+import javax.persistence.OneToOne;
+
+import org.apache.lucene.search.Query;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.search.FullTextQuery;
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.Search;
+import org.hibernate.search.annotations.ContainedIn;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.IndexedEmbedded;
+import org.hibernate.search.query.dsl.QueryBuilder;
+import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.testsupport.TestForIssue;
+import org.junit.Test;
+
+/**
+ * @author Yoann Rodiere
+ */
+@TestForIssue(jiraKey = "HSEARCH-2486")
+public class ContainedInEntityInheritanceTest extends SearchTestBase {
+
+	@Test
+	public void testContainedInIsInherited() {
+		// Initialize
+		Containing containing;
+		try (Session session = openSession()) {
+			Transaction transaction = session.beginTransaction();
+
+			containing = new Containing();
+			session.save( containing );
+
+			Contained contained = new Contained();
+			containing.contained = contained;
+			contained.containing = containing;
+			session.save( contained );
+			session.save( containing );
+
+			transaction.commit();
+		}
+		assertEquals( 1, queryResultSize( 0 ) );
+
+		// Update and test the containedIn
+		try (Session session = openSession()) {
+			Transaction transaction = session.beginTransaction();
+
+			containing = session.byId( Containing.class ).load( containing.id );
+			containing.contained.field = 1;
+			session.save( containing.contained );
+
+			transaction.commit();
+		}
+		assertEquals( 1, queryResultSize( 1 ) );
+		assertEquals( 0, queryResultSize( 0 ) );
+	}
+
+	private int queryResultSize(int fieldValue) {
+		try (Session session = openSession()) {
+			FullTextSession ftSession = Search.getFullTextSession( session );
+			QueryBuilder builder = ftSession.getSearchFactory().buildQueryBuilder()
+					.forEntity( Containing.class ).get();
+			Query luceneQuery = builder.keyword().onField( "contained.field" ).matching( fieldValue ).createQuery();
+			FullTextQuery query = ftSession.createFullTextQuery( luceneQuery, Containing.class );
+			return query.getResultSize();
+		}
+	}
+
+	@Override
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class[] { Containing.class, AbstractContained.class, Contained.class };
+	}
+
+	@Indexed
+	@Entity
+	private static class Containing {
+		@Id
+		@GeneratedValue
+		private long id;
+
+		@OneToOne
+		@IndexedEmbedded
+		private Contained contained;
+	}
+
+	@MappedSuperclass
+	private static class AbstractContained {
+		@OneToOne(mappedBy = "contained")
+		@ContainedIn
+		Containing containing;
+
+		@Field
+		int field;
+	}
+
+	/**
+	 * This entity doesn't carry any Search specific annotation,
+	 * but its superclass does.
+	 */
+	@Entity
+	private static class Contained extends AbstractContained {
+		@Id
+		@GeneratedValue
+		private long id;
+	}
+
+
+}


### PR DESCRIPTION
… is one of their superclasses

https://hibernate.atlassian.net/browse/HSEARCH-2486

Those classes were being ignored until now, because we were checking
whether classes are relevant to Hibernate Search without taking into
account their superclasses, thereby skipping metadata building entirely.