### PR TITLE
HSEARCH-2453 Add dedicated configuration options for Elasticsearch authentication

### DIFF
--- a/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
+++ b/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
@@ -124,6 +124,14 @@ You may also select multiple hosts (separated by whitespace characters), so that
 `hibernate.search.default.elasticsearch.host \http://es1.mycompany.com:9200 \http://es2.mycompany.com:9200`
 +
 In the example above, the first request will go to `es1`, the second to `es2`, the third to `es1`, and so on.
+Username for Elasticsearch connection:: `hibernate.search.default.elasticsearch.username ironman` (default is empty, meaning anonymous access)
+Password for Elasticsearch connection:: `hibernate.search.default.elasticsearch.password j@rV1s` (default is empty)
++
+[CAUTION]
+====
+If you used HTTP instead of HTTPS in any of the Elasticsearch host URLs (see above),
+your password will be transmitted in clear text over the network.
+====
 [[elasticsearch-schema-management-strategy]]Select the index creation strategy::
 `hibernate.search.default.elasticsearch.index_schema_management_strategy CREATE` (default)
 +
@@ -207,7 +215,7 @@ Properties prefixed with `hibernate.search.default` can be given globally as sho
 `hibernate.search.someindex.elasticsearch.index_schema_management_strategy MERGE`
 
 This excludes properties related to the internal Elasticsearch client, which at the moment is common to every index manager (but this will change in a future version).
-Excluded properties are `host`, `read_timeout`, `connection_timeout`, `max_total_connection`, `max_total_connection_per_route`, `discovery.enabled` and `discovery.refresh_interval`.
+Excluded properties are `host`, `username`, `password`, `read_timeout`, `connection_timeout`, `max_total_connection`, `max_total_connection_per_route`, `discovery.enabled` and `discovery.refresh_interval`.
 --
 
 === Mapping and indexing

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/ElasticsearchEnvironment.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/ElasticsearchEnvironment.java
@@ -49,9 +49,36 @@ public final class ElasticsearchEnvironment {
 	 * {@code hibernate.search.default.elasticsearch.host=http://myeshost.com:9200}), i.e. only a single Elasticsearch
 	 * cluster is supported for all the indexed entities. This limitation will be removed in a future version of
 	 * Hibernate Search.
-	 * <p>
 	 */
 	public static final String SERVER_URI = "elasticsearch.host";
+
+	/**
+	 * Property for specifying the username to send when connecting to the Elasticsearch servers.
+	 * <p>
+	 * A string is expected.
+	 * <p>
+	 * Defaults to no username (anonymous access).
+	 * <p>
+	 * Can only be given <b>globally</b> (e.g.
+	 * {@code hibernate.search.default.elasticsearch.username=ironman}), because. only a single Elasticsearch
+	 * cluster is supported for all the indexed entities. This limitation will be removed in a future version of
+	 * Hibernate Search.
+	 */
+	public static final String SERVER_USERNAME = "elasticsearch.username";
+
+	/**
+	 * Property for specifying the password to send when connecting to the Elasticsearch servers.
+	 * <p>
+	 * A string is expected.
+	 * <p>
+	 * Defaults to no password at all.
+	 * <p>
+	 * Can only be given <b>globally</b> (e.g.
+	 * {@code hibernate.search.default.elasticsearch.password=j@rV1s}), because only a single Elasticsearch
+	 * cluster is supported for all the indexed entities. This limitation will be removed in a future version of
+	 * Hibernate Search.
+	 */
+	public static final String SERVER_PASSWORD = "elasticsearch.password";
 
 	/**
 	 * Property for specifying the timeout when reading responses from an Elasticsearch server.

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/ElasticsearchEnvironment.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/ElasticsearchEnvironment.java
@@ -45,10 +45,9 @@ public final class ElasticsearchEnvironment {
 	 * Multiple servers may be specified for load-balancing: requests will be assigned to each host in turns.
 	 * Failover is not supported yet.
 	 * <p>
-	 * Can only be given <b>globally</b> (e.g.
-	 * {@code hibernate.search.default.elasticsearch.host=http://myeshost.com:9200}), i.e. only a single Elasticsearch
-	 * cluster is supported for all the indexed entities. This limitation will be removed in a future version of
-	 * Hibernate Search.
+	 * To be given <b>globally</b> only (i.e. prefixed with {@code hibernate.search.default.}).
+	 * <b>Cannot</b> be specified per index (e.g. {@code hibernate.search.myIndex.elasticsearch.host}).
+	 * This limitation will be removed in a future version of Hibernate Search.
 	 */
 	public static final String SERVER_URI = "elasticsearch.host";
 
@@ -59,10 +58,9 @@ public final class ElasticsearchEnvironment {
 	 * <p>
 	 * Defaults to no username (anonymous access).
 	 * <p>
-	 * Can only be given <b>globally</b> (e.g.
-	 * {@code hibernate.search.default.elasticsearch.username=ironman}), because. only a single Elasticsearch
-	 * cluster is supported for all the indexed entities. This limitation will be removed in a future version of
-	 * Hibernate Search.
+	 * To be given <b>globally</b> only (i.e. prefixed with {@code hibernate.search.default.}).
+	 * <b>Cannot</b> be specified per index (e.g. {@code hibernate.search.myIndex.elasticsearch.username}).
+	 * This limitation will be removed in a future version of Hibernate Search.
 	 */
 	public static final String SERVER_USERNAME = "elasticsearch.username";
 
@@ -73,10 +71,9 @@ public final class ElasticsearchEnvironment {
 	 * <p>
 	 * Defaults to no password at all.
 	 * <p>
-	 * Can only be given <b>globally</b> (e.g.
-	 * {@code hibernate.search.default.elasticsearch.password=j@rV1s}), because only a single Elasticsearch
-	 * cluster is supported for all the indexed entities. This limitation will be removed in a future version of
-	 * Hibernate Search.
+	 * To be given <b>globally</b> only (i.e. prefixed with {@code hibernate.search.default.}).
+	 * <b>Cannot</b> be specified per index (e.g. {@code hibernate.search.myIndex.elasticsearch.password}).
+	 * This limitation will be removed in a future version of Hibernate Search.
 	 */
 	public static final String SERVER_PASSWORD = "elasticsearch.password";
 
@@ -87,10 +84,9 @@ public final class ElasticsearchEnvironment {
 	 * <p>
 	 * Defaults to {@link Defaults#SERVER_READ_TIMEOUT}.
 	 * <p>
-	 * Can only be given <b>globally</b> (e.g.
-	 * {@code hibernate.search.default.elasticsearch.read_timeout=60000}), because only a single Elasticsearch
-	 * cluster is supported for all the indexed entities. This limitation will be removed in a future version of
-	 * Hibernate Search.
+	 * To be given <b>globally</b> only (i.e. prefixed with {@code hibernate.search.default.}).
+	 * <b>Cannot</b> be specified per index (e.g. {@code hibernate.search.myIndex.elasticsearch.read_timeout}).
+	 * This limitation will be removed in a future version of Hibernate Search.
 	 */
 	public static final String SERVER_READ_TIMEOUT = "elasticsearch.read_timeout";
 
@@ -101,10 +97,9 @@ public final class ElasticsearchEnvironment {
 	 * <p>
 	 * Defaults to {@link Defaults#SERVER_CONNECTION_TIMEOUT}.
 	 * <p>
-	 * Can only be given <b>globally</b> (e.g.
-	 * {@code hibernate.search.default.elasticsearch.connection_timeout=2000}), because only a single Elasticsearch
-	 * cluster is supported for all the indexed entities. This limitation will be removed in a future version of
-	 * Hibernate Search.
+	 * To be given <b>globally</b> only (i.e. prefixed with {@code hibernate.search.default.}).
+	 * <b>Cannot</b> be specified per index (e.g. {@code hibernate.search.myIndex.elasticsearch.connection_timeout}).
+	 * This limitation will be removed in a future version of Hibernate Search.
 	 */
 	public static final String SERVER_CONNECTION_TIMEOUT = "elasticsearch.connection_timeout";
 
@@ -115,10 +110,9 @@ public final class ElasticsearchEnvironment {
 	 * <p>
 	 * Defaults to {@link Defaults#MAX_TOTAL_CONNECTION}.
 	 * <p>
-	 * Can only be given <b>globally</b> (e.g.
-	 * {@code hibernate.search.default.elasticsearch.max_total_connection=30}), because only a single Elasticsearch
-	 * cluster is supported for all the indexed entities. This limitation will be removed in a future version of
-	 * Hibernate Search.
+	 * To be given <b>globally</b> only (i.e. prefixed with {@code hibernate.search.default.}).
+	 * <b>Cannot</b> be specified per index (e.g. {@code hibernate.search.myIndex.elasticsearch.max_total_connection}).
+	 * This limitation will be removed in a future version of Hibernate Search.
 	 */
 	public static final String MAX_TOTAL_CONNECTION = "elasticsearch.max_total_connection";
 
@@ -129,10 +123,9 @@ public final class ElasticsearchEnvironment {
 	 * <p>
 	 * Defaults to {@link Defaults#MAX_TOTAL_CONNECTION_PER_ROUTE}.
 	 * <p>
-	 * Can only be given <b>globally</b> (e.g.
-	 * {@code hibernate.search.default.elasticsearch.max_total_connection_per_route=3}), because only a single Elasticsearch
-	 * cluster is supported for all the indexed entities. This limitation will be removed in a future version of
-	 * Hibernate Search.
+	 * To be given <b>globally</b> only (i.e. prefixed with {@code hibernate.search.default.}).
+	 * <b>Cannot</b> be specified per index (e.g. {@code hibernate.search.myIndex.elasticsearch.max_total_connection_per_route}).
+	 * This limitation will be removed in a future version of Hibernate Search.
 	 */
 	public static final String MAX_TOTAL_CONNECTION_PER_ROUTE = "elasticsearch.max_total_connection_per_route";
 
@@ -143,10 +136,9 @@ public final class ElasticsearchEnvironment {
 	 * <p>
 	 * Defaults to {@link Defaults#DISCOVERY_ENABLED}.
 	 * <p>
-	 * Can only be given <b>globally</b> (e.g.
-	 * {@code hibernate.search.default.elasticsearch.discovery.enabled=true}), because only a single Elasticsearch
-	 * cluster is supported for all the indexed entities. This limitation will be removed in a future version of
-	 * Hibernate Search.
+	 * To be given <b>globally</b> only (i.e. prefixed with {@code hibernate.search.default.}).
+	 * <b>Cannot</b> be specified per index (e.g. {@code hibernate.search.myIndex.elasticsearch.discovery.enabled}).
+	 * This limitation will be removed in a future version of Hibernate Search.
 	 */
 	public static final String DISCOVERY_ENABLED = "elasticsearch.discovery.enabled";
 
@@ -157,10 +149,9 @@ public final class ElasticsearchEnvironment {
 	 * <p>
 	 * Defaults to {@link Defaults#DISCOVERY_REFRESH_INTERVAL}.
 	 * <p>
-	 * Can only be given <b>globally</b> (e.g.
-	 * {@code hibernate.search.default.elasticsearch.discovery.refresh_interval=20}), because only a single Elasticsearch
-	 * cluster is supported for all the indexed entities. This limitation will be removed in a future version of
-	 * Hibernate Search.
+	 * To be given <b>globally</b> only (i.e. prefixed with {@code hibernate.search.default.}).
+	 * <b>Cannot</b> be specified per index (e.g. {@code hibernate.search.myIndex.elasticsearch.discovery.refresh_interval}).
+	 * This limitation will be removed in a future version of Hibernate Search.
 	 */
 	public static final String DISCOVERY_REFRESH_INTERVAL = "elasticsearch.discovery.refresh_interval";
 

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/JestClient.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/JestClient.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.elasticsearch.client.impl;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -48,6 +49,8 @@ import io.searchbox.params.Parameters;
 public class JestClient implements Service, Startable, Stoppable {
 
 	private static final Log LOG = LoggerFactory.make( Log.class );
+
+	private static final String HTTP_SCHEME = "http";
 
 	/**
 	 * Prefix for accessing the client-related settings.
@@ -131,12 +134,25 @@ public class JestClient implements Service, Startable, Stoppable {
 					CLIENT_PROP_PREFIX + ElasticsearchEnvironment.SERVER_PASSWORD,
 					null
 			);
+			if ( password != null ) {
+				warnPasswordsOverHttp( serverUris );
+			}
 			builder = builder.defaultCredentials( username, password );
 		}
 
 		factory.setHttpClientConfig( builder.build() );
 
 		client = factory.getObject();
+	}
+
+	private boolean warnPasswordsOverHttp(Collection<String> serverUris) {
+		for ( String serverUriAsString : serverUris ) {
+			URI uri = URI.create( serverUriAsString );
+			if ( HTTP_SCHEME.equals( uri.getScheme() ) ) {
+				LOG.usingPasswordOverHttp( serverUriAsString );
+			}
+		}
+		return false;
 	}
 
 	@Override

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/JestClient.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/JestClient.java
@@ -83,8 +83,7 @@ public class JestClient implements Service, Startable, Stoppable {
 
 		Collection<String> serverUris = Arrays.asList( serverUrisString.trim().split( "\\s" ) );
 
-		factory.setHttpClientConfig(
-			new HttpClientConfig.Builder( serverUris )
+		HttpClientConfig.Builder builder = new HttpClientConfig.Builder( serverUris )
 				.multiThreaded( true )
 				.readTimeout( ConfigurationParseHelper.getIntValue(
 						properties,
@@ -119,9 +118,23 @@ public class JestClient implements Service, Startable, Stoppable {
 						),
 						TimeUnit.SECONDS
 				)
-				.gson( gsonService.getGson() )
-				.build()
+				.gson( gsonService.getGson() );
+
+		String username = ConfigurationParseHelper.getString(
+				properties,
+				CLIENT_PROP_PREFIX + ElasticsearchEnvironment.SERVER_USERNAME,
+				null
 		);
+		if ( username != null ) {
+			String password = ConfigurationParseHelper.getString(
+					properties,
+					CLIENT_PROP_PREFIX + ElasticsearchEnvironment.SERVER_PASSWORD,
+					null
+			);
+			builder = builder.defaultCredentials( username, password );
+		}
+
+		factory.setHttpClientConfig( builder.build() );
 
 		client = factory.getObject();
 	}

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
@@ -399,4 +399,11 @@ public interface Log extends org.hibernate.search.util.logging.impl.Log {
 			)
 	SearchException elasticsearchRequestDeleteByQueryNotFound(String request, String response);
 
+	@LogMessage(level = Level.WARN)
+	@Message(id = ES_BACKEND_MESSAGES_START_ID + 73,
+			value = "Hibernate Search will connect to Elasticsearch server '%1$s' with authentication over plain HTTP (not HTTPS)."
+					+ " The password will be sent in clear text over the network."
+			)
+	void usingPasswordOverHttp(String serverUris);
+
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2453

**To be backported to 5.6.1.**

Authentication was already possible, but a bit painful, since you had to
include the username and password in the host URLs. Which meant
repeating it over and over again when using multiple URLs, and also
meant you had to URL-encode the username and password yourself.

Tests are not included, because it's a pain to automate the setup of
authentication on the ES instance used for tests. Also, I'm quite sure
we can't do it with an embedded version of ES, and I don't even know if
the licensing terms would allow it (the Shield plugin is subject to a
commercial license).

To test manually, see:
https://www.elastic.co/blog/getting-started-with-elasticsearch-ssl-native-authentication