### PR TITLE
HSEARCH-2095 LuceneQueryTranslator is forcing to export the whole imp…

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -226,7 +226,6 @@
                             org.hibernate.search.query.dsl.sort;version="${project.version}",
                             org.hibernate.search.query.engine;version="${project.version}",
                             org.hibernate.search.query.engine.spi;version="${project.version}",
-                            org.hibernate.search.query.engine.impl;version="${project.version}",
                             org.hibernate.search.query.facet;version="${project.version}",
                             org.hibernate.search.query.fieldcache;version="${project.version}",
                             org.hibernate.search.spatial;version="${project.version}",

--- a/engine/src/main/java/org/hibernate/search/query/engine/impl/LuceneQueryTranslator.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/impl/LuceneQueryTranslator.java
@@ -11,9 +11,9 @@ import org.hibernate.search.engine.service.spi.Service;
 import org.hibernate.search.query.engine.spi.QueryDescriptor;
 
 /**
- * Implementations translate Lucene queries into other backend-specific representions.
+ * Implementations translate Lucene queries into other backend-specific representations.
  * <p>
- * Not a public contract for the time being!
+ * Not a public contract.
  *
  * @author Gunnar Morling
  */


### PR DESCRIPTION
…l package to OSGi headers

Looks like procrastination paid off in this case: I could simply remove the OSGi export statement, this was probably resolved by some of our other changes.

@gunnarmorling am I missing something maybe?

https://hibernate.atlassian.net/browse/HSEARCH-2095