### PR TITLE
Backport HSEARCH-3197 to branch 5.10 - Allow to set the minimum number of should clauses required to match for boolean predicates in the DSL

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ToElasticsearch.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ToElasticsearch.java
@@ -344,6 +344,11 @@ public class ToElasticsearch {
 
 		clauses.append( boostAppender( booleanQuery ) );
 
+		int minimumShouldMatchNumber = booleanQuery.getMinimumNumberShouldMatch();
+		if ( minimumShouldMatchNumber != 0 ) {
+			clauses.addProperty( "minimum_should_match", minimumShouldMatchNumber );
+		}
+
 		JsonObject bool = new JsonObject();
 		bool.add( "bool", clauses.build() );
 		return bool;

--- a/engine/src/main/java/org/hibernate/search/query/dsl/BooleanJunction.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/BooleanJunction.java
@@ -11,6 +11,61 @@ import org.apache.lucene.search.Query;
 
 /**
  * Represents a boolean query that can contains one or more elements to join
+ * <p>
+ * <h3 id="minimumshouldmatch">"minimumShouldMatch" constraints</h3>
+ * <p>
+ * "minimumShouldMatch" constraints define a minimum number of "should" clauses that have to match
+ * in order for the boolean junction to match.
+ * <p>
+ * The feature is similar, and will work identically, to
+ * <a href="https://lucene.apache.org/solr/7_3_0/solr-core/org/apache/solr/util/doc-files/min-should-match.html">"Min Number Should Match"</a>
+ * in Solr or
+ * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-minimum-should-match.html">{@code minimum_should_match}</a>
+ * in Elasticsearch.
+ * <h4 id="minimumshouldmatch-minimum">Definition of the minimum</h4>
+ * <p>
+ * The minimum may be defined either directly as a positive number, or indirectly as a negative number
+ * or positive or negative percentage representing a ratio of the total number of "should" clauses in this boolean junction.
+ * <p>
+ * Here is how each type of input is interpreted:
+ * <dl>
+ *     <dt>Positive number</dt>
+ *     <dd>
+ *         The value is interpreted directly as the minimum number of "should" clauses that have to match.
+ *     </dd>
+ *     <dt>Negative number</dt>
+ *     <dd>
+ *         The absolute value is interpreted as the maximum number of "should" clauses that may not match:
+ *         the absolute value is subtracted from the total number of "should" clauses.
+ *     </dd>
+ *     <dt>Positive percentage</dt>
+ *     <dd>
+ *         The value is interpreted as the minimum percentage of the total number of "should" clauses that have to match:
+ *         the percentage is applied to the total number of "should" clauses, then rounded down.
+ *     </dd>
+ *     <dt>Negative percentage</dt>
+ *     <dd>
+ *         The absolute value is interpreted as the maximum percentage of the total number of "should" clauses that may not match:
+ *         the absolute value of the percentage is applied to the total number of "should" clauses, then rounded down,
+ *         then subtracted from the total number of "should" clauses.
+ *     </dd>
+ * </dl>
+ * <p>
+ * In any case, if the computed minimum is 0 or less, or higher than the total number of "should" clauses,
+ * behavior is backend-specific (it may throw an exception, or produce unpredictable results,
+ * or fall back to some default behavior).
+ * <p>
+ * Examples:
+ * <pre><code>
+ *     // Example 1: at least 3 "should" clauses have to match
+ *     booleanContext1.minimumShouldMatchNumber( 3 );
+ *     // Example 2: at most 2 "should" clauses may not match
+ *     booleanContext2.minimumShouldMatchNumber( -2 );
+ *     // Example 3: at least 75% of "should" clauses have to match (rounded down)
+ *     booleanContext3.minimumShouldMatchPercent( 75 );
+ *     // Example 4: at most 25% of "should" clauses may not match (rounded down)
+ *     booleanContext4.minimumShouldMatchPercent( -25 );
+ * </code></pre>
  *
  * @author Emmanuel Bernard
  */
@@ -35,4 +90,26 @@ public interface BooleanJunction<T extends BooleanJunction> extends QueryCustomi
 	 * @return true if no restrictions have been applied
 	 */
 	boolean isEmpty();
+
+	/**
+	 * Sets the <a href="#minimumshouldmatch">"minimumShouldMatch" constraint</a>.
+	 *
+	 * @param matchingClausesNumber A definition of the number of "should" clauses that have to match.
+	 * If positive, it is the number of clauses that have to match.
+	 * See <a href="BooleanJunction.html#minimumshouldmatch-minimum">Definition of the minimum</a>
+	 * for details and possible values, in particular negative values.
+	 * @return {@code this}, for method chaining.
+	 */
+	BooleanJunction minimumShouldMatchNumber(int matchingClausesNumber);
+
+	/**
+	 * Sets the <a href="#minimumshouldmatch">"minimumShouldMatch" constraint</a>.
+	 *
+	 * @param matchingClausesPercent A definition of the number of "should" clauses that have to match, as a percentage.
+	 * If positive, it is the percentage of the total number of "should" clauses that have to match.
+	 * See <a href="BooleanJunction.html#minimumshouldmatch-minimum">Definition of the minimum</a>
+	 * for details and possible values, in particular negative values.
+	 * @return {@code this}, for method chaining.
+	 */
+	BooleanJunction minimumShouldMatchPercent(int matchingClausesPercent);
 }

--- a/engine/src/main/java/org/hibernate/search/query/dsl/impl/MinimumShouldMatchContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/impl/MinimumShouldMatchContextImpl.java
@@ -1,0 +1,83 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.query.dsl.impl;
+
+import java.lang.invoke.MethodHandles;
+
+import org.hibernate.search.util.logging.impl.Log;
+import org.hibernate.search.util.logging.impl.LoggerFactory;
+
+import org.apache.lucene.search.BooleanQuery;
+
+final class MinimumShouldMatchContextImpl {
+
+	private static final Log log = LoggerFactory.make( MethodHandles.lookup() );
+
+	private MinimumShouldMatchConstraint minimumShouldMatchConstraint;
+
+	public void requireNumber(int matchingClausesNumber) {
+		addMinimumShouldMatchConstraint(
+				new MinimumShouldMatchConstraint( matchingClausesNumber, null )
+		);
+	}
+
+	public void requirePercent(int matchingClausesPercent) {
+		addMinimumShouldMatchConstraint(
+				new MinimumShouldMatchConstraint( null, matchingClausesPercent )
+		);
+	}
+
+	void applyMinimum(BooleanQuery.Builder builder, int shouldClauseCount) {
+		if ( minimumShouldMatchConstraint != null ) {
+			int minimumShouldMatch = minimumShouldMatchConstraint.toMinimum( shouldClauseCount );
+			builder.setMinimumNumberShouldMatch( minimumShouldMatch );
+		}
+	}
+
+	private void addMinimumShouldMatchConstraint(MinimumShouldMatchConstraint constraint) {
+		if ( this.minimumShouldMatchConstraint != null ) {
+			throw log.minimumShouldMatchConflictingConstraints();
+		}
+		this.minimumShouldMatchConstraint = constraint;
+	}
+
+	private static final class MinimumShouldMatchConstraint {
+		private final Integer matchingClausesNumber;
+		private final Integer matchingClausesPercent;
+
+		MinimumShouldMatchConstraint(Integer matchingClausesNumber, Integer matchingClausesPercent) {
+			this.matchingClausesNumber = matchingClausesNumber;
+			this.matchingClausesPercent = matchingClausesPercent;
+		}
+
+		int toMinimum(int totalShouldClauseNumber) {
+			int minimum;
+			if ( matchingClausesNumber != null ) {
+				if ( matchingClausesNumber >= 0 ) {
+					minimum = matchingClausesNumber;
+				}
+				else {
+					minimum = totalShouldClauseNumber + matchingClausesNumber;
+				}
+			}
+			else {
+				if ( matchingClausesPercent >= 0 ) {
+					minimum = matchingClausesPercent * totalShouldClauseNumber / 100;
+				}
+				else {
+					minimum = totalShouldClauseNumber + matchingClausesPercent * totalShouldClauseNumber / 100;
+				}
+			}
+
+			if ( minimum < 1 || minimum > totalShouldClauseNumber ) {
+				throw log.minimumShouldMatchMinimumOutOfBounds( minimum, totalShouldClauseNumber );
+			}
+
+			return minimum;
+		}
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
@@ -1011,4 +1011,14 @@ public interface Log extends BaseHibernateSearchLogger {
 
 	@Message(id = 349, value = "Some of the specified entity types ('%s') are not indexed, nor is any of their subclasses." )
 	IllegalArgumentException someTargetedEntityTypesNotIndexed(String targetedEntities);
+
+	@Message(id = 350, value = "'%1$s' must be positive or zero.")
+	IllegalArgumentException mustBePositiveOrZero(String objectDescription);
+
+	@Message(id = 351, value = "Computed minimum for minimumShouldMatch constraint is out of bounds:"
+			+ " expected a number between 1 and '%1$s', got '%2$s'.")
+	SearchException minimumShouldMatchMinimumOutOfBounds(int minimum, int totalShouldClauseNumber);
+
+	@Message(id = 352, value = "Multiple conflicting minimumShouldMatch constraints")
+	SearchException minimumShouldMatchConflictingConstraints();
 }

--- a/engine/src/test/java/org/hibernate/search/test/dsl/BoolDSLTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/dsl/BoolDSLTest.java
@@ -1,0 +1,552 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.dsl;
+
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.exception.SearchException;
+import org.hibernate.search.query.dsl.QueryBuilder;
+import org.hibernate.search.query.engine.spi.HSQuery;
+import org.hibernate.search.testsupport.junit.SearchFactoryHolder;
+import org.hibernate.search.testsupport.junit.SearchITHelper;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Test backported from Search 6, was BoolSearchPredicateIT.
+ * Should not be ported when merging the Search 6 code, but simply removed.
+ */
+public class BoolDSLTest {
+
+	private static final String DOCUMENT_1 = "1";
+	private static final String DOCUMENT_2 = "2";
+	private static final String DOCUMENT_3 = "3";
+
+	// Document 1
+
+	private static final String FIELD1_VALUE1 = "Irving";
+	private static final Integer FIELD2_VALUE1 = 3;
+	private static final Integer FIELD3_VALUE1 = 4;
+	private static final Integer FIELD4_VALUE1AND2 = 1_000;
+	private static final Integer FIELD5_VALUE1AND2 = 2_000;
+
+	// Document 2
+
+	private static final String FIELD1_VALUE2 = "Auster";
+	private static final Integer FIELD2_VALUE2 = 13;
+	private static final Integer FIELD3_VALUE2 = 14;
+	// Field 4: Same as document 1
+	// Field 5: Same as document 1
+
+	// Document 3
+
+	private static final String FIELD1_VALUE3 = "Coe";
+	private static final Integer FIELD2_VALUE3 = 25;
+	private static final Integer FIELD3_VALUE3 = 42;
+	private static final Integer FIELD4_VALUE3 = 42_000; // Different from document 1
+	private static final Integer FIELD5_VALUE3 = 142_000; // Different from document 1
+
+	@Rule
+	public final SearchFactoryHolder sfHolder = new SearchFactoryHolder( IndexedEntity.class );
+
+	private final SearchITHelper helper = new SearchITHelper( sfHolder );
+
+	@Rule
+	public final ExpectedException thrown = ExpectedException.none();
+
+	@Before
+	public void setup() {
+		initData();
+	}
+
+	@Test
+	public void must() {
+		QueryBuilder queryBuilder = helper.queryBuilder( IndexedEntity.class );
+
+		HSQuery query = helper.hsQuery(
+				queryBuilder.bool()
+						.must( queryBuilder.keyword().onField( "field1" ).matching( FIELD1_VALUE1 ).createQuery() )
+				.createQuery()
+		);
+
+		helper.assertThat( query )
+				.matchesUnorderedIds( DOCUMENT_1 );
+
+		query = helper.hsQuery(
+				queryBuilder.bool()
+						.must( queryBuilder.keyword().onField( "field1" ).matching( FIELD1_VALUE1 ).createQuery() )
+						.must( queryBuilder.keyword().onField( "field2" ).matching( FIELD2_VALUE2 ).createQuery() )
+				.createQuery()
+		);
+
+		helper.assertThat( query ).matchesNone();
+
+		query = helper.hsQuery(
+				queryBuilder.bool()
+						.must( queryBuilder.keyword().onField( "field1" ).matching( FIELD1_VALUE1 ).createQuery() )
+						.must( queryBuilder.keyword().onField( "field2" ).matching( FIELD2_VALUE1 ).createQuery() )
+				.createQuery()
+		);
+
+		helper.assertThat( query )
+				.matchesUnorderedIds( DOCUMENT_1 );
+	}
+
+	@Test
+	public void should() {
+		QueryBuilder queryBuilder = helper.queryBuilder( IndexedEntity.class );
+
+		HSQuery query = helper.hsQuery(
+				queryBuilder.bool()
+						.should( queryBuilder.keyword().onField( "field1" ).matching( FIELD1_VALUE1 ).createQuery() )
+				.createQuery()
+		);
+
+		helper.assertThat( query )
+				.matchesUnorderedIds( DOCUMENT_1 );
+
+		query = helper.hsQuery(
+				queryBuilder.bool()
+						.should( queryBuilder.keyword().onField( "field1" ).matching( FIELD1_VALUE1 ).createQuery() )
+						.should( queryBuilder.keyword().onField( "field1" ).matching( FIELD1_VALUE2 ).createQuery() )
+				.createQuery()
+		);
+
+		helper.assertThat( query )
+				.matchesUnorderedIds( DOCUMENT_1, DOCUMENT_2 );
+	}
+
+	@Test
+	public void mustNot() {
+		QueryBuilder queryBuilder = helper.queryBuilder( IndexedEntity.class );
+
+		HSQuery query = helper.hsQuery(
+				queryBuilder.bool()
+						.must( queryBuilder.keyword().onField( "field1" ).matching( FIELD1_VALUE1 ).createQuery() ).not()
+				.createQuery()
+		);
+
+		helper.assertThat( query )
+				.matchesUnorderedIds( DOCUMENT_2, DOCUMENT_3 );
+
+		query = helper.hsQuery(
+				queryBuilder.bool()
+						.must( queryBuilder.keyword().onField( "field1" ).matching( FIELD1_VALUE1 ).createQuery() ).not()
+						.must( queryBuilder.keyword().onField( "field1" ).matching( FIELD1_VALUE3 ).createQuery() ).not()
+				.createQuery()
+		);
+
+		helper.assertThat( query )
+				.matchesUnorderedIds( DOCUMENT_2 );
+	}
+
+	@Test
+	public void should_mustNot() {
+		QueryBuilder queryBuilder = helper.queryBuilder( IndexedEntity.class );
+
+		HSQuery query = helper.hsQuery(
+				queryBuilder.bool()
+						.should( queryBuilder.keyword().onField( "field1" ).matching( FIELD1_VALUE1 ).createQuery() )
+						.should( queryBuilder.keyword().onField( "field1" ).matching( FIELD1_VALUE3 ).createQuery() )
+						.must( queryBuilder.keyword().onField( "field1" ).matching( FIELD1_VALUE1 ).createQuery() ).not()
+				.createQuery()
+		);
+
+		helper.assertThat( query )
+				.matchesUnorderedIds( DOCUMENT_3 );
+	}
+
+	@Test
+	public void must_mustNot() {
+		QueryBuilder queryBuilder = helper.queryBuilder( IndexedEntity.class );
+
+		HSQuery query = helper.hsQuery(
+				queryBuilder.bool()
+						.must( queryBuilder.keyword().onField( "field1" ).matching( FIELD1_VALUE1 ).createQuery() )
+						.must( queryBuilder.keyword().onField( "field1" ).matching( FIELD1_VALUE1 ).createQuery() ).not()
+				.createQuery()
+		);
+
+		helper.assertThat( query ).matchesNone();
+
+		query = helper.hsQuery(
+				queryBuilder.bool()
+						.must( queryBuilder.keyword().onField( "field1" ).matching( FIELD1_VALUE1 ).createQuery() )
+						.must( queryBuilder.keyword().onField( "field1" ).matching( FIELD1_VALUE2 ).createQuery() ).not()
+				.createQuery()
+		);
+
+		helper.assertThat( query )
+				.matchesUnorderedIds( DOCUMENT_1 );
+	}
+
+	@Test
+	public void must_should() {
+		QueryBuilder queryBuilder = helper.queryBuilder( IndexedEntity.class );
+
+		// A boolean predicate with must + should clauses:
+		// documents should match regardless of whether should clauses match.
+
+		// Non-matching "should" clauses
+		HSQuery query = helper.hsQuery(
+				queryBuilder.bool()
+						.must( queryBuilder.keyword().onField( "field1" ).matching( FIELD1_VALUE1 ).createQuery() )
+						.should( queryBuilder.keyword().onField( "field2" ).matching( FIELD2_VALUE2 ).createQuery() )
+						.should( queryBuilder.keyword().onField( "field3" ).matching( FIELD3_VALUE3 ).createQuery() )
+				.createQuery()
+		);
+
+		helper.assertThat( query )
+				.matchesUnorderedIds( DOCUMENT_1 );
+
+		// One matching and one non-matching "should" clause
+		query = helper.hsQuery(
+				queryBuilder.bool()
+						.must( queryBuilder.keyword().onField( "field1" ).matching( FIELD1_VALUE2 ).createQuery() )
+						.should( queryBuilder.keyword().onField( "field2" ).matching( FIELD2_VALUE1 ).createQuery() )
+						.should( queryBuilder.keyword().onField( "field3" ).matching( FIELD3_VALUE3 ).createQuery() )
+				.createQuery()
+		);
+
+		helper.assertThat( query )
+				.matchesUnorderedIds( DOCUMENT_2 );
+	}
+
+	@Test
+	public void filter_should() {
+		QueryBuilder queryBuilder = helper.queryBuilder( IndexedEntity.class );
+
+		// A boolean predicate with filter + should clauses:
+		// documents should match regardless of whether should clauses match.
+
+		// Non-matching "should" clauses
+		HSQuery query = helper.hsQuery(
+				queryBuilder.bool()
+						.must( queryBuilder.keyword().onField( "field1" ).matching( FIELD1_VALUE1 ).createQuery() ).disableScoring()
+						.should( queryBuilder.keyword().onField( "field2" ).matching( FIELD2_VALUE2 ).createQuery() )
+						.should( queryBuilder.keyword().onField( "field3" ).matching( FIELD3_VALUE3 ).createQuery() )
+				.createQuery()
+		);
+
+		helper.assertThat( query )
+				.matchesUnorderedIds( DOCUMENT_1 );
+
+		// One matching and one non-matching "should" clause
+		query = helper.hsQuery(
+				queryBuilder.bool()
+						.must( queryBuilder.keyword().onField( "field1" ).matching( FIELD1_VALUE1 ).createQuery() ).disableScoring()
+						.should( queryBuilder.keyword().onField( "field2" ).matching( FIELD2_VALUE1 ).createQuery() )
+						.should( queryBuilder.keyword().onField( "field3" ).matching( FIELD3_VALUE3 ).createQuery() )
+				.createQuery()
+		);
+
+		helper.assertThat( query )
+				.matchesUnorderedIds( DOCUMENT_1 );
+	}
+
+	@Test
+	public void mustNot_should() {
+		QueryBuilder queryBuilder = helper.queryBuilder( IndexedEntity.class );
+
+		// A boolean predicate with mustNot + should clauses:
+		// documents should match only if at least one should clause matches
+
+		// Non-matching "should" clauses
+		HSQuery query = helper.hsQuery(
+				queryBuilder.bool()
+						.must( queryBuilder.keyword().onField( "field1" ).matching( FIELD1_VALUE2 ).createQuery() ).not()
+						.must( queryBuilder.keyword().onField( "field1" ).matching( FIELD1_VALUE3 ).createQuery() ).not()
+						.should( queryBuilder.keyword().onField( "field2" ).matching( FIELD2_VALUE2 ).createQuery() )
+						.should( queryBuilder.keyword().onField( "field3" ).matching( FIELD3_VALUE3 ).createQuery() )
+				.createQuery()
+		);
+
+		helper.assertThat( query )
+				.matchesNone();
+
+		// One matching and one non-matching "should" clause
+		query = helper.hsQuery(
+				queryBuilder.bool()
+						.must( queryBuilder.keyword().onField( "field1" ).matching( FIELD1_VALUE1 ).createQuery() ).not()
+						.must( queryBuilder.keyword().onField( "field1" ).matching( FIELD1_VALUE3 ).createQuery() ).not()
+						.should( queryBuilder.keyword().onField( "field2" ).matching( FIELD2_VALUE2 ).createQuery() )
+						.should( queryBuilder.keyword().onField( "field3" ).matching( FIELD3_VALUE3 ).createQuery() )
+				.createQuery()
+		);
+
+		helper.assertThat( query )
+				.matchesUnorderedIds( DOCUMENT_2 );
+	}
+
+	@Test
+	public void minimumShouldMatchNumber_positive() {
+		QueryBuilder queryBuilder = helper.queryBuilder( IndexedEntity.class );
+
+		// Expect default behavior (1 "should" clause has to match)
+		HSQuery query = helper.hsQuery(
+				queryBuilder.bool()
+						.minimumShouldMatchNumber( 1 )
+						.should( queryBuilder.keyword().onField( "field1" ).matching( FIELD1_VALUE1 ).createQuery() )
+						.should( queryBuilder.keyword().onField( "field2" ).matching( FIELD2_VALUE3 ).createQuery() )
+				.createQuery()
+		);
+
+		helper.assertThat( query )
+				.matchesUnorderedIds( DOCUMENT_1, DOCUMENT_3 );
+
+		// Expect to require 1 "should" clause to match even though there's a "must"
+		query = helper.hsQuery(
+				queryBuilder.bool()
+						.must( queryBuilder.keyword().onField( "field4" ).matching( FIELD4_VALUE1AND2 ).createQuery() )
+						.minimumShouldMatchNumber( 1 )
+						.should( queryBuilder.keyword().onField( "field2" ).matching( FIELD2_VALUE2 ).createQuery() )
+						.should( queryBuilder.keyword().onField( "field3" ).matching( FIELD3_VALUE3 ).createQuery() )
+				.createQuery()
+		);
+
+		helper.assertThat( query )
+				.matchesUnorderedIds( DOCUMENT_2 );
+
+		// Expect to require 2 "should" clauses to match
+		query = helper.hsQuery(
+				queryBuilder.bool()
+						.minimumShouldMatchNumber( 2 )
+						.should( queryBuilder.keyword().onField( "field4" ).matching( FIELD4_VALUE1AND2 ).createQuery() )
+						.should( queryBuilder.keyword().onField( "field2" ).matching( FIELD2_VALUE1 ).createQuery() )
+						.should( queryBuilder.keyword().onField( "field3" ).matching( FIELD3_VALUE3 ).createQuery() )
+				.createQuery()
+		);
+
+		helper.assertThat( query )
+				.matchesUnorderedIds( DOCUMENT_1 );
+
+		// Expect to require all "should" clauses to match
+		query = helper.hsQuery(
+				queryBuilder.bool()
+						.minimumShouldMatchNumber( 2 )
+						.should( queryBuilder.keyword().onField( "field4" ).matching( FIELD4_VALUE1AND2 ).createQuery() )
+						.should( queryBuilder.keyword().onField( "field2" ).matching( FIELD2_VALUE1 ).createQuery() )
+				.createQuery()
+		);
+
+		helper.assertThat( query )
+				.matchesUnorderedIds( DOCUMENT_1 );
+	}
+
+	@Test
+	public void minimumShouldMatchNumber_negative() {
+		QueryBuilder queryBuilder = helper.queryBuilder( IndexedEntity.class );
+
+		// Expect default behavior (1 "should" clause has to match)
+		HSQuery query = helper.hsQuery(
+				queryBuilder.bool()
+						.minimumShouldMatchNumber( -1 )
+						.should( queryBuilder.keyword().onField( "field1" ).matching( FIELD1_VALUE1 ).createQuery() )
+						.should( queryBuilder.keyword().onField( "field2" ).matching( FIELD2_VALUE3 ).createQuery() )
+				.createQuery()
+		);
+
+		helper.assertThat( query )
+				.matchesUnorderedIds( DOCUMENT_1, DOCUMENT_3 );
+
+		// Expect to require 1 "should" clause to match even though there's a "must"
+		query = helper.hsQuery(
+				queryBuilder.bool()
+						.must( queryBuilder.keyword().onField( "field4" ).matching( FIELD4_VALUE1AND2 ).createQuery() )
+						.minimumShouldMatchNumber( -1 )
+						.should( queryBuilder.keyword().onField( "field2" ).matching( FIELD2_VALUE2 ).createQuery() )
+						.should( queryBuilder.keyword().onField( "field3" ).matching( FIELD3_VALUE3 ).createQuery() )
+				.createQuery()
+		);
+
+		helper.assertThat( query )
+				.matchesUnorderedIds( DOCUMENT_2 );
+
+		// Expect to require 2 "should" clauses to match
+		query = helper.hsQuery(
+				queryBuilder.bool()
+						.minimumShouldMatchNumber( -1 )
+						.should( queryBuilder.keyword().onField( "field4" ).matching( FIELD4_VALUE1AND2 ).createQuery() )
+						.should( queryBuilder.keyword().onField( "field2" ).matching( FIELD2_VALUE1 ).createQuery() )
+						.should( queryBuilder.keyword().onField( "field3" ).matching( FIELD3_VALUE3 ).createQuery() )
+				.createQuery()
+		);
+
+		helper.assertThat( query )
+				.matchesUnorderedIds( DOCUMENT_1 );
+	}
+
+	@Test
+	public void minimumShouldMatchPercent_positive() {
+		QueryBuilder queryBuilder = helper.queryBuilder( IndexedEntity.class );
+
+		// Expect default behavior (1 "should" clause has to match)
+		HSQuery query = helper.hsQuery(
+				queryBuilder.bool()
+						.minimumShouldMatchPercent( 50 )
+						.should( queryBuilder.keyword().onField( "field1" ).matching( FIELD1_VALUE1 ).createQuery() )
+						.should( queryBuilder.keyword().onField( "field2" ).matching( FIELD2_VALUE3 ).createQuery() )
+				.createQuery()
+		);
+
+		helper.assertThat( query )
+				.matchesUnorderedIds( DOCUMENT_1, DOCUMENT_3 );
+
+		// Expect to require 1 "should" clause to match even though there's a "must"
+		query = helper.hsQuery(
+				queryBuilder.bool()
+						.must( queryBuilder.keyword().onField( "field4" ).matching( FIELD4_VALUE1AND2 ).createQuery() )
+						.minimumShouldMatchPercent( 50 )
+						.should( queryBuilder.keyword().onField( "field2" ).matching( FIELD2_VALUE2 ).createQuery() )
+						.should( queryBuilder.keyword().onField( "field3" ).matching( FIELD3_VALUE3 ).createQuery() )
+				.createQuery()
+		);
+
+		helper.assertThat( query )
+				.matchesUnorderedIds( DOCUMENT_2 );
+
+		// Expect to require 2 "should" clauses to match
+		query = helper.hsQuery(
+				queryBuilder.bool()
+						.minimumShouldMatchPercent( 70 ) // The minimum should be rounded down to 2
+						.should( queryBuilder.keyword().onField( "field4" ).matching( FIELD4_VALUE1AND2 ).createQuery() )
+						.should( queryBuilder.keyword().onField( "field2" ).matching( FIELD2_VALUE1 ).createQuery() )
+						.should( queryBuilder.keyword().onField( "field3" ).matching( FIELD3_VALUE3 ).createQuery() )
+				.createQuery()
+		);
+
+		helper.assertThat( query )
+				.matchesUnorderedIds( DOCUMENT_1 );
+
+		// Expect to require all "should" clauses to match
+		query = helper.hsQuery(
+				queryBuilder.bool()
+						.minimumShouldMatchPercent( 100 )
+						.should( queryBuilder.keyword().onField( "field4" ).matching( FIELD4_VALUE1AND2 ).createQuery() )
+						.should( queryBuilder.keyword().onField( "field2" ).matching( FIELD2_VALUE1 ).createQuery() )
+				.createQuery()
+		);
+
+		helper.assertThat( query )
+				.matchesUnorderedIds( DOCUMENT_1 );
+	}
+
+	@Test
+	public void minimumShouldMatchPercent_negative() {
+		QueryBuilder queryBuilder = helper.queryBuilder( IndexedEntity.class );
+
+		// Expect default behavior (1 "should" clause has to match)
+		HSQuery query = helper.hsQuery(
+				queryBuilder.bool()
+						.minimumShouldMatchPercent( -50 )
+						.should( queryBuilder.keyword().onField( "field1" ).matching( FIELD1_VALUE1 ).createQuery() )
+						.should( queryBuilder.keyword().onField( "field2" ).matching( FIELD2_VALUE3 ).createQuery() )
+				.createQuery()
+		);
+
+		helper.assertThat( query )
+				.matchesUnorderedIds( DOCUMENT_1, DOCUMENT_3 );
+
+		// Expect to require 1 "should" clause to match even though there's a "must"
+		query = helper.hsQuery(
+				queryBuilder.bool()
+						.must( queryBuilder.keyword().onField( "field4" ).matching( FIELD4_VALUE1AND2 ).createQuery() )
+						.minimumShouldMatchPercent( -50 )
+						.should( queryBuilder.keyword().onField( "field2" ).matching( FIELD2_VALUE2 ).createQuery() )
+						.should( queryBuilder.keyword().onField( "field3" ).matching( FIELD3_VALUE3 ).createQuery() )
+				.createQuery()
+		);
+
+		helper.assertThat( query )
+				.matchesUnorderedIds( DOCUMENT_2 );
+
+		// Expect to require 2 "should" clauses to match
+		query = helper.hsQuery(
+				queryBuilder.bool()
+						.minimumShouldMatchPercent( -40 ) // The minimum should be rounded up to 2
+						.should( queryBuilder.keyword().onField( "field4" ).matching( FIELD4_VALUE1AND2 ).createQuery() )
+						.should( queryBuilder.keyword().onField( "field2" ).matching( FIELD2_VALUE1 ).createQuery() )
+						.should( queryBuilder.keyword().onField( "field3" ).matching( FIELD3_VALUE3 ).createQuery() )
+				.createQuery()
+		);
+
+		helper.assertThat( query )
+				.matchesUnorderedIds( DOCUMENT_1 );
+	}
+
+	@Test
+	public void minimumShouldMatch_error_multipleConflictingConstraints() {
+		QueryBuilder queryBuilder = helper.queryBuilder( IndexedEntity.class );
+
+		thrown.expect( SearchException.class );
+		thrown.expectMessage( "Multiple conflicting minimumShouldMatch constraints" );
+
+		queryBuilder.bool().minimumShouldMatchNumber( -1 ).minimumShouldMatchPercent( 100 );
+	}
+
+	private void initData() {
+		helper.index(
+				new IndexedEntity(
+						DOCUMENT_1,
+						FIELD1_VALUE1,
+						FIELD2_VALUE1,
+						FIELD3_VALUE1,
+						FIELD4_VALUE1AND2,
+						FIELD5_VALUE1AND2
+				),
+				new IndexedEntity(
+						DOCUMENT_2,
+						FIELD1_VALUE2,
+						FIELD2_VALUE2,
+						FIELD3_VALUE2,
+						FIELD4_VALUE1AND2,
+						FIELD5_VALUE1AND2
+				),
+				new IndexedEntity(
+						DOCUMENT_3,
+						FIELD1_VALUE3,
+						FIELD2_VALUE3,
+						FIELD3_VALUE3,
+						FIELD4_VALUE3,
+						FIELD5_VALUE3
+				)
+		);
+
+		// Check that all documents are searchable
+		helper.assertThat( helper.hsQuery( IndexedEntity.class ) )
+				.matchesUnorderedIds( DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
+	}
+
+	@Indexed
+	private static class IndexedEntity {
+		@DocumentId
+		private String id;
+		@Field
+		private String field1;
+		@Field
+		private Integer field2;
+		@Field
+		private Integer field3;
+		@Field
+		private Integer field4;
+		@Field
+		private Integer field5;
+
+		IndexedEntity(String id, String field1, Integer field2, Integer field3, Integer field4, Integer field5) {
+			this.id = id;
+			this.field1 = field1;
+			this.field2 = field2;
+			this.field3 = field3;
+			this.field4 = field4;
+			this.field5 = field5;
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3197

Backport of #1694 , which should be merged first.