### PR TITLE
Enable and upgrade Byte Buddy to prepare for ORM 5.3.0.CR2

### DIFF
--- a/integrationtest/osgi/karaf-features/src/main/features/features.xml
+++ b/integrationtest/osgi/karaf-features/src/main/features/features.xml
@@ -61,6 +61,7 @@
         <bundle>mvn:org.jboss/jandex/${version.org.jboss.jandex}</bundle>
         <bundle>mvn:com.fasterxml/classmate/${version.com.fasterxml.classmate}</bundle>
         <bundle>mvn:org.javassist/javassist/${version.org.javassist}</bundle>
+        <bundle>mvn:net.bytebuddy/byte-buddy/${version.net.bytebuddy}</bundle>
 
         <!-- Hibernate ORM -->
         <bundle>mvn:org.hibernate/hibernate-core/${version.org.hibernate}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
 
         <version.org.infinispan>9.0.1.Final</version.org.infinispan>
 
-        <version.net.bytebuddy>1.7.9</version.net.bytebuddy>
+        <version.net.bytebuddy>1.8.0</version.net.bytebuddy>
 
         <version.wildfly>12.0.0.Final</version.wildfly>
 


### PR DESCRIPTION

These two trivial ones are extracted from my WIP to update to ORM 5.3.0.CR2 (which isn't released yet)

 - https://hibernate.atlassian.net/browse/HSEARCH-3142
 - https://hibernate.atlassian.net/browse/HSEARCH-3144
