### PR TITLE
HSEARCH-2886 Follow-up: avoid allocating too many CharBuffer wrappers

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/GsonHttpEntity.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/GsonHttpEntity.java
@@ -75,7 +75,15 @@ public final class GsonHttpEntity implements HttpEntity, HttpAsyncContentProduce
 	 * be a penalty for small requests.
 	 * 1024 has been shown to produce reasonable, TLAB only garbage.
 	 */
-	private static final int BUFFER_PAGE_SIZE = 1024;
+	private static final int BYTE_BUFFER_PAGE_SIZE = 1024;
+
+	/**
+	 * We want the char buffer and byte buffer pages of approximately
+	 * the same size, however one is in characters and the other in bytes.
+	 * Considering we hardcoded UTF-8 as encoding, which has an average
+	 * conversion ratio of almost 1.0, this should be close enough.
+	 */
+	private static final int CHAR_BUFFER_SIZE = BYTE_BUFFER_PAGE_SIZE;
 
 	private final Gson gson;
 	private final List<JsonObject> bodyParts;
@@ -115,7 +123,8 @@ public final class GsonHttpEntity implements HttpEntity, HttpAsyncContentProduce
 	 * partially rendered JSON stored in its buffers while flow control
 	 * refuses to accept more bytes.
 	 */
-	private ProgressiveCharBufferWriter writer = new ProgressiveCharBufferWriter( CHARSET, BUFFER_PAGE_SIZE );
+	private ProgressiveCharBufferWriter writer =
+			new ProgressiveCharBufferWriter( CHARSET, CHAR_BUFFER_SIZE, BYTE_BUFFER_PAGE_SIZE );
 
 	public GsonHttpEntity(Gson gson, List<JsonObject> bodyParts) {
 		Objects.requireNonNull( gson );
@@ -183,7 +192,7 @@ public final class GsonHttpEntity implements HttpEntity, HttpAsyncContentProduce
 		//so that we can start from the beginning if needed
 		this.nextBodyToEncodeIndex = 0;
 		//Discard previous buffers as they might contain in-process content:
-		this.writer = new ProgressiveCharBufferWriter( CHARSET, BUFFER_PAGE_SIZE );
+		this.writer = new ProgressiveCharBufferWriter( CHARSET, CHAR_BUFFER_SIZE, BYTE_BUFFER_PAGE_SIZE );
 	}
 
 	/**
@@ -199,16 +208,17 @@ public final class GsonHttpEntity implements HttpEntity, HttpAsyncContentProduce
 		// as it's not set yet.
 		try {
 			triggerFullWrite();
+			if ( nextBodyToEncodeIndex == bodyParts.size() ) {
+				writer.flush();
+				// The buffer's current content size is the final content size,
+				// as we know the entire content has been encoded already,
+				// and we also know no content was consumed from the buffer yet.
+				hintContentLength( writer.byteBufferContentSize() );
+			}
 		}
 		catch (IOException e) {
 			// Unlikely: there's no output buffer yet!
 			throw new SearchException( e );
-		}
-		if ( nextBodyToEncodeIndex == bodyParts.size() ) {
-			// The buffer's current content size is the final content size,
-			// as we know the entire content has been encoded already,
-			// and we also know no content was consumed from the buffer yet.
-			hintContentLength( writer.bufferedContentSize() );
 		}
 	}
 

--- a/integrationtest/performance/engine-elasticsearch/src/main/java/org/hibernate/search/engineperformance/elasticsearch/Launcher.java
+++ b/integrationtest/performance/engine-elasticsearch/src/main/java/org/hibernate/search/engineperformance/elasticsearch/Launcher.java
@@ -29,7 +29,7 @@ public class Launcher {
 
 	public static void main(String... args) throws Exception {
 		Options opts = new OptionsBuilder()
-			.include( ".*" )
+			.include( "StreamWriteJMHBenchmarks\\.write" )
 			.warmupIterations( 1 )
 			.measurementIterations( 10 )
 			.param( "indexSize", "100" )

--- a/integrationtest/performance/engine-elasticsearch/src/main/java/org/hibernate/search/engineperformance/elasticsearch/stub/BlackholeElasticsearchClient.java
+++ b/integrationtest/performance/engine-elasticsearch/src/main/java/org/hibernate/search/engineperformance/elasticsearch/stub/BlackholeElasticsearchClient.java
@@ -60,7 +60,7 @@ public class BlackholeElasticsearchClient implements ElasticsearchClientImplemen
 		if ( "GET".equals( method ) && ( StringHelper.isEmpty( path ) || "/".equals( path ) ) ) {
 			return getResponse;
 		}
-		else if ( "POST".equals( method ) && path.endsWith( "/_bulk/" ) ) {
+		else if ( "POST".equals( method ) && path.endsWith( "/_bulk" ) ) {
 			JsonBuilder.Array builder = JsonBuilder.array();
 
 			// In our case we only bulk requests without a body


### PR DESCRIPTION
~Based on #1547 , which should be merged first.~ => Done

Should be backported to 5.8.

Ticket: https://hibernate.atlassian.net//browse/HSEARCH-2886

Allocation by class on 5.8.0.Final (total: 3.42 GB in 1min):

```
Class                                        Average Object Size(bytes)  Total Object Size(bytes)  TLABs  Average TLAB Size(bytes)  Total TLAB Size(bytes)  Pressure(%)
char[]                                       185.992                     531,752                   2,859  472,262.184               1,350,197,584           36.776
com.google.gson.internal.LinkedTreeMap$Node  48                          34,560                    720    464,505.956               334,444,288             9.11
java.lang.String                             24                          11,640                    485    533,218.095               258,610,776             7.044
java.util.concurrent.CompletableFuture       24                          6,144                     256    464,065.562               118,800,784             3.236
java.nio.HeapCharBuffer                      48                          11,664                    243    486,860.905               118,307,200             3.222
int[]                                        111.96                      22,504                    201    485,024.08                97,489,840              2.655
```

Current master (total: 12.80 GB in 1min):

```
Class                                        Average Object Size(bytes)  Total Object Size(bytes)  TLABs  Average TLAB Size(bytes)  Total TLAB Size(bytes)  Pressure(%)
java.nio.HeapCharBuffer                      48                          211,200                   4,400  1,910,441.92              8,405,944,448           61.175
byte[]                                       1,040                       957,840                   921    1,870,118.61              1,722,379,240           12.535
char[]                                       248.816                     551,376                   2,216  564,385.671               1,250,678,648           9.102
com.google.gson.internal.LinkedTreeMap$Node  48                          25,872                    539    647,080.772               348,776,536             2.538
java.lang.String                             24                          5,496                     229    892,311.755               204,339,392             1.487
int[]                                        115.333                     6,920                     60     2,142,010.667             128,520,640             0.935
```

After this PR, we're (almost) back to normal (total: 4.28 GB in 1min):

```
Class                                        Average Object Size(bytes)  Total Object Size(bytes)  TLABs  Average TLAB Size(bytes)  Total TLAB Size(bytes)  Pressure(%)
byte[]                                       1,036.948                   2,511,488                 2,422  637,092.145               1,543,037,176           33.58
char[]                                       215.934                     656,872                   3,042  366,532.991               1,114,993,360           24.265
com.google.gson.internal.LinkedTreeMap$Node  48                          34,368                    716    403,818.056               289,133,728             6.292
java.lang.String                             24                          9,264                     386    515,567.337               199,008,992             4.331
java.util.concurrent.CompletableFuture       24                          5,280                     220    425,995.091               93,718,920              2.04
int[]                                        128.338                     18,224                    142    634,649.521               90,120,232              1.961
java.lang.Object[]                           176.946                     52,376                    296    264,908.054               78,412,784              1.706
java.util.LinkedHashMap$LinkedKeyIterator    32                          9,856                     308    250,473.299               77,145,776              1.679
java.nio.HeapByteBuffer                      48                          5,808                     121    599,795.174               72,575,216              1.579
```

