### PR TITLE
HSEARCH-2818 Remove the need to allocate char buffers in GsonHttpEntity

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/AutoGrowingPagedBuffer.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/AutoGrowingPagedBuffer.java
@@ -1,0 +1,188 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.util.impl;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CoderResult;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.LinkedList;
+
+import org.apache.http.nio.ContentEncoder;
+
+/**
+ * An automatically growing, paged buffer.
+ * <p>
+ * To be used when you need an infinite-size buffer,
+ * for example when your class is pushed content to
+ * and generate bytes from this content,
+ * but cannot always flush them to your consumer.
+ *
+ * @author Yoann Rodiere
+ */
+class AutoGrowingPagedBuffer {
+
+	/**
+	 * Size of pages allocated by this object.
+	 */
+	private final int pageSize;
+
+	/**
+	 * Filled pages to be written, in write order.
+	 */
+	private final Deque<ByteBuffer> needWritingPages = new LinkedList<>();
+
+	/**
+	 * Current page, potentially null,
+	 * which may have some content but isn't full yet.
+	 */
+	private ByteBuffer currentPage = null;
+
+	/**
+	 * Previously used pages that are available for reuse.
+	 */
+	private final Deque<ByteBuffer> reusablePages = new LinkedList<>();
+
+	public AutoGrowingPagedBuffer(int pageSize) {
+		this.pageSize = pageSize;
+	}
+
+	/**
+	 * @return {@code true} if this buffer contains content to be written, {@code false} otherwise.
+	 */
+	public boolean hasRemaining() {
+		return !needWritingPages.isEmpty() || currentPage != null && currentPage.position() > 0;
+	}
+
+	/**
+	 * @return The number of pages in this buffer currently storing content.
+	 */
+	public int contentPageCount() {
+		return needWritingPages.size() + ( currentPage == null ? 0 : 1 );
+	}
+
+	/**
+	 * @return The current size of content stored in this buffer, in bytes.
+	 * This does not include the content that has already been {@link #writeTo(ContentEncoder) written}.
+	 */
+	public int contentSize() {
+		int pageCount = needWritingPages.size();
+		int contentSize = pageCount * pageSize;
+		if ( pageCount >= 1 ) {
+			ByteBuffer firstBuffer = needWritingPages.getFirst();
+			/*
+			 * Correct for the size of the first page, which may have been consumed in part
+			 * (and may not even be completely full in some cases).
+			 */
+			contentSize -= pageSize;
+			contentSize += firstBuffer.remaining();
+		}
+		if ( currentPage != null ) {
+			// Add the size of the current page, which may not be completely full.
+			contentSize += currentPage.position();
+		}
+		return contentSize;
+	}
+
+	/**
+	 * Transfer the given characters into this buffer.
+	 * @param input The characters to transfer
+	 * @param encoder The character encoder
+	 * @param endOfInput The {@code enfOfInput} parameter for {@link CharsetEncoder#encode(CharBuffer, ByteBuffer, boolean)}.
+	 * @throws CharacterCodingException as thrown by {@link CharsetEncoder#encode(CharBuffer, ByteBuffer, boolean)}
+	 */
+	public void put(CharBuffer input, CharsetEncoder encoder, boolean endOfInput) throws CharacterCodingException {
+		if ( currentPage == null ) {
+			currentPage = fetchPage();
+		}
+		while ( true ) {
+			CoderResult coderResult = encoder.encode( input, currentPage, endOfInput );
+			if ( coderResult.equals( CoderResult.UNDERFLOW ) ) {
+				break;
+			}
+			else if ( coderResult.equals( CoderResult.OVERFLOW ) ) {
+				currentPage.flip();
+				needWritingPages.add( currentPage );
+				currentPage = fetchPage();
+				continue;
+			}
+			else {
+				//Encoding exception
+				coderResult.throwException();
+				return; //Unreachable
+			}
+		}
+	}
+
+	/**
+	 * @param out The target to flush this buffer to.
+	 * @return {@code true} if the buffer could be consumed completely,
+	 * {@code false} if flow control pushed back when there was still content to be written.
+	 */
+	public boolean writeTo(ContentEncoder out) throws IOException {
+		Iterator<ByteBuffer> iterator = needWritingPages.iterator();
+		boolean flowControlPushingBack = false;
+		while ( iterator.hasNext() && !flowControlPushingBack ) {
+			ByteBuffer buffer = iterator.next();
+			boolean written = writeTo( out, buffer );
+			if ( written ) {
+				iterator.remove();
+				// Keep a reference to the buffer, we might need it later
+				reusablePages.add( buffer );
+			}
+			else {
+				flowControlPushingBack = true;
+			}
+		}
+		if ( ! flowControlPushingBack && currentPage != null ) {
+			// The encoder still accepts some input, let's use the current buffer
+			currentPage.flip();
+			boolean written = writeTo( out, currentPage );
+			if ( written ) {
+				reusablePages.add( currentPage );
+			}
+			else {
+				needWritingPages.add( currentPage );
+			}
+			currentPage = null;
+		}
+		return !flowControlPushingBack;
+	}
+
+	private ByteBuffer fetchPage() {
+		ByteBuffer buffer = reusablePages.pollFirst();
+		if ( buffer != null ) {
+			// If we happen to have an already-allocated buffer, clear it and use it
+			buffer.clear();
+		}
+		else {
+			// Otherwise, allocate a new buffer
+			buffer = ByteBuffer.allocate( pageSize );
+		}
+		return buffer;
+	}
+
+	private static boolean writeTo(ContentEncoder out, ByteBuffer buffer) throws IOException {
+		final int toWrite = buffer.remaining();
+		// We should never do 0-length writes, see HSEARCH-2854
+		if ( toWrite == 0 ) {
+			return true;
+		}
+		final int actuallyWritten = out.write( buffer );
+		if ( toWrite == actuallyWritten ) {
+			return true;
+		}
+		else {
+			return false;
+		}
+	}
+
+}

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/GsonHttpEntity.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/GsonHttpEntity.java
@@ -135,7 +135,8 @@ public final class GsonHttpEntity implements HttpEntity, HttpAsyncContentProduce
 		Objects.requireNonNull( bodyParts );
 		this.gson = gson;
 		this.bodyParts = bodyParts;
-		this.contentLength = attemptOnePassEncoding();
+		this.contentLength = -1;
+		attemptOnePassEncoding();
 	}
 
 	@Override
@@ -207,7 +208,7 @@ public final class GsonHttpEntity implements HttpEntity, HttpAsyncContentProduce
 	 * which is ideal precisely for small messages which can fit into a single buffer.
 	 * @return the size of the content, if all was written, or -1.
 	 */
-	private long attemptOnePassEncoding() {
+	private void attemptOnePassEncoding() {
 		// Essentially attempt to use the writer without going NPE on the output sink
 		// as it's not set yet.
 		try {
@@ -220,10 +221,7 @@ public final class GsonHttpEntity implements HttpEntity, HttpAsyncContentProduce
 		if ( writer.flowControlPushingBack == false ) {
 			//Can't flip the buffer yet but the position is final,
 			//as we know the entire content has been rendered already.
-			return writer.availableBuffer.position();
-		}
-		else {
-			return -1l;
+			hintContentLength( writer.availableBuffer.position() );
 		}
 	}
 


### PR DESCRIPTION
Follow-up on #1490 .

After this patch, we only use byte buffers to store data that couldn't be flushed (as many buffers as needed), whereas we previously used a mix of byte buffers and char buffers (2 byte buffers per request + as many char buffers as needed).
Functionally, this is identical to the previous implementation.
Performance-wise, there might be a small gain, but I doubt it can be significant.

All in all, the only reason for this patch is to make the code simpler. I think it succeeds, but that's my opinion.