### PR TITLE
HSEARCH-3189 + HSEARCH-3225: small API improvements

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/GeoPointFieldCodec.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/GeoPointFieldCodec.java
@@ -12,7 +12,6 @@ import org.hibernate.search.backend.elasticsearch.gson.impl.JsonAccessor;
 import org.hibernate.search.backend.elasticsearch.gson.impl.JsonElementTypes;
 import org.hibernate.search.backend.elasticsearch.logging.impl.Log;
 import org.hibernate.search.engine.spatial.GeoPoint;
-import org.hibernate.search.engine.spatial.ImmutableGeoPoint;
 import org.hibernate.search.util.impl.common.LoggerFactory;
 
 import com.google.gson.JsonElement;
@@ -52,7 +51,7 @@ public class GeoPointFieldCodec implements ElasticsearchFieldCodec<GeoPoint> {
 		JsonObject object = JsonElementTypes.OBJECT.fromElement( element );
 		double latitude = LATITUDE_ACCESSOR.get( object ).orElseThrow( log::elasticsearchResponseMissingData );
 		double longitude = LONGITUDE_ACCESSOR.get( object ).orElseThrow( log::elasticsearchResponseMissingData );
-		return new ImmutableGeoPoint( latitude, longitude );
+		return GeoPoint.of( latitude, longitude );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/GeoPointFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/GeoPointFieldCodec.java
@@ -21,7 +21,6 @@ import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
 import org.hibernate.search.engine.backend.document.model.dsl.Store;
 import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
 import org.hibernate.search.engine.spatial.GeoPoint;
-import org.hibernate.search.engine.spatial.ImmutableGeoPoint;
 import org.hibernate.search.util.AssertionFailure;
 import org.hibernate.search.util.impl.common.CollectionHelper;
 
@@ -100,7 +99,7 @@ public final class GeoPointFieldCodec implements LuceneFieldCodec<GeoPoint> {
 			return null;
 		}
 
-		return new ImmutableGeoPoint( (double) latitudeField.numericValue(), (double) longitudeField.numericValue() );
+		return GeoPoint.of( (double) latitudeField.numericValue(), (double) longitudeField.numericValue() );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/environment/bean/BeanReference.java
+++ b/engine/src/main/java/org/hibernate/search/engine/environment/bean/BeanReference.java
@@ -23,4 +23,38 @@ public interface BeanReference {
 	 */
 	Class<?> getType();
 
+	/**
+	 * Create a {@link BeanReference} referencing a bean by its name.
+	 * <p>
+	 * Note: when no dependency injection framework is used, Hibernate Search uses reflection to resolve beans,
+	 * and in that case "names" are interpreted as fully qualified class names.
+	 *
+	 * @param name The bean name.
+	 * @return The corresponding {@link BeanReference}.
+	 */
+	static BeanReference ofName(String name) {
+		return new ImmutableBeanReference( name, null );
+	}
+
+	/**
+	 * Create a {@link BeanReference} referencing a bean by its type.
+	 *
+	 * @param type The bean type.
+	 * @return The corresponding {@link BeanReference}.
+	 */
+	static BeanReference ofType(Class<?> type) {
+		return new ImmutableBeanReference( null, type );
+	}
+
+	/**
+	 * Create a {@link BeanReference} referencing a bean by its name and type.
+	 *
+	 * @param name The bean name.
+	 * @param type The bean type.
+	 * @return The corresponding {@link BeanReference}.
+	 */
+	static BeanReference of(String name, Class<?> type) {
+		return new ImmutableBeanReference( name, type );
+	}
+
 }

--- a/engine/src/main/java/org/hibernate/search/engine/environment/bean/ImmutableBeanReference.java
+++ b/engine/src/main/java/org/hibernate/search/engine/environment/bean/ImmutableBeanReference.java
@@ -4,31 +4,21 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.engine.environment.bean.spi;
+package org.hibernate.search.engine.environment.bean;
 
 
 import java.util.StringJoiner;
 
-import org.hibernate.search.engine.environment.bean.BeanReference;
-
 /**
  * @author Yoann Rodiere
  */
-public final class ImmutableBeanReference implements BeanReference {
+final class ImmutableBeanReference implements BeanReference {
 
 	private final String name;
 
 	private final Class<?> type;
 
-	public ImmutableBeanReference(String name) {
-		this( name, null );
-	}
-
-	public ImmutableBeanReference(Class<?> type) {
-		this( null, type );
-	}
-
-	public ImmutableBeanReference(String name, Class<?> type) {
+	ImmutableBeanReference(String name, Class<?> type) {
 		this.name = name;
 		this.type = type;
 	}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/SpatialWithinPredicateFieldSetContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/SpatialWithinPredicateFieldSetContext.java
@@ -11,8 +11,6 @@ import org.hibernate.search.engine.spatial.DistanceUnit;
 import org.hibernate.search.engine.spatial.GeoBoundingBox;
 import org.hibernate.search.engine.spatial.GeoPoint;
 import org.hibernate.search.engine.spatial.GeoPolygon;
-import org.hibernate.search.engine.spatial.ImmutableGeoBoundingBox;
-import org.hibernate.search.engine.spatial.ImmutableGeoPoint;
 
 /**
  * The context used when defining a spatial predicate, after at least one field was mentioned.
@@ -83,7 +81,7 @@ public interface SpatialWithinPredicateFieldSetContext<N> extends MultiFieldPred
 	 * @return A context allowing to end the predicate definition.
 	 */
 	default ExplicitEndContext<N> circle(double latitude, double longitude, double radius, DistanceUnit unit) {
-		return circle( new ImmutableGeoPoint( latitude, longitude ), radius, unit );
+		return circle( GeoPoint.of( latitude, longitude ), radius, unit );
 	}
 
 	/**
@@ -96,7 +94,7 @@ public interface SpatialWithinPredicateFieldSetContext<N> extends MultiFieldPred
 	 * @return A context allowing to end the predicate definition.
 	 */
 	default ExplicitEndContext<N> circle(double latitude, double longitude, double radiusInMeters) {
-		return circle( new ImmutableGeoPoint( latitude, longitude ), radiusInMeters, DistanceUnit.METERS );
+		return circle( GeoPoint.of( latitude, longitude ), radiusInMeters, DistanceUnit.METERS );
 	}
 
 	/**
@@ -126,6 +124,6 @@ public interface SpatialWithinPredicateFieldSetContext<N> extends MultiFieldPred
 	 */
 	default ExplicitEndContext<N> boundingBox(double topLeftLatitude, double topLeftLongitude, double bottomRightLatitude,
 			double bottomRightLongitude) {
-		return boundingBox( new ImmutableGeoBoundingBox( topLeftLatitude, topLeftLongitude, bottomRightLatitude, bottomRightLongitude ) );
+		return boundingBox( GeoBoundingBox.of( topLeftLatitude, topLeftLongitude, bottomRightLatitude, bottomRightLongitude ) );
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/sort/SearchSortContainerContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/sort/SearchSortContainerContext.java
@@ -11,7 +11,6 @@ import java.util.function.Consumer;
 import org.hibernate.search.engine.search.SearchSort;
 import org.hibernate.search.engine.search.dsl.ExplicitEndContext;
 import org.hibernate.search.engine.spatial.GeoPoint;
-import org.hibernate.search.engine.spatial.ImmutableGeoPoint;
 import org.hibernate.search.util.SearchException;
 
 /**
@@ -81,7 +80,7 @@ public interface SearchSortContainerContext<N> {
 	 * @throws SearchException If the field type does not constitute a valid location.
 	 */
 	default DistanceSortContext<N> byDistance(String absoluteFieldPath, double latitude, double longitude) {
-		return byDistance( absoluteFieldPath, new ImmutableGeoPoint( latitude, longitude ) );
+		return byDistance( absoluteFieldPath, GeoPoint.of( latitude, longitude ) );
 	}
 
 	// TODO other sorts

--- a/engine/src/main/java/org/hibernate/search/engine/spatial/GeoBoundingBox.java
+++ b/engine/src/main/java/org/hibernate/search/engine/spatial/GeoBoundingBox.java
@@ -11,4 +11,32 @@ public interface GeoBoundingBox {
 	GeoPoint getTopLeft();
 
 	GeoPoint getBottomRight();
+
+	/**
+	 * Create a {@link GeoBoundingBox} from the top-left and bottom-right corners.
+	 *
+	 * @param topLeft The coordinates of the top-left corner of the bounding box.
+	 * @param bottomRight The coordinates of the bottom-right corner of the bounding box.
+	 * @return The corresponding {@link GeoBoundingBox}.
+	 */
+	static GeoBoundingBox of(GeoPoint topLeft, GeoPoint bottomRight) {
+		return new ImmutableGeoBoundingBox( topLeft, bottomRight );
+	}
+
+	/**
+	 * Create a {@link GeoBoundingBox} from the latitude and longitude of the top-left and bottom-right corners.
+	 *
+	 * @param topLeftLatitude The latitude of the top-left corner of the bounding box.
+	 * @param topLeftLongitude The longitude of the top-left corner of the bounding box.
+	 * @param bottomRightLatitude The latitude of the bottom-right corner of the bounding box.
+	 * @param bottomRightLongitude The longitude of the bottom-right corner of the bounding box.
+	 * @return The corresponding {@link GeoBoundingBox}.
+	 */
+	static GeoBoundingBox of(double topLeftLatitude, double topLeftLongitude,
+			double bottomRightLatitude, double bottomRightLongitude) {
+		return new ImmutableGeoBoundingBox(
+				GeoPoint.of( topLeftLatitude, topLeftLongitude ),
+				GeoPoint.of( bottomRightLatitude, bottomRightLongitude )
+		);
+	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/spatial/GeoPoint.java
+++ b/engine/src/main/java/org/hibernate/search/engine/spatial/GeoPoint.java
@@ -19,4 +19,15 @@ public interface GeoPoint {
 	 * @return the longitude, in degrees
 	 */
 	double getLongitude();
+
+	/**
+	 * Create a {@link GeoPoint} from a latitude and a longitude.
+	 *
+	 * @param latitude The latitude of the GeoPoint, in degrees.
+	 * @param longitude The longitude of the GeoPoint, in degrees.
+	 * @return The corresponding {@link GeoPoint}.
+	 */
+	static GeoPoint of(double latitude, double longitude) {
+		return new ImmutableGeoPoint( latitude, longitude );
+	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/spatial/GeoPolygon.java
+++ b/engine/src/main/java/org/hibernate/search/engine/spatial/GeoPolygon.java
@@ -6,9 +6,60 @@
  */
 package org.hibernate.search.engine.spatial;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+
+import org.hibernate.search.util.impl.common.CollectionHelper;
+import org.hibernate.search.util.impl.common.Contracts;
 
 public interface GeoPolygon {
 
 	List<GeoPoint> getPoints();
+
+	/**
+	 * Create a {@link GeoPolygon} from a list of points.
+	 * <p>
+	 * The first and last points must be identical.
+	 *
+	 * @param points The list of points. Must not be null. Must contain at least four points.
+	 * @return The corresponding {@link GeoPolygon}.
+	 * @throws IllegalArgumentException If the list is null, or if the first and last points are not identical.
+	 */
+	static GeoPolygon of(List<GeoPoint> points) {
+		Contracts.assertNotNull( points, "points" );
+
+		return new ImmutableGeoPolygon( CollectionHelper.toImmutableList( new ArrayList<>( points ) ) );
+	}
+
+	/**
+	 * Create a {@link GeoPolygon} from points.
+	 * <p>
+	 * The first and last points must be identical.
+	 *
+	 * @param firstPoint The first point. Must not be null.
+	 * @param secondPoint The second point. Must not be null.
+	 * @param thirdPoint The third point. Must not be null.
+	 * @param fourthPoint The fourth point. Must not be null.
+	 * @param additionalPoints An array of additional points. Must not be null. May be empty.
+	 * @return The corresponding {@link GeoPolygon}.
+	 * @throws IllegalArgumentException If any of the arguments is null, or if the first and last points are not identical.
+	 */
+	static GeoPolygon of(GeoPoint firstPoint, GeoPoint secondPoint, GeoPoint thirdPoint, GeoPoint fourthPoint,
+			GeoPoint... additionalPoints) {
+		Contracts.assertNotNull( firstPoint, "firstPoint" );
+		Contracts.assertNotNull( secondPoint, "secondPoint" );
+		Contracts.assertNotNull( thirdPoint, "thirdPoint" );
+		Contracts.assertNotNull( fourthPoint, "fourthPoint" );
+		Contracts.assertNotNull( additionalPoints, "additionalPoints" );
+
+		List<GeoPoint> points = new ArrayList<>();
+		points.add( firstPoint );
+		points.add( secondPoint );
+		points.add( thirdPoint );
+		points.add( fourthPoint );
+		Collections.addAll( points, additionalPoints );
+
+		return new ImmutableGeoPolygon( CollectionHelper.toImmutableList( points ) );
+	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/spatial/ImmutableGeoBoundingBox.java
+++ b/engine/src/main/java/org/hibernate/search/engine/spatial/ImmutableGeoBoundingBox.java
@@ -10,23 +10,18 @@ import java.util.Objects;
 
 import org.hibernate.search.util.impl.common.Contracts;
 
-public class ImmutableGeoBoundingBox implements GeoBoundingBox {
+final class ImmutableGeoBoundingBox implements GeoBoundingBox {
 
 	private GeoPoint topLeft;
 
 	private GeoPoint bottomRight;
 
-	public ImmutableGeoBoundingBox(GeoPoint topLeft, GeoPoint bottomRight) {
+	ImmutableGeoBoundingBox(GeoPoint topLeft, GeoPoint bottomRight) {
 		Contracts.assertNotNull( topLeft, "topLeft" );
 		Contracts.assertNotNull( bottomRight, "bottomRight" );
 
 		this.topLeft = topLeft;
 		this.bottomRight = bottomRight;
-	}
-
-	public ImmutableGeoBoundingBox(double topLeftLatitude, double topLeftLongitude, double bottomRightLatitude, double bottomRightLongitude) {
-		this.topLeft = new ImmutableGeoPoint( topLeftLatitude, topLeftLongitude );
-		this.bottomRight = new ImmutableGeoPoint( bottomRightLatitude, bottomRightLongitude );
 	}
 
 	@Override
@@ -62,6 +57,6 @@ public class ImmutableGeoBoundingBox implements GeoBoundingBox {
 
 	@Override
 	public String toString() {
-		return "GeoBoundingBox [topLeft=" + topLeft + ", bottomRight=" + bottomRight + "]";
+		return "ImmutableGeoBoundingBox[topLeft=" + topLeft + ", bottomRight=" + bottomRight + "]";
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/spatial/ImmutableGeoPoint.java
+++ b/engine/src/main/java/org/hibernate/search/engine/spatial/ImmutableGeoPoint.java
@@ -8,12 +8,12 @@ package org.hibernate.search.engine.spatial;
 
 import java.util.Objects;
 
-public final class ImmutableGeoPoint implements GeoPoint {
+final class ImmutableGeoPoint implements GeoPoint {
 
 	private final double latitude;
 	private final double longitude;
 
-	public ImmutableGeoPoint(double latitude, double longitude) {
+	ImmutableGeoPoint(double latitude, double longitude) {
 		this.latitude = latitude;
 		this.longitude = longitude;
 	}

--- a/engine/src/main/java/org/hibernate/search/engine/spatial/ImmutableGeoPolygon.java
+++ b/engine/src/main/java/org/hibernate/search/engine/spatial/ImmutableGeoPolygon.java
@@ -16,13 +16,13 @@ import org.hibernate.search.util.impl.common.CollectionHelper;
 import org.hibernate.search.util.impl.common.Contracts;
 import org.hibernate.search.util.impl.common.LoggerFactory;
 
-public class ImmutableGeoPolygon implements GeoPolygon {
+final class ImmutableGeoPolygon implements GeoPolygon {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private List<GeoPoint> points;
 
-	public ImmutableGeoPolygon(List<GeoPoint> points) {
+	ImmutableGeoPolygon(List<GeoPoint> points) {
 		Contracts.assertNotNull( points, "points" );
 
 		GeoPoint firstPoint = points.get( 0 );
@@ -34,11 +34,8 @@ public class ImmutableGeoPolygon implements GeoPolygon {
 		this.points = CollectionHelper.toImmutableList( new ArrayList<>( points ) );
 	}
 
-	public ImmutableGeoPolygon(GeoPoint firstPoint, GeoPoint secondPoint, GeoPoint thirdPoint, GeoPoint fourthPoint, GeoPoint... additionalPoints) {
-		Contracts.assertNotNull( firstPoint, "firstPoint" );
-		Contracts.assertNotNull( secondPoint, "secondPoint" );
-		Contracts.assertNotNull( thirdPoint, "thirdPoint" );
-		Contracts.assertNotNull( fourthPoint, "fourthPoint" );
+	ImmutableGeoPolygon(GeoPoint firstPoint, GeoPoint secondPoint, GeoPoint thirdPoint, GeoPoint fourthPoint, GeoPoint... additionalPoints) {
+
 
 		List<GeoPoint> points = new ArrayList<>();
 		points.add( firstPoint );
@@ -86,6 +83,6 @@ public class ImmutableGeoPolygon implements GeoPolygon {
 
 	@Override
 	public String toString() {
-		return "GeoPolygon [points=" + points + "]";
+		return "ImmutableGeoPolygon[points=" + points + "]";
 	}
 }

--- a/engine/src/test/java/org/hibernate/search/engine/spatial/GeoPolygonTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/spatial/GeoPolygonTest.java
@@ -23,23 +23,23 @@ public class GeoPolygonTest {
 
 	@Test
 	public void validPolygon() {
-		GeoPolygon polygon = new ImmutableGeoPolygon( new ImmutableGeoPoint( 26, 23 ), new ImmutableGeoPoint( 26, 26 ), new ImmutableGeoPoint( 24, 26 ),
-				new ImmutableGeoPoint( 24, 23 ), new ImmutableGeoPoint( 26, 23 ) );
+		GeoPolygon polygon = GeoPolygon.of( GeoPoint.of( 26, 23 ), GeoPoint.of( 26, 26 ), GeoPoint.of( 24, 26 ),
+				GeoPoint.of( 24, 23 ), GeoPoint.of( 26, 23 ) );
 		assertNotNull( polygon );
 
-		polygon = new ImmutableGeoPolygon( Arrays.asList( new ImmutableGeoPoint( 26, 23 ), new ImmutableGeoPoint( 26, 26 ), new ImmutableGeoPoint( 24, 26 ),
-				new ImmutableGeoPoint( 24, 23 ), new ImmutableGeoPoint( 26, 23 ) ) );
+		polygon = GeoPolygon.of( Arrays.asList( GeoPoint.of( 26, 23 ), GeoPoint.of( 26, 26 ), GeoPoint.of( 24, 26 ),
+				GeoPoint.of( 24, 23 ), GeoPoint.of( 26, 23 ) ) );
 		assertNotNull( polygon );
 	}
 
 	@Test
 	public void invalidPolygon() {
 		SubTest.expectException(
-				() -> new ImmutableGeoPolygon(
-						new ImmutableGeoPoint( 26, 23 ),
-						new ImmutableGeoPoint( 26, 26 ),
-						new ImmutableGeoPoint( 24, 26 ),
-						new ImmutableGeoPoint( 24, 23 )
+				() -> GeoPolygon.of(
+						GeoPoint.of( 26, 23 ),
+						GeoPoint.of( 26, 26 ),
+						GeoPoint.of( 24, 26 ),
+						GeoPoint.of( 24, 23 )
 				)
 		)
 				.assertThrown()
@@ -47,11 +47,11 @@ public class GeoPolygonTest {
 				.hasMessageContaining( "HSEARCH000516" );
 
 		SubTest.expectException(
-				() -> new ImmutableGeoPolygon( Arrays.asList(
-						new ImmutableGeoPoint( 26, 23 ),
-						new ImmutableGeoPoint( 26, 26 ),
-						new ImmutableGeoPoint( 24, 26 ),
-						new ImmutableGeoPoint( 24, 23 )
+				() -> GeoPolygon.of( Arrays.asList(
+						GeoPoint.of( 26, 23 ),
+						GeoPoint.of( 26, 26 ),
+						GeoPoint.of( 24, 26 ),
+						GeoPoint.of( 24, 23 )
 				) )
 		)
 				.assertThrown()

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/ExtensionIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/ExtensionIT.java
@@ -46,7 +46,6 @@ import org.hibernate.search.engine.search.SearchPredicate;
 import org.hibernate.search.engine.search.SearchQuery;
 import org.hibernate.search.engine.search.SearchSort;
 import org.hibernate.search.engine.spatial.GeoPoint;
-import org.hibernate.search.engine.spatial.ImmutableGeoPoint;
 import org.hibernate.search.util.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
 import org.hibernate.search.util.impl.integrationtest.common.assertion.ProjectionsSearchResultAssert;
@@ -436,7 +435,7 @@ public class ExtensionIT {
 			indexAccessors.sort3.write( document, "z" );
 		} );
 		workPlan.add( referenceProvider( THIRD_ID ), document -> {
-			indexAccessors.geoPoint.write( document, new ImmutableGeoPoint( 40.12, -71.34 ) );
+			indexAccessors.geoPoint.write( document, GeoPoint.of( 40.12, -71.34 ) );
 
 			indexAccessors.nativeField.write( document, 13 );
 			indexAccessors.nativeField_unsupportedProjection.write( document, 13 );
@@ -457,7 +456,7 @@ public class ExtensionIT {
 			// This document should not match any query
 			indexAccessors.string.write( document, "text 2" );
 			indexAccessors.integer.write( document, 1 );
-			indexAccessors.geoPoint.write( document, new ImmutableGeoPoint( 45.12, -75.34 ) );
+			indexAccessors.geoPoint.write( document, GeoPoint.of( 45.12, -75.34 ) );
 
 			indexAccessors.nativeField.write( document, 53 );
 			indexAccessors.nativeField_unsupportedProjection.write( document, 53 );

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneSearchSortIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneSearchSortIT.java
@@ -24,7 +24,6 @@ import org.hibernate.search.engine.search.DocumentReference;
 import org.hibernate.search.engine.search.SearchQuery;
 import org.hibernate.search.engine.search.dsl.sort.SearchSortContainerContext;
 import org.hibernate.search.engine.spatial.GeoPoint;
-import org.hibernate.search.engine.spatial.ImmutableGeoPoint;
 import org.hibernate.search.util.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.stub.StubSessionContext;
 import org.junit.Before;
@@ -78,19 +77,19 @@ public class LuceneSearchSortIT {
 		thrown.expect( SearchException.class );
 		thrown.expectMessage( "HSEARCH600043" );
 
-		simpleQuery( b -> b.byDistance( "geoPoint", new ImmutableGeoPoint( 45.757864, 4.834496 ) ).desc() );
+		simpleQuery( b -> b.byDistance( "geoPoint", GeoPoint.of( 45.757864, 4.834496 ) ).desc() );
 	}
 
 	private void initData() {
 		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan( sessionContext );
 		workPlan.add( referenceProvider( FIRST_ID ), document -> {
-			indexAccessors.geoPoint.write( document, new ImmutableGeoPoint( 45.7705687,4.835233 ) );
+			indexAccessors.geoPoint.write( document, GeoPoint.of( 45.7705687,4.835233 ) );
 		} );
 		workPlan.add( referenceProvider( SECOND_ID ), document -> {
-			indexAccessors.geoPoint.write( document, new ImmutableGeoPoint( 45.7541719, 4.8386221 ) );
+			indexAccessors.geoPoint.write( document, GeoPoint.of( 45.7541719, 4.8386221 ) );
 		} );
 		workPlan.add( referenceProvider( THIRD_ID ), document -> {
-			indexAccessors.geoPoint.write( document, new ImmutableGeoPoint( 45.7530374, 4.8510299 ) );
+			indexAccessors.geoPoint.write( document, GeoPoint.of( 45.7530374, 4.8510299 ) );
 		} );
 		workPlan.add( referenceProvider( EMPTY_ID ), document -> { } );
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/IndexFieldAccessorIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/IndexFieldAccessorIT.java
@@ -27,7 +27,6 @@ import org.hibernate.search.engine.mapper.mapping.building.spi.IndexModelBinding
 import org.hibernate.search.integrationtest.backend.tck.configuration.DefaultAnalysisDefinitions;
 import org.hibernate.search.integrationtest.backend.tck.util.rule.SearchSetupHelper;
 import org.hibernate.search.engine.spatial.GeoPoint;
-import org.hibernate.search.engine.spatial.ImmutableGeoPoint;
 import org.hibernate.search.util.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.stub.StubSessionContext;
 import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubTypeModel;
@@ -225,7 +224,7 @@ public class IndexFieldAccessorIT {
 		accessors.string_analyzed.write( document, "text 1" );
 		accessors.integer.write( document, 1 );
 		accessors.localDate.write( document, LocalDate.of( 2018, 1, 1 ) );
-		accessors.geoPoint.write( document, new ImmutableGeoPoint( 0, 1 ) );
+		accessors.geoPoint.write( document, GeoPoint.of( 0, 1 ) );
 	}
 
 	private void setNullValues(AllTypesAccessors accessors, DocumentElement document) {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/SmokeIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/SmokeIT.java
@@ -25,7 +25,6 @@ import org.hibernate.search.engine.search.DocumentReference;
 import org.hibernate.search.engine.search.SearchPredicate;
 import org.hibernate.search.engine.search.SearchQuery;
 import org.hibernate.search.engine.spatial.GeoPoint;
-import org.hibernate.search.engine.spatial.ImmutableGeoPoint;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -283,7 +282,7 @@ public class SmokeIT {
 			indexAccessors.string_analyzed.write( document, "text 1" );
 			indexAccessors.integer.write( document, 1 );
 			indexAccessors.localDate.write( document, LocalDate.of( 2018, 1, 1 ) );
-			indexAccessors.geoPoint.write( document, new ImmutableGeoPoint( 0, 1 ) );
+			indexAccessors.geoPoint.write( document, GeoPoint.of( 0, 1 ) );
 
 			DocumentElement flattenedObject = indexAccessors.flattenedObject.self.add( document );
 			indexAccessors.flattenedObject.string.write( flattenedObject, "text 1_1" );
@@ -305,7 +304,7 @@ public class SmokeIT {
 			indexAccessors.string_analyzed.write( document, "text 2" );
 			indexAccessors.integer.write( document, 2 );
 			indexAccessors.localDate.write( document, LocalDate.of( 2018, 1, 2 ) );
-			indexAccessors.geoPoint.write( document, new ImmutableGeoPoint( 0, 2 ) );
+			indexAccessors.geoPoint.write( document, GeoPoint.of( 0, 2 ) );
 
 			DocumentElement flattenedObject = indexAccessors.flattenedObject.self.add( document );
 			indexAccessors.flattenedObject.string.write( flattenedObject, "text 2_1" );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/SearchResultLoadingOrTransformingIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/SearchResultLoadingOrTransformingIT.java
@@ -37,7 +37,6 @@ import org.hibernate.search.engine.search.ObjectLoader;
 import org.hibernate.search.engine.search.ProjectionConstants;
 import org.hibernate.search.engine.search.SearchQuery;
 import org.hibernate.search.engine.spatial.GeoPoint;
-import org.hibernate.search.engine.spatial.ImmutableGeoPoint;
 import org.hibernate.search.util.impl.integrationtest.common.stub.StubSessionContext;
 
 import org.junit.Before;
@@ -58,7 +57,7 @@ public class SearchResultLoadingOrTransformingIT {
 	private static final String STRING_VALUE = "string";
 	private static final String STRING_ANALYZED_VALUE = "analyzed string";
 	private static final LocalDate LOCAL_DATE_VALUE = LocalDate.of( 2018, 2, 1 );
-	private static final GeoPoint GEO_POINT_VALUE = new ImmutableGeoPoint( 42.0, -42.0 );
+	private static final GeoPoint GEO_POINT_VALUE = GeoPoint.of( 42.0, -42.0 );
 	private static final Integer NESTED_OBJECT_INTEGER_VALUE = 142;
 	private static final String NESTED_OBJECT_STRING_VALUE = "nested object string";
 	private static final Integer FLATTENED_OBJECT_INTEGER_VALUE = 242;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchSearchPredicateIT.java
@@ -34,7 +34,6 @@ import org.hibernate.search.engine.logging.spi.EventContexts;
 import org.hibernate.search.engine.search.DocumentReference;
 import org.hibernate.search.engine.search.SearchQuery;
 import org.hibernate.search.engine.spatial.GeoPoint;
-import org.hibernate.search.engine.spatial.ImmutableGeoPoint;
 import org.hibernate.search.util.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
 import org.hibernate.search.util.impl.integrationtest.common.assertion.DocumentReferencesSearchResultAssert;
@@ -416,8 +415,8 @@ public class MatchSearchPredicateIT {
 			unsupportedFieldModels = Arrays.asList(
 					ByTypeFieldModel.mapper(
 							GeoPoint.class,
-							new ImmutableGeoPoint( 40, 70 ),
-							new ImmutableGeoPoint( 45, 98 )
+							GeoPoint.of( 40, 70 ),
+							GeoPoint.of( 45, 98 )
 					)
 							.map( root, "geoPoint" )
 			);

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/RangeSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/RangeSearchPredicateIT.java
@@ -28,7 +28,6 @@ import org.hibernate.search.engine.search.DocumentReference;
 import org.hibernate.search.engine.search.SearchQuery;
 import org.hibernate.search.engine.search.dsl.predicate.RangeBoundInclusion;
 import org.hibernate.search.engine.spatial.GeoPoint;
-import org.hibernate.search.engine.spatial.ImmutableGeoPoint;
 import org.hibernate.search.integrationtest.backend.tck.util.InvalidType;
 import org.hibernate.search.integrationtest.backend.tck.util.StandardFieldMapper;
 import org.hibernate.search.integrationtest.backend.tck.util.ValueWrapper;
@@ -676,10 +675,10 @@ public class RangeSearchPredicateIT {
 			unsupportedFieldModels = Arrays.asList(
 					ByTypeFieldModel.mapper(
 							GeoPoint.class,
-							new ImmutableGeoPoint( 40, 70 ),
-							new ImmutableGeoPoint( 40, 71 ),
-							new ImmutableGeoPoint( 40, 72 ),
-							new ImmutableGeoPoint( 30, 60 ), new ImmutableGeoPoint( 50, 80 )
+							GeoPoint.of( 40, 70 ),
+							GeoPoint.of( 40, 71 ),
+							GeoPoint.of( 40, 72 ),
+							GeoPoint.of( 30, 60 ), GeoPoint.of( 50, 80 )
 					)
 							.map( root, "geoPoint" )
 			);

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/spatial/AbstractSpatialWithinSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/spatial/AbstractSpatialWithinSearchPredicateIT.java
@@ -20,7 +20,6 @@ import org.hibernate.search.integrationtest.backend.tck.util.rule.SearchSetupHel
 import org.hibernate.search.engine.search.DocumentReference;
 import org.hibernate.search.engine.search.SearchQuery;
 import org.hibernate.search.engine.spatial.GeoPoint;
-import org.hibernate.search.engine.spatial.ImmutableGeoPoint;
 import org.hibernate.search.util.impl.integrationtest.common.stub.StubSessionContext;
 import org.junit.Before;
 import org.junit.Rule;
@@ -30,15 +29,15 @@ public abstract class AbstractSpatialWithinSearchPredicateIT {
 	protected static final String INDEX_NAME = "IndexName";
 
 	protected static final String OURSON_QUI_BOIT_ID = "ourson qui boit";
-	protected static final GeoPoint OURSON_QUI_BOIT_GEO_POINT = new ImmutableGeoPoint( 45.7705687,4.835233 );
+	protected static final GeoPoint OURSON_QUI_BOIT_GEO_POINT = GeoPoint.of( 45.7705687,4.835233 );
 	protected static final String OURSON_QUI_BOIT_STRING = "L'ourson qui boit";
 
 	protected static final String IMOUTO_ID = "imouto";
-	protected static final GeoPoint IMOUTO_GEO_POINT = new ImmutableGeoPoint( 45.7541719, 4.8386221 );
+	protected static final GeoPoint IMOUTO_GEO_POINT = GeoPoint.of( 45.7541719, 4.8386221 );
 	protected static final String IMOUTO_STRING = "Imouto";
 
 	protected static final String CHEZ_MARGOTTE_ID = "chez margotte";
-	protected static final GeoPoint CHEZ_MARGOTTE_GEO_POINT = new ImmutableGeoPoint( 45.7530374, 4.8510299 );
+	protected static final GeoPoint CHEZ_MARGOTTE_GEO_POINT = GeoPoint.of( 45.7530374, 4.8510299 );
 	protected static final String CHEZ_MARGOTTE_STRING = "Chez Margotte";
 
 	protected static final String EMPTY_ID = "empty";
@@ -68,25 +67,25 @@ public abstract class AbstractSpatialWithinSearchPredicateIT {
 		workPlan.add( referenceProvider( OURSON_QUI_BOIT_ID ), document -> {
 			indexAccessors.string.write( document, OURSON_QUI_BOIT_STRING );
 			indexAccessors.geoPoint.write( document, OURSON_QUI_BOIT_GEO_POINT );
-			indexAccessors.geoPoint_1.write( document, new ImmutableGeoPoint( OURSON_QUI_BOIT_GEO_POINT.getLatitude() - 1,
+			indexAccessors.geoPoint_1.write( document, GeoPoint.of( OURSON_QUI_BOIT_GEO_POINT.getLatitude() - 1,
 					OURSON_QUI_BOIT_GEO_POINT.getLongitude() - 1 ) );
-			indexAccessors.geoPoint_2.write( document, new ImmutableGeoPoint( OURSON_QUI_BOIT_GEO_POINT.getLatitude() - 2,
+			indexAccessors.geoPoint_2.write( document, GeoPoint.of( OURSON_QUI_BOIT_GEO_POINT.getLatitude() - 2,
 					OURSON_QUI_BOIT_GEO_POINT.getLongitude() - 2 ) );
 		} );
 		workPlan.add( referenceProvider( IMOUTO_ID ), document -> {
 			indexAccessors.string.write( document, IMOUTO_STRING );
 			indexAccessors.geoPoint.write( document, IMOUTO_GEO_POINT );
-			indexAccessors.geoPoint_1.write( document, new ImmutableGeoPoint( IMOUTO_GEO_POINT.getLatitude() - 1,
+			indexAccessors.geoPoint_1.write( document, GeoPoint.of( IMOUTO_GEO_POINT.getLatitude() - 1,
 					IMOUTO_GEO_POINT.getLongitude() - 1 ) );
-			indexAccessors.geoPoint_2.write( document, new ImmutableGeoPoint( IMOUTO_GEO_POINT.getLatitude() - 2,
+			indexAccessors.geoPoint_2.write( document, GeoPoint.of( IMOUTO_GEO_POINT.getLatitude() - 2,
 					IMOUTO_GEO_POINT.getLongitude() - 2 ) );
 		} );
 		workPlan.add( referenceProvider( CHEZ_MARGOTTE_ID ), document -> {
 			indexAccessors.string.write( document, CHEZ_MARGOTTE_STRING );
 			indexAccessors.geoPoint.write( document, CHEZ_MARGOTTE_GEO_POINT );
-			indexAccessors.geoPoint_1.write( document, new ImmutableGeoPoint( CHEZ_MARGOTTE_GEO_POINT.getLatitude() - 1,
+			indexAccessors.geoPoint_1.write( document, GeoPoint.of( CHEZ_MARGOTTE_GEO_POINT.getLatitude() - 1,
 					CHEZ_MARGOTTE_GEO_POINT.getLongitude() - 1 ) );
-			indexAccessors.geoPoint_2.write( document, new ImmutableGeoPoint( CHEZ_MARGOTTE_GEO_POINT.getLatitude() - 2,
+			indexAccessors.geoPoint_2.write( document, GeoPoint.of( CHEZ_MARGOTTE_GEO_POINT.getLatitude() - 2,
 					CHEZ_MARGOTTE_GEO_POINT.getLongitude() - 2 ) );
 		} );
 		workPlan.add( referenceProvider( EMPTY_ID ), document -> { } );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/spatial/SpatialWithinBoundingBoxSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/spatial/SpatialWithinBoundingBoxSearchPredicateIT.java
@@ -16,8 +16,6 @@ import org.hibernate.search.engine.search.DocumentReference;
 import org.hibernate.search.engine.search.SearchQuery;
 import org.hibernate.search.engine.spatial.GeoBoundingBox;
 import org.hibernate.search.engine.spatial.GeoPoint;
-import org.hibernate.search.engine.spatial.ImmutableGeoBoundingBox;
-import org.hibernate.search.engine.spatial.ImmutableGeoPoint;
 import org.hibernate.search.util.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
 import org.hibernate.search.util.impl.integrationtest.common.assertion.DocumentReferencesSearchResultAssert;
@@ -27,20 +25,20 @@ import org.junit.Test;
 
 public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWithinSearchPredicateIT {
 
-	private static final GeoBoundingBox BOUNDING_BOX_1 = new ImmutableGeoBoundingBox(
-			new ImmutableGeoPoint( 45.785889, 4.819749 ),
-			new ImmutableGeoPoint( 45.746915, 4.844146 )
+	private static final GeoBoundingBox BOUNDING_BOX_1 = GeoBoundingBox.of(
+			GeoPoint.of( 45.785889, 4.819749 ),
+			GeoPoint.of( 45.746915, 4.844146 )
 	);
 
-	private static final GeoBoundingBox BOUNDING_BOX_2 = new ImmutableGeoBoundingBox(
-			new ImmutableGeoPoint( 45.762111, 4.83 ),
-			new ImmutableGeoPoint( 45.742692, 4.857632 )
+	private static final GeoBoundingBox BOUNDING_BOX_2 = GeoBoundingBox.of(
+			GeoPoint.of( 45.762111, 4.83 ),
+			GeoPoint.of( 45.742692, 4.857632 )
 	);
 
 
-	private static final GeoBoundingBox CHEZ_MARGOTTE_BOUNDING_BOX = new ImmutableGeoBoundingBox(
-			new ImmutableGeoPoint( 45.7530375, 4.8510298 ),
-			new ImmutableGeoPoint( 45.7530373, 4.8510300 )
+	private static final GeoBoundingBox CHEZ_MARGOTTE_BOUNDING_BOX = GeoBoundingBox.of(
+			GeoPoint.of( 45.7530375, 4.8510298 ),
+			GeoPoint.of( 45.7530373, 4.8510300 )
 	);
 
 	private static final GeoBoundingBox BOUNDING_BOX_1_1 = moveBoundingBox( BOUNDING_BOX_1, -1 );
@@ -49,10 +47,10 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 	private static final GeoBoundingBox BOUNDING_BOX_2_2 = moveBoundingBox( BOUNDING_BOX_2, -2 );
 
 	private static final String ADDITIONAL_POINT_1_ID = "additional_1";
-	private static final GeoPoint ADDITIONAL_POINT_1_GEO_POINT = new ImmutableGeoPoint( 24.5, 25.5 );
+	private static final GeoPoint ADDITIONAL_POINT_1_GEO_POINT = GeoPoint.of( 24.5, 25.5 );
 
 	private static final String ADDITIONAL_POINT_2_ID = "additional_2";
-	private static final GeoPoint ADDITIONAL_POINT_2_GEO_POINT = new ImmutableGeoPoint( 24.5, 23.5 );
+	private static final GeoPoint ADDITIONAL_POINT_2_GEO_POINT = GeoPoint.of( 24.5, 23.5 );
 
 	@Test
 	public void within_boundingBox() {
@@ -104,7 +102,7 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
 				.predicate().spatial().within().onField( "geoPoint" )
-						.boundingBox( new ImmutableGeoBoundingBox( new ImmutableGeoPoint( 25, 23 ), new ImmutableGeoPoint( 24, 26 ) ) ).end()
+						.boundingBox( GeoBoundingBox.of( GeoPoint.of( 25, 23 ), GeoPoint.of( 24, 26 ) ) ).end()
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
@@ -279,7 +277,7 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 	}
 
 	private static GeoBoundingBox moveBoundingBox(GeoBoundingBox originalBoundingBox, double degrees) {
-		return new ImmutableGeoBoundingBox( originalBoundingBox.getTopLeft().getLatitude() + degrees, originalBoundingBox.getTopLeft().getLongitude() + degrees,
+		return GeoBoundingBox.of( originalBoundingBox.getTopLeft().getLatitude() + degrees, originalBoundingBox.getTopLeft().getLongitude() + degrees,
 				originalBoundingBox.getBottomRight().getLatitude() + degrees, originalBoundingBox.getBottomRight().getLongitude() + degrees );
 	}
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/spatial/SpatialWithinCircleSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/spatial/SpatialWithinCircleSearchPredicateIT.java
@@ -12,7 +12,6 @@ import org.hibernate.search.engine.search.DocumentReference;
 import org.hibernate.search.engine.search.SearchQuery;
 import org.hibernate.search.engine.spatial.DistanceUnit;
 import org.hibernate.search.engine.spatial.GeoPoint;
-import org.hibernate.search.engine.spatial.ImmutableGeoPoint;
 import org.hibernate.search.util.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
 import org.hibernate.search.util.impl.integrationtest.common.assertion.DocumentReferencesSearchResultAssert;
@@ -22,15 +21,15 @@ import org.junit.Test;
 
 public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinSearchPredicateIT {
 
-	private static final GeoPoint METRO_HOTEL_DE_VILLE = new ImmutableGeoPoint( 45.7673396, 4.833743 );
-	private static final GeoPoint METRO_GARIBALDI = new ImmutableGeoPoint( 45.7515926, 4.8514779 );
+	private static final GeoPoint METRO_HOTEL_DE_VILLE = GeoPoint.of( 45.7673396, 4.833743 );
+	private static final GeoPoint METRO_GARIBALDI = GeoPoint.of( 45.7515926, 4.8514779 );
 
-	private static final GeoPoint METRO_HOTEL_DE_VILLE_1 = new ImmutableGeoPoint( METRO_HOTEL_DE_VILLE.getLatitude() - 1,
+	private static final GeoPoint METRO_HOTEL_DE_VILLE_1 = GeoPoint.of( METRO_HOTEL_DE_VILLE.getLatitude() - 1,
 			METRO_HOTEL_DE_VILLE.getLongitude() - 1 );
-	private static final GeoPoint METRO_HOTEL_DE_VILLE_2 = new ImmutableGeoPoint( METRO_HOTEL_DE_VILLE.getLatitude() - 2,
+	private static final GeoPoint METRO_HOTEL_DE_VILLE_2 = GeoPoint.of( METRO_HOTEL_DE_VILLE.getLatitude() - 2,
 			METRO_HOTEL_DE_VILLE.getLongitude() - 2 );
-	private static final GeoPoint METRO_GARIBALDI_1 = new ImmutableGeoPoint( METRO_GARIBALDI.getLatitude() - 1, METRO_GARIBALDI.getLongitude() - 1 );
-	private static final GeoPoint METRO_GARIBALDI_2 = new ImmutableGeoPoint( METRO_GARIBALDI.getLatitude() - 2, METRO_GARIBALDI.getLongitude() - 2 );
+	private static final GeoPoint METRO_GARIBALDI_1 = GeoPoint.of( METRO_GARIBALDI.getLatitude() - 1, METRO_GARIBALDI.getLongitude() - 1 );
+	private static final GeoPoint METRO_GARIBALDI_2 = GeoPoint.of( METRO_GARIBALDI.getLatitude() - 2, METRO_GARIBALDI.getLongitude() - 2 );
 
 	@Test
 	public void within_circle() {
@@ -209,7 +208,7 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 		SubTest.expectException(
 				"spatial().within().circle() predicate with null distance unit",
 				() -> searchTarget.predicate().spatial().within().onField( "geoPoint" )
-						.circle( new ImmutableGeoPoint( 45, 4 ), 100, null )
+						.circle( GeoPoint.of( 45, 4 ), 100, null )
 		)
 				.assertThrown()
 				.isInstanceOf( IllegalArgumentException.class )

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/spatial/SpatialWithinPolygonSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/spatial/SpatialWithinPolygonSearchPredicateIT.java
@@ -15,8 +15,6 @@ import org.hibernate.search.engine.search.DocumentReference;
 import org.hibernate.search.engine.search.SearchQuery;
 import org.hibernate.search.engine.spatial.GeoPoint;
 import org.hibernate.search.engine.spatial.GeoPolygon;
-import org.hibernate.search.engine.spatial.ImmutableGeoPoint;
-import org.hibernate.search.engine.spatial.ImmutableGeoPolygon;
 import org.hibernate.search.util.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
 import org.hibernate.search.util.impl.integrationtest.common.assertion.DocumentReferencesSearchResultAssert;
@@ -26,28 +24,28 @@ import org.junit.Test;
 
 public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithinSearchPredicateIT {
 
-	private static final GeoPolygon POLYGON_1 = new ImmutableGeoPolygon(
-			new ImmutableGeoPoint( 45.785889, 4.819749 ),
-			new ImmutableGeoPoint( 45.753050, 4.811030 ),
-			new ImmutableGeoPoint( 45.746915, 4.844146 ),
-			new ImmutableGeoPoint( 45.785889, 4.848877 ),
-			new ImmutableGeoPoint( 45.785889, 4.819749 )
+	private static final GeoPolygon POLYGON_1 = GeoPolygon.of(
+			GeoPoint.of( 45.785889, 4.819749 ),
+			GeoPoint.of( 45.753050, 4.811030 ),
+			GeoPoint.of( 45.746915, 4.844146 ),
+			GeoPoint.of( 45.785889, 4.848877 ),
+			GeoPoint.of( 45.785889, 4.819749 )
 	);
 
-	private static final GeoPolygon POLYGON_2 = new ImmutableGeoPolygon(
-			new ImmutableGeoPoint( 45.762111, 4.841442 ),
-			new ImmutableGeoPoint( 45.751826, 4.837118 ),
-			new ImmutableGeoPoint( 45.742692, 4.857632 ),
-			new ImmutableGeoPoint( 45.758982, 4.866473 ),
-			new ImmutableGeoPoint( 45.762111, 4.841442 )
+	private static final GeoPolygon POLYGON_2 = GeoPolygon.of(
+			GeoPoint.of( 45.762111, 4.841442 ),
+			GeoPoint.of( 45.751826, 4.837118 ),
+			GeoPoint.of( 45.742692, 4.857632 ),
+			GeoPoint.of( 45.758982, 4.866473 ),
+			GeoPoint.of( 45.762111, 4.841442 )
 	);
 
-	private static final GeoPolygon CHEZ_MARGOTTE_POLYGON = new ImmutableGeoPolygon(
-			new ImmutableGeoPoint( 45.7530375, 4.8510298 ),
-			new ImmutableGeoPoint( 45.7530373, 4.8510298 ),
-			new ImmutableGeoPoint( 45.7530373, 4.8510300 ),
-			new ImmutableGeoPoint( 45.7530375, 4.8510300 ),
-			new ImmutableGeoPoint( 45.7530375, 4.8510298 )
+	private static final GeoPolygon CHEZ_MARGOTTE_POLYGON = GeoPolygon.of(
+			GeoPoint.of( 45.7530375, 4.8510298 ),
+			GeoPoint.of( 45.7530373, 4.8510298 ),
+			GeoPoint.of( 45.7530373, 4.8510300 ),
+			GeoPoint.of( 45.7530375, 4.8510300 ),
+			GeoPoint.of( 45.7530375, 4.8510298 )
 	);
 
 	private static final GeoPolygon POLYGON_1_1 = movePolygon( POLYGON_1, -1 );
@@ -223,9 +221,9 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 		List<GeoPoint> movedPoints = new ArrayList<>();
 
 		for ( GeoPoint originalPoint : originalPolygon.getPoints() ) {
-			movedPoints.add( new ImmutableGeoPoint( originalPoint.getLatitude() + degrees, originalPoint.getLongitude() + degrees ) );
+			movedPoints.add( GeoPoint.of( originalPoint.getLatitude() + degrees, originalPoint.getLongitude() + degrees ) );
 		}
 
-		return new ImmutableGeoPolygon( movedPoints );
+		return GeoPolygon.of( movedPoints );
 	}
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/SearchProjectionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/SearchProjectionIT.java
@@ -36,7 +36,6 @@ import org.hibernate.search.engine.search.DocumentReference;
 import org.hibernate.search.engine.search.ProjectionConstants;
 import org.hibernate.search.engine.search.SearchQuery;
 import org.hibernate.search.engine.spatial.GeoPoint;
-import org.hibernate.search.engine.spatial.ImmutableGeoPoint;
 import org.hibernate.search.util.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.assertion.DocumentReferencesSearchResultAssert;
 import org.hibernate.search.util.impl.integrationtest.common.stub.StubSessionContext;
@@ -442,9 +441,9 @@ public class SearchProjectionIT {
 						.map( root, prefix + "localDate", additionalConfiguration ),
 				FieldModel.mapper(
 						GeoPoint.class,
-						new ImmutableGeoPoint( 40, 70 ),
-						new ImmutableGeoPoint( 40, 75 ),
-						new ImmutableGeoPoint( 40, 80 )
+						GeoPoint.of( 40, 70 ),
+						GeoPoint.of( 40, 75 ),
+						GeoPoint.of( 40, 80 )
 				)
 						.map( root, prefix + "geoPoint", additionalConfiguration )
 		);

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/SearchSortByFieldIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/SearchSortByFieldIT.java
@@ -41,7 +41,6 @@ import org.hibernate.search.engine.search.SearchQuery;
 import org.hibernate.search.engine.search.SearchSort;
 import org.hibernate.search.engine.search.dsl.sort.SearchSortContainerContext;
 import org.hibernate.search.engine.spatial.GeoPoint;
-import org.hibernate.search.engine.spatial.ImmutableGeoPoint;
 import org.hibernate.search.util.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
 import org.hibernate.search.util.impl.integrationtest.common.assertion.DocumentReferencesSearchResultAssert;
@@ -492,13 +491,13 @@ public class SearchSortByFieldIT {
 		return Arrays.asList(
 				ByTypeFieldModel.mapper(
 						GeoPoint.class,
-						new ImmutableGeoPoint( 40, 70 ),
-						new ImmutableGeoPoint( 40, 75 ),
-						new ImmutableGeoPoint( 40, 80 ),
-						new ImmutableGeoPoint( 0, 0 ),
-						new ImmutableGeoPoint( 40, 72 ),
-						new ImmutableGeoPoint( 40, 77 ),
-						new ImmutableGeoPoint( 89, 89 )
+						GeoPoint.of( 40, 70 ),
+						GeoPoint.of( 40, 75 ),
+						GeoPoint.of( 40, 80 ),
+						GeoPoint.of( 0, 0 ),
+						GeoPoint.of( 40, 72 ),
+						GeoPoint.of( 40, 77 ),
+						GeoPoint.of( 89, 89 )
 				)
 						.map( root, "geoPoint" )
 		);

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/SearchSortIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/SearchSortIT.java
@@ -34,7 +34,6 @@ import org.hibernate.search.engine.search.SearchResult;
 import org.hibernate.search.engine.search.SearchSort;
 import org.hibernate.search.engine.search.dsl.sort.SearchSortContainerContext;
 import org.hibernate.search.engine.spatial.GeoPoint;
-import org.hibernate.search.engine.spatial.ImmutableGeoPoint;
 import org.hibernate.search.util.impl.integrationtest.common.assertion.DocumentReferencesSearchResultAssert;
 import org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert;
 import org.hibernate.search.util.impl.integrationtest.common.stub.StubSessionContext;
@@ -228,7 +227,7 @@ public class SearchSortIT {
 
 	@Test
 	public void byDistance_asc() {
-		SearchQuery<DocumentReference> query = simpleQuery( b -> b.byDistance( "geoPoint", new ImmutableGeoPoint( 45.757864, 4.834496 ) ) );
+		SearchQuery<DocumentReference> query = simpleQuery( b -> b.byDistance( "geoPoint", GeoPoint.of( 45.757864, 4.834496 ) ) );
 		DocumentReferencesSearchResultAssert.assertThat( query )
 				.hasReferencesHitsExactOrder( INDEX_NAME, FIRST_ID, THIRD_ID, SECOND_ID, EMPTY_ID );
 
@@ -249,7 +248,7 @@ public class SearchSortIT {
 		);
 
 		SearchQuery<DocumentReference> query = simpleQuery(
-				b -> b.byDistance( "geoPoint", new ImmutableGeoPoint( 45.757864, 4.834496 ) ).desc()
+				b -> b.byDistance( "geoPoint", GeoPoint.of( 45.757864, 4.834496 ) ).desc()
 		);
 		DocumentReferencesSearchResultAssert.assertThat( query )
 				.hasReferencesHitsExactOrder( INDEX_NAME, EMPTY_ID, SECOND_ID, THIRD_ID, FIRST_ID );
@@ -264,7 +263,7 @@ public class SearchSortIT {
 		// Important: do not index the documents in the expected order after sorts
 		workPlan.add( referenceProvider( SECOND_ID ), document -> {
 			indexAccessors.string.write( document, "george" );
-			indexAccessors.geoPoint.write( document, new ImmutableGeoPoint( 45.7705687,4.835233 ) );
+			indexAccessors.geoPoint.write( document, GeoPoint.of( 45.7705687,4.835233 ) );
 
 			indexAccessors.string_analyzed_forScore.write( document, "Hooray Hooray" );
 			indexAccessors.unsortable.write( document, "george" );
@@ -281,7 +280,7 @@ public class SearchSortIT {
 		} );
 		workPlan.add( referenceProvider( FIRST_ID ), document -> {
 			indexAccessors.string.write( document, "aaron" );
-			indexAccessors.geoPoint.write( document, new ImmutableGeoPoint( 45.7541719, 4.8386221 ) );
+			indexAccessors.geoPoint.write( document, GeoPoint.of( 45.7541719, 4.8386221 ) );
 
 			indexAccessors.string_analyzed_forScore.write( document, "Hooray Hooray Hooray" );
 			indexAccessors.unsortable.write( document, "aaron" );
@@ -298,7 +297,7 @@ public class SearchSortIT {
 		} );
 		workPlan.add( referenceProvider( THIRD_ID ), document -> {
 			indexAccessors.string.write( document, "zach" );
-			indexAccessors.geoPoint.write( document, new ImmutableGeoPoint( 45.7530374, 4.8510299 ) );
+			indexAccessors.geoPoint.write( document, GeoPoint.of( 45.7530374, 4.8510299 ) );
 
 			indexAccessors.string_analyzed_forScore.write( document, "Hooray" );
 			indexAccessors.unsortable.write( document, "zach" );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BridgeUsingPropertyMarkerAccessIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BridgeUsingPropertyMarkerAccessIT.java
@@ -12,7 +12,6 @@ import javax.persistence.Id;
 import org.hibernate.SessionFactory;
 import org.hibernate.search.engine.backend.document.model.dsl.Store;
 import org.hibernate.search.engine.spatial.GeoPoint;
-import org.hibernate.search.engine.spatial.ImmutableGeoPoint;
 import org.hibernate.search.mapper.pojo.bridge.builtin.spatial.annotation.GeoPointBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.spatial.annotation.Latitude;
 import org.hibernate.search.mapper.pojo.bridge.builtin.spatial.annotation.Longitude;
@@ -92,7 +91,7 @@ public class BridgeUsingPropertyMarkerAccessIT<TIndexed> {
 
 			backendMock.expectWorks( INDEX_NAME )
 					.add( "1", b -> b
-							.field( "location", new ImmutableGeoPoint( 42.0, 42.0 ) )
+							.field( "location", GeoPoint.of( 42.0, 42.0 ) )
 					)
 					.preparedThenExecuted();
 		} );

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/spatial/AnnotationMappingGeoPointBridgeIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/spatial/AnnotationMappingGeoPointBridgeIT.java
@@ -8,7 +8,6 @@ package org.hibernate.search.integrationtest.mapper.pojo.spatial;
 
 import org.hibernate.search.engine.backend.document.model.dsl.Store;
 import org.hibernate.search.engine.spatial.GeoPoint;
-import org.hibernate.search.engine.spatial.ImmutableGeoPoint;
 import org.hibernate.search.integrationtest.mapper.pojo.test.util.rule.JavaBeanMappingSetupHelper;
 import org.hibernate.search.mapper.javabean.JavaBeanMapping;
 import org.hibernate.search.mapper.pojo.bridge.builtin.spatial.annotation.GeoPointBridge;
@@ -97,10 +96,10 @@ public class AnnotationMappingGeoPointBridgeIT {
 
 			backendMock.expectWorks( GeoPointOnTypeEntity.INDEX )
 					.add( "1", b -> b
-							.field( "homeLocation", new ImmutableGeoPoint(
+							.field( "homeLocation", GeoPoint.of(
 									entity1.getHomeLatitude(), entity1.getHomeLongitude()
 							) )
-							.field( "workLocation", new ImmutableGeoPoint(
+							.field( "workLocation", GeoPoint.of(
 									entity1.getWorkLatitude(), entity1.getWorkLongitude()
 							) )
 					)
@@ -113,10 +112,10 @@ public class AnnotationMappingGeoPointBridgeIT {
 					.preparedThenExecuted();
 			backendMock.expectWorks( GeoPointOnCustomCoordinatesPropertyEntity.INDEX )
 					.add( "3", b -> b
-							.field( "coord", new ImmutableGeoPoint(
+							.field( "coord", GeoPoint.of(
 									entity3.getCoord().getLat(), entity3.getCoord().getLon()
 							) )
-							.field( "location", new ImmutableGeoPoint(
+							.field( "location", GeoPoint.of(
 									entity3.getCoord().getLat(), entity3.getCoord().getLon()
 							) )
 					)

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/spatial/ProgrammaticMappingGeoPointBridgeIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/spatial/ProgrammaticMappingGeoPointBridgeIT.java
@@ -15,7 +15,6 @@ import org.hibernate.search.mapper.pojo.mapping.PojoSearchManager;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.ProgrammaticMappingDefinitionContext;
 import org.hibernate.search.integrationtest.mapper.pojo.test.util.rule.JavaBeanMappingSetupHelper;
 import org.hibernate.search.engine.spatial.GeoPoint;
-import org.hibernate.search.engine.spatial.ImmutableGeoPoint;
 import org.hibernate.search.util.impl.common.CollectionHelper;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 
@@ -146,10 +145,10 @@ public class ProgrammaticMappingGeoPointBridgeIT {
 
 			backendMock.expectWorks( GeoPointOnTypeEntity.INDEX )
 					.add( "1", b -> b
-							.field( "homeLocation", new ImmutableGeoPoint(
+							.field( "homeLocation", GeoPoint.of(
 									entity1.getHomeLatitude(), entity1.getHomeLongitude()
 							) )
-							.field( "workLocation", new ImmutableGeoPoint(
+							.field( "workLocation", GeoPoint.of(
 									entity1.getWorkLatitude(), entity1.getWorkLongitude()
 							) )
 					)
@@ -162,10 +161,10 @@ public class ProgrammaticMappingGeoPointBridgeIT {
 					.preparedThenExecuted();
 			backendMock.expectWorks( GeoPointOnCustomCoordinatesPropertyEntity.INDEX )
 					.add( "3", b -> b
-							.field( "coord", new ImmutableGeoPoint(
+							.field( "coord", GeoPoint.of(
 									entity3.getCoord().getLat(), entity3.getCoord().getLon()
 							) )
-							.field( "location", new ImmutableGeoPoint(
+							.field( "location", GeoPoint.of(
 									entity3.getCoord().getLat(), entity3.getCoord().getLon()
 							) )
 					)

--- a/integrationtest/showcase/library/src/test/java/org/hibernate/search/integrationtest/showcase/OrmElasticsearchLibraryShowcaseIT.java
+++ b/integrationtest/showcase/library/src/test/java/org/hibernate/search/integrationtest/showcase/OrmElasticsearchLibraryShowcaseIT.java
@@ -54,7 +54,6 @@ import org.hibernate.search.integrationtest.showcase.library.model.Video;
 import org.hibernate.search.integrationtest.showcase.library.model.VideoCopy;
 import org.hibernate.search.integrationtest.showcase.library.model.VideoMedium;
 import org.hibernate.search.engine.spatial.GeoPoint;
-import org.hibernate.search.engine.spatial.ImmutableGeoPoint;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.tool.schema.Action;
 
@@ -325,7 +324,7 @@ public class OrmElasticsearchLibraryShowcaseIT {
 		withinSession( sessionFactory, session -> {
 			DocumentDao dao = daoFactory.createDocumentDao( session );
 
-			GeoPoint myLocation = new ImmutableGeoPoint( 42.0, 0.5 );
+			GeoPoint myLocation = GeoPoint.of( 42.0, 0.5 );
 
 			List<Document<?>> documents = dao.searchAroundMe(
 					null, null,
@@ -367,7 +366,7 @@ public class OrmElasticsearchLibraryShowcaseIT {
 					session.get( Book.class, CALLIGRAPHY_ID )
 			);
 
-			myLocation = new ImmutableGeoPoint( 42.0, 0.75 );
+			myLocation = GeoPoint.of( 42.0, 0.75 );
 			documents = dao.searchAroundMe(
 					null, null,
 					myLocation, 40.0,

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/hibernate/FullTextSession.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/hibernate/FullTextSession.java
@@ -14,9 +14,6 @@ import org.hibernate.search.mapper.orm.jpa.FullTextEntityManager;
 public interface FullTextSession extends Session, FullTextEntityManager {
 
 	@Override
-	FullTextSearchTarget<Object> search();
-
-	@Override
 	<T> FullTextSearchTarget<T> search(Class<T> type);
 
 	@Override

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/impl/FullTextSessionImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/impl/FullTextSessionImpl.java
@@ -38,11 +38,6 @@ public class FullTextSessionImpl extends SessionDelegatorBaseImpl implements Ful
 	}
 
 	@Override
-	public FullTextSearchTarget<Object> search() {
-		return new FullTextSearchTargetImpl<>( getSearchManager().search() );
-	}
-
-	@Override
 	public final <T> FullTextSearchTarget<T> search(Class<T> type) {
 		return new FullTextSearchTargetImpl<>( getSearchManager().search( type ) );
 	}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/jpa/FullTextEntityManager.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/jpa/FullTextEntityManager.java
@@ -11,8 +11,6 @@ import javax.persistence.EntityManager;
 
 public interface FullTextEntityManager extends EntityManager {
 
-	FullTextSearchTarget<Object> search();
-
 	<T> FullTextSearchTarget<T> search(Class<T> type);
 
 	<T> FullTextSearchTarget<T> search(Collection<? extends Class<? extends T>> types);

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/HibernateOrmSearchManager.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/HibernateOrmSearchManager.java
@@ -15,11 +15,6 @@ import org.hibernate.search.mapper.pojo.mapping.PojoSearchManager;
 public interface HibernateOrmSearchManager extends PojoSearchManager {
 
 	@Override
-	default HibernateOrmSearchTarget<Object> search() {
-		return search( Collections.singleton( Object.class ) );
-	}
-
-	@Override
 	default <T> HibernateOrmSearchTarget<T> search(Class<T> targetedType) {
 		return search( Collections.singleton( targetedType ) );
 	}

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/spatial/GeoPointBridge.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/spatial/GeoPointBridge.java
@@ -26,7 +26,6 @@ import org.hibernate.search.mapper.pojo.model.PojoElement;
 import org.hibernate.search.mapper.pojo.model.PojoModelCompositeElement;
 import org.hibernate.search.mapper.pojo.model.PojoModelElementAccessor;
 import org.hibernate.search.engine.spatial.GeoPoint;
-import org.hibernate.search.engine.spatial.ImmutableGeoPoint;
 import org.hibernate.search.util.SearchException;
 import org.hibernate.search.util.impl.common.StreamHelper;
 import org.hibernate.search.util.impl.common.LoggerFactory;
@@ -141,7 +140,7 @@ public class GeoPointBridge implements TypeBridge, PropertyBridge {
 					return null;
 				}
 
-				return new ImmutableGeoPoint( latitude, longitude );
+				return GeoPoint.of( latitude, longitude );
 			};
 		}
 	}

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/PojoSearchManager.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/PojoSearchManager.java
@@ -17,10 +17,6 @@ import org.hibernate.search.engine.common.SearchManager;
  */
 public interface PojoSearchManager extends SearchManager {
 
-	default PojoSearchTarget<?> search() {
-		return search( Collections.singleton( Object.class ) );
-	}
-
 	default <T> PojoSearchTarget<?> search(Class<T> targetedType) {
 		return search( Collections.singleton( targetedType ) );
 	}

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/impl/AnnotationProcessorHelper.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/impl/AnnotationProcessorHelper.java
@@ -14,7 +14,6 @@ import java.util.stream.Collectors;
 
 import org.hibernate.search.engine.environment.bean.BeanProvider;
 import org.hibernate.search.engine.environment.bean.BeanReference;
-import org.hibernate.search.engine.environment.bean.spi.ImmutableBeanReference;
 import org.hibernate.search.engine.logging.spi.FailureCollector;
 import org.hibernate.search.mapper.pojo.bridge.IdentifierBridge;
 import org.hibernate.search.mapper.pojo.bridge.PropertyBridge;
@@ -281,7 +280,7 @@ class AnnotationProcessorHelper {
 			return Optional.empty();
 		}
 		else {
-			return Optional.of( new ImmutableBeanReference( cleanedUpName, cleanedUpType ) );
+			return Optional.of( BeanReference.of( cleanedUpName, cleanedUpType ) );
 		}
 	}
 }

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/PropertyDocumentIdMappingContext.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/PropertyDocumentIdMappingContext.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.mapper.pojo.mapping.definition.programmatic;
 
+import org.hibernate.search.engine.environment.bean.BeanReference;
 import org.hibernate.search.mapper.pojo.bridge.mapping.BridgeBuilder;
 import org.hibernate.search.mapper.pojo.bridge.IdentifierBridge;
 
@@ -14,12 +15,25 @@ import org.hibernate.search.mapper.pojo.bridge.IdentifierBridge;
  */
 public interface PropertyDocumentIdMappingContext extends PropertyMappingContext {
 
-	PropertyDocumentIdMappingContext identifierBridge(String bridgeName);
-
+	/**
+	 * @param bridgeClass The class of the bridge to use.
+	 * @return {@code this}, for method chaining.
+	 */
 	PropertyDocumentIdMappingContext identifierBridge(Class<? extends IdentifierBridge<?>> bridgeClass);
 
-	PropertyDocumentIdMappingContext identifierBridge(String bridgeName, Class<? extends IdentifierBridge<?>> bridgeClass);
+	/**
+	 * @param bridgeReference A {@link BeanReference} pointing to the bridge to use.
+	 * The bridge must implement {@link IdentifierBridge}.
+	 * See the static "ofXXX()" methods of {@link BeanReference} for details about the various type of references
+	 * (by name, by type, ...).
+	 * @return {@code this}, for method chaining.
+	 */
+	PropertyDocumentIdMappingContext identifierBridge(BeanReference bridgeReference);
 
+	/**
+	 * @param builder A bridge builder.
+	 * @return {@code this}, for method chaining.
+	 */
 	PropertyDocumentIdMappingContext identifierBridge(BridgeBuilder<? extends IdentifierBridge<?>> builder);
 
 }

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/PropertyFieldMappingContext.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/PropertyFieldMappingContext.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.mapper.pojo.mapping.definition.programmatic;
 
 import org.hibernate.search.engine.backend.document.model.dsl.Store;
+import org.hibernate.search.engine.environment.bean.BeanReference;
 import org.hibernate.search.mapper.pojo.bridge.ValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.mapping.BridgeBuilder;
 import org.hibernate.search.mapper.pojo.extractor.ContainerValueExtractor;
@@ -19,12 +20,25 @@ public interface PropertyFieldMappingContext<S extends PropertyFieldMappingConte
 
 	S store(Store store);
 
-	S valueBridge(String bridgeName);
-
+	/**
+	 * @param bridgeClass The class of the bridge to use.
+	 * @return {@code this}, for method chaining.
+	 */
 	S valueBridge(Class<? extends ValueBridge<?, ?>> bridgeClass);
 
-	S valueBridge(String bridgeName, Class<? extends ValueBridge<?, ?>> bridgeClass);
+	/**
+	 * @param bridgeReference A {@link BeanReference} pointing to the bridge to use.
+	 * The bridge must implement {@link ValueBridge}.
+	 * See the static "ofXXX()" methods of {@link BeanReference} for details about the various type of references
+	 * (by name, by type, ...).
+	 * @return {@code this}, for method chaining.
+	 */
+	S valueBridge(BeanReference bridgeReference);
 
+	/**
+	 * @param builder A bridge builder.
+	 * @return {@code this}, for method chaining.
+	 */
 	S valueBridge(BridgeBuilder<? extends ValueBridge<?, ?>> builder);
 
 	default S withExtractor(

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/PropertyMappingContext.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/PropertyMappingContext.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.mapper.pojo.mapping.definition.programmatic;
 
+import org.hibernate.search.engine.environment.bean.BeanReference;
 import org.hibernate.search.mapper.pojo.bridge.PropertyBridge;
 import org.hibernate.search.mapper.pojo.bridge.mapping.BridgeBuilder;
 import org.hibernate.search.mapper.pojo.bridge.mapping.MarkerBuilder;
@@ -25,12 +26,25 @@ public interface PropertyMappingContext {
 
 	PropertyDocumentIdMappingContext documentId();
 
-	PropertyMappingContext bridge(String bridgeName);
-
+	/**
+	 * @param bridgeClass The class of the bridge to use.
+	 * @return {@code this}, for method chaining.
+	 */
 	PropertyMappingContext bridge(Class<? extends PropertyBridge> bridgeClass);
 
-	PropertyMappingContext bridge(String bridgeName, Class<? extends PropertyBridge> bridgeClass);
+	/**
+	 * @param bridgeReference A {@link BeanReference} pointing to the bridge to use.
+	 * The bridge must implement {@link PropertyBridge}.
+	 * See the static "ofXXX()" methods of {@link BeanReference} for details about the various type of references
+	 * (by name, by type, ...).
+	 * @return {@code this}, for method chaining.
+	 */
+	PropertyMappingContext bridge(BeanReference bridgeReference);
 
+	/**
+	 * @param builder A bridge builder.
+	 * @return {@code this}, for method chaining.
+	 */
 	PropertyMappingContext bridge(BridgeBuilder<? extends PropertyBridge> builder);
 
 	PropertyMappingContext marker(MarkerBuilder builder);

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/TypeMappingContext.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/TypeMappingContext.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.mapper.pojo.mapping.definition.programmatic;
 
+import org.hibernate.search.engine.environment.bean.BeanReference;
 import org.hibernate.search.mapper.pojo.bridge.RoutingKeyBridge;
 import org.hibernate.search.mapper.pojo.bridge.TypeBridge;
 import org.hibernate.search.mapper.pojo.bridge.mapping.BridgeBuilder;
@@ -19,20 +20,46 @@ public interface TypeMappingContext {
 
 	TypeMappingContext indexed(String indexName);
 
-	TypeMappingContext routingKeyBridge(String bridgeName);
-
+	/**
+	 * @param bridgeClass The class of the bridge to use.
+	 * @return {@code this}, for method chaining.
+	 */
 	TypeMappingContext routingKeyBridge(Class<? extends RoutingKeyBridge> bridgeClass);
 
-	TypeMappingContext routingKeyBridge(String bridgeName, Class<? extends RoutingKeyBridge> bridgeClass);
+	/**
+	 * @param bridgeReference A {@link BeanReference} pointing to the bridge to use.
+	 * The bridge must implement {@link RoutingKeyBridge}.
+	 * See the static "ofXXX()" methods of {@link BeanReference} for details about the various type of references
+	 * (by name, by type, ...).
+	 * @return {@code this}, for method chaining.
+	 */
+	TypeMappingContext routingKeyBridge(BeanReference bridgeReference);
 
+	/**
+	 * @param builder A bridge builder.
+	 * @return {@code this}, for method chaining.
+	 */
 	TypeMappingContext routingKeyBridge(BridgeBuilder<? extends RoutingKeyBridge> builder);
 
-	TypeMappingContext bridge(String bridgeName);
-
+	/**
+	 * @param bridgeClass The class of the bridge to use.
+	 * @return {@code this}, for method chaining.
+	 */
 	TypeMappingContext bridge(Class<? extends TypeBridge> bridgeClass);
 
-	TypeMappingContext bridge(String bridgeName, Class<? extends TypeBridge> bridgeClass);
+	/**
+	 * @param bridgeReference A {@link BeanReference} pointing to the bridge to use.
+	 * The bridge must implement {@link TypeBridge}.
+	 * See the static "ofXXX()" methods of {@link BeanReference} for details about the various type of references
+	 * (by name, by type, ...).
+	 * @return {@code this}, for method chaining.
+	 */
+	TypeMappingContext bridge(BeanReference bridgeReference);
 
+	/**
+	 * @param builder A bridge builder.
+	 * @return {@code this}, for method chaining.
+	 */
 	TypeMappingContext bridge(BridgeBuilder<? extends TypeBridge> builder);
 
 	PropertyMappingContext property(String propertyName);

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/DelegatingPropertyMappingContext.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/DelegatingPropertyMappingContext.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.mapper.pojo.mapping.definition.programmatic.impl;
 
+import org.hibernate.search.engine.environment.bean.BeanReference;
 import org.hibernate.search.mapper.pojo.bridge.PropertyBridge;
 import org.hibernate.search.mapper.pojo.bridge.mapping.BridgeBuilder;
 import org.hibernate.search.mapper.pojo.bridge.mapping.MarkerBuilder;
@@ -42,18 +43,13 @@ class DelegatingPropertyMappingContext implements PropertyMappingContext {
 	}
 
 	@Override
-	public PropertyMappingContext bridge(String bridgeName) {
-		return delegate.bridge( bridgeName );
-	}
-
-	@Override
 	public PropertyMappingContext bridge(Class<? extends PropertyBridge> bridgeClass) {
 		return delegate.bridge( bridgeClass );
 	}
 
 	@Override
-	public PropertyMappingContext bridge(String bridgeName, Class<? extends PropertyBridge> bridgeClass) {
-		return delegate.bridge( bridgeName, bridgeClass );
+	public PropertyMappingContext bridge(BeanReference bridgeReference) {
+		return delegate.bridge( bridgeReference );
 	}
 
 	@Override

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/PropertyDocumentIdMappingContextImpl.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/PropertyDocumentIdMappingContextImpl.java
@@ -40,23 +40,14 @@ public class PropertyDocumentIdMappingContextImpl extends DelegatingPropertyMapp
 	}
 
 	@Override
-	public PropertyDocumentIdMappingContext identifierBridge(String bridgeName) {
-		return identifierBridge( BeanReference.ofName( bridgeName ) );
-	}
-
-	@Override
 	public PropertyDocumentIdMappingContext identifierBridge(Class<? extends IdentifierBridge<?>> bridgeClass) {
 		return identifierBridge( BeanReference.ofType( bridgeClass ) );
 	}
 
 	@Override
-	public PropertyDocumentIdMappingContext identifierBridge(String bridgeName, Class<? extends IdentifierBridge<?>> bridgeClass) {
-		return identifierBridge( BeanReference.of( bridgeName, bridgeClass ) );
-	}
-
 	// The builder will return an object of some class T where T extends IdentifierBridge, so this is safe
 	@SuppressWarnings( "unchecked" )
-	private PropertyDocumentIdMappingContext identifierBridge(BeanReference bridgeReference) {
+	public PropertyDocumentIdMappingContext identifierBridge(BeanReference bridgeReference) {
 		return identifierBridge(
 				(BridgeBuilder<? extends IdentifierBridge<?>>)
 						new BeanResolverBridgeBuilder( IdentifierBridge.class, bridgeReference )

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/PropertyDocumentIdMappingContextImpl.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/PropertyDocumentIdMappingContextImpl.java
@@ -7,7 +7,6 @@
 package org.hibernate.search.mapper.pojo.mapping.definition.programmatic.impl;
 
 import org.hibernate.search.engine.environment.bean.BeanReference;
-import org.hibernate.search.engine.environment.bean.spi.ImmutableBeanReference;
 import org.hibernate.search.mapper.pojo.bridge.IdentifierBridge;
 import org.hibernate.search.mapper.pojo.bridge.impl.BeanResolverBridgeBuilder;
 import org.hibernate.search.mapper.pojo.bridge.mapping.BridgeBuilder;
@@ -42,17 +41,17 @@ public class PropertyDocumentIdMappingContextImpl extends DelegatingPropertyMapp
 
 	@Override
 	public PropertyDocumentIdMappingContext identifierBridge(String bridgeName) {
-		return identifierBridge( new ImmutableBeanReference( bridgeName ) );
+		return identifierBridge( BeanReference.ofName( bridgeName ) );
 	}
 
 	@Override
 	public PropertyDocumentIdMappingContext identifierBridge(Class<? extends IdentifierBridge<?>> bridgeClass) {
-		return identifierBridge( new ImmutableBeanReference( bridgeClass ) );
+		return identifierBridge( BeanReference.ofType( bridgeClass ) );
 	}
 
 	@Override
 	public PropertyDocumentIdMappingContext identifierBridge(String bridgeName, Class<? extends IdentifierBridge<?>> bridgeClass) {
-		return identifierBridge( new ImmutableBeanReference( bridgeName, bridgeClass ) );
+		return identifierBridge( BeanReference.of( bridgeName, bridgeClass ) );
 	}
 
 	// The builder will return an object of some class T where T extends IdentifierBridge, so this is safe

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/PropertyFieldMappingContextImpl.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/PropertyFieldMappingContextImpl.java
@@ -65,23 +65,14 @@ abstract class PropertyFieldMappingContextImpl<S extends PropertyFieldMappingCon
 	}
 
 	@Override
-	public S valueBridge(String bridgeName) {
-		return valueBridge( BeanReference.ofName( bridgeName ) );
-	}
-
-	@Override
 	public S valueBridge(Class<? extends ValueBridge<?, ?>> bridgeClass) {
 		return valueBridge( BeanReference.ofType( bridgeClass ) );
 	}
 
 	@Override
-	public S valueBridge(String bridgeName, Class<? extends ValueBridge<?, ?>> bridgeClass) {
-		return valueBridge( BeanReference.of( bridgeName, bridgeClass ) );
-	}
-
 	// The builder will return an object of some class T where T extends ValueBridge<?, ?>, so this is safe
 	@SuppressWarnings( "unchecked" )
-	private S valueBridge(BeanReference bridgeReference) {
+	public S valueBridge(BeanReference bridgeReference) {
 		return valueBridge(
 				(BeanResolverBridgeBuilder<? extends ValueBridge<?, ?>>)
 						new BeanResolverBridgeBuilder( ValueBridge.class, bridgeReference )

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/PropertyFieldMappingContextImpl.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/PropertyFieldMappingContextImpl.java
@@ -14,7 +14,6 @@ import java.util.function.Function;
 import org.hibernate.search.engine.backend.document.model.dsl.StandardIndexSchemaFieldTypedContext;
 import org.hibernate.search.engine.backend.document.model.dsl.Store;
 import org.hibernate.search.engine.environment.bean.BeanReference;
-import org.hibernate.search.engine.environment.bean.spi.ImmutableBeanReference;
 import org.hibernate.search.engine.mapper.mapping.building.spi.FieldModelContributor;
 import org.hibernate.search.mapper.pojo.bridge.ValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.impl.BeanResolverBridgeBuilder;
@@ -67,17 +66,17 @@ abstract class PropertyFieldMappingContextImpl<S extends PropertyFieldMappingCon
 
 	@Override
 	public S valueBridge(String bridgeName) {
-		return valueBridge( new ImmutableBeanReference( bridgeName ) );
+		return valueBridge( BeanReference.ofName( bridgeName ) );
 	}
 
 	@Override
 	public S valueBridge(Class<? extends ValueBridge<?, ?>> bridgeClass) {
-		return valueBridge( new ImmutableBeanReference( bridgeClass ) );
+		return valueBridge( BeanReference.ofType( bridgeClass ) );
 	}
 
 	@Override
 	public S valueBridge(String bridgeName, Class<? extends ValueBridge<?, ?>> bridgeClass) {
-		return valueBridge( new ImmutableBeanReference( bridgeName, bridgeClass ) );
+		return valueBridge( BeanReference.of( bridgeName, bridgeClass ) );
 	}
 
 	// The builder will return an object of some class T where T extends ValueBridge<?, ?>, so this is safe

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/PropertyMappingContextImpl.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/PropertyMappingContextImpl.java
@@ -69,21 +69,12 @@ public class PropertyMappingContextImpl
 	}
 
 	@Override
-	public PropertyMappingContext bridge(String bridgeName) {
-		return bridge( BeanReference.ofName( bridgeName ) );
-	}
-
-	@Override
 	public PropertyMappingContext bridge(Class<? extends PropertyBridge> bridgeClass) {
 		return bridge( BeanReference.ofType( bridgeClass ) );
 	}
 
 	@Override
-	public PropertyMappingContext bridge(String bridgeName, Class<? extends PropertyBridge> bridgeClass) {
-		return bridge( BeanReference.of( bridgeName, bridgeClass ) );
-	}
-
-	private PropertyMappingContext bridge(BeanReference bridgeReference) {
+	public PropertyMappingContext bridge(BeanReference bridgeReference) {
 		return bridge( new BeanResolverBridgeBuilder<>( PropertyBridge.class, bridgeReference ) );
 	}
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/PropertyMappingContextImpl.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/PropertyMappingContextImpl.java
@@ -7,7 +7,6 @@
 package org.hibernate.search.mapper.pojo.mapping.definition.programmatic.impl;
 
 import org.hibernate.search.engine.environment.bean.BeanReference;
-import org.hibernate.search.engine.environment.bean.spi.ImmutableBeanReference;
 import org.hibernate.search.mapper.pojo.bridge.PropertyBridge;
 import org.hibernate.search.mapper.pojo.bridge.impl.BeanResolverBridgeBuilder;
 import org.hibernate.search.mapper.pojo.bridge.mapping.BridgeBuilder;
@@ -71,17 +70,17 @@ public class PropertyMappingContextImpl
 
 	@Override
 	public PropertyMappingContext bridge(String bridgeName) {
-		return bridge( new ImmutableBeanReference( bridgeName ) );
+		return bridge( BeanReference.ofName( bridgeName ) );
 	}
 
 	@Override
 	public PropertyMappingContext bridge(Class<? extends PropertyBridge> bridgeClass) {
-		return bridge( new ImmutableBeanReference( bridgeClass ) );
+		return bridge( BeanReference.ofType( bridgeClass ) );
 	}
 
 	@Override
 	public PropertyMappingContext bridge(String bridgeName, Class<? extends PropertyBridge> bridgeClass) {
-		return bridge( new ImmutableBeanReference( bridgeName, bridgeClass ) );
+		return bridge( BeanReference.of( bridgeName, bridgeClass ) );
 	}
 
 	private PropertyMappingContext bridge(BeanReference bridgeReference) {

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/TypeMappingContextImpl.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/TypeMappingContextImpl.java
@@ -77,21 +77,12 @@ public class TypeMappingContextImpl
 	}
 
 	@Override
-	public TypeMappingContext routingKeyBridge(String bridgeName) {
-		return routingKeyBridge( BeanReference.ofName( bridgeName ) );
-	}
-
-	@Override
 	public TypeMappingContext routingKeyBridge(Class<? extends RoutingKeyBridge> bridgeClass) {
 		return routingKeyBridge( BeanReference.ofType( bridgeClass ) );
 	}
 
 	@Override
-	public TypeMappingContext routingKeyBridge(String bridgeName, Class<? extends RoutingKeyBridge> bridgeClass) {
-		return routingKeyBridge( BeanReference.of( bridgeName, bridgeClass ) );
-	}
-
-	private TypeMappingContext routingKeyBridge(BeanReference bridgeReference) {
+	public TypeMappingContext routingKeyBridge(BeanReference bridgeReference) {
 		return routingKeyBridge( new BeanResolverBridgeBuilder<>( RoutingKeyBridge.class, bridgeReference ) );
 	}
 
@@ -102,21 +93,12 @@ public class TypeMappingContextImpl
 	}
 
 	@Override
-	public TypeMappingContext bridge(String bridgeName) {
-		return bridge( BeanReference.ofName( bridgeName ) );
-	}
-
-	@Override
 	public TypeMappingContext bridge(Class<? extends TypeBridge> bridgeClass) {
 		return bridge( BeanReference.ofType( bridgeClass ) );
 	}
 
 	@Override
-	public TypeMappingContext bridge(String bridgeName, Class<? extends TypeBridge> bridgeClass) {
-		return bridge( BeanReference.of( bridgeName, bridgeClass ) );
-	}
-
-	private TypeMappingContext bridge(BeanReference bridgeReference) {
+	public TypeMappingContext bridge(BeanReference bridgeReference) {
 		return bridge( new BeanResolverBridgeBuilder<>( TypeBridge.class, bridgeReference ) );
 	}
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/TypeMappingContextImpl.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/TypeMappingContextImpl.java
@@ -8,9 +8,8 @@ package org.hibernate.search.mapper.pojo.mapping.definition.programmatic.impl;
 
 import org.hibernate.search.engine.cfg.ConfigurationPropertySource;
 import org.hibernate.search.engine.environment.bean.BeanReference;
-import org.hibernate.search.engine.environment.bean.spi.ImmutableBeanReference;
-import org.hibernate.search.engine.mapper.mapping.spi.MappingBuildContext;
 import org.hibernate.search.engine.mapper.mapping.building.spi.MappingConfigurationCollector;
+import org.hibernate.search.engine.mapper.mapping.spi.MappingBuildContext;
 import org.hibernate.search.mapper.pojo.bridge.RoutingKeyBridge;
 import org.hibernate.search.mapper.pojo.bridge.TypeBridge;
 import org.hibernate.search.mapper.pojo.bridge.impl.BeanResolverBridgeBuilder;
@@ -79,17 +78,17 @@ public class TypeMappingContextImpl
 
 	@Override
 	public TypeMappingContext routingKeyBridge(String bridgeName) {
-		return routingKeyBridge( new ImmutableBeanReference( bridgeName ) );
+		return routingKeyBridge( BeanReference.ofName( bridgeName ) );
 	}
 
 	@Override
 	public TypeMappingContext routingKeyBridge(Class<? extends RoutingKeyBridge> bridgeClass) {
-		return routingKeyBridge( new ImmutableBeanReference( bridgeClass ) );
+		return routingKeyBridge( BeanReference.ofType( bridgeClass ) );
 	}
 
 	@Override
 	public TypeMappingContext routingKeyBridge(String bridgeName, Class<? extends RoutingKeyBridge> bridgeClass) {
-		return routingKeyBridge( new ImmutableBeanReference( bridgeName, bridgeClass ) );
+		return routingKeyBridge( BeanReference.of( bridgeName, bridgeClass ) );
 	}
 
 	private TypeMappingContext routingKeyBridge(BeanReference bridgeReference) {
@@ -104,17 +103,17 @@ public class TypeMappingContextImpl
 
 	@Override
 	public TypeMappingContext bridge(String bridgeName) {
-		return bridge( new ImmutableBeanReference( bridgeName ) );
+		return bridge( BeanReference.ofName( bridgeName ) );
 	}
 
 	@Override
 	public TypeMappingContext bridge(Class<? extends TypeBridge> bridgeClass) {
-		return bridge( new ImmutableBeanReference( bridgeClass ) );
+		return bridge( BeanReference.ofType( bridgeClass ) );
 	}
 
 	@Override
 	public TypeMappingContext bridge(String bridgeName, Class<? extends TypeBridge> bridgeClass) {
-		return bridge( new ImmutableBeanReference( bridgeName, bridgeClass ) );
+		return bridge( BeanReference.of( bridgeName, bridgeClass ) );
 	}
 
 	private TypeMappingContext bridge(BeanReference bridgeReference) {


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3189
https://hibernate.atlassian.net//browse/HSEARCH-3225

* HSEARCH-3189: Instantiate immutable implementations of data-carrier interfaces through static factory methods only
* HSEARCH-3225: Remove search() methods that implicitly create a search target encompassing all mapped types