### PR TITLE
Follow-up to HSEARCH-2978 - Use the new automatic module name for Hibernate ORM 5.3 in JDK9 tests

### DIFF
--- a/integrationtest/jdk9-modules/src/main/java/module-info.java
+++ b/integrationtest/jdk9-modules/src/main/java/module-info.java
@@ -3,7 +3,7 @@ module hibernate.search.integrationtest.jdk9.modules.client {
 	requires hibernate.search.engine;
 	requires hibernate.search.orm;
 	requires java.persistence;
-	requires hibernate.core;
+	requires org.hibernate.orm.core;
 	requires lucene.analyzers.common;
 	requires lucene.core;
 }


### PR DESCRIPTION
Follow-up to the previous PR #1598, because the JDK9 build started to fail.

@Sanne On a related note, the Hibernate ORM team defined module names explicitly in their manifest. Maybe we should do it for Search, too? Would org.hibernate.search.* work for you?