### PR TITLE
HSEARCH-2636 Throw a clear exception when an entity identifier/class could not be retrieved from the indexed document

### DIFF
--- a/engine/src/main/java/org/hibernate/search/query/engine/impl/EntityInfoImpl.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/impl/EntityInfoImpl.java
@@ -10,6 +10,8 @@ import java.io.Serializable;
 
 import org.hibernate.search.engine.ProjectionConstants;
 import org.hibernate.search.query.engine.spi.EntityInfo;
+import org.hibernate.search.util.logging.impl.Log;
+import org.hibernate.search.util.logging.impl.LoggerFactory;
 
 /**
  * Wrapper class describing the loading of an element.
@@ -18,6 +20,9 @@ import org.hibernate.search.query.engine.spi.EntityInfo;
  * @author Hardy Ferentschik
  */
 public class EntityInfoImpl implements EntityInfo {
+
+	private static final Log log = LoggerFactory.make();
+
 	/**
 	 * The entity class.
 	 */
@@ -54,11 +59,25 @@ public class EntityInfoImpl implements EntityInfo {
 
 	@Override
 	public Class<?> getClazz() {
+		if ( clazz == null ) {
+			/*
+			 * Only throw an exception here, not in the constructor,
+			 * because in some cases we don't need the class at all (e.g. projections).
+			 */
+			throw log.incompleteEntityInfo( clazz, id );
+		}
 		return clazz;
 	}
 
 	@Override
 	public Serializable getId() {
+		if ( id == null ) {
+			/*
+			 * Only throw an exception here, not in the constructor,
+			 * because in some cases we don't need the identifier at all (e.g. projections).
+			 */
+			throw log.incompleteEntityInfo( clazz, id );
+		}
 		return id;
 	}
 

--- a/engine/src/main/java/org/hibernate/search/query/engine/spi/EntityInfo.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/spi/EntityInfo.java
@@ -8,6 +8,8 @@ package org.hibernate.search.query.engine.spi;
 
 import java.io.Serializable;
 
+import org.hibernate.search.exception.SearchException;
+
 /**
  * Wrapper class describing the loading of an element.
  *
@@ -24,8 +26,16 @@ public interface EntityInfo {
 
 	};
 
+	/**
+	 * @return The entity class.
+	 * @throws SearchException If the entity class could not be retrieved from the indexed document.
+	 */
 	Class<?> getClazz();
 
+	/**
+	 * @return The entity identifier.
+	 * @throws SearchException If the entity identifier could not be retrieved from the indexed document.
+	 */
 	Serializable getId();
 
 	String getIdName();

--- a/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
@@ -1027,4 +1027,8 @@ public interface Log extends BasicLogger {
 	@Message(id = 337, value = "Conflicting usage of @Parameter annotation for parameter name: '%1$s'. Can't assign both value '%2$s' and '%3$s'" )
 	SearchException conflictingParameterDefined(String name, String value1, String value2);
 
+	@Message(id = 338, value = "Incomplete entity information in a document retrieved from the index:"
+			+ " the entity class ('%1$s') or identifier ('%2$s') was missing." )
+	SearchException incompleteEntityInfo(@FormatWith(ClassFormatter.class) Class<?> clazz, Object id);
+
 }

--- a/orm/src/test/java/org/hibernate/search/test/id/MissingIdTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/id/MissingIdTest.java
@@ -1,0 +1,105 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.id;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.search.Search;
+import org.hibernate.search.annotations.FieldBridge;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.bridge.LuceneOptions;
+import org.hibernate.search.bridge.TwoWayFieldBridge;
+import org.hibernate.search.exception.SearchException;
+import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.testsupport.TestForIssue;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+
+/**
+ * Test that we throw explicit exceptions when we cannot retrieve the ID from documents.
+ *
+ * @author Yoann Rodiere
+ */
+@TestForIssue(jiraKey = "HSEARCH-2636")
+public class MissingIdTest extends SearchTestBase {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void multipleResults_singleClass() throws Exception {
+		EntityWithMissingIdWhenRetrievedFromIndex entity1 = new EntityWithMissingIdWhenRetrievedFromIndex();
+		entity1.id = "1";
+		EntityWithMissingIdWhenRetrievedFromIndex entity2 = new EntityWithMissingIdWhenRetrievedFromIndex();
+		entity2.id = "2";
+
+		Session s = openSession();
+		Transaction tx = s.beginTransaction();
+		s.save( entity1 );
+		s.save( entity2 );
+		tx.commit();
+		s.clear();
+
+		thrown.expect( SearchException.class );
+		thrown.expectMessage( "HSEARCH000338" );
+		thrown.expectMessage( "Incomplete entity information" );
+		thrown.expectMessage( "'" + EntityWithMissingIdWhenRetrievedFromIndex.class.getName() + "'" );
+
+		tx = s.beginTransaction();
+		List<?> results = Search.getFullTextSession( s )
+				.createFullTextQuery( new MatchAllDocsQuery(), EntityWithMissingIdWhenRetrievedFromIndex.class )
+				.list();
+		assertEquals( 2, results.size() );
+		tx.commit();
+		s.close();
+	}
+
+	@Override
+	public Class<?>[] getAnnotatedClasses() {
+		return new Class[] {
+				EntityWithMissingIdWhenRetrievedFromIndex.class
+		};
+	}
+
+	@Entity
+	@Indexed
+	private class EntityWithMissingIdWhenRetrievedFromIndex {
+		@Id
+		@FieldBridge(impl = MissingIdMockingFieldBridge.class)
+		private String id;
+	}
+
+	public static class MissingIdMockingFieldBridge implements TwoWayFieldBridge {
+
+		@Override
+		public void set(String name, Object value, Document document, LuceneOptions luceneOptions) {
+			luceneOptions.addFieldToDocument( name, (String) value, document );
+		}
+
+		@Override
+		public Object get(String name, Document document) {
+			return null; // Simulate a document without an ID field
+		}
+
+		@Override
+		public String objectToString(Object object) {
+			return (String) object;
+		}
+
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2636