### PR TITLE
HSEARCH-3232 Upgrade to Byteman 4.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,7 @@
         <version.com.github.tomakehurst.wiremock>2.5.1</version.com.github.tomakehurst.wiremock>
         <!-- Fixes dependency convergence within Wiremock, see below -->
         <version.com.fasterxml.jackson>2.8.6</version.com.fasterxml.jackson>
-        <version.org.jboss.byteman>4.0.3</version.org.jboss.byteman>
+        <version.org.jboss.byteman>4.0.4</version.org.jboss.byteman>
         <version.io.takari.junit>1.2.7</version.io.takari.junit>
         <version.com.h2database>1.4.178</version.com.h2database>
 


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3232

Tests using Byteman still don't seem to be working with JDK11, unfortunately: 

```
[INFO] Running org.hibernate.search.test.backend.lucene.ResourcesClosedInOrderTest
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.077 s <<< FAILURE! - in org.hibernate.search.test.backend.lucene.ResourcesClosedInOrderTest
[ERROR] org.hibernate.search.test.backend.lucene.ResourcesClosedInOrderTest(org.hibernate.search.test.backend.lucene.ResourcesClosedInOrderTest)  Time elapsed: 0.077 s  <<< ERROR!
java.io.IOException: Can not attach to current VM

[INFO] Running org.hibernate.search.test.backend.lucene.ScheduledCommitPolicyTest
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.001 s <<< FAILURE! - in org.hibernate.search.test.backend.lucene.ScheduledCommitPolicyTest
[ERROR] org.hibernate.search.test.backend.lucene.ScheduledCommitPolicyTest(org.hibernate.search.test.backend.lucene.ScheduledCommitPolicyTest)  Time elapsed: 0.001 s  <<< ERROR!
java.lang.Exception: BMUnit test class configuration pushed without prior pop!

[INFO] Running org.hibernate.search.test.backend.lucene.SharedReleasesLocksTest
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0 s <<< FAILURE! - in org.hibernate.search.test.backend.lucene.SharedReleasesLocksTest
[ERROR] org.hibernate.search.test.backend.lucene.SharedReleasesLocksTest(org.hibernate.search.test.backend.lucene.SharedReleasesLocksTest)  Time elapsed: 0 s  <<< ERROR!
java.lang.Exception: BMUnit test class configuration pushed without prior pop!

[INFO] Running org.hibernate.search.test.backend.lucene.SyncWorkProcessorShutDownTest
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.001 s <<< FAILURE! - in org.hibernate.search.test.backend.lucene.SyncWorkProcessorShutDownTest
[ERROR] org.hibernate.search.test.backend.lucene.SyncWorkProcessorShutDownTest(org.hibernate.search.test.backend.lucene.SyncWorkProcessorShutDownTest)  Time elapsed: 0 s  <<< ERROR!
java.lang.Exception: BMUnit test class configuration pushed without prior pop!
```

Everything works fine on JDK9. @Sanne is it worth investigating, or do you already know what's wrong?