### PR TITLE
HSEARCH-2547 Nesting @IndexedEmbeddeds with "includePaths" results in invalid path restrictions

### DIFF
--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
@@ -237,7 +237,7 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 			);
 		}
 		else {
-			if ( parseContext.includeEmbeddedObjectId() || pathsContext.isIncluded( fieldPath ) ) {
+			if ( parseContext.includeEmbeddedObjectId() || pathsContext != null && pathsContext.isIncluded( fieldPath ) ) {
 				createPropertyMetadataForEmbeddedId( member, typeMetadataBuilder, propertyMetadataBuilder,
 						numericFields, configContext, parseContext, fieldPath );
 			}
@@ -1917,8 +1917,14 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 
 	private PathsContext updatePaths(String localPrefix, PathsContext pathsContext, IndexedEmbedded indexedEmbeddedAnnotation) {
 		if ( pathsContext != null ) {
+			// There is an upper-level path restriction: let it override any nested restriction
 			return pathsContext;
 		}
+		else if ( indexedEmbeddedAnnotation.includePaths().length == 0 ) {
+			// No upper-level restriction and no restriction on this level, either
+			return null;
+		}
+
 		PathsContext newPathsContext = new PathsContext();
 		for ( String path : indexedEmbeddedAnnotation.includePaths() ) {
 			newPathsContext.addIncludedPath( localPrefix + path );

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
@@ -1861,7 +1861,24 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 		parseContext.setMaxLevel( oldMaxLevel ); //set back the old max level
 
 		if ( pathsCreatedAtThisLevel ) {
+			/*
+			 * Validate that paths mentioned in IndexedEmbedded.includePaths, if any,
+			 * were actually encountered.
+			 * Only do this at the top level, so that we report all missing paths
+			 * when an error occurs (not just the ones for some lower level).
+			 */
 			validateAllPathsEncountered( member, updatedPathsContext, indexedEmbeddedAnnotation );
+		}
+		else if ( pathsContext != null && pathsContext != updatedPathsContext ) {
+			/*
+			 * If the paths were already constrained at an upper level,
+			 * and if we use a different pathsContext, make sure to
+			 * update the parent pathsContext so that encountered paths
+			 * can be validated (see above).
+			 */
+			for ( String path : updatedPathsContext.getEncounteredPaths() ) {
+				pathsContext.markEncounteredPath( path );
+			}
 		}
 	}
 
@@ -1916,18 +1933,21 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 	}
 
 	private PathsContext updatePaths(String localPrefix, PathsContext pathsContext, IndexedEmbedded indexedEmbeddedAnnotation) {
-		if ( pathsContext != null ) {
-			// There is an upper-level path restriction: let it override any nested restriction
+		if ( indexedEmbeddedAnnotation.includePaths().length == 0 ) {
+			// No restriction at this level: use upper-level restrictions (if any)
 			return pathsContext;
-		}
-		else if ( indexedEmbeddedAnnotation.includePaths().length == 0 ) {
-			// No upper-level restriction and no restriction on this level, either
-			return null;
 		}
 
 		PathsContext newPathsContext = new PathsContext();
 		for ( String path : indexedEmbeddedAnnotation.includePaths() ) {
-			newPathsContext.addIncludedPath( localPrefix + path );
+			String fullPath = localPrefix + path;
+			/*
+			 * If there is an upper-level path restriction, only include those paths
+			 * that match both restrictions
+			 */
+			if ( pathsContext == null || pathsContext.isIncluded( fullPath ) ) {
+				newPathsContext.addIncludedPath( fullPath );
+			}
 		}
 		return newPathsContext;
 	}

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/PathsContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/PathsContext.java
@@ -24,12 +24,20 @@ public class PathsContext {
 		pathsEncounteredState.put( path, Boolean.FALSE );
 	}
 
+	public boolean isIncluded(String path) {
+		return pathsEncounteredState.keySet().contains( path );
+	}
+
 	public boolean isIncluded(DocumentFieldPath path) {
-		return pathsEncounteredState.keySet().contains( path.getAbsoluteName() );
+		return isIncluded( path.getAbsoluteName() );
+	}
+
+	public void markEncounteredPath(String path) {
+		pathsEncounteredState.put( path, Boolean.TRUE );
 	}
 
 	public void markEncounteredPath(DocumentFieldPath path) {
-		pathsEncounteredState.put( path.getAbsoluteName(), Boolean.TRUE );
+		markEncounteredPath( path.getAbsoluteName() );
 	}
 
 	public Set<String> getEncounteredPaths() {

--- a/engine/src/test/java/org/hibernate/search/test/configuration/indexedembedded/IndexedEmbeddedWithBroaderIncludePathsTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/configuration/indexedembedded/IndexedEmbeddedWithBroaderIncludePathsTest.java
@@ -1,0 +1,79 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.configuration.indexedembedded;
+
+import org.hibernate.search.annotations.Analyze;
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.IndexedEmbedded;
+import org.hibernate.search.exception.SearchException;
+import org.hibernate.search.spi.SearchIntegrator;
+import org.hibernate.search.spi.SearchIntegratorBuilder;
+import org.hibernate.search.testsupport.TestForIssue;
+import org.hibernate.search.testsupport.setup.SearchConfigurationForTest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * @author Yoann Rodiere
+ */
+@TestForIssue(jiraKey = "HSEARCH-2547")
+public class IndexedEmbeddedWithBroaderIncludePathsTest {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void testBroaderIncludePathsDisallowed() {
+		thrown.expect( SearchException.class );
+		thrown.expectMessage( "HSEARCH000216" );
+		thrown.expectMessage( C.class.getName() );
+		thrown.expectMessage( "b.a.bar" );
+
+		SearchConfigurationForTest configuration = new SearchConfigurationForTest()
+				.addClass( A.class )
+				.addClass( B.class )
+				.addClass( C.class );
+
+		SearchIntegrator searchIntegrator = new SearchIntegratorBuilder().configuration( configuration ).buildSearchIntegrator();
+		searchIntegrator.close();
+	}
+
+	@Indexed
+	private static class A {
+		@DocumentId
+		private Long id;
+
+		@Field(analyze = Analyze.NO)
+		private String foo;
+
+		@Field(analyze = Analyze.NO)
+		private String bar;
+	}
+
+	@Indexed
+	private static class B {
+		@DocumentId
+		private Long id;
+
+		@IndexedEmbedded(includePaths = "foo") // Include only "a.foo"
+		private A a;
+	}
+
+	@Indexed
+	private static class C {
+		@DocumentId
+		private Long id;
+
+		@IndexedEmbedded(includePaths = { "a.foo", "a.bar" }) // Try to include "b.a.bar": this should not work, since "a.bar" is not included in b
+		private B b;
+	}
+}
+
+

--- a/orm/src/test/java/org/hibernate/search/test/embedded/path/DefaultPathsWithNestedIndexedEmbeddedTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/embedded/path/DefaultPathsWithNestedIndexedEmbeddedTest.java
@@ -1,0 +1,105 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.embedded.path;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.Search;
+import org.hibernate.search.annotations.Analyze;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.IndexedEmbedded;
+import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.testsupport.TestForIssue;
+import org.junit.Test;
+
+
+/**
+ * Test the behavior when an {@literal @IndexedEmbedded} with default paths (i.e. "include everything")
+ * has another, nested {@literal @IndexedEmbedded} with non-default paths (i.e. "include those paths only").
+ *
+ * @author Yoann Rodiere
+ */
+@TestForIssue(jiraKey = "HSEARCH-2547")
+public class DefaultPathsWithNestedIndexedEmbeddedTest extends SearchTestBase {
+
+	@Override
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class<?>[] { A.class, B.class, C.class };
+	}
+
+	@Test
+	public void testIndexAndSearch() {
+		try (Session session = openSession()) {
+			FullTextSession fts = Search.getFullTextSession( session );
+
+			Transaction tx = fts.beginTransaction();
+			A a = new A();
+			a.foo = "someValue";
+			B b = new B();
+			b.a = a;
+			C c = new C();
+			c.b = b;
+			fts.persist( a );
+			fts.persist( b );
+			fts.persist( c );
+			tx.commit();
+			fts.clear();
+
+			tx = fts.beginTransaction();
+			Query query = new TermQuery( new Term( "b.a.foo", a.foo ) );
+			assertEquals( 1, fts.createFullTextQuery( query, C.class ).getResultSize() );
+			tx.commit();
+			fts.clear();
+		}
+	}
+
+	@Entity
+	@Indexed
+	private static class A {
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		@Field(analyze = Analyze.NO)
+		private String foo;
+	}
+
+	@Entity
+	private static class B {
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		@OneToOne
+		@IndexedEmbedded(includePaths = "foo") // Include only "a.foo"
+		private A a;
+	}
+
+	@Entity
+	@Indexed
+	private static class C {
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		@OneToOne
+		@IndexedEmbedded // Include every field of "b"
+		private B b;
+	}
+}

--- a/orm/src/test/java/org/hibernate/search/test/embedded/path/Human.java
+++ b/orm/src/test/java/org/hibernate/search/test/embedded/path/Human.java
@@ -89,7 +89,7 @@ public class Human {
 	}
 
 	@OneToMany
-	@IndexedEmbedded(depth = 2, includePaths = { "parents.parents.name" })
+	@IndexedEmbedded(depth = 2, includePaths = { "name", "parents.name", "parents.parents.name" })
 	public Set<Human> getParents() {
 		return parents;
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2547

So... I think the first two commits should not raise many objections, since it's basically about allowing users to do something that previously failed miserably for no apparent reason.

The two last commits, on the other hand, will probably be less consensual.
Basically, we used to allow an `@IndexedEmbedded` on a property `b` of type `B` to include paths that were not included in type `B`. See the test for an example.
I think this should be forbidden, mainly because it feels like a violation of encapsulation to me, but also because the current behavior of `@ContainedIn` will not work well with such setups.


You'll note I had to fix a test to make it pass after my "fix", so breakage for existing users is to be expected.
Maybe we should fix this in 6.0, and not take the risk to break existing users?