### PR TITLE
HSEARCH-3332 Activate GitHub pull request decoration in Sonar

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,6 +50,23 @@ import org.jenkinsci.plugins.credentialsbinding.impl.CredentialNotFoundException
  *
  * Just run the script a few times, it will fail and display a link to allow these calls.
  *
+ * ### Integrations
+ *
+ * #### Coveralls (optional)
+ *
+ * You need to enable your repository in Coveralls first: see https://coveralls.io/repos/new.
+ *
+ * Then you will also need to add the Coveralls repository token as credentials in Jenkins
+ * (see "Credentials" section below).
+ *
+ * #### Sonarcloud (optional)
+ *
+ * You need to enable the SonarCloud GitHub app for your repository:
+ * see https://github.com/apps/sonarcloud.
+ *
+ * Then you will also need to add SonarCloud credentials in Jenkins (see below)
+ * and to configure the SonarCloud organization in the job configuration file (see below).
+ *
  * ### Job configuration
  *
  * This file gets its configuration from three sources: environment variables, a configuration file, and credentials.


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3332

"PR decoration" means:
 * Sonarcloud will leave a review for each push, with a comment for each issue found in the changeset (including a link to the issue on sonarcloud.io)
 * A check will be added at the bottom of the PR, next to the PR build status and the review status

You can find an example of PR decoration here: https://github.com/yrodiere/hibernate-search/pull/35
History:

* I first pushed a PR with a few issues: Sonarcloud posted the first review, the Sonarcloud check was set to "Failed".
* Then Coveralls posted its own comment.
* Then I force-pushed to fix the issues: the check status was updated (to green), but unfortunately the Sonarcloud review was not updated Probably not a big deal.
* Then I force-pushed to add issues again: the check status was updated (failed again), the comments on the first review were removed, and Sonarclud posted a second review.