### PR TITLE
HSEARCH-2967 Remove internal classes from the Javadoc

### DIFF
--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -36,6 +36,8 @@
 
         <!-- Skip artifact deployment -->
         <maven.deploy.skip>true</maven.deploy.skip>
+        <!-- Skip javadoc generation -->
+        <maven.javadoc.skip>true</maven.javadoc.skip>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -1138,6 +1138,8 @@
                         <quiet>true</quiet>
                         <verbose>false</verbose>
                         <failOnError>${failOnJavaDocError}</failOnError>
+                        <!-- Exclude implementation classes from the javadoc -->
+                        <excludePackageNames>*.impl,*.impl.*</excludePackageNames>
                         <links>
                             <link>http://download.oracle.com/javase/8/docs/api/</link>
                             <link>http://docs.jboss.org/hibernate/orm/5.2/javadocs/</link>


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-2967

Downsides:

1. Links to internal classes from API/SPI will be dead links. There are some, unfortunately, for example from `AbstractDocumentBuilder` to `TypeMetadata`.
2. We will have some errors in the logs (example below) because some artifacts do not have any SPI or API, so their javadoc is not generated. When times come for the aggregation, their javadoc cannot be found and this error appears. Everything works fine though, since the error is ignored.

Example of errors:
```
[ERROR] Error fetching link: /home/travis/build/yrodiere/hibernate-search/serialization/avro/target/site/apidocs/package-list. Ignored it.
```