### PR TITLE
HSEARCH-2593 Node discovery uses the HTTP (not HTTPS) scheme by default and isn't configurable

### DIFF
--- a/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
+++ b/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
@@ -186,6 +186,9 @@ and will remove them from the server list if they don't.
 Time interval between two executions of the automatic discovery (in seconds):: `hibernate.search.default.elasticsearch.discovery.refresh_interval 10` (default)
 +
 This setting will only be taken into account if automatic discovery is enabled (see above).
+Scheme to use when connecting to automatically discovered nodes (`http` or `https`):: `hibernate.search.default.elasticsearch.discovery.scheme http` (default)
++
+This setting will only be taken into account if automatic discovery is enabled (see above).
 Maximum time to wait for the indexes to become available before failing (in ms):: `hibernate.search.default.elasticsearch.index_management_wait_timeout 10000` (default)
 +
 This setting is ignored when the `NONE` strategy is selected, since the index will not be checked on startup (see above).
@@ -215,7 +218,7 @@ Properties prefixed with `hibernate.search.default` can be given globally as sho
 `hibernate.search.someindex.elasticsearch.index_schema_management_strategy MERGE`
 
 This excludes properties related to the internal Elasticsearch client, which at the moment is common to every index manager (but this will change in a future version).
-Excluded properties are `host`, `username`, `password`, `read_timeout`, `connection_timeout`, `max_total_connection`, `max_total_connection_per_route`, `discovery.enabled` and `discovery.refresh_interval`.
+Excluded properties are `host`, `username`, `password`, `read_timeout`, `connection_timeout`, `max_total_connection`, `max_total_connection_per_route`, `discovery.enabled`, `discovery.refresh_interval` and `discovery.scheme`.
 --
 
 === Mapping and indexing

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/ElasticsearchEnvironment.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/ElasticsearchEnvironment.java
@@ -28,6 +28,7 @@ public final class ElasticsearchEnvironment {
 		public static final int MAX_TOTAL_CONNECTION_PER_ROUTE = 2;
 		public static final boolean DISCOVERY_ENABLED = false;
 		public static final long DISCOVERY_REFRESH_INTERVAL = 10L;
+		public static final String DISCOVERY_SCHEME = "http";
 		public static final IndexSchemaManagementStrategy INDEX_SCHEMA_MANAGEMENT_STRATEGY = IndexSchemaManagementStrategy.CREATE;
 		public static final int INDEX_MANAGEMENT_WAIT_TIMEOUT = 10_000;
 		public static final ElasticsearchIndexStatus REQUIRED_INDEX_STATUS = ElasticsearchIndexStatus.GREEN;
@@ -156,6 +157,19 @@ public final class ElasticsearchEnvironment {
 	 * This limitation will be removed in a future version of Hibernate Search.
 	 */
 	public static final String DISCOVERY_REFRESH_INTERVAL = "elasticsearch.discovery.refresh_interval";
+
+	/**
+	 * Property for specifying the default scheme to use when connecting to automatically discovered nodes.
+	 * <p>
+	 * Either "http" or "https" is expected.
+	 * <p>
+	 * Defaults to {@link Defaults#DISCOVERY_SCHEME}.
+	 * <p>
+	 * To be given <b>globally</b> only (i.e. prefixed with {@code hibernate.search.default.}).
+	 * <b>Cannot</b> be specified per index (e.g. {@code hibernate.search.myIndex.elasticsearch.discovery.scheme}).
+	 * This limitation will be removed in a future version of Hibernate Search.
+	 */
+	public static final String DISCOVERY_SCHEME = "elasticsearch.discovery.default_scheme";
 
 	/**
 	 * Property for specifying the strategy for maintaining the Elasticsearch index.

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/JestClient.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/JestClient.java
@@ -121,6 +121,11 @@ public class JestClient implements Service, Startable, Stoppable {
 						),
 						TimeUnit.SECONDS
 				)
+				.defaultSchemeForDiscoveredNodes( ConfigurationParseHelper.getString(
+						properties,
+						CLIENT_PROP_PREFIX + ElasticsearchEnvironment.DISCOVERY_SCHEME,
+						ElasticsearchEnvironment.Defaults.DISCOVERY_SCHEME
+				) )
 				.gson( gsonService.getGson() );
 
 		String username = ConfigurationParseHelper.getString(


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2593

I decided to keep the "http" scheme as default, since it's in line with our policy to make it easy to test Hibernate Search, but I must admit I'm not really happy with that (it should be secure by default...).

I tried to add a unit test, but I only got so far as testing the discovery with a HTTP scheme, because we'd need some support for self-signed certificates to be able to test easily, and we don't have any (see [HSEARCH-2599](https://hibernate.atlassian.net/browse/HSEARCH-2599)). I left the test case anyway, since it's useful, but it definitely doesn't test HSEARCH-2593.