### PR TITLE
HSEARCH-2741 Fix dependency convergence issue between MariaDB and integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1779,7 +1779,7 @@ org.hibernate.search.spi.SearchIntegratorBuilder#buildSearchIntegrator()
                 <dependency>
                     <groupId>org.mariadb.jdbc</groupId>
                     <artifactId>mariadb-java-client</artifactId>
-                    <version>1.1.7</version>
+                    <version>1.5.9</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-2741

A build with this patch applied can be seen here: http://ci.hibernate.org/job/hibernate-search-yoann/1/

The build still has failing tests, but it's unrelated (seems to be a charset issue). I'm working on it and will submit another PR.