### PR TITLE
HSEARCH-2569 Make the 'delete-by-query' plugin requirement for ES clearer

### DIFF
--- a/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
+++ b/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
@@ -96,10 +96,25 @@ you will need the new `hibernate-search-elasticsearch` jar.
 ----
 ====
 
-==== [[elasticsearch-integration-configuration]] Configuration
+==== [[elasticsearch-integration-server-configuration]] Elasticsearch configuration
+
+Hibernate Search can work with an Elasticsearch server without altering its configuration.
+
+However some features offered by Hibernate Search require specific configuration:
+
+* if you want to be able to use the Hibernate Search <<search-batchindex-massindexer,MassIndexer>> with `purgeAllOnStart` enabled,
+  or to use `FullTextSession.purge()` or `FullTextSession.purgeAll()`,
+  install the link:https://www.elastic.co/guide/en/elasticsearch/plugins/current/plugins-delete-by-query.html[`delete-by-query` plugin]
+* if you want to retrieve the distance in a geolocation query, enable the `lang-groovy` plugin,
+  see <<elasticsearch-query-spatial, Elasticsearch Spatial queries>>
+* if you want to use paging (as opposed to <<elasticsearch-scrolling,scrolling>>) on result sets larger than 10000 elements
+(for instance access the 10001st result),
+you may increase the value of the `index.max_result_window` property (default is 10000).
+
+==== [[elasticsearch-integration-configuration]] Hibernate Search configuration
 
 Configuration is minimal.
-Add them to your `persistence.xml` or where you put the rest of your Hibernate Search configuration.
+Add the configuration properties to your `persistence.xml` or where you put the rest of your Hibernate Search configuration.
 
 Select Elasticsearch as the backend:: `hibernate.search.default.indexmanager elasticsearch`
 Hostname and port for Elasticsearch:: `hibernate.search.default.elasticsearch.host \http://127.0.0.1:9200` (default)
@@ -194,18 +209,6 @@ Properties prefixed with `hibernate.search.default` can be given globally as sho
 This excludes properties related to the internal Elasticsearch client, which at the moment is common to every index manager (but this will change in a future version).
 Excluded properties are `host`, `read_timeout`, `connection_timeout`, `max_total_connection`, `max_total_connection_per_route`, `discovery.enabled` and `discovery.refresh_interval`.
 --
-
-===== Elasticsearch configuration
-
-There is no specific configuration required on the Elasticsearch side.
-
-However there are a few features that would benefit from a few changes:
-
-* if you want to retrieve the distance in a geolocation query, enable the `lang-groovy` plugin,
-  see <<elasticsearch-query-spatial, Elasticsearch Spatial queries>>
-* if you want to be able to use the `purgeAll` Hibernate Search command,
-  install the link:https://www.elastic.co/guide/en/elasticsearch/plugins/current/plugins-delete-by-query.html[`delete-by-query`] plugin
-* if you want to use paging (as opposed to <<elasticsearch-scrolling,scrolling>>) on result sets larger than 10000 elements (for instance access the 10001st result), you may increase the value of the `index.max_result_window` property (default is 10000).
 
 === Mapping and indexing
 

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/BackendRequest.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/BackendRequest.java
@@ -6,10 +6,6 @@
  */
 package org.hibernate.search.elasticsearch.client.impl;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
 
@@ -26,41 +22,24 @@ import io.searchbox.client.JestResult;
 public class BackendRequest<T extends JestResult> {
 
 	private final Action<T> action;
-	private final Set<Integer> ignoredErrorStatuses;
 	private final LuceneWork luceneWork;
 	private final String indexName;
 	private final IndexingMonitor indexingMonitor;
+	private final BackendRequestResultAssessor<? super T> resultAssessor;
 	private final BackendRequestSuccessReporter<? super T> successReporter;
 	private final boolean refreshAfterWrite;
 
 	public BackendRequest(Action<T> action, LuceneWork luceneWork, String indexName,
+			BackendRequestResultAssessor<? super T> resultAssessor,
 			IndexingMonitor indexingMonitor, BackendRequestSuccessReporter<? super T> successReporter,
-			boolean refreshAfterWrite, int... ignoredErrorStatuses) {
+			boolean refreshAfterWrite) {
 		this.action = action;
 		this.luceneWork = luceneWork;
 		this.indexName = indexName;
+		this.resultAssessor = resultAssessor;
 		this.indexingMonitor = indexingMonitor;
 		this.successReporter = successReporter;
 		this.refreshAfterWrite = refreshAfterWrite;
-		this.ignoredErrorStatuses = asSet( ignoredErrorStatuses );
-	}
-
-	private static Set<Integer> asSet(int... ignoredErrorStatuses) {
-		if ( ignoredErrorStatuses == null || ignoredErrorStatuses.length == 0 ) {
-			return Collections.emptySet();
-		}
-		else if ( ignoredErrorStatuses.length == 1 ) {
-			return Collections.singleton( ignoredErrorStatuses[0] );
-		}
-		else {
-			Set<Integer> ignored = new HashSet<>();
-
-			for ( int ignoredErrorStatus : ignoredErrorStatuses ) {
-				ignored.add( ignoredErrorStatus );
-			}
-
-			return Collections.unmodifiableSet( ignored );
-		}
 	}
 
 	/**
@@ -78,6 +57,10 @@ public class BackendRequest<T extends JestResult> {
 		return indexName;
 	}
 
+	public BackendRequestResultAssessor<? super T> getResultAssessor() {
+		return resultAssessor;
+	}
+
 	public IndexingMonitor getIndexingMonitor() {
 		return indexingMonitor;
 	}
@@ -93,12 +76,8 @@ public class BackendRequest<T extends JestResult> {
 		return refreshAfterWrite;
 	}
 
-	public Set<Integer> getIgnoredErrorStatuses() {
-		return ignoredErrorStatuses;
-	}
-
 	@Override
 	public String toString() {
-		return "BackendRequest [action=" + action + ", ignoredErrorStatuses=" + ignoredErrorStatuses + "]";
+		return "BackendRequest [action=" + action + ", resultAssessor=" + resultAssessor + "]";
 	}
 }

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/BackendRequestResultAssessor.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/BackendRequestResultAssessor.java
@@ -1,0 +1,35 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.client.impl;
+
+import org.hibernate.search.exception.SearchException;
+
+import io.searchbox.action.Action;
+import io.searchbox.client.JestResult;
+import io.searchbox.core.BulkResult.BulkResultItem;
+
+/**
+ * @author Yoann Rodiere
+ */
+public interface BackendRequestResultAssessor<T extends JestResult> {
+
+	/**
+	 * Checks the given detailed result, throwing an exception if the result is a failure.
+	 * @param request The request that produced the result.
+	 * @param result The detailed result.
+	 * @throws SearchException If the result is a failure.
+	 */
+	void checkSuccess(Action<? extends T> request, T result) throws SearchException;
+
+	/**
+	 * Checks the given summary result, return {@code true} if it is successful, {@code false} otherwise.
+	 * @param bulkResultItem The summary result.
+	 * @return {@code true} if the result is successful, {@code false} otherwise.
+	 */
+	boolean isSuccess(BulkResultItem bulkResultItem);
+
+}

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/SingleRequest.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/SingleRequest.java
@@ -39,7 +39,7 @@ public class SingleRequest implements ExecutableRequest {
 
 	private <T extends JestResult> void doExecute(BackendRequest<T> request) {
 		try {
-			T result = jestClient.executeRequest( request.getAction(), request.getIgnoredErrorStatuses() );
+			T result = jestClient.executeRequest( request.getAction(), request.getResultAssessor() );
 			IndexingMonitor monitor = request.getIndexingMonitor();
 			if ( monitor != null ) {
 				request.getSuccessReporter().report( result, monitor );

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/DefaultBackendRequestResultAssessor.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/DefaultBackendRequestResultAssessor.java
@@ -1,0 +1,127 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.impl;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.hibernate.search.elasticsearch.client.impl.BackendRequestResultAssessor;
+import org.hibernate.search.elasticsearch.logging.impl.Log;
+import org.hibernate.search.exception.SearchException;
+import org.hibernate.search.util.logging.impl.LoggerFactory;
+
+import com.google.gson.JsonElement;
+
+import io.searchbox.action.Action;
+import io.searchbox.client.JestResult;
+import io.searchbox.core.BulkResult.BulkResultItem;
+
+
+/**
+ * @author Yoann Rodiere
+ */
+public class DefaultBackendRequestResultAssessor implements BackendRequestResultAssessor<JestResult> {
+
+	private static final Log LOG = LoggerFactory.make( Log.class );
+
+	private static final int TIME_OUT_HTTP_RESPONSE_CODE = 408;
+
+	public static Builder builder(JestAPIFormatter formatter) {
+		return new Builder( formatter );
+	}
+
+	public static class Builder {
+		private final JestAPIFormatter formatter;
+
+		private final Set<Integer> ignoredErrorStatuses = new HashSet<>();
+		private final Set<String> ignoredErrorTypes = new HashSet<>();
+
+		private Builder(JestAPIFormatter formatter) {
+			this.formatter = formatter;
+		}
+
+		public Builder ignoreErrorStatuses(int ... ignoredErrorStatuses) {
+			for ( int ignoredErrorStatus : ignoredErrorStatuses ) {
+				this.ignoredErrorStatuses.add( ignoredErrorStatus );
+			}
+			return this;
+		}
+
+		public Builder ignoreErrorTypes(String ... ignoredErrorTypes) {
+			for ( String ignoredErrorType : ignoredErrorTypes ) {
+				this.ignoredErrorTypes.add( ignoredErrorType );
+			}
+			return this;
+		}
+
+		public DefaultBackendRequestResultAssessor build() {
+			return new DefaultBackendRequestResultAssessor( this );
+		}
+	}
+
+	private final JestAPIFormatter formatter;
+	private final Set<Integer> ignoredErrorStatuses;
+	private final Set<String> ignoredErrorTypes;
+
+	private DefaultBackendRequestResultAssessor(Builder builder) {
+		this.formatter = builder.formatter;
+		this.ignoredErrorStatuses = Collections.unmodifiableSet( new HashSet<>( builder.ignoredErrorStatuses ) );
+		this.ignoredErrorTypes = Collections.unmodifiableSet( new HashSet<>( builder.ignoredErrorTypes ) );
+	}
+
+	@Override
+	public String toString() {
+		return new StringBuilder()
+				.append( getClass().getSimpleName() ).append( "[" )
+				.append( "ignoredErrorStatuses=" ).append( ignoredErrorStatuses )
+				.append( ", ignoredErrorTypes=" ).append( ignoredErrorTypes )
+				.append( "]" )
+				.toString();
+	}
+
+	@Override
+	public void checkSuccess(Action<? extends JestResult> request, JestResult result) throws SearchException {
+		if ( !isSuccess( result ) ) {
+			if ( result.getResponseCode() == TIME_OUT_HTTP_RESPONSE_CODE ) {
+				throw LOG.elasticsearchRequestTimeout( formatter.formatRequest( request ), formatter.formatResult( result ) );
+			}
+			else {
+				throw LOG.elasticsearchRequestFailed( formatter.formatRequest( request ), formatter.formatResult( result ), null );
+			}
+		}
+	}
+
+	@Override
+	public boolean isSuccess(BulkResultItem resultItem) {
+		// When getting a 404 for a DELETE, the error is null :(, so checking both
+		return (resultItem.error == null && resultItem.status < 400 )
+			|| ignoredErrorStatuses.contains( resultItem.status )
+			|| ignoredErrorTypes.contains( resultItem.errorType );
+	}
+
+	private boolean isSuccess(JestResult result) {
+		return result.isSucceeded()
+				|| ignoredErrorStatuses.contains( result.getResponseCode() )
+				|| ignoredErrorTypes.contains( getErrorType( result ) );
+	}
+
+	private String getErrorType(JestResult result) {
+		JsonElement error = result.getJsonObject().get( "error" );
+		if ( error == null || !error.isJsonObject() ) {
+			return null;
+		}
+
+		JsonElement errorType = error.getAsJsonObject().get( "type" );
+		if ( errorType == null || !errorType.isJsonPrimitive() ) {
+			return null;
+		}
+
+		return errorType.getAsString();
+	}
+
+}

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/DeleteByQueryResultAssessor.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/DeleteByQueryResultAssessor.java
@@ -1,0 +1,52 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.impl;
+
+import org.hibernate.search.elasticsearch.client.impl.BackendRequestResultAssessor;
+import org.hibernate.search.elasticsearch.logging.impl.Log;
+import org.hibernate.search.exception.AssertionFailure;
+import org.hibernate.search.exception.SearchException;
+import org.hibernate.search.util.logging.impl.LoggerFactory;
+
+import io.searchbox.action.Action;
+import io.searchbox.client.JestResult;
+import io.searchbox.core.BulkResult.BulkResultItem;
+
+
+/**
+ * @author Yoann Rodiere
+ */
+public class DeleteByQueryResultAssessor implements BackendRequestResultAssessor<JestResult> {
+
+	private static final Log LOG = LoggerFactory.make( Log.class );
+
+	private static final int NOT_FOUND_HTTP_STATUS_CODE = 404;
+
+	private final JestAPIFormatter formatter;
+
+	private final DefaultBackendRequestResultAssessor delegate;
+
+	public DeleteByQueryResultAssessor(JestAPIFormatter formatter) {
+		this.formatter = formatter;
+		this.delegate = DefaultBackendRequestResultAssessor.builder( formatter )
+				.ignoreErrorStatuses( NOT_FOUND_HTTP_STATUS_CODE ).build();
+	}
+
+	@Override
+	public void checkSuccess(Action<? extends JestResult> request, JestResult result) throws SearchException {
+		this.delegate.checkSuccess( request, result );
+		if ( result.getResponseCode() == NOT_FOUND_HTTP_STATUS_CODE ) {
+			throw LOG.elasticsearchRequestDeleteByQueryNotFound( formatter.formatRequest( request ), formatter.formatResult( result ) );
+		}
+	}
+
+	@Override
+	public boolean isSuccess(BulkResultItem bulkResultItem) {
+		throw new AssertionFailure( "This method should never be called, because DeleteByQuery actions are not Bulkable" );
+	}
+
+}

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchIndexManager.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchIndexManager.java
@@ -147,10 +147,12 @@ public class ElasticsearchIndexManager implements IndexManager, IndexNameNormali
 
 		this.similarity = similarity;
 
+		JestAPIFormatter jestApiFormatter = serviceManager.requestService( JestAPIFormatter.class );
 		this.visitor = new ElasticsearchIndexWorkVisitor(
 				this.actualIndexName,
 				this.refreshAfterWrite,
-				context.getUninitializedSearchIntegrator()
+				context.getUninitializedSearchIntegrator(),
+				jestApiFormatter
 		);
 		this.requestProcessor = context.getServiceManager().requestService( BackendRequestProcessor.class );
 	}
@@ -216,6 +218,8 @@ public class ElasticsearchIndexManager implements IndexManager, IndexNameNormali
 		if ( schemaManagementStrategy == IndexSchemaManagementStrategy.RECREATE_DELETE ) {
 			schemaDropper.dropIfExisting( actualIndexName, schemaManagementExecutionOptions );
 		}
+
+		serviceManager.releaseService( JestAPIFormatter.class );
 
 		requestProcessor = null;
 		serviceManager.releaseService( BackendRequestProcessor.class );

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/JestAPIFormatter.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/JestAPIFormatter.java
@@ -1,0 +1,123 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.impl;
+
+import java.util.Properties;
+
+import org.hibernate.search.engine.service.spi.Service;
+import org.hibernate.search.engine.service.spi.ServiceManager;
+import org.hibernate.search.engine.service.spi.Startable;
+import org.hibernate.search.engine.service.spi.Stoppable;
+import org.hibernate.search.spi.BuildContext;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+
+import io.searchbox.action.Action;
+import io.searchbox.action.DocumentTargetedAction;
+import io.searchbox.client.JestResult;
+import io.searchbox.core.BulkResult;
+import io.searchbox.core.BulkResult.BulkResultItem;
+
+/**
+ * @author Yoann Rodiere
+ */
+public class JestAPIFormatter implements Service, Startable, Stoppable {
+
+	private ServiceManager serviceManager;
+	private GsonService gsonService;
+
+	@Override
+	public void start(Properties properties, BuildContext context) {
+		serviceManager = context.getServiceManager();
+		gsonService = serviceManager.requestService( GsonService.class );
+	}
+
+	@Override
+	public void stop() {
+		gsonService = null;
+		serviceManager.releaseService( GsonService.class );
+		serviceManager = null;
+	}
+
+	public String formatRequest(Action<?> action) {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append( "Operation: " ).append( action.getClass().getSimpleName() ).append( "\n" );
+		sb.append( "URI:" ).append( action.getURI() ).append( "\n" );
+
+		if ( action instanceof DocumentTargetedAction ) {
+			sb.append( "Index: " ).append( ( (DocumentTargetedAction<?>) action ).getIndex() ).append( "\n" );
+			sb.append( "Type: " ).append( ( (DocumentTargetedAction<?>) action ).getType() ).append( "\n" );
+			sb.append( "Id: " ).append( ( (DocumentTargetedAction<?>) action ).getId() ).append( "\n" );
+		}
+
+		sb.append( "Data:\n" );
+		sb.append( formatRequestData( action ) );
+		sb.append( "\n" );
+		return sb.toString();
+	}
+
+	public String formatRequestData(Action<?> search) {
+		Gson gson = gsonService.getGson();
+		/*
+		 * The Gson we use as an argument is not always used, which means we have to reformat
+		 * the result ourselves to be sure it's pretty-printed.
+		 */
+		String data = search.getData( gson );
+
+		// Make sure the JSON is pretty-printed
+		try {
+			gson = gsonService.getGsonPrettyPrinting();
+			JsonElement tree = gson.fromJson( data, JsonElement.class );
+			return gson.toJson( tree );
+		}
+		catch (JsonParseException e) {
+			/*
+			 * Sometimes, for example for bulk requests, the data isn't really JSON,
+			 * but rather multiple "\n"-separated JSON documents.
+			 * In that case we just give up and return the raw, potentially not
+			 * pretty-printed data.
+			 */
+			return data;
+		}
+	}
+
+	public String formatResult(JestResult result) {
+		StringBuilder sb = new StringBuilder();
+		sb.append( "Status: " ).append( result.getResponseCode() ).append( "\n" );
+		sb.append( "Error message: " ).append( result.getErrorMessage() ).append( "\n" );
+		sb.append( "Cluster name: " ).append( property( result, "cluster_name" ) ).append( "\n" );
+		sb.append( "Cluster status: " ).append( property( result, "status" ) ).append( "\n" );
+		sb.append( "\n" );
+
+		if ( result instanceof BulkResult ) {
+			for ( BulkResultItem item : ( (BulkResult) result ).getItems() ) {
+				sb.append( "Operation: " ).append( item.operation ).append( "\n" );
+				sb.append( "  Index: " ).append( item.index ).append( "\n" );
+				sb.append( "  Type: " ).append( item.type ).append( "\n" );
+				sb.append( "  Id: " ).append( item.id ).append( "\n" );
+				sb.append( "  Status: " ).append( item.status ).append( "\n" );
+				sb.append( "  Error: " ).append( item.error ).append( "\n" );
+			}
+		}
+
+		return sb.toString();
+	}
+
+	private String property(JestResult result, String name) {
+		if ( result.getJsonObject() == null ) {
+			return null;
+		}
+		JsonElement propretyValue = result.getJsonObject().get( name );
+		if ( propretyValue == null ) {
+			return null;
+		}
+		return propretyValue.getAsString();
+	}
+}

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
@@ -390,4 +390,13 @@ public interface Log extends org.hibernate.search.util.logging.impl.Log {
 	)
 	void failedToOpenIndex(String indexName);
 
+	@Message(id = ES_BACKEND_MESSAGES_START_ID + 72,
+			value = "DeleteByQuery request to Elasticsearch failed with 404 result code."
+					+ "\nPlease check that 1. you installed the delete-by-query plugin on your Elasticsearch nodes"
+					+ " and 2. the targeted index exists"
+					+ "\n Request:\n========\n%1$s"
+					+ "Response:\n=========\n%2$s"
+			)
+	SearchException elasticsearchRequestDeleteByQueryNotFound(String request, String response);
+
 }

--- a/elasticsearch/src/main/resources/META-INF/services/org.hibernate.search.elasticsearch.impl.JestAPIFormatter
+++ b/elasticsearch/src/main/resources/META-INF/services/org.hibernate.search.elasticsearch.impl.JestAPIFormatter
@@ -1,0 +1,1 @@
+org.hibernate.search.elasticsearch.impl.JestAPIFormatter


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2569

This PR brings two changes:

 1. The documentation is clearer about the fact that the 'delete-by-query' plugin is required when using the "purgeAll" option on the mass indexer, and this part of the documentation is more visible.
 2. Whenever a user tries to purge indexes and a 404 error occurs, the error message now mentions that the 'delete-by-query' plugin is required.

We'll probably want to backport at least the first commit to 5.6.