### PR TITLE
HSEARCH-2535 @Facet on container (Iterable, Array, ...) properties indexes the container's toString()

### DIFF
--- a/engine/src/main/java/org/hibernate/search/engine/spi/DocumentBuilderIndexedEntity.java
+++ b/engine/src/main/java/org/hibernate/search/engine/spi/DocumentBuilderIndexedEntity.java
@@ -444,7 +444,7 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 			ConversionContext conversionContext,
 			InstanceInitializer objectInitializer,
 			final float inheritedBoost,
-			boolean multiValued,
+			boolean isParentPropertyMultiValued,
 			NestingContext nestingContext) {
 
 		// needed for field access: I cannot work in the proxied version
@@ -459,7 +459,7 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 				objectInitializer,
 				inheritedBoost,
 				unproxiedInstance,
-				multiValued
+				isParentPropertyMultiValued
 		);
 
 		// allow analyzer override for the fields added by the class and field bridges
@@ -477,7 +477,7 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 				objectInitializer,
 				inheritedBoost,
 				unproxiedInstance,
-				multiValued,
+				isParentPropertyMultiValued,
 				nestingContext
 		);
 	}
@@ -491,7 +491,7 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 			InstanceInitializer objectInitializer,
 			float inheritedBoost,
 			Object unproxiedInstance,
-			boolean multiValued,
+			boolean isParentPropertyMultiValued,
 			NestingContext nestingContext) {
 		for ( EmbeddedTypeMetadata embeddedTypeMetadata : typeMetadata.getEmbeddedTypeMetadata() ) {
 			XMember member = embeddedTypeMetadata.getEmbeddedGetter();
@@ -585,7 +585,7 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 								conversionContext,
 								objectInitializer,
 								embeddedBoost,
-								multiValued,
+								isParentPropertyMultiValued,
 								nestingContext
 						);
 						break;
@@ -604,7 +604,7 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 	}
 
 	/**
-	 * @param multiValued Whether the type whose properties should be added may appear more than once (within the same
+	 * @param isParentPropertyMultiValued Whether the type whose properties should be added may appear more than once (within the same
 	 * role) in a document or not. That's the case if the type is (directly or indirectly) contained within an embedded
 	 * to-many association.
 	 */
@@ -615,7 +615,7 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 			InstanceInitializer objectInitializer,
 			float documentBoost,
 			Object unproxiedInstance,
-			boolean multiValued) {
+			boolean isParentPropertyMultiValued) {
 		XMember previousMember = null;
 		Object currentFieldValue = null;
 
@@ -661,7 +661,7 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 					if ( fieldMetadata.hasFacets() ) {
 						faceting.enableFacetProcessing();
 						for ( FacetMetadata facetMetadata : fieldMetadata.getFacetMetadata() ) {
-							if ( multiValued ) {
+							if ( isParentPropertyMultiValued ) {
 								faceting.setMultiValued( facetMetadata.getAbsoluteName() );
 							}
 							addFacetDocValues( document, fieldMetadata, facetMetadata, currentFieldValue );
@@ -671,7 +671,7 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 
 				// add the doc value fields required for sorting, but only if this property is not part of an embedded
 				// to-many assoc, in which case sorting on these fields would not make sense
-				if ( !multiValued ) {
+				if ( !isParentPropertyMultiValued ) {
 					addSortFieldDocValues( document, propertyMetadata, documentBoost, currentFieldValue );
 				}
 			}
@@ -692,7 +692,7 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 
 		Field facetField;
 		switch ( facetMetadata.getEncoding() ) {
-			case STRING: {
+			case STRING:
 				String stringValue = value.toString();
 				// we don't add empty strings to the facet field
 				if ( stringValue.isEmpty() ) {
@@ -700,8 +700,7 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 				}
 				facetField = new SortedSetDocValuesFacetField( facetMetadata.getAbsoluteName(), stringValue );
 				break;
-			}
-			case LONG: {
+			case LONG:
 				if ( value instanceof Number ) {
 					facetField = new NumericDocValuesField(
 							facetMetadata.getAbsoluteName(),
@@ -740,8 +739,7 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 					throw new AssertionFailure( "Unexpected value type for faceting: " + value.getClass().getName() );
 				}
 				break;
-			}
-			case DOUBLE: {
+			case DOUBLE:
 				if ( value instanceof Number ) {
 					facetField = new DoubleDocValuesField(
 							facetMetadata.getAbsoluteName(),
@@ -752,17 +750,14 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 					throw new AssertionFailure( "Unexpected value type for faceting: " + value.getClass().getName() );
 				}
 				break;
-			}
-			case AUTO: {
+			case AUTO:
 				throw new AssertionFailure( "The facet type should have been resolved during bootstrapping" );
-			}
-			default: {
+			default:
 				throw new AssertionFailure(
 						"Unexpected facet encoding type '"
 								+ facetMetadata.getEncoding()
 								+ "' Has the enum been modified?"
 				);
-			}
 		}
 
 		document.add( facetField );

--- a/engine/src/main/java/org/hibernate/search/engine/spi/DocumentBuilderIndexedEntity.java
+++ b/engine/src/main/java/org/hibernate/search/engine/spi/DocumentBuilderIndexedEntity.java
@@ -661,10 +661,33 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 					if ( fieldMetadata.hasFacets() ) {
 						faceting.enableFacetProcessing();
 						for ( FacetMetadata facetMetadata : fieldMetadata.getFacetMetadata() ) {
-							if ( isParentPropertyMultiValued ) {
+							boolean multivalued = isParentPropertyMultiValued;
+
+							if ( member.isCollection() && currentFieldValue instanceof Collection ) {
+								multivalued = true;
+								for ( Object element : (Collection<?>) currentFieldValue ) {
+									addFacetDocValues( document, fieldMetadata, facetMetadata, element );
+								}
+							}
+							else if ( member.isCollection() && currentFieldValue instanceof Map ) {
+								multivalued = true;
+								for ( Object element : ((Map<?,?>) currentFieldValue).values() ) {
+									addFacetDocValues( document, fieldMetadata, facetMetadata, element );
+								}
+							}
+							else if ( member.isArray() ) {
+								multivalued = true;
+								for ( Object element : (Object[]) currentFieldValue ) {
+									addFacetDocValues( document, fieldMetadata, facetMetadata, element );
+								}
+							}
+							else {
+								addFacetDocValues( document, fieldMetadata, facetMetadata, currentFieldValue );
+							}
+
+							if ( multivalued ) {
 								faceting.setMultiValued( facetMetadata.getAbsoluteName() );
 							}
-							addFacetDocValues( document, fieldMetadata, facetMetadata, currentFieldValue );
 						}
 					}
 				}

--- a/orm/src/test/java/org/hibernate/search/test/query/facet/EmbeddedCollectionFacetingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/facet/EmbeddedCollectionFacetingTest.java
@@ -22,7 +22,7 @@ import org.hibernate.search.query.facet.Facet;
 import org.hibernate.search.query.facet.FacetSortOrder;
 import org.hibernate.search.query.facet.FacetingRequest;
 import org.hibernate.search.test.SearchTestBase;
-
+import org.hibernate.search.testsupport.TestForIssue;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -31,7 +31,8 @@ import static org.junit.Assert.assertEquals;
 /**
  * @author Elmer van Chastelet
  */
-public class CollectionFacetingTest extends SearchTestBase {
+@TestForIssue(jiraKey = "HSEARCH-726")
+public class EmbeddedCollectionFacetingTest extends SearchTestBase {
 	Author voltaire;
 	Author hugo;
 	Author moliere;

--- a/orm/src/test/java/org/hibernate/search/test/query/facet/MultiValuedFacetingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/facet/MultiValuedFacetingTest.java
@@ -1,0 +1,340 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.query.facet;
+
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.hibernate.search.annotations.Analyze;
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Index;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.IndexedEmbedded;
+import org.hibernate.search.backend.spi.Work;
+import org.hibernate.search.backend.spi.WorkType;
+import org.hibernate.search.query.dsl.QueryBuilder;
+import org.hibernate.search.query.engine.spi.HSQuery;
+import org.hibernate.search.query.facet.Facet;
+import org.hibernate.search.query.facet.FacetSortOrder;
+import org.hibernate.search.query.facet.FacetingRequest;
+import org.hibernate.search.testsupport.TestForIssue;
+import org.hibernate.search.testsupport.junit.SearchFactoryHolder;
+import org.hibernate.search.testsupport.setup.TransactionContextForTest;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+@TestForIssue(jiraKey = "HSEARCH-2535")
+public class MultiValuedFacetingTest {
+	@Rule
+	public SearchFactoryHolder sfHolder = new SearchFactoryHolder(
+			StringArrayFacetEntity.class, StringCollectionFacetEntity.class, StringMapFacetEntity.class,
+			NumberArrayFacetEntity.class, NumberCollectionFacetEntity.class, NumberMapFacetEntity.class );
+
+	@Test
+	public void stringArray() throws Exception {
+		StringArrayFacetEntity entity = new StringArrayFacetEntity( 1L );
+		storeData( entity.id, entity );
+		entity = new StringArrayFacetEntity( 1L, "foo" );
+		storeData( entity.id, entity );
+		entity = new StringArrayFacetEntity( 2L, "foo", "bar" );
+		storeData( entity.id, entity );
+
+		HSQuery hsQuery = sfHolder.getSearchFactory().createHSQuery( new MatchAllDocsQuery(), StringArrayFacetEntity.class );
+
+		QueryBuilder builder = sfHolder.getSearchFactory().buildQueryBuilder().forEntity( StringArrayFacetEntity.class ).get();
+		FacetingRequest facetReq = builder.facet()
+				.name( "someFacet" )
+				.onField( "facet" )
+				.discrete()
+				.orderedBy( FacetSortOrder.COUNT_DESC )
+				.includeZeroCounts( false )
+				.maxFacetCount( 10 )
+				.createFacetingRequest();
+
+		List<Facet> facets = hsQuery.getFacetManager().enableFaceting( facetReq ).getFacets( "someFacet" );
+		assertEquals( "There should be two facets", 2, facets.size() );
+		assertFacet( facets.get( 0 ), "foo", 2 );
+		assertFacet( facets.get( 1 ), "bar", 1 );
+	}
+
+	@Test
+	public void stringCollection() throws Exception {
+		StringCollectionFacetEntity entity = new StringCollectionFacetEntity( 1L );
+		storeData( entity.id, entity );
+		entity = new StringCollectionFacetEntity( 1L, "foo" );
+		storeData( entity.id, entity );
+		entity = new StringCollectionFacetEntity( 2L, "foo", "bar" );
+		storeData( entity.id, entity );
+
+		HSQuery hsQuery = sfHolder.getSearchFactory().createHSQuery( new MatchAllDocsQuery(), StringCollectionFacetEntity.class );
+
+		QueryBuilder builder = sfHolder.getSearchFactory().buildQueryBuilder().forEntity( StringCollectionFacetEntity.class ).get();
+		FacetingRequest facetReq = builder.facet()
+				.name( "someFacet" )
+				.onField( "facet" )
+				.discrete()
+				.orderedBy( FacetSortOrder.COUNT_DESC )
+				.includeZeroCounts( false )
+				.maxFacetCount( 10 )
+				.createFacetingRequest();
+
+		List<Facet> facets = hsQuery.getFacetManager().enableFaceting( facetReq ).getFacets( "someFacet" );
+		assertEquals( "There should be two facets", 2, facets.size() );
+		assertFacet( facets.get( 0 ), "foo", 2 );
+		assertFacet( facets.get( 1 ), "bar", 1 );
+	}
+
+	@Test
+	public void stringMap() throws Exception {
+		StringMapFacetEntity entity = new StringMapFacetEntity( 1L );
+		storeData( entity.id, entity );
+		entity = new StringMapFacetEntity( 1L, "foo" );
+		storeData( entity.id, entity );
+		entity = new StringMapFacetEntity( 2L, "foo", "bar" );
+		storeData( entity.id, entity );
+
+		HSQuery hsQuery = sfHolder.getSearchFactory().createHSQuery( new MatchAllDocsQuery(), StringMapFacetEntity.class );
+
+		QueryBuilder builder = sfHolder.getSearchFactory().buildQueryBuilder().forEntity( StringMapFacetEntity.class ).get();
+		FacetingRequest facetReq = builder.facet()
+				.name( "someFacet" )
+				.onField( "facet" )
+				.discrete()
+				.orderedBy( FacetSortOrder.COUNT_DESC )
+				.includeZeroCounts( false )
+				.maxFacetCount( 10 )
+				.createFacetingRequest();
+
+		List<Facet> facets = hsQuery.getFacetManager().enableFaceting( facetReq ).getFacets( "someFacet" );
+		assertEquals( "There should be two facets", 2, facets.size() );
+		assertFacet( facets.get( 0 ), "foo", 2 );
+		assertFacet( facets.get( 1 ), "bar", 1 );
+	}
+
+	@Test
+	@Ignore // HSEARCH-1927 : Range faceting on multiple numeric values does not work
+	public void numberArray() throws Exception {
+		NumberArrayFacetEntity entity = new NumberArrayFacetEntity( 1L );
+		storeData( entity.id, entity );
+		entity = new NumberArrayFacetEntity( 1L, 42 );
+		storeData( entity.id, entity );
+		entity = new NumberArrayFacetEntity( 2L, 43, 442 );
+		storeData( entity.id, entity );
+
+		HSQuery hsQuery = sfHolder.getSearchFactory().createHSQuery( new MatchAllDocsQuery(), NumberArrayFacetEntity.class );
+
+		QueryBuilder builder = sfHolder.getSearchFactory().buildQueryBuilder().forEntity( NumberArrayFacetEntity.class ).get();
+		FacetingRequest facetReq = builder.facet()
+				.name( "someFacet" )
+				.onField( "facet" )
+				.range()
+				.from( 0.0f ).to( 100.0f ).excludeLimit()
+				.from( 100.0f ).to( 500.0f ).excludeLimit()
+				.orderedBy( FacetSortOrder.COUNT_DESC )
+				.includeZeroCounts( false )
+				.maxFacetCount( 10 )
+				.createFacetingRequest();
+
+		List<Facet> facets = hsQuery.getFacetManager().enableFaceting( facetReq ).getFacets( "someFacet" );
+		assertEquals( "There should be two facets", 2, facets.size() );
+		assertFacet( facets.get( 0 ), "[0.0, 100.0)", 2 );
+		assertFacet( facets.get( 1 ), "[100.0, 500.0)", 1 );
+	}
+
+	@Test
+	@Ignore // HSEARCH-1927 : Range faceting on multiple numeric values does not work
+	public void numberCollection() throws Exception {
+		NumberCollectionFacetEntity entity = new NumberCollectionFacetEntity( 1L );
+		storeData( entity.id, entity );
+		entity = new NumberCollectionFacetEntity( 1L, 42.2f );
+		storeData( entity.id, entity );
+		entity = new NumberCollectionFacetEntity( 2L, 42.3f, 442.2f );
+		storeData( entity.id, entity );
+
+		HSQuery hsQuery = sfHolder.getSearchFactory().createHSQuery( new MatchAllDocsQuery(), NumberCollectionFacetEntity.class );
+
+		QueryBuilder builder = sfHolder.getSearchFactory().buildQueryBuilder().forEntity( NumberCollectionFacetEntity.class ).get();
+		FacetingRequest facetReq = builder.facet()
+				.name( "someFacet" )
+				.onField( "facet" )
+				.range()
+				.from( 0.0f ).to( 100.0f ).excludeLimit()
+				.from( 100.0f ).to( 500.0f ).excludeLimit()
+				.orderedBy( FacetSortOrder.COUNT_DESC )
+				.includeZeroCounts( false )
+				.maxFacetCount( 10 )
+				.createFacetingRequest();
+
+		List<Facet> facets = hsQuery.getFacetManager().enableFaceting( facetReq ).getFacets( "someFacet" );
+		assertEquals( "There should be two facets", 2, facets.size() );
+		assertFacet( facets.get( 0 ), "[0.0, 100.0)", 2 );
+		assertFacet( facets.get( 1 ), "[100.0, 500.0)", 1 );
+	}
+
+	@Test
+	@Ignore // HSEARCH-1927 : Range faceting on multiple numeric values does not work
+	public void numberMap() throws Exception {
+		NumberMapFacetEntity entity = new NumberMapFacetEntity( 1L );
+		storeData( entity.id, entity );
+		entity = new NumberMapFacetEntity( 1L, 42.2f );
+		storeData( entity.id, entity );
+		entity = new NumberMapFacetEntity( 2L, 42.3f, 442.2f );
+		storeData( entity.id, entity );
+
+		HSQuery hsQuery = sfHolder.getSearchFactory().createHSQuery( new MatchAllDocsQuery(), NumberMapFacetEntity.class );
+
+		QueryBuilder builder = sfHolder.getSearchFactory().buildQueryBuilder().forEntity( NumberMapFacetEntity.class ).get();
+		FacetingRequest facetReq = builder.facet()
+				.name( "someFacet" )
+				.onField( "facet" )
+				.range()
+				.from( 0.0f ).to( 100.0f ).excludeLimit()
+				.from( 100.0f ).to( 500.0f ).excludeLimit()
+				.orderedBy( FacetSortOrder.COUNT_DESC )
+				.includeZeroCounts( false )
+				.maxFacetCount( 10 )
+				.createFacetingRequest();
+
+		List<Facet> facets = hsQuery.getFacetManager().enableFaceting( facetReq ).getFacets( "someFacet" );
+		assertEquals( "There should be two facets", 2, facets.size() );
+		assertFacet( facets.get( 0 ), "[0.0, 100.0)", 2 );
+		assertFacet( facets.get( 1 ), "[100.0, 500.0)", 1 );
+	}
+
+	private void storeData(Long id, Object entry) {
+		Work work = new Work( entry, id, WorkType.ADD, false );
+		TransactionContextForTest tc = new TransactionContextForTest();
+		sfHolder.getSearchFactory().getWorker().performWork( work, tc );
+		tc.end();
+	}
+
+	private void assertFacet(Facet facet, String expectedValue, int expectedCount) {
+		assertEquals( "Wrong facet value", expectedValue, facet.getValue() );
+		assertEquals( "Wrong facet count", expectedCount, facet.getCount() );
+	}
+
+	@Indexed
+	private static class StringArrayFacetEntity {
+		@DocumentId
+		private Long id;
+
+		@Field(analyze = Analyze.NO)
+		@org.hibernate.search.annotations.Facet
+		@IndexedEmbedded // This enables ArrayBridge: not needed for faceting, but needed for indexing
+		private String[] facet;
+
+		private StringArrayFacetEntity(Long id, String ... facet) {
+			super();
+			this.id = id;
+			this.facet = facet;
+		}
+	}
+
+	@Indexed
+	private static class StringCollectionFacetEntity {
+		@DocumentId
+		private Long id;
+
+		@Field(analyze = Analyze.NO)
+		@org.hibernate.search.annotations.Facet
+		@IndexedEmbedded // This enables IterableBridge: not needed for faceting, but needed for indexing
+		private Collection<String> facet;
+
+		private StringCollectionFacetEntity(Long id, String ... facet) {
+			super();
+			this.id = id;
+			this.facet = Arrays.asList( facet );
+		}
+	}
+
+	@Indexed
+	private static class StringMapFacetEntity {
+		@DocumentId
+		private Long id;
+
+		@Field(analyze = Analyze.NO)
+		@org.hibernate.search.annotations.Facet
+		@IndexedEmbedded // This enables MapBridge: not needed for faceting, but needed for indexing
+		private Map<Integer, String> facet;
+
+		private StringMapFacetEntity(Long id, String ... facet) {
+			super();
+			this.id = id;
+			this.facet = new TreeMap<>();
+			int index = 0;
+			for ( String facetValue : facet ) {
+				this.facet.put( index, facetValue );
+				++index;
+			}
+		}
+	}
+
+	@Indexed
+	private static class NumberArrayFacetEntity {
+		@DocumentId
+		private Long id;
+
+		@Field(analyze = Analyze.NO)
+		@org.hibernate.search.annotations.Facet
+		@IndexedEmbedded // This enables ArrayBridge: not needed for faceting, but needed for indexing
+		private Integer[] facet;
+
+		private NumberArrayFacetEntity(Long id, Integer ... facet) {
+			super();
+			this.id = id;
+			this.facet = facet;
+		}
+	}
+
+	@Indexed
+	private static class NumberCollectionFacetEntity {
+		@DocumentId
+		private Long id;
+
+		@Field(analyze = Analyze.NO)
+		@org.hibernate.search.annotations.Facet
+		@IndexedEmbedded // This enables IterableBridge: not needed for faceting, but needed for indexing
+		private Collection<Float> facet;
+
+		private NumberCollectionFacetEntity(Long id, Float ... facet) {
+			super();
+			this.id = id;
+			this.facet = Arrays.asList( facet );
+		}
+	}
+
+	@Indexed
+	private static class NumberMapFacetEntity {
+		@DocumentId
+		private Long id;
+
+		@Field(analyze = Analyze.NO, index = Index.NO)
+		@org.hibernate.search.annotations.Facet
+		@IndexedEmbedded // This enables MapBridge: not needed for faceting, but needed for indexing
+		private Map<Integer, Float> facet;
+
+		private NumberMapFacetEntity(Long id, Float ... facet) {
+			super();
+			this.id = id;
+			this.facet = new TreeMap<>();
+			int index = 0;
+			for ( Float facetValue : facet ) {
+				this.facet.put( index, facetValue );
+				++index;
+			}
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2535

I added code to support both collections of Strings and collections of numeric values, but only containers of Strings work right now, due to [HSEARCH-1927](https://hibernate.atlassian.net/browse/HSEARCH-1927). This one will have to be fixed in another PR.

I think it's safe to merge this PR during the CR period, because the previous behavior was clearly suboptimal:

 * it simply failed for multi-valued numeric fields, which it still will unless you only have arrays/collections/maps with one element
 * and more importantly it used to index the result of calling `toString()` on arrays/collections/maps for multi-valued string fields, which may work in some cases but clearly isn't a good solution