### PR TITLE
Hsearch 2494 tika bridge bug

### DIFF
--- a/engine/src/main/java/org/hibernate/search/bridge/impl/BridgeFactory.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/impl/BridgeFactory.java
@@ -26,6 +26,7 @@ import org.hibernate.search.bridge.FieldBridge;
 import org.hibernate.search.bridge.ParameterizedBridge;
 import org.hibernate.search.bridge.TwoWayFieldBridge;
 import org.hibernate.search.bridge.TwoWayStringBridge;
+import org.hibernate.search.bridge.builtin.TikaBridge;
 import org.hibernate.search.bridge.builtin.impl.BuiltinArrayBridge;
 import org.hibernate.search.bridge.builtin.impl.BuiltinIterableBridge;
 import org.hibernate.search.bridge.builtin.impl.BuiltinMapBridge;
@@ -295,6 +296,9 @@ public final class BridgeFactory {
 		FieldBridge bridge = bridgeProvider.provideFieldBridge( context );
 		if ( bridge == null ) {
 			return null;
+		}
+		if ( bridge instanceof TikaBridge ) {
+			return bridge;
 		}
 		populateReturnType( context.getReturnType(), bridge.getClass(), bridge );
 		switch ( containerType ) {

--- a/engine/src/main/java/org/hibernate/search/bridge/impl/ExtendedBridgeProvider.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/impl/ExtendedBridgeProvider.java
@@ -58,5 +58,13 @@ public abstract class ExtendedBridgeProvider implements BridgeProvider {
 		 * not.
 		 */
 		boolean isExplicitlyMarkedAsNumeric();
+
+		/**
+		 * Returns the type of the indexed member/property; it works for arrays and collections too.
+		 *
+		 * @see #getReturnType()
+		 * @return the type of the indexed member
+		 */
+		Class<?> getElementOrContainerReturnType();
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/bridge/impl/TikaBridgeProvider.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/impl/TikaBridgeProvider.java
@@ -36,7 +36,7 @@ class TikaBridgeProvider extends ExtendedBridgeProvider {
 	public FieldBridge provideFieldBridge(ExtendedBridgeProviderContext context) {
 		AnnotatedElement annotatedElement = context.getAnnotatedElement();
 		if ( annotatedElement.isAnnotationPresent( TikaBridge.class ) ) {
-			Class<?> returnType = context.getReturnType();
+			Class<?> returnType = context.getElementOrContainerReturnType();
 			if ( ! Blob.class.isAssignableFrom( returnType )
 					&& ! byte[].class.isAssignableFrom( returnType )
 					&& ! String.class.isAssignableFrom( returnType )

--- a/engine/src/main/java/org/hibernate/search/bridge/impl/XMemberBridgeProviderContext.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/impl/XMemberBridgeProviderContext.java
@@ -22,6 +22,7 @@ class XMemberBridgeProviderContext implements ExtendedBridgeProvider.ExtendedBri
 
 	private final AnnotatedElement annotatedElement;
 	private final Class<?> returnTypeElement;
+	private final Class<?> returnType;
 	private final String memberName;
 	private final ServiceManager serviceManager;
 	private final boolean isId;
@@ -35,6 +36,7 @@ class XMemberBridgeProviderContext implements ExtendedBridgeProvider.ExtendedBri
 		this.annotatedElement = new XMemberToAnnotatedElementAdaptor( member );
 		// For arrays and collection, return the type of the contained elements
 		this.returnTypeElement = reflectionManager.toClass( member.getElementClass() );
+		this.returnType = reflectionManager.toClass( member.getType() );
 		this.memberName = member.getName();
 		this.serviceManager = serviceManager;
 		this.isId = isId;
@@ -44,6 +46,11 @@ class XMemberBridgeProviderContext implements ExtendedBridgeProvider.ExtendedBri
 	@Override
 	public Class<?> getReturnType() {
 		return returnTypeElement;
+	}
+
+	@Override
+	public Class<?> getElementOrContainerReturnType() {
+		return returnType;
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/bridge/spi/BridgeProvider.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/spi/BridgeProvider.java
@@ -34,7 +34,8 @@ public interface BridgeProvider {
 	interface BridgeProviderContext {
 
 		/**
-		 * Returns the type of the indexed member/property.
+		 * Returns the type of the indexed member/property;
+		 * for arrays and collections, returns the type of the contained elements.
 		 *
 		 * @return the type of the indexed member
 		 */

--- a/orm/src/test/java/org/hibernate/search/test/bridge/tika/Book.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/tika/Book.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.test.bridge.tika;
 
+import java.net.URI;
 import java.sql.Blob;
 
 import javax.persistence.Basic;
@@ -29,6 +30,7 @@ public class Book {
 	private Integer id;
 	private Blob contentAsBlob;
 	private byte[] contentAsBytes;
+	private URI contentAsURI;
 
 	public Book() {
 	}
@@ -39,6 +41,10 @@ public class Book {
 
 	public Book(byte[] content) {
 		this.contentAsBytes = content;
+	}
+
+	public Book(URI content) {
+		this.contentAsURI = content;
 	}
 
 	@Id
@@ -73,5 +79,17 @@ public class Book {
 
 	public void setContentAsBytes(byte[] contentAsBytes) {
 		this.contentAsBytes = contentAsBytes;
+	}
+
+	@Lob
+	@Basic(fetch = FetchType.LAZY)
+	@Field(indexNullAs = "<NULL>")
+	@TikaBridge
+	public URI getContentAsURI() {
+		return contentAsURI;
+	}
+
+	public void setContentAsURI(URI contentAsURI) {
+		this.contentAsURI = contentAsURI;
 	}
 }

--- a/orm/src/test/java/org/hibernate/search/test/bridge/tika/Book.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/tika/Book.java
@@ -27,7 +27,14 @@ import org.hibernate.search.annotations.TikaBridge;
 public class Book {
 
 	private Integer id;
-	private Blob content;
+	private Blob contentAsBlob;
+
+	public Book() {
+	}
+
+	public Book(Blob content) {
+		this.contentAsBlob = content;
+	}
 
 	@Id
 	@GeneratedValue
@@ -43,11 +50,11 @@ public class Book {
 	@Basic(fetch = FetchType.LAZY)
 	@Field(indexNullAs = "<NULL>")
 	@TikaBridge
-	public Blob getContent() {
-		return content;
+	public Blob getContentAsBlob() {
+		return contentAsBlob;
 	}
 
-	public void setContent(Blob content) {
-		this.content = content;
+	public void setContentAsBlob(Blob contentAsBlob) {
+		this.contentAsBlob = contentAsBlob;
 	}
 }

--- a/orm/src/test/java/org/hibernate/search/test/bridge/tika/Book.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/tika/Book.java
@@ -28,12 +28,17 @@ public class Book {
 
 	private Integer id;
 	private Blob contentAsBlob;
+	private byte[] contentAsBytes;
 
 	public Book() {
 	}
 
 	public Book(Blob content) {
 		this.contentAsBlob = content;
+	}
+
+	public Book(byte[] content) {
+		this.contentAsBytes = content;
 	}
 
 	@Id
@@ -56,5 +61,17 @@ public class Book {
 
 	public void setContentAsBlob(Blob contentAsBlob) {
 		this.contentAsBlob = contentAsBlob;
+	}
+
+	@Lob
+	@Basic(fetch = FetchType.LAZY)
+	@Field(indexNullAs = "<NULL>")
+	@TikaBridge
+	public byte[] getContentAsBytes() {
+		return contentAsBytes;
+	}
+
+	public void setContentAsBytes(byte[] contentAsBytes) {
+		this.contentAsBytes = contentAsBytes;
 	}
 }

--- a/orm/src/test/java/org/hibernate/search/test/bridge/tika/TikaBridgeBlobSupportTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/tika/TikaBridgeBlobSupportTest.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.test.bridge.tika;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -24,16 +26,14 @@ import org.hibernate.ScrollMode;
 import org.hibernate.ScrollableResults;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
-import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
+import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.test.util.impl.ClasspathResourceAsFile;
 import org.hibernate.search.testsupport.TestConstants;
 import org.junit.Rule;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * @author Hardy Ferentschik
@@ -45,26 +45,26 @@ public class TikaBridgeBlobSupportTest extends SearchTestBase {
 	public ClasspathResourceAsFile testDocumentPdf = new ClasspathResourceAsFile( getClass(), TEST_DOCUMENT_PDF );
 
 	@Test
-	public void testDefaultTikaBridgeWithBlobData() throws Exception {
-		Session session = openSession();
+	public void testDefaultTikaBridgeWithBlob() throws Exception {
+		try ( Session session = openSession() ) {
+			Blob content = dataAsBlob( testDocumentPdf.get(), session );
 
-		persistBook( session, getBlobData( testDocumentPdf.get().getPath(), session ) );
-		persistBook( session, null );
+			persistBook( session, new Book( content ) );
+			persistBook( session, new Book() );
 
-		// we have to index manually. Using the Blob (streaming approach) the indexing would try to re-read the
-		// input stream of the blob after it was persisted into the database
-		indexBook( session );
-		searchBook( session );
-
-		session.close();
+			// we have to index manually. Using the Blob (streaming approach) the indexing would try to re-read the
+			// input stream of the blob after it was persisted into the database
+			indexBook( session );
+			searchBook( session, "contentAsBlob" );
+		}
 	}
 
 	@SuppressWarnings("unchecked")
-	private void searchBook(Session session) throws ParseException {
+	private void searchBook(Session session, String field) throws ParseException {
 		FullTextSession fullTextSession = Search.getFullTextSession( session );
 		Transaction transaction = fullTextSession.beginTransaction();
 		QueryParser parser = new QueryParser(
-				"content",
+				field,
 				TestConstants.standardAnalyzer
 		);
 		Query query = parser.parse( "foo" );
@@ -89,12 +89,8 @@ public class TikaBridgeBlobSupportTest extends SearchTestBase {
 		fullTextSession.clear();
 	}
 
-	private void persistBook(Session session, Blob data) throws IOException {
+	private void persistBook(Session session, Book book) throws IOException {
 		Transaction tx = session.beginTransaction();
-
-		Book book = new Book();
-		book.setContent( data );
-
 		session.save( book );
 		session.flush();
 		tx.commit();
@@ -140,8 +136,7 @@ public class TikaBridgeBlobSupportTest extends SearchTestBase {
 		cfg.put( Environment.INDEXING_STRATEGY, "manual" );
 	}
 
-	private Blob getBlobData(String fileName, Session session) throws IOException {
-		File file = new File( fileName );
+	private Blob dataAsBlob(File file, Session session) throws IOException {
 		FileInputStream in = FileUtils.openInputStream( file );
 		return session.getLobHelper().createBlob( in, file.length() );
 	}

--- a/orm/src/test/java/org/hibernate/search/test/bridge/tika/TikaBridgeInputTypeTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/tika/TikaBridgeInputTypeTest.java
@@ -38,7 +38,7 @@ import org.junit.Test;
 /**
  * @author Hardy Ferentschik
  */
-public class TikaBridgeBlobSupportTest extends SearchTestBase {
+public class TikaBridgeInputTypeTest extends SearchTestBase {
 	private static final String TEST_DOCUMENT_PDF = "/org/hibernate/search/test/bridge/tika/test-document-1.pdf";
 
 	@Rule

--- a/orm/src/test/java/org/hibernate/search/test/bridge/tika/TikaBridgeInputTypeTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/tika/TikaBridgeInputTypeTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.sql.Blob;
 import java.util.List;
 import java.util.Map;
@@ -56,6 +57,19 @@ public class TikaBridgeInputTypeTest extends SearchTestBase {
 			// input stream of the blob after it was persisted into the database
 			indexBook( session );
 			searchBook( session, "contentAsBlob" );
+		}
+	}
+
+	@Test
+	public void testDefaultTikaBridgeWithByteArray() throws Exception {
+		try ( Session session = openSession() ) {
+			byte[] content = dataAsBytes( testDocumentPdf.get() );
+
+			persistBook( session, new Book( content ) );
+			persistBook( session, new Book() );
+
+			indexBook( session );
+			searchBook( session, "contentAsBytes" );
 		}
 	}
 
@@ -139,5 +153,9 @@ public class TikaBridgeInputTypeTest extends SearchTestBase {
 	private Blob dataAsBlob(File file, Session session) throws IOException {
 		FileInputStream in = FileUtils.openInputStream( file );
 		return session.getLobHelper().createBlob( in, file.length() );
+	}
+
+	private byte[] dataAsBytes(File file) throws IOException {
+		return Files.readAllBytes( file.toPath() );
 	}
 }

--- a/orm/src/test/java/org/hibernate/search/test/bridge/tika/TikaBridgeInputTypeTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/tika/TikaBridgeInputTypeTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Files;
 import java.sql.Blob;
 import java.util.List;
@@ -70,6 +71,19 @@ public class TikaBridgeInputTypeTest extends SearchTestBase {
 
 			indexBook( session );
 			searchBook( session, "contentAsBytes" );
+		}
+	}
+
+	@Test
+	public void testDefaultTikaBridgeWithURI() throws Exception {
+		try ( Session session = openSession() ) {
+			URI content = testDocumentPdf.get().toURI();
+
+			persistBook( session, new Book( content ) );
+			persistBook( session, new Book() );
+
+			indexBook( session );
+			searchBook( session, "contentAsURI" );
 		}
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2494

The issue is caused by to problems:

1. ExtendedBridgeProviderContext#getReturnType returns only the contained type for arrays and collections but the TikaBridgeProvider expects the complete type.

2. TikaBridge provider should overrides the default bridge we use for arrays.

I've also added a test to check the support for URI.