### PR TITLE
HSEARCH-3395 Make the .reference() and .object() projections type-safe in the Projection DSL

### DIFF
--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/MappedIndexManagerImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/MappedIndexManagerImpl.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.engine.common.impl;
 
+import java.util.function.Function;
+
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.index.IndexManager;
 import org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor;
@@ -14,6 +16,7 @@ import org.hibernate.search.engine.backend.index.spi.IndexWorkPlan;
 import org.hibernate.search.engine.mapper.mapping.context.spi.MappingContextImplementor;
 import org.hibernate.search.engine.mapper.session.context.spi.SessionContextImplementor;
 import org.hibernate.search.engine.mapper.mapping.spi.MappedIndexManager;
+import org.hibernate.search.engine.search.DocumentReference;
 
 class MappedIndexManagerImpl<D extends DocumentElement> implements MappedIndexManager<D> {
 
@@ -34,12 +37,16 @@ class MappedIndexManagerImpl<D extends DocumentElement> implements MappedIndexMa
 	}
 
 	@Override
-	public MappedIndexSearchTargetBuilder createSearchTargetBuilder(MappingContextImplementor mappingContext) {
-		return new MappedIndexSearchTargetBuilderImpl( implementor, mappingContext );
+	public <R, O> MappedIndexSearchTargetBuilder<R, O> createSearchTargetBuilder(MappingContextImplementor mappingContext,
+			Function<DocumentReference, R> documentReferenceTransformer) {
+		return new MappedIndexSearchTargetBuilderImpl<>(
+				implementor, mappingContext,
+				documentReferenceTransformer
+		);
 	}
 
 	@Override
-	public void addToSearchTarget(MappedIndexSearchTargetBuilder builder) {
-		((MappedIndexSearchTargetBuilderImpl) builder).add( implementor );
+	public void addToSearchTarget(MappedIndexSearchTargetBuilder<?, ?> builder) {
+		((MappedIndexSearchTargetBuilderImpl<?, ?>) builder).add( implementor );
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/MappedIndexSearchTargetBuilderImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/MappedIndexSearchTargetBuilderImpl.java
@@ -6,18 +6,24 @@
  */
 package org.hibernate.search.engine.common.impl;
 
+import java.util.function.Function;
+
 import org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor;
 import org.hibernate.search.engine.backend.index.spi.IndexSearchTargetContextBuilder;
 import org.hibernate.search.engine.mapper.mapping.context.spi.MappingContextImplementor;
 import org.hibernate.search.engine.mapper.mapping.spi.MappedIndexSearchTarget;
 import org.hibernate.search.engine.mapper.mapping.spi.MappedIndexSearchTargetBuilder;
+import org.hibernate.search.engine.search.DocumentReference;
 
-class MappedIndexSearchTargetBuilderImpl implements MappedIndexSearchTargetBuilder {
+class MappedIndexSearchTargetBuilderImpl<R, O> implements MappedIndexSearchTargetBuilder<R, O> {
 	private final IndexSearchTargetContextBuilder delegate;
+	private final Function<DocumentReference, R> documentReferenceTransformer;
 
 	MappedIndexSearchTargetBuilderImpl(IndexManagerImplementor<?> firstIndexManager,
-			MappingContextImplementor mappingContext) {
+			MappingContextImplementor mappingContext,
+			Function<DocumentReference, R> documentReferenceTransformer) {
 		this.delegate = firstIndexManager.createSearchTargetContextBuilder( mappingContext );
+		this.documentReferenceTransformer = documentReferenceTransformer;
 	}
 
 	void add(IndexManagerImplementor<?> indexManager) {
@@ -25,7 +31,7 @@ class MappedIndexSearchTargetBuilderImpl implements MappedIndexSearchTargetBuild
 	}
 
 	@Override
-	public MappedIndexSearchTarget build() {
-		return new MappedIndexSearchTargetImpl<>( delegate.build() );
+	public MappedIndexSearchTarget<R, O> build() {
+		return new MappedIndexSearchTargetImpl<>( delegate.build(), documentReferenceTransformer );
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/MappedIndexSearchTargetImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/MappedIndexSearchTargetImpl.java
@@ -113,7 +113,7 @@ class MappedIndexSearchTargetImpl<C, R, O> implements MappedIndexSearchTarget<R,
 	}
 
 	@Override
-	public SearchProjectionFactoryContext projection() {
-		return new SearchProjectionFactoryContextImpl( searchTargetContext.getSearchProjectionFactory() );
+	public SearchProjectionFactoryContext<R, O> projection() {
+		return new SearchProjectionFactoryContextImpl<>( searchTargetContext.getSearchProjectionFactory() );
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/spi/MappedIndexManager.java
+++ b/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/spi/MappedIndexManager.java
@@ -6,11 +6,14 @@
  */
 package org.hibernate.search.engine.mapper.mapping.spi;
 
+import java.util.function.Function;
+
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.index.IndexManager;
 import org.hibernate.search.engine.backend.index.spi.IndexWorkPlan;
 import org.hibernate.search.engine.mapper.mapping.context.spi.MappingContextImplementor;
 import org.hibernate.search.engine.mapper.session.context.spi.SessionContextImplementor;
+import org.hibernate.search.engine.search.DocumentReference;
 
 /**
  * The object responsible for applying works and searches to a full-text index.
@@ -23,7 +26,8 @@ public interface MappedIndexManager<D extends DocumentElement> {
 
 	IndexWorkPlan<D> createWorkPlan(SessionContextImplementor sessionContext);
 
-	MappedIndexSearchTargetBuilder createSearchTargetBuilder(MappingContextImplementor mappingContext);
+	<R, O> MappedIndexSearchTargetBuilder<R, O> createSearchTargetBuilder(MappingContextImplementor mappingContext,
+			Function<DocumentReference, R> documentReferenceTransformer);
 
-	void addToSearchTarget(MappedIndexSearchTargetBuilder builder);
+	void addToSearchTarget(MappedIndexSearchTargetBuilder<?, ?> builder);
 }

--- a/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/spi/MappedIndexSearchTarget.java
+++ b/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/spi/MappedIndexSearchTarget.java
@@ -40,6 +40,12 @@ public interface MappedIndexSearchTarget<R, O> {
 			Function<R, T> hitTransformer,
 			Function<SearchQuery<T>, Q> searchQueryWrapperFactory);
 
+	/*
+	 * IMPLEMENTATION NOTE: we *must* only accept an object loader with the same R/O type parameters as this class,
+	 * otherwise some casts in ObjectProjectionContextImpl and ReferenceProjectionContextImpl
+	 * will be wrong.
+	 * In particular, we cannot accept an ObjectLoader<R, T> like we do in queryAsLoadedObjects(...).
+	 */
 	<T, Q> SearchQueryResultContext<Q> queryAsProjections(
 			SessionContextImplementor sessionContext,
 			ObjectLoader<R, O> objectLoader,
@@ -51,6 +57,11 @@ public interface MappedIndexSearchTarget<R, O> {
 
 	SearchSortContainerContext sort();
 
-	SearchProjectionFactoryContext projection();
+	/*
+	 * IMPLEMENTATION NOTE: we *must* return a factory with the same R/O type arguments as this class,
+	 * otherwise some casts in ObjectProjectionContextImpl and ReferenceProjectionContextImpl
+	 * will be wrong.
+	 */
+	SearchProjectionFactoryContext<R, O> projection();
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/spi/MappedIndexSearchTarget.java
+++ b/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/spi/MappedIndexSearchTarget.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.function.Function;
 
 import org.hibernate.search.engine.mapper.session.context.spi.SessionContextImplementor;
-import org.hibernate.search.engine.search.DocumentReference;
 import org.hibernate.search.engine.search.SearchProjection;
 import org.hibernate.search.engine.search.SearchQuery;
 import org.hibernate.search.engine.search.dsl.query.SearchQueryResultContext;
@@ -19,23 +18,30 @@ import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryCo
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContext;
 import org.hibernate.search.engine.search.dsl.sort.SearchSortContainerContext;
 
-public interface MappedIndexSearchTarget {
+/**
+ * @param <R> The type of references, i.e. the type of hits returned by
+ * {@link #queryAsReferences(SessionContextImplementor, Function, Function) reference queries}
+ * when not using any hit transformer,
+ * or the type of objects returned for {@link SearchProjectionFactoryContext#reference() reference projections}.
+ * @param <O> The type of loaded objects, i.e. the type of hits returned by
+ * {@link #queryAsLoadedObjects(SessionContextImplementor, ObjectLoader, Function) loaded object queries}
+ * when not using any hit transformer,
+ * or the type of objects returned for {@link SearchProjectionFactoryContext#object() loaded object projections}.
+ */
+public interface MappedIndexSearchTarget<R, O> {
 
-	<R, O, Q> SearchQueryResultContext<Q> queryAsLoadedObjects(
+	<T, Q> SearchQueryResultContext<Q> queryAsLoadedObjects(
 			SessionContextImplementor sessionContext,
-			Function<DocumentReference, R> documentReferenceTransformer,
-			ObjectLoader<R, O> objectLoader,
-			Function<SearchQuery<O>, Q> searchQueryWrapperFactory);
+			ObjectLoader<R, T> objectLoader,
+			Function<SearchQuery<T>, Q> searchQueryWrapperFactory);
 
-	<R, T, Q> SearchQueryResultContext<Q> queryAsReferences(
+	<T, Q> SearchQueryResultContext<Q> queryAsReferences(
 			SessionContextImplementor sessionContext,
-			Function<DocumentReference, R> documentReferenceTransformer,
 			Function<R, T> hitTransformer,
 			Function<SearchQuery<T>, Q> searchQueryWrapperFactory);
 
-	<R, O, T, Q> SearchQueryResultContext<Q> queryAsProjections(
+	<T, Q> SearchQueryResultContext<Q> queryAsProjections(
 			SessionContextImplementor sessionContext,
-			Function<DocumentReference, R> documentReferenceTransformer,
 			ObjectLoader<R, O> objectLoader,
 			Function<List<?>, T> hitTransformer,
 			Function<SearchQuery<T>, Q> searchQueryWrapperFactory,

--- a/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/spi/MappedIndexSearchTargetBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/spi/MappedIndexSearchTargetBuilder.java
@@ -9,8 +9,8 @@ package org.hibernate.search.engine.mapper.mapping.spi;
 /**
  * @author Yoann Rodiere
  */
-public interface MappedIndexSearchTargetBuilder {
+public interface MappedIndexSearchTargetBuilder<R, O> {
 
-	MappedIndexSearchTarget build();
+	MappedIndexSearchTarget<R, O> build();
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/ObjectProjectionContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/ObjectProjectionContext.java
@@ -9,6 +9,6 @@ package org.hibernate.search.engine.search.dsl.projection;
 /**
  * The context used when starting to define an object projection.
  */
-public interface ObjectProjectionContext extends SearchProjectionTerminalContext<Object> {
+public interface ObjectProjectionContext<O> extends SearchProjectionTerminalContext<O> {
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/ReferenceProjectionContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/ReferenceProjectionContext.java
@@ -9,6 +9,6 @@ package org.hibernate.search.engine.search.dsl.projection;
 /**
  * The context used when starting to define a reference projection.
  */
-public interface ReferenceProjectionContext extends SearchProjectionTerminalContext<Object> {
+public interface ReferenceProjectionContext<R> extends SearchProjectionTerminalContext<R> {
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/SearchProjectionFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/SearchProjectionFactoryContext.java
@@ -11,8 +11,12 @@ import org.hibernate.search.engine.spatial.GeoPoint;
 
 /**
  * A context allowing to create a projection.
+ *
+ * @param <R> The type of references, i.e. the type of objects returned for {@link #reference() reference projections}.
+ * @param <O> The type of loaded objects, i.e. the type of objects returned for
+ * {@link #object() object projections}.
  */
-public interface SearchProjectionFactoryContext {
+public interface SearchProjectionFactoryContext<R, O> {
 
 	/**
 	 * Project the match to a {@link DocumentReference}.
@@ -29,7 +33,7 @@ public interface SearchProjectionFactoryContext {
 	 *
 	 * @return A context allowing to define the projection more precisely.
 	 */
-	ReferenceProjectionContext reference();
+	ReferenceProjectionContext<R> reference();
 
 	/**
 	 * Project to an object representing the match.
@@ -41,7 +45,7 @@ public interface SearchProjectionFactoryContext {
 	 *
 	 * @return A context allowing to define the projection more precisely.
 	 */
-	ObjectProjectionContext object();
+	ObjectProjectionContext<O> object();
 
 	/**
 	 * Project to a field of the indexed document.

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/impl/ObjectProjectionContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/impl/ObjectProjectionContextImpl.java
@@ -12,7 +12,7 @@ import org.hibernate.search.engine.search.projection.spi.ObjectSearchProjectionB
 import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilderFactory;
 
 
-public class ObjectProjectionContextImpl implements ObjectProjectionContext {
+public class ObjectProjectionContextImpl<O> implements ObjectProjectionContext<O> {
 
 	private ObjectSearchProjectionBuilder objectProjectionBuilder;
 
@@ -21,8 +21,15 @@ public class ObjectProjectionContextImpl implements ObjectProjectionContext {
 	}
 
 	@Override
-	public SearchProjection<Object> toProjection() {
-		return objectProjectionBuilder.build();
+	/*
+	 * The backend has no control over the type of loaded objects.
+	 * This cast is only safe because we make sure to only use SearchProjectionFactoryContext
+	 * with generic type arguments that are consistent with the type of object loaders.
+	 * See comments in MappedIndexSearchTarget.
+	 */
+	@SuppressWarnings("unchecked")
+	public SearchProjection<O> toProjection() {
+		return (SearchProjection<O>) objectProjectionBuilder.build();
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/impl/ReferenceProjectionContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/impl/ReferenceProjectionContextImpl.java
@@ -12,7 +12,7 @@ import org.hibernate.search.engine.search.projection.spi.ReferenceSearchProjecti
 import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilderFactory;
 
 
-public class ReferenceProjectionContextImpl implements ReferenceProjectionContext {
+public class ReferenceProjectionContextImpl<R> implements ReferenceProjectionContext<R> {
 
 	private ReferenceSearchProjectionBuilder referenceProjectionBuilder;
 
@@ -21,8 +21,15 @@ public class ReferenceProjectionContextImpl implements ReferenceProjectionContex
 	}
 
 	@Override
-	public SearchProjection<Object> toProjection() {
-		return referenceProjectionBuilder.build();
+	/*
+	 * The backend has no control over the type of loaded objects.
+	 * This cast is only safe because we make sure to only use SearchProjectionFactoryContext
+	 * with generic type arguments that are consistent with the type of object loaders.
+	 * See comments in MappedIndexSearchTarget.
+	 */
+	@SuppressWarnings("unchecked")
+	public SearchProjection<R> toProjection() {
+		return (SearchProjection<R>) referenceProjectionBuilder.build();
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/impl/SearchProjectionFactoryContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/impl/SearchProjectionFactoryContextImpl.java
@@ -18,7 +18,7 @@ import org.hibernate.search.engine.spatial.GeoPoint;
 import org.hibernate.search.util.impl.common.Contracts;
 
 
-public class SearchProjectionFactoryContextImpl implements SearchProjectionFactoryContext {
+public class SearchProjectionFactoryContextImpl<R, O> implements SearchProjectionFactoryContext<R, O> {
 
 	private final SearchProjectionBuilderFactory factory;
 
@@ -44,13 +44,13 @@ public class SearchProjectionFactoryContextImpl implements SearchProjectionFacto
 	}
 
 	@Override
-	public ReferenceProjectionContext reference() {
-		return new ReferenceProjectionContextImpl( factory );
+	public ReferenceProjectionContext<R> reference() {
+		return new ReferenceProjectionContextImpl<>( factory );
 	}
 
 	@Override
-	public ObjectProjectionContext object() {
-		return new ObjectProjectionContextImpl( factory );
+	public ObjectProjectionContext<O> object() {
+		return new ObjectProjectionContextImpl<>( factory );
 	}
 
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/StubDocumentReferenceTransformer.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/StubDocumentReferenceTransformer.java
@@ -13,6 +13,6 @@ import org.hibernate.search.engine.search.DocumentReference;
 /**
  * The only purpose of this class is to avoid unchecked cast warnings when creating mocks.
  */
-interface StubDocumentReferenceTransformer
+public interface StubDocumentReferenceTransformer
 		extends Function<DocumentReference, StubTransformedReference> {
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/StubLoadedObject.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/StubLoadedObject.java
@@ -8,10 +8,10 @@ package org.hibernate.search.integrationtest.backend.tck.search;
 
 import org.hibernate.search.engine.search.DocumentReference;
 
-class StubLoadedObject {
+public class StubLoadedObject {
 	private final DocumentReference documentReference;
 
-	StubLoadedObject(DocumentReference documentReference) {
+	public StubLoadedObject(DocumentReference documentReference) {
 		this.documentReference = documentReference;
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/StubObjectLoader.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/StubObjectLoader.java
@@ -11,6 +11,6 @@ import org.hibernate.search.engine.search.loading.spi.ObjectLoader;
 /**
  * The only purpose of this class is to avoid unchecked cast warnings when creating mocks.
  */
-interface StubObjectLoader
+public interface StubObjectLoader
 		extends ObjectLoader<StubTransformedReference, StubLoadedObject> {
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/StubTransformedReference.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/StubTransformedReference.java
@@ -8,10 +8,10 @@ package org.hibernate.search.integrationtest.backend.tck.search;
 
 import org.hibernate.search.engine.search.DocumentReference;
 
-class StubTransformedReference {
+public class StubTransformedReference {
 	private final DocumentReference documentReference;
 
-	StubTransformedReference(DocumentReference documentReference) {
+	public StubTransformedReference(DocumentReference documentReference) {
 		this.documentReference = documentReference;
 	}
 

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/search/JavaBeanSearchTarget.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/search/JavaBeanSearchTarget.java
@@ -10,6 +10,7 @@ import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryCo
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContext;
 import org.hibernate.search.engine.search.dsl.sort.SearchSortContainerContext;
 import org.hibernate.search.mapper.javabean.search.dsl.query.JavaBeanQueryResultDefinitionContext;
+import org.hibernate.search.mapper.pojo.search.PojoReference;
 
 public interface JavaBeanSearchTarget {
 
@@ -19,6 +20,6 @@ public interface JavaBeanSearchTarget {
 
 	SearchSortContainerContext sort();
 
-	SearchProjectionFactoryContext projection();
+	SearchProjectionFactoryContext<PojoReference, PojoReference> projection();
 
 }

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/search/dsl/query/impl/JavaBeanQueryResultDefinitionContextImpl.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/search/dsl/query/impl/JavaBeanQueryResultDefinitionContextImpl.java
@@ -18,9 +18,9 @@ import org.hibernate.search.mapper.pojo.search.PojoReference;
 import org.hibernate.search.mapper.pojo.search.spi.PojoSearchTargetDelegate;
 
 public class JavaBeanQueryResultDefinitionContextImpl implements JavaBeanQueryResultDefinitionContext {
-	private final PojoSearchTargetDelegate<?> delegate;
+	private final PojoSearchTargetDelegate<?, PojoReference> delegate;
 
-	public JavaBeanQueryResultDefinitionContextImpl(PojoSearchTargetDelegate<?> delegate) {
+	public JavaBeanQueryResultDefinitionContextImpl(PojoSearchTargetDelegate<?, PojoReference> delegate) {
 		this.delegate = delegate;
 	}
 

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/search/impl/JavaBeanSearchTargetImpl.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/search/impl/JavaBeanSearchTargetImpl.java
@@ -12,13 +12,14 @@ import org.hibernate.search.engine.search.dsl.sort.SearchSortContainerContext;
 import org.hibernate.search.mapper.javabean.search.JavaBeanSearchTarget;
 import org.hibernate.search.mapper.javabean.search.dsl.query.JavaBeanQueryResultDefinitionContext;
 import org.hibernate.search.mapper.javabean.search.dsl.query.impl.JavaBeanQueryResultDefinitionContextImpl;
+import org.hibernate.search.mapper.pojo.search.PojoReference;
 import org.hibernate.search.mapper.pojo.search.spi.PojoSearchTargetDelegate;
 
 public class JavaBeanSearchTargetImpl implements JavaBeanSearchTarget {
 
-	private final PojoSearchTargetDelegate<?> delegate;
+	private final PojoSearchTargetDelegate<?, PojoReference> delegate;
 
-	public JavaBeanSearchTargetImpl(PojoSearchTargetDelegate<?> delegate) {
+	public JavaBeanSearchTargetImpl(PojoSearchTargetDelegate<?, PojoReference> delegate) {
 		this.delegate = delegate;
 	}
 

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/search/impl/JavaBeanSearchTargetImpl.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/search/impl/JavaBeanSearchTargetImpl.java
@@ -39,7 +39,7 @@ public class JavaBeanSearchTargetImpl implements JavaBeanSearchTarget {
 	}
 
 	@Override
-	public SearchProjectionFactoryContext projection() {
+	public SearchProjectionFactoryContext<PojoReference, PojoReference> projection() {
 		return delegate.projection();
 	}
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/impl/FullTextSearchTargetImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/impl/FullTextSearchTargetImpl.java
@@ -12,6 +12,7 @@ import org.hibernate.search.engine.search.dsl.sort.SearchSortContainerContext;
 import org.hibernate.search.mapper.orm.hibernate.FullTextQueryResultDefinitionContext;
 import org.hibernate.search.mapper.orm.hibernate.FullTextSearchTarget;
 import org.hibernate.search.mapper.orm.search.spi.HibernateOrmSearchTarget;
+import org.hibernate.search.mapper.pojo.search.PojoReference;
 
 class FullTextSearchTargetImpl<T> implements FullTextSearchTarget<T> {
 
@@ -37,7 +38,7 @@ class FullTextSearchTargetImpl<T> implements FullTextSearchTarget<T> {
 	}
 
 	@Override
-	public SearchProjectionFactoryContext projection() {
+	public SearchProjectionFactoryContext<PojoReference, T> projection() {
 		return delegate.projection();
 	}
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/jpa/FullTextSearchTarget.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/jpa/FullTextSearchTarget.java
@@ -9,6 +9,7 @@ package org.hibernate.search.mapper.orm.jpa;
 import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryContext;
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContext;
 import org.hibernate.search.engine.search.dsl.sort.SearchSortContainerContext;
+import org.hibernate.search.mapper.pojo.search.PojoReference;
 
 public interface FullTextSearchTarget<T> {
 
@@ -18,6 +19,6 @@ public interface FullTextSearchTarget<T> {
 
 	SearchSortContainerContext sort();
 
-	SearchProjectionFactoryContext projection();
+	SearchProjectionFactoryContext<PojoReference, T> projection();
 
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/impl/FullTextQueryResultDefinitionContextImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/impl/FullTextQueryResultDefinitionContextImpl.java
@@ -21,12 +21,12 @@ import org.hibernate.search.mapper.pojo.search.spi.PojoSearchTargetDelegate;
 
 class FullTextQueryResultDefinitionContextImpl<O>
 		implements FullTextQueryResultDefinitionContext<O> {
-	private final PojoSearchTargetDelegate<O> searchTargetDelegate;
+	private final PojoSearchTargetDelegate<O, O> searchTargetDelegate;
 	private final SessionImplementor sessionImplementor;
 	private final ObjectLoaderBuilder<O> objectLoaderBuilder;
 
 	FullTextQueryResultDefinitionContextImpl(
-			PojoSearchTargetDelegate<O> searchTargetDelegate,
+			PojoSearchTargetDelegate<O, O> searchTargetDelegate,
 			SessionImplementor sessionImplementor) {
 		this.searchTargetDelegate = searchTargetDelegate;
 		this.sessionImplementor = sessionImplementor;

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/impl/HibernateOrmSearchTargetImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/impl/HibernateOrmSearchTargetImpl.java
@@ -14,19 +14,19 @@ import org.hibernate.search.mapper.pojo.search.spi.PojoSearchTargetDelegate;
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContext;
 import org.hibernate.search.engine.search.dsl.sort.SearchSortContainerContext;
 
-public class HibernateOrmSearchTargetImpl<T> implements HibernateOrmSearchTarget<T> {
+public class HibernateOrmSearchTargetImpl<O> implements HibernateOrmSearchTarget<O> {
 
-	private final PojoSearchTargetDelegate<T> searchTargetDelegate;
+	private final PojoSearchTargetDelegate<O, O> searchTargetDelegate;
 	private final SessionImplementor sessionImplementor;
 
-	public HibernateOrmSearchTargetImpl(PojoSearchTargetDelegate<T> searchTargetDelegate,
+	public HibernateOrmSearchTargetImpl(PojoSearchTargetDelegate<O, O> searchTargetDelegate,
 			SessionImplementor sessionImplementor) {
 		this.searchTargetDelegate = searchTargetDelegate;
 		this.sessionImplementor = sessionImplementor;
 	}
 
 	@Override
-	public FullTextQueryResultDefinitionContext<T> jpaQuery() {
+	public FullTextQueryResultDefinitionContext<O> jpaQuery() {
 		return new FullTextQueryResultDefinitionContextImpl<>( searchTargetDelegate, sessionImplementor );
 	}
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/impl/HibernateOrmSearchTargetImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/impl/HibernateOrmSearchTargetImpl.java
@@ -10,6 +10,7 @@ import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryContext;
 import org.hibernate.search.mapper.orm.hibernate.FullTextQueryResultDefinitionContext;
 import org.hibernate.search.mapper.orm.search.spi.HibernateOrmSearchTarget;
+import org.hibernate.search.mapper.pojo.search.PojoReference;
 import org.hibernate.search.mapper.pojo.search.spi.PojoSearchTargetDelegate;
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContext;
 import org.hibernate.search.engine.search.dsl.sort.SearchSortContainerContext;
@@ -41,7 +42,7 @@ public class HibernateOrmSearchTargetImpl<O> implements HibernateOrmSearchTarget
 	}
 
 	@Override
-	public SearchProjectionFactoryContext projection() {
+	public SearchProjectionFactoryContext<PojoReference, O> projection() {
 		return searchTargetDelegate.projection();
 	}
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/spi/HibernateOrmSearchTarget.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/spi/HibernateOrmSearchTarget.java
@@ -10,6 +10,7 @@ import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryCo
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContext;
 import org.hibernate.search.engine.search.dsl.sort.SearchSortContainerContext;
 import org.hibernate.search.mapper.orm.hibernate.FullTextQueryResultDefinitionContext;
+import org.hibernate.search.mapper.pojo.search.PojoReference;
 
 public interface HibernateOrmSearchTarget<T> {
 
@@ -19,6 +20,6 @@ public interface HibernateOrmSearchTarget<T> {
 
 	SearchSortContainerContext sort();
 
-	SearchProjectionFactoryContext projection();
+	SearchProjectionFactoryContext<PojoReference, T> projection();
 
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/HibernateOrmSearchManagerImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/HibernateOrmSearchManagerImpl.java
@@ -43,7 +43,7 @@ public class HibernateOrmSearchManagerImpl extends PojoSearchManagerImpl
 
 	@Override
 	public <T> HibernateOrmSearchTarget<T> search(Collection<? extends Class<? extends T>> targetedTypes) {
-		PojoSearchTargetDelegate<T> searchTargetDelegate = getDelegate().createPojoSearchTarget( targetedTypes );
+		PojoSearchTargetDelegate<T, T> searchTargetDelegate = getDelegate().createPojoSearchTarget( targetedTypes );
 		return new HibernateOrmSearchTargetImpl<>( searchTargetDelegate, sessionImplementor );
 	}
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoIndexedTypeManager.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoIndexedTypeManager.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.mapper.pojo.mapping.impl;
 
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.hibernate.search.engine.backend.document.DocumentElement;
@@ -14,6 +15,7 @@ import org.hibernate.search.engine.backend.index.spi.DocumentReferenceProvider;
 import org.hibernate.search.engine.mapper.mapping.spi.MappedIndexSearchTargetBuilder;
 import org.hibernate.search.engine.mapper.mapping.context.spi.MappingContextImplementor;
 import org.hibernate.search.engine.mapper.mapping.spi.MappedIndexManager;
+import org.hibernate.search.engine.search.DocumentReference;
 import org.hibernate.search.mapper.pojo.session.context.spi.PojoSessionContextImplementor;
 import org.hibernate.search.mapper.pojo.dirtiness.impl.PojoImplicitReindexingResolver;
 import org.hibernate.search.mapper.pojo.dirtiness.impl.PojoReindexingCollector;
@@ -123,11 +125,12 @@ public class PojoIndexedTypeManager<I, E, D extends DocumentElement> implements 
 		);
 	}
 
-	MappedIndexSearchTargetBuilder createSearchTargetBuilder(MappingContextImplementor mappingContext) {
-		return indexManager.createSearchTargetBuilder( mappingContext );
+	<R, O> MappedIndexSearchTargetBuilder<R, O> createSearchTargetBuilder(MappingContextImplementor mappingContext,
+			Function<DocumentReference, R> documentReferenceTransformer) {
+		return indexManager.createSearchTargetBuilder( mappingContext, documentReferenceTransformer );
 	}
 
-	void addToSearchTarget(MappedIndexSearchTargetBuilder builder) {
+	void addToSearchTarget(MappedIndexSearchTargetBuilder<?, ?> builder) {
 		indexManager.addToSearchTarget( builder );
 	}
 }

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoSearchManagerDelegateImpl.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoSearchManagerDelegateImpl.java
@@ -35,7 +35,7 @@ class PojoSearchManagerDelegateImpl implements PojoSearchManagerDelegate {
 	}
 
 	@Override
-	public <E> PojoSearchTargetDelegate<E> createPojoSearchTarget(
+	public <E, O> PojoSearchTargetDelegate<E, O> createPojoSearchTarget(
 			Collection<? extends Class<? extends E>> targetedTypes) {
 		if ( targetedTypes.isEmpty() ) {
 			throw log.cannotSearchOnEmptyTarget();

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoSearchTargetDelegateImpl.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoSearchTargetDelegateImpl.java
@@ -88,7 +88,7 @@ class PojoSearchTargetDelegateImpl<E, O> implements PojoSearchTargetDelegate<E, 
 	}
 
 	@Override
-	public SearchProjectionFactoryContext projection() {
+	public SearchProjectionFactoryContext<PojoReference, O> projection() {
 		return getIndexSearchTarget().projection();
 	}
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/search/spi/PojoSearchTargetDelegate.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/search/spi/PojoSearchTargetDelegate.java
@@ -19,19 +19,24 @@ import org.hibernate.search.engine.search.dsl.sort.SearchSortContainerContext;
 import org.hibernate.search.engine.search.loading.spi.ObjectLoader;
 import org.hibernate.search.mapper.pojo.search.PojoReference;
 
-public interface PojoSearchTargetDelegate<E> {
-
+/**
+ * @param <E> A common supertype of the targeted indexed types.
+ * @param <O> The type of loaded objects, i.e. the type of hits returned by
+ * {@link #queryAsLoadedObjects(ObjectLoader, Function) loaded object queries} when not using any hit transformer,
+ * or the type of objects returned for {@link SearchProjectionFactoryContext#object() loaded object projections}.
+ */
+public interface PojoSearchTargetDelegate<E, O> {
 	Set<Class<? extends E>> getTargetedIndexedTypes();
 
-	<O, Q> SearchQueryResultContext<Q> queryAsLoadedObjects(
-			ObjectLoader<PojoReference, O> objectLoader,
-			Function<SearchQuery<O>, Q> searchQueryWrapperFactory);
+	<T, Q> SearchQueryResultContext<Q> queryAsLoadedObjects(
+			ObjectLoader<PojoReference, T> objectLoader,
+			Function<SearchQuery<T>, Q> searchQueryWrapperFactory);
 
 	<T, Q> SearchQueryResultContext<Q> queryAsReferences(
 			Function<PojoReference, T> hitTransformer,
 			Function<SearchQuery<T>, Q> searchQueryWrapperFactory);
 
-	<O, T, Q> SearchQueryResultContext<Q> queryAsProjections(
+	<T, Q> SearchQueryResultContext<Q> queryAsProjections(
 			ObjectLoader<PojoReference, O> objectLoader,
 			Function<List<?>, T> hitTransformer,
 			Function<SearchQuery<T>, Q> searchQueryWrapperFactory,

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/search/spi/PojoSearchTargetDelegate.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/search/spi/PojoSearchTargetDelegate.java
@@ -46,6 +46,6 @@ public interface PojoSearchTargetDelegate<E, O> {
 
 	SearchSortContainerContext sort();
 
-	SearchProjectionFactoryContext projection();
+	SearchProjectionFactoryContext<PojoReference, O> projection();
 
 }

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/session/spi/PojoSearchManagerDelegate.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/session/spi/PojoSearchManagerDelegate.java
@@ -14,7 +14,7 @@ import org.hibernate.search.mapper.pojo.search.spi.PojoSearchTargetDelegate;
 
 public interface PojoSearchManagerDelegate {
 
-	<E> PojoSearchTargetDelegate<E> createPojoSearchTarget(Collection<? extends Class<? extends E>> targetedTypes);
+	<E, O> PojoSearchTargetDelegate<E, O> createPojoSearchTarget(Collection<? extends Class<? extends E>> targetedTypes);
 
 	PojoWorkPlan createWorkPlan();
 

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/EasyMockUtils.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/EasyMockUtils.java
@@ -10,6 +10,7 @@ import static org.hibernate.search.util.impl.integrationtest.common.Normalizatio
 import static org.hibernate.search.util.impl.integrationtest.common.NormalizationUtils.normalizeReference;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
@@ -62,5 +63,26 @@ public final class EasyMockUtils {
 			}
 		} );
 		return normalizedExpected;
+	}
+
+	public static <T, C extends Collection<T>> C collectionAnyOrderMatcher(C expected) {
+		EasyMock.reportMatcher( new IArgumentMatcher() {
+			@Override
+			public boolean matches(Object argument) {
+				if ( !( argument instanceof Collection ) ) {
+					return false;
+				}
+
+				Collection<?> other = (Collection<?>) argument;
+				return other.size() == expected.size()
+						&& other.containsAll( expected ) && expected.containsAll( other );
+			}
+
+			@Override
+			public void appendTo(StringBuffer buffer) {
+				buffer.append( expected );
+			}
+		} );
+		return expected;
 	}
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/GenericStubMappingSearchTarget.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/GenericStubMappingSearchTarget.java
@@ -1,0 +1,51 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.impl.integrationtest.common.stub.mapper;
+
+import org.hibernate.search.engine.mapper.mapping.spi.MappedIndexSearchTarget;
+import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryContext;
+import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContext;
+import org.hibernate.search.engine.search.dsl.sort.SearchSortContainerContext;
+import org.hibernate.search.engine.search.loading.spi.ObjectLoader;
+import org.hibernate.search.util.impl.integrationtest.common.stub.StubSessionContext;
+
+/**
+ * A wrapper around {@link MappedIndexSearchTarget} providing some syntactic sugar,
+ * such as methods that do not force to provide a session context.
+ */
+public class GenericStubMappingSearchTarget<R, O> {
+
+	private final MappedIndexSearchTarget<R, O> indexSearchTarget;
+
+	GenericStubMappingSearchTarget(MappedIndexSearchTarget<R, O> indexSearchTarget) {
+		this.indexSearchTarget = indexSearchTarget;
+	}
+
+	public StubMappingQueryResultDefinitionContext<R, O> query(ObjectLoader<R, O> objectLoader) {
+		return query( new StubSessionContext(), objectLoader );
+	}
+
+	public StubMappingQueryResultDefinitionContext<R, O> query(StubSessionContext sessionContext,
+			ObjectLoader<R, O> objectLoader) {
+		return new StubMappingQueryResultDefinitionContext<>(
+				indexSearchTarget, sessionContext,
+				objectLoader
+		);
+	}
+
+	public SearchPredicateFactoryContext predicate() {
+		return indexSearchTarget.predicate();
+	}
+
+	public SearchSortContainerContext sort() {
+		return indexSearchTarget.sort();
+	}
+
+	public SearchProjectionFactoryContext projection() {
+		return indexSearchTarget.projection();
+	}
+}

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/GenericStubMappingSearchTarget.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/GenericStubMappingSearchTarget.java
@@ -45,7 +45,7 @@ public class GenericStubMappingSearchTarget<R, O> {
 		return indexSearchTarget.sort();
 	}
 
-	public SearchProjectionFactoryContext projection() {
+	public SearchProjectionFactoryContext<R, O> projection() {
 		return indexSearchTarget.projection();
 	}
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/StubMappingQueryResultDefinitionContext.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/StubMappingQueryResultDefinitionContext.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.function.Function;
 
 import org.hibernate.search.engine.mapper.mapping.spi.MappedIndexSearchTarget;
-import org.hibernate.search.engine.search.DocumentReference;
 import org.hibernate.search.engine.search.SearchProjection;
 import org.hibernate.search.engine.search.SearchQuery;
 import org.hibernate.search.engine.search.dsl.query.SearchQueryResultContext;
@@ -19,18 +18,15 @@ import org.hibernate.search.util.impl.integrationtest.common.stub.StubSessionCon
 
 public final class StubMappingQueryResultDefinitionContext<R, O> {
 
-	private final MappedIndexSearchTarget indexSearchTarget;
+	private final MappedIndexSearchTarget<R, O> indexSearchTarget;
 	private final StubSessionContext sessionContext;
-	private final Function<DocumentReference, R> documentReferenceTransformer;
 	private final ObjectLoader<R, O> objectLoader;
 
-	StubMappingQueryResultDefinitionContext(MappedIndexSearchTarget indexSearchTarget,
+	StubMappingQueryResultDefinitionContext(MappedIndexSearchTarget<R, O> indexSearchTarget,
 			StubSessionContext sessionContext,
-			Function<DocumentReference, R> documentReferenceTransformer,
 			ObjectLoader<R, O> objectLoader) {
 		this.indexSearchTarget = indexSearchTarget;
 		this.sessionContext = sessionContext;
-		this.documentReferenceTransformer = documentReferenceTransformer;
 		this.objectLoader = objectLoader;
 	}
 
@@ -40,7 +36,7 @@ public final class StubMappingQueryResultDefinitionContext<R, O> {
 
 	public <Q> SearchQueryResultContext<Q> asObjects(Function<SearchQuery<O>, Q> searchQueryWrapperFactory) {
 		return indexSearchTarget.queryAsLoadedObjects(
-				sessionContext, documentReferenceTransformer, objectLoader, searchQueryWrapperFactory
+				sessionContext, objectLoader, searchQueryWrapperFactory
 		);
 	}
 
@@ -56,7 +52,7 @@ public final class StubMappingQueryResultDefinitionContext<R, O> {
 			Function<R, T> hitTransformer,
 			Function<SearchQuery<T>, Q> searchQueryWrapperFactory) {
 		return indexSearchTarget.queryAsReferences(
-				sessionContext, documentReferenceTransformer, hitTransformer, searchQueryWrapperFactory
+				sessionContext, hitTransformer, searchQueryWrapperFactory
 		);
 	}
 
@@ -76,7 +72,7 @@ public final class StubMappingQueryResultDefinitionContext<R, O> {
 			Function<SearchQuery<T>, Q> searchQueryWrapperFactory,
 			SearchProjection<?>... projections) {
 		return indexSearchTarget.queryAsProjections(
-				sessionContext, documentReferenceTransformer, objectLoader, hitTransformer, searchQueryWrapperFactory,
+				sessionContext, objectLoader, hitTransformer, searchQueryWrapperFactory,
 				projections
 		);
 	}

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/StubMappingSearchTarget.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/StubMappingSearchTarget.java
@@ -6,57 +6,29 @@
  */
 package org.hibernate.search.util.impl.integrationtest.common.stub.mapper;
 
-import java.util.function.Function;
-
 import org.hibernate.search.engine.mapper.mapping.spi.MappedIndexSearchTarget;
 import org.hibernate.search.engine.search.DocumentReference;
 import org.hibernate.search.engine.search.loading.spi.ObjectLoader;
-import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryContext;
-import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContext;
-import org.hibernate.search.engine.search.dsl.sort.SearchSortContainerContext;
 import org.hibernate.search.util.impl.integrationtest.common.stub.StubSessionContext;
 
 /**
  * A wrapper around {@link MappedIndexSearchTarget} providing some syntactic sugar,
  * such as methods that do not force to provide a session context.
+ * <p>
+ * This is a simpler version of {@link GenericStubMappingSearchTarget} that allows user to skip the generic parameters.
  */
-public class StubMappingSearchTarget {
+public class StubMappingSearchTarget extends GenericStubMappingSearchTarget<DocumentReference, DocumentReference> {
 
-	private final MappedIndexSearchTarget indexSearchTarget;
-
-	StubMappingSearchTarget(MappedIndexSearchTarget indexSearchTarget) {
-		this.indexSearchTarget = indexSearchTarget;
+	StubMappingSearchTarget(MappedIndexSearchTarget<DocumentReference, DocumentReference> indexSearchTarget) {
+		super( indexSearchTarget );
 	}
 
 	public StubMappingQueryResultDefinitionContext<DocumentReference, DocumentReference> query() {
-		return query( Function.identity(), ObjectLoader.identity() );
+		return query( ObjectLoader.identity() );
 	}
 
-	public <R, O> StubMappingQueryResultDefinitionContext<R, O> query(
-			Function<DocumentReference, R> documentReferenceTransformer, ObjectLoader<R, O> objectLoader) {
-		return query( new StubSessionContext(), documentReferenceTransformer, objectLoader );
-	}
-
-	public StubMappingQueryResultDefinitionContext<DocumentReference, DocumentReference> query(StubSessionContext sessionContext) {
-		return query( sessionContext, Function.identity(), ObjectLoader.identity() );
-	}
-
-	public <R, O> StubMappingQueryResultDefinitionContext<R, O> query(StubSessionContext sessionContext,
-			Function<DocumentReference, R> documentReferenceTransformer, ObjectLoader<R, O> objectLoader) {
-		return new StubMappingQueryResultDefinitionContext<>( indexSearchTarget, sessionContext,
-				documentReferenceTransformer, objectLoader
-		);
-	}
-
-	public SearchPredicateFactoryContext predicate() {
-		return indexSearchTarget.predicate();
-	}
-
-	public SearchSortContainerContext sort() {
-		return indexSearchTarget.sort();
-	}
-
-	public SearchProjectionFactoryContext projection() {
-		return indexSearchTarget.projection();
+	public StubMappingQueryResultDefinitionContext<DocumentReference, DocumentReference> query(
+			StubSessionContext sessionContext) {
+		return query( sessionContext, ObjectLoader.identity() );
 	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3395

Based on #1787 , which should be merged first.