### PR TITLE
HSEARCH-2788 Remove unnecessary calls to Thread.sleep in CDI/Wildfly tests

### DIFF
--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/wildfly/cdi/CDIInjectionIT.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/wildfly/cdi/CDIInjectionIT.java
@@ -84,7 +84,6 @@ public class CDIInjectionIT {
 
 	@Test
 	public void injectedFieldBridge() throws InterruptedException {
-		Thread.sleep( 10000 );
 		Function<String, List<EntityWithCDIAwareBridges>> search = dao::searchFieldBridge;
 
 		assertThat( search.apply( "bonjour" ) ).onProperty( "id" ).isEmpty();
@@ -117,7 +116,6 @@ public class CDIInjectionIT {
 
 	@Test
 	public void injectedClassBridge() throws InterruptedException {
-		Thread.sleep( 10000 );
 		Function<String, List<EntityWithCDIAwareBridges>> search = dao::searchClassBridge;
 
 		assertThat( search.apply( "bonjour" ) ).onProperty( "id" ).isEmpty();


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-2788
