### PR TITLE
Remove an obsolete Java service in Wildfly/CDI integration tests

### DIFF
--- a/integrationtest/wildfly/src/test/resources/cdi/META-INF/services/javax.enterprise.inject.spi.Extension
+++ b/integrationtest/wildfly/src/test/resources/cdi/META-INF/services/javax.enterprise.inject.spi.Extension
@@ -1,1 +1,0 @@
-org.hibernate.search.test.integration.wildfly.cdi.integration.CDIHibernateIntegrationExtension


### PR DESCRIPTION
It's a leftover from my experimentations...