### PR TITLE
HSEARCH-3088 Query id in DSL

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/MatchIdPredicateBuilderImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/MatchIdPredicateBuilderImpl.java
@@ -1,0 +1,74 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.search.predicate.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.search.backend.elasticsearch.gson.impl.JsonAccessor;
+import org.hibernate.search.backend.elasticsearch.gson.impl.JsonObjectAccessor;
+import org.hibernate.search.backend.elasticsearch.search.impl.ElasticsearchSearchContext;
+import org.hibernate.search.engine.search.predicate.spi.MatchIdPredicateBuilder;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+/**
+ * Generate the JSON for queries by id for Elasticsearch.
+ * <p>
+ * Example:
+ * <pre>
+ * {@code
+ * GET /_search
+ * {
+ *     "query": {
+ *         "ids" : {
+ *             "values" : ["1", "4", "100"]
+ *         }
+ *     }
+ * }
+ * }
+ * </pre>
+ *
+ * @author Davide D'Alto
+ */
+public class MatchIdPredicateBuilderImpl extends AbstractSearchPredicateBuilder
+		implements MatchIdPredicateBuilder<ElasticsearchSearchPredicateBuilder> {
+
+	private static final JsonObjectAccessor IDS = JsonAccessor.root().property( "ids" ).asObject();
+	private static final JsonAccessor<JsonElement> VALUES = JsonAccessor.root().property( "values" );
+	private List<String> values = new ArrayList<>();
+
+	public MatchIdPredicateBuilderImpl(ElasticsearchSearchContext searchContext) {
+	}
+
+	@Override
+	public void value(Object value) {
+		values.add( (String) value );
+	}
+
+	@Override
+	protected JsonObject doBuild() {
+		JsonArray array = convert( values );
+
+		JsonObject inner = getInnerObject();
+		VALUES.set( inner, array );
+
+		JsonObject outerObject = getOuterObject();
+		IDS.set( outerObject, getInnerObject() );
+		return outerObject;
+	}
+
+	private JsonArray convert(List<String> list) {
+		JsonArray jsonArray = new JsonArray( list.size() );
+		for ( String value : list ) {
+			jsonArray.add( value );
+		}
+		return jsonArray;
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/SearchPredicateBuilderFactoryImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/SearchPredicateBuilderFactoryImpl.java
@@ -17,6 +17,7 @@ import org.hibernate.search.backend.elasticsearch.types.predicate.impl.Elasticse
 import org.hibernate.search.engine.search.SearchPredicate;
 import org.hibernate.search.engine.search.predicate.spi.BooleanJunctionPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.MatchAllPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.MatchIdPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.MatchPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.NestedPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.RangePredicateBuilder;
@@ -76,6 +77,11 @@ public class SearchPredicateBuilderFactoryImpl implements ElasticsearchSearchPre
 	@Override
 	public MatchAllPredicateBuilder<ElasticsearchSearchPredicateBuilder> matchAll() {
 		return new MatchAllPredicateBuilderImpl();
+	}
+
+	@Override
+	public MatchIdPredicateBuilder<ElasticsearchSearchPredicateBuilder> id() {
+		return new MatchIdPredicateBuilderImpl( searchContext );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/impl/LuceneIndexSchemaObjectNode.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/impl/LuceneIndexSchemaObjectNode.java
@@ -15,9 +15,14 @@ import org.hibernate.search.backend.lucene.util.impl.LuceneFields;
 public class LuceneIndexSchemaObjectNode {
 
 	private static final LuceneIndexSchemaObjectNode ROOT = new LuceneIndexSchemaObjectNode( null, null, null );
+	private static final LuceneIndexSchemaObjectNode ID = new LuceneIndexSchemaObjectNode( null, null, null );
 
 	public static LuceneIndexSchemaObjectNode root() {
 		return ROOT;
+	}
+
+	public static LuceneIndexSchemaObjectNode id() {
+		return ID;
 	}
 
 	private final LuceneIndexSchemaObjectNode parent;

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/MatchIdPredicateBuilderImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/MatchIdPredicateBuilderImpl.java
@@ -1,0 +1,43 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.search.predicate.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BooleanQuery.Builder;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.hibernate.search.backend.lucene.util.impl.LuceneFields;
+import org.hibernate.search.engine.search.predicate.spi.MatchIdPredicateBuilder;
+
+public class MatchIdPredicateBuilderImpl extends AbstractSearchPredicateBuilder
+		implements MatchIdPredicateBuilder<LuceneSearchPredicateBuilder> {
+
+	private List<String> values = new ArrayList<>();
+
+	@Override
+	public void value(Object value) {
+		values.add( (String) value );
+	}
+
+	@Override
+	protected Query doBuild(LuceneSearchPredicateContext context) {
+		Builder builder = new BooleanQuery.Builder();
+		for ( String value : values ) {
+			builder.add( termQuery( value ), Occur.SHOULD );
+		}
+		return builder.build();
+	}
+
+	private TermQuery termQuery( String value ) {
+		return new TermQuery( new Term( LuceneFields.idFieldName(), value ) );
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/SearchPredicateBuilderFactoryImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/SearchPredicateBuilderFactoryImpl.java
@@ -18,6 +18,7 @@ import org.hibernate.search.backend.lucene.types.predicate.impl.LuceneFieldPredi
 import org.hibernate.search.engine.search.SearchPredicate;
 import org.hibernate.search.engine.search.predicate.spi.BooleanJunctionPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.MatchAllPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.MatchIdPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.MatchPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.NestedPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.RangePredicateBuilder;
@@ -69,6 +70,11 @@ public class SearchPredicateBuilderFactoryImpl implements LuceneSearchPredicateB
 	@Override
 	public MatchAllPredicateBuilder<LuceneSearchPredicateBuilder> matchAll() {
 		return new MatchAllPredicateBuilderImpl();
+	}
+
+	@Override
+	public MatchIdPredicateBuilder<LuceneSearchPredicateBuilder> id() {
+		return new MatchIdPredicateBuilderImpl();
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/MatchIdPredicateContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/MatchIdPredicateContext.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.engine.search.dsl.predicate;
 
+import java.util.Collection;
+
 /**
  * The context used when defining a match on an identifier.
  */
@@ -16,8 +18,23 @@ public interface MatchIdPredicateContext extends SearchPredicateTerminalContext 
 	 * <p>
 	 * If used multiple times, it will target any of the specified values.
 	 * <p>
+	 * @see #matchingAny(Collection)
 	 * @param value the value of the id we want to match.
 	 * @return {@code this} for method chaining.
 	 */
 	MatchIdPredicateContext matching(Object value);
+
+	/**
+	 * Target the identifiers matching any of the values in a collection.
+	 * <p>
+	 * @param values the collection of identifiers to match.
+	 * @return {@code this} for method chaining.
+	 */
+	default MatchIdPredicateContext matchingAny(Collection<Object> values) {
+		MatchIdPredicateContext context = null;
+		for ( Object value : values ) {
+			context = matching( value );
+		}
+		return context;
+	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/MatchIdPredicateContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/MatchIdPredicateContext.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.dsl.predicate;
+
+/**
+ * The context used when defining a match on an identifier.
+ */
+public interface MatchIdPredicateContext extends SearchPredicateTerminalContext {
+
+	/**
+	 * Target the identifier with the given id.
+	 * <p>
+	 * If used multiple times, it will target any of the specified values.
+	 * <p>
+	 * @param value the value of the id we want to match.
+	 * @return {@code this} for method chaining.
+	 */
+	MatchIdPredicateContext matching(Object value);
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/SearchPredicateFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/SearchPredicateFactoryContext.java
@@ -63,6 +63,8 @@ public interface SearchPredicateFactoryContext {
 	 */
 	MatchAllPredicateContext matchAll();
 
+	MatchIdPredicateContext id();
+
 	/**
 	 * Match documents if they match a combination of boolean clauses.
 	 *

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/MatchIdPredicateContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/MatchIdPredicateContextImpl.java
@@ -1,0 +1,37 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.dsl.predicate.impl;
+
+import org.hibernate.search.engine.search.dsl.predicate.MatchIdPredicateContext;
+import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryContext;
+import org.hibernate.search.engine.search.dsl.predicate.spi.AbstractSearchPredicateTerminalContext;
+import org.hibernate.search.engine.search.predicate.spi.MatchIdPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.SearchPredicateBuilderFactory;
+
+
+class MatchIdPredicateContextImpl<B>
+		extends AbstractSearchPredicateTerminalContext<B>
+		implements MatchIdPredicateContext {
+
+	private final MatchIdPredicateBuilder<B> matchIdBuilder;
+
+	MatchIdPredicateContextImpl(SearchPredicateBuilderFactory<?, B> factory, SearchPredicateFactoryContext factoryContext) {
+		super( factory );
+		this.matchIdBuilder = factory.id();
+	}
+
+	@Override
+	public MatchIdPredicateContext matching(Object value) {
+		matchIdBuilder.value( value );
+		return this;
+	}
+
+	@Override
+	protected B toImplementation() {
+		return matchIdBuilder.toImplementation();
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/SearchPredicateFactoryContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/SearchPredicateFactoryContextImpl.java
@@ -12,6 +12,7 @@ import org.hibernate.search.engine.common.dsl.impl.DslExtensionState;
 import org.hibernate.search.engine.search.SearchPredicate;
 import org.hibernate.search.engine.search.dsl.predicate.BooleanJunctionPredicateContext;
 import org.hibernate.search.engine.search.dsl.predicate.MatchAllPredicateContext;
+import org.hibernate.search.engine.search.dsl.predicate.MatchIdPredicateContext;
 import org.hibernate.search.engine.search.dsl.predicate.MatchPredicateContext;
 import org.hibernate.search.engine.search.dsl.predicate.NestedPredicateContext;
 import org.hibernate.search.engine.search.dsl.predicate.RangePredicateContext;
@@ -33,6 +34,11 @@ public class SearchPredicateFactoryContextImpl<B> implements SearchPredicateFact
 	@Override
 	public MatchAllPredicateContext matchAll() {
 		return new MatchAllPredicateContextImpl<>( factory, this );
+	}
+
+	@Override
+	public MatchIdPredicateContext id() {
+		return new MatchIdPredicateContextImpl<>( factory, this );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/spi/DelegatingSearchPredicateFactoryContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/spi/DelegatingSearchPredicateFactoryContextImpl.java
@@ -10,6 +10,7 @@ import java.util.function.Consumer;
 
 import org.hibernate.search.engine.search.SearchPredicate;
 import org.hibernate.search.engine.search.dsl.predicate.MatchAllPredicateContext;
+import org.hibernate.search.engine.search.dsl.predicate.MatchIdPredicateContext;
 import org.hibernate.search.engine.search.dsl.predicate.BooleanJunctionPredicateContext;
 import org.hibernate.search.engine.search.dsl.predicate.MatchPredicateContext;
 import org.hibernate.search.engine.search.dsl.predicate.NestedPredicateContext;
@@ -35,6 +36,11 @@ public class DelegatingSearchPredicateFactoryContextImpl implements SearchPredic
 	@Override
 	public MatchAllPredicateContext matchAll() {
 		return delegate.matchAll();
+	}
+
+	@Override
+	public MatchIdPredicateContext id() {
+		return delegate.id();
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/MatchIdPredicateBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/MatchIdPredicateBuilder.java
@@ -1,0 +1,13 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.predicate.spi;
+
+public interface MatchIdPredicateBuilder<B> extends SearchPredicateBuilder<B> {
+
+	void value(Object value);
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/SearchPredicateBuilderFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/SearchPredicateBuilderFactory.java
@@ -56,6 +56,8 @@ public interface SearchPredicateBuilderFactory<C, B> {
 
 	MatchAllPredicateBuilder<B> matchAll();
 
+	MatchIdPredicateBuilder<B> id();
+
 	BooleanJunctionPredicateBuilder<B> bool();
 
 	MatchPredicateBuilder<B> match(String absoluteFieldPath);

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchIdSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchIdSearchPredicateIT.java
@@ -1,0 +1,211 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.tck.search.predicate;
+
+import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.hibernate.search.engine.backend.document.DocumentElement;
+import org.hibernate.search.engine.backend.document.IndexFieldAccessor;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldContext;
+import org.hibernate.search.engine.backend.document.model.dsl.StandardIndexSchemaFieldTypedContext;
+import org.hibernate.search.engine.backend.index.spi.IndexWorkPlan;
+import org.hibernate.search.engine.search.DocumentReference;
+import org.hibernate.search.engine.search.SearchQuery;
+import org.hibernate.search.engine.spatial.GeoPoint;
+import org.hibernate.search.integrationtest.backend.tck.configuration.DefaultAnalysisDefinitions;
+import org.hibernate.search.integrationtest.backend.tck.util.StandardFieldMapper;
+import org.hibernate.search.integrationtest.backend.tck.util.ValueWrapper;
+import org.hibernate.search.integrationtest.backend.tck.util.rule.SearchSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingSearchTarget;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class MatchIdSearchPredicateIT {
+
+	private static final String INDEX_NAME = "IndexName";
+
+	private static final String DOCUMENT_1 = "document1";
+	private static final String DOCUMENT_2 = "document2";
+	private static final String DOCUMENT_3 = "document3";
+	private static final String EMPTY = "empty";
+
+	@Rule
+	public SearchSetupHelper setupHelper = new SearchSetupHelper();
+
+	private IndexMapping indexMapping;
+	private StubMappingIndexManager indexManager;
+
+	@Before
+	public void setup() {
+		setupHelper.withDefaultConfiguration()
+				.withIndex(
+						"MappedType", INDEX_NAME,
+						ctx -> this.indexMapping = new IndexMapping( ctx.getSchemaElement() ),
+						indexManager -> this.indexManager = indexManager
+				)
+				.setup();
+
+		initData();
+	}
+
+	@Test
+	public void match_id() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.id().matching( DOCUMENT_1 ).toPredicate() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
+	}
+
+	@Test
+	public void match_multiple_ids() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.id()
+						.matching( DOCUMENT_1 )
+						.matching( DOCUMENT_3 )
+						.toPredicate() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_3 );
+	}
+
+	private void initData() {
+		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
+		workPlan.add( referenceProvider( DOCUMENT_1 ), document -> {
+			indexMapping.supportedFieldModels.forEach( f -> f.document1Value.write( document ) );
+			indexMapping.supportedFieldWithDslConverterModels.forEach( f -> f.document1Value.write( document ) );
+			indexMapping.unsupportedFieldModels.forEach( f -> f.document1Value.write( document ) );
+		} );
+		workPlan.add( referenceProvider( DOCUMENT_2 ), document -> {
+			indexMapping.supportedFieldModels.forEach( f -> f.document2Value.write( document ) );
+			indexMapping.supportedFieldWithDslConverterModels.forEach( f -> f.document2Value.write( document ) );
+			indexMapping.unsupportedFieldModels.forEach( f -> f.document2Value.write( document ) );
+		} );
+		workPlan.add( referenceProvider( DOCUMENT_3 ), document -> { } );
+		workPlan.add( referenceProvider( EMPTY ), document -> { } );
+		workPlan.execute().join();
+
+		// Check that all documents are searchable
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.matchAll().toPredicate() )
+				.build();
+		assertThat( query ).hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, EMPTY,
+				DOCUMENT_3
+		);
+	}
+
+	private static class IndexMapping {
+		final List<ByTypeFieldModel<?>> supportedFieldModels;
+		final List<ByTypeFieldModel<?>> supportedFieldWithDslConverterModels;
+		final List<ByTypeFieldModel<?>> unsupportedFieldModels;
+
+		IndexMapping(IndexSchemaElement root) {
+			supportedFieldModels = mapSupportedFields( root, "supported_", ignored -> { } );
+			supportedFieldWithDslConverterModels = mapSupportedFields(
+					root, "supported_converted_", c -> c.dslConverter( ValueWrapper.toIndexFieldConverter() )
+			);
+			unsupportedFieldModels = Arrays.asList(
+					ByTypeFieldModel.mapper(
+							GeoPoint.class,
+							GeoPoint.of( 40, 70 ),
+							GeoPoint.of( 45, 98 )
+					)
+							.map( root, "geoPoint" )
+			);
+		}
+
+		private List<ByTypeFieldModel<?>> mapSupportedFields(IndexSchemaElement root, String prefix,
+				Consumer<StandardIndexSchemaFieldTypedContext<?, ?>> additionalConfiguration) {
+			return Arrays.asList(
+					ByTypeFieldModel.mapper(
+							c -> c.asString().analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD.name ),
+							"irving and company", "Auster", "Irving"
+					)
+							.map(
+									root, prefix + "analyzedString", additionalConfiguration
+							),
+					ByTypeFieldModel.mapper( String.class, "Irving", "Auster" )
+							.map( root, prefix + "nonAnalyzedString", additionalConfiguration ),
+					ByTypeFieldModel.mapper( Integer.class, 42, 67 )
+							.map( root, prefix + "integer", additionalConfiguration ),
+					ByTypeFieldModel.mapper(
+							LocalDate.class,
+							LocalDate.of( 1980, 10, 11 ),
+							LocalDate.of( 1984, 10, 7 )
+					)
+							.map( root, prefix + "localDate", additionalConfiguration )
+			);
+		}
+	}
+
+	private static class ValueModel<F> {
+		private final IndexFieldAccessor<F> accessor;
+		final F indexedValue;
+
+		private ValueModel(IndexFieldAccessor<F> accessor, F indexedValue) {
+			this.accessor = accessor;
+			this.indexedValue = indexedValue;
+		}
+
+		public void write(DocumentElement target) {
+			accessor.write( target, indexedValue );
+		}
+	}
+
+	private static class ByTypeFieldModel<F> {
+		static <F> StandardFieldMapper<F, ByTypeFieldModel<F>> mapper(Class<F> type,
+				F document1Value, F document2Value) {
+			return mapper(
+					c -> (StandardIndexSchemaFieldTypedContext<?, F>) c.as( type ),
+					document1Value, document2Value, document1Value
+			);
+		}
+
+		static <F> StandardFieldMapper<F, ByTypeFieldModel<F>> mapper(
+				Function<IndexSchemaFieldContext, StandardIndexSchemaFieldTypedContext<?, F>> configuration,
+				F document1Value, F document2Value, F predicateParameterValue) {
+			return (parent, name, additionalConfiguration) -> {
+				IndexSchemaFieldContext untypedContext = parent.field( name );
+				StandardIndexSchemaFieldTypedContext<?, F> context = configuration.apply( untypedContext );
+				additionalConfiguration.accept( context );
+				IndexFieldAccessor<F> accessor = context.createAccessor();
+				return new ByTypeFieldModel<>(
+						accessor, document1Value, document2Value
+				);
+			};
+		}
+
+		final ValueModel<F> document1Value;
+		final ValueModel<F> document2Value;
+
+		private ByTypeFieldModel(IndexFieldAccessor<F> accessor,
+				F document1Value, F document2Value) {
+			this.document1Value = new ValueModel<>( accessor, document1Value );
+			this.document2Value = new ValueModel<>( accessor, document2Value );
+		}
+	}
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchIdSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchIdSearchPredicateIT.java
@@ -91,6 +91,52 @@ public class MatchIdSearchPredicateIT {
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_3 );
 	}
 
+	@Test
+	public void match_any_and_match_single_id() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.id()
+						.matching( DOCUMENT_2 )
+						.matchingAny( Arrays.asList( DOCUMENT_1 ) )
+						.toPredicate() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2 );
+	}
+
+	@Test
+	public void match_any_single_id() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.id()
+						.matchingAny( Arrays.asList( DOCUMENT_1 ) )
+						.toPredicate() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
+	}
+
+	@Test
+	public void match_any_ids() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.id()
+						.matchingAny( Arrays.asList( DOCUMENT_1, DOCUMENT_3 ) )
+						.toPredicate() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_3 );
+	}
+
 	private void initData() {
 		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
 		workPlan.add( referenceProvider( DOCUMENT_1 ), document -> {

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubPredicateBuilder.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubPredicateBuilder.java
@@ -8,6 +8,7 @@ package org.hibernate.search.util.impl.integrationtest.common.stub.backend.searc
 
 import org.hibernate.search.engine.search.predicate.spi.BooleanJunctionPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.MatchAllPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.MatchIdPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.MatchPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.NestedPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.RangePredicateBuilder;
@@ -21,6 +22,7 @@ import org.hibernate.search.engine.spatial.GeoPolygon;
 
 public class StubPredicateBuilder implements MatchAllPredicateBuilder<StubPredicateBuilder>,
 		BooleanJunctionPredicateBuilder<StubPredicateBuilder>,
+		MatchIdPredicateBuilder<StubPredicateBuilder>,
 		MatchPredicateBuilder<StubPredicateBuilder>,
 		RangePredicateBuilder<StubPredicateBuilder>,
 		NestedPredicateBuilder<StubPredicateBuilder>,

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubSearchPredicateBuilderFactory.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubSearchPredicateBuilderFactory.java
@@ -9,6 +9,7 @@ package org.hibernate.search.util.impl.integrationtest.common.stub.backend.searc
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.StubQueryElementCollector;
 import org.hibernate.search.engine.search.SearchPredicate;
 import org.hibernate.search.engine.search.predicate.spi.MatchAllPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.MatchIdPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.BooleanJunctionPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.MatchPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.NestedPredicateBuilder;
@@ -35,6 +36,11 @@ public class StubSearchPredicateBuilderFactory
 	public void contribute(StubQueryElementCollector collector, StubPredicateBuilder builder) {
 		builder.simulateBuild();
 		collector.simulateCollectCall();
+	}
+
+	@Override
+	public MatchIdPredicateBuilder<StubPredicateBuilder> id() {
+		return new StubPredicateBuilder();
 	}
 
 	@Override


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3088

I hope it makes sense.
At the moment it only supports strings.

It looks like:
```
		SearchQuery<DocumentReference> query = searchTarget.query()
				.asReference()
				.predicate( f -> f.id().matching( DOCUMENT_1 ).toPredicate() )
				.build();
```