### PR TITLE
HSEARCH-2870 Test compatibility, upgrade to Elasticsearch 5.6

### DIFF
--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -31,12 +31,12 @@
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
-            <artifactId>rest</artifactId>
+            <artifactId>elasticsearch-rest-client</artifactId>
             <version>${elasticsearchClientVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
-            <artifactId>sniffer</artifactId>
+            <artifactId>elasticsearch-rest-client-sniffer</artifactId>
             <version>${elasticsearchSnifferVersion}</version>
         </dependency>
         <dependency>

--- a/modules/src/main/assembly/dist.xml
+++ b/modules/src/main/assembly/dist.xml
@@ -184,7 +184,7 @@
             <useTransitiveFiltering>false</useTransitiveFiltering>
             <unpack>false</unpack>
             <includes>
-                <include>org.elasticsearch.client:rest</include>
+                <include>org.elasticsearch.client:elasticsearch-rest-client</include>
             </includes>
         </dependencySet>
 
@@ -194,7 +194,7 @@
             <useTransitiveFiltering>false</useTransitiveFiltering>
             <unpack>false</unpack>
             <includes>
-                <include>org.elasticsearch.client:sniffer</include>
+                <include>org.elasticsearch.client:elasticsearch-rest-client-sniffer</include>
             </includes>
         </dependencySet>
 

--- a/modules/src/main/modules/es-client/module.xml
+++ b/modules/src/main/modules/es-client/module.xml
@@ -10,7 +10,7 @@
         <property name="jboss.api" value="private"/>
     </properties>
     <resources>
-        <resource-root path="rest-${elasticsearchClientVersion}.jar"/>
+        <resource-root path="elasticsearch-rest-client-${elasticsearchClientVersion}.jar"/>
     </resources>
     <dependencies>
         <module name="org.apache.httpcomponents"/>

--- a/modules/src/main/modules/es-sniffer/module.xml
+++ b/modules/src/main/modules/es-sniffer/module.xml
@@ -10,7 +10,7 @@
         <property name="jboss.api" value="private"/>
     </properties>
     <resources>
-        <resource-root path="sniffer-${elasticsearchSnifferVersion}.jar"/>
+        <resource-root path="elasticsearch-rest-client-sniffer-${elasticsearchSnifferVersion}.jar"/>
     </resources>
     <dependencies>
         <module name="org.hibernate.search.elasticsearch-client" slot="${hibernate.search.version}"/>

--- a/pom.xml
+++ b/pom.xml
@@ -214,8 +214,8 @@
         <commonsCodecVersion>1.10</commonsCodecVersion>
 
         <!-- Elasticsearch -->
-        <elasticsearchClientVersion>5.5.2</elasticsearchClientVersion>
-        <elasticsearchSnifferVersion>5.5.2</elasticsearchSnifferVersion>
+        <elasticsearchClientVersion>5.6.0</elasticsearchClientVersion>
+        <elasticsearchSnifferVersion>5.6.0</elasticsearchSnifferVersion>
         <elasticsearchGsonVersion>2.8.0</elasticsearchGsonVersion>
         <elasticsearchAWSV4SignerVersion>1.3</elasticsearchAWSV4SignerVersion>
         

--- a/pom.xml
+++ b/pom.xml
@@ -1845,7 +1845,7 @@ org.hibernate.search.spi.SearchIntegratorBuilder#buildSearchIntegrator()
             </activation>
             <properties>
                 <test.elasticsearch.mavenPlugin.version>5.7</test.elasticsearch.mavenPlugin.version>
-                <test.elasticsearch.host.version>5.5.2</test.elasticsearch.host.version>
+                <test.elasticsearch.host.version>5.6.0</test.elasticsearch.host.version>
             </properties>
             <build>
                 <pluginManagement>


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-2870

Tested on 2.2+, 5.1, 5.6: https://travis-ci.org/yrodiere/hibernate-search/builds/274503473
Test in progress on AWS (5.3): http://ci.hibernate.org/view/Personal%20runs/job/hibernate-search-master-elasticsearchAWS-yoann/12/