### PR TITLE
HSEARCH-2456 Wait for index status does not raise an exception

### DIFF
--- a/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
+++ b/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
@@ -116,7 +116,7 @@ Let's see the options for the `index_schema_management_strategy` property:
 [options="header"]
 |===============
 |Value|Definition
-|`NONE`|Indexes and their mappings will not be created, deleted nor altered.
+|`NONE`|Indexes and their mappings will not be created, deleted nor altered. Hibernate Search will only check that the indexes already exist.
 |`VALIDATE`|Existing indexes and mappings will be checked for conflicts with Hibernate Search's metamodel. Indexes and their mappings will not be created, deleted nor altered.
 |`MERGE`|Missing indexes and mappings will be created, existing mappings will be updated if there are no conflicts.
 |`CREATE`|**The default**: existing indexes will not be altered, missing indexes will be created along with their mappings.

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/ElasticsearchEnvironment.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/ElasticsearchEnvironment.java
@@ -27,7 +27,7 @@ public final class ElasticsearchEnvironment {
 		public static final long DISCOVERY_REFRESH_INTERVAL = 10L;
 		public static final IndexSchemaManagementStrategy INDEX_SCHEMA_MANAGEMENT_STRATEGY = IndexSchemaManagementStrategy.CREATE;
 		public static final int INDEX_MANAGEMENT_WAIT_TIMEOUT = 10_000;
-		public static final String REQUIRED_INDEX_STATUS = "green";
+		public static final ElasticsearchIndexStatus REQUIRED_INDEX_STATUS = ElasticsearchIndexStatus.GREEN;
 		public static final boolean REFRESH_AFTER_WRITE = false;
 		public static final int SCROLL_BACKTRACKING_WINDOW_SIZE = 10_000;
 		public static final int SCROLL_FETCH_SIZE = 1_000;

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/IndexSchemaManagementStrategy.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/IndexSchemaManagementStrategy.java
@@ -14,10 +14,10 @@ package org.hibernate.search.elasticsearch.cfg;
 public enum IndexSchemaManagementStrategy {
 
 	/**
-	 * Indexes will never be created or deleted. The index schema is not managed by Hibernate Search and is not checked.
+	 * Indexes will never be created or deleted. Hibernate Search will only check that the index actually exists.
+	 * The index schema (mapping) is not managed by Hibernate Search and is not checked.
 	 */
 	NONE,
-
 
 	/**
 	 * Upon session factory initialization, existing index mappings will be checked by Hibernate Search, causing an

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchIndexManager.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchIndexManager.java
@@ -232,6 +232,7 @@ public class ElasticsearchIndexManager implements IndexManager, IndexNameNormali
 	 */
 	private boolean initializeIndex(Set<Class<?>> entityTypesToInitialize) {
 		if ( schemaManagementStrategy == IndexSchemaManagementStrategy.NONE ) {
+			schemaCreator.checkIndexExists( actualIndexName, schemaManagementExecutionOptions );
 			return false;
 		}
 
@@ -257,6 +258,7 @@ public class ElasticsearchIndexManager implements IndexManager, IndexNameNormali
 				schemaMigrator.merge( indexMetadata, schemaManagementExecutionOptions );
 				break;
 			case VALIDATE:
+				schemaCreator.checkIndexExists( actualIndexName, schemaManagementExecutionOptions );
 				schemaValidator.validate( indexMetadata, schemaManagementExecutionOptions );
 				createdIndex = false;
 				break;

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchIndexManager.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchIndexManager.java
@@ -156,10 +156,15 @@ public class ElasticsearchIndexManager implements IndexManager, IndexNameNormali
 		String status = ConfigurationParseHelper.getString(
 				properties,
 				ElasticsearchEnvironment.REQUIRED_INDEX_STATUS,
-				ElasticsearchEnvironment.Defaults.REQUIRED_INDEX_STATUS
+				null
 		);
 
-		return ElasticsearchIndexStatus.fromString( status );
+		if ( status == null ) {
+			return ElasticsearchEnvironment.Defaults.REQUIRED_INDEX_STATUS;
+		}
+		else {
+			return ElasticsearchIndexStatus.fromString( status );
+		}
 	}
 
 	private static boolean getRefreshAfterWrite(Properties properties) {

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
@@ -279,4 +279,8 @@ public interface Log extends org.hibernate.search.util.logging.impl.Log {
 					+ " format (--MM-dd)." )
 	IllegalArgumentException invalidNullMarkerForMonthDay(@Cause Exception e);
 
+	@Message(id = ES_BACKEND_MESSAGES_START_ID + 50,
+			value = "The index '%1$s' does not exist in the Elasticsearch cluster." )
+	SearchException indexMissing(String indexName);
+
 }

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/schema/impl/ElasticsearchSchemaCreator.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/schema/impl/ElasticsearchSchemaCreator.java
@@ -35,6 +35,14 @@ public interface ElasticsearchSchemaCreator extends Service {
 	boolean createIndexIfAbsent(IndexMetadata indexMetadata, ExecutionOptions executionOptions);
 
 	/**
+	 * Checks that an index already exists.
+	 *
+	 * @param indexMetadata The expected index name.
+	 * @throws SearchException If the index doesn't exist, or if an error occurs.
+	 */
+	void checkIndexExists(String indexname, ExecutionOptions executionOptions);
+
+	/**
 	 * Create mappings on a supposedly existing index.
 	 *
 	 * <p>Mappings are supposed to be absent from the index.

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIndexExistsCheckIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIndexExistsCheckIT.java
@@ -1,0 +1,159 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.elasticsearch.cfg.ElasticsearchEnvironment;
+import org.hibernate.search.elasticsearch.cfg.ElasticsearchIndexStatus;
+import org.hibernate.search.elasticsearch.cfg.IndexSchemaManagementStrategy;
+import org.hibernate.search.elasticsearch.impl.ElasticsearchIndexManager;
+import org.hibernate.search.elasticsearch.impl.JsonBuilder;
+import org.hibernate.search.elasticsearch.testutil.TestElasticsearchClient;
+import org.hibernate.search.exception.SearchException;
+import org.hibernate.search.test.SearchInitializationTestBase;
+import org.hibernate.search.test.util.ImmutableTestConfiguration;
+import org.hibernate.testing.TestForIssue;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * Tests for {@link ElasticsearchIndexManager}'s schema validation feature.
+ *
+ * @author Yoann Rodiere
+ */
+@RunWith(Parameterized.class)
+@TestForIssue(jiraKey = "HSEARCH-2456")
+public class ElasticsearchIndexExistsCheckIT extends SearchInitializationTestBase {
+
+	@Parameters(name = "With strategy {0}")
+	public static IndexSchemaManagementStrategy[] strategies() {
+		return IndexSchemaManagementStrategy.values();
+	}
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Rule
+	public TestElasticsearchClient elasticSearchClient = new TestElasticsearchClient()
+			.requiredIndexStatus( ElasticsearchIndexStatus.YELLOW );
+
+	private IndexSchemaManagementStrategy strategy;
+
+	public ElasticsearchIndexExistsCheckIT(IndexSchemaManagementStrategy strategy) {
+		super();
+		this.strategy = strategy;
+	}
+
+	@Test
+	public void indexMissing() throws Exception {
+		Assume.assumeFalse( "The strategy " + strategy + " creates an index automatically."
+				+ " No point running this test.",
+				createsIndex( strategy ) );
+
+		elasticSearchClient.ensureIndexDoesNotExist( SimpleEntity.class );
+
+		thrown.expect( SearchException.class );
+		thrown.expectMessage( "HSEARCH400050" );
+
+		init( SimpleEntity.class );
+	}
+
+	@Test
+	public void invalidIndexStatus_creatingIndex() throws Exception {
+		Assume.assumeTrue( "The strategy " + strategy + " doesn't creates an index automatically."
+				+ " No point running this test.",
+				createsIndex( strategy ) );
+
+		// Make sure automatically created indexes will never be green
+		elasticSearchClient.createTemplate(
+				"yellow_index_because_not_enough_nodes_for_so_many_replicas",
+				"*",
+				/*
+				 * The exact number of replicas we ask for doesn't matter much,
+				 * since we're testing with only 1 node (the cluster can't replicate shards)
+				 */
+				JsonBuilder.object().addProperty( "number_of_replicas", 5 ).build()
+				);
+
+		elasticSearchClient.ensureIndexDoesNotExist( SimpleEntity.class );
+
+		thrown.expect( SearchException.class );
+		thrown.expectMessage( "HSEARCH400024" );
+
+		init( SimpleEntity.class );
+	}
+
+	@Test
+	public void invalidIndexStatus_usingPreexistingIndex() throws Exception {
+		// Make sure automatically created indexes will never be green
+		elasticSearchClient.createTemplate(
+				"yellow_index_because_not_enough_nodes_for_so_many_replicas",
+				"*",
+				/*
+				 * The exact number of replicas we ask for doesn't matter much,
+				 * since we're testing with only 1 node (the cluster can't replicate shards)
+				 */
+				JsonBuilder.object().addProperty( "number_of_replicas", 5 ).build()
+				);
+
+		elasticSearchClient.deleteAndCreateIndex( SimpleEntity.class );
+
+		thrown.expect( SearchException.class );
+		thrown.expectMessage( "HSEARCH400024" );
+
+		init( SimpleEntity.class );
+	}
+
+	@Override
+	protected void init(Class<?> ... entityClasses) {
+		Map<String, Object> settings = new HashMap<>();
+		settings.put(
+				"hibernate.search.default." + ElasticsearchEnvironment.INDEX_SCHEMA_MANAGEMENT_STRATEGY,
+				strategy.name()
+		);
+		settings.put(
+				"hibernate.search.default." + ElasticsearchEnvironment.INDEX_MANAGEMENT_WAIT_TIMEOUT,
+				"100"
+		);
+		settings.put(
+				"hibernate.search.default." + ElasticsearchEnvironment.REQUIRED_INDEX_STATUS,
+				ElasticsearchIndexStatus.GREEN.getElasticsearchString()
+		);
+
+		init( new ImmutableTestConfiguration( settings, entityClasses ) );
+	}
+
+	private boolean createsIndex(IndexSchemaManagementStrategy strategy) {
+		return !IndexSchemaManagementStrategy.NONE.equals( strategy )
+				&& !IndexSchemaManagementStrategy.VALIDATE.equals( strategy );
+	}
+
+	@Indexed
+	@Entity
+	private static class SimpleEntity {
+		@DocumentId
+		@Id
+		Long id;
+
+		@Field
+		String myField;
+	}
+
+}

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchSchemaValidationIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchSchemaValidationIT.java
@@ -28,7 +28,6 @@ import org.hibernate.search.elasticsearch.impl.ElasticsearchIndexManager;
 import org.hibernate.search.elasticsearch.impl.ToElasticsearch;
 import org.hibernate.search.elasticsearch.schema.impl.ElasticsearchSchemaValidationException;
 import org.hibernate.search.elasticsearch.testutil.TestElasticsearchClient;
-import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.test.SearchInitializationTestBase;
 import org.hibernate.search.test.util.ImmutableTestConfiguration;
 import org.junit.Rule;
@@ -43,8 +42,6 @@ import org.junit.rules.ExpectedException;
 public class ElasticsearchSchemaValidationIT extends SearchInitializationTestBase {
 
 	private static final String VALIDATION_FAILED_MESSAGE_ID = "HSEARCH400033";
-	private static final String MAPPINGS_RETRIEVAL_FAILED_MESSAGE_ID = "HSEARCH400034";
-	private static final String ELASTICSEARCH_REQUEST_FAILED_MESSAGE_ID = "HSEARCH400007";
 
 	@Rule
 	public ExpectedException thrown = ExpectedException.none();
@@ -142,19 +139,6 @@ public class ElasticsearchSchemaValidationIT extends SearchInitializationTestBas
 		init( SimpleDateEntity.class, SimpleBooleanEntity.class, FacetedDateEntity.class );
 
 		// If we get here, it means validation passed (no exception was thrown)
-	}
-
-	@Test
-	public void index_missing() throws Exception {
-		thrown.expect(
-				isException( SearchException.class )
-						.withMessage( MAPPINGS_RETRIEVAL_FAILED_MESSAGE_ID )
-				.causedBy( SearchException.class )
-						.withMessage( ELASTICSEARCH_REQUEST_FAILED_MESSAGE_ID )
-				.build()
-		);
-
-		init( SimpleDateEntity.class );
 	}
 
 	@Test

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/testutil/TestElasticsearchClient.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/testutil/TestElasticsearchClient.java
@@ -67,6 +67,10 @@ public class TestElasticsearchClient extends ExternalResource {
 		deleteAndCreateIndex( ElasticsearchIndexNameNormalizer.getElasticsearchIndexName( rootClass.getName() ) );
 	}
 
+	public void ensureIndexDoesNotExist(Class<?> rootClass) throws IOException {
+		ensureIndexDoesNotExist( ElasticsearchIndexNameNormalizer.getElasticsearchIndexName( rootClass.getName() ) );
+	}
+
 	public void registerForCleanup(Class<?> rootClass) {
 		createdIndicesNames.add( ElasticsearchIndexNameNormalizer.getElasticsearchIndexName( rootClass.getName() ) );
 	}
@@ -117,6 +121,17 @@ public class TestElasticsearchClient extends ExternalResource {
 		registerTemplateForCleanup( templateName );
 		if ( !result.isSucceeded() ) {
 			throw new AssertionFailure( "Error while creating template '" + templateName + "' for tests:" + result.getErrorMessage() );
+		}
+	}
+
+	public void ensureIndexDoesNotExist(String indexName) throws IOException {
+		JestResult result = client.execute( new DeleteIndex.Builder( indexName ).build() );
+		if ( !result.isSucceeded() && result.getResponseCode() != 404 /* Index not found is ok */ ) {
+			throw new AssertionFailure( String.format(
+					Locale.ENGLISH,
+					"Error while trying to delete index '%s' as part of test initialization: %s",
+					indexName, result.getErrorMessage()
+					) );
 		}
 	}
 

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/testutil/TestElasticsearchClient.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/testutil/TestElasticsearchClient.java
@@ -12,6 +12,7 @@ import java.net.URLEncoder;
 import java.util.List;
 
 import org.hibernate.search.elasticsearch.cfg.ElasticsearchEnvironment;
+import org.hibernate.search.elasticsearch.cfg.ElasticsearchIndexStatus;
 import org.hibernate.search.elasticsearch.impl.DefaultGsonService;
 import org.hibernate.search.elasticsearch.impl.ElasticsearchIndexNameNormalizer;
 import org.hibernate.search.elasticsearch.logging.impl.Log;
@@ -48,6 +49,13 @@ public class TestElasticsearchClient extends ExternalResource {
 	private JestClient client;
 
 	private final List<String> createdIndicesNames = Lists.newArrayList();
+
+	private ElasticsearchIndexStatus requiredIndexStatus = ElasticsearchEnvironment.Defaults.REQUIRED_INDEX_STATUS;
+
+	public TestElasticsearchClient requiredIndexStatus(ElasticsearchIndexStatus requiredIndexStatus) {
+		this.requiredIndexStatus = requiredIndexStatus;
+		return this;
+	}
 
 	public void deleteAndCreateIndex(Class<?> rootClass) throws IOException {
 		deleteAndCreateIndex( ElasticsearchIndexNameNormalizer.getElasticsearchIndexName( rootClass.getName() ) );
@@ -100,7 +108,7 @@ public class TestElasticsearchClient extends ExternalResource {
 
 	private void waitForIndexCreation(final String indexNameToWaitFor) throws IOException {
 		Builder healthBuilder = new Health.Builder()
-				.setParameter( "wait_for_status", ElasticsearchEnvironment.Defaults.REQUIRED_INDEX_STATUS.getElasticsearchString() )
+				.setParameter( "wait_for_status", requiredIndexStatus.getElasticsearchString() )
 				.setParameter( "timeout", ElasticsearchEnvironment.Defaults.INDEX_MANAGEMENT_WAIT_TIMEOUT + "ms" );
 
 		Health health = new Health( healthBuilder ) {

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/testutil/TestElasticsearchClient.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/testutil/TestElasticsearchClient.java
@@ -100,7 +100,7 @@ public class TestElasticsearchClient extends ExternalResource {
 
 	private void waitForIndexCreation(final String indexNameToWaitFor) throws IOException {
 		Builder healthBuilder = new Health.Builder()
-				.setParameter( "wait_for_status", ElasticsearchEnvironment.Defaults.REQUIRED_INDEX_STATUS )
+				.setParameter( "wait_for_status", ElasticsearchEnvironment.Defaults.REQUIRED_INDEX_STATUS.getElasticsearchString() )
 				.setParameter( "timeout", ElasticsearchEnvironment.Defaults.INDEX_MANAGEMENT_WAIT_TIMEOUT + "ms" );
 
 		Health health = new Health( healthBuilder ) {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2456

It appears we were not checking that the index at least existed in some situations, and more importantly we were not waiting for the index status to reach the expected level in some situations. This PR fixes that.