### PR TITLE
HSEARCH-2481 Byteman-based tests executed in the Elasticsearch module won't work

### DIFF
--- a/backends/jgroups/pom.xml
+++ b/backends/jgroups/pom.xml
@@ -179,10 +179,6 @@
                             <goal>integration-test</goal>
                             <goal>verify</goal>
                         </goals>
-                        <configuration>
-                            <argLine>${additionalRuntimeArgLine}</argLine>
-                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -139,6 +139,26 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jboss.byteman</groupId>
+            <artifactId>byteman</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.byteman</groupId>
+            <artifactId>byteman-bmunit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.byteman</groupId>
+            <artifactId>byteman-install</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
             <scope>test</scope>

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -260,7 +260,19 @@
                             </dependenciesToScan>
                             <includes>
                                 <include>**/*IT.java</include>
-                                <include>**/*.java</include>
+                                <!--
+                                    Warning: do not use a permissive wildcard such as '**/*.java',
+                                    as it would results in bugs such as HSEARCH-2481,
+                                    where Failsafe ended up loading every class from the classpath,
+                                    eventually loading Byteman classes which *must not* be loaded
+                                    before the Byteman agent has been launched.
+                                    Here we use the default surefire patterns documented there:
+                                    http://maven.apache.org/surefire/maven-surefire-plugin/examples/inclusion-exclusion.html
+                                 -->
+                                <include>**/Test*.java</include>
+                                <include>**/*Test.java</include>
+                                <include>**/*Tests.java</include>
+                                <include>**/*TestCase.java</include>
                             </includes>
                             <excludes>
                                 <!-- HSEARCH-2389 Support indexNullAs for @IndexedEmbedded applied on objects with Elasticsearch -->

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -234,8 +234,6 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
-                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                            <argLine>${additionalRuntimeArgLine}</argLine>
                             <dependenciesToScan>
                                 <dependency>org.hibernate:hibernate-search-engine</dependency>
                                 <dependency>org.hibernate:hibernate-search-orm</dependency>

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/DefaultElasticsearchClientFactoryTest.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/DefaultElasticsearchClientFactoryTest.java
@@ -35,7 +35,6 @@ import org.hibernate.search.testsupport.concurrency.Poller;
 import org.hibernate.search.testsupport.setup.SearchConfigurationForTest;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -374,7 +373,6 @@ public class DefaultElasticsearchClientFactoryTest {
 				+ " || host1 != null && host1.getSchemeName().equals( \"https\" )",
 		action = "pushEvent( \"https\" )"
 	)
-	@Ignore // HSEARCH-2481 Byteman-based tests executed in the Elasticsearch module won't work
 	public void discoveryScheme() throws Exception {
 		SearchConfigurationForTest configuration = new SearchConfigurationForTest()
 				// Need to use HTTP here, so that the sniffer can at least retrieve the host list

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -268,30 +268,4 @@
             </plugin>
         </plugins>
     </reporting>
-
-    <profiles>
-        <!-- tools classes are needed by byteman -->
-        <profile>
-            <id>default-toolsjar-profile</id>
-            <activation>
-                <file>
-                    <exists>${java.home}/../lib/tools.jar</exists>
-                </file>
-            </activation>
-            <properties>
-                <jdk-toolsjar>${java.home}/../lib/tools.jar</jdk-toolsjar>
-            </properties>
-        </profile>
-        <profile>
-            <id>mac-toolsjar-profile</id>
-            <activation>
-                <file>
-                    <exists>${java.home}/../Classes/classes.jar</exists>
-                </file>
-            </activation>
-            <properties>
-                <jdk-toolsjar>${java.home}/../Classes/classes.jar</jdk-toolsjar>
-            </properties>
-        </profile>
-    </profiles>
 </project>

--- a/engine/src/test/java/org/hibernate/search/test/searchfactory/SearchFactoryTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/searchfactory/SearchFactoryTest.java
@@ -27,7 +27,6 @@ import org.hibernate.search.testsupport.BytemanHelper;
 import org.hibernate.search.testsupport.TestForIssue;
 import org.hibernate.search.testsupport.BytemanHelper.BytemanAccessor;
 import org.hibernate.search.testsupport.BytemanHelper.SimulatedFailureException;
-import org.hibernate.search.testsupport.junit.ElasticsearchSupportInProgress;
 import org.hibernate.search.testsupport.junit.SearchIntegratorResource;
 import org.hibernate.search.testsupport.setup.SearchConfigurationForTest;
 import org.jboss.byteman.contrib.bmunit.BMRule;
@@ -35,7 +34,6 @@ import org.jboss.byteman.contrib.bmunit.BMRules;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -70,7 +68,6 @@ public class SearchFactoryTest {
 	}
 
 	@Test
-	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2481 Byteman-based tests re-executed in the Elasticsearch module won't work
 	@TestForIssue(jiraKey = "HSEARCH-2277")
 	@BMRules(rules = {
 			@BMRule(
@@ -103,7 +100,6 @@ public class SearchFactoryTest {
 	}
 
 	@Test
-	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2481 Byteman-based tests re-executed in the Elasticsearch module won't work
 	@TestForIssue(jiraKey = "HSEARCH-2277")
 	@BMRules(rules = {
 			@BMRule(
@@ -143,7 +139,6 @@ public class SearchFactoryTest {
 	}
 
 	@Test
-	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2481 Byteman-based tests re-executed in the Elasticsearch module won't work
 	@TestForIssue(jiraKey = "HSEARCH-2277")
 	@BMRules(rules = {
 			@BMRule(
@@ -174,7 +169,6 @@ public class SearchFactoryTest {
 	}
 
 	@Test
-	@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2481 Byteman-based tests re-executed in the Elasticsearch module won't work
 	@TestForIssue(jiraKey = "HSEARCH-2277")
 	@BMRules(rules = {
 			@BMRule(

--- a/engine/src/test/java/org/hibernate/search/testsupport/serialization/SerializationTestHelper.java
+++ b/engine/src/test/java/org/hibernate/search/testsupport/serialization/SerializationTestHelper.java
@@ -6,23 +6,19 @@
  */
 package org.hibernate.search.testsupport.serialization;
 
-import static org.junit.Assert.assertEquals;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.hibernate.search.testsupport.serialization.SerializationTestHelper.Foo.TestInnerClass;
-import org.junit.Test;
 
 /**
  * @author Sanne Grinovero
  */
-public class SerializationTestHelper {
+public final class SerializationTestHelper {
+
+	private SerializationTestHelper() {
+		// Do not instantiate this class
+	}
 
 	/**
 	 * Duplicates an object using Serialization, it moves
@@ -47,74 +43,6 @@ public class SerializationTestHelper {
 		ObjectInputStream objectInStream = new ObjectInputStream( inStream );
 		T copy = (T) objectInStream.readObject();
 		return copy;
-	}
-
-	@Test
-	public void testSelf() throws IOException, ClassNotFoundException {
-		Foo a = new Foo();
-		a.list.add( new TestInnerClass( 30 ) );
-		Foo b = (Foo) duplicateBySerialization( a );
-		assertEquals( Integer.valueOf( 6 ), a.integer );
-		assertEquals( Integer.valueOf( 7 ), b.integer );
-		assertEquals( a.list, b.list );
-	}
-
-	static class Foo implements Serializable {
-
-		List<TestInnerClass> list = new ArrayList<TestInnerClass>();
-		transient Integer integer = Integer.valueOf( 6 );
-
-		static class TestInnerClass implements Serializable {
-			private final int v;
-
-			public TestInnerClass(int i) {
-				v = i;
-			}
-
-			public void print() {
-				System.out.println( v );
-			}
-
-			@Override
-			public String toString() {
-				return "" + v;
-			}
-
-			@Override
-			public int hashCode() {
-				final int prime = 31;
-				int result = 1;
-				result = prime * result + v;
-				return result;
-			}
-
-			@Override
-			public boolean equals(Object obj) {
-				if ( this == obj ) {
-					return true;
-				}
-				if ( obj == null ) {
-					return false;
-				}
-				if ( getClass() != obj.getClass() ) {
-					return false;
-				}
-				final TestInnerClass other = (TestInnerClass) obj;
-				if ( v != other.v ) {
-					return false;
-				}
-				return true;
-			}
-		}
-
-		private void readObject(ObjectInputStream aInputStream) throws ClassNotFoundException, IOException {
-			aInputStream.defaultReadObject();
-			integer = Integer.valueOf( 7 );
-		}
-
-		private void writeObject(ObjectOutputStream aOutputStream) throws IOException {
-			aOutputStream.defaultWriteObject();
-		}
 	}
 
 }

--- a/engine/src/test/java/org/hibernate/search/testsupport/serialization/SerializationTestHelperTest.java
+++ b/engine/src/test/java/org/hibernate/search/testsupport/serialization/SerializationTestHelperTest.java
@@ -1,0 +1,94 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.testsupport.serialization;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.search.testsupport.serialization.SerializationTestHelperTest.Foo.TestInnerClass;
+import org.junit.Test;
+
+/**
+ * @author Sanne Grinovero
+ */
+public class SerializationTestHelperTest {
+
+	@Test
+	public void duplicatesAreEqual() throws IOException, ClassNotFoundException {
+		Foo a = new Foo();
+		a.list.add( new TestInnerClass( 30 ) );
+		Foo b = (Foo) SerializationTestHelper.duplicateBySerialization( a );
+		assertEquals( Integer.valueOf( 6 ), a.integer );
+		assertEquals( Integer.valueOf( 7 ), b.integer );
+		assertEquals( a.list, b.list );
+	}
+
+	static class Foo implements Serializable {
+
+		List<TestInnerClass> list = new ArrayList<TestInnerClass>();
+		transient Integer integer = Integer.valueOf( 6 );
+
+		static class TestInnerClass implements Serializable {
+			private final int v;
+
+			public TestInnerClass(int i) {
+				v = i;
+			}
+
+			public void print() {
+				System.out.println( v );
+			}
+
+			@Override
+			public String toString() {
+				return "" + v;
+			}
+
+			@Override
+			public int hashCode() {
+				final int prime = 31;
+				int result = 1;
+				result = prime * result + v;
+				return result;
+			}
+
+			@Override
+			public boolean equals(Object obj) {
+				if ( this == obj ) {
+					return true;
+				}
+				if ( obj == null ) {
+					return false;
+				}
+				if ( getClass() != obj.getClass() ) {
+					return false;
+				}
+				final TestInnerClass other = (TestInnerClass) obj;
+				if ( v != other.v ) {
+					return false;
+				}
+				return true;
+			}
+		}
+
+		private void readObject(ObjectInputStream aInputStream) throws ClassNotFoundException, IOException {
+			aInputStream.defaultReadObject();
+			integer = Integer.valueOf( 7 );
+		}
+
+		private void writeObject(ObjectOutputStream aOutputStream) throws IOException {
+			aOutputStream.defaultWriteObject();
+		}
+	}
+
+}

--- a/integrationtest/narayana/pom.xml
+++ b/integrationtest/narayana/pom.xml
@@ -74,10 +74,6 @@
                             <goal>integration-test</goal>
                             <goal>verify</goal>
                         </goals>
-                        <configuration>
-                            <argLine>${additionalRuntimeArgLine}</argLine>
-                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/integrationtest/spring/pom.xml
+++ b/integrationtest/spring/pom.xml
@@ -141,10 +141,6 @@
                             <goal>integration-test</goal>
                             <goal>verify</goal>
                         </goals>
-                        <configuration>
-                            <argLine>${additionalRuntimeArgLine}</argLine>
-                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/integrationtest/wildfly/pom.xml
+++ b/integrationtest/wildfly/pom.xml
@@ -235,9 +235,6 @@
                             <goal>integration-test</goal>
                             <goal>verify</goal>
                         </goals>
-                        <configuration>
-                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/orm/pom.xml
+++ b/orm/pom.xml
@@ -233,30 +233,4 @@
             </plugin>
         </plugins>
     </reporting>
-
-    <profiles>
-        <!-- tools classes are needed by byteman -->
-        <profile>
-            <id>default-toolsjar-profile</id>
-            <activation>
-                <file>
-                    <exists>${java.home}/../lib/tools.jar</exists>
-                </file>
-            </activation>
-            <properties>
-                <jdk-toolsjar>${java.home}/../lib/tools.jar</jdk-toolsjar>
-            </properties>
-        </profile>
-        <profile>
-            <id>mac-toolsjar-profile</id>
-            <activation>
-                <file>
-                    <exists>${java.home}/../Classes/classes.jar</exists>
-                </file>
-            </activation>
-            <properties>
-                <jdk-toolsjar>${java.home}/../Classes/classes.jar</jdk-toolsjar>
-            </properties>
-        </profile>
-    </profiles>
 </project>

--- a/orm/src/test/java/org/hibernate/search/test/batchindexing/MassIndexerErrorReportingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/batchindexing/MassIndexerErrorReportingTest.java
@@ -15,16 +15,13 @@ import org.hibernate.search.exception.ErrorHandler;
 import org.hibernate.search.spi.SearchIntegrator;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.test.errorhandling.MockErrorHandler;
-import org.hibernate.search.testsupport.junit.ElasticsearchSupportInProgress;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(BMUnitRunner.class)
-@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2481 Byteman-based tests re-executed in the Elasticsearch module won't work
 public class MassIndexerErrorReportingTest extends SearchTestBase {
 
 	@Test

--- a/orm/src/test/java/org/hibernate/search/test/configuration/integration/HibernateSearchSessionFactoryObserverTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/integration/HibernateSearchSessionFactoryObserverTest.java
@@ -12,14 +12,12 @@ import javax.persistence.Id;
 import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.testsupport.BytemanHelper;
 import org.hibernate.search.testsupport.BytemanHelper.BytemanAccessor;
-import org.hibernate.search.testsupport.junit.ElasticsearchSupportInProgress;
 import org.hibernate.search.test.util.FullTextSessionBuilder;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMRules;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
@@ -29,7 +27,6 @@ import static org.junit.Assert.fail;
  * @author Hardy Ferentschik
  */
 @RunWith(BMUnitRunner.class)
-@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2481 Byteman-based tests re-executed in the Elasticsearch module won't work
 public class HibernateSearchSessionFactoryObserverTest {
 
 	@Rule

--- a/orm/src/test/java/org/hibernate/search/test/errorhandling/ErrorHandlingDuringDocumentCreationTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/errorhandling/ErrorHandlingDuringDocumentCreationTest.java
@@ -20,12 +20,10 @@ import org.hibernate.search.spi.SearchIntegrator;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.test.util.progessmonitor.AssertingMassIndexerProgressMonitor;
 import org.hibernate.search.testsupport.TestForIssue;
-import org.hibernate.search.testsupport.junit.ElasticsearchSupportInProgress;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -36,7 +34,6 @@ import org.junit.runner.RunWith;
  */
 @TestForIssue(jiraKey = "HSEARCH-1354")
 @RunWith(BMUnitRunner.class)
-@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2481 Byteman-based tests re-executed in the Elasticsearch module won't work
 public class ErrorHandlingDuringDocumentCreationTest extends SearchTestBase {
 
 	@Test

--- a/orm/src/test/java/org/hibernate/search/test/query/facet/FacetIndexingFailureTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/facet/FacetIndexingFailureTest.java
@@ -12,7 +12,6 @@ import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import org.hibernate.search.bridge.util.impl.ContextualExceptionBridgeHelper;
@@ -20,7 +19,6 @@ import org.hibernate.search.engine.spi.DocumentBuilderIndexedEntity;
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.spi.DefaultInstanceInitializer;
 import org.hibernate.search.testsupport.TestForIssue;
-import org.hibernate.search.testsupport.junit.ElasticsearchSupportInProgress;
 import org.hibernate.search.testsupport.junit.SearchFactoryHolder;
 
 import static org.junit.Assert.assertTrue;
@@ -30,7 +28,6 @@ import static org.junit.Assert.fail;
  * @author Hardy Ferentschik
  */
 @RunWith(BMUnitRunner.class)
-@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2481 Byteman-based tests re-executed in the Elasticsearch module won't work
 public class FacetIndexingFailureTest {
 	@Rule
 	public SearchFactoryHolder factoryHolder = new SearchFactoryHolder( Car.class ).enableJPAAnnotationsProcessing( true );

--- a/orm/src/test/java/org/hibernate/search/test/query/initandlookup/CriteriaObjectInitializerAndHierarchyInheritanceTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/initandlookup/CriteriaObjectInitializerAndHierarchyInheritanceTest.java
@@ -38,12 +38,10 @@ import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.testsupport.BytemanHelper;
 import org.hibernate.search.testsupport.TestForIssue;
 import org.hibernate.search.testsupport.BytemanHelper.BytemanAccessor;
-import org.hibernate.search.testsupport.junit.ElasticsearchSupportInProgress;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -55,7 +53,6 @@ import org.junit.runner.RunWith;
  * The directory to store the dumped classes must exist already.
  */
 @RunWith(BMUnitRunner.class)
-@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2481 Byteman-based tests re-executed in the Elasticsearch module won't work
 public class CriteriaObjectInitializerAndHierarchyInheritanceTest extends SearchTestBase {
 
 	@Rule

--- a/orm/src/test/java/org/hibernate/search/test/query/initandlookup/ObjectLookupAndDatabaseRetrievalConfigurationTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/initandlookup/ObjectLookupAndDatabaseRetrievalConfigurationTest.java
@@ -23,13 +23,11 @@ import org.hibernate.search.test.util.FullTextSessionBuilder;
 import org.hibernate.search.testsupport.BytemanHelper;
 import org.hibernate.search.testsupport.TestForIssue;
 import org.hibernate.search.testsupport.BytemanHelper.BytemanAccessor;
-import org.hibernate.search.testsupport.junit.ElasticsearchSupportInProgress;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -41,7 +39,6 @@ import org.junit.runner.RunWith;
  */
 @TestForIssue(jiraKey = "HSEARCH-1119")
 @RunWith(BMUnitRunner.class)
-@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2481 Byteman-based tests re-executed in the Elasticsearch module won't work
 public class ObjectLookupAndDatabaseRetrievalConfigurationTest {
 
 	@Rule

--- a/orm/src/test/java/org/hibernate/search/test/query/objectloading/ObjectLoaderHelperTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/objectloading/ObjectLoaderHelperTest.java
@@ -18,14 +18,12 @@ import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.testsupport.BytemanHelper;
 import org.hibernate.search.testsupport.TestForIssue;
 import org.hibernate.search.testsupport.BytemanHelper.BytemanAccessor;
-import org.hibernate.search.testsupport.junit.ElasticsearchSupportInProgress;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
@@ -37,7 +35,6 @@ import static org.junit.Assert.assertEquals;
  */
 @TestForIssue(jiraKey = "HSEARCH-704")
 @RunWith(BMUnitRunner.class)
-@Category(ElasticsearchSupportInProgress.class) // HSEARCH-2481 Byteman-based tests re-executed in the Elasticsearch module won't work
 public class ObjectLoaderHelperTest extends SearchTestBase {
 
 	@Rule

--- a/pom.xml
+++ b/pom.xml
@@ -1512,6 +1512,33 @@ org.hibernate.search.spi.SearchIntegratorBuilder#buildSearchIntegrator()
             </properties>
         </profile>
 
+        <!-- ====================================== -->
+        <!-- Detection of tools classes for Byteman -->
+        <!-- ====================================== -->
+        <!-- See the configuration of the surefire and failsafe plugins -->
+        <profile>
+            <id>default-toolsjar-profile</id>
+            <activation>
+                <file>
+                    <exists>${java.home}/../lib/tools.jar</exists>
+                </file>
+            </activation>
+            <properties>
+                <jdk-toolsjar>${java.home}/../lib/tools.jar</jdk-toolsjar>
+            </properties>
+        </profile>
+        <profile>
+            <id>mac-toolsjar-profile</id>
+            <activation>
+                <file>
+                    <exists>${java.home}/../Classes/classes.jar</exists>
+                </file>
+            </activation>
+            <properties>
+                <jdk-toolsjar>${java.home}/../Classes/classes.jar</jdk-toolsjar>
+            </properties>
+        </profile>
+
         <!-- =============================== -->
         <!-- Elasticsearch IT profiles       -->
         <!-- =============================== -->

--- a/pom.xml
+++ b/pom.xml
@@ -1067,8 +1067,22 @@
                     <!-- 2.19.1 seems buggy, see https://hibernate.atlassian.net/browse/HV-1117 -->
                     <version>2.18.1</version>
                     <configuration>
+                        <forkCount>1</forkCount>
+                        <reuseForks>true</reuseForks>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                        <runOrder>alphabetical</runOrder>
+                        <systemPropertyVariables>
+                            <!-- See HSEARCH-1444 -->
+                            <hibernate.service.allow_crawling>false</hibernate.service.allow_crawling>
+                            <com.sun.management.jmxremote>true</com.sun.management.jmxremote>
+                            <org.hibernate.search.enable_performance_tests>${org.hibernate.search.enable_performance_tests}</org.hibernate.search.enable_performance_tests>
+                            <org.hibernate.search.fail_on_unreleased_service>true</org.hibernate.search.fail_on_unreleased_service>
+                        </systemPropertyVariables>
                         <argLine>${additionalRuntimeArgLine}</argLine>
+                        <additionalClasspathElements>
+                            <!-- Needed by Byteman to load the agent on demand -->
+                            <additionalClasspathElement>${jdk-toolsjar}</additionalClasspathElement>
+                        </additionalClasspathElements>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1066,6 +1066,10 @@
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <!-- 2.19.1 seems buggy, see https://hibernate.atlassian.net/browse/HV-1117 -->
                     <version>2.18.1</version>
+                    <configuration>
+                        <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                        <argLine>${additionalRuntimeArgLine}</argLine>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-2481

Note that only the last two commits (in topological order, so "HSEARCH-2481 Do not allow the maven-failsafe-plugin to scan the whole ..." and "HSEARCH-2481 Enable Byteman-based tests with Elasticsearch") are strictly necessary.
The other commits were my first attempts at solving the issue, but since they also clean up our poms, we may as well keep them.
