### PR TITLE
HSEARCH-2578 Include the lucene-grouping artifact in the WildFly modules

### DIFF
--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -71,6 +71,10 @@
             <artifactId>lucene-misc</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-grouping</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-search-backend-jgroups</artifactId>
         </dependency>

--- a/modules/src/main/assembly/dist.xml
+++ b/modules/src/main/assembly/dist.xml
@@ -129,6 +129,7 @@
                 <include>org.apache.lucene:lucene-queries</include>
                 <include>org.apache.lucene:lucene-facet</include>
                 <include>org.apache.lucene:lucene-analyzers-common</include>
+                <include>org.apache.lucene:lucene-grouping</include>
             </includes>
         </dependencySet>
 

--- a/modules/src/main/modules/lucene/module.xml
+++ b/modules/src/main/modules/lucene/module.xml
@@ -12,6 +12,7 @@
         <resource-root path="lucene-queries-${luceneVersion}.jar" />
         <resource-root path="lucene-facet-${luceneVersion}.jar" />
         <resource-root path="lucene-analyzers-common-${luceneVersion}.jar" />
+        <resource-root path="lucene-grouping-${luceneVersion}.jar" />
     </resources>
     <dependencies>
         <module name="javax.api" optional="true" />

--- a/pom.xml
+++ b/pom.xml
@@ -318,6 +318,11 @@
                 <version>${luceneVersion}</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-grouping</artifactId>
+                <version>${luceneVersion}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.tika</groupId>
                 <artifactId>tika-parsers</artifactId>
                 <version>${tikaVersion}</version>


### PR DESCRIPTION
This is to keep things easier until we don't actually move to use the separately packaged Lucene modules.

I'm including no tests as it's a temporary measure.

- https://hibernate.atlassian.net/browse/HSEARCH-2578
