### PR TITLE
HSEARCH-2809 Upgrade to Elasticsearch 5.5.0

### DIFF
--- a/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/testutil/TestElasticsearchClient.java
+++ b/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/testutil/TestElasticsearchClient.java
@@ -310,7 +310,12 @@ public class TestElasticsearchClient extends ExternalResource {
 	}
 
 	private String getMapping(URLEncodedString indexName, URLEncodedString mappingName) {
-		ElasticsearchResponse response = performRequest( ElasticsearchRequest.get()
+		/*
+		 * Elasticsearch 5.5+ triggers a 404 error when mappings are missing,
+		 * while 5.4 and below just return an empty mapping.
+		 * In our case, an empty mapping is fine, so we'll just ignore 404.
+		 */
+		ElasticsearchResponse response = performRequestIgnore404( ElasticsearchRequest.get()
 				.pathComponent( indexName ).pathComponent( Paths._MAPPING ).pathComponent( mappingName )
 				.build() );
 		JsonObject result = response.getBody();

--- a/pom.xml
+++ b/pom.xml
@@ -1804,7 +1804,7 @@ org.hibernate.search.spi.SearchIntegratorBuilder#buildSearchIntegrator()
             </activation>
             <properties>
                 <test.elasticsearch.mavenPlugin.version>5.7</test.elasticsearch.mavenPlugin.version>
-                <test.elasticsearch.host.version>5.4.2</test.elasticsearch.host.version>
+                <test.elasticsearch.host.version>5.5.0</test.elasticsearch.host.version>
             </properties>
             <build>
                 <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -213,8 +213,8 @@
         <commonsCodecVersion>1.10</commonsCodecVersion>
 
         <!-- Elasticsearch -->
-        <elasticsearchClientVersion>5.4.2</elasticsearchClientVersion>
-        <elasticsearchSnifferVersion>5.4.2</elasticsearchSnifferVersion>
+        <elasticsearchClientVersion>5.5.0</elasticsearchClientVersion>
+        <elasticsearchSnifferVersion>5.5.0</elasticsearchSnifferVersion>
         <elasticsearchGsonVersion>2.8.0</elasticsearchGsonVersion>
         <elasticsearchAWSV4SignerVersion>1.3</elasticsearchAWSV4SignerVersion>
         


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-2809

Tests in progress on Travis + Jenkins.