### PR TITLE
HSEARCH-2675 + HSEARCH-2710 Multiple JGroups fixes

### DIFF
--- a/backends/jgroups/src/main/java/org/hibernate/search/backend/jgroups/impl/JGroupsBackend.java
+++ b/backends/jgroups/src/main/java/org/hibernate/search/backend/jgroups/impl/JGroupsBackend.java
@@ -131,15 +131,14 @@ public class JGroupsBackend implements Backend {
 				messageSender, indexManager, masterNodeSelector, luceneWorkSerializer,
 				block, messageTimeout );
 
-		BackendQueueProcessor delegateQueueProcessor = null;
-		if ( selectionStrategy.isIndexOwnerLocal() ) {
-			delegateQueueProcessor = BackendFactory.createBackend(
-					delegateBackendName, indexManager, context, properties );
-		}
-
 		JGroupsBackendQueueProcessor queueProcessor = new JGroupsBackendQueueProcessor(
-				selectionStrategy, jgroupsProcessor, delegateQueueProcessor );
+				selectionStrategy, jgroupsProcessor,
+				() -> createDelegateQueueProcessor( indexManager, context ) );
 		return queueProcessor;
+	}
+
+	private BackendQueueProcessor createDelegateQueueProcessor(IndexManager indexManager, WorkerBuildContext context) {
+		return BackendFactory.createBackend(delegateBackendName, indexManager, context, properties );
 	}
 
 	protected NodeSelectorStrategy createNodeSelectorStrategy(IndexManager indexManager) {

--- a/backends/jgroups/src/test/java/org/hibernate/search/backend/jgroups/impl/SyncJGroupsBackendTest.java
+++ b/backends/jgroups/src/test/java/org/hibernate/search/backend/jgroups/impl/SyncJGroupsBackendTest.java
@@ -125,7 +125,7 @@ public class SyncJGroupsBackendTest {
 	public void alternativeBackendConfiguration() {
 		BackendQueueProcessor backendQueueProcessor = extractBackendQueue( masterNode, "dvds" );
 		JGroupsReceivingMockBackendQueueProcessor jgroupsProcessor = (JGroupsReceivingMockBackendQueueProcessor) backendQueueProcessor;
-		BackendQueueProcessor delegatedBackend = jgroupsProcessor.getDelegate().getDelegatedBackend();
+		BackendQueueProcessor delegatedBackend = jgroupsProcessor.getDelegate().getExistingDelegate();
 		Assert.assertTrue( "dvds backend was configured with a delegate to blackhole but it's not using it", delegatedBackend instanceof BlackHoleBackendQueueProcessor );
 	}
 

--- a/backends/jgroups/src/test/java/org/hibernate/search/test/jgroups/common/DynamicMasterSlaveSearchTestCase.java
+++ b/backends/jgroups/src/test/java/org/hibernate/search/test/jgroups/common/DynamicMasterSlaveSearchTestCase.java
@@ -1,0 +1,78 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.jgroups.common;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.hibernate.search.cfg.Environment;
+import org.hibernate.search.test.DefaultTestResourceManager;
+import org.hibernate.search.test.util.TestConfiguration;
+import org.junit.After;
+import org.junit.Before;
+
+/**
+ * Test class to simulate clustered environment with one master and one or more slave nodes,
+ * each role being determined dynamically.
+ *
+ * @author Lukasz Moren
+ */
+public abstract class DynamicMasterSlaveSearchTestCase implements TestConfiguration {
+
+	private String alreadySelectedBaseIndexDir = null;
+	private List<DefaultTestResourceManager> resourceManagers = new ArrayList<>();
+
+	@Override
+	public void configure(Map<String,Object> cfg) {
+		/*
+		 * Configure all nodes to read/write to the exact same index on disk.
+		 * This will lead to bad performance, but it's also the only way to
+		 * use dynamic master selection without an infinispan directory provider.
+		 */
+		cfg.put( "hibernate.search.default." + Environment.WORKER_BACKEND, "jgroups" );
+		cfg.put( "hibernate.search.default.directory_provider", "filesystem" );
+		cfg.put( "hibernate.search.default.exclusive_index_use", "false" );
+		if ( alreadySelectedBaseIndexDir != null ) {
+			cfg.put( "hibernate.search.default.indexBase", alreadySelectedBaseIndexDir );
+		}
+	}
+
+	@Override
+	public Set<String> multiTenantIds() {
+		return Collections.emptySet();
+	}
+
+	protected abstract int getExpectedNumberOfNodes();
+
+	@Before
+	public void setUp() throws Exception {
+		for ( int i = 0 ; i < getExpectedNumberOfNodes() ; ++i ) {
+			DefaultTestResourceManager resourceManager = new DefaultTestResourceManager( this, getClass() );
+			resourceManagers.add( resourceManager );
+			resourceManager.openSessionFactory();
+			if ( alreadySelectedBaseIndexDir == null ) {
+				// Set the base index dir to the dir selected for the first search factory
+				this.alreadySelectedBaseIndexDir = resourceManager.getBaseIndexDir().toAbsolutePath().toString();
+			}
+		}
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		for ( DefaultTestResourceManager resourceManager : resourceManagers ) {
+			resourceManager.defaultTearDown();
+		}
+	}
+
+	public List<DefaultTestResourceManager> getResourceManagers() {
+		return resourceManagers;
+	}
+
+}

--- a/backends/jgroups/src/test/java/org/hibernate/search/test/jgroups/common/JGroupsCommonTest.java
+++ b/backends/jgroups/src/test/java/org/hibernate/search/test/jgroups/common/JGroupsCommonTest.java
@@ -14,7 +14,6 @@ import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.search.Query;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
-import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
 import org.hibernate.search.backend.jgroups.impl.DispatchMessageSender;
@@ -28,7 +27,7 @@ import org.junit.Test;
  * @author Lukasz Moren
  * @author Sanne Grinovero
  */
-public class JGroupsCommonTest extends MultipleSessionsSearchTestCase {
+public class JGroupsCommonTest extends StaticMasterSlaveSearchTestCase {
 
 	public static final String TESTING_JGROUPS_CONFIGURATION_FILE = "testing-flush-loopback.xml";
 	public static final Poller POLLER = Poller.milliseconds( 10_000, 100 );
@@ -118,7 +117,6 @@ public class JGroupsCommonTest extends MultipleSessionsSearchTestCase {
 	public void configure(Map<String,Object> cfg) {
 		//master jgroups configuration
 		super.configure( cfg );
-		cfg.put( "hibernate.search.default." + Environment.WORKER_BACKEND, "jgroupsMaster" );
 		applyCommonJGroupsChannelConfiguration( cfg );
 	}
 
@@ -126,8 +124,6 @@ public class JGroupsCommonTest extends MultipleSessionsSearchTestCase {
 	protected void configureSlave(Map<String,Object> cfg) {
 		//slave jgroups configuration
 		super.configureSlave( cfg );
-		cfg.put( "hibernate.search.default." + Environment.WORKER_BACKEND, "jgroupsSlave" );
-		cfg.put( "hibernate.search.default.retry_initialize_period", "1" );
 		applyCommonJGroupsChannelConfiguration( cfg );
 	}
 

--- a/backends/jgroups/src/test/java/org/hibernate/search/test/jgroups/common/JGroupsDynamicMasterElectionTest.java
+++ b/backends/jgroups/src/test/java/org/hibernate/search/test/jgroups/common/JGroupsDynamicMasterElectionTest.java
@@ -1,0 +1,189 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.jgroups.common;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.apache.lucene.queryparser.classic.ParseException;
+import org.apache.lucene.queryparser.classic.QueryParser;
+import org.apache.lucene.search.Query;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.search.FullTextQuery;
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.Search;
+import org.hibernate.search.backend.jgroups.impl.DispatchMessageSender;
+import org.hibernate.search.backend.jgroups.impl.NodeSelectorService;
+import org.hibernate.search.backend.jgroups.impl.NodeSelectorStrategy;
+import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
+import org.hibernate.search.engine.service.spi.ServiceReference;
+import org.hibernate.search.test.DefaultTestResourceManager;
+import org.hibernate.search.test.TestResourceManager;
+import org.hibernate.search.test.jgroups.master.TShirt;
+import org.hibernate.search.testsupport.TestConstants;
+import org.hibernate.search.testsupport.TestForIssue;
+import org.hibernate.search.testsupport.concurrency.Poller;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Lukasz Moren
+ * @author Sanne Grinovero
+ */
+@TestForIssue(jiraKey = "HSEARCH-2675")
+public class JGroupsDynamicMasterElectionTest extends DynamicMasterSlaveSearchTestCase {
+
+	public static final String TESTING_JGROUPS_CONFIGURATION_FILE = "testing-flush-loopback.xml";
+	public static final Poller POLLER = Poller.milliseconds( 10_000, 100 );
+
+	/*
+	 * Must be at least 3 so as to highlight the bug mentioned in HSEARCH-2675:
+	 * for some reason, the master will change automatically when we spawn the second
+	 * node, so the first two nodes will always be able to handle master works.
+	 * The third one and later will not, however.
+	 */
+	private static final int DEFAULT_NUMBER_OF_NODES = 10;
+
+	/**
+	 * Name of the JGroups channel used in test
+	 */
+	public static final String CHANNEL_NAME = UUID.randomUUID().toString();
+
+	private final QueryParser parser = new QueryParser(
+			"id",
+			TestConstants.stopAnalyzer
+	);
+
+	@Override
+	protected int getExpectedNumberOfNodes() {
+		return DEFAULT_NUMBER_OF_NODES;
+	}
+
+	@Test
+	public void masterElection() throws Exception {
+		TestResourceManager masterResourceManager = determineJGroupsMaster().get();
+		List<DefaultTestResourceManager> slaveResourceManagers = determineJGroupsSlaves();
+		Assert.assertEquals( getExpectedNumberOfNodes() - 1, slaveResourceManagers.size() );
+
+		// Check that the first master works fine
+		TShirt ts = new TShirt();
+		ts.setLogo( "Boston" );
+		ts.setSize( "XXL" );
+		ts.setLength( 23.4d );
+		testAdd( masterResourceManager, slaveResourceManagers, ts, 1 );
+
+		// Kill the master
+		masterResourceManager.getSessionFactory().close();
+
+		// ... check that a new master is elected
+		POLLER.pollAssertion( () -> {
+			Assert.assertTrue( "Lots of time waited and still no new master has been elected!", determineJGroupsMaster().isPresent() );
+		} );
+
+		masterResourceManager = determineJGroupsMaster().get();
+		slaveResourceManagers = determineJGroupsSlaves();
+		Assert.assertEquals( getExpectedNumberOfNodes() - 2, slaveResourceManagers.size() );
+
+		// ... and check that the new master actually performs work
+		TShirt ts2 = new TShirt();
+		ts2.setLogo( "Mapple leaves" );
+		ts2.setSize( "L" );
+		ts2.setLength( 23.42d );
+		testAdd( masterResourceManager, slaveResourceManagers, ts2, 2 );
+	}
+
+	private void testAdd(TestResourceManager masterResourceManager, List<DefaultTestResourceManager> slaveResourceManagers,
+			TShirt ts, int expectedResults) throws ParseException {
+		try ( Session slaveSession = slaveResourceManagers.get( 0 ).openSession() ) {
+			Transaction tx = slaveSession.beginTransaction();
+			slaveSession.persist( ts );
+			tx.commit();
+
+			try ( Session masterSession = masterResourceManager.openSession() ) {
+				// since this is an async backend, we expect to see
+				// the values in the index *eventually*.
+				POLLER.pollAssertion( () -> {
+					List<?> result = doQuery( masterSession );
+					Assert.assertEquals( "Lots of time waited and still the document is not indexed on master yet!",
+							expectedResults, result.size() );
+				} );
+			}
+		}
+
+		// Wait for the changes to be visible from the slaves
+		POLLER.pollAssertion( () -> {
+			for ( TestResourceManager resourceManager : slaveResourceManagers ) {
+				try ( Session slaveSession = resourceManager.openSession() ) {
+					List<?> result = doQuery( slaveSession );
+					Assert.assertEquals( "Lots of time waited and still the document is not visible from the slave yet!",
+							expectedResults, result.size() );
+				}
+			}
+		} );
+	}
+
+	private List<?> doQuery(Session slaveSession) throws ParseException {
+		FullTextSession ftSession = Search.getFullTextSession( slaveSession );
+		Query luceneQuery = parser.parse( "logo:Boston or logo:Mapple leaves" );
+		slaveSession.getTransaction().begin();
+		FullTextQuery query = ftSession.createFullTextQuery( luceneQuery );
+		List<?> result = query.list();
+		slaveSession.getTransaction().commit();
+		return result;
+	}
+
+	@Override
+	public void configure(Map<String,Object> cfg) {
+		//master jgroups configuration
+		super.configure( cfg );
+		cfg.put( "hibernate.search.default.retry_initialize_period", "1" );
+		cfg.put( "hibernate.search.default." + DispatchMessageSender.CLUSTER_NAME, CHANNEL_NAME );
+		cfg.put( DispatchMessageSender.CONFIGURATION_FILE, TESTING_JGROUPS_CONFIGURATION_FILE );
+
+		/*
+		 * Do *not* drop the schema upon factory closing, or the slave won't be able to use it.
+		 */
+		cfg.put( org.hibernate.cfg.Environment.HBM2DDL_AUTO, "drop-and-create" );
+	}
+
+	@Override
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class[] { TShirt.class };
+	}
+
+	private boolean isActive(TestResourceManager manager) {
+		return !manager.getSessionFactory().isClosed();
+	}
+
+	private boolean isJGroupsMaster(TestResourceManager manager) {
+		ExtendedSearchIntegrator integrator = manager.getExtendedSearchIntegrator();
+
+		try ( ServiceReference<NodeSelectorService> service =
+				integrator.getServiceManager().requestReference( NodeSelectorService.class ) ) {
+			NodeSelectorStrategy nodeSelector = service.get().getMasterNodeSelector( TShirt.INDEX_NAME );
+			return nodeSelector.isIndexOwnerLocal();
+		}
+	}
+
+	private Optional<DefaultTestResourceManager> determineJGroupsMaster() {
+		return getResourceManagers().stream()
+				.filter( this::isActive )
+				.filter( this::isJGroupsMaster )
+				.findFirst();
+	}
+
+	private List<DefaultTestResourceManager> determineJGroupsSlaves() {
+		return getResourceManagers().stream()
+				.filter( this::isActive )
+				.filter( (manager) -> !isJGroupsMaster(manager) )
+				.collect( Collectors.toList() );
+	}
+}

--- a/backends/jgroups/src/test/java/org/hibernate/search/test/jgroups/common/StaticMasterSlaveSearchTestCase.java
+++ b/backends/jgroups/src/test/java/org/hibernate/search/test/jgroups/common/StaticMasterSlaveSearchTestCase.java
@@ -15,6 +15,7 @@ import java.util.Map;
 
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.test.DefaultTestResourceManager;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.test.util.ImmutableTestConfiguration;
@@ -22,11 +23,12 @@ import org.hibernate.search.test.util.TestConfiguration;
 import org.hibernate.search.testsupport.TestConstants;
 
 /**
- * Test class to simulate clustered environment (one master, and one slave node)
+ * Test class to simulate clustered environment (one master, and one slave node,
+ * each role being known in advance).
  *
  * @author Lukasz Moren
  */
-public abstract class MultipleSessionsSearchTestCase extends SearchTestBase {
+public abstract class StaticMasterSlaveSearchTestCase extends SearchTestBase {
 
 	protected static final String masterCopy = "/master/copy";
 
@@ -45,6 +47,7 @@ public abstract class MultipleSessionsSearchTestCase extends SearchTestBase {
 	@Override
 	public void configure(Map<String,Object> cfg) {
 		//master
+		cfg.put( "hibernate.search.default." + Environment.WORKER_BACKEND, "jgroupsMaster" );
 		cfg.put(
 				"hibernate.search.default.sourceBase",
 				TestConstants.getIndexDirectory( getTargetDir() ) + masterCopy
@@ -61,6 +64,8 @@ public abstract class MultipleSessionsSearchTestCase extends SearchTestBase {
 
 	protected void configureSlave(Map<String,Object> cfg) {
 		//slave(s)
+		cfg.put( "hibernate.search.default." + Environment.WORKER_BACKEND, "jgroupsSlave" );
+		cfg.put( "hibernate.search.default.retry_initialize_period", "1" );
 		cfg.put(
 				"hibernate.search.default.sourceBase",
 				TestConstants.getIndexDirectory( getTargetDir() ) + masterCopy

--- a/backends/jgroups/src/test/java/org/hibernate/search/test/jgroups/elasticsearch/JGroupsElasticsearchIT.java
+++ b/backends/jgroups/src/test/java/org/hibernate/search/test/jgroups/elasticsearch/JGroupsElasticsearchIT.java
@@ -19,10 +19,9 @@ import org.hibernate.search.Search;
 import org.hibernate.search.elasticsearch.ElasticsearchQueries;
 import org.hibernate.search.elasticsearch.impl.ElasticsearchIndexManager;
 import org.hibernate.search.backend.jgroups.impl.DispatchMessageSender;
-import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.query.engine.spi.QueryDescriptor;
 import org.hibernate.search.test.jgroups.common.JGroupsCommonTest;
-import org.hibernate.search.test.jgroups.common.MultipleSessionsSearchTestCase;
+import org.hibernate.search.test.jgroups.common.StaticMasterSlaveSearchTestCase;
 import org.hibernate.search.test.jgroups.master.TShirt;
 import org.hibernate.search.testsupport.concurrency.Poller;
 import org.junit.Test;
@@ -34,7 +33,7 @@ import org.junit.Test;
  * @author Lukasz Moren
  * @author Sanne Grinovero
  */
-public class JGroupsElasticsearchIT extends MultipleSessionsSearchTestCase {
+public class JGroupsElasticsearchIT extends StaticMasterSlaveSearchTestCase {
 
 	public static final String TESTING_JGROUPS_CONFIGURATION_FILE = "testing-flush-loopback.xml";
 	private static final Poller POLLER = JGroupsCommonTest.POLLER;
@@ -121,7 +120,6 @@ public class JGroupsElasticsearchIT extends MultipleSessionsSearchTestCase {
 	public void configure(Map<String,Object> cfg) {
 		//master jgroups configuration
 		super.configure( cfg );
-		cfg.put( "hibernate.search.default." + Environment.WORKER_BACKEND, "jgroupsMaster" );
 		applyCommonJGroupsChannelConfiguration( cfg );
 	}
 
@@ -129,8 +127,6 @@ public class JGroupsElasticsearchIT extends MultipleSessionsSearchTestCase {
 	protected void configureSlave(Map<String,Object> cfg) {
 		//slave jgroups configuration
 		super.configureSlave( cfg );
-		cfg.put( "hibernate.search.default." + Environment.WORKER_BACKEND, "jgroupsSlave" );
-		cfg.put( "hibernate.search.default.retry_initialize_period", "1" );
 		applyCommonJGroupsChannelConfiguration( cfg );
 	}
 

--- a/backends/jgroups/src/test/java/org/hibernate/search/test/jgroups/master/TShirt.java
+++ b/backends/jgroups/src/test/java/org/hibernate/search/test/jgroups/master/TShirt.java
@@ -21,6 +21,8 @@ import org.hibernate.search.annotations.Indexed;
 @Entity
 @Indexed
 public class TShirt {
+	public static final String INDEX_NAME = TShirt.class.getName();
+
 	@Id
 	@GeneratedValue
 	@DocumentId

--- a/backends/jms/src/main/java/org/hibernate/search/backend/impl/jms/AbstractJMSHibernateSearchController.java
+++ b/backends/jms/src/main/java/org/hibernate/search/backend/impl/jms/AbstractJMSHibernateSearchController.java
@@ -72,7 +72,7 @@ public abstract class AbstractJMSHibernateSearchController implements MessageLis
 			 * and update their shard list.
 			 * Thus the index name is rather useless in this case.
 			 */
-			OperationDispatcher dispatcher = integrator.getRemoteOperationDispatcher();
+			OperationDispatcher dispatcher = getOperationDispatcher( integrator );
 			dispatcher.dispatch( queue, null );
 		}
 		catch (JMSException e) {
@@ -86,6 +86,10 @@ public abstract class AbstractJMSHibernateSearchController implements MessageLis
 		finally {
 			afterMessage();
 		}
+	}
+
+	private OperationDispatcher getOperationDispatcher(SearchIntegrator integrator) {
+		return integrator.createRemoteOperationDispatcher( indexManager -> true );
 	}
 
 	private void logMessageDetails(ObjectMessage objectMessage, String indexName) throws JMSException {

--- a/engine/src/main/java/org/hibernate/search/backend/impl/TransactionalOperationDispatcher.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/TransactionalOperationDispatcher.java
@@ -9,6 +9,7 @@ package org.hibernate.search.backend.impl;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
@@ -29,34 +30,41 @@ import org.hibernate.search.store.IndexShardingStrategy;
  */
 public class TransactionalOperationDispatcher implements OperationDispatcher {
 	private final Function<Class<?>, EntityIndexBinding> bindingLookup;
-	private final TransactionalOperationExecutorSelector executorSelector;
+	private final IndexManagerHolder indexManagerHolder;
+	private final Predicate<IndexManager> indexManagerFilter;
 
 	public TransactionalOperationDispatcher(SearchIntegrator integrator) {
+		this( integrator, indexManager -> true );
+	}
+
+	public TransactionalOperationDispatcher(SearchIntegrator integrator, Predicate<IndexManager> indexManagerFilter) {
 		this( integrator.unwrap( ExtendedSearchIntegrator.class ).getIndexManagerHolder(),
-				integrator::getIndexBinding );
+				integrator::getIndexBinding, indexManagerFilter );
 	}
 
 	public TransactionalOperationDispatcher(IndexManagerHolder indexManagerHolder,
 			Map<Class<?>, EntityIndexBinding> bindings) {
-		this( indexManagerHolder, bindings::get );
+		this( indexManagerHolder, bindings::get, indexManager -> true );
 	}
 
 	private TransactionalOperationDispatcher(IndexManagerHolder indexManagerHolder,
-			Function<Class<?>, EntityIndexBinding> bindingLookup) {
-		this.executorSelector = new TransactionalOperationExecutorSelector( indexManagerHolder );
+			Function<Class<?>, EntityIndexBinding> bindingLookup,
+			Predicate<IndexManager> indexManagerFilter) {
+		this.indexManagerHolder = indexManagerHolder;
 		this.bindingLookup = bindingLookup;
+		this.indexManagerFilter = indexManagerFilter;
 	}
 
 	@Override
 	public void dispatch(LuceneWork work, IndexingMonitor monitor) {
-		WorkQueuePerIndexSplitter context = new WorkQueuePerIndexSplitter();
+		WorkQueuePerIndexSplitter context = new WorkQueuePerIndexSplitter( indexManagerHolder, indexManagerFilter );
 		appendWork( context, work );
 		context.commitOperations( monitor );
 	}
 
 	@Override
 	public void dispatch(List<LuceneWork> queue, IndexingMonitor monitor) {
-		WorkQueuePerIndexSplitter context = new WorkQueuePerIndexSplitter();
+		WorkQueuePerIndexSplitter context = new WorkQueuePerIndexSplitter( indexManagerHolder, indexManagerFilter );
 		for ( LuceneWork work : queue ) {
 			appendWork( context, work );
 		}
@@ -67,7 +75,7 @@ public class TransactionalOperationDispatcher implements OperationDispatcher {
 		final Class<?> entityType = work.getEntityClass();
 		EntityIndexBinding entityIndexBinding = bindingLookup.apply( entityType );
 		IndexShardingStrategy shardingStrategy = entityIndexBinding.getSelectionStrategy();
-		TransactionalOperationExecutor executor = work.acceptIndexWorkVisitor( executorSelector, null );
+		TransactionalOperationExecutor executor = work.acceptIndexWorkVisitor( TransactionalOperationExecutorSelector.INSTANCE, null );
 		executor.performOperation( work, shardingStrategy, context );
 	}
 

--- a/engine/src/main/java/org/hibernate/search/backend/impl/WorkQueuePerIndexSplitter.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/WorkQueuePerIndexSplitter.java
@@ -8,12 +8,13 @@ package org.hibernate.search.backend.impl;
 
 import java.util.HashMap;
 import java.util.LinkedList;
-import java.util.List;
+import java.util.function.Predicate;
 
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.backend.spi.BackendQueueProcessor;
 import org.hibernate.search.indexes.impl.IndexManagerHolder;
+import org.hibernate.search.indexes.spi.IndexManager;
 
 /**
  * Used by {@link org.hibernate.search.backend.impl.TransactionalOperationExecutor} to split a list of operations
@@ -23,15 +24,34 @@ import org.hibernate.search.indexes.impl.IndexManagerHolder;
  */
 public class WorkQueuePerIndexSplitter {
 
+	private final IndexManagerHolder indexManagerHolder;
+	private final Predicate<IndexManager> indexManagerFilter;
 	private final HashMap<String,WorkPlan> queues = new HashMap<String,WorkPlan>();
 
-	public List<LuceneWork> getIndexManagerQueue(String indexName, IndexManagerHolder indexManagerHolder) {
+	public WorkQueuePerIndexSplitter(IndexManagerHolder indexManagerHolder,
+			Predicate<IndexManager> indexManagerFilter) {
+		this.indexManagerHolder = indexManagerHolder;
+		this.indexManagerFilter = indexManagerFilter;
+	}
+
+	public void addToQueue(IndexManager indexManager, LuceneWork work) {
+		if ( !indexManagerFilter.test( indexManager ) ) {
+			return;
+		}
+		String indexName = indexManager.getIndexName();
 		WorkPlan plan = queues.get( indexName );
 		if ( plan == null ) {
 			plan = new WorkPlan( indexManagerHolder.getBackendQueueProcessor( indexName ) );
 			queues.put( indexName, plan );
 		}
-		return plan.queue;
+		plan.queue.add( work );
+	}
+
+	public void performStreamOperation(IndexManager indexManager, LuceneWork work) {
+		if ( !indexManagerFilter.test( indexManager ) ) {
+			return;
+		}
+		indexManager.performStreamOperation( work, null, false );
 	}
 
 	/**

--- a/engine/src/main/java/org/hibernate/search/engine/impl/ImmutableSearchFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/ImmutableSearchFactory.java
@@ -14,6 +14,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.Query;
@@ -131,7 +132,6 @@ public class ImmutableSearchFactory implements ExtendedSearchIntegratorWithShare
 	private final DatabaseRetrievalMethod defaultDatabaseRetrievalMethod;
 	private final boolean enlistWorkerInTransaction;
 	private final boolean indexUninvertingAllowed;
-	private final OperationDispatcher remoteOperationDispatcher;
 	private volatile LuceneWorkSerializer workSerializer;
 
 	public ImmutableSearchFactory(SearchFactoryState state) {
@@ -195,8 +195,6 @@ public class ImmutableSearchFactory implements ExtendedSearchIntegratorWithShare
 		this.indexUninvertingAllowed = ConfigurationParseHelper.getBooleanValue(
 				configurationProperties, Environment.INDEX_UNINVERTING_ALLOWED, false
 		);
-
-		this.remoteOperationDispatcher = new TransactionalOperationDispatcher( this );
 	}
 
 	private ObjectLookupMethod determineDefaultObjectLookupMethod() {
@@ -694,8 +692,8 @@ public class ImmutableSearchFactory implements ExtendedSearchIntegratorWithShare
 	}
 
 	@Override
-	public OperationDispatcher getRemoteOperationDispatcher() {
-		return remoteOperationDispatcher;
+	public OperationDispatcher createRemoteOperationDispatcher(Predicate<IndexManager> predicate) {
+		return new TransactionalOperationDispatcher( this, predicate );
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/impl/MutableSearchFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/MutableSearchFactory.java
@@ -11,6 +11,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Predicate;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.Query;
@@ -404,8 +405,8 @@ public class MutableSearchFactory implements ExtendedSearchIntegratorWithShareab
 	}
 
 	@Override
-	public OperationDispatcher getRemoteOperationDispatcher() {
-		return delegate.getRemoteOperationDispatcher();
+	public OperationDispatcher createRemoteOperationDispatcher(Predicate<IndexManager> indexManagerFilter) {
+		return delegate.createRemoteOperationDispatcher( indexManagerFilter );
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/search/spi/SearchIntegrator.java
+++ b/engine/src/main/java/org/hibernate/search/spi/SearchIntegrator.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.spi;
 
 import java.util.Set;
+import java.util.function.Predicate;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.Query;
@@ -237,11 +238,16 @@ public interface SearchIntegrator extends AutoCloseable {
 	LuceneWorkSerializer getWorkSerializer();
 
 	/**
+	 * @param indexManagerFilter A predicate allowing to exclude index managers from
+	 * dispatching. Works will not be applied to these index managers.
 	 * @return An operation dispatcher allowing to insert works retrieved from
-	 * remote sources (e.g. JMS or JGroups slaves).
+	 * remote sources (e.g. JMS or JGroups slaves), but only for index managers
+	 * verifying the given predicate.
+	 * This allows JMS or JGroups integrations to perform checks on index managers that
+	 * wouldn't exist before the dispatch, in the case of dynamic sharding in particular.
 	 *
 	 * @hsearch.experimental Operation dispatchers are under active development.
 	 * You should be prepared for incompatible changes in future releases.
 	 */
-	OperationDispatcher getRemoteOperationDispatcher();
+	OperationDispatcher createRemoteOperationDispatcher(Predicate<IndexManager> indexManagerFilter);
 }


### PR DESCRIPTION
Relevant JIRA tickets:

 * [HSEARCH-2710](https://hibernate.atlassian.net/browse/HSEARCH-2710): Restore master checking code in JGroupsMasterMessageListener. Note that the fix is not a simple revert of e62b27eeadb73c3c867866f4aeaed14fb77baa98, since I tried to retain the benefits of [HSEARCH-1886](https://hibernate.atlassian.net/browse/HSEARCH-1886) (which added partial support for dynamic sharding on JGroups)
 * [HSEARCH-2675](https://hibernate.atlassian.net/browse/HSEARCH-2675): JGroupsBackendQueueProcessor doesn't switch from slave to master dynamically. It turns out the problem was only visible with 3 or more nodes, which may explain why we ever thought it worked.