### PR TITLE
HSEARCH-2754 SpatialFieldBridge uses inefficient Reflection access

### DIFF
--- a/engine/src/main/java/org/hibernate/search/bridge/impl/BridgeFactory.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/impl/BridgeFactory.java
@@ -39,6 +39,7 @@ import org.hibernate.search.engine.service.classloading.spi.ClassLoaderService;
 import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.exception.AssertionFailure;
 import org.hibernate.search.indexes.spi.IndexManagerType;
+import org.hibernate.search.spatial.SpatialFieldBridge;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
@@ -150,15 +151,18 @@ public final class BridgeFactory {
 	 * This instantiates the SpatialFieldBridge from a {@code Spatial} annotation.
 	 *
 	 * @param spatial the {@code Spatial} annotation
-	 * @param clazz the {@code XClass} on which the annotation is defined on
+	 * @param clazz the class on which the annotation is defined
 	 * @return Returns the {@code SpatialFieldBridge} instance
 	 * @param latitudeField a {@link java.lang.String} object.
 	 * @param longitudeField a {@link java.lang.String} object.
 	 */
-	public FieldBridge buildSpatialBridge(Spatial spatial, XClass clazz, String latitudeField, String longitudeField) {
-		FieldBridge bridge;
+	public FieldBridge buildSpatialBridge(Spatial spatial, Class<?> clazz, String latitudeField, String longitudeField) {
+		SpatialFieldBridge bridge;
 		try {
 			bridge = SpatialBridgeProvider.buildSpatialBridge( spatial, latitudeField, longitudeField );
+			if ( bridge != null ) {
+				bridge.setAppliedOnType( clazz );
+			}
 		}
 		catch (Exception e) {
 			throw LOG.unableToInstantiateSpatial( clazz.getName(), e );

--- a/engine/src/main/java/org/hibernate/search/bridge/impl/SpatialBridgeProvider.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/impl/SpatialBridgeProvider.java
@@ -12,6 +12,7 @@ import java.lang.reflect.AnnotatedElement;
 import org.hibernate.search.annotations.Spatial;
 import org.hibernate.search.annotations.SpatialMode;
 import org.hibernate.search.bridge.FieldBridge;
+import org.hibernate.search.spatial.SpatialFieldBridge;
 import org.hibernate.search.spatial.SpatialFieldBridgeByHash;
 import org.hibernate.search.spatial.SpatialFieldBridgeByRange;
 import org.hibernate.search.util.logging.impl.Log;
@@ -56,8 +57,8 @@ class SpatialBridgeProvider extends ExtendedBridgeProvider {
 	 * @param latitudeField a {@link java.lang.String} object.
 	 * @param longitudeField a {@link java.lang.String} object.
 	 */
-	public static FieldBridge buildSpatialBridge(Spatial spatial, String latitudeField, String longitudeField) {
-		FieldBridge bridge = null;
+	public static SpatialFieldBridge buildSpatialBridge(Spatial spatial, String latitudeField, String longitudeField) {
+		SpatialFieldBridge bridge = null;
 		if ( spatial != null ) {
 			if ( spatial.spatialMode() == SpatialMode.HASH ) {
 				if ( latitudeField != null && longitudeField != null ) {

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
@@ -895,21 +895,22 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 
 	private FieldBridge determineSpatialFieldBridge(Spatial spatialAnnotation, ParseContext parseContext) {
 		final FieldBridge spatialBridge;
-		XClass clazz = parseContext.getCurrentClass();
-		if ( reflectionManager.toXClass( Coordinates.class ).isAssignableFrom( clazz ) ) {
+		XClass xClazz = parseContext.getCurrentClass();
+		Class<?> clazz = reflectionManager.toClass( xClazz );
+		if ( reflectionManager.toXClass( Coordinates.class ).isAssignableFrom( xClazz ) ) {
 			spatialBridge = bridgeFactory.buildSpatialBridge( spatialAnnotation, clazz, null, null );
 		}
 		else {
 			String latitudeField = null;
 			String longitudeField = null;
 
-			List<XProperty> fieldList = clazz.getDeclaredProperties( XClass.ACCESS_FIELD );
+			List<XProperty> fieldList = xClazz.getDeclaredProperties( XClass.ACCESS_FIELD );
 
 			for ( XProperty property : fieldList ) {
 				if ( property.isAnnotationPresent( Latitude.class ) && ( property.getAnnotation( Latitude.class ) ).of()
 						.equals( spatialAnnotation.name() ) ) {
 					if ( latitudeField != null ) {
-						throw log.ambiguousLatitudeDefinition( clazz.getName(), latitudeField, property.getName() );
+						throw log.ambiguousLatitudeDefinition( xClazz.getName(), latitudeField, property.getName() );
 					}
 					latitudeField = property.getName();
 				}
@@ -917,7 +918,7 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 						.equals( spatialAnnotation.name() ) ) {
 					if ( longitudeField != null ) {
 						throw log.ambiguousLongitudeDefinition(
-								clazz.getName(),
+								xClazz.getName(),
 								longitudeField,
 								property.getName()
 						);
@@ -926,13 +927,13 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 				}
 			}
 
-			List<XProperty> propertyList = clazz.getDeclaredProperties( XClass.ACCESS_PROPERTY );
+			List<XProperty> propertyList = xClazz.getDeclaredProperties( XClass.ACCESS_PROPERTY );
 
 			for ( XProperty property : propertyList ) {
 				if ( property.isAnnotationPresent( Latitude.class ) && ( property.getAnnotation( Latitude.class ) ).of()
 						.equals( spatialAnnotation.name() ) ) {
 					if ( latitudeField != null ) {
-						throw log.ambiguousLatitudeDefinition( clazz.getName(), latitudeField, property.getName() );
+						throw log.ambiguousLatitudeDefinition( xClazz.getName(), latitudeField, property.getName() );
 					}
 					latitudeField = property.getName();
 				}
@@ -940,7 +941,7 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 						.equals( spatialAnnotation.name() ) ) {
 					if ( longitudeField != null ) {
 						throw log.ambiguousLongitudeDefinition(
-								clazz.getName(),
+								xClazz.getName(),
 								longitudeField,
 								property.getName()
 						);
@@ -964,7 +965,7 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 		if ( spatialBridge == null ) {
 			throw log.cannotFindCoordinatesNorLatLongForSpatial(
 					spatialAnnotation.name()
-							.isEmpty() ? "default" : spatialAnnotation.name(), clazz.getName()
+							.isEmpty() ? "default" : spatialAnnotation.name(), xClazz.getName()
 			);
 		}
 		return spatialBridge;

--- a/engine/src/main/java/org/hibernate/search/spatial/SpatialFieldBridgeByHash.java
+++ b/engine/src/main/java/org/hibernate/search/spatial/SpatialFieldBridgeByHash.java
@@ -42,10 +42,9 @@ public class SpatialFieldBridgeByHash extends SpatialFieldBridge implements Para
 	}
 
 	public SpatialFieldBridgeByHash(int topSpatialHashLevel, int bottomSpatialHashLevel, String latitudeField, String longitudeField) {
+		super( latitudeField, longitudeField );
 		this.topSpatialHashLevel = topSpatialHashLevel;
 		this.bottomSpatialHashLevel = bottomSpatialHashLevel;
-		this.latitudeField = latitudeField;
-		this.longitudeField = longitudeField;
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/spatial/SpatialFieldBridgeByRange.java
+++ b/engine/src/main/java/org/hibernate/search/spatial/SpatialFieldBridgeByRange.java
@@ -24,8 +24,7 @@ public class SpatialFieldBridgeByRange extends SpatialFieldBridge {
 	}
 
 	public SpatialFieldBridgeByRange(String latitudeField, String longitudeField) {
-		this.latitudeField = latitudeField;
-		this.longitudeField = longitudeField;
+		super( latitudeField, longitudeField );
 	}
 
 	@Override

--- a/engine/src/test/java/org/hibernate/search/test/metadata/Snafu.java
+++ b/engine/src/test/java/org/hibernate/search/test/metadata/Snafu.java
@@ -65,4 +65,15 @@ public class Snafu {
 	@Field
 	@org.hibernate.search.annotations.Analyzer(impl = FooAnalyzer.class)
 	private String custom;
+
+
+	// Just so that @Spatial works; see HSEARCH-2759
+	public double getLatitude() {
+		return latitude;
+	}
+
+	// Just so that @Spatial works; see HSEARCH-2759
+	public double getLongitude() {
+		return longitude;
+	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-2754

We probably could do more ([HSEARCH-2759](https://hibernate.atlassian.net/browse/HSEARCH-2759) in particular), but unfortunately the `SpatialFieldBridge` class and its subclasses are API.
I chose to only fix the performance issue for now, so as not to break user code.