### PR TITLE
HSEARCH-3026 Support defining a path prefix for Elasticsearch

### DIFF
--- a/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
+++ b/documentation/src/main/asciidoc/elasticsearch-integration.asciidoc
@@ -194,6 +194,11 @@ the failure will be blamed on the node and no error will be reported to the appl
 +
 The failover feature will also be enabled when you only have one configured host
 but other hosts have been added thanks to automatic discovery (see below).
+Optional path prefix of the Elasticsearch instance:: `hibernate.search.default.elasticsearch.path_prefix /my/path`
++
+In a typical Elasticsearch setup, it should not be set.
++
+Use the path prefix if your Elasticsearch instance is located at a specific context path i.e. is, for instance, hosted at http://localhost/my/elasticsearch/.
 Username for Elasticsearch connection:: `hibernate.search.default.elasticsearch.username ironman` (default is empty, meaning anonymous access)
 Password for Elasticsearch connection:: `hibernate.search.default.elasticsearch.password j@rV1s` (default is empty)
 +

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/ElasticsearchEnvironment.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/cfg/ElasticsearchEnvironment.java
@@ -12,6 +12,8 @@ import org.hibernate.search.elasticsearch.analyzer.definition.ElasticsearchAnaly
  * Configuration properties for Elasticsearch,
  *
  * @author Gunnar Morling
+ * @author Yoann Rodiere
+ * @author Guillaume Smet
  */
 public final class ElasticsearchEnvironment {
 
@@ -55,6 +57,21 @@ public final class ElasticsearchEnvironment {
 	 * This limitation will be removed in a future version of Hibernate Search.
 	 */
 	public static final String SERVER_URI = "elasticsearch.host";
+
+	/**
+	 * Property for specifying the path prefix prepended to the request end point.
+	 * <p>
+	 * A string such as /my/path is expected.
+	 * <p>
+	 * Defaults to null.
+	 * <p>
+	 * The path prefix is defined globally for all the hosts if there are several of them.
+	 * <p>
+	 * To be given <b>globally</b> only (i.e. prefixed with {@code hibernate.search.default.}).
+	 * <b>Cannot</b> be specified per index (e.g. {@code hibernate.search.myIndex.elasticsearch.path_prefix}).
+	 * This limitation will be removed in a future version of Hibernate Search.
+	 */
+	public static final String PATH_PREFIX = "elasticsearch.path_prefix";
 
 	/**
 	 * Property for specifying the username to send when connecting to the Elasticsearch servers.


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/HSEARCH-3026

Let's do a review while the OP tests it works for him.