### PR TITLE
HSEARCH-2905 Follow-up: Fix JDK9 modules test following database profile changes

### DIFF
--- a/integrationtest/jdk9-modules/pom.xml
+++ b/integrationtest/jdk9-modules/pom.xml
@@ -54,6 +54,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>${jdbc.driver.groupId}</groupId>
+            <artifactId>${jdbc.driver.artifactId}</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
I forgot to add the dependency to the database driver... Before the
HSEARCH-2905 fix, the dependency was implicitly added for every module.

Ticket (already resolved): https://hibernate.atlassian.net/browse/HSEARCH-2905