### PR TITLE
HSEARCH-3348 Consider backend TCK and test utils as test code during the Sonar analysis

### DIFF
--- a/.empty/README.md
+++ b/.empty/README.md
@@ -1,0 +1,1 @@
+Do not move, rename or remove this directory, it *is* useful. See property 'rootProject.emptySubdirectory' in the parent POM.

--- a/integrationtest/backend/tck/pom.xml
+++ b/integrationtest/backend/tck/pom.xml
@@ -12,6 +12,15 @@
     <name>Hibernate Search Integration Tests - Backend TCK</name>
     <description>Hibernate Search backend TCK, including tests for every feature common to all the backends</description>
 
+    <properties>
+        <!--
+            Consider all sources as tests during Sonar analysis.
+            This is important because some analysis rules do not apply to test code.
+         -->
+        <sonar.sources>${rootProject.emptySubdirectory}</sonar.sources>
+        <sonar.tests>${project.build.sourceDirectory}</sonar.tests>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.hibernate.search</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -304,7 +304,7 @@
         <maven.compiler.argument.testSource>${maven.compiler.testSource}</maven.compiler.argument.testSource>
 
         <!--
-            The path to the root project directory.
+            The absolute path to the root project directory.
             This property is set by the build-helper plugin.
             We initialize it to some crude, potentially wrong value,
             because the Sonar Maven plugin uses this property indirectly,
@@ -315,6 +315,12 @@
              - https://www.mojohaus.org/build-helper-maven-plugin/rootlocation-mojo.html
          -->
         <rootProject.directory>${user.dir}</rootProject.directory>
+        <!--
+            The absolute path to an empty subdirectory of the root project.
+            This is used in places where we need a path to an existing, empty directory,
+            such as when fooling Sonar into thinking there is no "main" source in a project.
+         -->
+        <rootProject.emptySubdirectory>${rootProject.directory}/.empty</rootProject.emptySubdirectory>
 
         <!-- Version to be used as baseline for API/SPI change reports -->
         <previous.stable>5.10.3.Final</previous.stable>

--- a/util/internal/integrationtest/pom.xml
+++ b/util/internal/integrationtest/pom.xml
@@ -16,6 +16,13 @@
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
+
+        <!--
+            Consider all sources as tests during Sonar analysis.
+            This is important because some analysis rules do not apply to test code.
+         -->
+        <sonar.sources>${rootProject.emptySubdirectory}</sonar.sources>
+        <sonar.tests>${project.build.sourceDirectory}</sonar.tests>
     </properties>
 
     <modules>

--- a/util/internal/test/pom.xml
+++ b/util/internal/test/pom.xml
@@ -15,6 +15,13 @@
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
+
+        <!--
+            Consider all sources as tests during Sonar analysis.
+            This is important because some analysis rules do not apply to test code.
+         -->
+        <sonar.sources>${rootProject.emptySubdirectory}</sonar.sources>
+        <sonar.tests>${project.build.sourceDirectory}</sonar.tests>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3348

It's a rather ugly hack, but I couldn't find any other way. At least it should not cause much maintenance hassle.

Results of a full analysis after this patch: https://sonarcloud.io/project/activity?branch=sonartest-yrodiere&id=org.hibernate.search%3Ahibernate-search-parent&selected_date=2018-09-11T11%3A54%3A22%2B0000

To be compared with: https://sonarcloud.io/project/activity?id=org.hibernate.search%3Ahibernate-search-parent&selected_date=2018-09-11T12%3A13%3A24%2B0000

So yeah, that's quite a lot of noise we got rid of.