### PR TITLE
JDK11 related 5.10 backports

### DIFF
--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -175,4 +175,43 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>jdk9</id>
+            <activation>
+                <jdk>9</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jdk10</id>
+            <activation>
+                <jdk>10</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jdk11</id>
+            <activation>
+                <jdk>11</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/integrationtest/osgi/karaf-it/src/test/java/org/hibernate/search/test/integration/osgi/HibernateSearchWithKarafIT.java
+++ b/integrationtest/osgi/karaf-it/src/test/java/org/hibernate/search/test/integration/osgi/HibernateSearchWithKarafIT.java
@@ -130,14 +130,14 @@ public class HibernateSearchWithKarafIT {
 			mavenProperties.load( inputStream );
 		}
 
-		String jacocoVMArgs = mavenProperties.getProperty( "test.container.jacoco.args" );
+		String vmArgsFromProperties = mavenProperties.getProperty( "pax-exam.jvm.args" );
 
 		File examDir = new File( "target/exam" );
 		File ariesLogDir = new File( examDir, "/aries/log" );
 		return new Option[] {
 				DEBUG ? debugConfiguration( "5005", true ) : null,
-				jacocoVMArgs != null && !jacocoVMArgs.isEmpty()
-						? CoreOptions.vmOptions( jacocoVMArgs.split( " " ) ) : null,
+				vmArgsFromProperties != null && !vmArgsFromProperties.isEmpty()
+						? CoreOptions.vmOptions( vmArgsFromProperties.split( " " ) ) : null,
 				logLevel( LogLevelOption.LogLevel.WARN ),
 				karafDistributionConfiguration()
 						.frameworkUrl( karafUrl )

--- a/integrationtest/osgi/karaf-it/src/test/resources/maven.properties
+++ b/integrationtest/osgi/karaf-it/src/test/resources/maven.properties
@@ -1,3 +1,3 @@
 # This file contains properties that should be filtered by Maven
 maven.settings.localRepository=${settings.localRepository}
-test.container.jacoco.args=${test.container.jacoco.args}
+pax-exam.jvm.args=${pax-exam.jvm.args}

--- a/integrationtest/performance/orm/pom.xml
+++ b/integrationtest/performance/orm/pom.xml
@@ -30,7 +30,7 @@
         <jbosshome>${project.build.directory}/${serverName}/</jbosshome>
 
         <!-- Relax the JVM restrictions for integration tests, when using Jigsaw -->
-        <test.jvm.args>${test.wildfly.jvm.args}</test.jvm.args>
+        <test.jvm.args>${test.performance.jvm.args}</test.jvm.args>
     </properties>
 
     <dependencyManagement>

--- a/integrationtest/performance/orm/pom.xml
+++ b/integrationtest/performance/orm/pom.xml
@@ -28,9 +28,6 @@
         <scenario></scenario>
         <serverName>wildfly-${version.wildfly}</serverName>
         <jbosshome>${project.build.directory}/${serverName}/</jbosshome>
-
-        <!-- Relax the JVM restrictions for integration tests, when using Jigsaw -->
-        <test.jvm.args>${test.performance.jvm.args}</test.jvm.args>
     </properties>
 
     <dependencyManagement>

--- a/integrationtest/performance/orm/src/test/resources/arquillian.xml
+++ b/integrationtest/performance/orm/src/test/resources/arquillian.xml
@@ -29,7 +29,7 @@
                 -Xmx512m
                 -Djava.net.preferIPv4Stack=true
                 -Djgroups.bind_addr=127.0.0.1
-                ${test.container.jbossmodules.args}
+                ${arquillian.wildfly.jvm.args}
                 -Dee8.preview.mode=true
             </property>
         </configuration>

--- a/integrationtest/wildfly/pom.xml
+++ b/integrationtest/wildfly/pom.xml
@@ -31,9 +31,6 @@
         <byteman.agent.options>script:${basedir}${file.separator}src${file.separator}test${file.separator}resources${file.separator}disablejpadapters.btm,script:${basedir}${file.separator}src${file.separator}test${file.separator}resources${file.separator}jsr352${file.separator}JobInterruptor.btm</byteman.agent.options>
         <test.module-slot.org.hibernate.search>main</test.module-slot.org.hibernate.search>
         <test.module-slot.org.hibernate>${parsed-version.org.hibernate.majorVersion}.${parsed-version.org.hibernate.minorVersion}</test.module-slot.org.hibernate>
-
-        <!-- Relax the JVM restrictions for integration tests, when using Jigsaw -->
-        <test.jvm.args>${test.wildfly.jvm.args}</test.jvm.args>
     </properties>
 
     <dependencyManagement>

--- a/integrationtest/wildfly/src/test/resources/arquillian.xml
+++ b/integrationtest/wildfly/src/test/resources/arquillian.xml
@@ -31,21 +31,14 @@
                     -Xmx512m
                     -Djava.net.preferIPv4Stack=true
                     -Djgroups.bind_addr=127.0.0.1
-                    ${test.container.jbossmodules.args}
-                    ${test.container.jacoco.args}
+                    ${arquillian.wildfly.jvm.args}
                     -Dee8.preview.mode=true
                 </property>
-                <!-- To debug the Arquillian managed application server:
-                <property name="javaVmArguments">
+                <!--
+                    To debug the Arquillian managed application server,
+                    add the following line to the property just above:
+
                     -Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y
-                    -javaagent:${byteman.agent.path}=${byteman.agent.options}
-                    -Djboss.modules.system.pkgs=org.jboss.byteman
-                    -Xmx512m
-                    -Djava.net.preferIPv4Stack=true
-                    -Djgroups.bind_addr=127.0.0.1
-                    ${test.container.jbossmodules.args}
-                    ${test.container.jacoco.args}
-                </property>
                  -->
             </configuration>
         </container>
@@ -60,7 +53,7 @@
                     -Xmx512m
                     -Djava.net.preferIPv4Stack=true
                     -Djgroups.bind_addr=127.0.0.1
-                    ${test.container.jbossmodules.args}
+                    ${arquillian.wildfly.jvm.args}
                     -Dee8.preview.mode=true
                 </property>
                 <property name="managementPort">19990</property>

--- a/orm/pom.xml
+++ b/orm/pom.xml
@@ -236,4 +236,58 @@
             </plugin>
         </plugins>
     </reporting>
+
+    <profiles>
+        <profile>
+            <id>jdk9</id>
+            <activation>
+                <jdk>9</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>jaxb-runtime</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jdk10</id>
+            <activation>
+                <jdk>10</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>jaxb-runtime</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jdk11</id>
+            <activation>
+                <jdk>11</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>jaxb-runtime</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1985,6 +1985,21 @@
         </profile>
 
         <profile>
+            <id>jdk11</id>
+            <activation>
+                <jdk>11</jdk>
+            </activation>
+            <properties>
+                <test.wildfly.jvm.args>-Djdk.attach.allowAttachSelf=true</test.wildfly.jvm.args>
+                <test.performance.jvm.args>${test.wildfly.jvm.args}</test.performance.jvm.args>
+                <test.jvm.args>${test.performance.jvm.args} --illegal-access=deny</test.jvm.args>
+            </properties>
+            <modules>
+                <module>integrationtest/jdk9-modules</module>
+            </modules>
+        </profile>
+
+        <profile>
             <id>perf</id>
             <properties>
                 <org.hibernate.search.enable_performance_tests>true</org.hibernate.search.enable_performance_tests>

--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,13 @@
         <!-- Derby driver used by JBatch -->
         <version.org.apache.derby>10.13.1.1</version.org.apache.derby>
 
+        <!--
+            Using JAXB 2.3.0 as 2.2.11 seems to be broken in more than a few ways.
+            In particular version 2.2.11 of the impl depends on version 2.2.12-b140109.1041 of the API.
+         -->
+        <version.javax.xml.bind.jaxb-api>2.3.0</version.javax.xml.bind.jaxb-api>
+        <version.org.glassfish.jaxb>2.3.0.1</version.org.glassfish.jaxb>
+
         <version.org.slf4j>1.7.25</version.org.slf4j>
         <version.log4j>1.2.16</version.log4j>
         <version.org.jboss.logging.jboss-logging>3.3.2.Final</version.org.jboss.logging.jboss-logging>
@@ -1108,6 +1115,17 @@
                         <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${version.javax.xml.bind.jaxb-api}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
+                <version>${version.org.glassfish.jaxb}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,7 @@
         <version.com.github.tomakehurst.wiremock>2.5.1</version.com.github.tomakehurst.wiremock>
         <!-- Fixes dependency convergence within Wiremock, see below -->
         <version.com.fasterxml.jackson>2.8.6</version.com.fasterxml.jackson>
-        <version.org.jboss.byteman>4.0.2</version.org.jboss.byteman>
+        <version.org.jboss.byteman>4.0.3</version.org.jboss.byteman>
         <version.io.takari.junit>1.2.7</version.io.takari.junit>
         <version.com.h2database>1.4.178</version.com.h2database>
 

--- a/pom.xml
+++ b/pom.xml
@@ -390,24 +390,28 @@
         <maven.compiler.argument.testSource>${maven.compiler.testSource}</maven.compiler.argument.testSource>
 
         <!-- Set empty default values to avoid Maven leaving property references (${...}) when it doesn't find a value -->
-        <test.jvm.args></test.jvm.args>
-        <test.performance.jvm.args></test.performance.jvm.args>
-        <test.wildfly.jvm.args></test.wildfly.jvm.args>
-        <surefire.jacoco.args></surefire.jacoco.args>
-        <failsafe.jacoco.args></failsafe.jacoco.args>
-        <test.container.jacoco.args></test.container.jacoco.args>
+        <surefire.jvm.args.java-version></surefire.jvm.args.java-version>
+        <surefire.jvm.args.jacoco></surefire.jvm.args.jacoco>
+        <failsafe.jvm.args.jacoco></failsafe.jvm.args.jacoco>
+        <surefire.jvm.args>${surefire.jvm.args.java-version} ${surefire.jvm.args.jacoco}</surefire.jvm.args>
+        <failsafe.jvm.args>${surefire.jvm.args.java-version} ${failsafe.jvm.args.jacoco}</failsafe.jvm.args>
+
+        <arquillian.wildfly.jvm.args.java-version></arquillian.wildfly.jvm.args.java-version>
+        <arquillian.wildfly.jvm.args.jacoco></arquillian.wildfly.jvm.args.jacoco>
         <!--
           The arguments below are JBoss modules settings taken from
           https://github.com/jboss-modules/jboss-modules/blob/5b4744e74f35cbab23536e3e52c0724fdbbedcb7/src/main/java/org/jboss/modules/maven/MavenSettings.java#L264
           - remote.maven.repo: necessary for the WF provisioning to work when the JBoss Nexus is not in the user's settings
           - maven.repo.local: necessary for the WF provisioning to work when using a non-default local repository
          -->
-        <test.container.jbossmodules.args>
+        <arquillian.wildfly.jvm.args.jbossmodules>
             -Dremote.maven.repo=${jboss.public.repo.url}
             -Dmaven.repo.local=${settings.localRepository}
-        </test.container.jbossmodules.args>
-        <surefire.system.args>${test.jvm.args} ${surefire.jacoco.args}</surefire.system.args>
-        <failsafe.system.args>${test.jvm.args} ${failsafe.jacoco.args}</failsafe.system.args>
+        </arquillian.wildfly.jvm.args.jbossmodules>
+        <arquillian.wildfly.jvm.args>${arquillian.wildfly.jvm.args.java-version} ${arquillian.wildfly.jvm.args.jacoco} ${arquillian.wildfly.jvm.args.jbossmodules}</arquillian.wildfly.jvm.args>
+
+        <pax-exam.jvm.args.jacoco></pax-exam.jvm.args.jacoco>
+        <pax-exam.jvm.args>${pax-exam.jvm.args.jacoco}</pax-exam.jvm.args>
 
         <!-- JDK version required for the build; we target 1.8 since Hibernate ORM 5.3 requires Java 8 -->
         <jdk.min.version>${maven.compiler.argument.source}</jdk.min.version>
@@ -1446,7 +1450,7 @@
                             <!-- Javassist still not working when using stricter checks with Jigsaw: use ByteBuddy -->
                             <hibernate.bytecode.provider>bytebuddy</hibernate.bytecode.provider>
                         </systemPropertyVariables>
-                        <argLine>${surefire.system.args}</argLine>
+                        <argLine>${surefire.jvm.args}</argLine>
                         <additionalClasspathElements>
                             <!-- Needed by Byteman to load the agent on demand -->
                             <additionalClasspathElement>${jdk-toolsjar}</additionalClasspathElement>
@@ -1569,7 +1573,7 @@
                             <!-- Javassist still not working when using stricter checks with Jigsaw: use ByteBuddy -->
                             <hibernate.bytecode.provider>bytebuddy</hibernate.bytecode.provider>
                         </systemPropertyVariables>
-                        <argLine>${failsafe.system.args}</argLine>
+                        <argLine>${failsafe.jvm.args}</argLine>
                         <additionalClasspathElements>
                             <!-- Needed by Byteman to load the agent on demand -->
                             <additionalClasspathElement>${jdk-toolsjar}</additionalClasspathElement>
@@ -1978,9 +1982,13 @@
                 <jdk>9</jdk>
             </activation>
             <properties>
-                <test.wildfly.jvm.args>-Djdk.attach.allowAttachSelf=true</test.wildfly.jvm.args>
-                <test.performance.jvm.args>${test.wildfly.jvm.args}</test.performance.jvm.args>
-                <test.jvm.args>${test.performance.jvm.args} --illegal-access=deny</test.jvm.args>
+                <surefire.jvm.args.java-version>
+                    -Djdk.attach.allowAttachSelf=true
+                    --illegal-access=deny
+                </surefire.jvm.args.java-version>
+                <arquillian.wildfly.jvm.args.java-version>
+                    -Djdk.attach.allowAttachSelf=true
+                </arquillian.wildfly.jvm.args.java-version>
             </properties>
             <modules>
                 <module>integrationtest/jdk9-modules</module>
@@ -1993,9 +2001,13 @@
                 <jdk>10</jdk>
             </activation>
             <properties>
-                <test.wildfly.jvm.args>-Djdk.attach.allowAttachSelf=true</test.wildfly.jvm.args>
-                <test.performance.jvm.args>${test.wildfly.jvm.args}</test.performance.jvm.args>
-                <test.jvm.args>${test.performance.jvm.args} --illegal-access=deny</test.jvm.args>
+                <surefire.jvm.args.java-version>
+                    -Djdk.attach.allowAttachSelf=true
+                    --illegal-access=deny
+                </surefire.jvm.args.java-version>
+                <arquillian.wildfly.jvm.args.java-version>
+                    -Djdk.attach.allowAttachSelf=true
+                </arquillian.wildfly.jvm.args.java-version>
             </properties>
             <modules>
                 <module>integrationtest/jdk9-modules</module>
@@ -2008,9 +2020,14 @@
                 <jdk>11</jdk>
             </activation>
             <properties>
-                <test.wildfly.jvm.args>-Djdk.attach.allowAttachSelf=true</test.wildfly.jvm.args>
-                <test.performance.jvm.args>${test.wildfly.jvm.args}</test.performance.jvm.args>
-                <test.jvm.args>${test.performance.jvm.args} --illegal-access=deny -Dcom.sun.xml.bind.v2.bytecode.ClassTailor.noOptimize=true</test.jvm.args>
+                <surefire.jvm.args.java-version>
+                    -Djdk.attach.allowAttachSelf=true
+                    --illegal-access=deny
+                    -Dcom.sun.xml.bind.v2.bytecode.ClassTailor.noOptimize=true
+                </surefire.jvm.args.java-version>
+                <arquillian.wildfly.jvm.args.java-version>
+                    -Djdk.attach.allowAttachSelf=true
+                </arquillian.wildfly.jvm.args.java-version>
             </properties>
             <modules>
                 <module>integrationtest/jdk9-modules</module>
@@ -2485,14 +2502,15 @@
                     As a result, this profile will not work in IntelliJ,
                     but we don't need JaCoCo in IntelliJ anyway.
                  -->
-                <surefire.jacoco.args>@{surefire.jacoco.args.lateEval}</surefire.jacoco.args>
-                <failsafe.jacoco.args>@{failsafe.jacoco.args.lateEval}</failsafe.jacoco.args>
+                <surefire.jvm.args.jacoco>@{surefire.jvm.args.jacoco.lateEval}</surefire.jvm.args.jacoco>
+                <failsafe.jvm.args.jacoco>@{failsafe.jvm.args.jacoco.lateEval}</failsafe.jvm.args.jacoco>
                 <!--
                     We don't use @{...} for late property evaluation here,
                     because these properties are evaluated by the maven-resource-plugin,
                     which doesn't understand the @{...} syntax but somehow manages to always use late evaluation.
                  -->
-                <test.container.jacoco.args>${failsafe.jacoco.args.lateEval}</test.container.jacoco.args>
+                <arquillian.wildfly.jvm.args.jacoco>${failsafe.jvm.args.jacoco.lateEval}</arquillian.wildfly.jvm.args.jacoco>
+                <pax-exam.jvm.args.jacoco>${failsafe.jvm.args.jacoco.lateEval}</pax-exam.jvm.args.jacoco>
             </properties>
             <build>
                 <plugins>
@@ -2512,7 +2530,7 @@
                                     <goal>prepare-agent</goal>
                                 </goals>
                                 <configuration>
-                                    <propertyName>surefire.jacoco.args.lateEval</propertyName>
+                                    <propertyName>surefire.jvm.args.jacoco.lateEval</propertyName>
                                 </configuration>
                             </execution>
                             <execution>
@@ -2526,7 +2544,7 @@
                                     <goal>prepare-agent-integration</goal>
                                 </goals>
                                 <configuration>
-                                    <propertyName>failsafe.jacoco.args.lateEval</propertyName>
+                                    <propertyName>failsafe.jvm.args.jacoco.lateEval</propertyName>
                                 </configuration>
                             </execution>
                         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -2010,7 +2010,7 @@
             <properties>
                 <test.wildfly.jvm.args>-Djdk.attach.allowAttachSelf=true</test.wildfly.jvm.args>
                 <test.performance.jvm.args>${test.wildfly.jvm.args}</test.performance.jvm.args>
-                <test.jvm.args>${test.performance.jvm.args} --illegal-access=deny</test.jvm.args>
+                <test.jvm.args>${test.performance.jvm.args} --illegal-access=deny -Dcom.sun.xml.bind.v2.bytecode.ClassTailor.noOptimize=true</test.jvm.args>
             </properties>
             <modules>
                 <module>integrationtest/jdk9-modules</module>

--- a/pom.xml
+++ b/pom.xml
@@ -1979,7 +1979,7 @@
             </activation>
             <properties>
                 <test.wildfly.jvm.args>-Djdk.attach.allowAttachSelf=true</test.wildfly.jvm.args>
-                <test.performance.jvm.args>${test.wildfly.jvm.args} --add-modules java.xml.bind</test.performance.jvm.args>
+                <test.performance.jvm.args>${test.wildfly.jvm.args}</test.performance.jvm.args>
                 <test.jvm.args>${test.performance.jvm.args} --illegal-access=deny</test.jvm.args>
             </properties>
             <modules>
@@ -1994,7 +1994,7 @@
             </activation>
             <properties>
                 <test.wildfly.jvm.args>-Djdk.attach.allowAttachSelf=true</test.wildfly.jvm.args>
-                <test.performance.jvm.args>${test.wildfly.jvm.args} --add-modules java.xml.bind</test.performance.jvm.args>
+                <test.performance.jvm.args>${test.wildfly.jvm.args}</test.performance.jvm.args>
                 <test.jvm.args>${test.performance.jvm.args} --illegal-access=deny</test.jvm.args>
             </properties>
             <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -1947,7 +1947,7 @@
                 <jdk>9</jdk>
             </activation>
             <properties>
-                <test.wildfly.jvm.args>-Djdk.attach.allowAttachSelf=true --add-modules java.xml.bind --add-opens=java.base/java.lang=ALL-UNNAMED</test.wildfly.jvm.args>
+                <test.wildfly.jvm.args>-Djdk.attach.allowAttachSelf=true --add-modules java.xml.bind</test.wildfly.jvm.args>
                 <test.jvm.args>${test.wildfly.jvm.args} --illegal-access=deny</test.jvm.args>
             </properties>
             <modules>
@@ -1961,7 +1961,7 @@
                 <jdk>10</jdk>
             </activation>
             <properties>
-                <test.wildfly.jvm.args>-Djdk.attach.allowAttachSelf=true --add-modules java.xml.bind --add-opens=java.base/java.lang=ALL-UNNAMED</test.wildfly.jvm.args>
+                <test.wildfly.jvm.args>-Djdk.attach.allowAttachSelf=true --add-modules java.xml.bind</test.wildfly.jvm.args>
                 <test.jvm.args>${test.wildfly.jvm.args} --illegal-access=deny</test.jvm.args>
             </properties>
             <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -1609,12 +1609,24 @@
                                      <exclude>**/*_$bundle.class</exclude>
                                  </excludes>
                                  <bundledSignatures>
-                                     <!-- This will automatically choose the right signatures based on 'targetVersion': -->
-                                     <bundledSignature>jdk-unsafe</bundledSignature>
-                                     <bundledSignature>jdk-deprecated</bundledSignature>
+                                     <!-- These signatures on the top are not specific to any JDK version -->
                                      <bundledSignature>jdk-system-out</bundledSignature>
                                      <bundledSignature>jdk-non-portable</bundledSignature>
-                                     <bundledSignature>jdk-internal</bundledSignature>
+                                     <!-- The jdk-reflection is not yet something we can avoid -->
+                                     <!--<bundledSignature>jdk-reflection</bundledSignature>-->
+
+                                     <!-- All following signatures should be replicated for each target JDK version we intend to support -->
+                                     <bundledSignature>jdk-unsafe-1.8</bundledSignature>
+                                     <bundledSignature>jdk-unsafe-9</bundledSignature>
+                                     <bundledSignature>jdk-unsafe-10</bundledSignature>
+
+                                     <bundledSignature>jdk-deprecated-1.8</bundledSignature>
+                                     <bundledSignature>jdk-deprecated-9</bundledSignature>
+                                     <bundledSignature>jdk-deprecated-10</bundledSignature>
+
+                                     <bundledSignature>jdk-internal-1.8</bundledSignature>
+                                     <bundledSignature>jdk-internal-9</bundledSignature>
+                                     <bundledSignature>jdk-internal-10</bundledSignature>
                                  </bundledSignatures>
                                  <failOnMissingClasses>false</failOnMissingClasses>
                                  <failOnUnresolvableSignatures>false</failOnUnresolvableSignatures>

--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,7 @@
         <version.com.github.tomakehurst.wiremock>2.5.1</version.com.github.tomakehurst.wiremock>
         <!-- Fixes dependency convergence within Wiremock, see below -->
         <version.com.fasterxml.jackson>2.8.6</version.com.fasterxml.jackson>
-        <version.org.jboss.byteman>4.0.3</version.org.jboss.byteman>
+        <version.org.jboss.byteman>4.0.4</version.org.jboss.byteman>
         <version.io.takari.junit>1.2.7</version.io.takari.junit>
         <version.com.h2database>1.4.178</version.com.h2database>
 

--- a/pom.xml
+++ b/pom.xml
@@ -384,6 +384,7 @@
 
         <!-- Set empty default values to avoid Maven leaving property references (${...}) when it doesn't find a value -->
         <test.jvm.args></test.jvm.args>
+        <test.performance.jvm.args></test.performance.jvm.args>
         <test.wildfly.jvm.args></test.wildfly.jvm.args>
         <surefire.jacoco.args></surefire.jacoco.args>
         <failsafe.jacoco.args></failsafe.jacoco.args>
@@ -1947,8 +1948,9 @@
                 <jdk>9</jdk>
             </activation>
             <properties>
-                <test.wildfly.jvm.args>-Djdk.attach.allowAttachSelf=true --add-modules java.xml.bind</test.wildfly.jvm.args>
-                <test.jvm.args>${test.wildfly.jvm.args} --illegal-access=deny</test.jvm.args>
+                <test.wildfly.jvm.args>-Djdk.attach.allowAttachSelf=true</test.wildfly.jvm.args>
+                <test.performance.jvm.args>${test.wildfly.jvm.args} --add-modules java.xml.bind</test.performance.jvm.args>
+                <test.jvm.args>${test.performance.jvm.args} --illegal-access=deny</test.jvm.args>
             </properties>
             <modules>
                 <module>integrationtest/jdk9-modules</module>
@@ -1961,8 +1963,9 @@
                 <jdk>10</jdk>
             </activation>
             <properties>
-                <test.wildfly.jvm.args>-Djdk.attach.allowAttachSelf=true --add-modules java.xml.bind</test.wildfly.jvm.args>
-                <test.jvm.args>${test.wildfly.jvm.args} --illegal-access=deny</test.jvm.args>
+                <test.wildfly.jvm.args>-Djdk.attach.allowAttachSelf=true</test.wildfly.jvm.args>
+                <test.performance.jvm.args>${test.wildfly.jvm.args} --add-modules java.xml.bind</test.performance.jvm.args>
+                <test.jvm.args>${test.performance.jvm.args} --illegal-access=deny</test.jvm.args>
             </properties>
             <modules>
                 <module>integrationtest/jdk9-modules</module>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -75,4 +75,43 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>jdk9</id>
+            <activation>
+                <jdk>9</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>jaxb-runtime</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jdk10</id>
+            <activation>
+                <jdk>10</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>jaxb-runtime</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jdk11</id>
+            <activation>
+                <jdk>11</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>jaxb-runtime</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3219
https://hibernate.atlassian.net//browse/HSEARCH-3224
https://hibernate.atlassian.net//browse/HSEARCH-3232
https://hibernate.atlassian.net//browse/HSEARCH-3236
https://hibernate.atlassian.net//browse/HSEARCH-3235
https://hibernate.atlassian.net//browse/HSEARCH-3226
https://hibernate.atlassian.net//browse/HSEARCH-3241

Must wait for #1711 to be merged first.

Not sure it's worth it, let's discuss this.

We want to make Search work with JDK11 ultimately, and a version of HSearch compatible with JDK11 should ship with Wildfly 14, ideally.

We have to options:

* Release a micro on the 5.10 branch and update WF14 to use that micro
* Release a 5.11.0 and update WF14 to use 5.11.0

So far, the amount of changes is not enough to justify a 5.11, so I'd say let's target JDK11 support in 5.10. But on the ORM side we may need to add new dependencies (to JaxB in particular), and I'd argue adding new dependencies in a micro is not very nice.