### PR TITLE
HSEARCH-2682 Malformed HTTP responses from Elasticsearch are not handled consistently

### DIFF
--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/DefaultElasticsearchClientFactoryTest.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/DefaultElasticsearchClientFactoryTest.java
@@ -303,8 +303,7 @@ public class DefaultElasticsearchClientFactoryTest {
 	public void multipleHosts_failover_fault() throws Exception {
 		SearchConfigurationForTest configuration = SearchConfigurationForTest.noTestDefaults()
 				.addProperty( ElasticsearchEnvironment.SERVER_URI,
-						httpUrlFor( wireMockRule1 ) + " " + httpUrlFor( wireMockRule2 ) )
-				.addProperty( ElasticsearchEnvironment.SERVER_READ_TIMEOUT, "1000" /* 1s */ );
+						httpUrlFor( wireMockRule1 ) + " " + httpUrlFor( wireMockRule2 ) );
 
 		String payload = "{ \"foo\": \"bar\" }";
 		wireMockRule1.stubFor( post( urlPathLike( "/myIndex/myType" ) )


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-2682

It seems removing the (useless) timeout does the trick: I ran the test approximatively 70 times on the CI and got no failure (see http://ci.hibernate.org/job/hibernate-search-yoann/99/ and the previous ones).