### PR TITLE
 HSEARCH-2963 Remove duplicate dependency declarations

### DIFF
--- a/integrationtest/wildfly/pom.xml
+++ b/integrationtest/wildfly/pom.xml
@@ -88,25 +88,9 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-        
-        <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.ejb3</groupId>
-            <artifactId>jboss-ejb3-ext-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
         <dependency>
             <groupId>javax.batch</groupId>
             <artifactId>javax.batch-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.spec.javax.ejb</groupId>
-            <artifactId>jboss-ejb-api_3.2_spec</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -947,6 +947,7 @@
                         <requireMavenVersion>
                             <version>3.2.3</version>
                         </requireMavenVersion>
+                        <banDuplicatePomDependencyVersions />
                         <DependencyConvergence />
                     </rules>
                 </configuration>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2963

I also added an EnforcerRule [_"Ban Duplicate Pom Dependency Versions"_][1] to avoid similar ambiguity in the future.

[1]: https://maven.apache.org/enforcer/enforcer-rules/banDuplicatePomDependencyVersions.html