### PR TITLE
HSEARCH-3172 + HSEARCH-3184 + HSEARCH-3188 Fix build problems affecting IDEA

### DIFF
--- a/integrationtest/osgi/karaf-it/src/test/java/org/hibernate/search/test/integration/osgi/HibernateSearchWithKarafIT.java
+++ b/integrationtest/osgi/karaf-it/src/test/java/org/hibernate/search/test/integration/osgi/HibernateSearchWithKarafIT.java
@@ -130,7 +130,7 @@ public class HibernateSearchWithKarafIT {
 			mavenProperties.load( inputStream );
 		}
 
-		String jacocoVMArgs = System.getProperty( "container.jacoco.args" );
+		String jacocoVMArgs = mavenProperties.getProperty( "test.container.jacoco.args" );
 
 		File examDir = new File( "target/exam" );
 		File ariesLogDir = new File( examDir, "/aries/log" );

--- a/integrationtest/osgi/karaf-it/src/test/resources/maven.properties
+++ b/integrationtest/osgi/karaf-it/src/test/resources/maven.properties
@@ -1,2 +1,3 @@
 # This file contains properties that should be filtered by Maven
 maven.settings.localRepository=${settings.localRepository}
+test.container.jacoco.args=${test.container.jacoco.args}

--- a/integrationtest/performance/orm/pom.xml
+++ b/integrationtest/performance/orm/pom.xml
@@ -222,7 +222,7 @@
                         <goals>
                             <goal>build</goal>
                         </goals>
-                        <phase>process-test-resources</phase>
+                        <phase>generate-test-resources</phase>
                         <configuration>
                             <skip>${skipWildFlyPreparation}</skip>
                             <config-file>server-provisioning.xml</config-file>
@@ -256,6 +256,7 @@
                 <executions>
                     <execution>
                         <id>copy-drivers</id>
+                        <!-- Must execute after "generate-test-resources", during which we create the WildFly directory -->
                         <phase>process-test-resources</phase>
                         <goals>
                             <goal>copy</goal>
@@ -275,6 +276,7 @@
                     </execution>
                     <execution>
                         <id>fetch-jpa-patch</id>
+                        <!-- Must execute after "generate-test-resources", during which we create the WildFly directory -->
                         <phase>process-test-resources</phase>
                         <goals>
                             <goal>copy</goal>

--- a/integrationtest/performance/orm/pom.xml
+++ b/integrationtest/performance/orm/pom.xml
@@ -30,7 +30,7 @@
         <jbosshome>${project.build.directory}/${serverName}/</jbosshome>
 
         <!-- Relax the JVM restrictions for integration tests, when using Jigsaw -->
-        <additionalRuntimeArgLine>${additionalRuntimeArgLineForWildFlyTests}</additionalRuntimeArgLine>
+        <test.jvm.args>${test.wildfly.jvm.args}</test.jvm.args>
     </properties>
 
     <dependencyManagement>

--- a/integrationtest/performance/orm/pom.xml
+++ b/integrationtest/performance/orm/pom.xml
@@ -377,7 +377,7 @@
         <repository>
             <id>jboss-public-repository-group</id>
             <name>JBoss Public Maven Repository Group</name>
-            <url>${repository.jboss-public.url}</url>
+            <url>${jboss.public.repo.url}</url>
             <layout>default</layout>
             <releases>
                 <enabled>true</enabled>
@@ -403,7 +403,7 @@
         <pluginRepository>
             <id>jboss-public-repository-group</id>
             <name>JBoss Public Maven Repository Group</name>
-            <url>${repository.jboss-public.url}</url>
+            <url>${jboss.public.repo.url}</url>
             <layout>default</layout>
             <releases>
                 <enabled>true</enabled>

--- a/integrationtest/performance/orm/src/test/resources/arquillian.xml
+++ b/integrationtest/performance/orm/src/test/resources/arquillian.xml
@@ -35,7 +35,7 @@
                 -Xmx512m
                 -Djava.net.preferIPv4Stack=true
                 -Djgroups.bind_addr=127.0.0.1
-                -Dremote.maven.repo=${repository.jboss-public.url}
+                -Dremote.maven.repo=${jboss.public.repo.url}
                 -Dmaven.repo.local=${settings.localRepository}
                 -Dee8.preview.mode=true
             </property>

--- a/integrationtest/wildfly/pom.xml
+++ b/integrationtest/wildfly/pom.xml
@@ -33,7 +33,7 @@
         <test.module-slot.org.hibernate>${parsed-version.org.hibernate.majorVersion}.${parsed-version.org.hibernate.minorVersion}</test.module-slot.org.hibernate>
 
         <!-- Relax the JVM restrictions for integration tests, when using Jigsaw -->
-        <additionalRuntimeArgLine>${additionalRuntimeArgLineForWildFlyTests}</additionalRuntimeArgLine>
+        <test.jvm.args>${test.wildfly.jvm.args}</test.jvm.args>
     </properties>
 
     <dependencyManagement>

--- a/integrationtest/wildfly/pom.xml
+++ b/integrationtest/wildfly/pom.xml
@@ -289,7 +289,8 @@
                     <!-- Copy the AS configuration files so we can use our custom configurations -->
                     <execution>
                         <id>configure-as-node-node1</id>
-                        <phase>pre-integration-test</phase>
+                        <!-- Must execute after "generate-test-resources", during which we create the WildFly directory -->
+                        <phase>process-test-resources</phase>
                         <goals>
                             <goal>copy-resources</goal>
                         </goals>
@@ -306,7 +307,8 @@
                     </execution>
                     <execution>
                         <id>configure-as-node-node2</id>
-                        <phase>pre-integration-test</phase>
+                        <!-- Must execute after "generate-test-resources", during which we create the WildFly directory -->
+                        <phase>process-test-resources</phase>
                         <goals>
                             <goal>copy-resources</goal>
                         </goals>
@@ -359,7 +361,7 @@
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
-                                <phase>compile</phase>
+                                <phase>generate-test-resources</phase>
                                 <configuration>
                                     <skip>${skipWildFlyPreparation}</skip>
                                     <config-file>server-provisioning.xml</config-file>
@@ -371,7 +373,7 @@
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
-                                <phase>compile</phase>
+                                <phase>generate-test-resources</phase>
                                 <configuration>
                                     <skip>${skipWildFlyPreparation}</skip>
                                     <config-file>server-provisioning.xml</config-file>
@@ -429,7 +431,7 @@
                         <executions>
                             <execution>
                                 <id>fetch-jpa-patch</id>
-                                <phase>process-test-resources</phase>
+                                <phase>generate-test-resources</phase>
                                 <goals>
                                     <goal>copy</goal>
                                 </goals>
@@ -458,7 +460,8 @@
                             <!-- Install JPA 2.2 patch on node1 -->
                             <execution>
                                 <id>apply-wildfly-node1-jpa22-patch-file</id>
-                                <phase>pre-integration-test</phase>
+                                <!-- Must execute after "generate-test-resources", during which we create the WildFly directory -->
+                                <phase>process-test-resources</phase>
                                 <goals>
                                     <goal>execute-commands</goal>
                                 </goals>
@@ -476,7 +479,8 @@
                             <!-- Install JPA 2.2 patch on node2 -->
                             <execution>
                                 <id>apply-wildfly-node2-jpa22-patch-file</id>
-                                <phase>pre-integration-test</phase>
+                                <!-- Must execute after "generate-test-resources", during which we create the WildFly directory -->
+                                <phase>process-test-resources</phase>
                                 <goals>
                                     <goal>execute-commands</goal>
                                 </goals>
@@ -519,7 +523,8 @@
                         <executions>
                             <execution>
                                 <id>copy-drivers</id>
-                                <phase>pre-integration-test</phase>
+                                <!-- Must execute after "generate-test-resources", during which we create the WildFly directory -->
+                                <phase>process-test-resources</phase>
                                 <goals>
                                     <goal>copy</goal>
                                 </goals>

--- a/integrationtest/wildfly/src/test/resources/arquillian.xml
+++ b/integrationtest/wildfly/src/test/resources/arquillian.xml
@@ -37,7 +37,7 @@
                     -Xmx512m
                     -Djava.net.preferIPv4Stack=true
                     -Djgroups.bind_addr=127.0.0.1
-                    -Dremote.maven.repo=${repository.jboss-public.url}
+                    -Dremote.maven.repo=${jboss.public.repo.url}
                     -Dmaven.repo.local=${settings.localRepository}
                     ${test.container.jacoco.args}
                     -Dee8.preview.mode=true
@@ -50,7 +50,7 @@
                     -Xmx512m
                     -Djava.net.preferIPv4Stack=true
                     -Djgroups.bind_addr=127.0.0.1
-                    -Dremote.maven.repo=${repository.jboss-public.url}
+                    -Dremote.maven.repo=${jboss.public.repo.url}
                     -Dmaven.repo.local=${settings.localRepository}
                     ${test.container.jacoco.args}
                 </property>
@@ -68,7 +68,7 @@
                     -Xmx512m
                     -Djava.net.preferIPv4Stack=true
                     -Djgroups.bind_addr=127.0.0.1
-                    -Dremote.maven.repo=${repository.jboss-public.url}
+                    -Dremote.maven.repo=${jboss.public.repo.url}
                     -Dmaven.repo.local=${settings.localRepository}
                     -Dee8.preview.mode=true
                 </property>

--- a/integrationtest/wildfly/src/test/resources/arquillian.xml
+++ b/integrationtest/wildfly/src/test/resources/arquillian.xml
@@ -39,7 +39,7 @@
                     -Djgroups.bind_addr=127.0.0.1
                     -Dremote.maven.repo=${repository.jboss-public.url}
                     -Dmaven.repo.local=${settings.localRepository}
-                    ${container.jacoco.args}
+                    ${test.container.jacoco.args}
                     -Dee8.preview.mode=true
                 </property>
                 <!-- To debug the Arquillian managed application server:
@@ -52,7 +52,7 @@
                     -Djgroups.bind_addr=127.0.0.1
                     -Dremote.maven.repo=${repository.jboss-public.url}
                     -Dmaven.repo.local=${settings.localRepository}
-                    ${container.jacoco.args}
+                    ${test.container.jacoco.args}
                 </property>
                  -->
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -383,12 +383,12 @@
         <maven.compiler.argument.testSource>${maven.compiler.testSource}</maven.compiler.argument.testSource>
 
         <!-- Set empty default values to avoid Maven leaving property references (${...}) when it doesn't find a value -->
-        <additionalRuntimeArgLine></additionalRuntimeArgLine>
-        <additionalRuntimeArgLineForWildFlyTests></additionalRuntimeArgLineForWildFlyTests>
+        <test.jvm.args></test.jvm.args>
+        <test.wildfly.jvm.args></test.wildfly.jvm.args>
         <surefire.jacoco.args></surefire.jacoco.args>
         <failsafe.jacoco.args></failsafe.jacoco.args>
-        <surefire.system.args>${additionalRuntimeArgLine} ${surefire.jacoco.args}</surefire.system.args>
-        <failsafe.system.args>${additionalRuntimeArgLine} ${failsafe.jacoco.args}</failsafe.system.args>
+        <surefire.system.args>${test.jvm.args} ${surefire.jacoco.args}</surefire.system.args>
+        <failsafe.system.args>${test.jvm.args} ${failsafe.jacoco.args}</failsafe.system.args>
 
         <!-- JDK version required for the build; we target 1.8 since Hibernate ORM 5.3 requires Java 8 -->
         <jdk.min.version>${maven.compiler.argument.source}</jdk.min.version>
@@ -1948,8 +1948,8 @@
                 <jdk>9</jdk>
             </activation>
             <properties>
-                <additionalRuntimeArgLineForWildFlyTests>-Djdk.attach.allowAttachSelf=true --add-modules java.xml.bind --add-opens=java.base/java.lang=ALL-UNNAMED</additionalRuntimeArgLineForWildFlyTests>
-                <additionalRuntimeArgLine>${additionalRuntimeArgLineForWildFlyTests} --illegal-access=deny</additionalRuntimeArgLine>
+                <test.wildfly.jvm.args>-Djdk.attach.allowAttachSelf=true --add-modules java.xml.bind --add-opens=java.base/java.lang=ALL-UNNAMED</test.wildfly.jvm.args>
+                <test.jvm.args>${test.wildfly.jvm.args} --illegal-access=deny</test.jvm.args>
             </properties>
             <modules>
                 <module>integrationtest/jdk9-modules</module>
@@ -1962,8 +1962,8 @@
                 <jdk>10</jdk>
             </activation>
             <properties>
-                <additionalRuntimeArgLineForWildFlyTests>-Djdk.attach.allowAttachSelf=true --add-modules java.xml.bind --add-opens=java.base/java.lang=ALL-UNNAMED</additionalRuntimeArgLineForWildFlyTests>
-                <additionalRuntimeArgLine>${additionalRuntimeArgLineForWildFlyTests} --illegal-access=deny</additionalRuntimeArgLine>
+                <test.wildfly.jvm.args>-Djdk.attach.allowAttachSelf=true --add-modules java.xml.bind --add-opens=java.base/java.lang=ALL-UNNAMED</test.wildfly.jvm.args>
+                <test.jvm.args>${test.wildfly.jvm.args} --illegal-access=deny</test.jvm.args>
             </properties>
             <modules>
                 <module>integrationtest/jdk9-modules</module>

--- a/pom.xml
+++ b/pom.xml
@@ -2158,7 +2158,7 @@
                             <executions>
                                 <execution>
                                     <id>unpack-es-plugins</id>
-                                    <phase>pre-integration-test</phase>
+                                    <phase>generate-test-resources</phase>
                                     <goals>
                                         <goal>unpack</goal>
                                     </goals>
@@ -2245,7 +2245,7 @@
                             <executions>
                                 <execution>
                                     <id>unpack-es-plugins</id>
-                                    <phase>pre-integration-test</phase>
+                                    <phase>generate-test-resources</phase>
                                     <goals>
                                         <goal>unpack</goal>
                                     </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -387,6 +387,7 @@
         <test.wildfly.jvm.args></test.wildfly.jvm.args>
         <surefire.jacoco.args></surefire.jacoco.args>
         <failsafe.jacoco.args></failsafe.jacoco.args>
+        <test.container.jacoco.args></test.container.jacoco.args>
         <surefire.system.args>${test.jvm.args} ${surefire.jacoco.args}</surefire.system.args>
         <failsafe.system.args>${test.jvm.args} ${failsafe.jacoco.args}</failsafe.system.args>
 
@@ -1415,12 +1416,6 @@
                             <org.hibernate.search.fail_on_unreleased_service>true</org.hibernate.search.fail_on_unreleased_service>
                             <!-- Javassist still not working when using stricter checks with Jigsaw: use ByteBuddy -->
                             <hibernate.bytecode.provider>bytebuddy</hibernate.bytecode.provider>
-                            <!--
-                                Must be a separate property which is not set in Maven,
-                                so that it will be retrieved by the code launching the container (Arquillian, ...)
-                                at runtime, and will not be replaced at build time by Maven filtering in configuration files.
-                             -->
-                            <container.jacoco.args>${surefire.container.jacoco.args}</container.jacoco.args>
                         </systemPropertyVariables>
                         <argLine>${surefire.system.args}</argLine>
                         <additionalClasspathElements>
@@ -1544,12 +1539,6 @@
                             <org.hibernate.search.fail_on_unreleased_service>true</org.hibernate.search.fail_on_unreleased_service>
                             <!-- Javassist still not working when using stricter checks with Jigsaw: use ByteBuddy -->
                             <hibernate.bytecode.provider>bytebuddy</hibernate.bytecode.provider>
-                            <!--
-                                Must be a separate property which is not set in Maven,
-                                so that it will be retrieved by the code launching the container (Arquillian, ...)
-                                at runtime, and will not be replaced at build time by Maven filtering in configuration files.
-                             -->
-                            <container.jacoco.args>${failsafe.container.jacoco.args}</container.jacoco.args>
                         </systemPropertyVariables>
                         <argLine>${failsafe.system.args}</argLine>
                         <additionalClasspathElements>
@@ -2442,11 +2431,10 @@
                 <failsafe.jacoco.args>@{failsafe.jacoco.args.lateEval}</failsafe.jacoco.args>
                 <!--
                     We don't use @{...} for late property evaluation here,
-                    because these properties are evaluated by surefire/failsafe itself,
+                    because these properties are evaluated by the maven-resource-plugin,
                     which doesn't understand the @{...} syntax but somehow manages to always use late evaluation.
                  -->
-                <surefire.container.jacoco.args>${surefire.jacoco.args.lateEval}</surefire.container.jacoco.args>
-                <failsafe.container.jacoco.args>${failsafe.jacoco.args.lateEval}</failsafe.container.jacoco.args>
+                <test.container.jacoco.args>${failsafe.jacoco.args.lateEval}</test.container.jacoco.args>
             </properties>
             <build>
                 <plugins>
@@ -2471,6 +2459,11 @@
                             </execution>
                             <execution>
                                 <id>jacoco-prepare-prepare-agent-integration</id>
+                                <!--
+                                    This is necessary in order for the property to be set before we process resources,
+                                    such as arquillian.xml in WildFly tests or maven.properties in OSGi tests.
+                                 -->
+                                <phase>initialize</phase>
                                 <goals>
                                     <goal>prepare-agent-integration</goal>
                                 </goals>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3172
https://hibernate.atlassian.net/browse/HSEARCH-3184
https://hibernate.atlassian.net/browse/HSEARCH-3188

The first and last commits are only cleanup.

The second commit actually fixes the JaCoCo problem.

The third commit is not absolutely necessary, but it seems to make more sense that way... Also, it allows to make IDEA generate the WildFly instance by setting "Maven > Importing > Phase to be used for folders update" to "process-test-resources" in the IDEA settings, then clicking the "Generate Sources and Update Folders for All Projects" button in the Maven tool panel.

There doesn't seem to be any way to make IDEA generate the WildFly instance automatically, at least not without heavy customization of your IDEA project configuration.