### PR TITLE
HSEARCH-3413 Search 6 groundwork - Restore support for implicit index name

### DIFF
--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/IndexedIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/IndexedIT.java
@@ -29,6 +29,54 @@ public class IndexedIT {
 	public JavaBeanMappingSetupHelper setupHelper = new JavaBeanMappingSetupHelper( MethodHandles.lookup() );
 
 	@Test
+	public void implicitIndexName() {
+		@Indexed
+		class IndexedEntity {
+			Integer id;
+			String text;
+			@DocumentId
+			public Integer getId() {
+				return id;
+			}
+			@GenericField
+			public String getText() {
+				throw new UnsupportedOperationException( "Should not be called" );
+			}
+		}
+
+		backendMock.expectSchema( IndexedEntity.class.getName(), b -> b
+				.field( "text", String.class )
+		);
+		setupHelper.withBackendMock( backendMock )
+				.setup( IndexedEntity.class );
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void explicitIndexName() {
+		@Indexed(index = "explicitIndexName")
+		class IndexedEntity {
+			Integer id;
+			String text;
+			@DocumentId
+			public Integer getId() {
+				return id;
+			}
+			@GenericField
+			public String getText() {
+				throw new UnsupportedOperationException( "Should not be called" );
+			}
+		}
+
+		backendMock.expectSchema( "explicitIndexName", b -> b
+				.field( "text", String.class )
+		);
+		setupHelper.withBackendMock( backendMock )
+				.setup( IndexedEntity.class );
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
 	public void error_indexedWithoutEntityMetadata() {
 		@Indexed
 		class IndexedWithoutEntityMetadata {

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/impl/AnnotationMappingDefinitionContextImpl.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/impl/AnnotationMappingDefinitionContextImpl.java
@@ -83,8 +83,12 @@ public class AnnotationMappingDefinitionContextImpl implements AnnotationMapping
 				.forEach( typeModel -> {
 					Optional<Indexed> indexedAnnotation = typeModel.getAnnotationByType( Indexed.class );
 					if ( indexedAnnotation.isPresent() ) {
+						String defaultedIndexName = indexedAnnotation.get().index();
+						if ( defaultedIndexName.isEmpty() ) {
+							defaultedIndexName = typeModel.getJavaClass().getName();
+						}
 						try {
-							collector.mapToIndex( typeModel, indexedAnnotation.get().index() );
+							collector.mapToIndex( typeModel, defaultedIndexName );
 						}
 						catch (RuntimeException e) {
 							failureCollector.withContext( PojoEventContexts.fromType( typeModel ) )


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3413
