### PR TITLE
Upgrade to Hibernate ORM 5.2.6

### DIFF
--- a/elasticsearch/src/test/resources/hibernate.properties
+++ b/elasticsearch/src/test/resources/hibernate.properties
@@ -18,7 +18,7 @@ hibernate.connection.username ${jdbc.user}
 hibernate.connection.password ${jdbc.pass}
 hibernate.connection.isolation ${jdbc.isolation}
 
-hibernate.connection.pool_size 5
+hibernate.connection.pool_size 15
 
 hibernate.show_sql false
 hibernate.format_sql false

--- a/integrationtest/osgi/karaf-features/src/main/features/features.xml
+++ b/integrationtest/osgi/karaf-features/src/main/features/features.xml
@@ -60,6 +60,7 @@
         <bundle>mvn:org.jboss/jandex/${jandexVersion}</bundle>
         <bundle>mvn:com.fasterxml/classmate/${classMateVersion}</bundle>
         <bundle>mvn:org.javassist/javassist/${javassistVersion}</bundle>
+        <bundle>mvn:net.bytebuddy/byte-buddy/${bytebuddyVersion}</bundle>
 
         <!-- Hibernate ORM -->
         <bundle>mvn:org.hibernate/hibernate-core/${hibernateVersion}</bundle>

--- a/integrationtest/osgi/karaf-it/pom.xml
+++ b/integrationtest/osgi/karaf-it/pom.xml
@@ -42,6 +42,13 @@
         </dependency>
 
         <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>${bytebuddyVersion}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>hibernate-search-orm</artifactId>
             <version>${project.version}</version>

--- a/integrationtest/spring/src/test/resources/beans.xml
+++ b/integrationtest/spring/src/test/resources/beans.xml
@@ -69,8 +69,8 @@
                 <entry key="hibernate.generate_statistics" value="true"/>
                 <!-- 2 is TRANSACTION_READ_COMMITTED -->
                 <entry key="hibernate.connection.isolation" value="2"/>
-                <!-- http://docs.jboss.org/hibernate/core/3.3/reference/en/html/architecture.html#architecture-current-session -->
-                <entry key="hibernate.current_session_context_class" value="org.hibernate.context.JTASessionContext"/>
+                <!-- http://docs.jboss.org/hibernate/orm/5.2/userguide/html_single/Hibernate_User_Guide.html#configurations-general -->
+                <entry key="hibernate.current_session_context_class" value="jta"/>
 
                 <!--  trying things to make Oracle happy -->
                 <entry key="hibernate.jdbc.batch_size" value="0"/>

--- a/integrationtest/wildfly/pom.xml
+++ b/integrationtest/wildfly/pom.xml
@@ -374,6 +374,39 @@
                             </resources>
                         </configuration>
                     </execution>
+                    <!-- Temporary workaround for HHH-11394 -->
+                    <execution>
+                        <id>orm-module-patch-node1</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/node1/wildfly-${wildflyVersion}/modules/org/hibernate/${hibernateVersion}/</outputDirectory>
+                            <overwrite>true</overwrite>
+                            <resources>
+                                <resource>
+                                    <directory>${basedir}/src/orm-module-override</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>orm-module-patch-node2</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/node2/wildfly-${wildflyVersion}/modules/org/hibernate/${hibernateVersion}/</outputDirectory>
+                            <overwrite>true</overwrite>
+                            <resources>
+                                <resource>
+                                    <directory>${basedir}/src/orm-module-override</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/integrationtest/wildfly/src/orm-module-override/module.xml
+++ b/integrationtest/wildfly/src/orm-module-override/module.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<!--
+
+  This is not the original module from the Hibernate ORM project,
+  but a patched version to workaround a known issue:
+    https://hibernate.atlassian.net/browse/HHH-11394
+
+  See also the discussion on: http://lists.jboss.org/pipermail/hibernate-dev/2017-January/015721.html
+
+ -->
+<module xmlns="urn:jboss:module:1.3" name="org.hibernate" slot="5.2.6.Final">
+    <resources>
+        <resource-root path="hibernate-core-5.2.6.Final.jar"/>
+        <resource-root path="hibernate-envers-5.2.6.Final.jar"/>
+        <!-- The original module refers to an updated copy of javassist here:
+          intentionally removed to workaround HHH-11394 -->
+        <resource-root path="byte-buddy-1.5.4.jar"/>
+    </resources>
+
+    <dependencies>
+        <module name="asm.asm"/>
+        <module name="com.fasterxml.classmate"/>
+        <module name="javax.api"/>
+        <module name="javax.annotation.api"/>
+        <module name="javax.enterprise.api"/>
+        <module name="javax.persistence.api"/>
+        <module name="javax.transaction.api"/>
+        <module name="javax.validation.api"/>
+        <module name="javax.xml.bind.api"/>
+        <module name="org.antlr"/>
+        <module name="org.dom4j"/>
+        <!--
+          The following doesn't point to the right version of Javassist,
+          as it's older than the one required by Hibernate ORM 5.2.6
+          but happens to work for our testing purposes.
+          People wishing to use the right version should patch the org.javassist:main
+          module to upgrade Javassist, however this could break the older version
+          of Hibernate ORM included in WildFly out of the box.
+          Do it only if you know what you're doing; for example if all your deployments
+          will use Hibernate ORM 5.2.6+
+        -->
+        <module name="org.javassist"/>
+        <module name="org.jboss.as.jpa.spi"/>
+        <module name="org.jboss.jandex"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.jboss.vfs"/>
+        <module name="org.hibernate.commons-annotations"/>
+        <module name="org.hibernate.infinispan" services="import" optional="true" slot="5.2.6.Final"/>
+        <module name="org.hibernate.jipijapa-hibernate5" services="import" slot="5.2.6.Final"/>
+    </dependencies>
+</module>

--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/wildfly/MemberRegistrationIT.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/wildfly/MemberRegistrationIT.java
@@ -7,7 +7,6 @@
 package org.hibernate.search.test.integration.wildfly;
 
 import static org.hibernate.search.test.integration.VersionTestHelper.getHibernateORMModuleName;
-import static org.hibernate.search.test.integration.VersionTestHelper.getWildFlyModuleIdentifier;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -66,7 +65,7 @@ public class MemberRegistrationIT {
 					.createProperty().name( "hibernate.hbm2ddl.auto" ).value( "create-drop" ).up()
 					.createProperty().name( "hibernate.search.default.lucene_version" ).value( "LUCENE_CURRENT" ).up()
 					.createProperty().name( "hibernate.search.default.directory_provider" ).value( "ram" ).up()
-					.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( getWildFlyModuleIdentifier() ).up()
+					.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( "none" ).up()
 					.createProperty().name( "jboss.as.jpa.providerModule" ).value( getHibernateORMModuleName() ).up()
 				.up().up()
 			.exportAsString();

--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/wildfly/PackagerHelper.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/wildfly/PackagerHelper.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.test.integration.wildfly;
 
 import org.hibernate.search.engine.Version;
+import org.hibernate.search.test.integration.VersionTestHelper;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 import org.jboss.shrinkwrap.resolver.api.maven.strategy.RejectDependenciesStrategy;
@@ -55,9 +56,8 @@ public class PackagerHelper {
 	 * @return the set of dependencies a user would need to bundle in a web app
 	 */
 	public static JavaArchive[] hibernateSearchLibraries() {
-		String currentVersion = Version.getVersionString();
 		return Maven.resolver()
-			.resolve( "org.hibernate:hibernate-search-orm:" + currentVersion )
+			.resolve( "org.hibernate:hibernate-search-orm:" + getCurrentVersion() )
 			// we need some dependencies at the right version: Lucene, search-engine, etc..
 			.using( new RejectDependenciesStrategy( false, exclusions ) )
 			.as( JavaArchive.class );
@@ -68,9 +68,22 @@ public class PackagerHelper {
 	public static JavaArchive[] hibernateSearchTestingLibraries() {
 		String currentVersion = Version.getVersionString();
 		return Maven.resolver()
-			.resolve( "org.hibernate:hibernate-search-testing:" + currentVersion )
+			.resolve( "org.hibernate:hibernate-search-testing:" + getCurrentVersion() )
 			.using( new RejectDependenciesStrategy( false, exclusions ) )
 			.as( JavaArchive.class );
+	}
+
+	/**
+	 * @return the current version of Hibernate Search
+	 */
+	private static String getCurrentVersion() {
+		//This will return 'null' when running the tests from Eclipse
+		//while having all modules open, so be prepared to fall back to build properties:
+		String currentVersion = Version.getVersionString();
+		if ( currentVersion != null ) {
+			return currentVersion;
+		}
+		return VersionTestHelper.getDependencyVersionHibernateSearch();
 	}
 
 }

--- a/orm/src/main/java/org/hibernate/search/FullTextQuery.java
+++ b/orm/src/main/java/org/hibernate/search/FullTextQuery.java
@@ -13,7 +13,6 @@ import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.Sort;
 
 import org.hibernate.Criteria;
-import org.hibernate.Query;
 import org.hibernate.query.spi.QueryImplementor;
 import org.hibernate.search.engine.ProjectionConstants;
 import org.hibernate.search.filter.FullTextFilter;
@@ -29,7 +28,7 @@ import org.hibernate.transform.ResultTransformer;
  * @author Hardy Ferentschik
  * @author Emmanuel Bernard
  */
-public interface FullTextQuery<R> extends Query<R>, ProjectionConstants, QueryImplementor<R> {
+public interface FullTextQuery<R> extends ProjectionConstants, QueryImplementor<R> {
 
 	/**
 	 * Allows to let lucene sort the results. This is useful when you have
@@ -151,13 +150,13 @@ public interface FullTextQuery<R> extends Query<R>, ProjectionConstants, QueryIm
 	Explanation explain(int documentId);
 
 	/**
-	 * {@link Query#setFirstResult}
+	 * {@inheritDoc}
 	 */
 	@Override
 	FullTextQuery setFirstResult(int firstResult);
 
 	/**
-	 * {@link Query#setMaxResults}
+	 * {@inheritDoc}
 	 */
 	@Override
 	FullTextQuery setMaxResults(int maxResults);

--- a/orm/src/main/java/org/hibernate/search/impl/FullTextSharedSessionBuilderDelegator.java
+++ b/orm/src/main/java/org/hibernate/search/impl/FullTextSharedSessionBuilderDelegator.java
@@ -7,10 +7,12 @@
 package org.hibernate.search.impl;
 
 import java.sql.Connection;
+import java.util.TimeZone;
 
 import org.hibernate.ConnectionReleaseMode;
 import org.hibernate.FlushMode;
 import org.hibernate.Interceptor;
+import org.hibernate.SessionBuilder;
 import org.hibernate.SessionEventListener;
 import org.hibernate.SharedSessionBuilder;
 import org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode;
@@ -172,4 +174,11 @@ class FullTextSharedSessionBuilderDelegator implements FullTextSharedSessionBuil
 		builder.flushMode( flushMode );
 		return this;
 	}
+
+	@Override
+	public SessionBuilder jdbcTimeZone(TimeZone timeZone) {
+		builder.jdbcTimeZone( timeZone );
+		return this;
+	}
+
 }

--- a/orm/src/main/java/org/hibernate/search/query/hibernate/impl/FullTextQueryImpl.java
+++ b/orm/src/main/java/org/hibernate/search/query/hibernate/impl/FullTextQueryImpl.java
@@ -17,7 +17,6 @@ import org.apache.lucene.search.Sort;
 import org.hibernate.Criteria;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
-import org.hibernate.Query;
 import org.hibernate.QueryTimeoutException;
 import org.hibernate.ScrollMode;
 import org.hibernate.Session;
@@ -390,12 +389,12 @@ public class FullTextQueryImpl<R> extends AbstractProducedQuery<R> implements Fu
 	}
 
 	@Override
-	public Query setEntity(int position, Object val) {
+	public FullTextQuery<R> setEntity(int position, Object val) {
 		throw new UnsupportedOperationException( "setEntity(int,Object) is not implemented in Hibernate Search queries" );
 	}
 
 	@Override
-	public Query setEntity(String name, Object val) {
+	public FullTextQuery<R> setEntity(String name, Object val) {
 		throw new UnsupportedOperationException( "setEntity(String,Object) is not implemented in Hibernate Search queries" );
 	}
 

--- a/orm/src/test/java/org/hibernate/search/test/analyzer/AnalyzerTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/analyzer/AnalyzerTest.java
@@ -125,7 +125,7 @@ public class AnalyzerTest extends SearchTestBase {
 		query = s.createFullTextQuery( luceneQuery, MyEntity.class );
 		assertEquals( 1, query.getResultSize() );
 
-		s.delete( query.uniqueResult() );
+		s.delete( query.getSingleResult() );
 		tx.commit();
 
 		s.close();

--- a/orm/src/test/java/org/hibernate/search/test/util/DdlTransactionIsolatorTestingImpl.java
+++ b/orm/src/test/java/org/hibernate/search/test/util/DdlTransactionIsolatorTestingImpl.java
@@ -1,0 +1,85 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.util;
+
+import java.sql.Connection;
+
+import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
+import org.hibernate.engine.jdbc.spi.JdbcServices;
+import org.hibernate.engine.jdbc.spi.SqlExceptionHelper;
+import org.hibernate.engine.jdbc.spi.SqlStatementLogger;
+import org.hibernate.resource.transaction.backend.jdbc.internal.DdlTransactionIsolatorNonJtaImpl;
+import org.hibernate.service.ServiceRegistry;
+import org.hibernate.tool.schema.internal.exec.JdbcConnectionAccessConnectionProviderImpl;
+import org.hibernate.tool.schema.internal.exec.JdbcConnectionAccessProvidedConnectionImpl;
+import org.hibernate.tool.schema.internal.exec.JdbcContext;
+
+/**
+ * Copied from Hibernate ORM: being originally part of the `org.hibernate.test.util` package,
+ * this is not published in a jar which could be consumed by Hibernate Search.
+ * This copy is not meant to stay here for long.
+ * Original class name: org.hibernate.test.util.DdlTransactionIsolatorTestingImpl
+ *
+ * @author Steve Ebersole
+ */
+final class DdlTransactionIsolatorTestingImpl extends DdlTransactionIsolatorNonJtaImpl {
+	public DdlTransactionIsolatorTestingImpl(ServiceRegistry serviceRegistry, Connection jdbConnection) {
+		this( serviceRegistry, createJdbcConnectionAccess( jdbConnection ) );
+	}
+
+	public static JdbcConnectionAccess createJdbcConnectionAccess(Connection jdbcConnection) {
+		return new JdbcConnectionAccessProvidedConnectionImpl( jdbcConnection );
+	}
+
+	public DdlTransactionIsolatorTestingImpl(ServiceRegistry serviceRegistry, JdbcConnectionAccess jdbcConnectionAccess) {
+		super( createJdbcContext( jdbcConnectionAccess, serviceRegistry ) );
+	}
+
+	public static JdbcContext createJdbcContext(
+			JdbcConnectionAccess jdbcConnectionAccess,
+			ServiceRegistry serviceRegistry) {
+		return new JdbcContext() {
+			final JdbcServices jdbcServices = serviceRegistry.getService( JdbcServices.class );
+
+			@Override
+			public JdbcConnectionAccess getJdbcConnectionAccess() {
+				return jdbcConnectionAccess;
+			}
+
+			@Override
+			public Dialect getDialect() {
+				return jdbcServices.getJdbcEnvironment().getDialect();
+			}
+
+			@Override
+			public SqlStatementLogger getSqlStatementLogger() {
+				return jdbcServices.getSqlStatementLogger();
+			}
+
+			@Override
+			public SqlExceptionHelper getSqlExceptionHelper() {
+				return jdbcServices.getSqlExceptionHelper();
+			}
+
+			@Override
+			public ServiceRegistry getServiceRegistry() {
+				return serviceRegistry;
+			}
+		};
+	}
+
+	public DdlTransactionIsolatorTestingImpl(ServiceRegistry serviceRegistry, ConnectionProvider connectionProvider) {
+		this( serviceRegistry, createJdbcConnectionAccess( connectionProvider ) );
+	}
+
+	private static JdbcConnectionAccess createJdbcConnectionAccess(ConnectionProvider connectionProvider) {
+		return new JdbcConnectionAccessConnectionProviderImpl( connectionProvider );
+	}
+
+}

--- a/orm/src/test/java/org/hibernate/search/test/util/MultitenancyTestHelper.java
+++ b/orm/src/test/java/org/hibernate/search/test/util/MultitenancyTestHelper.java
@@ -21,7 +21,6 @@ import org.hibernate.engine.jdbc.connections.internal.DriverManagerConnectionPro
 import org.hibernate.engine.jdbc.connections.spi.AbstractMultiTenantConnectionProvider;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.engine.jdbc.connections.spi.MultiTenantConnectionProvider;
-import org.hibernate.engine.jdbc.spi.SqlStatementLogger;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.hibernate.testing.boot.JdbcConnectionAccessImpl;
 import org.hibernate.testing.env.ConnectionProviderBuilder;
@@ -29,7 +28,6 @@ import org.hibernate.tool.schema.internal.HibernateSchemaManagementTool;
 import org.hibernate.tool.schema.internal.SchemaCreatorImpl;
 import org.hibernate.tool.schema.internal.SchemaDropperImpl;
 import org.hibernate.tool.schema.internal.exec.GenerationTargetToDatabase;
-import org.hibernate.tool.schema.internal.exec.JdbcConnectionContextNonSharedImpl;
 
 /**
  * Utility to help setting up a test SessionFactory which uses multi-tenancy based
@@ -93,7 +91,7 @@ public class MultitenancyTestHelper implements Closeable {
 	public void exportSchema(ServiceRegistryImplementor serviceRegistry, Metadata metadata, Map<String, Object> settings) {
 		HibernateSchemaManagementTool tool = new HibernateSchemaManagementTool();
 		tool.injectServices( serviceRegistry );
-		final GenerationTargetToDatabase[] databaseTargets = createSchemaTargets();
+		final GenerationTargetToDatabase[] databaseTargets = createSchemaTargets( serviceRegistry );
 		new SchemaDropperImpl( serviceRegistry ).doDrop(
 				metadata,
 				serviceRegistry,
@@ -110,17 +108,14 @@ public class MultitenancyTestHelper implements Closeable {
 			);
 	}
 
-	private GenerationTargetToDatabase[] createSchemaTargets() {
+	private GenerationTargetToDatabase[] createSchemaTargets(ServiceRegistryImplementor serviceRegistry) {
 		GenerationTargetToDatabase[] targets = new GenerationTargetToDatabase[tenantSpecificConnectionProviders.size()];
 		int index = 0;
 		for ( Entry<String, DriverManagerConnectionProviderImpl> e : tenantSpecificConnectionProviders.entrySet() ) {
 			ConnectionProvider connectionProvider = e.getValue();
 			targets[index] = new GenerationTargetToDatabase(
-						new JdbcConnectionContextNonSharedImpl(
-								new JdbcConnectionAccessImpl( connectionProvider ),
-								new SqlStatementLogger( false, false ),
-								true )
-					);
+						new DdlTransactionIsolatorTestingImpl( serviceRegistry,
+								new JdbcConnectionAccessImpl( connectionProvider ) ) );
 			index++;
 		}
 		return targets;

--- a/orm/src/test/resources/hibernate.properties
+++ b/orm/src/test/resources/hibernate.properties
@@ -11,7 +11,7 @@ hibernate.connection.username ${jdbc.user}
 hibernate.connection.password ${jdbc.pass}
 hibernate.connection.isolation ${jdbc.isolation}
 
-hibernate.connection.pool_size 5
+hibernate.connection.pool_size 15
 
 hibernate.show_sql false
 hibernate.format_sql false

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,7 @@
         <jandexVersion>2.0.3.Final</jandexVersion>
         <classMateVersion>1.3.0</classMateVersion>
         <javassistVersion>3.20.0-GA</javassistVersion>
+        <bytebuddyVersion>1.5.4</bytebuddyVersion>
 
         <!-- OSGi ranges for some primary dependencies -->
         <!-- Warning:

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <jgroupsVersion>3.6.10.Final</jgroupsVersion>
 
         <!-- ORM and transitive deps; Make sure to match ORM's set of versions when updating -->
-        <hibernateVersion>5.2.3.Final</hibernateVersion>
+        <hibernateVersion>5.2.6.Final</hibernateVersion>
         <hibernateCommonsAnnotationVersion>5.0.1.Final</hibernateCommonsAnnotationVersion>
         <jandexVersion>2.0.3.Final</jandexVersion>
         <classMateVersion>1.3.0</classMateVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <jgroupsVersion>3.6.10.Final</jgroupsVersion>
 
         <!-- ORM and transitive deps; Make sure to match ORM's set of versions when updating -->
-        <hibernateVersion>5.2.1.Final</hibernateVersion>
+        <hibernateVersion>5.2.3.Final</hibernateVersion>
         <hibernateCommonsAnnotationVersion>5.0.1.Final</hibernateCommonsAnnotationVersion>
         <jandexVersion>2.0.3.Final</jandexVersion>
         <classMateVersion>1.3.0</classMateVersion>


### PR DESCRIPTION
This is for 5.7 only; we could backport the first two commits (HSEARCH-2549, HSEARCH-2550).

 - https://hibernate.atlassian.net/browse/HSEARCH-2380
 - https://hibernate.atlassian.net/browse/HSEARCH-2549
 - https://hibernate.atlassian.net/browse/HSEARCH-2550

Related:
 - https://hibernate.atlassian.net/browse/HHH-11309
