### PR TITLE
HSEARCH-2456 When timing out waiting for an Elasticsearch index status, show the timeout value

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
@@ -144,9 +144,9 @@ public interface Log extends org.hibernate.search.util.logging.impl.Log {
 	SearchException negativeTimeoutValue(int timeout);
 
 	@Message(id = ES_BACKEND_MESSAGES_START_ID + 24,
-			value = "Index '%1$s' has status '%3$s', but it is expected to be '%2$s'."
+			value = "Timed out while waiting for for index '%1$s' to reach status '%2$s'; status was still '%3$s' after %4$s."
 	)
-	SearchException unexpectedIndexStatus(String indexName, String expected, String actual);
+	SearchException unexpectedIndexStatus(String indexName, String expected, String actual, String timeoutAndUnit);
 
 	@Message(id = ES_BACKEND_MESSAGES_START_ID + 25,
 			value = "With an Elasticsearch backend it is not possible to get a ReaderProvider or an IndexReader"

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/schema/impl/ElasticsearchSchemaAccessor.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/schema/impl/ElasticsearchSchemaAccessor.java
@@ -158,9 +158,10 @@ public class ElasticsearchSchemaAccessor implements Service, Startable, Stoppabl
 
 	public void waitForIndexStatus(final String theIndexName, ExecutionOptions executionOptions) {
 		String requiredIndexStatusString = executionOptions.getRequiredIndexStatus().getElasticsearchString();
+		String timeoutAndUnit = executionOptions.getIndexManagementTimeoutInMs() + "ms";
 		Builder healthBuilder = new Health.Builder()
 				.setParameter( "wait_for_status", requiredIndexStatusString )
-				.setParameter( "timeout", executionOptions.getIndexManagementTimeoutInMs() + "ms" );
+				.setParameter( "timeout", timeoutAndUnit );
 
 		Health health = new Health( healthBuilder ) {
 			@Override
@@ -179,7 +180,7 @@ public class ElasticsearchSchemaAccessor implements Service, Startable, Stoppabl
 
 		if ( !result.isSucceeded() ) {
 			String status = result.getJsonObject().get( "status" ).getAsString();
-			throw LOG.unexpectedIndexStatus( theIndexName, requiredIndexStatusString, status );
+			throw LOG.unexpectedIndexStatus( theIndexName, requiredIndexStatusString, status, timeoutAndUnit );
 		}
 	}
 

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIndexExistsCheckIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIndexExistsCheckIT.java
@@ -96,6 +96,7 @@ public class ElasticsearchIndexExistsCheckIT extends SearchInitializationTestBas
 
 		thrown.expect( SearchException.class );
 		thrown.expectMessage( "HSEARCH400024" );
+		thrown.expectMessage( "100ms" );
 
 		init( SimpleEntity.class );
 	}
@@ -117,6 +118,7 @@ public class ElasticsearchIndexExistsCheckIT extends SearchInitializationTestBas
 
 		thrown.expect( SearchException.class );
 		thrown.expectMessage( "HSEARCH400024" );
+		thrown.expectMessage( "100ms" );
 
 		init( SimpleEntity.class );
 	}


### PR DESCRIPTION
... in the error message

This is a follow-up for #1255