### PR TITLE
HSEARCH-2503 Execute ExpectedLog4jLog properly even if log expectations are added *during* the test

### DIFF
--- a/engine/src/test/java/org/hibernate/search/test/util/impl/ExpectedLog4jLog.java
+++ b/engine/src/test/java/org/hibernate/search/test/util/impl/ExpectedLog4jLog.java
@@ -47,13 +47,7 @@ public class ExpectedLog4jLog implements TestRule {
 
 	@Override
 	public Statement apply(Statement base, org.junit.runner.Description description) {
-		if ( !expectations.isEmpty() || !absenceExpectations.isEmpty() ) {
-			return new ExpectedLogStatement( base );
-		}
-		else {
-			// Don't mess with loggers if we don't have anything to check
-			return base;
-		}
+		return new ExpectedLogStatement( base );
 	}
 
 	/**


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2503

This reverts commit b1867179159fa2784344d922cf142524c180ac61. That
commit added an optimization that turned out bypassing assertions
completely when expectations are defined during the test (and not inline
just after calling ExpectedLog4jLog.create()).