### PR TITLE
HSEARCH-2818

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/DigestSelfSigningCapable.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/DigestSelfSigningCapable.java
@@ -1,0 +1,27 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.util.impl;
+
+import java.io.IOException;
+
+/**
+ * In some cases we can have more efficient code by delegating
+ * the computation of the Sha256 to the container object.
+ *
+ * @author Sanne Grinovero (C) 2017 Red Hat Inc.
+ */
+public interface DigestSelfSigningCapable {
+
+	/**
+	 * Sign the content using an equivalent strategy to
+	 * {@link org.apache.commons.codec.digest.DigestUtils.sha256(InputStream)}
+	 * @return the computed digest
+	 * @throws IOException
+	 */
+	byte[] getSha256DigestSignature() throws IOException;
+
+}

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/ElasticsearchClientUtils.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/ElasticsearchClientUtils.java
@@ -49,31 +49,30 @@ public class ElasticsearchClientUtils {
 	}
 
 	public static String formatRequest(GsonProvider gsonProvider, ElasticsearchRequest request) {
-		StringBuilder sb = new StringBuilder();
+		//Wild guess for some tuning. The only certainty is that the default (16) is too small.
+		StringBuilder sb = new StringBuilder( 180 );
 
-		sb.append( "Method: " ).append( request.getMethod() ).append( "\n" );
-		sb.append( "Path: " ).append( request.getPath() ).append( "\n" );
-
-		sb.append( "Data:\n" );
-		sb.append( formatRequestData( gsonProvider, request ) );
+		sb.append( "Method: " ).append( request.getMethod() );
+		sb.append( "\nPath: " ).append( request.getPath() );
+		sb.append( "\nData:\n" );
+		appendRequestData( sb, gsonProvider, request );
 		sb.append( "\n" );
 		return sb.toString();
 	}
 
-	public static String formatRequestData(GsonProvider gsonProvider, ElasticsearchRequest request) {
+	private static void appendRequestData(StringBuilder sb, GsonProvider gsonProvider, ElasticsearchRequest request) {
 		List<JsonObject> bodyParts = request.getBodyParts();
 		Gson gson = gsonProvider.getGsonPrettyPrinting();
-		StringBuilder builder = new StringBuilder();
 		for ( JsonObject bodyPart : bodyParts ) {
-			gson.toJson( bodyPart, builder );
-			builder.append("\n");
+			gson.toJson( bodyPart, sb );
+			sb.append("\n");
 		}
-		return builder.toString();
 	}
 
-	public static String formatRequestData(GsonProvider gsonProvider, JsonObject body) {
-		Gson gson = gsonProvider.getGsonPrettyPrinting();
-		return gson.toJson( body );
+	public static String formatRequestData(GsonProvider gsonProvider, ElasticsearchRequest request) {
+		StringBuilder sb = new StringBuilder( 180 );
+		appendRequestData( sb, gsonProvider, request );
+		return sb.toString();
 	}
 
 	public static String formatResponse(GsonProvider gsonProvider, ElasticsearchResponse response) {
@@ -81,24 +80,27 @@ public class ElasticsearchClientUtils {
 			return null;
 		}
 		JsonObject body = response.getBody();
-		StringBuilder sb = new StringBuilder();
-		sb.append( "Status: " ).append( response.getStatusCode() ).append( " " ).append( response.getStatusMessage() ).append( "\n" );
-		sb.append( "Error message: " ).append( propertyAsString( body, "error" ) ).append( "\n" );
-		sb.append( "Cluster name: " ).append( propertyAsString( body, "cluster_name" ) ).append( "\n" );
-		sb.append( "Cluster status: " ).append( propertyAsString( body, "status" ) ).append( "\n" );
-		sb.append( "\n" );
+		//Wild guess for some tuning. The only certainty is that the default (16) is too small.
+		//Also useful to hint the builder to use larger increment steps.
+		StringBuilder sb = new StringBuilder( 180 );
+		sb.append( "Status: " ).append( response.getStatusCode() ).append( " " ).append( response.getStatusMessage() );
+		sb.append( "\nError message: " ).append( propertyAsString( body, "error" ) );
+		sb.append( "\nCluster name: " ).append( propertyAsString( body, "cluster_name" ) );
+		sb.append( "\nCluster status: " ).append( propertyAsString( body, "status" ) );
+		sb.append( "\n\n" );
 
 		JsonElement items = property( body, "items" );
 		if ( items != null && items.isJsonArray() ) {
 			for ( JsonElement item : items.getAsJsonArray() ) {
 				for ( Map.Entry<String, JsonElement> entry : item.getAsJsonObject().entrySet() ) {
-					sb.append( "Operation: " ).append( entry.getKey() ).append( "\n" );
+					sb.append( "Operation: " ).append( entry.getKey() );
 					JsonElement value = entry.getValue();
-					sb.append( "  Index: " ).append( propertyAsString( value, "_index" ) ).append( "\n" );
-					sb.append( "  Type: " ).append( propertyAsString( value, "_type" ) ).append( "\n" );
-					sb.append( "  Id: " ).append( propertyAsString( value, "_id" ) ).append( "\n" );
-					sb.append( "  Status: " ).append( propertyAsString( value, "status" ) ).append( "\n" );
-					sb.append( "  Error: " ).append( propertyAsString( value, "error" ) ).append( "\n" );
+					sb.append( "\n  Index: " ).append( propertyAsString( value, "_index" ) );
+					sb.append( "\n  Type: " ).append( propertyAsString( value, "_type" ) );
+					sb.append( "\n  Id: " ).append( propertyAsString( value, "_id" ) );
+					sb.append( "\n  Status: " ).append( propertyAsString( value, "status" ) );
+					sb.append( "\n  Error: " ).append( propertyAsString( value, "error" ) );
+					sb.append( "\n" );
 				}
 			}
 		}
@@ -117,10 +119,10 @@ public class ElasticsearchClientUtils {
 		if ( parent == null || !parent.isJsonObject() ) {
 			return null;
 		}
-		JsonElement propretyValue = property( parent.getAsJsonObject(), name );
-		if ( propretyValue == null ) {
+		JsonElement propertyValue = property( parent.getAsJsonObject(), name );
+		if ( propertyValue == null ) {
 			return null;
 		}
-		return propretyValue.toString(); // Also support non-string properties
+		return propertyValue.toString(); // Also support non-string properties
 	}
 }

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/ElasticsearchClientUtils.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/ElasticsearchClientUtils.java
@@ -10,8 +10,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.http.HttpEntity;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
 import org.hibernate.search.elasticsearch.client.impl.ElasticsearchRequest;
 import org.hibernate.search.elasticsearch.client.impl.ElasticsearchResponse;
 import org.hibernate.search.elasticsearch.gson.impl.GsonProvider;
@@ -25,8 +23,6 @@ import com.google.gson.JsonObject;
  */
 public class ElasticsearchClientUtils {
 
-	private static final ContentType JSON_CONTENT_TYPE = ContentType.APPLICATION_JSON.withCharset("utf-8");
-
 	private ElasticsearchClientUtils() {
 		// Private constructor
 	}
@@ -36,16 +32,11 @@ public class ElasticsearchClientUtils {
 	}
 
 	public static HttpEntity toEntity(Gson gson, ElasticsearchRequest request) {
-		List<JsonObject> bodyParts = request.getBodyParts();
+		final List<JsonObject> bodyParts = request.getBodyParts();
 		if ( bodyParts.isEmpty() ) {
 			return null;
 		}
-		StringBuilder builder = new StringBuilder();
-		for ( JsonObject bodyPart : bodyParts ) {
-			gson.toJson( bodyPart, builder );
-			builder.append("\n");
-		}
-		return new StringEntity( builder.toString(), JSON_CONTENT_TYPE );
+		return new GsonHttpEntity( gson, bodyParts );
 	}
 
 	public static String formatRequest(GsonProvider gsonProvider, ElasticsearchRequest request) {

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/GsonHttpEntity.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/GsonHttpEntity.java
@@ -1,0 +1,206 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.util.impl;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Writer;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.entity.ContentType;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.nio.ContentEncoder;
+import org.apache.http.nio.IOControl;
+import org.apache.http.nio.entity.HttpAsyncContentProducer;
+import org.apache.http.protocol.HTTP;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonIOException;
+import com.google.gson.JsonObject;
+import com.google.gson.stream.JsonWriter;
+
+/**
+ * Optimised adapter to encode GSON objects into HttpEntity instances.
+ * The naive approach was using various StringBuilders and the kind
+ * of objects we need to serialize into JSON were causing the internal
+ * StringBuilder buffers to need frequent resizing.
+ *
+ * Rather than trying to guess reasonable default sizes for these buffers,
+ * we can defer the serialization to write directly into the ByteBuffer
+ * of the HTTP client.
+ * By doing so we can use buffer pages of a fixed size, limit it to a
+ * reasonable threshold, and reuse it for the next pages.
+ *
+ * To implement this trick we have to implement both interfaces.
+ *
+ * @author Sanne Grinovero (C) 2017 Red Hat Inc.
+ */
+final class GsonHttpEntity implements HttpEntity, HttpAsyncContentProducer {
+
+	/**
+	 * A conservative guess at the size of the buffer (in characters!)
+	 * needed to hold the produced JSON document.
+	 * Picking a too low size will cause CPU overhead, a too large size
+	 * will allocate unnecessarily large buffers (waste memory).
+	 * The heap consumption is short lived: we aim at fitting in TLAB.
+	 */
+	private static final int WRITE_BUFFER_SIZE = 512;
+
+	private static final BasicHeader CONTENT_TYPE = new BasicHeader( HTTP.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString() );
+
+	private final Gson gson;
+	private final List<JsonObject> bodyParts;
+
+	GsonHttpEntity(Gson gson, List<JsonObject> bodyParts) {
+		Objects.requireNonNull( gson );
+		Objects.requireNonNull( bodyParts );
+		this.gson = gson;
+		this.bodyParts = bodyParts;
+	}
+
+	@Override
+	public boolean isRepeatable() {
+		return true;
+	}
+
+	@Override
+	public boolean isChunked() {
+		return false;
+	}
+
+	@Override
+	public long getContentLength() {
+		//Can't compute the size in advance using this strategy
+		return -1;
+	}
+
+	@Override
+	public Header getContentType() {
+		return CONTENT_TYPE;
+	}
+
+	@Override
+	public Header getContentEncoding() {
+		return null;
+	}
+
+	@Override
+	public InputStream getContent() {
+		//This could be implemented but would be inefficient.
+		//I therefore prefer throwing the exception so that we can easily spot unintended usage via tests.
+		throw new UnsupportedOperationException( "Not implemented! Expected to produce content only over produceContent()" );
+	}
+
+	@Override
+	public void writeTo(OutputStream outstream) throws IOException {
+		//This could be implemented but would be inefficient.
+		//I therefore prefer throwing the exception so that we can easily spot unintended usage via tests.
+		throw new UnsupportedOperationException( "Not implemented! Expected to produce content only over produceContent()" );
+	}
+
+	@Override
+	public boolean isStreaming() {
+		return false;
+	}
+
+	@Override
+	public void consumeContent() throws IOException {
+		//not used (and deprecated)
+	}
+
+	@Override
+	public void close() throws IOException {
+		//Nothing to close
+	}
+
+	@Override
+	public void produceContent(ContentEncoder encoder, IOControl ioctrl) throws IOException {
+		Objects.requireNonNull( encoder );
+		Objects.requireNonNull( ioctrl );
+
+		// We still need to allocate a buffer, but it's going to be of a fixed "page" size.
+		// when the page is full rather than growing and copying, we transfer that section
+		// into the network buffers.
+		// TODO verify if this causes actual network chunking - and if so which sizes we should suggest using.
+		BoundedCharBuffer sink = new BoundedCharBuffer( encoder );
+		JsonWriter writer = createGsonWriter( sink );
+
+		for ( JsonObject bodyPart : bodyParts ) {
+			gson.toJson( bodyPart, writer );
+			sink.appendNewline();
+		}
+		sink.flush();
+		encoder.complete();
+	}
+
+	private JsonWriter createGsonWriter(Writer builder) {
+		final JsonWriter writer;
+		try {
+			writer = gson.newJsonWriter( builder );
+		}
+		catch (IOException e) {
+			throw new JsonIOException( e );
+		}
+		return writer;
+	}
+
+	private static final class BoundedCharBuffer extends Writer {
+
+		final CharBuffer buffer = CharBuffer.allocate( WRITE_BUFFER_SIZE );
+		final ContentEncoder out;
+
+		BoundedCharBuffer(ContentEncoder underlying) {
+			this.out = underlying;
+		}
+
+		public void appendNewline() throws IOException {
+			if ( buffer.remaining() < 1 ) {
+				flush();
+			}
+			buffer.put( '\n' );
+		}
+
+		@Override
+		public void write(char[] cbuf, int off, int len) throws IOException {
+			while ( true ) {
+				int toCopy = Math.min( buffer.remaining(), len );
+				buffer.put( cbuf, off, toCopy );
+				len -= toCopy;
+				if ( len > 0 ) { // it didn't fit in the current buffer
+					flush();
+					off += toCopy;
+				}
+				else {
+					// Done
+					return;
+				}
+			}
+		}
+
+		@Override
+		public void flush() throws IOException {
+			buffer.flip();
+			ByteBuffer byteBuffer = StandardCharsets.UTF_8.encode( buffer );
+			out.write( byteBuffer );
+			buffer.clear();
+		}
+
+		@Override
+		public void close() {
+			//Nothing to close
+		}
+
+	}
+
+}


### PR DESCRIPTION
The first commit is trivial.

The second one is extremely interesting: see the screenshots I attached on JIRA.

It reduced the "out of TLAB allocations" from 4,20**GB** to 2,7**MB** of the whole system. Running the blackhole/ES benchmark using its default settings.

https://hibernate.atlassian.net/browse/HSEARCH-2818