### PR TITLE
Backport HSEARCH-3233 to branch 5.10 - Overriding an analyzer in the queryBuilder with an unknown analyzer should lead to a proper SearchException

### DIFF
--- a/engine/src/main/java/org/hibernate/search/query/dsl/impl/ConnectedQueryContextBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/impl/ConnectedQueryContextBuilder.java
@@ -7,6 +7,7 @@
 
 package org.hibernate.search.query.dsl.impl;
 
+import org.hibernate.search.analyzer.spi.AnalyzerReference;
 import org.hibernate.search.analyzer.spi.ScopedAnalyzerReference;
 import org.hibernate.search.engine.impl.AnalyzerRegistry;
 import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
@@ -94,7 +95,11 @@ public class ConnectedQueryContextBuilder implements QueryContextBuilder {
 
 		@Override
 		public EntityContext overridesForField(String field, String analyzerName) {
-			queryAnalyzerReferenceBuilder.addAnalyzerReference( field, analyzerRegistry.getAnalyzerReference( analyzerName ) );
+			AnalyzerReference reference = analyzerRegistry.getAnalyzerReference( analyzerName );
+			if ( reference == null ) {
+				throw log.unknownAnalyzerForOverride( analyzerName );
+			}
+			queryAnalyzerReferenceBuilder.addAnalyzerReference( field, reference );
 			return this;
 		}
 

--- a/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
@@ -1021,4 +1021,7 @@ public interface Log extends BaseHibernateSearchLogger {
 
 	@Message(id = 352, value = "Multiple conflicting minimumShouldMatch constraints")
 	SearchException minimumShouldMatchConflictingConstraints();
+
+	@Message(id = 353, value = "Unknown analyzer: '%1$s'. Make sure you defined this analyzer.")
+	SearchException unknownAnalyzerForOverride(String analyzerName);
 }

--- a/engine/src/test/java/org/hibernate/search/test/dsl/Month.java
+++ b/engine/src/test/java/org/hibernate/search/test/dsl/Month.java
@@ -96,6 +96,8 @@ class Month {
 			@Field,
 			@Field(name = "mythology_stem", analyzer = @Analyzer(definition = "stemmer")),
 			@Field(name = "mythology_ngram", analyzer = @Analyzer(definition = "ngram")),
+			// This field must exist in order for tests to pass with the Elasticsearch integration... See HSEARCH-2534
+			@Field(name = "mythology_same_base_as_ngram", analyzer = @Analyzer(definition = "same_base_as_ngram")),
 			@Field(name = "mythology_normalized", normalizer = @Normalizer(definition = "lower"))
 	})
 	public String getMythology() {


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3233

#1714 should be merged first.