### PR TITLE
HSEARCH-2656 Correctly detect numeric fields when they are default fields with their type overridden by a custom MetadataProvidingFieldBridge

### DIFF
--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/DocumentFieldMetadata.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/DocumentFieldMetadata.java
@@ -18,6 +18,7 @@ import org.hibernate.search.analyzer.spi.AnalyzerReference;
 import org.hibernate.search.annotations.NumericField;
 import org.hibernate.search.annotations.Store;
 import org.hibernate.search.bridge.FieldBridge;
+import org.hibernate.search.engine.metadata.impl.DocumentFieldMetadata.Builder;
 import org.hibernate.search.engine.nulls.codec.impl.NotEncodingCodec;
 import org.hibernate.search.engine.nulls.codec.impl.NullMarkerCodec;
 
@@ -212,7 +213,7 @@ public class DocumentFieldMetadata implements PartialDocumentFieldMetadata {
 		private final PartialPropertyMetadata partialSourceProperty;
 		private final DocumentFieldPath path;
 		private final Store store;
-		private final Field.Index index;
+		private Field.Index index;
 		private final Field.TermVector termVector;
 
 		// optional parameters
@@ -268,6 +269,11 @@ public class DocumentFieldMetadata implements PartialDocumentFieldMetadata {
 		@Override
 		public Index getIndex() {
 			return index;
+		}
+
+		public Builder index(Index index) {
+			this.index = index;
+			return this;
 		}
 
 		public Builder fieldBridge(FieldBridge fieldBridge) {

--- a/engine/src/main/java/org/hibernate/search/query/dsl/impl/ConnectedMultiFieldsTermQueryBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/impl/ConnectedMultiFieldsTermQueryBuilder.java
@@ -89,7 +89,7 @@ public class ConnectedMultiFieldsTermQueryBuilder implements TermTermination {
 		// Handle non-null numeric values
 		if ( value != null ) {
 			applyTokenization = fieldContext.applyAnalyzer();
-			if ( NumericFieldUtils.isNumericFieldBridge( fieldBridge ) ) {
+			if ( Helper.requiresNumericQuery( documentBuilder, fieldContext, value ) ) {
 				return NumericFieldUtils.createExactMatchQuery( fieldContext.getField(), value );
 			}
 		}

--- a/engine/src/test/java/org/hibernate/search/test/metadata/FieldDescriptorTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/metadata/FieldDescriptorTest.java
@@ -159,7 +159,7 @@ public class FieldDescriptorTest {
 		assertNotNull( fieldDescriptor.getFieldBridge() );
 		assertTrue( fieldDescriptor.getFieldBridge() instanceof SpatialFieldBridge );
 
-		assertTrue( FieldSettingsDescriptor.Type.SPATIAL.equals( fieldDescriptor.getType() ) );
+		assertEquals( FieldSettingsDescriptor.Type.SPATIAL, fieldDescriptor.getType() );
 	}
 
 	@Test

--- a/orm/src/test/java/org/hibernate/search/test/bridge/MapBridgeNullEmbeddedTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/MapBridgeNullEmbeddedTest.java
@@ -109,7 +109,7 @@ public class MapBridgeNullEmbeddedTest extends SearchTestBase {
 	@Test
 	public void testSearchNullNumericEntry() throws Exception {
 		List<MapBridgeNullEmbeddedTestEntity> results =
-				findResults( "numericNullIndexed", MapBridgeNullEmbeddedTestEntity.NULL_NUMERIC_TOKEN, false );
+				findResults( "numericNullIndexed", MapBridgeNullEmbeddedTestEntity.NULL_NUMERIC_TOKEN, true );
 
 		assertNotNull( "No result found for an indexed collection", results );
 		assertEquals( "Unexpected number of results in a collection", 1, results.size() );

--- a/orm/src/test/java/org/hibernate/search/test/bridge/MapBridgeTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/MapBridgeTest.java
@@ -102,7 +102,7 @@ public class MapBridgeTest extends SearchTestBase {
 	@Test
 	public void testSearchNullNumericEntry() throws Exception {
 		List<MapBridgeTestEntity> results =
-				findResults( "numericNullIndexed", MapBridgeTestEntity.NULL_NUMERIC_TOKEN, false );
+				findResults( "numericNullIndexed", MapBridgeTestEntity.NULL_NUMERIC_TOKEN, true );
 
 		assertNotNull( "No result found for an indexed collection", results );
 		assertEquals( "Unexpected number of results in a collection", 1, results.size() );

--- a/orm/src/test/java/org/hibernate/search/test/query/dsl/DSLTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/dsl/DSLTest.java
@@ -739,6 +739,46 @@ public class DSLTest extends SearchTestBase {
 	}
 
 	@Test
+	@TestForIssue(jiraKey = "HSEARCH-2656")
+	public void testNumericRangeQueryWithFieldTypeOverriddenByFieldBridge() throws Exception {
+		Transaction transaction = fullTextSession.beginTransaction();
+		final QueryBuilder monthQb = fullTextSession.getSearchFactory()
+				.buildQueryBuilder().forEntity( Month.class ).get();
+
+		Query query = monthQb
+				.range()
+					.onField( "monthBase0" )
+						.ignoreFieldBridge().ignoreAnalyzer()
+					.below( 1 ).excludeLimit()
+					.createQuery();
+		FullTextQuery hibQuery = fullTextSession.createFullTextQuery( query, Month.class );
+		assertEquals( 1, hibQuery.getResultSize() );
+		assertEquals( "January", ( (Month) hibQuery.list().get( 0 ) ).getName() );
+
+		transaction.commit();
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-2656")
+	public void testNumericQueryWithFieldTypeOverriddenByFieldBridge() throws Exception {
+		Transaction transaction = fullTextSession.beginTransaction();
+		final QueryBuilder monthQb = fullTextSession.getSearchFactory()
+				.buildQueryBuilder().forEntity( Month.class ).get();
+
+		Query query = monthQb
+				.keyword()
+					.onField( "monthBase0" )
+						.ignoreFieldBridge().ignoreAnalyzer()
+					.matching( 0 )
+					.createQuery();
+		FullTextQuery hibQuery = fullTextSession.createFullTextQuery( query, Month.class );
+		assertEquals( 1, hibQuery.getResultSize() );
+		assertEquals( "January", ( (Month) hibQuery.list().get( 0 ) ).getName() );
+
+		transaction.commit();
+	}
+
+	@Test
 	public void testPhraseQuery() throws Exception {
 		Transaction transaction = fullTextSession.beginTransaction();
 		final QueryBuilder monthQb = fullTextSession.getSearchFactory()

--- a/orm/src/test/java/org/hibernate/search/test/query/dsl/Month.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/dsl/Month.java
@@ -68,7 +68,11 @@ public class Month {
 			@Field(analyze = Analyze.NO,
 					norms = Norms.NO,
 					name = "monthRomanNumber",
-					bridge = @FieldBridge(impl = RomanNumberFieldBridge.class))
+					bridge = @FieldBridge(impl = RomanNumberFieldBridge.class)),
+			@Field(analyze = Analyze.NO,
+					norms = Norms.NO,
+					name = "monthBase0",
+					bridge = @FieldBridge(impl = MonthBase0FieldBridge.class))
 	})
 	public int getMonthValue() {
 		return monthValue;

--- a/orm/src/test/java/org/hibernate/search/test/query/dsl/MonthBase0FieldBridge.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/dsl/MonthBase0FieldBridge.java
@@ -1,0 +1,31 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+package org.hibernate.search.test.query.dsl;
+
+import org.apache.lucene.document.Document;
+import org.hibernate.search.bridge.LuceneOptions;
+import org.hibernate.search.bridge.MetadataProvidingFieldBridge;
+import org.hibernate.search.bridge.spi.FieldMetadataBuilder;
+import org.hibernate.search.bridge.spi.FieldType;
+
+/**
+ * Example of a MetadataProvidingFieldBridge overriding the field type to make it numeric.
+ */
+public class MonthBase0FieldBridge implements MetadataProvidingFieldBridge {
+
+	@Override
+	public void configureFieldMetadata(String name, FieldMetadataBuilder builder) {
+		builder.field( name, FieldType.INTEGER );
+	}
+
+	@Override
+	public void set(String name, Object value, Document document, LuceneOptions luceneOptions) {
+		luceneOptions.addNumericFieldToDocument( name, (Integer) value - 1, document );
+	}
+
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2656

Note: given there is a behavior change, I'm not sure we should backport this. The new behavior is definitely better, though.