### PR TITLE
Remove obsolete comments

### DIFF
--- a/orm/src/test/java/org/hibernate/search/test/configuration/BlogEntry.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/BlogEntry.java
@@ -29,10 +29,6 @@ import org.hibernate.search.exception.AssertionFailure;
  */
 @Entity
 @Indexed
-/*
- * CAUTION: those analyzer definitions are duplicated in the elasticsearch.yml for test with Elasticsearch.
- * Any update here should be reflected there.
- */
 @AnalyzerDefs({
 		@AnalyzerDef(name = BlogEntry.EN_ANALYZER_NAME,
 				tokenizer = @TokenizerDef(factory = StandardTokenizerFactory.class),

--- a/orm/src/test/java/org/hibernate/search/test/configuration/ProgrammaticSearchMappingFactory.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/ProgrammaticSearchMappingFactory.java
@@ -39,10 +39,6 @@ public class ProgrammaticSearchMappingFactory {
 		SearchMapping mapping = new SearchMapping();
 
 		mapping.fullTextFilterDef( "security", SecurityFilterFactory.class ).cache( FilterCacheModeType.INSTANCE_ONLY )
-				/*
-				 * CAUTION: those analyzer definitions are duplicated in the elasticsearch.yml for test with Elasticsearch.
-				 * Any update here should be reflected there.
-				 */
 				.analyzerDef( NGRAM_ANALYZER_NAME, StandardTokenizerFactory.class )
 					.filter( LowerCaseFilterFactory.class )
 					.filter( NGramFilterFactory.class )

--- a/orm/src/test/java/org/hibernate/search/test/query/facet/Car.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/facet/Car.java
@@ -35,10 +35,6 @@ import org.hibernate.search.bridge.builtin.IntegerBridge;
  */
 @Entity
 @Indexed
-/*
- * CAUTION: those analyzer definitions are duplicated in the elasticsearch.yml for test with Elasticsearch.
- * Any update here should be reflected there.
- */
 @AnalyzerDefs({
 	@AnalyzerDef(
 			name = Car.COLLATING_ANALYZER_NAME,


### PR DESCRIPTION
Analyzer definitions are no longer duplcated in the elasticsearch.yml
(since eac1a182a25fe373ef9490cbb8f9480ab2d19869).