### PR TITLE
HSEARCH-2580 Update of the "previous.stable" property following the 5.6.0.Final release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@
         <puppycrawl.checkstyle.version>7.4</puppycrawl.checkstyle.version>
 
         <!-- Version to be used as baseline for API/SPI change reports -->
-        <previous.stable>5.5.2.Final</previous.stable>
+        <previous.stable>5.6.0.Final</previous.stable>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2580

**To be backported to 5.6**. Backport for 5.6 available there: https://github.com/yrodiere/hibernate-search/tree/HSEARCH-2580-5.6