### PR TITLE
HSEARCH-2933 Upgrade to a version of the MariaDB driver not affected by CONJ-541

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2573,7 +2573,7 @@
                 <db.dialect>org.hibernate.dialect.MySQL5InnoDBDialect</db.dialect>
                 <jdbc.driver.groupId>org.mariadb.jdbc</jdbc.driver.groupId>
                 <jdbc.driver.artifactId>mariadb-java-client</jdbc.driver.artifactId>
-                <jdbc.driver.version>1.5.9</jdbc.driver.version>
+                <jdbc.driver.version>2.2.4</jdbc.driver.version>
                 <jdbc.driver>org.mariadb.jdbc.Driver</jdbc.driver>
                 <jdbc.url>jdbc:mariadb://localhost/testingdb</jdbc.url>
                 <jdbc.user>hibernate_user</jdbc.user>


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-2933

1.7.1 and 2.2.1 didn't use to work (WildFly hung for some reason), but 2.2.4 seems to be working, at least locally.

I started a build on CI just to be sure: http://ci.hibernate.org/job/hibernate-search-yoann/193/. ~~Let's wait for the result and merge if it works?~~ It worked.

