### PR TITLE
Backport to 5.10:  HSEARCH-3377 + HSEARCH-3151 - JDK10 build compatibility

### DIFF
--- a/integrationtest/osgi/karaf-features/src/main/features/features.xml
+++ b/integrationtest/osgi/karaf-features/src/main/features/features.xml
@@ -14,6 +14,8 @@
 
         <!-- JTA -->
         <bundle dependency="true" start-level="30">mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/1.1.1</bundle>
+        <bundle start-level="30">mvn:org.apache.aries.proxy/org.apache.aries.proxy/1.0.0</bundle>
+        <bundle start-level="30">mvn:org.apache.aries.blueprint/org.apache.aries.blueprint/1.0.0</bundle>
         <bundle start-level="30">mvn:org.apache.aries.transaction/org.apache.aries.transaction.blueprint/1.0.0</bundle>
         <bundle start-level="30">mvn:org.apache.aries.transaction/org.apache.aries.transaction.manager/1.0.1</bundle>
 

--- a/integrationtest/osgi/karaf-it/pom.xml
+++ b/integrationtest/osgi/karaf-it/pom.xml
@@ -151,12 +151,6 @@
     </dependencies>
 
     <build>
-        <testResources>
-            <testResource>
-                <filtering>true</filtering>
-                <directory>src/test/resources</directory>
-            </testResource>
-        </testResources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -176,6 +170,12 @@
 
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <maven.settings.localRepository>${settings.localRepository}</maven.settings.localRepository>
+                        <pax-exam.jvm.args>${pax-exam.jvm.args}</pax-exam.jvm.args>
+                    </systemPropertyVariables>
+                </configuration>
                 <executions>
                     <execution>
                         <id>verify</id>

--- a/integrationtest/osgi/karaf-it/src/test/java/org/hibernate/search/test/integration/osgi/HibernateSearchWithKarafIT.java
+++ b/integrationtest/osgi/karaf-it/src/test/java/org/hibernate/search/test/integration/osgi/HibernateSearchWithKarafIT.java
@@ -172,10 +172,15 @@ public class HibernateSearchWithKarafIT {
 						"rmiRegistryHost", "127.0.0.1"
 				),
 				// set the log level for the in container logging to INFO
-				// also just logging to file (out), check data/log/karaf.log w/i the Karaf installation for the test execution log
 				editConfigurationFilePut(
 						"etc/org.ops4j.pax.logging.cfg",
-						"log4j.rootLogger", "INFO, out"
+						"log4j2.rootLogger.level", "INFO"
+				),
+				// also log to the console, so that failsafe can capture the logs in the test output file
+				editConfigurationFilePut(
+						"etc/org.ops4j.pax.logging.cfg",
+						"log4j2.rootLogger.appenderRef.Console.filter.threshold.level",
+						"TRACE" // Means "whatever the root logger level is"
 				),
 				/*
 				 * Use the same local Maven repository as the build job.

--- a/integrationtest/osgi/karaf-it/src/test/resources/maven.properties
+++ b/integrationtest/osgi/karaf-it/src/test/resources/maven.properties
@@ -1,3 +1,0 @@
-# This file contains properties that should be filtered by Maven
-maven.settings.localRepository=${settings.localRepository}
-pax-exam.jvm.args=${pax-exam.jvm.args}

--- a/pom.xml
+++ b/pom.xml
@@ -418,8 +418,9 @@
         </arquillian.wildfly.jvm.args.jbossmodules>
         <arquillian.wildfly.jvm.args>${arquillian.wildfly.jvm.args.java-version} ${arquillian.wildfly.jvm.args.jacoco} ${arquillian.wildfly.jvm.args.jbossmodules}</arquillian.wildfly.jvm.args>
 
+        <pax-exam.jvm.args.java-version></pax-exam.jvm.args.java-version>
         <pax-exam.jvm.args.jacoco></pax-exam.jvm.args.jacoco>
-        <pax-exam.jvm.args>${pax-exam.jvm.args.jacoco}</pax-exam.jvm.args>
+        <pax-exam.jvm.args>${pax-exam.jvm.args.java-version} ${pax-exam.jvm.args.jacoco}</pax-exam.jvm.args>
 
         <!-- JDK version required for the build; we target 1.8 since Hibernate ORM 5.3 requires Java 8 -->
         <jdk.min.version>${maven.compiler.argument.source}</jdk.min.version>
@@ -2000,6 +2001,9 @@
                 <arquillian.wildfly.jvm.args.java-version>
                     -Djdk.attach.allowAttachSelf=true
                 </arquillian.wildfly.jvm.args.java-version>
+                <pax-exam.jvm.args.java-version>
+                    --add-modules=java.xml.bind
+                </pax-exam.jvm.args.java-version>
             </properties>
             <modules>
                 <module>integrationtest/jdk9-modules</module>
@@ -2022,6 +2026,9 @@
                 <arquillian.wildfly.jvm.args.java-version>
                     -Djdk.attach.allowAttachSelf=true
                 </arquillian.wildfly.jvm.args.java-version>
+                <pax-exam.jvm.args.java-version>
+                    --add-modules=java.xml.bind
+                </pax-exam.jvm.args.java-version>
             </properties>
             <modules>
                 <module>integrationtest/jdk9-modules</module>

--- a/pom.xml
+++ b/pom.xml
@@ -274,9 +274,9 @@
         <version.org.jboss.shrinkwrap.resolver>2.2.2</version.org.jboss.shrinkwrap.resolver>
         <version.org.wildfly.arquillian>2.0.0.Final</version.org.wildfly.arquillian>
         <version.org.springframework.boot>1.5.3.RELEASE</version.org.springframework.boot>
-        <version.org.apache.karaf>4.1.2</version.org.apache.karaf>
-        <version.org.ops4j.pax.exam>4.11.0</version.org.ops4j.pax.exam>
-        <version.org.ops4j.pax.url>1.6.0</version.org.ops4j.pax.url>
+        <version.org.apache.karaf>4.2.1</version.org.apache.karaf>
+        <version.org.ops4j.pax.exam>4.12.0</version.org.ops4j.pax.exam>
+        <version.org.ops4j.pax.url>2.5.4</version.org.ops4j.pax.url>
         <version.jpa22.wildfly-patch>1.0.0.Beta2</version.jpa22.wildfly-patch>
         <test.jpa22.wildfly-patch.filename>hibernate-jpa-api-2.2-wildflymodules-${version.jpa22.wildfly-patch}-wildfly-${version.wildfly}-patch.zip</test.jpa22.wildfly-patch.filename>
         <!-- Necessary for OSGi integration tests with Karaf -->

--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
         <!-- Test dependencies -->
 
         <version.junit>4.12</version.junit>
-        <version.org.easymock>3.5.1</version.org.easymock>
+        <version.org.easymock>3.6</version.org.easymock>
         <version.org.unitils>3.4.6</version.org.unitils>
         <version.simple-jndi>0.11.4.1</version.simple-jndi>
         <version.org.assertj.assertj-core>3.9.1</version.org.assertj.assertj-core>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3377
https://hibernate.atlassian.net/browse/HSEARCH-3151

This PR is a backport of #1750 , which should be reviewed and merged first.

After this PR, the entire build passes with JDK10, proving for good that we already had JDK10 compatibility. I ran the tests locally.

As to JDK11, there is still some work to do: [HSEARCH-3238](https://hibernate.atlassian.net/browse/HSEARCH-3238), [HSEARCH-3380](https://hibernate.atlassian.net/browse/HSEARCH-3380).