### PR TITLE
 HSEARCH-2958 Rework Mockito tests

### DIFF
--- a/jsr352/core/pom.xml
+++ b/jsr352/core/pom.xml
@@ -50,8 +50,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <groupId>org.easymock</groupId>
+            <artifactId>easymock</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/EntityReader.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/EntityReader.java
@@ -164,7 +164,9 @@ public class EntityReader extends AbstractItemReader {
 			String partitionIdStr,
 			String serializedLowerBound,
 			String serializedUpperBound,
-			String indexScopeName) {
+			String indexScopeName,
+			JobContext jobContext,
+			StepContext stepContext) {
 		this.serializedCacheMode = serializedCacheMode;
 		this.entityName = entityName;
 		this.serializedEntityFetchSize = serializedEntityFetchSize;
@@ -176,6 +178,8 @@ public class EntityReader extends AbstractItemReader {
 		this.serializedLowerBound = serializedLowerBound;
 		this.serializedUpperBound = serializedUpperBound;
 		this.indexScopeName = indexScopeName;
+		this.jobContext = jobContext;
+		this.stepContext = stepContext;
 	}
 
 	/**

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/PartitionMapper.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/PartitionMapper.java
@@ -115,7 +115,8 @@ public class PartitionMapper implements javax.batch.api.partition.PartitionMappe
 				String serializedMaxResultsPerEntity,
 				String serializedRowsPerPartition,
 				String serializedCheckpointInterval,
-				String tenantId) {
+				String tenantId,
+				JobContext jobContext) {
 		this.serializedIdFetchSize = serializedIdFetchSize;
 		this.customQueryHql = customQueryHql;
 		this.serializedMaxThreads = serializedMaxThreads;
@@ -123,6 +124,7 @@ public class PartitionMapper implements javax.batch.api.partition.PartitionMappe
 		this.serializedRowsPerPartition = serializedRowsPerPartition;
 		this.serializedCheckpointInterval = serializedCheckpointInterval;
 		this.tenantId = tenantId;
+		this.jobContext = jobContext;
 	}
 
 	@Override

--- a/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/EntityReaderTest.java
+++ b/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/EntityReaderTest.java
@@ -9,7 +9,6 @@ package org.hibernate.search.jsr352.massindexing.impl.steps.lucene;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-
 import javax.batch.runtime.context.JobContext;
 import javax.batch.runtime.context.StepContext;
 import javax.persistence.EntityManager;
@@ -25,11 +24,10 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
-
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.niceMock;
+import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -50,13 +48,10 @@ public class EntityReaderTest {
 
 	private EntityManagerFactory emf;
 
-	@Mock
 	private JobContext mockedJobContext;
 
-	@Mock
 	private StepContext mockedStepContext;
 
-	@InjectMocks
 	private EntityReader entityReader;
 
 	@Before
@@ -83,6 +78,10 @@ public class EntityReaderTest {
 		final String hql = null;
 		final String maxResults = String.valueOf( Integer.MAX_VALUE );
 		final String partitionId = String.valueOf( 0 );
+
+		mockedJobContext = niceMock( JobContext.class );
+		mockedStepContext = niceMock( StepContext.class );
+
 		entityReader = new EntityReader( cacheMode,
 				entityName,
 				entityFetchSize,
@@ -93,9 +92,9 @@ public class EntityReaderTest {
 				partitionId,
 				null,
 				null,
-				IndexScope.FULL_ENTITY.name() );
-
-		MockitoAnnotations.initMocks( this );
+				IndexScope.FULL_ENTITY.name(),
+				mockedJobContext,
+				mockedStepContext );
 	}
 
 	@After
@@ -107,15 +106,14 @@ public class EntityReaderTest {
 
 	@Test
 	public void testReadItem_withoutBoundary() throws Exception {
-		// mock job context
 		JobContextData jobData = new JobContextData();
 		jobData.setEntityManagerFactory( emf );
 		jobData.setCustomQueryCriteria( new HashSet<>() );
 		jobData.setEntityTypeDescriptors( Arrays.asList( JobTestUtil.createSimpleEntityTypeDescriptor( emf, Company.class ) ) );
-		Mockito.when( mockedJobContext.getTransientUserData() ).thenReturn( jobData );
 
-		// mock step context
-		Mockito.doNothing().when( mockedStepContext ).setTransientUserData( Mockito.any() );
+		expect( mockedJobContext.getTransientUserData() ).andReturn( jobData );
+		mockedStepContext.setTransientUserData( anyObject() );
+		replay( mockedJobContext, mockedStepContext );
 
 		try {
 			entityReader.open( null );

--- a/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/PartitionMapperTest.java
+++ b/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/impl/steps/lucene/PartitionMapperTest.java
@@ -25,11 +25,9 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
-
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.strictMock;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -46,10 +44,8 @@ public class PartitionMapperTest {
 
 	private EntityManagerFactory emf;
 
-	@Mock
 	private JobContext mockedJobContext;
 
-	@InjectMocks
 	private PartitionMapper partitionMapper;
 
 	@Before
@@ -77,6 +73,8 @@ public class PartitionMapperTest {
 		final String hql = null;
 		final String maxThreads = String.valueOf( 1 );
 		final String rowsPerPartition = String.valueOf( 3 );
+
+		mockedJobContext = strictMock( JobContext.class );
 		partitionMapper = new PartitionMapper(
 				fetchSize,
 				hql,
@@ -84,10 +82,9 @@ public class PartitionMapperTest {
 				null,
 				rowsPerPartition,
 				null,
-				null
+				null,
+				mockedJobContext
 		);
-
-		MockitoAnnotations.initMocks( this );
 	}
 
 	@After
@@ -101,13 +98,9 @@ public class PartitionMapperTest {
 	 * Prove that there're N partitions for each root entity,
 	 * where N stands for the ceiling number of the division
 	 * between the rows to index and the max rows per partition.
-	 *
-	 * @throws Exception
 	 */
 	@Test
 	public void testMapPartitions() throws Exception {
-
-		// mock job context
 		JobContextData jobData = new JobContextData();
 		jobData.setEntityManagerFactory( emf );
 		jobData.setCustomQueryCriteria( new HashSet<>() );
@@ -115,7 +108,8 @@ public class PartitionMapperTest {
 				JobTestUtil.createSimpleEntityTypeDescriptor( emf, Company.class ),
 				JobTestUtil.createSimpleEntityTypeDescriptor( emf, Person.class )
 				) );
-		Mockito.when( mockedJobContext.getTransientUserData() ).thenReturn( jobData );
+		expect( mockedJobContext.getTransientUserData() ).andReturn( jobData );
+		replay( mockedJobContext );
 
 		PartitionPlan partitionPlan = partitionMapper.mapPartitions();
 

--- a/jsr352/pom.xml
+++ b/jsr352/pom.xml
@@ -25,7 +25,6 @@
         <hibernate.search.version>${project.version}</hibernate.search.version>
         <hibernate.search.module.slot>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}</hibernate.search.module.slot>
         <jberetVersion>1.3.0.Beta2</jberetVersion>
-        <mockitoVersion>1.10.19</mockitoVersion>
     </properties>
 
     <modules>
@@ -84,12 +83,6 @@
     <dependencyManagement>
         <dependencies>
             <!-- Test -->
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-all</artifactId>
-                <version>${mockitoVersion}</version>
-                <scope>test</scope>
-            </dependency>
             <dependency>
                 <groupId>org.jberet</groupId>
                 <artifactId>jberet-core</artifactId>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2958

The first 2 commits transferred Mockito tests into EasyMock tests. But later, I realized that there's even no need to use mock! Using Java polymorphisme did the work, so I pushed my 3rd commit. I didn't squash them into one because I'm not sure if you want to keep the EasyMock version or the no-mock one.