### PR TITLE
HSEARCH-2522 Elasticsearch backend in the classpath causes eager initialization of non related IndexManagers

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/ElasticsearchEntityHelper.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/ElasticsearchEntityHelper.java
@@ -9,10 +9,10 @@ package org.hibernate.search.elasticsearch.util.impl;
 import java.util.Collection;
 import java.util.Set;
 
-import org.hibernate.search.elasticsearch.impl.ElasticsearchIndexManager;
+import org.hibernate.search.elasticsearch.spi.ElasticsearchIndexManagerType;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.engine.spi.EntityIndexBinding;
-import org.hibernate.search.indexes.spi.IndexManager;
+import org.hibernate.search.indexes.spi.IndexManagerType;
 
 /**
  * @author Yoann Rodiere
@@ -41,12 +41,10 @@ public final class ElasticsearchEntityHelper {
 				continue;
 			}
 
-			IndexManager[] indexManagers = binding.getIndexManagers();
+			IndexManagerType indexManagerType = binding.getIndexManagerType();
 
-			for ( IndexManager indexManager : indexManagers ) {
-				if ( indexManager instanceof ElasticsearchIndexManager ) {
-					return true;
-				}
+			if ( ElasticsearchIndexManagerType.INSTANCE.equals( indexManagerType ) ) {
+				return true;
 			}
 		}
 

--- a/engine/src/main/java/org/hibernate/search/engine/impl/DefaultMutableEntityIndexBinding.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/DefaultMutableEntityIndexBinding.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import org.apache.lucene.search.similarities.Similarity;
 import org.hibernate.search.engine.spi.DocumentBuilderIndexedEntity;
 import org.hibernate.search.indexes.spi.IndexManager;
+import org.hibernate.search.indexes.spi.IndexManagerType;
 import org.hibernate.search.indexes.interceptor.EntityIndexingInterceptor;
 import org.hibernate.search.store.IndexShardingStrategy;
 import org.hibernate.search.store.ShardIdentifierProvider;
@@ -23,16 +24,19 @@ public class DefaultMutableEntityIndexBinding implements MutableEntityIndexBindi
 	private final IndexShardingStrategy shardingStrategy;
 	private final Similarity similarityInstance;
 	private DocumentBuilderIndexedEntity documentBuilder;
+	private final IndexManagerType indexManagerType;
 	private final IndexManager[] indexManagers;
 	private final EntityIndexingInterceptor entityIndexingInterceptor;
 
 	public DefaultMutableEntityIndexBinding(
 			IndexShardingStrategy shardingStrategy,
 			Similarity similarityInstance,
+			IndexManagerType indexManagerType,
 			IndexManager[] providers,
 			EntityIndexingInterceptor entityIndexingInterceptor) {
 				this.shardingStrategy = shardingStrategy;
 				this.similarityInstance = similarityInstance;
+				this.indexManagerType = indexManagerType;
 				this.indexManagers = providers;
 				this.entityIndexingInterceptor = entityIndexingInterceptor;
 	}
@@ -65,6 +69,11 @@ public class DefaultMutableEntityIndexBinding implements MutableEntityIndexBindi
 	@Override
 	public void postInitialize(Set<Class<?>> indexedClasses) {
 		documentBuilder.postInitialize( indexedClasses );
+	}
+
+	@Override
+	public IndexManagerType getIndexManagerType() {
+		return indexManagerType;
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/impl/DynamicShardingEntityIndexBinding.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/DynamicShardingEntityIndexBinding.java
@@ -16,6 +16,7 @@ import org.hibernate.search.engine.spi.DocumentBuilderIndexedEntity;
 import org.hibernate.search.indexes.impl.IndexManagerHolder;
 import org.hibernate.search.indexes.interceptor.EntityIndexingInterceptor;
 import org.hibernate.search.indexes.spi.IndexManager;
+import org.hibernate.search.indexes.spi.IndexManagerType;
 import org.hibernate.search.store.IndexShardingStrategy;
 import org.hibernate.search.store.ShardIdentifierProvider;
 
@@ -29,6 +30,7 @@ public class DynamicShardingEntityIndexBinding implements MutableEntityIndexBind
 	private final ShardIdentifierProvider shardIdentityProvider;
 	private final Properties properties;
 	private final ExtendedSearchIntegrator extendedIntegrator;
+	private final IndexManagerType indexManagerType;
 	private final IndexManagerHolder indexManagerHolder;
 	private final String rootDirectoryProviderName;
 	private DocumentBuilderIndexedEntity documentBuilder;
@@ -41,6 +43,7 @@ public class DynamicShardingEntityIndexBinding implements MutableEntityIndexBind
 			EntityIndexingInterceptor entityIndexingInterceptor,
 			Properties properties,
 			ExtendedSearchIntegrator extendedIntegrator,
+			IndexManagerType indexManagerType,
 			IndexManagerHolder indexManagerHolder,
 			String rootDirectoryProviderName) {
 		this.shardIdentityProvider = shardIdentityProvider;
@@ -48,6 +51,7 @@ public class DynamicShardingEntityIndexBinding implements MutableEntityIndexBind
 		this.entityIndexingInterceptor = entityIndexingInterceptor;
 		this.properties = properties;
 		this.extendedIntegrator = extendedIntegrator;
+		this.indexManagerType = indexManagerType;
 		// TODO
 		this.indexManagerFactory = indexManagerFactory;
 		this.indexManagerHolder = indexManagerHolder;
@@ -91,6 +95,11 @@ public class DynamicShardingEntityIndexBinding implements MutableEntityIndexBind
 	}
 
 	@Override
+	public IndexManagerType getIndexManagerType() {
+		return indexManagerType;
+	}
+
+	@Override
 	public IndexManager[] getIndexManagers() {
 		return shardingStrategy.getIndexManagersForAllShards();
 	}
@@ -119,6 +128,7 @@ public class DynamicShardingEntityIndexBinding implements MutableEntityIndexBind
 				entityIndexingInterceptor,
 				properties,
 				extendedIntegrator,
+				indexManagerType,
 				indexManagerHolder,
 				rootDirectoryProviderName
 		);

--- a/engine/src/main/java/org/hibernate/search/engine/impl/EntityIndexBindingFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/EntityIndexBindingFactory.java
@@ -12,6 +12,7 @@ import org.apache.lucene.search.similarities.Similarity;
 import org.hibernate.search.indexes.impl.IndexManagerHolder;
 import org.hibernate.search.indexes.interceptor.EntityIndexingInterceptor;
 import org.hibernate.search.indexes.spi.IndexManager;
+import org.hibernate.search.indexes.spi.IndexManagerType;
 import org.hibernate.search.spi.WorkerBuildContext;
 import org.hibernate.search.store.IndexShardingStrategy;
 import org.hibernate.search.store.ShardIdentifierProvider;
@@ -31,8 +32,10 @@ public final class EntityIndexBindingFactory {
 		// not allowed
 	}
 
-	@SuppressWarnings( "unchecked" )
-	public static MutableEntityIndexBinding buildEntityIndexBinding(Class<?> type, IndexManager[] providers,
+	public static MutableEntityIndexBinding buildEntityIndexBinding(
+			Class<?> type,
+			IndexManagerType indexManagerType,
+			IndexManager[] providers,
 			IndexShardingStrategy shardingStrategy,
 			ShardIdentifierProvider shardIdentifierProvider,
 			Similarity similarity,
@@ -52,11 +55,12 @@ public final class EntityIndexBindingFactory {
 					safeInterceptor,
 					properties,
 					context.getUninitializedSearchIntegrator(),
+					indexManagerType,
 					indexManagerHolder,
 					rootDirectoryProviderName );
 		}
 		else {
-			return new DefaultMutableEntityIndexBinding( shardingStrategy, similarity, providers, interceptor );
+			return new DefaultMutableEntityIndexBinding( shardingStrategy, similarity, indexManagerType, providers, interceptor );
 		}
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/spi/EntityIndexBinding.java
+++ b/engine/src/main/java/org/hibernate/search/engine/spi/EntityIndexBinding.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import org.apache.lucene.search.similarities.Similarity;
 import org.hibernate.search.indexes.interceptor.EntityIndexingInterceptor;
 import org.hibernate.search.indexes.spi.IndexManager;
+import org.hibernate.search.indexes.spi.IndexManagerType;
 import org.hibernate.search.store.IndexShardingStrategy;
 import org.hibernate.search.store.ShardIdentifierProvider;
 
@@ -48,6 +49,11 @@ public interface EntityIndexBinding {
 	 * @param indexedClasses set of indexed classes
 	 */
 	void postInitialize(Set<Class<?>> indexedClasses);
+
+	/**
+	 * @return the type of index managers
+	 */
+	IndexManagerType getIndexManagerType();
 
 	/**
 	 * @return the array of index managers

--- a/engine/src/main/java/org/hibernate/search/indexes/impl/IndexManagerHolder.java
+++ b/engine/src/main/java/org/hibernate/search/indexes/impl/IndexManagerHolder.java
@@ -94,6 +94,7 @@ public class IndexManagerHolder {
 		Similarity similarity = createSimilarity( indexName, cfg, indexProperties[0], entity, buildContext );
 		boolean isDynamicSharding = isShardingDynamic( indexProperties[0], buildContext );
 
+		IndexManagerType indexManagerType = getIndexManagerType( entity, cfg, buildContext );
 		IndexManager[] indexManagers = new IndexManager[0];
 		if ( !isDynamicSharding ) {
 			indexManagers = createIndexManagers(
@@ -121,6 +122,7 @@ public class IndexManagerHolder {
 
 		return EntityIndexBindingFactory.buildEntityIndexBinding(
 				entity.getClass(),
+				indexManagerType,
 				indexManagers,
 				shardingStrategy,
 				shardIdentifierProvider,


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2522

I had to add one method to `org.hibernate.search.engine.spi.EntityIndexBinding` in order to avoid eager initialization of index managers when checking whether they are related to ES or not.
Thus, this commit sort of breaks an SPI. The important question is: are custom implementations of `EntityIndexBinding` actually possible/useful? And that I don't know.
Maybe @gustavonalle (who reported the bug) could tell us whether this interface is implemented somewhere in Infinispan, and whether it's acceptable to add this method or not?