### PR TITLE
Formatted Code

### DIFF
--- a/orm/src/main/java/org/hibernate/search/query/hibernate/impl/FullTextQueryImpl.java
+++ b/orm/src/main/java/org/hibernate/search/query/hibernate/impl/FullTextQueryImpl.java
@@ -661,5 +661,5 @@ public class FullTextQueryImpl extends AbstractProducedQuery implements FullText
 			return new javax.persistence.QueryTimeoutException( message, null, FullTextQueryImpl.this );
 		}
 
-	};
+	}
 }


### PR DESCRIPTION
Similar to #1698. Wercker CI bails out on the first error it sees. Initial wercker failure resulted in the creation of #1698. Another count of similar inappropriate formatting was realized soon after but by then #1698 had been merged. Right now Wercker passes on the master of my fork of hibernate-search.

We sincerely apologize for the inconvenience, as we should have rather fixed everything using my fork of hibernate-search first and only then created #1698 with all the necessary changes in a single PR.

Anyhow, please merge this PR to avoid problems with future checkstyle releases.

Apologies again. Thank you.