### PR TITLE
Backport HSEARCH-3343 to branch 5.10 - Upgrade to Hibernate ORM 5.3.6.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
 
         <!-- Dependencies versions -->
 
-        <version.org.hibernate>5.3.3.Final</version.org.hibernate>
+        <version.org.hibernate>5.3.6.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>5.0.4.Final</version.org.hibernate.commons.annotations>
         <version.javax.persistence>2.2</version.javax.persistence>
 
@@ -190,7 +190,7 @@
 
         <version.org.infinispan>9.2.2.Final</version.org.infinispan>
 
-        <version.net.bytebuddy>1.8.13</version.net.bytebuddy>
+        <version.net.bytebuddy>1.8.17</version.net.bytebuddy>
 
         <version.wildfly>12.0.0.Final</version.wildfly>
 


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3343

This is a backport of #1734 to branch 5.10.