### PR TITLE
Provide ability to customize parser in TikaBridge

### DIFF
--- a/engine/src/main/java/org/hibernate/search/bridge/builtin/TikaBridge.java
+++ b/engine/src/main/java/org/hibernate/search/bridge/builtin/TikaBridge.java
@@ -32,6 +32,7 @@ import org.hibernate.search.util.impl.ClassLoaderHelper;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
 import java.lang.invoke.MethodHandles;
+import java.util.Objects;
 
 import static org.apache.tika.io.IOUtils.closeQuietly;
 
@@ -42,14 +43,18 @@ import static org.apache.tika.io.IOUtils.closeQuietly;
  */
 public class TikaBridge implements MetadataProvidingFieldBridge {
 	private static final Log log = LoggerFactory.make( MethodHandles.lookup() );
-
-	// Expensive, so only do it once. The Parser is threadsafe.
-	private final Parser parser = new AutoDetectParser();
+	
+	private final Parser parser;
 
 	private TikaMetadataProcessor metadataProcessor;
 	private TikaParseContextProvider parseContextProvider;
 
+
 	public TikaBridge() {
+		this(new AutoDetectParser());
+	}
+	public TikaBridge(Parser parser) {
+		this.parser=Objects.requireNonNull(parser, "A parser must be defined!");
 		setMetadataProcessorClass( null );
 		setParseContextProviderClass( null );
 	}


### PR DESCRIPTION
Hi there,

while updating to a more recent version of Tika, we cannot rely on the default AutoDetectParser anymore, as we need to define a custom Tika instance with a special tika-config.xml to drop a specific parser (GrobIdParser). To reflect this customization in the TikaBridge as well, I need to provide a custom TikaBridge that should just extend from the built-in bridge, just use the previously customized parser.

Thank you for any feedback,

Regards,
Niko