### PR TITLE
HSEARCH-2449 Allow configuration of the pool sizes, timeouts and autodiscovery for the Jest client connections

### DIFF
--- a/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
+++ b/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
@@ -144,6 +144,12 @@ Maximum time to wait for a connection to the Elasticsearch server before failing
 Maximum time to wait for a response from the Elasticsearch server before failing (in ms):: `hibernate.search.default.elasticsearch.read_timeout 60000` (default)
 Maximum number of simultaneous connections to the Elasticsearch cluster:: `hibernate.search.default.elasticsearch.max_total_connection 20` (default)
 Maximum number of simultaneous connections to a single Elasticsearch server:: `hibernate.search.default.elasticsearch.max_total_connection_per_route 2` (default)
+Whether to enable automatic discovery of servers in the Elasticsearch cluster (`true` or `false`):: `hibernate.search.default.elasticsearch.discovery.enabled false` (default)
++
+When using automatic discovery, the Elasticsearch client will periodically probe for new nodes in the cluster,
+and will add those to the server list (see `host` above).
+Similarly, the client will periodically check whether registered servers still respond,
+and will remove them from the server list if they don't.
 Maximum time to wait for the indexes to become available before failing (in ms):: `hibernate.search.default.elasticsearch.index_management_wait_timeout 10000` (default)
 +
 This value must be lower than the read timeout (see above).
@@ -171,7 +177,7 @@ Properties prefixed with `hibernate.search.default` can be given globally as sho
 `hibernate.search.someindex.elasticsearch.index_schema_management_strategy MERGE`
 
 This excludes properties related to the internal Elasticsearch client, which at the moment is common to every index manager (but this will change in a future version).
-Excluded properties are `host`, `read_timeout`, `connection_timeout`, `max_total_connection` and `max_total_connection_per_route`.
+Excluded properties are `host`, `read_timeout`, `connection_timeout`, `max_total_connection`, `max_total_connection_per_route` and `discovery.enabled`.
 --
 
 ===== Elasticsearch configuration

--- a/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
+++ b/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
@@ -150,6 +150,9 @@ When using automatic discovery, the Elasticsearch client will periodically probe
 and will add those to the server list (see `host` above).
 Similarly, the client will periodically check whether registered servers still respond,
 and will remove them from the server list if they don't.
+Time interval between two executions of the automatic discovery (in seconds):: `hibernate.search.default.elasticsearch.discovery.refresh_interval 10` (default)
++
+This setting will only be taken into account if automatic discovery is enabled (see above).
 Maximum time to wait for the indexes to become available before failing (in ms):: `hibernate.search.default.elasticsearch.index_management_wait_timeout 10000` (default)
 +
 This value must be lower than the read timeout (see above).
@@ -177,7 +180,7 @@ Properties prefixed with `hibernate.search.default` can be given globally as sho
 `hibernate.search.someindex.elasticsearch.index_schema_management_strategy MERGE`
 
 This excludes properties related to the internal Elasticsearch client, which at the moment is common to every index manager (but this will change in a future version).
-Excluded properties are `host`, `read_timeout`, `connection_timeout`, `max_total_connection`, `max_total_connection_per_route` and `discovery.enabled`.
+Excluded properties are `host`, `read_timeout`, `connection_timeout`, `max_total_connection`, `max_total_connection_per_route`, `discovery.enabled` and `discovery.refresh_interval`.
 --
 
 ===== Elasticsearch configuration

--- a/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
+++ b/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
@@ -142,6 +142,8 @@ One exception should be noted, though: date formats must match exactly the forma
 --
 Maximum time to wait for a connection to the Elasticsearch server before failing (in ms):: `hibernate.search.default.elasticsearch.connection_timeout 3000` (default)
 Maximum time to wait for a response from the Elasticsearch server before failing (in ms):: `hibernate.search.default.elasticsearch.read_timeout 60000` (default)
+Maximum number of simultaneous connections to the Elasticsearch cluster:: `hibernate.search.default.elasticsearch.max_total_connection 20` (default)
+Maximum number of simultaneous connections to a single Elasticsearch server:: `hibernate.search.default.elasticsearch.max_total_connection_per_route 2` (default)
 Maximum time to wait for the indexes to become available before failing (in ms):: `hibernate.search.default.elasticsearch.index_management_wait_timeout 10000` (default)
 +
 This value must be lower than the read timeout (see above).
@@ -169,7 +171,7 @@ Properties prefixed with `hibernate.search.default` can be given globally as sho
 `hibernate.search.someindex.elasticsearch.index_schema_management_strategy MERGE`
 
 This excludes properties related to the internal Elasticsearch client, which at the moment is common to every index manager (but this will change in a future version).
-Excluded properties are `host`, `read_timeout` and `connection_timeout`.
+Excluded properties are `host`, `read_timeout`, `connection_timeout`, `max_total_connection` and `max_total_connection_per_route`.
 --
 
 ===== Elasticsearch configuration

--- a/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
+++ b/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
@@ -140,7 +140,7 @@ Mapping validation is as permissive as possible. Fields or mappings that are unk
 
 One exception should be noted, though: date formats must match exactly the formats specified by Hibernate Search, due to implementation constraints.
 --
-Maximum time to wait for a connection to the Elasticsearch server before failing (in ms):: `hibernate.search.default.elasticsearch.connection_timeout 2000` (default)
+Maximum time to wait for a connection to the Elasticsearch server before failing (in ms):: `hibernate.search.default.elasticsearch.connection_timeout 3000` (default)
 Maximum time to wait for a response from the Elasticsearch server before failing (in ms):: `hibernate.search.default.elasticsearch.read_timeout 60000` (default)
 Maximum time to wait for the indexes to become available before failing (in ms):: `hibernate.search.default.elasticsearch.index_management_wait_timeout 10000` (default)
 +

--- a/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
+++ b/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
@@ -140,7 +140,11 @@ Mapping validation is as permissive as possible. Fields or mappings that are unk
 
 One exception should be noted, though: date formats must match exactly the formats specified by Hibernate Search, due to implementation constraints.
 --
+Maximum time to wait for a connection to the Elasticsearch server before failing (in ms):: `hibernate.search.default.elasticsearch.connection_timeout 2000` (default)
+Maximum time to wait for a response from the Elasticsearch server before failing (in ms):: `hibernate.search.default.elasticsearch.read_timeout 60000` (default)
 Maximum time to wait for the indexes to become available before failing (in ms):: `hibernate.search.default.elasticsearch.index_management_wait_timeout 10000` (default)
++
+This value must be lower than the read timeout (see above).
 Status an index must at least have in order for Hibernate Search to work with it (one of "green", "yellow" or "red")::
 `hibernate.search.default.elasticsearch.required_index_status green` (default)
 +
@@ -158,8 +162,15 @@ When <<elasticsearch-scrolling,scrolling>>, the number of results fetched by eac
 When <<elasticsearch-scrolling,scrolling>>, the maximum duration `ScrollableResults` will be usable if no other results are fetched from Elasticsearch, in seconds::
 `hibernate.search.elasticsearch.scroll_timeout 60` (default)
 
-Note that all properties prefixed with `hibernate.search.default` (besides `host`) can be given globally as shown above and/or be given for specific indexes:
-`hibernate.search.someindex.elasticsearch.index_schema_management_strategy MERGE`.
+[NOTE]
+--
+Properties prefixed with `hibernate.search.default` can be given globally as shown above and/or be given for specific indexes:
+
+`hibernate.search.someindex.elasticsearch.index_schema_management_strategy MERGE`
+
+This excludes properties related to the internal Elasticsearch client, which at the moment is common to every index manager (but this will change in a future version).
+Excluded properties are `host`, `read_timeout` and `connection_timeout`.
+--
 
 ===== Elasticsearch configuration
 

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/ElasticsearchEnvironment.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/ElasticsearchEnvironment.java
@@ -21,6 +21,8 @@ public final class ElasticsearchEnvironment {
 		public static final String SERVER_URI = "http://localhost:9200";
 		public static final int SERVER_READ_TIMEOUT = 60000;
 		public static final int SERVER_CONNECTION_TIMEOUT = 3000;
+		public static final int MAX_TOTAL_CONNECTION = 20;
+		public static final int MAX_TOTAL_CONNECTION_PER_ROUTE = 2;
 		public static final IndexSchemaManagementStrategy INDEX_SCHEMA_MANAGEMENT_STRATEGY = IndexSchemaManagementStrategy.CREATE;
 		public static final int INDEX_MANAGEMENT_WAIT_TIMEOUT = 10_000;
 		public static final String REQUIRED_INDEX_STATUS = "green";
@@ -75,6 +77,34 @@ public final class ElasticsearchEnvironment {
 	 * Hibernate Search.
 	 */
 	public static final String SERVER_CONNECTION_TIMEOUT = "elasticsearch.connection_timeout";
+
+	/**
+	 * Property for specifying the maximum number of simultaneous connections to the Elasticsearch cluster.
+	 * <p>
+	 * A positive numeric value is expected.
+	 * <p>
+	 * Defaults to {@link Defaults#MAX_TOTAL_CONNECTION}.
+	 * <p>
+	 * Can only be given <b>globally</b> (e.g.
+	 * {@code hibernate.search.default.elasticsearch.max_total_connection=30}), because only a single Elasticsearch
+	 * cluster is supported for all the indexed entities. This limitation will be removed in a future version of
+	 * Hibernate Search.
+	 */
+	public static final String MAX_TOTAL_CONNECTION = "elasticsearch.max_total_connection";
+
+	/**
+	 * Property for specifying the maximum number of simultaneous connections to a single Elasticsearch server.
+	 * <p>
+	 * A positive numeric value is expected.
+	 * <p>
+	 * Defaults to {@link Defaults#MAX_TOTAL_CONNECTION_PER_ROUTE}.
+	 * <p>
+	 * Can only be given <b>globally</b> (e.g.
+	 * {@code hibernate.search.default.elasticsearch.max_total_connection_per_route=3}), because only a single Elasticsearch
+	 * cluster is supported for all the indexed entities. This limitation will be removed in a future version of
+	 * Hibernate Search.
+	 */
+	public static final String MAX_TOTAL_CONNECTION_PER_ROUTE = "elasticsearch.max_total_connection_per_route";
 
 	/**
 	 * Property for specifying the strategy for maintaining the Elasticsearch index.

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/ElasticsearchEnvironment.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/ElasticsearchEnvironment.java
@@ -20,7 +20,7 @@ public final class ElasticsearchEnvironment {
 
 		public static final String SERVER_URI = "http://localhost:9200";
 		public static final int SERVER_READ_TIMEOUT = 60000;
-		public static final int SERVER_CONNECTION_TIMEOUT = 2000;
+		public static final int SERVER_CONNECTION_TIMEOUT = 3000;
 		public static final IndexSchemaManagementStrategy INDEX_SCHEMA_MANAGEMENT_STRATEGY = IndexSchemaManagementStrategy.CREATE;
 		public static final int INDEX_MANAGEMENT_WAIT_TIMEOUT = 10_000;
 		public static final String REQUIRED_INDEX_STATUS = "green";

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/ElasticsearchEnvironment.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/ElasticsearchEnvironment.java
@@ -23,6 +23,7 @@ public final class ElasticsearchEnvironment {
 		public static final int SERVER_CONNECTION_TIMEOUT = 3000;
 		public static final int MAX_TOTAL_CONNECTION = 20;
 		public static final int MAX_TOTAL_CONNECTION_PER_ROUTE = 2;
+		public static final boolean DISCOVERY_ENABLED = false;
 		public static final IndexSchemaManagementStrategy INDEX_SCHEMA_MANAGEMENT_STRATEGY = IndexSchemaManagementStrategy.CREATE;
 		public static final int INDEX_MANAGEMENT_WAIT_TIMEOUT = 10_000;
 		public static final String REQUIRED_INDEX_STATUS = "green";
@@ -105,6 +106,20 @@ public final class ElasticsearchEnvironment {
 	 * Hibernate Search.
 	 */
 	public static final String MAX_TOTAL_CONNECTION_PER_ROUTE = "elasticsearch.max_total_connection_per_route";
+
+	/**
+	 * Property for specifying whether automatic discovery of nodes in the Elasticsearch cluster is enabled.
+	 * <p>
+	 * Either {@code true} or {@code false} is expected.
+	 * <p>
+	 * Defaults to {@link Defaults#DISCOVERY_ENABLED}.
+	 * <p>
+	 * Can only be given <b>globally</b> (e.g.
+	 * {@code hibernate.search.default.elasticsearch.discovery.enabled=true}), because only a single Elasticsearch
+	 * cluster is supported for all the indexed entities. This limitation will be removed in a future version of
+	 * Hibernate Search.
+	 */
+	public static final String DISCOVERY_ENABLED = "elasticsearch.discovery.enabled";
 
 	/**
 	 * Property for specifying the strategy for maintaining the Elasticsearch index.

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/ElasticsearchEnvironment.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/ElasticsearchEnvironment.java
@@ -49,6 +49,34 @@ public final class ElasticsearchEnvironment {
 	public static final String SERVER_URI = "elasticsearch.host";
 
 	/**
+	 * Property for specifying the timeout when reading responses from an Elasticsearch server.
+	 * <p>
+	 * A numeric value in milliseconds, such as 60000 is expected.
+	 * <p>
+	 * Defaults to {@link Defaults#SERVER_READ_TIMEOUT}.
+	 * <p>
+	 * Can only be given <b>globally</b> (e.g.
+	 * {@code hibernate.search.default.elasticsearch.read_timeout=60000}), because only a single Elasticsearch
+	 * cluster is supported for all the indexed entities. This limitation will be removed in a future version of
+	 * Hibernate Search.
+	 */
+	public static final String SERVER_READ_TIMEOUT = "elasticsearch.read_timeout";
+
+	/**
+	 * Property for specifying the timeout when connecting to an Elasticsearch server.
+	 * <p>
+	 * A numeric value in milliseconds, such as 2000 is expected.
+	 * <p>
+	 * Defaults to {@link Defaults#SERVER_CONNECTION_TIMEOUT}.
+	 * <p>
+	 * Can only be given <b>globally</b> (e.g.
+	 * {@code hibernate.search.default.elasticsearch.connection_timeout=2000}), because only a single Elasticsearch
+	 * cluster is supported for all the indexed entities. This limitation will be removed in a future version of
+	 * Hibernate Search.
+	 */
+	public static final String SERVER_CONNECTION_TIMEOUT = "elasticsearch.connection_timeout";
+
+	/**
 	 * Property for specifying the strategy for maintaining the Elasticsearch index.
 	 * <p>
 	 * The name of one of the {@link IndexSchemaManagementStrategy} constants is expected, e.g. MERGE.

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/ElasticsearchEnvironment.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/ElasticsearchEnvironment.java
@@ -24,6 +24,7 @@ public final class ElasticsearchEnvironment {
 		public static final int MAX_TOTAL_CONNECTION = 20;
 		public static final int MAX_TOTAL_CONNECTION_PER_ROUTE = 2;
 		public static final boolean DISCOVERY_ENABLED = false;
+		public static final long DISCOVERY_REFRESH_INTERVAL = 10L;
 		public static final IndexSchemaManagementStrategy INDEX_SCHEMA_MANAGEMENT_STRATEGY = IndexSchemaManagementStrategy.CREATE;
 		public static final int INDEX_MANAGEMENT_WAIT_TIMEOUT = 10_000;
 		public static final String REQUIRED_INDEX_STATUS = "green";
@@ -120,6 +121,20 @@ public final class ElasticsearchEnvironment {
 	 * Hibernate Search.
 	 */
 	public static final String DISCOVERY_ENABLED = "elasticsearch.discovery.enabled";
+
+	/**
+	 * Property for specifying the time interval between two executions of the automatic discovery, if enabled.
+	 * <p>
+	 * A positive numeric value in seconds is expected.
+	 * <p>
+	 * Defaults to {@link Defaults#DISCOVERY_REFRESH_INTERVAL}.
+	 * <p>
+	 * Can only be given <b>globally</b> (e.g.
+	 * {@code hibernate.search.default.elasticsearch.discovery.refresh_interval=20}), because only a single Elasticsearch
+	 * cluster is supported for all the indexed entities. This limitation will be removed in a future version of
+	 * Hibernate Search.
+	 */
+	public static final String DISCOVERY_REFRESH_INTERVAL = "elasticsearch.discovery.refresh_interval";
 
 	/**
 	 * Property for specifying the strategy for maintaining the Elasticsearch index.

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/JestClient.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/JestClient.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.hibernate.search.elasticsearch.cfg.ElasticsearchEnvironment;
 import org.hibernate.search.elasticsearch.impl.GsonService;
@@ -115,6 +116,14 @@ public class JestClient implements Service, Startable, Stoppable {
 						CLIENT_PROP_PREFIX + ElasticsearchEnvironment.DISCOVERY_ENABLED,
 						ElasticsearchEnvironment.Defaults.DISCOVERY_ENABLED
 				) )
+				.discoveryFrequency(
+						ConfigurationParseHelper.getLongValue(
+								properties,
+								CLIENT_PROP_PREFIX + ElasticsearchEnvironment.DISCOVERY_REFRESH_INTERVAL,
+								ElasticsearchEnvironment.Defaults.DISCOVERY_REFRESH_INTERVAL
+						),
+						TimeUnit.SECONDS
+				)
 				.gson( gsonService.getGson() )
 				.build()
 		);

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/JestClient.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/JestClient.java
@@ -100,6 +100,16 @@ public class JestClient implements Service, Startable, Stoppable {
 						CLIENT_PROP_PREFIX + ElasticsearchEnvironment.SERVER_CONNECTION_TIMEOUT,
 						ElasticsearchEnvironment.Defaults.SERVER_CONNECTION_TIMEOUT
 				) )
+				.maxTotalConnection( ConfigurationParseHelper.getIntValue(
+						properties,
+						CLIENT_PROP_PREFIX + ElasticsearchEnvironment.MAX_TOTAL_CONNECTION,
+						ElasticsearchEnvironment.Defaults.MAX_TOTAL_CONNECTION
+				) )
+				.defaultMaxTotalConnectionPerRoute( ConfigurationParseHelper.getIntValue(
+						properties,
+						CLIENT_PROP_PREFIX + ElasticsearchEnvironment.MAX_TOTAL_CONNECTION_PER_ROUTE,
+						ElasticsearchEnvironment.Defaults.MAX_TOTAL_CONNECTION_PER_ROUTE
+				) )
 				.gson( gsonService.getGson() )
 				.build()
 		);

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/JestClient.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/JestClient.java
@@ -110,6 +110,11 @@ public class JestClient implements Service, Startable, Stoppable {
 						CLIENT_PROP_PREFIX + ElasticsearchEnvironment.MAX_TOTAL_CONNECTION_PER_ROUTE,
 						ElasticsearchEnvironment.Defaults.MAX_TOTAL_CONNECTION_PER_ROUTE
 				) )
+				.discoveryEnabled( ConfigurationParseHelper.getBooleanValue(
+						properties,
+						CLIENT_PROP_PREFIX + ElasticsearchEnvironment.DISCOVERY_ENABLED,
+						ElasticsearchEnvironment.Defaults.DISCOVERY_ENABLED
+				) )
 				.gson( gsonService.getGson() )
 				.build()
 		);

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/JestClient.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/JestClient.java
@@ -58,12 +58,14 @@ public class JestClient implements Service, Startable, Stoppable {
 	private static final int TIME_OUT = 408;
 
 	/**
-	 * Prefix for accessing the {@link ElasticsearchEnvironment#SERVER_URI} variable. That's currently needed as we
-	 * don't access this one in the context of a specific index manager. The prefix is used to have the property name
-	 * in line with the other index-related property names, even though this property can not yet be override on
-	 * a per-index base.
+	 * Prefix for accessing the client-related settings.
+	 * That's currently needed as we only have a single client for all
+	 * index managers.
+	 * The prefix is used to have the property name in line with the other
+	 * index-related property names, even though this property can not yet
+	 * be overridden on a per-index basis.
 	 */
-	private static final String SERVER_URI_PROP_PREFIX = "hibernate.search.default.";
+	private static final String CLIENT_PROP_PREFIX = "hibernate.search.default.";
 
 	private io.searchbox.client.JestClient client;
 
@@ -79,18 +81,25 @@ public class JestClient implements Service, Startable, Stoppable {
 
 		String serverUrisString = ConfigurationParseHelper.getString(
 				properties,
-				SERVER_URI_PROP_PREFIX + ElasticsearchEnvironment.SERVER_URI,
+				CLIENT_PROP_PREFIX + ElasticsearchEnvironment.SERVER_URI,
 				ElasticsearchEnvironment.Defaults.SERVER_URI
 		);
 
 		Collection<String> serverUris = Arrays.asList( serverUrisString.trim().split( "\\s" ) );
 
-		// TODO HSEARCH-2062 Make timeouts configurable
 		factory.setHttpClientConfig(
 			new HttpClientConfig.Builder( serverUris )
 				.multiThreaded( true )
-				.readTimeout( ElasticsearchEnvironment.Defaults.SERVER_READ_TIMEOUT )
-				.connTimeout( ElasticsearchEnvironment.Defaults.SERVER_CONNECTION_TIMEOUT )
+				.readTimeout( ConfigurationParseHelper.getIntValue(
+						properties,
+						CLIENT_PROP_PREFIX + ElasticsearchEnvironment.SERVER_READ_TIMEOUT,
+						ElasticsearchEnvironment.Defaults.SERVER_READ_TIMEOUT
+				) )
+				.connTimeout( ConfigurationParseHelper.getIntValue(
+						properties,
+						CLIENT_PROP_PREFIX + ElasticsearchEnvironment.SERVER_CONNECTION_TIMEOUT,
+						ElasticsearchEnvironment.Defaults.SERVER_CONNECTION_TIMEOUT
+				) )
 				.gson( gsonService.getGson() )
 				.build()
 		);


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2449