### PR TITLE
HSEARCH-3032 Add test coverage analysis in an optional build profile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ env:
 before_install:
   # Build options must be set before install, so that
   # we properly retrieve *all* the necessary dependencies
-  - BUILD_OPTIONS='-Pdist'
+  - BUILD_OPTIONS='-Pdist -Pcoverage'
   - case $DB in
     "h2") ;;
     "pgsql") BUILD_OPTIONS+=' -Pci-postgresql' ;;
@@ -64,6 +64,8 @@ script:
   # then we run the actual build
   - ./mvnw $BUILD_OPTIONS checkstyle:check
     && ./mvnw $BUILD_OPTIONS clean install -Dcheckstyle.skip
+after_success:
+  - ./mvnw coveralls:report
 before_cache:
   # Do not put Hibernate Search artifacts into the cache
   - rm -r $HOME/.m2/repository/org/hibernate/hibernate-search*

--- a/integrationtest/osgi/karaf-it/src/test/java/org/hibernate/search/test/integration/osgi/HibernateSearchWithKarafIT.java
+++ b/integrationtest/osgi/karaf-it/src/test/java/org/hibernate/search/test/integration/osgi/HibernateSearchWithKarafIT.java
@@ -42,6 +42,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.CoreOptions;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.karaf.options.LogLevelOption;
@@ -129,10 +130,14 @@ public class HibernateSearchWithKarafIT {
 			mavenProperties.load( inputStream );
 		}
 
+		String jacocoVMArgs = System.getProperty( "container.jacoco.args" );
+
 		File examDir = new File( "target/exam" );
 		File ariesLogDir = new File( examDir, "/aries/log" );
 		return new Option[] {
 				DEBUG ? debugConfiguration( "5005", true ) : null,
+				jacocoVMArgs != null && !jacocoVMArgs.isEmpty()
+						? CoreOptions.vmOptions( jacocoVMArgs.split( " " ) ) : null,
 				logLevel( LogLevelOption.LogLevel.WARN ),
 				karafDistributionConfiguration()
 						.frameworkUrl( karafUrl )

--- a/integrationtest/performance/orm/pom.xml
+++ b/integrationtest/performance/orm/pom.xml
@@ -30,7 +30,7 @@
         <jbosshome>${project.build.directory}/${serverName}/</jbosshome>
 
         <!-- Relax the JVM restrictions for integration tests, when using Jigsaw -->
-        <additionalRuntimeArgLine>${additionalRuntimeArgLineForWildFyTests}</additionalRuntimeArgLine>
+        <additionalRuntimeArgLine>${additionalRuntimeArgLineForWildFlyTests}</additionalRuntimeArgLine>
     </properties>
 
     <dependencyManagement>

--- a/integrationtest/wildfly/pom.xml
+++ b/integrationtest/wildfly/pom.xml
@@ -33,7 +33,7 @@
         <test.module-slot.org.hibernate>${parsed-version.org.hibernate.majorVersion}.${parsed-version.org.hibernate.minorVersion}</test.module-slot.org.hibernate>
 
         <!-- Relax the JVM restrictions for integration tests, when using Jigsaw -->
-        <additionalRuntimeArgLine>${additionalRuntimeArgLineForWildFyTests}</additionalRuntimeArgLine>
+        <additionalRuntimeArgLine>${additionalRuntimeArgLineForWildFlyTests}</additionalRuntimeArgLine>
     </properties>
 
     <dependencyManagement>

--- a/integrationtest/wildfly/src/test/resources/arquillian.xml
+++ b/integrationtest/wildfly/src/test/resources/arquillian.xml
@@ -39,6 +39,7 @@
                     -Djgroups.bind_addr=127.0.0.1
                     -Dremote.maven.repo=${repository.jboss-public.url}
                     -Dmaven.repo.local=${settings.localRepository}
+                    ${container.jacoco.args}
                 </property>
                 <!-- To debug the Arquillian managed application server:
                 <property name="javaVmArguments">
@@ -50,6 +51,7 @@
                     -Djgroups.bind_addr=127.0.0.1
                     -Dremote.maven.repo=${repository.jboss-public.url}
                     -Dmaven.repo.local=${settings.localRepository}
+                    ${container.jacoco.args}
                 </property>
                  -->
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <module>integrationtest/performance/engine-lucene</module>
         <module>integrationtest/performance/engine-elasticsearch</module>
         <module>documentation</module>
+        <module>reports</module>
     </modules>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -1411,6 +1411,12 @@
                             <org.hibernate.search.fail_on_unreleased_service>true</org.hibernate.search.fail_on_unreleased_service>
                             <!-- Javassist still not working when using stricter checks with Jigsaw: use ByteBuddy -->
                             <hibernate.bytecode.provider>bytebuddy</hibernate.bytecode.provider>
+                            <!--
+                                Must be a separate property which is not set in Maven,
+                                so that it will be retrieved by the code launching the container (Arquillian, ...)
+                                at runtime, and will not be replaced at build time by Maven filtering in configuration files.
+                             -->
+                            <container.jacoco.args>${surefire.container.jacoco.args}</container.jacoco.args>
                         </systemPropertyVariables>
                         <argLine>${surefire.system.args}</argLine>
                         <additionalClasspathElements>
@@ -1534,6 +1540,12 @@
                             <org.hibernate.search.fail_on_unreleased_service>true</org.hibernate.search.fail_on_unreleased_service>
                             <!-- Javassist still not working when using stricter checks with Jigsaw: use ByteBuddy -->
                             <hibernate.bytecode.provider>bytebuddy</hibernate.bytecode.provider>
+                            <!--
+                                Must be a separate property which is not set in Maven,
+                                so that it will be retrieved by the code launching the container (Arquillian, ...)
+                                at runtime, and will not be replaced at build time by Maven filtering in configuration files.
+                             -->
+                            <container.jacoco.args>${failsafe.container.jacoco.args}</container.jacoco.args>
                         </systemPropertyVariables>
                         <argLine>${failsafe.system.args}</argLine>
                         <additionalClasspathElements>
@@ -2395,6 +2407,13 @@ org.hibernate.search.spi.SearchIntegratorBuilder#buildSearchIntegrator()
                  -->
                 <surefire.jacoco.args>@{surefire.jacoco.args.lateEval}</surefire.jacoco.args>
                 <failsafe.jacoco.args>@{failsafe.jacoco.args.lateEval}</failsafe.jacoco.args>
+                <!--
+                    We don't use @{...} for late property evaluation here,
+                    because these properties are evaluated by surefire/failsafe itself,
+                    which doesn't understand the @{...} syntax but somehow manages to always use late evaluation.
+                 -->
+                <surefire.container.jacoco.args>${surefire.jacoco.args.lateEval}</surefire.container.jacoco.args>
+                <failsafe.container.jacoco.args>${failsafe.jacoco.args.lateEval}</failsafe.container.jacoco.args>
             </properties>
             <build>
                 <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -1987,8 +1987,8 @@ org.hibernate.search.spi.SearchIntegratorBuilder#buildSearchIntegrator()
                 <jdk>9</jdk>
             </activation>
             <properties>
-                <additionalRuntimeArgLineForWildFyTests>-Djdk.attach.allowAttachSelf=true --add-modules java.xml.bind --add-opens=java.base/java.lang=ALL-UNNAMED</additionalRuntimeArgLineForWildFyTests>
-                <additionalRuntimeArgLine>${additionalRuntimeArgLineForWildFyTests} --illegal-access=deny</additionalRuntimeArgLine>
+                <additionalRuntimeArgLineForWildFlyTests>-Djdk.attach.allowAttachSelf=true --add-modules java.xml.bind --add-opens=java.base/java.lang=ALL-UNNAMED</additionalRuntimeArgLineForWildFlyTests>
+                <additionalRuntimeArgLine>${additionalRuntimeArgLineForWildFlyTests} --illegal-access=deny</additionalRuntimeArgLine>
             </properties>
             <modules>
                 <module>integrationtest/jdk9-modules</module>
@@ -2001,8 +2001,8 @@ org.hibernate.search.spi.SearchIntegratorBuilder#buildSearchIntegrator()
                 <jdk>10</jdk>
             </activation>
             <properties>
-                <additionalRuntimeArgLineForWildFyTests>-Djdk.attach.allowAttachSelf=true --add-modules java.xml.bind --add-opens=java.base/java.lang=ALL-UNNAMED</additionalRuntimeArgLineForWildFyTests>
-                <additionalRuntimeArgLine>${additionalRuntimeArgLineForWildFyTests} --illegal-access=deny</additionalRuntimeArgLine>
+                <additionalRuntimeArgLineForWildFlyTests>-Djdk.attach.allowAttachSelf=true --add-modules java.xml.bind --add-opens=java.base/java.lang=ALL-UNNAMED</additionalRuntimeArgLineForWildFlyTests>
+                <additionalRuntimeArgLine>${additionalRuntimeArgLineForWildFlyTests} --illegal-access=deny</additionalRuntimeArgLine>
                 <!-- For JDK10 we need to override this to: 2.18.1 See https://issues.apache.org/jira/browse/SUREFIRE-1439 -->
                 <version.surefire.plugin>2.18.1</version.surefire.plugin>
                 <version.failsafe.plugin>2.18.1</version.failsafe.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -341,6 +341,7 @@
         <version.wildfly.plugin>1.2.1.Final</version.wildfly.plugin>
         <version.org.wildfly.build-tools>1.2.9.Final</version.org.wildfly.build-tools>
         <version.jacoco.plugin>0.8.0</version.jacoco.plugin>
+        <version.coveralls.plugin>4.3.0</version.coveralls.plugin>
 
         <!--
             Please don't change the name of this property, it may be used and
@@ -1843,6 +1844,16 @@ org.hibernate.search.spi.SearchIntegratorBuilder#buildSearchIntegrator()
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>${version.jacoco.plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.eluder.coveralls</groupId>
+                    <artifactId>coveralls-maven-plugin</artifactId>
+                    <version>${version.coveralls.plugin}</version>
+                    <configuration>
+                        <relativeReportDirs>
+                            <relativeReportDir>jacoco-aggregate</relativeReportDir>
+                        </relativeReportDirs>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -339,6 +339,7 @@
         <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
         <version.wildfly.plugin>1.2.1.Final</version.wildfly.plugin>
         <version.org.wildfly.build-tools>1.2.9.Final</version.org.wildfly.build-tools>
+        <version.jacoco.plugin>0.8.0</version.jacoco.plugin>
 
         <!--
             Please don't change the name of this property, it may be used and
@@ -384,6 +385,14 @@
         <maven.compiler.argument.source>${maven.compiler.source}</maven.compiler.argument.source>
         <maven.compiler.argument.testTarget>${maven.compiler.testTarget}</maven.compiler.argument.testTarget>
         <maven.compiler.argument.testSource>${maven.compiler.testSource}</maven.compiler.argument.testSource>
+
+        <!-- Set empty default values to avoid Maven leaving property references (${...}) when it doesn't find a value -->
+        <additionalRuntimeArgLine></additionalRuntimeArgLine>
+        <additionalRuntimeArgLineForWildFlyTests></additionalRuntimeArgLineForWildFlyTests>
+        <surefire.jacoco.args></surefire.jacoco.args>
+        <failsafe.jacoco.args></failsafe.jacoco.args>
+        <surefire.system.args>${additionalRuntimeArgLine} ${surefire.jacoco.args}</surefire.system.args>
+        <failsafe.system.args>${additionalRuntimeArgLine} ${failsafe.jacoco.args}</failsafe.system.args>
 
         <!-- JDK version required for the build; we target 1.8 since Hibernate ORM 5.3 requires Java 8 -->
         <jdk.min.version>${maven.compiler.argument.source}</jdk.min.version>
@@ -1401,7 +1410,7 @@
                             <!-- Javassist still not working when using stricter checks with Jigsaw: use ByteBuddy -->
                             <hibernate.bytecode.provider>bytebuddy</hibernate.bytecode.provider>
                         </systemPropertyVariables>
-                        <argLine>${additionalRuntimeArgLine}</argLine>
+                        <argLine>${surefire.system.args}</argLine>
                         <additionalClasspathElements>
                             <!-- Needed by Byteman to load the agent on demand -->
                             <additionalClasspathElement>${jdk-toolsjar}</additionalClasspathElement>
@@ -1524,7 +1533,7 @@
                             <!-- Javassist still not working when using stricter checks with Jigsaw: use ByteBuddy -->
                             <hibernate.bytecode.provider>bytebuddy</hibernate.bytecode.provider>
                         </systemPropertyVariables>
-                        <argLine>${additionalRuntimeArgLine}</argLine>
+                        <argLine>${failsafe.system.args}</argLine>
                         <additionalClasspathElements>
                             <!-- Needed by Byteman to load the agent on demand -->
                             <additionalClasspathElement>${jdk-toolsjar}</additionalClasspathElement>
@@ -1828,6 +1837,11 @@ org.hibernate.search.spi.SearchIntegratorBuilder#buildSearchIntegrator()
                     <groupId>com.googlecode.maven-download-plugin</groupId>
                     <artifactId>download-maven-plugin</artifactId>
                     <version>${version.download.plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${version.jacoco.plugin}</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -2348,6 +2362,61 @@ org.hibernate.search.spi.SearchIntegratorBuilder#buildSearchIntegrator()
                         </plugin>
                     </plugins>
                 </pluginManagement>
+            </build>
+        </profile>
+
+        <profile>
+            <id>coverage</id>
+            <properties>
+                <!--
+                    Caution, we use @{...} for late property evaluation here:
+                    http://maven.apache.org/surefire/maven-surefire-plugin/faq.html#late-property-evaluation
+                    This is necessary for Jacoco to work as expected.
+                    However, we wrap the @{...} references into two early-evaluated properties
+                    because in certain environments (IntelliJ IDEA), the use of late property evaluation
+                    is not supported and breaks test execution.
+                    This is because IntelliJ tries to parse the POM to retrieve the surefire/failsafe
+                    argLine and pass them to the test execution directly,
+                    but then fails to evaluate "@{...}" references, resulting in errors.
+                    As a result, this profile will not work in IntelliJ,
+                    but we don't need JaCoCo in IntelliJ anyway.
+                 -->
+                <surefire.jacoco.args>@{surefire.jacoco.args.lateEval}</surefire.jacoco.args>
+                <failsafe.jacoco.args>@{failsafe.jacoco.args.lateEval}</failsafe.jacoco.args>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/*_$logger.class</exclude>
+                                <exclude>**/*_$bundle.class</exclude>
+                            </excludes>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>jacoco-prepare-agent</id>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                                <configuration>
+                                    <propertyName>surefire.jacoco.args.lateEval</propertyName>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>jacoco-prepare-prepare-agent-integration</id>
+                                <goals>
+                                    <goal>prepare-agent-integration</goal>
+                                </goals>
+                                <configuration>
+                                    <propertyName>failsafe.jacoco.args.lateEval</propertyName>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
             </build>
         </profile>
 

--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -102,7 +102,20 @@
             <type>pom</type>
             <scope>test</scope>
         </dependency>
-        <!-- TODO add JaCoCo reports to OSGi and WildFly integration tests? This will probably require some hacking. -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-search-integrationtest-wildfly</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-search-integrationtest-osgi</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate Search, full-text search for your domain model
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>hibernate-search-parent</artifactId>
+        <groupId>org.hibernate</groupId>
+        <version>5.10.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>hibernate-search-reports</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Hibernate Search Reports</name>
+    <description>Hibernate Search Build-Related Reports</description>
+
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+        <!--
+        Disable the dependency convergence rule, because the dependencies of various integration tests do not converge
+        -->
+        <enforcer.dependencyconvergence.skip>true</enforcer.dependencyconvergence.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-search-engine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-search-orm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-search-elasticsearch</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-search-backend-jms</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-search-backend-jgroups</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-search-elasticsearch-aws</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-search-jsr352-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-search-jsr352-jberet</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-search-serialization-avro</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-search-integrationtest-elasticsearch</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-search-integrationtest-jms</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-search-integrationtest-narayana</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-search-integrationtest-spring</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-search-integrationtest-jsr352</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+        <!-- TODO add JaCoCo reports to OSGi and WildFly integration tests? This will probably require some hacking. -->
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>coverage</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>jacoco-report-aggregate</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>report-aggregate</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3032

To generate a report, run `mvn clean install -Pcoverage`. You can then find the report in `reports/target/site/jacoco-aggregate/index.html`.

I added Coveralls support in the `.travis.yml`, but since some of us are not fans of continuous code coverage analysis, I will not configure it in Jenkins. If you want to enable coveralls on your fork, log into https://coveralls.io/ and add your repo.
Alternatively, we could go for https://codecov.io/, but I'm not sure we want to execute a bash script downloaded from the web in our CI :]
See https://coveralls.io/github/yrodiere/hibernate-search for an idea of what reports look like in Coveralls. There seems to be a problem with the tree view, but that has to do with Coveralls (the JaCoCo report is fine).

Regarding the problem I was originally interested in... Indeed, we do not need, nor test, executing delete works in a "stream" fashion: https://coveralls.io/builds/16121711/source?filename=engine%2Fsrc%2Fmain%2Fjava%2Forg%2Fhibernate%2Fsearch%2Fbackend%2Fimpl%2FStreamingOperationExecutorSelector.java#L62 . But as Sanne mentioned, this may be used in Infinispan.