### PR TITLE
HSEARCH-2510 ArrayBridge doesn't support arrays of primitive types

### DIFF
--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/ArrayBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/ArrayBridge.java
@@ -11,6 +11,7 @@ import org.apache.lucene.document.Document;
 import org.hibernate.search.bridge.ContainerBridge;
 import org.hibernate.search.bridge.FieldBridge;
 import org.hibernate.search.bridge.LuceneOptions;
+import org.hibernate.search.util.impl.CollectionHelper;
 
 /**
  * Each entry ({@code null included}) of an array is indexed using the specified {@link org.hibernate.search.bridge.FieldBridge}.
@@ -43,8 +44,8 @@ public class ArrayBridge implements FieldBridge, ContainerBridge {
 	}
 
 	private void indexNotNullArray(String name, Object value, Document document, LuceneOptions luceneOptions) {
-		Object[] collection = (Object[]) value;
-		for ( Object entry : collection ) {
+		// Use CollectionHelper.iterableFromArray to also support arrays of primitive values
+		for ( Object entry : CollectionHelper.iterableFromArray( value ) ) {
 			indexEntry( name, entry, document, luceneOptions );
 		}
 	}

--- a/engine/src/main/java/org/hibernate/search/engine/spi/DocumentBuilderIndexedEntity.java
+++ b/engine/src/main/java/org/hibernate/search/engine/spi/DocumentBuilderIndexedEntity.java
@@ -444,7 +444,7 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 			ConversionContext conversionContext,
 			InstanceInitializer objectInitializer,
 			final float inheritedBoost,
-			boolean multiValued,
+			boolean isParentPropertyMultiValued,
 			NestingContext nestingContext) {
 
 		// needed for field access: I cannot work in the proxied version
@@ -459,7 +459,7 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 				objectInitializer,
 				inheritedBoost,
 				unproxiedInstance,
-				multiValued
+				isParentPropertyMultiValued
 		);
 
 		// allow analyzer override for the fields added by the class and field bridges
@@ -477,7 +477,7 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 				objectInitializer,
 				inheritedBoost,
 				unproxiedInstance,
-				multiValued,
+				isParentPropertyMultiValued,
 				nestingContext
 		);
 	}
@@ -491,7 +491,7 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 			InstanceInitializer objectInitializer,
 			float inheritedBoost,
 			Object unproxiedInstance,
-			boolean multiValued,
+			boolean isParentPropertyMultiValued,
 			NestingContext nestingContext) {
 		for ( EmbeddedTypeMetadata embeddedTypeMetadata : typeMetadata.getEmbeddedTypeMetadata() ) {
 			XMember member = embeddedTypeMetadata.getEmbeddedGetter();
@@ -585,7 +585,7 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 								conversionContext,
 								objectInitializer,
 								embeddedBoost,
-								multiValued,
+								isParentPropertyMultiValued,
 								nestingContext
 						);
 						break;
@@ -604,7 +604,7 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 	}
 
 	/**
-	 * @param multiValued Whether the type whose properties should be added may appear more than once (within the same
+	 * @param isParentPropertyMultiValued Whether the type whose properties should be added may appear more than once (within the same
 	 * role) in a document or not. That's the case if the type is (directly or indirectly) contained within an embedded
 	 * to-many association.
 	 */
@@ -615,7 +615,7 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 			InstanceInitializer objectInitializer,
 			float documentBoost,
 			Object unproxiedInstance,
-			boolean multiValued) {
+			boolean isParentPropertyMultiValued) {
 		XMember previousMember = null;
 		Object currentFieldValue = null;
 
@@ -661,7 +661,7 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 					if ( fieldMetadata.hasFacets() ) {
 						faceting.enableFacetProcessing();
 						for ( FacetMetadata facetMetadata : fieldMetadata.getFacetMetadata() ) {
-							if ( multiValued ) {
+							if ( isParentPropertyMultiValued ) {
 								faceting.setMultiValued( facetMetadata.getAbsoluteName() );
 							}
 							addFacetDocValues( document, fieldMetadata, facetMetadata, currentFieldValue );
@@ -671,7 +671,7 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 
 				// add the doc value fields required for sorting, but only if this property is not part of an embedded
 				// to-many assoc, in which case sorting on these fields would not make sense
-				if ( !multiValued ) {
+				if ( !isParentPropertyMultiValued ) {
 					addSortFieldDocValues( document, propertyMetadata, documentBoost, currentFieldValue );
 				}
 			}
@@ -692,7 +692,7 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 
 		Field facetField;
 		switch ( facetMetadata.getEncoding() ) {
-			case STRING: {
+			case STRING:
 				String stringValue = value.toString();
 				// we don't add empty strings to the facet field
 				if ( stringValue.isEmpty() ) {
@@ -700,8 +700,7 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 				}
 				facetField = new SortedSetDocValuesFacetField( facetMetadata.getAbsoluteName(), stringValue );
 				break;
-			}
-			case LONG: {
+			case LONG:
 				if ( value instanceof Number ) {
 					facetField = new NumericDocValuesField(
 							facetMetadata.getAbsoluteName(),
@@ -740,8 +739,7 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 					throw new AssertionFailure( "Unexpected value type for faceting: " + value.getClass().getName() );
 				}
 				break;
-			}
-			case DOUBLE: {
+			case DOUBLE:
 				if ( value instanceof Number ) {
 					facetField = new DoubleDocValuesField(
 							facetMetadata.getAbsoluteName(),
@@ -752,17 +750,14 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 					throw new AssertionFailure( "Unexpected value type for faceting: " + value.getClass().getName() );
 				}
 				break;
-			}
-			case AUTO: {
+			case AUTO:
 				throw new AssertionFailure( "The facet type should have been resolved during bootstrapping" );
-			}
-			default: {
+			default:
 				throw new AssertionFailure(
 						"Unexpected facet encoding type '"
 								+ facetMetadata.getEncoding()
 								+ "' Has the enum been modified?"
 				);
-			}
 		}
 
 		document.add( facetField );

--- a/engine/src/main/java/org/hibernate/search/engine/spi/DocumentBuilderIndexedEntity.java
+++ b/engine/src/main/java/org/hibernate/search/engine/spi/DocumentBuilderIndexedEntity.java
@@ -661,10 +661,33 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 					if ( fieldMetadata.hasFacets() ) {
 						faceting.enableFacetProcessing();
 						for ( FacetMetadata facetMetadata : fieldMetadata.getFacetMetadata() ) {
-							if ( isParentPropertyMultiValued ) {
+							boolean multivalued = isParentPropertyMultiValued;
+
+							if ( member.isCollection() && currentFieldValue instanceof Collection ) {
+								multivalued = true;
+								for ( Object element : (Collection<?>) currentFieldValue ) {
+									addFacetDocValues( document, fieldMetadata, facetMetadata, element );
+								}
+							}
+							else if ( member.isCollection() && currentFieldValue instanceof Map ) {
+								multivalued = true;
+								for ( Object element : ((Map<?,?>) currentFieldValue).values() ) {
+									addFacetDocValues( document, fieldMetadata, facetMetadata, element );
+								}
+							}
+							else if ( member.isArray() ) {
+								multivalued = true;
+								for ( Object element : (Object[]) currentFieldValue ) {
+									addFacetDocValues( document, fieldMetadata, facetMetadata, element );
+								}
+							}
+							else {
+								addFacetDocValues( document, fieldMetadata, facetMetadata, currentFieldValue );
+							}
+
+							if ( multivalued ) {
 								faceting.setMultiValued( facetMetadata.getAbsoluteName() );
 							}
-							addFacetDocValues( document, fieldMetadata, facetMetadata, currentFieldValue );
 						}
 					}
 				}

--- a/engine/src/main/java/org/hibernate/search/util/impl/CollectionHelper.java
+++ b/engine/src/main/java/org/hibernate/search/util/impl/CollectionHelper.java
@@ -92,235 +92,246 @@ public final class CollectionHelper {
 	 * @return an {@code Iterator} iterating over the array
 	 */
 	public static Iterator<?> iteratorFromArray(Object object) {
-		Iterator<?> iterator;
+		return iterableFromArray( object ).iterator();
+	}
+
+	/**
+	 * Builds an {@link Iterable} for a given array. It is (un)necessarily ugly because we have to deal with array of primitives.
+	 *
+	 * @param object a given array
+	 * @return an {@code Iterable} providing iterators over the array
+	 */
+	public static Iterable<?> iterableFromArray(Object object) {
+		Iterable<?> iterable;
 		if ( Object.class.isAssignableFrom( object.getClass().getComponentType() ) ) {
-			iterator = new ObjectArrayIterator( (Object[]) object );
+			iterable = new ObjectArrayIterable( (Object[]) object );
 		}
 		else if ( object.getClass() == boolean[].class ) {
-			iterator = new BooleanArrayIterator( (boolean[]) object );
+			iterable = new BooleanArrayIterable( (boolean[]) object );
 		}
 		else if ( object.getClass() == int[].class ) {
-			iterator = new IntArrayIterator( (int[]) object );
+			iterable = new IntArrayIterable( (int[]) object );
 		}
 		else if ( object.getClass() == long[].class ) {
-			iterator = new LongArrayIterator( (long[]) object );
+			iterable = new LongArrayIterable( (long[]) object );
 		}
 		else if ( object.getClass() == double[].class ) {
-			iterator = new DoubleArrayIterator( (double[]) object );
+			iterable = new DoubleArrayIterable( (double[]) object );
 		}
 		else if ( object.getClass() == float[].class ) {
-			iterator = new FloatArrayIterator( (float[]) object );
+			iterable = new FloatArrayIterable( (float[]) object );
 		}
 		else if ( object.getClass() == byte[].class ) {
-			iterator = new ByteArrayIterator( (byte[]) object );
+			iterable = new ByteArrayIterable( (byte[]) object );
 		}
 		else if ( object.getClass() == short[].class ) {
-			iterator = new ShortArrayIterator( (short[]) object );
+			iterable = new ShortArrayIterable( (short[]) object );
 		}
 		else if ( object.getClass() == char[].class ) {
-			iterator = new CharArrayIterator( (char[]) object );
+			iterable = new CharArrayIterable( (char[]) object );
 		}
 		else {
 			throw new IllegalArgumentException( "Provided object " + object + " is not a supported array type" );
 		}
-		return iterator;
+		return iterable;
 	}
 
-	private static class ObjectArrayIterator implements Iterator<Object> {
+	private abstract static class ArrayIterable<T> implements Iterable<T> {
+
+		protected abstract int size();
+
+		protected abstract T get(int index);
+
+		@Override
+		public final Iterator<T> iterator() {
+			return new ArrayIterator();
+		}
+
+		private class ArrayIterator implements Iterator<T> {
+			private int current = 0;
+
+			@Override
+			public boolean hasNext() {
+				return current < size();
+			}
+
+			@Override
+			public T next() {
+				T result = get( current );
+				current++;
+				return result;
+			}
+		}
+	}
+
+	private static class ObjectArrayIterable extends ArrayIterable<Object> {
 
 		private Object[] values;
-		private int current = 0;
 
-		private ObjectArrayIterator(Object[] values) {
+		private ObjectArrayIterable(Object[] values) {
 			this.values = values;
 		}
 
 		@Override
-		public boolean hasNext() {
-			return current < values.length;
+		protected int size() {
+			return values.length;
 		}
 
 		@Override
-		public Object next() {
-			Object result = values[current];
-			current++;
-			return result;
+		protected Object get(int index) {
+			return values[index];
 		}
 	}
 
-	private static class BooleanArrayIterator implements Iterator<Boolean> {
+	private static class BooleanArrayIterable extends ArrayIterable<Boolean> {
 
 		private boolean[] values;
-		private int current = 0;
 
-		private BooleanArrayIterator(boolean[] values) {
+		private BooleanArrayIterable(boolean[] values) {
 			this.values = values;
 		}
 
 		@Override
-		public boolean hasNext() {
-			return current < values.length;
+		protected int size() {
+			return values.length;
 		}
 
 		@Override
-		public Boolean next() {
-			boolean result = values[current];
-			current++;
-			return result;
+		protected Boolean get(int index) {
+			return values[index];
 		}
 	}
 
-	private static class IntArrayIterator implements Iterator<Integer> {
+	private static class IntArrayIterable extends ArrayIterable<Integer> {
 
 		private int[] values;
-		private int current = 0;
 
-		private IntArrayIterator(int[] values) {
+		private IntArrayIterable(int[] values) {
 			this.values = values;
 		}
 
 		@Override
-		public boolean hasNext() {
-			return current < values.length;
+		protected int size() {
+			return values.length;
 		}
 
 		@Override
-		public Integer next() {
-			int result = values[current];
-			current++;
-			return result;
+		protected Integer get(int index) {
+			return values[index];
 		}
 	}
 
-	private static class LongArrayIterator implements Iterator<Long> {
+	private static class LongArrayIterable extends ArrayIterable<Long> {
 
 		private long[] values;
-		private int current = 0;
 
-		private LongArrayIterator(long[] values) {
+		private LongArrayIterable(long[] values) {
 			this.values = values;
 		}
 
 		@Override
-		public boolean hasNext() {
-			return current < values.length;
+		protected int size() {
+			return values.length;
 		}
 
 		@Override
-		public Long next() {
-			long result = values[current];
-			current++;
-			return result;
+		protected Long get(int index) {
+			return values[index];
 		}
 	}
 
-	private static class DoubleArrayIterator implements Iterator<Double> {
+	private static class DoubleArrayIterable extends ArrayIterable<Double> {
 
 		private double[] values;
-		private int current = 0;
 
-		private DoubleArrayIterator(double[] values) {
+		private DoubleArrayIterable(double[] values) {
 			this.values = values;
 		}
 
 		@Override
-		public boolean hasNext() {
-			return current < values.length;
+		protected int size() {
+			return values.length;
 		}
 
 		@Override
-		public Double next() {
-			double result = values[current];
-			current++;
-			return result;
+		protected Double get(int index) {
+			return values[index];
 		}
 	}
 
-	private static class FloatArrayIterator implements Iterator<Float> {
+	private static class FloatArrayIterable extends ArrayIterable<Float> {
 
 		private float[] values;
-		private int current = 0;
 
-		private FloatArrayIterator(float[] values) {
+		private FloatArrayIterable(float[] values) {
 			this.values = values;
 		}
 
 		@Override
-		public boolean hasNext() {
-			return current < values.length;
+		protected int size() {
+			return values.length;
 		}
 
 		@Override
-		public Float next() {
-			float result = values[current];
-			current++;
-			return result;
+		protected Float get(int index) {
+			return values[index];
 		}
 	}
 
-	private static class ByteArrayIterator implements Iterator<Byte> {
+	private static class ByteArrayIterable extends ArrayIterable<Byte> {
 
 		private byte[] values;
-		private int current = 0;
 
-		private ByteArrayIterator(byte[] values) {
+		private ByteArrayIterable(byte[] values) {
 			this.values = values;
 		}
 
 		@Override
-		public boolean hasNext() {
-			return current < values.length;
+		protected int size() {
+			return values.length;
 		}
 
 		@Override
-		public Byte next() {
-			byte result = values[current];
-			current++;
-			return result;
+		protected Byte get(int index) {
+			return values[index];
 		}
 	}
 
-	private static class ShortArrayIterator implements Iterator<Short> {
+	private static class ShortArrayIterable extends ArrayIterable<Short> {
 
 		private short[] values;
-		private int current = 0;
 
-		private ShortArrayIterator(short[] values) {
+		private ShortArrayIterable(short[] values) {
 			this.values = values;
 		}
 
 		@Override
-		public boolean hasNext() {
-			return current < values.length;
+		protected int size() {
+			return values.length;
 		}
 
 		@Override
-		public Short next() {
-			short result = values[current];
-			current++;
-			return result;
+		protected Short get(int index) {
+			return values[index];
 		}
 	}
 
-	private static class CharArrayIterator implements Iterator<Character> {
+	private static class CharArrayIterable extends ArrayIterable<Character> {
 
 		private char[] values;
-		private int current = 0;
 
-		private CharArrayIterator(char[] values) {
+		private CharArrayIterable(char[] values) {
 			this.values = values;
 		}
 
 		@Override
-		public boolean hasNext() {
-			return current < values.length;
+		protected int size() {
+			return values.length;
 		}
 
 		@Override
-		public Character next() {
-			char result = values[current];
-			current++;
-			return result;
+		protected Character get(int index) {
+			return values[index];
 		}
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/util/impl/CollectionHelper.java
+++ b/engine/src/main/java/org/hibernate/search/util/impl/CollectionHelper.java
@@ -13,6 +13,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.SortedMap;
@@ -84,4 +85,242 @@ public final class CollectionHelper {
 		}
 	}
 
+	/**
+	 * Builds an {@link Iterator} for a given array. It is (un)necessarily ugly because we have to deal with array of primitives.
+	 *
+	 * @param object a given array
+	 * @return an {@code Iterator} iterating over the array
+	 */
+	public static Iterator<?> iteratorFromArray(Object object) {
+		Iterator<?> iterator;
+		if ( Object.class.isAssignableFrom( object.getClass().getComponentType() ) ) {
+			iterator = new ObjectArrayIterator( (Object[]) object );
+		}
+		else if ( object.getClass() == boolean[].class ) {
+			iterator = new BooleanArrayIterator( (boolean[]) object );
+		}
+		else if ( object.getClass() == int[].class ) {
+			iterator = new IntArrayIterator( (int[]) object );
+		}
+		else if ( object.getClass() == long[].class ) {
+			iterator = new LongArrayIterator( (long[]) object );
+		}
+		else if ( object.getClass() == double[].class ) {
+			iterator = new DoubleArrayIterator( (double[]) object );
+		}
+		else if ( object.getClass() == float[].class ) {
+			iterator = new FloatArrayIterator( (float[]) object );
+		}
+		else if ( object.getClass() == byte[].class ) {
+			iterator = new ByteArrayIterator( (byte[]) object );
+		}
+		else if ( object.getClass() == short[].class ) {
+			iterator = new ShortArrayIterator( (short[]) object );
+		}
+		else if ( object.getClass() == char[].class ) {
+			iterator = new CharArrayIterator( (char[]) object );
+		}
+		else {
+			throw new IllegalArgumentException( "Provided object " + object + " is not a supported array type" );
+		}
+		return iterator;
+	}
+
+	private static class ObjectArrayIterator implements Iterator<Object> {
+
+		private Object[] values;
+		private int current = 0;
+
+		private ObjectArrayIterator(Object[] values) {
+			this.values = values;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return current < values.length;
+		}
+
+		@Override
+		public Object next() {
+			Object result = values[current];
+			current++;
+			return result;
+		}
+	}
+
+	private static class BooleanArrayIterator implements Iterator<Boolean> {
+
+		private boolean[] values;
+		private int current = 0;
+
+		private BooleanArrayIterator(boolean[] values) {
+			this.values = values;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return current < values.length;
+		}
+
+		@Override
+		public Boolean next() {
+			boolean result = values[current];
+			current++;
+			return result;
+		}
+	}
+
+	private static class IntArrayIterator implements Iterator<Integer> {
+
+		private int[] values;
+		private int current = 0;
+
+		private IntArrayIterator(int[] values) {
+			this.values = values;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return current < values.length;
+		}
+
+		@Override
+		public Integer next() {
+			int result = values[current];
+			current++;
+			return result;
+		}
+	}
+
+	private static class LongArrayIterator implements Iterator<Long> {
+
+		private long[] values;
+		private int current = 0;
+
+		private LongArrayIterator(long[] values) {
+			this.values = values;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return current < values.length;
+		}
+
+		@Override
+		public Long next() {
+			long result = values[current];
+			current++;
+			return result;
+		}
+	}
+
+	private static class DoubleArrayIterator implements Iterator<Double> {
+
+		private double[] values;
+		private int current = 0;
+
+		private DoubleArrayIterator(double[] values) {
+			this.values = values;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return current < values.length;
+		}
+
+		@Override
+		public Double next() {
+			double result = values[current];
+			current++;
+			return result;
+		}
+	}
+
+	private static class FloatArrayIterator implements Iterator<Float> {
+
+		private float[] values;
+		private int current = 0;
+
+		private FloatArrayIterator(float[] values) {
+			this.values = values;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return current < values.length;
+		}
+
+		@Override
+		public Float next() {
+			float result = values[current];
+			current++;
+			return result;
+		}
+	}
+
+	private static class ByteArrayIterator implements Iterator<Byte> {
+
+		private byte[] values;
+		private int current = 0;
+
+		private ByteArrayIterator(byte[] values) {
+			this.values = values;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return current < values.length;
+		}
+
+		@Override
+		public Byte next() {
+			byte result = values[current];
+			current++;
+			return result;
+		}
+	}
+
+	private static class ShortArrayIterator implements Iterator<Short> {
+
+		private short[] values;
+		private int current = 0;
+
+		private ShortArrayIterator(short[] values) {
+			this.values = values;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return current < values.length;
+		}
+
+		@Override
+		public Short next() {
+			short result = values[current];
+			current++;
+			return result;
+		}
+	}
+
+	private static class CharArrayIterator implements Iterator<Character> {
+
+		private char[] values;
+		private int current = 0;
+
+		private CharArrayIterator(char[] values) {
+			this.values = values;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return current < values.length;
+		}
+
+		@Override
+		public Character next() {
+			char result = values[current];
+			current++;
+			return result;
+		}
+	}
 }

--- a/orm/src/test/java/org/hibernate/search/test/bridge/ArrayBridgeTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/ArrayBridgeTest.java
@@ -62,6 +62,7 @@ public class ArrayBridgeTest extends SearchTestBase {
 		withoutNull.setNumericNullIndexed( new Integer[] { 1, 2 } );
 		withoutNull.setNullNotIndexed( new String[] { "DaltoValue", "DavideValue" } );
 		withoutNull.setNumericNullNotIndexed( new Long[] { 3L, 4L } );
+		withoutNull.setPrimitive( new float[] { 3.2f, 452.2f } );
 		withoutNull.setDates( new Date[] { indexedDate } );
 
 		withNullEntry = persistEntity( fullTextSession, "Worf" );
@@ -69,12 +70,14 @@ public class ArrayBridgeTest extends SearchTestBase {
 		withNullEntry.setNumericNullIndexed( new Integer[] { 11, null } );
 		withNullEntry.setNullNotIndexed( new String[] { "WorfValue", null } );
 		withNullEntry.setNumericNullNotIndexed( new Long[] { 33L, null } );
+		withNullEntry.setPrimitive( new float[] { 2.0f } );
 		withNullEntry.setDates( new Date[] { null } );
 
 		withNullEmbedded = persistEntity( fullTextSession, "Mime" );
 		withNullEmbedded.setDates( null );
 		withNullEmbedded.setNumericNullIndexed( null );
 		withNullEmbedded.setNumericNullNotIndexed( null );
+		withNullEmbedded.setPrimitive( null );
 		withNullEmbedded.setNullIndexed( null );
 		withNullEmbedded.setNullNotIndexed( null );
 		withNullEmbedded.setDates( null );
@@ -185,6 +188,21 @@ public class ArrayBridgeTest extends SearchTestBase {
 			assertEquals( "Wrong result returned from an indexed array", withNullEntry.getName(), results.get( 0 )
 					.getName() );
 		}
+	}
+
+	@Test
+	public void testPrimitiveIndexing() throws Exception {
+		List<ArrayBridgeTestEntity> results = findResultsWithRangeQuery(
+				"primitive",
+				100.0f
+		);
+
+		assertNotNull( "No result found for an indexed collection", results );
+		assertEquals( "Wrong number of results returned for an indexed collection", 1, results.size() );
+		assertEquals(
+				"Wrong result returned from a collection of primitive numbers", withoutNull.getName(), results.get( 0 )
+						.getName()
+		);
 	}
 
 	@Test

--- a/orm/src/test/java/org/hibernate/search/test/bridge/ArrayBridgeTestEntity.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/ArrayBridgeTestEntity.java
@@ -43,6 +43,7 @@ public class ArrayBridgeTestEntity {
 	private String[] nullNotIndexed = new String[0];
 	private Integer[] numericNullIndexed = new Integer[0];
 	private Long[] numericNullNotIndexed = new Long[0];
+	private float[] primitive = new float[0];
 
 	private Date[] dates = new Date[0];
 
@@ -125,6 +126,20 @@ public class ArrayBridgeTestEntity {
 
 	public void setNumericNullNotIndexed(Long[] numericSkipNullCollection) {
 		this.numericNullNotIndexed = numericSkipNullCollection;
+	}
+
+	@Field(store = Store.YES)
+	@ElementCollection
+	@IndexedEmbedded
+	@OrderColumn
+	@CollectionTable(name = "primitive", joinColumns = @JoinColumn(name = "array_id"))
+	@Column(name = "primitive")
+	public float[] getPrimitive() {
+		return primitive;
+	}
+
+	public void setPrimitive(float[] primitive) {
+		this.primitive = primitive;
 	}
 
 	@Field(analyze = Analyze.NO, store = Store.YES)

--- a/orm/src/test/java/org/hibernate/search/test/query/facet/EmbeddedCollectionFacetingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/facet/EmbeddedCollectionFacetingTest.java
@@ -22,7 +22,7 @@ import org.hibernate.search.query.facet.Facet;
 import org.hibernate.search.query.facet.FacetSortOrder;
 import org.hibernate.search.query.facet.FacetingRequest;
 import org.hibernate.search.test.SearchTestBase;
-
+import org.hibernate.search.testsupport.TestForIssue;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -31,7 +31,8 @@ import static org.junit.Assert.assertEquals;
 /**
  * @author Elmer van Chastelet
  */
-public class CollectionFacetingTest extends SearchTestBase {
+@TestForIssue(jiraKey = "HSEARCH-726")
+public class EmbeddedCollectionFacetingTest extends SearchTestBase {
 	Author voltaire;
 	Author hugo;
 	Author moliere;

--- a/orm/src/test/java/org/hibernate/search/test/query/facet/MultiValuedFacetingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/facet/MultiValuedFacetingTest.java
@@ -1,0 +1,340 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.query.facet;
+
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.hibernate.search.annotations.Analyze;
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Index;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.IndexedEmbedded;
+import org.hibernate.search.backend.spi.Work;
+import org.hibernate.search.backend.spi.WorkType;
+import org.hibernate.search.query.dsl.QueryBuilder;
+import org.hibernate.search.query.engine.spi.HSQuery;
+import org.hibernate.search.query.facet.Facet;
+import org.hibernate.search.query.facet.FacetSortOrder;
+import org.hibernate.search.query.facet.FacetingRequest;
+import org.hibernate.search.testsupport.TestForIssue;
+import org.hibernate.search.testsupport.junit.SearchFactoryHolder;
+import org.hibernate.search.testsupport.setup.TransactionContextForTest;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+@TestForIssue(jiraKey = "HSEARCH-2535")
+public class MultiValuedFacetingTest {
+	@Rule
+	public SearchFactoryHolder sfHolder = new SearchFactoryHolder(
+			StringArrayFacetEntity.class, StringCollectionFacetEntity.class, StringMapFacetEntity.class,
+			NumberArrayFacetEntity.class, NumberCollectionFacetEntity.class, NumberMapFacetEntity.class );
+
+	@Test
+	public void stringArray() throws Exception {
+		StringArrayFacetEntity entity = new StringArrayFacetEntity( 1L );
+		storeData( entity.id, entity );
+		entity = new StringArrayFacetEntity( 1L, "foo" );
+		storeData( entity.id, entity );
+		entity = new StringArrayFacetEntity( 2L, "foo", "bar" );
+		storeData( entity.id, entity );
+
+		HSQuery hsQuery = sfHolder.getSearchFactory().createHSQuery( new MatchAllDocsQuery(), StringArrayFacetEntity.class );
+
+		QueryBuilder builder = sfHolder.getSearchFactory().buildQueryBuilder().forEntity( StringArrayFacetEntity.class ).get();
+		FacetingRequest facetReq = builder.facet()
+				.name( "someFacet" )
+				.onField( "facet" )
+				.discrete()
+				.orderedBy( FacetSortOrder.COUNT_DESC )
+				.includeZeroCounts( false )
+				.maxFacetCount( 10 )
+				.createFacetingRequest();
+
+		List<Facet> facets = hsQuery.getFacetManager().enableFaceting( facetReq ).getFacets( "someFacet" );
+		assertEquals( "There should be two facets", 2, facets.size() );
+		assertFacet( facets.get( 0 ), "foo", 2 );
+		assertFacet( facets.get( 1 ), "bar", 1 );
+	}
+
+	@Test
+	public void stringCollection() throws Exception {
+		StringCollectionFacetEntity entity = new StringCollectionFacetEntity( 1L );
+		storeData( entity.id, entity );
+		entity = new StringCollectionFacetEntity( 1L, "foo" );
+		storeData( entity.id, entity );
+		entity = new StringCollectionFacetEntity( 2L, "foo", "bar" );
+		storeData( entity.id, entity );
+
+		HSQuery hsQuery = sfHolder.getSearchFactory().createHSQuery( new MatchAllDocsQuery(), StringCollectionFacetEntity.class );
+
+		QueryBuilder builder = sfHolder.getSearchFactory().buildQueryBuilder().forEntity( StringCollectionFacetEntity.class ).get();
+		FacetingRequest facetReq = builder.facet()
+				.name( "someFacet" )
+				.onField( "facet" )
+				.discrete()
+				.orderedBy( FacetSortOrder.COUNT_DESC )
+				.includeZeroCounts( false )
+				.maxFacetCount( 10 )
+				.createFacetingRequest();
+
+		List<Facet> facets = hsQuery.getFacetManager().enableFaceting( facetReq ).getFacets( "someFacet" );
+		assertEquals( "There should be two facets", 2, facets.size() );
+		assertFacet( facets.get( 0 ), "foo", 2 );
+		assertFacet( facets.get( 1 ), "bar", 1 );
+	}
+
+	@Test
+	public void stringMap() throws Exception {
+		StringMapFacetEntity entity = new StringMapFacetEntity( 1L );
+		storeData( entity.id, entity );
+		entity = new StringMapFacetEntity( 1L, "foo" );
+		storeData( entity.id, entity );
+		entity = new StringMapFacetEntity( 2L, "foo", "bar" );
+		storeData( entity.id, entity );
+
+		HSQuery hsQuery = sfHolder.getSearchFactory().createHSQuery( new MatchAllDocsQuery(), StringMapFacetEntity.class );
+
+		QueryBuilder builder = sfHolder.getSearchFactory().buildQueryBuilder().forEntity( StringMapFacetEntity.class ).get();
+		FacetingRequest facetReq = builder.facet()
+				.name( "someFacet" )
+				.onField( "facet" )
+				.discrete()
+				.orderedBy( FacetSortOrder.COUNT_DESC )
+				.includeZeroCounts( false )
+				.maxFacetCount( 10 )
+				.createFacetingRequest();
+
+		List<Facet> facets = hsQuery.getFacetManager().enableFaceting( facetReq ).getFacets( "someFacet" );
+		assertEquals( "There should be two facets", 2, facets.size() );
+		assertFacet( facets.get( 0 ), "foo", 2 );
+		assertFacet( facets.get( 1 ), "bar", 1 );
+	}
+
+	@Test
+	@Ignore // HSEARCH-1927 : Range faceting on multiple numeric values does not work
+	public void numberArray() throws Exception {
+		NumberArrayFacetEntity entity = new NumberArrayFacetEntity( 1L );
+		storeData( entity.id, entity );
+		entity = new NumberArrayFacetEntity( 1L, 42 );
+		storeData( entity.id, entity );
+		entity = new NumberArrayFacetEntity( 2L, 43, 442 );
+		storeData( entity.id, entity );
+
+		HSQuery hsQuery = sfHolder.getSearchFactory().createHSQuery( new MatchAllDocsQuery(), NumberArrayFacetEntity.class );
+
+		QueryBuilder builder = sfHolder.getSearchFactory().buildQueryBuilder().forEntity( NumberArrayFacetEntity.class ).get();
+		FacetingRequest facetReq = builder.facet()
+				.name( "someFacet" )
+				.onField( "facet" )
+				.range()
+				.from( 0.0f ).to( 100.0f ).excludeLimit()
+				.from( 100.0f ).to( 500.0f ).excludeLimit()
+				.orderedBy( FacetSortOrder.COUNT_DESC )
+				.includeZeroCounts( false )
+				.maxFacetCount( 10 )
+				.createFacetingRequest();
+
+		List<Facet> facets = hsQuery.getFacetManager().enableFaceting( facetReq ).getFacets( "someFacet" );
+		assertEquals( "There should be two facets", 2, facets.size() );
+		assertFacet( facets.get( 0 ), "[0.0, 100.0)", 2 );
+		assertFacet( facets.get( 1 ), "[100.0, 500.0)", 1 );
+	}
+
+	@Test
+	@Ignore // HSEARCH-1927 : Range faceting on multiple numeric values does not work
+	public void numberCollection() throws Exception {
+		NumberCollectionFacetEntity entity = new NumberCollectionFacetEntity( 1L );
+		storeData( entity.id, entity );
+		entity = new NumberCollectionFacetEntity( 1L, 42.2f );
+		storeData( entity.id, entity );
+		entity = new NumberCollectionFacetEntity( 2L, 42.3f, 442.2f );
+		storeData( entity.id, entity );
+
+		HSQuery hsQuery = sfHolder.getSearchFactory().createHSQuery( new MatchAllDocsQuery(), NumberCollectionFacetEntity.class );
+
+		QueryBuilder builder = sfHolder.getSearchFactory().buildQueryBuilder().forEntity( NumberCollectionFacetEntity.class ).get();
+		FacetingRequest facetReq = builder.facet()
+				.name( "someFacet" )
+				.onField( "facet" )
+				.range()
+				.from( 0.0f ).to( 100.0f ).excludeLimit()
+				.from( 100.0f ).to( 500.0f ).excludeLimit()
+				.orderedBy( FacetSortOrder.COUNT_DESC )
+				.includeZeroCounts( false )
+				.maxFacetCount( 10 )
+				.createFacetingRequest();
+
+		List<Facet> facets = hsQuery.getFacetManager().enableFaceting( facetReq ).getFacets( "someFacet" );
+		assertEquals( "There should be two facets", 2, facets.size() );
+		assertFacet( facets.get( 0 ), "[0.0, 100.0)", 2 );
+		assertFacet( facets.get( 1 ), "[100.0, 500.0)", 1 );
+	}
+
+	@Test
+	@Ignore // HSEARCH-1927 : Range faceting on multiple numeric values does not work
+	public void numberMap() throws Exception {
+		NumberMapFacetEntity entity = new NumberMapFacetEntity( 1L );
+		storeData( entity.id, entity );
+		entity = new NumberMapFacetEntity( 1L, 42.2f );
+		storeData( entity.id, entity );
+		entity = new NumberMapFacetEntity( 2L, 42.3f, 442.2f );
+		storeData( entity.id, entity );
+
+		HSQuery hsQuery = sfHolder.getSearchFactory().createHSQuery( new MatchAllDocsQuery(), NumberMapFacetEntity.class );
+
+		QueryBuilder builder = sfHolder.getSearchFactory().buildQueryBuilder().forEntity( NumberMapFacetEntity.class ).get();
+		FacetingRequest facetReq = builder.facet()
+				.name( "someFacet" )
+				.onField( "facet" )
+				.range()
+				.from( 0.0f ).to( 100.0f ).excludeLimit()
+				.from( 100.0f ).to( 500.0f ).excludeLimit()
+				.orderedBy( FacetSortOrder.COUNT_DESC )
+				.includeZeroCounts( false )
+				.maxFacetCount( 10 )
+				.createFacetingRequest();
+
+		List<Facet> facets = hsQuery.getFacetManager().enableFaceting( facetReq ).getFacets( "someFacet" );
+		assertEquals( "There should be two facets", 2, facets.size() );
+		assertFacet( facets.get( 0 ), "[0.0, 100.0)", 2 );
+		assertFacet( facets.get( 1 ), "[100.0, 500.0)", 1 );
+	}
+
+	private void storeData(Long id, Object entry) {
+		Work work = new Work( entry, id, WorkType.ADD, false );
+		TransactionContextForTest tc = new TransactionContextForTest();
+		sfHolder.getSearchFactory().getWorker().performWork( work, tc );
+		tc.end();
+	}
+
+	private void assertFacet(Facet facet, String expectedValue, int expectedCount) {
+		assertEquals( "Wrong facet value", expectedValue, facet.getValue() );
+		assertEquals( "Wrong facet count", expectedCount, facet.getCount() );
+	}
+
+	@Indexed
+	private static class StringArrayFacetEntity {
+		@DocumentId
+		private Long id;
+
+		@Field(analyze = Analyze.NO)
+		@org.hibernate.search.annotations.Facet
+		@IndexedEmbedded // This enables ArrayBridge: not needed for faceting, but needed for indexing
+		private String[] facet;
+
+		private StringArrayFacetEntity(Long id, String ... facet) {
+			super();
+			this.id = id;
+			this.facet = facet;
+		}
+	}
+
+	@Indexed
+	private static class StringCollectionFacetEntity {
+		@DocumentId
+		private Long id;
+
+		@Field(analyze = Analyze.NO)
+		@org.hibernate.search.annotations.Facet
+		@IndexedEmbedded // This enables IterableBridge: not needed for faceting, but needed for indexing
+		private Collection<String> facet;
+
+		private StringCollectionFacetEntity(Long id, String ... facet) {
+			super();
+			this.id = id;
+			this.facet = Arrays.asList( facet );
+		}
+	}
+
+	@Indexed
+	private static class StringMapFacetEntity {
+		@DocumentId
+		private Long id;
+
+		@Field(analyze = Analyze.NO)
+		@org.hibernate.search.annotations.Facet
+		@IndexedEmbedded // This enables MapBridge: not needed for faceting, but needed for indexing
+		private Map<Integer, String> facet;
+
+		private StringMapFacetEntity(Long id, String ... facet) {
+			super();
+			this.id = id;
+			this.facet = new TreeMap<>();
+			int index = 0;
+			for ( String facetValue : facet ) {
+				this.facet.put( index, facetValue );
+				++index;
+			}
+		}
+	}
+
+	@Indexed
+	private static class NumberArrayFacetEntity {
+		@DocumentId
+		private Long id;
+
+		@Field(analyze = Analyze.NO)
+		@org.hibernate.search.annotations.Facet
+		@IndexedEmbedded // This enables ArrayBridge: not needed for faceting, but needed for indexing
+		private Integer[] facet;
+
+		private NumberArrayFacetEntity(Long id, Integer ... facet) {
+			super();
+			this.id = id;
+			this.facet = facet;
+		}
+	}
+
+	@Indexed
+	private static class NumberCollectionFacetEntity {
+		@DocumentId
+		private Long id;
+
+		@Field(analyze = Analyze.NO)
+		@org.hibernate.search.annotations.Facet
+		@IndexedEmbedded // This enables IterableBridge: not needed for faceting, but needed for indexing
+		private Collection<Float> facet;
+
+		private NumberCollectionFacetEntity(Long id, Float ... facet) {
+			super();
+			this.id = id;
+			this.facet = Arrays.asList( facet );
+		}
+	}
+
+	@Indexed
+	private static class NumberMapFacetEntity {
+		@DocumentId
+		private Long id;
+
+		@Field(analyze = Analyze.NO, index = Index.NO)
+		@org.hibernate.search.annotations.Facet
+		@IndexedEmbedded // This enables MapBridge: not needed for faceting, but needed for indexing
+		private Map<Integer, Float> facet;
+
+		private NumberMapFacetEntity(Long id, Float ... facet) {
+			super();
+			this.id = id;
+			this.facet = new TreeMap<>();
+			int index = 0;
+			for ( Float facetValue : facet ) {
+				this.facet.put( index, facetValue );
+				++index;
+			}
+		}
+	}
+}

--- a/orm/src/test/java/org/hibernate/search/test/query/facet/MultiValuedFacetingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/facet/MultiValuedFacetingTest.java
@@ -290,9 +290,9 @@ public class MultiValuedFacetingTest {
 		@Field(analyze = Analyze.NO)
 		@org.hibernate.search.annotations.Facet
 		@IndexedEmbedded // This enables ArrayBridge: not needed for faceting, but needed for indexing
-		private Integer[] facet;
+		private int[] facet;
 
-		private NumberArrayFacetEntity(Long id, Integer ... facet) {
+		private NumberArrayFacetEntity(Long id, int ... facet) {
 			super();
 			this.id = id;
 			this.facet = facet;


### PR DESCRIPTION
This PR is based on #1273 (HSEARCH-2535), which will have to be merged first.

Relevant ticket: https://hibernate.atlassian.net/browse/HSEARCH-2510

Not sure it's the right time to merge this, but I had to investigate and found a solution while working on HSEARCH-2535, so I though we might as well discuss it.

~~The main drawback of the solution is performance: it appears `Array.*` static methods are notoriously slow, as [discussed there](http://stackoverflow.com/questions/30306160/performance-of-java-lang-reflect-array) and [reported there](https://bugs.openjdk.java.net/browse/JDK-8051447]. If it's an issue, I can set up our own utils in Java: it appears that would be faster. Not sure that's worth it, though: yes, these methods are slower than using the built-in equivalents (`[]` operator and `array.length`) but I suppose the latter are pretty fast to begin with.~~ => Addressed by adding utils to `CollectionHelper`.