### PR TITLE
Various bugfixes and improvements in ElasticsearchHSQueryImpl

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchHSQueryImpl.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchHSQueryImpl.java
@@ -337,7 +337,11 @@ public class ElasticsearchHSQueryImpl extends AbstractHSQuery {
 
 	private Iterable<Class<?>> getQueriedEntityTypes() {
 		if ( indexedTargetedEntities == null || indexedTargetedEntities.isEmpty() ) {
-			return extendedIntegrator.getIndexBindings().keySet();
+			Set<Class<?>> indexBindings = extendedIntegrator.getIndexBindings().keySet();
+			if ( indexBindings.isEmpty() ) {
+				throw LOG.queryWithNoIndexedType();
+			}
+			return indexBindings;
 		}
 		else {
 			return indexedTargetedEntities;

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchIndexManager.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchIndexManager.java
@@ -148,6 +148,13 @@ public class ElasticsearchIndexManager implements IndexManager, IndexNameNormali
 		this.workProcessor = elasticsearchService.getWorkProcessor();
 	}
 
+	/**
+	 * @return the ElasticsearchService used by this index manager.
+	 */
+	public ElasticsearchService getElasticsearchService() {
+		return elasticsearchService;
+	}
+
 	private static String getOverriddenIndexName(String indexName, Properties properties) {
 		String name = properties.getProperty( Environment.INDEX_NAME_PROP_NAME );
 		return name != null ? name : indexName;

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchQueryOptions.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchQueryOptions.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.impl;
+
+
+/**
+ * Options impacting Elasticsearch querying.
+ *
+ * @author Yoann Rodiere
+ */
+public interface ElasticsearchQueryOptions {
+
+	String getScrollTimeout();
+
+	int getScrollFetchSize();
+
+	int getScrollBacktrackingWindowSize();
+
+}

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchService.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchService.java
@@ -41,4 +41,6 @@ public interface ElasticsearchService extends Service {
 
 	MissingValueStrategy getMissingValueStrategy();
 
+	ElasticsearchQueryOptions getQueryOptions();
+
 }

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/EmptyDocumentExtractor.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/EmptyDocumentExtractor.java
@@ -1,0 +1,59 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.impl;
+
+import java.io.IOException;
+
+import org.apache.lucene.search.TopDocs;
+import org.hibernate.search.elasticsearch.logging.impl.Log;
+import org.hibernate.search.query.engine.spi.DocumentExtractor;
+import org.hibernate.search.query.engine.spi.EntityInfo;
+import org.hibernate.search.util.logging.impl.LoggerFactory;
+
+
+/**
+ * @author Yoann Rodiere
+ */
+class EmptyDocumentExtractor implements DocumentExtractor {
+
+	private static final Log log = LoggerFactory.make( Log.class );
+
+	private static final DocumentExtractor INSTANCE = new EmptyDocumentExtractor();
+
+	public static DocumentExtractor get() {
+		return INSTANCE;
+	}
+
+	private EmptyDocumentExtractor() {
+		// Use get()
+	}
+
+	@Override
+	public EntityInfo extract(int index) throws IOException {
+		throw new IndexOutOfBoundsException( "This document extractor is empty" );
+	}
+
+	@Override
+	public int getFirstIndex() {
+		return 0;
+	}
+
+	@Override
+	public int getMaxIndex() {
+		return -1;
+	}
+
+	@Override
+	public void close() {
+		// Nothing to do
+	}
+
+	@Override
+	public TopDocs getTopDocs() {
+		throw log.documentExtractorTopDocsUnsupported();
+	}
+}

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/EmptySearchResult.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/EmptySearchResult.java
@@ -1,0 +1,59 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.impl;
+
+import org.hibernate.search.elasticsearch.work.impl.SearchResult;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+/**
+ * @author Yoann Rodiere
+ */
+public class EmptySearchResult implements SearchResult {
+
+	private static final EmptySearchResult INSTANCE = new EmptySearchResult();
+
+	public static SearchResult get() {
+		return INSTANCE;
+	}
+
+	private EmptySearchResult() {
+		// Use get()
+	}
+
+	@Override
+	public JsonArray getHits() {
+		return new JsonArray();
+	}
+
+	@Override
+	public int getTotalHitCount() {
+		return 0;
+	}
+
+	@Override
+	public JsonObject getAggregations() {
+		return new JsonObject();
+	}
+
+	@Override
+	public int getTook() {
+		return 0;
+	}
+
+	@Override
+	public boolean getTimedOut() {
+		return false;
+	}
+
+	@Override
+	public String getScrollId() {
+		return null;
+	}
+
+}

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/work/impl/SearchResult.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/work/impl/SearchResult.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.elasticsearch.work.impl;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
 /**
@@ -13,8 +14,16 @@ import com.google.gson.JsonObject;
  */
 public interface SearchResult {
 
-	JsonObject getJsonObject();
+	JsonArray getHits();
 
 	int getTotalHitCount();
+
+	JsonObject getAggregations();
+
+	int getTook();
+
+	boolean getTimedOut();
+
+	String getScrollId();
 
 }

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/work/impl/SearchWork.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/work/impl/SearchWork.java
@@ -20,6 +20,8 @@ import org.hibernate.search.elasticsearch.work.impl.builder.SearchWorkBuilder;
 import org.hibernate.search.util.logging.impl.DefaultLogCategories;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 /**
@@ -114,7 +116,17 @@ public class SearchWork extends SimpleElasticsearchWork<SearchResult> {
 
 	static class SearchResultImpl implements SearchResult {
 
+		private static final JsonAccessor HITS_HITS_ACCESSOR = JsonAccessor.root().property( "hits" ).property( "hits" );
+
 		private static final JsonAccessor COUNT_ACCESSOR = JsonAccessor.root().property( "hits" ).property( "total" );
+
+		private static final JsonAccessor AGGREGATIONS_ACCESSOR = JsonAccessor.root().property( "aggregations" );
+
+		private static final JsonAccessor TOOK_ACCESSOR = JsonAccessor.root().property( "took" );
+
+		private static final JsonAccessor TIMED_OUT_ACCESSOR = JsonAccessor.root().property( "timed_out" );
+
+		private static final JsonAccessor SCROLL_ID_ACCESSOR = JsonAccessor.root().property( "_scroll_id" );
 
 		private final JsonObject jsonObject;
 
@@ -124,13 +136,35 @@ public class SearchWork extends SimpleElasticsearchWork<SearchResult> {
 		}
 
 		@Override
-		public JsonObject getJsonObject() {
-			return jsonObject;
+		public JsonArray getHits() {
+			return HITS_HITS_ACCESSOR.get( jsonObject ).getAsJsonArray();
 		}
 
 		@Override
 		public int getTotalHitCount() {
 			return COUNT_ACCESSOR.get( jsonObject ).getAsInt();
+		}
+
+		@Override
+		public JsonObject getAggregations() {
+			JsonElement element = AGGREGATIONS_ACCESSOR.get( jsonObject );
+			return element == null ? null : element.getAsJsonObject();
+		}
+
+		@Override
+		public int getTook() {
+			return TOOK_ACCESSOR.get( jsonObject ).getAsInt();
+		}
+
+		@Override
+		public boolean getTimedOut() {
+			return TIMED_OUT_ACCESSOR.get( jsonObject ).getAsBoolean();
+		}
+
+		@Override
+		public String getScrollId() {
+			JsonElement element = SCROLL_ID_ACCESSOR.get( jsonObject );
+			return element == null ? null : element.getAsString();
 		}
 
 	}

--- a/engine/src/main/java/org/hibernate/search/query/engine/impl/LuceneHSQuery.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/impl/LuceneHSQuery.java
@@ -458,6 +458,13 @@ public class LuceneHSQuery extends AbstractHSQuery implements HSQuery {
 		}
 		this.idFieldNames = idFieldNames;
 
+		if ( targetedIndexes.isEmpty() ) {
+			/*
+			 * May happen when searching on indexes with dynamic sharding that haven't any shard yet.
+			 */
+			return null;
+		}
+
 		//compute optimization needClassFilterClause
 		//if at least one DP contains one class that is not part of the targeted classesAndSubclasses we can't optimize
 		if ( classesAndSubclasses != null ) {

--- a/engine/src/main/java/org/hibernate/search/query/engine/impl/LuceneHSQuery.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/impl/LuceneHSQuery.java
@@ -405,9 +405,7 @@ public class LuceneHSQuery extends AbstractHSQuery implements HSQuery {
 			// empty indexedTargetedEntities array means search over all indexed entities,
 			// but we have to make sure there is at least one
 			if ( indexBindings.isEmpty() ) {
-				throw new SearchException(
-						"There are no mapped entities. Don't forget to add @Indexed to at least one class."
-				);
+				throw log.queryWithNoIndexedType();
 			}
 
 			for ( EntityIndexBinding entityIndexBinding : indexBindings.values() ) {

--- a/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
@@ -1019,4 +1019,7 @@ public interface Log extends BasicLogger {
 
 	@Message(id = 332, value = "None of the specified entity types ('%s') or any of their subclasses are configured." )
 	IllegalArgumentException targetedEntityTypesNotConfigured(String targetedEntities);
+
+	@Message(id = 333, value = "Cannot query: there aren't any mapped entity. Don't forget to add @Indexed to at least one class." )
+	SearchException queryWithNoIndexedType();
 }

--- a/orm/src/test/java/org/hibernate/search/test/query/QueryUnindexedEntityTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/QueryUnindexedEntityTest.java
@@ -49,7 +49,7 @@ public class QueryUnindexedEntityTest extends SearchTestBase {
 			fail();
 		}
 		catch (SearchException e) {
-			assertTrue( "Wrong message", e.getMessage().startsWith( "There are no mapped entities" ) );
+			assertTrue( "Wrong message", e.getMessage().contains( "Cannot query: there aren't any mapped entity" ) );
 		}
 
 		tx.rollback();


### PR DESCRIPTION
Grouping these as a single PR, because they touch the same area of code, and I'd rather not do a hundred separate rebases :)

Relevant tickets:

 * https://hibernate.atlassian.net/browse/HSEARCH-2361 : Make sure Elasticsearch related configuration properties are parsed and validated at boot time
 * https://hibernate.atlassian.net/browse/HSEARCH-2662: Querying an empty, dynamically sharded index won't work (Lucene + Elasticsearch)
   About this one: it actually "worked" with Elasticsearch, but we used to send a search query without specifying the index to search on, with type filters that reduced the results to nothing. So it was more a performance issue than anything else for the Elasticsearch part.
 * https://hibernate.atlassian.net/browse/HSEARCH-2661: Avoid the recurring calls to serviceManager.requestReference in ElasticsearchHSQueryImpl