### PR TITLE
HSEARCH-2934 Pending Elasticsearch streamed works may fail when stopping Hibernate Search and using the drop-and-create-and-drop strategy

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/ElasticsearchRequest.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/client/impl/ElasticsearchRequest.java
@@ -67,6 +67,17 @@ public final class ElasticsearchRequest {
 		return bodyParts;
 	}
 
+	@Override
+	public String toString() {
+		return new StringBuilder( getClass().getSimpleName() )
+				.append( "[" )
+				.append( "method=" ).append( method )
+				.append( ", path=" ).append( path )
+				.append( ", parameters=" ).append( parameters )
+				.append( "]" )
+				.toString();
+	}
+
 	public static final class Builder {
 		private static final char PATH_SEPARATOR = '/';
 

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchIndexManager.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchIndexManager.java
@@ -338,7 +338,6 @@ public class ElasticsearchIndexManager implements IndexManager, IndexNameNormali
 	 * <p>This method only may add new mappings to the existing index (depending on the strategy), but will never
 	 * create or drop the index (since it's supposed to have been created by Hibernate Search already, if necessary).
 	 *
-	 * @param indexCreatedByHibernateSearch If the index was created by Hibernate Search in {@link #initializeIndex(Set)}.
 	 * @param entityTypesToInitialize The entity types whose mapping will be added to the index
 	 * (if it's part of the schema management strategy).
 	 */

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/processor/impl/AbstractBarrierElasticsearchWorkOrchestrator.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/processor/impl/AbstractBarrierElasticsearchWorkOrchestrator.java
@@ -1,0 +1,84 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.processor.impl;
+
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.hibernate.search.elasticsearch.logging.impl.Log;
+import org.hibernate.search.elasticsearch.work.impl.ElasticsearchWork;
+import org.hibernate.search.util.logging.impl.LoggerFactory;
+
+
+/**
+ * An abstract base for {@link BarrierElasticsearchWorkOrchestrator} implementations,
+ * implementing a thread-safe shutdown.
+ *
+ * @author Yoann Rodiere
+ */
+abstract class AbstractBarrierElasticsearchWorkOrchestrator
+		implements BarrierElasticsearchWorkOrchestrator, AutoCloseable {
+
+	private static final Log LOG = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+
+	private final String name;
+
+	private boolean open = true; // Guarded by shutdownLock
+	private final ReadWriteLock shutdownLock = new ReentrantReadWriteLock();
+
+	protected AbstractBarrierElasticsearchWorkOrchestrator(String name) {
+		this.name = name;
+	}
+
+	protected final String getName() {
+		return name;
+	}
+
+	@Override
+	public CompletableFuture<Void> submit(Iterable<ElasticsearchWork<?>> works) {
+		if ( !shutdownLock.readLock().tryLock() ) {
+			// The orchestrator is shutting down: abort.
+			throw LOG.orchestratorShutDownBeforeSubmittingChangeset( name );
+		}
+		try {
+			if ( !open ) {
+				// The orchestrator has shut down: abort.
+				throw LOG.orchestratorShutDownBeforeSubmittingChangeset( name );
+			}
+			return doSubmit( works );
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw LOG.threadInterruptedWhileSubmittingChangeset( name );
+		}
+		finally {
+			shutdownLock.readLock().unlock();
+		}
+	}
+
+	protected abstract CompletableFuture<Void> doSubmit(Iterable<ElasticsearchWork<?>> works) throws InterruptedException;
+
+	@Override
+	public void close() {
+		shutdownLock.writeLock().lock();
+		try {
+			if ( !open ) {
+				return;
+			}
+			open = false;
+			doClose();
+		}
+		finally {
+			shutdownLock.writeLock().unlock();
+		}
+	}
+
+	protected abstract void doClose();
+
+}

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/processor/impl/BarrierElasticsearchWorkOrchestrator.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/processor/impl/BarrierElasticsearchWorkOrchestrator.java
@@ -23,6 +23,10 @@ public interface BarrierElasticsearchWorkOrchestrator extends ElasticsearchWorkO
 	 */
 	void awaitCompletion() throws InterruptedException;
 
+	/**
+	 * Prevent any more work to be submitted, block until there is no more work to execute,
+	 * then release resources.
+	 */
 	@Override
 	void close();
 

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/processor/impl/ElasticsearchWorkOrchestrator.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/processor/impl/ElasticsearchWorkOrchestrator.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.elasticsearch.processor.impl;
 
-import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.search.elasticsearch.work.impl.ElasticsearchWork;
@@ -19,9 +18,5 @@ import org.hibernate.search.elasticsearch.work.impl.ElasticsearchWork;
 public interface ElasticsearchWorkOrchestrator {
 
 	CompletableFuture<Void> submit(Iterable<ElasticsearchWork<?>> nonBulkedWorks);
-
-	default CompletableFuture<?> submit(ElasticsearchWork<?> work) {
-		return submit( Collections.singleton( work ) );
-	}
 
 }

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/LazyExecutorHolder.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/LazyExecutorHolder.java
@@ -93,7 +93,7 @@ final class LazyExecutorHolder {
 				asyncIndexingExecutor.awaitTermination( Long.MAX_VALUE, TimeUnit.SECONDS );
 			}
 			catch (InterruptedException e) {
-				log.interruptedWhileWaitingForIndexActivity( e );
+				log.interruptedWhileWaitingForIndexActivity( indexName, e );
 			}
 			if ( ! asyncIndexingExecutor.isTerminated() ) {
 				log.unableToShutdownAsynchronousIndexingByTimeout( indexName );

--- a/engine/src/main/java/org/hibernate/search/backend/impl/lucene/LuceneBackendQueueTask.java
+++ b/engine/src/main/java/org/hibernate/search/backend/impl/lucene/LuceneBackendQueueTask.java
@@ -47,7 +47,7 @@ final class LuceneBackendQueueTask implements Runnable {
 			applyUpdates();
 		}
 		catch (InterruptedException e) {
-			log.interruptedWhileWaitingForIndexActivity( e );
+			log.interruptedWhileWaitingForIndexActivity( resources.getIndexName(), e );
 			Thread.currentThread().interrupt();
 			handleException( e );
 		}

--- a/engine/src/main/java/org/hibernate/search/util/logging/impl/BaseHibernateSearchLogger.java
+++ b/engine/src/main/java/org/hibernate/search/util/logging/impl/BaseHibernateSearchLogger.java
@@ -50,8 +50,8 @@ public interface BaseHibernateSearchLogger extends BasicLogger {
 
 	@LogMessage(level = WARN)
 	@Message(id = 49,
-			value = "Was interrupted while waiting for index activity to finish. Index might be inconsistent or have a stale lock")
-	void interruptedWhileWaitingForIndexActivity(@Cause InterruptedException e);
+			value = "'%s' was interrupted while waiting for index activity to finish. Index might be inconsistent or have a stale lock")
+	void interruptedWhileWaitingForIndexActivity(String name, @Cause InterruptedException e);
 
 	@LogMessage(level = ERROR)
 	@Message(id = 69, value = "Illegal object retrieved from message")

--- a/engine/src/test/java/org/hibernate/search/testsupport/setup/SearchConfigurationForTest.java
+++ b/engine/src/test/java/org/hibernate/search/testsupport/setup/SearchConfigurationForTest.java
@@ -126,8 +126,9 @@ public class SearchConfigurationForTest extends SearchConfigurationBase implemen
 		return providedServices;
 	}
 
-	public void addProvidedService(Class<? extends Service> serviceRole, Object service) {
+	public SearchConfigurationForTest addProvidedService(Class<? extends Service> serviceRole, Object service) {
 		providedServices.put( serviceRole, service );
+		return this;
 	}
 
 	@Override

--- a/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIndexManagerClosingIT.java
+++ b/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIndexManagerClosingIT.java
@@ -1,0 +1,221 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.elasticsearch.test;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ForkJoinPool;
+import java.util.regex.Pattern;
+
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.backend.AddLuceneWork;
+import org.hibernate.search.bridge.util.impl.ContextualExceptionBridgeHelper;
+import org.hibernate.search.elasticsearch.cfg.ElasticsearchEnvironment;
+import org.hibernate.search.elasticsearch.cfg.IndexSchemaManagementStrategy;
+import org.hibernate.search.elasticsearch.client.impl.ElasticsearchClientFactory;
+import org.hibernate.search.elasticsearch.client.impl.ElasticsearchClientImplementor;
+import org.hibernate.search.elasticsearch.client.impl.ElasticsearchRequest;
+import org.hibernate.search.elasticsearch.client.impl.ElasticsearchResponse;
+import org.hibernate.search.elasticsearch.client.impl.URLEncodedString;
+import org.hibernate.search.engine.impl.SimpleInitializer;
+import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
+import org.hibernate.search.spi.IndexedTypeIdentifier;
+import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
+import org.hibernate.search.testsupport.TestForIssue;
+import org.hibernate.search.testsupport.junit.SearchIntegratorResource;
+import org.hibernate.search.testsupport.setup.SearchConfigurationForTest;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import org.easymock.EasyMock;
+import org.easymock.IArgumentMatcher;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.createStrictMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Yoann Rodiere
+ */
+@TestForIssue(jiraKey = "HSEARCH-2934")
+public class ElasticsearchIndexManagerClosingIT {
+
+	private static final String STUBBED_ELASTICSEARCH_VERSION = "5.6.0";
+
+	private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+
+	@Rule
+	public SearchIntegratorResource searchIntegratorResource = new SearchIntegratorResource();
+
+	@Test
+	public void closeWithPendingStreamWorks() throws Exception {
+		ElasticsearchClientFactory stubClientFactory = createStrictMock( ElasticsearchClientFactory.class );
+		ElasticsearchClientImplementor stubClient = createStrictMock( ElasticsearchClientImplementor.class );
+		CompletableFuture<ElasticsearchResponse> blockedResponseFuture = new CompletableFuture<>();
+
+		expect( stubClientFactory.create( anyObject() ) ).andReturn( stubClient );
+
+		expect( stubClient.submit( requestMatching( "GET", "^$" ) ) )
+				.andReturn( CompletableFuture.completedFuture( okResponse(
+						"{'version': {'number':" + STUBBED_ELASTICSEARCH_VERSION + "'} }"
+				) ) );
+
+		stubClient.init( anyObject() );
+
+		String indexUrlRegex = "^/" + Entity.INDEX_NAME + "$";
+		String indexAndTypeMappingUrlRegexPrefix = "^/" + Entity.INDEX_NAME + "/"
+				+ URLEncodedString.fromString( Entity.class.getName() ).encoded;
+
+		// ----------------------------------------------
+		// Expected Elasticsearch request sequence
+		// 1. Init the index
+		expect( stubClient.submit( requestMatching( "HEAD", indexUrlRegex ) ) )
+				.andReturn( CompletableFuture.completedFuture( notFoundResponse() ) );
+		expect( stubClient.submit( requestMatching( "PUT", indexUrlRegex ) ) )
+				.andReturn( CompletableFuture.completedFuture( okResponse() ) );
+		expect( stubClient.submit( requestMatching(
+						"GET",
+						"^/_cluster/health/" + Entity.INDEX_NAME + "$"
+				) ) )
+				.andReturn( CompletableFuture.completedFuture( okResponse() ) );
+		expect( stubClient.submit( requestMatching(
+						"PUT",
+						indexAndTypeMappingUrlRegexPrefix + "/_mapping$"
+				) ) )
+				.andReturn( CompletableFuture.completedFuture( okResponse() ) );
+		// 2. Index a document
+		expect( stubClient.submit( requestMatching( "POST", "^/_bulk$" ) ) )
+				.andReturn( blockedResponseFuture );
+		// 3. And only *then* probe for index existence and delete the index
+		expect( stubClient.submit( requestMatching( "HEAD", indexUrlRegex ) ) )
+				.andAnswer( () -> {
+					assertTrue( "Index was deleted before pending stream works were executed",
+							blockedResponseFuture.isDone() );
+					return CompletableFuture.completedFuture( okResponse() );
+				} );
+		expect( stubClient.submit( requestMatching( "DELETE", indexUrlRegex ) ) )
+				.andReturn( CompletableFuture.completedFuture( okResponse() ) );
+		// End of expected Elasticsearch request sequence
+		// ----------------------------------------------
+
+		stubClient.close();
+
+		replay( stubClientFactory, stubClient );
+
+		SearchConfigurationForTest configuration = new SearchConfigurationForTest()
+				.addClass( Entity.class )
+				.addProvidedService( ElasticsearchClientFactory.class, stubClientFactory )
+				.addProperty(
+						// This is absolutely mandatory to reproduce the bug
+						"hibernate.search.default." + ElasticsearchEnvironment.INDEX_SCHEMA_MANAGEMENT_STRATEGY,
+						IndexSchemaManagementStrategy.DROP_AND_CREATE_AND_DROP.getExternalName()
+				);
+
+
+		ExtendedSearchIntegrator searchIntegrator = searchIntegratorResource.create( configuration );
+
+		Entity entity = new Entity( 0 );
+		AddLuceneWork work = searchIntegrator.getIndexBinding( Entity.TYPE_IDENTIFIER )
+				.getDocumentBuilder().createAddWork(
+						null, Entity.TYPE_IDENTIFIER, entity, 0, "0",
+						SimpleInitializer.INSTANCE, new ContextualExceptionBridgeHelper()
+				);
+		// Important: we actually want to perform a stream, async operation here.
+		searchIntegrator.getIndexManager( Entity.INDEX_NAME )
+				.performStreamOperation( work, null, true );
+
+		/*
+		 * Schedule the indexing work to be actually executed a long time from now.
+		 *
+		 * This simulates the condition in which the bug used to occur:
+		 * the stream work queue is filled with plenty of works,
+		 * those works are still being processed,
+		 * and yet the index manager is asked to close.
+		 * We need to make sure that the index manager will wait for
+		 * the works to be processed before destroying anything,
+		 * in particular before dropping the index.
+		 *
+		 * In this test, we assert that the index manager actually waited
+		 * in the stub answer to the HEAD call (see above).
+		 */
+		ForkJoinPool.commonPool().submit( () -> {
+			try {
+				Thread.sleep( 1_000 );
+			}
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+			blockedResponseFuture.complete( okResponse( "{'items': [{'index': {'created': true, 'status': 201}}]}" ) );
+		} );
+
+		// Should not trigger an exception
+		searchIntegrator.close();
+	}
+
+	private ElasticsearchRequest requestMatching(String method, String regex) {
+		Pattern pattern = Pattern.compile( regex, Pattern.CASE_INSENSITIVE );
+		EasyMock.reportMatcher( new IArgumentMatcher() {
+			@Override
+			public boolean matches(Object argument) {
+				if ( !( argument instanceof ElasticsearchRequest ) ) {
+					return false;
+				}
+				ElasticsearchRequest request = (ElasticsearchRequest) argument;
+				return Objects.equals( method, request.getMethod() )
+						&& pattern.matcher( request.getPath() ).matches();
+			}
+
+			@Override
+			public void appendTo(StringBuffer buffer) {
+				buffer.append( "requestMatching(" )
+						.append( method )
+						.append( "," )
+						.append( regex )
+						.append( ")" );
+			}
+		} );
+		return null;
+	}
+
+	private static ElasticsearchResponse notFoundResponse() {
+		return new ElasticsearchResponse( 404, "Not found", null );
+	}
+
+	private static ElasticsearchResponse okResponse() {
+		return okResponse( null );
+	}
+
+	private static ElasticsearchResponse okResponse(String body) {
+		JsonObject jsonObjectBody = null;
+		if ( body != null ) {
+			jsonObjectBody = GSON.fromJson( body, JsonObject.class );
+		}
+		return new ElasticsearchResponse( 200, "OK", jsonObjectBody );
+	}
+
+	@Indexed(index = Entity.INDEX_NAME)
+	private static class Entity {
+
+		private static final String INDEX_NAME = "index_name";
+
+		private static final IndexedTypeIdentifier TYPE_IDENTIFIER = PojoIndexedTypeIdentifier.convertFromLegacy( Entity.class );
+
+		@DocumentId
+		private Integer id;
+
+		public Entity(Integer id) {
+			this.id = id;
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-2934

The solution I chose was to provide each index manager with its own view of the stream orchestrator, so that it can close its view when closing the index manager, which will automatically wait for pending stream works to be executed.

I could have simply added an explicit wait on the "shared" stream orchestrator, but my solution has the additional benefit of preventing new stream works to be accepted by the index manager while waiting for pending stream works to be executed.