### PR TITLE
HSEARCH-2916 Avoid random failures in TestRunnerStandalone.runPerformanceTest

### DIFF
--- a/integrationtest/performance/orm/src/test/java/org/hibernate/search/test/performance/task/UpdateBookRatingTask.java
+++ b/integrationtest/performance/orm/src/test/java/org/hibernate/search/test/performance/task/UpdateBookRatingTask.java
@@ -8,6 +8,7 @@ package org.hibernate.search.test.performance.task;
 
 import java.util.Random;
 
+import org.hibernate.LockMode;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.test.performance.model.Book;
 import org.hibernate.search.test.performance.scenario.TestScenarioContext;
@@ -27,7 +28,8 @@ public class UpdateBookRatingTask extends AbstractTask {
 	@Override
 	protected void execute(FullTextSession fts) {
 		long bookId = ctx.getRandomBookId();
-		Book book = (Book) fts.get( Book.class, bookId );
+		// See HSEARCH-2916, we often had concurrent write errors here
+		Book book = (Book) fts.get( Book.class, bookId, LockMode.PESSIMISTIC_WRITE );
 		if ( book != null ) {
 			book.setRating( Math.abs( RANDOM_RATING.nextFloat() ) * MAX_RATING );
 		}

--- a/integrationtest/performance/orm/src/test/java/org/hibernate/search/test/performance/task/UpdateBookTotalSoldTask.java
+++ b/integrationtest/performance/orm/src/test/java/org/hibernate/search/test/performance/task/UpdateBookTotalSoldTask.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.test.performance.task;
 
+import org.hibernate.LockMode;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.test.performance.model.Book;
 import org.hibernate.search.test.performance.scenario.TestScenarioContext;
@@ -22,7 +23,8 @@ public class UpdateBookTotalSoldTask extends AbstractTask {
 	@Override
 	protected void execute(FullTextSession fts) {
 		long bookId = ctx.getRandomBookId();
-		Book book = (Book) fts.get( Book.class, bookId );
+		// See HSEARCH-2916, we often had concurrent write errors here
+		Book book = (Book) fts.get( Book.class, bookId, LockMode.PESSIMISTIC_WRITE );
 		if ( book != null ) {
 			book.setTotalSold( book.getTotalSold() + 1 );
 		}


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-2916

Turns out there was a rather simple solution. I'm not sure it works, since I've been unable to reproduce the issue, but let's merge and hope it does?
