### PR TITLE
HSEARCH-2591 Upgrade to Apache Lucene 5.5.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
 
         <!-- Dependency versions -->
         <slf4jVersion>1.6.4</slf4jVersion>
-        <luceneVersion>5.5.2</luceneVersion>
+        <luceneVersion>5.5.4</luceneVersion>
         <infinispanVersion>8.2.4.Final</infinispanVersion>
         <jgroupsVersion>3.6.12.Final</jgroupsVersion>
 


### PR DESCRIPTION
Very complex patch ;)

But important: it fixes the Java 9 memory un-mapping problem.