### PR TITLE
HSEARCH-2363 Use a non-ambiguous representation in ZonedDateTimeBridge

### DIFF
--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/ZonedDateTimeBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/time/impl/ZonedDateTimeBridge.java
@@ -11,11 +11,13 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 
+import org.hibernate.search.util.impl.TimeHelper;
+
 /**
  * Converts a {@link ZonedDateTime} to a {@link String}.
  * <p>
- * A {@code ZonedDateTime} 2012-12-31T23:59:59.999 Europe/Paris becomes the string
- * {@code +0000020121231235959000000999Europe/Paris}.
+ * A {@code ZonedDateTime} 2012-12-31T23:59:59.999+01:00 Europe/Paris becomes the string
+ * {@code +0000020121231235959000000999+01:00Europe/Paris}.
  * <p>
  * The sign is always present for the year and the string is padded with 0 to allow field sorting.
  *
@@ -23,9 +25,33 @@ import java.time.format.DateTimeParseException;
  */
 public class ZonedDateTimeBridge extends TemporalAccessorStringBridge<ZonedDateTime> {
 
-	static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
+	private static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
 			.append( LocalDateTimeBridge.FORMATTER )
-			.appendZoneId()
+			/*
+			 * We include both the offset and the zone region ID, in order to handle
+			 * dates matching multiple instants, which happens when clocks are set back
+			 * due to switching daylight saving time.
+			 *
+			 * Both the offset and zone region ID are optional when parsing.
+			 * That's for two reasons.
+			 *
+			 * 1. The previous format, in Hibernate Search 5.5, used ".appendZoneId",
+			 * which may be the offset or the zone region ID, depending on how the
+			 * ZonedDateTime was built. Even in legacy format, we nevertheless expect
+			 * either the zone region ID or the offset to be provided.
+			 * 2. Depending on how a ZonedDateTime is built, there may be no zone region
+			 * ID to output, so we must not make this part of the string mandatory. It is
+			 * the case in particular when using ZoneOffsets to build ZonedDateTimes.
+			 *
+			 * See HSEARCH-2363 for more information.
+			 */
+			.optionalStart()
+			.appendOffsetId()
+			.optionalEnd()
+			.optionalStart()
+			.parseCaseSensitive()
+			.appendZoneRegionId()
+			.optionalEnd()
 			.toFormatter();
 
 	public static final ZonedDateTimeBridge INSTANCE = new ZonedDateTimeBridge();
@@ -36,6 +62,6 @@ public class ZonedDateTimeBridge extends TemporalAccessorStringBridge<ZonedDateT
 
 	@Override
 	ZonedDateTime parse(String stringValue) throws DateTimeParseException {
-		return ZonedDateTime.parse( stringValue, FORMATTER );
+		return TimeHelper.parseZoneDateTime( stringValue, FORMATTER );
 	}
 }

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/ZonedDateTimeBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/ZonedDateTimeBridgeTest.java
@@ -29,11 +29,16 @@ public class ZonedDateTimeBridgeTest {
 
 	private static final String MAX = "+9999999991231235959999999999+18:00";
 	private static final String MIN = "-9999999990101000000000000000-18:00";
-	private static final String CUSTOM = "-0000000010203040506000000007Europe/Paris";
+	private static final String CUSTOM_LEGACY_FORMAT = "+0000020010203040506000000007Europe/Paris";
+	private static final String CUSTOM = "+0000020010203040506000000007+01:00Europe/Paris";
+	private static final String BC_CUSTOM_LEGACY_FORMAT = "-0000000010203040506000000007Europe/Paris";
+	// The offset for Europe/Paris was 9 minutes 21 seconds until the beginning of the XXth century
+	private static final String BC_CUSTOM = "-0000000010203040506000000007+00:09:21Europe/Paris";
 
 	private static final ZonedDateTime MAX_VALUE = ZonedDateTime.of( LocalDateTime.MAX, ZoneOffset.MAX );
 	private static final ZonedDateTime MIN_VALUE = ZonedDateTime.of( LocalDateTime.MIN, ZoneOffset.MIN );
-	private static final ZonedDateTime CUSTOM_UTC = ZonedDateTime.of( LocalDate.of( -1, 2, 3 ), LocalTime.of( 4, 5, 6, 7 ), ZoneId.of( "Europe/Paris" ) );
+	private static final ZonedDateTime CUSTOM_VALUE = ZonedDateTime.of( LocalDate.of( 2001, 2, 3 ), LocalTime.of( 4, 5, 6, 7 ), ZoneId.of( "Europe/Paris" ) );
+	private static final ZonedDateTime BC_CUSTOM_VALUE = ZonedDateTime.of( LocalDate.of( -1, 2, 3 ), LocalTime.of( 4, 5, 6, 7 ), ZoneId.of( "Europe/Paris" ) );
 
 	@Rule
 	public final ExpectedException thrown = ExpectedException.none();
@@ -49,8 +54,13 @@ public class ZonedDateTimeBridgeTest {
 	}
 
 	@Test
-	public void testPaddingObjectToString() throws Exception {
-		assertThat( BRIDGE.objectToString( CUSTOM_UTC ) ).isEqualTo( CUSTOM );
+	public void testCustomObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( CUSTOM_VALUE ) ).isEqualTo( CUSTOM );
+	}
+
+	@Test
+	public void testBcCustomObjectToString() throws Exception {
+		assertThat( BRIDGE.objectToString( BC_CUSTOM_VALUE ) ).isEqualTo( BC_CUSTOM );
 	}
 
 	@Test
@@ -64,7 +74,22 @@ public class ZonedDateTimeBridgeTest {
 	}
 
 	@Test
-	public void testPaddingStringToObject() throws Exception {
-		assertThat( BRIDGE.stringToObject( CUSTOM ) ).isEqualTo( CUSTOM_UTC );
+	public void testCustomStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( CUSTOM ) ).isEqualTo( CUSTOM_VALUE );
+	}
+
+	@Test
+	public void testCustomLegacyStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( CUSTOM_LEGACY_FORMAT ) ).isEqualTo( CUSTOM_VALUE );
+	}
+
+	@Test
+	public void testBcCustomStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( BC_CUSTOM ) ).isEqualTo( BC_CUSTOM_VALUE );
+	}
+
+	@Test
+	public void testBcCustomLegacyStringToObject() throws Exception {
+		assertThat( BRIDGE.stringToObject( BC_CUSTOM_LEGACY_FORMAT ) ).isEqualTo( BC_CUSTOM_VALUE );
 	}
 }

--- a/orm/src/test/java/org/hibernate/search/test/bridge/time/JavaTimeTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/time/JavaTimeTest.java
@@ -22,6 +22,7 @@ import java.time.Year;
 import java.time.YearMonth;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -169,6 +170,21 @@ public class JavaTimeTest extends SearchTestBase {
 	}
 
 	@Test
+	public void testZonedDateTime() throws Exception {
+		// CET DST rolls back at 2011-10-30 2:59:59 (+02) to 2011-10-30 2:00:00 (+01)
+		// Credit: user leonbloy at http://stackoverflow.com/a/18794412/6692043
+		LocalDateTime localDateTime = LocalDateTime.of( 2011, 10, 30, 2, 50, 0, 0 );
+
+		ZonedDateTime value = localDateTime.atZone( ZoneId.of( "CET" ) ).withLaterOffsetAtOverlap();
+
+		Sample sample = new Sample( 1L, "ZonedDateTime example" );
+		sample.zonedDateTime = value;
+
+		assertThatFieldIsIndexed( "zonedDateTime", value, sample );
+	}
+
+
+	@Test
 	public void testYear() throws Exception {
 		/* Elasticsearch only accepts years in the range [-292275054,292278993]
 		 */
@@ -271,6 +287,9 @@ public class JavaTimeTest extends SearchTestBase {
 
 		@Field(analyze = Analyze.NO, store = Store.YES)
 		private OffsetDateTime offsetDateTime;
+
+		@Field(analyze = Analyze.NO, store = Store.YES)
+		private ZonedDateTime zonedDateTime;
 
 		@Field(analyze = Analyze.NO, store = Store.YES)
 		private OffsetTime offsetTime;


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2363

The new format for indexed `ZonedDateTime`s basically prevents data loss when indexing date/times representing instants around daylight saving time cut-over. See the ticket for a detailed explanation.

I tried to keep the change as backward-compatible as possible: users will still be able to project date/times indexed before this patch, though those projections will be subject to HSEARCH-2363.
Sorts will probably be off on indexes mixing the new and the previous format, but they've been off from the beginning, since we're sorting on string representations of date/times in different time zones. 