### PR TITLE
HSEARCH-2328 Allow inclusion of source code in the documentation

### DIFF
--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -43,6 +43,18 @@
             <artifactId>hibernate-search-orm</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-search-backend-lucene</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-search-util-internal-integrationtest-common</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -13,7 +13,7 @@
         <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>hibernate-search-documentation</artifactId>
-    <packaging>pom</packaging>
+    <packaging>jar</packaging>
 
     <name>Hibernate Search Documentation</name>
     <description>Hibernate Search reference documentation</description>
@@ -22,6 +22,8 @@
         <asciidoctor.base-output-dir>${project.build.directory}/asciidoctor/en-US</asciidoctor.base-output-dir>
         <asciidoctor.theme-dir>${project.build.directory}/hibernate-asciidoctor-theme</asciidoctor.theme-dir>
         <asciidoctor.aggregated-resources-dir>${project.build.directory}/aggregated-resources</asciidoctor.aggregated-resources-dir>
+        <asciidoctor.examples-source-dir>${basedir}/src/test/java</asciidoctor.examples-source-dir>
+        <asciidoctor.examples-resources-dir>${basedir}/src/test/resources</asciidoctor.examples-resources-dir>
 
         <html.meta.description>Hibernate Search, full text search for your entities - Reference Documentation</html.meta.description>
         <html.meta.keywords>hibernate, search, hibernate search, full text, lucene, elasticsearch</html.meta.keywords>
@@ -34,6 +36,14 @@
         <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         <maven.javadoc.skip>true</maven.javadoc.skip>
     </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-search-orm</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
     <build>
         <plugins>
@@ -160,6 +170,8 @@
                 <configuration>
                     <sourceDocumentName>index.asciidoc</sourceDocumentName>
                     <attributes>
+                        <sourcedir>${asciidoctor.examples-source-dir}</sourcedir>
+                        <resourcesdir>${asciidoctor.examples-resource-dir}</resourcesdir>
                         <docinfodir>${asciidoctor.aggregated-resources-dir}/docinfo/noorm-documentation</docinfodir>
                         <icons>font</icons>
                         <tabsize>4</tabsize>

--- a/documentation/src/main/asciidoc/getting-started.asciidoc
+++ b/documentation/src/main/asciidoc/getting-started.asciidoc
@@ -27,3 +27,11 @@ include::{sourcedir}/org/hibernate/search/gettingstarted/model/after/Author.java
 ----
 ====
 
+.GeoPolygon
+====
+[source, JAVA, indent=0]
+----
+include::{sourcedir}/org/hibernate/search/gettingstarted/example/GeoPolygonTest.java[tags=geopolygon-spatial-hsearch-gettingstarted]
+----
+====
+

--- a/documentation/src/main/asciidoc/getting-started.asciidoc
+++ b/documentation/src/main/asciidoc/getting-started.asciidoc
@@ -2,3 +2,28 @@
 == Getting started
 
 TODO
+
+.Book and Author entities BEFORE adding Hibernate Search specific annotations
+====
+[source, JAVA, indent=0]
+----
+include::{sourcedir}/org/hibernate/search/gettingstarted/model/before/Book.java[tags=book-entity-before-hsearch-gettingstarted]
+----
+[source, JAVA, indent=0]
+----
+include::{sourcedir}/org/hibernate/search/gettingstarted/model/before/Author.java[tags=author-entity-before-hsearch-gettingstarted]
+----
+====
+
+.Book and Author entities AFTER adding Hibernate Search specific annotations
+====
+[source, JAVA, indent=0]
+----
+include::{sourcedir}/org/hibernate/search/gettingstarted/model/after/Book.java[tags=book-entity-after-hsearch-gettingstarted]
+----
+[source, JAVA, indent=0]
+----
+include::{sourcedir}/org/hibernate/search/gettingstarted/model/after/Author.java[tags=author-entity-after-hsearch-gettingstarted]
+----
+====
+

--- a/documentation/src/test/java/org/hibernate/search/gettingstarted/example/GeoPolygonTest.java
+++ b/documentation/src/test/java/org/hibernate/search/gettingstarted/example/GeoPolygonTest.java
@@ -1,0 +1,65 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.gettingstarted.example;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Arrays;
+
+import org.hibernate.search.engine.spatial.GeoPoint;
+import org.hibernate.search.engine.spatial.GeoPolygon;
+import org.hibernate.search.util.impl.test.SubTest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class GeoPolygonTest {
+
+	@Rule
+	public final ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void validPolygon() {
+		// tag::geopolygon-spatial-hsearch-gettingstarted[]
+
+		GeoPolygon polygon = GeoPolygon.of( GeoPoint.of( 26, 23 ), GeoPoint.of( 26, 26 ), GeoPoint.of( 24, 26 ),
+				GeoPoint.of( 24, 23 ), GeoPoint.of( 26, 23 ) );
+		assertNotNull( polygon );
+
+		polygon = GeoPolygon.of( Arrays.asList( GeoPoint.of( 26, 23 ), GeoPoint.of( 26, 26 ), GeoPoint.of( 24, 26 ),
+				GeoPoint.of( 24, 23 ), GeoPoint.of( 26, 23 ) ) );
+		assertNotNull( polygon );
+		// end::geopolygon-spatial-hsearch-gettingstarted[]
+	}
+
+	@Test
+	public void invalidPolygon() {
+		SubTest.expectException(
+				() -> GeoPolygon.of(
+						GeoPoint.of( 26, 23 ),
+						GeoPoint.of( 26, 26 ),
+						GeoPoint.of( 24, 26 ),
+						GeoPoint.of( 24, 23 )
+				)
+		)
+				.assertThrown()
+				.isInstanceOf( IllegalArgumentException.class )
+				.hasMessageContaining( "HSEARCH000516" );
+
+		SubTest.expectException(
+				() -> GeoPolygon.of( Arrays.asList(
+						GeoPoint.of( 26, 23 ),
+						GeoPoint.of( 26, 26 ),
+						GeoPoint.of( 24, 26 ),
+						GeoPoint.of( 24, 23 )
+				) )
+		)
+				.assertThrown()
+				.isInstanceOf( IllegalArgumentException.class )
+				.hasMessageContaining( "HSEARCH000516" );
+	}
+}

--- a/documentation/src/test/java/org/hibernate/search/gettingstarted/model/after/Author.java
+++ b/documentation/src/test/java/org/hibernate/search/gettingstarted/model/after/Author.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.gettingstarted.model.after;
+
+// tag::author-entity-after-hsearch-gettingstarted[]
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+@Entity
+@Indexed
+public class Author {
+
+	@Id
+	@GeneratedValue
+	private Integer id;
+
+	@GenericField(sortable = Sortable.YES)
+	private String name;
+
+	public Author() {
+	}
+
+	// ...
+}
+// end::author-entity-after-hsearch-gettingstarted[]

--- a/documentation/src/test/java/org/hibernate/search/gettingstarted/model/after/Book.java
+++ b/documentation/src/test/java/org/hibernate/search/gettingstarted/model/after/Book.java
@@ -1,0 +1,46 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.gettingstarted.model.after;
+
+// tag::book-entity-after-hsearch-gettingstarted[]
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToMany;
+
+import org.hibernate.search.engine.backend.document.model.dsl.Store;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
+
+@Entity
+@Indexed
+public class Book {
+
+	@Id
+	@GeneratedValue
+	private Integer id;
+
+	@GenericField(store = Store.NO)
+	private String title;
+
+	@GenericField(store = Store.NO)
+	private String subtitle;
+
+	@IndexedEmbedded
+	@ManyToMany
+	private Set<Author> authors = new HashSet<Author>();
+
+	public Book() {
+	}
+
+	// ...
+}
+// end::book-entity-after-hsearch-gettingstarted[]

--- a/documentation/src/test/java/org/hibernate/search/gettingstarted/model/before/Author.java
+++ b/documentation/src/test/java/org/hibernate/search/gettingstarted/model/before/Author.java
@@ -1,0 +1,33 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.gettingstarted.model.before;
+
+// tag::author-entity-before-hsearch-gettingstarted[]
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+@Entity
+@Indexed
+public class Author {
+
+	@Id
+	@GeneratedValue
+	private Integer id;
+
+	@GenericField
+	private String name;
+
+	public Author() {
+	}
+
+	// ...
+}
+// end::author-entity-before-hsearch-gettingstarted[]

--- a/documentation/src/test/java/org/hibernate/search/gettingstarted/model/before/Book.java
+++ b/documentation/src/test/java/org/hibernate/search/gettingstarted/model/before/Book.java
@@ -1,0 +1,37 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.gettingstarted.model.before;
+
+// tag::book-entity-before-hsearch-gettingstarted[]
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToMany;
+
+@Entity
+public class Book {
+
+	@Id
+	@GeneratedValue
+	private Integer id;
+
+	private String title;
+
+	private String subtitle;
+
+	@ManyToMany
+	private Set<Author> authors = new HashSet<Author>();
+
+	public Book() {
+	}
+
+	// ...
+}
+// end::book-entity-before-hsearch-gettingstarted[]


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2328

I've added a couple of entities in the "Getting Started" section to test that it works.
It's safe to exclude the related commit (https://github.com/hibernate/hibernate-search/commit/8892ed37cb847a2113c0345c9e9bcfec01e627d5) if we want to keep the doc clear.