### PR TITLE
HSEARCH-3341 Do not send SUCCESS notifications when a  Jenkins pipeline build fails or is cancelled

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -522,13 +522,23 @@ stage('Release') {
 	}
 }
 
-currentBuild.result = 'SUCCESS'
 } // End of the code triggering notifications
 catch (any) {
 	mainScriptException = any
 	throw any
 }
 finally {
+	/*
+	 * Set the build result so that the email notifications correctly report it.
+	 * We have to do it manually because Jenkins only does that automatically *after* the build.
+	 */
+	if (mainScriptException) {
+		currentBuild.result = 'FAILURE'
+	}
+	else {
+		currentBuild.result = 'SUCCESS'
+	}
+	
 	try {
 		notifyBuildEnd()
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3341

This one is a bit embarrassing... I tested it, it should work now: I got a FAILURE notification for http://ci.hibernate.org/blue/organizations/jenkins/hibernate-search-yoann/detail/ci-test-this-please/8/pipeline .