### PR TITLE
Backport HSEARCH-3240 to branch 5.10 - Use the pre-installed JDK in the Travis build instead of trying to update it in each build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 # therefore deactivated. Activating Travis for your own fork is as easy as
 # activating it in the travis site of your fork.
 
-sudo: required
+sudo: false
 dist: trusty
 language: java
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ addons:
   # for now, let's test only with H2
   #postgresql: '9.4'
   #mariadb: '10.0'
-  apt:
-    packages:
-      - oracle-java8-installer
 # might be useful to push reports to an S3 bucket
 #  artifacts:
 #    paths:


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3240

#1709 should be merged first.