### PR TITLE
Backport HSEARCH-3248 to branch 5.10 - Restore lenient illegal access checks on the client side of Arquillian during integration tests

### DIFF
--- a/integrationtest/performance/orm/pom.xml
+++ b/integrationtest/performance/orm/pom.xml
@@ -28,6 +28,12 @@
         <scenario></scenario>
         <serverName>wildfly-${version.wildfly}</serverName>
         <jbosshome>${project.build.directory}/${serverName}/</jbosshome>
+
+        <!--
+            Relax the JVM restrictions on the client side of Arquillian:
+            strict restrictions wouldn't work and it's not what we want to check.
+         -->
+        <surefire.jvm.args.java-version>${surefire.jvm.args.java-version.lenient}</surefire.jvm.args.java-version>
     </properties>
 
     <dependencyManagement>

--- a/integrationtest/wildfly/pom.xml
+++ b/integrationtest/wildfly/pom.xml
@@ -31,6 +31,12 @@
         <byteman.agent.options>script:${basedir}${file.separator}src${file.separator}test${file.separator}resources${file.separator}disablejpadapters.btm,script:${basedir}${file.separator}src${file.separator}test${file.separator}resources${file.separator}jsr352${file.separator}JobInterruptor.btm</byteman.agent.options>
         <test.module-slot.org.hibernate.search>main</test.module-slot.org.hibernate.search>
         <test.module-slot.org.hibernate>${parsed-version.org.hibernate.majorVersion}.${parsed-version.org.hibernate.minorVersion}</test.module-slot.org.hibernate>
+
+        <!--
+            Relax the JVM restrictions on the client side of Arquillian:
+            strict restrictions wouldn't work and it's not what we want to check.
+         -->
+        <surefire.jvm.args.java-version>${surefire.jvm.args.java-version.lenient}</surefire.jvm.args.java-version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -390,7 +390,14 @@
         <maven.compiler.argument.testSource>${maven.compiler.testSource}</maven.compiler.argument.testSource>
 
         <!-- Set empty default values to avoid Maven leaving property references (${...}) when it doesn't find a value -->
-        <surefire.jvm.args.java-version></surefire.jvm.args.java-version>
+        <!--
+            Provide two sets of settings for settings specific to a java version.
+            This is mainly useful when running tests in Arquillian, where illegal-access=deny won't work
+            and is not useful, so we disable it.
+         -->
+        <surefire.jvm.args.java-version.strict></surefire.jvm.args.java-version.strict>
+        <surefire.jvm.args.java-version.lenient></surefire.jvm.args.java-version.lenient>
+        <surefire.jvm.args.java-version>${surefire.jvm.args.java-version.strict}</surefire.jvm.args.java-version>
         <surefire.jvm.args.jacoco></surefire.jvm.args.jacoco>
         <failsafe.jvm.args.jacoco></failsafe.jvm.args.jacoco>
         <surefire.jvm.args>${surefire.jvm.args.java-version} ${surefire.jvm.args.jacoco}</surefire.jvm.args>
@@ -1982,10 +1989,13 @@
                 <jdk>9</jdk>
             </activation>
             <properties>
-                <surefire.jvm.args.java-version>
+                <surefire.jvm.args.java-version.lenient>
                     -Djdk.attach.allowAttachSelf=true
+                </surefire.jvm.args.java-version.lenient>
+                <surefire.jvm.args.java-version.strict>
+                    ${surefire.jvm.args.java-version.lenient}
                     --illegal-access=deny
-                </surefire.jvm.args.java-version>
+                </surefire.jvm.args.java-version.strict>
                 <arquillian.wildfly.jvm.args.java-version>
                     -Djdk.attach.allowAttachSelf=true
                 </arquillian.wildfly.jvm.args.java-version>
@@ -2001,10 +2011,13 @@
                 <jdk>10</jdk>
             </activation>
             <properties>
-                <surefire.jvm.args.java-version>
+                <surefire.jvm.args.java-version.lenient>
                     -Djdk.attach.allowAttachSelf=true
+                </surefire.jvm.args.java-version.lenient>
+                <surefire.jvm.args.java-version.strict>
+                    ${surefire.jvm.args.java-version.lenient}
                     --illegal-access=deny
-                </surefire.jvm.args.java-version>
+                </surefire.jvm.args.java-version.strict>
                 <arquillian.wildfly.jvm.args.java-version>
                     -Djdk.attach.allowAttachSelf=true
                 </arquillian.wildfly.jvm.args.java-version>
@@ -2020,11 +2033,14 @@
                 <jdk>11</jdk>
             </activation>
             <properties>
-                <surefire.jvm.args.java-version>
+                <surefire.jvm.args.java-version.lenient>
                     -Djdk.attach.allowAttachSelf=true
-                    --illegal-access=deny
                     -Dcom.sun.xml.bind.v2.bytecode.ClassTailor.noOptimize=true
-                </surefire.jvm.args.java-version>
+                </surefire.jvm.args.java-version.lenient>
+                <surefire.jvm.args.java-version.strict>
+                    ${surefire.jvm.args.java-version.lenient}
+                    --illegal-access=deny
+                </surefire.jvm.args.java-version.strict>
                 <arquillian.wildfly.jvm.args.java-version>
                     -Djdk.attach.allowAttachSelf=true
                 </arquillian.wildfly.jvm.args.java-version>


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3248

Should be merged after #1717