### PR TITLE
HSEARCH-3034 Replace fest-assert with AssertJ

### DIFF
--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -81,8 +81,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/processor/impl/DefaultContextualErrorHandlerTest.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/processor/impl/DefaultContextualErrorHandlerTest.java
@@ -9,7 +9,7 @@ package org.hibernate.search.elasticsearch.processor.impl;
 import static org.easymock.EasyMock.capture;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/DefaultElasticsearchAnalyzerDefinitionTranslatorTest.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/DefaultElasticsearchAnalyzerDefinitionTranslatorTest.java
@@ -6,8 +6,8 @@
  */
 package org.hibernate.search.elasticsearch.test;
 
-import static org.fest.assertions.Assertions.assertThat;
-import static org.fest.assertions.MapAssert.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import java.lang.annotation.Annotation;
 import java.util.Map;
@@ -105,9 +105,9 @@ public class DefaultElasticsearchAnalyzerDefinitionTranslatorTest {
 		TokenizerDefinition definition = translator.translate( annotation );
 
 		assertThat( definition.getParameters() ).as( "parameters" )
-				.includes( entry( "max_token_length", new JsonPrimitive( "5" ) ) );
+				.containsEntry( "max_token_length", new JsonPrimitive( "5" ) );
 		assertThat( definition.getParameters().keySet() ).as( "parameter names" )
-				.excludes( "maxTokenLength" );
+				.doesNotContain( "maxTokenLength" );
 	}
 
 	@Test
@@ -137,10 +137,10 @@ public class DefaultElasticsearchAnalyzerDefinitionTranslatorTest {
 		CharFilterDefinition definition = translator.translate( annotation );
 
 		assertThat( definition.getParameters() ).as( "parameters" )
-				.includes( entry(
+				.containsEntry(
 						"escaped_tags",
 						JsonBuilder.array().add( new JsonPrimitive( "foo" ) ).add( new JsonPrimitive( "bar" ) ).build()
-				) );
+				);
 	}
 
 	@Test
@@ -154,10 +154,10 @@ public class DefaultElasticsearchAnalyzerDefinitionTranslatorTest {
 		TokenFilterDefinition definition = translator.translate( annotation );
 
 		assertThat( definition.getParameters() ).as( "parameters" )
-				.includes( entry(
+				.containsEntry(
 						"tokenizer",
 						new JsonPrimitive( "whitespace" )
-				) );
+				);
 	}
 
 	@Test
@@ -187,10 +187,10 @@ public class DefaultElasticsearchAnalyzerDefinitionTranslatorTest {
 		TokenFilterDefinition definition = translator.translate( annotation );
 
 		assertThat( definition.getParameters() ).as( "parameters" )
-				.includes( entry(
+				.containsEntry(
 						"patterns",
 						JsonBuilder.array().add( new JsonPrimitive( "foo" ) ).build()
-				) );
+				);
 	}
 
 	@Test
@@ -204,9 +204,9 @@ public class DefaultElasticsearchAnalyzerDefinitionTranslatorTest {
 
 		assertThat( definition.getType() ).as( "type" ).isEqualTo( "stemmer" );
 		assertThat( definition.getParameters() ).as( "parameters" )
-				.includes( entry(
+				.containsEntry(
 						"name", new JsonPrimitive( "light_norwegian" )
-				) );
+				);
 	}
 
 	@Test
@@ -221,9 +221,9 @@ public class DefaultElasticsearchAnalyzerDefinitionTranslatorTest {
 
 		assertThat( definition.getType() ).as( "type" ).isEqualTo( "stemmer" );
 		assertThat( definition.getParameters() ).as( "parameters" )
-				.includes( entry(
+				.containsEntry(
 						"name", new JsonPrimitive( "light_norwegian" )
-				) );
+				);
 	}
 
 	@Test
@@ -238,9 +238,9 @@ public class DefaultElasticsearchAnalyzerDefinitionTranslatorTest {
 
 		assertThat( definition.getType() ).as( "type" ).isEqualTo( "stemmer" );
 		assertThat( definition.getParameters() ).as( "parameters" )
-				.includes( entry(
+				.containsEntry(
 						"name", new JsonPrimitive( "light_nynorsk" )
-				) );
+				);
 	}
 
 	@Test
@@ -271,9 +271,9 @@ public class DefaultElasticsearchAnalyzerDefinitionTranslatorTest {
 		TokenFilterDefinition definition = translator.translate( annotation );
 
 		assertThat( definition.getParameters() ).as( "parameters" )
-				.includes( entry(
+				.containsEntry(
 						"all", new JsonPrimitive( "false" )
-				) );
+				);
 	}
 
 	@Test
@@ -291,28 +291,24 @@ public class DefaultElasticsearchAnalyzerDefinitionTranslatorTest {
 		TokenFilterDefinition definition = translator.translate( annotation );
 
 		assertThat( definition.getParameters() ).as( "parameters" )
-				.includes(
-						entry(
-								"output_unigrams",
-								new JsonPrimitive( "true" )
-						)
+				.containsEntry(
+						"output_unigrams",
+						new JsonPrimitive( "true" )
 				);
 
 		assertThat( definition.getParameters() ).as( "parameters" )
-				.includes(
-						entry(
-								"ignored_scripts",
-								JsonBuilder.array()
-										.add( new JsonPrimitive( "han" ) )
-										.add( new JsonPrimitive( "hiragana" ) )
-										.add( new JsonPrimitive( "katakana" ) )
-										.add( new JsonPrimitive( "hangul" ) )
-								.build()
-						)
+				.containsEntry(
+						"ignored_scripts",
+						JsonBuilder.array()
+								.add( new JsonPrimitive( "han" ) )
+								.add( new JsonPrimitive( "hiragana" ) )
+								.add( new JsonPrimitive( "katakana" ) )
+								.add( new JsonPrimitive( "hangul" ) )
+						.build()
 				);
 
 		assertThat( definition.getParameters().keySet() ).as( "parameter names" )
-				.excludes( "han", "hiragana", "katakana", "hangul", "outputUnigrams" );
+				.doesNotContain( "han", "hiragana", "katakana", "hangul", "outputUnigrams" );
 	}
 
 	@Test
@@ -366,13 +362,13 @@ public class DefaultElasticsearchAnalyzerDefinitionTranslatorTest {
 
 		assertThat( definition.getType() ).as( "type" ).isEqualTo( "keep_types" );
 		assertThat( definition.getParameters() ).as( "parameters" )
-				.includes( entry(
+				.containsEntry(
 						"types",
 						JsonBuilder.array()
 								.add( new JsonPrimitive( "<FOO>" ) )
 								.add( new JsonPrimitive( "<BAR>" ) )
 						.build()
-				) );
+				);
 		// No other parameter is expected, particularly not "useWhitelist"
 		assertThat( definition.getParameters() ).as( "parameters" ).hasSize( 1 );
 	}
@@ -395,7 +391,7 @@ public class DefaultElasticsearchAnalyzerDefinitionTranslatorTest {
 
 		assertThat( definition.getType() ).as( "type" ).isEqualTo( "foo" );
 		assertThat( definition.getParameters() ).as( "parameters" )
-				.includes(
+				.contains(
 						entry( "string", new JsonPrimitive( "foo" ) ),
 						entry( "boolean", new JsonPrimitive( true ) ),
 						entry( "integer", new JsonPrimitive( 42 ) ),
@@ -421,7 +417,7 @@ public class DefaultElasticsearchAnalyzerDefinitionTranslatorTest {
 						)
 				);
 		assertThat( definition.getParameters().keySet() ).as( "parameters" )
-				.excludes( "type" );
+				.doesNotContain( "type" );
 	}
 
 	@Test
@@ -437,9 +433,9 @@ public class DefaultElasticsearchAnalyzerDefinitionTranslatorTest {
 
 		assertThat( definition.getType() ).as( "type" ).isEqualTo( "stringWithoutQuotes" );
 		assertThat( definition.getParameters() ).as( "parameters" )
-				.includes( entry( "param", new JsonPrimitive( "stringWithoutQuotes" ) ) );
+				.containsEntry( "param", new JsonPrimitive( "stringWithoutQuotes" ) );
 		assertThat( definition.getParameters().keySet() ).as( "parameters" )
-				.excludes( "type" );
+				.doesNotContain( "type" );
 	}
 
 	@Test

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/DefaultElasticsearchClientFactoryTest.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/DefaultElasticsearchClientFactoryTest.java
@@ -12,7 +12,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.test.util.impl.ExceptionMatcherBuilder.isException;
 
 import java.io.IOException;

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/DefaultElasticsearchDialectFactoryTest.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/DefaultElasticsearchDialectFactoryTest.java
@@ -8,7 +8,7 @@ package org.hibernate.search.elasticsearch.test;
 
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/DefaultElasticsearchServiceTest.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/DefaultElasticsearchServiceTest.java
@@ -6,20 +6,20 @@
  */
 package org.hibernate.search.elasticsearch.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.getCurrentArguments;
 import static org.easymock.EasyMock.replay;
-import static org.fest.assertions.Assertions.assertThat;
 
 import java.util.Properties;
 
+import org.assertj.core.api.AbstractCharSequenceAssert;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockRunner;
 import org.easymock.Mock;
 import org.easymock.MockType;
-import org.fest.assertions.StringAssert;
 import org.hibernate.search.elasticsearch.client.impl.ElasticsearchClientFactory;
 import org.hibernate.search.elasticsearch.client.impl.ElasticsearchClientImplementor;
 import org.hibernate.search.elasticsearch.dialect.impl.ElasticsearchDialect;
@@ -106,7 +106,7 @@ public class DefaultElasticsearchServiceTest {
 		assertProperty( maskedProperties, "default.elasticsearch.4" ).isEqualTo( "4" );
 	}
 
-	private StringAssert assertProperty(Properties maskedProperties, String name) {
+	private AbstractCharSequenceAssert<?, String> assertProperty(Properties maskedProperties, String name) {
 		return assertThat( maskedProperties.getProperty( name ) ).as( "Property from masked properties '" + name + "'" );
 	}
 

--- a/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/LogTest.java
+++ b/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/LogTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
-import org.fest.assertions.Assertions;
+import org.assertj.core.api.Assertions;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hibernate.search.test.util.impl.ExceptionMatcherBuilder.isException;

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -79,8 +79,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/engine/src/test/java/org/hibernate/search/test/analyzer/analyzerdef/AnalyzerDefAnnotationTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/analyzer/analyzerdef/AnalyzerDefAnnotationTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.analyzer.analyzerdef;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
 

--- a/engine/src/test/java/org/hibernate/search/test/analyzer/analyzerdefinitionprovider/LuceneAnalysisDefinitionProviderTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/analyzer/analyzerdefinitionprovider/LuceneAnalysisDefinitionProviderTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.analyzer.analyzerdefinitionprovider;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.lucene.analysis.core.KeywordTokenizerFactory;
 import org.apache.lucene.analysis.core.LowerCaseFilterFactory;

--- a/engine/src/test/java/org/hibernate/search/test/analyzer/analyzerdefs/AnalyzerDefsAnnotationTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/analyzer/analyzerdefs/AnalyzerDefsAnnotationTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.analyzer.analyzerdefs;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.LinkedHashSet;
 import java.util.Set;

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/DurationBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/DurationBridgeTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.bridge.time;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
 

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/InstantBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/InstantBridgeTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.bridge.time;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Instant;
 

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/LocalDateBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/LocalDateBridgeTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.bridge.time;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
 

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/LocalDateTimeBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/LocalDateTimeBridgeTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.bridge.time;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/LocalTimeBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/LocalTimeBridgeTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.bridge.time;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalTime;
 

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/MonthDayBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/MonthDayBridgeTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.bridge.time;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.MonthDay;
 

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/OffsetDateTimeBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/OffsetDateTimeBridgeTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.bridge.time;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/OffsetTimeBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/OffsetTimeBridgeTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.bridge.time;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalTime;
 import java.time.OffsetTime;

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/PeriodBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/PeriodBridgeTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.bridge.time;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Period;
 

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/YearBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/YearBridgeTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.bridge.time;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Year;
 

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/YearMonthBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/YearMonthBridgeTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.bridge.time;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Year;
 import java.time.YearMonth;

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/ZoneIdBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/ZoneIdBridgeTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.bridge.time;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.ZoneId;
 

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/ZoneOffsetBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/ZoneOffsetBridgeTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.bridge.time;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.ZoneOffset;
 

--- a/engine/src/test/java/org/hibernate/search/test/bridge/time/ZonedDateTimeBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/time/ZonedDateTimeBridgeTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.bridge.time;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/engine/src/test/java/org/hibernate/search/test/configuration/IndexNameOverrideTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/configuration/IndexNameOverrideTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.configuration;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.Serializable;
 
@@ -47,7 +47,7 @@ public class IndexNameOverrideTest {
 				integrator.getIndexBindings().get( NoAnnotationIndexNameOverrideEntity.class )
 						.getIndexManagerSelector().all()
 				)
-				.onProperty( "indexName" )
+				.extracting( "indexName" )
 				.as( "Index names for entity " + NoAnnotationIndexNameOverrideEntity.class )
 				.containsOnly( NoAnnotationIndexNameOverrideEntity.class.getName() );
 
@@ -67,7 +67,7 @@ public class IndexNameOverrideTest {
 				integrator.getIndexBindings().get( IndexedAnnotationIndexNameOverriddeEntity.class )
 						.getIndexManagerSelector().all()
 				)
-				.onProperty( "indexName" )
+				.extracting( "indexName" )
 				.as( "Index names for entity " + IndexedAnnotationIndexNameOverriddeEntity.class )
 				.containsOnly( INDEXED_ANNOTATION_OVERRIDDEN_INDEX_NAME );
 
@@ -96,7 +96,7 @@ public class IndexNameOverrideTest {
 				integrator.getIndexBindings().get( NoAnnotationIndexNameOverrideEntity.class )
 						.getIndexManagerSelector().all()
 				)
-				.onProperty( "indexName" )
+				.extracting( "indexName" )
 				.as( "Index names for entity " + NoAnnotationIndexNameOverrideEntity.class )
 				.containsOnly( NoAnnotationIndexNameOverrideEntity.class.getName() );
 
@@ -125,7 +125,7 @@ public class IndexNameOverrideTest {
 				integrator.getIndexBindings().get( IndexedAnnotationIndexNameOverriddeEntity.class )
 						.getIndexManagerSelector().all()
 				)
-				.onProperty( "indexName" )
+				.extracting( "indexName" )
 				.as( "Index names for entity " + IndexedAnnotationIndexNameOverriddeEntity.class )
 				.containsOnly( INDEXED_ANNOTATION_OVERRIDDEN_INDEX_NAME );
 

--- a/engine/src/test/java/org/hibernate/search/test/configuration/TypeMetadataTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/configuration/TypeMetadataTest.java
@@ -30,7 +30,7 @@ import org.hibernate.search.testsupport.setup.SearchConfigurationForTest;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -70,10 +70,10 @@ public class TypeMetadataTest {
 		TypeMetadata metadata = metadataProvider.getTypeMetadataFor( Bar.class, LuceneEmbeddedIndexManagerType.INSTANCE );
 
 		Set<SortableFieldMetadata> fieldMetadata = metadata.getPropertyMetadataForProperty( "name" ).getSortableFieldMetadata();
-		assertThat( fieldMetadata ).onProperty( "absoluteName" ).containsOnly( "name" );
+		assertThat( fieldMetadata ).extracting( "absoluteName" ).containsOnly( "name" );
 
 		fieldMetadata = metadata.getPropertyMetadataForProperty( "age" ).getSortableFieldMetadata();
-		assertThat( fieldMetadata ).onProperty( "absoluteName" ).containsOnly( "ageForStringSorting", "ageForIntSorting" );
+		assertThat( fieldMetadata ).extracting( "absoluteName" ).containsOnly( "ageForStringSorting", "ageForIntSorting" );
 	}
 
 	@Indexed

--- a/engine/src/test/java/org/hibernate/search/test/dsl/MoreLikeThisTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/dsl/MoreLikeThisTest.java
@@ -6,12 +6,12 @@
  */
 package org.hibernate.search.test.dsl;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
-import java.util.Collection;
+import java.lang.invoke.MethodHandles;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -22,7 +22,6 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
-import org.fest.assertions.Condition;
 import org.hibernate.search.engine.ProjectionConstants;
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.query.dsl.QueryBuilder;
@@ -32,7 +31,6 @@ import org.hibernate.search.testsupport.junit.SearchFactoryHolder;
 import org.hibernate.search.testsupport.junit.SearchITHelper;
 import org.hibernate.search.util.logging.impl.Log;
 import org.hibernate.search.util.logging.impl.LoggerFactory;
-import java.lang.invoke.MethodHandles;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -76,20 +74,8 @@ public class MoreLikeThisTest {
 
 		assertThat( terms )
 				.describedAs( "internalDescription should be ignored" )
-				.doesNotSatisfy(
-						new Condition<Collection<?>>() {
-							@SuppressWarnings("unchecked")
-							@Override
-							public boolean matches(Collection<?> value) {
-								for ( Term term : (Collection<Term>) value ) {
-									if ( "internalDescription".equals( term.field() ) ) {
-										return true;
-									}
-								}
-								return false;
-							}
-						}
-				);
+				.extracting( t -> t.field() )
+				.doesNotContain( "internalDescription" );
 		outputQueryAndResults( decaffInstance, mltQuery, results );
 
 		//custom fields
@@ -105,7 +91,7 @@ public class MoreLikeThisTest {
 		assertThat( mltQuery instanceof BooleanQuery );
 		BooleanQuery topMltQuery = (BooleanQuery) mltQuery;
 		// FIXME: I'd prefer a test that uses data instead of how the query is actually built
-		assertThat( topMltQuery.clauses() ).onProperty( "query.boost" ).contains( 1f, 10f );
+		assertThat( topMltQuery.clauses() ).extracting( "query.boost" ).contains( 1f, 10f );
 
 		outputQueryAndResults( decaffInstance, mltQuery, results );
 

--- a/engine/src/test/java/org/hibernate/search/test/engine/numeric/LuceneNumericFieldTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/engine/numeric/LuceneNumericFieldTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.engine.numeric;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.util.HashSet;

--- a/engine/src/test/java/org/hibernate/search/test/engine/numeric/NumericFieldTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/engine/numeric/NumericFieldTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.engine.numeric;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -176,7 +176,7 @@ public class NumericFieldTest {
 				.getProperty( "rating" )
 				.getIndexedFields();
 
-		assertThat( fields ).onProperty( "name" )
+		assertThat( fields ).extracting( "name" )
 				.containsOnly( "rating", "ratingNumericPrecision1", "ratingNumericPrecision2" );
 
 		for ( FieldDescriptor field : fields ) {

--- a/engine/src/test/java/org/hibernate/search/test/filters/FreshReadersProvidedTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/filters/FreshReadersProvidedTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.filters;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -105,9 +105,9 @@ public class FreshReadersProvidedTest {
 		expectedTermsForQuery( secondRecordingWrapper, "thorin", "oakenshield", "balin" );
 	}
 
-	private void expectedTermsForQuery(RecordingQueryWrapper recordingWrapper, String... term) {
-		Assert.assertEquals( term.length, recordingWrapper.seenTerms.size() );
-		assertThat( recordingWrapper.seenTerms ).as( "seen terms" ).contains( (Object[]) term );
+	private void expectedTermsForQuery(RecordingQueryWrapper recordingWrapper, String... terms) {
+		Assert.assertEquals( terms.length, recordingWrapper.seenTerms.size() );
+		assertThat( recordingWrapper.seenTerms ).as( "seen terms" ).contains( terms );
 	}
 
 	/**
@@ -122,7 +122,7 @@ public class FreshReadersProvidedTest {
 		try {
 			List<IndexReader> allSubReaders = getSubIndexReaders( (MultiReader) currentIndexReader );
 			assertThat( recordingWrapper.visitedReaders ).as( "visited readers" )
-					.contains( allSubReaders.toArray() );
+					.contains( allSubReaders.toArray( new IndexReader[allSubReaders.size()] ) );
 		}
 		finally {
 			searchFactory.getIndexReaderAccessor().close( currentIndexReader );

--- a/engine/src/test/java/org/hibernate/search/test/sorting/CustomTypeMetadataSortingTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/sorting/CustomTypeMetadataSortingTest.java
@@ -16,7 +16,7 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
-import org.fest.assertions.Assertions;
+import org.assertj.core.api.Assertions;
 import org.hibernate.search.annotations.Analyze;
 import org.hibernate.search.annotations.DocumentId;
 import org.hibernate.search.annotations.Field;
@@ -84,11 +84,11 @@ public class CustomTypeMetadataSortingTest {
 		HSQuery query = factoryHolder.getSearchFactory().createHSQuery( luceneQuery, PropertySet.class, Person.class )
 				.sort( FIRST_NAME_SORT );
 
-		Assertions.assertThat( query.queryEntityInfos() ).onProperty( "id" ).as( "Sorted IDs" )
+		Assertions.assertThat( query.queryEntityInfos() ).extracting( "id" ).as( "Sorted IDs" )
 				.containsExactly( 0, 1, 2 );
 
 		query.sort( FIRST_NAME_SORT_REVERSED );
-		Assertions.assertThat( query.queryEntityInfos() ).onProperty( "id" ).as( "Sorted IDs" )
+		Assertions.assertThat( query.queryEntityInfos() ).extracting( "id" ).as( "Sorted IDs" )
 				.containsExactly( 2, 1, 0 );
 	}
 
@@ -122,11 +122,11 @@ public class CustomTypeMetadataSortingTest {
 		HSQuery query = factoryHolder.getSearchFactory().createHSQuery( luceneQuery, metadata )
 				.sort( FIRST_NAME_SORT );
 
-		Assertions.assertThat( query.queryEntityInfos() ).onProperty( "id" ).as( "Sorted IDs" )
+		Assertions.assertThat( query.queryEntityInfos() ).extracting( "id" ).as( "Sorted IDs" )
 				.containsExactly( 0, 1, 2 );
 
 		query.sort( FIRST_NAME_SORT_REVERSED );
-		Assertions.assertThat( query.queryEntityInfos() ).onProperty( "id" ).as( "Sorted IDs" )
+		Assertions.assertThat( query.queryEntityInfos() ).extracting( "id" ).as( "Sorted IDs" )
 				.containsExactly( 2, 1, 0 );
 	}
 
@@ -155,11 +155,11 @@ public class CustomTypeMetadataSortingTest {
 		HSQuery query = factoryHolder.getSearchFactory().createHSQuery( luceneQuery, metadata )
 				.sort( FIRST_NAME_SORT );
 
-		Assertions.assertThat( query.queryEntityInfos() ).onProperty( "id" ).as( "Sorted IDs" )
+		Assertions.assertThat( query.queryEntityInfos() ).extracting( "id" ).as( "Sorted IDs" )
 				.containsExactly( 0, 1, 2 );
 
 		query.sort( FIRST_NAME_SORT_REVERSED );
-		Assertions.assertThat( query.queryEntityInfos() ).onProperty( "id" ).as( "Sorted IDs" )
+		Assertions.assertThat( query.queryEntityInfos() ).extracting( "id" ).as( "Sorted IDs" )
 				.containsExactly( 2, 1, 0 );
 	}
 

--- a/engine/src/test/java/org/hibernate/search/test/sorting/ManagedMultiReaderTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/sorting/ManagedMultiReaderTest.java
@@ -33,7 +33,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test to verify that the uninverting reader is only applied if actually needed.

--- a/engine/src/test/java/org/hibernate/search/test/util/impl/IterableFlatteningTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/util/impl/IterableFlatteningTest.java
@@ -12,8 +12,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-import org.fest.assertions.Assertions;
-import org.fest.assertions.ListAssert;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ListAssert;
 import org.hibernate.search.testsupport.TestForIssue;
 import org.hibernate.search.util.impl.CollectionHelper;
 import org.junit.Assert;

--- a/engine/src/test/java/org/hibernate/search/testsupport/junit/SearchITHelper.java
+++ b/engine/src/test/java/org/hibernate/search/testsupport/junit/SearchITHelper.java
@@ -23,9 +23,9 @@ import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.TermQuery;
-import org.fest.assertions.Assertions;
-import org.fest.assertions.IntAssert;
-import org.fest.assertions.ListAssert;
+import org.assertj.core.api.AbstractIntegerAssert;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ListAssert;
 import org.hibernate.search.backend.spi.Work;
 import org.hibernate.search.backend.spi.WorkType;
 import org.hibernate.search.query.dsl.QueryBuilder;
@@ -36,7 +36,6 @@ import org.hibernate.search.spi.SearchIntegrator;
 import org.hibernate.search.spi.impl.PojoIndexedTypeIdentifier;
 import org.hibernate.search.testsupport.setup.TransactionContextForTest;
 import org.hibernate.search.util.StringHelper;
-
 import org.junit.Assert;
 
 /**
@@ -293,7 +292,7 @@ public class SearchITHelper {
 					.as( "Results of query " + toString( hsQuery ) );
 		}
 
-		public IntAssert asResultSize() {
+		public AbstractIntegerAssert<?> asResultSize() {
 			HSQuery hsQuery = getHSQuery();
 			int actualSize = hsQuery.queryResultSize();
 			return Assertions.assertThat( actualSize )

--- a/integrationtest/elasticsearch/pom.xml
+++ b/integrationtest/elasticsearch/pom.xml
@@ -125,8 +125,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/CombiningLuceneAndElasticsearchIT.java
+++ b/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/CombiningLuceneAndElasticsearchIT.java
@@ -25,8 +25,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
-import static org.fest.assertions.Fail.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
 
 
 /**
@@ -62,14 +62,14 @@ public class CombiningLuceneAndElasticsearchIT extends SearchTestBase {
 				ResearchPaper.class
 		).list();
 
-		assertThat( result ).onProperty( "title" ).containsExactly( "important research" );
+		assertThat( result ).extracting( "title" ).containsExactly( "important research" );
 
 		result = session.createFullTextQuery(
 				queryParser.parse( "title:tales" ),
 				ComicBook.class
 		).list();
 
-		assertThat( result ).onProperty( "title" ).containsExactly( "The tales of Bob" );
+		assertThat( result ).extracting( "title" ).containsExactly( "The tales of Bob" );
 
 		tx.commit();
 		s.close();

--- a/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchAnalysisDefinitionProviderIT.java
+++ b/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchAnalysisDefinitionProviderIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.elasticsearch.test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.lucene.analysis.core.KeywordTokenizerFactory;
 import org.apache.lucene.analysis.core.LowerCaseFilterFactory;

--- a/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchAnalyzerIT.java
+++ b/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchAnalyzerIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.elasticsearch.test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
@@ -105,7 +105,7 @@ public class ElasticsearchAnalyzerIT extends SearchTestBase {
 			TermQuery query = new TermQuery( new Term( "englishTweet", "fox" ) );
 			@SuppressWarnings("unchecked")
 			List<Tweet> list = fullTextSession.createFullTextQuery( query ).list();
-			assertThat( list ).onProperty( "englishTweet" ).containsExactly( tweet.getEnglishTweet() );
+			assertThat( list ).extracting( "englishTweet" ).containsExactly( tweet.getEnglishTweet() );
 		}
 	}
 
@@ -120,7 +120,7 @@ public class ElasticsearchAnalyzerIT extends SearchTestBase {
 			TermQuery query = new TermQuery( new Term( "whitespaceTweet", "fox" ) );
 			@SuppressWarnings("unchecked")
 			List<Tweet> list = fullTextSession.createFullTextQuery( query, Tweet.class ).list();
-			assertThat( list ).onProperty( "whitespaceTweet" ).containsExactly( tweet.getWhitespaceTweet() );
+			assertThat( list ).extracting( "whitespaceTweet" ).containsExactly( tweet.getWhitespaceTweet() );
 		}
 	}
 
@@ -134,7 +134,7 @@ public class ElasticsearchAnalyzerIT extends SearchTestBase {
 
 			@SuppressWarnings("unchecked")
 			List<Tweet> expectedResult = fullTextSession.createFullTextQuery( termQuery( "customTweet", "open" ), Tweet.class ).list();
-			assertThat( expectedResult ).onProperty( "customTweet" ).containsExactly( tweet.getCustomTweet() );
+			assertThat( expectedResult ).extracting( "customTweet" ).containsExactly( tweet.getCustomTweet() );
 
 			@SuppressWarnings("unchecked")
 			List<Tweet> expectedEmpty = fullTextSession.createFullTextQuery( termQuery( "customTweet", "CLOSE" ), Tweet.class ).list();
@@ -152,7 +152,7 @@ public class ElasticsearchAnalyzerIT extends SearchTestBase {
 
 			@SuppressWarnings("unchecked")
 			List<Tweet> expectedResult = fullTextSession.createFullTextQuery( termQuery( "tweetWithCustom", "open" ), Tweet.class ).list();
-			assertThat( expectedResult ).onProperty( "multipleTweets" ).containsExactly( tweet.getMultipleTweets() );
+			assertThat( expectedResult ).extracting( "multipleTweets" ).containsExactly( tweet.getMultipleTweets() );
 
 			@SuppressWarnings("unchecked")
 			List<Tweet> expectedEmpty = fullTextSession.createFullTextQuery( termQuery( "tweetWithCustom", "CLOSE" ), Tweet.class ).list();
@@ -170,7 +170,7 @@ public class ElasticsearchAnalyzerIT extends SearchTestBase {
 
 			@SuppressWarnings("unchecked")
 			List<Tweet> expectedResult = fullTextSession.createFullTextQuery( termQuery( "tweetNotAnalyzed", "close OPEN SOURCE test1" ), Tweet.class ).list();
-			assertThat( expectedResult ).onProperty( "multipleTweets" ).containsExactly( tweet.getMultipleTweets() );
+			assertThat( expectedResult ).extracting( "multipleTweets" ).containsExactly( tweet.getMultipleTweets() );
 		}
 	}
 

--- a/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchClassBridgeIT.java
+++ b/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchClassBridgeIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.elasticsearch.test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Calendar;
 import java.util.List;
@@ -90,11 +90,11 @@ public class ElasticsearchClassBridgeIT extends SearchTestBase {
 
 		QueryDescriptor query = ElasticsearchQueries.fromQueryString( "fullName:\"Klaus Hergesheimer\"" );
 		List<?> result = session.createFullTextQuery( query, GolfPlayer.class ).list();
-		assertThat( result ).onProperty( "id" ).describedAs( "Class-bridge provided string field" ).containsOnly( 1L );
+		assertThat( result ).extracting( "id" ).describedAs( "Class-bridge provided string field" ).containsOnly( 1L );
 
 		query = ElasticsearchQueries.fromQueryString( "age:34" );
 		result = session.createFullTextQuery( query, GolfPlayer.class ).list();
-		assertThat( result ).onProperty( "id" ).describedAs( "Class-bridge provided numeric field" ).containsOnly( 1L );
+		assertThat( result ).extracting( "id" ).describedAs( "Class-bridge provided numeric field" ).containsOnly( 1L );
 
 		tx.commit();
 		s.close();

--- a/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchDSLIT.java
+++ b/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchDSLIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.elasticsearch.test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.test.util.JsonHelper.assertJsonEquals;
 
 import java.util.Calendar;
@@ -328,7 +328,7 @@ public class ElasticsearchDSLIT extends SearchTestBase {
 			Sort sort = queryBuilder.sort().byNative( "idSort", "\"desc\"" ).createSort();
 			fullTextQuery.setSort( sort );
 			List<?> list = fullTextQuery.list();
-			assertThat( list ).onProperty( "id" )
+			assertThat( list ).extracting( "id" )
 					.containsExactly( letter2.getId(), letter1.getId() );
 
 			// Make sure the assertion above didn't just pass by chance
@@ -336,7 +336,7 @@ public class ElasticsearchDSLIT extends SearchTestBase {
 			sort = queryBuilder.sort().byNative( "idSort", "\"asc\"" ).createSort();
 			fullTextQuery.setSort( sort );
 			list = fullTextQuery.list();
-			assertThat( list ).onProperty( "id" )
+			assertThat( list ).extracting( "id" )
 					.containsExactly( letter1.getId(), letter2.getId() );
 		}
 	}
@@ -360,7 +360,7 @@ public class ElasticsearchDSLIT extends SearchTestBase {
 			Sort sort = queryBuilder.sort().byNative( "idSort", "{\"order\":\"desc\"}" ).createSort();
 			fullTextQuery.setSort( sort );
 			List<?> list = fullTextQuery.list();
-			assertThat( list ).onProperty( "id" )
+			assertThat( list ).extracting( "id" )
 					.containsExactly( letter2.getId(), letter1.getId() );
 
 			// Make sure the first assertion above didn't just pass by chance
@@ -368,7 +368,7 @@ public class ElasticsearchDSLIT extends SearchTestBase {
 			sort = queryBuilder.sort().byNative( "idSort", "{\"order\":\"asc\"}" ).createSort();
 			fullTextQuery.setSort( sort );
 			list = fullTextQuery.list();
-			assertThat( list ).onProperty( "id" )
+			assertThat( list ).extracting( "id" )
 					.containsExactly( letter1.getId(), letter2.getId() );
 		}
 	}

--- a/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIT.java
+++ b/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.elasticsearch.test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -164,7 +164,7 @@ public class ElasticsearchIT extends SearchTestBase {
 		QueryDescriptor query = ElasticsearchQueries.fromJson( "{ 'query': { 'match' : { 'abstract' : 'Hibernate' } } }" );
 		List<?> result = session.createFullTextQuery( query, ScientificArticle.class ).list();
 
-		assertThat( result ).onProperty( "title" ).containsOnly(
+		assertThat( result ).extracting( "title" ).containsOnly(
 				"Latest in ORM",
 				"ORM for dummies",
 				"High-performance ORM",
@@ -183,7 +183,7 @@ public class ElasticsearchIT extends SearchTestBase {
 		QueryDescriptor query = ElasticsearchQueries.fromJson( "{ 'query': { 'range' : { 'wordCount' : { 'gte' : 8, 'lt' : 10 } } } }" );
 		List<?> result = session.createFullTextQuery( query ).list();
 
-		assertThat( result ).onProperty( "title" ).containsOnly( "Latest in ORM", "ORM for beginners" );
+		assertThat( result ).extracting( "title" ).containsOnly( "Latest in ORM", "ORM for beginners" );
 		tx.commit();
 		s.close();
 	}
@@ -200,7 +200,7 @@ public class ElasticsearchIT extends SearchTestBase {
 				.setSort( new Sort( new SortField( "id", SortField.Type.STRING ) ) )
 				.list();
 
-		assertThat( result ).onProperty( "firstName" ).containsOnly( "Klaus" );
+		assertThat( result ).extracting( "firstName" ).containsOnly( "Klaus" );
 		tx.commit();
 		s.close();
 	}
@@ -344,7 +344,7 @@ public class ElasticsearchIT extends SearchTestBase {
 		QueryDescriptor query = ElasticsearchQueries.fromJson( "{ 'query': { 'match' : { 'title' : 'findings' } } }" );
 		List<?> result = session.createFullTextQuery( query, MasterThesis.class, BachelorThesis.class ).list();
 
-		assertThat( result ).onProperty( "title" ).containsOnly( "Great findings", "Latest findings" );
+		assertThat( result ).extracting( "title" ).containsOnly( "Great findings", "Latest findings" );
 		tx.commit();
 		s.close();
 	}
@@ -358,7 +358,7 @@ public class ElasticsearchIT extends SearchTestBase {
 		QueryDescriptor query = ElasticsearchQueries.fromJson( "{ 'query': { 'match' : { 'abstract' : 'Hibernate' } } }" );
 		List<?> result = session.createFullTextQuery( query, ResearchPaper.class ).list();
 
-		assertThat( result ).onProperty( "title" ).containsOnly( "Very important research on Hibernate", "Some research" );
+		assertThat( result ).extracting( "title" ).containsOnly( "Very important research on Hibernate", "Some research" );
 		tx.commit();
 		s.close();
 	}
@@ -376,7 +376,7 @@ public class ElasticsearchIT extends SearchTestBase {
 				.setSort( new Sort( new SortField( "id", SortField.Type.STRING, false ) ) )
 				.list();
 
-		assertThat( result ).onProperty( "title" ).containsOnly( "Latest in ORM", "High-performance ORM" );
+		assertThat( result ).extracting( "title" ).containsOnly( "Latest in ORM", "High-performance ORM" );
 		tx.commit();
 		s.close();
 	}
@@ -419,7 +419,7 @@ public class ElasticsearchIT extends SearchTestBase {
 		}
 		scrollableResults.close();
 
-		assertThat( articles ).onProperty( "title" ).containsExactly(
+		assertThat( articles ).extracting( "title" ).containsExactly(
 				"ORM for dummies",
 				"Latest in ORM",
 				"High-performance ORM",
@@ -445,7 +445,7 @@ public class ElasticsearchIT extends SearchTestBase {
 		}
 		scrollableResults.close();
 
-		assertThat( articles ).onProperty( "title" ).containsExactly(
+		assertThat( articles ).extracting( "title" ).containsExactly(
 				"Latest in ORM",
 				"High-performance ORM"
 		);
@@ -468,7 +468,7 @@ public class ElasticsearchIT extends SearchTestBase {
 				.setSort( new Sort( new SortField( "title", SortField.Type.STRING, false ) ) )
 				.list();
 
-		assertThat( result ).onProperty( "title" ).containsExactly(
+		assertThat( result ).extracting( "title" ).containsExactly(
 				"High-performance ORM",
 				"Latest in ORM",
 				"ORM for dummies",
@@ -480,7 +480,7 @@ public class ElasticsearchIT extends SearchTestBase {
 				.setSort( new Sort( new SortField( "id", SortField.Type.STRING, true ) ) )
 				.list();
 
-		assertThat( result ).onProperty( "id" ).containsExactly(
+		assertThat( result ).extracting( "id" ).containsExactly(
 				5L,
 				4L,
 				2L,
@@ -512,7 +512,7 @@ public class ElasticsearchIT extends SearchTestBase {
 
 		List<?> result = session.createFullTextQuery( query, ResearchPaper.class ).list();
 
-		assertThat( result ).onProperty( "title" ).containsExactly(
+		assertThat( result ).extracting( "title" ).containsExactly(
 				"Very important research on Hibernate",
 				"Some research"
 		);
@@ -530,7 +530,7 @@ public class ElasticsearchIT extends SearchTestBase {
 		QueryDescriptor query = ElasticsearchQueries.fromQueryString( "abstract:Hibernate" );
 		List<?> result = session.createFullTextQuery( query, ScientificArticle.class ).list();
 
-		assertThat( result ).onProperty( "title" ).containsOnly(
+		assertThat( result ).extracting( "title" ).containsOnly(
 				"Latest in ORM",
 				"ORM for dummies",
 				"High-performance ORM",
@@ -540,7 +540,7 @@ public class ElasticsearchIT extends SearchTestBase {
 		query = ElasticsearchQueries.fromQueryString( "abstract:important OR title:important" );
 		result = session.createFullTextQuery( query, ResearchPaper.class ).list();
 
-		assertThat( result ).onProperty( "title" ).containsOnly(
+		assertThat( result ).extracting( "title" ).containsOnly(
 				"Very important research on Hibernate",
 				"Some research"
 		);
@@ -548,7 +548,7 @@ public class ElasticsearchIT extends SearchTestBase {
 		query = ElasticsearchQueries.fromQueryString( "wordCount:[8 TO 10}" );
 		result = session.createFullTextQuery( query, ScientificArticle.class ).list();
 
-		assertThat( result ).onProperty( "title" ).containsOnly( "Latest in ORM", "ORM for beginners" );
+		assertThat( result ).extracting( "title" ).containsOnly( "Latest in ORM", "ORM for beginners" );
 
 		tx.commit();
 		s.close();
@@ -624,7 +624,7 @@ public class ElasticsearchIT extends SearchTestBase {
 
 		List<?> result = session.createFullTextQuery( query, ScientificArticle.class ).list();
 
-		assertThat( result ).onProperty( "title" ).containsOnly(
+		assertThat( result ).extracting( "title" ).containsOnly(
 				"ORM for dummies",
 				"ORM for beginners"
 		);
@@ -632,7 +632,7 @@ public class ElasticsearchIT extends SearchTestBase {
 		query = ElasticsearchQueries.fromQueryString( "_id:1 OR _id:3" );
 		result = session.createFullTextQuery( query, ScientificArticle.class ).list();
 
-		assertThat( result ).onProperty( "title" ).containsOnly(
+		assertThat( result ).extracting( "title" ).containsOnly(
 				"ORM for dummies",
 				"ORM for beginners"
 		);

--- a/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIndexNullAsIT.java
+++ b/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIndexNullAsIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.elasticsearch.test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
 import java.time.Instant;

--- a/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchNullValueIT.java
+++ b/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchNullValueIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.elasticsearch.test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Calendar;
 import java.util.List;
@@ -85,19 +85,19 @@ public class ElasticsearchNullValueIT extends SearchTestBase {
 
 		QueryDescriptor query = ElasticsearchQueries.fromQueryString( "firstName:&lt;NULL&gt;" );
 		List<?> result = session.createFullTextQuery( query, GolfPlayer.class ).list();
-		assertThat( result ).onProperty( "id" ).describedAs( "Querying null-encoded String" ).containsOnly( 2L );
+		assertThat( result ).extracting( "id" ).describedAs( "Querying null-encoded String" ).containsOnly( 2L );
 
 		query = ElasticsearchQueries.fromQueryString( "dateOfBirth:1970-01-01" );
 		result = session.createFullTextQuery( query, GolfPlayer.class ).list();
-		assertThat( result ).onProperty( "id" ).describedAs( "Querying null-encoded Date" ).containsOnly( 2L );
+		assertThat( result ).extracting( "id" ).describedAs( "Querying null-encoded Date" ).containsOnly( 2L );
 
 		query = ElasticsearchQueries.fromQueryString( "active:false" );
 		result = session.createFullTextQuery( query, GolfPlayer.class ).list();
-		assertThat( result ).onProperty( "id" ).describedAs( "Querying null-encoded Boolean" ).containsOnly( 2L );
+		assertThat( result ).extracting( "id" ).describedAs( "Querying null-encoded Boolean" ).containsOnly( 2L );
 
 		query = ElasticsearchQueries.fromQueryString( "driveWidth:\\-1" );
 		result = session.createFullTextQuery( query, GolfPlayer.class ).list();
-		assertThat( result ).onProperty( "id" ).describedAs( "Querying null-encoded Integer" ).containsOnly( 2L );
+		assertThat( result ).extracting( "id" ).describedAs( "Querying null-encoded Integer" ).containsOnly( 2L );
 
 		tx.commit();
 		s.close();

--- a/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchSpatialIT.java
+++ b/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchSpatialIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.elasticsearch.test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
@@ -99,7 +99,7 @@ public class ElasticsearchSpatialIT extends SearchTestBase {
 		List<?> result = session.createFullTextQuery( query, POI.class )
 				.setSort( new Sort( new DistanceSortField( 24, 32, "location" ) ) )
 				.list();
-		assertThat( result ).onProperty( "id" ).describedAs( "Geo distance query" ).containsOnly( 1, 2, 3 );
+		assertThat( result ).extracting( "id" ).describedAs( "Geo distance query" ).containsOnly( 1, 2, 3 );
 
 		tx.commit();
 		s.close();
@@ -136,7 +136,7 @@ public class ElasticsearchSpatialIT extends SearchTestBase {
 
 		QueryDescriptor query = ElasticsearchQueries.fromJson( boundingBoxQuery );
 		List<?> result = session.createFullTextQuery( query, POI.class ).list();
-		assertThat( result ).onProperty( "id" ).describedAs( "Geo distance query" ).containsOnly( 1, 2, 3, 4 );
+		assertThat( result ).extracting( "id" ).describedAs( "Geo distance query" ).containsOnly( 1, 2, 3, 4 );
 
 		tx.commit();
 		s.close();

--- a/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ToElasticsearchIT.java
+++ b/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ToElasticsearchIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.elasticsearch.test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.test.util.JsonHelper.assertJsonEquals;
 
 import java.util.Calendar;
@@ -82,7 +82,7 @@ public class ToElasticsearchIT extends SearchTestBase {
 			List<Letter> letters = fullTextQuery.list();
 
 			assertThat( letters ).hasSize( 1 );
-			assertThat( letters ).onProperty( "message" ).containsExactly( "Important letter" );
+			assertThat( letters ).extracting( "message" ).containsExactly( "Important letter" );
 		}
 	}
 
@@ -104,7 +104,7 @@ public class ToElasticsearchIT extends SearchTestBase {
 			List<Letter> letters = fullTextQuery.list();
 
 			assertThat( letters ).hasSize( 1 );
-			assertThat( letters ).onProperty( "message" ).containsExactly( "Important letter" );
+			assertThat( letters ).extracting( "message" ).containsExactly( "Important letter" );
 		}
 	}
 
@@ -127,7 +127,7 @@ public class ToElasticsearchIT extends SearchTestBase {
 			List<Letter> letters = fullTextQuery.list();
 
 			assertThat( letters ).hasSize( 1 );
-			assertThat( letters ).onProperty( "message" ).containsExactly( "Important letter" );
+			assertThat( letters ).extracting( "message" ).containsExactly( "Important letter" );
 		}
 	}
 
@@ -150,7 +150,7 @@ public class ToElasticsearchIT extends SearchTestBase {
 			List<Letter> letters = fullTextQuery.list();
 
 			assertThat( letters ).hasSize( 1 );
-			assertThat( letters ).onProperty( "message" ).containsExactly( "Important letter" );
+			assertThat( letters ).extracting( "message" ).containsExactly( "Important letter" );
 		}
 	}
 

--- a/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/bridge/DynamicMappingIT.java
+++ b/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/bridge/DynamicMappingIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.elasticsearch.test.bridge;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/deletebyquery/DeleteByQueryIT.java
+++ b/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/deletebyquery/DeleteByQueryIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.elasticsearch.test.deletebyquery;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
@@ -102,7 +102,7 @@ public class DeleteByQueryIT extends SearchTestBase {
 		@SuppressWarnings("unchecked")
 		List<HockeyPlayer> result = session.createFullTextQuery( query, HockeyPlayer.class ).list();
 
-		assertThat( result ).onProperty( "name" ).containsOnly( "Hergesheimer", "Brand" );
+		assertThat( result ).extracting( "name" ).containsOnly( "Hergesheimer", "Brand" );
 
 		tx.commit();
 		s.close();

--- a/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/deletebyquery/DeleteByQueryMultiTenancyIT.java
+++ b/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/deletebyquery/DeleteByQueryMultiTenancyIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.elasticsearch.test.deletebyquery;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -156,7 +156,7 @@ public class DeleteByQueryMultiTenancyIT extends SearchTestBase {
 		@SuppressWarnings("unchecked")
 		List<HockeyPlayer> result = session.createFullTextQuery( query, HockeyPlayer.class ).list();
 
-		assertThat( result ).onProperty( "name" ).containsOnly( "Hergesheimer", "Brand" );
+		assertThat( result ).extracting( "name" ).containsOnly( "Hergesheimer", "Brand" );
 
 		tx.commit();
 
@@ -178,7 +178,7 @@ public class DeleteByQueryMultiTenancyIT extends SearchTestBase {
 
 		assertThat( result )
 			.describedAs( "Running delete-by-query for other tenant should not affect entities of this entity" )
-			.onProperty( "name" )
+			.extracting( "name" )
 			.containsOnly( "Metz", "Plenty" );
 
 		tx.commit();

--- a/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/filter/ElasticsearchFilterIT.java
+++ b/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/filter/ElasticsearchFilterIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.elasticsearch.test.filter;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Calendar;
 import java.util.GregorianCalendar;
@@ -44,13 +44,13 @@ public class ElasticsearchFilterIT extends SearchTestBase {
 		FullTextQuery ftQuery = fullTextSession.createFullTextQuery( ElasticsearchQueries.fromJson( "{ 'query': { 'match_all': {} } }" ), Driver.class );
 		ftQuery.enableFullTextFilter( "bestDriver" );
 
-		assertThat( ftQuery.list() ).onProperty( "name" ).containsOnly( "Liz", "Emmanuel" );
+		assertThat( ftQuery.list() ).extracting( "name" ).containsOnly( "Liz", "Emmanuel" );
 
 		TermQuery termQuery = new TermQuery( new Term( "name", "liz" ) );
 		Filter termFilter = new QueryWrapperFilter( termQuery );
 		ftQuery.setFilter( termFilter );
 
-		assertThat( ftQuery.list() ).onProperty( "name" ).containsOnly( "Liz" );
+		assertThat( ftQuery.list() ).extracting( "name" ).containsOnly( "Liz" );
 
 		tx.commit();
 		s.close();
@@ -66,7 +66,7 @@ public class ElasticsearchFilterIT extends SearchTestBase {
 		ftQuery.enableFullTextFilter( "namedDriver" )
 				.setParameter( "name", "liz" );
 
-		assertThat( ftQuery.list() ).onProperty( "name" ).containsOnly( "Liz" );
+		assertThat( ftQuery.list() ).extracting( "name" ).containsOnly( "Liz" );
 
 		tx.commit();
 		s.close();
@@ -85,7 +85,7 @@ public class ElasticsearchFilterIT extends SearchTestBase {
 				.setParameter( "field", "teacher" )
 				.setParameter( "value", "andre" );
 
-		assertThat( ftQuery.list() ).onProperty( "name" ).containsOnly( "Emmanuel" );
+		assertThat( ftQuery.list() ).extracting( "name" ).containsOnly( "Emmanuel" );
 
 		tx.commit();
 		s.close();

--- a/integrationtest/jsr352/pom.xml
+++ b/integrationtest/jsr352/pom.xml
@@ -68,8 +68,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integrationtest/jsr352/src/test/java/org/hibernate/search/jsr352/massindexing/BatchIndexingJobIT.java
+++ b/integrationtest/jsr352/src/test/java/org/hibernate/search/jsr352/massindexing/BatchIndexingJobIT.java
@@ -34,8 +34,8 @@ import org.hibernate.search.util.logging.impl.LoggerFactory;
 
 import org.junit.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
-import static org.fest.assertions.MapAssert.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -368,7 +368,7 @@ public class BatchIndexingJobIT extends AbstractBatchIndexingIT {
 		assertThat( partitionProgress )
 				.as( "Entities processed per partition" )
 				.hasSize( 3 * 2 )
-				.includes(
+				.contains(
 						// First entity type
 						entry( 0, INSTANCE_PER_ENTITY_TYPE - 1L ), // Partition 1 for first entity type
 						entry( 1, 1L ), // Partition 2 for first entity type

--- a/integrationtest/jsr352/src/test/java/org/hibernate/search/jsr352/massindexing/MassIndexingJobWithCompositeIdIT.java
+++ b/integrationtest/jsr352/src/test/java/org/hibernate/search/jsr352/massindexing/MassIndexingJobWithCompositeIdIT.java
@@ -25,7 +25,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests that mass indexing job can handle entity having

--- a/integrationtest/jsr352/src/test/java/org/hibernate/search/jsr352/massindexing/MassIndexingJobWithMultiTenancyIT.java
+++ b/integrationtest/jsr352/src/test/java/org/hibernate/search/jsr352/massindexing/MassIndexingJobWithMultiTenancyIT.java
@@ -6,11 +6,15 @@
  */
 package org.hibernate.search.jsr352.massindexing;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.jsr352.test.util.JobTestUtil.findIndexedResultsInTenant;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import javax.batch.operations.JobOperator;
 import javax.batch.runtime.BatchRuntime;
 import javax.batch.runtime.BatchStatus;
@@ -24,16 +28,11 @@ import org.hibernate.search.jsr352.massindexing.test.entity.Company;
 import org.hibernate.search.jsr352.test.util.JobTestUtil;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
-
+import org.hibernate.search.util.impl.CollectionHelper;
 import org.hibernate.testing.RequiresDialect;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-
-import org.fest.util.Collections;
-
-import static org.fest.assertions.Assertions.assertThat;
-import static org.hibernate.search.jsr352.test.util.JobTestUtil.findIndexedResultsInTenant;
 
 /**
  * @author Mincong Huang
@@ -120,7 +119,7 @@ public class MassIndexingJobWithMultiTenancyIT extends SearchTestBase {
 
 	@Override
 	public Set<String> multiTenantIds() {
-		return Collections.set( TARGET_TENANT_ID, UNUSED_TENANT_ID );
+		return CollectionHelper.asSet( TARGET_TENANT_ID, UNUSED_TENANT_ID );
 	}
 
 	@Override

--- a/integrationtest/spring/pom.xml
+++ b/integrationtest/spring/pom.xml
@@ -101,8 +101,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/integrationtest/spring/src/test/java/org/hibernate/search/test/integration/spring/injection/SpringInjectionIT.java
+++ b/integrationtest/spring/src/test/java/org/hibernate/search/test/integration/spring/injection/SpringInjectionIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.integration.spring.injection;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.function.Function;
@@ -42,75 +42,75 @@ public class SpringInjectionIT {
 	public void injectedFieldBridge() {
 		Function<String, List<EntityWithSpringAwareBridges>> search = dao::searchFieldBridge;
 
-		assertThat( search.apply( "bonjour" ) ).onProperty( "id" ).isEmpty();
-		assertThat( search.apply( "hello" ) ).onProperty( "id" ).isEmpty();
-		assertThat( search.apply( "hallo" ) ).onProperty( "id" ).isEmpty();
-		assertThat( search.apply( "au revoir" ) ).onProperty( "id" ).isEmpty();
+		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).isEmpty();
+		assertThat( search.apply( "hello" ) ).extracting( "id" ).isEmpty();
+		assertThat( search.apply( "hallo" ) ).extracting( "id" ).isEmpty();
+		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).isEmpty();
 
 		EntityWithSpringAwareBridges entity = new EntityWithSpringAwareBridges();
 		entity.setInternationalizedValue( InternationalizedValue.HELLO );
 		dao.create( entity );
-		assertThat( search.apply( "bonjour" ) ).onProperty( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "hello" ) ).onProperty( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "hallo" ) ).onProperty( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "au revoir" ) ).onProperty( "id" ).isEmpty();
+		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).containsOnly( entity.getId() );
+		assertThat( search.apply( "hello" ) ).extracting( "id" ).containsOnly( entity.getId() );
+		assertThat( search.apply( "hallo" ) ).extracting( "id" ).containsOnly( entity.getId() );
+		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).isEmpty();
 
 		EntityWithSpringAwareBridges entity2 = new EntityWithSpringAwareBridges();
 		entity2.setInternationalizedValue( InternationalizedValue.GOODBYE );
 		dao.create( entity2 );
-		assertThat( search.apply( "bonjour" ) ).onProperty( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "hello" ) ).onProperty( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "hallo" ) ).onProperty( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "au revoir" ) ).onProperty( "id" ).containsOnly( entity2.getId() );
+		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).containsOnly( entity.getId() );
+		assertThat( search.apply( "hello" ) ).extracting( "id" ).containsOnly( entity.getId() );
+		assertThat( search.apply( "hallo" ) ).extracting( "id" ).containsOnly( entity.getId() );
+		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).containsOnly( entity2.getId() );
 
 		dao.delete( entity );
-		assertThat( search.apply( "bonjour" ) ).onProperty( "id" ).isEmpty();
-		assertThat( search.apply( "hello" ) ).onProperty( "id" ).isEmpty();
-		assertThat( search.apply( "hallo" ) ).onProperty( "id" ).isEmpty();
-		assertThat( search.apply( "au revoir" ) ).onProperty( "id" ).containsOnly( entity2.getId() );
+		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).isEmpty();
+		assertThat( search.apply( "hello" ) ).extracting( "id" ).isEmpty();
+		assertThat( search.apply( "hallo" ) ).extracting( "id" ).isEmpty();
+		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).containsOnly( entity2.getId() );
 	}
 
 	@Test
 	public void injectedClassBridge() {
 		Function<String, List<EntityWithSpringAwareBridges>> search = dao::searchClassBridge;
 
-		assertThat( search.apply( "bonjour" ) ).onProperty( "id" ).isEmpty();
-		assertThat( search.apply( "hello" ) ).onProperty( "id" ).isEmpty();
-		assertThat( search.apply( "hallo" ) ).onProperty( "id" ).isEmpty();
-		assertThat( search.apply( "au revoir" ) ).onProperty( "id" ).isEmpty();
+		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).isEmpty();
+		assertThat( search.apply( "hello" ) ).extracting( "id" ).isEmpty();
+		assertThat( search.apply( "hallo" ) ).extracting( "id" ).isEmpty();
+		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).isEmpty();
 
 		EntityWithSpringAwareBridges entity = new EntityWithSpringAwareBridges();
 		entity.setInternationalizedValue( InternationalizedValue.HELLO );
 		dao.create( entity );
-		assertThat( search.apply( "bonjour" ) ).onProperty( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "hello" ) ).onProperty( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "hallo" ) ).onProperty( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "au revoir" ) ).onProperty( "id" ).isEmpty();
+		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).containsOnly( entity.getId() );
+		assertThat( search.apply( "hello" ) ).extracting( "id" ).containsOnly( entity.getId() );
+		assertThat( search.apply( "hallo" ) ).extracting( "id" ).containsOnly( entity.getId() );
+		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).isEmpty();
 
 		EntityWithSpringAwareBridges entity2 = new EntityWithSpringAwareBridges();
 		entity2.setInternationalizedValue( InternationalizedValue.GOODBYE );
 		dao.create( entity2 );
-		assertThat( search.apply( "bonjour" ) ).onProperty( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "hello" ) ).onProperty( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "hallo" ) ).onProperty( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "au revoir" ) ).onProperty( "id" ).containsOnly( entity2.getId() );
+		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).containsOnly( entity.getId() );
+		assertThat( search.apply( "hello" ) ).extracting( "id" ).containsOnly( entity.getId() );
+		assertThat( search.apply( "hallo" ) ).extracting( "id" ).containsOnly( entity.getId() );
+		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).containsOnly( entity2.getId() );
 
 		dao.delete( entity );
-		assertThat( search.apply( "bonjour" ) ).onProperty( "id" ).isEmpty();
-		assertThat( search.apply( "hello" ) ).onProperty( "id" ).isEmpty();
-		assertThat( search.apply( "hallo" ) ).onProperty( "id" ).isEmpty();
-		assertThat( search.apply( "au revoir" ) ).onProperty( "id" ).containsOnly( entity2.getId() );
+		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).isEmpty();
+		assertThat( search.apply( "hello" ) ).extracting( "id" ).isEmpty();
+		assertThat( search.apply( "hallo" ) ).extracting( "id" ).isEmpty();
+		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).containsOnly( entity2.getId() );
 	}
 
 	@Test
 	public void nonSpringFieldBridge() {
 		Function<String, List<EntityWithSpringAwareBridges>> search = dao::searchNonSpringBridge;
 
-		assertThat( search.apply( NonSpringBridge.PREFIX + InternationalizedValue.HELLO.name() ) ).onProperty( "id" ).isEmpty();
+		assertThat( search.apply( NonSpringBridge.PREFIX + InternationalizedValue.HELLO.name() ) ).extracting( "id" ).isEmpty();
 
 		EntityWithSpringAwareBridges entity = new EntityWithSpringAwareBridges();
 		entity.setInternationalizedValue( InternationalizedValue.HELLO );
 		dao.create( entity );
-		assertThat( search.apply( NonSpringBridge.PREFIX + InternationalizedValue.HELLO.name() ) ).onProperty( "id" ).containsOnly( entity.getId() );
+		assertThat( search.apply( NonSpringBridge.PREFIX + InternationalizedValue.HELLO.name() ) ).extracting( "id" ).containsOnly( entity.getId() );
 	}
 }

--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/wildfly/cdi/CDIInjectionIT.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/wildfly/cdi/CDIInjectionIT.java
@@ -35,7 +35,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.persistence20.PersistenceDescriptor;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.test.integration.VersionTestHelper.getHibernateORMModuleName;
 import static org.hibernate.search.test.integration.VersionTestHelper.getWildFlyModuleIdentifier;
 
@@ -91,63 +91,63 @@ public class CDIInjectionIT {
 	public void injectedFieldBridge() throws InterruptedException {
 		Function<String, List<EntityWithCDIAwareBridges>> search = dao::searchFieldBridge;
 
-		assertThat( search.apply( "bonjour" ) ).onProperty( "id" ).isEmpty();
-		assertThat( search.apply( "hello" ) ).onProperty( "id" ).isEmpty();
-		assertThat( search.apply( "hallo" ) ).onProperty( "id" ).isEmpty();
-		assertThat( search.apply( "au revoir" ) ).onProperty( "id" ).isEmpty();
+		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).isEmpty();
+		assertThat( search.apply( "hello" ) ).extracting( "id" ).isEmpty();
+		assertThat( search.apply( "hallo" ) ).extracting( "id" ).isEmpty();
+		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).isEmpty();
 
 		EntityWithCDIAwareBridges entity = new EntityWithCDIAwareBridges();
 		entity.setInternationalizedValue( InternationalizedValue.HELLO );
 		dao.create( entity );
-		assertThat( search.apply( "bonjour" ) ).onProperty( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "hello" ) ).onProperty( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "hallo" ) ).onProperty( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "au revoir" ) ).onProperty( "id" ).isEmpty();
+		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).containsOnly( entity.getId() );
+		assertThat( search.apply( "hello" ) ).extracting( "id" ).containsOnly( entity.getId() );
+		assertThat( search.apply( "hallo" ) ).extracting( "id" ).containsOnly( entity.getId() );
+		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).isEmpty();
 
 		EntityWithCDIAwareBridges entity2 = new EntityWithCDIAwareBridges();
 		entity2.setInternationalizedValue( InternationalizedValue.GOODBYE );
 		dao.create( entity2 );
-		assertThat( search.apply( "bonjour" ) ).onProperty( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "hello" ) ).onProperty( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "hallo" ) ).onProperty( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "au revoir" ) ).onProperty( "id" ).containsOnly( entity2.getId() );
+		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).containsOnly( entity.getId() );
+		assertThat( search.apply( "hello" ) ).extracting( "id" ).containsOnly( entity.getId() );
+		assertThat( search.apply( "hallo" ) ).extracting( "id" ).containsOnly( entity.getId() );
+		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).containsOnly( entity2.getId() );
 
 		dao.delete( entity );
-		assertThat( search.apply( "bonjour" ) ).onProperty( "id" ).isEmpty();
-		assertThat( search.apply( "hello" ) ).onProperty( "id" ).isEmpty();
-		assertThat( search.apply( "hallo" ) ).onProperty( "id" ).isEmpty();
-		assertThat( search.apply( "au revoir" ) ).onProperty( "id" ).containsOnly( entity2.getId() );
+		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).isEmpty();
+		assertThat( search.apply( "hello" ) ).extracting( "id" ).isEmpty();
+		assertThat( search.apply( "hallo" ) ).extracting( "id" ).isEmpty();
+		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).containsOnly( entity2.getId() );
 	}
 
 	@Test
 	public void injectedClassBridge() throws InterruptedException {
 		Function<String, List<EntityWithCDIAwareBridges>> search = dao::searchClassBridge;
 
-		assertThat( search.apply( "bonjour" ) ).onProperty( "id" ).isEmpty();
-		assertThat( search.apply( "hello" ) ).onProperty( "id" ).isEmpty();
-		assertThat( search.apply( "hallo" ) ).onProperty( "id" ).isEmpty();
-		assertThat( search.apply( "au revoir" ) ).onProperty( "id" ).isEmpty();
+		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).isEmpty();
+		assertThat( search.apply( "hello" ) ).extracting( "id" ).isEmpty();
+		assertThat( search.apply( "hallo" ) ).extracting( "id" ).isEmpty();
+		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).isEmpty();
 
 		EntityWithCDIAwareBridges entity = new EntityWithCDIAwareBridges();
 		entity.setInternationalizedValue( InternationalizedValue.HELLO );
 		dao.create( entity );
-		assertThat( search.apply( "bonjour" ) ).onProperty( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "hello" ) ).onProperty( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "hallo" ) ).onProperty( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "au revoir" ) ).onProperty( "id" ).isEmpty();
+		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).containsOnly( entity.getId() );
+		assertThat( search.apply( "hello" ) ).extracting( "id" ).containsOnly( entity.getId() );
+		assertThat( search.apply( "hallo" ) ).extracting( "id" ).containsOnly( entity.getId() );
+		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).isEmpty();
 
 		EntityWithCDIAwareBridges entity2 = new EntityWithCDIAwareBridges();
 		entity2.setInternationalizedValue( InternationalizedValue.GOODBYE );
 		dao.create( entity2 );
-		assertThat( search.apply( "bonjour" ) ).onProperty( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "hello" ) ).onProperty( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "hallo" ) ).onProperty( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "au revoir" ) ).onProperty( "id" ).containsOnly( entity2.getId() );
+		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).containsOnly( entity.getId() );
+		assertThat( search.apply( "hello" ) ).extracting( "id" ).containsOnly( entity.getId() );
+		assertThat( search.apply( "hallo" ) ).extracting( "id" ).containsOnly( entity.getId() );
+		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).containsOnly( entity2.getId() );
 
 		dao.delete( entity );
-		assertThat( search.apply( "bonjour" ) ).onProperty( "id" ).isEmpty();
-		assertThat( search.apply( "hello" ) ).onProperty( "id" ).isEmpty();
-		assertThat( search.apply( "hallo" ) ).onProperty( "id" ).isEmpty();
-		assertThat( search.apply( "au revoir" ) ).onProperty( "id" ).containsOnly( entity2.getId() );
+		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).isEmpty();
+		assertThat( search.apply( "hello" ) ).extracting( "id" ).isEmpty();
+		assertThat( search.apply( "hallo" ) ).extracting( "id" ).isEmpty();
+		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).containsOnly( entity2.getId() );
 	}
 }

--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/wildfly/cdi/CDIInjectionLifecycleEventsIT.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/wildfly/cdi/CDIInjectionLifecycleEventsIT.java
@@ -44,7 +44,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.persistence20.PersistenceDescriptor;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.test.integration.VersionTestHelper.getHibernateORMModuleName;
 import static org.hibernate.search.test.integration.VersionTestHelper.getWildFlyModuleIdentifier;
 

--- a/jsr352/core/pom.xml
+++ b/jsr352/core/pom.xml
@@ -49,8 +49,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/impl/util/SerializationUtilTest.java
+++ b/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/impl/util/SerializationUtilTest.java
@@ -19,7 +19,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 

--- a/jsr352/core/src/test/java/org/hibernate/search/jsr352/test/util/JobTestUtil.java
+++ b/jsr352/core/src/test/java/org/hibernate/search/jsr352/test/util/JobTestUtil.java
@@ -31,7 +31,7 @@ import java.lang.invoke.MethodHandles;
 
 import org.apache.lucene.search.Query;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Yoann Rodiere

--- a/orm/pom.xml
+++ b/orm/pom.xml
@@ -101,8 +101,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/orm/src/test/java/org/hibernate/search/test/batchindexing/DatabaseMultitenancyTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/batchindexing/DatabaseMultitenancyTest.java
@@ -6,12 +6,13 @@
  */
 package org.hibernate.search.test.batchindexing;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
 import org.apache.lucene.search.Query;
-import org.fest.util.Collections;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.dialect.Dialect;
@@ -21,12 +22,11 @@ import org.hibernate.search.Search;
 import org.hibernate.search.engine.spi.DocumentBuilderIndexedEntity;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.util.impl.CollectionHelper;
 import org.hibernate.testing.RequiresDialect;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.fest.assertions.Assertions.assertThat;
 
 /**
  * This is a test class to check that search can be used with ORM in multi-tenancy.
@@ -61,17 +61,17 @@ public class DatabaseMultitenancyTest extends SearchTestBase {
 	 */
 	private static final String GEOCHRON_TID = "geochron";
 
-	private static Object[] METAMEC_MODELS = {
+	private static Clock[] METAMEC_MODELS = {
 			new Clock( 1, "Metamec - Model A850" ),
 			new Clock( 2, "Metamec - Model 4562" ),
 			new Clock( 5, "Metamec - Model 792" )
-		};
+	};
 
-	private static Object[] GEOCHRON_MODELS = {
+	private static Clock[] GEOCHRON_MODELS = {
 			new Clock( 1, "Geochron - Model The Original Kilburg" ),
 			new Clock( 2, "Geochron - Model The Boardroom" ),
 			new Clock( 9, "Geochron - Model Designer Series" )
-		};
+	};
 
 	@Override
 	@Before
@@ -265,7 +265,7 @@ public class DatabaseMultitenancyTest extends SearchTestBase {
 
 	@Override
 	public Set<String> multiTenantIds() {
-		return Collections.set( METAMEC_TID, GEOCHRON_TID );
+		return CollectionHelper.asSet( METAMEC_TID, GEOCHRON_TID );
 	}
 
 }

--- a/orm/src/test/java/org/hibernate/search/test/bridge/provider/BridgeProviderTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/provider/BridgeProviderTest.java
@@ -7,7 +7,7 @@
 
 package org.hibernate.search.test.bridge.provider;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.lucene.search.Query;
 import org.hibernate.Session;

--- a/orm/src/test/java/org/hibernate/search/test/bridge/provider/ConflictingBridgeDefinitionTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/provider/ConflictingBridgeDefinitionTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.bridge.provider;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.hibernate.search.cfg.spi.SearchConfiguration;
 import org.hibernate.search.exception.SearchException;

--- a/orm/src/test/java/org/hibernate/search/test/bridge/tika/TikaBridgeTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/bridge/tika/TikaBridgeTest.java
@@ -44,7 +44,7 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 /**

--- a/orm/src/test/java/org/hibernate/search/test/configuration/LuceneProgrammaticMappingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/LuceneProgrammaticMappingTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.configuration;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.util.List;

--- a/orm/src/test/java/org/hibernate/search/test/configuration/ProgrammaticMappingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/configuration/ProgrammaticMappingTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.configuration;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -176,14 +176,14 @@ public class ProgrammaticMappingTest extends SearchTestBase {
 		query.setSort( new Sort( new SortField( "price", SortField.Type.INT ) ) );
 
 		List<?> results = query.list();
-		assertThat( results ).onProperty( "price" )
+		assertThat( results ).extracting( "price" )
 			.describedAs( "Sortable field via programmatic config" )
 			.containsExactly( (short) 3354, (short) 3454, (short) 3554 );
 
 		query.setSort( new Sort( new SortField( "id", SortField.Type.STRING ) ) );
 
 		results = query.list();
-		assertThat( results ).onProperty( "id" )
+		assertThat( results ).extracting( "id" )
 			.describedAs( "Sortable field via programmatic config" )
 			.containsExactly( 1, 2, 3 );
 
@@ -241,10 +241,10 @@ public class ProgrammaticMappingTest extends SearchTestBase {
 		List<Facet> results = query.list();
 
 		List<Facet> facets = query.getFacetManager().getFacets( "myFacet" );
-		assertThat( facets ).onProperty( "value" )
+		assertThat( facets ).extracting( "value" )
 				.describedAs( "Retrieved facets - values" )
 				.containsExactly( "[, 50.0)", "[50.0, 1000.0)", "[1000.0, ]" );
-		assertThat( facets ).onProperty( "count" )
+		assertThat( facets ).extracting( "count" )
 				.describedAs( "Retrieved facets - counts" )
 				.containsExactly( 2, 1, 1 );
 

--- a/orm/src/test/java/org/hibernate/search/test/directoryProvider/DirectoryLifecycleTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/directoryProvider/DirectoryLifecycleTest.java
@@ -7,7 +7,7 @@
 
 package org.hibernate.search.test.directoryProvider;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Set;
 

--- a/orm/src/test/java/org/hibernate/search/test/embedded/depth/RecursiveGraphTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/embedded/depth/RecursiveGraphTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.embedded.depth;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.io.Serializable;

--- a/orm/src/test/java/org/hibernate/search/test/embedded/sorting/EmbeddedSortableIdFieldTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/embedded/sorting/EmbeddedSortableIdFieldTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.embedded.sorting;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 

--- a/orm/src/test/java/org/hibernate/search/test/engine/optimizations/IndexReaderSeeOptimizedIndexTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/engine/optimizations/IndexReaderSeeOptimizedIndexTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.engine.optimizations;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.Serializable;

--- a/orm/src/test/java/org/hibernate/search/test/engine/optimizations/deletebyterm/DeleteByTermTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/engine/optimizations/deletebyterm/DeleteByTermTest.java
@@ -26,7 +26,7 @@ import org.hibernate.search.spi.SearchIntegrator;
 import org.hibernate.search.test.util.FullTextSessionBuilder;
 import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Emmanuel Bernard &lt;emmanuel@hibernate.org&gt;

--- a/orm/src/test/java/org/hibernate/search/test/filter/FullTextFilterTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/filter/FullTextFilterTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.filter;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 

--- a/orm/src/test/java/org/hibernate/search/test/filter/OrmFilterTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/filter/OrmFilterTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.filter;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.persistence.Basic;
 import javax.persistence.Entity;
@@ -47,11 +47,11 @@ public class OrmFilterTest extends SearchTestBase {
 			criteria.orderBy( cb.asc( root.get( "id" ) ) );
 			org.hibernate.query.Query<FilterableEntity> query = session.createQuery( criteria );
 			query.setMaxResults( 3 );
-			assertThat( query.getResultList() ).onProperty( "id" )
+			assertThat( query.getResultList() ).extracting( "id" )
 					.containsExactly( 0, 2, 3 );
 
 			session.enableFilter( "filter1" ).setParameter( "excludedNumericValue", 3 );
-			assertThat( query.getResultList() ).onProperty( "id" )
+			assertThat( query.getResultList() ).extracting( "id" )
 					.containsExactly( 0, 2, 4 );
 		}
 	}
@@ -66,7 +66,7 @@ public class OrmFilterTest extends SearchTestBase {
 			ftQuery.setSort( qb.sort().byField( "idSort" ).createSort() );
 			ftQuery.setMaxResults( 3 );
 			assertThat( ftQuery.getResultSize() ).isEqualTo( 4 ); // Ignores max results, that's expected
-			assertThat( ftQuery.getResultList() ).onProperty( "id" )
+			assertThat( ftQuery.getResultList() ).extracting( "id" )
 					.containsExactly( 0, 2, 3 );
 
 			// TODO we'll need to change the following assertions when fixing HSEARCH-2848.
@@ -79,7 +79,7 @@ public class OrmFilterTest extends SearchTestBase {
 			 * but the filter will be applied after the result limit.
 			 * Thus the result 4 is missing here, while we would expect it to be included.
 			 */
-			assertThat( ftQuery.getResultList() ).onProperty( "id" )
+			assertThat( ftQuery.getResultList() ).extracting( "id" )
 					.containsExactly( 0, 2 );
 		}
 	}

--- a/orm/src/test/java/org/hibernate/search/test/filter/deprecated/FilterTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/filter/deprecated/FilterTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.filter.deprecated;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 

--- a/orm/src/test/java/org/hibernate/search/test/filter/fulltextfilterdef/FullTextFilterDefAnnotationTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/filter/fulltextfilterdef/FullTextFilterDefAnnotationTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.filter.fulltextfilterdef;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
 

--- a/orm/src/test/java/org/hibernate/search/test/filter/fulltextfilterdefs/FullTextFilterDefsAnnotationTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/filter/fulltextfilterdefs/FullTextFilterDefsAnnotationTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.filter.fulltextfilterdefs;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
 

--- a/orm/src/test/java/org/hibernate/search/test/interceptor/IndexingActionInterceptorTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/interceptor/IndexingActionInterceptorTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.interceptor;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -69,8 +69,8 @@ public class IndexingActionInterceptorTest extends SearchTestBase {
 		Transaction tx = fullTextSession.beginTransaction();
 
 		List<Blog> blogEntries = getBlogEntries();
-		assertThat( blogEntries ).as( "Blog is explicitly intercepted" ).excludes( blog );
-		assertThat( blogEntries ).as( "Article is inherently intercepted" ).excludes( article );
+		assertThat( blogEntries ).as( "Blog is explicitly intercepted" ).doesNotContain( blog );
+		assertThat( blogEntries ).as( "Article is inherently intercepted" ).doesNotContain( article );
 
 		tx.commit();
 	}
@@ -104,8 +104,8 @@ public class IndexingActionInterceptorTest extends SearchTestBase {
 		Transaction tx = fullTextSession.beginTransaction();
 
 		List<Blog> blogEntries = getBlogEntries();
-		assertThat( blogEntries ).excludes( blog );
-		assertThat( blogEntries ).as( "Article is inherently intercepted" ).excludes( article );
+		assertThat( blogEntries ).doesNotContain( blog );
+		assertThat( blogEntries ).as( "Article is inherently intercepted" ).doesNotContain( article );
 
 		tx.commit();
 	}

--- a/orm/src/test/java/org/hibernate/search/test/query/boost/embeddable/EmbeddedFieldBoostTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/boost/embeddable/EmbeddedFieldBoostTest.java
@@ -15,7 +15,7 @@ import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.testsupport.TestForIssue;
 import org.junit.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
 
@@ -93,7 +93,7 @@ public class EmbeddedFieldBoostTest extends SearchTestBase {
 		// Then
 		assertThat( fullTextSession.createFullTextQuery( query, Magazine.class ).list() )
 				.describedAs( "Query results are not in the order expected as per configured field boosts" )
-				.onProperty( "id" )
+				.extracting( "id" )
 				.containsExactly( 2L, 4L, 3L, 1L );
 
 		tx.commit();

--- a/orm/src/test/java/org/hibernate/search/test/query/criteria/ResultSizeOnCriteriaTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/criteria/ResultSizeOnCriteriaTest.java
@@ -23,7 +23,7 @@ import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.test.SearchTestBase;
 import org.junit.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 /**

--- a/orm/src/test/java/org/hibernate/search/test/query/initandlookup/CriteriaObjectInitializerAndHierarchyInheritanceTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/initandlookup/CriteriaObjectInitializerAndHierarchyInheritanceTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.query.initandlookup;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Locale;
@@ -105,19 +105,19 @@ public class CriteriaObjectInitializerAndHierarchyInheritanceTest extends Search
 		FullTextSession session = Search.getFullTextSession( s );
 
 		List<?> results = getResults( session, AAA.class );
-		assertThat( results ).onProperty( "name" ).containsOnly( "A AA AAA" );
+		assertThat( results ).extracting( "name" ).containsOnly( "A AA AAA" );
 		assertThat( byteman.consumeNextRecordedEvent() ).isEqualTo( AAA.class.getName() );
 
 		results = getResults( session, AAA.class, AAB.class );
-		assertThat( results ).onProperty( "name" ).containsOnly( "A AA AAA", "A AA AAB" );
+		assertThat( results ).extracting( "name" ).containsOnly( "A AA AAA", "A AA AAB" );
 		assertThat( byteman.consumeNextRecordedEvent() ).isEqualTo( AA.class.getName() );
 
 		results = getResults( session, AAA.class, AB.class );
-		assertThat( results ).onProperty( "name" ).containsOnly( "A AA AAA", "A AB", "A AB ABA" );
+		assertThat( results ).extracting( "name" ).containsOnly( "A AA AAA", "A AB", "A AB ABA" );
 		assertThat( byteman.consumeNextRecordedEvent() ).isEqualTo( A.class.getName() );
 
 		results = getResults( session, AAA.class, BA.class );
-		assertThat( results ).onProperty( "name" ).containsOnly( "A AA AAA", "B BA" );
+		assertThat( results ).extracting( "name" ).containsOnly( "A AA AAA", "B BA" );
 		// here, we have 2 Criterias returned: we only test the first one
 		assertThat( byteman.consumeNextRecordedEvent() ).isIn( AAA.class.getName(), BA.class.getName() );
 

--- a/orm/src/test/java/org/hibernate/search/test/query/initandlookup/SecondLCAndPCLookupTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/initandlookup/SecondLCAndPCLookupTest.java
@@ -6,12 +6,13 @@
  */
 package org.hibernate.search.test.query.initandlookup;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 import java.util.Map;
 
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
-import org.fest.assertions.Condition;
 import org.hibernate.Hibernate;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
@@ -27,8 +28,6 @@ import org.hibernate.search.testsupport.backend.GatedLuceneBackend;
 import org.hibernate.stat.Statistics;
 import org.hibernate.testing.cache.CachingRegionFactory;
 import org.junit.Test;
-
-import static org.fest.assertions.Assertions.assertThat;
 
 /**
  * Test second level cache and persistence context lookup methods
@@ -234,14 +233,7 @@ public class SecondLCAndPCLookupTest extends SearchTestBase {
 		fullTextQuery.initializeObjectsWith( ObjectLookupMethod.SKIP, DatabaseRetrievalMethod.FIND_BY_ID );
 		List list = fullTextQuery.list();
 		assertThat( list.size() ).isEqualTo( 2 );
-		for ( Object o : list ) {
-			assertThat( o ).satisfies( new Condition<Object>() {
-				@Override
-				public boolean matches(Object value) {
-					return Hibernate.isInitialized( value );
-				}
-			} );
-		}
+		assertThat( list ).allSatisfy( o -> assertThat( Hibernate.isInitialized( o ) ).isTrue() );
 
 		for ( Object o : list ) {
 			o.toString(); //check true initialization

--- a/orm/src/test/java/org/hibernate/search/test/query/initandlookup/StrictSecondLCAndPCLookupTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/initandlookup/StrictSecondLCAndPCLookupTest.java
@@ -24,7 +24,7 @@ import org.hibernate.stat.Statistics;
 import org.hibernate.testing.cache.CachingRegionFactory;
 import org.junit.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test second level cache and persistence context lookup methods

--- a/orm/src/test/java/org/hibernate/search/test/query/objectloading/mixedhierarchy/ObjectLoadingCrossHierarchyTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/objectloading/mixedhierarchy/ObjectLoadingCrossHierarchyTest.java
@@ -22,7 +22,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for using object loading with queries spanning across multiple id spaces
@@ -97,7 +97,7 @@ public class ObjectLoadingCrossHierarchyTest extends SearchTestBase {
 		List<College> results = fullTextSession.createFullTextQuery( query, EducationalInstitution.class ).list();
 
 		assertThat( results )
-				.onProperty( "name" )
+				.extracting( "name" )
 				.describedAs( "Can load results originating from different id spaces, using different id types and names" )
 				.containsOnly(
 				"Southern Florida College of Golf",

--- a/orm/src/test/java/org/hibernate/search/test/query/sorting/SortOnFieldsFromCustomBridgeTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/sorting/SortOnFieldsFromCustomBridgeTest.java
@@ -21,7 +21,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 
 /**
@@ -86,7 +86,7 @@ public class SortOnFieldsFromCustomBridgeTest extends SearchTestBase {
 			.list();
 
 		assertNotNull( result );
-		assertThat( result ).onProperty( "id" ).containsExactly( 3, 1, 2 );
+		assertThat( result ).extracting( "id" ).containsExactly( 3, 1, 2 );
 
 		tx.commit();
 		fullTextSession.close();
@@ -103,7 +103,7 @@ public class SortOnFieldsFromCustomBridgeTest extends SearchTestBase {
 			.list();
 
 		assertNotNull( result );
-		assertThat( result ).onProperty( "id" ).containsExactly( 3, 1, 2 );
+		assertThat( result ).extracting( "id" ).containsExactly( 3, 1, 2 );
 
 		tx.commit();
 		fullTextSession.close();
@@ -125,7 +125,7 @@ public class SortOnFieldsFromCustomBridgeTest extends SearchTestBase {
 			.list();
 
 		assertNotNull( result );
-		assertThat( result ).onProperty( "id" ).containsExactly( 3, 2, 1 );
+		assertThat( result ).extracting( "id" ).containsExactly( 3, 2, 1 );
 
 		tx.commit();
 		fullTextSession.close();
@@ -147,7 +147,7 @@ public class SortOnFieldsFromCustomBridgeTest extends SearchTestBase {
 			.list();
 
 		assertNotNull( result );
-		assertThat( result ).onProperty( "id" ).containsExactly( 1, 2, 3 );
+		assertThat( result ).extracting( "id" ).containsExactly( 1, 2, 3 );
 
 		tx.commit();
 		fullTextSession.close();
@@ -164,7 +164,7 @@ public class SortOnFieldsFromCustomBridgeTest extends SearchTestBase {
 			.list();
 
 		assertNotNull( result );
-		assertThat( result ).onProperty( "id" ).containsExactly( 2, 1, 3 );
+		assertThat( result ).extracting( "id" ).containsExactly( 2, 1, 3 );
 
 		tx.commit();
 		fullTextSession.close();

--- a/orm/src/test/java/org/hibernate/search/test/query/sorting/SortTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/sorting/SortTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.query.sorting;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -105,7 +105,7 @@ public class SortTest extends SearchTestBase {
 		hibQuery.setSort( sort );
 		List<Book> result = hibQuery.list();
 		assertNotNull( result );
-		assertThat( result ).onProperty( "id" ).containsExactly( 1, 10, 2, 3 );
+		assertThat( result ).extracting( "id" ).containsExactly( 1, 10, 2, 3 );
 
 		tx.commit();
 	}
@@ -121,7 +121,7 @@ public class SortTest extends SearchTestBase {
 		hibQuery.setSort( sort );
 		List<Book> result = hibQuery.list();
 		assertNotNull( result );
-		assertThat( result ).onProperty( "id" ).containsExactly( 1, 2, 3, 10 );
+		assertThat( result ).extracting( "id" ).containsExactly( 1, 2, 3, 10 );
 
 		tx.commit();
 	}
@@ -137,15 +137,15 @@ public class SortTest extends SearchTestBase {
 
 		hibQuery.setSort( new Sort( new SortField( "id", SortField.Type.STRING, false ) ) );
 		List<Book> result = hibQuery.list();
-		assertThat( result ).onProperty( "id" ).containsExactly( 1, 10, 2, 3 );
+		assertThat( result ).extracting( "id" ).containsExactly( 1, 10, 2, 3 );
 
 		hibQuery.setSort( new Sort( new SortField( "id_forIntegerSort", SortField.Type.INT, false ) ) );
 		result = hibQuery.list();
-		assertThat( result ).onProperty( "id" ).containsExactly( 1, 2, 3, 10 );
+		assertThat( result ).extracting( "id" ).containsExactly( 1, 2, 3, 10 );
 
 		hibQuery.setSort( new Sort( new SortField( "id", SortField.Type.STRING, false ) ) );
 		result = hibQuery.list();
-		assertThat( result ).onProperty( "id" ).containsExactly( 1, 10, 2, 3 );
+		assertThat( result ).extracting( "id" ).containsExactly( 1, 10, 2, 3 );
 
 		tx.commit();
 	}
@@ -198,7 +198,7 @@ public class SortTest extends SearchTestBase {
 		hibQuery.setSort( sort );
 		List<Book> result = hibQuery.list();
 		assertNotNull( result );
-		assertThat( result ).onProperty( "id" ).containsExactly( 4, 10, 3, 2, 1 );
+		assertThat( result ).extracting( "id" ).containsExactly( 4, 10, 3, 2, 1 );
 		assertEquals( "Groovy in Action", result.get( 0 ).getSummary() );
 
 		tx.commit();
@@ -262,7 +262,7 @@ public class SortTest extends SearchTestBase {
 		List<Book> result = hibQuery.list();
 
 		assertNotNull( result );
-		assertThat( result ).onProperty( "id" ).containsOnly( 1, 2, 3, 10 );
+		assertThat( result ).extracting( "id" ).containsOnly( 1, 2, 3, 10 );
 
 		tx.commit();
 	}
@@ -279,7 +279,7 @@ public class SortTest extends SearchTestBase {
 		hibQuery.setSort( sort );
 		List<Book> result = hibQuery.list();
 		assertNotNull( result );
-		assertThat( result ).onProperty( "id" ).containsExactly( 2, 1, 3, 4, 10 );
+		assertThat( result ).extracting( "id" ).containsExactly( 2, 1, 3, 4, 10 );
 
 		tx.commit();
 	}
@@ -297,10 +297,10 @@ public class SortTest extends SearchTestBase {
 		@SuppressWarnings("unchecked")
 		List<Book> result = hibQuery.list();
 		assertNotNull( result );
-		assertThat( result ).onProperty( "lastName" )
+		assertThat( result ).extracting( "lastName" )
 			.containsExactly( "Higgins", "Higgins", "Johnson", "Johnson" );
 
-		assertThat( result ).onProperty( "name" )
+		assertThat( result ).extracting( "name" )
 			.containsExactly( "Barny the brick layer", "Bart the brick layer", "Barny the brick layer", "Bill the brick layer" );
 
 		tx.commit();
@@ -317,11 +317,11 @@ public class SortTest extends SearchTestBase {
 
 		hibQuery.setSort( new Sort( new SortField( "id_forIntegerSort", SortField.Type.INT, false ) ) );
 		List<Book> result = hibQuery.list();
-		assertThat( result ).onProperty( "id" ).containsExactly( 1, 2, 3, 10 );
+		assertThat( result ).extracting( "id" ).containsExactly( 1, 2, 3, 10 );
 
 		hibQuery.setSort( new Sort( new SortField( "id_forIntegerSort", SortField.Type.INT, true ) ) );
 		result = hibQuery.list();
-		assertThat( result ).onProperty( "id" ).containsExactly( 10, 3, 2, 1 );
+		assertThat( result ).extracting( "id" ).containsExactly( 10, 3, 2, 1 );
 
 		tx.commit();
 	}

--- a/orm/src/test/java/org/hibernate/search/test/query/sorting/SortUsingEntityManagerTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/sorting/SortUsingEntityManagerTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.query.sorting;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Calendar;
 import java.util.Date;

--- a/orm/src/test/java/org/hibernate/search/test/query/sorting/SortWithIndexUninvertingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/query/sorting/SortWithIndexUninvertingTest.java
@@ -28,7 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
@@ -80,7 +80,7 @@ public class SortWithIndexUninvertingTest extends SearchTestBase {
 		@SuppressWarnings("unchecked")
 		List<Book> result = hibQuery.list();
 		assertNotNull( result );
-		assertThat( result ).onProperty( "name" )
+		assertThat( result ).extracting( "name" )
 			.describedAs( "Expecting results from index with sort field and uninverted index in the correct sort order" )
 			.containsExactly( "Bill the brick layer", "Bill the plumber" );
 

--- a/orm/src/test/java/org/hibernate/search/test/shards/DynamicShardingTest.java
+++ b/orm/src/test/java/org/hibernate/search/test/shards/DynamicShardingTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.shards;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.io.Serializable;

--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,7 @@
         <version.org.easymock>3.5.1</version.org.easymock>
         <version.org.unitils>3.4.6</version.org.unitils>
         <version.simple-jndi>0.11.4.1</version.simple-jndi>
-        <version.org.easytesting.fest-assert>1.4</version.org.easytesting.fest-assert>
+        <version.org.assertj.assertj-core>3.9.1</version.org.assertj.assertj-core>
         <version.org.skyscreamer.jsonassert>1.2.3</version.org.skyscreamer.jsonassert>
         <version.com.github.tomakehurst.wiremock>2.5.1</version.com.github.tomakehurst.wiremock>
         <!-- Fixes dependency convergence within Wiremock, see below -->
@@ -895,9 +895,9 @@
                 <version>${version.simple-jndi}</version>
             </dependency>
             <dependency>
-                <groupId>org.easytesting</groupId>
-                <artifactId>fest-assert</artifactId>
-                <version>${version.org.easytesting.fest-assert}</version>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${version.org.assertj.assertj-core}</version>
             </dependency>
             <dependency>
                 <groupId>org.skyscreamer</groupId>

--- a/serialization/avro/pom.xml
+++ b/serialization/avro/pom.xml
@@ -48,8 +48,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/serialization/avro/src/test/java/org/hibernate/search/test/serialization/SerializationTest.java
+++ b/serialization/avro/src/test/java/org/hibernate/search/test/serialization/SerializationTest.java
@@ -44,7 +44,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Emmanuel Bernard &lt;emmanuel@hibernate.org&gt;

--- a/serialization/avro/src/test/java/org/hibernate/search/test/util/SerializationTestHelper.java
+++ b/serialization/avro/src/test/java/org/hibernate/search/test/util/SerializationTestHelper.java
@@ -45,7 +45,7 @@ import org.hibernate.search.backend.spi.DeleteByQueryLuceneWork;
 import org.hibernate.search.indexes.serialization.impl.CopyTokenStream;
 import org.hibernate.search.indexes.serialization.spi.SerializableTokenStream;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -48,8 +48,8 @@
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.skyscreamer</groupId>

--- a/testing/src/main/java/org/hibernate/search/test/util/FutureAssert.java
+++ b/testing/src/main/java/org/hibernate/search/test/util/FutureAssert.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.test.util;
 
-import static org.fest.assertions.Formatting.format;
+import static org.assertj.core.util.Strings.formatIfArgs;
 
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
@@ -15,41 +15,37 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
-import org.fest.assertions.Assertions;
-import org.fest.assertions.GenericAssert;
+import org.assertj.core.api.AbstractObjectAssert;
+import org.assertj.core.api.Assertions;
 import org.hamcrest.Matcher;
 import org.junit.Assert;
 
 /**
  * @author Yoann Rodiere
  */
-public class FutureAssert<T> extends GenericAssert<FutureAssert<T>, Future<T>> {
+public class FutureAssert<T> extends AbstractObjectAssert<FutureAssert<T>, Future<T>> {
 
 	public static <T> FutureAssert<T> assertThat(Future<T> future) {
 		return new FutureAssert<>( future );
 	}
 
-	@SuppressWarnings({ "rawtypes", "unchecked" })
 	protected FutureAssert(Future<T> actual) {
-		super( (Class) FutureAssert.class, actual );
+		super( actual, FutureAssert.class );
 	}
 
 	public FutureAssert<T> isPending() {
 		try {
 			Object result = getNow();
-			failIfCustomMessageIsSet();
-			fail( format( "future <%s> should be pending, but instead it succeeded with result <%s>", actual, result ) );
+			failWithMessage( "future <%s> should be pending, but instead it succeeded with result <%s>", actual, result );
 		}
 		catch (TimeoutException e) {
 			// All's good
 		}
 		catch (CancellationException e) {
-			failIfCustomMessageIsSet( e );
-			fail( format( "future <%s> should be pending, but instead it's been cancelled", actual ), e );
+			failWithMessage( "future <%s> should be pending, but instead it's been cancelled", actual );
 		}
 		catch (ExecutionException e) {
-			failIfCustomMessageIsSet( e );
-			fail( format( "future <%s> should be pending, but instead it failed with exception: %s", actual, e ), e );
+			failWithMessage( "future <%s> should be pending, but instead it failed with exception: %s", actual, e );
 		}
 		return this;
 	}
@@ -70,21 +66,17 @@ public class FutureAssert<T> extends GenericAssert<FutureAssert<T>, Future<T>> {
 				valueAssertion.accept( result );
 			}
 			catch (AssertionError e2) {
-				failIfCustomMessageIsSet( e2 );
-				fail( format( "future <%s> succeeded as expected, but the result is wrong: %s", actual, e2 ), e2 );
+				failWithMessage( formatIfArgs( "future <%s> succeeded as expected, but the result is wrong: %s", actual, e2 ) );
 			}
 		}
 		catch (TimeoutException e) {
-			failIfCustomMessageIsSet();
-			fail( format( "future <%s> should have succeeded, but instead it's still pending", actual ) );
+			failWithMessage( "future <%s> should have succeeded, but instead it's still pending", actual );
 		}
 		catch (CancellationException e) {
-			failIfCustomMessageIsSet( e );
-			fail( format( "future <%s> should have succeeded, but instead it's been cancelled", actual ), e );
+			failWithMessage( "future <%s> should have succeeded, but instead it's been cancelled", actual );
 		}
 		catch (ExecutionException e) {
-			failIfCustomMessageIsSet( e );
-			fail( format( "future <%s> should have succeeded, but instead it failed with exception: %s", actual, e ), e );
+			failWithMessage( "future <%s> should have succeeded, but instead it failed with exception: %s", actual, e );
 		}
 		return this;
 	}
@@ -105,24 +97,20 @@ public class FutureAssert<T> extends GenericAssert<FutureAssert<T>, Future<T>> {
 		Object result;
 		try {
 			result = getNow();
-			failIfCustomMessageIsSet();
-			fail( format( "future <%s> should have failed, but instead it succeeded with result <%s>", actual, result ) );
+			failWithMessage( "future <%s> should have failed, but instead it succeeded with result <%s>", actual, result );
 		}
 		catch (TimeoutException e) {
-			failIfCustomMessageIsSet( e );
-			fail( format( "future <%s> should have failed, but instead it's still pending", actual ), e );
+			failWithMessage( "future <%s> should have failed, but instead it's still pending", actual );
 		}
 		catch (CancellationException e) {
-			failIfCustomMessageIsSet( e );
-			fail( format( "future <%s> should have failed, but instead it's been cancelled", actual ), e );
+			failWithMessage( "future <%s> should have failed, but instead it's been cancelled", actual );
 		}
 		catch (ExecutionException e) {
 			try {
 				exceptionAssertion.accept( e.getCause() );
 			}
 			catch (AssertionError e2) {
-				failIfCustomMessageIsSet( e2 );
-				fail( format( "future <%s> failed as expected, but the exception is wrong: %s", actual, e2 ), e2 );
+				failWithMessage( "future <%s> failed as expected, but the exception is wrong: %s", actual, e2 );
 			}
 		}
 		return this;
@@ -143,12 +131,11 @@ public class FutureAssert<T> extends GenericAssert<FutureAssert<T>, Future<T>> {
 			Throwable t = e;
 			while ( t != null ) {
 				if ( t instanceof AssertionError ) {
-					fail( format( "future <%s> failed because of a failing assertion: %s", actual, e.getCause() ), e.getCause() );
+					failWithMessage( "future <%s> failed because of a failing assertion: %s", actual, e.getCause() );
 				}
 				t = t.getCause();
 			}
 			throw e;
 		}
 	}
-
 }


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/HSEARCH-3034

In `FutureAssert`, we lose the cause but I haven't found anything in AssertJ allowing to pass the cause.

We could either throw the exception and have the message as a comment or write custom failure handling. Not sure it's worth it.

Another option could be to contribute to AssertJ and allow to pass the cause to `failWithMessage()` (or more probably `failWithMessageAndCause()` as the methods would conflict).