### PR TITLE
HSEARCH-2933 Upgrade to a version of the MariaDB driver not affected by CONJ-541

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2137,7 +2137,7 @@ org.hibernate.search.spi.SearchIntegratorBuilder#buildSearchIntegrator()
                 <db.dialect>org.hibernate.dialect.MySQL5InnoDBDialect</db.dialect>
                 <jdbc.driver.groupId>org.mariadb.jdbc</jdbc.driver.groupId>
                 <jdbc.driver.artifactId>mariadb-java-client</jdbc.driver.artifactId>
-                <jdbc.driver.version>1.5.9</jdbc.driver.version>
+                <jdbc.driver.version>1.7.0</jdbc.driver.version>
                 <jdbc.driver>org.mariadb.jdbc.Driver</jdbc.driver>
                 <jdbc.url>jdbc:mariadb://localhost/testingdb</jdbc.url>
                 <jdbc.user>hibernate_user</jdbc.user>


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-2933

Proof the JSR-352 tests now work on MariaDB: http://ci.hibernate.org/job/hibernate-search-yoann/187/ (still a dead link because the build is pending at the moment).