### PR TITLE
HSEARCH-2883 Follow-up: perfomance tests fix

### DIFF
--- a/integrationtest/performance/engine-elasticsearch/src/main/java/org/hibernate/search/engineperformance/elasticsearch/stub/BlackholeElasticsearchClient.java
+++ b/integrationtest/performance/engine-elasticsearch/src/main/java/org/hibernate/search/engineperformance/elasticsearch/stub/BlackholeElasticsearchClient.java
@@ -60,7 +60,7 @@ public class BlackholeElasticsearchClient implements ElasticsearchClientImplemen
 		if ( "GET".equals( method ) && ( StringHelper.isEmpty( path ) || "/".equals( path ) ) ) {
 			return getResponse;
 		}
-		else if ( "POST".equals( method ) && path.endsWith( "/_bulk/" ) ) {
+		else if ( "POST".equals( method ) && path.endsWith( "/_bulk" ) ) {
 			JsonBuilder.Array builder = JsonBuilder.array();
 
 			// In our case we only bulk requests without a body


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-2883

To be backported to 5.8, I guess (it's not useful to users, but since we backported the previous commits for the same ticket...)