### PR TITLE
HSEARCH-3005 Upgrade to Hibernate Commons Annotations 5.0.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
         <!-- ORM and transitive deps; Make sure to match ORM's set of versions when updating -->
         <hibernateVersion>5.3.0.Beta1</hibernateVersion>
         <hibernateShortVersion>5.3</hibernateShortVersion>
-        <hibernateCommonsAnnotationVersion>5.0.1.Final</hibernateCommonsAnnotationVersion>
+        <hibernateCommonsAnnotationVersion>5.0.2.Final</hibernateCommonsAnnotationVersion>
         <jandexVersion>2.0.3.Final</jandexVersion>
         <classMateVersion>1.3.0</classMateVersion>
         <javassistVersion>3.22.0-GA</javassistVersion>


### PR DESCRIPTION
 - https://hibernate.atlassian.net/browse/HSEARCH-3005

The required dependency was just released on Nexus. Will probably take some time to be available in central.