### PR TITLE
Enable Apache HTTP and Elasticsearch RestClient logs in tests

### DIFF
--- a/backends/jgroups/src/test/resources/log4j.properties
+++ b/backends/jgroups/src/test/resources/log4j.properties
@@ -26,6 +26,7 @@ log4j.logger.org.hibernate=warn
 
 log4j.logger.org.hibernate.search=debug
 log4j.logger.org.apache.http=info
+log4j.logger.org.elasticsearch.client=debug
 #log4j.logger.org.hibernate.search.backend=debug
 
 ### log just the SQL

--- a/elasticsearch/src/test/resources/log4j.properties
+++ b/elasticsearch/src/test/resources/log4j.properties
@@ -25,6 +25,8 @@ log4j.logger.org.jboss=info
 log4j.logger.org.hibernate=warn
 
 log4j.logger.org.hibernate.search=debug
+log4j.logger.org.apache.http=info
+log4j.logger.org.elasticsearch.client=debug
 #log4j.logger.org.hibernate.search.elasticsearch.request=trace
 #log4j.logger.org.hibernate.search.backend=debug
 


### PR DESCRIPTION
This should help debug [HSEARCH-2682](https://hibernate.atlassian.net//browse/HSEARCH-2682) (not fixed yet), which I cannot reproduce on my machine, and which I'm having trouble to reproduce on the CI through repeated builds...
