### PR TITLE
HSEARCH-2823 The elasticsearch-aws JAR and its dependencies are missing from the .tar.gz/zip distributions

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -60,6 +60,10 @@
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-search-elasticsearch-aws</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
             <artifactId>hibernate-search-backend-jms</artifactId>
         </dependency>
         <dependency>
@@ -103,6 +107,7 @@
                         ${basedir}/../backends/jgroups/src/main/java;
                         ${basedir}/../backends/jms/src/main/java;
                         ${basedir}/../elasticsearch/src/main/java;
+                        ${basedir}/../elasticsearch-aws/src/main/java;
                     </sourcepath>
                     <docfilessubdirs>true</docfilessubdirs>
                     <stylesheetfile>${basedir}/src/main/javadoc/stylesheet.css</stylesheetfile>

--- a/distribution/src/main/assembly/dist.xml
+++ b/distribution/src/main/assembly/dist.xml
@@ -101,7 +101,22 @@
             <useTransitiveDependencies>true</useTransitiveDependencies>
             <useTransitiveFiltering>true</useTransitiveFiltering>
             <includes>
-                <include>org.hibernate:hibernate-search-elasticsearch</include>
+                <!--
+                    The ':*' suffix is necessary to not include elasticsearch-aws,
+                    because of a bug in maven-assembly-plugin.
+                    See https://issues.apache.org/jira/browse/MASSEMBLY-865
+                 -->
+                <include>org.hibernate:hibernate-search-elasticsearch:*</include>
+            </includes>
+        </dependencySet>
+
+        <dependencySet>
+            <outputDirectory>dist/lib/optional/elasticsearch-aws</outputDirectory>
+            <scope>runtime</scope>
+            <useTransitiveDependencies>true</useTransitiveDependencies>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <includes>
+                <include>org.hibernate:hibernate-search-elasticsearch-aws</include>
             </includes>
         </dependencySet>
 


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-2823
