### PR TITLE
Milestone 1 for "Free Form Indexing"

### DIFF
--- a/backends/jgroups/src/test/java/org/hibernate/search/test/jgroups/master/JGroupsMasterTest.java
+++ b/backends/jgroups/src/test/java/org/hibernate/search/test/jgroups/master/JGroupsMasterTest.java
@@ -28,7 +28,9 @@ import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.engine.ProjectionConstants;
 import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.indexes.serialization.spi.LuceneWorkSerializer;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.spi.IndexingMode;
+import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.test.jgroups.common.JGroupsCommonTest;
 import org.hibernate.search.testsupport.TestConstants;
@@ -53,6 +55,7 @@ import static org.junit.Assert.assertEquals;
 public class JGroupsMasterTest extends SearchTestBase {
 
 	private static final Poller POLLER = JGroupsCommonTest.POLLER;
+	private static final IndexedTypeIdentifier tshirtType = new PojoIndexedTypeIdentifier( TShirt.class );
 
 	private final QueryParser parser = new QueryParser( "id", TestConstants.stopAnalyzer );
 
@@ -115,7 +118,7 @@ public class JGroupsMasterTest extends SearchTestBase {
 	}
 
 	protected String getIndexName() {
-		return org.hibernate.search.test.jgroups.master.TShirt.class.getName();
+		return tshirtType.getName();
 	}
 
 	/**
@@ -138,7 +141,7 @@ public class JGroupsMasterTest extends SearchTestBase {
 		DoubleField numField = new DoubleField( "length", shirt.getLength(), Field.Store.NO );
 		doc.add( numField );
 		LuceneWork luceneWork = new AddLuceneWork(
-				shirt.getId(), String.valueOf( shirt.getId() ), shirt.getClass(), doc
+				shirt.getId(), String.valueOf( shirt.getId() ), tshirtType, doc
 		);
 		List<LuceneWork> queue = new ArrayList<LuceneWork>();
 		queue.add( luceneWork );

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchHSQueryImpl.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchHSQueryImpl.java
@@ -73,6 +73,7 @@ import org.hibernate.search.query.facet.Facet;
 import org.hibernate.search.query.facet.FacetSortOrder;
 import org.hibernate.search.query.facet.FacetingRequest;
 import org.hibernate.search.spatial.DistanceSortField;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.util.impl.CollectionHelper;
 import org.hibernate.search.util.impl.ReflectionHelper;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
@@ -740,10 +741,10 @@ public class ElasticsearchHSQueryImpl extends AbstractHSQuery {
 			}
 
 			DocumentBuilderIndexedEntity documentBuilder = binding.getDocumentBuilder();
-			Class<?> clazz = documentBuilder.getBeanClass();
+			IndexedTypeIdentifier typeId = documentBuilder.getTypeIdentifier();
 
 			ConversionContext conversionContext = new ContextualExceptionBridgeHelper();
-			conversionContext.setClass( clazz );
+			conversionContext.setConvertedTypeId( typeId );
 			FieldProjection idProjection = idProjectionByEntityBinding.get( binding );
 			Object id = idProjection.convertHit( hit, conversionContext );
 			Object[] projections = null;
@@ -764,7 +765,7 @@ public class ElasticsearchHSQueryImpl extends AbstractHSQuery {
 							projections[i] = id;
 							break;
 						case ElasticsearchProjectionConstants.OBJECT_CLASS:
-							projections[i] = clazz;
+							projections[i] = typeId.getPojoType();
 							break;
 						case ElasticsearchProjectionConstants.SCORE:
 							projections[i] = hit.getAsJsonObject().get( "_score" ).getAsFloat();
@@ -825,7 +826,7 @@ public class ElasticsearchHSQueryImpl extends AbstractHSQuery {
 				}
 			}
 
-			return new EntityInfoImpl( clazz, documentBuilder.getIdPropertyName(), (Serializable) id, projections );
+			return new EntityInfoImpl( typeId, documentBuilder.getIdPropertyName(), (Serializable) id, projections );
 		}
 
 	}

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchLuceneQueryTranslator.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchLuceneQueryTranslator.java
@@ -7,7 +7,6 @@
 package org.hibernate.search.elasticsearch.impl;
 
 import java.util.Properties;
-import java.util.Set;
 
 import org.apache.lucene.search.Query;
 import org.hibernate.search.elasticsearch.util.impl.ElasticsearchEntityHelper;
@@ -16,7 +15,8 @@ import org.hibernate.search.engine.service.spi.Startable;
 import org.hibernate.search.query.engine.impl.LuceneQueryTranslator;
 import org.hibernate.search.query.engine.spi.QueryDescriptor;
 import org.hibernate.search.spi.BuildContext;
-import org.hibernate.search.util.impl.CollectionHelper;
+import org.hibernate.search.spi.IndexedTypeSet;
+import org.hibernate.search.spi.impl.IndexedTypesSets;
 
 import com.google.gson.JsonObject;
 
@@ -47,17 +47,18 @@ public class ElasticsearchLuceneQueryTranslator implements LuceneQueryTranslator
 	}
 
 	@Override
-	public boolean conversionRequired(Class<?>... entities) {
-		Set<Class<?>> queriedEntityTypes = getQueriedEntityTypes( entities );
+	public boolean conversionRequired(IndexedTypeSet entities) {
+		IndexedTypeSet queriedEntityTypes = getQueriedEntityTypes( entities );
 		return ElasticsearchEntityHelper.isAnyMappedToElasticsearch( extendedIntegrator, queriedEntityTypes );
 	}
 
-	private Set<Class<?>> getQueriedEntityTypes(Class<?>... indexedTargetedEntities) {
-		if ( indexedTargetedEntities == null || indexedTargetedEntities.length == 0 ) {
+	private IndexedTypeSet getQueriedEntityTypes(IndexedTypeSet indexedTargetedEntities) {
+		if ( indexedTargetedEntities == null || indexedTargetedEntities.isEmpty() ) {
 			return extendedIntegrator.getIndexBindings().keySet();
 		}
 		else {
-			return CollectionHelper.asSet( indexedTargetedEntities );
+			return IndexedTypesSets.fromIdentifiers( indexedTargetedEntities );
 		}
 	}
+
 }

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchNestingContextFactoryProvider.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchNestingContextFactoryProvider.java
@@ -25,6 +25,7 @@ import org.hibernate.search.engine.nesting.impl.NestingContextFactoryProvider;
 import org.hibernate.search.engine.nesting.impl.NoOpNestingContext;
 import org.hibernate.search.engine.service.spi.Startable;
 import org.hibernate.search.spi.BuildContext;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.util.impl.CollectionHelper;
 
 public class ElasticsearchNestingContextFactoryProvider implements NestingContextFactoryProvider, Startable {
@@ -51,7 +52,7 @@ public class ElasticsearchNestingContextFactoryProvider implements NestingContex
 		}
 
 		@Override
-		public NestingContext createNestingContext(Class<?> indexedEntityType) {
+		public NestingContext createNestingContext(IndexedTypeIdentifier indexedEntityType) {
 			ContextCreationStrategy strategy = strategies.get( indexedEntityType.getName() );
 
 			if ( strategy == null ) {

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
@@ -202,7 +202,7 @@ public interface Log extends org.hibernate.search.util.logging.impl.Log {
 
 	@Message(id = ES_BACKEND_MESSAGES_START_ID + 36,
 			value = "Mapping conflict detected for field '%2$s' on entity '%1$s'."
-					+ " The current mapping would require the field to be mapped to  both a composite field"
+					+ " The current mapping would require the field to be mapped to both a composite field"
 					+ " ('object' datatype) and a \"concrete\" field ('integer', 'date', etc.) holding a value,"
 					+ " which Elasticsearch does not allow. If you're seeing this issue, you probably added both"
 					+ " an @IndexedEmbedded annotation and a @Field (or similar) annotation on the same property:"

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/nulls/impl/ElasticsearchMissingValueStrategy.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/nulls/impl/ElasticsearchMissingValueStrategy.java
@@ -19,6 +19,7 @@ import org.hibernate.search.elasticsearch.schema.impl.ElasticsearchSchemaTransla
 import org.hibernate.search.engine.metadata.impl.PartialDocumentFieldMetadata;
 import org.hibernate.search.engine.nulls.codec.impl.NullMarkerCodec;
 import org.hibernate.search.engine.nulls.impl.MissingValueStrategy;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
 public final class ElasticsearchMissingValueStrategy implements MissingValueStrategy {
@@ -32,7 +33,7 @@ public final class ElasticsearchMissingValueStrategy implements MissingValueStra
 	}
 
 	@Override
-	public NullMarkerCodec createNullMarkerCodec(Class<?> entityType,
+	public NullMarkerCodec createNullMarkerCodec(IndexedTypeIdentifier entityType,
 			PartialDocumentFieldMetadata fieldMetadata, NullMarker nullMarker) {
 		Object nullEncoded = nullMarker.nullEncoded();
 		if ( nullEncoded instanceof String ) {
@@ -64,8 +65,10 @@ public final class ElasticsearchMissingValueStrategy implements MissingValueStra
 			return new ElasticsearchBooleanNullMarkerCodec( nullMarker );
 		}
 		else {
-			throw LOG.unsupportedNullTokenType( entityType, fieldMetadata.getPath().getRelativeName(),
+			throw LOG.unsupportedNullTokenType( entityType.getName(), fieldMetadata.getPath().getRelativeName(),
 					nullEncoded.getClass() );
 		}
 	}
+
 }
+

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/schema/impl/Elasticsearch2SchemaTranslator.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/schema/impl/Elasticsearch2SchemaTranslator.java
@@ -503,7 +503,7 @@ public class Elasticsearch2SchemaTranslator implements ElasticsearchSchemaTransl
 			return new JsonPrimitive( (Boolean) indexedNullToken );
 		}
 		else {
-			throw LOG.unsupportedNullTokenType( mappingBuilder.getBeanClass(), fieldPath.getAbsoluteName(),
+			throw LOG.unsupportedNullTokenType( mappingBuilder.getBeanClass().getName(), fieldPath.getAbsoluteName(),
 					indexedNullToken.getClass() );
 		}
 	}

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/ElasticsearchEntityHelper.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/ElasticsearchEntityHelper.java
@@ -6,13 +6,12 @@
  */
 package org.hibernate.search.elasticsearch.util.impl;
 
-import java.util.Collection;
-import java.util.Set;
-
 import org.hibernate.search.elasticsearch.spi.ElasticsearchIndexManagerType;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.engine.spi.EntityIndexBinding;
 import org.hibernate.search.indexes.spi.IndexManagerType;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.IndexedTypeSet;
 
 /**
  * @author Yoann Rodiere
@@ -23,19 +22,18 @@ public final class ElasticsearchEntityHelper {
 		// private constructor
 	}
 
-	public static boolean isMappedToElasticsearch(ExtendedSearchIntegrator integrator, Class<?> entityType) {
-		Set<Class<?>> entityTypesWithSubTypes = integrator.getIndexedTypesPolymorphic( new Class<?>[] { entityType } );
+	public static boolean isMappedToElasticsearch(ExtendedSearchIntegrator integrator, IndexedTypeIdentifier entityType) {
+		IndexedTypeSet entityTypesWithSubTypes = integrator.getIndexedTypesPolymorphic( entityType.asTypeSet() );
 		return hasElasticsearchIndexManager( integrator, entityTypesWithSubTypes );
 	}
 
-	public static boolean isAnyMappedToElasticsearch(ExtendedSearchIntegrator integrator, Collection<Class<?>> entityTypes) {
-		Set<Class<?>> entityTypesWithSubTypes = integrator.getIndexedTypesPolymorphic(
-				entityTypes.toArray( new Class<?>[entityTypes.size()] ) );
+	public static boolean isAnyMappedToElasticsearch(ExtendedSearchIntegrator integrator, IndexedTypeSet entityTypes) {
+		IndexedTypeSet entityTypesWithSubTypes = integrator.getIndexedTypesPolymorphic( entityTypes );
 		return hasElasticsearchIndexManager( integrator, entityTypesWithSubTypes );
 	}
 
-	private static boolean hasElasticsearchIndexManager(ExtendedSearchIntegrator integrator, Collection<Class<?>> entityTypes) {
-		for ( Class<?> entityType : entityTypes ) {
+	private static boolean hasElasticsearchIndexManager(ExtendedSearchIntegrator integrator, IndexedTypeSet entityTypes) {
+		for ( IndexedTypeIdentifier entityType : entityTypes ) {
 			EntityIndexBinding binding = integrator.getIndexBinding( entityType );
 			if ( binding == null ) {
 				continue;

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchFlushIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchFlushIT.java
@@ -8,7 +8,6 @@ package org.hibernate.search.elasticsearch.test;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.Collections;
 
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
@@ -23,6 +22,9 @@ import org.hibernate.search.engine.spi.DocumentBuilderIndexedEntity;
 import org.hibernate.search.engine.spi.EntityIndexBinding;
 import org.hibernate.search.query.engine.spi.HSQuery;
 import org.hibernate.search.spi.DefaultInstanceInitializer;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.impl.IndexedTypesSets;
+import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.hibernate.search.testsupport.TestForIssue;
 import org.hibernate.search.testsupport.junit.SearchFactoryHolder;
 
@@ -81,7 +83,7 @@ public class ElasticsearchFlushIT {
 	}
 
 	private void flush(Class<?> clazz) {
-		sfHolder.getBatchBackend().flush( Collections.<Class<?>>singleton( clazz ) );
+		sfHolder.getBatchBackend().flush( IndexedTypesSets.fromClass( clazz ) );
 	}
 
 	private void indexAsStream(Serializable id, Object entity) throws InterruptedException {
@@ -91,12 +93,13 @@ public class ElasticsearchFlushIT {
 
 	private LuceneWork createUpdateWork(Serializable id, Object entity) {
 		Class<?> clazz = entity.getClass();
+		IndexedTypeIdentifier typeId = new PojoIndexedTypeIdentifier( clazz );
 		ExtendedSearchIntegrator searchFactory = sfHolder.getSearchFactory();
-		EntityIndexBinding entityIndexBinding = searchFactory.getIndexBinding( clazz );
+		EntityIndexBinding entityIndexBinding = searchFactory.getIndexBinding( typeId );
 		DocumentBuilderIndexedEntity docBuilder = entityIndexBinding.getDocumentBuilder();
 		return docBuilder.createUpdateWork(
 				null,
-				clazz,
+				typeId,
 				entity,
 				id,
 				id.toString(),

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/deletebyquery/DeleteByQueryIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/deletebyquery/DeleteByQueryIT.java
@@ -20,6 +20,7 @@ import org.hibernate.search.backend.spi.SingularTermDeletionQuery;
 import org.hibernate.search.elasticsearch.ElasticsearchQueries;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.query.engine.spi.QueryDescriptor;
+import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.testsupport.setup.TransactionContextForTest;
 import org.junit.After;
@@ -87,7 +88,7 @@ public class DeleteByQueryIT extends SearchTestBase {
 		ExtendedSearchIntegrator integrator = session.getSearchFactory()
 				.unwrap( ExtendedSearchIntegrator.class );
 
-		DeleteByQueryWork queryWork = new DeleteByQueryWork( HockeyPlayer.class, new SingularTermDeletionQuery( "active", "false" ) );
+		DeleteByQueryWork queryWork = new DeleteByQueryWork( new PojoIndexedTypeIdentifier( HockeyPlayer.class ), new SingularTermDeletionQuery( "active", "false" ) );
 
 		TransactionContext tc = new TransactionContextForTest();
 

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/deletebyquery/DeleteByQueryMultiTenancyIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/deletebyquery/DeleteByQueryMultiTenancyIT.java
@@ -23,6 +23,7 @@ import org.hibernate.search.backend.spi.SingularTermDeletionQuery;
 import org.hibernate.search.elasticsearch.ElasticsearchQueries;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.query.engine.spi.QueryDescriptor;
+import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.testsupport.setup.TransactionContextForTest;
 import org.junit.After;
@@ -131,7 +132,7 @@ public class DeleteByQueryMultiTenancyIT extends SearchTestBase {
 
 		DeleteByQueryWork queryWork = new DeleteByQueryWork(
 				DOWN_TO_THE_EARTH,
-				HockeyPlayer.class,
+				new PojoIndexedTypeIdentifier( HockeyPlayer.class ),
 				new SingularTermDeletionQuery( "active", "false" )
 		);
 

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/testutil/ElasticsearchBackendTestHelper.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/testutil/ElasticsearchBackendTestHelper.java
@@ -26,6 +26,7 @@ import org.hibernate.search.elasticsearch.work.impl.SimpleElasticsearchWork;
 import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.engine.service.spi.ServiceReference;
 import org.hibernate.search.indexes.spi.IndexManager;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.test.TestResourceManager;
 import org.hibernate.search.test.util.BackendTestHelper;
 
@@ -45,7 +46,7 @@ public class ElasticsearchBackendTestHelper extends BackendTestHelper {
 	}
 
 	@Override
-	public int getNumberOfDocumentsInIndex(Class<?> entityType) {
+	public int getNumberOfDocumentsInIndex(IndexedTypeIdentifier entityType) {
 		ServiceManager serviceManager = resourceManager.getExtendedSearchIntegrator().getServiceManager();
 
 		IndexManager[] indexManagers = resourceManager.getExtendedSearchIntegrator()

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -231,6 +231,7 @@
                             org.hibernate.search.spatial;version="${project.version}",
                             org.hibernate.search.spatial.impl;version="${project.version}",
                             org.hibernate.search.spi;version="${project.version}",
+                            org.hibernate.search.spi.impl;version="${project.version}",
                             org.hibernate.search.stat;version="${project.version}",
                             org.hibernate.search.stat.spi;version="${project.version}",
                             org.hibernate.search.store;version="${project.version}",

--- a/engine/src/main/java/org/hibernate/search/backend/AddLuceneWork.java
+++ b/engine/src/main/java/org/hibernate/search/backend/AddLuceneWork.java
@@ -10,30 +10,29 @@ import java.io.Serializable;
 import java.util.Map;
 
 import org.apache.lucene.document.Document;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 
 /**
  * @author Emmanuel Bernard
  */
 public class AddLuceneWork extends LuceneWork {
 
-	private static final long serialVersionUID = -2450349312813297371L;
-
 	private final Map<String, String> fieldToAnalyzerMap;
 
-	public AddLuceneWork(Serializable id, String idInString, Class<?> entity, Document document) {
-		this( null, id, idInString, entity, document, null );
+	public AddLuceneWork(Serializable id, String idInString, IndexedTypeIdentifier entityType, Document document) {
+		this( null, id, idInString, entityType, document, null );
 	}
 
-	public AddLuceneWork(String tenantId, Serializable id, String idInString, Class<?> entity, Document document) {
-		this( tenantId, id, idInString, entity, document, null );
+	public AddLuceneWork(String tenantId, Serializable id, String idInString, IndexedTypeIdentifier entityType, Document document) {
+		this( tenantId, id, idInString, entityType, document, null );
 	}
 
-	public AddLuceneWork(Serializable id, String idInString, Class<?> entity, Document document, Map<String, String> fieldToAnalyzerMap) {
-		this( null, id, idInString, entity, document, fieldToAnalyzerMap );
+	public AddLuceneWork(Serializable id, String idInString, IndexedTypeIdentifier entityType, Document document, Map<String, String> fieldToAnalyzerMap) {
+		this( null, id, idInString, entityType, document, fieldToAnalyzerMap );
 	}
 
-	public AddLuceneWork(String tenantId, Serializable id, String idInString, Class<?> entity, Document document, Map<String, String> fieldToAnalyzerMap) {
-		super( tenantId, id, idInString, entity, document );
+	public AddLuceneWork(String tenantId, Serializable id, String idInString, IndexedTypeIdentifier entityType, Document document, Map<String, String> fieldToAnalyzerMap) {
+		super( tenantId, id, idInString, entityType, document );
 		this.fieldToAnalyzerMap = fieldToAnalyzerMap;
 	}
 
@@ -50,7 +49,7 @@ public class AddLuceneWork extends LuceneWork {
 	@Override
 	public String toString() {
 		String tenant = getTenantId() == null ? "" : " [" + getTenantId() + "] ";
-		return "AddLuceneWork" + tenant + ": " + this.getEntityClass().getName() + "#" + this.getIdInString();
+		return "AddLuceneWork" + tenant + ": " + this.getEntityType().getName() + "#" + this.getIdInString();
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/search/backend/DeleteLuceneWork.java
+++ b/engine/src/main/java/org/hibernate/search/backend/DeleteLuceneWork.java
@@ -8,19 +8,19 @@ package org.hibernate.search.backend;
 
 import java.io.Serializable;
 
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+
 /**
  * @author Emmanuel Bernard
  */
 public class DeleteLuceneWork extends LuceneWork {
 
-	private static final long serialVersionUID = -854604138119230246L;
-
-	public DeleteLuceneWork(Serializable id, String idInString, Class<?> entity) {
-		this( null, id, idInString, entity );
+	public DeleteLuceneWork(Serializable id, String idInString, IndexedTypeIdentifier typeIdentifier) {
+		this( null, id, idInString, typeIdentifier );
 	}
 
-	public DeleteLuceneWork(String tenantId, Serializable id, String idInString, Class<?> entity) {
-		super( tenantId, id, idInString, entity );
+	public DeleteLuceneWork(String tenantId, Serializable id, String idInString, IndexedTypeIdentifier typeIdentifier) {
+		super( tenantId, id, idInString, typeIdentifier );
 	}
 
 	@Override
@@ -31,7 +31,7 @@ public class DeleteLuceneWork extends LuceneWork {
 	@Override
 	public String toString() {
 		String tenant = getTenantId() == null ? "" : " [" + getTenantId() + "] ";
-		return "DeleteLuceneWork" + tenant + ": " + this.getEntityClass().getName() + "#" + this.getIdInString();
+		return "DeleteLuceneWork" + tenant + ": " + this.getEntityType().getName() + "#" + this.getIdInString();
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/search/backend/FlushLuceneWork.java
+++ b/engine/src/main/java/org/hibernate/search/backend/FlushLuceneWork.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.backend;
 
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 
 /**
  * Used to flush and commit asynchronous and other pending operations on the Indexes.
@@ -22,10 +23,10 @@ public class FlushLuceneWork extends LuceneWork {
 	 * Flushes all index operations for a specific entity.
 	 *
 	 * @param tenantId the tenant identifier. It might be null
-	 * @param entity the entity type for which to flush the index
+	 * @param typeIdentifier the entity type for which to flush the index
 	 */
-	public FlushLuceneWork(String tenantId, Class<?> entity) {
-		super( tenantId, null, null, entity );
+	public FlushLuceneWork(String tenantId, IndexedTypeIdentifier typeIdentifier) {
+		super( tenantId, null, null, typeIdentifier );
 	}
 
 	/**
@@ -42,12 +43,12 @@ public class FlushLuceneWork extends LuceneWork {
 
 	@Override
 	public String toString() {
-		Class entityClass = this.getEntityClass();
+		IndexedTypeIdentifier entityClass = this.getEntityType();
 		if ( entityClass == null ) {
 			return "FlushLuceneWork: global";
 		}
 		else {
-			return "FlushLuceneWork: " + this.getEntityClass().getName();
+			return "FlushLuceneWork: " + entityClass.getName();
 		}
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/backend/LuceneWork.java
+++ b/engine/src/main/java/org/hibernate/search/backend/LuceneWork.java
@@ -10,6 +10,7 @@ import java.io.Serializable;
 import java.util.Map;
 
 import org.apache.lucene.document.Document;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 
 /**
  * Represent a unit of work to be applied against the Lucene index.
@@ -27,20 +28,20 @@ import org.apache.lucene.document.Document;
 public abstract class LuceneWork {
 
 	private final Document document;
-	private final Class<?> entityClass;
+	private final IndexedTypeIdentifier entityType;
 	private final String tenantId;
 	private final Serializable id;
 	private final String idInString;
 
-	public LuceneWork(String tenantId, Serializable id, String idInString, Class<?> entity) {
-		this( tenantId, id, idInString, entity, null );
+	public LuceneWork(String tenantId, Serializable id, String idInString, IndexedTypeIdentifier typeIdentifier) {
+		this( tenantId, id, idInString, typeIdentifier, null );
 	}
 
-	public LuceneWork(String tenantId, Serializable id, String idInString, Class<?> entity, Document document) {
+	public LuceneWork(String tenantId, Serializable id, String idInString, IndexedTypeIdentifier typeIdentifier, Document document) {
 		this.tenantId = tenantId;
 		this.id = id;
 		this.idInString = idInString;
-		this.entityClass = entity;
+		this.entityType = typeIdentifier;
 		this.document = document;
 	}
 
@@ -48,8 +49,17 @@ public abstract class LuceneWork {
 		return document;
 	}
 
+	/**
+	 * @deprecated use {@link #getEntityType()}: this method will be removed!
+	 * @return the Class identifying the entity type
+	 */
+	@Deprecated
 	public Class<?> getEntityClass() {
-		return entityClass;
+		return entityType.getPojoType();
+	}
+
+	public IndexedTypeIdentifier getEntityType() {
+		return entityType;
 	}
 
 	public Serializable getId() {

--- a/engine/src/main/java/org/hibernate/search/backend/OptimizeLuceneWork.java
+++ b/engine/src/main/java/org/hibernate/search/backend/OptimizeLuceneWork.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.backend;
 
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 
 /**
  * A unit of work triggering an optimize operation.
@@ -21,10 +22,10 @@ public class OptimizeLuceneWork extends LuceneWork {
 
 	/**
 	 * Optimizes the index(es) of a specific entity
-	 * @param entity the entity type
+	 * @param entityType the entity type
 	 */
-	public OptimizeLuceneWork(Class<?> entity) {
-		super( null, null, null, entity );
+	public OptimizeLuceneWork(IndexedTypeIdentifier entityType) {
+		super( null, null, null, entityType );
 	}
 
 	/**
@@ -41,12 +42,12 @@ public class OptimizeLuceneWork extends LuceneWork {
 
 	@Override
 	public String toString() {
-		Class entityClass = this.getEntityClass();
+		IndexedTypeIdentifier entityClass = this.getEntityType();
 		if ( entityClass == null ) {
 			return "OptimizeLuceneWork: global";
 		}
 		else {
-			return "OptimizeLuceneWork: " + this.getEntityClass().getName();
+			return "OptimizeLuceneWork: " + entityClass.getName();
 		}
 	}
 

--- a/engine/src/main/java/org/hibernate/search/backend/PurgeAllLuceneWork.java
+++ b/engine/src/main/java/org/hibernate/search/backend/PurgeAllLuceneWork.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.backend;
 
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 
 /**
  * A unit of work used to purge an entire index.
@@ -14,14 +15,12 @@ package org.hibernate.search.backend;
  */
 public class PurgeAllLuceneWork extends LuceneWork {
 
-	private static final long serialVersionUID = 8124091288284011715L;
-
-	public PurgeAllLuceneWork(Class<?> entity) {
-		this( null, entity );
+	public PurgeAllLuceneWork(IndexedTypeIdentifier type) {
+		this( null, type );
 	}
 
-	public PurgeAllLuceneWork(String tenantId, Class<?> entity) {
-		super( tenantId, null, null, entity, null );
+	public PurgeAllLuceneWork(String tenantId, IndexedTypeIdentifier type) {
+		super( tenantId, null, null, type, null );
 	}
 
 	@Override
@@ -32,7 +31,7 @@ public class PurgeAllLuceneWork extends LuceneWork {
 	@Override
 	public String toString() {
 		String tenant = getTenantId() == null ? "" : " [" + getTenantId() + "] ";
-		return "PurgeAllLuceneWork" + tenant + ": " + this.getEntityClass().getName();
+		return "PurgeAllLuceneWork" + tenant + ": " + this.getEntityType().getName();
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/search/backend/UpdateLuceneWork.java
+++ b/engine/src/main/java/org/hibernate/search/backend/UpdateLuceneWork.java
@@ -11,6 +11,7 @@ import java.io.Serializable;
 import java.util.Map;
 
 import org.apache.lucene.document.Document;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 
 /**
  * Carries a Lucene update operation from the engine to the backend
@@ -20,24 +21,22 @@ import org.apache.lucene.document.Document;
  */
 public class UpdateLuceneWork extends LuceneWork {
 
-	private static final long serialVersionUID = -5267394465359187688L;
-
 	private final Map<String, String> fieldToAnalyzerMap;
 
-	public UpdateLuceneWork(Serializable id, String idInString, Class<?> entity, Document document) {
-		this( null, id, idInString, entity, document, null );
+	public UpdateLuceneWork(Serializable id, String idInString, IndexedTypeIdentifier entityType, Document document) {
+		this( null, id, idInString, entityType, document, null );
 	}
 
-	public UpdateLuceneWork(String tenantId, Serializable id, String idInString, Class<?> entity, Document document) {
-		this( tenantId, id, idInString, entity, document, null );
+	public UpdateLuceneWork(String tenantId, Serializable id, String idInString, IndexedTypeIdentifier entityType, Document document) {
+		this( tenantId, id, idInString, entityType, document, null );
 	}
 
-	public UpdateLuceneWork(Serializable id, String idInString, Class<?> entity, Document document, Map<String, String> fieldToAnalyzerMap) {
-		this( null, id, idInString, entity, document );
+	public UpdateLuceneWork(Serializable id, String idInString, IndexedTypeIdentifier entityType, Document document, Map<String, String> fieldToAnalyzerMap) {
+		this( null, id, idInString, entityType, document );
 	}
 
-	public UpdateLuceneWork(String tenantId, Serializable id, String idInString, Class<?> entity, Document document, Map<String, String> fieldToAnalyzerMap) {
-		super( tenantId, id, idInString, entity, document );
+	public UpdateLuceneWork(String tenantId, Serializable id, String idInString, IndexedTypeIdentifier entityType, Document document, Map<String, String> fieldToAnalyzerMap) {
+		super( tenantId, id, idInString, entityType, document );
 		this.fieldToAnalyzerMap = fieldToAnalyzerMap;
 	}
 
@@ -54,7 +53,7 @@ public class UpdateLuceneWork extends LuceneWork {
 	@Override
 	public String toString() {
 		String tenant = getTenantId() == null ? "" : " [" + getTenantId() + "] ";
-		return "UpdateLuceneWork" + tenant + ": " + this.getEntityClass().getName() + "#" + this.getIdInString();
+		return "UpdateLuceneWork" + tenant + ": " + this.getEntityType().getName() + "#" + this.getIdInString();
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/search/backend/impl/BatchedQueueingProcessor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/BatchedQueueingProcessor.java
@@ -7,7 +7,6 @@
 package org.hibernate.search.backend.impl;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 
 import org.hibernate.search.backend.LuceneWork;
@@ -15,6 +14,7 @@ import org.hibernate.search.backend.spi.Work;
 import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.engine.spi.EntityIndexBinding;
 import org.hibernate.search.indexes.impl.IndexManagerHolder;
+import org.hibernate.search.spi.IndexedTypeMap;
 import org.hibernate.search.util.configuration.impl.ConfigurationParseHelper;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
@@ -32,9 +32,9 @@ public class BatchedQueueingProcessor implements QueueingProcessor {
 	private final int batchSize;
 	private final TransactionalOperationDispatcher operationDispatcher;
 
-	public BatchedQueueingProcessor(Map<Class<?>, EntityIndexBinding> entityIndexBindings, Properties properties, IndexManagerHolder indexManagerHolder) {
+	public BatchedQueueingProcessor(IndexedTypeMap<EntityIndexBinding> documentBuildersIndexedEntities, Properties properties, IndexManagerHolder indexManagerHolder) {
 		batchSize = ConfigurationParseHelper.getIntValue( properties, Environment.QUEUEINGPROCESSOR_BATCHSIZE, 0 );
-		this.operationDispatcher = new TransactionalOperationDispatcher( indexManagerHolder, entityIndexBindings );
+		this.operationDispatcher = new TransactionalOperationDispatcher( indexManagerHolder, documentBuildersIndexedEntities );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/backend/impl/StreamingOperationDispatcher.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/StreamingOperationDispatcher.java
@@ -13,6 +13,7 @@ import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.backend.spi.OperationDispatcher;
 import org.hibernate.search.engine.spi.EntityIndexBinding;
 import org.hibernate.search.indexes.spi.IndexManager;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.spi.SearchIntegrator;
 import org.hibernate.search.store.IndexShardingStrategy;
 
@@ -46,7 +47,7 @@ public class StreamingOperationDispatcher implements OperationDispatcher {
 	}
 
 	private void executeWork(LuceneWork work, IndexingMonitor progressMonitor) {
-		final Class<?> entityType = work.getEntityClass();
+		final IndexedTypeIdentifier entityType = work.getEntityType();
 		EntityIndexBinding entityIndexBinding = integrator.getIndexBinding( entityType );
 		IndexShardingStrategy shardingStrategy = entityIndexBinding.getSelectionStrategy();
 		StreamingOperationExecutor executor =

--- a/engine/src/main/java/org/hibernate/search/backend/impl/StreamingOperationExecutorSelector.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/StreamingOperationExecutorSelector.java
@@ -84,7 +84,8 @@ public class StreamingOperationExecutorSelector implements IndexWorkVisitor<Void
 
 		@Override
 		public void performStreamOperation(LuceneWork work, IndexShardingStrategy shardingStrategy, IndexingMonitor monitor, boolean forceAsync) {
-			IndexManager[] indexManagers = shardingStrategy.getIndexManagersForDeletion( work.getEntityClass(), work.getId(), work.getIdInString() );
+			IndexManager[] indexManagers = shardingStrategy.getIndexManagersForDeletion(
+					work.getEntityType().getPojoType(), work.getId(), work.getIdInString() );
 			for ( IndexManager indexManager : indexManagers ) {
 				indexManager.performStreamOperation( work, monitor, forceAsync );
 			}
@@ -98,7 +99,7 @@ public class StreamingOperationExecutorSelector implements IndexWorkVisitor<Void
 		public final void performStreamOperation(LuceneWork work,
 				IndexShardingStrategy shardingStrategy, IndexingMonitor monitor, boolean forceAsync) {
 			IndexManager indexManager = shardingStrategy.getIndexManagerForAddition(
-					work.getEntityClass(),
+					work.getEntityType().getPojoType(),
 					work.getId(),
 					work.getIdInString(),
 					work.getDocument()
@@ -114,7 +115,7 @@ public class StreamingOperationExecutorSelector implements IndexWorkVisitor<Void
 		public final void performStreamOperation(LuceneWork work,
 				IndexShardingStrategy shardingStrategy, IndexingMonitor monitor, boolean forceAsync) {
 			IndexManager[] indexManagers = shardingStrategy.getIndexManagersForDeletion(
-					work.getEntityClass(),
+					work.getEntityType().getPojoType(),
 					work.getId(),
 					work.getIdInString()
 			);
@@ -144,7 +145,7 @@ public class StreamingOperationExecutorSelector implements IndexWorkVisitor<Void
 		public final void performStreamOperation(LuceneWork work,
 				IndexShardingStrategy shardingStrategy, IndexingMonitor monitor, boolean forceAsync) {
 			IndexManager[] indexManagers = shardingStrategy.getIndexManagersForDeletion(
-					work.getEntityClass(),
+					work.getEntityType().getPojoType(),
 					work.getId(),
 					work.getIdInString()
 			);

--- a/engine/src/main/java/org/hibernate/search/backend/impl/TransactionalOperationDispatcher.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/TransactionalOperationDispatcher.java
@@ -7,7 +7,6 @@
 package org.hibernate.search.backend.impl;
 
 import java.util.List;
-import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -18,7 +17,9 @@ import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.engine.spi.EntityIndexBinding;
 import org.hibernate.search.indexes.impl.IndexManagerHolder;
 import org.hibernate.search.indexes.spi.IndexManager;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.spi.SearchIntegrator;
+import org.hibernate.search.spi.IndexedTypeMap;
 import org.hibernate.search.store.IndexShardingStrategy;
 
 /**
@@ -29,7 +30,7 @@ import org.hibernate.search.store.IndexShardingStrategy;
  * @author Yoann Rodiere
  */
 public class TransactionalOperationDispatcher implements OperationDispatcher {
-	private final Function<Class<?>, EntityIndexBinding> bindingLookup;
+	private final Function<IndexedTypeIdentifier, EntityIndexBinding> bindingLookup;
 	private final IndexManagerHolder indexManagerHolder;
 	private final Predicate<IndexManager> indexManagerFilter;
 
@@ -43,12 +44,12 @@ public class TransactionalOperationDispatcher implements OperationDispatcher {
 	}
 
 	public TransactionalOperationDispatcher(IndexManagerHolder indexManagerHolder,
-			Map<Class<?>, EntityIndexBinding> bindings) {
+			IndexedTypeMap<EntityIndexBinding> bindings) {
 		this( indexManagerHolder, bindings::get, indexManager -> true );
 	}
 
 	private TransactionalOperationDispatcher(IndexManagerHolder indexManagerHolder,
-			Function<Class<?>, EntityIndexBinding> bindingLookup,
+			Function<IndexedTypeIdentifier, EntityIndexBinding> bindingLookup,
 			Predicate<IndexManager> indexManagerFilter) {
 		this.indexManagerHolder = indexManagerHolder;
 		this.bindingLookup = bindingLookup;
@@ -72,7 +73,7 @@ public class TransactionalOperationDispatcher implements OperationDispatcher {
 	}
 
 	private void appendWork(WorkQueuePerIndexSplitter context, LuceneWork work) {
-		final Class<?> entityType = work.getEntityClass();
+		final IndexedTypeIdentifier entityType = work.getEntityType();
 		EntityIndexBinding entityIndexBinding = bindingLookup.apply( entityType );
 		IndexShardingStrategy shardingStrategy = entityIndexBinding.getSelectionStrategy();
 		TransactionalOperationExecutor executor = work.acceptIndexWorkVisitor( TransactionalOperationExecutorSelector.INSTANCE, null );

--- a/engine/src/main/java/org/hibernate/search/backend/impl/TransactionalOperationExecutorSelector.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/TransactionalOperationExecutorSelector.java
@@ -88,7 +88,7 @@ public class TransactionalOperationExecutorSelector implements IndexWorkVisitor<
 		public final void performOperation(LuceneWork work, IndexShardingStrategy shardingStrategy,
 				WorkQueuePerIndexSplitter context) {
 			IndexManager indexManager = shardingStrategy.getIndexManagerForAddition(
-					work.getEntityClass(),
+					work.getEntityType().getPojoType(),
 					work.getId(),
 					work.getIdInString(),
 					work.getDocument()
@@ -104,7 +104,7 @@ public class TransactionalOperationExecutorSelector implements IndexWorkVisitor<
 		public final void performOperation(LuceneWork work, IndexShardingStrategy shardingStrategy,
 				WorkQueuePerIndexSplitter context) {
 			IndexManager[] indexManagers = shardingStrategy.getIndexManagersForDeletion(
-					work.getEntityClass(),
+					work.getEntityType().getPojoType(),
 					work.getId(),
 					work.getIdInString()
 			);
@@ -121,7 +121,7 @@ public class TransactionalOperationExecutorSelector implements IndexWorkVisitor<
 		public final void performOperation(LuceneWork work, IndexShardingStrategy shardingStrategy,
 				WorkQueuePerIndexSplitter context) {
 			IndexManager[] indexManagers = shardingStrategy.getIndexManagersForDeletion(
-					work.getEntityClass(),
+					work.getEntityType().getPojoType(),
 					work.getId(),
 					work.getIdInString()
 			);
@@ -168,7 +168,7 @@ public class TransactionalOperationExecutorSelector implements IndexWorkVisitor<
 		public final void performOperation(LuceneWork work, IndexShardingStrategy shardingStrategy,
 				WorkQueuePerIndexSplitter context) {
 			IndexManager[] indexManagers = shardingStrategy.getIndexManagersForDeletion(
-					work.getEntityClass(),
+					work.getEntityType().getPojoType(),
 					work.getId(),
 					work.getIdInString()
 			);

--- a/engine/src/main/java/org/hibernate/search/backend/impl/batch/DefaultBatchBackend.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/batch/DefaultBatchBackend.java
@@ -8,8 +8,6 @@ package org.hibernate.search.backend.impl.batch;
 
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
 
 import org.hibernate.search.backend.FlushLuceneWork;
 import org.hibernate.search.backend.LuceneWork;
@@ -22,6 +20,9 @@ import org.hibernate.search.batchindexing.MassIndexerProgressMonitor;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.engine.spi.EntityIndexBinding;
 import org.hibernate.search.indexes.spi.IndexManager;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.IndexedTypeSet;
+import org.hibernate.search.spi.IndexedTypeMap;
 
 /**
  * This is not meant to be used as a regular
@@ -52,7 +53,7 @@ public class DefaultBatchBackend implements BatchBackend {
 
 	@Override
 	public void awaitAsyncProcessingCompletion() {
-		Map<Class<?>, EntityIndexBinding> indexBindings = integrator.getIndexBindings();
+		IndexedTypeMap<EntityIndexBinding> indexBindings = integrator.getIndexBindings();
 		for ( EntityIndexBinding indexBinding : indexBindings.values() ) {
 			for ( IndexManager indexManager : indexBinding.getIndexManagers() ) {
 				indexManager.awaitAsyncProcessingCompletion();
@@ -67,7 +68,7 @@ public class DefaultBatchBackend implements BatchBackend {
 	}
 
 	@Override
-	public void flush(Set<Class<?>> entityTypes) {
+	public void flush(IndexedTypeSet entityTypes) {
 		Collection<IndexManager> uniqueIndexManagers = uniqueIndexManagerForTypes( entityTypes );
 		for ( IndexManager indexManager : uniqueIndexManagers ) {
 			indexManager.performStreamOperation( FlushLuceneWork.INSTANCE, progressMonitor, false );
@@ -75,16 +76,16 @@ public class DefaultBatchBackend implements BatchBackend {
 	}
 
 	@Override
-	public void optimize(Set<Class<?>> entityTypes) {
+	public void optimize(IndexedTypeSet entityTypes) {
 		Collection<IndexManager> uniqueIndexManagers = uniqueIndexManagerForTypes( entityTypes );
 		for ( IndexManager indexManager : uniqueIndexManagers ) {
 			indexManager.performStreamOperation( OptimizeLuceneWork.INSTANCE, progressMonitor, false );
 		}
 	}
 
-	private Collection<IndexManager> uniqueIndexManagerForTypes(Collection<Class<?>> entityTypes) {
+	private Collection<IndexManager> uniqueIndexManagerForTypes(IndexedTypeSet entityTypes) {
 		HashMap<String,IndexManager> uniqueBackends = new HashMap<String, IndexManager>( entityTypes.size() );
-		for ( Class<?> type : entityTypes ) {
+		for ( IndexedTypeIdentifier type : entityTypes ) {
 			EntityIndexBinding indexBindingForEntity = integrator.getIndexBinding( type );
 			if ( indexBindingForEntity != null ) {
 				IndexManager[] indexManagers = indexBindingForEntity.getIndexManagers();

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/AddWorkExecutor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/AddWorkExecutor.java
@@ -17,6 +17,7 @@ import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.backend.impl.lucene.IndexWriterDelegate;
 import org.hibernate.search.engine.spi.DocumentBuilderIndexedEntity;
 import org.hibernate.search.exception.SearchException;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.store.Workspace;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
@@ -42,7 +43,7 @@ class AddWorkExecutor implements LuceneWorkExecutor {
 
 	@Override
 	public void performWork(LuceneWork work, IndexWriterDelegate delegate, IndexingMonitor monitor) {
-		final Class<?> entityType = work.getEntityClass();
+		final IndexedTypeIdentifier entityType = work.getEntityType();
 		DocumentBuilderIndexedEntity documentBuilder = workspace.getDocumentBuilder( entityType );
 		Map<String, String> fieldToAnalyzerMap = work.getFieldToAnalyzerMap();
 		ScopedAnalyzerReference analyzerReference = documentBuilder.getAnalyzerReference();

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/ByTermDeleteWorkExecutor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/ByTermDeleteWorkExecutor.java
@@ -15,6 +15,7 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.hibernate.search.exception.SearchException;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.backend.impl.lucene.IndexWriterDelegate;
@@ -42,7 +43,7 @@ public final class ByTermDeleteWorkExecutor extends DeleteWorkExecutor {
 
 	@Override
 	public void performWork(LuceneWork work, IndexWriterDelegate delegate, IndexingMonitor monitor) {
-		final Class<?> managedType = work.getEntityClass();
+		final IndexedTypeIdentifier managedType = work.getEntityType();
 		final String tenantId = work.getTenantId();
 		DocumentBuilderIndexedEntity builder = workspace.getDocumentBuilder( managedType );
 		Serializable id = work.getId();

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/ByTermUpdateWorkExecutor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/ByTermUpdateWorkExecutor.java
@@ -16,6 +16,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.hibernate.search.exception.SearchException;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.analyzer.spi.ScopedAnalyzerReference;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
@@ -51,7 +52,7 @@ public final class ByTermUpdateWorkExecutor extends UpdateWorkExecutor {
 	public void performWork(LuceneWork work, IndexWriterDelegate delegate, IndexingMonitor monitor) {
 		final Serializable id = work.getId();
 		final String tenantId = work.getTenantId();
-		final Class<?> managedType = work.getEntityClass();
+		final IndexedTypeIdentifier managedType = work.getEntityType();
 		DocumentBuilderIndexedEntity builder = workspace.getDocumentBuilder( managedType );
 		try {
 			if ( DeleteWorkExecutor.isIdNumeric( builder ) ) {

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/DeleteByQueryWorkExecutor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/DeleteByQueryWorkExecutor.java
@@ -21,6 +21,7 @@ import org.hibernate.search.backend.spi.DeletionQuery;
 import org.hibernate.search.engine.ProjectionConstants;
 import org.hibernate.search.engine.spi.DocumentBuilderIndexedEntity;
 import org.hibernate.search.exception.SearchException;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.store.Workspace;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
@@ -45,7 +46,7 @@ class DeleteByQueryWorkExecutor implements LuceneWorkExecutor {
 	public void performWork(LuceneWork work, IndexWriterDelegate delegate, IndexingMonitor monitor) {
 		DeleteByQueryLuceneWork deleteWork = (DeleteByQueryLuceneWork) work;
 
-		final Class<?> entityType = work.getEntityClass();
+		final IndexedTypeIdentifier entityType = work.getEntityType();
 		final DeletionQuery query = deleteWork.getDeletionQuery();
 
 		if ( log.isTraceEnabled() ) {

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/DeleteExtWorkExecutor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/DeleteExtWorkExecutor.java
@@ -11,6 +11,7 @@ import java.io.Serializable;
 import org.apache.lucene.index.Term;
 import org.hibernate.search.exception.AssertionFailure;
 import org.hibernate.search.exception.SearchException;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.backend.impl.lucene.IndexWriterDelegate;
@@ -30,7 +31,7 @@ import org.hibernate.search.util.logging.impl.Log;
  */
 public final class DeleteExtWorkExecutor extends DeleteWorkExecutor {
 
-	private final Class<?> managedType;
+	private final IndexedTypeIdentifier managedType;
 	private final DocumentBuilderIndexedEntity builder;
 	private static final Log log = LoggerFactory.make();
 	private final boolean idIsNumeric;
@@ -64,7 +65,7 @@ public final class DeleteExtWorkExecutor extends DeleteWorkExecutor {
 	}
 
 	private void checkType(final LuceneWork work) {
-		if ( work.getEntityClass() != managedType ) {
+		if ( ! work.getEntityType().equals( managedType ) ) {
 			throw new AssertionFailure( "Unexpected type" );
 		}
 	}

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/DeleteWorkExecutor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/DeleteWorkExecutor.java
@@ -21,6 +21,7 @@ import org.hibernate.search.engine.spi.DocumentBuilderIndexedEntity;
 import org.hibernate.search.store.Workspace;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.exception.SearchException;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.backend.impl.lucene.IndexWriterDelegate;
@@ -47,7 +48,7 @@ class DeleteWorkExecutor implements LuceneWorkExecutor {
 
 	@Override
 	public void performWork(LuceneWork work, IndexWriterDelegate delegate, IndexingMonitor monitor) {
-		final Class<?> entityType = work.getEntityClass();
+		final IndexedTypeIdentifier entityType = work.getEntityType();
 		final Serializable id = work.getId();
 		log.tracef( "Removing %s#%s by query.", entityType, id );
 		DocumentBuilderIndexedEntity builder = workspace.getDocumentBuilder( entityType );

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/OptimizeWorkExecutor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/OptimizeWorkExecutor.java
@@ -11,6 +11,7 @@ import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.backend.impl.lucene.IndexWriterDelegate;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
 /**
@@ -35,7 +36,7 @@ class OptimizeWorkExecutor implements LuceneWorkExecutor {
 
 	@Override
 	public void performWork(LuceneWork work, IndexWriterDelegate delegate, IndexingMonitor monitor) {
-		final Class<?> entityType = work.getEntityClass();
+		final IndexedTypeIdentifier entityType = work.getEntityType();
 		log.tracef( "optimize Lucene index: %s", entityType );
 		workspace.performOptimization( delegate.getIndexWriter() );
 	}

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/PurgeAllWorkExecutor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/PurgeAllWorkExecutor.java
@@ -15,6 +15,7 @@ import org.hibernate.search.engine.spi.DocumentBuilderIndexedEntity;
 import org.hibernate.search.store.Workspace;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.exception.SearchException;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.backend.impl.lucene.IndexWriterDelegate;
@@ -40,7 +41,7 @@ class PurgeAllWorkExecutor implements LuceneWorkExecutor {
 
 	@Override
 	public void performWork(LuceneWork work, IndexWriterDelegate delegate, IndexingMonitor monitor) {
-		final Class<?> entityType = work.getEntityClass();
+		final IndexedTypeIdentifier entityType = work.getEntityType();
 		final String tenantId = work.getTenantId();
 		try {
 			Term entityTypeTerm = new Term( ProjectionConstants.OBJECT_CLASS, entityType.getName() );

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/UpdateExtWorkExecutor.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/works/UpdateExtWorkExecutor.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import org.apache.lucene.index.Term;
 import org.hibernate.search.exception.AssertionFailure;
 import org.hibernate.search.exception.SearchException;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.analyzer.spi.ScopedAnalyzerReference;
 import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
@@ -37,7 +38,7 @@ public final class UpdateExtWorkExecutor extends UpdateWorkExecutor {
 	private static final Log log = LoggerFactory.make();
 
 	private final AddWorkExecutor addDelegate;
-	private final Class<?> managedType;
+	private final IndexedTypeIdentifier managedType;
 	private final DocumentBuilderIndexedEntity builder;
 	private final boolean idIsNumeric;
 	private final Workspace workspace;
@@ -82,8 +83,8 @@ public final class UpdateExtWorkExecutor extends UpdateWorkExecutor {
 	}
 
 	private void checkType(final LuceneWork work) {
-		if ( work.getEntityClass() != managedType ) {
-			throw new AssertionFailure( "Unexpected type: " + work.getEntityClass() + " This workspace expects: " + managedType );
+		if ( ! work.getEntityType().equals( managedType ) ) {
+			throw new AssertionFailure( "Unexpected type: " + work.getEntityType() + " This workspace expects: " + managedType );
 		}
 	}
 

--- a/engine/src/main/java/org/hibernate/search/backend/spi/BatchBackend.java
+++ b/engine/src/main/java/org/hibernate/search/backend/spi/BatchBackend.java
@@ -7,9 +7,8 @@
 package org.hibernate.search.backend.spi;
 
 
-import java.util.Set;
-
 import org.hibernate.search.backend.LuceneWork;
+import org.hibernate.search.spi.IndexedTypeSet;
 
 /**
  * Implementations of this interface are not drop-in replacements for the standard BackendQueueProcessor,
@@ -51,7 +50,7 @@ public interface BatchBackend {
 	 *
 	 * @param indexedRootTypes a {@link java.util.Set} object.
 	 */
-	void flush(Set<Class<?>> indexedRootTypes);
+	void flush(IndexedTypeSet indexedRootTypes);
 
 	/**
 	 * Triggers optimization of all indexes containing at least one instance of the
@@ -59,6 +58,6 @@ public interface BatchBackend {
 	 *
 	 * @param targetedClasses Used to specify which indexes need optimization.
 	 */
-	void optimize(Set<Class<?>> targetedClasses);
+	void optimize(IndexedTypeSet targetedClasses);
 
 }

--- a/engine/src/main/java/org/hibernate/search/backend/spi/DeleteByQueryLuceneWork.java
+++ b/engine/src/main/java/org/hibernate/search/backend/spi/DeleteByQueryLuceneWork.java
@@ -8,6 +8,7 @@ package org.hibernate.search.backend.spi;
 
 import org.hibernate.search.backend.IndexWorkVisitor;
 import org.hibernate.search.backend.LuceneWork;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 
 
 /**
@@ -22,12 +23,12 @@ public class DeleteByQueryLuceneWork extends LuceneWork {
 
 	private final DeletionQuery deletionQuery;
 
-	public DeleteByQueryLuceneWork(Class<?> entity, DeletionQuery deletionQuery) {
-		this( null, entity, deletionQuery );
+	public DeleteByQueryLuceneWork(IndexedTypeIdentifier typeIdentifier, DeletionQuery deletionQuery) {
+		this( null, typeIdentifier, deletionQuery );
 	}
 
-	public DeleteByQueryLuceneWork(String tenantId, Class<?> entity, DeletionQuery deletionQuery) {
-		super( tenantId, null, null, entity );
+	public DeleteByQueryLuceneWork(String tenantId, IndexedTypeIdentifier typeIdentifier, DeletionQuery deletionQuery) {
+		super( tenantId, null, null, typeIdentifier );
 		this.deletionQuery = deletionQuery;
 	}
 
@@ -42,7 +43,7 @@ public class DeleteByQueryLuceneWork extends LuceneWork {
 
 	@Override
 	public String toString() {
-		return "DeleteByQueryLuceneWork: " + this.getEntityClass().getName() + ": " + this.deletionQuery.toString();
+		return "DeleteByQueryLuceneWork: " + this.getEntityType().getName() + ": " + this.deletionQuery.toString();
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/search/backend/spi/DeleteByQueryWork.java
+++ b/engine/src/main/java/org/hibernate/search/backend/spi/DeleteByQueryWork.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.backend.spi;
 
 import org.hibernate.search.backend.impl.DeleteByQuerySupport;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 
 /**
  * Delete via a serializable query
@@ -23,7 +24,7 @@ public class DeleteByQueryWork extends Work {
 
 	private final DeletionQuery deleteByQuery;
 
-	public DeleteByQueryWork(Class<?> entityType, DeletionQuery deletionQuery) {
+	public DeleteByQueryWork(IndexedTypeIdentifier entityType, DeletionQuery deletionQuery) {
 		this( null, entityType, deletionQuery );
 	}
 
@@ -31,11 +32,11 @@ public class DeleteByQueryWork extends Work {
 	 * Creates a DeleteByWork
 	 *
 	 * @param tenantId the tenant identifier
-	 * @param entityType the class to operate on
+	 * @param entityType the type to operate on
 	 * @param deletionQuery the query to delete by
 	 * @throws IllegalArgumentException if a unsupported SerializableQuery is passed
 	 */
-	public DeleteByQueryWork(String tenantId, Class<?> entityType, DeletionQuery deletionQuery) {
+	public DeleteByQueryWork(String tenantId, IndexedTypeIdentifier entityType, DeletionQuery deletionQuery) {
 		super( tenantId, entityType, null, WorkType.DELETE_BY_QUERY );
 		if ( entityType == null ) {
 			throw new IllegalArgumentException( "entityType must not be null" );

--- a/engine/src/main/java/org/hibernate/search/backend/spi/Work.java
+++ b/engine/src/main/java/org/hibernate/search/backend/spi/Work.java
@@ -8,6 +8,9 @@ package org.hibernate.search.backend.spi;
 
 import java.io.Serializable;
 
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
+
 /**
  * A unit of work. Only make sense inside the same session since it uses the scope principle.
  *
@@ -16,56 +19,77 @@ import java.io.Serializable;
  */
 public class Work {
 	private final Object entity;
-	private final Class<?> entityClass;
+	private final IndexedTypeIdentifier entityTypeId;
 	private final Serializable id;
 	private final WorkType type;
 	private final boolean identifierWasRolledBack;
 	private final String tenantIdentifier;
 
 	public Work(Object entity, Serializable id, WorkType type) {
-		this( null, entity, null, id, type, false );
+		this( null, entity, (IndexedTypeIdentifier) null, id, type, false );
 	}
 
 	public Work(Object entity, Serializable id, WorkType type, boolean identifierRollbackEnabled) {
-		this( null, entity, null, id, type, identifierRollbackEnabled );
+		this( null, entity, (IndexedTypeIdentifier) null, id, type, identifierRollbackEnabled );
 	}
 
+	@Deprecated
 	public Work(Class<?> entityType, Serializable id, WorkType type) {
 		this( null, null, entityType, id, type, false );
 	}
 
+	public Work(IndexedTypeIdentifier entityType, Serializable id, WorkType type) {
+		this( null, null, entityType, id, type, false );
+	}
+
 	public Work(Object entity, WorkType type) {
-		this( null, entity, null, null, type, false );
+		this( null, entity, (IndexedTypeIdentifier) null, null, type, false );
 	}
 
 	public Work(String tenantId, Object entity, Serializable id, WorkType type) {
-		this( tenantId, entity, null, id, type, false );
+		this( tenantId, entity, (IndexedTypeIdentifier) null, id, type, false );
 	}
 
 	public Work(String tenantId, Object entity, Serializable id, WorkType type, boolean identifierRollbackEnabled) {
-		this( tenantId, entity, null, id, type, identifierRollbackEnabled );
+		this( tenantId, entity, (IndexedTypeIdentifier) null, id, type, identifierRollbackEnabled );
 	}
 
+	@Deprecated
 	public Work(String tenantId, Class<?> entityType, Serializable id, WorkType type) {
 		this( tenantId, null, entityType, id, type, false );
 	}
 
-	public Work(String tenantId, Object entity, WorkType type) {
-		this( tenantId, entity, null, null, type, false );
+	public Work(String tenantId, IndexedTypeIdentifier entityType, Serializable id, WorkType type) {
+		this( tenantId, null, entityType, id, type, false );
 	}
 
-	private Work(String tenantId, Object entity, Class<?> entityClass, Serializable id,
-			WorkType type, boolean identifierWasRolledBack) {
+	public Work(String tenantId, Object entity, WorkType type) {
+		this( tenantId, entity, (IndexedTypeIdentifier) null, null, type, false );
+	}
+
+	@Deprecated
+	private Work(String tenantId, Object entity, Class<?> entityClass, Serializable id, WorkType type, boolean identifierWasRolledBack) {
+		this( tenantId, entity,
+				entityClass == null ? null : new PojoIndexedTypeIdentifier( entityClass ),
+						id, type, identifierWasRolledBack );
+	}
+
+	private Work(String tenantId, Object entity, IndexedTypeIdentifier entityTypeId, Serializable id, WorkType type, boolean identifierWasRolledBack) {
 		this.entity = entity;
-		this.entityClass = entityClass;
+		this.entityTypeId = entityTypeId;
 		this.id = id;
 		this.type = type;
 		this.identifierWasRolledBack = identifierWasRolledBack;
 		this.tenantIdentifier = tenantId;
 	}
 
+	@Deprecated
 	public Class<?> getEntityClass() {
-		return entityClass;
+		return entityTypeId != null ? entityTypeId.getPojoType() : null;
+	}
+
+	public IndexedTypeIdentifier getTypeIdentifier() {
+		return entityTypeId;
 	}
 
 	public String getTenantIdentifier() {
@@ -91,7 +115,7 @@ public class Work {
 	@Override
 	public String toString() {
 		final StringBuilder sb = new StringBuilder( "Work{" );
-		sb.append( "entityClass=" ).append( entityClass );
+		sb.append( "entityTypeId=" ).append( entityTypeId );
 		sb.append( ", tenantId=" ).append( tenantIdentifier );
 		sb.append( ", id=" ).append( id );
 		sb.append( ", type=" ).append( type );

--- a/engine/src/main/java/org/hibernate/search/bridge/spi/ConversionContext.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/spi/ConversionContext.java
@@ -9,6 +9,7 @@ package org.hibernate.search.bridge.spi;
 import org.hibernate.search.bridge.FieldBridge;
 import org.hibernate.search.bridge.StringBridge;
 import org.hibernate.search.bridge.TwoWayFieldBridge;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 
 
 /**
@@ -48,11 +49,21 @@ public interface ConversionContext {
 
 	/**
 	 * In case the next conversion fails, the error message will point to this type.
+	 * @deprecated Use {@link #setConvertedTypeId(IndexedTypeIdentifier)}
 	 *
 	 * @param beanClass the class type which is going to be converted
 	 * @return this for method chaining.
 	 */
+	@Deprecated
 	ConversionContext setClass(Class<?> beanClass);
+
+	/**
+	 * In case the next conversion fails, the error message will point to this type.
+	 *
+	 * @param type the type which is going to be converted
+	 * @return this for method chaining.
+	 */
+	ConversionContext setConvertedTypeId(IndexedTypeIdentifier type);
 
 	/**
 	 * In case the next conversion fails, the error message will point to the

--- a/engine/src/main/java/org/hibernate/search/bridge/util/impl/ContextualExceptionBridgeHelper.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/util/impl/ContextualExceptionBridgeHelper.java
@@ -17,6 +17,8 @@ import org.hibernate.search.bridge.LuceneOptions;
 import org.hibernate.search.bridge.StringBridge;
 import org.hibernate.search.bridge.TwoWayFieldBridge;
 import org.hibernate.search.bridge.spi.ConversionContext;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.hibernate.search.util.StringHelper;
 
 /**
@@ -32,7 +34,7 @@ public final class ContextualExceptionBridgeHelper implements ConversionContext 
 	private static final String IDENTIFIER = "identifier";
 
 	// Mutable state:
-	private Class<?> clazz;
+	private IndexedTypeIdentifier type;
 	private StringBridge stringBridge;
 	private FieldBridge oneWayBridge;
 	private TwoWayFieldBridge twoWayBridge;
@@ -44,8 +46,14 @@ public final class ContextualExceptionBridgeHelper implements ConversionContext 
 	private final StringConversionContextImpl stringAdapter = new StringConversionContextImpl();
 
 	@Override
+	@Deprecated
 	public ConversionContext setClass(Class<?> clazz) {
-		this.clazz = clazz;
+		return setConvertedTypeId( new PojoIndexedTypeIdentifier( clazz ) );
+	}
+
+	@Override
+	public ConversionContext setConvertedTypeId(IndexedTypeIdentifier type) {
+		this.type = type;
 		return this;
 	}
 
@@ -72,8 +80,8 @@ public final class ContextualExceptionBridgeHelper implements ConversionContext 
 
 	protected BridgeException buildBridgeException(Exception e, String method, String fieldName, Object bridge) {
 		StringBuilder errorMessage = new StringBuilder( "Exception while calling bridge#" ).append( method );
-		if ( clazz != null ) {
-			errorMessage.append( "\n\tentity class: " ).append( clazz.getName() );
+		if ( type != null ) {
+			errorMessage.append( "\n\tentity class: " ).append( type.getName() );
 		}
 		if ( propertyPath.size() > 0 ) {
 			errorMessage.append( "\n\tentity property path: " );
@@ -184,4 +192,5 @@ public final class ContextualExceptionBridgeHelper implements ConversionContext 
 			}
 		}
 	}
+
 }

--- a/engine/src/main/java/org/hibernate/search/engine/impl/AbstractMutableEntityIndexBinding.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/AbstractMutableEntityIndexBinding.java
@@ -6,11 +6,10 @@
  */
 package org.hibernate.search.engine.impl;
 
-import java.util.Set;
-
 import org.apache.lucene.search.similarities.Similarity;
 import org.hibernate.search.engine.spi.DocumentBuilderIndexedEntity;
 import org.hibernate.search.indexes.spi.IndexManagerType;
+import org.hibernate.search.spi.IndexedTypeSet;
 import org.hibernate.search.indexes.impl.IndexManagerGroupHolder;
 import org.hibernate.search.indexes.interceptor.EntityIndexingInterceptor;
 
@@ -46,7 +45,7 @@ public abstract class AbstractMutableEntityIndexBinding implements MutableEntity
 	}
 
 	@Override
-	public void postInitialize(Set<Class<?>> indexedClasses) {
+	public void postInitialize(IndexedTypeSet indexedClasses) {
 		documentBuilder.postInitialize( indexedClasses );
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/impl/AnnotationProcessingHelper.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/AnnotationProcessingHelper.java
@@ -28,6 +28,7 @@ import org.hibernate.search.engine.BoostStrategy;
 import org.hibernate.search.engine.metadata.impl.DocumentFieldPath;
 import org.hibernate.search.exception.AssertionFailure;
 import org.hibernate.search.indexes.spi.IndexManagerType;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.util.StringHelper;
 import org.hibernate.search.util.impl.ClassLoaderHelper;
 import org.hibernate.search.util.logging.impl.Log;
@@ -133,13 +134,13 @@ public final class AnnotationProcessingHelper {
 	}
 
 	public static AnalyzerReference getAnalyzerReference(
-			Class<?> entityType, DocumentFieldPath fieldPath,
+			IndexedTypeIdentifier indexedTypeIdentifier, DocumentFieldPath fieldPath,
 			org.hibernate.search.annotations.Analyzer analyzerAnn,
 			Normalizer normalizerAnn, ConfigContext configContext, IndexManagerType indexManagerType) {
 		AnalyzerReference analyzerReference = getAnalyzerReference( analyzerAnn, configContext, indexManagerType );
 		AnalyzerReference normalizerReference = getNormalizerReference( normalizerAnn, configContext, indexManagerType );
 		if ( analyzerReference != null && normalizerReference != null ) {
-			throw log.cannotReferenceAnalyzerAndNormalizer( entityType, fieldPath.getRelativeName() );
+			throw log.cannotReferenceAnalyzerAndNormalizer( indexedTypeIdentifier, fieldPath.getRelativeName() );
 		}
 		return analyzerReference != null ? analyzerReference : normalizerReference;
 	}

--- a/engine/src/main/java/org/hibernate/search/engine/impl/ImmutableSearchFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/ImmutableSearchFactory.java
@@ -12,7 +12,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 
@@ -65,11 +64,17 @@ import org.hibernate.search.query.engine.spi.HSQuery;
 import org.hibernate.search.query.engine.spi.QueryDescriptor;
 import org.hibernate.search.query.engine.spi.TimeoutExceptionFactory;
 import org.hibernate.search.spi.CustomTypeMetadata;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.IndexedTypeSet;
 import org.hibernate.search.spi.IndexingMode;
 import org.hibernate.search.spi.InstanceInitializer;
 import org.hibernate.search.spi.SearchIntegrator;
+import org.hibernate.search.spi.IndexedTypeMap;
 import org.hibernate.search.spi.WorkerBuildContext;
+import org.hibernate.search.spi.impl.ConcurrentIndexedTypeMap;
 import org.hibernate.search.spi.impl.ExtendedSearchIntegratorWithShareableState;
+import org.hibernate.search.spi.impl.IndexedTypesSets;
+import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.hibernate.search.spi.impl.TypeHierarchy;
 import org.hibernate.search.spi.impl.SearchFactoryState;
 import org.hibernate.search.stat.Statistics;
@@ -92,12 +97,12 @@ public class ImmutableSearchFactory implements ExtendedSearchIntegratorWithShare
 
 	private static final Log log = LoggerFactory.make();
 
-	private final Map<Class<?>, EntityIndexBinding> indexBindingForEntities;
-	private final Map<Class<?>, DocumentBuilderContainedEntity> documentBuildersContainedEntities;
+	private final IndexedTypeMap<EntityIndexBinding> indexBindingForEntities;
+	private final IndexedTypeMap<DocumentBuilderContainedEntity> documentBuildersContainedEntities;
 	/**
 	 * Lazily populated map of type descriptors
 	 */
-	private final ConcurrentHashMap<Class, IndexedTypeDescriptor> indexedTypeDescriptors;
+	private final IndexedTypeMap<IndexedTypeDescriptor> indexedTypeDescriptors;
 	private final Worker worker;
 	private final Map<String, FilterDef> filterDefinitions;
 	private final FilterCachingStrategy filterCachingStrategy;
@@ -185,7 +190,7 @@ public class ImmutableSearchFactory implements ExtendedSearchIntegratorWithShare
 		}
 
 		this.indexReaderAccessor = new DefaultIndexReaderAccessor( this );
-		this.indexedTypeDescriptors = new ConcurrentHashMap<>();
+		this.indexedTypeDescriptors = new ConcurrentIndexedTypeMap<>();
 
 		this.defaultObjectLookupMethod = determineDefaultObjectLookupMethod();
 		this.defaultDatabaseRetrievalMethod = determineDefaultDatabaseRetrievalMethod();
@@ -287,24 +292,22 @@ public class ImmutableSearchFactory implements ExtendedSearchIntegratorWithShare
 
 	@Override
 	public HSQuery createHSQuery(Query luceneQuery, Class<?>... entityTypes) {
-		QueryDescriptor descriptor = createQueryDescriptor( luceneQuery, entityTypes );
-
-		return descriptor.createHSQuery( this ).targetedEntities( Arrays.asList( entityTypes ) );
+		IndexedTypeSet newtypes = IndexedTypesSets.fromClasses( entityTypes );
+		QueryDescriptor descriptor = createQueryDescriptor( luceneQuery, newtypes );
+		return descriptor.createHSQuery( this ).targetedEntities( newtypes );
 	}
 
 	@Override
 	public HSQuery createHSQuery(Query luceneQuery, CustomTypeMetadata... types) {
 		List<CustomTypeMetadata> typeList = Arrays.asList( types );
-		Class<?>[] entityTypes = typeList.stream()
+		IndexedTypeSet entityTypes = typeList.stream()
 				.map( CustomTypeMetadata::getEntityType )
-				.toArray( Class<?>[]::new );
-
+				.collect( IndexedTypesSets.streamCollector() );
 		QueryDescriptor descriptor = createQueryDescriptor( luceneQuery, entityTypes );
-
 		return descriptor.createHSQuery( this ).targetedTypes( typeList );
 	}
 
-	private QueryDescriptor createQueryDescriptor(Query luceneQuery, Class<?>[] entityTypes) {
+	private QueryDescriptor createQueryDescriptor(Query luceneQuery, IndexedTypeSet entityTypes) {
 		QueryDescriptor descriptor = null;
 
 		if ( queryTranslatorPresent ) {
@@ -324,22 +327,34 @@ public class ImmutableSearchFactory implements ExtendedSearchIntegratorWithShare
 	}
 
 	@Override
-	public Map<Class<?>, DocumentBuilderContainedEntity> getDocumentBuildersContainedEntities() {
+	public IndexedTypeMap<DocumentBuilderContainedEntity> getDocumentBuildersContainedEntities() {
 		return documentBuildersContainedEntities;
 	}
 
 	@Override
-	public Map<Class<?>, EntityIndexBinding> getIndexBindings() {
+	public IndexedTypeMap<EntityIndexBinding> getIndexBindings() {
 		return indexBindingForEntities;
 	}
 
 	@Override
+	@Deprecated
 	public EntityIndexBinding getIndexBinding(Class<?> entityType) {
+		return indexBindingForEntities.get( new PojoIndexedTypeIdentifier( entityType ) );
+	}
+
+	@Override
+	public EntityIndexBinding getIndexBinding(IndexedTypeIdentifier entityType) {
 		return indexBindingForEntities.get( entityType );
 	}
 
 	@Override
+	@Deprecated
 	public DocumentBuilderContainedEntity getDocumentBuilderContainedEntity(Class entityType) {
+		return documentBuildersContainedEntities.get( entityType );
+	}
+
+	@Override
+	public DocumentBuilderContainedEntity getDocumentBuilderContainedEntity(IndexedTypeIdentifier entityType) {
 		return documentBuildersContainedEntities.get( entityType );
 	}
 
@@ -361,7 +376,16 @@ public class ImmutableSearchFactory implements ExtendedSearchIntegratorWithShare
 	}
 
 	@Override
+	@Deprecated
 	public void optimize(Class entityType) {
+		EntityIndexBinding entityIndexBinding = getSafeIndexBindingForEntity( entityType );
+		for ( IndexManager im : entityIndexBinding.getIndexManagers() ) {
+			im.optimize();
+		}
+	}
+
+	@Override
+	public void optimize(IndexedTypeIdentifier entityType) {
 		EntityIndexBinding entityIndexBinding = getSafeIndexBindingForEntity( entityType );
 		for ( IndexManager im : entityIndexBinding.getIndexManagers() ) {
 			im.optimize();
@@ -398,13 +422,27 @@ public class ImmutableSearchFactory implements ExtendedSearchIntegratorWithShare
 	}
 
 	@Override
+	@Deprecated
 	public Analyzer getAnalyzer(Class<?> clazz) {
 		return getAnalyzerReference( clazz ).unwrap( LuceneAnalyzerReference.class ).getAnalyzer();
 	}
 
 	@Override
+	public Analyzer getAnalyzer(IndexedTypeIdentifier type) {
+		return getAnalyzerReference( type ).unwrap( LuceneAnalyzerReference.class ).getAnalyzer();
+	}
+
+	@Override
+	@Deprecated
 	public ScopedAnalyzerReference getAnalyzerReference(Class<?> clazz) {
 		EntityIndexBinding entityIndexBinding = getSafeIndexBindingForEntity( clazz );
+		DocumentBuilderIndexedEntity builder = entityIndexBinding.getDocumentBuilder();
+		return builder.getAnalyzerReference();
+	}
+
+	@Override
+	public ScopedAnalyzerReference getAnalyzerReference(IndexedTypeIdentifier type) {
+		EntityIndexBinding entityIndexBinding = getSafeIndexBindingForEntity( type );
 		DocumentBuilderIndexedEntity builder = entityIndexBinding.getDocumentBuilder();
 		return builder.getAnalyzerReference();
 	}
@@ -455,13 +493,25 @@ public class ImmutableSearchFactory implements ExtendedSearchIntegratorWithShare
 	}
 
 	@Override
-	public Set<Class<?>> getConfiguredTypesPolymorphic(Class<?>[] classes) {
-		return configuredTypeHierarchy.getConfiguredClasses( classes );
+	@Deprecated
+	public IndexedTypeSet getConfiguredTypesPolymorphic(Class<?>[] types) {
+		return getConfiguredTypesPolymorphic( IndexedTypesSets.fromClasses( types ) );
 	}
 
 	@Override
-	public Set<Class<?>> getIndexedTypesPolymorphic(Class<?>[] classes) {
-		return indexedTypeHierarchy.getConfiguredClasses( classes );
+	public IndexedTypeSet getConfiguredTypesPolymorphic(IndexedTypeSet types) {
+		return configuredTypeHierarchy.getConfiguredClasses( types );
+	}
+
+	@Override
+	@Deprecated
+	public IndexedTypeSet getIndexedTypesPolymorphic(Class<?>[] types) {
+		return getIndexedTypesPolymorphic( IndexedTypesSets.fromClasses( types ) );
+	}
+
+	@Override
+	public IndexedTypeSet getIndexedTypesPolymorphic(IndexedTypeSet types) {
+		return indexedTypeHierarchy.getConfiguredClasses( types );
 	}
 
 	@Override
@@ -546,6 +596,7 @@ public class ImmutableSearchFactory implements ExtendedSearchIntegratorWithShare
 		return this.allIndexesManager;
 	}
 
+	@Deprecated
 	public EntityIndexBinding getSafeIndexBindingForEntity(Class<?> entityType) {
 		if ( entityType == null ) {
 			throw log.nullIsInvalidIndexedType();
@@ -553,6 +604,17 @@ public class ImmutableSearchFactory implements ExtendedSearchIntegratorWithShare
 		EntityIndexBinding entityIndexBinding = getIndexBinding( entityType );
 		if ( entityIndexBinding == null ) {
 			throw log.notAnIndexedType( entityType.getName() );
+		}
+		return entityIndexBinding;
+	}
+
+	public EntityIndexBinding getSafeIndexBindingForEntity(IndexedTypeIdentifier type) {
+		if ( type == null ) {
+			throw log.nullIsInvalidIndexedType();
+		}
+		EntityIndexBinding entityIndexBinding = getIndexBinding( type );
+		if ( entityIndexBinding == null ) {
+			throw log.notAnIndexedType( type.getName() );
 		}
 		return entityIndexBinding;
 	}
@@ -568,16 +630,20 @@ public class ImmutableSearchFactory implements ExtendedSearchIntegratorWithShare
 	}
 
 	@Override
-	public IndexedTypeDescriptor getIndexedTypeDescriptor(Class<?> entityType) {
-		IndexedTypeDescriptor typeDescriptor;
-		if ( indexedTypeDescriptors.containsKey( entityType ) ) {
-			typeDescriptor = indexedTypeDescriptors.get( entityType );
-		}
-		else {
-			EntityIndexBinding indexBinder = indexBindingForEntities.get( entityType );
+	@Deprecated
+	public IndexedTypeDescriptor getIndexedTypeDescriptor(Class<?> classType) {
+		final IndexedTypeIdentifier type = new PojoIndexedTypeIdentifier( classType );
+		return getIndexedTypeDescriptor( type );
+	}
+
+	@Override
+	public IndexedTypeDescriptor getIndexedTypeDescriptor(IndexedTypeIdentifier type) {
+		IndexedTypeDescriptor typeDescriptor = indexedTypeDescriptors.get( type );
+		if ( typeDescriptor == null ) {
+			EntityIndexBinding indexBinder = indexBindingForEntities.get( type );
 			IndexedTypeDescriptor indexedTypeDescriptor;
 			if ( indexBinder == null ) {
-				indexedTypeDescriptor = new IndexedTypeDescriptorForUnindexedType( entityType );
+				indexedTypeDescriptor = new IndexedTypeDescriptorForUnindexedType( type );
 			}
 			else {
 				indexedTypeDescriptor = new IndexedTypeDescriptorImpl(
@@ -585,14 +651,20 @@ public class ImmutableSearchFactory implements ExtendedSearchIntegratorWithShare
 						indexBinder.getIndexManagers()
 				);
 			}
-			indexedTypeDescriptors.put( entityType, indexedTypeDescriptor );
+			indexedTypeDescriptors.put( type, indexedTypeDescriptor );
 			typeDescriptor = indexedTypeDescriptor;
 		}
 		return typeDescriptor;
 	}
 
+	@Deprecated
 	@Override
 	public Set<Class<?>> getIndexedTypes() {
+		return indexBindingForEntities.keySet().toPojosSet();
+	}
+
+	@Override
+	public IndexedTypeSet getIndexedTypeIdentifiers() {
 		return indexBindingForEntities.keySet();
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/impl/ImmutableSearchFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/ImmutableSearchFactory.java
@@ -286,12 +286,6 @@ public class ImmutableSearchFactory implements ExtendedSearchIntegratorWithShare
 	}
 
 	@Override
-	@Deprecated
-	public HSQuery createHSQuery() {
-		return createLuceneBasedHSQuery();
-	}
-
-	@Override
 	public HSQuery createHSQuery(Query luceneQuery, Class<?>... entityTypes) {
 		QueryDescriptor descriptor = createQueryDescriptor( luceneQuery, entityTypes );
 

--- a/engine/src/main/java/org/hibernate/search/engine/impl/MutableSearchFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/MutableSearchFactory.java
@@ -42,10 +42,13 @@ import org.hibernate.search.query.dsl.QueryContextBuilder;
 import org.hibernate.search.query.engine.spi.HSQuery;
 import org.hibernate.search.query.engine.spi.TimeoutExceptionFactory;
 import org.hibernate.search.spi.CustomTypeMetadata;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.IndexedTypeSet;
 import org.hibernate.search.spi.IndexingMode;
 import org.hibernate.search.spi.InstanceInitializer;
 import org.hibernate.search.spi.SearchIntegrator;
 import org.hibernate.search.spi.SearchIntegratorBuilder;
+import org.hibernate.search.spi.IndexedTypeMap;
 import org.hibernate.search.spi.WorkerBuildContext;
 import org.hibernate.search.spi.impl.ExtendedSearchIntegratorWithShareableState;
 import org.hibernate.search.spi.impl.TypeHierarchy;
@@ -80,11 +83,12 @@ public class MutableSearchFactory implements ExtendedSearchIntegratorWithShareab
 	}
 
 	@Override
-	public Map<Class<?>, EntityIndexBinding> getIndexBindings() {
+	public IndexedTypeMap<EntityIndexBinding> getIndexBindings() {
 		return delegate.getIndexBindings();
 	}
 
 	@Override
+	@Deprecated
 	public EntityIndexBinding getIndexBinding(Class<?> entityType) {
 		return delegate.getIndexBinding( entityType );
 	}
@@ -161,12 +165,14 @@ public class MutableSearchFactory implements ExtendedSearchIntegratorWithShareab
 	}
 
 	@Override
-	public Set<Class<?>> getConfiguredTypesPolymorphic(Class<?>[] classes) {
+	@Deprecated
+	public IndexedTypeSet getConfiguredTypesPolymorphic(Class<?>[] classes) {
 		return delegate.getConfiguredTypesPolymorphic( classes );
 	}
 
 	@Override
-	public Set<Class<?>> getIndexedTypesPolymorphic(Class<?>[] classes) {
+	@Deprecated
+	public IndexedTypeSet getIndexedTypesPolymorphic(Class<?>[] classes) {
 		return delegate.getIndexedTypesPolymorphic( classes );
 	}
 
@@ -216,7 +222,13 @@ public class MutableSearchFactory implements ExtendedSearchIntegratorWithShareab
 	}
 
 	@Override
+	@Deprecated
 	public void optimize(Class entityType) {
+		delegate.optimize( entityType );
+	}
+
+	@Override
+	public void optimize(IndexedTypeIdentifier entityType) {
 		delegate.optimize( entityType );
 	}
 
@@ -231,11 +243,18 @@ public class MutableSearchFactory implements ExtendedSearchIntegratorWithShareab
 	}
 
 	@Override
+	@Deprecated
 	public Analyzer getAnalyzer(Class<?> clazz) {
 		return delegate.getAnalyzer( clazz );
 	}
 
 	@Override
+	public Analyzer getAnalyzer(IndexedTypeIdentifier type) {
+		return delegate.getAnalyzer( type );
+	}
+
+	@Override
+	@Deprecated
 	public ScopedAnalyzerReference getAnalyzerReference(Class<?> clazz) {
 		return delegate.getAnalyzerReference( clazz );
 	}
@@ -251,7 +270,7 @@ public class MutableSearchFactory implements ExtendedSearchIntegratorWithShareab
 	}
 
 	@Override
-	public Map<Class<?>, DocumentBuilderContainedEntity> getDocumentBuildersContainedEntities() {
+	public IndexedTypeMap<DocumentBuilderContainedEntity> getDocumentBuildersContainedEntities() {
 		return delegate.getDocumentBuildersContainedEntities();
 	}
 
@@ -313,6 +332,11 @@ public class MutableSearchFactory implements ExtendedSearchIntegratorWithShareab
 	@Override
 	public Set<Class<?>> getIndexedTypes() {
 		return delegate.getIndexedTypes();
+	}
+
+	@Override
+	public IndexedTypeSet getIndexedTypeIdentifiers() {
+		return delegate.getIndexedTypeIdentifiers();
 	}
 
 	@Override
@@ -403,6 +427,36 @@ public class MutableSearchFactory implements ExtendedSearchIntegratorWithShareab
 	@Override
 	public OperationDispatcher createRemoteOperationDispatcher(Predicate<IndexManager> indexManagerFilter) {
 		return delegate.createRemoteOperationDispatcher( indexManagerFilter );
+	}
+
+	@Override
+	public EntityIndexBinding getIndexBinding(IndexedTypeIdentifier entityType) {
+		return delegate.getIndexBinding( entityType );
+	}
+
+	@Override
+	public IndexedTypeSet getConfiguredTypesPolymorphic(IndexedTypeSet types) {
+		return delegate.getConfiguredTypesPolymorphic( types );
+	}
+
+	@Override
+	public IndexedTypeSet getIndexedTypesPolymorphic(IndexedTypeSet queryTarget) {
+		return delegate.getIndexedTypesPolymorphic( queryTarget );
+	}
+
+	@Override
+	public DocumentBuilderContainedEntity getDocumentBuilderContainedEntity(IndexedTypeIdentifier entityType) {
+		return delegate.getDocumentBuilderContainedEntity( entityType );
+	}
+
+	@Override
+	public ScopedAnalyzerReference getAnalyzerReference(IndexedTypeIdentifier type) {
+		return delegate.getAnalyzerReference( type );
+	}
+
+	@Override
+	public IndexedTypeDescriptor getIndexedTypeDescriptor(IndexedTypeIdentifier typeId) {
+		return delegate.getIndexedTypeDescriptor( typeId );
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/impl/MutableSearchFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/MutableSearchFactory.java
@@ -146,11 +146,6 @@ public class MutableSearchFactory implements ExtendedSearchIntegratorWithShareab
 	}
 
 	@Override
-	public HSQuery createHSQuery() {
-		return delegate.createHSQuery();
-	}
-
-	@Override
 	public HSQuery createHSQuery(Query luceneQuery, Class<?>... entities) {
 		return delegate.createHSQuery( luceneQuery, entities );
 	}

--- a/engine/src/main/java/org/hibernate/search/engine/impl/MutableSearchFactoryState.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/MutableSearchFactoryState.java
@@ -29,6 +29,7 @@ import org.hibernate.search.indexes.spi.IndexManagerType;
 import org.hibernate.search.query.engine.spi.TimeoutExceptionFactory;
 import org.hibernate.search.spi.IndexingMode;
 import org.hibernate.search.spi.InstanceInitializer;
+import org.hibernate.search.spi.IndexedTypeMap;
 import org.hibernate.search.spi.impl.ExtendedSearchIntegratorWithShareableState;
 import org.hibernate.search.spi.impl.TypeHierarchy;
 import org.hibernate.search.spi.impl.SearchFactoryState;
@@ -42,8 +43,8 @@ import org.hibernate.search.util.configuration.impl.ConfigurationParseHelper;
  */
 public class MutableSearchFactoryState implements SearchFactoryState {
 
-	private Map<Class<?>, DocumentBuilderContainedEntity> documentBuildersContainedEntities;
-	private Map<Class<?>, EntityIndexBinding> indexBindingsPerEntity;
+	private IndexedTypeMap<DocumentBuilderContainedEntity> documentBuildersContainedEntities;
+	private IndexedTypeMap<EntityIndexBinding> indexBindingsPerEntity;
 	private IndexingMode indexingMode;
 	private Worker worker;
 	private BackendQueueProcessor backendQueueProcessor;
@@ -112,12 +113,12 @@ public class MutableSearchFactoryState implements SearchFactoryState {
 	}
 
 	@Override
-	public Map<Class<?>, DocumentBuilderContainedEntity> getDocumentBuildersContainedEntities() {
+	public IndexedTypeMap<DocumentBuilderContainedEntity> getDocumentBuildersContainedEntities() {
 		return documentBuildersContainedEntities;
 	}
 
 	@Override
-	public Map<Class<?>, EntityIndexBinding> getIndexBindings() {
+	public IndexedTypeMap<EntityIndexBinding> getIndexBindings() {
 		return indexBindingsPerEntity;
 	}
 
@@ -170,11 +171,11 @@ public class MutableSearchFactoryState implements SearchFactoryState {
 		return indexedTypeHierarchy;
 	}
 
-	public void setDocumentBuildersContainedEntities(Map<Class<?>, DocumentBuilderContainedEntity> documentBuildersContainedEntities) {
+	public void setDocumentBuildersContainedEntities(IndexedTypeMap<DocumentBuilderContainedEntity> documentBuildersContainedEntities) {
 		this.documentBuildersContainedEntities = documentBuildersContainedEntities;
 	}
 
-	public void setDocumentBuildersIndexedEntities(Map<Class<?>, EntityIndexBinding> documentBuildersIndexedEntities) {
+	public void setDocumentBuildersIndexedEntities(IndexedTypeMap<EntityIndexBinding> documentBuildersIndexedEntities) {
 		this.indexBindingsPerEntity = documentBuildersIndexedEntities;
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/impl/SimpleInitializer.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/SimpleInitializer.java
@@ -10,7 +10,9 @@ import java.util.Collection;
 import java.util.Map;
 
 import org.hibernate.search.backend.spi.Work;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.spi.InstanceInitializer;
+import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 
 /**
  * Simple pass-through implementation of {@code InstanceInitializer}.
@@ -30,11 +32,19 @@ public final class SimpleInitializer implements InstanceInitializer {
 		return entity;
 	}
 
+	@Deprecated
 	@Override
 	public Class<?> getClassFromWork(Work work) {
 		return work.getEntityClass() != null ?
 				work.getEntityClass() :
 				getClass( work.getEntity() );
+	}
+
+	@Override
+	public IndexedTypeIdentifier getIndexedTypeIdFromWork(Work work) {
+		return work.getTypeIdentifier() != null ?
+				work.getTypeIdentifier() :
+				new PojoIndexedTypeIdentifier( getClass( work.getEntity() ) );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/integration/impl/ExtendedSearchIntegrator.java
+++ b/engine/src/main/java/org/hibernate/search/engine/integration/impl/ExtendedSearchIntegrator.java
@@ -8,13 +8,11 @@ package org.hibernate.search.engine.integration.impl;
 
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 
 import org.hibernate.search.analyzer.spi.ScopedAnalyzerReference;
 import org.hibernate.search.cfg.spi.SearchConfiguration;
 import org.hibernate.search.engine.impl.FilterDef;
 import org.hibernate.search.engine.spi.DocumentBuilderContainedEntity;
-import org.hibernate.search.engine.spi.EntityIndexBinding;
 import org.hibernate.search.engine.spi.TimingSource;
 import org.hibernate.search.filter.FilterCachingStrategy;
 import org.hibernate.search.indexes.impl.IndexManagerHolder;
@@ -22,8 +20,10 @@ import org.hibernate.search.indexes.spi.IndexManagerType;
 import org.hibernate.search.query.DatabaseRetrievalMethod;
 import org.hibernate.search.query.ObjectLookupMethod;
 import org.hibernate.search.query.engine.spi.HSQuery;
+import org.hibernate.search.spi.IndexedTypeSet;
 import org.hibernate.search.spi.InstanceInitializer;
 import org.hibernate.search.spi.SearchIntegrator;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.stat.spi.StatisticsImplementor;
 
 /**
@@ -35,15 +35,10 @@ import org.hibernate.search.stat.spi.StatisticsImplementor;
  */
 public interface ExtendedSearchIntegrator extends SearchIntegrator {
 
-	/**
-	 * Returns a map of all known entity index binding (indexed entities) keyed against the indexed type
-	 *
-	 * @return a map of all known entity index binding (indexed entities) keyed against the indexed type. The empty
-	 * map is returned if there are no indexed types.
-	 */
-	Map<Class<?>, EntityIndexBinding> getIndexBindings();
-
+	@Deprecated
 	DocumentBuilderContainedEntity getDocumentBuilderContainedEntity(Class<?> entityType);
+
+	DocumentBuilderContainedEntity getDocumentBuilderContainedEntity(IndexedTypeIdentifier entityType);
 
 	FilterCachingStrategy getFilterCachingStrategy();
 
@@ -60,7 +55,10 @@ public interface ExtendedSearchIntegrator extends SearchIntegrator {
 	 * @param classes an array of types
 	 * @return the set of configured subtypes
 	 */
-	Set<Class<?>> getConfiguredTypesPolymorphic(Class<?>[] classes);
+	@Deprecated
+	IndexedTypeSet getConfiguredTypesPolymorphic(Class<?>[] classes);
+
+	IndexedTypeSet getConfiguredTypesPolymorphic(IndexedTypeSet types);
 
 	/**
 	 * Given a set of target entities, return the set of configured subtypes that are indexed.
@@ -77,7 +75,10 @@ public interface ExtendedSearchIntegrator extends SearchIntegrator {
 	 * @param classes an array of types
 	 * @return the set of configured subtypes that are indexed
 	 */
-	Set<Class<?>> getIndexedTypesPolymorphic(Class<?>[] classes);
+	@Deprecated
+	IndexedTypeSet getIndexedTypesPolymorphic(Class<?>[] classes);
+
+	IndexedTypeSet getIndexedTypesPolymorphic(IndexedTypeSet queryTarget);
 
 	/**
 	 * @return {@code true} if JMX is enabled
@@ -163,15 +164,21 @@ public interface ExtendedSearchIntegrator extends SearchIntegrator {
 	SearchIntegration getIntegration(IndexManagerType indexManagerType);
 
 	/**
-	 * Retrieve the scoped analyzer reference for a given class.
+	 * Retrieve the scoped analyzer reference for a given indexed type.
 	 *
-	 * @param clazz The class for which to retrieve the analyzer.
+	 * @param type The type for which to retrieve the analyzer.
 	 *
 	 * @return The scoped analyzer for the specified class.
 	 *
-	 * @throws java.lang.IllegalArgumentException in case {@code clazz == null} or the specified
-	 * class is not an indexed entity.
+	 * @throws java.lang.IllegalArgumentException in case {@code type == null} or the specified
+	 * type is not an indexed entity.
 	 */
+	ScopedAnalyzerReference getAnalyzerReference(IndexedTypeIdentifier type);
+
+	/**
+	 * @deprecated use {@link #getAnalyzerReference(IndexedTypeIdentifier)}
+	 */
+	@Deprecated
 	ScopedAnalyzerReference getAnalyzerReference(Class<?> clazz);
 
 	/**
@@ -181,4 +188,5 @@ public interface ExtendedSearchIntegrator extends SearchIntegrator {
 	 * @return an Hibernate Search query object
 	 */
 	HSQuery createLuceneBasedHSQuery();
+
 }

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
@@ -91,6 +91,8 @@ import org.hibernate.search.indexes.spi.IndexManagerType;
 import org.hibernate.search.metadata.NumericFieldSettingsDescriptor.NumericEncodingType;
 import org.hibernate.search.spatial.Coordinates;
 import org.hibernate.search.spatial.SpatialFieldBridge;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.hibernate.search.util.StringHelper;
 import org.hibernate.search.util.impl.ClassLoaderHelper;
 import org.hibernate.search.util.impl.ReflectionHelper;
@@ -145,7 +147,8 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 	}
 
 	@Override
-	public TypeMetadata getTypeMetadataForContainedIn(Class<?> clazz) {
+	public TypeMetadata getTypeMetadataForContainedIn(IndexedTypeIdentifier type) {
+		final Class<?> clazz = type.getPojoType();
 		XClass xClass = reflectionManager.toXClass( clazz );
 
 		ParseContext parseContext = new ParseContext();
@@ -156,6 +159,16 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 	}
 
 	@Override
+	public TypeMetadata getTypeMetadataFor(IndexedTypeIdentifier type, IndexManagerType indexManagerType) {
+		final Class<?> clazz = type.getPojoType();
+		return getTypeMetadataFor( clazz, indexManagerType );
+	}
+
+	/**
+	 * Use {@link #getTypeMetadataFor(IndexedTypeIdentifier, IndexManagerType)} instead.
+	 * @deprecated
+	 */
+	@Deprecated
 	public TypeMetadata getTypeMetadataFor(Class<?> clazz, IndexManagerType indexManagerType) {
 		XClass xClass = reflectionManager.toXClass( clazz );
 
@@ -168,7 +181,8 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 	}
 
 	private TypeMetadata doGetTypeMetadataFor(Class<?> clazz, XClass xClass, ParseContext parseContext) {
-		TypeMetadata.Builder typeMetadataBuilder = new TypeMetadata.Builder( clazz, configContext, parseContext )
+		IndexedTypeIdentifier classTypeId = new PojoIndexedTypeIdentifier( clazz );
+		TypeMetadata.Builder typeMetadataBuilder = new TypeMetadata.Builder( classTypeId, configContext, parseContext )
 				.boost( getBoost( xClass ) )
 				.boostStrategy( AnnotationProcessingHelper.getDynamicBoost( xClass ) );
 
@@ -208,7 +222,8 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 	}
 
 	@Override
-	public boolean containsSearchMetadata(Class<?> clazz) {
+	public boolean containsSearchMetadata(IndexedTypeIdentifier type) {
+		final Class<?> clazz = type.getPojoType();
 		XClass xClass = reflectionManager.toXClass( clazz );
 		return ReflectionHelper.containsSearchAnnotations( xClass );
 	}
@@ -1181,7 +1196,7 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 		}
 	}
 
-	private NumericFieldsConfiguration buildNumericFieldsConfiguration(Class<?> indexedType,
+	private NumericFieldsConfiguration buildNumericFieldsConfiguration(IndexedTypeIdentifier indexedTypeIdentifier,
 			XProperty member,
 			String prefix,
 			PathsContext pathsContext,
@@ -1211,13 +1226,13 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 				) || !parseContext.isMaxLevelReached() ) {
 					NumericField existing = fieldsMarkedAsNumeric.put( numericField.forField(), numericField );
 					if ( existing != null ) {
-						throw log.severalNumericFieldAnnotationsForSameField( indexedType, member.getName() );
+						throw log.severalNumericFieldAnnotationsForSameField( indexedTypeIdentifier, member.getName() );
 					}
 				}
 			}
 		}
 
-		return new NumericFieldsConfiguration( indexedType, member, fieldsMarkedAsNumeric );
+		return new NumericFieldsConfiguration( indexedTypeIdentifier, member.getName(), fieldsMarkedAsNumeric );
 	}
 
 	private void checkForField(XProperty member,
@@ -1484,7 +1499,7 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 
 	private NullMarkerCodec determineNullMarkerCodec(PartialDocumentFieldMetadata fieldMetadata,
 			FieldBridge fieldBridge, org.hibernate.search.annotations.Field fieldAnnotation,
-			ConfigContext context, ParseContext parseContext, Class<?> indexedType) {
+			ConfigContext context, ParseContext parseContext, IndexedTypeIdentifier indexedTypeIdentifier) {
 		if ( parseContext.skipNullMarkerCodec() ) {
 			return NotEncodingCodec.SINGLETON;
 		}
@@ -1515,7 +1530,7 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 			IndexManagerType indexManagerType = parseContext.getIndexManagerType();
 			MissingValueStrategy missingValueStrategy = context.forType( indexManagerType ).getMissingValueStrategy();
 
-			return missingValueStrategy.createNullMarkerCodec( indexedType, fieldMetadata, nullMarker );
+			return missingValueStrategy.createNullMarkerCodec( indexedTypeIdentifier, fieldMetadata, nullMarker );
 		}
 	}
 
@@ -1865,11 +1880,12 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 				indexedEmbeddedAnnotation
 		) ) {
 			parseContext.processingClass( elementClass ); //push
+			final IndexedTypeIdentifier elementTypeIdentifier = new PojoIndexedTypeIdentifier( reflectionManager.toClass( elementClass ) );
 
 			EmbeddedTypeMetadata.Builder embeddedTypeMetadataBuilder =
 					new EmbeddedTypeMetadata.Builder(
 							typeMetadataBuilder,
-							reflectionManager.toClass( elementClass ),
+							elementTypeIdentifier,
 							propertyMetadataBuilder.getResultReference(),
 							member,
 							localPrefix

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/EmbeddedTypeMetadata.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/EmbeddedTypeMetadata.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 import org.hibernate.annotations.common.reflection.XMember;
 import org.hibernate.search.bridge.FieldBridge;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.util.impl.ReflectionHelper;
 
 /**
@@ -109,7 +110,7 @@ public class EmbeddedTypeMetadata extends TypeMetadata {
 		private FieldBridge embeddedNullFieldBridge;
 
 		public Builder(TypeMetadata.Builder parentTypeBuilder,
-				Class<?> indexedType, BackReference<PropertyMetadata> sourceProperty, XMember embeddedGetter,
+				IndexedTypeIdentifier indexedType, BackReference<PropertyMetadata> sourceProperty, XMember embeddedGetter,
 				String embeddedFieldPrefix) {
 			super( indexedType, parentTypeBuilder );
 			this.sourceProperty = sourceProperty;

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/MetadataProvider.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/MetadataProvider.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.engine.metadata.impl;
 
 import org.hibernate.search.indexes.spi.IndexManagerType;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 
 /**
  * @author Hardy Ferentschik
@@ -16,11 +17,17 @@ public interface MetadataProvider {
 	/**
 	 * Returns the Search related metadata for the specified type.
 	 *
-	 * @param clazz The type of interest.
+	 * @param type The type of interest.
 	 * @param indexManagerType the {@code IndexManagerType} type managing this entity type
 	 *
 	 * @return the {@code TypeMetadata} for the specified type
 	 */
+	TypeMetadata getTypeMetadataFor(IndexedTypeIdentifier type, IndexManagerType indexManagerType);
+
+	/**
+	 * @deprecated use {@link #getTypeMetadataFor(IndexedTypeIdentifier, IndexManagerType)}
+	 */
+	@Deprecated
 	TypeMetadata getTypeMetadataFor(Class<?> clazz, IndexManagerType indexManagerType);
 
 	/**
@@ -32,11 +39,12 @@ public interface MetadataProvider {
 	 * {@code ContainedIn} are not tied to an {@code IndexManager}.
 	 * <p>It's of no use for {@code ContainedIn} resolution anyway.
 	 *
-	 * @param clazz The type of interest.
+	 * @param type The type of interest.
 	 *
 	 * @return the {@code ContainedInTypeMetadata} for the specified type
 	 */
-	TypeMetadata getTypeMetadataForContainedIn(Class<?> clazz);
+	TypeMetadata getTypeMetadataForContainedIn(IndexedTypeIdentifier type);
 
-	boolean containsSearchMetadata(Class<?> clazz);
+	boolean containsSearchMetadata(IndexedTypeIdentifier type);
+
 }

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/NumericFieldsConfiguration.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/NumericFieldsConfiguration.java
@@ -10,8 +10,8 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.hibernate.annotations.common.reflection.XProperty;
 import org.hibernate.search.annotations.NumericField;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
@@ -24,14 +24,14 @@ class NumericFieldsConfiguration {
 
 	private static final Log LOG = LoggerFactory.make();
 
-	private final Class<?> indexedType;
-	private final XProperty member;
+	private final IndexedTypeIdentifier indexedType;
+	private final String propertyName;
 	private final Map<String, NumericField> fieldsMarkedAsNumeric;
 	private final Set<String> fieldsOfProperty = new LinkedHashSet<>();
 
-	NumericFieldsConfiguration(Class<?> indexedType, XProperty member, Map<String, NumericField> fieldsMarkedAsNumeric) {
-		this.indexedType = indexedType;
-		this.member = member;
+	NumericFieldsConfiguration(IndexedTypeIdentifier indexedTypeIdentifier, String propertyName, Map<String, NumericField> fieldsMarkedAsNumeric) {
+		this.indexedType = indexedTypeIdentifier;
+		this.propertyName = propertyName;
 		this.fieldsMarkedAsNumeric = fieldsMarkedAsNumeric;
 	}
 
@@ -69,7 +69,7 @@ class NumericFieldsConfiguration {
 				continue;
 			}
 
-			throw LOG.numericFieldAnnotationWithoutMatchingField( indexedType, member.getName() );
+			throw LOG.numericFieldAnnotationWithoutMatchingField( indexedType, propertyName );
 		}
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/TypeMetadata.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/TypeMetadata.java
@@ -30,6 +30,7 @@ import org.hibernate.search.engine.impl.ConfigContext;
 import org.hibernate.search.engine.impl.LuceneOptionsImpl;
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.indexes.spi.IndexManagerType;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.util.StringHelper;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
@@ -46,7 +47,7 @@ public class TypeMetadata {
 	/**
 	 * The type for this metadata
 	 */
-	private final Class<?> indexedType;
+	private final IndexedTypeIdentifier type;
 
 	/**
 	 * The class boost for this type (class level @Boost)
@@ -162,7 +163,7 @@ public class TypeMetadata {
 	private final Set<SortableFieldMetadata> classBridgeSortableFieldMetadata;
 
 	protected TypeMetadata(Builder builder) {
-		this.indexedType = builder.indexedType;
+		this.type = builder.indexedType;
 		this.boost = builder.boost;
 		this.scopedAnalyzerReference = builder.scopedAnalyzerReferenceBuilder == null ? null
 				: builder.scopedAnalyzerReferenceBuilder.build();
@@ -187,8 +188,8 @@ public class TypeMetadata {
 		this.classBridgeSortableFieldMetadata = Collections.unmodifiableSet( builder.classBridgeSortableFieldMetadata );
 	}
 
-	public Class<?> getType() {
-		return indexedType;
+	public IndexedTypeIdentifier getType() {
+		return type;
 	}
 
 	public Set<PropertyMetadata> getAllPropertyMetadata() {
@@ -486,7 +487,7 @@ public class TypeMetadata {
 
 	public static class Builder {
 		protected final BackReference<TypeMetadata> resultReference = new BackReference<>();
-		private final Class<?> indexedType;
+		private final IndexedTypeIdentifier indexedType;
 		private final ScopedAnalyzerReference.Builder scopedAnalyzerReferenceBuilder;
 		private final MutableAnalyzerRegistry analyzerRegistry;
 
@@ -505,7 +506,7 @@ public class TypeMetadata {
 		private XProperty jpaProperty;
 		private final Set<SortableFieldMetadata> classBridgeSortableFieldMetadata = new LinkedHashSet<>();
 
-		public Builder(Class<?> indexedType, ConfigContext configContext, ParseContext parseContext) {
+		public Builder(IndexedTypeIdentifier indexedType, ConfigContext configContext, ParseContext parseContext) {
 			this.indexedType = indexedType;
 			if ( parseContext.skipAnalyzers() ) {
 				this.analyzerRegistry = null;
@@ -518,7 +519,7 @@ public class TypeMetadata {
 			}
 		}
 
-		public Builder(Class<?> indexedType, Builder containerTypeBuilder) {
+		public Builder(IndexedTypeIdentifier indexedType, Builder containerTypeBuilder) {
 			this.indexedType = indexedType;
 			this.analyzerRegistry = containerTypeBuilder.analyzerRegistry;
 			this.scopedAnalyzerReferenceBuilder = containerTypeBuilder.scopedAnalyzerReferenceBuilder;
@@ -639,7 +640,7 @@ public class TypeMetadata {
 			return stateInspectionOptimizationsEnabled;
 		}
 
-		public Class<?> getIndexedType() {
+		public IndexedTypeIdentifier getIndexedType() {
 			return indexedType;
 		}
 

--- a/engine/src/main/java/org/hibernate/search/engine/nesting/impl/DefaultNestingContextFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/nesting/impl/DefaultNestingContextFactory.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.engine.nesting.impl;
 
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+
 /**
  * Always returns the no-op context.
  *
@@ -16,7 +18,8 @@ public class DefaultNestingContextFactory implements NestingContextFactory {
 	public static final NestingContextFactory INSTANCE = new DefaultNestingContextFactory();
 
 	@Override
-	public NestingContext createNestingContext(Class<?> indexedEntityType) {
+	public NestingContext createNestingContext(IndexedTypeIdentifier indexedEntityType) {
 		return NoOpNestingContext.INSTANCE;
 	}
+
 }

--- a/engine/src/main/java/org/hibernate/search/engine/nesting/impl/NestingContextFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/nesting/impl/NestingContextFactory.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.engine.nesting.impl;
 
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+
 /**
  * Factory for creating {@link NestingContext}s.
  *
@@ -13,5 +15,6 @@ package org.hibernate.search.engine.nesting.impl;
  */
 public interface NestingContextFactory {
 
-	NestingContext createNestingContext(Class<?> indexedEntityType);
+	NestingContext createNestingContext(IndexedTypeIdentifier indexedEntityType);
+
 }

--- a/engine/src/main/java/org/hibernate/search/engine/nulls/impl/LuceneMissingValueStrategy.java
+++ b/engine/src/main/java/org/hibernate/search/engine/nulls/impl/LuceneMissingValueStrategy.java
@@ -14,6 +14,7 @@ import org.hibernate.search.engine.nulls.codec.impl.LuceneIntegerNullMarkerCodec
 import org.hibernate.search.engine.nulls.codec.impl.LuceneLongNullMarkerCodec;
 import org.hibernate.search.engine.nulls.codec.impl.LuceneStringNullMarkerCodec;
 import org.hibernate.search.engine.nulls.codec.impl.NullMarkerCodec;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
@@ -31,7 +32,7 @@ public class LuceneMissingValueStrategy implements MissingValueStrategy {
 	}
 
 	@Override
-	public NullMarkerCodec createNullMarkerCodec(Class<?> entityType,
+	public NullMarkerCodec createNullMarkerCodec(IndexedTypeIdentifier entityType,
 			PartialDocumentFieldMetadata fieldMetadata, NullMarker nullMarker) {
 		Object nullEncoded = nullMarker.nullEncoded();
 		if ( nullEncoded instanceof String ) {
@@ -50,7 +51,7 @@ public class LuceneMissingValueStrategy implements MissingValueStrategy {
 			return new LuceneDoubleNullMarkerCodec( nullMarker );
 		}
 		else {
-			throw LOG.unsupportedNullTokenType( entityType, fieldMetadata.getPath().getAbsoluteName(),
+			throw LOG.unsupportedNullTokenType( entityType.getName(), fieldMetadata.getPath().getAbsoluteName(),
 					nullEncoded.getClass() );
 		}
 	}

--- a/engine/src/main/java/org/hibernate/search/engine/nulls/impl/MissingValueStrategy.java
+++ b/engine/src/main/java/org/hibernate/search/engine/nulls/impl/MissingValueStrategy.java
@@ -9,6 +9,7 @@ package org.hibernate.search.engine.nulls.impl;
 import org.hibernate.search.bridge.spi.NullMarker;
 import org.hibernate.search.engine.metadata.impl.PartialDocumentFieldMetadata;
 import org.hibernate.search.engine.nulls.codec.impl.NullMarkerCodec;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 
 /**
  * Strategy for handling missing values.
@@ -26,7 +27,7 @@ public interface MissingValueStrategy {
 	 * @param marker The null marker to use when indexing/querying null values.
 	 * @return A codec that will index and query the given marker.
 	 */
-	NullMarkerCodec createNullMarkerCodec(Class<?> entityType,
+	NullMarkerCodec createNullMarkerCodec(IndexedTypeIdentifier entityType,
 			PartialDocumentFieldMetadata fieldMetadata, NullMarker marker);
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/spi/AbstractDocumentBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/engine/spi/AbstractDocumentBuilder.java
@@ -28,6 +28,8 @@ import org.hibernate.search.engine.metadata.impl.EmbeddedTypeMetadata;
 import org.hibernate.search.engine.metadata.impl.PropertyMetadata;
 import org.hibernate.search.engine.metadata.impl.TypeMetadata;
 import org.hibernate.search.exception.AssertionFailure;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.IndexedTypeSet;
 import org.hibernate.search.spi.InstanceInitializer;
 import org.hibernate.search.util.impl.ReflectionHelper;
 import org.hibernate.search.util.logging.impl.Log;
@@ -53,16 +55,17 @@ public abstract class AbstractDocumentBuilder {
 
 	protected EntityState entityState;
 
+
 	/**
 	 * Constructor.
-	 *
 	 * @param xClass The class for which to build a document builder
 	 * @param typeMetadata metadata for the specified class
 	 * @param reflectionManager Reflection manager to use for processing the annotations
 	 * @param optimizationBlackList keeps track of types on which we need to disable collection events optimizations
 	 * @param instanceInitializer a {@link org.hibernate.search.spi.InstanceInitializer} object.
 	 */
-	public AbstractDocumentBuilder(XClass xClass,
+	public AbstractDocumentBuilder(
+			XClass xClass,
 			TypeMetadata typeMetadata,
 			ReflectionManager reflectionManager,
 			Set<XClass> optimizationBlackList,
@@ -82,7 +85,7 @@ public abstract class AbstractDocumentBuilder {
 
 	public abstract void addWorkToQueue(
 			String tenantIdentifier,
-			Class<?> entityClass,
+			IndexedTypeIdentifier typeIdentifier,
 			Object entity, Serializable id,
 			boolean delete,
 			boolean add,
@@ -109,14 +112,26 @@ public abstract class AbstractDocumentBuilder {
 		return isRoot;
 	}
 
+	/**
+	 * @deprecated use {@link #getTypeMetadata()}
+	 */
+	@Deprecated
 	public Class<?> getBeanClass() {
 		return beanClass;
 	}
 
+	/**
+	 * @deprecated use {@link #getTypeMetadata()}
+	 */
+	@Deprecated
 	public XClass getBeanXClass() {
 		return beanXClass;
 	}
 
+	/**
+	 * @deprecated use {@link #getTypeMetadata()}
+	 */
+	@Deprecated
 	public TypeMetadata getMetadata() {
 		return typeMetadata;
 	}
@@ -133,7 +148,8 @@ public abstract class AbstractDocumentBuilder {
 		return mappedSubclasses;
 	}
 
-	public void postInitialize(Set<Class<?>> indexedClasses) {
+	public void postInitialize(IndexedTypeSet indexedClassesSet) {
+		Set<Class<?>> indexedClasses = indexedClassesSet.toPojosSet();
 		//we initialize only once because we no longer have a reference to the reflectionManager
 		//in theory
 		Class<?> plainClass = beanClass;

--- a/engine/src/main/java/org/hibernate/search/engine/spi/DocumentBuilderContainedEntity.java
+++ b/engine/src/main/java/org/hibernate/search/engine/spi/DocumentBuilderContainedEntity.java
@@ -15,6 +15,7 @@ import org.hibernate.annotations.common.reflection.XClass;
 import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.bridge.spi.ConversionContext;
 import org.hibernate.search.engine.metadata.impl.TypeMetadata;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.spi.InstanceInitializer;
 
 /**
@@ -53,7 +54,7 @@ public class DocumentBuilderContainedEntity extends AbstractDocumentBuilder {
 	@Override
 	public void addWorkToQueue(
 			String tenantId,
-			Class<?> entityClass,
+			IndexedTypeIdentifier typeIdentifier,
 			Object entity,
 			Serializable id,
 			boolean delete,

--- a/engine/src/main/java/org/hibernate/search/engine/spi/EntityIndexBinding.java
+++ b/engine/src/main/java/org/hibernate/search/engine/spi/EntityIndexBinding.java
@@ -6,12 +6,11 @@
  */
 package org.hibernate.search.engine.spi;
 
-import java.util.Set;
-
 import org.apache.lucene.search.similarities.Similarity;
 import org.hibernate.search.indexes.interceptor.EntityIndexingInterceptor;
 import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.indexes.spi.IndexManagerType;
+import org.hibernate.search.spi.IndexedTypeSet;
 import org.hibernate.search.store.IndexShardingStrategy;
 import org.hibernate.search.store.ShardIdentifierProvider;
 
@@ -48,7 +47,7 @@ public interface EntityIndexBinding {
 	 *
 	 * @param indexedClasses set of indexed classes
 	 */
-	void postInitialize(Set<Class<?>> indexedClasses);
+	void postInitialize(IndexedTypeSet indexedClasses);
 
 	/**
 	 * @return the type of index managers

--- a/engine/src/main/java/org/hibernate/search/exception/impl/LogErrorHandler.java
+++ b/engine/src/main/java/org/hibernate/search/exception/impl/LogErrorHandler.java
@@ -11,6 +11,7 @@ import java.util.List;
 import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.exception.ErrorContext;
 import org.hibernate.search.exception.ErrorHandler;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 import org.hibernate.search.util.logging.impl.Log;
 
@@ -53,7 +54,7 @@ public class LogErrorHandler implements ErrorHandler {
 	}
 
 	public static final void appendFailureMessage(StringBuilder message, LuceneWork workThatFailed) {
-		Class<?> entityClass = workThatFailed.getEntityClass();
+		IndexedTypeIdentifier entityClass = workThatFailed.getEntityType();
 		String entityClassName = entityClass == null ? null : entityClass.getName();
 		message.append( "\tEntity " )
 			.append( entityClassName )

--- a/engine/src/main/java/org/hibernate/search/indexes/IndexReaderAccessor.java
+++ b/engine/src/main/java/org/hibernate/search/indexes/IndexReaderAccessor.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.indexes;
 
 import org.apache.lucene.index.IndexReader;
+import org.hibernate.search.spi.IndexedTypeSet;
 
 /**
  * The {@code IndexReaderAccessor} exposes {@link org.apache.lucene.index.IndexReader}s directly, making it possible to query the Lucene
@@ -45,6 +46,15 @@ public interface IndexReaderAccessor {
 	 * @throws java.lang.IllegalArgumentException if one of the specified classes is not indexed
 	 */
 	IndexReader open(Class<?>... entities);
+
+	/**
+	 * This method is intended for integrators which use alternative entity mappings over annotated
+	 * Class objects.
+	 * @param types the entity types for which to return a (multi)reader
+	 * @return an IndexReader containing at least all listed entities
+	 * @throws java.lang.IllegalArgumentException if one of the specified classes is not indexed
+	 */
+	IndexReader open(IndexedTypeSet types);
 
 	/**
 	 * Opens an IndexReader on all named indexes.

--- a/engine/src/main/java/org/hibernate/search/indexes/impl/DynamicShardingEntityIndexBinder.java
+++ b/engine/src/main/java/org/hibernate/search/indexes/impl/DynamicShardingEntityIndexBinder.java
@@ -11,6 +11,7 @@ import java.util.Properties;
 import org.hibernate.search.engine.impl.DynamicShardingEntityIndexBinding;
 import org.hibernate.search.engine.impl.MutableEntityIndexBinding;
 import org.hibernate.search.indexes.interceptor.EntityIndexingInterceptor;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.spi.WorkerBuildContext;
 import org.hibernate.search.store.ShardIdentifierProvider;
 import org.hibernate.search.util.configuration.impl.MaskedProperty;
@@ -31,7 +32,7 @@ class DynamicShardingEntityIndexBinder implements EntityIndexBinder {
 	}
 
 	@Override
-	public MutableEntityIndexBinding bind(IndexManagerGroupHolder holder, Class<?> entityType,
+	public MutableEntityIndexBinding bind(IndexManagerGroupHolder holder, IndexedTypeIdentifier entityType,
 			EntityIndexingInterceptor<?> interceptor, WorkerBuildContext buildContext) {
 		Properties maskedProperties = new MaskedProperty( properties, IndexManagerHolder.SHARDING_STRATEGY );
 		ShardIdentifierProvider shardIdentifierProvider = createShardIdentifierProvider(

--- a/engine/src/main/java/org/hibernate/search/indexes/impl/DynamicShardingStrategy.java
+++ b/engine/src/main/java/org/hibernate/search/indexes/impl/DynamicShardingStrategy.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import org.apache.lucene.document.Document;
 import org.hibernate.search.filter.FullTextFilterImplementor;
 import org.hibernate.search.indexes.spi.IndexManager;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.store.IndexShardingStrategy;
 import org.hibernate.search.store.ShardIdentifierProvider;
 
@@ -26,10 +27,10 @@ public class DynamicShardingStrategy implements IndexShardingStrategy {
 	private final ShardIdentifierProvider shardIdentifierProvider;
 	private final IndexManagerGroupHolder indexManagerGroupHolder;
 	private final Properties indexProperties;
-	private final Class<?> entityType;
+	private final IndexedTypeIdentifier entityType;
 
 	public DynamicShardingStrategy(ShardIdentifierProvider shardIdentifierProvider,
-			IndexManagerGroupHolder indexManagerGroupHolder, Properties indexProperties, Class<?> entityType) {
+			IndexManagerGroupHolder indexManagerGroupHolder, Properties indexProperties, IndexedTypeIdentifier entityType) {
 		this.shardIdentifierProvider = shardIdentifierProvider;
 		this.indexManagerGroupHolder = indexManagerGroupHolder;
 		this.indexProperties = indexProperties;

--- a/engine/src/main/java/org/hibernate/search/indexes/impl/EntityIndexBinder.java
+++ b/engine/src/main/java/org/hibernate/search/indexes/impl/EntityIndexBinder.java
@@ -8,6 +8,7 @@ package org.hibernate.search.indexes.impl;
 
 import org.hibernate.search.engine.impl.MutableEntityIndexBinding;
 import org.hibernate.search.indexes.interceptor.EntityIndexingInterceptor;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.spi.WorkerBuildContext;
 
 /**
@@ -18,8 +19,7 @@ import org.hibernate.search.spi.WorkerBuildContext;
  */
 interface EntityIndexBinder {
 
-	MutableEntityIndexBinding bind(IndexManagerGroupHolder holder, Class<?> entityType,
-			EntityIndexingInterceptor<?> interceptor, WorkerBuildContext buildContext);
+	MutableEntityIndexBinding bind(IndexManagerGroupHolder holder, IndexedTypeIdentifier entityType, EntityIndexingInterceptor<?> interceptor, WorkerBuildContext buildContext);
 
 	/**
 	 * Controls how backends are identified.

--- a/engine/src/main/java/org/hibernate/search/indexes/impl/IndexManagerGroupHolder.java
+++ b/engine/src/main/java/org/hibernate/search/indexes/impl/IndexManagerGroupHolder.java
@@ -23,6 +23,7 @@ import org.hibernate.search.engine.service.spi.ServiceReference;
 import org.hibernate.search.indexes.interceptor.EntityIndexingInterceptor;
 import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.indexes.spi.IndexManagerType;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.spi.WorkerBuildContext;
 import org.hibernate.search.util.StringHelper;
 import org.hibernate.search.util.configuration.impl.MaskedProperty;
@@ -92,7 +93,7 @@ public class IndexManagerGroupHolder implements AutoCloseable {
 		return indexManagerType;
 	}
 
-	MutableEntityIndexBinding bind(Class<?> entityType, EntityIndexingInterceptor<?> interceptor,
+	MutableEntityIndexBinding bind(IndexedTypeIdentifier entityType, EntityIndexingInterceptor<?> interceptor,
 			WorkerBuildContext buildContext) {
 		// This will create the binding, but also initialize the indexes as necessary
 		return entityIndexBinder.bind( this, entityType, interceptor, buildContext );
@@ -128,7 +129,7 @@ public class IndexManagerGroupHolder implements AutoCloseable {
 		}
 	}
 
-	IndexManager getOrCreateIndexManager(String shardName, Properties indexProperties, Class<?> entityType,
+	IndexManager getOrCreateIndexManager(String shardName, Properties indexProperties, IndexedTypeIdentifier entityType,
 			WorkerBuildContext context) {
 		String indexName = indexNameBase;
 		if ( shardName != null ) {
@@ -156,7 +157,7 @@ public class IndexManagerGroupHolder implements AutoCloseable {
 		return indexManager;
 	}
 
-	private synchronized IndexManager doCreateIndexManager(String indexName, Class<?> entityType,
+	private synchronized IndexManager doCreateIndexManager(String indexName, IndexedTypeIdentifier entityType,
 			Properties indexProperties, WorkerBuildContext workerBuildContext) {
 		ExtendedSearchIntegrator activeIntegrator = null;
 

--- a/engine/src/main/java/org/hibernate/search/indexes/impl/IndexManagerHolder.java
+++ b/engine/src/main/java/org/hibernate/search/indexes/impl/IndexManagerHolder.java
@@ -32,6 +32,7 @@ import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.indexes.interceptor.EntityIndexingInterceptor;
 import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.indexes.spi.IndexManagerType;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.spi.WorkerBuildContext;
 import org.hibernate.search.store.IndexShardingStrategy;
 import org.hibernate.search.store.ShardIdentifierProvider;
@@ -85,7 +86,7 @@ public class IndexManagerHolder {
 	// (for both fieldCaches and cached filters)
 	public synchronized MutableEntityIndexBinding buildEntityIndexBinding(
 			XClass entity,
-			Class<?> mappedClass,
+			IndexedTypeIdentifier mappedClassId,
 			SearchConfiguration cfg,
 			WorkerBuildContext buildContext
 	) {
@@ -95,7 +96,7 @@ public class IndexManagerHolder {
 
 		EntityIndexingInterceptor<?> interceptor = createEntityIndexingInterceptor( entity );
 
-		return groupHolder.bind( mappedClass, interceptor, buildContext );
+		return groupHolder.bind( mappedClassId, interceptor, buildContext );
 	}
 
 	private synchronized IndexManagerGroupHolder getOrCreateGroupHolder(

--- a/engine/src/main/java/org/hibernate/search/indexes/impl/NonDynamicShardingEntityIndexBinder.java
+++ b/engine/src/main/java/org/hibernate/search/indexes/impl/NonDynamicShardingEntityIndexBinder.java
@@ -12,6 +12,7 @@ import org.hibernate.search.engine.impl.MutableEntityIndexBinding;
 import org.hibernate.search.engine.impl.NonDynamicShardingEntityIndexBinding;
 import org.hibernate.search.indexes.interceptor.EntityIndexingInterceptor;
 import org.hibernate.search.indexes.spi.IndexManager;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.spi.WorkerBuildContext;
 import org.hibernate.search.store.IndexShardingStrategy;
 import org.hibernate.search.util.configuration.impl.MaskedProperty;
@@ -37,7 +38,7 @@ class NonDynamicShardingEntityIndexBinder implements EntityIndexBinder {
 	}
 
 	@Override
-	public MutableEntityIndexBinding bind(IndexManagerGroupHolder holder, Class<?> entityType,
+	public MutableEntityIndexBinding bind(IndexManagerGroupHolder holder, IndexedTypeIdentifier entityType,
 			EntityIndexingInterceptor<?> interceptor, WorkerBuildContext buildContext) {
 		IndexShardingStrategy shardingStrategy = ClassLoaderHelper.instanceFromClass(
 				IndexShardingStrategy.class,
@@ -65,7 +66,7 @@ class NonDynamicShardingEntityIndexBinder implements EntityIndexBinder {
 	}
 
 	private IndexManager[] preInitializeIndexManagersAndBackends(IndexManagerGroupHolder holder,
-			Class<?> entityType, WorkerBuildContext context) {
+			IndexedTypeIdentifier entityType, WorkerBuildContext context) {
 		IndexManager[] indexManagers;
 		int nbrOfIndexManagers = properties.length;
 		if ( nbrOfIndexManagers == 0 ) {

--- a/engine/src/main/java/org/hibernate/search/indexes/serialization/impl/LuceneWorkSerializerImpl.java
+++ b/engine/src/main/java/org/hibernate/search/indexes/serialization/impl/LuceneWorkSerializerImpl.java
@@ -94,27 +94,27 @@ public class LuceneWorkSerializerImpl implements LuceneWorkSerializer, Startable
 					serializer.addOptimizeAll();
 				}
 				else if ( work instanceof PurgeAllLuceneWork ) {
-					serializer.addPurgeAll( work.getEntityClass().getName() );
+					serializer.addPurgeAll( work.getEntityType().getName() );
 				}
 				else if ( work instanceof FlushLuceneWork ) {
 					serializer.addFlush();
 				}
 				else if ( work instanceof DeleteLuceneWork ) {
 					processId( work, serializer );
-					serializer.addDelete( work.getEntityClass().getName() );
+					serializer.addDelete( work.getEntityType().getName() );
 				}
 				else if ( work instanceof DeleteByQueryLuceneWork ) {
-					serializer.addDeleteByQuery( work.getEntityClass().getName(), ( (DeleteByQueryLuceneWork) work ).getDeletionQuery() );
+					serializer.addDeleteByQuery( work.getEntityType().getName(), ( (DeleteByQueryLuceneWork) work ).getDeletionQuery() );
 				}
 				else if ( work instanceof AddLuceneWork ) {
 					serializeDocument( work.getDocument(), serializer );
 					processId( work, serializer );
-					serializer.addAdd( work.getEntityClass().getName(), work.getFieldToAnalyzerMap() );
+					serializer.addAdd( work.getEntityType().getName(), work.getFieldToAnalyzerMap() );
 				}
 				else if ( work instanceof UpdateLuceneWork ) {
 					serializeDocument( work.getDocument(), serializer );
 					processId( work, serializer );
-					serializer.addUpdate( work.getEntityClass().getName(), work.getFieldToAnalyzerMap() );
+					serializer.addUpdate( work.getEntityType().getName(), work.getFieldToAnalyzerMap() );
 				}
 			}
 			return serializer.serialize();

--- a/engine/src/main/java/org/hibernate/search/indexes/spi/IndexManager.java
+++ b/engine/src/main/java/org/hibernate/search/indexes/spi/IndexManager.java
@@ -8,7 +8,6 @@ package org.hibernate.search.indexes.spi;
 
 import java.util.List;
 import java.util.Properties;
-import java.util.Set;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.similarities.Similarity;
@@ -16,6 +15,8 @@ import org.hibernate.search.backend.IndexingMonitor;
 import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.indexes.serialization.spi.LuceneWorkSerializer;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.IndexedTypeSet;
 import org.hibernate.search.spi.WorkerBuildContext;
 
 /**
@@ -92,7 +93,7 @@ public interface IndexManager {
 	/**
 	 * @return the set of classes being indexed in this manager
 	 */
-	Set<Class<?>> getContainedTypes();
+	IndexedTypeSet getContainedTypes();
 
 	/**
 	 * @return the {@code Similarity} applied to this index. Note, only a single {@code Similarity} can be applied to
@@ -116,9 +117,9 @@ public interface IndexManager {
 	void setSearchFactory(ExtendedSearchIntegrator boundSearchIntegrator);
 
 	/**
-	 * @param entity Adds the specified entity type to this index manager, making it responsible for manging this type.
+	 * @param entityType Adds the specified entity type to this index manager, making it responsible for manging this type.
 	 */
-	void addContainedEntity(Class<?> entity);
+	void addContainedEntity(IndexedTypeIdentifier entityType);
 
 	/**
 	 * To optimize the underlying index. Some implementations might ignore the request, if it doesn't apply to them.

--- a/engine/src/main/java/org/hibernate/search/metadata/IndexedTypeDescriptor.java
+++ b/engine/src/main/java/org/hibernate/search/metadata/IndexedTypeDescriptor.java
@@ -9,6 +9,7 @@ package org.hibernate.search.metadata;
 import java.util.Set;
 
 import org.hibernate.search.engine.BoostStrategy;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 
 /**
  * Top level descriptor of the metadata API. Giving access to the indexing information for a single type.
@@ -18,9 +19,16 @@ import org.hibernate.search.engine.BoostStrategy;
 public interface IndexedTypeDescriptor extends FieldContributor {
 
 	/**
+	 * @deprecated Use {@link #getIndexedType()} instead. This method will be removed.
 	 * @return the type for which this descriptor provides meta information
 	 */
+	@Deprecated
 	Class<?> getType();
+
+	/**
+	 * @return the type for which this descriptor provides meta information
+	 */
+	IndexedTypeIdentifier getIndexedType();
 
 	/**
 	 * @return {@code true} if the type for this descriptor is indexed, {@code false} otherwise

--- a/engine/src/main/java/org/hibernate/search/metadata/impl/IndexedTypeDescriptorForUnindexedType.java
+++ b/engine/src/main/java/org/hibernate/search/metadata/impl/IndexedTypeDescriptorForUnindexedType.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.metadata.impl;
 
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 
 import org.hibernate.search.engine.BoostStrategy;
@@ -15,6 +16,7 @@ import org.hibernate.search.metadata.FieldDescriptor;
 import org.hibernate.search.metadata.IndexDescriptor;
 import org.hibernate.search.metadata.IndexedTypeDescriptor;
 import org.hibernate.search.metadata.PropertyDescriptor;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 
 /**
  * Dummy descriptor for an unindexed type
@@ -22,15 +24,18 @@ import org.hibernate.search.metadata.PropertyDescriptor;
  * @author Hardy Ferentschik
  */
 public class IndexedTypeDescriptorForUnindexedType implements IndexedTypeDescriptor {
-	private final Class<?> type;
 
-	public IndexedTypeDescriptorForUnindexedType(Class<?> type) {
-		this.type = type;
+	private final IndexedTypeIdentifier freeFormType;
+
+	public IndexedTypeDescriptorForUnindexedType(IndexedTypeIdentifier freeFormType) {
+		Objects.requireNonNull( freeFormType );
+		this.freeFormType = freeFormType;
 	}
 
 	@Override
+	@Deprecated
 	public Class<?> getType() {
-		return type;
+		return freeFormType.getPojoType();
 	}
 
 	@Override
@@ -88,10 +93,15 @@ public class IndexedTypeDescriptorForUnindexedType implements IndexedTypeDescrip
 	@Override
 	public String toString() {
 		final StringBuilder sb = new StringBuilder( "IndexedTypeDescriptorForUnindexedType{" );
-		sb.append( "type=" ).append( type );
+		sb.append( "type=" ).append( freeFormType );
 		sb.append( '}' );
 		return sb.toString();
 	}
-}
 
+	@Override
+	public IndexedTypeIdentifier getIndexedType() {
+		return freeFormType;
+	}
+
+}
 

--- a/engine/src/main/java/org/hibernate/search/metadata/impl/IndexedTypeDescriptorImpl.java
+++ b/engine/src/main/java/org/hibernate/search/metadata/impl/IndexedTypeDescriptorImpl.java
@@ -21,6 +21,7 @@ import org.hibernate.search.metadata.FieldDescriptor;
 import org.hibernate.search.metadata.IndexDescriptor;
 import org.hibernate.search.metadata.IndexedTypeDescriptor;
 import org.hibernate.search.metadata.PropertyDescriptor;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
@@ -28,9 +29,10 @@ import org.hibernate.search.util.logging.impl.LoggerFactory;
  * @author Hardy Ferentschik
  */
 public class IndexedTypeDescriptorImpl implements IndexedTypeDescriptor {
+
 	private static final Log log = LoggerFactory.make();
 
-	private final Class<?> indexedType;
+	private final IndexedTypeIdentifier indexedType;
 	private final float classBoost;
 	@Deprecated
 	private final BoostStrategy boostStrategy;
@@ -81,7 +83,7 @@ public class IndexedTypeDescriptorImpl implements IndexedTypeDescriptor {
 
 	@Override
 	public Class<?> getType() {
-		return indexedType;
+		return indexedType.getPojoType();
 	}
 
 	@Override
@@ -223,6 +225,12 @@ public class IndexedTypeDescriptorImpl implements IndexedTypeDescriptor {
 		}
 		return fieldDescriptorMap;
 	}
+
+	@Override
+	public IndexedTypeIdentifier getIndexedType() {
+		return this.indexedType;
+	}
+
 }
 
 

--- a/engine/src/main/java/org/hibernate/search/query/dsl/impl/ConnectedMoreLikeThisQueryBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/impl/ConnectedMoreLikeThisQueryBuilder.java
@@ -68,7 +68,7 @@ public abstract class ConnectedMoreLikeThisQueryBuilder {
 		Query query;
 		final ExtendedSearchIntegrator searchIntegrator = queryContext.getExtendedSearchIntegrator();
 		final DocumentBuilderIndexedEntity documentBuilder = queryContext.getDocumentBuilder();
-		IndexReader indexReader = searchIntegrator.getIndexReaderAccessor().open( queryContext.getEntityType() );
+		IndexReader indexReader = searchIntegrator.getIndexReaderAccessor().open( queryContext.getEntityType().asTypeSet() );
 		// retrieving the docId and building the more like this query form the term vectors must be using the same index reader
 		try {
 			String[] fieldNames = getAllCompatibleFieldNames( documentBuilder );
@@ -106,7 +106,7 @@ public abstract class ConnectedMoreLikeThisQueryBuilder {
 			}
 		}
 		if ( fieldNames.size() == 0 ) {
-			throw log.noFieldCompatibleForMoreLikeThis( documentBuilder.getBeanClass() );
+			throw log.noFieldCompatibleForMoreLikeThis( documentBuilder.getTypeIdentifier() );
 		}
 		return fieldNames.toArray( new String[fieldNames.size()] );
 	}

--- a/engine/src/main/java/org/hibernate/search/query/dsl/impl/FacetBuildingContext.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/impl/FacetBuildingContext.java
@@ -15,6 +15,7 @@ import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.engine.spi.EntityIndexBinding;
 import org.hibernate.search.query.facet.FacetSortOrder;
 import org.hibernate.search.query.facet.FacetingRequest;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.util.StringHelper;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
@@ -40,7 +41,7 @@ class FacetBuildingContext<T> {
 		);
 
 	private final ExtendedSearchIntegrator factory;
-	private final Class<?> entityType;
+	private final IndexedTypeIdentifier entityType;
 
 	private String name;
 	private String fieldName;
@@ -54,9 +55,9 @@ class FacetBuildingContext<T> {
 	private boolean includeRangeEnd = true;
 	private int maxFacetCount = -1;
 
-	public FacetBuildingContext(ExtendedSearchIntegrator factory, Class<?> entityType) {
+	public FacetBuildingContext(ExtendedSearchIntegrator factory, IndexedTypeIdentifier indexedTypeIdentifier) {
 		this.factory = factory;
-		this.entityType = entityType;
+		this.entityType = indexedTypeIdentifier;
 	}
 
 	void setName(String name) {

--- a/engine/src/main/java/org/hibernate/search/query/dsl/impl/MoreLikeThisBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/impl/MoreLikeThisBuilder.java
@@ -98,12 +98,12 @@ public class MoreLikeThisBuilder<T> {
 
 	public MoreLikeThisBuilder( DocumentBuilderIndexedEntity documentBuilder, ExtendedSearchIntegrator searchIntegrator ) {
 		this.documentBuilder = documentBuilder;
-		Similarity configuredSimilarity = searchIntegrator.getIndexBindings().get( documentBuilder.getBeanClass() ).getSimilarity();
+		Similarity configuredSimilarity = searchIntegrator.getIndexBindings().get( documentBuilder.getTypeIdentifier() ).getSimilarity();
 		if ( configuredSimilarity instanceof TFIDFSimilarity ) {
 			this.similarity = (TFIDFSimilarity) configuredSimilarity;
 		}
 		else {
-			throw log.requireTFIDFSimilarity( documentBuilder.getBeanClass() );
+			throw log.requireTFIDFSimilarity( documentBuilder.getTypeIdentifier() );
 		}
 	}
 
@@ -134,7 +134,7 @@ public class MoreLikeThisBuilder<T> {
 			return maybeExcludeComparedEntity( createQuery( retrieveTerms() ) );
 		}
 		catch (IOException e) {
-			throw log.ioExceptionOnIndexOfEntity( e, documentBuilder.getBeanClass() );
+			throw log.ioExceptionOnIndexOfEntity( e, documentBuilder.getTypeIdentifier() );
 		}
 	}
 
@@ -163,7 +163,7 @@ public class MoreLikeThisBuilder<T> {
 			return null;
 		}
 		findById = new TermQuery( new Term( documentBuilder.getIdFieldName(), id ) );
-		HSQuery query = queryContext.getExtendedSearchIntegrator().createHSQuery( findById, queryContext.getEntityType() );
+		HSQuery query = queryContext.getExtendedSearchIntegrator().createHSQuery( findById, queryContext.getEntityType().getPojoType() );
 		List<EntityInfo> entityInfos = query
 				.maxResults( 1 )
 				.projection( HSQuery.DOCUMENT_ID )
@@ -230,7 +230,7 @@ public class MoreLikeThisBuilder<T> {
 			if ( fieldBridge instanceof NumericFieldBridge ) {
 				// we probably can do something here
 				//TODO how to build the query where we don't have the value?
-				throw log.numericFieldCannotBeUsedInMoreLikeThis( fieldContext.getField(), documentBuilder.getBeanClass() );
+				throw log.numericFieldCannotBeUsedInMoreLikeThis( fieldContext.getField(), documentBuilder.getTypeIdentifier() );
 			}
 			DocumentFieldMetadata fieldMetadata = documentBuilder.getTypeMetadata().getDocumentFieldMetadataFor(
 					fieldContext.getField()
@@ -244,11 +244,11 @@ public class MoreLikeThisBuilder<T> {
 			boolean hasTermVector = fieldMetadata.getTermVector() != Field.TermVector.NO;
 			boolean isStored = fieldMetadata.getStore() != Store.NO;
 			if ( ! ( hasTermVector || isStored ) ) {
-				throw log.fieldNotStoredNorTermVectorCannotBeUsedInMoreLikeThis( fieldContext.getField(), documentBuilder.getBeanClass() );
+				throw log.fieldNotStoredNorTermVectorCannotBeUsedInMoreLikeThis( fieldContext.getField(), documentBuilder.getTypeIdentifier() );
 			}
 			boolean isIdOrEmbeddedId = fieldMetadata.isId() || fieldMetadata.isIdInEmbedded();
 			if ( isIdOrEmbeddedId ) {
-				throw log.fieldIdCannotBeUsedInMoreLikeThis( fieldContext.getField(), documentBuilder.getBeanClass() );
+				throw log.fieldIdCannotBeUsedInMoreLikeThis( fieldContext.getField(), documentBuilder.getTypeIdentifier() );
 			}
 		}
 

--- a/engine/src/main/java/org/hibernate/search/query/dsl/impl/QueryBuildingContext.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/impl/QueryBuildingContext.java
@@ -12,6 +12,7 @@ import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.engine.spi.DocumentBuilderIndexedEntity;
 import org.hibernate.search.engine.spi.EntityIndexBinding;
 import org.hibernate.search.exception.AssertionFailure;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 
 /**
  * Keep the query builder contextual information
@@ -23,18 +24,18 @@ public class QueryBuildingContext {
 	private final DocumentBuilderIndexedEntity documentBuilder;
 	private final ScopedAnalyzerReference originalAnalyzerReference;
 	private final ScopedAnalyzerReference queryAnalyzerReference;
-	private final Class<?> entityType;
+	private final IndexedTypeIdentifier entityType;
 
 	public QueryBuildingContext(ExtendedSearchIntegrator factory, ScopedAnalyzerReference originalAnalyzerReference,
-			ScopedAnalyzerReference queryAnalyzerReference, Class<?> entityType) {
+			ScopedAnalyzerReference queryAnalyzerReference, IndexedTypeIdentifier indexBoundType) {
 		this.factory = factory;
 		this.originalAnalyzerReference = originalAnalyzerReference;
 		this.queryAnalyzerReference = queryAnalyzerReference;
-		this.entityType = entityType;
+		this.entityType = indexBoundType;
 
-		EntityIndexBinding indexBinding = factory.getIndexBinding( entityType );
+		EntityIndexBinding indexBinding = factory.getIndexBinding( indexBoundType );
 		if ( indexBinding == null ) {
-			throw new AssertionFailure( "Class is not indexed: " + entityType );
+			throw new AssertionFailure( "Class is not indexed: " + indexBoundType );
 		}
 		documentBuilder = indexBinding.getDocumentBuilder();
 	}
@@ -55,7 +56,7 @@ public class QueryBuildingContext {
 		return queryAnalyzerReference;
 	}
 
-	public Class<?> getEntityType() {
+	public IndexedTypeIdentifier getEntityType() {
 		return entityType;
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/query/engine/impl/DocumentExtractorImpl.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/impl/DocumentExtractorImpl.java
@@ -23,6 +23,7 @@ import org.hibernate.search.engine.spi.DocumentBuilderIndexedEntity;
 import org.hibernate.search.engine.spi.EntityIndexBinding;
 import org.hibernate.search.query.engine.spi.DocumentExtractor;
 import org.hibernate.search.query.engine.spi.EntityInfo;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 
 
 /**
@@ -183,7 +184,7 @@ public class DocumentExtractorImpl implements DocumentExtractor {
 		Document document = extractDocument( scoreDocIndex );
 
 		DocumentBuilderIndexedEntity documentBuilder = extractDocumentBuilder( document );
-		Class<?> clazz = documentBuilder.getBeanClass();
+		IndexedTypeIdentifier type = documentBuilder.getTypeIdentifier();
 		String idName = documentBuilder.getIdPropertyName();
 		Serializable id = extractId( documentBuilder, document );
 		Object[] projected = null;
@@ -209,7 +210,7 @@ public class DocumentExtractorImpl implements DocumentExtractor {
 						projected[x] = queryHits.explain( scoreDocIndex );
 					}
 					else if ( ProjectionConstants.OBJECT_CLASS.equals( projection[x] ) ) {
-						projected[x] = clazz;
+						projected[x] = type.getPojoType();
 					}
 					else if ( ProjectionConstants.SPATIAL_DISTANCE.equals( projection[x] ) ) {
 						projected[x] = queryHits.spatialDistance( scoreDocIndex );
@@ -225,7 +226,7 @@ public class DocumentExtractorImpl implements DocumentExtractor {
 				}
 			}
 		}
-		return new EntityInfoImpl( clazz, idName, id, projected );
+		return new EntityInfoImpl( type, idName, id, projected );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/query/engine/impl/EntityInfoImpl.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/impl/EntityInfoImpl.java
@@ -10,6 +10,7 @@ import java.io.Serializable;
 
 import org.hibernate.search.engine.ProjectionConstants;
 import org.hibernate.search.query.engine.spi.EntityInfo;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
@@ -24,9 +25,9 @@ public class EntityInfoImpl implements EntityInfo {
 	private static final Log log = LoggerFactory.make();
 
 	/**
-	 * The entity class.
+	 * The entity type.
 	 */
-	private final Class<?> clazz;
+	private final IndexedTypeIdentifier type;
 
 	/**
 	 * The document id.
@@ -50,23 +51,29 @@ public class EntityInfoImpl implements EntityInfo {
 	 */
 	private Object entityInstance;
 
-	public EntityInfoImpl(Class clazz, String idName, Serializable id, Object[] projection) {
-		this.clazz = clazz;
+	public EntityInfoImpl(IndexedTypeIdentifier type, String idName, Serializable id, Object[] projection) {
+		this.type = type;
 		this.idName = idName;
 		this.id = id;
 		this.projection = projection;
 	}
 
 	@Override
+	public IndexedTypeIdentifier getType() {
+		return type;
+	}
+
+	@Override
+	@Deprecated
 	public Class<?> getClazz() {
-		if ( clazz == null ) {
+		if ( type == null ) {
 			/*
 			 * Only throw an exception here, not in the constructor,
 			 * because in some cases we don't need the class at all (e.g. projections).
 			 */
-			throw log.incompleteEntityInfo( clazz, id );
+			throw log.incompleteEntityInfo( null, id );
 		}
-		return clazz;
+		return type.getPojoType();
 	}
 
 	@Override
@@ -76,7 +83,7 @@ public class EntityInfoImpl implements EntityInfo {
 			 * Only throw an exception here, not in the constructor,
 			 * because in some cases we don't need the identifier at all (e.g. projections).
 			 */
-			throw log.incompleteEntityInfo( clazz, id );
+			throw log.incompleteEntityInfo( type, id );
 		}
 		return id;
 	}
@@ -111,7 +118,8 @@ public class EntityInfoImpl implements EntityInfo {
 		return "EntityInfoImpl{" +
 				"idName='" + idName + '\'' +
 				", id=" + id +
-				", clazz=" + clazz +
+				", clazz=" + type +
 				'}';
 	}
+
 }

--- a/engine/src/main/java/org/hibernate/search/query/engine/impl/LazyQueryState.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/impl/LazyQueryState.java
@@ -8,7 +8,6 @@ package org.hibernate.search.query.engine.impl;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -46,7 +45,7 @@ public final class LazyQueryState implements Closeable {
 	private final boolean fieldSortDoTrackScores;
 	private final boolean fieldSortDoMaxScore;
 	private final ExtendedSearchIntegrator extendedIntegrator;
-	private final Collection<EntityIndexBinding> targetedEntityBindings;
+	private final Iterable<EntityIndexBinding> targetedEntityBindings;
 	private final QueryFilters facetingFilters;
 
 	private Query rewrittenQuery;
@@ -56,7 +55,7 @@ public final class LazyQueryState implements Closeable {
 			IndexReader reader,
 			Similarity searcherSimilarity,
 			ExtendedSearchIntegrator extendedIntegrator,
-			Collection<EntityIndexBinding> targetedEntityBindings,
+			Iterable<EntityIndexBinding> targetedEntityBindings,
 			boolean fieldSortDoTrackScores,
 			boolean fieldSortDoMaxScore) {
 		this.userQuery = userQuery;

--- a/engine/src/main/java/org/hibernate/search/query/engine/impl/LuceneHSQuery.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/impl/LuceneHSQuery.java
@@ -53,6 +53,8 @@ import org.hibernate.search.query.engine.spi.HSQuery;
 import org.hibernate.search.query.facet.FacetingRequest;
 import org.hibernate.search.reader.impl.MultiReaderFactory;
 import org.hibernate.search.spi.CustomTypeMetadata;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.IndexedTypeSet;
 import org.hibernate.search.util.impl.CollectionHelper;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
@@ -285,7 +287,7 @@ public class LuceneHSQuery extends AbstractHSQuery implements HSQuery {
 		for ( IndexManager indexManager : indexManagers ) {
 			if ( !( indexManager instanceof DirectoryBasedIndexManager ) ) {
 				throw log.cannotRunLuceneQueryTargetingEntityIndexedWithNonLuceneIndexManager(
-						binding.getDocumentBuilder().getBeanClass(),
+						binding.getDocumentBuilder().getTypeIdentifier(),
 						luceneQuery.toString()
 				);
 			}
@@ -438,11 +440,11 @@ public class LuceneHSQuery extends AbstractHSQuery implements HSQuery {
 		//if at least one DP contains one class that is not part of the targeted classesAndSubclasses we can't optimize
 		if ( indexedTargetedEntities.size() > 0 ) {
 			for ( IndexManager indexManager : targetedIndexes ) {
-				final Set<Class<?>> classesInIndexManager = indexManager.getContainedTypes();
+				final IndexedTypeSet classesInIndexManager = indexManager.getContainedTypes();
 				// if an IndexManager contains only one class, we know for sure it's part of classesAndSubclasses
 				if ( classesInIndexManager.size() > 1 ) {
 					//risk of needClassFilterClause
-					for ( Class<?> clazz : classesInIndexManager ) {
+					for ( IndexedTypeIdentifier clazz : classesInIndexManager ) {
 						if ( !targetedEntityBindingsByName.containsKey( clazz.getName() ) ) {
 							this.needClassFilterClause = true;
 							break;

--- a/engine/src/main/java/org/hibernate/search/query/engine/impl/LuceneQueryTranslator.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/impl/LuceneQueryTranslator.java
@@ -9,6 +9,7 @@ package org.hibernate.search.query.engine.impl;
 import org.apache.lucene.search.Query;
 import org.hibernate.search.engine.service.spi.Service;
 import org.hibernate.search.query.engine.spi.QueryDescriptor;
+import org.hibernate.search.spi.IndexedTypeSet;
 
 /**
  * Implementations translate Lucene queries into other backend-specific representations.
@@ -21,5 +22,5 @@ public interface LuceneQueryTranslator extends Service {
 
 	QueryDescriptor convertLuceneQuery(Query query);
 
-	boolean conversionRequired(Class<?>... entities);
+	boolean conversionRequired(IndexedTypeSet entities);
 }

--- a/engine/src/main/java/org/hibernate/search/query/engine/spi/EntityInfo.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/spi/EntityInfo.java
@@ -9,6 +9,7 @@ package org.hibernate.search.query.engine.spi;
 import java.io.Serializable;
 
 import org.hibernate.search.exception.SearchException;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 
 /**
  * Wrapper class describing the loading of an element.
@@ -27,10 +28,18 @@ public interface EntityInfo {
 	};
 
 	/**
+	 * @deprecated Use {@link #getType()}
 	 * @return The entity class.
 	 * @throws SearchException If the entity class could not be retrieved from the indexed document.
 	 */
+	@Deprecated
 	Class<?> getClazz();
+
+	/**
+	 * @return The entity type.
+	 * @throws SearchException If the entity class could not be retrieved from the indexed document.
+	 */
+	IndexedTypeIdentifier getType();
 
 	/**
 	 * @return The entity identifier.

--- a/engine/src/main/java/org/hibernate/search/query/engine/spi/HSQuery.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/spi/HSQuery.java
@@ -7,7 +7,6 @@
 package org.hibernate.search.query.engine.spi;
 
 import java.util.List;
-import java.util.Set;
 
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.Filter;
@@ -20,6 +19,7 @@ import org.hibernate.search.query.dsl.BooleanJunction;
 import org.hibernate.search.query.dsl.MustJunction;
 import org.hibernate.search.spatial.Coordinates;
 import org.hibernate.search.spi.CustomTypeMetadata;
+import org.hibernate.search.spi.IndexedTypeSet;
 import org.hibernate.search.spi.SearchIntegrator;
 
 /**
@@ -72,10 +72,10 @@ public interface HSQuery extends ProjectionConstants {
 	 * {@link SearchIntegrator#createHSQuery(Query, Class...)}, unless you want to change the targeted
 	 * entities.
 	 *
-	 * @param classes the list of classes (indexes) targeted by this query
+	 * @param types the list of classes (indexes) targeted by this query
 	 * @return {@code this} to allow for method chaining
 	 */
-	HSQuery targetedEntities(List<Class<?>> classes);
+	HSQuery targetedEntities(IndexedTypeSet types);
 
 	/**
 	 * Defines the targeted types, which may carry custom metadata which should override the supporting entity type's metadata.
@@ -159,12 +159,12 @@ public interface HSQuery extends ProjectionConstants {
 	/**
 	 * @return the targeted entity types
 	 */
-	List<Class<?>> getTargetedEntities();
+	IndexedTypeSet getTargetedEntities();
 
 	/**
 	 * @return a set of indexed entities corresponding to the class hierarchy of the targeted entities
 	 */
-	Set<Class<?>> getIndexedTargetedEntities();
+	IndexedTypeSet getIndexedTargetedEntities();
 
 	/**
 	 * @return the projected field names

--- a/engine/src/main/java/org/hibernate/search/reader/impl/ManagedMultiReader.java
+++ b/engine/src/main/java/org/hibernate/search/reader/impl/ManagedMultiReader.java
@@ -26,6 +26,7 @@ import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.indexes.spi.ReaderProvider;
 import org.hibernate.search.query.engine.impl.SortConfigurations;
 import org.hibernate.search.query.engine.impl.SortConfigurations.SortConfiguration;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.util.StringHelper;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
@@ -134,7 +135,7 @@ public class ManagedMultiReader extends MultiReader {
 			boolean foundEntityWithAllRequiredSorts = false;
 			boolean foundEntityWithMissingSorts = false;
 
-			for ( Class<?> entityType : sortConfiguration.getEntityTypes() ) {
+			for ( IndexedTypeIdentifier entityType : sortConfiguration.getEntityTypes() ) {
 				List<String> uncoveredSorts = sortConfiguration.getUncoveredSorts( entityType, sort );
 
 				if ( !uncoveredSorts.isEmpty() ) {

--- a/engine/src/main/java/org/hibernate/search/reader/impl/MultiReaderFactory.java
+++ b/engine/src/main/java/org/hibernate/search/reader/impl/MultiReaderFactory.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.reader.impl;
 
 import java.io.IOException;
+import java.util.Map;
 
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.Sort;
@@ -26,6 +27,11 @@ public final class MultiReaderFactory {
 
 	private MultiReaderFactory() {
 		//not allowed
+	}
+
+	public static IndexReader openReader(Map<String, IndexManager> indexManagers) {
+		IndexManager[] uniqueIndexManagers = indexManagers.values().toArray( new IndexManager[indexManagers.size()] );
+		return openReader( uniqueIndexManagers );
 	}
 
 	public static IndexReader openReader(IndexManager... indexManagers) {

--- a/engine/src/main/java/org/hibernate/search/spi/CustomTypeMetadata.java
+++ b/engine/src/main/java/org/hibernate/search/spi/CustomTypeMetadata.java
@@ -13,7 +13,7 @@ import java.util.Set;
  */
 public interface CustomTypeMetadata {
 
-	Class<?> getEntityType();
+	IndexedTypeIdentifier getEntityType();
 
 	Set<String> getSortableFields();
 

--- a/engine/src/main/java/org/hibernate/search/spi/IndexedTypeIdentifier.java
+++ b/engine/src/main/java/org/hibernate/search/spi/IndexedTypeIdentifier.java
@@ -1,0 +1,41 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.spi;
+
+/**
+ * Identifies and indexed type. In applications based on Hibernate ORM this will essentially
+ * encapsulate a {@code Class} instance. In upcoming extensions an identifier might be backed
+ * by a String.
+ * N.B. the Class case is simultaneously considered "legacy" and a special case:
+ * an annotated class has direct access to its metadata, while a typical identifier would need
+ * to be used to lookup the metadata related to it from an external source.
+ *
+ * @author Sanne Grinovero (C) 2014 Red Hat Inc.
+ */
+public interface IndexedTypeIdentifier {
+
+	/**
+	 * Each indexed type must be identified by name which is unique
+	 * within the scope of a {@link SearchIntegrator}.
+	 * @return the name of this type.
+	 */
+	String getName();
+
+	/**
+	 * Return the class type of the unrelying POJO.
+	 * @deprecated This only exists to facilitate an iterative integration, and will be removed ASAP.
+	 * @return the class of the indexed POJO, or null if not using POJO mapping.
+	 */
+	@Deprecated
+	Class<?> getPojoType();
+
+	/**
+	 * @return a representation of this type as a singleton IndexedTypesSet
+	 */
+	IndexedTypeSet asTypeSet();
+
+}

--- a/engine/src/main/java/org/hibernate/search/spi/IndexedTypeMap.java
+++ b/engine/src/main/java/org/hibernate/search/spi/IndexedTypeMap.java
@@ -1,0 +1,91 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.spi;
+
+import java.util.Map.Entry;
+
+/**
+ * This represents a Map but exposes a more restricted set of operations,
+ * allowing us to better encapsulate the contract and perform some optimisations.
+ *
+ * Also improves type-safety as it enforces usage of IndexedTypeIdentifier as keys,
+ * something the standard Map contract doesn't help with.
+ *
+ * In an ideal world, we will expose less methods than what is currently listed:
+ * some methods have been introduced as Deprecated since the beginning as the plan
+ * is to eventually remove them; they currently exist merely to allow a
+ * pratical migration of code to the new approach in smaller, testable steps.
+ *
+ * @author Sanne Grinovero
+ */
+public interface IndexedTypeMap<V> {
+
+	V get(IndexedTypeIdentifier type);
+
+	Iterable<Entry<IndexedTypeIdentifier, V>> entrySet();
+
+	IndexedTypeSet keySet();
+
+	int size();
+
+	boolean isEmpty();
+
+	Iterable<V> values();
+
+	boolean containsKey(IndexedTypeIdentifier type);
+
+	/**
+	 * @deprecated This method will be removed. The implementations will be refactored to become immutable.
+	 * @param type The key to be used.
+	 * @param typeBinding The value being put in the underlying key/value map.
+	 */
+	@Deprecated
+	void put(IndexedTypeIdentifier type, V typeBinding);
+
+	/**
+	 * @deprecated use {@link #get(IndexedTypeIdentifier)}. This method will be removed.
+	 * @param legacyPojoClass the Class whose type is to be used as a key.
+	 * @return the value mapped to this key.
+	 */
+	@Deprecated
+	V get(Class<?> legacyPojoClass);
+
+	/**
+	 * @param legacyPojoClass the Class whose type is to be used as a key.
+	 * @return true if the argument represents an identifier which is mapped to something.
+	 */
+	@Deprecated
+	boolean containsKey(Class<?> legacyPojoClass);
+
+	/**
+	 * @deprecated This method will be removed. The implementations will be refactored to become immutable.
+	 * @param type The key to be used.
+	 * @param typeBinding The value being put in the underlying key/value map.
+	 */
+	@Deprecated
+	void put(Class<?> type, V typeBinding);
+
+	/**
+	 * Returns a type identified by its unique name.
+	 * This method returns instance from a pool of known types,
+	 * and will throw an exception when requesting an unknown type name.
+	 * @param entityClassName
+	 * @return
+	 */
+	IndexedTypeIdentifier keyFromName(String entityClassName);
+
+	/**
+	 * Returns a type identifier to the passed class.
+	 * This method could return a type which is not recognized
+	 * as an indexed type by other components: it is not coming
+	 * from a pool of known types.
+	 * @param clazz
+	 * @return
+	 */
+	IndexedTypeIdentifier keyFromPojoType(Class<?> clazz);
+
+}

--- a/engine/src/main/java/org/hibernate/search/spi/IndexedTypeSet.java
+++ b/engine/src/main/java/org/hibernate/search/spi/IndexedTypeSet.java
@@ -1,0 +1,30 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.spi;
+
+import java.util.Set;
+
+public interface IndexedTypeSet extends Iterable<IndexedTypeIdentifier> {
+
+	int size();
+
+	boolean isEmpty();
+
+	/**
+	 * Return the set of the unrelying POJOs.
+	 * @deprecated This only exists to facilitate an iterative integration, and will be removed ASAP.
+	 */
+	@Deprecated
+	Set<Class<?>> toPojosSet();
+
+	/**
+	 * @param subsetCandidate
+	 * @return
+	 */
+	boolean containsAll(IndexedTypeSet subsetCandidate);
+
+}

--- a/engine/src/main/java/org/hibernate/search/spi/InstanceInitializer.java
+++ b/engine/src/main/java/org/hibernate/search/spi/InstanceInitializer.java
@@ -22,6 +22,12 @@ import org.hibernate.search.backend.spi.Work;
  */
 public interface InstanceInitializer {
 
+	/**
+	 * @deprecated Use {@link #getIndexedTypeIdFromWork(Work)}
+	 * @param work
+	 * @return
+	 */
+	@Deprecated
 	Class<?> getClassFromWork(Work work);
 
 	/**
@@ -57,5 +63,11 @@ public interface InstanceInitializer {
 	 * @return the initialized array, to be used on lazily-loading arrays
 	 */
 	Object[] initializeArray(Object[] value);
+
+	/**
+	 * @param work
+	 * @return the identification of the user type being indexed
+	 */
+	IndexedTypeIdentifier getIndexedTypeIdFromWork(Work work);
 
 }

--- a/engine/src/main/java/org/hibernate/search/spi/SearchIntegrator.java
+++ b/engine/src/main/java/org/hibernate/search/spi/SearchIntegrator.java
@@ -57,21 +57,6 @@ public interface SearchIntegrator extends AutoCloseable {
 
 	/**
 	 * Return an Hibernate Search query object.
-	 * This method does NOT support non-Lucene backends (e.g. Elasticsearch).
-	 * The returned object uses fluent APIs to define the query executed.
-	 * Offers a few execution approaches:
-	 * - return the list of results eagerly
-	 * - return the list of results lazily
-	 * - get the number of results
-	 *
-	 * @return an Hibernate Search query object
-	 * @deprecated This method will be removed. Use {@link #createHSQuery(Query, Class...)}
-	 */
-	@Deprecated
-	HSQuery createHSQuery();
-
-	/**
-	 * Return an Hibernate Search query object.
 	 * This method DOES support non-Lucene backends (e.g. Elasticsearch).
 	 * The returned object uses fluent APIs to define additional query settings.
 	 * <p>Be aware that some backends may not implement {@link HSQuery#luceneQuery(Query)},

--- a/engine/src/main/java/org/hibernate/search/spi/impl/ConcurrentIndexedTypeMap.java
+++ b/engine/src/main/java/org/hibernate/search/spi/impl/ConcurrentIndexedTypeMap.java
@@ -1,0 +1,113 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.spi.impl;
+
+import java.util.Collection;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.IndexedTypeMap;
+import org.hibernate.search.spi.IndexedTypeSet;
+import org.hibernate.search.util.logging.impl.Log;
+import org.hibernate.search.util.logging.impl.LoggerFactory;
+
+public class ConcurrentIndexedTypeMap<V> implements IndexedTypeMap<V> {
+
+	private static final Log log = LoggerFactory.make();
+	private static final IndexedTypeIdentifier ROOT_OBJECT = new PojoIndexedTypeIdentifier( Object.class );
+
+	private final ConcurrentHashMap<IndexedTypeIdentifier,V> map = new ConcurrentHashMap<>();
+	private final ConcurrentHashMap<String,IndexedTypeIdentifier> name2keyMapping = new ConcurrentHashMap<>();
+
+	@Override
+	public V get(IndexedTypeIdentifier key) {
+		return map.get( key );
+	}
+
+	@Override
+	public Iterable<Entry<IndexedTypeIdentifier, V>> entrySet() {
+		return map.entrySet();
+	}
+
+	@Override
+	public V get(Class<?> legacyPojo) {
+		return map.get( new PojoIndexedTypeIdentifier( legacyPojo ) );
+	}
+
+	@Override
+	public IndexedTypeSet keySet() {
+		return IndexedTypesSets.fromIdentifiers( map.keySet() );
+	}
+
+	@Override
+	public int size() {
+		return map.size();
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return map.isEmpty();
+	}
+
+	@Override
+	public Collection<V> values() {
+		return map.values();
+	}
+
+	@Override
+	public boolean containsKey(IndexedTypeIdentifier type) {
+		return map.containsKey( type );
+	}
+
+	@Override
+	public boolean containsKey(Class<?> legacyPojo) {
+		return map.containsKey( new PojoIndexedTypeIdentifier( legacyPojo ) );
+	}
+
+	@Override
+	public void put(IndexedTypeIdentifier type, V value) {
+		//technically there's a race condition here but we only do
+		//writes during initialization, which is sequential.
+		//Writing the names first makes this safe even for parallel
+		//initializations.
+		name2keyMapping.put( type.getName(), type );
+		map.put( type, value );
+	}
+
+	@Override
+	public void put(Class<?> type, V typeBinding) {
+		put( new PojoIndexedTypeIdentifier( type ), typeBinding );
+	}
+
+	@Override
+	public IndexedTypeIdentifier keyFromName(String entityClassName) {
+		if ( entityClassName == null ) {
+			throw log.nullIsInvalidIndexedType();
+		}
+		IndexedTypeIdentifier id = name2keyMapping.get( entityClassName );
+		if ( id == null ) {
+			throw log.notAnIndexedType( entityClassName );
+		}
+		return id;
+	}
+
+	@Override
+	public IndexedTypeIdentifier keyFromPojoType(Class<?> clazz) {
+		if ( clazz == null ) {
+			throw log.nullIsInvalidIndexedType();
+		}
+		if ( clazz == Object.class ) {
+			// Odd case: to handle existing semantics we need to be able to
+			// identify the root Object even though we consider it's not included
+			// in the maps.
+			return ROOT_OBJECT;
+		}
+		return new PojoIndexedTypeIdentifier( clazz );
+	}
+
+}

--- a/engine/src/main/java/org/hibernate/search/spi/impl/HashSetIndexedTypeSet.java
+++ b/engine/src/main/java/org/hibernate/search/spi/impl/HashSetIndexedTypeSet.java
@@ -1,0 +1,106 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.spi.impl;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.hibernate.search.exception.AssertionFailure;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.IndexedTypeSet;
+
+final class HashSetIndexedTypeSet implements IndexedTypeSet, Serializable {
+
+	public static final IndexedTypeSet EMPTY = new HashSetIndexedTypeSet( Collections.EMPTY_SET );
+
+	private final Set<IndexedTypeIdentifier> set;
+
+	HashSetIndexedTypeSet(IndexedTypeIdentifier singleton) {
+		Objects.requireNonNull( singleton );
+		this.set = Collections.singleton( singleton );
+	}
+
+	HashSetIndexedTypeSet(Set<IndexedTypeIdentifier> set) {
+		Objects.requireNonNull( set );
+		if ( set.size() == 1 ) {
+			throw new AssertionFailure( "singleton sets should not be constructed using this implementation" );
+		}
+		this.set = set;
+	}
+
+	@Override
+	public Iterator<IndexedTypeIdentifier> iterator() {
+		return set.iterator();
+	}
+
+	@Override
+	public int size() {
+		return set.size();
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return set.isEmpty();
+	}
+
+	@Override
+	@Deprecated
+	public Set<Class<?>> toPojosSet() {
+		return set.stream().map( IndexedTypeIdentifier::getPojoType ).collect( Collectors.toSet() );
+	}
+
+	boolean contains(IndexedTypeIdentifier id) {
+		return set.contains( id );
+	}
+
+	Set<IndexedTypeIdentifier> cloneInternalSet() {
+		return new HashSet( set );
+	}
+
+	@Override
+	public String toString() {
+		return set.toString();
+	}
+
+	@Override
+	public int hashCode() {
+		return set.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ( this == obj ) {
+			return true;
+		}
+		else if ( obj == null ) {
+			return false;
+		}
+		else if ( HashSetIndexedTypeSet.class != obj.getClass() ) {
+				return false;
+		}
+		else {
+			HashSetIndexedTypeSet other = (HashSetIndexedTypeSet) obj;
+			return set.equals( other.set );
+		}
+	}
+
+	@Override
+	public boolean containsAll(IndexedTypeSet subsetCandidate) {
+		for ( IndexedTypeIdentifier e : subsetCandidate ) {
+			if ( ! set.contains( e ) ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+}

--- a/engine/src/main/java/org/hibernate/search/spi/impl/IndexedTypesSets.java
+++ b/engine/src/main/java/org/hibernate/search/spi/impl/IndexedTypesSets.java
@@ -1,0 +1,170 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.spi.impl;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.IndexedTypeSet;
+
+public final class IndexedTypesSets {
+
+	private IndexedTypesSets() {
+		//Utility class: not to be constructed
+	}
+
+	public static IndexedTypeSet fromClasses(Class<?>... classes) {
+		if ( classes == null || classes.length == 0 ) {
+			// "null" needs to be acceptable to support some legacy use cases
+			return empty();
+		}
+		else if ( classes.length == 1 ) {
+			return fromClass( classes[0] );
+		}
+		else {
+			return Arrays.stream( classes ).map( PojoIndexedTypeIdentifier::new ).collect( streamCollector() );
+		}
+	}
+
+	public static IndexedTypeSet fromClass(Class<?> clazz) {
+		Objects.requireNonNull( clazz );
+		return new PojoIndexedTypeIdentifier( clazz ).asTypeSet();
+	}
+
+	public static IndexedTypeSet empty() {
+		return HashSetIndexedTypeSet.EMPTY;
+	}
+
+	public static IndexedTypeSet fromIdentifiers(Iterable<IndexedTypeIdentifier> entityTypes) {
+		Objects.requireNonNull( entityTypes );
+		if ( entityTypes instanceof Set<?> ) {
+			Set<IndexedTypeIdentifier> set = (Set<IndexedTypeIdentifier>) entityTypes;
+			fromSafeHashSet( new HashSet<IndexedTypeIdentifier>( set ) );
+		}
+		HashSet<IndexedTypeIdentifier> set = new HashSet<>();
+		for ( IndexedTypeIdentifier iti : entityTypes ) {
+			set.add( iti );
+		}
+		return fromSafeHashSet( set );
+	}
+
+	public static IndexedTypeSet fromIdentifiers(IndexedTypeIdentifier... types) {
+		if ( types == null || types.length == 0 ) {
+			// "null" needs to be acceptable to support some legacy use cases
+			return empty();
+		}
+		else if ( types.length == 1 ) {
+			return types[0].asTypeSet();
+		}
+		else {
+			return Arrays.stream( types ).collect( streamCollector() );
+		}
+	}
+
+	private static IndexedTypeSet fromSafeHashSet(HashSet<IndexedTypeIdentifier> set) {
+		if ( set.isEmpty() ) {
+			return empty();
+		}
+		else if ( set.size() == 1 ) {
+			return set.iterator().next().asTypeSet();
+		}
+		else {
+			return new HashSetIndexedTypeSet( set );
+		}
+	}
+
+	public static IndexedTypeSet composite(final IndexedTypeSet set, final IndexedTypeIdentifier additionalId) {
+		return composite( set, additionalId.asTypeSet() );
+	}
+
+	public static IndexedTypeSet composite(final IndexedTypeSet setA, final IndexedTypeSet setB) {
+		if ( setA.isEmpty() ) {
+			return setB;
+		}
+		else if ( setB.isEmpty() ) {
+			return setA;
+		}
+		else if ( setB.equals( setA ) ) {
+			return setA;
+		}
+		else {
+			HashSet<IndexedTypeIdentifier> newSet = new HashSet<>( setA.size() + setB.size() );
+			setA.forEach( newSet::add );
+			setB.forEach( newSet::add );
+			return fromSafeHashSet( newSet );
+		}
+	}
+
+	public static IndexedTypeSet subtraction(IndexedTypeSet referenceSet, IndexedTypeSet subtraend) {
+		if ( referenceSet.isEmpty() || subtraend.isEmpty() ) {
+			return referenceSet;
+		}
+		else {
+			HashSetIndexedTypeSet casted = (HashSetIndexedTypeSet) referenceSet;
+			Set<IndexedTypeIdentifier> cloned = casted.cloneInternalSet();
+			for ( IndexedTypeIdentifier toRemove : subtraend ) {
+				cloned.remove( toRemove );
+			}
+			if ( cloned.isEmpty() ) {
+				return empty();
+			}
+			if ( cloned.size() == 1 ) {
+				return cloned.iterator().next().asTypeSet();
+			}
+			else {
+				return new HashSetIndexedTypeSet( cloned );
+			}
+		}
+	}
+
+	private static final Set<Collector.Characteristics> CH_UNORDERED = Collections.unmodifiableSet( EnumSet.of( Collector.Characteristics.UNORDERED ) );
+
+	public static Collector<IndexedTypeIdentifier,?,IndexedTypeSet> streamCollector() {
+		return new Collector<IndexedTypeIdentifier,HashSet<IndexedTypeIdentifier>,IndexedTypeSet>() {
+
+			@Override
+			public Supplier<HashSet<IndexedTypeIdentifier>> supplier() {
+				return HashSet::new;
+			}
+
+			@Override
+			public BiConsumer<HashSet<IndexedTypeIdentifier>, IndexedTypeIdentifier> accumulator() {
+				return ( s, i ) -> s.add( i );
+			}
+
+			@Override
+			public BinaryOperator<HashSet<IndexedTypeIdentifier>> combiner() {
+				return ( a, b ) -> {
+						a.addAll( b );
+						return a;
+					};
+			}
+
+			@Override
+			public Function<HashSet<IndexedTypeIdentifier>, IndexedTypeSet> finisher() {
+				return IndexedTypesSets::fromSafeHashSet;
+			}
+
+			@Override
+			public Set<java.util.stream.Collector.Characteristics> characteristics() {
+				return CH_UNORDERED;
+			}
+
+		};
+	}
+
+}

--- a/engine/src/main/java/org/hibernate/search/spi/impl/PojoIndexedTypeIdentifier.java
+++ b/engine/src/main/java/org/hibernate/search/spi/impl/PojoIndexedTypeIdentifier.java
@@ -1,0 +1,72 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.spi.impl;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.IndexedTypeSet;
+
+/**
+ * @author Sanne Grinovero (C) 2017 Red Hat Inc.
+ */
+public final class PojoIndexedTypeIdentifier implements IndexedTypeIdentifier, Serializable {
+
+	private final Class<?> pojoType;
+
+	public PojoIndexedTypeIdentifier(Class<?> pojoType) {
+		Objects.requireNonNull( pojoType );
+		this.pojoType = pojoType;
+	}
+
+	@Override
+	public String getName() {
+		return pojoType.getName();
+	}
+
+	@Override
+	public Class<?> getPojoType() {
+		return pojoType;
+	}
+
+	@Override
+	public IndexedTypeSet asTypeSet() {
+		return new HashSetIndexedTypeSet( this );
+	}
+
+	@Override
+	public int hashCode() {
+		return pojoType.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ( this == obj ) {
+			return true;
+		}
+		else if ( obj == null ) {
+			return false;
+		}
+		else {
+			//Be paranoid about type matching: converting among types on Map isn't entirely typesafe as Map#get, remove, etc.. accept Object rather than
+			//restricting to the generic type of the Map.
+			//This new "type system" is designed having in mind that only one type model will be used, so no mixed implementations of IndexedTypeIdentifier
+			//are allowed.
+			//We prefer a ClassCastException here over "return false" to spot any mistakes aggressively.
+			assert PojoIndexedTypeIdentifier.class == obj.getClass() : "This should never happen. If it happens, you're mixing types in the same Map and that's a bug";
+			PojoIndexedTypeIdentifier other = (PojoIndexedTypeIdentifier) obj;
+			return pojoType.equals( other.pojoType );
+		}
+	}
+
+	@Override
+	public String toString() {
+		return getName();
+	}
+
+}

--- a/engine/src/main/java/org/hibernate/search/spi/impl/SearchFactoryState.java
+++ b/engine/src/main/java/org/hibernate/search/spi/impl/SearchFactoryState.java
@@ -27,6 +27,7 @@ import org.hibernate.search.indexes.spi.IndexManagerType;
 import org.hibernate.search.query.engine.spi.TimeoutExceptionFactory;
 import org.hibernate.search.spi.IndexingMode;
 import org.hibernate.search.spi.InstanceInitializer;
+import org.hibernate.search.spi.IndexedTypeMap;
 import org.hibernate.search.stat.Statistics;
 
 /**
@@ -35,9 +36,10 @@ import org.hibernate.search.stat.Statistics;
  * @author Emmanuel Bernard
  */
 public interface SearchFactoryState {
-	Map<Class<?>, DocumentBuilderContainedEntity> getDocumentBuildersContainedEntities();
 
-	Map<Class<?>, EntityIndexBinding> getIndexBindings();
+	IndexedTypeMap<DocumentBuilderContainedEntity> getDocumentBuildersContainedEntities();
+
+	IndexedTypeMap<EntityIndexBinding> getIndexBindings();
 
 	IndexingMode getIndexingMode();
 

--- a/engine/src/main/java/org/hibernate/search/stat/impl/StatisticsImpl.java
+++ b/engine/src/main/java/org/hibernate/search/stat/impl/StatisticsImpl.java
@@ -32,6 +32,7 @@ import org.hibernate.search.engine.ProjectionConstants;
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
 import org.hibernate.search.indexes.spi.IndexManager;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.engine.Version;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.engine.service.classloading.spi.ClassLoadingException;
@@ -214,7 +215,7 @@ public class StatisticsImpl implements Statistics, StatisticsImplementor {
 	@Override
 	public Set<String> getIndexedClassNames() {
 		Set<String> indexedClasses = new HashSet<String>();
-		for ( Class clazz : extendedIntegrator.getIndexBindings().keySet() ) {
+		for ( IndexedTypeIdentifier clazz : extendedIntegrator.getIndexBindings().keySet() ) {
 			indexedClasses.add( clazz.getName() );
 		}
 		return indexedClasses;

--- a/engine/src/main/java/org/hibernate/search/store/Workspace.java
+++ b/engine/src/main/java/org/hibernate/search/store/Workspace.java
@@ -6,13 +6,13 @@
  */
 package org.hibernate.search.store;
 
-import java.util.Set;
-
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.IndexWriter;
 import org.hibernate.search.backend.LuceneWork;
 import org.hibernate.search.backend.impl.CommitPolicy;
 import org.hibernate.search.engine.spi.DocumentBuilderIndexedEntity;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.IndexedTypeSet;
 
 /**
  * @deprecated This interface will be moved and should be considered non-public API [HSEARCH-1915]
@@ -22,7 +22,7 @@ import org.hibernate.search.engine.spi.DocumentBuilderIndexedEntity;
 @Deprecated
 public interface Workspace {
 
-	DocumentBuilderIndexedEntity getDocumentBuilder(Class<?> entity);
+	DocumentBuilderIndexedEntity getDocumentBuilder(IndexedTypeIdentifier type);
 
 	Analyzer getAnalyzer(String name);
 
@@ -38,7 +38,7 @@ public interface Workspace {
 	 * @param writer the IndexWriter to use for optimization
 	 * @see org.hibernate.search.backend.OptimizeLuceneWork
 	 * @see org.hibernate.search.spi.SearchIntegrator#optimize()
-	 * @see org.hibernate.search.spi.SearchIntegrator#optimize(Class)
+	 * @see org.hibernate.search.spi.SearchIntegrator#optimize(IndexedTypeIdentifier)
 	 */
 	void performOptimization(IndexWriter writer);
 
@@ -53,7 +53,7 @@ public interface Workspace {
 	 * @return The set of entity types being indexed
 	 * in the underlying IndexManager backing this Workspace.
 	 */
-	Set<Class<?>> getEntitiesInIndexManager();
+	IndexedTypeSet getEntitiesInIndexManager();
 
 	/**
 	 * Invoked after all changes of a transaction are applied.

--- a/engine/src/main/java/org/hibernate/search/util/logging/impl/IndexedTypeIdentifierFormatter.java
+++ b/engine/src/main/java/org/hibernate/search/util/logging/impl/IndexedTypeIdentifierFormatter.java
@@ -1,0 +1,24 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.logging.impl;
+
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+
+public final class IndexedTypeIdentifierFormatter {
+
+	private final IndexedTypeIdentifier type;
+
+	public IndexedTypeIdentifierFormatter(final IndexedTypeIdentifier type) {
+		this.type = type;
+	}
+
+	@Override
+	public String toString() {
+		return type == null ? "null" : type.getName();
+	}
+
+}

--- a/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
@@ -34,6 +34,7 @@ import org.hibernate.search.analyzer.impl.LuceneAnalyzerReference;
 import org.hibernate.search.exception.AssertionFailure;
 import org.hibernate.search.exception.EmptyQueryException;
 import org.hibernate.search.exception.SearchException;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.store.DirectoryProvider;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger.Level;
@@ -419,15 +420,15 @@ public interface Log extends BasicLogger {
 
 	@LogMessage(level = TRACE)
 	@Message(id = 125, value = "Interceptor enforces skip index operation %2$s on instance of class %1$s")
-	void forceSkipIndexOperationViaInterception(@FormatWith(ClassFormatter.class) Class<?> entityClass, WorkType type);
+	void forceSkipIndexOperationViaInterception(@FormatWith(IndexedTypeIdentifierFormatter.class) IndexedTypeIdentifier entityType, WorkType type);
 
 	@LogMessage(level = TRACE)
 	@Message(id = 126, value = "Interceptor enforces removal of index data instead of index operation %2$s on instance of class %1$s")
-	void forceRemoveOnIndexOperationViaInterception(@FormatWith(ClassFormatter.class) Class<?> entityClass, WorkType type);
+	void forceRemoveOnIndexOperationViaInterception(@FormatWith(IndexedTypeIdentifierFormatter.class) IndexedTypeIdentifier entityType, WorkType type);
 
 	@LogMessage(level = TRACE)
 	@Message(id = 128, value = "Interceptor enforces update of index data instead of index operation %2$s on instance of class %1$s")
-	void forceUpdateOnIndexOperationViaInterception(@FormatWith(ClassFormatter.class) Class<?> entityClass, WorkType type);
+	void forceUpdateOnIndexOperationViaInterception(@FormatWith(IndexedTypeIdentifierFormatter.class) IndexedTypeIdentifier entityType, WorkType type);
 
 	@Message(id = 131, value = "The field '%1$s#%2$s' used for the spatial query is not configured as spatial field. Check the proper use of @Spatial respectively SpatialFieldBridge")
 	SearchException targetedFieldNotSpatial(String className, String fieldName);
@@ -553,7 +554,7 @@ public interface Log extends BasicLogger {
 	String massIndexerUnableToIndexInstance(String clazz, String value);
 
 	@Message(id = 184, value = "Cannot define an entity with 0 shard on '%1$s'")
-	SearchException entityWithNoShard(@FormatWith(ClassFormatter.class) Class<?> type);
+	SearchException entityWithNoShard(@FormatWith(IndexedTypeIdentifierFormatter.class) IndexedTypeIdentifier type);
 
 	@Message(id = 186, value = "[AssertionFailure: open a bug report] SearchFactory from entityIndexBinding is not assignable to WorkerBuilderContext. Actual class is %1$s")
 	SearchException assertionFailureCannotCastToWorkerBuilderContext(@FormatWith(ClassFormatter.class) Class<?> type);
@@ -593,19 +594,19 @@ public interface Log extends BasicLogger {
 	SearchException incorrectEditDistance();
 
 	@Message(id = 202, value = "Unable to find entity $1%s with id $2%s")
-	SearchException entityWithIdNotFound(@FormatWith(ClassFormatter.class) Class<?> entityType, String id);
+	SearchException entityWithIdNotFound(@FormatWith(IndexedTypeIdentifierFormatter.class) IndexedTypeIdentifier entityType, String id);
 
 	@Message(id = 203, value = "No field from %s can be used for More Like This queries. They are neither stored or including the term vectors.")
-	SearchException noFieldCompatibleForMoreLikeThis(@FormatWith(ClassFormatter.class) Class<?> entityType);
+	SearchException noFieldCompatibleForMoreLikeThis(@FormatWith(IndexedTypeIdentifierFormatter.class) IndexedTypeIdentifier entityType);
 
 	@Message(id = 205, value = "An IOException happened while accessing the Lucene indexes related to '%1$s'")
-	SearchException ioExceptionOnIndexOfEntity(@Cause IOException e, @FormatWith(ClassFormatter.class) Class<?> entityType);
+	SearchException ioExceptionOnIndexOfEntity(@Cause IOException e, @FormatWith(IndexedTypeIdentifierFormatter.class) IndexedTypeIdentifier entityType);
 
 	@Message(id = 206, value = "MoreLikeThis queries require a TFIDFSimilarity for entity '$1%s'")
-	SearchException requireTFIDFSimilarity(@FormatWith(ClassFormatter.class) Class<?> beanClass);
+	SearchException requireTFIDFSimilarity(@FormatWith(IndexedTypeIdentifierFormatter.class) IndexedTypeIdentifier entityType);
 
 	@Message(id = 207, value = "Field %s of entity %s cannot be used in a MoreLikeThis query: the term vector (preferred) or the value itself need to be stored.")
-	SearchException fieldNotStoredNorTermVectorCannotBeUsedInMoreLikeThis(String fieldName, @FormatWith(ClassFormatter.class) Class<?> entityType);
+	SearchException fieldNotStoredNorTermVectorCannotBeUsedInMoreLikeThis(String fieldName, @FormatWith(IndexedTypeIdentifierFormatter.class) IndexedTypeIdentifier entityType);
 
 	@Message(id = 208, value = "ClassLoaderService cannot be provided via SearchConfiguration#getProvidedServices. Use SearchConfiguration#getClassLoaderService!")
 	SearchException classLoaderServiceContainedInProvidedServicesException();
@@ -623,10 +624,10 @@ public interface Log extends BasicLogger {
 	String massIndexerExceptionWhileTransformingIds();
 
 	@Message(id = 213, value = "Field %s of entity %s cannot be used in a MoreLikeThis query. Ids and embedded ids are excluded.")
-	SearchException fieldIdCannotBeUsedInMoreLikeThis(String fieldName, @FormatWith(ClassFormatter.class) Class<?> entityType);
+	SearchException fieldIdCannotBeUsedInMoreLikeThis(String fieldName, @FormatWith(IndexedTypeIdentifierFormatter.class) IndexedTypeIdentifier entityType);
 
 	@Message(id = 214, value = "Field %s of entity %s cannot be used in a MoreLikeThis query. Numeric fields are not considered for the moment.")
-	SearchException numericFieldCannotBeUsedInMoreLikeThis(String fieldName, @FormatWith(ClassFormatter.class) Class<?> entityType);
+	SearchException numericFieldCannotBeUsedInMoreLikeThis(String fieldName, @FormatWith(IndexedTypeIdentifierFormatter.class) IndexedTypeIdentifier entityType);
 
 	@Message(id = 215, value = "Multiple matching FieldBridges found for %s of return type %s: %s" )
 	SearchException multipleMatchingFieldBridges(XMember member, XClass memberType, String listOfFieldBridges);
@@ -773,7 +774,7 @@ public interface Log extends BasicLogger {
 	void loadingNonExistentField(String name);
 
 	@Message(id = 259, value = "Unable to delete all %s matching Query: %s")
-	SearchException unableToDeleteByQuery(@FormatWith(ClassFormatter.class) Class<?> entityClass, DeletionQuery deletionQuery, @Cause Exception e );
+	SearchException unableToDeleteByQuery(@FormatWith(IndexedTypeIdentifierFormatter.class) IndexedTypeIdentifier entityType, DeletionQuery deletionQuery, @Cause Exception e );
 
 	// Only used in ORM; Defining it here for now until there is a Log interface in hibernate-search-orm
 	@LogMessage(level = Level.WARN)
@@ -786,7 +787,7 @@ public interface Log extends BasicLogger {
 	SearchException unknownDeletionQueryKeySpecified(int queryKey);
 
 	@Message(id = 262, value = "@NumericField annotation is used on %1$s#%2$s without a matching @Field annotation")
-	SearchException numericFieldAnnotationWithoutMatchingField(@FormatWith(ClassFormatter.class) Class<?> entityClass, String memberName);
+	SearchException numericFieldAnnotationWithoutMatchingField(@FormatWith(IndexedTypeIdentifierFormatter.class) IndexedTypeIdentifier entityType, String memberName);
 
 	@Message(id = 263, value = "@Facet annotation is used on %1$s#%2$s without a matching @Field annotation")
 	SearchException facetAnnotationWithoutMatchingField(String className, String memberName);
@@ -830,7 +831,7 @@ public interface Log extends BasicLogger {
 	SearchException serializationProviderNotFoundException(@Cause Exception cause);
 
 	@Message(id = 276, value = "No transaction is active while indexing entity type '%1$s'; Consider increasing the connection time-out")
-	SearchException transactionNotActiveWhileProducingIdsForBatchIndexing(@FormatWith(ClassFormatter.class) Class<?> entityClass);
+	SearchException transactionNotActiveWhileProducingIdsForBatchIndexing(@FormatWith(IndexedTypeIdentifierFormatter.class) IndexedTypeIdentifier entityType);
 
 	@Message(id = 277, value = "Worker configured to be enlisted in transaction but the backend %1$s is not transactional for index %2$s")
 	SearchException backendNonTransactional(String indexName, String backend);
@@ -872,7 +873,7 @@ public interface Log extends BasicLogger {
 
 	@LogMessage(level = Level.WARN)
 	@Message(id = 289, value = "Requested sort field(s) %3$s are not configured for entity type %1$s mapped to index %2$s, thus an uninverting reader must be created. You should declare the missing sort fields using @SortableField." )
-	void uncoveredSortsRequested(@FormatWith(ClassFormatter.class) Class<?> entityType, String indexName, String uncoveredSorts);
+	void uncoveredSortsRequested(@FormatWith(IndexedTypeIdentifierFormatter.class) IndexedTypeIdentifier entityType, String indexName, String uncoveredSorts);
 
 	@Message(id = 290, value = "The 'indexNullAs' property for fields indexed as Doubles must represent a Double number." )
 	IllegalArgumentException invalidNullMarkerForDouble(@Cause Exception e);
@@ -899,16 +900,16 @@ public interface Log extends BasicLogger {
 	SearchException inconsistentSortableFieldConfigurationForSharedIndex(String indexName, String requestedSortFields);
 
 	@Message(id = 299, value = "@SortableField declared on %s#%s references to undeclared field '%s'" )
-	SearchException sortableFieldRefersToUndefinedField(@FormatWith(ClassFormatter.class) Class<?> entityType, String property, String sortedFieldName);
+	SearchException sortableFieldRefersToUndefinedField(@FormatWith(IndexedTypeIdentifierFormatter.class) IndexedTypeIdentifier entityType, String property, String sortedFieldName);
 
 	@Message(id = 300, value = "Several @NumericField annotations used on %1$s#%2$s refer to the same field")
-	SearchException severalNumericFieldAnnotationsForSameField(@FormatWith(ClassFormatter.class) Class<?> entityClass, String memberName);
+	SearchException severalNumericFieldAnnotationsForSameField(@FormatWith(IndexedTypeIdentifierFormatter.class) IndexedTypeIdentifier entityType, String memberName);
 
 	@Message(id = 301, value = "Requested sort field(s) %3$s are not configured for entity type %1$s mapped to index %2$s, thus an uninverting reader must be created. You should declare the missing sort fields using @SortableField." )
-	SearchException uncoveredSortsRequestedWithUninvertingNotAllowed(@FormatWith(ClassFormatter.class) Class<?> entityType, String indexName, String uncoveredSorts);
+	SearchException uncoveredSortsRequestedWithUninvertingNotAllowed(@FormatWith(IndexedTypeIdentifierFormatter.class) IndexedTypeIdentifier entityType, String indexName, String uncoveredSorts);
 
 	@Message(id = 302, value = "Cannot execute query '%2$s', as targeted entity type '%1$s' is not mapped to an embedded Lucene index." )
-	SearchException cannotRunLuceneQueryTargetingEntityIndexedWithNonLuceneIndexManager(@FormatWith(ClassFormatter.class) Class<?> entityType, String query);
+	SearchException cannotRunLuceneQueryTargetingEntityIndexedWithNonLuceneIndexManager(@FormatWith(IndexedTypeIdentifierFormatter.class) IndexedTypeIdentifier entityType, String query);
 
 	@LogMessage(level = Level.WARN)
 	@Message(id = 303, value = "Timeout while waiting for indexing resources to properly flush and close on shut down of"
@@ -981,7 +982,7 @@ public interface Log extends BasicLogger {
 	SearchException indexNamesCollisionDetected(String string);
 
 	@Message(id = 327, value = "Unsupported indexNullAs token type '%3$s' on field '%2$s' of entity '%1$s'." )
-	SearchException unsupportedNullTokenType(Class<?> entityType, String fieldName, Class<?> tokenType);
+	SearchException unsupportedNullTokenType(String entityName, String fieldName, Class<?> tokenType);
 
 	@Message(id = 328, value = "Cannot create context for class: %1$s" )
 	SearchException cannotCreateBridgeDefinedField(@FormatWith(ClassFormatter.class) Class<?> backend, @Cause Exception e);
@@ -1018,8 +1019,8 @@ public interface Log extends BasicLogger {
 	SearchException conflictingParameterDefined(String name, String value1, String value2);
 
 	@Message(id = 338, value = "Incomplete entity information in a document retrieved from the index:"
-			+ " the entity class ('%1$s') or identifier ('%2$s') was missing." )
-	SearchException incompleteEntityInfo(@FormatWith(ClassFormatter.class) Class<?> clazz, Object id);
+			+ " the entity type ('%1$s') or identifier ('%2$s') was missing." )
+	SearchException incompleteEntityInfo(@FormatWith(IndexedTypeIdentifierFormatter.class) IndexedTypeIdentifier entityType, Object id);
 
 	@Message(id = 339, value = "BeanResolver cannot be provided via SearchConfiguration#getProvidedServices. Use SearchConfiguration#getBeanResolver!")
 	SearchException beanResolverContainedInProvidedServicesException();
@@ -1031,7 +1032,7 @@ public interface Log extends BasicLogger {
 	SearchException normalizerDefinitionNamingConflict(String normalizerDefinitionName);
 
 	@Message(id = 342, value = "Field '%2$s' on entity '%1$s' refers to both an analyzer and a normalizer." )
-	SearchException cannotReferenceAnalyzerAndNormalizer(@FormatWith(ClassFormatter.class) Class<?> entityType, String relativeFieldPath);
+	SearchException cannotReferenceAnalyzerAndNormalizer(@FormatWith(IndexedTypeIdentifierFormatter.class) IndexedTypeIdentifier entityType, String relativeFieldPath);
 
 	@Message(id = 343, value = "Normalizer definition for '%s' must define at least a char filter or a token filter (or both)." )
 	SearchException invalidEmptyNormalizerDefinition(String name);
@@ -1047,7 +1048,7 @@ public interface Log extends BasicLogger {
 	@Message(id = 345, value = "Field '%2$s' on entity '%1$s' is marked as sortable and will be analyzed,"
 			+ " but is assigned an Analyzer instead of a Normalizer."
 			+ " Sortable fields should be assigned normalizers in order to avoid problems with tokenization.")
-	void sortableFieldWithNonNormalizerAnalyzer(@FormatWith(ClassFormatter.class) Class<?> entityType, String absoluteFieldPath);
+	void sortableFieldWithNonNormalizerAnalyzer(@FormatWith(IndexedTypeIdentifierFormatter.class) IndexedTypeIdentifier entityType, String absoluteFieldPath);
 
 	@LogMessage(level = Level.WARN)
 	@Message(id = 346, value = "The 'ram' directory provider is deprecated and will be removed in a future version."

--- a/engine/src/test/java/org/hibernate/search/test/backend/DeleteByQueryTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/backend/DeleteByQueryTest.java
@@ -28,6 +28,8 @@ import org.hibernate.search.backend.spi.WorkType;
 import org.hibernate.search.backend.spi.Worker;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.query.engine.spi.HSQuery;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.hibernate.search.testsupport.junit.SearchFactoryHolder;
 import org.hibernate.search.testsupport.setup.TransactionContextForTest;
 import org.junit.Rule;
@@ -37,6 +39,9 @@ import org.junit.Test;
  * @author Martin Braun
  */
 public class DeleteByQueryTest {
+
+	private static final IndexedTypeIdentifier BOOK_TYPE = new PojoIndexedTypeIdentifier( Book.class );
+	private static final IndexedTypeIdentifier MOVIE_TYPE = new PojoIndexedTypeIdentifier( Movie.class );
 
 	@Rule
 	public SearchFactoryHolder factoryHolder = new SearchFactoryHolder( Book.class, Movie.class );
@@ -95,14 +100,14 @@ public class DeleteByQueryTest {
 
 		{
 			TransactionContextForTest tc = new TransactionContextForTest();
-			worker.performWork( new DeleteByQueryWork( Book.class, new SingularTermDeletionQuery( "url", "lordoftherings" ) ), tc );
+			worker.performWork( new DeleteByQueryWork( BOOK_TYPE, new SingularTermDeletionQuery( "url", "lordoftherings" ) ), tc );
 			tc.end();
 		}
 		this.assertCount( Book.class, 1, integrator );
 
 		{
 			TransactionContextForTest tc = new TransactionContextForTest();
-			worker.performWork( new DeleteByQueryWork( Book.class, new SingularTermDeletionQuery( "url", "thehobbit" ) ), tc );
+			worker.performWork( new DeleteByQueryWork( BOOK_TYPE, new SingularTermDeletionQuery( "url", "thehobbit" ) ), tc );
 			tc.end();
 		}
 		this.assertCount( Book.class, 0, integrator );
@@ -125,14 +130,14 @@ public class DeleteByQueryTest {
 
 		{
 			TransactionContextForTest tc = new TransactionContextForTest();
-			worker.performWork( new DeleteByQueryWork( Book.class, new SingularTermDeletionQuery( "id", String.valueOf( 5 ) ) ), tc );
+			worker.performWork( new DeleteByQueryWork( BOOK_TYPE, new SingularTermDeletionQuery( "id", String.valueOf( 5 ) ) ), tc );
 			tc.end();
 		}
 		this.assertCount( Book.class, 1, integrator );
 
 		{
 			TransactionContextForTest tc = new TransactionContextForTest();
-			worker.performWork( new DeleteByQueryWork( Book.class, new SingularTermDeletionQuery( "id", String.valueOf( 6 ) ) ), tc );
+			worker.performWork( new DeleteByQueryWork( BOOK_TYPE, new SingularTermDeletionQuery( "id", String.valueOf( 6 ) ) ), tc );
 			tc.end();
 		}
 		this.assertCount( Book.class, 0, integrator );
@@ -155,14 +160,14 @@ public class DeleteByQueryTest {
 
 		{
 			TransactionContextForTest tc = new TransactionContextForTest();
-			worker.performWork( new DeleteByQueryWork( Movie.class, new SingularTermDeletionQuery( "id", 3 ) ), tc );
+			worker.performWork( new DeleteByQueryWork( MOVIE_TYPE, new SingularTermDeletionQuery( "id", 3 ) ), tc );
 			tc.end();
 		}
 		this.assertCount( Movie.class, 1, integrator );
 
 		{
 			TransactionContextForTest tc = new TransactionContextForTest();
-			worker.performWork( new DeleteByQueryWork( Movie.class, new SingularTermDeletionQuery( "id", 4 ) ), tc );
+			worker.performWork( new DeleteByQueryWork( MOVIE_TYPE, new SingularTermDeletionQuery( "id", 4 ) ), tc );
 			tc.end();
 		}
 		this.assertCount( Movie.class, 0, integrator );
@@ -201,14 +206,14 @@ public class DeleteByQueryTest {
 
 		{
 			TransactionContextForTest tc = new TransactionContextForTest();
-			worker.performWork( new DeleteByQueryWork( Book.class, query ), tc );
+			worker.performWork( new DeleteByQueryWork( BOOK_TYPE, query ), tc );
 			tc.end();
 		}
 		this.assertCount( entityType, expectedCount, integrator );
 
 		{
 			TransactionContextForTest tc = new TransactionContextForTest();
-			worker.performWork( new Work( Book.class, null, WorkType.PURGE_ALL ), tc );
+			worker.performWork( new Work( BOOK_TYPE, null, WorkType.PURGE_ALL ), tc );
 			tc.end();
 		}
 		this.assertCount( entityType, 0, integrator );

--- a/engine/src/test/java/org/hibernate/search/test/backend/serialization/SerializationInstanceNotReusedTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/backend/serialization/SerializationInstanceNotReusedTest.java
@@ -22,6 +22,8 @@ import org.hibernate.search.indexes.serialization.spi.Deserializer;
 import org.hibernate.search.indexes.serialization.spi.LuceneWorkSerializer;
 import org.hibernate.search.indexes.serialization.spi.SerializationProvider;
 import org.hibernate.search.indexes.serialization.spi.Serializer;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.hibernate.search.testsupport.TestForIssue;
 import org.hibernate.search.testsupport.junit.SearchFactoryHolder;
 import org.junit.Assert;
@@ -47,6 +49,8 @@ import org.junit.Test;
  */
 @TestForIssue(jiraKey = "HSEARCH-1637")
 public class SerializationInstanceNotReusedTest {
+
+	private static final IndexedTypeIdentifier testTypeId = new PojoIndexedTypeIdentifier( Book.class );
 
 	private final CountingSerializationProvider countingServiceInstance = new CountingSerializationProvider();
 
@@ -93,8 +97,8 @@ public class SerializationInstanceNotReusedTest {
 	private List<LuceneWork> makeSomeWork() {
 		List<LuceneWork> list = new LinkedList<>();
 		//just some random data:
-		list.add( new AddLuceneWork( Integer.valueOf( 5 ), "id:5", Book.class, new Document() ) );
-		list.add( new AddLuceneWork( Integer.valueOf( 6 ), "id:6", Book.class, new Document() ) );
+		list.add( new AddLuceneWork( Integer.valueOf( 5 ), "id:5", testTypeId, new Document() ) );
+		list.add( new AddLuceneWork( Integer.valueOf( 6 ), "id:6", testTypeId, new Document() ) );
 		return list;
 	}
 

--- a/engine/src/test/java/org/hibernate/search/test/engine/typehandling/BasicTypeCollectionsTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/engine/typehandling/BasicTypeCollectionsTest.java
@@ -1,0 +1,160 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.engine.typehandling;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Set;
+
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.IndexedTypeSet;
+import org.hibernate.search.spi.impl.IndexedTypesSets;
+import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class BasicTypeCollectionsTest {
+
+	private static final IndexedTypeIdentifier TYPE_A = new PojoIndexedTypeIdentifier( BasicTypeCollectionsTest.class );
+	private static final IndexedTypeIdentifier TYPE_B = new PojoIndexedTypeIdentifier( String.class );
+
+	@Test
+	public void emptyStream() {
+		assertIsEmpty( Collections.<IndexedTypeIdentifier>emptyList().stream().collect( IndexedTypesSets.streamCollector() ) );
+	}
+
+	@Test
+	public void nullVararg() {
+		assertIsEmpty( IndexedTypesSets.fromClasses( null ) );
+	}
+
+	@Test
+	public void emptyArray() {
+		assertIsEmpty( IndexedTypesSets.fromIdentifiers( new IndexedTypeIdentifier[0] ) );
+	}
+
+	@Test
+	public void emptyIterable() {
+		assertIsEmpty( IndexedTypesSets.fromIdentifiers( Collections.<IndexedTypeIdentifier>emptyList() ) );
+	}
+
+	@Test
+	public void singleElementClass() {
+		assertIsSingletonSet( IndexedTypesSets.fromClass( BasicTypeCollectionsTest.class ), BasicTypeCollectionsTest.class, true );
+	}
+
+	@Test
+	public void singleElementIterable() {
+		assertIsSingletonSet( IndexedTypesSets.fromIdentifiers( TYPE_A.asTypeSet() ), BasicTypeCollectionsTest.class, true );
+	}
+
+	@Test
+	public void singleElementStream() {
+		assertIsSingletonSet(
+				Collections.<IndexedTypeIdentifier>singleton( TYPE_A ).stream().collect( IndexedTypesSets.streamCollector() ),
+				BasicTypeCollectionsTest.class, true );
+	}
+
+	@Test
+	public void singleElementArray() {
+		assertIsSingletonSet(
+				IndexedTypesSets.fromIdentifiers( new IndexedTypeIdentifier[] { TYPE_A } ),
+				BasicTypeCollectionsTest.class, true );
+	}
+
+	@Test
+	public void compositeEmpty() {
+		assertIsEmpty( IndexedTypesSets.composite( IndexedTypesSets.empty(), IndexedTypesSets.empty() ) );
+	}
+
+	@Test
+	public void compositeSingle() {
+		assertIsSingletonSet( IndexedTypesSets.composite( TYPE_A.asTypeSet(), TYPE_A ), BasicTypeCollectionsTest.class, true );
+	}
+
+	@Test
+	public void compositeSingleAndEmpty() {
+		assertIsSingletonSet( IndexedTypesSets.composite( TYPE_A.asTypeSet(), IndexedTypesSets.empty() ), BasicTypeCollectionsTest.class, true );
+	}
+
+	@Test
+	public void subtractionEmpty() {
+		assertIsEmpty( IndexedTypesSets.subtraction( IndexedTypesSets.empty(), IndexedTypesSets.empty() ) );
+	}
+
+	@Test
+	public void subtractionOfSingletons() {
+		assertIsEmpty( IndexedTypesSets.subtraction( TYPE_A.asTypeSet(), TYPE_A.asTypeSet() ) );
+	}
+
+	@Test
+	public void subtractionOfSingletonFromEmpty() {
+		assertIsEmpty( IndexedTypesSets.subtraction( IndexedTypesSets.empty(), TYPE_A.asTypeSet() ) );
+	}
+
+	@Test
+	public void subtractionOfEmptyFromSingleton() {
+		assertIsSingletonSet( IndexedTypesSets.subtraction( TYPE_A.asTypeSet(), IndexedTypesSets.empty() ), BasicTypeCollectionsTest.class, true );
+	}
+
+	@Test
+	public void buildCoupleSet() {
+		assertIsDoubleSet( IndexedTypesSets.composite( TYPE_A.asTypeSet(), TYPE_B ) );
+	}
+
+	@Test
+	public void subtractionOfOneFromCouple() {
+		assertIsSingletonSet( IndexedTypesSets.subtraction( IndexedTypesSets.composite( TYPE_A.asTypeSet(), TYPE_B ), TYPE_B.asTypeSet() ), TYPE_A.getPojoType(), true );
+		assertIsSingletonSet( IndexedTypesSets.subtraction( IndexedTypesSets.composite( TYPE_A.asTypeSet(), TYPE_B ), TYPE_A.asTypeSet() ), TYPE_B.getPojoType(), true );
+	}
+
+	private void assertIsDoubleSet(IndexedTypeSet typeSet) {
+		Assert.assertFalse( "Verify it's not a singleton", typeSet == IndexedTypesSets.empty() );
+		Assert.assertFalse( typeSet.isEmpty() );
+		Assert.assertEquals( 2, typeSet.size() );
+		Iterator<IndexedTypeIdentifier> iterator = typeSet.iterator();
+		Assert.assertTrue( iterator.hasNext() );
+		IndexedTypeIdentifier firstElement = iterator.next(); // increment once
+		IndexedTypeIdentifier secondElement = iterator.next(); // increment twice
+		Assert.assertFalse( iterator.hasNext() );
+		iterator.forEachRemaining( l -> Assert.fail( "should never happen" ) ); //no more elements
+		Set<Class<?>> pojosSet = typeSet.toPojosSet();
+		Assert.assertTrue( pojosSet.contains( TYPE_A.getPojoType() ) );
+		Assert.assertTrue( pojosSet.contains( TYPE_B.getPojoType() ) );
+		Assert.assertEquals( 2, pojosSet.size() );
+	}
+
+	private void assertIsEmpty(IndexedTypeSet typeSet) {
+		Assert.assertTrue( "Verify the singleton optimisation applies", typeSet == IndexedTypesSets.empty() );
+		Assert.assertTrue( typeSet.isEmpty() );
+		Assert.assertEquals( 0, typeSet.size() );
+		typeSet.iterator().forEachRemaining( l -> Assert.fail( "should never happen" ) );
+		Assert.assertEquals( 0, typeSet.toPojosSet().size() );
+	}
+
+	private void assertIsSingletonSet(IndexedTypeSet typeSet, Class<?> someType, boolean recursive) {
+		Assert.assertFalse( "Verify it's not a singleton", typeSet == IndexedTypesSets.empty() );
+		Assert.assertFalse( typeSet.isEmpty() );
+		Assert.assertEquals( 1, typeSet.size() );
+		Iterator<IndexedTypeIdentifier> iterator = typeSet.iterator();
+		Assert.assertTrue( iterator.hasNext() );
+		IndexedTypeIdentifier firstElement = iterator.next(); // increment once
+		Assert.assertFalse( iterator.hasNext() );
+		iterator.forEachRemaining( l -> Assert.fail( "should never happen" ) ); //no more elements
+		Set<Class<?>> pojosSet = typeSet.toPojosSet();
+		Assert.assertTrue( pojosSet.contains( someType ) );
+		Assert.assertEquals( 1, pojosSet.size() );
+		IndexedTypeSet typeSet2 = firstElement.asTypeSet();
+		if ( recursive ) {
+			assertIsSingletonSet( typeSet2, someType, false );
+		}
+		Assert.assertEquals( typeSet2, typeSet2 );
+		Assert.assertEquals( firstElement.getPojoType(), someType );
+	}
+
+
+}

--- a/engine/src/test/java/org/hibernate/search/test/metadata/DescriptorTestHelper.java
+++ b/engine/src/test/java/org/hibernate/search/test/metadata/DescriptorTestHelper.java
@@ -16,6 +16,8 @@ import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.indexes.spi.LuceneEmbeddedIndexManagerType;
 import org.hibernate.search.metadata.IndexedTypeDescriptor;
 import org.hibernate.search.metadata.impl.IndexedTypeDescriptorImpl;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 
 /**
  * @author Hardy Ferentschik
@@ -29,8 +31,16 @@ public final class DescriptorTestHelper {
 		//not allowed
 	}
 
+	/**
+	 * @deprecated use {@link #getTypeDescriptor(AnnotationMetadataProvider, IndexedTypeIdentifier)}
+	 */
+	@Deprecated
 	public static IndexedTypeDescriptor getTypeDescriptor(AnnotationMetadataProvider metadataProvider, Class<?> clazz) {
-		TypeMetadata typeMetadata = metadataProvider.getTypeMetadataFor( clazz, LuceneEmbeddedIndexManagerType.INSTANCE );
+		return getTypeDescriptor( metadataProvider, new PojoIndexedTypeIdentifier( clazz ) );
+	}
+
+	public static IndexedTypeDescriptor getTypeDescriptor(AnnotationMetadataProvider metadataProvider, IndexedTypeIdentifier type) {
+		TypeMetadata typeMetadata = metadataProvider.getTypeMetadataFor( type, LuceneEmbeddedIndexManagerType.INSTANCE );
 		return new IndexedTypeDescriptorImpl(
 				typeMetadata,
 				getDummyUnShardedIndexManager()

--- a/engine/src/test/java/org/hibernate/search/test/metadata/DummyIndexManager.java
+++ b/engine/src/test/java/org/hibernate/search/test/metadata/DummyIndexManager.java
@@ -9,7 +9,6 @@ package org.hibernate.search.test.metadata;
 
 import java.util.List;
 import java.util.Properties;
-import java.util.Set;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.similarities.Similarity;
@@ -21,6 +20,8 @@ import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.indexes.spi.IndexManagerType;
 import org.hibernate.search.indexes.spi.LuceneEmbeddedIndexManagerType;
 import org.hibernate.search.indexes.spi.ReaderProvider;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.IndexedTypeSet;
 import org.hibernate.search.spi.WorkerBuildContext;
 
 /**
@@ -69,7 +70,7 @@ class DummyIndexManager implements IndexManager {
 	}
 
 	@Override
-	public Set<Class<?>> getContainedTypes() {
+	public IndexedTypeSet getContainedTypes() {
 		throw new UnsupportedOperationException( "Not supported in dummy index manager" );
 	}
 
@@ -89,7 +90,7 @@ class DummyIndexManager implements IndexManager {
 	}
 
 	@Override
-	public void addContainedEntity(Class<?> entity) {
+	public void addContainedEntity(IndexedTypeIdentifier entity) {
 		throw new UnsupportedOperationException( "Not supported in dummy index manager" );
 	}
 

--- a/engine/src/test/java/org/hibernate/search/test/metadata/types/IndexedTypesSetsTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/metadata/types/IndexedTypesSetsTest.java
@@ -1,0 +1,65 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.metadata.types;
+
+import java.util.Collections;
+
+import org.hibernate.search.spi.IndexedTypeSet;
+import org.hibernate.search.spi.impl.IndexedTypesSets;
+import org.hibernate.search.test.metadata.Foo;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Verify some key contracts on Class adaptor for IndexedTypesSet
+ */
+public class IndexedTypesSetsTest {
+
+	/**
+	 * We actually verify the toString() of IndexedTypesSets as it's being used in logging
+	 * messages and diagnostic output.
+	 */
+	@Test
+	public void testingLogFormat() {
+		//take any two random classes:
+		final IndexedTypeSet fromClasses = IndexedTypesSets.fromClasses( IndexedTypesSetsTest.class, Foo.class );
+		final String tostring = fromClasses.toString();
+		//being a set, the order is unspecified. The toString output is going to match A,B or B,A :
+		Assert.assertTrue(
+				"[org.hibernate.search.test.metadata.Foo, org.hibernate.search.test.metadata.types.IndexedTypesSetsTest]".equals( tostring ) ||
+				"[org.hibernate.search.test.metadata.types.IndexedTypesSetsTest, org.hibernate.search.test.metadata.Foo]".equals( tostring ) );
+	}
+
+	@Test
+	public void testCreationOfEmptySets() {
+		//This is more to test about creation from special parameters than to test the isEmpty() method
+		Assert.assertTrue( IndexedTypesSets.fromClasses().isEmpty() );
+		Assert.assertTrue( IndexedTypesSets.empty().isEmpty() );
+		Assert.assertTrue( IndexedTypesSets.fromIdentifiers( Collections.emptySet() ).isEmpty() );
+	}
+
+	@Test
+	public void testSize() {
+		Assert.assertEquals( 2, IndexedTypesSets.fromClasses( IndexedTypesSetsTest.class, Foo.class ).size() );
+		Assert.assertEquals( 1, IndexedTypesSets.fromClasses( Foo.class, Foo.class ).size() );
+		Assert.assertEquals( 0, IndexedTypesSets.fromClasses( ).size() );
+	}
+
+	@Test
+	public void testEquality() {
+		final IndexedTypeSet a = IndexedTypesSets.fromClasses( IndexedTypesSetsTest.class, Foo.class );
+		final IndexedTypeSet b = IndexedTypesSets.fromClasses( Foo.class, IndexedTypesSetsTest.class );
+		final IndexedTypeSet c = IndexedTypesSets.fromClasses( Foo.class );
+		Assert.assertEquals( a, b );
+		Assert.assertEquals( b, a );
+		Assert.assertEquals( a, a );
+		Assert.assertNotEquals( a, c );
+		Assert.assertNotEquals( b, c );
+	}
+
+}
+

--- a/engine/src/test/java/org/hibernate/search/test/polymorphism/PolymorhicIndexingTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/polymorphism/PolymorhicIndexingTest.java
@@ -8,20 +8,18 @@ package org.hibernate.search.test.polymorphism;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-
 import org.hibernate.search.annotations.DocumentId;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
+import org.hibernate.search.spi.IndexedTypeSet;
+import org.hibernate.search.spi.impl.IndexedTypesSets;
 import org.hibernate.search.testsupport.junit.SearchFactoryHolder;
 import org.junit.Rule;
 import org.junit.Test;
 
 /**
- * Test to verify the contract of {@link org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator#getIndexedTypesPolymorphic(Class[])}
+ * Test to verify the contract of {@link org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator#getIndexedTypesPolymorphic(IndexedTypeSet)}
  *
  * @author Sanne Grinovero
  */
@@ -55,9 +53,8 @@ public class PolymorhicIndexingTest {
 
 	private void expectingForArgument(Class[] argument, Class... expectedInResult) {
 		ExtendedSearchIntegrator searchIntegrator = factoryHolder.getSearchFactory();
-		Set<Class<?>> set = searchIntegrator.getIndexedTypesPolymorphic( argument );
-		HashSet<Class<?>> expectation = new HashSet<>();
-		expectation.addAll( Arrays.<Class<?>>asList( expectedInResult ) );
+		IndexedTypeSet set = searchIntegrator.getIndexedTypesPolymorphic( IndexedTypesSets.fromClasses( argument ) );
+		IndexedTypeSet expectation = IndexedTypesSets.fromClasses( expectedInResult );
 		assertEquals( expectation, set );
 	}
 

--- a/engine/src/test/java/org/hibernate/search/test/searchfactory/SearchFactoryTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/searchfactory/SearchFactoryTest.java
@@ -14,15 +14,15 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.util.Set;
-
 import org.hibernate.search.annotations.DocumentId;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.cfg.SearchMapping;
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.metadata.IndexedTypeDescriptor;
+import org.hibernate.search.spi.IndexedTypeSet;
 import org.hibernate.search.spi.SearchIntegrator;
+import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.hibernate.search.testsupport.BytemanHelper;
 import org.hibernate.search.testsupport.TestForIssue;
 import org.hibernate.search.testsupport.BytemanHelper.BytemanAccessor;
@@ -206,7 +206,7 @@ public class SearchFactoryTest {
 		SearchConfigurationForTest cfg = getManualConfiguration();
 
 		SearchIntegrator si = integratorResource.create( cfg );
-		Set<Class<?>> indexedClasses = si.getIndexedTypes();
+		IndexedTypeSet indexedClasses = si.getIndexedTypeIdentifiers();
 		assertEquals( "Wrong number of indexed entities", 0, indexedClasses.size() );
 	}
 
@@ -222,9 +222,9 @@ public class SearchFactoryTest {
 		cfg.setProgrammaticMapping( mapping );
 
 		SearchIntegrator si = integratorResource.create( cfg );
-		Set<Class<?>> indexedClasses = si.getIndexedTypes();
+		IndexedTypeSet indexedClasses = si.getIndexedTypeIdentifiers();
 		assertEquals( "Wrong number of indexed entities", 1, indexedClasses.size() );
-		assertTrue( indexedClasses.iterator().next().equals( Foo.class ) );
+		assertTrue( indexedClasses.iterator().next().equals( new PojoIndexedTypeIdentifier( Foo.class ) ) );
 	}
 
 	@Test
@@ -241,7 +241,7 @@ public class SearchFactoryTest {
 		cfg.setProgrammaticMapping( mapping );
 
 		SearchIntegrator si = integratorResource.create( cfg );
-		Set<Class<?>> indexedClasses = si.getIndexedTypes();
+		IndexedTypeSet indexedClasses = si.getIndexedTypeIdentifiers();
 		assertEquals( "Wrong number of indexed entities", 2, indexedClasses.size() );
 	}
 

--- a/engine/src/test/java/org/hibernate/search/test/sharding/LogRotationExampleTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/sharding/LogRotationExampleTest.java
@@ -30,6 +30,7 @@ import org.hibernate.search.filter.ShardSensitiveOnlyFilter;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.query.engine.spi.HSQuery;
 import org.hibernate.search.spi.BuildContext;
+import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.hibernate.search.store.ShardIdentifierProvider;
 import org.hibernate.search.testsupport.setup.TransactionContextForTest;
 import org.hibernate.search.testsupport.junit.SearchFactoryHolder;
@@ -131,7 +132,7 @@ public class LogRotationExampleTest {
 		log.timestamp = timestamp;
 
 		ExtendedSearchIntegrator searchFactory = sfHolder.getSearchFactory();
-		Work work = new Work( LogMessage.class, log.timestamp, WorkType.DELETE );
+		Work work = new Work( new PojoIndexedTypeIdentifier( LogMessage.class ), log.timestamp, WorkType.DELETE );
 		TransactionContextForTest tc = new TransactionContextForTest();
 		searchFactory.getWorker().performWork( work, tc );
 		tc.end();

--- a/engine/src/test/java/org/hibernate/search/test/sorting/CustomTypeMetadataSortingTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/sorting/CustomTypeMetadataSortingTest.java
@@ -30,6 +30,8 @@ import org.hibernate.search.bridge.LuceneOptions;
 import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.query.engine.spi.HSQuery;
 import org.hibernate.search.spi.CustomTypeMetadata;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.hibernate.search.test.util.impl.ExpectedLog4jLog;
 import org.hibernate.search.testsupport.TestForIssue;
 import org.hibernate.search.testsupport.junit.SearchFactoryHolder;
@@ -251,8 +253,8 @@ public class CustomTypeMetadataSortingTest {
 		}
 
 		@Override
-		public Class<?> getEntityType() {
-			return PropertySet.class;
+		public IndexedTypeIdentifier getEntityType() {
+			return new PojoIndexedTypeIdentifier( PropertySet.class );
 		}
 
 		@Override
@@ -264,8 +266,8 @@ public class CustomTypeMetadataSortingTest {
 	private static class PersonMetadata implements CustomTypeMetadata {
 
 		@Override
-		public Class<?> getEntityType() {
-			return Person.class;
+		public IndexedTypeIdentifier getEntityType() {
+			return new PojoIndexedTypeIdentifier( Person.class );
 		}
 
 		@Override

--- a/engine/src/test/java/org/hibernate/search/test/util/logging/LoggerInfoStreamTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/util/logging/LoggerInfoStreamTest.java
@@ -18,7 +18,6 @@ import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.store.RAMDirectory;
-import org.apache.lucene.util.Version;
 import org.hibernate.search.util.logging.impl.LoggerInfoStream;
 import org.hibernate.search.util.logging.impl.LuceneLogCategories;
 import org.junit.After;
@@ -29,7 +28,6 @@ import static junit.framework.TestCase.assertFalse;
 
 public class LoggerInfoStreamTest {
 
-	private static final Version VERSION = Version.LUCENE_5_4_0;
 	private Level hsearchLevel;
 	private final Logger hsearchLogger = Logger.getLogger( "org.hibernate.search" );
 	private final Logger rootLogger = Logger.getRootLogger();

--- a/integrationtest/engine-performance/src/main/java/org/hibernate/search/engineperformance/JMHBenchmarks.java
+++ b/integrationtest/engine-performance/src/main/java/org/hibernate/search/engineperformance/JMHBenchmarks.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.engineperformance;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.apache.lucene.search.Query;
@@ -19,6 +18,7 @@ import org.hibernate.search.engineperformance.model.BookEntity;
 import org.hibernate.search.query.engine.spi.EntityInfo;
 import org.hibernate.search.query.engine.spi.HSQuery;
 import org.hibernate.search.spi.SearchIntegrator;
+import org.hibernate.search.spi.impl.IndexedTypesSets;
 import org.hibernate.search.testsupport.setup.TransactionContextForTest;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;
@@ -59,7 +59,7 @@ public class JMHBenchmarks {
 		int maxResults = eh.getMaxResults();
 
 		HSQuery hsQuery = searchIntegrator.createHSQuery( luceneQuery, BookEntity.class );
-		hsQuery.targetedEntities( Arrays.<Class<?>>asList( BookEntity.class ) );
+		hsQuery.targetedEntities( IndexedTypesSets.fromClass( BookEntity.class ) );
 		hsQuery.sort( new Sort( new SortField( "rating", SortField.Type.FLOAT, true ) ) );
 		hsQuery.maxResults( maxResults );
 		int queryResultSize = hsQuery.queryResultSize();
@@ -94,7 +94,7 @@ public class JMHBenchmarks {
 		int maxResults = eh.getMaxResults();
 
 		HSQuery hsQuery = searchIntegrator.createHSQuery( luceneQuery, BookEntity.class );
-		hsQuery.targetedEntities( Arrays.<Class<?>>asList( BookEntity.class ) );
+		hsQuery.targetedEntities( IndexedTypesSets.fromClass( BookEntity.class ) );
 		hsQuery.maxResults( maxResults );
 		int queryResultSize = hsQuery.queryResultSize();
 		List<EntityInfo> queryEntityInfos = hsQuery.queryEntityInfos();

--- a/integrationtest/jms/src/test/java/org/hibernate/search/test/jms/master/JMSMasterTest.java
+++ b/integrationtest/jms/src/test/java/org/hibernate/search/test/jms/master/JMSMasterTest.java
@@ -42,7 +42,9 @@ import org.hibernate.search.backend.spi.SingularTermDeletionQuery;
 import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.engine.ProjectionConstants;
 import org.hibernate.search.query.engine.spi.HSQuery;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.spi.IndexingMode;
+import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.testsupport.TestConstants;
 import org.hibernate.search.testsupport.concurrency.Poller;
@@ -58,6 +60,8 @@ import org.junit.Test;
  * @author Sanne Grinovero
  */
 public class JMSMasterTest extends SearchTestBase {
+
+	private static final IndexedTypeIdentifier tshirtType = new PojoIndexedTypeIdentifier( TShirt.class );
 
 	/**
 	 * Name of the test queue as found in JNDI (see jndi.properties).
@@ -115,7 +119,7 @@ public class JMSMasterTest extends SearchTestBase {
 			POLLER.pollAssertion( () -> assertEquals( 1, listByQuery( "logo:jboss" ).size() ) );
 
 			{
-				DeleteByQueryLuceneWork work = new DeleteByQueryLuceneWork( TShirt.class, new SingularTermDeletionQuery( "logo", "jboss" ) );
+				DeleteByQueryLuceneWork work = new DeleteByQueryLuceneWork( tshirtType, new SingularTermDeletionQuery( "logo", "jboss" ) );
 				List<LuceneWork> l = new ArrayList<>();
 				l.add( work );
 				this.registerMessageListener();
@@ -222,7 +226,7 @@ public class JMSMasterTest extends SearchTestBase {
 		DoubleField numField = new DoubleField( "length", shirt.getLength(), Field.Store.NO );
 		doc.add( numField );
 		LuceneWork luceneWork = new AddLuceneWork(
-				shirt.getId(), String.valueOf( shirt.getId() ), shirt.getClass(), doc
+				shirt.getId(), String.valueOf( shirt.getId() ), tshirtType, doc
 		);
 		List<LuceneWork> queue = new ArrayList<LuceneWork>();
 		queue.add( luceneWork );

--- a/integrationtest/jms/src/test/java/org/hibernate/search/test/jms/master/MDBSearchController.java
+++ b/integrationtest/jms/src/test/java/org/hibernate/search/test/jms/master/MDBSearchController.java
@@ -14,7 +14,7 @@ import org.hibernate.search.spi.SearchIntegrator;
  */
 public class MDBSearchController extends AbstractJMSHibernateSearchController {
 
-	final SearchIntegrator integrator;
+	private final SearchIntegrator integrator;
 
 	MDBSearchController(SearchIntegrator integrator) {
 		this.integrator = integrator;

--- a/integrationtest/jms/src/test/java/org/hibernate/search/test/jms/slave/JMSSlaveTest.java
+++ b/integrationtest/jms/src/test/java/org/hibernate/search/test/jms/slave/JMSSlaveTest.java
@@ -22,6 +22,8 @@ import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.hibernate.search.backend.jms.impl.JmsBackendQueueProcessor;
 import org.hibernate.search.backend.spi.DeleteByQueryWork;
 import org.hibernate.search.backend.spi.SingularTermDeletionQuery;
@@ -42,6 +44,8 @@ import static org.junit.Assert.assertEquals;
  * @author Hardy Ferentschik
  */
 public class JMSSlaveTest extends SearchTestBase {
+
+	private static final IndexedTypeIdentifier TSHIRT_TYPE = new PojoIndexedTypeIdentifier( TShirt.class );
 
 	/**
 	 * Name of the test queue as found in JNDI  (see jndi.properties).
@@ -125,7 +129,7 @@ public class JMSSlaveTest extends SearchTestBase {
 			Transaction tx = s.beginTransaction();
 			TransactionContextForTest tc = new TransactionContextForTest();
 			ExtendedSearchIntegrator integrator = this.getExtendedSearchIntegrator();
-			integrator.getWorker().performWork( new DeleteByQueryWork( TShirt.class, new SingularTermDeletionQuery( "id", String.valueOf( ts.getId() ) ) ), tc );
+			integrator.getWorker().performWork( new DeleteByQueryWork( TSHIRT_TYPE, new SingularTermDeletionQuery( "id", String.valueOf( ts.getId() ) ) ), tc );
 			tc.end();
 			tx.commit();
 		}

--- a/orm/src/main/java/org/hibernate/search/batchindexing/impl/BatchCoordinator.java
+++ b/orm/src/main/java/org/hibernate/search/batchindexing/impl/BatchCoordinator.java
@@ -8,7 +8,6 @@ package org.hibernate.search.batchindexing.impl;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -21,6 +20,8 @@ import org.hibernate.search.backend.spi.BatchBackend;
 import org.hibernate.search.batchindexing.MassIndexerProgressMonitor;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.exception.AssertionFailure;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.IndexedTypeSet;
 import org.hibernate.search.util.impl.Executors;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
@@ -36,7 +37,7 @@ public class BatchCoordinator extends ErrorHandledRunnable {
 
 	private static final Log log = LoggerFactory.make();
 
-	private final Class<?>[] rootEntities; //entity types to reindex excluding all subtypes of each-other
+	private final IndexedTypeSet rootEntities; //entity types to reindex excluding all subtypes of each-other
 	private final SessionFactoryImplementor sessionFactory;
 	private final int typesToIndexInParallel;
 	private final int documentBuilderThreads;
@@ -53,7 +54,7 @@ public class BatchCoordinator extends ErrorHandledRunnable {
 	private final String tenantId;
 	private final List<Future<?>> indexingTasks = new ArrayList<>();
 
-	public BatchCoordinator(Set<Class<?>> rootEntities,
+	public BatchCoordinator(IndexedTypeSet rootEntities,
 							ExtendedSearchIntegrator extendedIntegrator,
 							SessionFactoryImplementor sessionFactory,
 							int typesToIndexInParallel,
@@ -72,7 +73,7 @@ public class BatchCoordinator extends ErrorHandledRunnable {
 		this.idFetchSize = idFetchSize;
 		this.transactionTimeout = transactionTimeout;
 		this.tenantId = tenantId;
-		this.rootEntities = rootEntities.toArray( new Class<?>[rootEntities.size()] );
+		this.rootEntities = rootEntities;
 		this.sessionFactory = sessionFactory;
 		this.typesToIndexInParallel = typesToIndexInParallel;
 		this.documentBuilderThreads = documentBuilderThreads;
@@ -127,7 +128,7 @@ public class BatchCoordinator extends ErrorHandledRunnable {
 	 */
 	private void doBatchWork(BatchBackend backend) throws InterruptedException, ExecutionException {
 		ExecutorService executor = Executors.newFixedThreadPool( typesToIndexInParallel, "BatchIndexingWorkspace" );
-		for ( Class<?> type : rootEntities ) {
+		for ( IndexedTypeIdentifier type : rootEntities ) {
 			indexingTasks.add( executor.submit( new BatchIndexingWorkspace( extendedIntegrator, sessionFactory, type, documentBuilderThreads, cacheMode,
 					objectLoadingBatchSize, endAllSignal, monitor, backend, objectsLimit, idFetchSize, transactionTimeout, tenantId ) ) );
 
@@ -141,7 +142,7 @@ public class BatchCoordinator extends ErrorHandledRunnable {
 	 * @param backend
 	 */
 	private void afterBatch(BatchBackend backend) {
-		Set<Class<?>> targetedClasses = extendedIntegrator.getIndexedTypesPolymorphic( rootEntities );
+		IndexedTypeSet targetedClasses = extendedIntegrator.getIndexedTypesPolymorphic( rootEntities );
 		if ( this.optimizeAtEnd ) {
 			backend.optimize( targetedClasses );
 		}
@@ -154,7 +155,7 @@ public class BatchCoordinator extends ErrorHandledRunnable {
 	 * @param backend
 	 */
 	private void afterBatchOnInterruption(BatchBackend backend) {
-		Set<Class<?>> targetedClasses = extendedIntegrator.getIndexedTypesPolymorphic( rootEntities );
+		IndexedTypeSet targetedClasses = extendedIntegrator.getIndexedTypesPolymorphic( rootEntities );
 		backend.flush( targetedClasses );
 	}
 
@@ -165,10 +166,10 @@ public class BatchCoordinator extends ErrorHandledRunnable {
 	private void beforeBatch(BatchBackend backend) {
 		if ( this.purgeAtStart ) {
 			//purgeAll for affected entities
-			Set<Class<?>> targetedClasses = extendedIntegrator.getIndexedTypesPolymorphic( rootEntities );
-			for ( Class<?> clazz : targetedClasses ) {
+			IndexedTypeSet targetedClasses = extendedIntegrator.getIndexedTypesPolymorphic( rootEntities );
+			for ( IndexedTypeIdentifier type : targetedClasses ) {
 				//needs do be in-sync work to make sure we wait for the end of it.
-				backend.doWorkInSync( new PurgeAllLuceneWork( tenantId, clazz ) );
+				backend.doWorkInSync( new PurgeAllLuceneWork( tenantId, type ) );
 			}
 			if ( this.optimizeAfterPurge ) {
 				backend.optimize( targetedClasses );

--- a/orm/src/main/java/org/hibernate/search/batchindexing/impl/BatchIndexingWorkspace.java
+++ b/orm/src/main/java/org/hibernate/search/batchindexing/impl/BatchIndexingWorkspace.java
@@ -21,6 +21,7 @@ import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.exception.AssertionFailure;
 import org.hibernate.search.exception.ErrorHandler;
 import org.hibernate.search.exception.SearchException;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.util.impl.Executors;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
@@ -40,7 +41,7 @@ public class BatchIndexingWorkspace extends ErrorHandledRunnable {
 	private final ProducerConsumerQueue<List<Serializable>> primaryKeyStream;
 
 	private final int documentBuilderThreads;
-	private final Class<?> indexedType;
+	private final IndexedTypeIdentifier indexedType;
 	private final String idNameOfIndexedType;
 
 	// status control
@@ -67,7 +68,7 @@ public class BatchIndexingWorkspace extends ErrorHandledRunnable {
 
 	public BatchIndexingWorkspace(ExtendedSearchIntegrator extendedIntegrator,
 								SessionFactoryImplementor sessionFactory,
-								Class<?> entityType,
+								IndexedTypeIdentifier type,
 								int objectLoadingThreads,
 								CacheMode cacheMode,
 								int objectLoadingBatchSize,
@@ -79,11 +80,11 @@ public class BatchIndexingWorkspace extends ErrorHandledRunnable {
 								Integer transactionTimeout,
 								String tenantId) {
 		super( extendedIntegrator );
-		this.indexedType = entityType;
+		this.indexedType = type;
 		this.idFetchSize = idFetchSize;
 		this.transactionTimeout = transactionTimeout;
 		this.tenantId = tenantId;
-		this.idNameOfIndexedType = extendedIntegrator.getIndexBinding( entityType )
+		this.idNameOfIndexedType = extendedIntegrator.getIndexBinding( type )
 				.getDocumentBuilder()
 				.getIdPropertyName();
 		this.sessionFactory = sessionFactory;

--- a/orm/src/main/java/org/hibernate/search/batchindexing/impl/IdentifierProducer.java
+++ b/orm/src/main/java/org/hibernate/search/batchindexing/impl/IdentifierProducer.java
@@ -22,6 +22,7 @@ import org.hibernate.internal.CriteriaImpl;
 import org.hibernate.internal.StatelessSessionImpl;
 import org.hibernate.search.batchindexing.MassIndexerProgressMonitor;
 import org.hibernate.search.exception.ErrorHandler;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
@@ -44,7 +45,7 @@ public class IdentifierProducer implements StatelessSessionAwareRunnable {
 	private final ProducerConsumerQueue<List<Serializable>> destination;
 	private final SessionFactory sessionFactory;
 	private final int batchSize;
-	private final Class<?> indexedType;
+	private final IndexedTypeIdentifier indexedType;
 	private final MassIndexerProgressMonitor monitor;
 	private final long objectsLimit;
 	private final int idFetchSize;
@@ -66,7 +67,7 @@ public class IdentifierProducer implements StatelessSessionAwareRunnable {
 			ProducerConsumerQueue<List<Serializable>> fromIdentifierListToEntities,
 			SessionFactory sessionFactory,
 			int objectLoadingBatchSize,
-			Class<?> indexedType, MassIndexerProgressMonitor monitor,
+			IndexedTypeIdentifier indexedType, MassIndexerProgressMonitor monitor,
 			long objectsLimit, ErrorHandler errorHandler, int idFetchSize, String tenantId) {
 				this.destination = fromIdentifierListToEntities;
 				this.sessionFactory = sessionFactory;

--- a/orm/src/main/java/org/hibernate/search/engine/impl/HibernateStatelessInitializer.java
+++ b/orm/src/main/java/org/hibernate/search/engine/impl/HibernateStatelessInitializer.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 import java.util.Map;
 
 import org.hibernate.search.backend.spi.Work;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.spi.InstanceInitializer;
 import org.hibernate.search.hcore.util.impl.HibernateHelper;
 
@@ -61,6 +62,11 @@ public class HibernateStatelessInitializer implements InstanceInitializer {
 	@Override
 	public Class<?> getClassFromWork(Work work) {
 		return HibernateHelper.getClassFromWork( work );
+	}
+
+	@Override
+	public IndexedTypeIdentifier getIndexedTypeIdFromWork(Work work) {
+		return HibernateHelper.getIndexedTypeIdFromWork( work );
 	}
 
 }

--- a/orm/src/main/java/org/hibernate/search/hcore/util/impl/HibernateHelper.java
+++ b/orm/src/main/java/org/hibernate/search/hcore/util/impl/HibernateHelper.java
@@ -10,6 +10,8 @@ package org.hibernate.search.hcore.util.impl;
 import org.hibernate.Hibernate;
 import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.search.backend.spi.Work;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 
 /**
  * @author Emmanuel Bernard
@@ -38,10 +40,17 @@ public final class HibernateHelper {
 		return Hibernate.isInitialized( entity );
 	}
 
+	@Deprecated
 	public static Class<?> getClassFromWork(Work work) {
 		return work.getEntityClass() != null ?
 				work.getEntityClass() :
 				getClass( work.getEntity() );
+	}
+
+	public static IndexedTypeIdentifier getIndexedTypeIdFromWork(Work work) {
+		return work.getTypeIdentifier() != null ?
+				work.getTypeIdentifier() :
+				new PojoIndexedTypeIdentifier( getClass( work.getEntity() ) );
 	}
 
 	public static Object unproxy(Object value) {
@@ -50,4 +59,5 @@ public final class HibernateHelper {
 		}
 		return value;
 	}
+
 }

--- a/orm/src/main/java/org/hibernate/search/impl/ImplementationFactory.java
+++ b/orm/src/main/java/org/hibernate/search/impl/ImplementationFactory.java
@@ -8,7 +8,7 @@ package org.hibernate.search.impl;
 
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.SearchFactory;
-import org.hibernate.search.spi.SearchIntegrator;
+import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
@@ -35,7 +35,7 @@ public final class ImplementationFactory {
 		}
 	}
 
-	public static SearchFactory createSearchFactory(SearchIntegrator searchIntegrator) {
+	public static SearchFactory createSearchFactory(ExtendedSearchIntegrator searchIntegrator) {
 		return new SearchFactoryImpl( searchIntegrator );
 	}
 

--- a/orm/src/main/java/org/hibernate/search/impl/SearchFactoryImpl.java
+++ b/orm/src/main/java/org/hibernate/search/impl/SearchFactoryImpl.java
@@ -10,9 +10,11 @@ import java.util.Set;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.hibernate.search.SearchFactory;
+import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.indexes.IndexReaderAccessor;
 import org.hibernate.search.metadata.IndexedTypeDescriptor;
 import org.hibernate.search.query.dsl.QueryContextBuilder;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.spi.SearchIntegrator;
 import org.hibernate.search.stat.Statistics;
 
@@ -25,9 +27,9 @@ import org.hibernate.search.stat.Statistics;
  */
 final class SearchFactoryImpl implements SearchFactory {
 
-	private final SearchIntegrator searchIntegrator;
+	private final ExtendedSearchIntegrator searchIntegrator;
 
-	public SearchFactoryImpl(SearchIntegrator searchIntegrator) {
+	public SearchFactoryImpl(ExtendedSearchIntegrator searchIntegrator) {
 		this.searchIntegrator = searchIntegrator;
 	}
 
@@ -37,8 +39,9 @@ final class SearchFactoryImpl implements SearchFactory {
 	}
 
 	@Override
-	public void optimize(Class<?> entityType) {
-		searchIntegrator.optimize( entityType );
+	public void optimize(Class<?> clazz) {
+		IndexedTypeIdentifier typeId = searchIntegrator.getIndexBindings().keyFromPojoType( clazz );
+		searchIntegrator.optimize( typeId );
 	}
 
 	@Override
@@ -48,7 +51,8 @@ final class SearchFactoryImpl implements SearchFactory {
 
 	@Override
 	public Analyzer getAnalyzer(Class<?> clazz) {
-		return searchIntegrator.getAnalyzer( clazz );
+		IndexedTypeIdentifier typeId = searchIntegrator.getIndexBindings().keyFromPojoType( clazz );
+		return searchIntegrator.getAnalyzer( typeId );
 	}
 
 	@Override

--- a/orm/src/main/java/org/hibernate/search/jmx/impl/IndexControl.java
+++ b/orm/src/main/java/org/hibernate/search/jmx/impl/IndexControl.java
@@ -18,6 +18,7 @@ import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.engine.service.classloading.spi.ClassLoaderService;
 import org.hibernate.search.engine.service.classloading.spi.ClassLoadingException;
 import org.hibernate.search.jmx.IndexControlMBean;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 
 /**
  * Implementation of the {@code IndexControlMBean} JMX attributes and operations.
@@ -88,8 +89,8 @@ public class IndexControl implements IndexControlMBean {
 
 	@Override
 	public void optimize(String entity) {
-		Class<?> clazz = getEntityClass( entity );
-		extendedIntegrator.optimize( clazz );
+		IndexedTypeIdentifier typeIdentifier = extendedIntegrator.getIndexBindings().keyFromName( entity );
+		extendedIntegrator.optimize( typeIdentifier );
 	}
 
 	@Override

--- a/orm/src/main/java/org/hibernate/search/query/hibernate/impl/FullTextQueryImpl.java
+++ b/orm/src/main/java/org/hibernate/search/query/hibernate/impl/FullTextQueryImpl.java
@@ -84,7 +84,7 @@ public class FullTextQueryImpl extends AbstractProducedQuery implements FullText
 	/**
 	 * Constructs a  <code>FullTextQueryImpl</code> instance.
 	 *
-	 * @param hSearchQuery The query, with the {@link HSQuery#targetedEntities(List) targeted entities} already set if necessary.
+	 * @param hSearchQuery The query, with the {@link HSQuery#targetedEntities(org.hibernate.search.spi.IndexedTypesSet) targeted entities} already set if necessary.
 	 * @param session Access to the Hibernate session.
 	 * @param parameterMetadata Additional query metadata.
 	 */
@@ -164,7 +164,7 @@ public class FullTextQueryImpl extends AbstractProducedQuery implements FullText
 		ObjectLoaderBuilder loaderBuilder = new ObjectLoaderBuilder()
 				.criteria( criteria )
 				.targetedEntities( hSearchQuery.getTargetedEntities() )
-				.indexedTargetedEntities( hSearchQuery.getIndexedTargetedEntities() )
+				.indexedTargetedEntities( hSearchQuery.getIndexedTargetedEntities().toPojosSet() )
 				.session( session )
 				.searchFactory( hSearchQuery.getExtendedSearchIntegrator() )
 				.timeoutManager( hSearchQuery.getTimeoutManager() )

--- a/orm/src/main/java/org/hibernate/search/query/hibernate/impl/MultiClassesQueryLoader.java
+++ b/orm/src/main/java/org/hibernate/search/query/hibernate/impl/MultiClassesQueryLoader.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import org.hibernate.Session;
@@ -19,6 +20,7 @@ import org.hibernate.search.engine.spi.EntityIndexBinding;
 import org.hibernate.search.exception.AssertionFailure;
 import org.hibernate.search.query.engine.spi.EntityInfo;
 import org.hibernate.search.query.engine.spi.TimeoutManager;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 
 /**
  * A loader which loads objects of multiple types.
@@ -55,10 +57,10 @@ public class MultiClassesQueryLoader extends AbstractLoader {
 		// root entity could lead to quite inefficient queries in Hibernate when using table per class
 		if ( entityTypes.size() == 0 ) {
 			//support all classes
-			for ( Map.Entry<Class<?>, EntityIndexBinding> entry : extendedIntegrator.getIndexBindings().entrySet() ) {
+			for ( Entry<IndexedTypeIdentifier, EntityIndexBinding> entry : extendedIntegrator.getIndexBindings().entrySet() ) {
 				//get only root entities to limit queries
 				if ( entry.getValue().getDocumentBuilder().isRoot() ) {
-					safeEntityTypes.add( entry.getKey() );
+					safeEntityTypes.add( entry.getKey().getPojoType() );
 				}
 			}
 		}

--- a/orm/src/main/java/org/hibernate/search/query/hibernate/impl/ObjectLoaderBuilder.java
+++ b/orm/src/main/java/org/hibernate/search/query/hibernate/impl/ObjectLoaderBuilder.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.query.hibernate.impl;
 
-import java.util.List;
 import java.util.Set;
 
 import org.hibernate.Criteria;
@@ -22,6 +21,7 @@ import org.hibernate.search.exception.AssertionFailure;
 import org.hibernate.search.query.DatabaseRetrievalMethod;
 import org.hibernate.search.query.ObjectLookupMethod;
 import org.hibernate.search.query.engine.spi.TimeoutManager;
+import org.hibernate.search.spi.IndexedTypeSet;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
@@ -30,7 +30,7 @@ import org.hibernate.search.util.logging.impl.LoggerFactory;
  */
 public class ObjectLoaderBuilder {
 	private Criteria criteria;
-	private List<Class<?>> targetedEntities;
+	private IndexedTypeSet targetedEntities;
 	private SessionImplementor session;
 	private ExtendedSearchIntegrator extendedIntegrator;
 	private Set<Class<?>> indexedTargetedEntities;
@@ -44,7 +44,7 @@ public class ObjectLoaderBuilder {
 		return this;
 	}
 
-	public ObjectLoaderBuilder targetedEntities(List<Class<?>> targetedEntities) {
+	public ObjectLoaderBuilder targetedEntities(IndexedTypeSet targetedEntities) {
 		this.targetedEntities = targetedEntities;
 		return this;
 	}
@@ -81,7 +81,7 @@ public class ObjectLoaderBuilder {
 	private Loader getSingleEntityLoader() {
 		final QueryLoader queryLoader = new QueryLoader();
 		queryLoader.init( (Session) session, extendedIntegrator, getObjectInitializer(), timeoutManager );
-		queryLoader.setEntityType( targetedEntities.iterator().next() );
+		queryLoader.setEntityType( targetedEntities.iterator().next().getPojoType() );
 		return queryLoader;
 	}
 
@@ -89,7 +89,7 @@ public class ObjectLoaderBuilder {
 		if ( targetedEntities.size() > 1 ) {
 			throw new SearchException( "Cannot mix criteria and multiple entity types" );
 		}
-		Class entityType = targetedEntities.size() == 0 ? null : targetedEntities.iterator().next();
+		Class entityType = targetedEntities.size() == 0 ? null : targetedEntities.iterator().next().getPojoType();
 		if ( criteria instanceof CriteriaImpl ) {
 			String targetEntity = ( (CriteriaImpl) criteria ).getEntityOrClassName();
 			if ( entityType == null ) {

--- a/orm/src/main/java/org/hibernate/search/query/hibernate/impl/PersistenceContextObjectInitializer.java
+++ b/orm/src/main/java/org/hibernate/search/query/hibernate/impl/PersistenceContextObjectInitializer.java
@@ -37,9 +37,7 @@ public class PersistenceContextObjectInitializer implements ObjectInitializer {
 		final int numberOfObjectsToInitialize = entityInfos.size();
 
 		if ( numberOfObjectsToInitialize == 0 ) {
-			if ( log.isTraceEnabled() ) {
-				log.tracef( "No object to initialize" );
-			}
+			log.tracef( "No object to initialize" );
 			return;
 		}
 
@@ -59,7 +57,7 @@ public class PersistenceContextObjectInitializer implements ObjectInitializer {
 					remainingEntityInfos.add( entityInfo );
 				}
 				else {
-					EntityInfoLoadKey key = new EntityInfoLoadKey( entityInfo.getClazz(), entityInfo.getId() );
+					EntityInfoLoadKey key = new EntityInfoLoadKey( entityInfo.getType().getPojoType(), entityInfo.getId() );
 					idToObjectMap.put( key, o );
 				}
 			}

--- a/orm/src/test/java/org/hibernate/search/test/SearchTestBase.java
+++ b/orm/src/test/java/org/hibernate/search/test/SearchTestBase.java
@@ -16,6 +16,8 @@ import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.search.SearchFactory;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.hibernate.search.test.util.BackendTestHelper;
 import org.hibernate.search.test.util.TestConfiguration;
 import org.hibernate.search.testsupport.TestConstants;
@@ -106,7 +108,17 @@ public abstract class SearchTestBase implements TestResourceManager, TestConfigu
 		return Collections.emptySet();
 	}
 
+	/**
+	 * Use {@link #getNumberOfDocumentsInIndex(IndexedTypeIdentifier)}
+	 * @param entityType
+	 * @return
+	 */
+	@Deprecated
 	protected int getNumberOfDocumentsInIndex(Class<?> entityType) {
+		return getNumberOfDocumentsInIndex( new PojoIndexedTypeIdentifier( entityType ) );
+	}
+
+	protected int getNumberOfDocumentsInIndex(IndexedTypeIdentifier entityType) {
 		return getBackendTestHelper().getNumberOfDocumentsInIndex( entityType );
 	}
 

--- a/orm/src/test/java/org/hibernate/search/test/batchindexing/SearchIndexerTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/batchindexing/SearchIndexerTest.java
@@ -92,7 +92,7 @@ public class SearchIndexerTest {
 		}
 
 		public Set<Class<?>> getRootEntities() {
-			return this.rootEntities;
+			return this.rootEntities.toPojosSet();
 		}
 
 	}

--- a/orm/src/test/java/org/hibernate/search/test/directoryProvider/RamDirectoryTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/directoryProvider/RamDirectoryTest.java
@@ -16,6 +16,7 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.search.TermQuery;
 import org.hibernate.Session;
 import org.hibernate.search.Search;
+import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.hibernate.search.test.AlternateDocument;
 import org.hibernate.search.test.Document;
 import org.hibernate.search.test.SearchInitializationTestBase;
@@ -101,6 +102,7 @@ public class RamDirectoryTest extends SearchInitializationTestBase {
 	}
 
 	private int getDocumentNbr() throws Exception {
-		return getBackendTestHelper().getNumberOfDocumentsInIndex( Document.class );
+		return getBackendTestHelper().getNumberOfDocumentsInIndex( new PojoIndexedTypeIdentifier( Document.class ) );
 	}
+
 }

--- a/orm/src/test/java/org/hibernate/search/test/errorhandling/LuceneErrorHandlingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/errorhandling/LuceneErrorHandlingTest.java
@@ -26,7 +26,9 @@ import org.hibernate.search.exception.ErrorHandler;
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.exception.impl.LogErrorHandler;
 import org.hibernate.search.indexes.spi.IndexManager;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.spi.SearchIntegrator;
+import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
 import org.junit.Assert;
@@ -45,12 +47,14 @@ import org.junit.experimental.categories.Category;
 @Category(SkipOnElasticsearch.class) // This test is Lucene-specific. The equivalent for Elasticsearch is ElasticsearchIndexWorkProcessorErrorHandlingTest
 public class LuceneErrorHandlingTest extends SearchTestBase {
 
-	static final AtomicInteger WORK_COUNTER = new AtomicInteger();
+	private static final IndexedTypeIdentifier testTypeId = new PojoIndexedTypeIdentifier( Foo.class );
+
+	private static final AtomicInteger WORK_COUNTER = new AtomicInteger();
 
 	@Test
 	public void testErrorHandling() {
 		MockErrorHandler mockErrorHandler = getErrorHandlerAndAssertCorrectTypeIsUsed();
-		EntityIndexBinding mappingForEntity = getExtendedSearchIntegrator().getIndexBinding( Foo.class );
+		EntityIndexBinding mappingForEntity = getExtendedSearchIntegrator().getIndexBinding( testTypeId );
 		IndexManager indexManager = mappingForEntity.getIndexManagers()[0];
 
 		List<LuceneWork> queue = new ArrayList<LuceneWork>();
@@ -94,7 +98,7 @@ public class LuceneErrorHandlingTest extends SearchTestBase {
 	@Test
 	public void testNoEntityErrorHandling() {
 		MockErrorHandler mockErrorHandler = getErrorHandlerAndAssertCorrectTypeIsUsed();
-		EntityIndexBinding mappingForEntity = getExtendedSearchIntegrator().getIndexBinding( Foo.class );
+		EntityIndexBinding mappingForEntity = getExtendedSearchIntegrator().getIndexBinding( testTypeId );
 		IndexManager indexManager = mappingForEntity.getIndexManagers()[0];
 
 		List<LuceneWork> queue = new ArrayList<LuceneWork>();
@@ -148,7 +152,7 @@ public class LuceneErrorHandlingTest extends SearchTestBase {
 	static class HarmlessWork extends DeleteLuceneWork {
 
 		public HarmlessWork(String workIdentifier) {
-			super( workIdentifier, workIdentifier, Foo.class );
+			super( workIdentifier, workIdentifier, testTypeId );
 		}
 
 		@Override
@@ -189,7 +193,7 @@ public class LuceneErrorHandlingTest extends SearchTestBase {
 	static class FailingWork extends DeleteLuceneWork {
 
 		public FailingWork(String workIdentifier) {
-			super( workIdentifier, workIdentifier, Foo.class );
+			super( workIdentifier, workIdentifier, testTypeId );
 		}
 
 		@Override

--- a/orm/src/test/java/org/hibernate/search/test/util/BackendTestHelper.java
+++ b/orm/src/test/java/org/hibernate/search/test/util/BackendTestHelper.java
@@ -22,6 +22,7 @@ import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.indexes.IndexReaderAccessor;
 import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
 import org.hibernate.search.indexes.spi.IndexManager;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
 import org.hibernate.search.test.TestResourceManager;
 
 /**
@@ -55,7 +56,7 @@ public abstract class BackendTestHelper {
 	/**
 	 * Returns the number of indexed documents for the given type.
 	 */
-	public abstract int getNumberOfDocumentsInIndex(Class<?> entityType);
+	public abstract int getNumberOfDocumentsInIndex(IndexedTypeIdentifier entityType);
 
 	/**
 	 * Returns the number of indexed documents for the given index.
@@ -76,7 +77,7 @@ public abstract class BackendTestHelper {
 			this.resourceManager = resourceManager;
 		}
 
-		public Directory getDirectory(Class<?> entityType) {
+		public Directory getDirectory(IndexedTypeIdentifier entityType) {
 			ExtendedSearchIntegrator integrator = resourceManager.getExtendedSearchIntegrator();
 			IndexManager[] indexManagers = integrator.getIndexBinding( entityType ).getIndexManagers();
 			DirectoryBasedIndexManager indexManager = (DirectoryBasedIndexManager) indexManagers[0];
@@ -84,7 +85,7 @@ public abstract class BackendTestHelper {
 		}
 
 		@Override
-		public int getNumberOfDocumentsInIndex(Class<?> entityType) {
+		public int getNumberOfDocumentsInIndex(IndexedTypeIdentifier entityType) {
 			try ( IndexReader reader = DirectoryReader.open( getDirectory( entityType ) ) ) {
 				return reader.numDocs();
 			}

--- a/serialization/avro/src/test/java/org/hibernate/search/test/serialization/ConcurrentServiceTest.java
+++ b/serialization/avro/src/test/java/org/hibernate/search/test/serialization/ConcurrentServiceTest.java
@@ -17,6 +17,8 @@ import org.hibernate.search.backend.OptimizeLuceneWork;
 import org.hibernate.search.backend.PurgeAllLuceneWork;
 import org.hibernate.search.engine.service.spi.ServiceReference;
 import org.hibernate.search.indexes.serialization.spi.LuceneWorkSerializer;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.hibernate.search.testsupport.TestForIssue;
 import org.hibernate.search.testsupport.concurrency.ConcurrentRunner;
 import org.hibernate.search.testsupport.concurrency.ConcurrentRunner.TaskFactory;
@@ -113,12 +115,13 @@ public class ConcurrentServiceTest {
 		List<LuceneWork> works = new ArrayList<>();
 		works.add( OptimizeLuceneWork.INSTANCE );
 		works.add( OptimizeLuceneWork.INSTANCE );
-		works.add( new OptimizeLuceneWork( RemoteEntity.class ) ); //class won't be send over
-		works.add( new PurgeAllLuceneWork( RemoteEntity.class ) );
-		works.add( new PurgeAllLuceneWork( RemoteEntity.class ) );
-		works.add( new DeleteLuceneWork( 123l, "123", RemoteEntity.class ) );
-		works.add( new DeleteLuceneWork( "Foo", "Bar", RemoteEntity.class ) );
-		works.add( new AddLuceneWork( 125, "125", RemoteEntity.class, new Document() ) );
+		IndexedTypeIdentifier type = new PojoIndexedTypeIdentifier( RemoteEntity.class );
+		works.add( new OptimizeLuceneWork( type ) ); //won't be send over
+		works.add( new PurgeAllLuceneWork( type ) );
+		works.add( new PurgeAllLuceneWork( type ) );
+		works.add( new DeleteLuceneWork( 123l, "123", type ) );
+		works.add( new DeleteLuceneWork( "Foo", "Bar", type ) );
+		works.add( new AddLuceneWork( 125, "125", type, new Document() ) );
 		return works;
 	}
 

--- a/serialization/avro/src/test/java/org/hibernate/search/test/serialization/DocValuesSerializationTest.java
+++ b/serialization/avro/src/test/java/org/hibernate/search/test/serialization/DocValuesSerializationTest.java
@@ -21,6 +21,8 @@ import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.engine.service.impl.StandardServiceManager;
 import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.indexes.serialization.spi.LuceneWorkSerializer;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.hibernate.search.test.util.SerializationTestHelper;
 import org.hibernate.search.testsupport.TestForIssue;
 import org.hibernate.search.testsupport.junit.SearchFactoryHolder;
@@ -35,6 +37,8 @@ import org.junit.Test;
  */
 @TestForIssue(jiraKey = "HSEARCH-1795")
 public class DocValuesSerializationTest {
+
+	private static final IndexedTypeIdentifier remoteTypeId = new PojoIndexedTypeIdentifier( RemoteEntity.class );
 
 	@Rule
 	public SearchFactoryHolder searchFactoryHolder = new SearchFactoryHolder( RemoteEntity.class );
@@ -124,7 +128,7 @@ public class DocValuesSerializationTest {
 
 	private List<LuceneWork> buildLuceneWorks(Document document) {
 		List<LuceneWork> works = new ArrayList<>();
-		works.add( new AddLuceneWork( 123, "123", RemoteEntity.class, document ) );
+		works.add( new AddLuceneWork( 123, "123", remoteTypeId, document ) );
 		return works;
 	}
 }

--- a/serialization/avro/src/test/java/org/hibernate/search/test/serialization/ProtocolBackwardCompatibilityTest.java
+++ b/serialization/avro/src/test/java/org/hibernate/search/test/serialization/ProtocolBackwardCompatibilityTest.java
@@ -46,6 +46,8 @@ import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.indexes.serialization.avro.impl.KnownProtocols;
 import org.hibernate.search.indexes.serialization.impl.CopyTokenStream;
 import org.hibernate.search.indexes.serialization.spi.LuceneWorkSerializer;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.hibernate.search.test.util.SerializationTestHelper;
 import org.hibernate.search.testsupport.junit.SearchFactoryHolder;
 import org.hibernate.search.testsupport.setup.BuildContextForTest;
@@ -61,7 +63,9 @@ import org.junit.Test;
  * @author Hardy Ferentschik
  */
 public class ProtocolBackwardCompatibilityTest {
+
 	private static final String RESOURCE_BASE_NAME = "persistent-work-avro-";
+	private static final IndexedTypeIdentifier remoteTypeId = new PojoIndexedTypeIdentifier( RemoteEntity.class );
 
 	@Rule
 	public SearchFactoryHolder searchFactoryHolder = new SearchFactoryHolder( RemoteEntity.class );
@@ -128,16 +132,16 @@ public class ProtocolBackwardCompatibilityTest {
 		List<LuceneWork> works = new ArrayList<>();
 		works.add( OptimizeLuceneWork.INSTANCE );
 		works.add( OptimizeLuceneWork.INSTANCE );
-		works.add( new OptimizeLuceneWork( RemoteEntity.class ) ); //class won't be send over
-		works.add( new PurgeAllLuceneWork( RemoteEntity.class ) );
-		works.add( new PurgeAllLuceneWork( RemoteEntity.class ) );
-		works.add( new DeleteLuceneWork( 123l, "123", RemoteEntity.class ) );
-		works.add( new DeleteLuceneWork( "Sissi", "Sissi", RemoteEntity.class ) );
+		works.add( new OptimizeLuceneWork( remoteTypeId ) ); //class won't be send over
+		works.add( new PurgeAllLuceneWork( remoteTypeId ) );
+		works.add( new PurgeAllLuceneWork( remoteTypeId ) );
+		works.add( new DeleteLuceneWork( 123l, "123", remoteTypeId ) );
+		works.add( new DeleteLuceneWork( "Sissi", "Sissi", remoteTypeId ) );
 		works.add(
 				new DeleteLuceneWork(
 						new URL( "http://emmanuelbernard.com" ),
 						"http://emmanuelbernard.com",
-						RemoteEntity.class
+						remoteTypeId
 				)
 		);
 
@@ -153,7 +157,8 @@ public class ProtocolBackwardCompatibilityTest {
 
 		Map<String, String> analyzers = new HashMap<>();
 		analyzers.put( "godo", "ngram" );
-		works.add( new AddLuceneWork( 123, "123", RemoteEntity.class, doc, analyzers ) );
+
+		works.add( new AddLuceneWork( 123, "123", remoteTypeId, doc, analyzers ) );
 
 		doc = new Document();
 		Field field = new Field(
@@ -194,8 +199,8 @@ public class ProtocolBackwardCompatibilityTest {
 		field.setBoost( 3f );
 		doc.add( field );
 
-		works.add( new UpdateLuceneWork( 1234, "1234", RemoteEntity.class, doc ) );
-		works.add( new AddLuceneWork( 125, "125", RemoteEntity.class, new Document() ) );
+		works.add( new UpdateLuceneWork( 1234, "1234", remoteTypeId, doc ) );
+		works.add( new AddLuceneWork( 125, "125", remoteTypeId, new Document() ) );
 		return works;
 	}
 
@@ -212,7 +217,7 @@ public class ProtocolBackwardCompatibilityTest {
 		document.add( new BinaryDocValuesField( "foo", new BytesRef( "world" ) ) );
 		document.add( new SortedSetDocValuesField( "foo", new BytesRef( "hello" ) ) );
 		document.add( new SortedDocValuesField( "foo", new BytesRef( "world" ) ) );
-		works.add( new AddLuceneWork( 123, "123", RemoteEntity.class, document ) );
+		works.add( new AddLuceneWork( 123, "123", remoteTypeId, document ) );
 		return works;
 	}
 

--- a/serialization/avro/src/test/java/org/hibernate/search/test/serialization/SerializationTest.java
+++ b/serialization/avro/src/test/java/org/hibernate/search/test/serialization/SerializationTest.java
@@ -33,6 +33,8 @@ import org.hibernate.search.engine.service.impl.StandardServiceManager;
 import org.hibernate.search.engine.service.spi.ServiceManager;
 import org.hibernate.search.indexes.serialization.impl.CopyTokenStream;
 import org.hibernate.search.indexes.serialization.spi.LuceneWorkSerializer;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.hibernate.search.test.util.SerializationTestHelper;
 import org.hibernate.search.test.util.SerializationTestHelper.SerializableStringReader;
 import org.hibernate.search.testsupport.junit.SearchFactoryHolder;
@@ -49,6 +51,8 @@ import static org.fest.assertions.Assertions.assertThat;
  * @author Hardy Ferentschik
  */
 public class SerializationTest {
+
+	private static final IndexedTypeIdentifier remoteTypeId = new PojoIndexedTypeIdentifier( RemoteEntity.class );
 
 	@Rule
 	public SearchFactoryHolder searchFactoryHolder = new SearchFactoryHolder( RemoteEntity.class );
@@ -96,29 +100,30 @@ public class SerializationTest {
 		List<LuceneWork> works = new ArrayList<LuceneWork>();
 		works.add( OptimizeLuceneWork.INSTANCE );
 		works.add( OptimizeLuceneWork.INSTANCE );
-		works.add( new OptimizeLuceneWork( RemoteEntity.class ) ); //class won't be send over
-		works.add( new PurgeAllLuceneWork( RemoteEntity.class ) );
-		works.add( new PurgeAllLuceneWork( RemoteEntity.class ) );
-		works.add( new DeleteByQueryLuceneWork( RemoteEntity.class, new SingularTermDeletionQuery( "key", "value" ) ) );
-		works.add( new DeleteLuceneWork( 123l, "123", RemoteEntity.class ) );
-		works.add( new DeleteLuceneWork( "Sissi", "Sissi", RemoteEntity.class ) );
+		IndexedTypeIdentifier remoteTypeId = new PojoIndexedTypeIdentifier( RemoteEntity.class );
+		works.add( new OptimizeLuceneWork( remoteTypeId ) ); //won't be send over
+		works.add( new PurgeAllLuceneWork( remoteTypeId ) );
+		works.add( new PurgeAllLuceneWork( remoteTypeId ) );
+		works.add( new DeleteByQueryLuceneWork( remoteTypeId, new SingularTermDeletionQuery( "key", "value" ) ) );
+		works.add( new DeleteLuceneWork( 123l, "123", remoteTypeId ) );
+		works.add( new DeleteLuceneWork( "Sissi", "Sissi", remoteTypeId ) );
 		works.add(
 				new DeleteLuceneWork(
 						new URL( "http://emmanuelbernard.com" ),
 						"http://emmanuelbernard.com",
-						RemoteEntity.class
+						remoteTypeId
 				)
 		);
 
 		Document doc = buildDocumentWithNumericFields();
 		Map<String, String> analyzers = new HashMap<String, String>();
 		analyzers.put( "godo", "ngram" );
-		works.add( new AddLuceneWork( 123, "123", RemoteEntity.class, doc, analyzers ) );
+		works.add( new AddLuceneWork( 123, "123", remoteTypeId, doc, analyzers ) );
 
 		doc = buildDocumentWithMultipleMixedTypeFields();
-		works.add( new UpdateLuceneWork( 1234, "1234", RemoteEntity.class, doc ) );
+		works.add( new UpdateLuceneWork( 1234, "1234", remoteTypeId, doc ) );
 
-		works.add( new AddLuceneWork( 125, "125", RemoteEntity.class, new Document() ) );
+		works.add( new AddLuceneWork( 125, "125", remoteTypeId, new Document() ) );
 		return works;
 	}
 

--- a/serialization/avro/src/test/java/org/hibernate/search/test/util/SerializationTestHelper.java
+++ b/serialization/avro/src/test/java/org/hibernate/search/test/util/SerializationTestHelper.java
@@ -128,7 +128,7 @@ public final class SerializationTestHelper {
 	}
 
 	private static void assertAdd(AddLuceneWork work, AddLuceneWork copy) {
-		assertThat( copy.getEntityClass() ).as( "Add.getEntityClass is not copied" ).isEqualTo( work.getEntityClass() );
+		assertThat( copy.getEntityType() ).as( "Add.getEntityClass is not copied" ).isEqualTo( work.getEntityType() );
 		assertThat( copy.getId() ).as( "Add.getId is not copied" ).isEqualTo( work.getId() );
 		assertThat( copy.getIdInString() ).as( "Add.getIdInString is not the same" ).isEqualTo( work.getIdInString() );
 		assertThat( copy.getFieldToAnalyzerMap() ).as( "Add.getFieldToAnalyzerMap is not the same" )
@@ -137,7 +137,7 @@ public final class SerializationTestHelper {
 	}
 
 	private static void assertUpdate(UpdateLuceneWork work, UpdateLuceneWork copy) {
-		assertThat( copy.getEntityClass() ).as( "Add.getEntityClass is not copied" ).isEqualTo( work.getEntityClass() );
+		assertThat( copy.getEntityType() ).as( "Add.getEntityClass is not copied" ).isEqualTo( work.getEntityType() );
 		assertThat( copy.getId() ).as( "Add.getId is not copied" ).isEqualTo( work.getId() );
 		assertThat( copy.getIdInString() ).as( "Add.getIdInString is not the same" ).isEqualTo( work.getIdInString() );
 		assertThat( copy.getFieldToAnalyzerMap() ).as( "Add.getFieldToAnalyzerMap is not the same" )
@@ -146,7 +146,7 @@ public final class SerializationTestHelper {
 	}
 
 	private static void assertDeleteByQuery(DeleteByQueryLuceneWork work, DeleteByQueryLuceneWork copy) {
-		assertThat( work.getEntityClass() ).as( "DeleteByQuery.getEntityClass is not copied" ).isEqualTo( copy.getEntityClass() );
+		assertThat( work.getEntityType() ).as( "DeleteByQuery.getEntityClass is not copied" ).isEqualTo( copy.getEntityType() );
 		assertThat( work.getDeletionQuery() ).as( "DeleteByQuery.getDeletionQuery is not copied" ).isEqualTo( copy.getDeletionQuery() );
 	}
 
@@ -273,8 +273,8 @@ public final class SerializationTestHelper {
 	}
 
 	private static void assertDelete(DeleteLuceneWork work, DeleteLuceneWork copy) {
-		assertThat( work.getEntityClass() ).as( "Delete.getEntityClass is not copied" )
-				.isEqualTo( copy.getEntityClass() );
+		assertThat( work.getEntityType() ).as( "Delete.getEntityClass is not copied" )
+				.isEqualTo( copy.getEntityType() );
 		assertThat( work.getId() ).as( "Delete.getId is not copied" ).isEqualTo( copy.getId() );
 		assertThat( (Object) work.getDocument() ).as( "Delete.getDocument is not the same" )
 				.isEqualTo( copy.getDocument() );
@@ -285,13 +285,13 @@ public final class SerializationTestHelper {
 	}
 
 	private static void assertPurgeAll(PurgeAllLuceneWork work, PurgeAllLuceneWork copy) {
-		assertThat( work.getEntityClass() ).as( "PurgeAllLuceneWork.getEntityClass is not copied" )
-				.isEqualTo( copy.getEntityClass() );
+		assertThat( work.getEntityType() ).as( "PurgeAllLuceneWork.getEntityClass is not copied" )
+				.isEqualTo( copy.getEntityType() );
 	}
 
 	private static void assertFlush(FlushLuceneWork work, FlushLuceneWork copy) {
-		assertThat( copy.getEntityClass() ).as( "FlushLuceneWork.getEntityClass is not copied" )
-				.isEqualTo( work.getEntityClass() );
+		assertThat( copy.getEntityType() ).as( "FlushLuceneWork.getEntityClass is not copied" )
+				.isEqualTo( work.getEntityType() );
 	}
 
 	public static class SerializableStringReader extends Reader implements Serializable {


### PR DESCRIPTION
 - https://hibernate.atlassian.net/browse/HSEARCH-1404

The new utility and collection classes have more functionality than what is going to be needed in future; in part that's to keep many of the new-deprecated methods standing. They are not cast in stone, I expect we'll polish them later.

In particular I don't want this double-type system to become a burden on performance, so part of the design is driven to make it possible to (eventually) avoid allocating any of these objects on hot paths.

Not least, I hope to reuse some of these structures: while previously we would create Sets of classes as needed, for example to compute the polymorphic hiearchy of a specific root - of only the known indexed types - such sets can be pre-computed and reused for each known type.
To get there this includes seeds towards a type registry, incidentally if we manage to push the no-allocation to the limits this will allow reference based comparisons and to optimise for fast, uncontended lookups in read-only.

The reason I avoided Java standard collections is to evolve into immutable structures and aggressively trim down on the exposed methods so that we can understand how to tune these; to keep some of the deprecated methods "afloat" for now they are not immutable yet.