### PR TITLE
HSEARCH-3033 Internal links to "section-custom-similarity" in the documentation are dead

### DIFF
--- a/documentation/src/main/asciidoc/advanced-features.asciidoc
+++ b/documentation/src/main/asciidoc/advanced-features.asciidoc
@@ -411,6 +411,7 @@ extend the base class `org.hibernate.search.cfg.spi.SearchConfigurationBase`: th
 compatibility by not breaking your code when we need to add new methods to this interface.
 ====
 
+[[section-custom-similarity]]
 === Customizing Lucene's scoring formula
 
 Lucene allows the user to customize its scoring formula by extending


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3033
