### PR TITLE
HSEARCH-2512 Force OSGi integration tests to use the loopback device …

### DIFF
--- a/integrationtest/osgi/karaf-it/src/test/java/org/hibernate/search/test/integration/osgi/HibernateSearchWithKarafIT.java
+++ b/integrationtest/osgi/karaf-it/src/test/java/org/hibernate/search/test/integration/osgi/HibernateSearchWithKarafIT.java
@@ -144,6 +144,14 @@ public class HibernateSearchWithKarafIT {
 						"etc/org.apache.aries.transaction.cfg",
 						"aries.transaction.timeout", "600"
 				),
+				editConfigurationFilePut(
+						"etc/org.apache.karaf.management.cfg",
+						"rmiServerHost", "127.0.0.1"
+				),
+				editConfigurationFilePut(
+						"etc/org.apache.karaf.management.cfg",
+						"rmiRegistryHost", "127.0.0.1"
+				),
 				// set the log level for the in container logging to INFO
 				// also just logging to file (out), check data/log/karaf.log w/i the Karaf installation for the test execution log
 				editConfigurationFilePut(


### PR DESCRIPTION
…for RMI

https://hibernate.atlassian.net/browse/HSEARCH-2512