### PR TITLE
HSEARCH-2802 Make sure the default elasticsearch profile will only be enabled if the ES version is not provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1790,9 +1790,9 @@ org.hibernate.search.spi.SearchIntegratorBuilder#buildSearchIntegrator()
         <profile>
             <id>elasticsearch-5.2</id>
             <activation>
-                <!-- Activate by default, i.e. if testElasticsearchVersion has not been defined explicitly -->
+                <!-- Activate by default, i.e. if test.elasticsearch.host.version has not been defined explicitly -->
                 <property>
-                    <name>!test.elasticsearch.mavenPlugin.version</name>
+                    <name>!test.elasticsearch.host.version</name>
                 </property>
             </activation>
             <properties>


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-2802

@Sanne I didn't remove your modifications to the README, it's probably safer that way.