### PR TITLE
HSEARCH-3064 - HSEARCH-3253 Add more checks for unsortable/non-projectable fields

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
@@ -321,4 +321,8 @@ public interface Log extends BasicLogger {
 
 	@Message(id = ID_OFFSET_3 + 46, value = "You cannot set the type of a field more than once.")
 	SearchException tryToSetFieldTypeMoreThanOnce(@Param EventContext context);
+
+	@Message(id = ID_OFFSET_3 + 47,
+			value = "Projections are not enabled for field '%1$s'. Make sure the field is marked as projectable.")
+	SearchException nonProjectableField(String absoluteFieldPath, @Param EventContext context);
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
@@ -325,4 +325,8 @@ public interface Log extends BasicLogger {
 	@Message(id = ID_OFFSET_3 + 47,
 			value = "Projections are not enabled for field '%1$s'. Make sure the field is marked as projectable.")
 	SearchException nonProjectableField(String absoluteFieldPath, @Param EventContext context);
+
+	@Message(id = ID_OFFSET_3 + 48,
+			value = "Sorting is not enabled for field '%1$s'. Make sure the field is marked as sortable.")
+	SearchException unsortableField(String absoluteFieldPath, @Param EventContext context);
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/AbstractElasticsearchScalarFieldTypedContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/AbstractElasticsearchScalarFieldTypedContext.java
@@ -22,8 +22,12 @@ abstract class AbstractElasticsearchScalarFieldTypedContext<S extends AbstractEl
 		extends AbstractElasticsearchStandardIndexSchemaFieldTypedContext<S, F> {
 
 	private final DataType dataType;
-	protected Projectable projectable = Projectable.DEFAULT;
-	protected Sortable sortable = Sortable.DEFAULT;
+
+	private Sortable sortable = Sortable.DEFAULT;
+	protected boolean resolvedSortable;
+
+	private Projectable projectable = Projectable.DEFAULT;
+	protected boolean resolvedProjectable;
 
 	AbstractElasticsearchScalarFieldTypedContext(IndexSchemaContext schemaContext,
 			Class<F> fieldType, DataType dataType) {
@@ -52,27 +56,11 @@ abstract class AbstractElasticsearchScalarFieldTypedContext<S extends AbstractEl
 
 		mapping.setType( dataType );
 
-		switch ( projectable ) {
-			case DEFAULT:
-				break;
-			case NO:
-				mapping.setStore( false );
-				break;
-			case YES:
-				mapping.setStore( true );
-				break;
-		}
+		resolvedSortable = resolveDefault( sortable );
+		resolvedProjectable = resolveDefault( projectable );
 
-		switch ( sortable ) {
-			case DEFAULT:
-				break;
-			case NO:
-				mapping.setDocValues( false );
-				break;
-			case YES:
-				mapping.setDocValues( true );
-				break;
-		}
+		mapping.setStore( resolvedProjectable );
+		mapping.setDocValues( resolvedSortable );
 
 		return mapping;
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/AbstractElasticsearchScalarFieldTypedContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/AbstractElasticsearchScalarFieldTypedContext.java
@@ -22,8 +22,8 @@ abstract class AbstractElasticsearchScalarFieldTypedContext<S extends AbstractEl
 		extends AbstractElasticsearchStandardIndexSchemaFieldTypedContext<S, F> {
 
 	private final DataType dataType;
-	private Projectable projectable = Projectable.DEFAULT;
-	private Sortable sortable = Sortable.DEFAULT;
+	protected Projectable projectable = Projectable.DEFAULT;
+	protected Sortable sortable = Sortable.DEFAULT;
 
 	AbstractElasticsearchScalarFieldTypedContext(IndexSchemaContext schemaContext,
 			Class<F> fieldType, DataType dataType) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/AbstractElasticsearchScalarFieldTypedContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/AbstractElasticsearchScalarFieldTypedContext.java
@@ -11,7 +11,7 @@ import org.hibernate.search.backend.elasticsearch.document.model.impl.Elasticsea
 import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.DataType;
 import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.PropertyMapping;
 import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
-import org.hibernate.search.engine.backend.document.model.dsl.Store;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaContext;
 import org.hibernate.search.engine.backend.document.spi.IndexSchemaFieldDefinitionHelper;
 
@@ -22,7 +22,7 @@ abstract class AbstractElasticsearchScalarFieldTypedContext<S extends AbstractEl
 		extends AbstractElasticsearchStandardIndexSchemaFieldTypedContext<S, F> {
 
 	private final DataType dataType;
-	private Store store = Store.DEFAULT;
+	private Projectable projectable = Projectable.DEFAULT;
 	private Sortable sortable = Sortable.DEFAULT;
 
 	AbstractElasticsearchScalarFieldTypedContext(IndexSchemaContext schemaContext,
@@ -32,8 +32,8 @@ abstract class AbstractElasticsearchScalarFieldTypedContext<S extends AbstractEl
 	}
 
 	@Override
-	public S store(Store store) {
-		this.store = store;
+	public S projectable(Projectable projectable) {
+		this.projectable = projectable;
 		return thisAsS();
 	}
 
@@ -52,15 +52,13 @@ abstract class AbstractElasticsearchScalarFieldTypedContext<S extends AbstractEl
 
 		mapping.setType( dataType );
 
-		switch ( store ) {
+		switch ( projectable ) {
 			case DEFAULT:
 				break;
 			case NO:
 				mapping.setStore( false );
 				break;
 			case YES:
-			case COMPRESS:
-				// TODO what about Store.COMPRESS?
 				mapping.setStore( true );
 				break;
 		}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/AbstractElasticsearchStandardIndexSchemaFieldTypedContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/AbstractElasticsearchStandardIndexSchemaFieldTypedContext.java
@@ -14,8 +14,11 @@ import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.P
 import org.hibernate.search.engine.backend.document.IndexFieldAccessor;
 import org.hibernate.search.engine.backend.document.converter.FromIndexFieldValueConverter;
 import org.hibernate.search.engine.backend.document.converter.ToIndexFieldValueConverter;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
+import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
 import org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaContext;
 import org.hibernate.search.engine.backend.document.spi.IndexSchemaFieldDefinitionHelper;
+import org.hibernate.search.util.AssertionFailure;
 
 /**
  * @author Yoann Rodiere
@@ -65,4 +68,27 @@ public abstract class AbstractElasticsearchStandardIndexSchemaFieldTypedContext<
 		return helper.getSchemaContext();
 	}
 
+	protected static boolean resolveDefault(Projectable projectable) {
+		switch ( projectable ) {
+			case DEFAULT:
+			case NO:
+				return false;
+			case YES:
+				return true;
+			default:
+				throw new AssertionFailure( "Unexpected value for Projectable: " + projectable );
+		}
+	}
+
+	protected static boolean resolveDefault(Sortable sortable) {
+		switch ( sortable ) {
+			case DEFAULT:
+			case NO:
+				return false;
+			case YES:
+				return true;
+			default:
+				throw new AssertionFailure( "Unexpected value for Sortable: " + sortable );
+		}
+	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchGeoPointIndexSchemaFieldContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchGeoPointIndexSchemaFieldContextImpl.java
@@ -53,7 +53,7 @@ public class ElasticsearchGeoPointIndexSchemaFieldContextImpl
 				parentNode, converter, GeoPointFieldCodec.INSTANCE,
 				GeoPointFieldPredicateBuilderFactory.INSTANCE,
 				GeoPointFieldSortBuilderFactory.INSTANCE,
-				new GeoPointFieldProjectionBuilderFactory( converter )
+				new GeoPointFieldProjectionBuilderFactory( projectable, converter )
 		);
 
 		JsonAccessor<JsonElement> jsonAccessor = JsonAccessor.root().property( relativeFieldName );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchGeoPointIndexSchemaFieldContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchGeoPointIndexSchemaFieldContextImpl.java
@@ -52,8 +52,8 @@ public class ElasticsearchGeoPointIndexSchemaFieldContextImpl
 		ElasticsearchIndexSchemaFieldNode<GeoPoint> node = new ElasticsearchIndexSchemaFieldNode<>(
 				parentNode, converter, GeoPointFieldCodec.INSTANCE,
 				GeoPointFieldPredicateBuilderFactory.INSTANCE,
-				new GeoPointFieldSortBuilderFactory( sortable ),
-				new GeoPointFieldProjectionBuilderFactory( projectable, converter )
+				new GeoPointFieldSortBuilderFactory( resolvedSortable ),
+				new GeoPointFieldProjectionBuilderFactory( resolvedProjectable, converter )
 		);
 
 		JsonAccessor<JsonElement> jsonAccessor = JsonAccessor.root().property( relativeFieldName );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchGeoPointIndexSchemaFieldContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchGeoPointIndexSchemaFieldContextImpl.java
@@ -52,7 +52,7 @@ public class ElasticsearchGeoPointIndexSchemaFieldContextImpl
 		ElasticsearchIndexSchemaFieldNode<GeoPoint> node = new ElasticsearchIndexSchemaFieldNode<>(
 				parentNode, converter, GeoPointFieldCodec.INSTANCE,
 				GeoPointFieldPredicateBuilderFactory.INSTANCE,
-				GeoPointFieldSortBuilderFactory.INSTANCE,
+				new GeoPointFieldSortBuilderFactory( sortable ),
 				new GeoPointFieldProjectionBuilderFactory( projectable, converter )
 		);
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchIntegerIndexSchemaFieldContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchIntegerIndexSchemaFieldContextImpl.java
@@ -51,7 +51,7 @@ public class ElasticsearchIntegerIndexSchemaFieldContextImpl
 		ElasticsearchIndexSchemaFieldNode<Integer> node = new ElasticsearchIndexSchemaFieldNode<>(
 				parentNode, converter, IntegerFieldCodec.INSTANCE,
 				new StandardFieldPredicateBuilderFactory( converter ),
-				new StandardFieldSortBuilderFactory( converter ),
+				new StandardFieldSortBuilderFactory( sortable, converter ),
 				new StandardFieldProjectionBuilderFactory( projectable, converter )
 		);
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchIntegerIndexSchemaFieldContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchIntegerIndexSchemaFieldContextImpl.java
@@ -51,8 +51,8 @@ public class ElasticsearchIntegerIndexSchemaFieldContextImpl
 		ElasticsearchIndexSchemaFieldNode<Integer> node = new ElasticsearchIndexSchemaFieldNode<>(
 				parentNode, converter, IntegerFieldCodec.INSTANCE,
 				new StandardFieldPredicateBuilderFactory( converter ),
-				new StandardFieldSortBuilderFactory( sortable, converter ),
-				new StandardFieldProjectionBuilderFactory( projectable, converter )
+				new StandardFieldSortBuilderFactory( resolvedSortable, converter ),
+				new StandardFieldProjectionBuilderFactory( resolvedProjectable, converter )
 		);
 
 		JsonAccessor<JsonElement> jsonAccessor = JsonAccessor.root().property( relativeFieldName );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchIntegerIndexSchemaFieldContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchIntegerIndexSchemaFieldContextImpl.java
@@ -52,7 +52,7 @@ public class ElasticsearchIntegerIndexSchemaFieldContextImpl
 				parentNode, converter, IntegerFieldCodec.INSTANCE,
 				new StandardFieldPredicateBuilderFactory( converter ),
 				new StandardFieldSortBuilderFactory( converter ),
-				new StandardFieldProjectionBuilderFactory( converter )
+				new StandardFieldProjectionBuilderFactory( projectable, converter )
 		);
 
 		JsonAccessor<JsonElement> jsonAccessor = JsonAccessor.root().property( relativeFieldName );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchLocalDateIndexSchemaFieldContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchLocalDateIndexSchemaFieldContextImpl.java
@@ -74,7 +74,7 @@ public class ElasticsearchLocalDateIndexSchemaFieldContextImpl
 				parentNode, converter, codec,
 				new StandardFieldPredicateBuilderFactory( converter ),
 				new StandardFieldSortBuilderFactory( converter ),
-				new StandardFieldProjectionBuilderFactory( converter )
+				new StandardFieldProjectionBuilderFactory( projectable, converter )
 		);
 
 		JsonAccessor<JsonElement> jsonAccessor = JsonAccessor.root().property( relativeFieldName );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchLocalDateIndexSchemaFieldContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchLocalDateIndexSchemaFieldContextImpl.java
@@ -73,7 +73,7 @@ public class ElasticsearchLocalDateIndexSchemaFieldContextImpl
 		ElasticsearchIndexSchemaFieldNode<LocalDate> node = new ElasticsearchIndexSchemaFieldNode<>(
 				parentNode, converter, codec,
 				new StandardFieldPredicateBuilderFactory( converter ),
-				new StandardFieldSortBuilderFactory( converter ),
+				new StandardFieldSortBuilderFactory( sortable, converter ),
 				new StandardFieldProjectionBuilderFactory( projectable, converter )
 		);
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchLocalDateIndexSchemaFieldContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchLocalDateIndexSchemaFieldContextImpl.java
@@ -17,8 +17,6 @@ import java.time.format.SignStyle;
 import java.util.Arrays;
 import java.util.Locale;
 
-import org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaContext;
-import org.hibernate.search.engine.backend.document.spi.IndexSchemaFieldDefinitionHelper;
 import org.hibernate.search.backend.elasticsearch.document.impl.ElasticsearchIndexFieldAccessor;
 import org.hibernate.search.backend.elasticsearch.document.model.impl.ElasticsearchIndexSchemaFieldNode;
 import org.hibernate.search.backend.elasticsearch.document.model.impl.ElasticsearchIndexSchemaNodeCollector;
@@ -31,6 +29,8 @@ import org.hibernate.search.backend.elasticsearch.types.converter.impl.StandardF
 import org.hibernate.search.backend.elasticsearch.types.predicate.impl.StandardFieldPredicateBuilderFactory;
 import org.hibernate.search.backend.elasticsearch.types.projection.impl.StandardFieldProjectionBuilderFactory;
 import org.hibernate.search.backend.elasticsearch.types.sort.impl.StandardFieldSortBuilderFactory;
+import org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaContext;
+import org.hibernate.search.engine.backend.document.spi.IndexSchemaFieldDefinitionHelper;
 
 import com.google.gson.JsonElement;
 
@@ -73,8 +73,8 @@ public class ElasticsearchLocalDateIndexSchemaFieldContextImpl
 		ElasticsearchIndexSchemaFieldNode<LocalDate> node = new ElasticsearchIndexSchemaFieldNode<>(
 				parentNode, converter, codec,
 				new StandardFieldPredicateBuilderFactory( converter ),
-				new StandardFieldSortBuilderFactory( sortable, converter ),
-				new StandardFieldProjectionBuilderFactory( projectable, converter )
+				new StandardFieldSortBuilderFactory( resolvedSortable, converter ),
+				new StandardFieldProjectionBuilderFactory( resolvedProjectable, converter )
 		);
 
 		JsonAccessor<JsonElement> jsonAccessor = JsonAccessor.root().property( relativeFieldName );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchStringIndexSchemaFieldContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchStringIndexSchemaFieldContextImpl.java
@@ -22,7 +22,7 @@ import org.hibernate.search.backend.elasticsearch.types.predicate.impl.StandardF
 import org.hibernate.search.backend.elasticsearch.types.projection.impl.StandardFieldProjectionBuilderFactory;
 import org.hibernate.search.backend.elasticsearch.types.sort.impl.StandardFieldSortBuilderFactory;
 import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
-import org.hibernate.search.engine.backend.document.model.dsl.Store;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.engine.backend.document.model.dsl.StringIndexSchemaFieldTypedContext;
 import org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaContext;
 import org.hibernate.search.engine.backend.document.spi.IndexSchemaFieldDefinitionHelper;
@@ -43,7 +43,7 @@ public class ElasticsearchStringIndexSchemaFieldContextImpl
 	private final String relativeFieldName;
 	private String analyzerName;
 	private String normalizerName;
-	private Store store = Store.DEFAULT;
+	private Projectable projectable = Projectable.DEFAULT;
 	private Sortable sortable = Sortable.DEFAULT;
 
 	public ElasticsearchStringIndexSchemaFieldContextImpl(IndexSchemaContext schemaContext, String relativeFieldName) {
@@ -64,8 +64,8 @@ public class ElasticsearchStringIndexSchemaFieldContextImpl
 	}
 
 	@Override
-	public ElasticsearchStringIndexSchemaFieldContextImpl store(Store store) {
-		this.store = store;
+	public ElasticsearchStringIndexSchemaFieldContextImpl projectable(Projectable projectable) {
+		this.projectable = projectable;
 		return this;
 	}
 
@@ -127,15 +127,13 @@ public class ElasticsearchStringIndexSchemaFieldContextImpl
 			}
 		}
 
-		switch ( store ) {
+		switch ( projectable ) {
 			case DEFAULT:
 				break;
 			case NO:
 				mapping.setStore( false );
 				break;
 			case YES:
-			case COMPRESS:
-				// TODO what about Store.COMPRESS?
 				mapping.setStore( true );
 				break;
 		}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchStringIndexSchemaFieldContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchStringIndexSchemaFieldContextImpl.java
@@ -88,7 +88,7 @@ public class ElasticsearchStringIndexSchemaFieldContextImpl
 		ElasticsearchIndexSchemaFieldNode<String> node = new ElasticsearchIndexSchemaFieldNode<>(
 				parentNode, converter, StringFieldCodec.INSTANCE,
 				new StandardFieldPredicateBuilderFactory( converter ),
-				new StandardFieldSortBuilderFactory( converter ),
+				new StandardFieldSortBuilderFactory( sortable, converter ),
 				new StandardFieldProjectionBuilderFactory( projectable, converter )
 		);
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchStringIndexSchemaFieldContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchStringIndexSchemaFieldContextImpl.java
@@ -89,7 +89,7 @@ public class ElasticsearchStringIndexSchemaFieldContextImpl
 				parentNode, converter, StringFieldCodec.INSTANCE,
 				new StandardFieldPredicateBuilderFactory( converter ),
 				new StandardFieldSortBuilderFactory( converter ),
-				new StandardFieldProjectionBuilderFactory( converter )
+				new StandardFieldProjectionBuilderFactory( projectable, converter )
 		);
 
 		JsonAccessor<JsonElement> jsonAccessor = JsonAccessor.root().property( relativeFieldName );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/JsonStringIndexSchemaFieldContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/JsonStringIndexSchemaFieldContextImpl.java
@@ -22,6 +22,7 @@ import org.hibernate.search.engine.backend.document.IndexFieldAccessor;
 import org.hibernate.search.engine.backend.document.converter.FromIndexFieldValueConverter;
 import org.hibernate.search.engine.backend.document.converter.ToIndexFieldValueConverter;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldTypedContext;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaContext;
 import org.hibernate.search.engine.backend.document.spi.IndexSchemaFieldDefinitionHelper;
 
@@ -86,7 +87,7 @@ public class JsonStringIndexSchemaFieldContextImpl implements IndexSchemaFieldTy
 				parentNode, converter, CODEC,
 				new StandardFieldPredicateBuilderFactory( converter ),
 				new StandardFieldSortBuilderFactory( converter ),
-				new StandardFieldProjectionBuilderFactory( converter )
+				new StandardFieldProjectionBuilderFactory( Projectable.YES, converter )
 		);
 
 		JsonAccessor<JsonElement> jsonAccessor = JsonAccessor.root().property( relativeFieldName );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/JsonStringIndexSchemaFieldContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/JsonStringIndexSchemaFieldContextImpl.java
@@ -22,8 +22,6 @@ import org.hibernate.search.engine.backend.document.IndexFieldAccessor;
 import org.hibernate.search.engine.backend.document.converter.FromIndexFieldValueConverter;
 import org.hibernate.search.engine.backend.document.converter.ToIndexFieldValueConverter;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldTypedContext;
-import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
-import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
 import org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaContext;
 import org.hibernate.search.engine.backend.document.spi.IndexSchemaFieldDefinitionHelper;
 
@@ -87,8 +85,8 @@ public class JsonStringIndexSchemaFieldContextImpl implements IndexSchemaFieldTy
 		ElasticsearchIndexSchemaFieldNode<String> node = new ElasticsearchIndexSchemaFieldNode<>(
 				parentNode, converter, CODEC,
 				new StandardFieldPredicateBuilderFactory( converter ),
-				new StandardFieldSortBuilderFactory( Sortable.YES, converter ),
-				new StandardFieldProjectionBuilderFactory( Projectable.YES, converter )
+				new StandardFieldSortBuilderFactory( true, converter ),
+				new StandardFieldProjectionBuilderFactory( true, converter )
 		);
 
 		JsonAccessor<JsonElement> jsonAccessor = JsonAccessor.root().property( relativeFieldName );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/JsonStringIndexSchemaFieldContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/JsonStringIndexSchemaFieldContextImpl.java
@@ -23,6 +23,7 @@ import org.hibernate.search.engine.backend.document.converter.FromIndexFieldValu
 import org.hibernate.search.engine.backend.document.converter.ToIndexFieldValueConverter;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldTypedContext;
 import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
+import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
 import org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaContext;
 import org.hibernate.search.engine.backend.document.spi.IndexSchemaFieldDefinitionHelper;
 
@@ -86,7 +87,7 @@ public class JsonStringIndexSchemaFieldContextImpl implements IndexSchemaFieldTy
 		ElasticsearchIndexSchemaFieldNode<String> node = new ElasticsearchIndexSchemaFieldNode<>(
 				parentNode, converter, CODEC,
 				new StandardFieldPredicateBuilderFactory( converter ),
-				new StandardFieldSortBuilderFactory( converter ),
+				new StandardFieldSortBuilderFactory( Sortable.YES, converter ),
 				new StandardFieldProjectionBuilderFactory( Projectable.YES, converter )
 		);
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/GeoPointFieldProjectionBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/GeoPointFieldProjectionBuilderFactory.java
@@ -12,7 +12,6 @@ import org.hibernate.search.backend.elasticsearch.logging.impl.Log;
 import org.hibernate.search.backend.elasticsearch.search.projection.impl.DistanceToFieldSearchProjectionBuilderImpl;
 import org.hibernate.search.backend.elasticsearch.search.projection.impl.FieldSearchProjectionBuilderImpl;
 import org.hibernate.search.backend.elasticsearch.types.converter.impl.ElasticsearchFieldConverter;
-import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.engine.logging.spi.EventContexts;
 import org.hibernate.search.engine.search.projection.spi.DistanceToFieldSearchProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.FieldSearchProjectionBuilder;
@@ -23,11 +22,11 @@ public class GeoPointFieldProjectionBuilderFactory implements ElasticsearchField
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private final Projectable projectable;
+	private final boolean projectable;
 
 	private final ElasticsearchFieldConverter converter;
 
-	public GeoPointFieldProjectionBuilderFactory(Projectable projectable, ElasticsearchFieldConverter converter) {
+	public GeoPointFieldProjectionBuilderFactory(boolean projectable, ElasticsearchFieldConverter converter) {
 		this.projectable = projectable;
 		this.converter = converter;
 	}
@@ -67,12 +66,8 @@ public class GeoPointFieldProjectionBuilderFactory implements ElasticsearchField
 		return converter.isDslCompatibleWith( other.converter );
 	}
 
-	private static void checkProjectable(String absoluteFieldPath, Projectable projectable) {
-		switch ( projectable ) {
-			case YES:
-				break;
-			case DEFAULT:
-			case NO:
+	private static void checkProjectable(String absoluteFieldPath, boolean projectable) {
+		if ( !projectable ) {
 				throw log.nonProjectableField( absoluteFieldPath,
 						EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
 		}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/GeoPointFieldProjectionBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/GeoPointFieldProjectionBuilderFactory.java
@@ -63,7 +63,8 @@ public class GeoPointFieldProjectionBuilderFactory implements ElasticsearchField
 
 		GeoPointFieldProjectionBuilderFactory other = (GeoPointFieldProjectionBuilderFactory) obj;
 
-		return converter.isDslCompatibleWith( other.converter );
+		return projectable == other.projectable &&
+				converter.isDslCompatibleWith( other.converter );
 	}
 
 	private static void checkProjectable(String absoluteFieldPath, boolean projectable) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/GeoPointFieldProjectionBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/GeoPointFieldProjectionBuilderFactory.java
@@ -12,6 +12,7 @@ import org.hibernate.search.backend.elasticsearch.logging.impl.Log;
 import org.hibernate.search.backend.elasticsearch.search.projection.impl.DistanceToFieldSearchProjectionBuilderImpl;
 import org.hibernate.search.backend.elasticsearch.search.projection.impl.FieldSearchProjectionBuilderImpl;
 import org.hibernate.search.backend.elasticsearch.types.converter.impl.ElasticsearchFieldConverter;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.engine.logging.spi.EventContexts;
 import org.hibernate.search.engine.search.projection.spi.DistanceToFieldSearchProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.FieldSearchProjectionBuilder;
@@ -22,15 +23,20 @@ public class GeoPointFieldProjectionBuilderFactory implements ElasticsearchField
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
+	private final Projectable projectable;
+
 	private final ElasticsearchFieldConverter converter;
 
-	public GeoPointFieldProjectionBuilderFactory(ElasticsearchFieldConverter converter) {
+	public GeoPointFieldProjectionBuilderFactory(Projectable projectable, ElasticsearchFieldConverter converter) {
+		this.projectable = projectable;
 		this.converter = converter;
 	}
 
 	@Override
 	public <T> FieldSearchProjectionBuilder<T> createFieldValueProjectionBuilder(String absoluteFieldPath,
 			Class<T> expectedType) {
+		checkProjectable( absoluteFieldPath, projectable );
+
 		if ( !converter.isProjectionCompatibleWith( expectedType ) ) {
 			throw log.invalidProjectionInvalidType( absoluteFieldPath, expectedType,
 					EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
@@ -42,6 +48,8 @@ public class GeoPointFieldProjectionBuilderFactory implements ElasticsearchField
 	@Override
 	public DistanceToFieldSearchProjectionBuilder createDistanceProjectionBuilder(String absoluteFieldPath,
 			GeoPoint center) {
+		checkProjectable( absoluteFieldPath, projectable );
+
 		return new DistanceToFieldSearchProjectionBuilderImpl( absoluteFieldPath, center );
 	}
 
@@ -57,5 +65,16 @@ public class GeoPointFieldProjectionBuilderFactory implements ElasticsearchField
 		GeoPointFieldProjectionBuilderFactory other = (GeoPointFieldProjectionBuilderFactory) obj;
 
 		return converter.isDslCompatibleWith( other.converter );
+	}
+
+	private static void checkProjectable(String absoluteFieldPath, Projectable projectable) {
+		switch ( projectable ) {
+			case YES:
+				break;
+			case DEFAULT:
+			case NO:
+				throw log.nonProjectableField( absoluteFieldPath,
+						EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
+		}
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/StandardFieldProjectionBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/StandardFieldProjectionBuilderFactory.java
@@ -62,7 +62,8 @@ public class StandardFieldProjectionBuilderFactory implements ElasticsearchField
 
 		StandardFieldProjectionBuilderFactory other = (StandardFieldProjectionBuilderFactory) obj;
 
-		return converter.isDslCompatibleWith( other.converter );
+		return projectable == other.projectable &&
+				converter.isDslCompatibleWith( other.converter );
 	}
 
 	private static void checkProjectable(String absoluteFieldPath, boolean projectable) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/StandardFieldProjectionBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/StandardFieldProjectionBuilderFactory.java
@@ -11,7 +11,6 @@ import java.lang.invoke.MethodHandles;
 import org.hibernate.search.backend.elasticsearch.logging.impl.Log;
 import org.hibernate.search.backend.elasticsearch.search.projection.impl.FieldSearchProjectionBuilderImpl;
 import org.hibernate.search.backend.elasticsearch.types.converter.impl.ElasticsearchFieldConverter;
-import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.engine.logging.spi.EventContexts;
 import org.hibernate.search.engine.search.projection.spi.DistanceToFieldSearchProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.FieldSearchProjectionBuilder;
@@ -22,11 +21,11 @@ public class StandardFieldProjectionBuilderFactory implements ElasticsearchField
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private final Projectable projectable;
+	private final boolean projectable;
 
 	private final ElasticsearchFieldConverter converter;
 
-	public StandardFieldProjectionBuilderFactory(Projectable projectable, ElasticsearchFieldConverter converter) {
+	public StandardFieldProjectionBuilderFactory(boolean projectable, ElasticsearchFieldConverter converter) {
 		this.projectable = projectable;
 		this.converter = converter;
 	}
@@ -66,12 +65,8 @@ public class StandardFieldProjectionBuilderFactory implements ElasticsearchField
 		return converter.isDslCompatibleWith( other.converter );
 	}
 
-	private static void checkProjectable(String absoluteFieldPath, Projectable projectable) {
-		switch ( projectable ) {
-			case YES:
-				break;
-			case DEFAULT:
-			case NO:
+	private static void checkProjectable(String absoluteFieldPath, boolean projectable) {
+		if ( !projectable ) {
 				throw log.nonProjectableField( absoluteFieldPath,
 						EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
 		}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/StandardFieldProjectionBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/StandardFieldProjectionBuilderFactory.java
@@ -11,6 +11,7 @@ import java.lang.invoke.MethodHandles;
 import org.hibernate.search.backend.elasticsearch.logging.impl.Log;
 import org.hibernate.search.backend.elasticsearch.search.projection.impl.FieldSearchProjectionBuilderImpl;
 import org.hibernate.search.backend.elasticsearch.types.converter.impl.ElasticsearchFieldConverter;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.engine.logging.spi.EventContexts;
 import org.hibernate.search.engine.search.projection.spi.DistanceToFieldSearchProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.FieldSearchProjectionBuilder;
@@ -21,15 +22,20 @@ public class StandardFieldProjectionBuilderFactory implements ElasticsearchField
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
+	private final Projectable projectable;
+
 	private final ElasticsearchFieldConverter converter;
 
-	public StandardFieldProjectionBuilderFactory(ElasticsearchFieldConverter converter) {
+	public StandardFieldProjectionBuilderFactory(Projectable projectable, ElasticsearchFieldConverter converter) {
+		this.projectable = projectable;
 		this.converter = converter;
 	}
 
 	@Override
 	public <T> FieldSearchProjectionBuilder<T> createFieldValueProjectionBuilder(String absoluteFieldPath,
 			Class<T> expectedType) {
+		checkProjectable( absoluteFieldPath, projectable );
+
 		if ( !converter.isProjectionCompatibleWith( expectedType ) ) {
 			throw log.invalidProjectionInvalidType( absoluteFieldPath, expectedType,
 					EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
@@ -58,5 +64,16 @@ public class StandardFieldProjectionBuilderFactory implements ElasticsearchField
 		StandardFieldProjectionBuilderFactory other = (StandardFieldProjectionBuilderFactory) obj;
 
 		return converter.isDslCompatibleWith( other.converter );
+	}
+
+	private static void checkProjectable(String absoluteFieldPath, Projectable projectable) {
+		switch ( projectable ) {
+			case YES:
+				break;
+			case DEFAULT:
+			case NO:
+				throw log.nonProjectableField( absoluteFieldPath,
+						EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
+		}
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/sort/impl/GeoPointFieldSortBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/sort/impl/GeoPointFieldSortBuilderFactory.java
@@ -11,7 +11,6 @@ import java.lang.invoke.MethodHandles;
 import org.hibernate.search.backend.elasticsearch.logging.impl.Log;
 import org.hibernate.search.backend.elasticsearch.search.sort.impl.DistanceSortBuilderImpl;
 import org.hibernate.search.backend.elasticsearch.search.sort.impl.ElasticsearchSearchSortBuilder;
-import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
 import org.hibernate.search.engine.logging.spi.EventContexts;
 import org.hibernate.search.engine.search.sort.spi.DistanceSortBuilder;
 import org.hibernate.search.engine.search.sort.spi.FieldSortBuilder;
@@ -22,9 +21,9 @@ public class GeoPointFieldSortBuilderFactory implements ElasticsearchFieldSortBu
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private final Sortable sortable;
+	private final boolean sortable;
 
-	public GeoPointFieldSortBuilderFactory(Sortable sortable) {
+	public GeoPointFieldSortBuilderFactory(boolean sortable) {
 		this.sortable = sortable;
 	}
 
@@ -54,14 +53,10 @@ public class GeoPointFieldSortBuilderFactory implements ElasticsearchFieldSortBu
 		return other.sortable == this.sortable;
 	}
 
-	private static void checkSortable(String absoluteFieldPath, Sortable sortable) {
-		switch ( sortable ) {
-			case YES:
-				break;
-			case DEFAULT:
-			case NO:
-				throw log.unsortableField( absoluteFieldPath,
-						EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
+	private static void checkSortable(String absoluteFieldPath, boolean sortable) {
+		if ( !sortable ) {
+			throw log.unsortableField( absoluteFieldPath,
+					EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
 		}
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/sort/impl/StandardFieldSortBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/sort/impl/StandardFieldSortBuilderFactory.java
@@ -12,7 +12,6 @@ import org.hibernate.search.backend.elasticsearch.logging.impl.Log;
 import org.hibernate.search.backend.elasticsearch.search.sort.impl.ElasticsearchSearchSortBuilder;
 import org.hibernate.search.backend.elasticsearch.search.sort.impl.FieldSortBuilderImpl;
 import org.hibernate.search.backend.elasticsearch.types.converter.impl.ElasticsearchFieldConverter;
-import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
 import org.hibernate.search.engine.logging.spi.EventContexts;
 import org.hibernate.search.engine.search.sort.spi.DistanceSortBuilder;
 import org.hibernate.search.engine.search.sort.spi.FieldSortBuilder;
@@ -23,11 +22,11 @@ public class StandardFieldSortBuilderFactory implements ElasticsearchFieldSortBu
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private final Sortable sortable;
+	private final boolean sortable;
 
 	private final ElasticsearchFieldConverter converter;
 
-	public StandardFieldSortBuilderFactory(Sortable sortable, ElasticsearchFieldConverter converter) {
+	public StandardFieldSortBuilderFactory(boolean sortable, ElasticsearchFieldConverter converter) {
 		this.sortable = sortable;
 		this.converter = converter;
 	}
@@ -61,14 +60,10 @@ public class StandardFieldSortBuilderFactory implements ElasticsearchFieldSortBu
 		return converter.isDslCompatibleWith( other.converter );
 	}
 
-	private static void checkSortable(String absoluteFieldPath, Sortable sortable) {
-		switch ( sortable ) {
-			case YES:
-				break;
-			case DEFAULT:
-			case NO:
-				throw log.unsortableField( absoluteFieldPath,
-						EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
+	private static void checkSortable(String absoluteFieldPath, boolean sortable) {
+		if ( !sortable ) {
+			throw log.unsortableField( absoluteFieldPath,
+					EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
 		}
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/sort/impl/StandardFieldSortBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/sort/impl/StandardFieldSortBuilderFactory.java
@@ -57,7 +57,8 @@ public class StandardFieldSortBuilderFactory implements ElasticsearchFieldSortBu
 
 		StandardFieldSortBuilderFactory other = (StandardFieldSortBuilderFactory) obj;
 
-		return converter.isDslCompatibleWith( other.converter );
+		return sortable == other.sortable &&
+				converter.isDslCompatibleWith( other.converter );
 	}
 
 	private static void checkSortable(String absoluteFieldPath, boolean sortable) {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
@@ -398,4 +398,8 @@ public interface Log extends BasicLogger {
 
 	@Message(id = ID_OFFSET_2 + 64, value = "Unexpected index: documentId '%1$s' was not collected." )
 	SearchException documentIdNotCollected(Integer documentId);
+
+	@Message(id = ID_OFFSET_2 + 65,
+			value = "Projections are not enabled for field '%1$s'. Make sure the field is marked as projectable.")
+	SearchException nonProjectableField(String absoluteFieldPath, @Param EventContext context);
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
@@ -402,4 +402,8 @@ public interface Log extends BasicLogger {
 	@Message(id = ID_OFFSET_2 + 65,
 			value = "Projections are not enabled for field '%1$s'. Make sure the field is marked as projectable.")
 	SearchException nonProjectableField(String absoluteFieldPath, @Param EventContext context);
+
+	@Message(id = ID_OFFSET_2 + 66,
+			value = "Sorting is not enabled for field '%1$s'. Make sure the field is marked as sortable.")
+	SearchException unsortableField(String absoluteFieldPath, @Param EventContext context);
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/GeoPointFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/GeoPointFieldCodec.java
@@ -19,7 +19,7 @@ import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexableField;
 import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
 import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
-import org.hibernate.search.engine.backend.document.model.dsl.Store;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.engine.spatial.GeoPoint;
 import org.hibernate.search.util.AssertionFailure;
 import org.hibernate.search.util.impl.common.CollectionHelper;
@@ -29,7 +29,7 @@ public final class GeoPointFieldCodec implements LuceneFieldCodec<GeoPoint> {
 	private static final String LATITUDE = "latitude";
 	private static final String LONGITUDE = "longitude";
 
-	private final Store store;
+	private final Projectable projectable;
 	private final Sortable sortable;
 
 	private final String latitudeAbsoluteFieldPath;
@@ -37,26 +37,24 @@ public final class GeoPointFieldCodec implements LuceneFieldCodec<GeoPoint> {
 
 	private final Set<String> storedFields;
 
-	public GeoPointFieldCodec(String absoluteFieldPath, Store store, Sortable sortable) {
-		this.store = store;
+	public GeoPointFieldCodec(String absoluteFieldPath, Projectable projectable, Sortable sortable) {
+		this.projectable = projectable;
 		this.sortable = sortable;
 
-		switch ( store ) {
+		switch ( projectable ) {
 			case DEFAULT:
 			case NO:
 				latitudeAbsoluteFieldPath = null;
 				longitudeAbsoluteFieldPath = null;
 				storedFields = Collections.emptySet();
 				break;
-			case COMPRESS:
-				// TODO HSEARCH-3081
 			case YES:
 				latitudeAbsoluteFieldPath = internalFieldName( absoluteFieldPath, LATITUDE );
 				longitudeAbsoluteFieldPath = internalFieldName( absoluteFieldPath, LONGITUDE );
 				storedFields = CollectionHelper.asSet( latitudeAbsoluteFieldPath, longitudeAbsoluteFieldPath );
 				break;
 			default: // The compiler wants a default entry, even if it doesn't make any sense
-				throw new AssertionFailure( "Unexpected value for Store: " + store );
+				throw new AssertionFailure( "Unexpected value for Projectable: " + projectable );
 		}
 	}
 
@@ -66,16 +64,13 @@ public final class GeoPointFieldCodec implements LuceneFieldCodec<GeoPoint> {
 			return;
 		}
 
-		switch ( store ) {
+		switch ( projectable ) {
 			case DEFAULT:
 			case NO:
 				break;
 			case YES:
 				documentBuilder.addField( new StoredField( latitudeAbsoluteFieldPath, value.getLatitude() ) );
 				documentBuilder.addField( new StoredField( longitudeAbsoluteFieldPath, value.getLongitude() ) );
-				break;
-			case COMPRESS:
-				// TODO HSEARCH-3081
 				break;
 		}
 
@@ -112,7 +107,7 @@ public final class GeoPointFieldCodec implements LuceneFieldCodec<GeoPoint> {
 
 		GeoPointFieldCodec other = (GeoPointFieldCodec) obj;
 
-		return Objects.equals( store, other.store ) &&
+		return Objects.equals( projectable, other.projectable ) &&
 				Objects.equals( sortable, other.sortable ) &&
 				Objects.equals( latitudeAbsoluteFieldPath, other.latitudeAbsoluteFieldPath ) &&
 				Objects.equals( longitudeAbsoluteFieldPath, other.longitudeAbsoluteFieldPath );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/GeoPointFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/GeoPointFieldCodec.java
@@ -74,7 +74,7 @@ public final class GeoPointFieldCodec implements LuceneFieldCodec<GeoPoint> {
 				break;
 		}
 
-		// the doc values field is also used when projecting on the distance
+		// doc values fields are required for predicates, distance projections and distance sorts
 		documentBuilder.addField( new LatLonDocValuesField( absoluteFieldPath, value.getLatitude(), value.getLongitude() ) );
 		documentBuilder.addField( new LatLonPoint( absoluteFieldPath, value.getLatitude(), value.getLongitude() ) );
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/IntegerFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/IntegerFieldCodec.java
@@ -6,24 +6,20 @@
  */
 package org.hibernate.search.backend.lucene.types.codec.impl;
 
-import java.util.Objects;
-
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexableField;
 import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
-import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
-import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 
 public final class IntegerFieldCodec implements LuceneFieldCodec<Integer> {
 
-	private final Projectable projectable;
+	private final boolean projectable;
 
-	private final Sortable sortable;
+	private final boolean sortable;
 
-	public IntegerFieldCodec(Projectable projectable, Sortable sortable) {
+	public IntegerFieldCodec(boolean projectable, boolean sortable) {
 		this.projectable = projectable;
 		this.sortable = sortable;
 	}
@@ -34,22 +30,12 @@ public final class IntegerFieldCodec implements LuceneFieldCodec<Integer> {
 			return;
 		}
 
-		switch ( projectable ) {
-			case DEFAULT:
-			case NO:
-				break;
-			case YES:
-				documentBuilder.addField( new StoredField( absoluteFieldPath, value ) );
-				break;
+		if ( projectable ) {
+			documentBuilder.addField( new StoredField( absoluteFieldPath, value ) );
 		}
 
-		switch ( sortable ) {
-			case DEFAULT:
-			case NO:
-				break;
-			case YES:
-				documentBuilder.addField( new NumericDocValuesField( absoluteFieldPath, value.longValue() ) );
-				break;
+		if ( sortable ) {
+			documentBuilder.addField( new NumericDocValuesField( absoluteFieldPath, value.longValue() ) );
 		}
 
 		documentBuilder.addField( new IntPoint( absoluteFieldPath, value ) );
@@ -77,6 +63,7 @@ public final class IntegerFieldCodec implements LuceneFieldCodec<Integer> {
 
 		IntegerFieldCodec other = (IntegerFieldCodec) obj;
 
-		return Objects.equals( projectable, other.projectable ) && Objects.equals( sortable, other.sortable );
+		return ( projectable == other.projectable ) &&
+				( sortable == other.sortable );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/IntegerFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/IntegerFieldCodec.java
@@ -15,16 +15,16 @@ import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexableField;
 import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
 import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
-import org.hibernate.search.engine.backend.document.model.dsl.Store;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 
 public final class IntegerFieldCodec implements LuceneFieldCodec<Integer> {
 
-	private final Store store;
+	private final Projectable projectable;
 
 	private final Sortable sortable;
 
-	public IntegerFieldCodec(Store store, Sortable sortable) {
-		this.store = store;
+	public IntegerFieldCodec(Projectable projectable, Sortable sortable) {
+		this.projectable = projectable;
 		this.sortable = sortable;
 	}
 
@@ -34,15 +34,12 @@ public final class IntegerFieldCodec implements LuceneFieldCodec<Integer> {
 			return;
 		}
 
-		switch ( store ) {
+		switch ( projectable ) {
 			case DEFAULT:
 			case NO:
 				break;
 			case YES:
 				documentBuilder.addField( new StoredField( absoluteFieldPath, value ) );
-				break;
-			case COMPRESS:
-				// TODO HSEARCH-3081
 				break;
 		}
 
@@ -80,6 +77,6 @@ public final class IntegerFieldCodec implements LuceneFieldCodec<Integer> {
 
 		IntegerFieldCodec other = (IntegerFieldCodec) obj;
 
-		return Objects.equals( store, other.store ) && Objects.equals( sortable, other.sortable );
+		return Objects.equals( projectable, other.projectable ) && Objects.equals( sortable, other.sortable );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LocalDateFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LocalDateFieldCodec.java
@@ -16,7 +16,6 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.ResolverStyle;
 import java.time.format.SignStyle;
 import java.util.Locale;
-import java.util.Objects;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.LongPoint;
@@ -24,8 +23,6 @@ import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexableField;
 import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
-import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
-import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 
 public final class LocalDateFieldCodec implements LuceneFieldCodec<LocalDate> {
 
@@ -38,11 +35,11 @@ public final class LocalDateFieldCodec implements LuceneFieldCodec<LocalDate> {
 			.toFormatter( Locale.ROOT )
 			.withResolverStyle( ResolverStyle.STRICT );
 
-	private final Projectable projectable;
+	private final boolean projectable;
 
-	private final Sortable sortable;
+	private final boolean sortable;
 
-	public LocalDateFieldCodec(Projectable projectable, Sortable sortable) {
+	public LocalDateFieldCodec(boolean projectable, boolean sortable) {
 		this.projectable = projectable;
 		this.sortable = sortable;
 	}
@@ -53,24 +50,14 @@ public final class LocalDateFieldCodec implements LuceneFieldCodec<LocalDate> {
 			return;
 		}
 
-		switch ( projectable ) {
-			case DEFAULT:
-			case NO:
-				break;
-			case YES:
-				documentBuilder.addField( new StoredField( absoluteFieldPath, FORMATTER.format( value ) ) );
-				break;
+		if ( projectable ) {
+			documentBuilder.addField( new StoredField( absoluteFieldPath, FORMATTER.format( value ) ) );
 		}
 
 		long valueToEpochDay = value.toEpochDay();
 
-		switch ( sortable ) {
-			case DEFAULT:
-			case NO:
-				break;
-			case YES:
-				documentBuilder.addField( new NumericDocValuesField( absoluteFieldPath, valueToEpochDay ) );
-				break;
+		if ( sortable ) {
+			documentBuilder.addField( new NumericDocValuesField( absoluteFieldPath, valueToEpochDay ) );
 		}
 
 		documentBuilder.addField( new LongPoint( absoluteFieldPath, valueToEpochDay ) );
@@ -104,6 +91,6 @@ public final class LocalDateFieldCodec implements LuceneFieldCodec<LocalDate> {
 
 		LocalDateFieldCodec other = (LocalDateFieldCodec) obj;
 
-		return Objects.equals( projectable, other.projectable ) && Objects.equals( sortable, other.sortable );
+		return ( projectable == other.projectable ) && ( sortable == other.sortable );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LocalDateFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LocalDateFieldCodec.java
@@ -25,7 +25,7 @@ import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexableField;
 import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
 import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
-import org.hibernate.search.engine.backend.document.model.dsl.Store;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 
 public final class LocalDateFieldCodec implements LuceneFieldCodec<LocalDate> {
 
@@ -38,12 +38,12 @@ public final class LocalDateFieldCodec implements LuceneFieldCodec<LocalDate> {
 			.toFormatter( Locale.ROOT )
 			.withResolverStyle( ResolverStyle.STRICT );
 
-	private final Store store;
+	private final Projectable projectable;
 
 	private final Sortable sortable;
 
-	public LocalDateFieldCodec(Store store, Sortable sortable) {
-		this.store = store;
+	public LocalDateFieldCodec(Projectable projectable, Sortable sortable) {
+		this.projectable = projectable;
 		this.sortable = sortable;
 	}
 
@@ -53,15 +53,12 @@ public final class LocalDateFieldCodec implements LuceneFieldCodec<LocalDate> {
 			return;
 		}
 
-		switch ( store ) {
+		switch ( projectable ) {
 			case DEFAULT:
 			case NO:
 				break;
 			case YES:
 				documentBuilder.addField( new StoredField( absoluteFieldPath, FORMATTER.format( value ) ) );
-				break;
-			case COMPRESS:
-				// TODO HSEARCH-3081
 				break;
 		}
 
@@ -107,6 +104,6 @@ public final class LocalDateFieldCodec implements LuceneFieldCodec<LocalDate> {
 
 		LocalDateFieldCodec other = (LocalDateFieldCodec) obj;
 
-		return Objects.equals( store, other.store ) && Objects.equals( sortable, other.sortable );
+		return Objects.equals( projectable, other.projectable ) && Objects.equals( sortable, other.sortable );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/StringFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/StringFieldCodec.java
@@ -14,19 +14,18 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.util.BytesRef;
-import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
 import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
 import org.hibernate.search.backend.lucene.util.impl.AnalyzerUtils;
 
 public final class StringFieldCodec implements LuceneFieldCodec<String> {
 
-	private final Sortable sortable;
+	private final boolean sortable;
 
 	private final FieldType fieldType;
 
 	private final Analyzer normalizer;
 
-	public StringFieldCodec(Sortable sortable, FieldType fieldType, Analyzer normalizer) {
+	public StringFieldCodec(boolean sortable, FieldType fieldType, Analyzer normalizer) {
 		this.sortable = sortable;
 		this.fieldType = fieldType;
 		this.normalizer = normalizer;
@@ -40,18 +39,13 @@ public final class StringFieldCodec implements LuceneFieldCodec<String> {
 
 		documentBuilder.addField( new Field( absoluteFieldPath, value, fieldType ) );
 
-		switch ( sortable ) {
-			case DEFAULT:
-			case NO:
-				break;
-			case YES:
-				documentBuilder.addField( new SortedDocValuesField(
-						absoluteFieldPath,
-						new BytesRef(
-								normalizer != null ? AnalyzerUtils.normalize( normalizer, absoluteFieldPath, value ) :
-										value )
-				) );
-				break;
+		if ( sortable ) {
+			documentBuilder.addField( new SortedDocValuesField(
+					absoluteFieldPath,
+					new BytesRef(
+							normalizer != null ? AnalyzerUtils.normalize( normalizer, absoluteFieldPath, value ) :
+									value )
+			) );
 		}
 	}
 
@@ -71,7 +65,7 @@ public final class StringFieldCodec implements LuceneFieldCodec<String> {
 
 		StringFieldCodec other = (StringFieldCodec) obj;
 
-		return Objects.equals( sortable, other.sortable ) &&
+		return ( sortable == other.sortable ) &&
 				Objects.equals( fieldType, other.fieldType ) &&
 				Objects.equals( normalizer, other.normalizer );
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/AbstractLuceneStandardIndexSchemaFieldTypedContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/AbstractLuceneStandardIndexSchemaFieldTypedContext.java
@@ -32,7 +32,7 @@ public abstract class AbstractLuceneStandardIndexSchemaFieldTypedContext<S exten
 
 	private final String relativeFieldName;
 
-	private Store store = Store.DEFAULT;
+	protected Store store = Store.DEFAULT;
 
 	protected AbstractLuceneStandardIndexSchemaFieldTypedContext(LuceneIndexSchemaContext schemaContext, String relativeFieldName,
 			Class<F> fieldType) {
@@ -78,10 +78,6 @@ public abstract class AbstractLuceneStandardIndexSchemaFieldTypedContext<S exten
 
 	protected String getRelativeFieldName() {
 		return relativeFieldName;
-	}
-
-	protected Store getStore() {
-		return store;
 	}
 
 	protected final LuceneIndexSchemaContext getSchemaContext() {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/AbstractLuceneStandardIndexSchemaFieldTypedContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/AbstractLuceneStandardIndexSchemaFieldTypedContext.java
@@ -14,7 +14,7 @@ import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexSchema
 import org.hibernate.search.engine.backend.document.IndexFieldAccessor;
 import org.hibernate.search.engine.backend.document.converter.FromIndexFieldValueConverter;
 import org.hibernate.search.engine.backend.document.converter.ToIndexFieldValueConverter;
-import org.hibernate.search.engine.backend.document.model.dsl.Store;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.engine.backend.document.spi.IndexSchemaFieldDefinitionHelper;
 
 /**
@@ -32,7 +32,7 @@ public abstract class AbstractLuceneStandardIndexSchemaFieldTypedContext<S exten
 
 	private final String relativeFieldName;
 
-	protected Store store = Store.DEFAULT;
+	protected Projectable projectable = Projectable.DEFAULT;
 
 	protected AbstractLuceneStandardIndexSchemaFieldTypedContext(LuceneIndexSchemaContext schemaContext, String relativeFieldName,
 			Class<F> fieldType) {
@@ -69,8 +69,8 @@ public abstract class AbstractLuceneStandardIndexSchemaFieldTypedContext<S exten
 			LuceneIndexSchemaObjectNode parentNode);
 
 	@Override
-	public S store(Store store) {
-		this.store = store;
+	public S projectable(Projectable projectable) {
+		this.projectable = projectable;
 		return thisAsS();
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/AbstractLuceneStandardIndexSchemaFieldTypedContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/AbstractLuceneStandardIndexSchemaFieldTypedContext.java
@@ -15,7 +15,9 @@ import org.hibernate.search.engine.backend.document.IndexFieldAccessor;
 import org.hibernate.search.engine.backend.document.converter.FromIndexFieldValueConverter;
 import org.hibernate.search.engine.backend.document.converter.ToIndexFieldValueConverter;
 import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
+import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
 import org.hibernate.search.engine.backend.document.spi.IndexSchemaFieldDefinitionHelper;
+import org.hibernate.search.util.AssertionFailure;
 
 /**
  * @param <S> The concrete type of this context.
@@ -82,5 +84,29 @@ public abstract class AbstractLuceneStandardIndexSchemaFieldTypedContext<S exten
 
 	protected final LuceneIndexSchemaContext getSchemaContext() {
 		return schemaContext;
+	}
+
+	protected static boolean resolveDefault(Projectable projectable) {
+		switch ( projectable ) {
+			case DEFAULT:
+			case NO:
+				return false;
+			case YES:
+				return true;
+			default:
+				throw new AssertionFailure( "Unexpected value for Projectable: " + projectable );
+		}
+	}
+
+	protected static boolean resolveDefault(Sortable sortable) {
+		switch ( sortable ) {
+			case DEFAULT:
+			case NO:
+				return false;
+			case YES:
+				return true;
+			default:
+				throw new AssertionFailure( "Unexpected value for Sortable: " + sortable );
+		}
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneFieldIndexSchemaFieldContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneFieldIndexSchemaFieldContextImpl.java
@@ -19,7 +19,6 @@ import org.hibernate.search.backend.lucene.types.projection.impl.StandardFieldPr
 import org.hibernate.search.engine.backend.document.IndexFieldAccessor;
 import org.hibernate.search.engine.backend.document.converter.ToIndexFieldValueConverter;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldTerminalContext;
-import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaContext;
 import org.hibernate.search.engine.backend.document.spi.IndexSchemaFieldDefinitionHelper;
 import org.hibernate.search.util.AssertionFailure;
@@ -84,8 +83,7 @@ public class LuceneFieldIndexSchemaFieldContextImpl<F>
 				codec,
 				null,
 				null,
-				new StandardFieldProjectionBuilderFactory<>(
-						fieldValueExtractor != null ? Projectable.YES : Projectable.NO, codec, converter )
+				new StandardFieldProjectionBuilderFactory<>( fieldValueExtractor != null, codec, converter )
 		);
 
 		helper.initialize( new LuceneIndexFieldAccessor<>( schemaNode ) );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneFieldIndexSchemaFieldContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneFieldIndexSchemaFieldContextImpl.java
@@ -19,6 +19,7 @@ import org.hibernate.search.backend.lucene.types.projection.impl.StandardFieldPr
 import org.hibernate.search.engine.backend.document.IndexFieldAccessor;
 import org.hibernate.search.engine.backend.document.converter.ToIndexFieldValueConverter;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldTerminalContext;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaContext;
 import org.hibernate.search.engine.backend.document.spi.IndexSchemaFieldDefinitionHelper;
 import org.hibernate.search.util.AssertionFailure;
@@ -83,7 +84,8 @@ public class LuceneFieldIndexSchemaFieldContextImpl<F>
 				codec,
 				null,
 				null,
-				new StandardFieldProjectionBuilderFactory<>( codec, converter )
+				new StandardFieldProjectionBuilderFactory<>(
+						fieldValueExtractor != null ? Projectable.YES : Projectable.NO, codec, converter )
 		);
 
 		helper.initialize( new LuceneIndexFieldAccessor<>( schemaNode ) );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneGeoPointIndexSchemaFieldContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneGeoPointIndexSchemaFieldContextImpl.java
@@ -53,7 +53,7 @@ public class LuceneGeoPointIndexSchemaFieldContextImpl
 				codec,
 				GeoPointFieldPredicateBuilderFactory.INSTANCE,
 				GeoPointFieldSortBuilderFactory.INSTANCE,
-				new GeoPointFieldProjectionBuilderFactory<>( codec, converter )
+				new GeoPointFieldProjectionBuilderFactory<>( projectable, codec, converter )
 		);
 
 		helper.initialize( new LuceneIndexFieldAccessor<>( schemaNode ) );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneGeoPointIndexSchemaFieldContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneGeoPointIndexSchemaFieldContextImpl.java
@@ -41,10 +41,13 @@ public class LuceneGeoPointIndexSchemaFieldContextImpl
 	@Override
 	protected void contribute(IndexSchemaFieldDefinitionHelper<GeoPoint> helper, LuceneIndexSchemaNodeCollector collector,
 			LuceneIndexSchemaObjectNode parentNode) {
+		boolean resolvedSortable = resolveDefault( sortable );
+		boolean resolvedProjectable = resolveDefault( projectable );
+
 		StandardFieldConverter<GeoPoint> converter = new StandardFieldConverter<>(
 				helper.createUserIndexFieldConverter() );
 		GeoPointFieldCodec codec = new GeoPointFieldCodec( parentNode.getAbsolutePath( getRelativeFieldName() ),
-				projectable, sortable );
+				resolvedProjectable, resolvedSortable );
 
 		LuceneIndexSchemaFieldNode<GeoPoint> schemaNode = new LuceneIndexSchemaFieldNode<>(
 				parentNode,
@@ -52,8 +55,8 @@ public class LuceneGeoPointIndexSchemaFieldContextImpl
 				converter,
 				codec,
 				GeoPointFieldPredicateBuilderFactory.INSTANCE,
-				new GeoPointFieldSortBuilderFactory( sortable ),
-				new GeoPointFieldProjectionBuilderFactory<>( projectable, codec, converter )
+				new GeoPointFieldSortBuilderFactory( resolvedSortable ),
+				new GeoPointFieldProjectionBuilderFactory<>( resolvedProjectable, codec, converter )
 		);
 
 		helper.initialize( new LuceneIndexFieldAccessor<>( schemaNode ) );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneGeoPointIndexSchemaFieldContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneGeoPointIndexSchemaFieldContextImpl.java
@@ -52,7 +52,7 @@ public class LuceneGeoPointIndexSchemaFieldContextImpl
 				converter,
 				codec,
 				GeoPointFieldPredicateBuilderFactory.INSTANCE,
-				GeoPointFieldSortBuilderFactory.INSTANCE,
+				new GeoPointFieldSortBuilderFactory( sortable ),
 				new GeoPointFieldProjectionBuilderFactory<>( projectable, codec, converter )
 		);
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneGeoPointIndexSchemaFieldContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneGeoPointIndexSchemaFieldContextImpl.java
@@ -44,7 +44,7 @@ public class LuceneGeoPointIndexSchemaFieldContextImpl
 		StandardFieldConverter<GeoPoint> converter = new StandardFieldConverter<>(
 				helper.createUserIndexFieldConverter() );
 		GeoPointFieldCodec codec = new GeoPointFieldCodec( parentNode.getAbsolutePath( getRelativeFieldName() ),
-				store, sortable );
+				projectable, sortable );
 
 		LuceneIndexSchemaFieldNode<GeoPoint> schemaNode = new LuceneIndexSchemaFieldNode<>(
 				parentNode,

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneGeoPointIndexSchemaFieldContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneGeoPointIndexSchemaFieldContextImpl.java
@@ -44,7 +44,7 @@ public class LuceneGeoPointIndexSchemaFieldContextImpl
 		StandardFieldConverter<GeoPoint> converter = new StandardFieldConverter<>(
 				helper.createUserIndexFieldConverter() );
 		GeoPointFieldCodec codec = new GeoPointFieldCodec( parentNode.getAbsolutePath( getRelativeFieldName() ),
-				getStore(), sortable );
+				store, sortable );
 
 		LuceneIndexSchemaFieldNode<GeoPoint> schemaNode = new LuceneIndexSchemaFieldNode<>(
 				parentNode,

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIntegerIndexSchemaFieldContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIntegerIndexSchemaFieldContextImpl.java
@@ -49,7 +49,7 @@ public class LuceneIntegerIndexSchemaFieldContextImpl
 				converter,
 				codec,
 				new IntegerFieldPredicateBuilderFactory( converter ),
-				new IntegerFieldSortBuilderFactory( converter ),
+				new IntegerFieldSortBuilderFactory( sortable, converter ),
 				new StandardFieldProjectionBuilderFactory<>( projectable, codec, converter )
 		);
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIntegerIndexSchemaFieldContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIntegerIndexSchemaFieldContextImpl.java
@@ -41,7 +41,7 @@ public class LuceneIntegerIndexSchemaFieldContextImpl
 	protected void contribute(IndexSchemaFieldDefinitionHelper<Integer> helper, LuceneIndexSchemaNodeCollector collector,
 			LuceneIndexSchemaObjectNode parentNode) {
 		StandardFieldConverter<Integer> converter = new StandardFieldConverter<>( helper.createUserIndexFieldConverter() );
-		IntegerFieldCodec codec = new IntegerFieldCodec( store, sortable );
+		IntegerFieldCodec codec = new IntegerFieldCodec( projectable, sortable );
 
 		LuceneIndexSchemaFieldNode<Integer> schemaNode = new LuceneIndexSchemaFieldNode<>(
 				parentNode,

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIntegerIndexSchemaFieldContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIntegerIndexSchemaFieldContextImpl.java
@@ -40,8 +40,11 @@ public class LuceneIntegerIndexSchemaFieldContextImpl
 	@Override
 	protected void contribute(IndexSchemaFieldDefinitionHelper<Integer> helper, LuceneIndexSchemaNodeCollector collector,
 			LuceneIndexSchemaObjectNode parentNode) {
+		boolean resolvedSortable = resolveDefault( sortable );
+		boolean resolvedProjectable = resolveDefault( projectable );
+
 		StandardFieldConverter<Integer> converter = new StandardFieldConverter<>( helper.createUserIndexFieldConverter() );
-		IntegerFieldCodec codec = new IntegerFieldCodec( projectable, sortable );
+		IntegerFieldCodec codec = new IntegerFieldCodec( resolvedProjectable, resolvedSortable );
 
 		LuceneIndexSchemaFieldNode<Integer> schemaNode = new LuceneIndexSchemaFieldNode<>(
 				parentNode,
@@ -49,8 +52,8 @@ public class LuceneIntegerIndexSchemaFieldContextImpl
 				converter,
 				codec,
 				new IntegerFieldPredicateBuilderFactory( converter ),
-				new IntegerFieldSortBuilderFactory( sortable, converter ),
-				new StandardFieldProjectionBuilderFactory<>( projectable, codec, converter )
+				new IntegerFieldSortBuilderFactory( resolvedSortable, converter ),
+				new StandardFieldProjectionBuilderFactory<>( resolvedProjectable, codec, converter )
 		);
 
 		helper.initialize( new LuceneIndexFieldAccessor<>( schemaNode ) );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIntegerIndexSchemaFieldContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIntegerIndexSchemaFieldContextImpl.java
@@ -50,7 +50,7 @@ public class LuceneIntegerIndexSchemaFieldContextImpl
 				codec,
 				new IntegerFieldPredicateBuilderFactory( converter ),
 				new IntegerFieldSortBuilderFactory( converter ),
-				new StandardFieldProjectionBuilderFactory<>( codec, converter )
+				new StandardFieldProjectionBuilderFactory<>( projectable, codec, converter )
 		);
 
 		helper.initialize( new LuceneIndexFieldAccessor<>( schemaNode ) );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIntegerIndexSchemaFieldContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIntegerIndexSchemaFieldContextImpl.java
@@ -41,7 +41,7 @@ public class LuceneIntegerIndexSchemaFieldContextImpl
 	protected void contribute(IndexSchemaFieldDefinitionHelper<Integer> helper, LuceneIndexSchemaNodeCollector collector,
 			LuceneIndexSchemaObjectNode parentNode) {
 		StandardFieldConverter<Integer> converter = new StandardFieldConverter<>( helper.createUserIndexFieldConverter() );
-		IntegerFieldCodec codec = new IntegerFieldCodec( getStore(), sortable );
+		IntegerFieldCodec codec = new IntegerFieldCodec( store, sortable );
 
 		LuceneIndexSchemaFieldNode<Integer> schemaNode = new LuceneIndexSchemaFieldNode<>(
 				parentNode,

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneLocalDateIndexSchemaFieldContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneLocalDateIndexSchemaFieldContextImpl.java
@@ -51,7 +51,7 @@ public class LuceneLocalDateIndexSchemaFieldContextImpl
 				converter,
 				codec,
 				new LocalDateFieldPredicateBuilderFactory( converter ),
-				new LocalDateFieldSortBuilderFactory( converter ),
+				new LocalDateFieldSortBuilderFactory( sortable, converter ),
 				new StandardFieldProjectionBuilderFactory<>( projectable, codec, converter )
 		);
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneLocalDateIndexSchemaFieldContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneLocalDateIndexSchemaFieldContextImpl.java
@@ -52,7 +52,7 @@ public class LuceneLocalDateIndexSchemaFieldContextImpl
 				codec,
 				new LocalDateFieldPredicateBuilderFactory( converter ),
 				new LocalDateFieldSortBuilderFactory( converter ),
-				new StandardFieldProjectionBuilderFactory<>( codec, converter )
+				new StandardFieldProjectionBuilderFactory<>( projectable, codec, converter )
 		);
 
 		helper.initialize( new LuceneIndexFieldAccessor<>( schemaNode ) );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneLocalDateIndexSchemaFieldContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneLocalDateIndexSchemaFieldContextImpl.java
@@ -43,7 +43,7 @@ public class LuceneLocalDateIndexSchemaFieldContextImpl
 	protected void contribute(IndexSchemaFieldDefinitionHelper<LocalDate> helper, LuceneIndexSchemaNodeCollector collector,
 			LuceneIndexSchemaObjectNode parentNode) {
 		LocalDateFieldConverter converter = new LocalDateFieldConverter( helper.createUserIndexFieldConverter() );
-		LocalDateFieldCodec codec = new LocalDateFieldCodec( store, sortable );
+		LocalDateFieldCodec codec = new LocalDateFieldCodec( projectable, sortable );
 
 		LuceneIndexSchemaFieldNode<LocalDate> schemaNode = new LuceneIndexSchemaFieldNode<>(
 				parentNode,

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneLocalDateIndexSchemaFieldContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneLocalDateIndexSchemaFieldContextImpl.java
@@ -42,8 +42,11 @@ public class LuceneLocalDateIndexSchemaFieldContextImpl
 	@Override
 	protected void contribute(IndexSchemaFieldDefinitionHelper<LocalDate> helper, LuceneIndexSchemaNodeCollector collector,
 			LuceneIndexSchemaObjectNode parentNode) {
+		boolean resolvedSortable = resolveDefault( sortable );
+		boolean resolvedProjectable = resolveDefault( projectable );
+
 		LocalDateFieldConverter converter = new LocalDateFieldConverter( helper.createUserIndexFieldConverter() );
-		LocalDateFieldCodec codec = new LocalDateFieldCodec( projectable, sortable );
+		LocalDateFieldCodec codec = new LocalDateFieldCodec( resolvedProjectable, resolvedSortable );
 
 		LuceneIndexSchemaFieldNode<LocalDate> schemaNode = new LuceneIndexSchemaFieldNode<>(
 				parentNode,
@@ -51,8 +54,8 @@ public class LuceneLocalDateIndexSchemaFieldContextImpl
 				converter,
 				codec,
 				new LocalDateFieldPredicateBuilderFactory( converter ),
-				new LocalDateFieldSortBuilderFactory( sortable, converter ),
-				new StandardFieldProjectionBuilderFactory<>( projectable, codec, converter )
+				new LocalDateFieldSortBuilderFactory( resolvedSortable, converter ),
+				new StandardFieldProjectionBuilderFactory<>( resolvedProjectable, codec, converter )
 		);
 
 		helper.initialize( new LuceneIndexFieldAccessor<>( schemaNode ) );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneLocalDateIndexSchemaFieldContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneLocalDateIndexSchemaFieldContextImpl.java
@@ -43,7 +43,7 @@ public class LuceneLocalDateIndexSchemaFieldContextImpl
 	protected void contribute(IndexSchemaFieldDefinitionHelper<LocalDate> helper, LuceneIndexSchemaNodeCollector collector,
 			LuceneIndexSchemaObjectNode parentNode) {
 		LocalDateFieldConverter converter = new LocalDateFieldConverter( helper.createUserIndexFieldConverter() );
-		LocalDateFieldCodec codec = new LocalDateFieldCodec( getStore(), sortable );
+		LocalDateFieldCodec codec = new LocalDateFieldCodec( store, sortable );
 
 		LuceneIndexSchemaFieldNode<LocalDate> schemaNode = new LuceneIndexSchemaFieldNode<>(
 				parentNode,

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneStringIndexSchemaFieldContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneStringIndexSchemaFieldContextImpl.java
@@ -114,7 +114,7 @@ public class LuceneStringIndexSchemaFieldContextImpl
 				codec,
 				new StringFieldPredicateBuilderFactory( converter, analyzer != null, queryBuilder ),
 				new StringFieldSortBuilderFactory( converter ),
-				new StandardFieldProjectionBuilderFactory<>( codec, converter )
+				new StandardFieldProjectionBuilderFactory<>( projectable, codec, converter )
 		);
 
 		helper.initialize( new LuceneIndexFieldAccessor<>( schemaNode ) );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneStringIndexSchemaFieldContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneStringIndexSchemaFieldContextImpl.java
@@ -25,7 +25,7 @@ import org.hibernate.search.backend.lucene.types.predicate.impl.StringFieldPredi
 import org.hibernate.search.backend.lucene.types.projection.impl.StandardFieldProjectionBuilderFactory;
 import org.hibernate.search.backend.lucene.types.sort.impl.StringFieldSortBuilderFactory;
 import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
-import org.hibernate.search.engine.backend.document.model.dsl.Store;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.engine.backend.document.model.dsl.StringIndexSchemaFieldTypedContext;
 import org.hibernate.search.engine.backend.document.spi.IndexSchemaFieldDefinitionHelper;
 import org.hibernate.search.util.impl.common.LoggerFactory;
@@ -103,7 +103,7 @@ public class LuceneStringIndexSchemaFieldContextImpl
 		);
 		StringFieldCodec codec = new StringFieldCodec(
 				sortable,
-				getFieldType( store, analyzer != null ),
+				getFieldType( projectable, analyzer != null ),
 				analyzerOrNormalizer
 		);
 
@@ -135,7 +135,7 @@ public class LuceneStringIndexSchemaFieldContextImpl
 		return getSchemaContext().getRoot().getAnalysisDefinitionRegistry();
 	}
 
-	private static FieldType getFieldType(Store store, boolean analyzed) {
+	private static FieldType getFieldType(Projectable projectable, boolean analyzed) {
 		FieldType fieldType = new FieldType();
 		if ( analyzed ) {
 			// TODO GSM: take into account the norms and term vectors options
@@ -156,16 +156,13 @@ public class LuceneStringIndexSchemaFieldContextImpl
 			 */
 			fieldType.setTokenized( true );
 		}
-		switch ( store ) {
+		switch ( projectable ) {
 			case DEFAULT:
 			case NO:
 				fieldType.setStored( false );
 				break;
 			case YES:
 				fieldType.setStored( true );
-				break;
-			case COMPRESS:
-				// TODO HSEARCH-3081
 				break;
 		}
 		fieldType.freeze();

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneStringIndexSchemaFieldContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneStringIndexSchemaFieldContextImpl.java
@@ -113,7 +113,7 @@ public class LuceneStringIndexSchemaFieldContextImpl
 				converter,
 				codec,
 				new StringFieldPredicateBuilderFactory( converter, analyzer != null, queryBuilder ),
-				new StringFieldSortBuilderFactory( converter ),
+				new StringFieldSortBuilderFactory( sortable, converter ),
 				new StandardFieldProjectionBuilderFactory<>( projectable, codec, converter )
 		);
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneStringIndexSchemaFieldContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneStringIndexSchemaFieldContextImpl.java
@@ -103,7 +103,7 @@ public class LuceneStringIndexSchemaFieldContextImpl
 		);
 		StringFieldCodec codec = new StringFieldCodec(
 				sortable,
-				getFieldType( getStore(), analyzer != null ),
+				getFieldType( store, analyzer != null ),
 				analyzerOrNormalizer
 		);
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/GeoPointFieldProjectionBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/GeoPointFieldProjectionBuilderFactory.java
@@ -13,7 +13,6 @@ import org.hibernate.search.backend.lucene.search.projection.impl.DistanceToFiel
 import org.hibernate.search.backend.lucene.search.projection.impl.FieldSearchProjectionBuilderImpl;
 import org.hibernate.search.backend.lucene.types.codec.impl.LuceneFieldCodec;
 import org.hibernate.search.backend.lucene.types.converter.impl.LuceneFieldConverter;
-import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.engine.logging.spi.EventContexts;
 import org.hibernate.search.engine.search.projection.spi.DistanceToFieldSearchProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.FieldSearchProjectionBuilder;
@@ -24,13 +23,13 @@ public class GeoPointFieldProjectionBuilderFactory<T> implements LuceneFieldProj
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private final Projectable projectable;
+	private final boolean projectable;
 
 	private final LuceneFieldCodec<T> codec;
 
 	private final LuceneFieldConverter<T, ?> converter;
 
-	public GeoPointFieldProjectionBuilderFactory(Projectable projectable, LuceneFieldCodec<T> codec,
+	public GeoPointFieldProjectionBuilderFactory(boolean projectable, LuceneFieldCodec<T> codec,
 			LuceneFieldConverter<T, ?> converter) {
 		this.projectable = projectable;
 		this.codec = codec;
@@ -73,14 +72,10 @@ public class GeoPointFieldProjectionBuilderFactory<T> implements LuceneFieldProj
 				converter.isDslCompatibleWith( other.converter );
 	}
 
-	private static void checkProjectable(String absoluteFieldPath, Projectable projectable) {
-		switch ( projectable ) {
-			case YES:
-				break;
-			case DEFAULT:
-			case NO:
-				throw log.nonProjectableField( absoluteFieldPath,
-						EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
+	private static void checkProjectable(String absoluteFieldPath, boolean projectable) {
+		if ( !projectable ) {
+			throw log.nonProjectableField( absoluteFieldPath,
+					EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
 		}
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/GeoPointFieldProjectionBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/GeoPointFieldProjectionBuilderFactory.java
@@ -68,7 +68,8 @@ public class GeoPointFieldProjectionBuilderFactory<T> implements LuceneFieldProj
 
 		GeoPointFieldProjectionBuilderFactory<?> other = (GeoPointFieldProjectionBuilderFactory<?>) obj;
 
-		return codec.isCompatibleWith( other.codec ) &&
+		return projectable == other.projectable &&
+				codec.isCompatibleWith( other.codec ) &&
 				converter.isDslCompatibleWith( other.converter );
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/GeoPointFieldProjectionBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/GeoPointFieldProjectionBuilderFactory.java
@@ -13,6 +13,7 @@ import org.hibernate.search.backend.lucene.search.projection.impl.DistanceToFiel
 import org.hibernate.search.backend.lucene.search.projection.impl.FieldSearchProjectionBuilderImpl;
 import org.hibernate.search.backend.lucene.types.codec.impl.LuceneFieldCodec;
 import org.hibernate.search.backend.lucene.types.converter.impl.LuceneFieldConverter;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.engine.logging.spi.EventContexts;
 import org.hibernate.search.engine.search.projection.spi.DistanceToFieldSearchProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.FieldSearchProjectionBuilder;
@@ -23,11 +24,15 @@ public class GeoPointFieldProjectionBuilderFactory<T> implements LuceneFieldProj
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
+	private final Projectable projectable;
+
 	private final LuceneFieldCodec<T> codec;
 
 	private final LuceneFieldConverter<T, ?> converter;
 
-	public GeoPointFieldProjectionBuilderFactory(LuceneFieldCodec<T> codec, LuceneFieldConverter<T, ?> converter) {
+	public GeoPointFieldProjectionBuilderFactory(Projectable projectable, LuceneFieldCodec<T> codec,
+			LuceneFieldConverter<T, ?> converter) {
+		this.projectable = projectable;
 		this.codec = codec;
 		this.converter = converter;
 	}
@@ -35,6 +40,8 @@ public class GeoPointFieldProjectionBuilderFactory<T> implements LuceneFieldProj
 	@Override
 	public <U> FieldSearchProjectionBuilder<U> createFieldValueProjectionBuilder(String absoluteFieldPath,
 			Class<U> expectedType) {
+		checkProjectable( absoluteFieldPath, projectable );
+
 		if ( !converter.isProjectionCompatibleWith( expectedType ) ) {
 			throw log.invalidProjectionInvalidType( absoluteFieldPath, expectedType,
 					EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
@@ -46,6 +53,8 @@ public class GeoPointFieldProjectionBuilderFactory<T> implements LuceneFieldProj
 	@Override
 	public DistanceToFieldSearchProjectionBuilder createDistanceProjectionBuilder(String absoluteFieldPath,
 			GeoPoint center) {
+		checkProjectable( absoluteFieldPath, projectable );
+
 		return new DistanceToFieldSearchProjectionBuilderImpl( absoluteFieldPath, center );
 	}
 
@@ -62,5 +71,16 @@ public class GeoPointFieldProjectionBuilderFactory<T> implements LuceneFieldProj
 
 		return codec.isCompatibleWith( other.codec ) &&
 				converter.isDslCompatibleWith( other.converter );
+	}
+
+	private static void checkProjectable(String absoluteFieldPath, Projectable projectable) {
+		switch ( projectable ) {
+			case YES:
+				break;
+			case DEFAULT:
+			case NO:
+				throw log.nonProjectableField( absoluteFieldPath,
+						EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
+		}
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/StandardFieldProjectionBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/StandardFieldProjectionBuilderFactory.java
@@ -12,7 +12,6 @@ import org.hibernate.search.backend.lucene.logging.impl.Log;
 import org.hibernate.search.backend.lucene.search.projection.impl.FieldSearchProjectionBuilderImpl;
 import org.hibernate.search.backend.lucene.types.codec.impl.LuceneFieldCodec;
 import org.hibernate.search.backend.lucene.types.converter.impl.LuceneFieldConverter;
-import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.engine.logging.spi.EventContexts;
 import org.hibernate.search.engine.search.projection.spi.DistanceToFieldSearchProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.FieldSearchProjectionBuilder;
@@ -23,13 +22,13 @@ public class StandardFieldProjectionBuilderFactory<T> implements LuceneFieldProj
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private final Projectable projectable;
+	private final boolean projectable;
 
 	private final LuceneFieldCodec<T> codec;
 
 	private final LuceneFieldConverter<T, ?> converter;
 
-	public StandardFieldProjectionBuilderFactory(Projectable projectable, LuceneFieldCodec<T> codec,
+	public StandardFieldProjectionBuilderFactory(boolean projectable, LuceneFieldCodec<T> codec,
 			LuceneFieldConverter<T, ?> converter) {
 		this.projectable = projectable;
 		this.codec = codec;
@@ -72,14 +71,10 @@ public class StandardFieldProjectionBuilderFactory<T> implements LuceneFieldProj
 				converter.isDslCompatibleWith( other.converter );
 	}
 
-	private static void checkProjectable(String absoluteFieldPath, Projectable projectable) {
-		switch ( projectable ) {
-			case YES:
-				break;
-			case DEFAULT:
-			case NO:
-				throw log.nonProjectableField( absoluteFieldPath,
-						EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
+	private static void checkProjectable(String absoluteFieldPath, boolean projectable) {
+		if ( !projectable ) {
+			throw log.nonProjectableField( absoluteFieldPath,
+					EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
 		}
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/StandardFieldProjectionBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/StandardFieldProjectionBuilderFactory.java
@@ -12,6 +12,7 @@ import org.hibernate.search.backend.lucene.logging.impl.Log;
 import org.hibernate.search.backend.lucene.search.projection.impl.FieldSearchProjectionBuilderImpl;
 import org.hibernate.search.backend.lucene.types.codec.impl.LuceneFieldCodec;
 import org.hibernate.search.backend.lucene.types.converter.impl.LuceneFieldConverter;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.engine.logging.spi.EventContexts;
 import org.hibernate.search.engine.search.projection.spi.DistanceToFieldSearchProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.FieldSearchProjectionBuilder;
@@ -22,11 +23,15 @@ public class StandardFieldProjectionBuilderFactory<T> implements LuceneFieldProj
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
+	private final Projectable projectable;
+
 	private final LuceneFieldCodec<T> codec;
 
 	private final LuceneFieldConverter<T, ?> converter;
 
-	public StandardFieldProjectionBuilderFactory(LuceneFieldCodec<T> codec, LuceneFieldConverter<T, ?> converter) {
+	public StandardFieldProjectionBuilderFactory(Projectable projectable, LuceneFieldCodec<T> codec,
+			LuceneFieldConverter<T, ?> converter) {
+		this.projectable = projectable;
 		this.codec = codec;
 		this.converter = converter;
 	}
@@ -34,6 +39,8 @@ public class StandardFieldProjectionBuilderFactory<T> implements LuceneFieldProj
 	@Override
 	public <U> FieldSearchProjectionBuilder<U> createFieldValueProjectionBuilder(String absoluteFieldPath,
 			Class<U> expectedType) {
+		checkProjectable( absoluteFieldPath, projectable );
+
 		if ( !converter.isProjectionCompatibleWith( expectedType ) ) {
 			throw log.invalidProjectionInvalidType( absoluteFieldPath, expectedType,
 					EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
@@ -63,5 +70,16 @@ public class StandardFieldProjectionBuilderFactory<T> implements LuceneFieldProj
 
 		return codec.isCompatibleWith( other.codec ) &&
 				converter.isDslCompatibleWith( other.converter );
+	}
+
+	private static void checkProjectable(String absoluteFieldPath, Projectable projectable) {
+		switch ( projectable ) {
+			case YES:
+				break;
+			case DEFAULT:
+			case NO:
+				throw log.nonProjectableField( absoluteFieldPath,
+						EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
+		}
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/StandardFieldProjectionBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/StandardFieldProjectionBuilderFactory.java
@@ -67,7 +67,8 @@ public class StandardFieldProjectionBuilderFactory<T> implements LuceneFieldProj
 
 		StandardFieldProjectionBuilderFactory<?> other = (StandardFieldProjectionBuilderFactory<?>) obj;
 
-		return codec.isCompatibleWith( other.codec ) &&
+		return projectable == other.projectable &&
+				codec.isCompatibleWith( other.codec ) &&
 				converter.isDslCompatibleWith( other.converter );
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/AbstractStandardLuceneFieldSortBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/AbstractStandardLuceneFieldSortBuilderFactory.java
@@ -48,7 +48,8 @@ abstract class AbstractStandardLuceneFieldSortBuilderFactory<F> implements Lucen
 
 		AbstractStandardLuceneFieldSortBuilderFactory<?> other = (AbstractStandardLuceneFieldSortBuilderFactory<?>) obj;
 
-		return converter.isDslCompatibleWith( other.converter );
+		return sortable == other.sortable &&
+				converter.isDslCompatibleWith( other.converter );
 	}
 
 	protected void checkSortable(String absoluteFieldPath) {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/AbstractStandardLuceneFieldSortBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/AbstractStandardLuceneFieldSortBuilderFactory.java
@@ -11,6 +11,7 @@ import java.lang.invoke.MethodHandles;
 import org.hibernate.search.backend.lucene.logging.impl.Log;
 import org.hibernate.search.backend.lucene.search.sort.impl.LuceneSearchSortBuilder;
 import org.hibernate.search.backend.lucene.types.converter.impl.LuceneFieldConverter;
+import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
 import org.hibernate.search.engine.logging.spi.EventContexts;
 import org.hibernate.search.engine.search.sort.spi.DistanceSortBuilder;
 import org.hibernate.search.engine.spatial.GeoPoint;
@@ -20,9 +21,12 @@ abstract class AbstractStandardLuceneFieldSortBuilderFactory<F> implements Lucen
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
+	private final Sortable sortable;
+
 	protected final LuceneFieldConverter<F, ?> converter;
 
-	protected AbstractStandardLuceneFieldSortBuilderFactory(LuceneFieldConverter<F, ?> converter) {
+	protected AbstractStandardLuceneFieldSortBuilderFactory(Sortable sortable, LuceneFieldConverter<F, ?> converter) {
+		this.sortable = sortable;
 		this.converter = converter;
 	}
 
@@ -46,5 +50,16 @@ abstract class AbstractStandardLuceneFieldSortBuilderFactory<F> implements Lucen
 		AbstractStandardLuceneFieldSortBuilderFactory<?> other = (AbstractStandardLuceneFieldSortBuilderFactory<?>) obj;
 
 		return converter.isDslCompatibleWith( other.converter );
+	}
+
+	protected void checkSortable(String absoluteFieldPath) {
+		switch ( sortable ) {
+			case YES:
+				break;
+			case DEFAULT:
+			case NO:
+				throw log.unsortableField( absoluteFieldPath,
+						EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
+		}
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/AbstractStandardLuceneFieldSortBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/AbstractStandardLuceneFieldSortBuilderFactory.java
@@ -11,7 +11,6 @@ import java.lang.invoke.MethodHandles;
 import org.hibernate.search.backend.lucene.logging.impl.Log;
 import org.hibernate.search.backend.lucene.search.sort.impl.LuceneSearchSortBuilder;
 import org.hibernate.search.backend.lucene.types.converter.impl.LuceneFieldConverter;
-import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
 import org.hibernate.search.engine.logging.spi.EventContexts;
 import org.hibernate.search.engine.search.sort.spi.DistanceSortBuilder;
 import org.hibernate.search.engine.spatial.GeoPoint;
@@ -21,11 +20,11 @@ abstract class AbstractStandardLuceneFieldSortBuilderFactory<F> implements Lucen
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private final Sortable sortable;
+	private final boolean sortable;
 
 	protected final LuceneFieldConverter<F, ?> converter;
 
-	protected AbstractStandardLuceneFieldSortBuilderFactory(Sortable sortable, LuceneFieldConverter<F, ?> converter) {
+	protected AbstractStandardLuceneFieldSortBuilderFactory(boolean sortable, LuceneFieldConverter<F, ?> converter) {
 		this.sortable = sortable;
 		this.converter = converter;
 	}
@@ -53,13 +52,9 @@ abstract class AbstractStandardLuceneFieldSortBuilderFactory<F> implements Lucen
 	}
 
 	protected void checkSortable(String absoluteFieldPath) {
-		switch ( sortable ) {
-			case YES:
-				break;
-			case DEFAULT:
-			case NO:
-				throw log.unsortableField( absoluteFieldPath,
-						EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
+		if ( !sortable ) {
+			throw log.unsortableField( absoluteFieldPath,
+					EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
 		}
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/GeoPointFieldSortBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/GeoPointFieldSortBuilderFactory.java
@@ -10,7 +10,6 @@ import java.lang.invoke.MethodHandles;
 
 import org.hibernate.search.backend.lucene.logging.impl.Log;
 import org.hibernate.search.backend.lucene.search.sort.impl.LuceneSearchSortBuilder;
-import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
 import org.hibernate.search.engine.logging.spi.EventContexts;
 import org.hibernate.search.engine.search.sort.spi.DistanceSortBuilder;
 import org.hibernate.search.engine.search.sort.spi.FieldSortBuilder;
@@ -21,9 +20,9 @@ public class GeoPointFieldSortBuilderFactory implements LuceneFieldSortBuilderFa
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private final Sortable sortable;
+	private final boolean sortable;
 
-	public GeoPointFieldSortBuilderFactory(Sortable sortable) {
+	public GeoPointFieldSortBuilderFactory(boolean sortable) {
 		this.sortable = sortable;
 	}
 
@@ -53,13 +52,9 @@ public class GeoPointFieldSortBuilderFactory implements LuceneFieldSortBuilderFa
 	}
 
 	protected void checkSortable(String absoluteFieldPath) {
-		switch ( sortable ) {
-			case YES:
-				break;
-			case DEFAULT:
-			case NO:
-				throw log.unsortableField( absoluteFieldPath,
-						EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
+		if ( !sortable ) {
+			throw log.unsortableField( absoluteFieldPath,
+					EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
 		}
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/IntegerFieldSortBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/IntegerFieldSortBuilderFactory.java
@@ -8,12 +8,11 @@ package org.hibernate.search.backend.lucene.types.sort.impl;
 
 import org.hibernate.search.backend.lucene.search.sort.impl.LuceneSearchSortBuilder;
 import org.hibernate.search.backend.lucene.types.converter.impl.LuceneFieldConverter;
-import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
 import org.hibernate.search.engine.search.sort.spi.FieldSortBuilder;
 
 public class IntegerFieldSortBuilderFactory extends AbstractStandardLuceneFieldSortBuilderFactory<Integer> {
 
-	public IntegerFieldSortBuilderFactory(Sortable sortable, LuceneFieldConverter<Integer, ?> converter) {
+	public IntegerFieldSortBuilderFactory(boolean sortable, LuceneFieldConverter<Integer, ?> converter) {
 		super( sortable, converter );
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/IntegerFieldSortBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/IntegerFieldSortBuilderFactory.java
@@ -8,16 +8,19 @@ package org.hibernate.search.backend.lucene.types.sort.impl;
 
 import org.hibernate.search.backend.lucene.search.sort.impl.LuceneSearchSortBuilder;
 import org.hibernate.search.backend.lucene.types.converter.impl.LuceneFieldConverter;
+import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
 import org.hibernate.search.engine.search.sort.spi.FieldSortBuilder;
 
 public class IntegerFieldSortBuilderFactory extends AbstractStandardLuceneFieldSortBuilderFactory<Integer> {
 
-	public IntegerFieldSortBuilderFactory(LuceneFieldConverter<Integer, ?> converter) {
-		super( converter );
+	public IntegerFieldSortBuilderFactory(Sortable sortable, LuceneFieldConverter<Integer, ?> converter) {
+		super( sortable, converter );
 	}
 
 	@Override
 	public FieldSortBuilder<LuceneSearchSortBuilder> createFieldSortBuilder(String absoluteFieldPath) {
+		checkSortable( absoluteFieldPath );
+
 		return new IntegerFieldSortBuilder( absoluteFieldPath, converter );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/LocalDateFieldSortBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/LocalDateFieldSortBuilderFactory.java
@@ -10,12 +10,11 @@ import java.time.LocalDate;
 
 import org.hibernate.search.backend.lucene.search.sort.impl.LuceneSearchSortBuilder;
 import org.hibernate.search.backend.lucene.types.converter.impl.LuceneFieldConverter;
-import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
 import org.hibernate.search.engine.search.sort.spi.FieldSortBuilder;
 
 public class LocalDateFieldSortBuilderFactory extends AbstractStandardLuceneFieldSortBuilderFactory<LocalDate> {
 
-	public LocalDateFieldSortBuilderFactory(Sortable sortable, LuceneFieldConverter<LocalDate, ?> converter) {
+	public LocalDateFieldSortBuilderFactory(boolean sortable, LuceneFieldConverter<LocalDate, ?> converter) {
 		super( sortable, converter );
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/LocalDateFieldSortBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/LocalDateFieldSortBuilderFactory.java
@@ -10,16 +10,19 @@ import java.time.LocalDate;
 
 import org.hibernate.search.backend.lucene.search.sort.impl.LuceneSearchSortBuilder;
 import org.hibernate.search.backend.lucene.types.converter.impl.LuceneFieldConverter;
+import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
 import org.hibernate.search.engine.search.sort.spi.FieldSortBuilder;
 
 public class LocalDateFieldSortBuilderFactory extends AbstractStandardLuceneFieldSortBuilderFactory<LocalDate> {
 
-	public LocalDateFieldSortBuilderFactory(LuceneFieldConverter<LocalDate, ?> converter) {
-		super( converter );
+	public LocalDateFieldSortBuilderFactory(Sortable sortable, LuceneFieldConverter<LocalDate, ?> converter) {
+		super( sortable, converter );
 	}
 
 	@Override
 	public FieldSortBuilder<LuceneSearchSortBuilder> createFieldSortBuilder(String absoluteFieldPath) {
+		checkSortable( absoluteFieldPath );
+
 		return new LocalDateFieldSortBuilder( absoluteFieldPath, converter );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/StringFieldSortBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/StringFieldSortBuilderFactory.java
@@ -8,12 +8,11 @@ package org.hibernate.search.backend.lucene.types.sort.impl;
 
 import org.hibernate.search.backend.lucene.search.sort.impl.LuceneSearchSortBuilder;
 import org.hibernate.search.backend.lucene.types.converter.impl.LuceneFieldConverter;
-import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
 import org.hibernate.search.engine.search.sort.spi.FieldSortBuilder;
 
 public class StringFieldSortBuilderFactory extends AbstractStandardLuceneFieldSortBuilderFactory<String> {
 
-	public StringFieldSortBuilderFactory(Sortable sortable, LuceneFieldConverter<String, ?> converter) {
+	public StringFieldSortBuilderFactory(boolean sortable, LuceneFieldConverter<String, ?> converter) {
 		super( sortable, converter );
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/StringFieldSortBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/StringFieldSortBuilderFactory.java
@@ -8,16 +8,19 @@ package org.hibernate.search.backend.lucene.types.sort.impl;
 
 import org.hibernate.search.backend.lucene.search.sort.impl.LuceneSearchSortBuilder;
 import org.hibernate.search.backend.lucene.types.converter.impl.LuceneFieldConverter;
+import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
 import org.hibernate.search.engine.search.sort.spi.FieldSortBuilder;
 
 public class StringFieldSortBuilderFactory extends AbstractStandardLuceneFieldSortBuilderFactory<String> {
 
-	public StringFieldSortBuilderFactory(LuceneFieldConverter<String, ?> converter) {
-		super( converter );
+	public StringFieldSortBuilderFactory(Sortable sortable, LuceneFieldConverter<String, ?> converter) {
+		super( sortable, converter );
 	}
 
 	@Override
 	public FieldSortBuilder<LuceneSearchSortBuilder> createFieldSortBuilder(String absoluteFieldPath) {
+		checkSortable( absoluteFieldPath );
+
 		return new StringFieldSortBuilder( absoluteFieldPath, converter );
 	}
 }

--- a/documentation/src/test/java/org/hibernate/search/gettingstarted/model/after/Book.java
+++ b/documentation/src/test/java/org/hibernate/search/gettingstarted/model/after/Book.java
@@ -15,7 +15,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.ManyToMany;
 
-import org.hibernate.search.engine.backend.document.model.dsl.Store;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
@@ -28,10 +28,10 @@ public class Book {
 	@GeneratedValue
 	private Integer id;
 
-	@GenericField(store = Store.NO)
+	@GenericField(projectable = Projectable.NO)
 	private String title;
 
-	@GenericField(store = Store.NO)
+	@GenericField(projectable = Projectable.NO)
 	private String subtitle;
 
 	@IndexedEmbedded

--- a/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/Projectable.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/Projectable.java
@@ -8,25 +8,22 @@ package org.hibernate.search.engine.backend.document.model.dsl;
 
 
 /**
- * Whether or not the value is stored in the document
- *
- * @author Emmanuel Bernard
+ * Whether or not we want to be able to obtain the value of the field as a projection.
+ * <p>
+ * This usually means that the field will be stored in the index but it is more subtle than that, for instance in the
+ * case of projection by distance.
  */
-public enum Store {
+public enum Projectable {
 	/**
 	 * Use the backend-specific default.
 	 */
 	DEFAULT,
 	/**
-	 * does not store the value in the index
+	 * Do not allow projection on the field.
 	 */
 	NO,
 	/**
-	 * stores the value in the index
+	 * Allow projection on the field.
 	 */
-	YES,
-	/**
-	 * stores the value in the index in a compressed form
-	 */
-	COMPRESS
+	YES
 }

--- a/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/StandardIndexSchemaFieldTypedContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/StandardIndexSchemaFieldTypedContext.java
@@ -9,7 +9,7 @@ package org.hibernate.search.engine.backend.document.model.dsl;
 public interface StandardIndexSchemaFieldTypedContext<S extends StandardIndexSchemaFieldTypedContext<? extends S, F>, F>
 		extends IndexSchemaFieldTypedContext<S, F> {
 
-	S store(Store store);
+	S projectable(Projectable projectable);
 
 	S sortable(Sortable sortable);
 

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/ExtensionIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/ExtensionIT.java
@@ -319,9 +319,9 @@ public class ExtensionIT {
 						projectionQuery.execute();
 				} )
 				.assertThrown()
-				.hasCauseInstanceOf( SearchException.class )
-				.hasMessageContaining( "This native field does not support projection." )
-				.satisfies( FailureReportUtils.hasCauseWithContext(
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Projections are not enabled for field" )
+				.satisfies( FailureReportUtils.hasContext(
 						EventContexts.fromIndexFieldAbsolutePath( "nativeField_unsupportedProjection" )
 				) );
 	}

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneSearchMultiIndexIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneSearchMultiIndexIT.java
@@ -13,7 +13,7 @@ import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldAccessor;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
-import org.hibernate.search.engine.backend.document.model.dsl.Store;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.engine.backend.index.spi.IndexWorkPlan;
 import org.hibernate.search.engine.mapper.mapping.spi.MappedIndexManager;
 import org.hibernate.search.engine.backend.index.spi.IndexSearchTarget;
@@ -164,7 +164,7 @@ public class LuceneSearchMultiIndexIT {
 
 		IndexAccessors_1_1(IndexSchemaElement root) {
 			string = root.field( "string" ).asString().createAccessor();
-			additionalField = root.field( "additionalField" ).asString().sortable( Sortable.YES ).store( Store.YES ).createAccessor();
+			additionalField = root.field( "additionalField" ).asString().sortable( Sortable.YES ).projectable( Projectable.YES ).createAccessor();
 		}
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/MultiTenancyIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/MultiTenancyIT.java
@@ -17,7 +17,7 @@ import org.hibernate.search.engine.backend.document.IndexFieldAccessor;
 import org.hibernate.search.engine.backend.document.IndexObjectFieldAccessor;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
-import org.hibernate.search.engine.backend.document.model.dsl.Store;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectField;
 import org.hibernate.search.engine.backend.index.spi.IndexWorkPlan;
 import org.hibernate.search.engine.mapper.mapping.spi.MappedIndexManager;
@@ -539,8 +539,8 @@ public class MultiTenancyIT {
 		final ObjectAccessors nestedObject;
 
 		IndexAccessors(IndexSchemaElement root) {
-			string = root.field( "string" ).asString().store( Store.YES ).createAccessor();
-			integer = root.field( "integer" ).asInteger().store( Store.YES ).createAccessor();
+			string = root.field( "string" ).asString().projectable( Projectable.YES ).createAccessor();
+			integer = root.field( "integer" ).asInteger().projectable( Projectable.YES ).createAccessor();
 			IndexSchemaObjectField nestedObjectField =
 					root.objectField( "nestedObject", ObjectFieldStorage.NESTED );
 			nestedObject = new ObjectAccessors( nestedObjectField );
@@ -554,8 +554,8 @@ public class MultiTenancyIT {
 
 		ObjectAccessors(IndexSchemaObjectField objectField) {
 			self = objectField.createAccessor();
-			string = objectField.field( "string" ).asString().store( Store.YES ).createAccessor();
-			integer = objectField.field( "integer" ).asInteger().store( Store.YES ).createAccessor();
+			string = objectField.field( "string" ).asString().projectable( Projectable.YES ).createAccessor();
+			integer = objectField.field( "integer" ).asInteger().projectable( Projectable.YES ).createAccessor();
 		}
 	}
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/SearchMultiIndexIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/SearchMultiIndexIT.java
@@ -15,7 +15,7 @@ import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldAccessor;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
-import org.hibernate.search.engine.backend.document.model.dsl.Store;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.engine.backend.index.spi.IndexWorkPlan;
 import org.hibernate.search.engine.mapper.mapping.spi.MappedIndexManager;
 import org.hibernate.search.engine.backend.index.spi.IndexSearchTarget;
@@ -400,9 +400,9 @@ public class SearchMultiIndexIT {
 
 		IndexAccessors_1_1(IndexSchemaElement root) {
 			string = root.field( "string" ).asString().createAccessor();
-			additionalField = root.field( "additionalField" ).asString().sortable( Sortable.YES ).store( Store.YES ).createAccessor();
-			differentTypesField = root.field( "differentTypesField" ).asString().sortable( Sortable.YES ).store( Store.YES ).createAccessor();
-			sortField = root.field( "sortField" ).asString().sortable( Sortable.YES ).store( Store.YES ).createAccessor();
+			additionalField = root.field( "additionalField" ).asString().sortable( Sortable.YES ).projectable( Projectable.YES ).createAccessor();
+			differentTypesField = root.field( "differentTypesField" ).asString().sortable( Sortable.YES ).projectable( Projectable.YES ).createAccessor();
+			sortField = root.field( "sortField" ).asString().sortable( Sortable.YES ).projectable( Projectable.YES ).createAccessor();
 		}
 	}
 
@@ -413,8 +413,8 @@ public class SearchMultiIndexIT {
 
 		IndexAccessors_1_2(IndexSchemaElement root) {
 			string = root.field( "string" ).asString().createAccessor();
-			differentTypesField = root.field( "differentTypesField" ).asInteger().sortable( Sortable.YES ).store( Store.YES ).createAccessor();
-			sortField = root.field( "sortField" ).asString().sortable( Sortable.YES ).store( Store.YES ).createAccessor();
+			differentTypesField = root.field( "differentTypesField" ).asInteger().sortable( Sortable.YES ).projectable( Projectable.YES ).createAccessor();
+			sortField = root.field( "sortField" ).asString().sortable( Sortable.YES ).projectable( Projectable.YES ).createAccessor();
 		}
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/SearchResultLoadingOrTransformingIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/SearchResultLoadingOrTransformingIT.java
@@ -26,7 +26,7 @@ import org.hibernate.search.engine.backend.document.IndexObjectFieldAccessor;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectField;
 import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
-import org.hibernate.search.engine.backend.document.model.dsl.Store;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.engine.backend.index.spi.IndexSearchTarget;
 import org.hibernate.search.engine.backend.index.spi.IndexWorkPlan;
 import org.hibernate.search.engine.common.spi.SessionContext;
@@ -365,14 +365,14 @@ public class SearchResultLoadingOrTransformingIT {
 		final ObjectAccessors nestedObject;
 
 		IndexAccessors(IndexSchemaElement root) {
-			string = root.field( "string" ).asString().store( Store.YES ).createAccessor();
+			string = root.field( "string" ).asString().projectable( Projectable.YES ).createAccessor();
 			string_analyzed = root.field( "string_analyzed" ).asString()
-					.store( Store.YES )
+					.projectable( Projectable.YES )
 					.analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD.name )
 					.createAccessor();
-			integer = root.field( "integer" ).asInteger().store( Store.YES ).createAccessor();
-			localDate = root.field( "localDate" ).asLocalDate().store( Store.YES ).createAccessor();
-			geoPoint = root.field( "geoPoint" ).asGeoPoint().store( Store.YES ).createAccessor();
+			integer = root.field( "integer" ).asInteger().projectable( Projectable.YES ).createAccessor();
+			localDate = root.field( "localDate" ).asLocalDate().projectable( Projectable.YES ).createAccessor();
+			geoPoint = root.field( "geoPoint" ).asGeoPoint().projectable( Projectable.YES ).createAccessor();
 			IndexSchemaObjectField flattenedObjectField =
 					root.objectField( "flattenedObject", ObjectFieldStorage.FLATTENED );
 			flattenedObject = new ObjectAccessors( flattenedObjectField );
@@ -389,8 +389,8 @@ public class SearchResultLoadingOrTransformingIT {
 
 		ObjectAccessors(IndexSchemaObjectField objectField) {
 			self = objectField.createAccessor();
-			string = objectField.field( "string" ).asString().store( Store.YES ).createAccessor();
-			integer = objectField.field( "integer" ).asInteger().store( Store.YES ).createAccessor();
+			string = objectField.field( "string" ).asString().projectable( Projectable.YES ).createAccessor();
+			integer = objectField.field( "integer" ).asInteger().projectable( Projectable.YES ).createAccessor();
 		}
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/SearchProjectionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/SearchProjectionIT.java
@@ -25,7 +25,7 @@ import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldCo
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectField;
 import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
 import org.hibernate.search.engine.backend.document.model.dsl.StandardIndexSchemaFieldTypedContext;
-import org.hibernate.search.engine.backend.document.model.dsl.Store;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.engine.backend.index.spi.IndexSearchTarget;
 import org.hibernate.search.engine.backend.index.spi.IndexWorkPlan;
 import org.hibernate.search.engine.common.spi.SessionContext;
@@ -429,9 +429,9 @@ public class SearchProjectionIT {
 	}
 
 	@Test
-	public void error_notStored() {
-		Assume.assumeTrue( "Checks preventing from projecting on un-stored fields are not implemented yet", false );
-		// TODO  Throw an exception when trying to project on an un-stored field
+	public void error_notProjectable() {
+		Assume.assumeTrue( "Checks preventing from projecting on un-projectable fields are not implemented yet", false );
+		// TODO  Throw an exception when trying to project on an un-projectable field
 	}
 
 	private void initData() {
@@ -606,7 +606,7 @@ public class SearchProjectionIT {
 			return (parent, name, additionalConfiguration) -> {
 				IndexSchemaFieldContext untypedContext = parent.field( name );
 				StandardIndexSchemaFieldTypedContext<?, F> context = configuration.apply( untypedContext );
-				context.store( Store.YES );
+				context.projectable( Projectable.YES );
 				additionalConfiguration.accept( context );
 				IndexFieldAccessor<F> accessor = context.createAccessor();
 				return new FieldModel<>(

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/AbstractSpatialWithinSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/AbstractSpatialWithinSearchPredicateIT.java
@@ -112,14 +112,17 @@ public abstract class AbstractSpatialWithinSearchPredicateIT {
 		final IndexFieldAccessor<GeoPoint> geoPoint_2;
 		final IndexFieldAccessor<GeoPoint> geoPoint_with_longName;
 		final IndexFieldAccessor<GeoPoint> nonProjectableGeoPoint;
+		final IndexFieldAccessor<GeoPoint> unsortableGeoPoint;
 		final IndexFieldAccessor<String> string;
 
 		IndexAccessors(IndexSchemaElement root) {
-			geoPoint = root.field( "geoPoint" ).asGeoPoint().projectable( Projectable.YES ).createAccessor();
-			geoPoint_1 = root.field( "geoPoint_1" ).asGeoPoint().projectable( Projectable.YES ).createAccessor();
-			geoPoint_2 = root.field( "geoPoint_2" ).asGeoPoint().projectable( Projectable.YES ).createAccessor();
-			geoPoint_with_longName = root.field( "geoPoint_with_a_veeeeeeeeeeeeeeeeeeeeerrrrrrrrrrrrrrrrrryyyyyyyyyyyyyyyy_long_name" ).asGeoPoint().projectable( Projectable.YES ).createAccessor();
+			geoPoint = root.field( "geoPoint" ).asGeoPoint().sortable( Sortable.YES ).projectable( Projectable.YES ).createAccessor();
+			geoPoint_1 = root.field( "geoPoint_1" ).asGeoPoint().sortable( Sortable.YES ).projectable( Projectable.YES ).createAccessor();
+			geoPoint_2 = root.field( "geoPoint_2" ).asGeoPoint().sortable( Sortable.YES ).projectable( Projectable.YES ).createAccessor();
+			geoPoint_with_longName = root.field( "geoPoint_with_a_veeeeeeeeeeeeeeeeeeeeerrrrrrrrrrrrrrrrrryyyyyyyyyyyyyyyy_long_name" )
+					.asGeoPoint().sortable( Sortable.YES ).projectable( Projectable.YES ).createAccessor();
 			nonProjectableGeoPoint = root.field( "nonProjectableGeoPoint" ).asGeoPoint().projectable( Projectable.NO ).createAccessor();
+			unsortableGeoPoint = root.field( "unsortableGeoPoint" ).asGeoPoint().sortable( Sortable.NO ).createAccessor();
 			string = root.field( "string" ).asString().projectable( Projectable.YES ).sortable( Sortable.YES ).createAccessor();
 		}
 	}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/AbstractSpatialWithinSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/AbstractSpatialWithinSearchPredicateIT.java
@@ -111,13 +111,15 @@ public abstract class AbstractSpatialWithinSearchPredicateIT {
 		final IndexFieldAccessor<GeoPoint> geoPoint_1;
 		final IndexFieldAccessor<GeoPoint> geoPoint_2;
 		final IndexFieldAccessor<GeoPoint> geoPoint_with_longName;
+		final IndexFieldAccessor<GeoPoint> nonProjectableGeoPoint;
 		final IndexFieldAccessor<String> string;
 
 		IndexAccessors(IndexSchemaElement root) {
-			geoPoint = root.field( "geoPoint" ).asGeoPoint().createAccessor();
-			geoPoint_1 = root.field( "geoPoint_1" ).asGeoPoint().createAccessor();
-			geoPoint_2 = root.field( "geoPoint_2" ).asGeoPoint().createAccessor();
-			geoPoint_with_longName = root.field( "geoPoint_with_a_veeeeeeeeeeeeeeeeeeeeerrrrrrrrrrrrrrrrrryyyyyyyyyyyyyyyy_long_name" ).asGeoPoint().createAccessor();
+			geoPoint = root.field( "geoPoint" ).asGeoPoint().projectable( Projectable.YES ).createAccessor();
+			geoPoint_1 = root.field( "geoPoint_1" ).asGeoPoint().projectable( Projectable.YES ).createAccessor();
+			geoPoint_2 = root.field( "geoPoint_2" ).asGeoPoint().projectable( Projectable.YES ).createAccessor();
+			geoPoint_with_longName = root.field( "geoPoint_with_a_veeeeeeeeeeeeeeeeeeeeerrrrrrrrrrrrrrrrrryyyyyyyyyyyyyyyy_long_name" ).asGeoPoint().projectable( Projectable.YES ).createAccessor();
+			nonProjectableGeoPoint = root.field( "nonProjectableGeoPoint" ).asGeoPoint().projectable( Projectable.NO ).createAccessor();
 			string = root.field( "string" ).asString().projectable( Projectable.YES ).sortable( Sortable.YES ).createAccessor();
 		}
 	}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/AbstractSpatialWithinSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/AbstractSpatialWithinSearchPredicateIT.java
@@ -13,7 +13,7 @@ import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldAccessor;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
-import org.hibernate.search.engine.backend.document.model.dsl.Store;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.engine.backend.index.spi.IndexSearchTarget;
 import org.hibernate.search.engine.backend.index.spi.IndexWorkPlan;
 import org.hibernate.search.engine.common.spi.SessionContext;
@@ -118,7 +118,7 @@ public abstract class AbstractSpatialWithinSearchPredicateIT {
 			geoPoint_1 = root.field( "geoPoint_1" ).asGeoPoint().createAccessor();
 			geoPoint_2 = root.field( "geoPoint_2" ).asGeoPoint().createAccessor();
 			geoPoint_with_longName = root.field( "geoPoint_with_a_veeeeeeeeeeeeeeeeeeeeerrrrrrrrrrrrrrrrrryyyyyyyyyyyyyyyy_long_name" ).asGeoPoint().createAccessor();
-			string = root.field( "string" ).asString().store( Store.YES ).sortable( Sortable.YES ).createAccessor();
+			string = root.field( "string" ).asString().projectable( Projectable.YES ).sortable( Sortable.YES ).createAccessor();
 		}
 	}
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/DistanceSearchProjectionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/DistanceSearchProjectionIT.java
@@ -209,6 +209,18 @@ public class DistanceSearchProjectionIT extends AbstractSpatialWithinSearchPredi
 				.hasMessageContaining( "nonProjectableGeoPoint" );
 	}
 
+	@Test
+	public void distanceProjection_unsortable() {
+		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
+
+		SubTest.expectException( () -> {
+			searchTarget.sort().byDistance( "unsortableGeoPoint", GeoPoint.of( 43d, 4d ) );
+		} ).assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Sorting is not enabled for field" )
+				.hasMessageContaining( "unsortableGeoPoint" );
+	}
+
 	private void checkResult(List<?> result, String name, int distanceIndex, Double distance, Offset<Double> offset) {
 		Assertions.assertThat( result.get( 0 ) ).as( name + " - name" ).isEqualTo( name );
 		if ( distance == null ) {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/DistanceSearchProjectionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/DistanceSearchProjectionIT.java
@@ -16,6 +16,7 @@ import org.hibernate.search.engine.search.SearchResult;
 import org.hibernate.search.engine.spatial.DistanceUnit;
 import org.hibernate.search.engine.spatial.GeoPoint;
 import org.hibernate.search.util.SearchException;
+import org.hibernate.search.util.impl.test.SubTest;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -187,6 +188,25 @@ public class DistanceSearchProjectionIT extends AbstractSpatialWithinSearchPredi
 		searchTarget.projection()
 				.distance( "geoPoint", GeoPoint.of( 45.749828, 4.854172 ) ).unit( null )
 				.toProjection();
+	}
+
+	@Test
+	public void distanceProjection_nonProjectable() {
+		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
+
+		SubTest.expectException( () -> {
+			searchTarget.projection().field( "nonProjectableGeoPoint", GeoPoint.class ).toProjection();
+		} ).assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Projections are not enabled for field" )
+				.hasMessageContaining( "nonProjectableGeoPoint" );
+
+		SubTest.expectException( () -> {
+			searchTarget.projection().distance( "nonProjectableGeoPoint", GeoPoint.of( 43d, 4d ) ).toProjection();
+		} ).assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Projections are not enabled for field" )
+				.hasMessageContaining( "nonProjectableGeoPoint" );
 	}
 
 	private void checkResult(List<?> result, String name, int distanceIndex, Double distance, Offset<Double> offset) {

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BridgeUsingPropertyMarkerAccessIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BridgeUsingPropertyMarkerAccessIT.java
@@ -10,7 +10,7 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 
 import org.hibernate.SessionFactory;
-import org.hibernate.search.engine.backend.document.model.dsl.Store;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.engine.spatial.GeoPoint;
 import org.hibernate.search.mapper.pojo.bridge.builtin.spatial.annotation.GeoPointBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.spatial.annotation.Latitude;
@@ -71,7 +71,7 @@ public class BridgeUsingPropertyMarkerAccessIT<TIndexed> {
 	@Before
 	public void setup() {
 		backendMock.expectSchema( INDEX_NAME, b -> b
-				.field( "location", GeoPoint.class, b2 -> b2.store( Store.DEFAULT ) )
+				.field( "location", GeoPoint.class, b2 -> b2.projectable( Projectable.DEFAULT ) )
 		);
 		sessionFactory = ormSetupHelper.withBackendMock( backendMock )
 				.setup( modelPrimitives.getModelClass() );

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/spatial/AnnotationMappingGeoPointBridgeIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/spatial/AnnotationMappingGeoPointBridgeIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.mapper.pojo.spatial;
 
-import org.hibernate.search.engine.backend.document.model.dsl.Store;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.engine.spatial.GeoPoint;
 import org.hibernate.search.integrationtest.mapper.pojo.test.util.rule.JavaBeanMappingSetupHelper;
 import org.hibernate.search.mapper.javabean.JavaBeanMapping;
@@ -38,16 +38,16 @@ public class AnnotationMappingGeoPointBridgeIT {
 	@Before
 	public void setup() {
 		backendMock.expectSchema( GeoPointOnTypeEntity.INDEX, b -> b
-				.field( "homeLocation", GeoPoint.class, b2 -> b2.store( Store.YES ) )
-				.field( "workLocation", GeoPoint.class, b2 -> b2.store( Store.DEFAULT ) )
+				.field( "homeLocation", GeoPoint.class, b2 -> b2.projectable( Projectable.YES ) )
+				.field( "workLocation", GeoPoint.class, b2 -> b2.projectable( Projectable.DEFAULT ) )
 		);
 		backendMock.expectSchema( GeoPointOnCoordinatesPropertyEntity.INDEX, b -> b
-				.field( "coord", GeoPoint.class, b2 -> b2.store( Store.DEFAULT ) )
-				.field( "location", GeoPoint.class, b2 -> b2.store( Store.NO ) )
+				.field( "coord", GeoPoint.class, b2 -> b2.projectable( Projectable.DEFAULT ) )
+				.field( "location", GeoPoint.class, b2 -> b2.projectable( Projectable.NO ) )
 		);
 		backendMock.expectSchema( GeoPointOnCustomCoordinatesPropertyEntity.INDEX, b -> b
-				.field( "coord", GeoPoint.class, b2 -> b2.store( Store.DEFAULT ) )
-				.field( "location", GeoPoint.class, b2 -> b2.store( Store.DEFAULT ) )
+				.field( "coord", GeoPoint.class, b2 -> b2.projectable( Projectable.DEFAULT ) )
+				.field( "location", GeoPoint.class, b2 -> b2.projectable( Projectable.DEFAULT ) )
 		);
 
 		mapping = setupHelper.withBackendMock( backendMock )
@@ -124,7 +124,7 @@ public class AnnotationMappingGeoPointBridgeIT {
 	}
 
 	@Indexed(index = GeoPointOnTypeEntity.INDEX)
-	@GeoPointBridge(fieldName = "homeLocation", markerSet = "home", store = Store.YES)
+	@GeoPointBridge(fieldName = "homeLocation", markerSet = "home", projectable = Projectable.YES)
 	@GeoPointBridge(fieldName = "workLocation", markerSet = "work")
 	public static final class GeoPointOnTypeEntity {
 
@@ -206,7 +206,7 @@ public class AnnotationMappingGeoPointBridgeIT {
 		}
 
 		@GeoPointBridge
-		@GeoPointBridge(fieldName = "location", store = Store.NO)
+		@GeoPointBridge(fieldName = "location", projectable = Projectable.NO)
 		public GeoPoint getCoord() {
 			return coord;
 		}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/spatial/ProgrammaticMappingGeoPointBridgeIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/spatial/ProgrammaticMappingGeoPointBridgeIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.mapper.pojo.spatial;
 
-import org.hibernate.search.engine.backend.document.model.dsl.Store;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.mapper.javabean.JavaBeanMapping;
 import org.hibernate.search.mapper.pojo.bridge.builtin.spatial.GeoPointBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.spatial.LatitudeMarker;
@@ -38,16 +38,16 @@ public class ProgrammaticMappingGeoPointBridgeIT {
 	@Before
 	public void setup() {
 		backendMock.expectSchema( GeoPointOnTypeEntity.INDEX, b -> b
-				.field( "homeLocation", GeoPoint.class, b2 -> b2.store( Store.YES ) )
-				.field( "workLocation", GeoPoint.class, b2 -> b2.store( Store.DEFAULT ) )
+				.field( "homeLocation", GeoPoint.class, b2 -> b2.projectable( Projectable.YES ) )
+				.field( "workLocation", GeoPoint.class, b2 -> b2.projectable( Projectable.DEFAULT ) )
 		);
 		backendMock.expectSchema( GeoPointOnCoordinatesPropertyEntity.INDEX, b -> b
-				.field( "coord", GeoPoint.class, b2 -> b2.store( Store.DEFAULT ) )
-				.field( "location", GeoPoint.class, b2 -> b2.store( Store.NO ) )
+				.field( "coord", GeoPoint.class, b2 -> b2.projectable( Projectable.DEFAULT ) )
+				.field( "location", GeoPoint.class, b2 -> b2.projectable( Projectable.NO ) )
 		);
 		backendMock.expectSchema( GeoPointOnCustomCoordinatesPropertyEntity.INDEX, b -> b
-				.field( "coord", GeoPoint.class, b2 -> b2.store( Store.DEFAULT ) )
-				.field( "location", GeoPoint.class, b2 -> b2.store( Store.DEFAULT ) )
+				.field( "coord", GeoPoint.class, b2 -> b2.projectable( Projectable.DEFAULT ) )
+				.field( "location", GeoPoint.class, b2 -> b2.projectable( Projectable.DEFAULT ) )
 		);
 
 		mapping = setupHelper.withBackendMock( backendMock )
@@ -64,7 +64,7 @@ public class ProgrammaticMappingGeoPointBridgeIT {
 							.bridge( new GeoPointBridge.Builder()
 									.fieldName( "homeLocation" )
 									.markerSet( "home" )
-									.store( Store.YES )
+									.projectable( Projectable.YES )
 							)
 							.bridge(
 									new GeoPointBridge.Builder()
@@ -90,7 +90,7 @@ public class ProgrammaticMappingGeoPointBridgeIT {
 									.bridge( new GeoPointBridge.Builder() )
 									.bridge( new GeoPointBridge.Builder()
 											.fieldName( "location" )
-											.store( Store.NO )
+											.projectable( Projectable.NO )
 									);
 
 					mappingDefinition.type( GeoPointOnCustomCoordinatesPropertyEntity.class )

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/spatial/GeoPointBridge.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/spatial/GeoPointBridge.java
@@ -14,7 +14,7 @@ import java.util.stream.Collector;
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldAccessor;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
-import org.hibernate.search.engine.backend.document.model.dsl.Store;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.mapper.pojo.bridge.PropertyBridge;
 import org.hibernate.search.mapper.pojo.bridge.binding.PropertyBridgeBindingContext;
 import org.hibernate.search.mapper.pojo.bridge.TypeBridge;
@@ -40,7 +40,7 @@ public class GeoPointBridge implements TypeBridge, PropertyBridge {
 			AnnotationBridgeBuilder<GeoPointBridge, org.hibernate.search.mapper.pojo.bridge.builtin.spatial.annotation.GeoPointBridge> {
 
 		private String fieldName;
-		private Store store = Store.DEFAULT;
+		private Projectable projectable = Projectable.DEFAULT;
 		private String markerSet;
 
 		@Override
@@ -48,7 +48,7 @@ public class GeoPointBridge implements TypeBridge, PropertyBridge {
 				org.hibernate.search.mapper.pojo.bridge.builtin.spatial.annotation.GeoPointBridge annotation) {
 			fieldName( annotation.fieldName() );
 			markerSet( annotation.markerSet() );
-			store( annotation.store() );
+			projectable( annotation.projectable() );
 		}
 
 		public Builder fieldName(String fieldName) {
@@ -56,8 +56,8 @@ public class GeoPointBridge implements TypeBridge, PropertyBridge {
 			return this;
 		}
 
-		public Builder store(Store store) {
-			this.store = store;
+		public Builder projectable(Projectable projectable) {
+			this.projectable = projectable;
 			return this;
 		}
 
@@ -68,13 +68,13 @@ public class GeoPointBridge implements TypeBridge, PropertyBridge {
 
 		@Override
 		public GeoPointBridge build(BridgeBuildContext buildContext) {
-			return new GeoPointBridge( fieldName, store, markerSet );
+			return new GeoPointBridge( fieldName, projectable, markerSet );
 		}
 
 	}
 
 	private final String fieldName;
-	private final Store store;
+	private final Projectable projectable;
 	private final String markerSet;
 
 	private IndexFieldAccessor<GeoPoint> fieldAccessor;
@@ -83,9 +83,9 @@ public class GeoPointBridge implements TypeBridge, PropertyBridge {
 	/*
 	 * Private constructor, use the Builder instead.
 	 */
-	private GeoPointBridge(String fieldName, Store store, String markerSet) {
+	private GeoPointBridge(String fieldName, Projectable projectable, String markerSet) {
 		this.fieldName = fieldName;
-		this.store = store;
+		this.projectable = projectable;
 		this.markerSet = markerSet;
 	}
 
@@ -113,7 +113,7 @@ public class GeoPointBridge implements TypeBridge, PropertyBridge {
 
 	private void bind(String defaultedFieldName, IndexSchemaElement indexSchemaElement,
 			PojoModelCompositeElement bridgedPojoModelElement) {
-		fieldAccessor = indexSchemaElement.field( defaultedFieldName ).asGeoPoint().store( store ).createAccessor();
+		fieldAccessor = indexSchemaElement.field( defaultedFieldName ).asGeoPoint().projectable( projectable ).createAccessor();
 
 		if ( bridgedPojoModelElement.isAssignableTo( GeoPoint.class ) ) {
 			PojoModelElementAccessor<GeoPoint> sourceAccessor = bridgedPojoModelElement.createAccessor( GeoPoint.class );

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/spatial/annotation/GeoPointBridge.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/spatial/annotation/GeoPointBridge.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.hibernate.search.engine.backend.document.model.dsl.Store;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.mapper.pojo.bridge.declaration.PropertyBridgeMapping;
 import org.hibernate.search.mapper.pojo.bridge.declaration.PropertyBridgeAnnotationBuilderReference;
 import org.hibernate.search.mapper.pojo.bridge.declaration.TypeBridgeMapping;
@@ -89,10 +89,10 @@ public @interface GeoPointBridge {
 	String fieldName() default "";
 
 	/**
-	 * @return Returns an instance of the {@link Store} enum, indicating whether the value should be stored in the document.
-	 *         Defaults to {@code Store.DEFAULT}
+	 * @return Returns an instance of the {@link Projectable} enum, indicating whether projections are enabled for this
+	 * field. Defaults to {@code Projectable.DEFAULT}.
 	 */
-	Store store() default Store.DEFAULT;
+	Projectable projectable() default Projectable.DEFAULT;
 
 	/**
 	 * @return The name of the marker set this spatial should look into

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/FullTextField.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/FullTextField.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.hibernate.search.engine.backend.document.model.dsl.Store;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 
 /**
  * A full-text field in the full text index, potentially holding multiple tokens (words) of text.
@@ -49,10 +49,10 @@ public @interface FullTextField {
 	String analyzer();
 
 	/**
-	 * @return Whether values for this field should be stored (enables projections).
-	 * @see GenericField#store()
+	 * @return Whether projections are enabled for this field.
+	 * @see GenericField#projectable()
 	 */
-	Store store() default Store.DEFAULT;
+	Projectable projectable() default Projectable.DEFAULT;
 
 	/**
 	 * @return A reference to the value bridge to use for this field.

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/GenericField.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/GenericField.java
@@ -14,7 +14,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
-import org.hibernate.search.engine.backend.document.model.dsl.Store;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 
 /**
  * A generic annotation that will work for any supported type of field in the full text index:
@@ -38,9 +38,9 @@ public @interface GenericField {
 	String name() default "";
 
 	/**
-	 * @return Whether values for this field should be stored (enables projections).
+	 * @return Whether projections are enabled for this field.
 	 */
-	Store store() default Store.DEFAULT;
+	Projectable projectable() default Projectable.DEFAULT;
 
 	/**
 	 * @return Whether this field should be sortable.

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/KeywordField.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/KeywordField.java
@@ -14,7 +14,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
-import org.hibernate.search.engine.backend.document.model.dsl.Store;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 
 /**
  * A keyword field in the full text index, holding a single token (word) of text.
@@ -52,10 +52,10 @@ public @interface KeywordField {
 	String normalizer() default "";
 
 	/**
-	 * @return Whether values for this field should be stored (enables projections).
-	 * @see GenericField#store()
+	 * @return Whether projections are enabled for this field.
+	 * @see GenericField#projectable()
 	 */
-	Store store() default Store.DEFAULT;
+	Projectable projectable() default Projectable.DEFAULT;
 
 	/**
 	 * @return Whether this field should be sortable.

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/impl/AnnotationProcessorProvider.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/impl/AnnotationProcessorProvider.java
@@ -16,7 +16,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
-import org.hibernate.search.engine.backend.document.model.dsl.Store;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.engine.environment.bean.BeanProvider;
 import org.hibernate.search.engine.logging.spi.FailureCollector;
 import org.hibernate.search.mapper.pojo.bridge.IdentifierBridge;
@@ -263,8 +263,8 @@ class AnnotationProcessorProvider {
 		}
 
 		@Override
-		Store getStore(GenericField annotation) {
-			return annotation.store();
+		Projectable getProjectable(GenericField annotation) {
+			return annotation.projectable();
 		}
 
 		@Override
@@ -306,8 +306,8 @@ class AnnotationProcessorProvider {
 		}
 
 		@Override
-		Store getStore(FullTextField annotation) {
-			return annotation.store();
+		Projectable getProjectable(FullTextField annotation) {
+			return annotation.projectable();
 		}
 
 		@Override
@@ -348,8 +348,8 @@ class AnnotationProcessorProvider {
 		}
 
 		@Override
-		Store getStore(KeywordField annotation) {
-			return annotation.store();
+		Projectable getProjectable(KeywordField annotation) {
+			return annotation.projectable();
 		}
 
 		@Override

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/impl/PropertyFieldAnnotationProcessor.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/impl/PropertyFieldAnnotationProcessor.java
@@ -9,7 +9,7 @@ package org.hibernate.search.mapper.pojo.mapping.definition.annotation.impl;
 import java.lang.annotation.Annotation;
 import java.util.stream.Stream;
 
-import org.hibernate.search.engine.backend.document.model.dsl.Store;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.mapper.pojo.bridge.ValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.mapping.BridgeBuilder;
 import org.hibernate.search.mapper.pojo.extractor.ContainerValueExtractorPath;
@@ -57,9 +57,9 @@ abstract class PropertyFieldAnnotationProcessor<A extends Annotation> extends Pr
 				helper.getExtractorPath( getExtractors( annotation ) );
 		fieldContext.withExtractors( extractorPath );
 
-		Store store = getStore( annotation );
-		if ( !Store.DEFAULT.equals( store ) ) {
-			fieldContext.store( store );
+		Projectable projectable = getProjectable( annotation );
+		if ( !Projectable.DEFAULT.equals( projectable ) ) {
+			fieldContext.projectable( projectable );
 		}
 	}
 
@@ -68,7 +68,7 @@ abstract class PropertyFieldAnnotationProcessor<A extends Annotation> extends Pr
 
 	abstract String getName(A annotation);
 
-	abstract Store getStore(A annotation);
+	abstract Projectable getProjectable(A annotation);
 
 	abstract ValueBridgeBeanReference getValueBridge(A annotation);
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/PropertyFieldMappingContext.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/PropertyFieldMappingContext.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.mapper.pojo.mapping.definition.programmatic;
 
-import org.hibernate.search.engine.backend.document.model.dsl.Store;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.engine.environment.bean.BeanReference;
 import org.hibernate.search.mapper.pojo.bridge.ValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.mapping.BridgeBuilder;
@@ -18,7 +18,7 @@ import org.hibernate.search.mapper.pojo.extractor.ContainerValueExtractorPath;
  */
 public interface PropertyFieldMappingContext<S extends PropertyFieldMappingContext<?>> extends PropertyMappingContext {
 
-	S store(Store store);
+	S projectable(Projectable projectable);
 
 	/**
 	 * @param bridgeClass The class of the bridge to use.

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/PropertyFieldMappingContextImpl.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/PropertyFieldMappingContextImpl.java
@@ -12,7 +12,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.hibernate.search.engine.backend.document.model.dsl.StandardIndexSchemaFieldTypedContext;
-import org.hibernate.search.engine.backend.document.model.dsl.Store;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.engine.environment.bean.BeanReference;
 import org.hibernate.search.engine.mapper.mapping.building.spi.FieldModelContributor;
 import org.hibernate.search.mapper.pojo.bridge.ValueBridge;
@@ -59,8 +59,8 @@ abstract class PropertyFieldMappingContextImpl<S extends PropertyFieldMappingCon
 	abstract S thisAsS();
 
 	@Override
-	public S store(Store store) {
-		fieldModelContributor.add( c -> c.store( store ) );
+	public S projectable(Projectable projectable) {
+		fieldModelContributor.add( c -> c.projectable( projectable ) );
 		return thisAsS();
 	}
 

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/document/model/StubIndexSchemaNode.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/document/model/StubIndexSchemaNode.java
@@ -10,7 +10,7 @@ import java.util.function.Consumer;
 
 import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
 import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
-import org.hibernate.search.engine.backend.document.model.dsl.Store;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaContext;
 import org.hibernate.search.engine.logging.spi.EventContexts;
 import org.hibernate.search.util.EventContext;
@@ -108,8 +108,8 @@ public final class StubIndexSchemaNode extends StubTreeNode<StubIndexSchemaNode>
 			return this;
 		}
 
-		public Builder store(Store store) {
-			attribute( "store", store );
+		public Builder projectable(Projectable projectable) {
+			attribute( "projectable", projectable );
 			return this;
 		}
 

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/document/model/impl/StubStandardIndexSchemaFieldTypedContext.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/document/model/impl/StubStandardIndexSchemaFieldTypedContext.java
@@ -11,7 +11,7 @@ import org.hibernate.search.engine.backend.document.converter.FromIndexFieldValu
 import org.hibernate.search.engine.backend.document.converter.ToIndexFieldValueConverter;
 import org.hibernate.search.engine.backend.document.model.dsl.Sortable;
 import org.hibernate.search.engine.backend.document.model.dsl.StandardIndexSchemaFieldTypedContext;
-import org.hibernate.search.engine.backend.document.model.dsl.Store;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
 import org.hibernate.search.engine.backend.document.spi.IndexSchemaFieldDefinitionHelper;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.document.model.StubIndexSchemaNode;
 
@@ -44,8 +44,8 @@ abstract class StubStandardIndexSchemaFieldTypedContext<S extends StubStandardIn
 	}
 
 	@Override
-	public S store(Store store) {
-		builder.store( store );
+	public S projectable(Projectable projectable) {
+		builder.projectable( projectable );
 		return thisAsS();
 	}
 


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/HSEARCH-3064
 * https://hibernate.atlassian.net/browse/HSEARCH-3253

Maybe we could refactor things a bit more, creating abstract classes or utils. Not sure it's really worth it but open to discussion.

Better reviewed commit per commit because the store -> projectable commit contains a lot of noise.