### PR TITLE
HSEARCH-2832 Hibernate Search produces huge stack traces when Elasticsearch request processing threads are interrupted

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/ElasticsearchRequestFormatter.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/ElasticsearchRequestFormatter.java
@@ -7,7 +7,6 @@
 package org.hibernate.search.elasticsearch.logging.impl;
 
 import org.hibernate.search.elasticsearch.client.impl.ElasticsearchRequest;
-import org.hibernate.search.elasticsearch.util.impl.JsonLogHelper;
 
 /**
  * Used with JBoss Logging's {@link org.jboss.logging.annotations.FormatWith}
@@ -27,11 +26,11 @@ public class ElasticsearchRequestFormatter {
 		//Wild guess for some tuning. The only certainty is that the default (16) is too small.
 		StringBuilder sb = new StringBuilder( 180 );
 
-		sb.append( "Method: " ).append( request.getMethod() );
-		sb.append( "\nPath: " ).append( request.getPath() );
-		sb.append( "\nData:\n" );
-		JsonLogHelper.get().append( sb, request.getBodyParts() );
-		sb.append( "\n\n" );
+		sb.append( request.getMethod() )
+				.append( " " )
+				.append( request.getPath() )
+				.append( " with parameters " )
+				.append( request.getParameters() );
 
 		return sb.toString();
 	}

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/ElasticsearchResponseFormatter.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/ElasticsearchResponseFormatter.java
@@ -6,13 +6,10 @@
  */
 package org.hibernate.search.elasticsearch.logging.impl;
 
-import java.util.Map;
-
 import org.hibernate.search.elasticsearch.client.impl.ElasticsearchRequest;
 import org.hibernate.search.elasticsearch.client.impl.ElasticsearchResponse;
 import org.hibernate.search.elasticsearch.util.impl.JsonLogHelper;
 
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 /**
@@ -40,27 +37,11 @@ public class ElasticsearchResponseFormatter {
 		//Wild guess for some tuning. The only certainty is that the default (16) is too small.
 		//Also useful to hint the builder to use larger increment steps.
 		StringBuilder sb = new StringBuilder( 180 );
-		sb.append( "Status: " ).append( response.getStatusCode() ).append( " " ).append( response.getStatusMessage() );
-		sb.append( "\nError message: " ).append( helper.propertyAsString( body, "error" ) );
-		sb.append( "\nCluster name: " ).append( helper.propertyAsString( body, "cluster_name" ) );
-		sb.append( "\nCluster status: " ).append( helper.propertyAsString( body, "status" ) );
-		sb.append( "\n\n" );
-
-		JsonElement items = helper.property( body, "items" );
-		if ( items != null && items.isJsonArray() ) {
-			for ( JsonElement item : items.getAsJsonArray() ) {
-				for ( Map.Entry<String, JsonElement> entry : item.getAsJsonObject().entrySet() ) {
-					sb.append( "Operation: " ).append( entry.getKey() );
-					JsonElement value = entry.getValue();
-					sb.append( "\n  Index: " ).append( helper.propertyAsString( value, "_index" ) );
-					sb.append( "\n  Type: " ).append( helper.propertyAsString( value, "_type" ) );
-					sb.append( "\n  Id: " ).append( helper.propertyAsString( value, "_id" ) );
-					sb.append( "\n  Status: " ).append( helper.propertyAsString( value, "status" ) );
-					sb.append( "\n  Error: " ).append( helper.propertyAsString( value, "error" ) );
-					sb.append( "\n" );
-				}
-			}
-		}
+		sb.append( response.getStatusCode() )
+				.append( " '" )
+				.append( response.getStatusMessage() )
+				.append( "' with body " )
+				.append( helper.toString( response.getBody() ) );
 
 		return sb.toString();
 	}

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
@@ -60,7 +60,7 @@ public interface Log extends org.hibernate.search.util.logging.impl.Log {
 	SearchException cannotQueryOnEmptyPhraseQuery();
 
 	@Message(id = ES_BACKEND_MESSAGES_START_ID + 7,
-			value = "Elasticsearch request failed\nRequest:\n========\n%1$sResponse:\n=========\n%2$s"
+			value = "Elasticsearch request failed.\nRequest: %1$s\nResponse: %2$s"
 	)
 	SearchException elasticsearchRequestFailed(
 			@FormatWith( ElasticsearchRequestFormatter.class ) ElasticsearchRequest request,
@@ -68,11 +68,11 @@ public interface Log extends org.hibernate.search.util.logging.impl.Log {
 			@Cause Exception cause);
 
 	@Message(id = ES_BACKEND_MESSAGES_START_ID + 8,
-			value = "Elasticsearch bulked request failed\nRequest:\n========\n%1$s\n%2$sResponse:\n=========\n%3$s"
+			// Note: no need to add a '\n' before "Response", since the formatter will always add one
+			value = "Elasticsearch bulked request failed.\nRequest metadata: %1$sResponse: %2$s"
 	)
 	SearchException elasticsearchBulkedRequestFailed(
 			@FormatWith( ElasticsearchJsonObjectFormatter.class ) JsonObject requestMetadata,
-			@FormatWith( ElasticsearchJsonObjectFormatter.class ) JsonObject requestBody,
 			@FormatWith( ElasticsearchJsonObjectFormatter.class ) JsonObject response,
 			@Cause Exception cause);
 

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/JsonLogHelper.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/JsonLogHelper.java
@@ -86,17 +86,6 @@ public class JsonLogHelper {
 		return parent.get( name );
 	}
 
-	public String propertyAsString(JsonElement parent, String name) {
-		if ( parent == null || !parent.isJsonObject() ) {
-			return null;
-		}
-		JsonElement propretyValue = property( parent.getAsJsonObject(), name );
-		if ( propretyValue == null ) {
-			return null;
-		}
-		return propretyValue.toString(); // Also support non-string properties
-	}
-
 	private void beforeValue(StringBuilder sb) {
 		if ( prettyPrinting ) {
 			sb.append( "\n" );

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/work/impl/BulkWork.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/work/impl/BulkWork.java
@@ -72,7 +72,8 @@ public class BulkWork implements ElasticsearchWork<BulkResult> {
 		return Futures.create( () -> context.getClient().submit( request ) )
 				.thenApply( this::generateResult )
 				.exceptionally( Futures.handler(
-						throwable -> { throw LOG.elasticsearchRequestFailed( request, null, Throwables.expectException( throwable ) ); }
+						throwable -> {
+							throw LOG.elasticsearchRequestFailed( request, null, Throwables.expectException( throwable ) ); }
 				) );
 	}
 

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/work/impl/SimpleBulkableElasticsearchWork.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/work/impl/SimpleBulkableElasticsearchWork.java
@@ -87,16 +87,16 @@ public abstract class SimpleBulkableElasticsearchWork<R>
 			}
 		}
 		catch (RuntimeException e) {
-			throw LOG.elasticsearchBulkedRequestFailed( getBulkableActionMetadata(), getBulkableActionBody(), bulkResponseItem, e );
+			throw LOG.elasticsearchBulkedRequestFailed( getBulkableActionMetadata(), bulkResponseItem, e );
 		}
 
 		return afterSuccess( executionContext )
 				.exceptionally( Futures.handler(
 						throwable -> {
 							throw LOG.elasticsearchBulkedRequestFailed(
-									getBulkableActionMetadata(), getBulkableActionBody(),
+									getBulkableActionMetadata(),
 									bulkResponseItem, Throwables.expectException( throwable )
-									);
+							);
 						}
 				) )
 				.thenApply( ignored -> result );

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/LogTest.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/LogTest.java
@@ -1,0 +1,196 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.test;
+
+import java.util.Arrays;
+
+import org.hibernate.search.elasticsearch.client.impl.ElasticsearchRequest;
+import org.hibernate.search.elasticsearch.client.impl.ElasticsearchResponse;
+import org.hibernate.search.elasticsearch.client.impl.URLEncodedString;
+import org.hibernate.search.elasticsearch.logging.impl.Log;
+import org.hibernate.search.elasticsearch.util.impl.JsonLogHelper;
+import org.hibernate.search.exception.SearchException;
+import org.hibernate.search.util.logging.impl.LoggerFactory;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import org.fest.assertions.Assertions;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hibernate.search.test.util.impl.ExceptionMatcherBuilder.isException;
+
+/**
+ * @author Yoann Rodiere
+ */
+public class LogTest {
+
+	private static final Log log = LoggerFactory.make( Log.class );
+
+	private static final Gson GSON = new Gson();
+
+	private static final String NON_EMPTY_JSON_OBJECT_1_AS_STRING =
+			"{\"property\":{\"subProperty\":\"value1\"}}";
+
+	private static final JsonObject NON_EMPTY_JSON_OBJECT_1 =
+			GSON.fromJson( NON_EMPTY_JSON_OBJECT_1_AS_STRING, JsonObject.class );
+
+	private static final String NON_EMPTY_JSON_OBJECT_2_AS_STRING =
+			"{\"property\":{\"subProperty\":\"value2\"}}";
+
+	private static final JsonObject NON_EMPTY_JSON_OBJECT_2 =
+			GSON.fromJson( NON_EMPTY_JSON_OBJECT_2_AS_STRING, JsonObject.class );
+
+	@Test
+	public void jsonObjectList_prettyPrinting() {
+		JsonLogHelper logHelper = JsonLogHelper.create( new GsonBuilder(), true );
+
+		Assertions.assertThat( logHelper.toString( Arrays.asList( NON_EMPTY_JSON_OBJECT_1, NON_EMPTY_JSON_OBJECT_2 ) ) )
+				.isEqualTo(
+						"\n"
+						+ "{\n"
+						+ "  \"property\": {\n"
+						+ "    \"subProperty\": \"value1\"\n"
+						+ "  }\n"
+						+ "}\n"
+						+ "{\n"
+						+ "  \"property\": {\n"
+						+ "    \"subProperty\": \"value2\"\n"
+						+ "  }\n"
+						+ "}\n"
+				);
+	}
+
+	@Test
+	public void jsonObjectList_noPrettyPrinting() {
+		JsonLogHelper logHelper = JsonLogHelper.create( new GsonBuilder(), false );
+
+		Assertions.assertThat( logHelper.toString( Arrays.asList( NON_EMPTY_JSON_OBJECT_1, NON_EMPTY_JSON_OBJECT_2 ) ) )
+				.isEqualTo(
+						"{\"property\":{\"subProperty\":\"value1\"}}\\n"
+						+ "{\"property\":{\"subProperty\":\"value2\"}}"
+				);
+	}
+
+	@Test
+	public void elasticsearchRequestFailed() {
+		ElasticsearchRequest request = ElasticsearchRequest.head()
+				.pathComponent( URLEncodedString.fromString( "foo" ) )
+				.pathComponent( URLEncodedString.fromString( "bar" ) )
+				.param( "param1", "value1" )
+				.param( "param2", "value2" )
+				.body( NON_EMPTY_JSON_OBJECT_1 )
+				.body( NON_EMPTY_JSON_OBJECT_1 )
+				.build();
+		ElasticsearchResponse response = new ElasticsearchResponse(
+				454, "A status message", NON_EMPTY_JSON_OBJECT_2 );
+		Exception cause = new Exception();
+
+		SearchException result = log.elasticsearchRequestFailed( request, response, cause );
+		Assert.assertThat(
+				result,
+				isException( SearchException.class )
+						.withMessage( equalTo(
+								"HSEARCH400007: Elasticsearch request failed.\n"
+								+ "Request: HEAD /foo/bar with parameters {param1=value1, param2=value2}\n"
+								+ "Response: 454 'A status message' with body \n"
+								+ "{\n"
+								+ "  \"property\": {\n"
+								+ "    \"subProperty\": \"value2\"\n"
+								+ "  }\n"
+								+ "}\n"
+						) )
+						.causedBy( cause )
+						.build()
+		);
+	}
+
+	@Test
+	public void elasticsearchRequestFailed_nullResponse() {
+		ElasticsearchRequest request = ElasticsearchRequest.head()
+				.pathComponent( URLEncodedString.fromString( "foo" ) )
+				.pathComponent( URLEncodedString.fromString( "bar" ) )
+				.param( "param1", "value1" )
+				.param( "param2", "value2" )
+				.body( NON_EMPTY_JSON_OBJECT_1 )
+				.body( NON_EMPTY_JSON_OBJECT_1 )
+				.build();
+		Exception cause = new Exception();
+
+		SearchException result = log.elasticsearchRequestFailed( request, null, cause );
+		Assert.assertThat(
+				result,
+				isException( SearchException.class )
+						.withMessage( equalTo(
+								"HSEARCH400007: Elasticsearch request failed.\n"
+								+ "Request: HEAD /foo/bar with parameters {param1=value1, param2=value2}\n"
+								+ "Response: null"
+						) )
+						.causedBy( cause )
+						.build()
+		);
+	}
+
+	@Test
+	public void elasticsearchBulkedRequestFailed() {
+		JsonObject requestMetadata = NON_EMPTY_JSON_OBJECT_1;
+		JsonObject response = NON_EMPTY_JSON_OBJECT_2;
+		Exception cause = new Exception();
+
+		SearchException result = log.elasticsearchBulkedRequestFailed( requestMetadata, response, cause );
+		Assert.assertThat(
+				result,
+				isException( SearchException.class )
+						.withMessage( equalTo(
+								"HSEARCH400008: Elasticsearch bulked request failed.\n"
+								+ "Request metadata: \n"
+								+ "{\n"
+								+ "  \"property\": {\n"
+								+ "    \"subProperty\": \"value1\"\n"
+								+ "  }\n"
+								+ "}\n"
+								+ "Response: \n"
+								+ "{\n"
+								+ "  \"property\": {\n"
+								+ "    \"subProperty\": \"value2\"\n"
+								+ "  }\n"
+								+ "}\n"
+						) )
+						.causedBy( cause )
+						.build()
+		);
+	}
+
+	@Test
+	public void elasticsearchBulkedRequestFailed_nullResponse() {
+		JsonObject requestMetadata = NON_EMPTY_JSON_OBJECT_1;
+		Exception cause = new Exception();
+
+		SearchException result = log.elasticsearchBulkedRequestFailed( requestMetadata, null, cause );
+		Assert.assertThat(
+				result,
+				isException( SearchException.class )
+						.withMessage( equalTo(
+								"HSEARCH400008: Elasticsearch bulked request failed.\n"
+								+ "Request metadata: \n"
+								+ "{\n"
+								+ "  \"property\": {\n"
+								+ "    \"subProperty\": \"value1\"\n"
+								+ "  }\n"
+								+ "}\n"
+								+ "Response: \n"
+								+ "null\n"
+						) )
+						.causedBy( cause )
+						.build()
+		);
+	}
+
+}


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-2832

This makes exceptions much shorter by removing the body of each request from the exception message.
Rationale:
 * when something was wrong in the request body, Elasticsearch error messages include a snippet of what was wrong, so the request body is not strictly necessary
 * in case of recurring issues, users can always enable request logging
 * when a lot of exception occur, for instance because the ES server is down, or security is mis-configured, including the full body of each request leads to huge exception messages, to the point of being unreadable and consuming a significant amount of resources.

While this PR does not solve the issue completely, at least it reduces the magnitude of the problem by several factors: most requests are bulk requests, containing up to 500 JSON objects. We used to log those 500 objects, plus the response, which is generally short where there was an error; now we only log the response and a one-line summary of the request (method, path, parameters).