### PR TITLE
HSEARCH-2789 Test that the CREATE strategy actually doesn't create mappings when the index already exists

### DIFF
--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIndexStatusCheckIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIndexStatusCheckIT.java
@@ -35,13 +35,14 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 /**
- * Tests for {@link ElasticsearchIndexManager}'s schema validation feature.
+ * Tests for {@link ElasticsearchIndexManager}'s behavior with respect
+ * to checking that the index has the correct status before starting to work with it.
  *
  * @author Yoann Rodiere
  */
 @RunWith(Parameterized.class)
 @TestForIssue(jiraKey = "HSEARCH-2456")
-public class ElasticsearchIndexExistsCheckIT extends SearchInitializationTestBase {
+public class ElasticsearchIndexStatusCheckIT extends SearchInitializationTestBase {
 
 	@Parameters(name = "With strategy {0}")
 	public static Iterable<IndexSchemaManagementStrategy> strategies() {
@@ -57,7 +58,7 @@ public class ElasticsearchIndexExistsCheckIT extends SearchInitializationTestBas
 
 	private IndexSchemaManagementStrategy strategy;
 
-	public ElasticsearchIndexExistsCheckIT(IndexSchemaManagementStrategy strategy) {
+	public ElasticsearchIndexStatusCheckIT(IndexSchemaManagementStrategy strategy) {
 		super();
 		this.strategy = strategy;
 	}

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchSchemaCreateStrategyIT.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchSchemaCreateStrategyIT.java
@@ -1,0 +1,96 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.test;
+
+import static org.hibernate.search.elasticsearch.testutil.JsonHelper.assertJsonEquals;
+import static org.hibernate.search.elasticsearch.testutil.JsonHelper.assertJsonEqualsIgnoringUnknownFields;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.elasticsearch.cfg.ElasticsearchEnvironment;
+import org.hibernate.search.elasticsearch.cfg.IndexSchemaManagementStrategy;
+import org.hibernate.search.elasticsearch.impl.ElasticsearchIndexManager;
+import org.hibernate.search.elasticsearch.testutil.TestElasticsearchClient;
+import org.hibernate.search.test.SearchInitializationTestBase;
+import org.hibernate.search.test.util.ImmutableTestConfiguration;
+import org.hibernate.testing.TestForIssue;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests for {@link ElasticsearchIndexManager}'s schema creation feature.
+ *
+ * @author Yoann Rodiere
+ */
+public class ElasticsearchSchemaCreateStrategyIT extends SearchInitializationTestBase {
+
+	@Rule
+	public final TestElasticsearchClient elasticSearchClient = new TestElasticsearchClient();
+
+	@Override
+	protected void init(Class<?>... annotatedClasses) {
+		Map<String, Object> settings = new HashMap<>();
+		settings.put(
+				"hibernate.search.default." + ElasticsearchEnvironment.INDEX_SCHEMA_MANAGEMENT_STRATEGY,
+				IndexSchemaManagementStrategy.CREATE.getExternalName()
+		);
+		init( new ImmutableTestConfiguration( settings, annotatedClasses ) );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-2789")
+	public void alreadyExists() throws Exception {
+		elasticSearchClient.index( SimpleStringEntity.class ).deleteAndCreate();
+
+		assertJsonEquals(
+				"{ }",
+				elasticSearchClient.type( SimpleStringEntity.class ).getMapping()
+		);
+
+		init( SimpleStringEntity.class );
+
+		assertJsonEquals(
+				"{ }",
+				elasticSearchClient.type( SimpleStringEntity.class ).getMapping()
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-2789")
+	public void doesNotExist() throws Exception {
+		elasticSearchClient.index( SimpleStringEntity.class )
+				.ensureDoesNotExist().registerForCleanup();
+
+		init( SimpleStringEntity.class );
+
+		// Just check that *something* changed
+		// Other test classes check that the changes actually make sense
+		assertJsonEqualsIgnoringUnknownFields(
+				"{ 'properties': { 'field': { } } }",
+				elasticSearchClient.type( SimpleStringEntity.class ).getMapping()
+		);
+	}
+
+	@Indexed
+	@Entity
+	private static class SimpleStringEntity {
+		@DocumentId
+		@Id
+		Long id;
+
+		@Field
+		String field;
+	}
+
+}


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-2789
