### PR TITLE
HSEARCH-2927 Backport to 5.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
 
         <!-- Dependency versions -->
         <slf4jVersion>1.6.4</slf4jVersion>
-        <luceneVersion>5.5.4</luceneVersion>
+        <luceneVersion>5.5.5</luceneVersion>
         <infinispanVersion>8.2.4.Final</infinispanVersion>
         <jgroupsVersion>3.6.10.Final</jgroupsVersion>
 


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-2927 (Update to Apache Lucene 5.5.5)

Opening a PR instead of merging the backport directly, since 5.6 was not originally marked for backport.
@Sanne any reason not to backport?
