### PR TITLE
Fix abstract method errors in Checkstyle 8

### DIFF
--- a/build-config/src/main/java/org/hibernate/checkstyle/checks/regexp/DoubleSpacesCheck.java
+++ b/build-config/src/main/java/org/hibernate/checkstyle/checks/regexp/DoubleSpacesCheck.java
@@ -40,6 +40,16 @@ public class DoubleSpacesCheck extends AbstractCheck {
 	}
 
 	@Override
+	public int[] getAcceptableTokens() {
+		return getDefaultTokens();
+	}
+
+	@Override
+	public int[] getRequiredTokens() {
+		return getDefaultTokens();
+	}
+
+	@Override
 	public void beginTree(DetailAST aRootAST) {
 		initializeSuppressors( getFileContents() );
 		processLines( Arrays.asList( getLines() ) );


### PR DESCRIPTION
This PR is being created because of a new compilation error found in CheckStyle's regression of hibernate-search.
PR: checkstyle/checkstyle#4573
Original Issue: checkstyle/checkstyle#605
New Issue: checkstyle/checkstyle#4582

We are breaking multiple APIs in Checkstyle 8 to clean up some bad coding styles. This changed the 2 methods to abstract forcing all Checks to specifically implement their intended behavior for their token handling.

You can either accept this PR and not have an issue when you upgrade CS with this fix in the future,
or make your own change/fix later when you do upgrade CS.
Please let us know which way you intend to go.

Feel free to ask any other questions or propose any additional changes.
Thanks.