### PR TITLE
HSEARCH-2850 options to run WildFly TS against prepared distribution …

### DIFF
--- a/integrationtest/wildfly/README.md
+++ b/integrationtest/wildfly/README.md
@@ -1,0 +1,8 @@
+## Explanation of testing profiles
+### Obtaining WildFly distribution
+- The default is that the TS obtains WildFly from Maven and prepares it automatically.
+- To test against WildFly distributions which you prepared yourself, just pass the `-DjbossHome.node1` and `-DjbossHome.node2` properties containing paths to the distributions
+
+### Testing included modules vs. preparing modules 
+- The default mode is that the TS unzips Hibernate Search and required libraries as WildFly modules into the distributions
+- If you want to test against the modules included in the official WildFly distributions, pass the property `-DuseBuiltinModules`. In this case, you should also specify the expected Hibernate Search version (the one included in the WildFly distribution), using the `-DbuiltinVersion` property. If not specified, the test suite will expect that the included version is the same as the one you are running the test suite from. 

--- a/integrationtest/wildfly/pom.xml
+++ b/integrationtest/wildfly/pom.xml
@@ -30,6 +30,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <byteman.agent.path>${org.jboss.byteman:byteman:jar}</byteman.agent.path>
         <byteman.script.path>${basedir}${file.separator}src${file.separator}test${file.separator}resources${file.separator}disablejpadapters.btm</byteman.script.path>
+        <test.hibernate.search.module.slot>main</test.hibernate.search.module.slot>
     </properties>
 
     <dependencyManagement>
@@ -270,74 +271,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>unpack</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>unpack</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.wildfly</groupId>
-                                    <artifactId>wildfly-dist</artifactId>
-                                    <version>${wildflyVersion}</version>
-                                    <type>zip</type>
-                                    <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/node1</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.wildfly</groupId>
-                                    <artifactId>wildfly-dist</artifactId>
-                                    <version>${wildflyVersion}</version>
-                                    <type>zip</type>
-                                    <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/node2</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.hibernate</groupId>
-                                    <artifactId>hibernate-search-modules</artifactId>
-                                    <version>${project.version}</version>
-                                    <classifier>wildfly-10-dist</classifier>
-                                    <type>zip</type>
-                                    <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/node1/wildfly-${wildflyVersion}/modules</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.hibernate</groupId>
-                                    <artifactId>hibernate-search-modules</artifactId>
-                                    <version>${project.version}</version>
-                                    <classifier>wildfly-10-dist</classifier>
-                                    <type>zip</type>
-                                    <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/node2/wildfly-${wildflyVersion}/modules</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.hibernate</groupId>
-                                    <artifactId>hibernate-orm-modules</artifactId>
-                                    <version>${hibernateVersion}</version>
-                                    <classifier>wildfly-10-dist</classifier>
-                                    <type>zip</type>
-                                    <overWrite>false</overWrite>
-                                    <outputDirectory>${project.build.directory}/node1/wildfly-${wildflyVersion}/modules</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.hibernate</groupId>
-                                    <artifactId>hibernate-orm-modules</artifactId>
-                                    <version>${hibernateVersion}</version>
-                                    <classifier>wildfly-10-dist</classifier>
-                                    <type>zip</type>
-                                    <overWrite>false</overWrite>
-                                    <outputDirectory>${project.build.directory}/node2/wildfly-${wildflyVersion}/modules</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
                 <executions>
@@ -349,7 +282,7 @@
                             <goal>copy-resources</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>${project.build.directory}/node1/wildfly-${wildflyVersion}</outputDirectory>
+                            <outputDirectory>${jbossHome.node1}</outputDirectory>
                             <overwrite>true</overwrite>
                             <resources>
                                 <resource>
@@ -365,7 +298,7 @@
                             <goal>copy-resources</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>${project.build.directory}/node2/wildfly-${wildflyVersion}</outputDirectory>
+                            <outputDirectory>${jbossHome.node2}</outputDirectory>
                             <overwrite>true</overwrite>
                             <resources>
                                 <resource>
@@ -378,4 +311,150 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <!--
+                With this testing profile, the TS will automatically unzip WildFly distributions obtained via
+                Maven's dependency resolution mechanisms, as opposed to the mode where
+                the user is expected to prepare the distributions beforehand.
+                This is active by default, unless you specify a value for jbossHome.node1.
+            -->
+            <id>unzipWildFly</id>
+            <activation>
+                <property>
+                    <name>!jbossHome.node1</name>
+                </property>
+            </activation>
+            <properties>
+                <jbossHome.node1>${project.build.directory}/node1/wildfly-${wildflyVersion}</jbossHome.node1>
+                <jbossHome.node2>${project.build.directory}/node2/wildfly-${wildflyVersion}</jbossHome.node2>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack-wildfly</id>
+                                <phase>process-test-resources</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.wildfly</groupId>
+                                            <artifactId>wildfly-dist</artifactId>
+                                            <version>${wildflyVersion}</version>
+                                            <type>zip</type>
+                                            <overWrite>true</overWrite>
+                                            <outputDirectory>${project.build.directory}/node1
+                                            </outputDirectory>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>org.wildfly</groupId>
+                                            <artifactId>wildfly-dist</artifactId>
+                                            <version>${wildflyVersion}</version>
+                                            <type>zip</type>
+                                            <overWrite>true</overWrite>
+                                            <outputDirectory>${project.build.directory}/node2
+                                            </outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <!--
+                With this profile, the TS will create Hibernate Search modules by itself, as opposed to testing the
+                modules already included in WildFly distribution (org.hibernate.search.orm:main).
+                This is active by default.
+             -->
+            <id>createModules</id>
+            <activation>
+                <property>
+                    <name>!useBuiltinModules</name>
+                </property>
+            </activation>
+            <properties>
+                <!-- the slot will be inferred at runtime -->
+                <test.hibernate.search.module.slot/>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack-modules</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.hibernate</groupId>
+                                            <artifactId>hibernate-search-modules</artifactId>
+                                            <version>${project.version}</version>
+                                            <classifier>wildfly-10-dist</classifier>
+                                            <type>zip</type>
+                                            <overWrite>true</overWrite>
+                                            <outputDirectory>${jbossHome.node1}/modules</outputDirectory>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>org.hibernate</groupId>
+                                            <artifactId>hibernate-search-modules</artifactId>
+                                            <version>${project.version}</version>
+                                            <classifier>wildfly-10-dist</classifier>
+                                            <type>zip</type>
+                                            <overWrite>true</overWrite>
+                                            <outputDirectory>${jbossHome.node2}/modules</outputDirectory>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>org.hibernate</groupId>
+                                            <artifactId>hibernate-orm-modules</artifactId>
+                                            <version>${hibernateVersion}</version>
+                                            <classifier>wildfly-10-dist</classifier>
+                                            <type>zip</type>
+                                            <overWrite>false</overWrite>
+                                            <outputDirectory>${jbossHome.node1}/modules</outputDirectory>
+                                        </artifactItem>
+                                        <artifactItem>
+                                             <groupId>org.hibernate</groupId>
+                                             <artifactId>hibernate-orm-modules</artifactId>
+                                             <version>${hibernateVersion}</version>
+                                             <classifier>wildfly-10-dist</classifier>
+                                             <type>zip</type>
+                                             <overWrite>false</overWrite>
+                                             <outputDirectory>${jbossHome.node2}/modules</outputDirectory>
+                                         </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <!--
+                When using built-in modules, set the correct Hibernate ORM module slot (main).
+            -->
+            <id>useBuiltinModules</id>
+            <activation>
+                <property>
+                    <name>useBuiltinModules</name>
+                </property>
+            </activation>
+            <properties>
+                <hibernate-orm.module.slot>main</hibernate-orm.module.slot>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/VersionTestHelper.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/VersionTestHelper.java
@@ -24,6 +24,7 @@ import java.util.Map.Entry;
 public class VersionTestHelper {
 
 	private static String hibernateSearchVersion = null;
+	private static String hibernateSearchVersionBuiltIn = null;
 	private static String hibernateSearchModuleSlot = null;
 	private static String hibernateOrmModuleName = null;
 	private static String luceneFullVersion = null;
@@ -38,9 +39,12 @@ public class VersionTestHelper {
 	 */
 	public static synchronized String getModuleSlotString() {
 		if ( hibernateSearchModuleSlot == null ) {
-			String versionHibernateSearch = getDependencyVersionHibernateSearch();
-			String[] split = versionHibernateSearch.split( "\\." );
-			hibernateSearchModuleSlot = split[0] + '.' + split[1];
+			hibernateSearchModuleSlot = injectVariables( "${test.hibernate.search.module.slot}" );
+			if ( hibernateSearchModuleSlot == null || hibernateSearchModuleSlot.isEmpty() ) {
+				String versionHibernateSearch = getDependencyVersionHibernateSearch();
+				String[] split = versionHibernateSearch.split( "\\." );
+				hibernateSearchModuleSlot = split[0] + '.' + split[1];
+			}
 		}
 		return hibernateSearchModuleSlot;
 	}
@@ -57,6 +61,19 @@ public class VersionTestHelper {
 			hibernateOrmModuleName = "org.hibernate:" + injectVariables( "${hibernate-orm.module.slot}" );
 		}
 		return hibernateOrmModuleName;
+	}
+
+	public static synchronized String getDependencyVersionHibernateSearchBuiltIn() {
+		if ( hibernateSearchVersionBuiltIn == null ) {
+			hibernateSearchVersionBuiltIn = injectVariables( "${dependency.version.HibernateSearch.builtin}" );
+			// if no built-in version is specified, default to the version from Maven
+			if ( hibernateSearchVersionBuiltIn == null
+					|| hibernateSearchVersionBuiltIn.isEmpty()
+					|| hibernateSearchVersionBuiltIn.startsWith( "${" ) ) {
+				hibernateSearchVersionBuiltIn = getDependencyVersionHibernateSearch();
+			}
+		}
+		return hibernateSearchVersionBuiltIn;
 	}
 
 	public static synchronized String getDependencyVersionLucene() {

--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/wildfly/ModuleMemberRegistrationEarArchiveWithJbossDeploymentIT.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/wildfly/ModuleMemberRegistrationEarArchiveWithJbossDeploymentIT.java
@@ -85,7 +85,11 @@ public class ModuleMemberRegistrationEarArchiveWithJbossDeploymentIT {
 		String webXml = Descriptors.create( org.jboss.shrinkwrap.descriptor.api.webapp31.WebAppDescriptor.class )
 			.createEnvEntry()
 				.envEntryName( EXPECTED_SEARCH_VERSION_RESOURCE )
-				.envEntryValue( VersionTestHelper.getDependencyVersionHibernateSearch() )
+				.envEntryValue(
+						"main".equals( VersionTestHelper.getModuleSlotString() ) ?
+								VersionTestHelper.getDependencyVersionHibernateSearchBuiltIn() :
+								VersionTestHelper.getDependencyVersionHibernateSearch()
+				)
 				.envEntryType( "java.lang.String" )
 				.up()
 			.exportAsString();

--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/wildfly/ModuleMemberRegistrationIT.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/wildfly/ModuleMemberRegistrationIT.java
@@ -61,7 +61,10 @@ public class ModuleMemberRegistrationIT {
 		String webXml = Descriptors.create( org.jboss.shrinkwrap.descriptor.api.webapp31.WebAppDescriptor.class )
 			.createEnvEntry()
 				.envEntryName( EXPECTED_SEARCH_VERSION_RESOURCE )
-				.envEntryValue( VersionTestHelper.getDependencyVersionHibernateSearch() )
+				.envEntryValue(
+						"main".equals( VersionTestHelper.getModuleSlotString() ) ?
+						VersionTestHelper.getDependencyVersionHibernateSearchBuiltIn() :
+						VersionTestHelper.getDependencyVersionHibernateSearch() )
 				.envEntryType( "java.lang.String" )
 				.up()
 			.exportAsString();

--- a/integrationtest/wildfly/src/test/resources/arquillian.xml
+++ b/integrationtest/wildfly/src/test/resources/arquillian.xml
@@ -22,7 +22,7 @@
     <group qualifier="Grid" default="true">
         <container qualifier="container.active-1" mode="suite" default="true">
             <configuration>
-                <property name="jbossHome">${project.build.directory}/node1/wildfly-${wildflyVersion}</property>
+                <property name="jbossHome">${jbossHome.node1}</property>
                 <!-- Needed for JMS tests -->
                 <property name="serverConfig">standalone-full-testqueues.xml</property>
                 <property name="javaVmArguments">-javaagent:${byteman.agent.path}=script:${byteman.script.path} -Xmx512m -Djava.net.preferIPv4Stack=true -Djgroups.bind_addr=127.0.0.1</property>
@@ -33,7 +33,7 @@
         <!-- Copy of the above, except a port offset is applied and running from a different copy -->
         <container qualifier="container.active-2" mode="suite">
             <configuration>
-                <property name="jbossHome">${project.build.directory}/node2/wildfly-${wildflyVersion}</property>
+                <property name="jbossHome">${jbossHome.node2}</property>
                 <!-- Needed for JMS tests -->
                 <property name="serverConfig">standalone-full-testqueues.xml</property>
                 <property name="javaVmArguments">-Djboss.socket.binding.port-offset=10000 -Xmx512m -Djava.net.preferIPv4Stack=true -Djgroups.bind_addr=127.0.0.1</property>

--- a/integrationtest/wildfly/src/test/resources/module-versions.properties
+++ b/integrationtest/wildfly/src/test/resources/module-versions.properties
@@ -3,3 +3,5 @@ dependency.version.HibernateSearch = ${project.version}
 dependency.version.Lucene = ${luceneVersion}
 dependency.version.hcann = ${hibernateCommonsAnnotationVersion}
 hibernate-orm.module.slot = ${hibernate-orm.module.slot}
+test.hibernate.search.module.slot = ${test.hibernate.search.module.slot}
+dependency.version.HibernateSearch.builtin = ${builtinVersion}


### PR DESCRIPTION
…and built-in modules

Note that `-DuseBuiltinModules` will not currently work due to incompatibilities with Hibernate Search included in WildFly.