### PR TITLE
HSEARCH-2496 Smarter dirty checking when using @ContainedIn with custom field bridges

### DIFF
--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingBridgeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingBridgeIT.java
@@ -42,6 +42,7 @@ import org.hibernate.search.mapper.pojo.model.PojoModelType;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.orm.OrmSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.orm.OrmUtils;
+import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -495,6 +496,7 @@ public class AutomaticIndexingBridgeIT {
 	}
 
 	@Test
+	@TestForIssue(jiraKey = "HSEARCH-2496")
 	public void indirectValueUpdate_propertyBridge() {
 		OrmUtils.withinTransaction( sessionFactory, session -> {
 			IndexedEntity entity1 = new IndexedEntity();

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/automaticindexing/ContainedInThroughNonContainingIndexedType.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/automaticindexing/ContainedInThroughNonContainingIndexedType.java
@@ -1,0 +1,228 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.orm.nonregression.automaticindexing;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.search.engine.backend.document.DocumentElement;
+import org.hibernate.search.engine.backend.document.IndexFieldAccessor;
+import org.hibernate.search.mapper.pojo.bridge.PropertyBridge;
+import org.hibernate.search.mapper.pojo.bridge.binding.PropertyBridgeBindingContext;
+import org.hibernate.search.mapper.pojo.bridge.declaration.PropertyBridgeMapping;
+import org.hibernate.search.mapper.pojo.bridge.declaration.PropertyBridgeReference;
+import org.hibernate.search.mapper.pojo.bridge.runtime.PropertyBridgeWriteContext;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.model.PojoElement;
+import org.hibernate.search.mapper.pojo.model.PojoModelElementAccessor;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.integrationtest.orm.OrmSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.orm.OrmUtils;
+import org.hibernate.search.util.impl.test.annotation.TestForIssue;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests a corner case that is not covered by
+ * {@link org.hibernate.search.integrationtest.mapper.orm.automaticindexing.AutomaticIndexingBridgeIT},
+ * where the contained entity type is also indexed.
+ * This should not matter given the current implementation, but better safe than sorry.
+ */
+@TestForIssue(jiraKey = "HSEARCH-2496")
+public class ContainedInThroughNonContainingIndexedType {
+
+	@Rule
+	public BackendMock backendMock = new BackendMock( "stubBackend" );
+
+	@Rule
+	public OrmSetupHelper ormSetupHelper = new OrmSetupHelper();
+
+	private SessionFactory sessionFactory;
+
+	@Before
+	public void setup() {
+		backendMock.expectAnySchema( Containing.INDEX );
+		backendMock.expectAnySchema( Contained.INDEX );
+
+		sessionFactory = ormSetupHelper.withBackendMock( backendMock )
+				.setup(
+						Containing.class,
+						Contained.class
+				);
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void test() {
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			Containing containing = new Containing();
+			containing.setId( 1 );
+
+			Contained contained = new Contained();
+			contained.setId( 2 );
+			containing.setContained( contained );
+			contained.setContaining( containing );
+
+			session.persist( contained );
+			session.persist( containing );
+
+			backendMock.expectWorks( Containing.INDEX )
+					.add( "1", b -> b
+							.field( "indexedInContaining", 0 )
+					)
+					.preparedThenExecuted();
+
+			backendMock.expectWorks( Contained.INDEX )
+					.add( "2", b -> b
+							.field( "indexedInContained", 0 )
+					)
+					.preparedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+
+		// Test updating the value
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			Contained contained = session.get( Contained.class, 2 );
+			contained.setIndexedInContaining( 42 );
+
+			/*
+			 * We expect the index for the Containing entity to be updated,
+			 * even though the mapping for the contained entity does not depend on
+			 * the modified property.
+			 */
+			backendMock.expectWorks( Containing.INDEX )
+					.update( "1", b -> b
+							.field( "indexedInContaining", 42 )
+					)
+					.preparedThenExecuted();
+
+			// No work is expected on the index for the Contained entity
+		} );
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Entity
+	@Indexed(index = Containing.INDEX)
+	public static class Containing {
+		static final String INDEX = "Containing";
+
+		@Id
+		private Integer id;
+
+		@BridgeGoingThroughEntityBoundariesAnnotation
+		@OneToOne
+		private Contained contained;
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public Contained getContained() {
+			return contained;
+		}
+
+		public void setContained(
+				Contained contained) {
+			this.contained = contained;
+		}
+	}
+
+	@Entity
+	@Indexed(index = Contained.INDEX)
+	public static class Contained {
+		static final String INDEX = "Contained";
+
+		@Id
+		private Integer id;
+
+		@OneToOne(mappedBy = "contained")
+		private Containing containing;
+
+		@GenericField
+		private int indexedInContained;
+
+		/*
+		 * This property is considered irrelevant when doing dirty-checking on Contained,
+		 * because it's not indexed as far as Contained is concerned.
+		 * The property is used when indexing Containing, though, but its dirtiness is being
+		 * ignored anyway...
+		 */
+		private int indexedInContaining;
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public Containing getContaining() {
+			return containing;
+		}
+
+		public void setContaining(
+				Containing containing) {
+			this.containing = containing;
+		}
+
+		public int getIndexedInContained() {
+			return indexedInContained;
+		}
+
+		public void setIndexedInContained(int indexedInContained) {
+			this.indexedInContained = indexedInContained;
+		}
+
+		public int getIndexedInContaining() {
+			return indexedInContaining;
+		}
+
+		public void setIndexedInContaining(int indexedInContaining) {
+			this.indexedInContaining = indexedInContaining;
+		}
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target({ ElementType.FIELD, ElementType.METHOD })
+	@PropertyBridgeMapping(bridge = @PropertyBridgeReference(type = BridgeGoingThroughEntityBoundaries.class))
+	public @interface BridgeGoingThroughEntityBoundariesAnnotation {
+	}
+
+	public static class BridgeGoingThroughEntityBoundaries implements PropertyBridge {
+
+		private PojoModelElementAccessor<Integer> sourceFieldAccessor;
+		private IndexFieldAccessor<Integer> indexFieldAccessor;
+
+		@Override
+		public void bind(PropertyBridgeBindingContext context) {
+			sourceFieldAccessor = context.getBridgedElement().property( "indexedInContaining" )
+					.createAccessor( Integer.class );
+			indexFieldAccessor = context.getIndexSchemaElement().field( "indexedInContaining" )
+					.asInteger().createAccessor();
+		}
+
+		@Override
+		public void write(DocumentElement target, PojoElement source, PropertyBridgeWriteContext context) {
+			Integer value = sourceFieldAccessor.read( source );
+			indexFieldAccessor.write( target, value );
+		}
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/DocumentIdBaseIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/DocumentIdBaseIT.java
@@ -114,9 +114,9 @@ public class DocumentIdBaseIT {
 	public void error_unableToResolveDefaultIdentifierBridgeFromSourceType_enumSuperClassWithParameters() {
 		@Indexed
 		class IndexedEntity {
-			Enum<FieldBaseIT.EnumForEnumSuperClassTest> id;
+			Enum<EnumForEnumSuperClassTest> id;
 			@DocumentId
-			public Enum<FieldBaseIT.EnumForEnumSuperClassTest> getId() {
+			public Enum<EnumForEnumSuperClassTest> getId() {
 				return id;
 			}
 		}
@@ -130,7 +130,7 @@ public class DocumentIdBaseIT {
 						.pathContext( ".id" )
 						.failure(
 								"Unable to find a default identifier bridge implementation for type 'java.lang.Enum<"
-										+ FieldBaseIT.EnumForEnumSuperClassTest.class.getName() + ">'"
+										+ EnumForEnumSuperClassTest.class.getName() + ">'"
 						)
 						.build()
 				);

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/providedid/ProvidedIdIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/providedid/ProvidedIdIT.java
@@ -1,0 +1,115 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.providedid;
+
+import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Collections;
+
+import org.hibernate.search.engine.search.SearchQuery;
+import org.hibernate.search.integrationtest.mapper.pojo.test.util.rule.JavaBeanMappingSetupHelper;
+import org.hibernate.search.mapper.javabean.JavaBeanMapping;
+import org.hibernate.search.mapper.javabean.session.JavaBeanSearchManager;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.impl.PojoReferenceImpl;
+import org.hibernate.search.mapper.pojo.search.PojoReference;
+import org.hibernate.search.util.SearchException;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.integrationtest.common.rule.StubSearchWorkBehavior;
+import org.hibernate.search.util.impl.integrationtest.common.stub.backend.StubBackendUtils;
+import org.hibernate.search.util.impl.test.SubTest;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ProvidedIdIT {
+
+	private static final String INDEX_NAME = "IndexName";
+
+	@Rule
+	public BackendMock backendMock = new BackendMock( "stubBackend" );
+
+	@Rule
+	public JavaBeanMappingSetupHelper setupHelper = new JavaBeanMappingSetupHelper( MethodHandles.lookup() );
+
+	@Test
+	public void indexAndSearch() {
+		@Indexed(index = INDEX_NAME)
+		class IndexedEntity {
+		}
+
+		// Schema
+		backendMock.expectSchema( INDEX_NAME, b -> { } );
+		JavaBeanMapping mapping = withBaseConfiguration().setup( IndexedEntity.class );
+		backendMock.verifyExpectationsMet();
+
+		// Indexing
+		try ( JavaBeanSearchManager manager = mapping.createSearchManager() ) {
+			IndexedEntity entity1 = new IndexedEntity();
+
+			manager.getMainWorkPlan().add( "42", entity1 );
+
+			backendMock.expectWorks( INDEX_NAME )
+					.add( "42", b -> { } )
+					.preparedThenExecuted();
+		}
+		backendMock.verifyExpectationsMet();
+
+		// Searching
+		try ( JavaBeanSearchManager manager = mapping.createSearchManager() ) {
+			backendMock.expectSearchReferences(
+					Collections.singletonList( INDEX_NAME ),
+					b -> { },
+					StubSearchWorkBehavior.of(
+							1L,
+							c -> {
+								c.collectReference( StubBackendUtils.reference( INDEX_NAME, "42" ) );
+							}
+					)
+			);
+
+			SearchQuery<PojoReference> query = manager.search( IndexedEntity.class )
+					.query()
+					.asReferences()
+					.predicate( f -> f.matchAll().toPredicate() )
+					.build();
+
+			assertThat( query )
+					.hasHitsExactOrder( new PojoReferenceImpl( IndexedEntity.class, "42" ) );
+		}
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void error_nullProvidedId() {
+		@Indexed(index = INDEX_NAME)
+		class IndexedEntity {
+		}
+
+		backendMock.expectAnySchema( INDEX_NAME );
+		JavaBeanMapping mapping = withBaseConfiguration().setup( IndexedEntity.class );
+		backendMock.verifyExpectationsMet();
+
+		try ( JavaBeanSearchManager manager = mapping.createSearchManager() ) {
+			IndexedEntity entity1 = new IndexedEntity();
+
+			SubTest.expectException(
+					() -> manager.getMainWorkPlan().add( entity1 )
+			)
+					.assertThrown()
+					.isInstanceOf( SearchException.class )
+					.hasMessageContaining( "the provided identifier was null" );
+		}
+	}
+
+	private JavaBeanMappingSetupHelper.SetupContext withBaseConfiguration() {
+		return setupHelper.withBackendMock( backendMock )
+				.withConfiguration( b -> b.setImplicitProvidedId( true ) );
+	}
+
+}

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/JavaBeanMappingBuilder.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/JavaBeanMappingBuilder.java
@@ -72,6 +72,11 @@ public final class JavaBeanMappingBuilder {
 		return this;
 	}
 
+	public JavaBeanMappingBuilder setImplicitProvidedId(boolean multiTenancyEnabled) {
+		mappingInitiator.setImplicitProvidedId( multiTenancyEnabled );
+		return this;
+	}
+
 	public JavaBeanMappingBuilder setAnnotatedTypeDiscoveryEnabled(boolean annotatedTypeDiscoveryEnabled) {
 		mappingInitiator.setAnnotatedTypeDiscoveryEnabled( annotatedTypeDiscoveryEnabled );
 		return this;

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/model/impl/JavaBeanPropertyModel.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/model/impl/JavaBeanPropertyModel.java
@@ -95,7 +95,7 @@ class JavaBeanPropertyModel<T> implements PojoPropertyModel<T> {
 						.createGenericTypeModel( getGetterGenericReturnType() );
 			}
 			catch (RuntimeException e) {
-				log.errorRetrievingPropertyTypeModel( getName(), parentTypeModel, e );
+				throw log.errorRetrievingPropertyTypeModel( getName(), parentTypeModel, e );
 			}
 		}
 		return typeModel;
@@ -108,7 +108,7 @@ class JavaBeanPropertyModel<T> implements PojoPropertyModel<T> {
 				handle = introspector.createPropertyHandle( getName(), descriptor.getReadMethod() );
 			}
 			catch (IllegalAccessException | RuntimeException e) {
-				log.errorRetrievingPropertyTypeModel( getName(), parentTypeModel, e );
+				throw log.errorRetrievingPropertyTypeModel( getName(), parentTypeModel, e );
 			}
 		}
 		return handle;

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/ProvidedStringIdentifierMapping.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/ProvidedStringIdentifierMapping.java
@@ -31,7 +31,7 @@ public class ProvidedStringIdentifierMapping implements IdentifierMapping<String
 	@Override
 	public String getIdentifier(Object providedId, Supplier<?> entityProvider) {
 		if ( providedId == null ) {
-			log.nullProvidedIdentifier();
+			throw log.nullProvidedIdentifier();
 		}
 		return String.valueOf( providedId );
 	}

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/impl/AbstractPojoModelCompositeElement.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/impl/AbstractPojoModelCompositeElement.java
@@ -48,7 +48,7 @@ abstract class AbstractPojoModelCompositeElement<V> implements PojoModelComposit
 	@SuppressWarnings("unchecked") // The cast is checked using reflection
 	public final <T> PojoModelElementAccessor<T> createAccessor(Class<T> requestedType) {
 		if ( !isAssignableTo( requestedType ) ) {
-			log.incompatibleRequestedType( getModelPathTypeNode().toUnboundPath(), requestedType );
+			throw log.incompatibleRequestedType( getModelPathTypeNode().toUnboundPath(), requestedType );
 		}
 		return (PojoModelElementAccessor<T>) createAccessor();
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-2496

Based on #1794 , which should be merged first.

I only had to add a test, as this is already supported in Search 6.