### PR TITLE
HSEARCH-2854 IllegalStateException when sending an Elasticsearch request with a content-length

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/GsonHttpEntity.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/GsonHttpEntity.java
@@ -412,7 +412,7 @@ public final class GsonHttpEntity implements HttpEntity, HttpAsyncContentProduce
 		}
 
 		private void flushCurrentBuffer() throws IOException {
-			if ( availableBuffer == null ) {
+			if ( availableBuffer == null || availableBuffer.position() == 0 ) {
 				//Nothing to flush
 				return;
 			}


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-2854
