### PR TITLE
HSEARCH-2972 + HSEARCH-2984 Fix dependencies in the distribution ZIP

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -79,10 +79,6 @@
             <artifactId>hibernate-search-jsr352-jberet</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jberet</groupId>
-            <artifactId>jberet-core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.spec.javax.jms</groupId>
             <artifactId>jboss-jms-api_2.0_spec</artifactId>
             <scope>provided</scope>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -75,14 +75,6 @@
             <artifactId>hibernate-search-jsr352-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.batch</groupId>
-            <artifactId>javax.batch-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-search-jsr352-jberet</artifactId>
         </dependency>
@@ -108,6 +100,21 @@
         <dependency>
             <groupId>org.jboss.spec.javax.transaction</groupId>
             <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.batch</groupId>
+            <artifactId>javax.batch-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/distribution/src/main/assembly/dist.xml
+++ b/distribution/src/main/assembly/dist.xml
@@ -160,6 +160,9 @@
                 <include>org.jboss.spec.javax.annotation:*</include>
                 <include>org.hibernate.javax.persistence:*</include>
                 <include>org.jboss.spec.javax.transaction:*</include>
+                <include>javax.batch:javax.batch-api</include>
+                <include>javax.inject:javax.inject</include>
+                <include>javax.enterprise:cdi-api</include>
             </includes>
         </dependencySet>
 


### PR DESCRIPTION
* https://hibernate.atlassian.net//browse/HSEARCH-2972 Missing provided dependencies in the distribution ZIP
* https://hibernate.atlassian.net/browse/HSEARCH-2984 Remove an unnecessary jberet dependency in the distribution module

The added dependencies are licensed under ASL2, so this should be fine.