### PR TITLE
HSEARCH-2807 DSLTest numeric tests use order-sensitive assertions on queries without a sort

### DIFF
--- a/engine/src/test/java/org/hibernate/search/test/dsl/DSLTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/dsl/DSLTest.java
@@ -615,7 +615,7 @@ public class DSLTest {
 						.ignoreFieldBridge().ignoreAnalyzer()
 					.below( 1 ).excludeLimit()
 					.createQuery();
-		helper.assertThat( query ).from( Month.class ).matchesExactlyIds( 1 );
+		helper.assertThat( query ).from( Month.class ).matchesUnorderedIds( 1 );
 	}
 
 	@Test
@@ -629,7 +629,7 @@ public class DSLTest {
 						.ignoreFieldBridge().ignoreAnalyzer()
 					.matching( 0 )
 					.createQuery();
-		helper.assertThat( query ).from( Month.class ).matchesExactlyIds( 1 );
+		helper.assertThat( query ).from( Month.class ).matchesUnorderedIds( 1 );
 	}
 
 	@Test
@@ -785,7 +785,7 @@ public class DSLTest {
 
 		assertTrue( query.getClass().isAssignableFrom( NumericRangeQuery.class ) );
 
-		helper.assertThat( query ).from( Month.class ).matchesExactlyIds( 1, 2, 3 );
+		helper.assertThat( query ).from( Month.class ).matchesUnorderedIds( 1, 2, 3 );
 
 		//exclusive
 		query = monthQb
@@ -795,7 +795,7 @@ public class DSLTest {
 					.excludeLimit()
 					.createQuery();
 
-		helper.assertThat( query ).from( Month.class ).matchesExactlyIds( 2, 3 );
+		helper.assertThat( query ).from( Month.class ).matchesUnorderedIds( 2, 3 );
 	}
 
 	@Test
@@ -812,7 +812,7 @@ public class DSLTest {
 
 		assertTrue( query.getClass().isAssignableFrom( NumericRangeQuery.class ) );
 
-		helper.assertThat( query ).from( Month.class ).matchesExactlyIds( 1, 2, 3 );
+		helper.assertThat( query ).from( Month.class ).matchesUnorderedIds( 1, 2, 3 );
 
 		//exclusive
 		query = monthQb
@@ -822,7 +822,7 @@ public class DSLTest {
 					.excludeLimit()
 					.createQuery();
 
-		helper.assertThat( query ).from( Month.class ).matchesExactlyIds( 1 );
+		helper.assertThat( query ).from( Month.class ).matchesUnorderedIds( 1 );
 	}
 
 	@Test

--- a/engine/src/test/java/org/hibernate/search/testsupport/junit/SearchITHelper.java
+++ b/engine/src/test/java/org/hibernate/search/testsupport/junit/SearchITHelper.java
@@ -309,6 +309,19 @@ public class SearchITHelper {
 		}
 
 		@SafeVarargs
+		public final AssertHSQueryContext matchesUnorderedIds(Serializable ... expectedIds) {
+			Object[] objectArray = Arrays.stream( expectedIds ).toArray();
+			asResultIds().containsOnly( objectArray );
+			return this;
+		}
+
+		public final AssertHSQueryContext matchesUnorderedIds(int[] expectedIds) {
+			Object[] objectArray = Arrays.stream( expectedIds ).mapToObj( i -> i ).toArray();
+			asResultIds().containsOnly( objectArray );
+			return this;
+		}
+
+		@SafeVarargs
 		public final AssertHSQueryContext matchesExactlyProjections(Object[] ... expectedProjections) {
 			Object[] objectArray = Arrays.stream( expectedProjections )
 					.map( Arrays::asList ) // Take advantage of List.equals
@@ -323,6 +336,24 @@ public class SearchITHelper {
 					.map( p -> Arrays.asList( p ) ) // Take advantage of List.equals
 					.toArray();
 			asResultProjectionsAsLists().containsExactly( objectArray );
+			return this;
+		}
+
+		@SafeVarargs
+		public final AssertHSQueryContext matchesUnorderedProjections(Object[] ... expectedProjections) {
+			Object[] objectArray = Arrays.stream( expectedProjections )
+					.map( Arrays::asList ) // Take advantage of List.equals
+					.toArray();
+			asResultProjectionsAsLists().containsOnly( objectArray );
+			return this;
+		}
+
+		@SafeVarargs
+		public final <T> AssertHSQueryContext matchesUnorderedSingleProjections(T ... expectedSingleElementProjections) {
+			Object[] objectArray = Arrays.stream( expectedSingleElementProjections )
+					.map( p -> Arrays.asList( p ) ) // Take advantage of List.equals
+					.toArray();
+			asResultProjectionsAsLists().containsOnly( objectArray );
 			return this;
 		}
 


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-2807
