### PR TITLE
added hint to .travis.yml about deactivated state

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+# The main CI of Hibernate Search is http://ci.hibernate.org/. Travis CI can be
+# used in github forks. https://travis-ci.org/hibernate/hibernate-search is
+# therefore deactivated. Activating Travis for your own fork is as easy as
+# activating it in the travis site of your fork.
+
 sudo: required
 dist: trusty
 language: java


### PR DESCRIPTION
added hint that the main CI is http://ci.hibernate.org/ and that Travis is supposed to be used for github forks (see https://hibernate.atlassian.net/browse/HSEARCH-2712)