### PR TITLE
HSEARCH-2849 Improve the previously useless content-length hinting when computing Elasticsearch request hash

### DIFF
--- a/elasticsearch-aws/src/main/java/org/hibernate/search/elasticsearch/aws/impl/AWSElasticsearchHttpClientConfigurer.java
+++ b/elasticsearch-aws/src/main/java/org/hibernate/search/elasticsearch/aws/impl/AWSElasticsearchHttpClientConfigurer.java
@@ -37,12 +37,15 @@ public class AWSElasticsearchHttpClientConfigurer implements ElasticsearchHttpCl
 		String secretKey = requireNonEmpty( properties, SECRET_KEY_PROPERTY );
 		String region = requireNonEmpty( properties, REGION_PROPERTY );
 
-		AWSSigningRequestInterceptor interceptor = new AWSSigningRequestInterceptor(
+		AWSPayloadHashingRequestInterceptor payloadHashingInterceptor =
+				new AWSPayloadHashingRequestInterceptor();
+		AWSSigningRequestInterceptor signingInterceptor = new AWSSigningRequestInterceptor(
 				accessKey, secretKey, region,
 				ELASTICSEARCH_SERVICE_NAME
 				);
 
-		builder.addInterceptorLast( interceptor );
+		builder.addInterceptorFirst( payloadHashingInterceptor );
+		builder.addInterceptorLast( signingInterceptor );
 	}
 
 	private String requireNonEmpty(Properties properties, String name) {

--- a/elasticsearch-aws/src/main/java/org/hibernate/search/elasticsearch/aws/impl/AWSPayloadHashingRequestInterceptor.java
+++ b/elasticsearch-aws/src/main/java/org/hibernate/search/elasticsearch/aws/impl/AWSPayloadHashingRequestInterceptor.java
@@ -1,0 +1,74 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.aws.impl;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.MessageDigest;
+
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpEntityEnclosingRequest;
+import org.apache.http.HttpException;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.protocol.HttpContext;
+import org.hibernate.search.elasticsearch.spi.DigestSelfSigningCapable;
+
+/**
+ * Interceptor computing the hash of the request payload.
+ * <p>
+ * Implemented separately from {@link AWSSigningRequestInterceptor} in order
+ * to trigger content-length computation before the Apache HTTP client
+ * generates the content-length header.
+ *
+ * @see <a href="https://hibernate.atlassian.net/browse/HSEARCH-2831">HSEARCH-2831</a>
+ *
+ * @author Yoann Rodiere
+ */
+class AWSPayloadHashingRequestInterceptor implements HttpRequestInterceptor {
+
+	public static final String CONTEXT_ATTRIBUTE_HASH = AWSPayloadHashingRequestInterceptor.class.getName() + "_hash";
+
+	@Override
+	public void process(HttpRequest request, HttpContext context) throws HttpException, IOException {
+		String contentHash = computeContentHash( request );
+		context.setAttribute( CONTEXT_ATTRIBUTE_HASH, contentHash );
+	}
+
+	private String computeContentHash(HttpRequest request) throws IOException {
+		HttpEntity entity = getEntity( request );
+		if ( entity == null ) {
+			return DigestUtils.sha256Hex( "" );
+		}
+		if ( entity instanceof DigestSelfSigningCapable ) {
+			DigestSelfSigningCapable e = (DigestSelfSigningCapable) entity;
+			MessageDigest digest = DigestUtils.getSha256Digest();
+			e.fillDigest( digest );
+			return Hex.encodeHexString( digest.digest() );
+		}
+		else {
+			if ( !entity.isRepeatable() ) {
+				throw new IllegalStateException( "Cannot sign AWS requests with non-repeatable entities" );
+			}
+			try ( InputStream content = entity.getContent() ) {
+				return DigestUtils.sha256Hex( content );
+			}
+		}
+	}
+
+	private HttpEntity getEntity(HttpRequest request) throws IOException {
+		if ( request instanceof HttpEntityEnclosingRequest ) {
+			return ( (HttpEntityEnclosingRequest) request ).getEntity();
+		}
+		else {
+			return null;
+		}
+	}
+
+}

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/GsonHttpEntity.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/GsonHttpEntity.java
@@ -412,7 +412,7 @@ public final class GsonHttpEntity implements HttpEntity, HttpAsyncContentProduce
 		}
 
 		private void flushCurrentBuffer() throws IOException {
-			if ( availableBuffer == null ) {
+			if ( availableBuffer == null || availableBuffer.position() == 0 ) {
 				//Nothing to flush
 				return;
 			}

--- a/integrationtest/elasticsearch/pom.xml
+++ b/integrationtest/elasticsearch/pom.xml
@@ -23,7 +23,14 @@
 
     <properties>
         <test.elasticsearch.failsafe.excludedGroups.version></test.elasticsearch.failsafe.excludedGroups.version>
-        <test.elasticsearch.failsafe.excludedGroups.aws></test.elasticsearch.failsafe.excludedGroups.aws>
+        <!--
+             By default, the following property skips AWS-related tests;
+             when the aws profile is enabled, it will skip tests that cannot pass on AWS
+         -->
+        <test.elasticsearch.failsafe.excludedGroups.aws>
+            ,
+            org.hibernate.search.elasticsearch.testutil.junit.SkipWithoutAWS
+        </test.elasticsearch.failsafe.excludedGroups.aws>
     </properties>
 
     <dependencies>
@@ -162,6 +169,19 @@
             <classifier>build-resources</classifier>
             <type>zip</type>
             <scope>provided</scope>
+        </dependency>
+        
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <!-- Exclude dependencies that conflict with the ES Rest client -->
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/client/ElasticsearchContentLengthIT.java
+++ b/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/client/ElasticsearchContentLengthIT.java
@@ -1,0 +1,215 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.test.client;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Properties;
+
+import org.hibernate.search.cfg.spi.SearchConfiguration;
+import org.hibernate.search.elasticsearch.cfg.ElasticsearchEnvironment;
+import org.hibernate.search.elasticsearch.client.impl.DefaultElasticsearchClientFactory;
+import org.hibernate.search.elasticsearch.client.impl.ElasticsearchClient;
+import org.hibernate.search.elasticsearch.client.impl.ElasticsearchRequest;
+import org.hibernate.search.elasticsearch.client.impl.ElasticsearchRequest.Builder;
+import org.hibernate.search.elasticsearch.client.impl.ElasticsearchResponse;
+import org.hibernate.search.elasticsearch.client.impl.URLEncodedString;
+import org.hibernate.search.elasticsearch.testutil.junit.SkipOnAWS;
+import org.hibernate.search.elasticsearch.testutil.junit.SkipWithoutAWS;
+import org.hibernate.search.testsupport.TestForIssue;
+import org.hibernate.search.testsupport.setup.BuildContextForTest;
+import org.hibernate.search.testsupport.setup.SearchConfigurationForTest;
+import org.hibernate.search.util.configuration.impl.MaskedProperty;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.stream.JsonWriter;
+
+/**
+ * Test that we manage to compute the content-length of Elasticsearch
+ * requests appropriately (for small requests, or when computing digests, e.g. on AWS),
+ * and use the "chunked" transfer-encoding otherwise.
+ *
+ * @author Yoann Rodiere
+ */
+@TestForIssue(jiraKey = "HSEARCH-2849")
+public class ElasticsearchContentLengthIT {
+
+	private static final JsonObject BODY_PART = new JsonParser().parse( "{ \"foo\": \"bar\" }" ).getAsJsonObject();
+
+	private static final int BODY_PART_BYTE_SIZE;
+	static {
+		Gson gson = new Gson();
+		try ( ByteArrayOutputStream out = new ByteArrayOutputStream();
+				Writer writer = new OutputStreamWriter( out, StandardCharsets.UTF_8 );
+				JsonWriter jsonWriter = new JsonWriter( writer ) ) {
+			gson.toJson( BODY_PART, jsonWriter );
+			writer.write( '\n' ); // Account for EOL at the end of each body part
+			jsonWriter.flush();
+			BODY_PART_BYTE_SIZE = out.size();
+		}
+		catch (IOException e) {
+			throw new IllegalStateException( "Error while initializing a constant", e );
+		}
+	}
+
+	private static final int BUFFER_LIMIT = 1024;
+
+	@Rule
+	public WireMockRule wireMockRule = new WireMockRule( wireMockConfig().port( 0 ).httpsPort( 0 ) /* Automatic port selection */ );
+
+	private DefaultElasticsearchClientFactory clientFactory = new DefaultElasticsearchClientFactory();
+
+	@After
+	public void stop() {
+		clientFactory.stop();
+	}
+
+	@Test
+	public void tinyPayload() throws Exception {
+		SearchConfigurationForTest configuration = createConfiguration();
+
+		wireMockRule.stubFor( post( urlPathLike( "/myIndex/myType" ) )
+				.willReturn( elasticsearchResponse().withStatus( 200 ) ) );
+
+		try ( ElasticsearchClient client = createClient( configuration ) ) {
+			doPost( client, "/myIndex/myType", produceBody( 1 ) );
+			wireMockRule.verify(
+					postRequestedFor( urlPathLike( "/myIndex/myType" ) )
+							.withoutHeader( "Transfer-Encoding" )
+							.withHeader( "Content-length", equalTo( String.valueOf( BODY_PART_BYTE_SIZE ) ) )
+					);
+		}
+	}
+
+	@Test
+	public void payloadJustBelowBufferSize() throws Exception {
+		SearchConfigurationForTest configuration = createConfiguration();
+
+		wireMockRule.stubFor( post( urlPathLike( "/myIndex/myType" ) )
+				.willReturn( elasticsearchResponse().withStatus( 200 ) ) );
+
+		int bodyPartCount = BUFFER_LIMIT / BODY_PART_BYTE_SIZE - 1;
+
+		try ( ElasticsearchClient client = createClient( configuration ) ) {
+			doPost( client, "/myIndex/myType", produceBody( bodyPartCount ) );
+			wireMockRule.verify(
+					postRequestedFor( urlPathLike( "/myIndex/myType" ) )
+							.withoutHeader( "Transfer-Encoding" )
+							.withHeader( "Content-length", equalTo( String.valueOf( bodyPartCount * BODY_PART_BYTE_SIZE ) ) )
+					);
+		}
+	}
+
+	@Test
+	@Category(SkipOnAWS.class)
+	public void payloadJustAboveBufferSize_nonAws() throws Exception {
+		SearchConfigurationForTest configuration = createConfiguration();
+
+		wireMockRule.stubFor( post( urlPathLike( "/myIndex/myType" ) )
+				.willReturn( elasticsearchResponse().withStatus( 200 ) ) );
+
+		int bodyPartCount = BUFFER_LIMIT / BODY_PART_BYTE_SIZE + 1;
+
+		try ( ElasticsearchClient client = createClient( configuration ) ) {
+			doPost( client, "/myIndex/myType", produceBody( bodyPartCount ) );
+			wireMockRule.verify(
+					postRequestedFor( urlPathLike( "/myIndex/myType" ) )
+							.withHeader( "Transfer-Encoding", equalTo( "chunked" ) )
+							.withoutHeader( "Content-length" )
+					);
+		}
+	}
+
+	@Test
+	@Category(SkipWithoutAWS.class)
+	public void payloadJustAboveBufferSize_aws() throws Exception {
+		SearchConfigurationForTest configuration = createConfiguration();
+
+		wireMockRule.stubFor( post( urlPathLike( "/myIndex/myType" ) )
+				.willReturn( elasticsearchResponse().withStatus( 200 ) ) );
+
+		int bodyPartCount = BUFFER_LIMIT / BODY_PART_BYTE_SIZE + 1;
+
+		try ( ElasticsearchClient client = createClient( configuration ) ) {
+			doPost( client, "/myIndex/myType", produceBody( bodyPartCount ) );
+			wireMockRule.verify(
+					postRequestedFor( urlPathLike( "/myIndex/myType" ) )
+							.withoutHeader( "Transfer-Encoding" )
+							.withHeader( "Content-length", equalTo( String.valueOf( bodyPartCount * BODY_PART_BYTE_SIZE ) ) )
+					);
+		}
+	}
+
+	private SearchConfigurationForTest createConfiguration() {
+		return new SearchConfigurationForTest()
+				.addProperty( "hibernate.search.default." + ElasticsearchEnvironment.SERVER_URI, httpUrlFor( wireMockRule ) );
+	}
+
+	private ElasticsearchClient createClient(SearchConfiguration configuration) {
+		clientFactory.start( configuration.getProperties(), new BuildContextForTest( configuration ) );
+		Properties maskedProperties = new MaskedProperty( configuration.getProperties(), "hibernate.search.default" );
+		return clientFactory.create( maskedProperties );
+	}
+
+	private ElasticsearchResponse doPost(ElasticsearchClient client, String path, Collection<JsonObject> bodyParts) {
+		return client.submit( buildRequest( ElasticsearchRequest.post(), path, bodyParts ) ).join();
+	}
+
+	private ElasticsearchRequest buildRequest(Builder builder, String path, Collection<JsonObject> bodyParts) {
+		for ( String pathComponent : path.split( "/" ) ) {
+			if ( !pathComponent.isEmpty() ) {
+				URLEncodedString fromString = URLEncodedString.fromString( pathComponent );
+				builder = builder.pathComponent( fromString );
+			}
+		}
+		for ( JsonObject bodyPart : bodyParts ) {
+			builder = builder.body( bodyPart );
+		}
+		return builder.build();
+	}
+
+	private static String httpUrlFor(WireMockRule rule) {
+		return "http://localhost:" + rule.port();
+	}
+
+	private static UrlPathPattern urlPathLike(String path) {
+		return urlPathMatching( path + "/?" );
+	}
+
+	private static ResponseDefinitionBuilder elasticsearchResponse() {
+		return ResponseDefinitionBuilder.okForEmptyJson();
+	}
+
+	private static Collection<JsonObject> produceBody(int bodyPartCount) {
+		Collection<JsonObject> result = new ArrayList<>( bodyPartCount );
+		for ( int i = 0; i < bodyPartCount; i++ ) {
+			result.add( BODY_PART );
+		}
+		return result;
+	}
+
+}

--- a/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/testutil/junit/SkipWithoutAWS.java
+++ b/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/testutil/junit/SkipWithoutAWS.java
@@ -1,0 +1,18 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.testutil.junit;
+
+
+/**
+ * JUnit category marker.
+ * <p>
+ * Used to ignore tests which will not work when testing against a non-AWS Elasticsearch cluster.
+ * This includes tests relying on the content-length computation .
+ */
+public class SkipWithoutAWS {
+
+}


### PR DESCRIPTION
~This PR is based on #1516 (HSEARCH-2854), which should be merged first.~ => Done

Relevant JIRA ticket: https://hibernate.atlassian.net//browse/HSEARCH-2849

See the ticket for an explanation of why this PR is necessary.

Proof that we used to do chunked requests on AWS, even if we did create digests: http://ci.hibernate.org/job/hibernate-search-master-elasticsearchAWS-yoann/org.hibernate$hibernate-search-integrationtest-elasticsearch/9/testReport/junit/org.hibernate.search.elasticsearch.test.client/ElasticsearchContentLengthIT/payloadJustAboveBufferSize_aws/
Proof that this PR fixes the issue: http://ci.hibernate.org/job/hibernate-search-master-elasticsearchAWS-yoann/11/