### PR TITLE
[WIP] HSEARCH-2358 Use field storage instead of source document for projections

### DIFF
--- a/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
+++ b/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
@@ -671,10 +671,7 @@ List results = query.list();
 
 ==== Projections
 
-All fields are stored by Elasticsearch in the JSON document it indexes,
-there is no specific need to mark fields as stored when you want to project them.
-The downside is that to project a field, Elasticsearch needs to read the whole JSON document.
-If you want to avoid that, use the `Store.YES` marker.
+As with Lucene, fields must be marked as stored (`store = Store.YES`) in order to be able to project them.
 
 You can also retrieve the full JSON document by using `org.hibernate.search.elasticsearch.ElasticsearchProjectionConstants.SOURCE`.
 

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchHSQueryImpl.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchHSQueryImpl.java
@@ -544,6 +544,10 @@ public class ElasticsearchHSQueryImpl extends AbstractHSQuery {
 			FieldBridge fieldBridge = fieldMetadata.getFieldBridge();
 			ExtendedFieldType type = FieldHelper.getType( fieldMetadata );
 
+			if ( !org.hibernate.search.annotations.Store.YES.equals( fieldMetadata.getStore() ) ) {
+				throw LOG.projectingNonStoredField( absoluteName );
+			}
+
 			if ( ExtendedFieldType.BOOLEAN.equals( type ) ) {
 				sourceFilterCollector.add( new JsonPrimitive( absoluteName ) );
 

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchHSQueryImpl.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchHSQueryImpl.java
@@ -583,6 +583,10 @@ public class ElasticsearchHSQueryImpl extends AbstractHSQuery {
 			String absoluteName = bridgeDefinedField.getAbsoluteName();
 			ExtendedFieldType type = FieldHelper.getType( bridgeDefinedField );
 
+			if ( !org.hibernate.search.annotations.Store.YES.equals( bridgeDefinedField.getSourceField().getStore() ) ) {
+				throw LOG.projectingNonStoredField( absoluteName );
+			}
+
 			sourceFilterCollector.add( new JsonPrimitive( absoluteName ) );
 
 			return new PrimitiveProjection( rootTypeMetadata, absoluteName, type );

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/schema/impl/Elasticsearch2SchemaTranslator.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/schema/impl/Elasticsearch2SchemaTranslator.java
@@ -148,7 +148,7 @@ public class Elasticsearch2SchemaTranslator implements ElasticsearchSchemaTransl
 		addTypeOptions( propertyMapping, fieldMetadata );
 
 		if ( propertyMapping.getType() != DataType.OBJECT ) {
-			propertyMapping.setStore( fieldMetadata.getStore() == Store.NO ? false : true );
+			propertyMapping.setStore( fieldMetadata.getStore() != Store.NO );
 		}
 
 		addIndexOptions( propertyMapping, mappingBuilder, settingsBuilder,
@@ -192,12 +192,16 @@ public class Elasticsearch2SchemaTranslator implements ElasticsearchSchemaTransl
 	private void addPropertyMapping(ElasticsearchMappingBuilder mappingBuilder, ElasticsearchIndexSettingsBuilder settingsBuilder,
 			BridgeDefinedField bridgeDefinedField) {
 		String propertyPath = bridgeDefinedField.getAbsoluteName();
+		DocumentFieldMetadata sourceFieldMetadata = bridgeDefinedField.getSourceField();
+
+		PropertyMapping propertyMapping = new PropertyMapping();
+
+		propertyMapping.setStore( sourceFieldMetadata.getStore() != Store.NO );
 
 		if ( !SpatialHelper.isSpatialField( propertyPath ) ) {
 			// we don't overwrite already defined fields. Typically, in the case of spatial, the geo_point field
 			// is defined before the double field and we want to keep the geo_point one
 			if ( !mappingBuilder.hasPropertyAbsolute( propertyPath ) ) {
-				PropertyMapping propertyMapping = new PropertyMapping();
 				addTypeOptions( propertyMapping, bridgeDefinedField );
 				addIndexOptions( propertyMapping, mappingBuilder, settingsBuilder,
 						bridgeDefinedField.getSourceField().getSourceProperty(),
@@ -207,8 +211,8 @@ public class Elasticsearch2SchemaTranslator implements ElasticsearchSchemaTransl
 				mappingBuilder.setPropertyAbsolute( propertyPath, propertyMapping );
 			}
 			else {
-				TypeMapping propertyMapping = mappingBuilder.getPropertyAbsolute( propertyPath );
-				addDynamicOption( bridgeDefinedField, propertyMapping );
+				TypeMapping existingPropertyMapping = mappingBuilder.getPropertyAbsolute( propertyPath );
+				addDynamicOption( bridgeDefinedField, existingPropertyMapping );
 			}
 		}
 		else {
@@ -218,8 +222,6 @@ public class Elasticsearch2SchemaTranslator implements ElasticsearchSchemaTransl
 			}
 			else if ( SpatialHelper.isSpatialFieldLatitude( propertyPath ) ) {
 				// we only add the geo_point for the latitude field
-				PropertyMapping propertyMapping = new PropertyMapping();
-
 				propertyMapping.setType( DataType.GEO_POINT );
 
 				// in this case, the spatial field has precedence over an already defined field
@@ -227,7 +229,6 @@ public class Elasticsearch2SchemaTranslator implements ElasticsearchSchemaTransl
 			}
 			else {
 				// the fields potentially created for the spatial hash queries
-				PropertyMapping propertyMapping = new PropertyMapping();
 				propertyMapping.setType( DataType.STRING );
 				propertyMapping.setIndex( IndexType.NOT_ANALYZED );
 

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchClassBridgeIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchClassBridgeIT.java
@@ -129,13 +129,13 @@ public class ElasticsearchClassBridgeIT extends SearchTestBase {
 
 		QueryDescriptor query = ElasticsearchQueries.fromQueryString( "Hergesheimer" );
 		List<?> result = session.createFullTextQuery( query, GolfPlayer.class )
-				.setProjection( "fullNameStored" )
+				.setProjection( "fullNameNotIndexed" )
 				.list();
 
 		assertThat( result ).hasSize( 1 );
 
 		Object[] projection = (Object[]) result.iterator().next();
-		assertThat( projection[0] ).describedAs( "fullNameStored" ).isEqualTo( "Klaus Hergesheimer" );
+		assertThat( projection[0] ).describedAs( "fullNameNotIndexed" ).isEqualTo( "Klaus Hergesheimer" );
 
 		tx.commit();
 		s.close();

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIndexMappingIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIndexMappingIT.java
@@ -135,34 +135,41 @@ public class ElasticsearchIndexMappingIT extends SearchTestBase {
 					"'properties':{" +
 						"'active':{" +
 							"'type':'boolean'," +
+							"'store':true," +
 							"'null_value':false" +
 						"}," +
 						"'age':{" +
-							"'type':'integer'" +
+							"'type':'integer'," +
+							"'store':true" +
 						"}," +
 						"'dateOfBirth':{" +
 							"'type':'date'," +
 							"'format':'strict_date_optional_time||epoch_millis'," +
-							"'null_value': '" + toElasticsearchDateHelperDateString("1970-01-01+00:00") + "'" +
+							"'store':true," +
+							"'null_value':'" + toElasticsearchDateHelperDateString("1970-01-01+00:00") + "'" +
 						"}," +
 						"'driveWidth':{" +
 							"'type':'integer'," +
+							"'store':true," +
 							"'null_value':-1" +
 						"}," +
 						"'firstName':{" +
 							"'type':'string'," +
+							"'store':true," +
 							"'null_value':'<NULL>'" +
 						"}," +
 						"'fullName':{" +
-							"'type':'string'" +
+							"'type':'string'," +
+							"'store':true" +
 						"}," +
-						"'fullNameStored':{" +
+						"'fullNameNotIndexed':{" +
 							"'type':'string'," +
 							"'index':'no'," +
 							"'store':true" +
 						"}," +
 						"'handicap':{" +
-							"'type':'double'" +
+							"'type':'double'," +
+							"'store':true" +
 						"}," +
 						"'id':{" +
 							"'type':'string'," +
@@ -170,7 +177,8 @@ public class ElasticsearchIndexMappingIT extends SearchTestBase {
 							"'store':true" +
 						"}," +
 						"'lastName':{" +
-							"'type':'string'" +
+							"'type':'string'," +
+							"'store':true" +
 						"}," +
 						"'playedCourses':{" +
 							"'properties':{" +
@@ -193,12 +201,14 @@ public class ElasticsearchIndexMappingIT extends SearchTestBase {
 							"}" +
 						"}," +
 						"'puttingStrength':{" +
-							"'type':'string'" +
+							"'type':'string'," +
+							"'store':true" +
 						"}," +
 						"'ranking':{" +
 							"'properties':{" +
 									"'value':{" +
-										"'type':'string'" +
+										"'type':'string'," +
+										"'store':true" +
 									"}" +
 							"}" +
 						"}," +
@@ -208,7 +218,8 @@ public class ElasticsearchIndexMappingIT extends SearchTestBase {
 						"'subscriptionEndDate':{" +
 							"'type':'date'," +
 							"'format':'strict_date_optional_time||epoch_millis'," +
-							"'null_value': '" + toElasticsearchDateHelperDateString("1970-01-01+00:00") + "'" +
+							"'store':true," +
+							"'null_value':'" + toElasticsearchDateHelperDateString("1970-01-01+00:00") + "'" +
 						"}," +
 						"'won_holes':{" +
 							"'properties':{" +
@@ -443,7 +454,7 @@ public class ElasticsearchIndexMappingIT extends SearchTestBase {
 					"\"puttingStrength\": \"0.0\"," + // not nullable
 					"\"lastName\": \"Kidd\"," +
 					"\"fullName\": \"Kidd\"," +
-					"\"fullNameStored\": \"Kidd\"" +
+					"\"fullNameNotIndexed\": \"Kidd\"" +
 					// ranking.value is null but indexNullAs() has not been given, so it's
 					// not present in the index at all
 					// "\"ranking\": {" +

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/GolfPlayer.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/GolfPlayer.java
@@ -39,9 +39,9 @@ import org.hibernate.search.bridge.builtin.DoubleBridge;
  */
 @Entity
 @Indexed(index = "golfplayer")
-@ClassBridge(name = "fullName", impl = NameConcatenationBridge.class)
+@ClassBridge(name = "fullName", store = Store.YES, impl = NameConcatenationBridge.class)
 @ClassBridge(name = "fullNameStored", index = Index.NO, store = Store.YES, impl = NameConcatenationBridge.class)
-@ClassBridge(name = "age", impl = AgeBridge.class)
+@ClassBridge(name = "age", store = Store.YES, impl = AgeBridge.class)
 public class GolfPlayer {
 
 	@Id
@@ -54,30 +54,30 @@ public class GolfPlayer {
 	@DocumentId
 	private Long id;
 
-	@Field(indexNullAs = "<NULL>")
+	@Field(indexNullAs = "<NULL>", store = Store.YES)
 	private String firstName;
 
-	@Field
+	@Field(store = Store.YES)
 	private String lastName;
 
-	@Field(indexNullAs = "false")
+	@Field(indexNullAs = "false", store = Store.YES)
 	private Boolean active;
 
-	@Field(indexNullAs = "1970-01-01+00:00")
+	@Field(indexNullAs = "1970-01-01+00:00", store = Store.YES)
 	@DateBridge(resolution = Resolution.DAY)
 	private Date dateOfBirth;
 
-	@Field(indexNullAs = "1970-01-01+00:00")
+	@Field(indexNullAs = "1970-01-01+00:00", store = Store.YES)
 	@CalendarBridge(resolution = Resolution.DAY)
 	private Calendar subscriptionEndDate;
 
-	@Field
+	@Field(store = Store.YES)
 	private double handicap;
 
-	@Field(bridge = @FieldBridge(impl = DoubleBridge.class))
+	@Field(bridge = @FieldBridge(impl = DoubleBridge.class), store = Store.YES)
 	private double puttingStrength;
 
-	@Field(indexNullAs = "-1")
+	@Field(indexNullAs = "-1", store = Store.YES)
 	private Integer driveWidth;
 
 	@IndexedEmbedded

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/Ranking.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/Ranking.java
@@ -11,6 +11,7 @@ import java.math.BigInteger;
 import javax.persistence.Embeddable;
 
 import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Store;
 
 /**
  * @author Gunnar Morling
@@ -18,7 +19,7 @@ import org.hibernate.search.annotations.Field;
 @Embeddable
 public class Ranking {
 
-	@Field
+	@Field(store = Store.YES)
 	private BigInteger value;
 
 	Ranking() {

--- a/orm/src/test/java/org/hibernate/search/test/query/ProjectionQueryTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/ProjectionQueryTest.java
@@ -41,9 +41,7 @@ import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.testsupport.TestConstants;
 import org.hibernate.search.testsupport.TestForIssue;
-import org.hibernate.search.testsupport.junit.ElasticsearchSupportInProgress;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
 /**
  * Tests several aspects of projection queries.
@@ -572,7 +570,6 @@ public class ProjectionQueryTest extends SearchTestBase {
 	}
 
 	@Test(expected = SearchException.class)
-	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2423 Projecting an unstored field should raise an exception
 	public void testProjectionOnUnstoredField() throws Exception {
 		FullTextSession s = Search.getFullTextSession( openSession() );
 		Transaction tx = s.beginTransaction();


### PR DESCRIPTION
**This is work in progress**, and the tests currently fail. I'm just opening this PR for discussion.

Relevant tickets:

 * https://hibernate.atlassian.net/browse/HSEARCH-2423
 * https://hibernate.atlassian.net/browse/HSEARCH-2358

So, here we change how projections work with Elasticsearch by using Elasticsearch's [field storage](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/search-request-fields.html) feature instead of [source documents](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/search-request-source-filtering.html) as a data source.
Those features are quite similar, with the main difference being the field storage is configurable per property in the mapping, while source document storage is configurable per index only (or maybe only globally).
Presumably, the data structures behind field storage may be a bit more advanced and efficient, since they are probably strongly typed, but I haven't checked that.

Anyway... as shown on [this build](https://travis-ci.org/yrodiere/hibernate-search/builds/193696440), switching to field storage brings a few challenges:

 * Elasticsearch doesn't store time zone information for dates, so we lose some information when storing/retrieving some types of fields, such as `Calendar` or `ZonedDateTime`. This could be solved by adding bridge-defined fields containing only the time zone/offset for such types.
  See how `ElasticsearchDateCalendarBridgeIT` or `JavaTimeTest.testZonedDateTime` fail, for instance.
 * We use the `indexNullAs` feature in Hibernate Search to populate the `null_value` attribute in the ES mapping, which has the effect of making documents with a null in a field match some search queries on this field, by assuming that null is in fact some pre-defined value.
  Unfortunately, this pre-defined value is also returned for null fields when retrieving the stored value. So `ElasticsearchIndexNullAsIT` now fail, because when we store `null`, we expect to retrieve `null` when projecting, but we get the `indexNullAs` instead.
  See how `ElasticsearchIndexNullAsIT` fails, for instance.
 * Elasticsearch seems to store timestamps with millisecond resolution, while date/time objects in Java 8 have nanosecond resolution.
  See how `JavaTimeTest.testLocalTime` fails, for instance.
 * For some reasons spatial projections seem to fail with this patch, but I'm fairly confident it's related to my changes and not to Elasticsearch. I'll look into it if we decide to go this way.
  See how `SpatialIndexingTest` fails, for instance.