### PR TITLE
HSEARCH-2568 Do no check that the index exists with the NONE schema management strategy

### DIFF
--- a/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
+++ b/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
@@ -118,7 +118,7 @@ Let's see the options for the `index_schema_management_strategy` property:
 |===============
 |Value|Definition
 |`NONE`|Indexes, their mappings and their analyzer definitions will not be created, deleted nor altered.
-Hibernate Search will only check that the indexes already exist.
+Hibernate Search will **not even check** that the indexes already exist.
 |`VALIDATE`|Existing indexes, mappings and analyzer definitions will be checked for conflicts with Hibernate Search's metamodel.
 Indexes, their mappings and their analyzer definitions will not be created, deleted nor altered.
 |`MERGE`|Missing indexes, mappings and analyzer definitions will be created, existing mappings will be updated if there are no conflicts.
@@ -164,6 +164,8 @@ Time interval between two executions of the automatic discovery (in seconds):: `
 +
 This setting will only be taken into account if automatic discovery is enabled (see above).
 Maximum time to wait for the indexes to become available before failing (in ms):: `hibernate.search.default.elasticsearch.index_management_wait_timeout 10000` (default)
++
+This setting is ignored when the `NONE` strategy is selected, since the index will not be checked on startup (see above).
 +
 This value must be lower than the read timeout (see above).
 Status an index must at least have in order for Hibernate Search to work with it (one of "green", "yellow" or "red")::

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/IndexSchemaManagementStrategy.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/IndexSchemaManagementStrategy.java
@@ -14,7 +14,8 @@ package org.hibernate.search.elasticsearch.cfg;
 public enum IndexSchemaManagementStrategy {
 
 	/**
-	 * Indexes will never be created or deleted. Hibernate Search will only check that the index actually exists.
+	 * Indexes will never be created or deleted.
+	 * <p>Hibernate Search will not even check that the index actually exists.
 	 * <p>The index schema (mapping and analyzer definitions) is not managed by Hibernate Search and is not checked.
 	 */
 	NONE,

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchIndexManager.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchIndexManager.java
@@ -273,7 +273,6 @@ public class ElasticsearchIndexManager implements IndexManager, IndexNameNormali
 	 */
 	private boolean initializeIndex(Set<Class<?>> entityTypesToInitialize) {
 		if ( schemaManagementStrategy == IndexSchemaManagementStrategy.NONE ) {
-			schemaCreator.checkIndexExists( actualIndexName, schemaManagementExecutionOptions );
 			return false;
 		}
 

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIndexExistsCheckIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIndexExistsCheckIT.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.elasticsearch.test;
 
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -43,8 +44,9 @@ import org.junit.runners.Parameterized.Parameters;
 public class ElasticsearchIndexExistsCheckIT extends SearchInitializationTestBase {
 
 	@Parameters(name = "With strategy {0}")
-	public static IndexSchemaManagementStrategy[] strategies() {
-		return IndexSchemaManagementStrategy.values();
+	public static Iterable<IndexSchemaManagementStrategy> strategies() {
+		// The "NONE" strategy never checks that the index exists.
+		return EnumSet.complementOf( EnumSet.of( IndexSchemaManagementStrategy.NONE ) );
 	}
 
 	@Rule


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2568

To be discussed, but it feels a bit strange that the `NONE` strategy does in fact do something (check if the index exists). This PR reverts the `NONE` strategy to the pre-HSEARCH-2456 behavior of not doing anything, not even checking whether the index exists.

I'm not sure we should backport this to 5.6, though, since it's a behavior change.