### PR TITLE
HSEARCH-3138 Restore binary compatibility with applications compiled against Hibernate Search 5.5

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -261,6 +261,23 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <!--
+                     Use briger to restore binary compatibility with Hibernate Search 5.5; see HSEARCH-3138.
+                     The only bridged class is org.hibernate.search.filter.FilterCachingStrategy at the moment.
+                 -->
+                <groupId>org.jboss.bridger</groupId>
+                <artifactId>bridger</artifactId>
+                <executions>
+                    <execution>
+                        <id>weave</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>transform</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/engine/src/main/java/org/hibernate/search/filter/FilterCachingStrategy.java
+++ b/engine/src/main/java/org/hibernate/search/filter/FilterCachingStrategy.java
@@ -8,6 +8,8 @@ package org.hibernate.search.filter;
 
 import java.util.Properties;
 
+import org.hibernate.search.exception.SearchException;
+
 import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryWrapperFilter;
@@ -26,13 +28,35 @@ public interface FilterCachingStrategy {
 	 * @param properties the caching strategy configuration
 	 */
 	void initialize(Properties properties);
+
 	/**
 	 * Retrieve the cached filter for a given key or null if not cached.
+	 * <p>
+	 * <strong>Caution:</strong> this method has a default implementation for technical reasons,
+	 * but it <em>must</em> be implemented.
 	 *
 	 * @param key the filter key
 	 * @return the cached filter or null if not cached
 	 */
-	Query getCachedFilter(FilterKey key);
+	default Query getCachedFilter(FilterKey key) {
+		return getCachedFilter$$bridge$$FilterReturnType( key );
+	}
+
+	/**
+	 * <strong>Not part of the API!</strong> Do not use or implement this.
+	 * @deprecated This method is only here so that Hibernate Search build tools can generate bytecode
+	 * allowing to preserve binary compatibility with applications written for Hibernate Search 5.5.
+	 * It will be removed in a future version. Please implement {@link #getCachedFilter(FilterKey)} instead.
+	 * @param key the filter key
+	 * @return the cached filter or null if not cached
+	 */
+	@Deprecated
+	default Filter getCachedFilter$$bridge$$FilterReturnType(FilterKey key) {
+		throw new SearchException(
+				"Custom filter caching strategy " + getClass().getName()
+				+ " does not implement getCachedFilter(FilterKey) as required."
+		);
+	}
 
 	/**
 	 * Propose a candidate filter for caching

--- a/engine/src/main/java/org/hibernate/search/query/dsl/QueryCustomization.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/QueryCustomization.java
@@ -7,6 +7,7 @@
 
 package org.hibernate.search.query.dsl;
 
+import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.Query;
 
 /**
@@ -41,6 +42,18 @@ public interface QueryCustomization<T> {
 	 * @return an instance of T for method chaining
 	 */
 	T filteredBy(Query filter);
+
+	/**
+	 * Filter the query results with the given Query instance
+	 * @deprecated Lucene {@link Filter}s have been deprecated and will be removed in a future version.
+	 * Please use {@link Query Queries} instead of {@link Filter}s
+	 * and use {@link #filteredBy(Query)} instead of this method.
+	 * @param filter the Query to use as a filter
+	 * @return an instance of T for method chaining
+	 */
+	default T filteredBy(Filter filter) {
+		return filteredBy( (Query) filter );
+	}
 
 	//TODO filter(String) + parameters
 }

--- a/pom.xml
+++ b/pom.xml
@@ -335,6 +335,7 @@
         <version.org.wildfly.build-tools>1.2.9.Final</version.org.wildfly.build-tools>
         <version.jacoco.plugin>0.8.0</version.jacoco.plugin>
         <version.coveralls.plugin>4.3.0</version.coveralls.plugin>
+        <version.org.jboss.bridger.plugin>1.5.Final</version.org.jboss.bridger.plugin>
 
         <!--
             Please don't change the name of this property, it may be used and
@@ -1761,6 +1762,11 @@ org.hibernate.search.spi.SearchIntegratorBuilder#buildSearchIntegrator()
                             <relativeReportDir>jacoco-aggregate</relativeReportDir>
                         </relativeReportDirs>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.jboss.bridger</groupId>
+                    <artifactId>bridger</artifactId>
+                    <version>${version.org.jboss.bridger.plugin}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3138

To test it:

```
# build the PR locally and install the artifacts to the local Maven repository
cd <your clone of the repo>
git checkout <the branch of this PR>
mvn clean install -DskipTests
# clone the binary compatibility tests
cd $(mktemp -d)
git clone -b search-5-5-vs-5-10-binary-compatibility https://github.com/yrodiere/hibernate-test-case-templates.git
# cd to the binary compatibility tests
cd hibernate-test-case-templates/search/hibernate-search-wildfly
# run the tests against WF 12 vanilla to see how everything works nicely
mvn clean install -DuseBuiltinModules -DbuiltinVersion=5.5.8.Final
# => BUILD SUCCESS
# run the tests against Hibernate Search 5.10.Beta2 to see how binary compatibility is lost
mvn clean install
# => BUILD FAILURE
# run the tests against Hibernate Search 5.10.0-SNAPSHOT (built from this PR) to see how binary compatibility is restored
mvn clean install -Dversion.org.hibernate.search=5.10.0-SNAPSHOT
# => BUILD SUCCESS
```
