### PR TITLE
HSEARCH-2600 Update javadoc configuration

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -101,6 +101,7 @@
                         ${basedir}/../serialization/avro/src/main/java;
                         ${basedir}/../backends/jgroups/src/main/java;
                         ${basedir}/../backends/jms/src/main/java;
+                        ${basedir}/../elasticsearch/src/main/java;
                     </sourcepath>
                     <docfilessubdirs>true</docfilessubdirs>
                     <stylesheetfile>${basedir}/src/main/javadoc/stylesheet.css</stylesheetfile>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -106,8 +106,8 @@
                     <docfilessubdirs>true</docfilessubdirs>
                     <stylesheetfile>${basedir}/src/main/javadoc/stylesheet.css</stylesheetfile>
                     <links>
-                        <link>http://download.oracle.com/javase/7/docs/api/</link>
-                        <link>http://docs.jboss.org/hibernate/orm/5.0/javadocs/</link>
+                        <link>http://download.oracle.com/javase/8/docs/api/</link>
+                        <link>http://docs.jboss.org/hibernate/orm/5.2/javadocs/</link>
                         <link>http://lucene.apache.org/core/5_4_0/core/</link>
                         <link>http://lucene.apache.org/core/5_4_0/analyzers-common/</link>
                         <link>http://lucene.apache.org/core/5_4_0/queryparser/</link>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -108,9 +108,9 @@
                     <links>
                         <link>http://download.oracle.com/javase/8/docs/api/</link>
                         <link>http://docs.jboss.org/hibernate/orm/5.2/javadocs/</link>
-                        <link>http://lucene.apache.org/core/5_4_0/core/</link>
-                        <link>http://lucene.apache.org/core/5_4_0/analyzers-common/</link>
-                        <link>http://lucene.apache.org/core/5_4_0/queryparser/</link>
+                        <link>http://lucene.apache.org/core/5_5_4/core/</link>
+                        <link>http://lucene.apache.org/core/5_5_4/analyzers-common/</link>
+                        <link>http://lucene.apache.org/core/5_5_4/queryparser/</link>
                         <link>http://jgroups.org/javadoc</link>
                     </links>
                     <packagesheader>Hibernate Search Packages</packagesheader>


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/HSEARCH-2600

@yrodiere @Sanne waiting for your feedback on whether we should disable or not the individual javadocs.

The first commit should be backported to 5.6 and IIRC 5.6 depends on 5.1 so we should probably update the ORM javadoc link here too.