### PR TITLE
HSEARCH-2614 JSR-352: Test starting/stopping the job using WildFly tooling (e.g. CLI) 

### DIFF
--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/jsr352/massindexing/RemoteExecutionIT.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/jsr352/massindexing/RemoteExecutionIT.java
@@ -1,0 +1,195 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.integration.jsr352.massindexing;
+
+import static org.hibernate.search.test.integration.VersionTestHelper.getHibernateORMModuleName;
+import static org.hibernate.search.test.integration.VersionTestHelper.getWildFlyModuleIdentifier;
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import javax.batch.runtime.BatchStatus;
+import javax.inject.Inject;
+
+import org.hibernate.search.jsr352.massindexing.MassIndexingJob;
+import org.hibernate.search.test.integration.arquillian.DataSourceConfigurator;
+import org.hibernate.search.test.integration.jsr352.massindexing.test.common.Message;
+import org.hibernate.search.test.integration.jsr352.massindexing.test.common.MessageManager;
+import org.hibernate.search.test.integration.jsr352.massindexing.test.util.JobInterruptorUtil;
+import org.hibernate.search.test.integration.jsr352.massindexing.test.util.ManagementClientJobTestUtil;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.persistence20.PersistenceDescriptor;
+
+/**
+ * Test remote execution of the Hibernate Search JSR-352 batch job.
+ * <p>
+ * <strong>Important:</strong> Note that methods are executed in sequence,
+ * some of the methods being executed in-container (because it's easier for data initialization and such)
+ * and some others being executed as client (because that's what we want to test).
+ */
+@RunWith(Arquillian.class)
+public class RemoteExecutionIT {
+	private static final String DEPLOYMENT_ARCHIVE_NAME = RemoteExecutionIT.class.getSimpleName() + ".war";
+
+	private static final PathAddress JBERET_SUBSYSTEM_ADDRESS =
+			PathAddress.pathAddress( "deployment", DEPLOYMENT_ARCHIVE_NAME )
+					.append( "subsystem", "batch-jberet" );
+
+	private static final int JOB_TIMEOUT_MS = 40_000;
+
+	private static final Date DB_DAY1;
+	private static final int DB_DAY1_ROWS = 2000;
+	private static final Date DB_DAY2;
+	private static final int DB_DAY2_ROWS = 3000;
+	static {
+		SimpleDateFormat format = new SimpleDateFormat( "dd/MM/yyyy", Locale.ROOT );
+		try {
+			DB_DAY1 = format.parse( "31/08/2016" );
+			DB_DAY2 = format.parse( "01/09/2016" );
+		}
+		catch (ParseException e) {
+			throw new IllegalStateException( e );
+		}
+	}
+
+	@Deployment
+	public static WebArchive createDeployment() {
+		WebArchive war = ShrinkWrap
+				.create( WebArchive.class, DEPLOYMENT_ARCHIVE_NAME )
+				.addAsResource( persistenceXml(), "META-INF/persistence.xml" )
+				.addAsWebInfResource( "jboss-deployment-structure-jsr352-wildflycontroller.xml", "/jboss-deployment-structure.xml" )
+				.addAsWebInfResource( EmptyAsset.INSTANCE, "beans.xml" )
+				.addPackage( JobInterruptorUtil.class.getPackage() )
+				.addPackage( Message.class.getPackage() )
+				.addClasses( ManagementClient.class );
+		return war;
+	}
+
+	private static Asset persistenceXml() {
+		String persistenceXml = Descriptors.create( PersistenceDescriptor.class )
+			.version( "2.0" )
+			.createPersistenceUnit()
+				.name( MessageManager.PERSISTENCE_UNIT_NAME )
+				.jtaDataSource( DataSourceConfigurator.DATA_SOURCE_JNDI_NAME )
+				.getOrCreateProperties()
+					.createProperty().name( "hibernate.hbm2ddl.auto" ).value( "create-drop" ).up()
+					.createProperty().name( "hibernate.search.default.lucene_version" ).value( "LUCENE_CURRENT" ).up()
+					.createProperty().name( "hibernate.search.default.directory_provider" ).value( "local-heap" ).up()
+					.createProperty().name( "hibernate.search.indexing_strategy" ).value( "manual" ).up()
+					.createProperty().name( "wildfly.jpa.hibernate.search.module" ).value( getWildFlyModuleIdentifier() ).up()
+					.createProperty().name( "jboss.as.jpa.providerModule" ).value( getHibernateORMModuleName() ).up()
+				.up().up()
+			.exportAsString();
+		return new StringAsset( persistenceXml );
+	}
+
+	@Inject
+	private MessageManager messageManager;
+
+	/*
+	 * Cannot be in a @Before because @Before is executed on both sides
+	 * (in the client and in the container).
+ 	 */
+	@Test
+	@InSequence(0)
+	public void insertData() {
+		List<Message> messages = new LinkedList<>();
+		for ( int i = 0; i < DB_DAY1_ROWS; i++ ) {
+			messages.add( new Message( String.valueOf( i ), DB_DAY1 ) );
+		}
+		for ( int i = 0; i < DB_DAY2_ROWS; i++ ) {
+			messages.add( new Message( String.valueOf( i ), DB_DAY2 ) );
+		}
+		messageManager.persist( messages );
+	}
+
+	@Test
+	@InSequence(1)
+	public void enableInterruptor() {
+		// Simulate a failure for the next execution
+		JobInterruptorUtil.enable();
+	}
+
+	@Test
+	@InSequence(2)
+	public void checkIndexEmpty() {
+		assertEquals( 0, messageManager.findMessagesFor( DB_DAY1 ).size() );
+		assertEquals( 0, messageManager.findMessagesFor( DB_DAY2 ).size() );
+	}
+
+	@Test
+	@InSequence(3)
+	@RunAsClient
+	public void startAndFail(@ArquillianResource ManagementClient managementClient) throws InterruptedException, IOException {
+		ManagementClientJobTestUtil jobTestUtil = new ManagementClientJobTestUtil(
+				managementClient, JBERET_SUBSYSTEM_ADDRESS, MassIndexingJob.NAME
+		);
+
+		long execId1 = jobTestUtil.start(
+				MassIndexingJob.parameters()
+						.forEntity( Message.class )
+						.build()
+		);
+		BatchStatus executionStatus = jobTestUtil.waitForTermination( execId1, JOB_TIMEOUT_MS );
+		assertEquals( BatchStatus.FAILED, executionStatus );
+	}
+
+	@Test
+	@InSequence(4)
+	public void disableInterruptor() {
+		// Do not simulate any failure for the next execution
+		JobInterruptorUtil.disable();
+	}
+
+	@Test
+	@InSequence(5)
+	@RunAsClient
+	public void restartAndSucceed(@ArquillianResource ManagementClient managementClient) throws InterruptedException, IOException {
+		ManagementClientJobTestUtil jobTestUtil = new ManagementClientJobTestUtil(
+				managementClient, JBERET_SUBSYSTEM_ADDRESS, MassIndexingJob.NAME
+		);
+		// Restart the job. This is the 2nd execution.
+		long execId2 = jobTestUtil.restart( jobTestUtil.getLastExecutionId().get(), null );
+		BatchStatus executionStatus = jobTestUtil.waitForTermination( execId2, JOB_TIMEOUT_MS );
+		assertEquals( BatchStatus.COMPLETED, executionStatus );
+	}
+
+	@Test
+	@InSequence(6)
+	public void checkIndexPopulated() {
+		assertEquals( DB_DAY1_ROWS, messageManager.findMessagesFor( DB_DAY1 ).size() );
+		assertEquals( DB_DAY2_ROWS, messageManager.findMessagesFor( DB_DAY2 ).size() );
+	}
+
+	@Test
+	@InSequence(7)
+	public void removeAll() {
+		messageManager.removeAll();
+	}
+
+}

--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/jsr352/massindexing/RestartIT.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/jsr352/massindexing/RestartIT.java
@@ -129,6 +129,7 @@ public class RestartIT {
 				);
 		JobExecution jobExec1 = jobOperator.getJobExecution( execId1 );
 		jobExec1 = JobTestUtil.waitForTermination( jobOperator, jobExec1, JOB_TIMEOUT_MS );
+		assertEquals( BatchStatus.FAILED, jobExec1.getBatchStatus() );
 		JobInterruptorUtil.disable();
 
 		// Restart the job. This is the 2nd execution.
@@ -159,6 +160,7 @@ public class RestartIT {
 				);
 		JobExecution jobExec1 = jobOperator.getJobExecution( execId1 );
 		jobExec1 = JobTestUtil.waitForTermination( jobOperator, jobExec1, JOB_TIMEOUT_MS );
+		assertEquals( BatchStatus.FAILED, jobExec1.getBatchStatus() );
 		JobInterruptorUtil.disable();
 
 		// Restart the job. This is the 2nd execution.
@@ -188,9 +190,8 @@ public class RestartIT {
 				);
 		JobExecution jobExec1 = BatchRuntime.getJobOperator().getJobExecution( execId1 );
 		jobExec1 = JobTestUtil.waitForTermination( jobOperator, jobExec1, JOB_TIMEOUT_MS );
-		JobInterruptorUtil.disable();
-
 		assertEquals( BatchStatus.FAILED, jobExec1.getBatchStatus() );
+		JobInterruptorUtil.disable();
 
 		// Restart the job.
 		long execId2 = jobOperator.restart( execId1, null );

--- a/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/jsr352/massindexing/test/util/ManagementClientJobTestUtil.java
+++ b/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/jsr352/massindexing/test/util/ManagementClientJobTestUtil.java
@@ -1,0 +1,151 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.integration.jsr352.massindexing.test.util;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Properties;
+import javax.batch.runtime.BatchStatus;
+
+import org.hibernate.search.jsr352.logging.impl.Log;
+import org.hibernate.search.jsr352.massindexing.MassIndexingJob;
+import org.hibernate.search.util.logging.impl.LoggerFactory;
+
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
+
+public class ManagementClientJobTestUtil {
+
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+
+	private static final DateTimeFormatter WILDFLY_INSTANT_FORMAT = new DateTimeFormatterBuilder()
+			.parseCaseInsensitive()
+			.append( DateTimeFormatter.ISO_LOCAL_DATE_TIME )
+			.appendOffset( "+HHMM", "+0000" )
+			.toFormatter( Locale.ROOT );
+
+	private static final int THREAD_SLEEP = 1000;
+
+	private final ManagementClient managementClient;
+	private final PathAddress jberetSubsystemAddress;
+	private final String xmlJobName;
+
+	public ManagementClientJobTestUtil(ManagementClient managementClient,
+			PathAddress jberetSubsystemAddress, String xmlJobName) {
+		this.managementClient = managementClient;
+		this.jberetSubsystemAddress = jberetSubsystemAddress;
+		this.xmlJobName = xmlJobName;
+	}
+
+	public long start(Properties properties) throws IOException {
+		ModelNode op = Operations.createOperation( "start-job", jberetSubsystemAddress.toModelNode() );
+		op.get( "job-xml-name" ).set( MassIndexingJob.NAME );
+		if ( properties != null ) {
+			op.get( "properties" ).set( toModelNode( properties ) );
+		}
+		final ModelNode outcome = managementClient.getControllerClient().execute( op );
+		if ( !Operations.isSuccessfulOutcome( outcome ) ) {
+			throw new IllegalStateException( "Could not start job: " + outcome );
+		}
+		return outcome.get( "result" ).asLong();
+	}
+
+	public long restart(long executionId, Properties properties) throws IOException {
+		ModelNode op = Operations.createOperation( "restart-job", jberetSubsystemAddress.toModelNode() );
+		op.get( "execution-id" ).set( executionId );
+		if ( properties != null ) {
+			op.get( "properties" ).set( toModelNode( properties ) );
+		}
+		final ModelNode outcome = managementClient.getControllerClient().execute( op );
+		if ( !Operations.isSuccessfulOutcome( outcome ) ) {
+			throw new IllegalStateException( "Could not restart job: " + outcome );
+		}
+		return outcome.get( "result" ).asLong();
+	}
+
+	public BatchStatus waitForTermination(long executionId, int timeoutInMs)
+			throws InterruptedException, IOException {
+		long endTime = System.currentTimeMillis() + timeoutInMs;
+
+		BatchStatus executionStatus;
+
+		executionStatus = getExecutionStatus( executionId );
+		while ( !executionStatus.equals( BatchStatus.COMPLETED )
+				&& !executionStatus.equals( BatchStatus.STOPPED )
+				&& !executionStatus.equals( BatchStatus.FAILED )
+				&& System.currentTimeMillis() < endTime ) {
+			log.infof(
+					"Job execution (id=%d) has status %s. Thread sleeps %d ms...",
+					executionId,
+					executionStatus,
+					THREAD_SLEEP
+			);
+			Thread.sleep( THREAD_SLEEP );
+			executionStatus = getExecutionStatus( executionId );
+		}
+
+		return executionStatus;
+	}
+
+	public Optional<Long> getLastExecutionId() throws IOException {
+		ModelNode address = PathAddress.pathAddress( jberetSubsystemAddress )
+				.append( "job", xmlJobName )
+				.append( "execution" )
+				.toModelNode();
+		ModelNode op = Operations.createOperation( "read-resource", address );
+		op.get( "include-runtime" ).set( true );
+		ModelNode outcome = managementClient.getControllerClient().execute( op );
+		if ( !Operations.isSuccessfulOutcome( outcome ) ) {
+			throw new IllegalStateException( "Could not restart job: " + outcome );
+		}
+		List<ModelNode> resultList = outcome.get( "result" ).asList();
+		return resultList.stream()
+				/*
+				 * Each result item is an object containing several attributes,
+				 * among which the "result" which is the execution we are looking for.
+				 */
+				.map( resultItem -> resultItem.get( "result" ) )
+				// Executions are not ordered, so we must use a comparator to find the last one
+				.max( Comparator.comparing( execution -> {
+					String instantString = execution.get( "create-time" ).asString();
+					return WILDFLY_INSTANT_FORMAT.parse( instantString, Instant::from );
+				} ) )
+				.map( execution -> execution.get( "instance-id" ).asLong() );
+	}
+
+	private BatchStatus getExecutionStatus(long executionId) throws IOException {
+		ModelNode address = PathAddress.pathAddress( jberetSubsystemAddress )
+				.append( "job", xmlJobName )
+				.append( "execution", String.valueOf( executionId ) )
+				.toModelNode();
+		ModelNode op = Operations.createOperation( "read-resource", address );
+		op.get( "recursive" ).set( true );
+		op.get( "include-runtime" ).set( true );
+		final ModelNode outcome = managementClient.getControllerClient().execute( op );
+		if ( !Operations.isSuccessfulOutcome( outcome ) ) {
+			throw new IllegalStateException( "Could not restart job: " + outcome );
+		}
+		return BatchStatus.valueOf( outcome.get( "result" ).get( "batch-status" ).asString() );
+	}
+
+	private static ModelNode toModelNode(Properties properties) {
+		ModelNode modelNode = new ModelNode();
+		for ( String key : properties.stringPropertyNames() ) {
+			modelNode.add( key, properties.getProperty( key ) );
+		}
+		return modelNode;
+	}
+}

--- a/integrationtest/wildfly/src/test/resources/jboss-deployment-structure-jsr352-wildflycontroller.xml
+++ b/integrationtest/wildfly/src/test/resources/jboss-deployment-structure-jsr352-wildflycontroller.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate Search, full-text search for your domain model
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.1">
+    <deployment>
+        <dependencies>
+            <module name="org.hibernate.search.jsr352" slot="${project.version}" meta-inf="import"/>
+            <!--
+                 Only necessary so that classes referenced in the test class are loaded properly;
+                 we don't actually use the controller from within the container.
+             -->
+            <module name="org.jboss.as.controller" slot="main"/>
+        </dependencies>
+    </deployment>
+</jboss-deployment-structure>


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-2614

Here we use WildFly's management APIs to start/restart jobs;
see https://docs.jboss.org/author/display/WFLY/Batch+%28JSR-352%29+Subsystem+Configuration#Batch%28JSR-352%29SubsystemConfiguration-DeploymentResources