### PR TITLE
HSEARCH-2867 Duplicate package names in orm/engine, causes problem with jdk9 modules

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -240,6 +240,7 @@
                             org.hibernate.search.util;version="${project.version}",
                             org.hibernate.search.util.impl;version="${project.version}",
                             org.hibernate.search.util.logging.impl;version="${project.version}",
+                            org.hibernate.search.util.jmx.impl;version="${project.version}",
                             org.hibernate.search.engine.service.named.spi;version="${project.version}",
                             org.hibernate.search.engine.service.beanresolver.spi;version="${project.version}"
                         </Export-Package>

--- a/engine/src/main/java/org/hibernate/search/engine/impl/ImmutableSearchFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/impl/ImmutableSearchFactory.java
@@ -47,7 +47,7 @@ import org.hibernate.search.indexes.spi.IndexManager;
 import org.hibernate.search.indexes.spi.IndexManagerType;
 import org.hibernate.search.indexes.spi.LuceneEmbeddedIndexManagerType;
 import org.hibernate.search.jmx.StatisticsInfoMBean;
-import org.hibernate.search.jmx.impl.JMXRegistrar;
+import org.hibernate.search.util.jmx.impl.JMXRegistrar;
 import org.hibernate.search.metadata.IndexedTypeDescriptor;
 import org.hibernate.search.metadata.impl.IndexedTypeDescriptorForUnindexedType;
 import org.hibernate.search.metadata.impl.IndexedTypeDescriptorImpl;

--- a/engine/src/main/java/org/hibernate/search/util/jmx/impl/JMXRegistrar.java
+++ b/engine/src/main/java/org/hibernate/search/util/jmx/impl/JMXRegistrar.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.jmx.impl;
+package org.hibernate.search.util.jmx.impl;
 
 import java.lang.management.ManagementFactory;
 import java.util.Map;

--- a/engine/src/test/java/org/hibernate/search/test/jmx/MultipleStatisticsMBeanTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/jmx/MultipleStatisticsMBeanTest.java
@@ -22,7 +22,7 @@ import javax.management.ObjectName;
 
 import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.jmx.StatisticsInfoMBean;
-import org.hibernate.search.jmx.impl.JMXRegistrar;
+import org.hibernate.search.util.jmx.impl.JMXRegistrar;
 import org.hibernate.search.spi.SearchIntegrator;
 import org.hibernate.search.testsupport.TestForIssue;
 import org.hibernate.search.testsupport.junit.SearchIntegratorResource;

--- a/integrationtest/jdk9-modules/pom.xml
+++ b/integrationtest/jdk9-modules/pom.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate Search, full-text search for your domain model
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>hibernate-search-parent</artifactId>
+        <groupId>org.hibernate</groupId>
+        <version>5.8.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>hibernate-search-integrationtest-jdk9-modules</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Hibernate Search JDK9 Modules Integration Tests</name>
+    <description>Hibernate Search integration tests for JDK9 modules</description>
+
+    <properties>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-search-orm</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-search-engine</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.easytesting</groupId>
+            <artifactId>fest-assert</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <filtering>true</filtering>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>verify</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>9</source>
+                    <target>9</target>
+                    <showWarnings>true</showWarnings>
+                    <showDeprecation>true</showDeprecation>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+        </plugins>
+    </build>
+
+
+</project>

--- a/integrationtest/jdk9-modules/src/main/java/module-info.java
+++ b/integrationtest/jdk9-modules/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module hibernate.search.integrationtest.jdk9.modules.client {
+	exports org.hibernate.search.test.integration.jdk9_modules.client.service;
+	requires hibernate.search.engine;
+	requires hibernate.search.orm;
+}

--- a/integrationtest/jdk9-modules/src/main/java/org/hibernate/search/test/integration/jdk9_modules/client/model/MyEntity.java
+++ b/integrationtest/jdk9-modules/src/main/java/org/hibernate/search/test/integration/jdk9_modules/client/model/MyEntity.java
@@ -1,0 +1,42 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.integration.jdk9_modules.client.model;
+
+import javax.persistence.Basic;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+
+@Indexed
+@Entity
+public class MyEntity {
+
+	@Id
+	private Integer id;
+
+	@Basic
+	@Field
+	private String name;
+
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/integrationtest/jdk9-modules/src/main/java/org/hibernate/search/test/integration/jdk9_modules/client/service/MyEntityService.java
+++ b/integrationtest/jdk9-modules/src/main/java/org/hibernate/search/test/integration/jdk9_modules/client/service/MyEntityService.java
@@ -1,0 +1,112 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.integration.jdk9_modules.client.service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.EntityTransaction;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.SessionFactoryBuilder;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.search.cfg.Environment;
+import org.hibernate.search.jpa.FullTextEntityManager;
+import org.hibernate.search.jpa.FullTextQuery;
+import org.hibernate.search.jpa.Search;
+import org.hibernate.search.query.dsl.QueryBuilder;
+import org.hibernate.search.test.integration.jdk9_modules.client.model.MyEntity;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+
+import org.apache.lucene.analysis.en.EnglishAnalyzer;
+import org.apache.lucene.search.Query;
+
+public class MyEntityService implements AutoCloseable {
+
+	private final EntityManagerFactory emf;
+
+	public MyEntityService() {
+		emf = createSessionFactory();
+	}
+
+	private EntityManagerFactory createSessionFactory() {
+		Map<String, Object> settings = new HashMap<>();
+		settings.put( "hibernate.search.default.directory_provider", "local-heap" );
+		settings.put( Environment.ANALYZER_CLASS, EnglishAnalyzer.class.getName() );
+		settings.put( "hibernate.search.default.indexwriter.merge_factor", "100" );
+		settings.put( "hibernate.search.default.indexwriter.max_buffered_docs", "1000" );
+
+		StandardServiceRegistryBuilder registryBuilder = new StandardServiceRegistryBuilder()
+				.applySettings( settings );
+
+		ServiceRegistryImplementor serviceRegistry = (ServiceRegistryImplementor) registryBuilder.build();
+		Metadata metadata = new MetadataSources( serviceRegistry ).addAnnotatedClass( MyEntity.class ).buildMetadata();
+		SessionFactoryBuilder sfb = metadata.getSessionFactoryBuilder();
+		return sfb.build();
+	}
+
+	public void add(int id, String name) {
+		EntityManager em = emf.createEntityManager();
+		try {
+			EntityTransaction tx = em.getTransaction();
+			tx.begin();
+			try {
+				MyEntity entity = new MyEntity();
+				entity.setId( id );
+				entity.setName( name );
+				em.persist( entity );
+				tx.commit();
+			}
+			catch (Throwable e) {
+				try {
+					tx.rollback();
+				}
+				catch (Throwable e2) {
+					e.addSuppressed( e2 );
+				}
+				throw e;
+			}
+		}
+		finally {
+			em.close();
+		}
+	}
+
+	public List<Integer> search(String term) {
+		EntityManager em = emf.createEntityManager();
+		try {
+			EntityTransaction tx = em.getTransaction();
+			tx.begin();
+			FullTextEntityManager ftEm = Search.getFullTextEntityManager( em );
+			QueryBuilder queryBuilder = ftEm.getSearchFactory()
+					.buildQueryBuilder()
+					.forEntity( MyEntity.class )
+					.get();
+			Query luceneQuery = queryBuilder.keyword()
+					.onField( "name" )
+					.matching( term )
+					.createQuery();
+			FullTextQuery ftQuery = ftEm.createFullTextQuery( luceneQuery );
+			List<MyEntity> entities = ftQuery.getResultList();
+			List<Integer> ids = entities.stream().map( MyEntity::getId ).collect( Collectors.toList() );
+			tx.rollback();
+			return ids;
+		}
+		finally {
+			em.close();
+		}
+	}
+
+	@Override
+	public void close() {
+		emf.close();
+	}
+}

--- a/integrationtest/jdk9-modules/src/main/resources/hibernate.properties
+++ b/integrationtest/jdk9-modules/src/main/resources/hibernate.properties
@@ -1,0 +1,23 @@
+################################################################################################
+# Hibernate Search, full-text search for your domain model                                     #
+#                                                                                              #
+# License: GNU Lesser General Public License (LGPL), version 2.1 or later                      #
+# See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.  #
+################################################################################################
+hibernate.dialect ${db.dialect}
+hibernate.connection.driver_class ${jdbc.driver}
+hibernate.connection.url ${jdbc.url}
+hibernate.connection.username ${jdbc.user}
+hibernate.connection.password ${jdbc.pass}
+hibernate.connection.isolation ${jdbc.isolation}
+
+hibernate.hbm2ddl.auto create-drop
+
+hibernate.show_sql true
+hibernate.format_sql true
+
+hibernate.max_fetch_depth 5
+
+hibernate.cache.region_prefix hibernate.test
+hibernate.cache.provider_class org.hibernate.cache.HashtableCacheProvider
+

--- a/integrationtest/jdk9-modules/src/test/java/org/hibernate/search/test/integration/jdk9_modules/MyEntityServiceIT.java
+++ b/integrationtest/jdk9-modules/src/test/java/org/hibernate/search/test/integration/jdk9_modules/MyEntityServiceIT.java
@@ -1,0 +1,35 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.integration.jdk9_modules;
+
+import org.hibernate.search.test.integration.jdk9_modules.client.service.MyEntityService;
+
+import org.junit.Test;
+
+import org.fest.assertions.Assertions;
+
+public class MyEntityServiceIT {
+
+	/*
+	 * Test that the service successfully uses Hibernate Search in a JDK9 module.
+	 * We don't really care about the features themselves,
+	 * but that's the easiest way to check that Hibernate Search is being used.
+	 */
+	@Test
+	public void test() {
+		MyEntityService service = new MyEntityService();
+		service.add( 1, "foo" );
+		service.add( 2, "bar" );
+		service.add( 3, "foo bar" );
+		Assertions.assertThat( service.search( "foo" ) )
+				.containsOnly( 1, 3 );
+	}
+
+
+}
+
+

--- a/integrationtest/jdk9-modules/src/test/java/org/hibernate/search/test/integration/jdk9_modules/MyEntityServiceIT.java
+++ b/integrationtest/jdk9-modules/src/test/java/org/hibernate/search/test/integration/jdk9_modules/MyEntityServiceIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.test.integration.jdk9_modules;
 
 import org.hibernate.search.test.integration.jdk9_modules.client.service.MyEntityService;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import org.fest.assertions.Assertions;

--- a/integrationtest/jdk9-modules/src/test/resources/log4j.properties
+++ b/integrationtest/jdk9-modules/src/test/resources/log4j.properties
@@ -1,0 +1,54 @@
+### direct log messages to stdout ###
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} (%t) %5p %c{1}:%L - %m%n
+
+### direct messages to file hibernate.log ###
+log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file.File=hibernate.log
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{ABSOLUTE} (%t) %5p %c{1}:%L - %m%n
+
+### direct messages to socket - chainsaw ###
+log4j.appender.socket=org.apache.log4j.net.SocketAppender
+log4j.appender.socket.remoteHost=localhost
+log4j.appender.socket.port=4560
+log4j.appender.socket.locationInfo=true
+
+### set log levels - for more verbose logging change 'info' to 'debug' ###
+
+log4j.rootLogger=debug, stdout
+log4j.logger.org.jboss=info
+#log4j.logger.com.jboss=debug
+
+log4j.logger.org.hibernate=warn
+
+log4j.logger.org.hibernate.search=debug
+#log4j.logger.org.hibernate.search.backend=debug
+
+### log just the SQL
+log4j.logger.org.hibernate.SQL=debug
+
+#log4j.logger.org.hibernate.engine.CascadingAction=debug
+
+### log JDBC bind parameters ###
+#log4j.logger.org.hibernate.type=debug
+
+### log schema export/update ###
+log4j.logger.org.hibernate.tool.hbm2ddl=warn
+
+### log cache activity ###
+#log4j.logger.org.hibernate.cache=debug
+
+### enable the following line if you want to track down connection ###
+### leakages when using DriverManagerConnectionProvider ###
+#log4j.logger.org.hibernate.connection.DriverManagerConnectionProvider=trace
+
+### annotation logs
+#log4j.logger.org.hibernate.annotation=info
+#log4j.logger.org.hibernate.cfg=info
+#log4j.logger.org.hibernate.cfg.SettingsFactory=info
+#log4j.logger.org.hibernate.cfg.AnnotationBinder=info
+#log4j.logger.org.hibernate.cfg.AnnotationConfiguration=info
+#log4j.logger.org.hibernate.cfg.Ejb3Column=info

--- a/orm/src/main/java/org/hibernate/search/batchindexing/impl/IdentifierConsumerDocumentProducer.java
+++ b/orm/src/main/java/org/hibernate/search/batchindexing/impl/IdentifierConsumerDocumentProducer.java
@@ -30,7 +30,7 @@ import org.hibernate.search.batchindexing.MassIndexerProgressMonitor;
 import org.hibernate.search.bridge.TwoWayFieldBridge;
 import org.hibernate.search.bridge.spi.ConversionContext;
 import org.hibernate.search.bridge.util.impl.ContextualExceptionBridgeHelper;
-import org.hibernate.search.engine.impl.HibernateSessionLoadingInitializer;
+import org.hibernate.search.orm.loading.impl.HibernateSessionLoadingInitializer;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.engine.spi.DocumentBuilderIndexedEntity;
 import org.hibernate.search.engine.spi.EntityIndexBinding;

--- a/orm/src/main/java/org/hibernate/search/batchindexing/impl/MassIndexerImpl.java
+++ b/orm/src/main/java/org/hibernate/search/batchindexing/impl/MassIndexerImpl.java
@@ -17,7 +17,7 @@ import org.hibernate.search.MassIndexer;
 import org.hibernate.search.batchindexing.MassIndexerProgressMonitor;
 import org.hibernate.search.batchindexing.spi.MassIndexerWithTenant;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
-import org.hibernate.search.jmx.impl.JMXRegistrar;
+import org.hibernate.search.util.jmx.impl.JMXRegistrar;
 import org.hibernate.search.spi.IndexedTypeSet;
 import org.hibernate.search.spi.SearchIntegrator;
 import org.hibernate.search.spi.impl.IndexedTypeSets;

--- a/orm/src/main/java/org/hibernate/search/cfg/impl/SearchConfigurationFromHibernateCore.java
+++ b/orm/src/main/java/org/hibernate/search/cfg/impl/SearchConfigurationFromHibernateCore.java
@@ -26,7 +26,7 @@ import org.hibernate.search.cfg.SearchMapping;
 import org.hibernate.search.cfg.spi.IdUniquenessResolver;
 import org.hibernate.search.cfg.spi.SearchConfiguration;
 import org.hibernate.search.cfg.spi.SearchConfigurationBase;
-import org.hibernate.search.engine.impl.HibernateStatelessInitializer;
+import org.hibernate.search.orm.loading.impl.HibernateStatelessInitializer;
 import org.hibernate.search.engine.service.beanresolver.spi.BeanResolver;
 import org.hibernate.search.engine.service.classloading.spi.ClassLoaderService;
 import org.hibernate.search.engine.service.named.spi.NamedResolver;

--- a/orm/src/main/java/org/hibernate/search/event/impl/EventSourceTransactionContext.java
+++ b/orm/src/main/java/org/hibernate/search/event/impl/EventSourceTransactionContext.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.backend.impl;
+package org.hibernate.search.event.impl;
 
 import java.io.Serializable;
 
@@ -22,7 +22,6 @@ import org.hibernate.event.spi.EventSource;
 import org.hibernate.event.spi.EventType;
 import org.hibernate.event.spi.FlushEventListener;
 import org.hibernate.search.backend.TransactionContext;
-import org.hibernate.search.event.impl.FullTextIndexEventListener;
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;

--- a/orm/src/main/java/org/hibernate/search/event/impl/FullTextIndexEventListener.java
+++ b/orm/src/main/java/org/hibernate/search/event/impl/FullTextIndexEventListener.java
@@ -34,7 +34,6 @@ import org.hibernate.event.spi.PostInsertEventListener;
 import org.hibernate.event.spi.PostUpdateEvent;
 import org.hibernate.event.spi.PostUpdateEventListener;
 import org.hibernate.persister.entity.EntityPersister;
-import org.hibernate.search.backend.impl.EventSourceTransactionContext;
 import org.hibernate.search.backend.spi.Work;
 import org.hibernate.search.backend.spi.WorkType;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;

--- a/orm/src/main/java/org/hibernate/search/hcore/impl/JMXHook.java
+++ b/orm/src/main/java/org/hibernate/search/hcore/impl/JMXHook.java
@@ -18,7 +18,7 @@ import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.exception.AssertionFailure;
 import org.hibernate.search.jmx.IndexControlMBean;
 import org.hibernate.search.orm.jmx.impl.IndexControl;
-import org.hibernate.search.jmx.impl.JMXRegistrar;
+import org.hibernate.search.util.jmx.impl.JMXRegistrar;
 import org.hibernate.search.util.StringHelper;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;

--- a/orm/src/main/java/org/hibernate/search/hcore/impl/JMXHook.java
+++ b/orm/src/main/java/org/hibernate/search/hcore/impl/JMXHook.java
@@ -17,7 +17,7 @@ import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.exception.AssertionFailure;
 import org.hibernate.search.jmx.IndexControlMBean;
-import org.hibernate.search.jmx.impl.IndexControl;
+import org.hibernate.search.orm.jmx.impl.IndexControl;
 import org.hibernate.search.jmx.impl.JMXRegistrar;
 import org.hibernate.search.util.StringHelper;
 import org.hibernate.search.util.logging.impl.Log;

--- a/orm/src/main/java/org/hibernate/search/impl/FullTextSessionImpl.java
+++ b/orm/src/main/java/org/hibernate/search/impl/FullTextSessionImpl.java
@@ -19,7 +19,7 @@ import org.hibernate.search.FullTextSharedSessionBuilder;
 import org.hibernate.search.MassIndexer;
 import org.hibernate.search.SearchFactory;
 import org.hibernate.search.backend.TransactionContext;
-import org.hibernate.search.backend.impl.EventSourceTransactionContext;
+import org.hibernate.search.event.impl.EventSourceTransactionContext;
 import org.hibernate.search.backend.spi.Work;
 import org.hibernate.search.backend.spi.WorkType;
 import org.hibernate.search.backend.spi.Worker;

--- a/orm/src/main/java/org/hibernate/search/orm/jmx/impl/IndexControl.java
+++ b/orm/src/main/java/org/hibernate/search/orm/jmx/impl/IndexControl.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.jmx.impl;
+package org.hibernate.search.orm.jmx.impl;
 
 import org.hibernate.CacheMode;
 import org.hibernate.Session;

--- a/orm/src/main/java/org/hibernate/search/orm/loading/impl/HibernateSessionLoadingInitializer.java
+++ b/orm/src/main/java/org/hibernate/search/orm/loading/impl/HibernateSessionLoadingInitializer.java
@@ -5,7 +5,7 @@
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
 
-package org.hibernate.search.engine.impl;
+package org.hibernate.search.orm.loading.impl;
 
 import java.util.Collection;
 import java.util.Map;

--- a/orm/src/main/java/org/hibernate/search/orm/loading/impl/HibernateStatelessInitializer.java
+++ b/orm/src/main/java/org/hibernate/search/orm/loading/impl/HibernateStatelessInitializer.java
@@ -5,7 +5,7 @@
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
 
-package org.hibernate.search.engine.impl;
+package org.hibernate.search.orm.loading.impl;
 
 import java.util.Collection;
 import java.util.Map;

--- a/orm/src/test/java/org/hibernate/search/test/jmx/IndexControlMBeanWithSuffixTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/jmx/IndexControlMBeanWithSuffixTest.java
@@ -15,7 +15,7 @@ import javax.management.ObjectName;
 
 import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.jmx.IndexControlMBean;
-import org.hibernate.search.jmx.impl.JMXRegistrar;
+import org.hibernate.search.util.jmx.impl.JMXRegistrar;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.testsupport.TestForIssue;
 import org.junit.After;

--- a/orm/src/test/java/org/hibernate/search/test/util/HibernateManualConfiguration.java
+++ b/orm/src/test/java/org/hibernate/search/test/util/HibernateManualConfiguration.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.test.util;
 
 import org.hibernate.search.cfg.spi.SearchConfiguration;
-import org.hibernate.search.engine.impl.HibernateStatelessInitializer;
+import org.hibernate.search.orm.loading.impl.HibernateStatelessInitializer;
 import org.hibernate.search.testsupport.setup.SearchConfigurationForTest;
 
 /**

--- a/pom.xml
+++ b/pom.xml
@@ -1582,6 +1582,9 @@ org.hibernate.search.spi.SearchIntegratorBuilder#buildSearchIntegrator()
             <properties>
                 <additionalRuntimeArgLine>-Djdk.attach.allowAttachSelf=true --add-modules java.xml.bind --add-opens=java.base/java.lang=ALL-UNNAMED</additionalRuntimeArgLine>
             </properties>
+            <modules>
+                <module>integrationtest/jdk9-modules</module>
+            </modules>
         </profile>
 
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -1583,7 +1583,11 @@ org.hibernate.search.spi.SearchIntegratorBuilder#buildSearchIntegrator()
                 <additionalRuntimeArgLine>-Djdk.attach.allowAttachSelf=true --add-modules java.xml.bind --add-opens=java.base/java.lang=ALL-UNNAMED</additionalRuntimeArgLine>
             </properties>
             <modules>
-                <module>integrationtest/jdk9-modules</module>
+                <!--
+                     Disabled for now, because Lucene and Hibernate ORM use the same packages in different JARs,
+                     thus the module won't compile.
+                 -->
+                <!--<module>integrationtest/jdk9-modules</module>-->
             </modules>
         </profile>
 


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-2867

Turns out this change is not really useful, because we're far from being the only ones using the same (exported) package name in multiple JARs. It's also the case in Apache Lucene, and to a lesser extent in Hibernate ORM and Hibernate Annotations.

But since it's not a big change... let's merge it, at least it's a step in the right direction.

The errors before and after this patch: https://gist.github.com/yrodiere/473f2db4902d90b0a261ac134737f404
(note there are as many errors after than before, but I suspect it's because the JVM can now inspect Hibernate Search modules that previously failed loading, and thus discovers errors that it previously couldn't detect).

Note that removing the `module-info.java` file will make the test pass, since obviously we won't be using modules anymore.