### PR TITLE
HSEARCH-2509 & HSEARCH-2467 Upgrade to Jest 2.0.4 to fix gson serialization issues with numeric range queries 

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/ArbitrarySort.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/ArbitrarySort.java
@@ -6,10 +6,10 @@
  */
 package org.hibernate.search.elasticsearch.client.impl;
 
-import java.util.HashMap;
-import java.util.Map;
+import org.hibernate.search.elasticsearch.impl.JsonBuilder;
 
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 
 import io.searchbox.core.search.sort.Sort;
 
@@ -33,10 +33,10 @@ public class ArbitrarySort extends Sort {
 	}
 
 	@Override
-	public Map<String, Object> toMap() {
-		Map<String, Object> rootMap = new HashMap<String, Object>();
-		rootMap.put( fieldName, sortDescription );
-		return rootMap;
+	public JsonObject toJsonObject() {
+		return JsonBuilder.object()
+				.add( fieldName, sortDescription )
+				.build();
 	}
 
 }

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/DistanceSort.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/DistanceSort.java
@@ -6,10 +6,10 @@
  */
 package org.hibernate.search.elasticsearch.client.impl;
 
-import java.util.HashMap;
-import java.util.Map;
-
+import org.hibernate.search.elasticsearch.impl.JsonBuilder;
 import org.hibernate.search.spatial.Coordinates;
+
+import com.google.gson.JsonObject;
 
 import io.searchbox.core.search.sort.Sort;
 
@@ -31,22 +31,19 @@ public class DistanceSort extends Sort {
 		this.center = center;
 	}
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public Map<String, Object> toMap() {
-		Map<String, Object> rootMap = super.toMap();
-		Map<String, Object> innerMap = (Map<String, Object>) rootMap.get( GEO_DISTANCE_FIELD );
-
-		Map<String, Double> location = new HashMap<String, Double>( 3 );
-		location.put( "lat", center.getLatitude() );
-		location.put( "lon", center.getLongitude() );
-
-		innerMap.put( fieldName, location );
-
-		innerMap.put( "unit", "km" );
-		innerMap.put( "distance_type", "arc" );
-
-		return rootMap;
+	public JsonObject toJsonObject() {
+		JsonObject rootObject = super.toJsonObject();
+		JsonObject gsonDistanceFieldObject = rootObject.getAsJsonObject( GEO_DISTANCE_FIELD );
+		JsonBuilder.object( gsonDistanceFieldObject )
+				.add( fieldName, JsonBuilder.object()
+						.addProperty( "lat", center.getLatitude() )
+						.addProperty( "lon", center.getLongitude() )
+						.build()
+				)
+				.addProperty( "unit", "km" )
+				.addProperty( "distance_type", "arc" );
+		return rootObject;
 	}
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
         <!-- Elasticsearch -->
         <elasticsearchJestVersion>2.0.4</elasticsearchJestVersion>
         <elasticsearchCommonsLang3Version>3.4</elasticsearchCommonsLang3Version>
-        <elasticsearchGsonVersion>2.4</elasticsearchGsonVersion>
+        <elasticsearchGsonVersion>2.6.2</elasticsearchGsonVersion>
 
         <!-- Integration tests -->
         <arquillianVersion>1.1.11.Final</arquillianVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
         <commonsLangVersion>2.6</commonsLangVersion>
 
         <!-- Elasticsearch -->
-        <elasticsearchJestVersion>2.0.0</elasticsearchJestVersion>
+        <elasticsearchJestVersion>2.0.4</elasticsearchJestVersion>
         <elasticsearchCommonsLang3Version>3.4</elasticsearchCommonsLang3Version>
         <elasticsearchGsonVersion>2.4</elasticsearchGsonVersion>
 


### PR DESCRIPTION
Relevant tickets:

 * https://hibernate.atlassian.net/browse/HSEARCH-2509
 * https://hibernate.atlassian.net/browse/HSEARCH-2467