### PR TITLE
HSEARCH-3246 Generate Coveralls and Sonar reports from the Jenkinsfile instead of Travis

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,25 +25,12 @@ import org.jenkinsci.plugins.credentialsbinding.impl.CredentialNotFoundException
  */
 
 /*
- * Expected configuration (optional): multibranch-configuration.yaml, set up using the config file provider plugin
- * (https://plugins.jenkins.io/config-file-provider).
- * Expected structure of this file:
- *
- * notification:
- *   email:
- *     recipients: ... # string containing a space-separated list of email addresses to notify in case of failing non-PR builds>
- *
- * The following credentials are necessary for some features:
- *
- * - 'aws-elasticsearch' AWS credentials, to test Elasticsearch as a service on AWS
- * - 'coveralls-repository-token' secret text credentials containing the repository token,
- * to send coverage reports to coveralls.io. Note these credentials should be registered at the job level, not system-wide.
- * - 'sonarcloud-hibernate-token' secret text credentials containing a Sonar access token for the Hibernate organization,
- * to send Sonar analysis input to sonarcloud.io.
- *
  * See http://ci.hibernate.org/pipeline-syntax/ for help writing Jenkins pipeline steps.
  *
+ * ### Jenkins configuration
+ *
  * This file requires the following plugins in particular:
+ *
  * - https://plugins.jenkins.io/pipeline-maven
  * - https://plugins.jenkins.io/ec2
  * - https://plugins.jenkins.io/lockable-resources
@@ -53,6 +40,7 @@ import org.jenkinsci.plugins.credentialsbinding.impl.CredentialNotFoundException
  * - https://plugins.jenkins.io/pipeline-utility-steps
  *
  * Also you might need to allow the following calls in <jenkinsUrl>/scriptApproval/:
+ *
  * - method java.util.Map putIfAbsent java.lang.Object java.lang.Object
  * - staticMethod org.jenkinsci.plugins.pipeline.modeldefinition.Utils markStageSkippedForConditional java.lang.String
  * - new java.lang.IllegalArgumentException java.lang.String
@@ -61,6 +49,43 @@ import org.jenkinsci.plugins.credentialsbinding.impl.CredentialNotFoundException
  * - method java.lang.Throwable addSuppressed java.lang.Throwable
  *
  * Just run the script a few times, it will fail and display a link to allow these calls.
+ *
+ * ### Job configuration
+ *
+ * This file gets its configuration from three sources: environment variables, a configuration file, and credentials.
+ * All configuration is optional for the default build (and it should stay that way),
+ * but some features require some configuration.
+ *
+ * #### Environment variables
+ *
+ * The following environment variables are necessary for some features:
+ *
+ * - 'ES_AWS_REGION', containing the name of an AWS region such as 'us-east-1', to test Elasticsearch as a service on AWS.
+ * - 'ES_AWS_<majorminor without dot>_ENDPOINT' (e.g. 'ES_AWS_52_ENDPOINT'),
+ * containing the URL of an AWS Elasticsearch service endpoint using that exact version,
+ * to test Elasticsearch as a service on AWS.
+ *
+ * #### Configuration file
+ *
+ * The configuration file is optional. Its purpose is to host job-specific configuration, such as notification recipients.
+ *
+ * The file is named 'multibranch-configuration.yaml', and it should be set up using the config file provider plugin
+ * (https://plugins.jenkins.io/config-file-provider).
+ * Expected structure of this file:
+ *
+ *     notification:
+ *       email:
+ *         recipients: ... # string containing a space-separated list of email addresses to notify in case of failing non-PR builds>
+ *
+ * #### Credentials
+ *
+ * The following credentials are necessary for some features:
+ *
+ * - 'aws-elasticsearch' AWS credentials, to test Elasticsearch as a service on AWS
+ * - 'coveralls-repository-token' secret text credentials containing the repository token,
+ * to send coverage reports to coveralls.io. Note these credentials should be registered at the job level, not system-wide.
+ * - 'sonarcloud-hibernate-token' secret text credentials containing a Sonar access token for the Hibernate organization,
+ * to send Sonar analysis input to sonarcloud.io.
  */
 
 @Field final String MAVEN_LOCAL_REPOSITORY_RELATIVE = '.repository'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,6 @@
  */
 
 import groovy.transform.Field
-import groovy.json.JsonSlurper
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 import org.jenkinsci.plugins.credentialsbinding.impl.CredentialNotFoundException
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -432,7 +432,11 @@ stage('Non-default environment ITs') {
 				node(NODE_PATTERN_BASE + '&&AWS') {
 					withDefaultedMaven {
 						resumeFromDefaultBuild()
-						withAwsCredentials {
+						withCredentials([[$class: 'AmazonWebServicesCredentialsBinding',
+										 credentialsId   : 'aws-elasticsearch',
+										 usernameVariable: 'AWS_ACCESS_KEY_ID',
+										 passwordVariable: 'AWS_SECRET_ACCESS_KEY'
+						]]) {
 							mavenNonDefaultIT itEnv, """ \\
 								clean install -pl org.hibernate.search:hibernate-search-integrationtest-backend-elasticsearch \\
 								${toMavenElasticsearchProfileArg(itEnv.mavenProfile)} \\
@@ -582,17 +586,6 @@ void withDefaultedMaven(Map args, Closure body) {
 	args.putIfAbsent('options', [artifactsPublisher(disabled: true)])
 	args.putIfAbsent('mavenLocalRepo', "$env.WORKSPACE/$MAVEN_LOCAL_REPOSITORY_RELATIVE")
 	withMaven(args, body)
-}
-
-void withAwsCredentials(Closure body) {
-	withCredentials(
-		[[$class: 'AmazonWebServicesCredentialsBinding',
-			credentialsId: 'aws-elasticsearch',
-			usernameVariable: 'AWS_ACCESS_KEY_ID',
-			passwordVariable: 'AWS_SECRET_ACCESS_KEY'
-		]],
-		body
-	)
 }
 
 void resumeFromDefaultBuild() {


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3246

~Based on #1723 , which should be merged first.~ => Done