### PR TITLE
HSEARCH-2818 Optimise encoding of GSON elements into HTTP client buffers

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/spi/DigestSelfSigningCapable.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/spi/DigestSelfSigningCapable.java
@@ -1,0 +1,24 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.spi;
+
+import java.io.IOException;
+import java.security.MessageDigest;
+
+/**
+ * Interface to be applied on HttpEntity instances to
+ * customize the digest encoding:
+ * in some cases we can have more efficient code by delegating
+ * the computation of digests to the container object.
+ *
+ * @author Sanne Grinovero (C) 2017 Red Hat Inc.
+ */
+public interface DigestSelfSigningCapable {
+
+	void fillDigest(MessageDigest dig) throws IOException;
+
+}

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/ElasticsearchClientUtils.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/ElasticsearchClientUtils.java
@@ -9,8 +9,6 @@ package org.hibernate.search.elasticsearch.util.impl;
 import java.util.List;
 
 import org.apache.http.HttpEntity;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
 import org.hibernate.search.elasticsearch.client.impl.ElasticsearchRequest;
 
 import com.google.gson.Gson;
@@ -21,8 +19,6 @@ import com.google.gson.JsonObject;
  */
 public class ElasticsearchClientUtils {
 
-	private static final ContentType JSON_CONTENT_TYPE = ContentType.APPLICATION_JSON.withCharset("utf-8");
-
 	private ElasticsearchClientUtils() {
 		// Private constructor
 	}
@@ -32,16 +28,11 @@ public class ElasticsearchClientUtils {
 	}
 
 	public static HttpEntity toEntity(Gson gson, ElasticsearchRequest request) {
-		List<JsonObject> bodyParts = request.getBodyParts();
+		final List<JsonObject> bodyParts = request.getBodyParts();
 		if ( bodyParts.isEmpty() ) {
 			return null;
 		}
-		StringBuilder builder = new StringBuilder();
-		for ( JsonObject bodyPart : bodyParts ) {
-			gson.toJson( bodyPart, builder );
-			builder.append("\n");
-		}
-		return new StringEntity( builder.toString(), JSON_CONTENT_TYPE );
+		return new GsonHttpEntity( gson, bodyParts );
 	}
 
 }

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/GsonHttpEntity.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/GsonHttpEntity.java
@@ -6,12 +6,15 @@
  */
 package org.hibernate.search.elasticsearch.util.impl;
 
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Writer;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CoderResult;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.ArrayList;
@@ -61,6 +64,20 @@ public final class GsonHttpEntity implements HttpEntity, HttpAsyncContentProduce
 
 	private static final BasicHeader CONTENT_TYPE = new BasicHeader( HTTP.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString() );
 
+	/**
+	 * N.B. two different buffers of this same size are created.
+	 * We want them both of approximately the same "page size",
+	 * however one is in characters and the other in bytes.
+	 * Considering we hardcoded UTF-8 as encoding, which has an average
+	 * conversion ratio of 1.0 this should be close enough.
+	 *
+	 * It's a rather large size: a tradeoff for very large JSON
+	 * documents as we do heavy bulking, and not too large to
+	 * be a penalty for small requests.
+	 * 1024 has been shown to produce reasonable, TLAB only garbage.
+	 */
+	private static final int BUFFER_SIZES = 1024;
+
 	private final Gson gson;
 	private final List<JsonObject> bodyParts;
 
@@ -70,6 +87,16 @@ public final class GsonHttpEntity implements HttpEntity, HttpAsyncContentProduce
 	 * content needs to be computed.
 	 */
 	private long contentLength = -1l;
+
+	/**
+	 * We can lazily compute the contentLenght, but we need to avoid changing the value
+	 * we report over time as this confuses the Apache HTTP client as it initially defines
+	 * the encoding strategy based on this, then assumes it can rely on this being
+	 * a constant.
+	 * After the {@link #getContentLength()} was invoked at least once, freeze
+	 * the value.
+	 */
+	private boolean contentlengthWasProvided = false;
 
 	/**
 	 * Since flow control might hint to stop producing data,
@@ -87,7 +114,13 @@ public final class GsonHttpEntity implements HttpEntity, HttpAsyncContentProduce
 	 * partially rendered JSON stored in its buffers while flow control
 	 * refuses to accept more bytes.
 	 */
-	private final ProgressiveByteBufWriter writer = new ProgressiveByteBufWriter();
+	private final ProgressiveCharBufferWriter writer = new ProgressiveCharBufferWriter();
+
+	/**
+	 * Add a layer of buffering at the char writer level,
+	 * to avoid handling an excessive number of small buffers:
+	 */
+	private final BufferedWriter bufferedWriter = new BufferedWriter( writer, BUFFER_SIZES );
 
 	public GsonHttpEntity(Gson gson, List<JsonObject> bodyParts) {
 		Objects.requireNonNull( gson );
@@ -108,7 +141,8 @@ public final class GsonHttpEntity implements HttpEntity, HttpAsyncContentProduce
 
 	@Override
 	public long getContentLength() {
-		return contentLength;
+		this.contentlengthWasProvided = true;
+		return this.contentLength;
 	}
 
 	@Override
@@ -170,18 +204,27 @@ public final class GsonHttpEntity implements HttpEntity, HttpAsyncContentProduce
 
 		while ( nextBodyToEncodeIndex < bodyParts.size() ) {
 			JsonObject bodyPart = bodyParts.get( nextBodyToEncodeIndex++ );
-			gson.toJson( bodyPart, writer );
-			writer.insertNewline();
+			gson.toJson( bodyPart, bufferedWriter );
+			bufferedWriter.append( '\n' );
+			bufferedWriter.flush();
 			if ( writer.flowControlPushingBack ) {
 				//Just quit: return control to the caller and trust we'll be called again.
 				return;
 			}
 		}
+		writer.flush();
+		if ( writer.flowControlPushingBack ) {
+			//Just quit: return control to the caller and trust we'll be called again.
+			return;
+		}
 
 		// If we haven't aborted yet, we finished!
 		encoder.complete();
-		// We finally know the content length in bytes:
-		this.contentLength = writer.getTotalWrittenAndReset();
+
+		// Design note: we could finally know the content length in bytes at this point
+		// (we had an accumulator in previous versions) but that's always pointless
+		// as the HTTP CLient will request the size before starting produce content.
+
 		//Allow to repeat the content rendering from the beginning:
 		this.nextBodyToEncodeIndex = 0;
 	}
@@ -195,19 +238,26 @@ public final class GsonHttpEntity implements HttpEntity, HttpAsyncContentProduce
 			digestWriter.insertNewline();
 		}
 		//Now we finally know the content size in bytes:
-		this.contentLength = digestWriter.getContentLenght();
+		hintContentLenght( digestWriter.getContentLenght() );
 	}
 
-	private static final class ProgressiveByteBufWriter extends Writer {
+	private void hintContentLenght(long contentLenght) {
+		if ( contentlengthWasProvided == false ) {
+			this.contentLength = contentLenght;
+		}
+	}
 
-		//Initially null: must be set before writing,
-		//as it might change between writes.
+	private static final class ProgressiveCharBufferWriter extends Writer {
+
+		//Initially null: must be set before writing is starter and each
+		//time it's resumed as it might change between writes during
+		//chunked encoding.
 		ContentEncoder out;
 
 		//This is to keep the buffers which could not be written to socket
 		//because of flow control. Make sure to eventually push them out.
 		//Initialised only if/when needed.
-		List<ByteBuffer> unwrittenLazyBuffers;
+		List<CharBuffer> unwrittenLazyBuffers;
 
 		//Set this to true when we detect clogging, so we can stop trying.
 		//Make sure to reset this when the HTTP Client hints so.
@@ -215,61 +265,106 @@ public final class GsonHttpEntity implements HttpEntity, HttpAsyncContentProduce
 		//unnecessarily.
 		boolean flowControlPushingBack = false;
 
-		//Accumulate the content length while it's being produced so we can hint
-		//other components.
-		long totalWrittenBytes = 0;
+		private final CharsetEncoder utf8Encoder = StandardCharsets.UTF_8.newEncoder();
+		private ByteBuffer availableBuffer = ByteBuffer.allocate( BUFFER_SIZES );
+		private ByteBuffer needsWritingBuffer;
 
 		@Override
 		public void write(char[] cbuf, int off, int len) throws IOException {
 			CharBuffer toWriteChars = CharBuffer.wrap( cbuf, off, len );
-			ByteBuffer toWriteBytes = StandardCharsets.UTF_8.encode( toWriteChars );
-			writeOrBufferWrite( toWriteBytes );
-		}
-
-		public long getTotalWrittenAndReset() {
-			final long total = totalWrittenBytes;
-			//To not count size multiple times on repeated renders:
-			totalWrittenBytes = 0;
-			return total;
+			if ( flowControlPushingBack == false ) {
+				writeOrStore( toWriteChars, false, true );
+			}
+			else {
+				storeForLater( toWriteChars );
+			}
 		}
 
 		public void resumePendingWrites() throws IOException {
 			flowControlPushingBack = false;
-			flushPendingBuffers();
-		}
-
-		public void insertNewline() throws IOException {
-			writeOrBufferWrite( ByteBuffer.wrap( NEWLINE ) );
-		}
-
-		private void writeOrBufferWrite(ByteBuffer toWriteBytes) throws IOException {
-			totalWrittenBytes += toWriteBytes.remaining();
-			flushPendingBuffers();
-			if ( flowControlPushingBack == false ) {
-				//If it wasn't all written, buffer for later
-				if ( fullyWrite( toWriteBytes ) == false ) {
-					addToBuffers( toWriteBytes );
-				}
-			}
-			else {
-				addToBuffers( toWriteBytes );
+			if ( availableBuffer == null ) {
+				attemptFlushPendingBuffers( false );
 			}
 		}
 
-		private void addToBuffers(ByteBuffer toWriteBytes) {
+		private void storeForLater(CharBuffer toWriteLater) {
 			if ( unwrittenLazyBuffers == null ) {
 				unwrittenLazyBuffers = new ArrayList<>( 16 );
 			}
-			unwrittenLazyBuffers.add( toWriteBytes );
+			//The original CharBuffer is not safe as it's backed by a char array
+			//which happens to be the GSON write buffer: it will get mutated.
+			CharBuffer defensiveCopy = CharBuffer.allocate( toWriteLater.remaining() );
+			defensiveCopy.put( toWriteLater );
+			defensiveCopy.flip();
+			unwrittenLazyBuffers.add( defensiveCopy );
 		}
 
-		private void flushPendingBuffers() throws IOException {
+		private void attemptFlushPendingBuffers(boolean lastWrite) throws IOException {
+			flushCurrentBuffer();
+			if ( flowControlPushingBack == false && needsWritingBuffer != null ) {
+				if ( fullyWrite( needsWritingBuffer ) ) {
+					//No longer needed: make it available for reuse by the next writes
+					needsWritingBuffer.clear();
+					availableBuffer = needsWritingBuffer;
+					needsWritingBuffer = null;
+				}
+			}
 			while ( flowControlPushingBack == false && unwrittenLazyBuffers != null && unwrittenLazyBuffers.isEmpty() == false ) {
-				ByteBuffer nextBufferToWrite = unwrittenLazyBuffers.get( 0 );
-				if ( fullyWrite( nextBufferToWrite ) ) {
-					//We can finally discard this one:
+				CharBuffer charBuffer = unwrittenLazyBuffers.get( 0 );
+				if ( writeOrStore( charBuffer, lastWrite, false ) ) {
 					unwrittenLazyBuffers.remove( 0 );
 				}
+			}
+		}
+
+		/**
+		 * Main writer loop: keeps writing until we either run out of data
+		 * to write, or the output buffer signals to back off.
+		 * @param toWriteChars the CharBuffer representing the chars to write
+		 * @param lastWrite set it to true at the end of the data stream (and never before) to detect malformed streams.
+		 * @param saveOnPushback when true an aborted CharBuffer will be enqueued in the write-later buffer. Disable for retries from that same buffer.
+		 * @return
+		 * @throws IOException
+		 */
+		private boolean writeOrStore(CharBuffer toWriteChars, boolean lastWrite, boolean saveOnPushback) throws IOException {
+			while ( true ) {
+				CoderResult coderResult = utf8Encoder.encode( toWriteChars, availableBuffer, lastWrite );
+				if ( coderResult.equals( CoderResult.UNDERFLOW ) ) {
+					//source consumed. All good, had enough space.
+					return true;
+				}
+				else if ( coderResult.equals( CoderResult.OVERFLOW ) ) {
+					//output buffer not large enough. Flush it & repeat:
+					flushCurrentBuffer();
+					if ( flowControlPushingBack ) {
+						//we need to stop pushing data. Save work to continue later & return.
+						if ( saveOnPushback ) {
+							storeForLater( toWriteChars );
+						}
+						return false;
+					}
+					//[else] continue in the while loop to write further data blocks
+				}
+				else {
+					//Encoding exception
+					coderResult.throwException();
+					return false; //Unreachable
+				}
+			}
+		}
+
+		private void flushCurrentBuffer() throws IOException {
+			if ( availableBuffer == null ) {
+				//Nothing to flush
+				return;
+			}
+			availableBuffer.flip();
+			if ( fullyWrite( availableBuffer ) ) {
+				availableBuffer.clear();
+			}
+			else {
+				needsWritingBuffer = availableBuffer;
+				availableBuffer = null;
 			}
 		}
 
@@ -287,7 +382,7 @@ public final class GsonHttpEntity implements HttpEntity, HttpAsyncContentProduce
 
 		@Override
 		public void flush() throws IOException {
-			// Nothing to do
+			attemptFlushPendingBuffers( true );
 		}
 
 		@Override

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/GsonHttpEntity.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/GsonHttpEntity.java
@@ -1,0 +1,338 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.util.impl;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Writer;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.entity.ContentType;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.nio.ContentEncoder;
+import org.apache.http.nio.IOControl;
+import org.apache.http.nio.entity.HttpAsyncContentProducer;
+import org.apache.http.protocol.HTTP;
+
+import org.hibernate.search.elasticsearch.spi.DigestSelfSigningCapable;
+import org.hibernate.search.exception.SearchException;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+/**
+ * Optimised adapter to encode GSON objects into HttpEntity instances.
+ * The naive approach was using various StringBuilders; the objects we
+ * need to serialise into JSON might get large and this was causing the
+ * internal StringBuilder buffers to need frequent resizing and cause
+ * problems with excessive allocations.
+ *
+ * Rather than trying to guess reasonable default sizes for these buffers,
+ * we can defer the serialisation to write directly into the ByteBuffer
+ * of the HTTP client, this has the additional benefit of making the
+ * intermediary buffers short lived.
+ *
+ * The one complexity to watch for is flow control: when writing into
+ * the output buffer chances are that not all bytes are accepted; in
+ * this case we have to hold on the remaining portion of data to
+ * be written when the flow control is re-enabled.
+ *
+ * A side effect of this strategy is that the total content length which
+ * is being produced is not known in advance.
+ *
+ * @author Sanne Grinovero (C) 2017 Red Hat Inc.
+ */
+public final class GsonHttpEntity implements HttpEntity, HttpAsyncContentProducer, DigestSelfSigningCapable {
+
+	private static final byte[] NEWLINE = "\n".getBytes( StandardCharsets.UTF_8 );
+
+	private static final BasicHeader CONTENT_TYPE = new BasicHeader( HTTP.CONTENT_TYPE, ContentType.APPLICATION_JSON.toString() );
+
+	private final Gson gson;
+	private final List<JsonObject> bodyParts;
+
+	/**
+	 * We don't want to compute the length in advance as it would defeat all optimisations.
+	 * Still it's possible that we happen to find out, for example if a Digest from all
+	 * content needs to be computed.
+	 */
+	private long contentLength = -1l;
+
+	/**
+	 * Since flow control might hint to stop producing data,
+	 * while we can't interrupt the rendering of a single JSON body
+	 * we can avoid starting the rendering of any subsequent JSON body.
+	 * So keep track of the next body which still needs to be rendered;
+	 * to allow the output to be "repeatable" we also need to reset this
+	 * at the end.
+	 */
+	private int nextBodyToEncodeIndex = 0;
+
+	/**
+	 * Adaptor from string output rendered into the actual output sink.
+	 * We keep this as a field level attribute as we might have
+	 * partially rendered JSON stored in its buffers while flow control
+	 * refuses to accept more bytes.
+	 */
+	private final ProgressiveByteBufWriter writer = new ProgressiveByteBufWriter();
+
+	public GsonHttpEntity(Gson gson, List<JsonObject> bodyParts) {
+		Objects.requireNonNull( gson );
+		Objects.requireNonNull( bodyParts );
+		this.gson = gson;
+		this.bodyParts = bodyParts;
+	}
+
+	@Override
+	public boolean isRepeatable() {
+		return true;
+	}
+
+	@Override
+	public boolean isChunked() {
+		return false;
+	}
+
+	@Override
+	public long getContentLength() {
+		return contentLength;
+	}
+
+	@Override
+	public Header getContentType() {
+		return CONTENT_TYPE;
+	}
+
+	@Override
+	public Header getContentEncoding() {
+		//Apparently this is the correct value:
+		return null;
+	}
+
+	@Override
+	public InputStream getContent() throws IOException {
+		//This could be implemented but would be sub-optimal compared to using produceContent().
+		//We therefore prefer throwing the exception so that we can easily spot unintended usage via tests.
+		throw new UnsupportedOperationException( "Not implemented! Expected to produce content only over produceContent()" );
+	}
+
+	@Override
+	public void writeTo(OutputStream outstream) throws IOException {
+		//This could be implemented but would be sub-optimal compared to using produceContent().
+		//We therefore prefer throwing the exception so that we can easily spot unintended usage via tests.
+		throw new UnsupportedOperationException( "Not implemented! Expected to produce content only over produceContent()" );
+	}
+
+	@Override
+	public boolean isStreaming() {
+		return false;
+	}
+
+	@Override
+	public void consumeContent() throws IOException {
+		//not used (and deprecated)
+	}
+
+	@Override
+	public void close() throws IOException {
+		//Nothing to close
+	}
+
+	@Override
+	public void produceContent(ContentEncoder encoder, IOControl ioctrl) throws IOException {
+		Objects.requireNonNull( encoder );
+		// Warning: this method is possibly invoked multiple times, depending on the output buffers
+		// to have available space !
+		// Production of data is expected to complete only after we invoke ContentEncoder#complete.
+
+		//Re-set the encoder as it might be a different one than a previously used instance:
+		writer.out = encoder;
+
+		//First write unfinished business from previous attempts
+		writer.resumePendingWrites();
+		if ( writer.flowControlPushingBack ) {
+			//Just quit: return control to the caller and trust we'll be called again.
+			return;
+		}
+
+		while ( nextBodyToEncodeIndex < bodyParts.size() ) {
+			JsonObject bodyPart = bodyParts.get( nextBodyToEncodeIndex++ );
+			gson.toJson( bodyPart, writer );
+			writer.insertNewline();
+			if ( writer.flowControlPushingBack ) {
+				//Just quit: return control to the caller and trust we'll be called again.
+				return;
+			}
+		}
+
+		// If we haven't aborted yet, we finished!
+		encoder.complete();
+		// We finally know the content length in bytes:
+		this.contentLength = writer.getTotalWrittenAndReset();
+		//Allow to repeat the content rendering from the beginning:
+		this.nextBodyToEncodeIndex = 0;
+	}
+
+	@Override
+	public void fillDigest(MessageDigest digest) throws IOException {
+		//For digest computation we use no pagination, so ignore the mutable fields.
+		final DigestWriter digestWriter = new DigestWriter( digest );
+		for ( JsonObject bodyPart : bodyParts ) {
+			gson.toJson( bodyPart, digestWriter );
+			digestWriter.insertNewline();
+		}
+		//Now we finally know the content size in bytes:
+		this.contentLength = digestWriter.getContentLenght();
+	}
+
+	private static final class ProgressiveByteBufWriter extends Writer {
+
+		//Initially null: must be set before writing,
+		//as it might change between writes.
+		ContentEncoder out;
+
+		//This is to keep the buffers which could not be written to socket
+		//because of flow control. Make sure to eventually push them out.
+		//Initialised only if/when needed.
+		List<ByteBuffer> unwrittenLazyBuffers;
+
+		//Set this to true when we detect clogging, so we can stop trying.
+		//Make sure to reset this when the HTTP Client hints so.
+		//It's never dangerous to re-enable, just not efficient to try writing
+		//unnecessarily.
+		boolean flowControlPushingBack = false;
+
+		//Accumulate the content length while it's being produced so we can hint
+		//other components.
+		long totalWrittenBytes = 0;
+
+		@Override
+		public void write(char[] cbuf, int off, int len) throws IOException {
+			CharBuffer toWriteChars = CharBuffer.wrap( cbuf, off, len );
+			ByteBuffer toWriteBytes = StandardCharsets.UTF_8.encode( toWriteChars );
+			writeOrBufferWrite( toWriteBytes );
+		}
+
+		public long getTotalWrittenAndReset() {
+			final long total = totalWrittenBytes;
+			//To not count size multiple times on repeated renders:
+			totalWrittenBytes = 0;
+			return total;
+		}
+
+		public void resumePendingWrites() throws IOException {
+			flowControlPushingBack = false;
+			flushPendingBuffers();
+		}
+
+		public void insertNewline() throws IOException {
+			writeOrBufferWrite( ByteBuffer.wrap( NEWLINE ) );
+		}
+
+		private void writeOrBufferWrite(ByteBuffer toWriteBytes) throws IOException {
+			totalWrittenBytes += toWriteBytes.remaining();
+			flushPendingBuffers();
+			if ( flowControlPushingBack == false ) {
+				//If it wasn't all written, buffer for later
+				if ( fullyWrite( toWriteBytes ) == false ) {
+					addToBuffers( toWriteBytes );
+				}
+			}
+			else {
+				addToBuffers( toWriteBytes );
+			}
+		}
+
+		private void addToBuffers(ByteBuffer toWriteBytes) {
+			if ( unwrittenLazyBuffers == null ) {
+				unwrittenLazyBuffers = new ArrayList<>( 16 );
+			}
+			unwrittenLazyBuffers.add( toWriteBytes );
+		}
+
+		private void flushPendingBuffers() throws IOException {
+			while ( flowControlPushingBack == false && unwrittenLazyBuffers != null && unwrittenLazyBuffers.isEmpty() == false ) {
+				ByteBuffer nextBufferToWrite = unwrittenLazyBuffers.get( 0 );
+				if ( fullyWrite( nextBufferToWrite ) ) {
+					//We can finally discard this one:
+					unwrittenLazyBuffers.remove( 0 );
+				}
+			}
+		}
+
+		private boolean fullyWrite(ByteBuffer buffer) throws IOException {
+			final int toWrite = buffer.remaining();
+			final int actuallyWritten = out.write( buffer );
+			if ( toWrite == actuallyWritten ) {
+				return true;
+			}
+			else {
+				flowControlPushingBack = true;
+				return false;
+			}
+		}
+
+		@Override
+		public void flush() throws IOException {
+			// Nothing to do
+		}
+
+		@Override
+		public void close() throws IOException {
+			// Nothing to do
+		}
+
+	}
+
+	private static final class DigestWriter extends Writer {
+
+		private final MessageDigest digest;
+		private long totalWrittenBytes = 0;
+
+		public DigestWriter(MessageDigest digest) {
+			this.digest = digest;
+		}
+
+		@Override
+		public void write(char[] input, int offset, int len) throws IOException {
+			CharBuffer charBuffer = CharBuffer.wrap( input, offset, len );
+			ByteBuffer byteBuffer = StandardCharsets.UTF_8.encode( charBuffer );
+			this.totalWrittenBytes += byteBuffer.remaining();
+			this.digest.update( byteBuffer );
+		}
+
+		@Override
+		public void flush() throws IOException {
+			// Nothing to do
+		}
+
+		@Override
+		public void close() throws IOException {
+			// Nothing to do
+		}
+
+		public void insertNewline() {
+			this.totalWrittenBytes += NEWLINE.length;
+			this.digest.update( NEWLINE );
+		}
+
+		public long getContentLenght() {
+			return this.totalWrittenBytes;
+		}
+
+	}
+
+}

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/GsonStreamedEncodingTest.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/GsonStreamedEncodingTest.java
@@ -114,11 +114,8 @@ public class GsonStreamedEncodingTest {
 	}
 
 	@Test
-	public void testDigestToTriggerLenghtComputation() {
-		final List<JsonObject> list = new ArrayList<>( 3 );
-		list.add( buildEmptyJSON() );
-		list.add( buildVersionJSON() );
-		list.add( buildEmptyJSON() );
+	public void testDigestToTriggerLengthComputation() {
+		final List<JsonObject> list = produceLargeBulkJSON();
 		try ( GsonHttpEntity entity = new GsonHttpEntity( gson, list ) ) {
 			assertEquals( -1l, entity.getContentLength() );
 		}
@@ -134,6 +131,21 @@ public class GsonStreamedEncodingTest {
 			assertNotEquals( -1l, entity.getContentLength() );
 			final byte[] content = produceContentWithCustomEncoder( entity );
 			assertEquals( content.length, entity.getContentLength() );
+		}
+		catch (IOException e) {
+			throw new RuntimeException( "We're mocking IO operations, this should not happen?", e );
+		}
+	}
+
+	@Test
+	public void testShortMessageIsNotChunked() {
+		final List<JsonObject> list = new ArrayList<>( 3 );
+		list.add( buildEmptyJSON() );
+		list.add( buildVersionJSON() );
+		list.add( buildEmptyJSON() );
+		final byte[] traditionalEncoding = traditionalEncoding( list );
+		try ( GsonHttpEntity entity = new GsonHttpEntity( gson, list ) ) {
+			assertEquals( traditionalEncoding.length, entity.getContentLength() );
 		}
 		catch (IOException e) {
 			throw new RuntimeException( "We're mocking IO operations, this should not happen?", e );

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/GsonStreamedEncodingTest.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/GsonStreamedEncodingTest.java
@@ -21,6 +21,7 @@ import org.hibernate.search.elasticsearch.impl.JsonBuilder;
 import org.hibernate.search.elasticsearch.util.impl.GsonHttpEntity;
 import org.hibernate.search.testsupport.TestForIssue;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import com.google.gson.Gson;
@@ -193,7 +194,11 @@ public class GsonStreamedEncodingTest {
 	byte[] optimisedEncoding(List<JsonObject> bodyParts) {
 		notEmpty( bodyParts );
 		try ( GsonHttpEntity entity = new GsonHttpEntity( gson, bodyParts ) ) {
-			return produceContentWithCustomEncoder( entity );
+			byte[] firstRun = produceContentWithCustomEncoder( entity );
+			entity.close();
+			byte[] secondRun = produceContentWithCustomEncoder( entity );
+			Assert.assertArrayEquals( "Being repeatable, we expect it to be able to reproduce all content even after being closed", firstRun, secondRun );
+			return secondRun;
 		}
 		catch (IOException e) {
 			throw new RuntimeException( "We're mocking IO operations, this should not happen?", e );

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/GsonStreamedEncodingTest.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/GsonStreamedEncodingTest.java
@@ -1,0 +1,326 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+package org.hibernate.search.elasticsearch.test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.search.elasticsearch.dialect.impl.es52.Elasticsearch52Dialect;
+import org.hibernate.search.elasticsearch.impl.JsonBuilder;
+import org.hibernate.search.elasticsearch.util.impl.GsonHttpEntity;
+import org.hibernate.search.testsupport.TestForIssue;
+
+import org.junit.Test;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+import org.apache.http.nio.ContentEncoder;
+import org.apache.http.nio.IOControl;
+
+import static java.util.Collections.singletonList;
+import static org.apache.commons.codec.binary.Hex.encodeHexString;
+import static org.apache.commons.codec.digest.DigestUtils.getSha256Digest;
+import static org.apache.commons.codec.digest.DigestUtils.sha256Hex;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for GsonHttpEntity to be able to write the whole JSON string
+ * out correctly, and produce a matching sha256 digest.
+ *
+ * @author Sanne Grinovero (C) 2017 Red Hat Inc.
+ */
+@TestForIssue( jiraKey = "HSEARCH-2818" )
+public class GsonStreamedEncodingTest {
+
+	public static final int MAX_TESTING_BUFFER_BYTES = 4000;
+	private static final String JSON_TEST_PAYLOAD_VERSION = "{\"version\":{\"number\":\"5.5.0\"}}\n";
+	private static final String JSON_TEST_PAYLOAD_EMPTY = "{}\n";
+	private static final int BULK_BATCH_SIZE = 100;
+	private static final String JSON_TEST_PAYLOAD_LARGE_BULK = produceLargeBukJSONContent();
+
+	private static final Gson gson = new Elasticsearch52Dialect()
+			.createGsonProvider()
+			.getGson();
+
+	@Test
+	public void testEmptyJSON() {
+		final List<JsonObject> list = singletonList( buildEmptyJSON() );
+		verifyProducedContent( list );
+		verifySha256Signature( list );
+		verifyOutput( JSON_TEST_PAYLOAD_EMPTY, list );
+	}
+
+	@Test
+	public void testSinglePropertyJSON() {
+		final List<JsonObject> list = singletonList( buildVersionJSON() );
+		verifyProducedContent( list );
+		verifySha256Signature( list );
+		verifyOutput( JSON_TEST_PAYLOAD_VERSION, list );
+	}
+
+	@Test
+	public void testTripleBulkJSON() {
+		final List<JsonObject> list = new ArrayList<>( 3 );
+		list.add( buildEmptyJSON() );
+		list.add( buildVersionJSON() );
+		list.add( buildEmptyJSON() );
+		verifyProducedContent( list );
+		verifySha256Signature( list );
+		verifyOutput(
+				JSON_TEST_PAYLOAD_EMPTY +
+				JSON_TEST_PAYLOAD_VERSION +
+				JSON_TEST_PAYLOAD_EMPTY,
+				list );
+	}
+
+	@Test
+	public void testHugeBulkJSON() {
+		final List<JsonObject> list = produceLargeBulkJSON();
+		verifyProducedContent( list );
+		verifySha256Signature( list );
+		verifyOutput( JSON_TEST_PAYLOAD_LARGE_BULK, list );
+	}
+
+	@Test
+	public void testContentIsRepeatable() {
+		final List<JsonObject> list = new ArrayList<>( 3 );
+		list.add( buildEmptyJSON() );
+		list.add( buildVersionJSON() );
+		list.add( buildEmptyJSON() );
+		try ( GsonHttpEntity entity = new GsonHttpEntity( gson, list ) ) {
+			final byte[] productionOne = produceContentWithCustomEncoder( entity );
+			final byte[] productionTwo = produceContentWithCustomEncoder( entity );
+			assertArrayEquals( productionOne, productionTwo );
+		}
+		catch (IOException e) {
+			throw new RuntimeException( "We're mocking IO operations, this should not happen?", e );
+		}
+	}
+
+	@Test
+	public void testDigestToTriggerLenghtComputation() {
+		final List<JsonObject> list = new ArrayList<>( 3 );
+		list.add( buildEmptyJSON() );
+		list.add( buildVersionJSON() );
+		list.add( buildEmptyJSON() );
+		try ( GsonHttpEntity entity = new GsonHttpEntity( gson, list ) ) {
+			assertEquals( -1l, entity.getContentLength() );
+			final MessageDigest digest = getSha256Digest();
+			entity.fillDigest( digest );
+			assertNotEquals( -1l, entity.getContentLength() );
+			final byte[] content = produceContentWithCustomEncoder( entity );
+			assertEquals( content.length, entity.getContentLength() );
+		}
+		catch (IOException e) {
+			throw new RuntimeException( "We're mocking IO operations, this should not happen?", e );
+		}
+	}
+
+	@Test
+	public void testContentProductionTriggersLenghtComputation() {
+		final List<JsonObject> list = new ArrayList<>( 3 );
+		list.add( buildEmptyJSON() );
+		list.add( buildVersionJSON() );
+		list.add( buildEmptyJSON() );
+		try ( GsonHttpEntity entity = new GsonHttpEntity( gson, list ) ) {
+			assertEquals( -1l, entity.getContentLength() );
+			final byte[] content = produceContentWithCustomEncoder( entity );
+			assertNotEquals( -1l, entity.getContentLength() );
+			assertEquals( content.length, entity.getContentLength() );
+		}
+		catch (IOException e) {
+			throw new RuntimeException( "We're mocking IO operations, this should not happen?", e );
+		}
+	}
+
+	private void verifyOutput(final String expected, final List<JsonObject> list) {
+		assertEquals( expected, encodeToString( list ) );
+	}
+
+	private void verifySha256Signature(final List<JsonObject> jsonObjects) {
+		final String optimisedEncoding = optimisedSha256( jsonObjects );
+		final String traditionalEncoding = traditionalSha256( jsonObjects );
+		assertEquals( "SHA-256 signatures not matching", traditionalEncoding, optimisedEncoding );
+	}
+
+	private String optimisedSha256(final List<JsonObject> bodyParts) {
+		notEmpty( bodyParts );
+		try ( GsonHttpEntity entity = new GsonHttpEntity( gson, bodyParts ) ) {
+			final MessageDigest digest = getSha256Digest();
+			entity.fillDigest( digest );
+			return encodeHexString( digest.digest() );
+		}
+		catch (IOException e) {
+			throw new RuntimeException( "We're mocking IO operations, this should not happen?", e );
+		}
+	}
+
+	private String traditionalSha256(final List<JsonObject> jsonObjects) {
+		return sha256Hex( traditionalEncoding( jsonObjects ) );
+	}
+
+	private void verifyProducedContent(final List<JsonObject> jsonObjects) {
+		assertArrayEquals(
+				traditionalEncoding( jsonObjects ),
+				optimisedEncoding( jsonObjects ) );
+	}
+
+	byte[] optimisedEncoding(List<JsonObject> bodyParts) {
+		notEmpty( bodyParts );
+		try ( GsonHttpEntity entity = new GsonHttpEntity( gson, bodyParts ) ) {
+			return produceContentWithCustomEncoder( entity );
+		}
+		catch (IOException e) {
+			throw new RuntimeException( "We're mocking IO operations, this should not happen?", e );
+		}
+	}
+
+	private byte[] produceContentWithCustomEncoder(GsonHttpEntity entity) throws IOException {
+		IOControl fakeIO = new FakeIOControl();
+		HeapContentEncoder sink = new HeapContentEncoder();
+		int loopCounter = 0;
+		while ( sink.isCompleted() == false ) {
+			entity.produceContent( sink, fakeIO );
+			sink.setNextAcceptedBytesSize( loopCounter++ );
+		}
+		return sink.flipAndRead();
+	}
+
+	private void notEmpty(final List<JsonObject> bodyParts) {
+		assertFalse( "Pointless to test this, we don't use this strategy for empty blocks", bodyParts.isEmpty() );
+	}
+
+	/**
+	 * This is the simplest encoding strategy; we don't use this as
+	 * it would require to allocate significantly larger intermediate
+	 * buffers. See also HSEARCH-2818.
+	 */
+	byte[] traditionalEncoding(final List<JsonObject> bodyParts) {
+		return encodeToString( bodyParts ).getBytes( StandardCharsets.UTF_8 );
+	}
+
+	private String encodeToString(final List<JsonObject> bodyParts) {
+		notEmpty( bodyParts );
+		final StringBuilder builder = new StringBuilder();
+		for ( JsonObject bodyPart : bodyParts ) {
+			gson.toJson( bodyPart, builder );
+			builder.append( '\n' );
+		}
+		return builder.toString();
+	}
+
+	private static List<JsonObject> produceLargeBulkJSON() {
+		ArrayList<JsonObject> list = new ArrayList<>( BULK_BATCH_SIZE );
+		for ( int i = 0; i < 100; i++ ) {
+			list.add( buildVersionJSON() );
+		}
+		return list;
+	}
+
+
+	private static JsonObject buildEmptyJSON() {
+		return JsonBuilder.object()
+				.build();
+	}
+
+	private static JsonObject buildVersionJSON() {
+		return JsonBuilder.object()
+				.add( "version", JsonBuilder.object()
+						.addProperty( "number", "5.5.0" )
+				).build();
+	}
+
+	private static String produceLargeBukJSONContent() {
+		final StringBuilder content = new StringBuilder( BULK_BATCH_SIZE * JSON_TEST_PAYLOAD_VERSION.length() );
+		for ( int i = 0; i < BULK_BATCH_SIZE; i++ ) {
+			content.append( JSON_TEST_PAYLOAD_VERSION );
+		}
+		return content.toString();
+	}
+
+	private static final class HeapContentEncoder implements ContentEncoder {
+
+		private boolean contentComplete = false;
+		private int nextWriteAcceptLimit = 0;
+		private ByteBuffer buf = ByteBuffer.allocate( MAX_TESTING_BUFFER_BYTES );
+		private boolean closed = false;
+
+		@Override
+		public int write(final ByteBuffer byteBuffer) throws IOException {
+			assertFalse( closed );
+			int toRead = Math.min( byteBuffer.remaining(), nextWriteAcceptLimit );
+			byte[] currentRead = new byte[toRead];
+			byteBuffer.get( currentRead );
+			buf.put( currentRead );
+			return toRead;
+		}
+
+		@Override
+		public void complete() throws IOException {
+			assertFalse( closed );
+			assertFalse( "Can't mark it 'complete' multiple times", contentComplete );
+			contentComplete = true;
+		}
+
+		@Override
+		public boolean isCompleted() {
+			return contentComplete;
+		}
+
+		public byte[] flipAndRead() {
+			assertFalse( "can read the buffer only once", closed );
+			closed = true;
+			buf.flip();
+			byte[] currentRead = new byte[buf.remaining()];
+			buf.get( currentRead );
+			return currentRead;
+		}
+
+		public void setNextAcceptedBytesSize(int size) {
+			this.nextWriteAcceptLimit = size;
+		}
+
+	}
+
+	private static final class FakeIOControl implements IOControl {
+		@Override
+		public void requestInput() {
+			fail( "Should not invoke this" );
+		}
+
+		@Override
+		public void suspendInput() {
+			fail( "Should not invoke this" );
+		}
+
+		@Override
+		public void requestOutput() {
+			fail( "Should not invoke this" );
+		}
+
+		@Override
+		public void suspendOutput() {
+			fail( "Should not invoke this" );
+		}
+
+		@Override
+		public void shutdown() throws IOException {
+			fail( "Should not invoke this" );
+		}
+	}
+
+}


### PR DESCRIPTION
Similar optimisations as proposed before but using a different approach, now more carefully taking into account the AWS digest requests.

Also taking into account flow control of the underlying buffers, this was a bug in the previous proposal.

https://hibernate.atlassian.net/browse/HSEARCH-2818