### PR TITLE
HSEARCH-3217 Search 6 groundwork - Make sure the index schema definition DSL allows for non-standard or extended accessor types

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/dsl/ElasticsearchIndexSchemaFieldContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/dsl/ElasticsearchIndexSchemaFieldContext.java
@@ -7,7 +7,6 @@
 package org.hibernate.search.backend.elasticsearch.document.model.dsl;
 
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldContext;
-import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldTypedContext;
 
 
 /**
@@ -15,6 +14,6 @@ import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldTy
  */
 public interface ElasticsearchIndexSchemaFieldContext extends IndexSchemaFieldContext {
 
-	IndexSchemaFieldTypedContext<?, String> asJsonString(String mappingJsonString);
+	JsonStringIndexSchemaFieldTypedContext asJsonString(String mappingJsonString);
 
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/dsl/JsonStringIndexSchemaFieldTypedContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/dsl/JsonStringIndexSchemaFieldTypedContext.java
@@ -1,0 +1,16 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.document.model.dsl;
+
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldTerminalContext;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldTypedContext;
+
+public interface JsonStringIndexSchemaFieldTypedContext
+		extends IndexSchemaFieldTypedContext<JsonStringIndexSchemaFieldTypedContext, String>,
+		IndexSchemaFieldTerminalContext<String> {
+
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/dsl/impl/ElasticsearchIndexSchemaFieldContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/dsl/impl/ElasticsearchIndexSchemaFieldContextImpl.java
@@ -9,8 +9,8 @@ package org.hibernate.search.backend.elasticsearch.document.model.dsl.impl;
 import java.lang.invoke.MethodHandles;
 import java.time.LocalDate;
 
+import org.hibernate.search.backend.elasticsearch.document.model.dsl.JsonStringIndexSchemaFieldTypedContext;
 import org.hibernate.search.backend.elasticsearch.logging.impl.Log;
-import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldTypedContext;
 import org.hibernate.search.engine.backend.document.model.dsl.StandardIndexSchemaFieldTypedContext;
 import org.hibernate.search.engine.backend.document.model.dsl.StringIndexSchemaFieldTypedContext;
 import org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaContext;
@@ -94,7 +94,7 @@ class ElasticsearchIndexSchemaFieldContextImpl
 	}
 
 	@Override
-	public IndexSchemaFieldTypedContext<?, String> asJsonString(String mappingJsonString) {
+	public JsonStringIndexSchemaFieldTypedContext asJsonString(String mappingJsonString) {
 		return setDelegate( new JsonStringIndexSchemaFieldContextImpl( this, relativeFieldName, mappingJsonString ) );
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/JsonStringIndexSchemaFieldContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/JsonStringIndexSchemaFieldContextImpl.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.backend.elasticsearch.types.dsl.impl;
 
 import org.hibernate.search.backend.elasticsearch.document.impl.ElasticsearchIndexFieldAccessor;
+import org.hibernate.search.backend.elasticsearch.document.model.dsl.JsonStringIndexSchemaFieldTypedContext;
 import org.hibernate.search.backend.elasticsearch.document.model.impl.ElasticsearchIndexSchemaFieldNode;
 import org.hibernate.search.backend.elasticsearch.document.model.impl.ElasticsearchIndexSchemaNodeCollector;
 import org.hibernate.search.backend.elasticsearch.document.model.impl.ElasticsearchIndexSchemaNodeContributor;
@@ -21,7 +22,6 @@ import org.hibernate.search.backend.elasticsearch.types.sort.impl.StandardFieldS
 import org.hibernate.search.engine.backend.document.IndexFieldAccessor;
 import org.hibernate.search.engine.backend.document.converter.FromIndexFieldValueConverter;
 import org.hibernate.search.engine.backend.document.converter.ToIndexFieldValueConverter;
-import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldTypedContext;
 import org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaContext;
 import org.hibernate.search.engine.backend.document.spi.IndexSchemaFieldDefinitionHelper;
 
@@ -33,7 +33,7 @@ import com.google.gson.JsonElement;
  * @author Yoann Rodiere
  * @author Guillaume Smet
  */
-public class JsonStringIndexSchemaFieldContextImpl implements IndexSchemaFieldTypedContext<JsonStringIndexSchemaFieldContextImpl, String>,
+public class JsonStringIndexSchemaFieldContextImpl implements JsonStringIndexSchemaFieldTypedContext,
 		ElasticsearchIndexSchemaNodeContributor<PropertyMapping> {
 
 	private static final Gson GSON = new GsonBuilder().create();

--- a/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/IndexSchemaFieldTypedContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/IndexSchemaFieldTypedContext.java
@@ -13,8 +13,7 @@ import org.hibernate.search.engine.backend.document.converter.ToIndexFieldValueC
  * @param <S> The concrete type of this context.
  * @param <F> The type of field values.
  */
-public interface IndexSchemaFieldTypedContext<S extends IndexSchemaFieldTypedContext<? extends S, F>, F>
-		extends IndexSchemaFieldTerminalContext<F> {
+public interface IndexSchemaFieldTypedContext<S extends IndexSchemaFieldTypedContext<? extends S, F>, F> {
 
 	S dslConverter(ToIndexFieldValueConverter<?, ? extends F> toIndexConverter);
 

--- a/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/StandardIndexSchemaFieldTypedContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/StandardIndexSchemaFieldTypedContext.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.engine.backend.document.model.dsl;
 
 public interface StandardIndexSchemaFieldTypedContext<S extends StandardIndexSchemaFieldTypedContext<? extends S, F>, F>
-		extends IndexSchemaFieldTypedContext<S, F> {
+		extends IndexSchemaFieldTypedContext<S, F>, IndexSchemaFieldTerminalContext<F> {
 
 	S projectable(Projectable projectable);
 


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3217

Essentially I only had to make sure that `IndexSchemaFieldTypedContext` does not extend `IndexSchemaFieldTerminalContext`, but only its sub-interfaces do (where relevant). This will allow us, in the future, to introduce new "typed contexts" whose terminal context is not exactly the same, i.e. it returns a different type of accessor that offers a different API, like for example an accessor that expects two values instead of one (the center of a circle and its radius). Not sure we will need it, but at least we'll be able to do it if need be.

You can find an example of what this would allow to change in our APIs in the HEAD commit of this branch: https://github.com/yrodiere/hibernate-search/tree/HSEARCH-3217_proofitworks

Looking back, it's not a very interesting change, nor a very useful one since we'll probably rework these APIs in [HSEARCH-3291](https://hibernate.atlassian.net/browse/HSEARCH-3291) . But it's done and doesn't hurt, so let's merge it?