### PR TITLE
HSEARCH-2501 Elasticsearch calendar resolution handling is not consistent with Lucene's

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/ElasticsearchDateHelper.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/ElasticsearchDateHelper.java
@@ -15,7 +15,6 @@ import javax.xml.bind.DatatypeConverter;
 
 import org.apache.lucene.document.DateTools;
 import org.apache.lucene.document.DateTools.Resolution;
-import org.hibernate.search.exception.AssertionFailure;
 
 /**
  * Various utilities to manipulate dates and comply with Elasticsearch date format.
@@ -57,30 +56,13 @@ public final class ElasticsearchDateHelper {
 	 *
 	 * @see DateTools#round(Date, Resolution)
 	 */
-	@SuppressWarnings("fallthrough")
 	public static Calendar round(Calendar calendar, Resolution resolution) {
 		final Calendar calInstance = (Calendar) calendar.clone();
-
-		switch ( resolution ) {
-			// NOTE: switch statement fall-through is deliberate
-			case YEAR:
-				calInstance.set( Calendar.MONTH, 0 );
-			case MONTH:
-				calInstance.set( Calendar.DAY_OF_MONTH, 1 );
-			case DAY:
-				calInstance.set( Calendar.HOUR_OF_DAY, 0 );
-			case HOUR:
-				calInstance.set( Calendar.MINUTE, 0 );
-			case MINUTE:
-				calInstance.set( Calendar.SECOND, 0 );
-			case SECOND:
-				calInstance.set( Calendar.MILLISECOND, 0 );
-			case MILLISECOND:
-				// don't cut off anything
-				break;
-			default:
-				throw new AssertionFailure( "unknown resolution " + resolution );
-		}
+		/*
+		 * Make sure we keep the timezone: use a cloned version of the calendar
+		 * to set the rounded time on it, not a new calendar instance.
+		 */
+		calInstance.setTime( DateTools.round( calInstance.getTime(), resolution ) );
 		return calInstance;
 	}
 

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIndexMappingIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIndexMappingIT.java
@@ -243,7 +243,7 @@ public class ElasticsearchIndexMappingIT extends SearchTestBase {
 				"{" +
 					"\"active\": true," +
 					"\"dateOfBirth\": \"1958-04-07T00:00:00Z\"," +
-					"\"subscriptionEndDate\": \"2016-06-07T00:00:00+02:00\"," +
+					"\"subscriptionEndDate\": \"2016-06-07T02:00:00+02:00\"," +
 					"\"driveWidth\": 285," +
 					"\"firstName\": \"Klaus\"," +
 					"\"handicap\": 3.4," +

--- a/orm/src/test/java/org/hibernate/search/test/bridge/BridgeTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/BridgeTest.java
@@ -181,7 +181,7 @@ public class BridgeTest extends SearchTestBase {
 	@Test
 	@SkipForDialect(PostgreSQL81Dialect.class)//PosgreSQL doesn't allow storing null with these column types
 	public void testDateBridge() throws Exception {
-		Calendar c = Calendar.getInstance( TimeZone.getTimeZone( "GMT" ), Locale.ROOT ); //for the sake of tests
+		Calendar c = Calendar.getInstance( TimeZone.getTimeZone( "Europe/Rome" ), Locale.ROOT ); //for the sake of tests
 		c.set( 2000, Calendar.DECEMBER, 15, 3, 43, 2 );
 		c.set( Calendar.MILLISECOND, 5 );
 		Date date = new Date( c.getTimeInMillis() );
@@ -267,7 +267,7 @@ public class BridgeTest extends SearchTestBase {
 	@Test
 	public void testCalendarBridge() throws Exception {
 		Cloud cloud = new Cloud();
-		Calendar calendar = Calendar.getInstance( TimeZone.getTimeZone( "GMT" ), Locale.ROOT ); //for the sake of tests
+		Calendar calendar = Calendar.getInstance( TimeZone.getTimeZone( "Europe/Rome" ), Locale.ROOT ); //for the sake of tests
 		calendar.set( 2000, 11, 15, 3, 43, 2 );
 		calendar.set( Calendar.MILLISECOND, 5 );
 

--- a/orm/src/test/java/org/hibernate/search/test/query/dsl/NumericEncodingQueriesTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/dsl/NumericEncodingQueriesTest.java
@@ -52,7 +52,9 @@ public class NumericEncodingQueriesTest extends SearchTestBase {
 	}
 
 	private static Calendar createCalendar() {
-		return Calendar.getInstance( TimeZone.getTimeZone( "Europe/Rome" ), Locale.ITALY );
+		Calendar calendar = Calendar.getInstance( TimeZone.getTimeZone( "Europe/Rome" ), Locale.ITALY );
+		calendar.setTimeInMillis( 0 ); // Reset to epoch; clears hours/minutes/seconds in particular
+		return calendar;
 	}
 
 	@Before


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2501

Please note that with Lucene, we always truncate date/calendars with the GMT timezone, regardless of the timezone that has been set on the calendar.

If we are to solve this issue, I think we should solve it in a way that is consistent between ES and Lucene. For instance we could add a configuration option to set the timezone to use when truncating dates ('GMT', '+01:00', 'default' for the JVM's default, ...) and another for calendars (same options + another to instruct to use the calendar's timezone).

See also the thread I started on the hibernate-dev mailing list: http://lists.jboss.org/pipermail/hibernate-dev/2017-January/015712.html

For now, I made the Elasticsearch integration behave the same as Lucene.