### PR TITLE
HSEARCH-2670 Facet drill-down will never return any result when the source field has a different name

### DIFF
--- a/engine/src/main/java/org/hibernate/search/query/dsl/impl/AbstractFacet.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/impl/AbstractFacet.java
@@ -18,13 +18,15 @@ import org.hibernate.search.query.facet.Facet;
  */
 public abstract class AbstractFacet implements Facet {
 	private final String facetingName;
-	private final String fieldName;
+	private final String facetFieldName;
+	private final String sourceFieldName;
 	private final String value;
 	private final int count;
 
-	public AbstractFacet(String facetingName, String fieldName, String value, int count) {
+	public AbstractFacet(String facetingName, String facetFieldName, String sourceFieldName, String value, int count) {
 		this.facetingName = facetingName;
-		this.fieldName = fieldName;
+		this.facetFieldName = facetFieldName;
+		this.sourceFieldName = sourceFieldName;
 		this.count = count;
 		this.value = value;
 	}
@@ -39,9 +41,21 @@ public abstract class AbstractFacet implements Facet {
 		return value;
 	}
 
+	/**
+	 * @deprecated Use {@link #getFacetFieldName()} instead.
+	 */
 	@Override
+	@Deprecated
 	public String getFieldName() {
-		return fieldName;
+		return getFacetFieldName();
+	}
+
+	public String getFacetFieldName() {
+		return facetFieldName;
+	}
+
+	public String getSourceFieldName() {
+		return sourceFieldName;
 	}
 
 	@Override
@@ -66,7 +80,10 @@ public abstract class AbstractFacet implements Facet {
 		if ( facetingName != null ? !facetingName.equals( that.facetingName ) : that.facetingName != null ) {
 			return false;
 		}
-		if ( fieldName != null ? !fieldName.equals( that.fieldName ) : that.fieldName != null ) {
+		if ( facetFieldName != null ? !facetFieldName.equals( that.facetFieldName ) : that.facetFieldName != null ) {
+			return false;
+		}
+		if ( sourceFieldName != null ? !sourceFieldName.equals( that.sourceFieldName ) : that.sourceFieldName != null ) {
 			return false;
 		}
 		if ( value != null ? !value.equals( that.value ) : that.value != null ) {
@@ -79,7 +96,8 @@ public abstract class AbstractFacet implements Facet {
 	@Override
 	public int hashCode() {
 		int result = facetingName != null ? facetingName.hashCode() : 0;
-		result = 31 * result + ( fieldName != null ? fieldName.hashCode() : 0 );
+		result = 31 * result + ( facetFieldName != null ? facetFieldName.hashCode() : 0 );
+		result = 31 * result + ( sourceFieldName != null ? sourceFieldName.hashCode() : 0 );
 		result = 31 * result + ( value != null ? value.hashCode() : 0 );
 		return result;
 	}
@@ -89,7 +107,8 @@ public abstract class AbstractFacet implements Facet {
 		final StringBuilder sb = new StringBuilder();
 		sb.append( "AbstractFacet" );
 		sb.append( "{facetingName='" ).append( facetingName ).append( '\'' );
-		sb.append( ", fieldName='" ).append( fieldName ).append( '\'' );
+		sb.append( ", facetFieldName='" ).append( facetFieldName ).append( '\'' );
+		sb.append( ", sourceFieldName='" ).append( sourceFieldName ).append( '\'' );
 		sb.append( ", value='" ).append( value ).append( '\'' );
 		sb.append( ", count=" ).append( count );
 		sb.append( '}' );

--- a/engine/src/main/java/org/hibernate/search/query/dsl/impl/DiscreteFacetRequest.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/impl/DiscreteFacetRequest.java
@@ -10,6 +10,7 @@ package org.hibernate.search.query.dsl.impl;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
+import org.hibernate.search.engine.metadata.impl.FacetMetadata;
 import org.hibernate.search.query.facet.Facet;
 
 /**
@@ -28,18 +29,18 @@ public class DiscreteFacetRequest extends FacetingRequestImpl {
 	}
 
 	@Override
-	public Facet createFacet(String value, int count) {
-		return new SimpleFacet( getFacetingName(), getFieldName(), value, count );
+	public Facet createFacet(FacetMetadata facetMetadata, String value, int count) {
+		return new SimpleFacet( getFacetingName(), getFieldName(), facetMetadata.getSourceField().getAbsoluteName(), value, count );
 	}
 
 	static class SimpleFacet extends AbstractFacet {
-		SimpleFacet(String facetingName, String fieldName, String value, int count) {
-			super( facetingName, fieldName, value, count );
+		SimpleFacet(String facetingName, String facetFieldName, String sourceFieldName, String value, int count) {
+			super( facetingName, facetFieldName, sourceFieldName, value, count );
 		}
 
 		@Override
 		public Query getFacetQuery() {
-			return new TermQuery( new Term( getFieldName(), getValue() ) );
+			return new TermQuery( new Term( getSourceFieldName(), getValue() ) );
 		}
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/query/dsl/impl/FacetingRequestImpl.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/impl/FacetingRequestImpl.java
@@ -7,6 +7,7 @@
 
 package org.hibernate.search.query.dsl.impl;
 
+import org.hibernate.search.engine.metadata.impl.FacetMetadata;
 import org.hibernate.search.query.facet.Facet;
 import org.hibernate.search.query.facet.FacetSortOrder;
 import org.hibernate.search.query.facet.FacetingRequest;
@@ -23,7 +24,7 @@ public abstract class FacetingRequestImpl implements FacetingRequest {
 	private final String name;
 
 	/**
-	 * The document field name to facet on
+	 * The document facet name to facet on (@Facet.name)
 	 */
 	private final String fieldName;
 
@@ -87,7 +88,7 @@ public abstract class FacetingRequestImpl implements FacetingRequest {
 	 */
 	public abstract Class<?> getFacetValueType();
 
-	public abstract Facet createFacet(String value, int count);
+	public abstract Facet createFacet(FacetMetadata facetMetadata, String value, int count);
 
 	@Override
 	public boolean hasZeroCountsIncluded() {

--- a/engine/src/main/java/org/hibernate/search/query/dsl/impl/RangeFacetRequest.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/impl/RangeFacetRequest.java
@@ -8,6 +8,7 @@ package org.hibernate.search.query.dsl.impl;
 
 import java.util.List;
 
+import org.hibernate.search.engine.metadata.impl.FacetMetadata;
 import org.hibernate.search.query.facet.Facet;
 
 /**
@@ -40,10 +41,10 @@ public class RangeFacetRequest<T> extends FacetingRequestImpl {
 	}
 
 	@Override
-	public Facet createFacet(String value, int count) {
+	public Facet createFacet(FacetMetadata facetMetadata, String value, int count) {
 		int facetIndex = findFacetRangeIndex( value );
 		FacetRange<T> range = facetRangeList.get( facetIndex );
-		return new RangeFacetImpl<>( getFacetingName(), getFieldName(), range, count, facetIndex );
+		return new RangeFacetImpl<>( getFacetingName(), getFieldName(), facetMetadata.getSourceField().getAbsoluteName(), range, count, facetIndex );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/query/engine/impl/LazyQueryState.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/impl/LazyQueryState.java
@@ -8,6 +8,7 @@ package org.hibernate.search.query.engine.impl;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -22,6 +23,7 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.similarities.Similarity;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
+import org.hibernate.search.engine.spi.EntityIndexBinding;
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.metadata.FieldDescriptor;
 import org.hibernate.search.metadata.IndexedTypeDescriptor;
@@ -45,7 +47,7 @@ public final class LazyQueryState implements Closeable {
 	private final boolean fieldSortDoTrackScores;
 	private final boolean fieldSortDoMaxScore;
 	private final ExtendedSearchIntegrator extendedIntegrator;
-	private final Set<Class<?>> targetedTypes;
+	private final Collection<EntityIndexBinding> targetedEntityBindings;
 	private final QueryFilters facetingFilters;
 
 	private Query rewrittenQuery;
@@ -55,7 +57,7 @@ public final class LazyQueryState implements Closeable {
 			IndexReader reader,
 			Similarity searcherSimilarity,
 			ExtendedSearchIntegrator extendedIntegrator,
-			Set<Class<?>> targetedTypes,
+			Collection<EntityIndexBinding> targetedEntityBindings,
 			boolean fieldSortDoTrackScores,
 			boolean fieldSortDoMaxScore) {
 		this.userQuery = userQuery;
@@ -65,7 +67,7 @@ public final class LazyQueryState implements Closeable {
 		this.searcher = new IndexSearcher( reader );
 		this.searcher.setSimilarity( searcherSimilarity );
 		this.extendedIntegrator = extendedIntegrator;
-		this.targetedTypes = targetedTypes;
+		this.targetedEntityBindings = targetedEntityBindings;
 	}
 
 	public boolean isFieldSortDoTrackScores() {
@@ -129,9 +131,9 @@ public final class LazyQueryState implements Closeable {
 		// rewrites queries to use filters
 		Set<String> stringEncodedFieldNames = new HashSet<>();
 		Set<String> numericEncodedFieldNames = new HashSet<>();
-		for ( Class<?> targetedType : targetedTypes ) {
+		for ( EntityIndexBinding binding : targetedEntityBindings ) {
 			IndexedTypeDescriptor indexedTypeDescriptor = extendedIntegrator.getIndexedTypeDescriptor(
-					targetedType
+					binding.getDocumentBuilder().getBeanClass()
 			);
 			// get the field contributions from the type (class bridges)
 			for ( FieldDescriptor fieldDescriptor : indexedTypeDescriptor.getIndexedFields() ) {

--- a/engine/src/main/java/org/hibernate/search/query/engine/impl/LuceneHSQuery.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/impl/LuceneHSQuery.java
@@ -34,6 +34,7 @@ import org.hibernate.search.engine.ProjectionConstants;
 import org.hibernate.search.engine.impl.FilterDef;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.engine.metadata.impl.EmbeddedTypeMetadata;
+import org.hibernate.search.engine.metadata.impl.FacetMetadata;
 import org.hibernate.search.engine.metadata.impl.PropertyMetadata;
 import org.hibernate.search.engine.metadata.impl.SortableFieldMetadata;
 import org.hibernate.search.engine.metadata.impl.TypeMetadata;
@@ -53,6 +54,7 @@ import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.query.engine.spi.DocumentExtractor;
 import org.hibernate.search.query.engine.spi.EntityInfo;
 import org.hibernate.search.query.engine.spi.HSQuery;
+import org.hibernate.search.query.facet.FacetingRequest;
 import org.hibernate.search.reader.impl.MultiReaderFactory;
 import org.hibernate.search.spi.CustomTypeMetadata;
 import org.hibernate.search.util.impl.CollectionHelper;
@@ -308,13 +310,17 @@ public class LuceneHSQuery extends AbstractHSQuery implements HSQuery {
 			startTime = System.nanoTime();
 		}
 
+		Collection<FacetingRequest> facetingRequests = getFacetManager().getFacetRequests().values();
+		Map<FacetingRequest, FacetMetadata> facetingRequestsAndMetadata =
+				buildFacetingRequestsAndMetadata( facetingRequests, targetedEntityBindingsByName.values() );
+
 		if ( n == null ) { // try to make sure that we get the right amount of top docs
 			queryHits = new QueryHits(
 					searcher,
 					filter,
 					sort,
 					getTimeoutManager(),
-					getFacetManager().getFacetRequests(),
+					facetingRequestsAndMetadata,
 					this.timeoutExceptionFactory,
 					spatialSearchCenter,
 					spatialFieldName
@@ -340,7 +346,7 @@ public class LuceneHSQuery extends AbstractHSQuery implements HSQuery {
 					sort,
 					n,
 					getTimeoutManager(),
-					getFacetManager().getFacetRequests(),
+					facetingRequestsAndMetadata,
 					this.timeoutExceptionFactory,
 					spatialSearchCenter,
 					spatialFieldName

--- a/engine/src/main/java/org/hibernate/search/query/facet/FacetingRequest.java
+++ b/engine/src/main/java/org/hibernate/search/query/facet/FacetingRequest.java
@@ -18,7 +18,7 @@ public interface FacetingRequest {
 	String getFacetingName();
 
 	/**
-	 * @return the {@code Document} field name on which this faceting request is defined on
+	 * @return the name of the facet field this faceting request is defined on
 	 */
 	String getFieldName();
 

--- a/engine/src/test/java/org/hibernate/search/test/id/providedId/ProvidedIdTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/id/providedId/ProvidedIdTest.java
@@ -6,7 +6,9 @@
  */
 package org.hibernate.search.test.id.providedId;
 
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.lucene.index.IndexReader;
@@ -19,6 +21,7 @@ import org.apache.lucene.search.similarities.Similarity;
 import org.hibernate.search.backend.spi.Work;
 import org.hibernate.search.backend.spi.WorkType;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
+import org.hibernate.search.engine.spi.EntityIndexBinding;
 import org.hibernate.search.query.engine.QueryTimeoutException;
 import org.hibernate.search.query.engine.impl.DocumentExtractorImpl;
 import org.hibernate.search.query.engine.impl.LazyQueryState;
@@ -95,7 +98,7 @@ public class ProvidedIdTest {
 				indexReader,
 				defaultSimilarity,
 				extendedIntegrator,
-				extendedIntegrator.getIndexedTypes(),
+				extendedIntegrator.getIndexBindings().values(),
 				false,
 				false
 		);
@@ -110,15 +113,15 @@ public class ProvidedIdTest {
 		);
 		Set<String> identifiers = new HashSet<String>();
 		identifiers.add( "providedId" );
-		Set<Class<?>> targetedClasses = new HashSet<Class<?>>();
-		targetedClasses.add( ProvidedIdPerson.class );
-		targetedClasses.add( ProvidedIdPersonSub.class );
+		Map<String, EntityIndexBinding> targetedEntityBindings = new HashMap<>();
+		targetedEntityBindings.put( ProvidedIdPerson.class.getName(), extendedIntegrator.getIndexBinding( ProvidedIdPerson.class ) );
+		targetedEntityBindings.put( ProvidedIdPersonSub.class.getName(), extendedIntegrator.getIndexBinding( ProvidedIdPersonSub.class ) );
 		DocumentExtractor extractor = new DocumentExtractorImpl(
 				queryHits, extendedIntegrator, new String[] { "name" },
 				identifiers, false,
 				lowLevelSearcher,
 				0, 0, //not used in this case
-				targetedClasses
+				targetedEntityBindings
 		);
 		HashSet<String> titles = new HashSet<String>( 3 );
 		for ( int id = 0; id < hits.totalHits; id++ ) {

--- a/orm/src/test/java/org/hibernate/search/test/query/facet/Car.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/facet/Car.java
@@ -49,6 +49,10 @@ public class Car {
 
 	public static final String COLLATING_ANALYZER_NAME = "org_hibernate_search_test_query_facet_Car" + "_collatingAnalyzer";
 
+	// Those facet names must be different from the original field name, for testing purposes
+	public static final String CUBIC_CAPACITY_STRING = "cubicCapacity_string";
+	public static final String CUBIC_CAPACITY_NUMERIC = "cubicCapacity_numeric";
+
 	@Id
 	@GeneratedValue
 	private int id;
@@ -68,9 +72,9 @@ public class Car {
 
 	private String make;
 
-	@Field(name = "cubicCapacity", analyze = Analyze.NO, bridge = @FieldBridge(impl = IntegerBridge.class))
-	@Facet(name = "cubicCapacity", forField = "cubicCapacity", encoding = FacetEncodingType.STRING)
-	@Facet(name = "cubicCapacity_Numeric", forField = "cubicCapacity", encoding = FacetEncodingType.LONG)
+	@Field(name = CUBIC_CAPACITY_STRING, analyze = Analyze.NO, bridge = @FieldBridge(impl = IntegerBridge.class))
+	@Facet(name = CUBIC_CAPACITY_STRING, forField = CUBIC_CAPACITY_STRING, encoding = FacetEncodingType.STRING)
+	@Facet(name = CUBIC_CAPACITY_NUMERIC, forField = CUBIC_CAPACITY_STRING, encoding = FacetEncodingType.LONG)
 	private Integer cubicCapacity;
 
 	public Car() {

--- a/orm/src/test/java/org/hibernate/search/test/query/facet/Car.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/facet/Car.java
@@ -49,9 +49,11 @@ public class Car {
 
 	public static final String COLLATING_ANALYZER_NAME = "org_hibernate_search_test_query_facet_Car" + "_collatingAnalyzer";
 
-	// Those facet names must be different from the original field name, for testing purposes
 	public static final String CUBIC_CAPACITY_STRING = "cubicCapacity_string";
-	public static final String CUBIC_CAPACITY_NUMERIC = "cubicCapacity_numeric";
+
+	// Those facet names must be different from the source field name, for testing purposes
+	public static final String CUBIC_CAPACITY_STRING_FACET_STRING_ENCODING = "cubicCapacity_string_facet_string";
+	public static final String CUBIC_CAPACITY_STRING_FACET_NUMERIC_ENCODING = "cubicCapacity_string_facet_numeric";
 
 	@Id
 	@GeneratedValue
@@ -73,8 +75,8 @@ public class Car {
 	private String make;
 
 	@Field(name = CUBIC_CAPACITY_STRING, analyze = Analyze.NO, bridge = @FieldBridge(impl = IntegerBridge.class))
-	@Facet(name = CUBIC_CAPACITY_STRING, forField = CUBIC_CAPACITY_STRING, encoding = FacetEncodingType.STRING)
-	@Facet(name = CUBIC_CAPACITY_NUMERIC, forField = CUBIC_CAPACITY_STRING, encoding = FacetEncodingType.LONG)
+	@Facet(name = CUBIC_CAPACITY_STRING_FACET_STRING_ENCODING, forField = CUBIC_CAPACITY_STRING, encoding = FacetEncodingType.STRING)
+	@Facet(name = CUBIC_CAPACITY_STRING_FACET_NUMERIC_ENCODING, forField = CUBIC_CAPACITY_STRING, encoding = FacetEncodingType.LONG)
 	private Integer cubicCapacity;
 
 	public Car() {

--- a/orm/src/test/java/org/hibernate/search/test/query/facet/EdgeCaseFacetTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/facet/EdgeCaseFacetTest.java
@@ -30,7 +30,7 @@ public class EdgeCaseFacetTest extends AbstractFacetTest {
 	public void testFacetingOnEmptyIndex() throws Exception {
 		FacetingRequest request = queryBuilder( Car.class ).facet()
 				.name( facetName )
-				.onField( Car.CUBIC_CAPACITY_STRING )
+				.onField( Car.CUBIC_CAPACITY_STRING_FACET_STRING_ENCODING )
 				.discrete()
 				.createFacetingRequest();
 		FullTextQuery query = queryHondaWithFacet( request );

--- a/orm/src/test/java/org/hibernate/search/test/query/facet/EdgeCaseFacetTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/facet/EdgeCaseFacetTest.java
@@ -24,14 +24,13 @@ import static org.junit.Assert.assertEquals;
  * @author Emmanuel Bernard
  */
 public class EdgeCaseFacetTest extends AbstractFacetTest {
-	private final String indexFieldName = "cubicCapacity";
 	private final String facetName = "ccs";
 
 	@Test
 	public void testFacetingOnEmptyIndex() throws Exception {
 		FacetingRequest request = queryBuilder( Car.class ).facet()
 				.name( facetName )
-				.onField( indexFieldName )
+				.onField( Car.CUBIC_CAPACITY_STRING )
 				.discrete()
 				.createFacetingRequest();
 		FullTextQuery query = queryHondaWithFacet( request );

--- a/orm/src/test/java/org/hibernate/search/test/query/facet/FacetFilteringTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/facet/FacetFilteringTest.java
@@ -33,12 +33,11 @@ public class FacetFilteringTest extends AbstractFacetTest {
 
 	@Test
 	public void testDiscreteFacetDrillDown() throws Exception {
-		final String indexFieldName = "cubicCapacity";
 		final String facetName = "ccs";
 		Query luceneQuery = queryBuilder( Car.class ).keyword().onField( "make" ).matching( "Honda" ).createQuery();
 		FacetingRequest request = queryBuilder( Car.class ).facet()
 				.name( facetName )
-				.onField( indexFieldName )
+				.onField( Car.CUBIC_CAPACITY_STRING )
 				.discrete()
 				.includeZeroCounts( true )
 				.createFacetingRequest();
@@ -68,10 +67,9 @@ public class FacetFilteringTest extends AbstractFacetTest {
 	@Test
 	public void testMultipleFacetDrillDown() throws Exception {
 		final String ccsFacetName = "ccs";
-		final String ccsFacetFieldName = "cubicCapacity";
 		FacetingRequest ccsFacetRequest = queryBuilder( Car.class ).facet()
 				.name( ccsFacetName )
-				.onField( ccsFacetFieldName )
+				.onField( Car.CUBIC_CAPACITY_STRING )
 				.discrete()
 				.includeZeroCounts( true )
 				.createFacetingRequest();

--- a/orm/src/test/java/org/hibernate/search/test/query/facet/FacetFilteringTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/facet/FacetFilteringTest.java
@@ -37,7 +37,7 @@ public class FacetFilteringTest extends AbstractFacetTest {
 		Query luceneQuery = queryBuilder( Car.class ).keyword().onField( "make" ).matching( "Honda" ).createQuery();
 		FacetingRequest request = queryBuilder( Car.class ).facet()
 				.name( facetName )
-				.onField( Car.CUBIC_CAPACITY_STRING )
+				.onField( Car.CUBIC_CAPACITY_STRING_FACET_STRING_ENCODING )
 				.discrete()
 				.includeZeroCounts( true )
 				.createFacetingRequest();
@@ -69,7 +69,7 @@ public class FacetFilteringTest extends AbstractFacetTest {
 		final String ccsFacetName = "ccs";
 		FacetingRequest ccsFacetRequest = queryBuilder( Car.class ).facet()
 				.name( ccsFacetName )
-				.onField( Car.CUBIC_CAPACITY_STRING )
+				.onField( Car.CUBIC_CAPACITY_STRING_FACET_STRING_ENCODING )
 				.discrete()
 				.includeZeroCounts( true )
 				.createFacetingRequest();

--- a/orm/src/test/java/org/hibernate/search/test/query/facet/FacetUnknownFieldFailureTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/facet/FacetUnknownFieldFailureTest.java
@@ -28,9 +28,8 @@ public class FacetUnknownFieldFailureTest extends AbstractFacetTest {
 				.onField( "foobar" ) // foobar is not a valid field name
 				.discrete()
 				.createFacetingRequest();
-		FullTextQuery query = queryHondaWithFacet( request );
-
 		try {
+			FullTextQuery query = queryHondaWithFacet( request );
 			query.getFacetManager().getFacets( "foo" );
 			fail( "The specified field name did not exist. Faceting request should fail" );
 		}
@@ -47,11 +46,11 @@ public class FacetUnknownFieldFailureTest extends AbstractFacetTest {
 				.discrete()
 				.createFacetingRequest();
 
-		FullTextQuery query = fullTextSession.createFullTextQuery( new MatchAllDocsQuery(), Fruit.class );
-		query.getFacetManager().enableFaceting( request );
-		assertEquals( "Wrong number of query matches", 1, query.getResultSize() );
-
 		try {
+			FullTextQuery query = fullTextSession.createFullTextQuery( new MatchAllDocsQuery(), Fruit.class );
+			query.getFacetManager().enableFaceting( request );
+			assertEquals( "Wrong number of query matches", 1, query.getResultSize() );
+
 			query.getFacetManager().getFacets( "foo" );
 			fail( "The specified field name did not exist. Faceting request should fail" );
 		}

--- a/orm/src/test/java/org/hibernate/search/test/query/facet/NoQueryResultsFacetingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/facet/NoQueryResultsFacetingTest.java
@@ -30,14 +30,13 @@ import static org.junit.Assert.assertTrue;
  * @author Hardy Ferentschik
  */
 public class NoQueryResultsFacetingTest extends AbstractFacetTest {
-	private final String facetFieldName = "cubicCapacity";
 	private final String facetName = "ccs";
 
 	@Test
 	public void testSimpleDiscretFacetingWithNoResultsQuery() throws Exception {
 		FacetingRequest request = queryBuilder( Car.class ).facet()
 				.name( facetName )
-				.onField( facetFieldName )
+				.onField( Car.CUBIC_CAPACITY_STRING )
 				.discrete()
 				.createFacetingRequest();
 		FullTextQuery query = queryHondaNoResultsWithFacet( request );
@@ -51,7 +50,7 @@ public class NoQueryResultsFacetingTest extends AbstractFacetTest {
 		final String descendingOrderedFacet = "desc";
 		FacetingRequest requestDesc = queryBuilder( Car.class ).facet()
 				.name( descendingOrderedFacet )
-				.onField( facetFieldName )
+				.onField( Car.CUBIC_CAPACITY_STRING )
 				.discrete()
 				.includeZeroCounts( true )
 				.createFacetingRequest();
@@ -59,7 +58,7 @@ public class NoQueryResultsFacetingTest extends AbstractFacetTest {
 		final String ascendingOrderedFacet = "asc";
 		FacetingRequest requestAsc = queryBuilder( Car.class ).facet()
 				.name( ascendingOrderedFacet )
-				.onField( facetFieldName )
+				.onField( Car.CUBIC_CAPACITY_STRING )
 				.discrete()
 				.orderedBy( FacetSortOrder.COUNT_ASC )
 				.includeZeroCounts( true )
@@ -107,7 +106,7 @@ public class NoQueryResultsFacetingTest extends AbstractFacetTest {
 	public void testSimpleDiscretFacetingQuery() throws Exception {
 		FacetingRequest request = queryBuilder( Car.class ).facet()
 				.name( facetName )
-				.onField( facetFieldName )
+				.onField( Car.CUBIC_CAPACITY_STRING )
 				.discrete()
 				.createFacetingRequest();
 		FullTextQuery query = queryHondaWithFacet( request );
@@ -121,7 +120,7 @@ public class NoQueryResultsFacetingTest extends AbstractFacetTest {
 		final String descendingOrderedFacet = "desc";
 		FacetingRequest requestDesc = queryBuilder( Car.class ).facet()
 				.name( descendingOrderedFacet )
-				.onField( facetFieldName )
+				.onField( Car.CUBIC_CAPACITY_STRING )
 				.discrete()
 				.includeZeroCounts( true )
 				.createFacetingRequest();
@@ -129,7 +128,7 @@ public class NoQueryResultsFacetingTest extends AbstractFacetTest {
 		final String ascendingOrderedFacet = "asc";
 		FacetingRequest requestAsc = queryBuilder( Car.class ).facet()
 				.name( ascendingOrderedFacet )
-				.onField( facetFieldName )
+				.onField( Car.CUBIC_CAPACITY_STRING )
 				.discrete()
 				.orderedBy( FacetSortOrder.COUNT_ASC )
 				.includeZeroCounts( true )

--- a/orm/src/test/java/org/hibernate/search/test/query/facet/NoQueryResultsFacetingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/facet/NoQueryResultsFacetingTest.java
@@ -36,7 +36,7 @@ public class NoQueryResultsFacetingTest extends AbstractFacetTest {
 	public void testSimpleDiscretFacetingWithNoResultsQuery() throws Exception {
 		FacetingRequest request = queryBuilder( Car.class ).facet()
 				.name( facetName )
-				.onField( Car.CUBIC_CAPACITY_STRING )
+				.onField( Car.CUBIC_CAPACITY_STRING_FACET_STRING_ENCODING )
 				.discrete()
 				.createFacetingRequest();
 		FullTextQuery query = queryHondaNoResultsWithFacet( request );
@@ -50,7 +50,7 @@ public class NoQueryResultsFacetingTest extends AbstractFacetTest {
 		final String descendingOrderedFacet = "desc";
 		FacetingRequest requestDesc = queryBuilder( Car.class ).facet()
 				.name( descendingOrderedFacet )
-				.onField( Car.CUBIC_CAPACITY_STRING )
+				.onField( Car.CUBIC_CAPACITY_STRING_FACET_STRING_ENCODING )
 				.discrete()
 				.includeZeroCounts( true )
 				.createFacetingRequest();
@@ -58,7 +58,7 @@ public class NoQueryResultsFacetingTest extends AbstractFacetTest {
 		final String ascendingOrderedFacet = "asc";
 		FacetingRequest requestAsc = queryBuilder( Car.class ).facet()
 				.name( ascendingOrderedFacet )
-				.onField( Car.CUBIC_CAPACITY_STRING )
+				.onField( Car.CUBIC_CAPACITY_STRING_FACET_STRING_ENCODING )
 				.discrete()
 				.orderedBy( FacetSortOrder.COUNT_ASC )
 				.includeZeroCounts( true )
@@ -106,7 +106,7 @@ public class NoQueryResultsFacetingTest extends AbstractFacetTest {
 	public void testSimpleDiscretFacetingQuery() throws Exception {
 		FacetingRequest request = queryBuilder( Car.class ).facet()
 				.name( facetName )
-				.onField( Car.CUBIC_CAPACITY_STRING )
+				.onField( Car.CUBIC_CAPACITY_STRING_FACET_STRING_ENCODING )
 				.discrete()
 				.createFacetingRequest();
 		FullTextQuery query = queryHondaWithFacet( request );
@@ -120,7 +120,7 @@ public class NoQueryResultsFacetingTest extends AbstractFacetTest {
 		final String descendingOrderedFacet = "desc";
 		FacetingRequest requestDesc = queryBuilder( Car.class ).facet()
 				.name( descendingOrderedFacet )
-				.onField( Car.CUBIC_CAPACITY_STRING )
+				.onField( Car.CUBIC_CAPACITY_STRING_FACET_STRING_ENCODING )
 				.discrete()
 				.includeZeroCounts( true )
 				.createFacetingRequest();
@@ -128,7 +128,7 @@ public class NoQueryResultsFacetingTest extends AbstractFacetTest {
 		final String ascendingOrderedFacet = "asc";
 		FacetingRequest requestAsc = queryBuilder( Car.class ).facet()
 				.name( ascendingOrderedFacet )
-				.onField( Car.CUBIC_CAPACITY_STRING )
+				.onField( Car.CUBIC_CAPACITY_STRING_FACET_STRING_ENCODING )
 				.discrete()
 				.orderedBy( FacetSortOrder.COUNT_ASC )
 				.includeZeroCounts( true )

--- a/orm/src/test/java/org/hibernate/search/test/query/facet/NumberFacetingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/facet/NumberFacetingTest.java
@@ -30,7 +30,7 @@ public class NumberFacetingTest extends AbstractFacetTest {
 		String facetName = "ccs";
 		FacetingRequest request = queryBuilder( Car.class ).facet()
 				.name( facetName )
-				.onField( Car.CUBIC_CAPACITY_STRING )
+				.onField( Car.CUBIC_CAPACITY_STRING_FACET_STRING_ENCODING )
 				.discrete()
 				.createFacetingRequest();
 		FullTextQuery query = matchAll( request );

--- a/orm/src/test/java/org/hibernate/search/test/query/facet/NumberFacetingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/facet/NumberFacetingTest.java
@@ -27,11 +27,10 @@ public class NumberFacetingTest extends AbstractFacetTest {
 
 	@Test
 	public void testSimpleFaceting() throws Exception {
-		String indexFieldName = "cubicCapacity";
 		String facetName = "ccs";
 		FacetingRequest request = queryBuilder( Car.class ).facet()
 				.name( facetName )
-				.onField( indexFieldName )
+				.onField( Car.CUBIC_CAPACITY_STRING )
 				.discrete()
 				.createFacetingRequest();
 		FullTextQuery query = matchAll( request );

--- a/orm/src/test/java/org/hibernate/search/test/query/facet/SimpleFacetingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/facet/SimpleFacetingTest.java
@@ -36,7 +36,7 @@ public class SimpleFacetingTest extends AbstractFacetTest {
 	public void testSimpleDiscretFaceting() throws Exception {
 		FacetingRequest request = queryBuilder( Car.class ).facet()
 				.name( facetName )
-				.onField( Car.CUBIC_CAPACITY_STRING )
+				.onField( Car.CUBIC_CAPACITY_STRING_FACET_STRING_ENCODING )
 				.discrete()
 				.createFacetingRequest();
 		FullTextQuery query = queryHondaWithFacet( request );
@@ -49,7 +49,7 @@ public class SimpleFacetingTest extends AbstractFacetTest {
 	public void testDefaultSortOrderIsCount() throws Exception {
 		FacetingRequest request = queryBuilder( Car.class ).facet()
 				.name( facetName )
-				.onField( Car.CUBIC_CAPACITY_STRING )
+				.onField( Car.CUBIC_CAPACITY_STRING_FACET_STRING_ENCODING )
 				.discrete()
 				.createFacetingRequest();
 		FullTextQuery query = queryHondaWithFacet( request );
@@ -62,7 +62,7 @@ public class SimpleFacetingTest extends AbstractFacetTest {
 	public void testCountSortOrderAsc() throws Exception {
 		FacetingRequest request = queryBuilder( Car.class ).facet()
 				.name( facetName )
-				.onField( Car.CUBIC_CAPACITY_STRING )
+				.onField( Car.CUBIC_CAPACITY_STRING_FACET_STRING_ENCODING )
 				.discrete()
 				.orderedBy( FacetSortOrder.COUNT_ASC )
 				.createFacetingRequest();
@@ -76,7 +76,7 @@ public class SimpleFacetingTest extends AbstractFacetTest {
 	public void testCountSortOrderDesc() throws Exception {
 		FacetingRequest request = queryBuilder( Car.class ).facet()
 				.name( facetName )
-				.onField( Car.CUBIC_CAPACITY_STRING )
+				.onField( Car.CUBIC_CAPACITY_STRING_FACET_STRING_ENCODING )
 				.discrete()
 				.orderedBy( FacetSortOrder.COUNT_DESC )
 				.createFacetingRequest();
@@ -90,7 +90,7 @@ public class SimpleFacetingTest extends AbstractFacetTest {
 	public void testAlphabeticalSortOrder() throws Exception {
 		FacetingRequest request = queryBuilder( Car.class ).facet()
 				.name( facetName )
-				.onField( Car.CUBIC_CAPACITY_STRING )
+				.onField( Car.CUBIC_CAPACITY_STRING_FACET_STRING_ENCODING )
 				.discrete()
 				.orderedBy( FacetSortOrder.FIELD_VALUE )
 				.createFacetingRequest();
@@ -108,7 +108,7 @@ public class SimpleFacetingTest extends AbstractFacetTest {
 	public void testZeroCountsExcluded() throws Exception {
 		FacetingRequest request = queryBuilder( Car.class ).facet()
 				.name( facetName )
-				.onField( Car.CUBIC_CAPACITY_STRING )
+				.onField( Car.CUBIC_CAPACITY_STRING_FACET_STRING_ENCODING )
 				.discrete()
 				.orderedBy( FacetSortOrder.COUNT_DESC )
 				.includeZeroCounts( false )
@@ -123,7 +123,7 @@ public class SimpleFacetingTest extends AbstractFacetTest {
 	public void testZeroCountsIncluded() throws Exception {
 		FacetingRequest request = queryBuilder( Car.class ).facet()
 				.name( facetName )
-				.onField( Car.CUBIC_CAPACITY_STRING )
+				.onField( Car.CUBIC_CAPACITY_STRING_FACET_STRING_ENCODING )
 				.discrete()
 				.orderedBy( FacetSortOrder.COUNT_DESC )
 				.includeZeroCounts( true )
@@ -139,7 +139,7 @@ public class SimpleFacetingTest extends AbstractFacetTest {
 	public void testMaxFacetCounts() throws Exception {
 		FacetingRequest request = queryBuilder( Car.class ).facet()
 				.name( facetName )
-				.onField( Car.CUBIC_CAPACITY_STRING )
+				.onField( Car.CUBIC_CAPACITY_STRING_FACET_STRING_ENCODING )
 				.discrete()
 				.orderedBy( FacetSortOrder.COUNT_DESC )
 				.maxFacetCount( 1 )
@@ -171,7 +171,7 @@ public class SimpleFacetingTest extends AbstractFacetTest {
 		try {
 			queryBuilder( Car.class ).facet()
 					.name( null )
-					.onField( Car.CUBIC_CAPACITY_STRING )
+					.onField( Car.CUBIC_CAPACITY_STRING_FACET_STRING_ENCODING )
 					.discrete()
 					.createFacetingRequest();
 			fail( "null should not be a valid request name" );
@@ -186,7 +186,7 @@ public class SimpleFacetingTest extends AbstractFacetTest {
 		try {
 			queryBuilder( Car.class ).facet()
 					.name( facetName )
-					.onField( Car.CUBIC_CAPACITY_STRING )
+					.onField( Car.CUBIC_CAPACITY_STRING_FACET_STRING_ENCODING )
 					.discrete()
 					.orderedBy( FacetSortOrder.RANGE_DEFINITION_ORDER )
 					.createFacetingRequest();
@@ -201,7 +201,7 @@ public class SimpleFacetingTest extends AbstractFacetTest {
 	public void testEnableDisableFacets() {
 		FacetingRequest request = queryBuilder( Car.class ).facet()
 				.name( facetName )
-				.onField( Car.CUBIC_CAPACITY_STRING )
+				.onField( Car.CUBIC_CAPACITY_STRING_FACET_STRING_ENCODING )
 				.discrete()
 				.createFacetingRequest();
 		FullTextQuery query = queryHondaWithFacet( request );
@@ -219,7 +219,7 @@ public class SimpleFacetingTest extends AbstractFacetTest {
 		final String descendingOrderedFacet = "desc";
 		FacetingRequest requestDesc = queryBuilder( Car.class ).facet()
 				.name( descendingOrderedFacet )
-				.onField( Car.CUBIC_CAPACITY_STRING )
+				.onField( Car.CUBIC_CAPACITY_STRING_FACET_STRING_ENCODING )
 				.discrete()
 				.includeZeroCounts( true )
 				.createFacetingRequest();
@@ -227,7 +227,7 @@ public class SimpleFacetingTest extends AbstractFacetTest {
 		final String ascendingOrderedFacet = "asc";
 		FacetingRequest requestAsc = queryBuilder( Car.class ).facet()
 				.name( ascendingOrderedFacet )
-				.onField( Car.CUBIC_CAPACITY_STRING )
+				.onField( Car.CUBIC_CAPACITY_STRING_FACET_STRING_ENCODING )
 				.discrete()
 				.orderedBy( FacetSortOrder.COUNT_ASC )
 				.includeZeroCounts( true )

--- a/orm/src/test/java/org/hibernate/search/test/query/facet/SimpleFacetingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/facet/SimpleFacetingTest.java
@@ -30,14 +30,13 @@ import org.junit.Test;
  * @author Hardy Ferentschik
  */
 public class SimpleFacetingTest extends AbstractFacetTest {
-	private final String facetFieldName = "cubicCapacity";
 	private final String facetName = "ccs";
 
 	@Test
 	public void testSimpleDiscretFaceting() throws Exception {
 		FacetingRequest request = queryBuilder( Car.class ).facet()
 				.name( facetName )
-				.onField( facetFieldName )
+				.onField( Car.CUBIC_CAPACITY_STRING )
 				.discrete()
 				.createFacetingRequest();
 		FullTextQuery query = queryHondaWithFacet( request );
@@ -50,7 +49,7 @@ public class SimpleFacetingTest extends AbstractFacetTest {
 	public void testDefaultSortOrderIsCount() throws Exception {
 		FacetingRequest request = queryBuilder( Car.class ).facet()
 				.name( facetName )
-				.onField( facetFieldName )
+				.onField( Car.CUBIC_CAPACITY_STRING )
 				.discrete()
 				.createFacetingRequest();
 		FullTextQuery query = queryHondaWithFacet( request );
@@ -63,7 +62,7 @@ public class SimpleFacetingTest extends AbstractFacetTest {
 	public void testCountSortOrderAsc() throws Exception {
 		FacetingRequest request = queryBuilder( Car.class ).facet()
 				.name( facetName )
-				.onField( facetFieldName )
+				.onField( Car.CUBIC_CAPACITY_STRING )
 				.discrete()
 				.orderedBy( FacetSortOrder.COUNT_ASC )
 				.createFacetingRequest();
@@ -77,7 +76,7 @@ public class SimpleFacetingTest extends AbstractFacetTest {
 	public void testCountSortOrderDesc() throws Exception {
 		FacetingRequest request = queryBuilder( Car.class ).facet()
 				.name( facetName )
-				.onField( facetFieldName )
+				.onField( Car.CUBIC_CAPACITY_STRING )
 				.discrete()
 				.orderedBy( FacetSortOrder.COUNT_DESC )
 				.createFacetingRequest();
@@ -91,7 +90,7 @@ public class SimpleFacetingTest extends AbstractFacetTest {
 	public void testAlphabeticalSortOrder() throws Exception {
 		FacetingRequest request = queryBuilder( Car.class ).facet()
 				.name( facetName )
-				.onField( facetFieldName )
+				.onField( Car.CUBIC_CAPACITY_STRING )
 				.discrete()
 				.orderedBy( FacetSortOrder.FIELD_VALUE )
 				.createFacetingRequest();
@@ -109,7 +108,7 @@ public class SimpleFacetingTest extends AbstractFacetTest {
 	public void testZeroCountsExcluded() throws Exception {
 		FacetingRequest request = queryBuilder( Car.class ).facet()
 				.name( facetName )
-				.onField( facetFieldName )
+				.onField( Car.CUBIC_CAPACITY_STRING )
 				.discrete()
 				.orderedBy( FacetSortOrder.COUNT_DESC )
 				.includeZeroCounts( false )
@@ -124,7 +123,7 @@ public class SimpleFacetingTest extends AbstractFacetTest {
 	public void testZeroCountsIncluded() throws Exception {
 		FacetingRequest request = queryBuilder( Car.class ).facet()
 				.name( facetName )
-				.onField( facetFieldName )
+				.onField( Car.CUBIC_CAPACITY_STRING )
 				.discrete()
 				.orderedBy( FacetSortOrder.COUNT_DESC )
 				.includeZeroCounts( true )
@@ -140,7 +139,7 @@ public class SimpleFacetingTest extends AbstractFacetTest {
 	public void testMaxFacetCounts() throws Exception {
 		FacetingRequest request = queryBuilder( Car.class ).facet()
 				.name( facetName )
-				.onField( facetFieldName )
+				.onField( Car.CUBIC_CAPACITY_STRING )
 				.discrete()
 				.orderedBy( FacetSortOrder.COUNT_DESC )
 				.maxFacetCount( 1 )
@@ -172,7 +171,7 @@ public class SimpleFacetingTest extends AbstractFacetTest {
 		try {
 			queryBuilder( Car.class ).facet()
 					.name( null )
-					.onField( facetFieldName )
+					.onField( Car.CUBIC_CAPACITY_STRING )
 					.discrete()
 					.createFacetingRequest();
 			fail( "null should not be a valid request name" );
@@ -187,7 +186,7 @@ public class SimpleFacetingTest extends AbstractFacetTest {
 		try {
 			queryBuilder( Car.class ).facet()
 					.name( facetName )
-					.onField( facetFieldName )
+					.onField( Car.CUBIC_CAPACITY_STRING )
 					.discrete()
 					.orderedBy( FacetSortOrder.RANGE_DEFINITION_ORDER )
 					.createFacetingRequest();
@@ -202,7 +201,7 @@ public class SimpleFacetingTest extends AbstractFacetTest {
 	public void testEnableDisableFacets() {
 		FacetingRequest request = queryBuilder( Car.class ).facet()
 				.name( facetName )
-				.onField( facetFieldName )
+				.onField( Car.CUBIC_CAPACITY_STRING )
 				.discrete()
 				.createFacetingRequest();
 		FullTextQuery query = queryHondaWithFacet( request );
@@ -220,7 +219,7 @@ public class SimpleFacetingTest extends AbstractFacetTest {
 		final String descendingOrderedFacet = "desc";
 		FacetingRequest requestDesc = queryBuilder( Car.class ).facet()
 				.name( descendingOrderedFacet )
-				.onField( facetFieldName )
+				.onField( Car.CUBIC_CAPACITY_STRING )
 				.discrete()
 				.includeZeroCounts( true )
 				.createFacetingRequest();
@@ -228,7 +227,7 @@ public class SimpleFacetingTest extends AbstractFacetTest {
 		final String ascendingOrderedFacet = "asc";
 		FacetingRequest requestAsc = queryBuilder( Car.class ).facet()
 				.name( ascendingOrderedFacet )
-				.onField( facetFieldName )
+				.onField( Car.CUBIC_CAPACITY_STRING )
 				.discrete()
 				.orderedBy( FacetSortOrder.COUNT_ASC )
 				.includeZeroCounts( true )

--- a/orm/src/test/java/org/hibernate/search/test/query/facet/WebShopTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/facet/WebShopTest.java
@@ -171,7 +171,7 @@ public class WebShopTest extends AbstractFacetTest {
 			// range faceting
 			final FacetingRequest priceFacet = builder.facet()
 					.name( cubicCapacityFacetName )
-					.onField( "cubicCapacity_Numeric" )
+					.onField( Car.CUBIC_CAPACITY_NUMERIC )
 					.range()
 					.below( 2500 ).excludeLimit()
 					.from( 2500 ).to( 3000 )

--- a/orm/src/test/java/org/hibernate/search/test/query/facet/WebShopTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/facet/WebShopTest.java
@@ -171,7 +171,7 @@ public class WebShopTest extends AbstractFacetTest {
 			// range faceting
 			final FacetingRequest priceFacet = builder.facet()
 					.name( cubicCapacityFacetName )
-					.onField( Car.CUBIC_CAPACITY_NUMERIC )
+					.onField( Car.CUBIC_CAPACITY_STRING_FACET_NUMERIC_ENCODING )
 					.range()
 					.below( 2500 ).excludeLimit()
 					.from( 2500 ).to( 3000 )


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2670

There are a few behavior changes that may prevent us from backporting this PR:

 * Faceting will no longer work when there is no faceting metadata (but I suppose we don't support creating facets from custom bridges?)
 * Errors when selecting field bridge that don't have faceting enabled will now happen sooner (when querying, instead of when retrieving the facets).