### PR TITLE
HSEARCH-2688 Clearing scroll IDs (when closing ScrollableResults) fails systematically with Elasticsearch

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/work/impl/ClearScrollWork.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/work/impl/ClearScrollWork.java
@@ -12,6 +12,7 @@ import org.hibernate.search.elasticsearch.impl.JsonBuilder;
 import org.hibernate.search.elasticsearch.work.impl.builder.ClearScrollWorkBuilder;
 
 import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 
 /**
  * @author Yoann Rodiere
@@ -44,7 +45,7 @@ public class ClearScrollWork extends SimpleElasticsearchWork<Void> {
 					.pathComponent( "_search" )
 					.pathComponent( "scroll" )
 					.body(JsonBuilder.object()
-							.addProperty( "scroll_id", scrollId )
+							.add( "scroll_id", JsonBuilder.array().add( new JsonPrimitive( scrollId ) ) )
 							.build()
 					);
 

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchScrollingIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchScrollingIT.java
@@ -74,12 +74,13 @@ public class ElasticsearchScrollingIT {
 		generateData( 0, DEFAULT_MAX_RESULT_WINDOW + 10 );
 
 		Query query = builder().all().createQuery();
-		DocumentExtractor extractor = getQuery( query )
-				.queryDocumentExtractor();
-		for ( int i = 0; i < DEFAULT_MAX_RESULT_WINDOW + 10; ++i ) {
-			EntityInfo info = extractor.extract(i);
-			assertNotNull( info );
-			assertEquals( i, info.getId() );
+		try ( DocumentExtractor extractor = getQuery( query )
+				.queryDocumentExtractor() ) {
+			for ( int i = 0; i < DEFAULT_MAX_RESULT_WINDOW + 10; ++i ) {
+				EntityInfo info = extractor.extract(i);
+				assertNotNull( info );
+				assertEquals( i, info.getId() );
+			}
 		}
 	}
 
@@ -88,16 +89,16 @@ public class ElasticsearchScrollingIT {
 		generateData( 0, 1000 );
 
 		Query query = builder().all().createQuery();
-		DocumentExtractor extractor = getQuery( query )
-				.queryDocumentExtractor();
+		try ( DocumentExtractor extractor = getQuery( query )
+				.queryDocumentExtractor() ) {
+			EntityInfo info = extractor.extract( 1 );
+			assertNotNull( info );
+			assertEquals( 1, info.getId() );
 
-		EntityInfo info = extractor.extract( 1 );
-		assertNotNull( info );
-		assertEquals( 1, info.getId() );
-
-		info = extractor.extract( 500 );
-		assertNotNull( info );
-		assertEquals( 500, info.getId() );
+			info = extractor.extract( 500 );
+			assertNotNull( info );
+			assertEquals( 500, info.getId() );
+		}
 	}
 
 	@Test
@@ -105,17 +106,17 @@ public class ElasticsearchScrollingIT {
 		generateData( 0, 1001 );
 
 		Query query = builder().all().createQuery();
-		DocumentExtractor extractor = getQuery( query )
-				.queryDocumentExtractor();
+		try ( DocumentExtractor extractor = getQuery( query )
+				.queryDocumentExtractor() ) {
+			EntityInfo info = extractor.extract( 1000 );
+			assertNotNull( info );
+			assertEquals( 1000, info.getId() );
 
-		EntityInfo info = extractor.extract( 1000 );
-		assertNotNull( info );
-		assertEquals( 1000, info.getId() );
-
-		// Backtrack exactly 1000 positions
-		info = extractor.extract( 0 );
-		assertNotNull( info );
-		assertEquals( 0, info.getId() );
+			// Backtrack exactly 1000 positions
+			info = extractor.extract( 0 );
+			assertNotNull( info );
+			assertEquals( 0, info.getId() );
+		}
 	}
 
 	private QueryBuilder builder() {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2688

Note: there's no need to backport this after all, as explained in comments on the JIRA ticket.