### PR TITLE
HSEARCH-2698 Move the empty Jar requirements to the parent pom

### DIFF
--- a/infinispan/pom.xml
+++ b/infinispan/pom.xml
@@ -34,14 +34,6 @@
             <plugin>
                 <artifactId>maven-deploy-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <!-- We need an empty JAR, otherwise the build will fail -->
-                    <skipIfEmpty>false</skipIfEmpty>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/legacy/pom.xml
+++ b/legacy/pom.xml
@@ -33,14 +33,6 @@
             <plugin>
                 <artifactId>maven-deploy-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <!-- We need an empty JAR, otherwise the build will fail -->
-                    <skipIfEmpty>false</skipIfEmpty>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -814,7 +814,8 @@
                             <Implementation-URL>http://search.hibernate.org</Implementation-URL>
                         </manifestEntries>
                     </archive>
-                    <skipIfEmpty>true</skipIfEmpty>
+                    <!-- We need an empty JAR, otherwise the build will fail -->
+                    <skipIfEmpty>false</skipIfEmpty>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION

Follow up on #1378 : I already merged it but then realized that the new `skipIffEmpty` requirement fails the build when building with `-Pdist` (as it's missing in the distribution module).

Let's move the attribute to the parent pom?