### PR TITLE
HSEARCH-3226 Add test dependencies to javax.xml.bind when building with JDK9 and above

### DIFF
--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -175,4 +175,43 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>jdk9</id>
+            <activation>
+                <jdk>9</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jdk10</id>
+            <activation>
+                <jdk>10</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jdk11</id>
+            <activation>
+                <jdk>11</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/Elasticsearch2IndexMappingIT.java
+++ b/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/Elasticsearch2IndexMappingIT.java
@@ -263,7 +263,7 @@ public class Elasticsearch2IndexMappingIT extends SearchTestBase {
 	}
 
 	/*
-	 * Allows generating a date exactly as it would be outputed by the Elasticsearch date Helper.
+	 * Allows formatting a date exactly as the Elasticsearch date helper would.
 	 * This helper internally uses the JVM's timezone to format dates, so the actual output
 	 * depends on the platform and cannot be stored as a constant string.
 	 */

--- a/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/Elasticsearch5IndexMappingIT.java
+++ b/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/Elasticsearch5IndexMappingIT.java
@@ -259,7 +259,7 @@ public class Elasticsearch5IndexMappingIT extends SearchTestBase {
 	}
 
 	/*
-	 * Allows generating a date exactly as it would be outputed by the Elasticsearch date Helper.
+	 * Allows formatting a date exactly as the Elasticsearch date helper would.
 	 * This helper internally uses the JVM's timezone to format dates, so the actual output
 	 * depends on the platform and cannot be stored as a constant string.
 	 */

--- a/orm/pom.xml
+++ b/orm/pom.xml
@@ -236,4 +236,58 @@
             </plugin>
         </plugins>
     </reporting>
+
+    <profiles>
+        <profile>
+            <id>jdk9</id>
+            <activation>
+                <jdk>9</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>jaxb-runtime</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jdk10</id>
+            <activation>
+                <jdk>10</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>jaxb-runtime</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jdk11</id>
+            <activation>
+                <jdk>11</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>jaxb-runtime</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2002,7 +2002,7 @@
             <properties>
                 <test.wildfly.jvm.args>-Djdk.attach.allowAttachSelf=true</test.wildfly.jvm.args>
                 <test.performance.jvm.args>${test.wildfly.jvm.args}</test.performance.jvm.args>
-                <test.jvm.args>${test.performance.jvm.args} --illegal-access=deny</test.jvm.args>
+                <test.jvm.args>${test.performance.jvm.args} --illegal-access=deny -Dcom.sun.xml.bind.v2.bytecode.ClassTailor.noOptimize=true</test.jvm.args>
             </properties>
             <modules>
                 <module>integrationtest/jdk9-modules</module>

--- a/pom.xml
+++ b/pom.xml
@@ -1971,7 +1971,7 @@
             </activation>
             <properties>
                 <test.wildfly.jvm.args>-Djdk.attach.allowAttachSelf=true</test.wildfly.jvm.args>
-                <test.performance.jvm.args>${test.wildfly.jvm.args} --add-modules java.xml.bind</test.performance.jvm.args>
+                <test.performance.jvm.args>${test.wildfly.jvm.args}</test.performance.jvm.args>
                 <test.jvm.args>${test.performance.jvm.args} --illegal-access=deny</test.jvm.args>
             </properties>
             <modules>
@@ -1986,7 +1986,7 @@
             </activation>
             <properties>
                 <test.wildfly.jvm.args>-Djdk.attach.allowAttachSelf=true</test.wildfly.jvm.args>
-                <test.performance.jvm.args>${test.wildfly.jvm.args} --add-modules java.xml.bind</test.performance.jvm.args>
+                <test.performance.jvm.args>${test.wildfly.jvm.args}</test.performance.jvm.args>
                 <test.jvm.args>${test.performance.jvm.args} --illegal-access=deny</test.jvm.args>
             </properties>
             <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,13 @@
         <!-- Derby driver used by JBatch -->
         <version.org.apache.derby>10.13.1.1</version.org.apache.derby>
 
+        <!--
+            Using JAXB 2.3.0 as 2.2.11 seems to be broken in more than a few ways.
+            In particular version 2.2.11 of the impl depends on version 2.2.12-b140109.1041 of the API.
+         -->
+        <version.javax.xml.bind.jaxb-api>2.3.0</version.javax.xml.bind.jaxb-api>
+        <version.org.glassfish.jaxb>2.3.0.1</version.org.glassfish.jaxb>
+
         <version.org.slf4j>1.7.25</version.org.slf4j>
         <version.log4j>1.2.16</version.log4j>
         <version.org.jboss.logging.jboss-logging>3.3.2.Final</version.org.jboss.logging.jboss-logging>
@@ -1105,6 +1112,17 @@
                         <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${version.javax.xml.bind.jaxb-api}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
+                <version>${version.org.glassfish.jaxb}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -75,4 +75,43 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>jdk9</id>
+            <activation>
+                <jdk>9</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>jaxb-runtime</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jdk10</id>
+            <activation>
+                <jdk>10</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>jaxb-runtime</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jdk11</id>
+            <activation>
+                <jdk>11</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>jaxb-runtime</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3226

This does not fix everything, far from it, but at least the tests now mostly pass with JDK11.

Disabling a feature of JAXB is necessary in order for the tests to run with JDK11, because this feature makes use of `sun.misc.Unsafe`. So I disabled it in tests. The feature is apparently going to be removed in the next release of JAXB, see the commit message.

In the end I had to add a dependency to javax.xml.bind in the Elasticsearch module. For now the dependency only shows up when building with JDK9 and above, which means our released JARs simply will not work with JDK11. I will try to remove the dependency as part of https://hibernate.atlassian.net/browse/HSEARCH-3237, and if I can't, we'll see what we want to do. On the bright side, we only rely on the API, not on the runtime.