### PR TITLE
HSEARCH-2930 + HSEARCH-2931 + HSEARCH-2932 JSR-352 test fixes

### DIFF
--- a/integrationtest/jsr352/pom.xml
+++ b/integrationtest/jsr352/pom.xml
@@ -37,6 +37,11 @@
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-search-elasticsearch-aws</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
             <artifactId>hibernate-testing</artifactId>
             <scope>test</scope>
         </dependency>

--- a/integrationtest/jsr352/src/test/java/org/hibernate/search/jsr352/massindexing/BatchIndexingJobIT.java
+++ b/integrationtest/jsr352/src/test/java/org/hibernate/search/jsr352/massindexing/BatchIndexingJobIT.java
@@ -44,13 +44,13 @@ public class BatchIndexingJobIT extends AbstractBatchIndexingIT {
 
 	private static final Log log = LoggerFactory.make( Log.class );
 
-	private static final int JOB_TIMEOUT_MS = 10_000;
+	private static final int JOB_TIMEOUT_MS = 30_000;
 
 	/*
 	 * Make sure to have more than one checkpoint,
 	 * because we had errors related to that in the past.
 	 */
-	private static final int CHECKPOINT_INTERVAL = 10;
+	private static final int CHECKPOINT_INTERVAL = INSTANCES_PER_DATA_TEMPLATE / 2;
 
 	private static final String MAIN_STEP_NAME = "produceLuceneDoc";
 

--- a/integrationtest/jsr352/src/test/java/org/hibernate/search/jsr352/massindexing/MassIndexingJobWithCompositeIdIT.java
+++ b/integrationtest/jsr352/src/test/java/org/hibernate/search/jsr352/massindexing/MassIndexingJobWithCompositeIdIT.java
@@ -39,6 +39,8 @@ public class MassIndexingJobWithCompositeIdIT {
 
 	private static final String PERSISTENCE_UNIT_NAME = PersistenceUnitTestUtil.getPersistenceUnitName();
 
+	private static final int JOB_TIMEOUT_MS = 30_000;
+
 	private static final LocalDate START = LocalDate.of( 2017, 6, 1 );
 
 	private static final LocalDate END = LocalDate.of( 2017, 8, 1 );
@@ -86,7 +88,7 @@ public class MassIndexingJobWithCompositeIdIT {
 				.rowsPerPartition( 13 ) // Ensure there're more than 1 partition, so that a WHERE clause is applied.
 				.checkpointInterval( 4 )
 				.build();
-		JobTestUtil.startJobAndWait( MassIndexingJob.NAME, props );
+		JobTestUtil.startJobAndWait( MassIndexingJob.NAME, props, JOB_TIMEOUT_MS );
 
 		int expectedDays = (int) ChronoUnit.DAYS.between( START, END );
 		assertThat( JobTestUtil.nbDocumentsInIndex( emf, EntityWithIdClass.class ) ).isEqualTo( expectedDays );
@@ -100,7 +102,7 @@ public class MassIndexingJobWithCompositeIdIT {
 				.rowsPerPartition( 13 ) // Ensure there're more than 1 partition, so that a WHERE clause is applied.
 				.checkpointInterval( 4 )
 				.build();
-		JobTestUtil.startJobAndWait( MassIndexingJob.NAME, props );
+		JobTestUtil.startJobAndWait( MassIndexingJob.NAME, props, JOB_TIMEOUT_MS );
 
 		int expectedDays = (int) ChronoUnit.DAYS.between( LocalDate.of( 2017, 7, 1 ), END );
 		int actualDays = JobTestUtil.nbDocumentsInIndex( emf, EntityWithIdClass.class );
@@ -115,7 +117,7 @@ public class MassIndexingJobWithCompositeIdIT {
 				.checkpointInterval( 4 )
 				.build();
 
-		JobTestUtil.startJobAndWait( MassIndexingJob.NAME, props );
+		JobTestUtil.startJobAndWait( MassIndexingJob.NAME, props, JOB_TIMEOUT_MS );
 
 		int expectedDays = (int) ChronoUnit.DAYS.between( START, END );
 		int actualDays = JobTestUtil.nbDocumentsInIndex( emf, EntityWithEmbeddedId.class );
@@ -130,7 +132,7 @@ public class MassIndexingJobWithCompositeIdIT {
 				.rowsPerPartition( 13 ) // Ensure there're more than 1 partition, so that a WHERE clause is applied.
 				.checkpointInterval( 4 )
 				.build();
-		JobTestUtil.startJobAndWait( MassIndexingJob.NAME, props );
+		JobTestUtil.startJobAndWait( MassIndexingJob.NAME, props, JOB_TIMEOUT_MS );
 
 		int expectedDays = (int) ChronoUnit.DAYS.between( LocalDate.of( 2017, 7, 1 ), END );
 		int actualDays = JobTestUtil.nbDocumentsInIndex( emf, EntityWithEmbeddedId.class );

--- a/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/test/entity/Person.java
+++ b/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/test/entity/Person.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.jsr352.massindexing.test.entity;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
@@ -22,6 +23,8 @@ public class Person {
 
 	@Id
 	@DocumentId
+	// We use UTF-8, let's avoid the error "Specified key was too long; max key length is 767 bytes" on MariaDB
+	@Column(length = 50)
 	private String id;
 
 	@Field

--- a/jsr352/core/src/test/java/org/hibernate/search/jsr352/test/util/JobTestUtil.java
+++ b/jsr352/core/src/test/java/org/hibernate/search/jsr352/test/util/JobTestUtil.java
@@ -41,16 +41,14 @@ public final class JobTestUtil {
 
 	private static final int THREAD_SLEEP = 1000;
 
-	private static final int JOB_TIMEOUT_MS = 10_000;
-
 	private JobTestUtil() {
 	}
 
-	public static void startJobAndWait(String jobName, Properties jobParams) throws InterruptedException {
+	public static void startJobAndWait(String jobName, Properties jobParams, int timeoutInMs) throws InterruptedException {
 		JobOperator jobOperator = BatchRuntime.getJobOperator();
 		long execId = jobOperator.start( jobName, jobParams );
 		JobExecution jobExec = jobOperator.getJobExecution( execId );
-		jobExec = JobTestUtil.waitForTermination( jobOperator, jobExec, JOB_TIMEOUT_MS );
+		jobExec = JobTestUtil.waitForTermination( jobOperator, jobExec, timeoutInMs );
 		assertThat( jobExec.getBatchStatus() ).isEqualTo( BatchStatus.COMPLETED );
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-2930
https://hibernate.atlassian.net//browse/HSEARCH-2931
https://hibernate.atlassian.net//browse/HSEARCH-2932

Note: this does not fix tests on MariaDB completely, only part of it. We'll have to wait for https://hibernate.atlassian.net/browse/HSEARCH-2933[HSEARCH-2933] to be fixed before JSR-352 can work with the MariaDB JDBC driver.

