### PR TITLE
HSEARCH-2697 Only use setAccessible when strictly necessary

### DIFF
--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
@@ -230,6 +230,9 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 			return;
 		}
 
+		// Make sure we'll be able to access values
+		ReflectionHelper.setAccessible( member );
+
 		final String relativeFieldName = getIdAttributeName( member, idAnnotation );
 		final DocumentFieldPath fieldPath = new DocumentFieldPath( prefix, relativeFieldName );
 		if ( isRoot ) {
@@ -1065,6 +1068,15 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 
 		PropertyMetadata property = propertyMetadataBuilder.build();
 		if ( !property.getFieldMetadataSet().isEmpty() ) {
+			/*
+			 * Make sure we'll be able to access values.
+			 * This should only be called when we're absolutely sure we'll have to access values,
+			 * because this call may fail (in JDK 9 in particular),
+			 * which would make the whole bootstrapping process fail.
+			 * See HSEARCH-2697 (fixed).
+			 */
+			ReflectionHelper.setAccessible( member );
+
 			typeMetadataBuilder.addProperty( property );
 		}
 	}
@@ -2064,4 +2076,5 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 
 		return false;
 	}
+
 }

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/PropertyMetadata.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/PropertyMetadata.java
@@ -17,7 +17,6 @@ import java.util.Set;
 import org.hibernate.annotations.common.reflection.XProperty;
 import org.hibernate.search.engine.BoostStrategy;
 import org.hibernate.search.engine.impl.DefaultBoostStrategy;
-import org.hibernate.search.util.impl.ReflectionHelper;
 
 /**
  * Encapsulating the metadata for a single indexed property (field or getter).
@@ -125,9 +124,6 @@ public class PropertyMetadata implements PartialPropertyMetadata {
 
 		public Builder(BackReference<TypeMetadata> declaringType, XProperty propertyAccessor, Class<?> propertyClass) {
 			this.declaringType = declaringType;
-			if ( propertyAccessor != null ) {
-				ReflectionHelper.setAccessible( propertyAccessor );
-			}
 			this.propertyAccessor = propertyAccessor;
 			this.propertyClass = propertyClass;
 			this.fieldMetadataSet = new LinkedHashSet<>();


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2697

This fixes the last remaining problem in the -engine build on JDK9. The -orm build still seems to fail on JDK9, mainly due to Hibernate ORM issues, but that's another story :)