### PR TITLE
HSEARCH-3259 Search 6 groundwork - Restore support for projections on fields within flattened object fields in Elasticsearch

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/gson/impl/JsonObjectAccessor.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/gson/impl/JsonObjectAccessor.java
@@ -9,5 +9,9 @@ package org.hibernate.search.backend.elasticsearch.gson.impl;
 import com.google.gson.JsonObject;
 
 public interface JsonObjectAccessor extends JsonAccessor<JsonObject> {
+
 	UnknownTypeJsonAccessor property(String propertyName);
+
+	UnknownTypeJsonAccessor path(String dotSeparatedPath);
+
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/gson/impl/JsonObjectAccessorImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/gson/impl/JsonObjectAccessorImpl.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.backend.elasticsearch.gson.impl;
 
+import java.util.regex.Pattern;
+
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
@@ -17,6 +19,8 @@ import com.google.gson.JsonObject;
  */
 public class JsonObjectAccessorImpl extends TypingJsonAccessor<JsonObject>
 		implements JsonObjectAccessor, JsonCompositeAccessor<JsonObject> {
+
+	private static final Pattern DOT_REGEX = Pattern.compile( "\\." );
 
 	public JsonObjectAccessorImpl(JsonAccessor<JsonElement> parent) {
 		super( parent );
@@ -37,4 +41,17 @@ public class JsonObjectAccessorImpl extends TypingJsonAccessor<JsonObject>
 		return new ObjectPropertyJsonAccessor( this, propertyName );
 	}
 
+	@Override
+	public UnknownTypeJsonAccessor path(String dotSeparatedPath) {
+		String[] components = DOT_REGEX.split( dotSeparatedPath );
+		String leaf = components[components.length - 1];
+
+		JsonObjectAccessor parent = this;
+
+		for ( int i = 0; i < components.length - 1; i++ ) {
+			parent = parent.property( components[i] ).asObject();
+		}
+
+		return parent.property( leaf );
+	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/gson/impl/JsonObjectAccessorImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/gson/impl/JsonObjectAccessorImpl.java
@@ -8,6 +8,8 @@ package org.hibernate.search.backend.elasticsearch.gson.impl;
 
 import java.util.regex.Pattern;
 
+import org.hibernate.search.util.impl.common.Contracts;
+
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
@@ -38,11 +40,14 @@ public class JsonObjectAccessorImpl extends TypingJsonAccessor<JsonObject>
 
 	@Override
 	public UnknownTypeJsonAccessor property(String propertyName) {
+		Contracts.assertNotNullNorEmpty( propertyName, "propertyName" );
 		return new ObjectPropertyJsonAccessor( this, propertyName );
 	}
 
 	@Override
 	public UnknownTypeJsonAccessor path(String dotSeparatedPath) {
+		Contracts.assertNotNullNorEmpty( dotSeparatedPath, "dotSeparatedPath" );
+
 		String[] components = DOT_REGEX.split( dotSeparatedPath );
 		String leaf = components[components.length - 1];
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/gson/impl/RootJsonAccessor.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/gson/impl/RootJsonAccessor.java
@@ -11,21 +11,23 @@ import java.util.function.Supplier;
 
 import org.hibernate.search.util.AssertionFailure;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 /**
  * @author Yoann Rodiere
  */
-class RootJsonAccessor implements JsonObjectAccessor, JsonCompositeAccessor<JsonObject> {
+class RootJsonAccessor implements JsonCompositeAccessor<JsonElement> {
 
-	static final JsonObjectAccessor INSTANCE = new RootJsonAccessor();
+	// Wrap the instance in a JsonObjectAccessor, because we know the root is an object
+	static final JsonObjectAccessor INSTANCE = new JsonObjectAccessorImpl( new RootJsonAccessor() );
 
 	private RootJsonAccessor() {
 		// Private, use INSTANCE instead.
 	}
 
 	@Override
-	public Optional<JsonObject> get(JsonObject root) {
+	public Optional<JsonElement> get(JsonObject root) {
 		return Optional.of( requireRoot( root ) );
 	}
 
@@ -39,17 +41,17 @@ class RootJsonAccessor implements JsonObjectAccessor, JsonCompositeAccessor<Json
 	}
 
 	@Override
-	public void set(JsonObject root, JsonObject value) {
+	public void set(JsonObject root, JsonElement value) {
 		throw new UnsupportedOperationException( "Cannot set the root element" );
 	}
 
 	@Override
-	public void add(JsonObject root, JsonObject value) {
+	public void add(JsonObject root, JsonElement value) {
 		throw new UnsupportedOperationException( "Cannot add a value to the root element" );
 	}
 
 	@Override
-	public JsonObject getOrCreate(JsonObject root, Supplier<? extends JsonObject> newValueSupplier) throws UnexpectedJsonElementTypeException {
+	public JsonObject getOrCreate(JsonObject root, Supplier<? extends JsonElement> newValueSupplier) throws UnexpectedJsonElementTypeException {
 		return requireRoot( root );
 	}
 
@@ -66,10 +68,5 @@ class RootJsonAccessor implements JsonObjectAccessor, JsonCompositeAccessor<Json
 	@Override
 	public String getStaticAbsolutePath() {
 		return null;
-	}
-
-	@Override
-	public UnknownTypeJsonAccessor property(String propertyName) {
-		return new ObjectPropertyJsonAccessor( this, propertyName );
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/FieldSearchProjectionImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/FieldSearchProjectionImpl.java
@@ -29,7 +29,7 @@ class FieldSearchProjectionImpl<T> implements ElasticsearchSearchProjection<T> {
 
 	FieldSearchProjectionImpl(String absoluteFieldPath, ElasticsearchFieldConverter converter) {
 		this.absoluteFieldPath = absoluteFieldPath;
-		this.hitFieldValueAccessor = HIT_SOURCE_ACCESSOR.property( absoluteFieldPath );
+		this.hitFieldValueAccessor = HIT_SOURCE_ACCESSOR.path( absoluteFieldPath );
 		this.converter = converter;
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/SearchProjectionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/SearchProjectionIT.java
@@ -324,9 +324,6 @@ public class SearchProjectionIT {
 
 	@Test
 	public void field_inFlattenedObject() {
-		Assume.assumeTrue( "Projections on fields within flattened object fields are not supported yet in Elasticsearch", false );
-		// TODO support projections on fields within flattened object fields
-
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 
 		for ( FieldModel<?> fieldModel : indexMapping.flattenedObject.supportedFieldModels ) {
@@ -350,7 +347,7 @@ public class SearchProjectionIT {
 	@Test
 	public void field_inNestedObject() {
 		Assume.assumeTrue( "Projections on fields within nested object fields are not supported yet", false );
-		// TODO support projections on fields within nested object fields
+		// TODO HSEARCH-3062 support projections on fields within nested object fields
 
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 

--- a/util/internal/common/src/main/java/org/hibernate/search/util/impl/common/Contracts.java
+++ b/util/internal/common/src/main/java/org/hibernate/search/util/impl/common/Contracts.java
@@ -26,13 +26,19 @@ public final class Contracts {
 
 	public static void assertNotNullNorEmpty(Collection<?> object, String objectDescription) {
 		if ( object == null || object.isEmpty() ) {
-			throw log.mustNotBeNullNorEmpty( objectDescription );
+			throw log.collectionMustNotBeNullNorEmpty( objectDescription );
 		}
 	}
 
 	public static void assertPositiveOrZero(int number, String objectDescription) {
 		if ( number < 0 ) {
 			throw log.mustBePositiveOrZero( objectDescription );
+		}
+	}
+
+	public static void assertNotNullNorEmpty(String object, String objectDescription) {
+		if ( object == null || object.isEmpty() ) {
+			throw log.stringMustNotBeNullNorEmpty( objectDescription );
 		}
 	}
 }

--- a/util/internal/common/src/main/java/org/hibernate/search/util/impl/common/logging/Log.java
+++ b/util/internal/common/src/main/java/org/hibernate/search/util/impl/common/logging/Log.java
@@ -51,9 +51,13 @@ public interface Log extends BasicLogger {
 
 	@Message(id = ID_OFFSET_2 + 1,
 			value = "'%1$s' must not be null or empty.")
-	IllegalArgumentException mustNotBeNullNorEmpty(String objectDescription);
+	IllegalArgumentException collectionMustNotBeNullNorEmpty(String objectDescription);
 
 	@Message(id = ID_OFFSET_2 + 2,
 			value = "'%1$s' must be positive or zero.")
 	IllegalArgumentException mustBePositiveOrZero(String objectDescription);
+
+	@Message(id = ID_OFFSET_2 + 3,
+			value = "'%1$s' must not be null or empty.")
+	IllegalArgumentException stringMustNotBeNullNorEmpty(String objectDescription);
 }


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3259
