### PR TITLE
HSEARCH-3335 Search 6 groundwork - Restore the distribution module

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -12,7 +12,7 @@
         <artifactId>hibernate-search-legacy-parent</artifactId>
         <groupId>org.hibernate</groupId>
         <version>6.0.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../legacy/pom.xml</relativePath>
     </parent>
 
     <artifactId>hibernate-search-distribution</artifactId>
@@ -129,15 +129,15 @@
                         <id>generate-javadoc</id>
                         <configuration>
                             <sourcepath>
-                                ${basedir}/../engine/src/main/java;
-                                ${basedir}/../orm/src/main/java;
-                                ${basedir}/../serialization/avro/src/main/java;
-                                ${basedir}/../backends/jgroups/src/main/java;
-                                ${basedir}/../backends/jms/src/main/java;
-                                ${basedir}/../elasticsearch/src/main/java;
-                                ${basedir}/../elasticsearch-aws/src/main/java;
-                                ${basedir}/../jsr352/core/src/main/java;
-                                ${basedir}/../jsr352/jberet/src/main/java;
+                                ${basedir}/../legacy/engine/src/main/java;
+                                ${basedir}/../legacy/orm/src/main/java;
+                                ${basedir}/../legacy/serialization/avro/src/main/java;
+                                ${basedir}/../legacy/backends/jgroups/src/main/java;
+                                ${basedir}/../legacy/backends/jms/src/main/java;
+                                ${basedir}/../legacy/elasticsearch/src/main/java;
+                                ${basedir}/../legacy/elasticsearch-aws/src/main/java;
+                                ${basedir}/../legacy/jsr352/core/src/main/java;
+                                ${basedir}/../legacy/jsr352/jberet/src/main/java;
                             </sourcepath>
                             <docfilessubdirs>true</docfilessubdirs>
                             <packagesheader>Hibernate Search Packages</packagesheader>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -26,33 +26,48 @@
     </properties>
 
     <dependencies>
-        <!-- The modules to include in the distribution. Any non-optional/provided dependencies will
-                     automatically be included as well -->
+        <!--
+             Add dependencies to the modules included in the assembly,
+             in order to make sure that these modules are built before the distribution module.
+             WARNING: All dependencies must have the "provided" scope, in order for the <moduleSet> mechanism
+             to work correctly.
+             If any of the dependencies has a "compile" or "runtime" scope, the maven-dependency plugin
+             will consider that this dependency should be added to every <dependencySet> in every <moduleSet>,
+             and we'll end up with a completely bloated assembly.
+         -->
         <dependency>
             <groupId>org.hibernate.search</groupId>
             <artifactId>hibernate-search-engine</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.hibernate.search</groupId>
             <artifactId>hibernate-search-orm</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.hibernate.search</groupId>
             <artifactId>hibernate-search-backend-lucene</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.hibernate.search</groupId>
             <artifactId>hibernate-search-backend-elasticsearch</artifactId>
+            <scope>provided</scope>
         </dependency>
-
-        <!-- Making sure the docs get build prior to running the assembly -->
         <dependency>
             <groupId>org.hibernate.search</groupId>
             <artifactId>hibernate-search-documentation</artifactId>
+            <scope>provided</scope>
             <type>pom</type>
         </dependency>
 
-        <!-- Need to list out optional/provided dependencies here again in order to include them via assembly dependency set -->
+        <!--
+             Need to list out optional/provided dependencies here again in order
+             to include them via assembly dependency set.
+             WARNING: All dependencies must have the "provided" scope, in order for the <moduleSet> mechanism
+             to work correctly. See the comment above for details.
+         -->
         <dependency>
             <groupId>org.jboss.spec.javax.annotation</groupId>
             <artifactId>jboss-annotations-api_1.2_spec</artifactId>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -9,10 +9,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <artifactId>hibernate-search-legacy-parent</artifactId>
-        <groupId>org.hibernate</groupId>
+        <artifactId>hibernate-search-parent</artifactId>
+        <groupId>org.hibernate.search</groupId>
         <version>6.0.0-SNAPSHOT</version>
-        <relativePath>../legacy/pom.xml</relativePath>
     </parent>
 
     <artifactId>hibernate-search-distribution</artifactId>
@@ -30,59 +29,30 @@
         <!-- The modules to include in the distribution. Any non-optional/provided dependencies will
                      automatically be included as well -->
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.search</groupId>
             <artifactId>hibernate-search-engine</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.search</groupId>
             <artifactId>hibernate-search-orm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-backend-lucene</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-backend-elasticsearch</artifactId>
         </dependency>
 
         <!-- Making sure the docs get build prior to running the assembly -->
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.search</groupId>
             <artifactId>hibernate-search-documentation</artifactId>
             <type>pom</type>
         </dependency>
 
         <!-- Need to list out optional/provided dependencies here again in order to include them via assembly dependency set -->
-        <dependency>
-            <groupId>org.apache.tika</groupId>
-            <artifactId>tika-parsers</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-search-serialization-avro</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-search-elasticsearch</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-search-elasticsearch-aws</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-search-backend-jms</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-search-backend-jgroups</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-search-jsr352-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-search-jsr352-jberet</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.spec.javax.jms</groupId>
-            <artifactId>jboss-jms-api_2.0_spec</artifactId>
-            <scope>provided</scope>
-        </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.annotation</groupId>
             <artifactId>jboss-annotations-api_1.2_spec</artifactId>
@@ -129,15 +99,12 @@
                         <id>generate-javadoc</id>
                         <configuration>
                             <sourcepath>
-                                ${basedir}/../legacy/engine/src/main/java;
-                                ${basedir}/../legacy/orm/src/main/java;
-                                ${basedir}/../legacy/serialization/avro/src/main/java;
-                                ${basedir}/../legacy/backends/jgroups/src/main/java;
-                                ${basedir}/../legacy/backends/jms/src/main/java;
-                                ${basedir}/../legacy/elasticsearch/src/main/java;
-                                ${basedir}/../legacy/elasticsearch-aws/src/main/java;
-                                ${basedir}/../legacy/jsr352/core/src/main/java;
-                                ${basedir}/../legacy/jsr352/jberet/src/main/java;
+                                ${basedir}/../engine/src/main/java;
+                                ${basedir}/../util/internal/common/src/main/java;
+                                ${basedir}/../mapper/pojo/src/main/java;
+                                ${basedir}/../mapper/orm/src/main/java;
+                                ${basedir}/../backend/elasticsearch/src/main/java;
+                                ${basedir}/../backend/lucene/src/main/java;
                             </sourcepath>
                             <docfilessubdirs>true</docfilessubdirs>
                             <packagesheader>Hibernate Search Packages</packagesheader>

--- a/distribution/src/main/assembly/dist.xml
+++ b/distribution/src/main/assembly/dist.xml
@@ -173,28 +173,28 @@
 
     <files>
         <file>
-            <source>../../README.md</source>
+            <source>../README.md</source>
             <outputDirectory></outputDirectory>
             <filtered>true</filtered>
         </file>
         <file>
-            <source>../../CONTRIBUTING.md</source>
+            <source>../CONTRIBUTING.md</source>
             <outputDirectory></outputDirectory>
         </file>
         <file>
-            <source>../../lgpl.txt</source>
+            <source>../lgpl.txt</source>
             <outputDirectory></outputDirectory>
         </file>
         <file>
-            <source>../../changelog.txt</source>
+            <source>../changelog.txt</source>
             <outputDirectory></outputDirectory>
         </file>
         <file>
-            <source>../../copyright.txt</source>
+            <source>../copyright.txt</source>
             <outputDirectory></outputDirectory>
         </file>
         <file>
-            <source>../infinispan/moved.txt</source>
+            <source>../legacy/infinispan/moved.txt</source>
             <!-- The following path is where we used to distribute the Infinispan integration -->
             <outputDirectory>dist/lib/optional/clustering/directory-infinispan</outputDirectory>
         </file>
@@ -233,6 +233,9 @@
                 <exclude>**/*.iml</exclude>
                 <exclude>atlassian-ide-plugin.xml</exclude>
                 <exclude>.sonar-ide.properties</exclude>
+                <exclude>Jenkinsfile</exclude>
+                <exclude>jenkins/**</exclude>
+                <exclude>.empty/**</exclude>
             </excludes>
         </fileSet>
 

--- a/distribution/src/main/assembly/dist.xml
+++ b/distribution/src/main/assembly/dist.xml
@@ -25,82 +25,45 @@
     </formats>
 
     <!-- Configure the module artifacts which make it into the distribution bundle -->
-    <!-- first the actual project artifacts -->
     <dependencySets>
         <dependencySet>
-            <outputDirectory>dist</outputDirectory>
-            <includes>
-                <include>org.hibernate:hibernate-search-engine</include>
-                <include>org.hibernate:hibernate-search-orm</include>
-            </includes>
-        </dependencySet>
-
-        <dependencySet>
-            <outputDirectory>dist/lib/required</outputDirectory>
+            <outputDirectory>dist/engine</outputDirectory>
             <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
             <useTransitiveDependencies>true</useTransitiveDependencies>
             <useTransitiveFiltering>true</useTransitiveFiltering>
             <includes>
-                <!-- hibernate-search-engine -->
-                <include>org.apache.lucene:lucene-core</include>
-                <include>org.apache.lucene:lucene-queryparser</include>
-                <include>org.hibernate.common:hibernate-commons-annotations</include>
-                <include>org.jboss.logging:jboss-logging</include>
-
-                <!-- hibernate-search-orm -->
-                <include>org.hibernate:hibernate-core</include>
-                <include>dom4j:dom4j</include>
-                <include>org.javassist:javassist</include>
+                <include>org.hibernate.search:hibernate-search-engine</include>
             </includes>
-            <excludes>
-                <exclude>org.jboss:jandex</exclude>
-            </excludes>
         </dependencySet>
 
         <dependencySet>
-            <outputDirectory>dist/lib/optional/analyzers</outputDirectory>
+            <outputDirectory>dist/mapper/orm</outputDirectory>
             <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
             <useTransitiveDependencies>true</useTransitiveDependencies>
             <useTransitiveFiltering>true</useTransitiveFiltering>
             <includes>
-                <include>org.apache.lucene:lucene-analyzers</include>
+                <include>org.hibernate.search:hibernate-search-orm</include>
+                <include>org.hibernate.search:hibernate-search-mapper-pojo</include>
             </includes>
         </dependencySet>
 
         <dependencySet>
-            <outputDirectory>dist/lib/optional/tika</outputDirectory>
+            <outputDirectory>dist/backend/lucene</outputDirectory>
             <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
             <useTransitiveDependencies>true</useTransitiveDependencies>
             <useTransitiveFiltering>true</useTransitiveFiltering>
             <includes>
-                <include>org.apache.tika:tika-parsers</include>
+                <include>org.hibernate.search:hibernate-search-backend-lucene</include>
             </includes>
         </dependencySet>
 
         <dependencySet>
-            <outputDirectory>dist/lib/optional/clustering/backend-jgroups</outputDirectory>
+            <outputDirectory>dist/backend/elasticsearch</outputDirectory>
             <scope>runtime</scope>
-            <useTransitiveDependencies>true</useTransitiveDependencies>
-            <useTransitiveFiltering>true</useTransitiveFiltering>
-            <includes>
-                <include>org.hibernate:hibernate-search-backend-jgroups</include>
-                <include>org.jgroups:jgroups</include>
-            </includes>
-        </dependencySet>
-
-        <dependencySet>
-            <outputDirectory>dist/lib/optional/clustering/backend-jms</outputDirectory>
-            <scope>runtime</scope>
-            <useTransitiveDependencies>true</useTransitiveDependencies>
-            <useTransitiveFiltering>true</useTransitiveFiltering>
-            <includes>
-                <include>org.hibernate:hibernate-search-backend-jms</include>
-            </includes>
-        </dependencySet>
-
-        <dependencySet>
-            <outputDirectory>dist/lib/optional/elasticsearch</outputDirectory>
-            <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
             <useTransitiveDependencies>true</useTransitiveDependencies>
             <useTransitiveFiltering>true</useTransitiveFiltering>
             <includes>
@@ -109,57 +72,16 @@
                     because of a bug in maven-assembly-plugin.
                     See https://issues.apache.org/jira/browse/MASSEMBLY-865
                  -->
-                <include>org.hibernate:hibernate-search-elasticsearch:*</include>
+                <include>org.hibernate.search:hibernate-search-backend-elasticsearch:*</include>
             </includes>
         </dependencySet>
 
         <dependencySet>
-            <outputDirectory>dist/lib/optional/elasticsearch-aws</outputDirectory>
-            <scope>runtime</scope>
-            <useTransitiveDependencies>true</useTransitiveDependencies>
-            <useTransitiveFiltering>true</useTransitiveFiltering>
-            <includes>
-                <include>org.hibernate:hibernate-search-elasticsearch-aws</include>
-            </includes>
-        </dependencySet>
-
-        <dependencySet>
-            <outputDirectory>dist/lib/optional/clustering/serialization-avro</outputDirectory>
-            <scope>runtime</scope>
-            <useTransitiveDependencies>true</useTransitiveDependencies>
-            <useTransitiveFiltering>true</useTransitiveFiltering>
-            <includes>
-                <include>org.hibernate:hibernate-search-serialization-avro</include>
-                <include>org.apache.avro:avro</include>
-            </includes>
-        </dependencySet>
-
-        <dependencySet>
-            <outputDirectory>dist/lib/optional/jsr352-core</outputDirectory>
-            <scope>runtime</scope>
-            <useTransitiveDependencies>true</useTransitiveDependencies>
-            <useTransitiveFiltering>true</useTransitiveFiltering>
-            <includes>
-                <include>org.hibernate:hibernate-search-jsr352-core</include>
-            </includes>
-        </dependencySet>
-
-        <dependencySet>
-            <outputDirectory>dist/lib/optional/jsr352-jberet</outputDirectory>
-            <scope>runtime</scope>
-            <useTransitiveDependencies>true</useTransitiveDependencies>
-            <useTransitiveFiltering>true</useTransitiveFiltering>
-            <includes>
-                <include>org.hibernate:hibernate-search-jsr352-jberet</include>
-            </includes>
-        </dependencySet>
-
-        <dependencySet>
-            <useProjectArtifact>false</useProjectArtifact>
-            <outputDirectory>/dist/lib/provided</outputDirectory>
+            <outputDirectory>dist/provided</outputDirectory>
             <scope>provided</scope>
+            <useProjectArtifact>false</useProjectArtifact>
+            <useTransitiveDependencies>false</useTransitiveDependencies>
             <includes>
-                <include>org.jboss.spec.javax.jms:*</include>
                 <include>org.jboss.spec.javax.annotation:*</include>
                 <include>javax.persistence:javax.persistence-api</include>
                 <include>org.jboss.spec.javax.transaction:*</include>
@@ -168,7 +90,6 @@
                 <include>javax.enterprise:cdi-api</include>
             </includes>
         </dependencySet>
-
     </dependencySets>
 
     <files>
@@ -193,18 +114,13 @@
             <source>../copyright.txt</source>
             <outputDirectory></outputDirectory>
         </file>
-        <file>
-            <source>../legacy/infinispan/moved.txt</source>
-            <!-- The following path is where we used to distribute the Infinispan integration -->
-            <outputDirectory>dist/lib/optional/clustering/directory-infinispan</outputDirectory>
-        </file>
     </files>
 
     <fileSets>
         <!-- Include all sources -->
         <fileSet>
             <directory>..</directory>
-            <outputDirectory>project</outputDirectory>
+            <outputDirectory>src</outputDirectory>
             <useDefaultExcludes>true</useDefaultExcludes>
             <excludes>
                 <!-- we already have these files at the top level of the distribution -->

--- a/distribution/src/main/assembly/dist.xml
+++ b/distribution/src/main/assembly/dist.xml
@@ -35,6 +35,7 @@
             <includes>
                 <include>org.hibernate.search:hibernate-search-engine</include>
             </includes>
+            <useStrictFiltering>true</useStrictFiltering>
         </dependencySet>
 
         <dependencySet>
@@ -47,6 +48,7 @@
                 <include>org.hibernate.search:hibernate-search-orm</include>
                 <include>org.hibernate.search:hibernate-search-mapper-pojo</include>
             </includes>
+            <useStrictFiltering>true</useStrictFiltering>
         </dependencySet>
 
         <dependencySet>
@@ -58,6 +60,7 @@
             <includes>
                 <include>org.hibernate.search:hibernate-search-backend-lucene</include>
             </includes>
+            <useStrictFiltering>true</useStrictFiltering>
         </dependencySet>
 
         <dependencySet>
@@ -74,6 +77,7 @@
                  -->
                 <include>org.hibernate.search:hibernate-search-backend-elasticsearch:*</include>
             </includes>
+            <useStrictFiltering>true</useStrictFiltering>
         </dependencySet>
 
         <dependencySet>
@@ -89,6 +93,7 @@
                 <include>javax.inject:javax.inject</include>
                 <include>javax.enterprise:cdi-api</include>
             </includes>
+            <useStrictFiltering>true</useStrictFiltering>
         </dependencySet>
     </dependencySets>
 

--- a/distribution/src/main/assembly/dist.xml
+++ b/distribution/src/main/assembly/dist.xml
@@ -191,7 +191,7 @@
     <dependencySets>
         <dependencySet>
             <useProjectArtifact>false</useProjectArtifact>
-            <outputDirectory>dist/provided</outputDirectory>
+            <outputDirectory>dist/lib/provided</outputDirectory>
             <scope>provided</scope>
             <includes>
                 <include>org.jboss.spec.javax.annotation:*</include>

--- a/distribution/src/main/assembly/dist.xml
+++ b/distribution/src/main/assembly/dist.xml
@@ -24,67 +24,114 @@
         -->
     </formats>
 
-    <!-- Configure the module artifacts which make it into the distribution bundle -->
-    <dependencySets>
-        <dependencySet>
-            <outputDirectory>dist/engine</outputDirectory>
-            <scope>runtime</scope>
-            <useProjectArtifact>false</useProjectArtifact>
-            <useTransitiveDependencies>true</useTransitiveDependencies>
-            <useTransitiveFiltering>true</useTransitiveFiltering>
+    <moduleSets>
+        <moduleSet>
+            <useAllReactorProjects>true</useAllReactorProjects>
             <includes>
+                <include>org.hibernate.search:hibernate-search-util-internal-common</include>
                 <include>org.hibernate.search:hibernate-search-engine</include>
             </includes>
-            <useStrictFiltering>true</useStrictFiltering>
-        </dependencySet>
-
-        <dependencySet>
-            <outputDirectory>dist/mapper/orm</outputDirectory>
-            <scope>runtime</scope>
-            <useProjectArtifact>false</useProjectArtifact>
-            <useTransitiveDependencies>true</useTransitiveDependencies>
-            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <binaries>
+                <outputDirectory>dist/engine</outputDirectory>
+                <unpack>false</unpack>
+                <dependencySets>
+                    <dependencySet>
+                        <useProjectArtifact>false</useProjectArtifact>
+                        <outputDirectory>dist/engine</outputDirectory>
+                        <scope>runtime</scope>
+                        <useTransitiveDependencies>true</useTransitiveDependencies>
+                        <useTransitiveFiltering>true</useTransitiveFiltering>
+                        <useStrictFiltering>true</useStrictFiltering>
+                    </dependencySet>
+                </dependencySets>
+            </binaries>
+        </moduleSet>
+        <moduleSet>
+            <useAllReactorProjects>true</useAllReactorProjects>
             <includes>
-                <include>org.hibernate.search:hibernate-search-orm</include>
                 <include>org.hibernate.search:hibernate-search-mapper-pojo</include>
+                <include>org.hibernate.search:hibernate-search-orm</include>
             </includes>
-            <useStrictFiltering>true</useStrictFiltering>
-        </dependencySet>
-
-        <dependencySet>
-            <outputDirectory>dist/backend/lucene</outputDirectory>
-            <scope>runtime</scope>
-            <useProjectArtifact>false</useProjectArtifact>
-            <useTransitiveDependencies>true</useTransitiveDependencies>
-            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <binaries>
+                <outputDirectory>dist/mapper/orm</outputDirectory>
+                <unpack>false</unpack>
+                <dependencySets>
+                    <dependencySet>
+                        <useProjectArtifact>false</useProjectArtifact>
+                        <outputDirectory>dist/mapper/orm</outputDirectory>
+                        <scope>runtime</scope>
+                        <useTransitiveDependencies>true</useTransitiveDependencies>
+                        <useTransitiveFiltering>true</useTransitiveFiltering>
+                        <excludes>
+                            <!-- Do not repeat dependencies that are already included by the engine -->
+                            <exclude>org.hibernate.search:hibernate-search-engine</exclude>
+                            <exclude>org.hibernate.search:hibernate-search-util-internal-common</exclude>
+                            <exclude>org.jboss.logging:jboss-logging</exclude>
+                        </excludes>
+                        <useStrictFiltering>true</useStrictFiltering>
+                    </dependencySet>
+                </dependencySets>
+            </binaries>
+        </moduleSet>
+        <moduleSet>
+            <useAllReactorProjects>true</useAllReactorProjects>
             <includes>
                 <include>org.hibernate.search:hibernate-search-backend-lucene</include>
             </includes>
-            <useStrictFiltering>true</useStrictFiltering>
-        </dependencySet>
-
-        <dependencySet>
-            <outputDirectory>dist/backend/elasticsearch</outputDirectory>
-            <scope>runtime</scope>
-            <useProjectArtifact>false</useProjectArtifact>
-            <useTransitiveDependencies>true</useTransitiveDependencies>
-            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <binaries>
+                <outputDirectory>dist/backend/lucene</outputDirectory>
+                <unpack>false</unpack>
+                <dependencySets>
+                    <dependencySet>
+                        <useProjectArtifact>false</useProjectArtifact>
+                        <outputDirectory>dist/backend/lucene</outputDirectory>
+                        <scope>runtime</scope>
+                        <useTransitiveDependencies>true</useTransitiveDependencies>
+                        <useTransitiveFiltering>true</useTransitiveFiltering>
+                        <excludes>
+                            <!-- Do not repeat dependencies that are already included by the engine -->
+                            <exclude>org.hibernate.search:hibernate-search-engine</exclude>
+                            <exclude>org.hibernate.search:hibernate-search-util-internal-common</exclude>
+                            <exclude>org.jboss.logging:jboss-logging</exclude>
+                        </excludes>
+                        <useStrictFiltering>true</useStrictFiltering>
+                    </dependencySet>
+                </dependencySets>
+            </binaries>
+        </moduleSet>
+        <moduleSet>
+            <useAllReactorProjects>true</useAllReactorProjects>
             <includes>
-                <!--
-                    The ':*' suffix is necessary to not include elasticsearch-aws,
-                    because of a bug in maven-assembly-plugin.
-                    See https://issues.apache.org/jira/browse/MASSEMBLY-865
-                 -->
-                <include>org.hibernate.search:hibernate-search-backend-elasticsearch:*</include>
+                <include>org.hibernate.search:hibernate-search-backend-elasticsearch</include>
             </includes>
-            <useStrictFiltering>true</useStrictFiltering>
-        </dependencySet>
+            <binaries>
+                <outputDirectory>dist/backend/elasticsearch</outputDirectory>
+                <unpack>false</unpack>
+                <dependencySets>
+                    <dependencySet>
+                        <useProjectArtifact>false</useProjectArtifact>
+                        <outputDirectory>dist/backend/elasticsearch</outputDirectory>
+                        <scope>runtime</scope>
+                        <useTransitiveDependencies>true</useTransitiveDependencies>
+                        <useTransitiveFiltering>true</useTransitiveFiltering>
+                        <excludes>
+                            <!-- Do not repeat dependencies that are already included by the engine -->
+                            <exclude>org.hibernate.search:hibernate-search-engine</exclude>
+                            <exclude>org.hibernate.search:hibernate-search-util-internal-common</exclude>
+                            <exclude>org.jboss.logging:jboss-logging</exclude>
+                        </excludes>
+                        <useStrictFiltering>true</useStrictFiltering>
+                    </dependencySet>
+                </dependencySets>
+            </binaries>
+        </moduleSet>
+    </moduleSets>
 
+    <dependencySets>
         <dependencySet>
+            <useProjectArtifact>false</useProjectArtifact>
             <outputDirectory>dist/provided</outputDirectory>
             <scope>provided</scope>
-            <useProjectArtifact>false</useProjectArtifact>
-            <useTransitiveDependencies>false</useTransitiveDependencies>
             <includes>
                 <include>org.jboss.spec.javax.annotation:*</include>
                 <include>javax.persistence:javax.persistence-api</include>

--- a/distribution/src/main/assembly/dist.xml
+++ b/distribution/src/main/assembly/dist.xml
@@ -28,8 +28,14 @@
         <moduleSet>
             <useAllReactorProjects>true</useAllReactorProjects>
             <includes>
+                <!--
+                     We cannot just merge the -engine moduleSet with the utils moduleSets,
+                     because that would result in the utils JARs being included twice:
+                     once in dist/engine/, and once in dist/engine/lib/required.
+                     Excluding it from the dependency set is not an option either,
+                     since it would exclude transitive dependencies too.
+                 -->
                 <include>org.hibernate.search:hibernate-search-util-internal-common</include>
-                <include>org.hibernate.search:hibernate-search-engine</include>
             </includes>
             <binaries>
                 <outputDirectory>dist/engine</outputDirectory>
@@ -37,7 +43,7 @@
                 <dependencySets>
                     <dependencySet>
                         <useProjectArtifact>false</useProjectArtifact>
-                        <outputDirectory>dist/engine</outputDirectory>
+                        <outputDirectory>dist/engine/lib/required</outputDirectory>
                         <scope>runtime</scope>
                         <useTransitiveDependencies>true</useTransitiveDependencies>
                         <useTransitiveFiltering>true</useTransitiveFiltering>
@@ -49,8 +55,35 @@
         <moduleSet>
             <useAllReactorProjects>true</useAllReactorProjects>
             <includes>
+                <include>org.hibernate.search:hibernate-search-engine</include>
+            </includes>
+            <binaries>
+                <outputDirectory>dist/engine</outputDirectory>
+                <unpack>false</unpack>
+                <dependencySets>
+                    <dependencySet>
+                        <useProjectArtifact>false</useProjectArtifact>
+                        <outputDirectory>dist/engine/lib/required</outputDirectory>
+                        <scope>runtime</scope>
+                        <useTransitiveDependencies>true</useTransitiveDependencies>
+                        <useTransitiveFiltering>true</useTransitiveFiltering>
+                        <excludes>
+                            <!-- Do not include the utils JAR, nor its dependencies that are already included above -->
+                            <exclude>org.hibernate.search:hibernate-search-util-internal-common</exclude>
+                        </excludes>
+                        <useStrictFiltering>true</useStrictFiltering>
+                    </dependencySet>
+                </dependencySets>
+            </binaries>
+        </moduleSet>
+        <moduleSet>
+            <useAllReactorProjects>true</useAllReactorProjects>
+            <includes>
+                <!--
+                     We cannot just merge the -orm moduleSet with the -mapper-pojo moduleSet,
+                     for the same reason as above with the -engine and utils moduleSets.
+                 -->
                 <include>org.hibernate.search:hibernate-search-mapper-pojo</include>
-                <include>org.hibernate.search:hibernate-search-orm</include>
             </includes>
             <binaries>
                 <outputDirectory>dist/mapper/orm</outputDirectory>
@@ -58,7 +91,7 @@
                 <dependencySets>
                     <dependencySet>
                         <useProjectArtifact>false</useProjectArtifact>
-                        <outputDirectory>dist/mapper/orm</outputDirectory>
+                        <outputDirectory>dist/mapper/orm/lib/required</outputDirectory>
                         <scope>runtime</scope>
                         <useTransitiveDependencies>true</useTransitiveDependencies>
                         <useTransitiveFiltering>true</useTransitiveFiltering>
@@ -76,6 +109,34 @@
         <moduleSet>
             <useAllReactorProjects>true</useAllReactorProjects>
             <includes>
+                <include>org.hibernate.search:hibernate-search-orm</include>
+            </includes>
+            <binaries>
+                <outputDirectory>dist/mapper/orm</outputDirectory>
+                <unpack>false</unpack>
+                <dependencySets>
+                    <dependencySet>
+                        <useProjectArtifact>false</useProjectArtifact>
+                        <outputDirectory>dist/mapper/orm/lib/required</outputDirectory>
+                        <scope>runtime</scope>
+                        <useTransitiveDependencies>true</useTransitiveDependencies>
+                        <useTransitiveFiltering>true</useTransitiveFiltering>
+                        <excludes>
+                            <!-- Do not repeat dependencies that are already included by the engine -->
+                            <exclude>org.hibernate.search:hibernate-search-engine</exclude>
+                            <exclude>org.hibernate.search:hibernate-search-util-internal-common</exclude>
+                            <exclude>org.jboss.logging:jboss-logging</exclude>
+                            <!-- Do not include the mapper-pojo JAR, nor its dependencies that are already included above -->
+                            <exclude>org.hibernate.search:hibernate-search-mapper-pojo</exclude>
+                        </excludes>
+                        <useStrictFiltering>true</useStrictFiltering>
+                    </dependencySet>
+                </dependencySets>
+            </binaries>
+        </moduleSet>
+        <moduleSet>
+            <useAllReactorProjects>true</useAllReactorProjects>
+            <includes>
                 <include>org.hibernate.search:hibernate-search-backend-lucene</include>
             </includes>
             <binaries>
@@ -84,7 +145,7 @@
                 <dependencySets>
                     <dependencySet>
                         <useProjectArtifact>false</useProjectArtifact>
-                        <outputDirectory>dist/backend/lucene</outputDirectory>
+                        <outputDirectory>dist/backend/lucene/lib/required</outputDirectory>
                         <scope>runtime</scope>
                         <useTransitiveDependencies>true</useTransitiveDependencies>
                         <useTransitiveFiltering>true</useTransitiveFiltering>
@@ -110,7 +171,7 @@
                 <dependencySets>
                     <dependencySet>
                         <useProjectArtifact>false</useProjectArtifact>
-                        <outputDirectory>dist/backend/elasticsearch</outputDirectory>
+                        <outputDirectory>dist/backend/elasticsearch/lib/required</outputDirectory>
                         <scope>runtime</scope>
                         <useTransitiveDependencies>true</useTransitiveDependencies>
                         <useTransitiveFiltering>true</useTransitiveFiltering>

--- a/legacy/pom.xml
+++ b/legacy/pom.xml
@@ -784,13 +784,6 @@
 
     <profiles>
         <profile>
-            <id>dist</id>
-            <modules>
-                <module>../distribution</module>
-            </modules>
-        </profile>
-
-        <profile>
             <id>jdk8</id>
             <activation>
                 <jdk>1.8</jdk>

--- a/legacy/pom.xml
+++ b/legacy/pom.xml
@@ -786,7 +786,7 @@
         <profile>
             <id>dist</id>
             <modules>
-                <module>distribution</module>
+                <module>../distribution</module>
             </modules>
         </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -528,6 +528,12 @@
             </dependency>
             <dependency>
                 <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-documentation</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
                 <artifactId>hibernate-search-integrationtest-orm</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -1669,6 +1675,9 @@
             <properties>
                 <failOnJavaDocError>true</failOnJavaDocError>
             </properties>
+            <modules>
+                <module>distribution</module>
+            </modules>
             <build>
                 <plugins>
                     <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -157,11 +157,6 @@
         <module>integrationtest</module>
         <module>documentation</module>
         <module>legacy</module>
-        <!--
-             WARNING: this MUST be the very last module, in particular when deploying artifacts to a Nexus repository.
-             See this module's POM for more information.
-         -->
-        <module>reports</module>
     </modules>
 
     <properties>
@@ -2456,5 +2451,25 @@
                 <jdbc.isolation>4096</jdbc.isolation>
             </properties>
         </profile>
+
+        <!--
+             WARNING: this MUST be the very last profile,
+             so that the "report" module is the very last module,
+             in particular when deploying artifacts to a Nexus repository.
+             See the "reports" module POM for more information.
+         -->
+        <profile>
+            <id>report-as-last-module</id>
+            <activation>
+                <property>
+                    <name>!some.property.that.will.never.exist</name>
+                </property>
+            </activation>
+            <modules>
+                <module>reports</module>
+            </modules>
+        </profile>
+
+        <!-- DO NOT ADD ANY PROFILE AFTER THIS: see above -->
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -208,8 +208,11 @@
         <javadoc.org.jberet.url>http://docs.jboss.org/jberet/1.2.0.Final/javadoc/jberet-core/</javadoc.org.jberet.url>
 
         <!-- >>> Java EE/Jakarta EE dependencies -->
-        <!-- Used in the ORM integration and various tests -->
+        <!-- Used in the JSR352 integration in particular, but also in the ORM integration (?) and various tests -->
+        <version.javax.inject>1</version.javax.inject>
         <version.javax.enterprise>2.0</version.javax.enterprise>
+        <version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>1.0.2.Final</version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>
+        <version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>1.1.1.Final</version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>
         <!-- This is used to generate a link to the Java EE javadoc -->
         <javadoc.javaee.url>https://docs.oracle.com/javaee/7/api/</javadoc.javaee.url>
 
@@ -693,16 +696,6 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>javax.persistence</groupId>
-                <artifactId>javax.persistence-api</artifactId>
-                <version>${version.javax.persistence}</version>
-            </dependency>
-            <dependency>
-                <groupId>javax.enterprise</groupId>
-                <artifactId>cdi-api</artifactId>
-                <version>${version.javax.enterprise}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.hibernate.common</groupId>
                 <artifactId>hibernate-commons-annotations</artifactId>
                 <version>${version.org.hibernate.commons.annotations}</version>
@@ -755,6 +748,44 @@
                 <groupId>org.apache.lucene</groupId>
                 <artifactId>lucene-sandbox</artifactId>
                 <version>${version.org.apache.lucene}</version>
+            </dependency>
+
+            <!-- JavaEE/JakartaEE dependencies -->
+            <dependency>
+                <groupId>javax.persistence</groupId>
+                <artifactId>javax.persistence-api</artifactId>
+                <version>${version.javax.persistence}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>javax.enterprise</groupId>
+                <artifactId>cdi-api</artifactId>
+                <version>${version.javax.enterprise}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>javax.inject</groupId>
+                <artifactId>javax.inject</artifactId>
+                <version>${version.javax.inject}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.annotation</groupId>
+                <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+                <version>${version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.transaction</groupId>
+                <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+                <version>${version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>javax.batch</groupId>
+                <artifactId>javax.batch-api</artifactId>
+                <version>${version.javax.batch}</version>
+                <scope>provided</scope>
             </dependency>
 
             <!-- To be removed in HSEARCH-3376 -->


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3335

I tried to improve the configuration while I was at it, so that we don't have to explicitly list the dependencies anymore: any new dependency will be added automatically. The only updates we will have to perform manually are:

* When we add a new module
* When we add a provided dependency
* When we change the inter-module dependencies (though if we forget to update in this case, the worst thing that can happen is that some JAR will appear twice)

To test it quickly, run this:

```
mvn clean install -DskipTests -Pdist -pl distribution -am -Dmaven.javadoc.skip=true
```

The distribution bundles will be in `distribution/target/dist/`

I'm not sure if we should merge the last commit, any opinion on that? I'll copy the commit message with the details:

> Not sure it's really an improvement, since the structure is
> significantly more complex, and I don't think consumers of this bundle
> will care much about which artifact comes from the Hibernate team and
> which one comes from an external source.
> 
> But at least that's closer to what we used to offer...
> 
> After this patch, the structure is as follows:
>
> ```
> $ tree hibernate-search-6.0.0-SNAPSHOT/dist
> hibernate-search-6.0.0-SNAPSHOT/dist
> ├── backend
> │   ├── elasticsearch
> │   │   ├── hibernate-search-backend-elasticsearch-6.0.0-SNAPSHOT.jar
> │   │   └── lib
> │   │       └── required
> │   │           ├── commons-codec-1.10.jar
> │   │           ├── commons-logging-1.1.3.jar
> │   │           ├── elasticsearch-rest-client-6.3.1.jar
> │   │           ├── elasticsearch-rest-client-sniffer-6.3.1.jar
> │   │           ├── gson-2.8.5.jar
> │   │           ├── httpasyncclient-4.1.2.jar
> │   │           ├── httpclient-4.5.2.jar
> │   │           ├── httpcore-4.4.5.jar
> │   │           ├── httpcore-nio-4.4.5.jar
> │   │           └── jackson-core-2.8.10.jar
> │   └── lucene
> │       ├── hibernate-search-backend-lucene-6.0.0-SNAPSHOT.jar
> │       └── lib
> │           └── required
> │               ├── lucene-analyzers-common-7.4.0.jar
> │               ├── lucene-core-7.4.0.jar
> │               ├── lucene-join-7.4.0.jar
> │               └── lucene-sandbox-7.4.0.jar
> ├── engine
> │   ├── hibernate-search-engine-6.0.0-SNAPSHOT.jar
> │   ├── hibernate-search-util-internal-common-6.0.0-SNAPSHOT.jar
> │   └── lib
> │       └── required
> │           └── jboss-logging-3.3.2.Final.jar
> ├── mapper
> │   └── orm
> │       ├── hibernate-search-mapper-pojo-6.0.0-SNAPSHOT.jar
> │       ├── hibernate-search-orm-6.0.0-SNAPSHOT.jar
> │       └── lib
> │           └── required
> │               ├── antlr-2.7.7.jar
> │               ├── byte-buddy-1.8.17.jar
> │               ├── classmate-1.3.4.jar
> │               ├── dom4j-1.6.1.jar
> │               ├── hibernate-commons-annotations-5.0.4.Final.jar
> │               ├── hibernate-core-5.3.6.Final.jar
> │               ├── jandex-2.0.5.Final.jar
> │               ├── javassist-3.23.1-GA.jar
> │               ├── javax.activation-api-1.2.0.jar
> │               └── xml-apis-1.0.b2.jar
> └── provided
>     ├── cdi-api-2.0.jar
>     ├── javax.batch-api-1.0.jar
>     ├── javax.inject-1.jar
>     ├── javax.persistence-api-2.2.jar
>     ├── jboss-annotations-api_1.2_spec-1.0.2.Final.jar
>     └── jboss-transaction-api_1.2_spec-1.1.1.Final.jar
> ```
> 
> For reference, before this patch, the structure was something like this:
> 
> ```
> $ tree hibernate-search-6.0.0-SNAPSHOT/dist
> hibernate-search-6.0.0-SNAPSHOT/dist
> ├── backend
> │   ├── elasticsearch
> │   │   ├── commons-codec-1.10.jar
> │   │   ├── commons-logging-1.1.3.jar
> │   │   ├── elasticsearch-rest-client-6.3.1.jar
> │   │   ├── elasticsearch-rest-client-sniffer-6.3.1.jar
> │   │   ├── gson-2.8.5.jar
> │   │   ├── hibernate-search-backend-elasticsearch-6.0.0-SNAPSHOT.jar
> │   │   ├── httpasyncclient-4.1.2.jar
> │   │   ├── httpclient-4.5.2.jar
> │   │   ├── httpcore-4.4.5.jar
> │   │   ├── httpcore-nio-4.4.5.jar
> │   │   └── jackson-core-2.8.10.jar
> │   └── lucene
> │       ├── hibernate-search-backend-lucene-6.0.0-SNAPSHOT.jar
> │       ├── lucene-analyzers-common-7.4.0.jar
> │       ├── lucene-core-7.4.0.jar
> │       ├── lucene-join-7.4.0.jar
> │       └── lucene-sandbox-7.4.0.jar
> ├── engine
> │   ├── hibernate-search-engine-6.0.0-SNAPSHOT.jar
> │   ├── hibernate-search-util-internal-common-6.0.0-SNAPSHOT.jar
> │   └── jboss-logging-3.3.2.Final.jar
> ├── mapper
> │   └── orm
> │       ├── antlr-2.7.7.jar
> │       ├── byte-buddy-1.8.17.jar
> │       ├── classmate-1.3.4.jar
> │       ├── dom4j-1.6.1.jar
> │       ├── hibernate-commons-annotations-5.0.4.Final.jar
> │       ├── hibernate-core-5.3.6.Final.jar
> │       ├── hibernate-search-mapper-pojo-6.0.0-SNAPSHOT.jar
> │       ├── hibernate-search-orm-6.0.0-SNAPSHOT.jar
> │       ├── jandex-2.0.5.Final.jar
> │       ├── javassist-3.23.1-GA.jar
> │       ├── javax.activation-api-1.2.0.jar
> │       └── xml-apis-1.0.b2.jar
> └── provided
>     ├── cdi-api-2.0.jar
>     ├── javax.batch-api-1.0.jar
>     ├── javax.inject-1.jar
>     ├── javax.persistence-api-2.2.jar
>     ├── jboss-annotations-api_1.2_spec-1.0.2.Final.jar
>     └── jboss-transaction-api_1.2_spec-1.1.1.Final.jar
> ```