### PR TITLE
HSEARCH-3173 Upgrade to Hibernate ORM 5.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
 
         <!-- Dependencies versions -->
 
-        <version.org.hibernate>5.3.0.Final</version.org.hibernate>
+        <version.org.hibernate>5.3.1.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>5.0.3.Final</version.org.hibernate.commons.annotations>
         <version.javax.persistence>2.2</version.javax.persistence>
 
@@ -190,7 +190,7 @@
 
         <version.org.infinispan>9.2.2.Final</version.org.infinispan>
 
-        <version.net.bytebuddy>1.8.0</version.net.bytebuddy>
+        <version.net.bytebuddy>1.8.11</version.net.bytebuddy>
 
         <version.wildfly>12.0.0.Final</version.wildfly>
 


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3173

**WARNING: Not to be merged yet,** since ORM 5.3.1 hasn't been released yet.

Tested locally against ORM 5.3.1-SNAPSHOT: all tests passed.