### PR TITLE
HSEARCH-2441 ElasticsearchQueries.fromJson expects top-level JSON but only the "query" parameter is supported

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/ElasticsearchQueries.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/ElasticsearchQueries.java
@@ -21,6 +21,7 @@ import org.hibernate.search.util.logging.impl.LoggerFactory;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
 
 /**
  * Creates queries to be used with Elasticsearch.
@@ -51,7 +52,14 @@ public class ElasticsearchQueries {
 	 * official documentation</a> for the complete payload syntax.
 	 */
 	public static QueryDescriptor fromJson(String payload) {
-		JsonObject payloadAsJsonObject = PARSER.parse( payload ).getAsJsonObject();
+		JsonObject payloadAsJsonObject;
+
+		try {
+			payloadAsJsonObject = PARSER.parse( payload ).getAsJsonObject();
+		}
+		catch (IllegalStateException | JsonSyntaxException e) {
+			throw LOG.invalidSearchAPIPayload( e );
+		}
 
 		List<String> invalidAttributes = new ArrayList<>();
 		for ( Map.Entry<String, ?> entry : payloadAsJsonObject.entrySet() ) {

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/ElasticsearchQueries.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/ElasticsearchQueries.java
@@ -28,19 +28,21 @@ public class ElasticsearchQueries {
 	}
 
 	/**
-	 * Creates an Elasticsearch query from the given JSON query representation. See the <a
-	 * href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html">official
-	 * documentation</a> for the complete query syntax.
+	 * Creates an Elasticsearch query from the given JSON payload for the Elasticsearch Search API.
+	 * <p>
+	 * See the <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html">
+	 * official documentation</a> for the complete payload syntax.
 	 */
-	public static QueryDescriptor fromJson(String jsonQuery) {
-		return new ElasticsearchJsonQueryDescriptor( PARSER.parse( jsonQuery ).getAsJsonObject() );
+	public static QueryDescriptor fromJson(String payload) {
+		return new ElasticsearchJsonQueryDescriptor( PARSER.parse( payload ).getAsJsonObject() );
 	}
 
 	/**
 	 * Creates an Elasticsearch query from the given Query String Query, as e.g. to be used with the "q" parameter in
-	 * the Elasticsearch API. See the <a
-	 * href="https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html">official
-	 * documentation</a> for a description of the query syntax.
+	 * the Elasticsearch Search API.
+	 * <p>
+	 * See the <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html">
+	 * official documentation</a> for the query syntax.
 	 */
 	public static QueryDescriptor fromQueryString(String queryStringQuery) {
 		// Payload looks like so:

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchJsonQueryDescriptor.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchJsonQueryDescriptor.java
@@ -20,19 +20,23 @@ import com.google.gson.JsonObject;
  */
 public class ElasticsearchJsonQueryDescriptor implements QueryDescriptor {
 
-	private final JsonObject jsonQuery;
+	/**
+	 * The raw payload for the Search API, which will serve as a base
+	 * to build the actual payload.
+	 */
+	private final JsonObject rawSearchPayload;
 
-	public ElasticsearchJsonQueryDescriptor(JsonObject jsonQuery) {
-		this.jsonQuery = jsonQuery;
+	public ElasticsearchJsonQueryDescriptor(JsonObject rawSearchPayload) {
+		this.rawSearchPayload = rawSearchPayload;
 	}
 
 	@Override
 	public HSQuery createHSQuery(SearchIntegrator searchIntegrator) {
-		return new ElasticsearchHSQueryImpl( jsonQuery, searchIntegrator.unwrap( ExtendedSearchIntegrator.class ) );
+		return new ElasticsearchHSQueryImpl( rawSearchPayload, searchIntegrator.unwrap( ExtendedSearchIntegrator.class ) );
 	}
 
 	@Override
 	public String toString() {
-		return jsonQuery.toString();
+		return rawSearchPayload.toString();
 	}
 }

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
@@ -279,4 +279,8 @@ public interface Log extends org.hibernate.search.util.logging.impl.Log {
 					+ " format (--MM-dd)." )
 	IllegalArgumentException invalidNullMarkerForMonthDay(@Cause Exception e);
 
+	@Message(id = ES_BACKEND_MESSAGES_START_ID + 50,
+			value = "The given payload contains unsupported attributes: %1$s. Only 'query' is supported." )
+	SearchException unsupportedSearchAPIPayloadAttributes(List<String> invalidAttributes);
+
 }

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
@@ -283,4 +283,8 @@ public interface Log extends org.hibernate.search.util.logging.impl.Log {
 			value = "The given payload contains unsupported attributes: %1$s. Only 'query' is supported." )
 	SearchException unsupportedSearchAPIPayloadAttributes(List<String> invalidAttributes);
 
+	@Message(id = ES_BACKEND_MESSAGES_START_ID + 51,
+			value = "The given payload is not a valid JSON object." )
+	SearchException invalidSearchAPIPayload(@Cause Exception e);
+
 }

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchQueriesTest.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchQueriesTest.java
@@ -1,0 +1,47 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.test;
+
+import org.hibernate.search.elasticsearch.ElasticsearchQueries;
+import org.hibernate.search.exception.SearchException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * @author Yoann Rodiere
+ */
+public class ElasticsearchQueriesTest {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	/*
+	 * Check that using the 'query' attribute with valid JSON works (does not throw an exception)
+	 */
+	@Test
+	public void valid() {
+		ElasticsearchQueries.fromJson(
+				"{'query':{'match_all':{}}}"
+		);
+	}
+
+	@Test
+	public void invalidAttribute() {
+		thrown.expect( SearchException.class );
+		thrown.expectMessage( "HSEARCH400050" );
+
+		ElasticsearchQueries.fromJson(
+				"{"
+					+ "'aggs' : {"
+						+ "'avg_grade' : { 'avg' : { 'field' : 'grade' } }"
+					+ "}"
+				+ "}"
+		);
+	}
+
+}

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchQueriesTest.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchQueriesTest.java
@@ -44,4 +44,24 @@ public class ElasticsearchQueriesTest {
 		);
 	}
 
+	@Test
+	public void malformatedJson() {
+		thrown.expect( SearchException.class );
+		thrown.expectMessage( "HSEARCH400051" );
+
+		ElasticsearchQueries.fromJson(
+				"{ 'query': }"
+		);
+	}
+
+	@Test
+	public void nonObjectJson() {
+		thrown.expect( SearchException.class );
+		thrown.expectMessage( "HSEARCH400051" );
+
+		ElasticsearchQueries.fromJson(
+				"'foo'"
+		);
+	}
+
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2441

Given that users cannot retrieve the results from aggregations (yet), I chose to disallow any attribute other than 'query'.

Other attributes seemed to be either:

 * query parameters, hence not in the JSON (`search_type`, `request_cache`)
 * related to aggregations (`aggs`)
 * already used by our implementations (`from`, `size`, `sort`, `timeout`, `_source`, `script_fields`)
 * or quite specific ( `terminate_after`, `post_filter`, ...)

All in all, since attributes other than `query` never worked anyway in our betas, I think we should disallow everything for the moment and take the time to think about how we want to provide access to features that are not directly supported by Hibernate Search.
In particular, it seems a shame that in order to use aggregations, for instance, one would have to write the query's JSON by hand and can't use the DSL anymore.
Maybe some crude mechanism could be added to `FullTextQuery` in order to allow passing additional, implementation-specific parameters? Something along the lines of `myQuery.setHint(ElasticsearchHints.POST_FILTER, queryBuilder.....createQuery()`?
