### PR TITLE
HSEARCH-3340 + HSEARCH-3334 Add support for snapshot releases to the Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,6 +29,8 @@ import org.jenkinsci.plugins.credentialsbinding.impl.CredentialNotFoundException
  *
  * ### Jenkins configuration
  *
+ * #### Jenkins plugins
+ *
  * This file requires the following plugins in particular:
  *
  * - https://plugins.jenkins.io/pipeline-maven
@@ -38,6 +40,8 @@ import org.jenkinsci.plugins.credentialsbinding.impl.CredentialNotFoundException
  * - https://plugins.jenkins.io/email-ext
  * - https://plugins.jenkins.io/config-file-provider
  * - https://plugins.jenkins.io/pipeline-utility-steps
+ *
+ * #### Script approval
  *
  * Also you might need to allow the following calls in <jenkinsUrl>/scriptApproval/:
  *
@@ -51,6 +55,16 @@ import org.jenkinsci.plugins.credentialsbinding.impl.CredentialNotFoundException
  * Just run the script a few times, it will fail and display a link to allow these calls.
  *
  * ### Integrations
+ *
+ * #### Nexus deployment
+ *
+ * This job includes two deployment modes:
+ *
+ * - A deployment of snapshot artifacts for every non-PR build on "primary" branches (master and maintenance branches).
+ * - A full release when starting the job with specific parameters.
+ *
+ * In the first case, the name of a Maven settings file must be provided in the job configuration file
+ * (see below).
  *
  * #### Coveralls (optional)
  *
@@ -87,9 +101,9 @@ import org.jenkinsci.plugins.credentialsbinding.impl.CredentialNotFoundException
  * containing the URL of an AWS Elasticsearch service endpoint using that exact version,
  * to test Elasticsearch as a service on AWS.
  *
- * #### Configuration file
+ * #### Job configuration file
  *
- * The configuration file is optional. Its purpose is to host job-specific configuration, such as notification recipients.
+ * The job configuration file is optional. Its purpose is to host job-specific configuration, such as notification recipients.
  *
  * The file is named 'job-configuration.yaml', and it should be set up using the config file provider plugin
  * (https://plugins.jenkins.io/config-file-provider).
@@ -97,9 +111,17 @@ import org.jenkinsci.plugins.credentialsbinding.impl.CredentialNotFoundException
  *
  *     notification:
  *       email:
- *         recipients: ... # string containing a space-separated list of email addresses to notify in case of failing non-PR builds>
+ *         # String containing a space-separated list of email addresses to notify in case of failing non-PR builds.
+ *         recipients: ...
  *     sonar:
- *       organization: ... # string containing the sonar organization. Mandatory in order to enable Sonar analysis.
+ *       # String containing the sonar organization. Mandatory in order to enable Sonar analysis.
+ *       organization: ...
+ *     deployment:
+ *       maven:
+ *         # String containing the ID of a Maven settings file registered using the config-file-provider Jenkins plugin.
+ *         # The settings must provide credentials to the servers with ID
+ *         # 'jboss-releases-repository' and 'jboss-snapshots-repository'.
+ *         settingsId: ...
  *
  * #### Credentials
  *
@@ -156,6 +178,8 @@ import org.jenkinsci.plugins.credentialsbinding.impl.CredentialNotFoundException
 @Field boolean enableDefaultEnvLegacyIT = false
 @Field boolean enableNonDefaultSupportedEnvIT = false
 @Field boolean enableExperimentalEnvIT = false
+@Field boolean performRelease = false
+@Field boolean deploySnapshot = false
 
 @Field def jobConfiguration = null
 @Field ScmSource scmSource = null
@@ -221,6 +245,17 @@ ALL_ENV""",
 			])
 	])
 
+	performRelease = (params.RELEASE_VERSION ? true : false)
+
+	if (!performRelease && scmSource.branch.primary && !scmSource.pullRequest) {
+		if (jobConfiguration?.deployment?.maven?.settingsId) {
+			deploySnapshot = true
+		}
+		else {
+			echo "Missing deployment configuration in job configuration file - snapshot deployment will be skipped."
+		}
+	}
+
 	switch (params.INTEGRATION_TESTS) {
 		case 'DEFAULT_ENV_ONLY':
 			enableDefaultEnvIT = true
@@ -267,14 +302,17 @@ ALL_ENV""",
 		enableDefaultEnvLegacyIT = true
 	}
 
-	enableDefaultBuild = enableDefaultEnvIT || enableNonDefaultSupportedEnvIT || enableExperimentalEnvIT
+	enableDefaultBuild =
+			enableDefaultEnvIT || enableNonDefaultSupportedEnvIT || enableExperimentalEnvIT || deploySnapshot
 
-	echo """Integration test setting: $params.INTEGRATION_TESTS, result:
+	echo """Branch: ${scmSource.branch.name}, PR: ${scmSource.pullRequest?.id}, integration test setting: $params.INTEGRATION_TESTS, resulting execution plan:
 enableDefaultBuild=$enableDefaultBuild
 enableDefaultEnvIT=$enableDefaultEnvIT
 enableNonDefaultSupportedEnvIT=$enableNonDefaultSupportedEnvIT
 enableExperimentalEnvIT=$enableExperimentalEnvIT
-enableDefaultEnvLegacyIT=$enableDefaultEnvLegacyIT"""
+enableDefaultEnvLegacyIT=$enableDefaultEnvLegacyIT
+performRelease=$performRelease
+deploySnapshot=$deploySnapshot"""
 
 	allEnvironmentLists.each { envList ->
 		// No need to re-test these environments, they are already tested as part of the default build
@@ -327,7 +365,7 @@ enableDefaultEnvLegacyIT=$enableDefaultEnvLegacyIT"""
 
 	// Compute the version truncated to the minor component, a.k.a. the version family
 	// To be used for the documentation upload in particular
-	if (params.RELEASE_VERSION) {
+	if (performRelease) {
 		def matcher = (params.RELEASE_VERSION =~ versionPattern)
 		if (!matcher.matches()) {
 			throw new IllegalArgumentException(
@@ -367,9 +405,15 @@ stage('Default build') {
 	}
 	node(NODE_PATTERN_BASE) {
 		initWorkspace()
-		withDefaultedMaven {
+		withDefaultedMaven(mavenSettingsConfig: deploySnapshot ? jobConfiguration.deployment.maven.settingsId : null) {
 			sh """ \\
-					mvn clean install -Pdist -Pcoverage -Pjqassistant \\
+					mvn clean \\
+					${deploySnapshot ? """ \\
+							deploy \\
+					""" : """ \\
+							install \\
+					"""} \\
+					-Pdist -Pcoverage -Pjqassistant \\
 					${enableDefaultEnvIT ? '' : '-DskipITs'} \\
 					${enableDefaultEnvLegacyIT ? '-Dsurefire.legacy.skip=false -Dfailsafe.legacy.skip=false' : ''}
 			"""
@@ -515,38 +559,42 @@ stage('Non-default environment ITs') {
 	}
 }
 
-stage('Release') {
-	if (!params.RELEASE_VERSION) {
-		echo "Skipping the release"
+stage('Deploy') {
+	if (deploySnapshot) {
+		// TODO delay the release to this stage? This would require to use staging repositories for snapshots, not sure it's possible.
+		echo "Already deployed snapshot as part of the 'Default build' stage."
+	}
+	else if (performRelease) {
+		echo "Performing full release for version ${params.RELEASE_VERSION}"
+		node(NODE_PATTERN_BASE) {
+			initWorkspace()
+			withDefaultedMaven {
+				sh "git clone https://github.com/hibernate/hibernate-noorm-release-scripts.git"
+				sh "bash -xe hibernate-noorm-release-scripts/prepare-release.sh search ${params.RELEASE_VERSION}"
+
+				if (!params.RELEASE_DRY_RUN) {
+					sh "bash -xe hibernate-noorm-release-scripts/deploy.sh search"
+				} else {
+					echo "WARNING: Not deploying"
+				}
+
+				if (!params.RELEASE_DRY_RUN) {
+					sh "bash -xe hibernate-noorm-release-scripts/upload-distribution.sh search ${params.RELEASE_VERSION}"
+					sh "bash -xe hibernate-noorm-release-scripts/upload-documentation.sh search ${params.RELEASE_VERSION} ${releaseVersionFamily}"
+				}
+				else {
+					echo "WARNING: Not uploading anything"
+				}
+
+				sh "bash -xe hibernate-noorm-release-scripts/update-version.sh search ${params.RELEASE_DEVELOPMENT_VERSION}"
+				sh "bash -xe hibernate-noorm-release-scripts/push-upstream.sh search ${params.RELEASE_VERSION} ${scmSource.branch.name} ${!params.RELEASE_DRY_RUN}"
+			}
+		}
+	}
+	else {
+		echo "Skipping deployment"
 		Utils.markStageSkippedForConditional(STAGE_NAME)
 		return
-	}
-	node(NODE_PATTERN_BASE) {
-		initWorkspace()
-
-		withDefaultedMaven {
-			checkout scm
-
-			sh "git clone https://github.com/hibernate/hibernate-noorm-release-scripts.git"
-			sh "bash -xe hibernate-noorm-release-scripts/prepare-release.sh search ${params.RELEASE_VERSION}"
-
-			if (!params.RELEASE_DRY_RUN) {
-				sh "bash -xe hibernate-noorm-release-scripts/deploy.sh search"
-			} else {
-				echo "WARNING: Not deploying"
-			}
-
-			if (!params.RELEASE_DRY_RUN) {
-				sh "bash -xe hibernate-noorm-release-scripts/upload-distribution.sh search ${params.RELEASE_VERSION}"
-				sh "bash -xe hibernate-noorm-release-scripts/upload-documentation.sh search ${params.RELEASE_VERSION} ${releaseVersionFamily}"
-			}
-			else {
-				echo "WARNING: Not uploading anything"
-			}
-
-			sh "bash -xe hibernate-noorm-release-scripts/update-version.sh search ${params.RELEASE_DEVELOPMENT_VERSION}"
-			sh "bash -xe hibernate-noorm-release-scripts/push-upstream.sh search ${params.RELEASE_VERSION} ${scmSource.branch.name} ${!params.RELEASE_DRY_RUN}"
-		}
 	}
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,9 +69,14 @@ import org.jenkinsci.plugins.credentialsbinding.impl.CredentialNotFoundException
  *
  * ### Job configuration
  *
- * This file gets its configuration from three sources: environment variables, a configuration file, and credentials.
+ * This file gets its configuration from four sources: branch name, environment variables, a configuration file, and credentials.
  * All configuration is optional for the default build (and it should stay that way),
  * but some features require some configuration.
+ *
+ * #### Branch name
+ *
+ * Branches named "master" or matching the regex /[0-9]+.[0-9]+/ will be considered as "primary" branches,
+ * and will undergo additional testing.
  *
  * #### Environment variables
  *
@@ -153,7 +158,7 @@ import org.jenkinsci.plugins.credentialsbinding.impl.CredentialNotFoundException
 @Field boolean enableExperimentalEnvIT = false
 
 @Field def jobConfiguration = null
-@Field String gitHubRepoId = null
+@Field ScmSource scmSource = null
 
 @Field String releaseVersionFamily
 
@@ -171,17 +176,8 @@ stage('Configure') {
 		echo "Job configuration: $jobConfiguration"
 	}
 
-	// See https://stackoverflow.com/a/38255364/6692043
-	def scmUrl = scm.getUserRemoteConfigs()[0].getUrl()
-	def gitHubUrlMatcher = (scmUrl =~ /^(?:git@github.com:|https:\/\/github\.com\/)([^\/]+)\/([^.]+)\.git$/)
-	if (gitHubUrlMatcher.matches()) {
-		String owner = gitHubUrlMatcher.group(1)
-		String name = gitHubUrlMatcher.group(2)
-		gitHubRepoId = owner + '/' + name
-		echo "Detected GitHub repository ID: $gitHubRepoId"
-	} else {
-		echo "Could not detect GitHub repository ID for URL: $scmUrl"
-	}
+	scmSource = new ScmSource(env, scm)
+	echo "SCM source: $scmSource"
 
 	properties([
 			pipelineTriggers([
@@ -244,18 +240,18 @@ ALL_ENV""",
 		case 'AUTOMATIC':
 			if (params.RELEASE_VERSION) {
 				echo "Skipping default build and integration tests to speed up the release of version $params.RELEASE_VERSION"
-			} else if (env.CHANGE_ID) {
-				echo "Enabling only the default build and integration tests in the default environment for pull request $env.CHANGE_ID"
+			} else if (scmSource.pullRequest) {
+				echo "Enabling only the default build and integration tests in the default environment for pull request $scmSource.pullRequest.id"
 				enableDefaultEnvIT = true
-			} else if (env.BRANCH_NAME ==~ /master|\d+\.\d+/) {
-				echo "Enabling integration tests on all supported environments for master or maintenance branch '$env.BRANCH_NAME'"
+			} else if (scmSource.branch.primary) {
+				echo "Enabling integration tests on all supported environments for primary branch '$scmSource.branch.name'"
 				enableDefaultBuild = true
 				enableDefaultEnvIT = true
 				enableNonDefaultSupportedEnvIT = true
-				echo "Enabling legacy integration tests for master or maintenance branch '$env.BRANCH_NAME'"
+				echo "Enabling legacy integration tests for primary branch '$scmSource.branch.name'"
 				enableDefaultEnvLegacyIT = true
 			} else {
-				echo "Enabling only the default build and integration tests in the default environment for feature branch $env.BRANCH_NAME"
+				echo "Enabling only the default build and integration tests in the default environment for feature branch $scmSource.branch.name"
 				enableDefaultBuild = true
 				enableDefaultEnvIT = true
 			}
@@ -385,10 +381,10 @@ stage('Default build') {
 						sh """ \\
 								mvn coveralls:report \\
 								-DrepoToken=${COVERALLS_TOKEN} \\
-								${env.CHANGE_ID ? """ \\
-										-DpullRequest=${env.CHANGE_ID} \\
+								${scmSource.pullRequest ? """ \\
+										-DpullRequest=${scmSource.pullRequest.id} \\
 								""" : """ \\
-										-Dbranch=${env.BRANCH_NAME} \\
+										-Dbranch=${scmSource.branch.name} \\
 								"""} \\
 						"""
 					}
@@ -405,16 +401,16 @@ stage('Default build') {
 								-Dsonar.organization=${sonarOrganization} \\
 								-Dsonar.host.url=https://sonarcloud.io \\
 								-Dsonar.login=${SONARCLOUD_TOKEN} \\
-								${env.CHANGE_ID ? """ \\
-										-Dsonar.pullrequest.branch=${env.BRANCH_NAME} \\
-										-Dsonar.pullrequest.key=${env.CHANGE_ID} \\
-										-Dsonar.pullrequest.base=${env.CHANGE_TARGET} \\
-										${gitHubRepoId ? """ \\
+								${scmSource.pullRequest ? """ \\
+										-Dsonar.pullrequest.branch=${scmSource.branch.name} \\
+										-Dsonar.pullrequest.key=${scmSource.pullRequest.id} \\
+										-Dsonar.pullrequest.base=${scmSource.pullRequest.target.name} \\
+										${scmSource.gitHubRepoId ? """ \\
 												-Dsonar.pullrequest.provider=GitHub \\
-												-Dsonar.pullrequest.github.repository=${gitHubRepoId} \\
+												-Dsonar.pullrequest.github.repository=${scmSource.gitHubRepoId} \\
 										""" : ''} \\
 								""" : """ \\
-										-Dsonar.branch.name=${env.BRANCH_NAME} \\
+										-Dsonar.branch.name=${scmSource.branch.name} \\
 								"""} \\
 						"""
 					}
@@ -546,7 +542,7 @@ stage('Release') {
 			}
 
 			sh "bash -xe hibernate-noorm-release-scripts/update-version.sh search ${params.RELEASE_DEVELOPMENT_VERSION}"
-			sh "bash -xe hibernate-noorm-release-scripts/push-upstream.sh search ${params.RELEASE_VERSION} ${env.BRANCH_NAME} ${!params.RELEASE_DRY_RUN}"
+			sh "bash -xe hibernate-noorm-release-scripts/push-upstream.sh search ${params.RELEASE_VERSION} ${scmSource.branch.name} ${!params.RELEASE_DRY_RUN}"
 		}
 	}
 }
@@ -584,6 +580,64 @@ finally {
 }
 
 // Helpers
+
+class ScmSource {
+	final String remoteUrl
+	final String gitHubRepoId
+	final ScmBranch branch
+	final ScmPullRequest pullRequest
+
+	ScmSource(env, scm) {
+		// See https://stackoverflow.com/a/38255364/6692043
+		remoteUrl = scm.getUserRemoteConfigs()[0].getUrl()
+		def gitHubUrlMatcher = (remoteUrl =~ /^(?:git@github.com:|https:\/\/github\.com\/)([^\/]+)\/([^.]+)\.git$/)
+		if (gitHubUrlMatcher.matches()) {
+			String owner = gitHubUrlMatcher.group(1)
+			String name = gitHubUrlMatcher.group(2)
+			gitHubRepoId = owner + '/' + name
+		}
+		else {
+			gitHubRepoId = null
+		}
+		if (env.CHANGE_ID) {
+			def source = new ScmBranch(name: env.CHANGE_BRANCH)
+			def target = new ScmBranch(name: env.CHANGE_TARGET)
+			pullRequest = new ScmPullRequest(id: env.CHANGE_ID, source: source, target: target)
+			branch = source
+		}
+		else {
+			branch = new ScmBranch(name: env.BRANCH_NAME)
+			pullRequest = null
+		}
+	}
+
+	String toString() {
+		"ScmSource(remoteUrl: $remoteUrl, gitHubRepoId: $gitHubRepoId, branch: $branch, pullRequest: $pullRequest)"
+	}
+}
+
+class ScmBranch {
+	String name
+
+	String toString() { "ScmBranch(name:$name)" }
+
+	/**
+	 * @return Whether this branch is "primary", i.e. it's either "master" or a maintenance branch.
+	 * The purpose of primary branches is to hold the history of a major version of the code,
+	 * whereas the only purpose  of "feature" branches is to eventually be merged into a primary branch.
+	 */
+	boolean isPrimary() {
+		(name ==~ /master|\d+\.\d+/)
+	}
+}
+
+class ScmPullRequest {
+	String id
+	ScmBranch source
+	ScmBranch target
+
+	String toString() { "ScmPullRequest(id: $id, source: $source, target: $target)" }
+}
 
 enum ITEnvironmentStatus {
 	// For environments used as part of the integration tests in the default build (tested on all branches)
@@ -713,7 +767,7 @@ def notifyBuildEnd() {
 
 	// Notify the notification recipients configured on the job,
 	// except in the case of a PR build or of a "success after a success"
-	if (!env.CHANGE_ID && !successAfterSuccess) {
+	if (!scmSource.pullRequest && !successAfterSuccess) {
 		explicitRecipients = jobConfiguration?.notification?.email?.recipients
 	}
 

--- a/build-config/pom.xml
+++ b/build-config/pom.xml
@@ -18,7 +18,7 @@
     <description>Hibernate Search common build configuration files</description>
 
     <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <jqassistant.skip>true</jqassistant.skip>
 

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -31,7 +31,7 @@
         <html.google-analytics.tag-manager.channel>Hibernate</html.google-analytics.tag-manager.channel>
         <html.outdated-content.project-key>${html.meta.project-key}</html.outdated-content.project-key>
 
-        <maven.deploy.skip>true</maven.deploy.skip>
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         <maven.javadoc.skip>true</maven.javadoc.skip>
     </properties>
 

--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -13,7 +13,7 @@
     <description>Parent POM of Hibernate Search integration tests</description>
 
     <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <jqassistant.skip>true</jqassistant.skip>
     </properties>

--- a/legacy/pom.xml
+++ b/legacy/pom.xml
@@ -59,6 +59,9 @@
         <sonar.skip>true</sonar.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <jacoco.skip>true</jacoco.skip>
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+        <!-- The above plus the parent configuration should be enough, but just in case... -->
+        <maven.deploy.skip>true</maven.deploy.skip>
 
         <!-- Dependencies versions -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,10 @@
         <module>integrationtest</module>
         <module>documentation</module>
         <module>legacy</module>
+        <!--
+             WARNING: this MUST be the very last module, in particular when deploying artifacts to a Nexus repository.
+             See this module's POM for more information.
+         -->
         <module>reports</module>
     </modules>
 
@@ -239,7 +243,7 @@
         <version.jar.plugin>3.0.2</version.jar.plugin>
         <version.javadoc.plugin>3.0.0</version.javadoc.plugin>
         <version.jdeps.plugin>0.4.0</version.jdeps.plugin>
-        <version.nexus.plugin>2.1</version.nexus.plugin>
+        <version.nexus-staging.plugin>1.6.8</version.nexus-staging.plugin>
         <version.processor.plugin>3.2.0</version.processor.plugin>
         <version.project-info.plugin>2.9</version.project-info.plugin>
         <version.release.plugin>2.5.3</version.release.plugin>
@@ -280,6 +284,7 @@
 
         <jboss.releases.repo.id>jboss-releases-repository</jboss.releases.repo.id>
         <jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</jboss.releases.repo.url>
+        <jboss.releases.repo.baseUrl>https://repository.jboss.org/nexus/</jboss.releases.repo.baseUrl>
         <jboss.snapshots.repo.id>jboss-snapshots-repository</jboss.snapshots.repo.id>
         <jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>
 
@@ -904,13 +909,40 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Skip the deploy plugin explicitly: we use nexus-staging-maven-plugin instead -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <!--
+                 Configure the nexus-staging-maven-plugin explicitly (without <extension>true</extension>)
+                 in order to work around a problem in the "reports" module (see that module's POM for more info).
+             -->
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-maven-plugin</artifactId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <extensions>false</extensions><!-- This is essential: do not put true here -->
                 <configuration>
-                    <nexusUrl>https://repository.jboss.org/nexus</nexusUrl>
-                    <automatic>true</automatic>
+                    <serverId>${jboss.releases.repo.id}</serverId>
+                    <!-- The following, by default, is only used for actual releases, not for snapshot deployments -->
+                    <nexusUrl>${jboss.releases.repo.baseUrl}</nexusUrl>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>default-deploy</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <!--
+                                 Use the default "deploy" goal in every module, except in the "reports" module where
+                                 this is overridden
+                             -->
+                            <goal>deploy</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -1060,8 +1092,8 @@
                 </plugin>
                 <plugin>
                     <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-maven-plugin</artifactId>
-                    <version>${version.nexus.plugin}</version>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>${version.nexus-staging.plugin}</version>
                 </plugin>
                 <plugin>
                     <groupId>ch.mfrey.maven.plugin</groupId>

--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -18,7 +18,6 @@
     <description>Hibernate Search build reports</description>
 
     <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <!--
              Do NOT skip jqassistant: we want to execute analysis here so as to fail the build if anything is wrong.
@@ -87,6 +86,43 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <!--
+                Hack to deploy in the "reports" module without deploying the "reports" module itself.
+                The default lifecycle bindings of the plugin is to "stage locally" every artifact throughout
+                the maven execution, and only actually deploy the "locally staged" artifacts
+                in the very last executed module, which happens to be this "reports" module.
+                However, this "reports" module does not generate any artifact we want to deploy.
+                Thus, we'd like to prevent even its POM from being deployed: just deploy the "locally staged" artifacts,
+                without adding the POM from the "reports" module to these artifacts.
+                The default lifecycle bindings of the plugin does not offer a configuration option to do that,
+                so we have to explicitly bind it
+             -->
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <extensions>false</extensions>
+                <!-- The <configuration> element is inherited from the parent module. -->
+                <executions>
+                    <!-- Skip the default deployment, as explained above we don't want it. -->
+                    <execution>
+                        <id>default-deploy</id>
+                        <phase>none</phase>
+                    </execution>
+                    <!-- ... but execute the deferred deployment for the other modules -->
+                    <execution>
+                        <id>deferred-deploy</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>deploy-staged</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
     <profiles>
         <profile>

--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -16,6 +16,7 @@
 
     <name>Hibernate Search Reports</name>
     <description>Hibernate Search build reports</description>
+    <packaging>pom</packaging>
 
     <properties>
         <maven.javadoc.skip>true</maven.javadoc.skip>

--- a/util/internal/integrationtest/pom.xml
+++ b/util/internal/integrationtest/pom.xml
@@ -14,7 +14,7 @@
     <description>Parent POM of Hibernate Search integration testing utilities</description>
 
     <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         <maven.javadoc.skip>true</maven.javadoc.skip>
 
         <!--

--- a/util/internal/integrationtest/sharedresources/pom.xml
+++ b/util/internal/integrationtest/sharedresources/pom.xml
@@ -21,7 +21,7 @@
     <description>Contains resources which we want to reuse across multiple modules for integration testing purposes</description>
 
     <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <jqassistant.skip>true</jqassistant.skip>
     </properties>

--- a/util/internal/test/pom.xml
+++ b/util/internal/test/pom.xml
@@ -13,7 +13,7 @@
     <description>Hibernate Search common test utilities</description>
 
     <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         <maven.javadoc.skip>true</maven.javadoc.skip>
 
         <!--


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3340
https://hibernate.atlassian.net//browse/HSEARCH-3334

This PR is twofold:

* First, as part of HSEARCH-3340, I tried to restore something similar to nightly releases for master and maintenance branches. As it turns out, it's easier to just deploy snapshot artifacts as part of the main build, so that's what I did. Apparently the JBoss Nexus removes the older artifacts for a given snapshot version each time we deploy, so this shouldn't cause storage space issues.
* Second, since the snapshot artifact deployment is now done as part of the main build, a failing integration test could lead to a partial deployment: some artifacts are on Nexus, others are not. I had a look at HSEARCH-3334, and it turns out that just using the `nexus-staging-maven-plugin`, which replaces the (apparently useless) `nexus-maven-plugin`, does the trick: it allows us to stage artifacts locally, and only push them to the Nexus repository once every module built successfully.

This brings us one step closer to continuous delivery and proper integration testing, where we would actually test the JARs that we pushed to the staging repository, instead of what we do currently (build a first time, test, then build a second time and release). While we're still far from it, and I don't intend to actively work toward it for now, I still think it's nice to at least clear the way.

Regarding the Maven configuration, I tested both the snapshot deployment (on a local Nexus) and the non-snapshot deployment (with remote staging, on the JBoss Nexus). It worked as expected.
Regarding the pipeline, I tested snapshot deployment and it worked well too: http://ci.hibernate.org/blue/organizations/jenkins/hibernate-search-yoann/detail/ci-test-this-please/12/pipeline/23 (don't mind the subsequent IT failures, they are unrelated).