### PR TITLE
 HSEARCH-3377 +  HSEARCH-3362 +  HSEARCH-3226 + HSEARCH-3151 : JDK10 build compatibility on master branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -147,9 +147,9 @@ import org.jenkinsci.plugins.credentialsbinding.impl.CredentialNotFoundException
 @Field final List<JdkITEnvironment> jdkEnvs = [
 		// This should not include every JDK; in particular let's not care too much about EOL'd JDKs like version 9
 		// See http://www.oracle.com/technetwork/java/javase/eol-135779.html
-		// TODO add support for JDK10/JDK11
 		new JdkITEnvironment(version: '8', tool: 'Oracle JDK 8', status: ITEnvironmentStatus.USED_IN_DEFAULT_BUILD),
-		new JdkITEnvironment(version: '10', tool: 'Oracle JDK 10.0.1', status: ITEnvironmentStatus.EXPERIMENTAL),
+		new JdkITEnvironment(version: '10', tool: 'Oracle JDK 10.0.1', status: ITEnvironmentStatus.SUPPORTED),
+		// TODO HSEARCH-3238 (and maybe more) to support JDK11 builds
 		new JdkITEnvironment(version: '11', tool: 'OpenJDK 11 Latest', status: ITEnvironmentStatus.EXPERIMENTAL)
 ]
 @Field JdkITEnvironment defaultJdkEnv

--- a/build-config/src/main/resources/forbidden-runtime.txt
+++ b/build-config/src/main/resources/forbidden-runtime.txt
@@ -32,5 +32,4 @@ org.hibernate.SharedSessionContract#getTransaction() @ Using this method is ofte
 ################################################################################################################
 # Use our Contracts class instead
 com.google.common.base.Preconditions @ Use our Contracts class instead
-java.util.Objects#requireNonNull(java.lang.Object) @ Use our Contracts class instead
 java.util.Objects#requireNonNull(java.lang.Object, java.lang.String) @ Use our Contracts class instead

--- a/legacy/integrationtest/osgi/karaf-features/src/main/features/features.xml
+++ b/legacy/integrationtest/osgi/karaf-features/src/main/features/features.xml
@@ -14,6 +14,8 @@
 
         <!-- JTA -->
         <bundle dependency="true" start-level="30">mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/1.1.1</bundle>
+        <bundle start-level="30">mvn:org.apache.aries.proxy/org.apache.aries.proxy/1.0.0</bundle>
+        <bundle start-level="30">mvn:org.apache.aries.blueprint/org.apache.aries.blueprint/1.0.0</bundle>
         <bundle start-level="30">mvn:org.apache.aries.transaction/org.apache.aries.transaction.blueprint/1.0.0</bundle>
         <bundle start-level="30">mvn:org.apache.aries.transaction/org.apache.aries.transaction.manager/1.0.1</bundle>
 

--- a/legacy/integrationtest/osgi/karaf-it/pom.xml
+++ b/legacy/integrationtest/osgi/karaf-it/pom.xml
@@ -151,12 +151,6 @@
     </dependencies>
 
     <build>
-        <testResources>
-            <testResource>
-                <filtering>true</filtering>
-                <directory>src/test/resources</directory>
-            </testResource>
-        </testResources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -176,6 +170,12 @@
 
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <maven.settings.localRepository>${settings.localRepository}</maven.settings.localRepository>
+                        <pax-exam.jvm.args>${pax-exam.jvm.args}</pax-exam.jvm.args>
+                    </systemPropertyVariables>
+                </configuration>
                 <executions>
                     <execution>
                         <id>verify</id>

--- a/legacy/integrationtest/osgi/karaf-it/src/test/java/org/hibernate/search/test/integration/osgi/HibernateSearchWithKarafIT.java
+++ b/legacy/integrationtest/osgi/karaf-it/src/test/java/org/hibernate/search/test/integration/osgi/HibernateSearchWithKarafIT.java
@@ -172,10 +172,15 @@ public class HibernateSearchWithKarafIT {
 						"rmiRegistryHost", "127.0.0.1"
 				),
 				// set the log level for the in container logging to INFO
-				// also just logging to file (out), check data/log/karaf.log w/i the Karaf installation for the test execution log
 				editConfigurationFilePut(
 						"etc/org.ops4j.pax.logging.cfg",
-						"log4j.rootLogger", "INFO, out"
+						"log4j2.rootLogger.level", "INFO"
+				),
+				// also log to the console, so that failsafe can capture the logs in the test output file
+				editConfigurationFilePut(
+						"etc/org.ops4j.pax.logging.cfg",
+						"log4j2.rootLogger.appenderRef.Console.filter.threshold.level",
+						"TRACE" // Means "whatever the root logger level is"
 				),
 				/*
 				 * Use the same local Maven repository as the build job.

--- a/legacy/integrationtest/osgi/karaf-it/src/test/resources/maven.properties
+++ b/legacy/integrationtest/osgi/karaf-it/src/test/resources/maven.properties
@@ -1,3 +1,0 @@
-# This file contains properties that should be filtered by Maven
-maven.settings.localRepository=${settings.localRepository}
-pax-exam.jvm.args=${pax-exam.jvm.args}

--- a/legacy/pom.xml
+++ b/legacy/pom.xml
@@ -176,9 +176,9 @@
         <version.org.springframework.boot>1.5.3.RELEASE</version.org.springframework.boot>
 
         <!-- >>> OSGi ITs with Karaf-->
-        <version.org.apache.karaf>4.1.2</version.org.apache.karaf>
-        <version.org.ops4j.pax.exam>4.11.0</version.org.ops4j.pax.exam>
-        <version.org.ops4j.pax.url>1.6.0</version.org.ops4j.pax.url>
+        <version.org.apache.karaf>4.2.1</version.org.apache.karaf>
+        <version.org.ops4j.pax.exam>4.12.0</version.org.ops4j.pax.exam>
+        <version.org.ops4j.pax.url>2.5.4</version.org.ops4j.pax.url>
 
         <!-- >>> JSR-352 ITs -->
         <version.com.ibm.jbatch>1.0</version.com.ibm.jbatch>

--- a/mapper/orm/pom.xml
+++ b/mapper/orm/pom.xml
@@ -86,4 +86,61 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>jdk9</id>
+            <activation>
+                <jdk>9</jdk>
+            </activation>
+            <!-- Explicit JAXB/javax.xml.bind dependencies: to be removed in HSEARCH-3376 -->
+            <dependencies>
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>jaxb-runtime</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jdk10</id>
+            <activation>
+                <jdk>10</jdk>
+            </activation>
+            <!-- Explicit JAXB/javax.xml.bind dependencies: to be removed in HSEARCH-3376 -->
+            <dependencies>
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>jaxb-runtime</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jdk11</id>
+            <activation>
+                <jdk>11</jdk>
+            </activation>
+            <!-- Explicit JAXB/javax.xml.bind dependencies: to be removed in HSEARCH-3376 -->
+            <dependencies>
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>jaxb-runtime</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,13 @@
         <javadoc.org.hibernate.url>http://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.majorVersion}.${parsed-version.org.hibernate.minorVersion}/javadocs/</javadoc.org.hibernate.url>
         <version.org.hibernate.commons.annotations>5.0.4.Final</version.org.hibernate.commons.annotations>
         <version.javax.persistence>2.2</version.javax.persistence>
+        <!--
+            Explicit JAXB/javax.xml.bind dependencies: to be removed in HSEARCH-3376
+            Using JAXB 2.3.0 as 2.2.11 seems to be broken in more than a few ways.
+            In particular version 2.2.11 of the impl depends on version 2.2.12-b140109.1041 of the API.
+         -->
+        <version.javax.xml.bind.jaxb-api>2.3.0</version.javax.xml.bind.jaxb-api>
+        <version.org.glassfish.jaxb>2.3.0.1</version.org.glassfish.jaxb>
 
         <!-- >>> JSR 352 -->
         <version.javax.batch>1.0</version.javax.batch>
@@ -747,6 +754,18 @@
                 <groupId>org.apache.lucene</groupId>
                 <artifactId>lucene-sandbox</artifactId>
                 <version>${version.org.apache.lucene}</version>
+            </dependency>
+
+            <!-- To be removed in HSEARCH-3376 -->
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${version.javax.xml.bind.jaxb-api}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
+                <version>${version.org.glassfish.jaxb}</version>
             </dependency>
 
             <!-- Test -->

--- a/pom.xml
+++ b/pom.xml
@@ -401,8 +401,9 @@
         </arquillian.wildfly.jvm.args.jbossmodules>
         <arquillian.wildfly.jvm.args>${arquillian.wildfly.jvm.args.java-version} ${arquillian.wildfly.jvm.args.jacoco} ${arquillian.wildfly.jvm.args.jbossmodules}</arquillian.wildfly.jvm.args>
 
+        <pax-exam.jvm.args.java-version></pax-exam.jvm.args.java-version>
         <pax-exam.jvm.args.jacoco></pax-exam.jvm.args.jacoco>
-        <pax-exam.jvm.args>${pax-exam.jvm.args.jacoco}</pax-exam.jvm.args>
+        <pax-exam.jvm.args>${pax-exam.jvm.args.java-version} ${pax-exam.jvm.args.jacoco}</pax-exam.jvm.args>
 
         <!--
             The path to a single merged JaCoCo coverage file including all of the coverage data for all modules.
@@ -1686,6 +1687,9 @@
                 <arquillian.wildfly.jvm.args.java-version>
                     -Djdk.attach.allowAttachSelf=true
                 </arquillian.wildfly.jvm.args.java-version>
+                <pax-exam.jvm.args.java-version>
+                    --add-modules=java.xml.bind
+                </pax-exam.jvm.args.java-version>
             </properties>
             <modules>
                 <!-- Nothing at the moment -->
@@ -1708,6 +1712,9 @@
                 <arquillian.wildfly.jvm.args.java-version>
                     -Djdk.attach.allowAttachSelf=true
                 </arquillian.wildfly.jvm.args.java-version>
+                <pax-exam.jvm.args.java-version>
+                    --add-modules=java.xml.bind
+                </pax-exam.jvm.args.java-version>
             </properties>
             <modules>
                 <!-- Nothing at the moment -->

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
         <version.org.slf4j>1.7.25</version.org.slf4j>
         <version.log4j>1.2.16</version.log4j>
         <version.junit>4.12</version.junit>
-        <version.org.easymock>3.5.1</version.org.easymock>
+        <version.org.easymock>3.6</version.org.easymock>
         <version.org.unitils>3.4.6</version.org.unitils>
         <version.org.assertj.assertj-core>3.9.1</version.org.assertj.assertj-core>
         <version.org.skyscreamer.jsonassert>1.2.3</version.org.skyscreamer.jsonassert>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3377
https://hibernate.atlassian.net/browse/HSEARCH-3362 
https://hibernate.atlassian.net/browse/HSEARCH-3226 (follow-up on #1708)
https://hibernate.atlassian.net/browse/HSEARCH-3151

So, this is just a matter of making the build compatible with JDK10 again, following the merge of Search 6 code into master. This also happens to solve most issues preventing the build from passing with JDK11, though [there is still some work to do](https://hibernate.atlassian.net/browse/HSEARCH-3238)

See [this build](http://ci.hibernate.org/blue/organizations/jenkins/hibernate-search-yoann/detail/jdk10/5/pipeline/51) for a proof the JDK10 build now passes.

Note that legacy ITs also pass with JDK10, but we don't execute them in JDK10/JDK11 builds on CI. I'll send a dedicated PR to update the 5.10 branch.