### PR TITLE
HSEARCH-2353 Add support for the 'norms' mapping attribute with Elasticsearch 5

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/dialect/impl/es2/Elasticsearch2Dialect.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/dialect/impl/es2/Elasticsearch2Dialect.java
@@ -17,8 +17,10 @@ import org.hibernate.search.elasticsearch.schema.impl.ElasticsearchSchemaTransla
 import org.hibernate.search.elasticsearch.schema.impl.ElasticsearchSchemaValidator;
 import org.hibernate.search.elasticsearch.schema.impl.model.FieldDataType;
 import org.hibernate.search.elasticsearch.schema.impl.model.IndexType;
+import org.hibernate.search.elasticsearch.schema.impl.model.NormsType;
 import org.hibernate.search.elasticsearch.util.impl.gson.ES2FieldDataTypeJsonAdapter;
 import org.hibernate.search.elasticsearch.util.impl.gson.ES2IndexTypeJsonAdapter;
+import org.hibernate.search.elasticsearch.util.impl.gson.ES2NormsTypeJsonAdapter;
 import org.hibernate.search.elasticsearch.work.impl.factory.Elasticsearch2WorkFactory;
 import org.hibernate.search.elasticsearch.work.impl.factory.ElasticsearchWorkFactory;
 import org.hibernate.search.engine.nulls.impl.MissingValueStrategy;
@@ -35,7 +37,8 @@ public class Elasticsearch2Dialect implements ElasticsearchDialect {
 		return DefaultGsonProvider.create( () -> {
 			return new GsonBuilder()
 					.registerTypeAdapter( IndexType.class, new ES2IndexTypeJsonAdapter().nullSafe() )
-					.registerTypeAdapter( FieldDataType.class, new ES2FieldDataTypeJsonAdapter().nullSafe() );
+					.registerTypeAdapter( FieldDataType.class, new ES2FieldDataTypeJsonAdapter().nullSafe() )
+					.registerTypeAdapter( NormsType.class, new ES2NormsTypeJsonAdapter().nullSafe() );
 		} );
 	}
 

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/dialect/impl/es5/Elasticsearch5Dialect.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/dialect/impl/es5/Elasticsearch5Dialect.java
@@ -17,8 +17,10 @@ import org.hibernate.search.elasticsearch.schema.impl.ElasticsearchSchemaTransla
 import org.hibernate.search.elasticsearch.schema.impl.ElasticsearchSchemaValidator;
 import org.hibernate.search.elasticsearch.schema.impl.model.FieldDataType;
 import org.hibernate.search.elasticsearch.schema.impl.model.IndexType;
+import org.hibernate.search.elasticsearch.schema.impl.model.NormsType;
 import org.hibernate.search.elasticsearch.util.impl.gson.ES5FieldDataTypeJsonAdapter;
 import org.hibernate.search.elasticsearch.util.impl.gson.ES5IndexTypeJsonAdapter;
+import org.hibernate.search.elasticsearch.util.impl.gson.ES5NormsTypeJsonAdapter;
 import org.hibernate.search.elasticsearch.work.impl.factory.Elasticsearch5WorkFactory;
 import org.hibernate.search.elasticsearch.work.impl.factory.ElasticsearchWorkFactory;
 import org.hibernate.search.engine.nulls.impl.MissingValueStrategy;
@@ -35,7 +37,8 @@ public class Elasticsearch5Dialect implements ElasticsearchDialect {
 		return DefaultGsonProvider.create( () -> {
 			return new GsonBuilder()
 					.registerTypeAdapter( IndexType.class, new ES5IndexTypeJsonAdapter().nullSafe() )
-					.registerTypeAdapter( FieldDataType.class, new ES5FieldDataTypeJsonAdapter().nullSafe() );
+					.registerTypeAdapter( FieldDataType.class, new ES5FieldDataTypeJsonAdapter().nullSafe() )
+					.registerTypeAdapter( NormsType.class, new ES5NormsTypeJsonAdapter().nullSafe() );
 		} );
 	}
 

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/schema/impl/Elasticsearch5SchemaTranslator.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/schema/impl/Elasticsearch5SchemaTranslator.java
@@ -15,6 +15,7 @@ import org.hibernate.search.elasticsearch.logging.impl.Log;
 import org.hibernate.search.elasticsearch.schema.impl.model.DataType;
 import org.hibernate.search.elasticsearch.schema.impl.model.FieldDataType;
 import org.hibernate.search.elasticsearch.schema.impl.model.IndexType;
+import org.hibernate.search.elasticsearch.schema.impl.model.NormsType;
 import org.hibernate.search.elasticsearch.schema.impl.model.PropertyMapping;
 import org.hibernate.search.elasticsearch.settings.impl.ElasticsearchIndexSettingsBuilder;
 import org.hibernate.search.elasticsearch.util.impl.FieldHelper;
@@ -75,6 +76,11 @@ public class Elasticsearch5SchemaTranslator extends Elasticsearch2SchemaTranslat
 				String analyzerName = settingsBuilder.register( analyzer, propertyPath );
 				propertyMapping.setAnalyzer( analyzerName );
 			}
+		}
+
+		// Only text and keyword fields can have norms
+		if ( DataType.TEXT.equals( type ) || DataType.KEYWORD.equals( type ) ) {
+			propertyMapping.setNorms( index.omitNorms() ? NormsType.FALSE : NormsType.TRUE );
 		}
 	}
 

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/schema/impl/Elasticsearch5SchemaValidator.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/schema/impl/Elasticsearch5SchemaValidator.java
@@ -9,6 +9,7 @@ package org.hibernate.search.elasticsearch.schema.impl;
 import org.hibernate.search.elasticsearch.schema.impl.model.DataType;
 import org.hibernate.search.elasticsearch.schema.impl.model.FieldDataType;
 import org.hibernate.search.elasticsearch.schema.impl.model.IndexType;
+import org.hibernate.search.elasticsearch.schema.impl.model.NormsType;
 import org.hibernate.search.elasticsearch.schema.impl.model.PropertyMapping;
 
 import com.google.gson.JsonPrimitive;
@@ -45,6 +46,13 @@ public class Elasticsearch5SchemaValidator extends Elasticsearch2SchemaValidator
 			// From ES 5.0 on, all indexable fields are indexed by default
 			IndexType indexDefault = IndexType.TRUE;
 			validateEqualWithDefault( errorCollector, "index", expectedIndex, actualMapping.getIndex(), indexDefault );
+		}
+
+		NormsType expectedNorms = expectedMapping.getNorms();
+		if ( NormsType.TRUE.equals( expectedNorms ) ) { // If we don't need norms, we don't care
+			// From ES 5.0 on, norms are enabled by default on text fields only
+			NormsType normsDefault = DataType.TEXT.equals( expectedMapping.getType() ) ? NormsType.TRUE : NormsType.FALSE;
+			validateEqualWithDefault( errorCollector, "norms", expectedNorms, actualMapping.getNorms(), normsDefault );
 		}
 
 		FieldDataType expectedFieldData = expectedMapping.getFieldData();

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/schema/impl/model/NormsType.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/schema/impl/model/NormsType.java
@@ -1,0 +1,24 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.schema.impl.model;
+
+/**
+ * An enum for Elasticsearch "norms" attribute values.
+ * <p>
+ * Values of this type are ignored in ES2, because field data isn't used
+ * (and configuration is more complex)
+ * <p>
+ * See https://www.elastic.co/guide/en/elasticsearch/reference/current/norms.html
+ *
+ * @author Yoann Rodiere
+ */
+public enum NormsType {
+
+	TRUE,
+	FALSE
+	;
+}

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/schema/impl/model/PropertyMapping.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/schema/impl/model/PropertyMapping.java
@@ -33,6 +33,8 @@ public class PropertyMapping extends TypeMapping {
 
 	private IndexType index;
 
+	private NormsType norms;
+
 	@SerializedName("doc_values")
 	private Boolean docValues;
 
@@ -105,6 +107,14 @@ public class PropertyMapping extends TypeMapping {
 
 	public void setIndex(IndexType index) {
 		this.index = index;
+	}
+
+	public NormsType getNorms() {
+		return norms;
+	}
+
+	public void setNorms(NormsType norms) {
+		this.norms = norms;
 	}
 
 	public Boolean getDocValues() {

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/gson/ES2NormsTypeJsonAdapter.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/gson/ES2NormsTypeJsonAdapter.java
@@ -1,0 +1,38 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.util.impl.gson;
+
+import java.io.IOException;
+
+import org.hibernate.search.elasticsearch.schema.impl.model.NormsType;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+/**
+ * @author Yoann Rodiere
+ */
+public class ES2NormsTypeJsonAdapter extends TypeAdapter<NormsType> {
+
+	@Override
+	public void write(JsonWriter out, NormsType value) throws IOException {
+		// Ignore the value: we don't support norms on ES2
+		boolean previousSerializeNulls = out.getSerializeNulls();
+		out.setSerializeNulls( false );
+		out.nullValue();
+		out.setSerializeNulls( previousSerializeNulls );
+	}
+
+	@Override
+	public NormsType read(JsonReader in) throws IOException {
+		// Ignore: we don't support norms on ES2
+		in.skipValue();
+		return null;
+	}
+
+}

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/gson/ES5NormsTypeJsonAdapter.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/gson/ES5NormsTypeJsonAdapter.java
@@ -1,0 +1,46 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.util.impl.gson;
+
+import java.io.IOException;
+
+import org.hibernate.search.elasticsearch.schema.impl.model.NormsType;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+/**
+ * @author Yoann Rodiere
+ */
+public class ES5NormsTypeJsonAdapter extends TypeAdapter<NormsType> {
+
+	@Override
+	public void write(JsonWriter out, NormsType value) throws IOException {
+		switch ( value ) {
+			case TRUE:
+				out.value( true );
+				break;
+			case FALSE:
+				out.value( false );
+				break;
+			default:
+				throw new IllegalStateException( "Invalid value for NormsType in ES5: " + value );
+		}
+	}
+
+	@Override
+	public NormsType read(JsonReader in) throws IOException {
+		if ( in.nextBoolean() ) {
+			return NormsType.TRUE;
+		}
+		else {
+			return NormsType.FALSE;
+		}
+	}
+
+}

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/Elasticsearch5SchemaCreationIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/Elasticsearch5SchemaCreationIT.java
@@ -28,6 +28,7 @@ import org.hibernate.search.annotations.CharFilterDef;
 import org.hibernate.search.annotations.DocumentId;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.Norms;
 import org.hibernate.search.annotations.Parameter;
 import org.hibernate.search.annotations.TokenFilterDef;
 import org.hibernate.search.annotations.TokenizerDef;
@@ -134,6 +135,55 @@ public class Elasticsearch5SchemaCreationIT extends SearchInitializationTestBase
 					+ "}"
 				+ "}",
 				elasticSearchClient.type( SimpleBooleanEntity.class ).getMapping()
+				);
+	}
+
+	@Test
+	public void textField() throws Exception {
+		elasticSearchClient.index( SimpleTextEntity.class )
+				.ensureDoesNotExist().registerForCleanup();
+
+		init( SimpleTextEntity.class );
+
+		assertJsonEquals(
+				"{"
+					+ "'dynamic': 'strict',"
+					+ "'properties': {"
+							+ "'id': {"
+									+ "'type': 'keyword',"
+									+ "'store': true"
+							+ "},"
+							+ "'myField': {"
+									+ "'type': 'text'"
+							+ "}"
+					+ "}"
+				+ "}",
+				elasticSearchClient.type( SimpleTextEntity.class ).getMapping()
+				);
+	}
+
+	@Test
+	public void textField_noNorms() throws Exception {
+		elasticSearchClient.index( NoNormsTextEntity.class )
+				.ensureDoesNotExist().registerForCleanup();
+
+		init( NoNormsTextEntity.class );
+
+		assertJsonEquals(
+				"{"
+					+ "'dynamic': 'strict',"
+					+ "'properties': {"
+							+ "'id': {"
+									+ "'type': 'keyword',"
+									+ "'store': true"
+							+ "},"
+							+ "'myField': {"
+									+ "'type': 'text',"
+									+ "'norms': false"
+							+ "}"
+					+ "}"
+				+ "}",
+				elasticSearchClient.type( NoNormsTextEntity.class ).getMapping()
 				);
 	}
 
@@ -298,6 +348,28 @@ public class Elasticsearch5SchemaCreationIT extends SearchInitializationTestBase
 
 		@Field
 		Date myField;
+	}
+
+	@Indexed
+	@Entity
+	private static class SimpleTextEntity {
+		@DocumentId
+		@Id
+		Long id;
+
+		@Field
+		String myField;
+	}
+
+	@Indexed
+	@Entity
+	private static class NoNormsTextEntity {
+		@DocumentId
+		@Id
+		Long id;
+
+		@Field(norms = Norms.NO)
+		String myField;
 	}
 
 	@Indexed


### PR DESCRIPTION
~~This PR is based on #1329, which will have to be merged first.~~ => Done

Relevant JIRA ticket: https://hibernate.atlassian.net/browse/HSEARCH-2353

I didn't add support for this on ES2 because the syntax is not the same as in ES5, it's more complex with more options (lazy/eager loading for instance). See [the docs for ES2](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/norms.html) and [the equivalent for ES5](https://www.elastic.co/guide/en/elasticsearch/reference/5.2/norms.html).

I'm not convinced there would be much value, but if you want I can have a look at how to support norms on ES2.