### PR TITLE
Backport HSEARCH-3396 to branch 5.10 - Allow to use snapshot artifacts in OSGi integration tests

### DIFF
--- a/integrationtest/osgi/karaf-it/pom.xml
+++ b/integrationtest/osgi/karaf-it/pom.xml
@@ -173,6 +173,7 @@
                 <configuration>
                     <systemPropertyVariables>
                         <maven.settings.localRepository>${settings.localRepository}</maven.settings.localRepository>
+                        <maven.jboss.public.repo.url>${jboss.public.repo.url}</maven.jboss.public.repo.url>
                         <pax-exam.jvm.args>${pax-exam.jvm.args}</pax-exam.jvm.args>
                     </systemPropertyVariables>
                 </configuration>

--- a/integrationtest/osgi/karaf-it/src/test/java/org/hibernate/search/test/integration/osgi/HibernateSearchWithKarafIT.java
+++ b/integrationtest/osgi/karaf-it/src/test/java/org/hibernate/search/test/integration/osgi/HibernateSearchWithKarafIT.java
@@ -200,6 +200,7 @@ public class HibernateSearchWithKarafIT {
 						"etc/org.ops4j.pax.url.mvn.cfg",
 						"org.ops4j.pax.url.mvn.defaultRepositories",
 						"file://" + mavenLocalRepository
+								+ "@id=local-repo-from-maven-settings"
 				),
 				editConfigurationFilePut(
 						"etc/org.ops4j.pax.url.mvn.cfg",

--- a/integrationtest/osgi/karaf-it/src/test/java/org/hibernate/search/test/integration/osgi/HibernateSearchWithKarafIT.java
+++ b/integrationtest/osgi/karaf-it/src/test/java/org/hibernate/search/test/integration/osgi/HibernateSearchWithKarafIT.java
@@ -195,11 +195,15 @@ public class HibernateSearchWithKarafIT {
 				 * Use the same local Maven repository as the build job.
 				 * This allows to retrieve the just-installed artifacts in case
 				 * the local repo was overridden from the command line.
+				 *
+				 * See https://ops4j1.jira.com/wiki/spaces/paxurl/pages/3833866/Mvn+Protocol for more information
+				 * on the configuration below.
 				 */
 				editConfigurationFilePut(
 						"etc/org.ops4j.pax.url.mvn.cfg",
 						"org.ops4j.pax.url.mvn.defaultRepositories",
 						"file://" + mavenLocalRepository
+								+ "@snapshots" // Include snapshots, useful when experimenting with new ORM versions
 								+ "@id=local-repo-from-maven-settings"
 				),
 				editConfigurationFilePut(

--- a/integrationtest/osgi/karaf-it/src/test/java/org/hibernate/search/test/integration/osgi/HibernateSearchWithKarafIT.java
+++ b/integrationtest/osgi/karaf-it/src/test/java/org/hibernate/search/test/integration/osgi/HibernateSearchWithKarafIT.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.ops4j.pax.exam.CoreOptions.maven;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureConsole;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.debugConfiguration;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.editConfigurationFileExtend;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.editConfigurationFilePut;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.features;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
@@ -134,6 +135,7 @@ public class HibernateSearchWithKarafIT {
 				.versionAsInProject();
 
 		String mavenLocalRepository = System.getProperty( "maven.settings.localRepository" );
+		String jbossPublicRepository = System.getProperty( "maven.jboss.public.repo.url" );
 		String[] vmArgsFromProperties =
 				Arrays.stream(
 						System.getProperty( "pax-exam.jvm.args", "" ).split( "\\s" )
@@ -210,6 +212,14 @@ public class HibernateSearchWithKarafIT {
 						"etc/org.ops4j.pax.url.mvn.cfg",
 						"org.ops4j.pax.url.mvn.localRepository",
 						mavenLocalRepository
+				),
+				editConfigurationFileExtend( // Extend, not put: we want to keep the defaults (Maven Central in particular)
+						"etc/org.ops4j.pax.url.mvn.cfg",
+						"org.ops4j.pax.url.mvn.repositories",
+						jbossPublicRepository
+								+ "@snapshots" // Include snapshots, useful when experimenting with new ORM versions
+								+ "@noreleases" // Exclude releases as we expect all releases to be available on central
+								+ "@id=jboss-public-repository"
 				)
 		};
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3396

This is based on #1769 , which should be merged first.