### PR TITLE
HSEARCH-3183 Remove obsolete and invalid Maven configuration in hibernate-search-jbossmodules-parent

### DIFF
--- a/jbossmodules/pom.xml
+++ b/jbossmodules/pom.xml
@@ -46,31 +46,4 @@
         -->
         <enforcer.dependencyconvergence.skip>true</enforcer.dependencyconvergence.skip>
     </properties>
-
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-enforcer-plugin</artifactId>
-                    <configuration>
-                        <rules>
-                            <requireJavaVersion>
-                                <!-- require JDK 1.8 to run the build -->
-                                <version>[${minJdkVersion},)</version>
-                            </requireJavaVersion>
-                            <requireMavenVersion>
-                                <version>${minMavenVersion}</version>
-                            </requireMavenVersion>
-                            <banDuplicatePomDependencyVersions />
-                            <!-- Disable the dependency convergence rule, because the dependencies of WildFly artifacts
-                                 do not converge
-                            <DependencyConvergence />
-                             -->
-                        </rules>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
 </project>


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3183
