### PR TITLE
HSEARCH-2640 Improve resilience of cleanup methods (close, etc.)

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/DefaultElasticsearchClient.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/DefaultElasticsearchClient.java
@@ -25,6 +25,7 @@ import org.hibernate.search.elasticsearch.gson.impl.GsonProvider;
 import org.hibernate.search.elasticsearch.logging.impl.ElasticsearchLogCategories;
 import org.hibernate.search.elasticsearch.logging.impl.Log;
 import org.hibernate.search.elasticsearch.util.impl.ElasticsearchClientUtils;
+import org.hibernate.search.util.impl.Closer;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 
 import com.google.gson.Gson;
@@ -131,13 +132,11 @@ public class DefaultElasticsearchClient implements ElasticsearchClientImplemento
 
 	@Override
 	public void close() throws IOException {
-		try ( RestClient restClient = this.restClient;
-				Sniffer sniffer = this.sniffer; ) {
-			/*
-			 * Nothing to do: we simply take advantage of Java's auto-closing,
-			 * which adds suppressed exceptions as needed and always tries
-			 * to close every resource.
-			 */
+		try ( Closer<IOException> closer = new Closer<>() ) {
+			if ( this.sniffer != null ) {
+				closer.push( this.sniffer::close );
+			}
+			closer.push( this.restClient::close );
 		}
 	}
 

--- a/engine/src/main/java/org/hibernate/search/util/impl/Closeables.java
+++ b/engine/src/main/java/org/hibernate/search/util/impl/Closeables.java
@@ -8,6 +8,7 @@ package org.hibernate.search.util.impl;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Arrays;
 
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
@@ -21,6 +22,38 @@ public final class Closeables {
 
 	private Closeables() {
 		// Private constructor
+	}
+
+	/**
+	 * Close multiple resources, ensuring that all resources get closed
+	 * even if one of them throws a Throwable.
+	 * <p>
+	 * The first caught throwable will be re-thrown, and any additional
+	 * throwable will be {@link Throwable#addSuppressed(Throwable) suppressed}.
+	 *
+	 * @see #close(Iterable)
+	 * @param closeables The resources to close
+	 * @throws E if a closeable throws such an exception
+	 */
+	@SuppressWarnings("unchecked")
+	public static <E extends Exception> void close(GenericCloseable<? extends E> ... closeables) throws E {
+		close( Arrays.asList( closeables ) );
+	}
+
+	/**
+	 * Close multiple resources, ensuring that all resources get closed
+	 * even if one of them throws a Throwable.
+	 * <p>
+	 * The first caught throwable will be re-thrown, and any additional
+	 * throwable will be {@link Throwable#addSuppressed(Throwable) suppressed}.
+	 *
+	 * @param closeables The resources to close
+	 * @throws E if a closeable throws such an exception
+	 */
+	public static <E extends Exception> void close(Iterable<? extends GenericCloseable<? extends E>> closeables) throws E {
+		try ( Closer<E> closer = new Closer<>() ) {
+			closer.pushAll( GenericCloseable::close, closeables );
+		}
 	}
 
 	/**

--- a/engine/src/main/java/org/hibernate/search/util/impl/Closer.java
+++ b/engine/src/main/java/org/hibernate/search/util/impl/Closer.java
@@ -1,0 +1,204 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.impl;
+
+/**
+ * A helper for closing multiple resources and re-throwing only one exception,
+ * {@link Throwable#addSuppressed(Throwable) suppressing} the others as necessary.
+ * <p>
+ * This class is not thread safe.
+ * <p>
+ * This helper is mainly useful when implementing {@link AutoCloseable#close()}
+ * or a similar closing method in your own class, to make sure that all resources are
+ * at least given the chance to close, even if closing one of them fails.
+ * When creating then closing resources in the scope of a single method call,
+ * try-with-resource blocks should be favored.
+ * <p>
+ * <strong>Warning:</strong> In order not to ignore exceptions,
+ * you should <strong>always</strong> call {@link Closer#close()}
+ * once you closed all of your resources. The most straightforward way
+ * to do this is to use a try-with-resource block:
+ * <pre><code>
+ * public void myCloseFunction() throws MyException {
+ *   try ( Closer&lt;MyException&gt; closer = new Closer&lt;&gt;() ) {
+ *     closer.push( this.myCloseable::close );
+ *     closer.pushAll( this.myListOfCloseables, MyCloseableType::close );
+ *   }
+ * }
+ * </code></pre>
+ *
+ * <h3>Exception type</h3>
+ * <p>
+ * Note that the closer has a generic type parameter, allowing it to
+ * re-throw a given checked exception.
+ * If you don't want to use this feature, you can simply use a
+ * {@code Closer<RuntimeException>}.
+ *
+ * <h3><a name="splitting">Splitting</a></h3>
+ * <p>
+ * If you need to close multiple resources throwing different checked
+ * exceptions, and those exceptions don't have a practical common superclass,
+ * you can "split" the closer:
+ * <pre><code>
+ * public void myCloseFunction() throws IOException, MyException, MyOtherException {
+ *   try ( Closer&lt;MyException&gt; closer1 = new Closer&lt;&gt;();
+ *       Closer&lt;IOException&gt; closer2 = closer1.split();
+ *       Closer&lt;MyOtherException&gt; closer3 = closer1.split() ) {
+ *     closer2.push( this.someJavaIOCloseable::close );
+ *     closer1.pushAll( this.myListOfCloseables1, MyCloseableTypeThrowingMyException::close );
+ *     closer3.pushAll( this.myListOfCloseables2, MyCloseableTypeThrowingMyOtherException::close );
+ *   }
+ * }
+ * </code></pre>
+ * <p>
+ * The multiple closers will share the same state, which means the first
+ * exception to be caught by any of the closers will be the one to be re-thrown,
+ * and all subsequent exceptions caught by any closer will be added as suppressed
+ * to this first exception.
+ * <strong>Be careful though, you will have to close every single closer.</strong>
+ * Closing just the original one will not be enough.
+ *
+ * @param E The supertype of exceptions this closer can catch and re-throw,
+ * besides {@link RuntimeException} and {@link Error}.
+ *
+ * @author Yoann Rodiere
+ */
+public final class Closer<E extends Exception> implements AutoCloseable {
+
+	private final State state;
+
+	public Closer() {
+		this( new State() );
+	}
+
+	private Closer(State state) {
+		this.state = state;
+	}
+
+	/**
+	 * Execute the given close {@code operator} <strong>immediately</strong> on
+	 * the given {@code objectToClose}, swallowing any throwable in order to
+	 * throw it {@link #close() later}.
+	 * @param operator An operator to close {@code objectToClose}. Accepts lambdas
+	 * such as {@code MyType::close}.
+	 * @param objectToClose An object to close
+	 */
+	public <T> void push(ClosingOperator<T, ? extends E> operator, T objectToClose) {
+		try {
+			operator.close( objectToClose );
+		}
+		catch (Throwable t) {
+			state.addThrowable( this, t );
+		}
+	}
+
+	/**
+	 * Close the given {@code closeable} <strong>immediately</strong>,
+	 * swallowing any throwable in order to throw it {@link #close() later}.
+	 *
+	 * @param closeable A {@link GenericCloseable} to close. Accepts lambdas
+	 * such as {@code myObject::close}.
+	 */
+	public void push(GenericCloseable<? extends E> closeable) {
+		push( GenericCloseable::close, closeable );
+	}
+
+	/**
+	 * Execute the given close {@code operator} <strong>immediately</strong> on
+	 * each element of the given iterable, swallowing any throwable in order to
+	 * throw them {@link #close() later}.
+	 * @param operator An operator to close each element in {@code objectsToClose}. Accepts lambdas
+	 * such as {@code MyType::close}.
+	 * @param objectsToClose An iterable of objects to close
+	 */
+	public <T> void pushAll(ClosingOperator<T, ? extends E> operator, Iterable<T> objectsToClose) {
+		for ( T objectToClose : objectsToClose ) {
+			push( operator, objectToClose );
+		}
+	}
+
+	/**
+	 * Execute the given close {@code operator} <strong>immediately</strong> on
+	 * each element of the given array, swallowing any throwable in order to
+	 * throw them {@link #close() later}.
+	 * @param operator An operator to close each element in {@code objectsToClose}. Accepts lambdas
+	 * such as {@code MyType::close}.
+	 * @param objectsToClose An array of objects to close
+	 */
+	@SafeVarargs
+	public final <T> void pushAll(ClosingOperator<T, ? extends E> operator, T ... objectsToClose) {
+		for ( T objectToClose : objectsToClose ) {
+			push( operator, objectToClose );
+		}
+	}
+
+	/**
+	 * @return A closer sharing the same state as {@code this}, allowing to handle
+	 * multiple exception types.
+	 * @see <a href="#splitting">splitting</a>
+	 */
+	public <E2 extends Exception> Closer<E2> split() {
+		return new Closer<>();
+	}
+
+	/**
+	 * @throws E The first throwable caught when executing the {@code push} methods, if any.
+	 * Any throwable caught after the first will have been
+	 * {@link Throwable#addSuppressed(Throwable) suppressed}.
+	 */
+	@Override
+	public void close() throws E {
+		state.close( this );
+	}
+
+	/**
+	 * This is implemented in a separate class so that multiple closers
+	 * can share the same state, allowing them to elect a single "first throwable".
+	 */
+	private static class State {
+		private Closer<?> firstThrower;
+		private Throwable firstThrowable;
+
+		public void addThrowable(Closer<?> source, Throwable throwable) {
+			if ( firstThrowable == null ) {
+				firstThrowable = throwable;
+				firstThrower = source;
+			}
+			else {
+				firstThrowable.addSuppressed( throwable );
+			}
+		}
+
+		@SuppressWarnings("unchecked")
+		public <E extends Exception> void close(Closer<E> source) throws E {
+			if ( firstThrowable != null && source == firstThrower ) {
+				try {
+					if ( firstThrowable instanceof RuntimeException ) {
+						throw (RuntimeException) firstThrowable;
+					}
+					else if ( firstThrowable instanceof Error ) {
+						throw (Error) firstThrowable;
+					}
+					else if ( firstThrowable != null ) {
+						/*
+						 * At this point we know that throwable is an instance of E,
+						 * because that's the only checked exception that the source
+						 * can catch.
+						 */
+						throw (E) firstThrowable;
+					}
+				}
+				finally {
+					// Ensure the next calls to Closer.close won't throw
+					this.firstThrower = null;
+					this.firstThrowable = null;
+				}
+			}
+		}
+	}
+
+}

--- a/engine/src/main/java/org/hibernate/search/util/impl/ClosingOperator.java
+++ b/engine/src/main/java/org/hibernate/search/util/impl/ClosingOperator.java
@@ -1,0 +1,14 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.impl;
+
+@FunctionalInterface
+public interface ClosingOperator<T, E extends Throwable> {
+
+	void close(T objectToClose) throws E;
+
+}

--- a/engine/src/main/java/org/hibernate/search/util/impl/GenericCloseable.java
+++ b/engine/src/main/java/org/hibernate/search/util/impl/GenericCloseable.java
@@ -1,0 +1,14 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.impl;
+
+@FunctionalInterface
+public interface GenericCloseable<E extends Throwable> {
+
+	void close() throws E;
+
+}

--- a/engine/src/test/java/org/hibernate/search/test/util/impl/CloserTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/util/impl/CloserTest.java
@@ -1,0 +1,238 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.util.impl;
+
+import static org.hibernate.search.test.util.impl.ExceptionMatcherBuilder.isException;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.hibernate.search.util.impl.Closer;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * @author Yoann Rodiere
+ */
+public class CloserTest {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void javaIOCloseable() throws IOException {
+		IOException exception1 = new IOException();
+		RuntimeException exception2 = new IllegalStateException();
+		@SuppressWarnings("resource")
+		Closeable closeable = new Closeable() {
+			@Override
+			public void close() throws IOException {
+				throw exception1;
+			}
+		};
+
+		thrown.expect(
+				isException( exception1 )
+				.withSuppressed( exception2 )
+				.build()
+		);
+
+		try ( Closer<IOException> closer = new Closer<>() ) {
+			closer.push( closeable::close );
+			closer.push( () -> { throw exception2; } );
+		}
+	}
+
+	@Test
+	public void autoCloseable() throws Exception {
+		Exception exception1 = new Exception();
+		RuntimeException exception2 = new IllegalStateException();
+		@SuppressWarnings("resource")
+		AutoCloseable closeable = new AutoCloseable() {
+			@Override
+			public void close() throws Exception {
+				throw exception1;
+			}
+		};
+
+		thrown.expect(
+				isException( exception1 )
+				.withSuppressed( exception2 )
+				.build()
+		);
+
+		try ( Closer<Exception> closer = new Closer<>() ) {
+			closer.push( closeable::close );
+			closer.push( () -> { throw exception2; } );
+		}
+	}
+
+	@Test
+	public void runtimeException() {
+		RuntimeException exception1 = new RuntimeException();
+		RuntimeException exception2 = new IllegalStateException();
+		RuntimeException exception3 = new UnsupportedOperationException();
+
+		thrown.expect(
+				isException( exception1 )
+				.withSuppressed( exception2 )
+				.withSuppressed( exception3 )
+				.build()
+		);
+
+		try ( Closer<RuntimeException> closer = new Closer<>() ) {
+			closer.push( () -> { throw exception1; } );
+			closer.push( () -> { throw exception2; } );
+			closer.push( () -> { throw exception3; } );
+		}
+	}
+
+	@Test
+	public void nonFailingCloseables() {
+		RuntimeException exception1 = new RuntimeException();
+		RuntimeException exception2 = new RuntimeException();
+		RuntimeException exception3 = new RuntimeException();
+
+		thrown.expect(
+				isException( exception1 )
+				.withSuppressed( exception2 )
+				.withSuppressed( exception3 )
+				.build()
+		);
+
+		try ( Closer<RuntimeException> closer = new Closer<>() ) {
+			closer.push( () -> { /* Do not fail */ } );
+			closer.push( () -> { throw exception1; } );
+			closer.push( () -> { throw exception2; } );
+			closer.push( () -> { /* Do not fail */ } );
+			closer.push( () -> { throw exception3; } );
+			closer.push( () -> { /* Do not fail */ } );
+		}
+	}
+
+	@Test
+	public void customCloseable() throws MyException1 {
+		MyException1 exception1 = new MyException1();
+		RuntimeException exception2 = new IllegalStateException();
+		@SuppressWarnings("resource")
+		MyException1Closeable closeable = new MyException1Closeable() {
+			@Override
+			public void close() throws MyException1 {
+				throw exception1;
+			}
+		};
+
+		thrown.expect(
+				isException( exception1 )
+				.withSuppressed( exception2 )
+				.build()
+		);
+
+		try ( Closer<MyException1> closer = new Closer<>() ) {
+			closer.push( closeable::close );
+			closer.push( () -> { throw exception2; } );
+		}
+	}
+
+	@Test
+	public void iterable() throws IOException {
+		IOException exception1 = new IOException();
+		RuntimeException exception2 = new IllegalStateException();
+		IOException exception3 = new IOException();
+		RuntimeException exception4 = new UnsupportedOperationException();
+		List<Closeable> closeables = Arrays.asList(
+				() -> { throw exception1; },
+				() -> { throw exception2; },
+				() -> { throw exception3; },
+				() -> { throw exception4; }
+				);
+
+		thrown.expect(
+				isException( exception1 )
+				.withSuppressed( exception2 )
+				.withSuppressed( exception3 )
+				.withSuppressed( exception4 )
+				.build()
+		);
+
+		try ( Closer<IOException> closer = new Closer<>() ) {
+			closer.pushAll( Closeable::close, closeables );
+		}
+	}
+
+	@Test
+	public void split() throws IOException, MyException1, MyException2 {
+		MyException2 exception1 = new MyException2();
+		MyException1 exception2 = new MyException1();
+		IOException exception3 = new IOException();
+
+		thrown.expect(
+				isException( exception1 )
+				.withSuppressed( exception2 )
+				.withSuppressed( exception3 )
+				.build()
+		);
+
+		try ( Closer<IOException> closer1 = new Closer<>();
+				Closer<MyException1> closer2 = closer1.split();
+				Closer<MyException2> closer3 = closer1.split() ) {
+			/*
+			 * The first exception is caught by closer3,
+			 * but regardless of the fact that closer3 is the third
+			 * closer in the resource list, this exception should be
+			 * the one that is rethrown.
+			 */
+			closer3.push( () -> { throw exception1; } );
+			closer2.push( () -> { throw exception2; } );
+			closer1.push( () -> { throw exception3; } );
+		}
+	}
+
+	@Test
+	public void split_transitive() throws IOException, MyException1, MyException2 {
+		MyException2 exception1 = new MyException2();
+		MyException1 exception2 = new MyException1();
+		IOException exception3 = new IOException();
+
+		thrown.expect(
+				isException( exception1 )
+				.withSuppressed( exception2 )
+				.withSuppressed( exception3 )
+				.build()
+		);
+
+		try ( Closer<IOException> closer1 = new Closer<>();
+				Closer<MyException1> closer2 = closer1.split();
+				// splitting on closer2 should be the same as splitting on closer1
+				Closer<MyException2> closer3 = closer2.split() ) {
+			/*
+			 * The first exception is caught by closer3,
+			 * but regardless of the fact that closer3 is the third
+			 * closer in the resource list, this exception should be
+			 * the one that is rethrown.
+			 */
+			closer3.push( () -> { throw exception1; } );
+			closer2.push( () -> { throw exception2; } );
+			closer1.push( () -> { throw exception3; } );
+		}
+	}
+
+	private static class MyException1 extends Exception {
+	}
+
+	private interface MyException1Closeable extends AutoCloseable {
+		@Override
+		void close() throws MyException1;
+	}
+
+	private static class MyException2 extends Exception {
+	}
+
+}

--- a/engine/src/test/java/org/hibernate/search/test/util/impl/ExceptionMatcherBuilder.java
+++ b/engine/src/test/java/org/hibernate/search/test/util/impl/ExceptionMatcherBuilder.java
@@ -25,15 +25,27 @@ import org.hibernate.search.util.impl.CollectionHelper;
 public class ExceptionMatcherBuilder {
 
 	public static ExceptionMatcherBuilder isException(Class<? extends Throwable> clazz) {
-		return new ExceptionMatcherBuilder( clazz );
+		return new ExceptionMatcherBuilder( CoreMatchers.<Throwable>instanceOf( clazz ) );
+	}
+
+	public static ExceptionMatcherBuilder isException(Throwable throwable) {
+		return new ExceptionMatcherBuilder( CoreMatchers.sameInstance( throwable ) );
 	}
 
 	private final List<Matcher<?>> matchers = new ArrayList<>();
 
 	private final List<Matcher<?>> suppressedMatchers = new ArrayList<>();
 
-	private ExceptionMatcherBuilder(Class<? extends Throwable> clazz) {
-		matchers.add( CoreMatchers.<Throwable>instanceOf( clazz ) );
+	private ExceptionMatcherBuilder(Matcher<? extends Throwable> matcher) {
+		matchers.add( matcher );
+	}
+
+	public ExceptionMatcherBuilder withMainOrSuppressed(Throwable throwable) {
+		return withMainOrSuppressed( CoreMatchers.sameInstance( throwable ) );
+	}
+
+	public ExceptionMatcherBuilder withSuppressed(Throwable throwable) {
+		return withSuppressed( CoreMatchers.sameInstance( throwable ) );
 	}
 
 	public ExceptionMatcherBuilder withMainOrSuppressed(Matcher<?> matcher) {
@@ -46,7 +58,11 @@ public class ExceptionMatcherBuilder {
 	}
 
 	public ExceptionMatcherBuilder causedBy(Class<? extends Throwable> clazz) {
-		return new NestedExceptionCauseMatcherBuilder( clazz );
+		return new NestedExceptionCauseMatcherBuilder( CoreMatchers.<Throwable>instanceOf( clazz ) );
+	}
+
+	public ExceptionMatcherBuilder causedBy(Throwable throwable) {
+		return new NestedExceptionCauseMatcherBuilder( CoreMatchers.sameInstance( throwable ) );
 	}
 
 	public Matcher<? super Throwable> build() {
@@ -91,8 +107,8 @@ public class ExceptionMatcherBuilder {
 	 * @author Yoann Rodiere
 	 */
 	private class NestedExceptionCauseMatcherBuilder extends ExceptionMatcherBuilder {
-		public NestedExceptionCauseMatcherBuilder(Class<? extends Throwable> clazz) {
-			super( clazz );
+		public NestedExceptionCauseMatcherBuilder(Matcher<? extends Throwable> matcher) {
+			super( matcher );
 		}
 
 		@Override


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-2640

This isn't strictly necessary in 5.8, but I think it's an improvement, and I'll need the `Closer` class to fix an issue in our JSR-352 integration (https://hibernate.atlassian.net/browse/HSEARCH-2673).