### PR TITLE
HSEARCH-2699 Javassist not being included in the distribution tarballs

### DIFF
--- a/distribution/src/main/assembly/dist.xml
+++ b/distribution/src/main/assembly/dist.xml
@@ -47,7 +47,7 @@
                 <!-- hibernate-search-orm -->
                 <include>org.hibernate:hibernate-core</include>
                 <include>dom4j:dom4j</include>
-                <include>javassist:javassist</include>
+                <include>org.javassist:javassist</include>
             </includes>
             <excludes>
                 <exclude>org.jboss:jandex</exclude>


### PR DESCRIPTION
 - https://hibernate.atlassian.net/browse/HSEARCH-2699

Turns out it was a dumb mistake.