### PR TITLE
HSEARCH-2698 Make the distribution module a POM artifact, instead of a JAR artifact

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -19,6 +19,7 @@
 
     <name>Hibernate Search Distribution</name>
     <description>Builds the distribution bundles</description>
+    <packaging>pom</packaging>
 
     <properties>
         <!-- Skip artifact deployment -->


### PR DESCRIPTION
Follow-up on #1378 , supersedes #1379

Relevant ticket (**I reopened it**): https://hibernate.atlassian.net/browse/HSEARCH-2698

We don't produce any JAR for this module, and we produce *multiple*
artifacts, so the easier solution is to just not declare anything.

The travis build is in progress: https://travis-ci.org/yrodiere/hibernate-search/builds/225892334
I ran a quick build locally without tests and it went fine.