### PR TITLE
HSEARCH-2834 Upgrade Elasticsearch versions to 5.5.1 and 2.4.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,8 +214,8 @@
         <commonsCodecVersion>1.10</commonsCodecVersion>
 
         <!-- Elasticsearch -->
-        <elasticsearchClientVersion>5.5.0</elasticsearchClientVersion>
-        <elasticsearchSnifferVersion>5.5.0</elasticsearchSnifferVersion>
+        <elasticsearchClientVersion>5.5.1</elasticsearchClientVersion>
+        <elasticsearchSnifferVersion>5.5.1</elasticsearchSnifferVersion>
         <elasticsearchGsonVersion>2.8.0</elasticsearchGsonVersion>
         <elasticsearchAWSV4SignerVersion>1.3</elasticsearchAWSV4SignerVersion>
         

--- a/pom.xml
+++ b/pom.xml
@@ -1713,7 +1713,7 @@ org.hibernate.search.spi.SearchIntegratorBuilder#buildSearchIntegrator()
             <id>elasticsearch-2.2</id>
             <properties>
                 <test.elasticsearch.mavenPlugin.version>2.2</test.elasticsearch.mavenPlugin.version>
-                <test.elasticsearch.host.version>2.4.5</test.elasticsearch.host.version>
+                <test.elasticsearch.host.version>2.4.6</test.elasticsearch.host.version>
             </properties>
             <build>
                 <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -1835,7 +1835,7 @@ org.hibernate.search.spi.SearchIntegratorBuilder#buildSearchIntegrator()
             </activation>
             <properties>
                 <test.elasticsearch.mavenPlugin.version>5.7</test.elasticsearch.mavenPlugin.version>
-                <test.elasticsearch.host.version>5.5.0</test.elasticsearch.host.version>
+                <test.elasticsearch.host.version>5.5.1</test.elasticsearch.host.version>
             </properties>
             <build>
                 <pluginManagement>


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-2834
