### PR TITLE
HSEARCH-2552 @IndexedEmbedded.includePaths allows to pick paths that were excluded from the embedded entity

### DIFF
--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
@@ -1861,7 +1861,24 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 		parseContext.setMaxLevel( oldMaxLevel ); //set back the old max level
 
 		if ( pathsCreatedAtThisLevel ) {
+			/*
+			 * Validate that paths mentioned in IndexedEmbedded.includePaths, if any,
+			 * were actually encountered.
+			 * Only do this at the top level, so that we report all missing paths
+			 * when an error occurs (not just the ones for some lower level).
+			 */
 			validateAllPathsEncountered( member, updatedPathsContext, indexedEmbeddedAnnotation );
+		}
+		else if ( pathsContext != null && pathsContext != updatedPathsContext ) {
+			/*
+			 * If the paths were already constrained at an upper level,
+			 * and if we use a different pathsContext, make sure to
+			 * update the parent pathsContext so that encountered paths
+			 * can be validated (see above).
+			 */
+			for ( String path : updatedPathsContext.getEncounteredPaths() ) {
+				pathsContext.markEncounteredPath( path );
+			}
 		}
 	}
 
@@ -1916,18 +1933,21 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 	}
 
 	private PathsContext updatePaths(String localPrefix, PathsContext pathsContext, IndexedEmbedded indexedEmbeddedAnnotation) {
-		if ( pathsContext != null ) {
-			// There is an upper-level path restriction: let it override any nested restriction
+		if ( indexedEmbeddedAnnotation.includePaths().length == 0 ) {
+			// No restriction at this level: use upper-level restrictions (if any)
 			return pathsContext;
-		}
-		else if ( indexedEmbeddedAnnotation.includePaths().length == 0 ) {
-			// No upper-level restriction and no restriction on this level, either
-			return null;
 		}
 
 		PathsContext newPathsContext = new PathsContext();
 		for ( String path : indexedEmbeddedAnnotation.includePaths() ) {
-			newPathsContext.addIncludedPath( localPrefix + path );
+			String fullPath = localPrefix + path;
+			/*
+			 * If there is an upper-level path restriction, only include those paths
+			 * that match both restrictions
+			 */
+			if ( pathsContext == null || pathsContext.isIncluded( fullPath ) ) {
+				newPathsContext.addIncludedPath( fullPath );
+			}
 		}
 		return newPathsContext;
 	}

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/PathsContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/PathsContext.java
@@ -24,12 +24,20 @@ public class PathsContext {
 		pathsEncounteredState.put( path, Boolean.FALSE );
 	}
 
+	public boolean isIncluded(String path) {
+		return pathsEncounteredState.keySet().contains( path );
+	}
+
 	public boolean isIncluded(DocumentFieldPath path) {
-		return pathsEncounteredState.keySet().contains( path.getAbsoluteName() );
+		return isIncluded( path.getAbsoluteName() );
+	}
+
+	public void markEncounteredPath(String path) {
+		pathsEncounteredState.put( path, Boolean.TRUE );
 	}
 
 	public void markEncounteredPath(DocumentFieldPath path) {
-		pathsEncounteredState.put( path.getAbsoluteName(), Boolean.TRUE );
+		markEncounteredPath( path.getAbsoluteName() );
 	}
 
 	public Set<String> getEncounteredPaths() {

--- a/engine/src/test/java/org/hibernate/search/test/configuration/indexedembedded/IndexedEmbeddedWithBroaderIncludePathsTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/configuration/indexedembedded/IndexedEmbeddedWithBroaderIncludePathsTest.java
@@ -1,0 +1,79 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.configuration.indexedembedded;
+
+import org.hibernate.search.annotations.Analyze;
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.IndexedEmbedded;
+import org.hibernate.search.exception.SearchException;
+import org.hibernate.search.spi.SearchIntegrator;
+import org.hibernate.search.spi.SearchIntegratorBuilder;
+import org.hibernate.search.testsupport.TestForIssue;
+import org.hibernate.search.testsupport.setup.SearchConfigurationForTest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * @author Yoann Rodiere
+ */
+@TestForIssue(jiraKey = "HSEARCH-2547")
+public class IndexedEmbeddedWithBroaderIncludePathsTest {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void testBroaderIncludePathsDisallowed() {
+		thrown.expect( SearchException.class );
+		thrown.expectMessage( "HSEARCH000216" );
+		thrown.expectMessage( C.class.getName() );
+		thrown.expectMessage( "b.a.bar" );
+
+		SearchConfigurationForTest configuration = new SearchConfigurationForTest()
+				.addClass( A.class )
+				.addClass( B.class )
+				.addClass( C.class );
+
+		SearchIntegrator searchIntegrator = new SearchIntegratorBuilder().configuration( configuration ).buildSearchIntegrator();
+		searchIntegrator.close();
+	}
+
+	@Indexed
+	private static class A {
+		@DocumentId
+		private Long id;
+
+		@Field(analyze = Analyze.NO)
+		private String foo;
+
+		@Field(analyze = Analyze.NO)
+		private String bar;
+	}
+
+	@Indexed
+	private static class B {
+		@DocumentId
+		private Long id;
+
+		@IndexedEmbedded(includePaths = "foo") // Include only "a.foo"
+		private A a;
+	}
+
+	@Indexed
+	private static class C {
+		@DocumentId
+		private Long id;
+
+		@IndexedEmbedded(includePaths = { "a.foo", "a.bar" }) // Try to include "b.a.bar": this should not work, since "a.bar" is not included in b
+		private B b;
+	}
+}
+
+

--- a/orm/src/test/java/org/hibernate/search/test/embedded/path/Human.java
+++ b/orm/src/test/java/org/hibernate/search/test/embedded/path/Human.java
@@ -89,7 +89,7 @@ public class Human {
 	}
 
 	@OneToMany
-	@IndexedEmbedded(depth = 2, includePaths = { "parents.parents.name" })
+	@IndexedEmbedded(depth = 2, includePaths = { "name", "parents.name", "parents.parents.name" })
 	public Set<Human> getParents() {
 		return parents;
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2552

Please do not merge yet, we'll probably have to wait until 6.0 because this changes the behavior of `@IndexedEmbedded`.
Submitting this PR anyway so that we don't lose the commits.