### PR TITLE
Backport to 5.9: HSEARCH-3134 Error message in MassIndexerImpl#toRootEntities mentions "a subclass of an indexed entity" but should mention "supertype" instead

### DIFF
--- a/engine/src/main/java/org/hibernate/search/spi/impl/IndexedTypeSets.java
+++ b/engine/src/main/java/org/hibernate/search/spi/impl/IndexedTypeSets.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.spi.impl;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -25,6 +26,16 @@ public final class IndexedTypeSets {
 
 	private IndexedTypeSets() {
 		//Utility class: not to be constructed
+	}
+
+	public static IndexedTypeSet fromClasses(Collection<Class<?>> classes) {
+		if ( classes == null || classes.isEmpty() ) {
+			// "null" needs to be acceptable to support some legacy use cases
+			return empty();
+		}
+		else {
+			return classes.stream().filter( c -> c != null ).map( PojoIndexedTypeIdentifier::new ).collect( streamCollector() );
+		}
 	}
 
 	public static IndexedTypeSet fromClasses(Class<?>... classes) {

--- a/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
@@ -1009,4 +1009,9 @@ public interface Log extends BaseHibernateSearchLogger {
 			+ "or not compatible with this version of Hibernate Search." )
 	SearchException incompatibleEntityManagerFactory(String emfClassName);
 
+	@Message(id = 348, value = "Some of the specified entity types ('%s') are not configured, nor is any of their subclasses." )
+	IllegalArgumentException someTargetedEntityTypesNotConfigured(String targetedEntities);
+
+	@Message(id = 349, value = "Some of the specified entity types ('%s') are not indexed, nor is any of their subclasses." )
+	IllegalArgumentException someTargetedEntityTypesNotIndexed(String targetedEntities);
 }

--- a/engine/src/test/java/org/hibernate/search/test/engine/typehandling/BasicTypeCollectionsTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/engine/typehandling/BasicTypeCollectionsTest.java
@@ -29,7 +29,7 @@ public class BasicTypeCollectionsTest {
 
 	@Test
 	public void nullVararg() {
-		assertIsEmpty( IndexedTypeSets.fromClasses( null ) );
+		assertIsEmpty( IndexedTypeSets.fromClasses( (Class<?>[]) null ) );
 	}
 
 	@Test


### PR DESCRIPTION
**WARNING**: #1662 should be reviewed and merged first.

https://hibernate.atlassian.net//browse/HSEARCH-3134