### PR TITLE
HSEARCH-3158 Define default index name and possibility to have index type

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchIndexWorkVisitor.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchIndexWorkVisitor.java
@@ -32,6 +32,7 @@ import org.hibernate.search.elasticsearch.gson.impl.UnexpectedJsonElementTypeExc
 import org.hibernate.search.elasticsearch.gson.impl.UnknownTypeJsonAccessor;
 import org.hibernate.search.elasticsearch.impl.NestingMarker.NestingPathComponent;
 import org.hibernate.search.elasticsearch.logging.impl.Log;
+import org.hibernate.search.elasticsearch.util.impl.ElasticsearchEntityHelper;
 import org.hibernate.search.elasticsearch.util.impl.FieldHelper;
 import org.hibernate.search.elasticsearch.util.impl.FieldHelper.ExtendedFieldType;
 import org.hibernate.search.elasticsearch.util.impl.ParentPathMismatchException;
@@ -118,7 +119,7 @@ class ElasticsearchIndexWorkVisitor implements IndexWorkVisitor<IndexingMonitor,
 		 * Deleting only the given type.
 		 * Inheritance trees are handled at a higher level by creating multiple purge works.
 		 */
-		builder.type( URLEncodedString.fromString( work.getEntityType().getName() ) );
+		builder.type( URLEncodedString.fromString( ElasticsearchEntityHelper.getIndexedTypeName( work.getEntityType() ) ) );
 		return builder.build();
 	}
 
@@ -145,7 +146,8 @@ class ElasticsearchIndexWorkVisitor implements IndexWorkVisitor<IndexingMonitor,
 				searchIntegrator.getIndexBinding( work.getEntityType() ).getDocumentBuilder(),
 				work.getDeletionQuery()
 		);
-		URLEncodedString typeName = URLEncodedString.fromString( work.getEntityType().getName() );
+		URLEncodedString typeName = URLEncodedString.fromString(
+				ElasticsearchEntityHelper.getIndexedTypeName( work.getEntityType() ) );
 
 		JsonObject payload = createDeleteByQueryPayload( convertedQuery, work.getTenantId() );
 
@@ -182,7 +184,7 @@ class ElasticsearchIndexWorkVisitor implements IndexWorkVisitor<IndexingMonitor,
 
 	private IndexWorkBuilder indexDocument(URLEncodedString id, Document document, IndexedTypeIdentifier entityType) {
 		JsonObject source = convertDocumentToJson( document, entityType );
-		URLEncodedString typeName = URLEncodedString.fromString( entityType.getName() );
+		URLEncodedString typeName = URLEncodedString.fromString( ElasticsearchEntityHelper.getIndexedTypeName( entityType ) );
 		return workFactory.index( indexName, typeName, id, source );
 	}
 
@@ -366,7 +368,7 @@ class ElasticsearchIndexWorkVisitor implements IndexWorkVisitor<IndexingMonitor,
 	}
 
 	private static URLEncodedString entityName(LuceneWork work) {
-		return URLEncodedString.fromString( work.getEntityType().getName() );
+		return URLEncodedString.fromString( ElasticsearchEntityHelper.getIndexedTypeName( work.getEntityType() ) );
 	}
 
 }

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchNestingContextFactoryProvider.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ElasticsearchNestingContextFactoryProvider.java
@@ -53,12 +53,13 @@ public class ElasticsearchNestingContextFactoryProvider implements NestingContex
 
 		@Override
 		public NestingContext createNestingContext(IndexedTypeIdentifier indexedEntityType) {
-			ContextCreationStrategy strategy = strategies.get( indexedEntityType.getName() );
+			String typeName = ElasticsearchEntityHelper.getIndexedTypeName( indexedEntityType );
+			ContextCreationStrategy strategy = strategies.get( typeName );
 
 			if ( strategy == null ) {
 				strategy = ElasticsearchEntityHelper.isMappedToElasticsearch( searchIntegrator, indexedEntityType )
 						? ContextCreationStrategy.ES : ContextCreationStrategy.NO_OP;
-				strategies.putIfAbsent( indexedEntityType.getName(), strategy );
+				strategies.putIfAbsent( typeName, strategy );
 			}
 
 			return strategy.create();

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/schema/impl/Elasticsearch2SchemaTranslator.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/schema/impl/Elasticsearch2SchemaTranslator.java
@@ -15,6 +15,7 @@ import java.util.Set;
 
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.Field.Index;
+
 import org.hibernate.search.analyzer.spi.AnalyzerReference;
 import org.hibernate.search.annotations.Store;
 import org.hibernate.search.bridge.spi.NullMarker;
@@ -31,6 +32,7 @@ import org.hibernate.search.elasticsearch.schema.impl.model.IndexType;
 import org.hibernate.search.elasticsearch.schema.impl.model.PropertyMapping;
 import org.hibernate.search.elasticsearch.schema.impl.model.TypeMapping;
 import org.hibernate.search.elasticsearch.settings.impl.ElasticsearchIndexSettingsBuilder;
+import org.hibernate.search.elasticsearch.util.impl.ElasticsearchEntityHelper;
 import org.hibernate.search.elasticsearch.util.impl.FieldHelper;
 import org.hibernate.search.elasticsearch.util.impl.FieldHelper.ExtendedFieldType;
 import org.hibernate.search.engine.BoostStrategy;
@@ -72,7 +74,7 @@ public class Elasticsearch2SchemaTranslator implements ElasticsearchSchemaTransl
 
 		ElasticsearchIndexSettingsBuilder settingsBuilder = new ElasticsearchIndexSettingsBuilder();
 		for ( EntityIndexBinding descriptor : descriptors ) {
-			String typeName = descriptor.getDocumentBuilder().getTypeIdentifier().getName();
+			String typeName = ElasticsearchEntityHelper.getIndexedTypeName( descriptor.getDocumentBuilder().getTypeIdentifier() );
 
 			TypeMapping mapping = translate( descriptor, settingsBuilder, executionOptions );
 

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/ElasticsearchEntityHelper.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/util/impl/ElasticsearchEntityHelper.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.elasticsearch.util.impl;
 
+import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.elasticsearch.spi.ElasticsearchIndexManagerType;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
 import org.hibernate.search.engine.spi.EntityIndexBinding;
@@ -30,6 +31,21 @@ public final class ElasticsearchEntityHelper {
 	public static boolean isAnyMappedToElasticsearch(ExtendedSearchIntegrator integrator, IndexedTypeSet entityTypes) {
 		IndexedTypeSet entityTypesWithSubTypes = integrator.getIndexedTypesPolymorphic( entityTypes );
 		return hasElasticsearchIndexManager( integrator, entityTypesWithSubTypes );
+	}
+
+	/**
+	 * Get Indexed Type name to be user by elasticsearch See HSEARCH-3158
+	 * @param typeIdentifier Indexed Entity Type Identifier
+	 * @return Indexed Entity Type Name
+	 */
+	public static String getIndexedTypeName(IndexedTypeIdentifier typeIdentifier) {
+		Indexed indexAnn = typeIdentifier.getPojoType().getAnnotation( Indexed.class );
+		if ( indexAnn != null ) {
+			if ( indexAnn.type().length() != 0 ) {
+				return indexAnn.type();
+			}
+		}
+		return typeIdentifier.getPojoType().getSimpleName();
 	}
 
 	private static boolean hasElasticsearchIndexManager(ExtendedSearchIntegrator integrator, IndexedTypeSet entityTypes) {

--- a/engine/src/main/java/org/hibernate/search/annotations/Indexed.java
+++ b/engine/src/main/java/org/hibernate/search/annotations/Indexed.java
@@ -27,7 +27,7 @@ public @interface Indexed {
 	String index() default "";
 
 	/**
-	 * @apiNote Used by hibernate-search-elasticsearch only See HSEARCH-3158
+	 * Used by hibernate-search-elasticsearch only See HSEARCH-3158
 	 * @return The type of the entity. Default to empty string
 	 */
 	String type() default "";

--- a/engine/src/main/java/org/hibernate/search/annotations/Indexed.java
+++ b/engine/src/main/java/org/hibernate/search/annotations/Indexed.java
@@ -27,6 +27,12 @@ public @interface Indexed {
 	String index() default "";
 
 	/**
+	 * @apiNote Used by hibernate-search-elasticsearch only See HSEARCH-3158
+	 * @return The type of the entity. Default to empty string
+	 */
+	String type() default "";
+
+	/**
 	 * Custom converter to change operations upon indexing
 	 * Useful for soft deletes and similar patterns
 	 *

--- a/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/testutil/ElasticsearchBackendTestHelper.java
+++ b/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/testutil/ElasticsearchBackendTestHelper.java
@@ -21,6 +21,7 @@ import org.hibernate.search.elasticsearch.impl.ElasticsearchIndexManager;
 import org.hibernate.search.elasticsearch.impl.ElasticsearchIndexNameNormalizer;
 import org.hibernate.search.elasticsearch.impl.ElasticsearchService;
 import org.hibernate.search.elasticsearch.impl.JsonBuilder;
+import org.hibernate.search.elasticsearch.util.impl.ElasticsearchEntityHelper;
 import org.hibernate.search.elasticsearch.work.impl.DefaultElasticsearchRequestSuccessAssessor;
 import org.hibernate.search.elasticsearch.work.impl.ElasticsearchWorkExecutionContext;
 import org.hibernate.search.elasticsearch.work.impl.SimpleElasticsearchWork;
@@ -63,7 +64,7 @@ public class ElasticsearchBackendTestHelper extends BackendTestHelper {
 		try ( ServiceReference<ElasticsearchService> esService =
 				serviceManager.requestReference( ElasticsearchService.class ) ) {
 			CountWork work = new CountWork.Builder( indexNames )
-					.type( URLEncodedString.fromString( entityType.getName() ) )
+					.type( URLEncodedString.fromString( ElasticsearchEntityHelper.getIndexedTypeName( entityType ) ) )
 					.build();
 			return esService.get().getWorkProcessor().executeSyncUnsafe( work );
 		}


### PR DESCRIPTION
- Add possibility to define Indexed Type Name for hibernate-search-elasticsearch by defining a new attribute type in @Indexed
 - Force hibernate-search-elasticsearch to use type as name if it defined or simple class name (without package)