### PR TITLE
HSEARCH-3264 follow-up: Add minimal documentation for bridges

### DIFF
--- a/documentation/src/main/asciidoc/getting-started.asciidoc
+++ b/documentation/src/main/asciidoc/getting-started.asciidoc
@@ -71,6 +71,12 @@ This is not new for the Lucene integration, but it is for the Elasticsearch inte
 See `org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryContext.extension(SearchPredicateFactoryContextExtension<T>)`
 `org.hibernate.search.backend.elasticsearch.ElasticsearchExtension.get()` and
 `org.hibernate.search.backend.lucene.LuceneExtension.get()`.
+* Bridges benefit from several improvements:
+** Custom (user-defined) bridge annotations, allowing to pass type-safe parameters, and not just strings.
+** Better support for dirty checking optimization in bridges (in `TypeBridge` in particular),
+by allowing bridges to declare what parts of the entity they use.
+** Predicates on non-String fields will work without having to bypass bridges (`.ignoreFieldBridge()`) like in Search 5.
+** And more!
 
 [[getting-started-compatibility]]
 === Compatibility

--- a/documentation/src/main/asciidoc/getting-started.asciidoc
+++ b/documentation/src/main/asciidoc/getting-started.asciidoc
@@ -11,72 +11,9 @@ Hibernate Search {hibernateSearchVersion} is a *technology preview* and is *not 
 Use it to have a sneak peak at the APIs, make suggestions or warn us of what you consider blocking early so we can fix it,
 but *do not* use it to address business needs!
 
-Read <<getting-started-preview-status>> for more information.
+Read http://hibernate.org/search/releases/6.0/#preview-status[the dedicated page on our website]
+for more detailed and up-to-date information.
 ====
-
-[[getting-started-preview-status]]
-=== Preview status
-
-Hibernate Search {hibernateSearchVersion} is a technology preview.
-While the core of Hibernate Search 6 is there, there are still a lot of limitations:
-
-* Features are partially implemented or simply missing.
-For example, you cannot index a `Double` property yet,
-you cannot configure custom Lucene directories,
-you cannot ignore bridges in the predicate DSL,
-and so on.
-* APIs are not considered stable yet.
-* The low-level parts of Hibernate Search 5 that made its efficiency haven't been
-ported to Hibernate Search 6 yet.
-This results in obvious performance bottlenecks,
-such as all the indexing works from a multi-threaded application being executed
-one after another and without any form of batching.
-
-The exact features that are currently implemented and expected to work will be documented
-as new Alpha versions are released, but to sum up, here is what you can start to play with:
-
-* ORM integration:
-** Mapping of entities using either annotation mapping or programmatic mapping.
-However, we do not offer all the options that were available in Search 5 (yet),
-and we do not support all the data types (yet).
-** Automatic indexing of ORM entities as they are persisted within a transaction
-(enabled automatically if Hibernate Search is in your classpath and the entity is mapped).
-** Search for ORM entities using their Hibernate Search index,
-and retrieving managed entities as results.
-However, we do not offer many options regarding how the entities are retrieved and initialized (yet).
-** Custom, user-defined type bridges, property bridges or value bridges.
-However, the API to retrieve information from POJOs is currently quite cumbersome:
-we know it and will work on a lighter API
-(see https://hibernate.atlassian.net/browse/HSEARCH-3297[HSEARCH-3297],
-https://hibernate.atlassian.net/browse/HSEARCH-3298[HSEARCH-3298]).
-* Search DSL
-** All the predicates listed in `org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryContext`.
-However, we do not offer all the options that were available in Search 5 (yet).
-** All the sorts listed in `org.hibernate.search.engine.search.dsl.sort.SearchSortContainerContext`.
-However, we do not offer all the options that were available in Search 5 (yet).
-** All the projections listed in `org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContext`.
-However, we do not offer all the options that were available in Search 5 (yet).
-
-Here are the most interesting new features:
-
-* Changes on indexed-embedded entities trigger reindexing of the "embedding" entity automatically,
-and annotating the inverse side of the association with `@ContainedIn` is no longer needed in most cases.
-A mapping error will be reported when the inverse side of the association cannot be resolved.
-* "nested" fields and predicates, similar to the feature with the same name in Elasticsearch.
-See `org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded.storage`
-and `org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryContext.nested()`.
-* Injection of native predicates (`org.apache.lucene.search.Query`, JSON for Elasticsearch)
-within DSL-created predicates.
-This is not new for the Lucene integration, but it is for the Elasticsearch integration.
-See `org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryContext.extension(SearchPredicateFactoryContextExtension<T>)`
-`org.hibernate.search.backend.elasticsearch.ElasticsearchExtension.get()` and
-`org.hibernate.search.backend.lucene.LuceneExtension.get()`.
-* Bridges benefit from several improvements:
-** Custom (user-defined) bridge annotations, allowing to pass type-safe parameters, and not just strings.
-** Better support for dirty checking optimization in bridges (in `TypeBridge` in particular),
-by allowing bridges to declare what parts of the entity they use.
-** Predicates on non-String fields will work without having to bypass bridges (`.ignoreFieldBridge()`) like in Search 5.
-** And more!
 
 [[getting-started-compatibility]]
 === Compatibility

--- a/documentation/src/main/asciidoc/mapper-pojo.asciidoc
+++ b/documentation/src/main/asciidoc/mapper-pojo.asciidoc
@@ -34,6 +34,41 @@ TODO The getting started section has a link pointing here and expects the sectio
 include a detailed description of how to define and use bridges.
 ////
 
+Starting with Hibernate Search 6, there are three main interfaces for bridges:
+
+* `ValueBridge` can be used for simple use cases when mapping an object's property.
++
+The `ValueBridge` is applied at the property level using one of the pre-defined `@*Field` annotations:
+`@GenericField`, `@FullTextField`, ...
++
+`ValueBridge` is a suitable interface for your custom bridge if:
++
+** The property value should be mapped to a single index field.
+** The bridge should be applied to a property whose type is effectively immutable.
+For example `Integer`, or a custom `enum` type, or a custom bean type whose content never changes would be suitable candidates,
+but a custom bean type with setters would most definitely not.
+* `PropertyBridge` can be used for more complex uses cases when mapping an object's property.
++
+The `PropertyBridge` is applied at the property level using a custom annotation.
++
+`PropertyBridge` can be used even if the property being mapped has a mutable type,
+or if its value should be mapped to multiple index fields.
+* `TypeBridge` should be used when mapping multiple properties of an object, potentially combining them in the process.
++
+The `TypeBridge` is applied at the type level using a custom annotation.
++
+Similarly to `PropertyBridge`, `TypeBridge` can be used even if the properties being mapped have a mutable type,
+or if their values should be mapped to multiple index fields.
+
+You can find example of custom bridges in the
+https://github.com/hibernate/hibernate-search[Hibernate Search source code]:
+
+* `org.hibernate.search.integrationtest.showcase.library.bridge.ISBNBridge` implements `ValueBridge`.
+* `org.hibernate.search.integrationtest.showcase.library.bridge.MultiKeywordStringBridge` implements `PropertyBridge`.
+The corresponding annotation is `org.hibernate.search.integrationtest.showcase.library.bridge.annotation.MultiKeywordStringBridge`.
+* `org.hibernate.search.integrationtest.showcase.library.bridge.AccountBorrowalSummaryBridge` implements `TypeBridge`.
+The corresponding annotation is `org.hibernate.search.integrationtest.showcase.library.bridge.annotation.AccountBorrowalSummaryBridge`.
+
 [[mapper-pojo-indexedembedded]]
 === Indexed-embedded
 // Search 5 anchors backward compatibility

--- a/documentation/src/main/asciidoc/todo-placeholder.asciidoc
+++ b/documentation/src/main/asciidoc/todo-placeholder.asciidoc
@@ -1,4 +1,4 @@
 [IMPORTANT]
 ====
-This section is incomplete. It will be completed during the Alpha/Beta phases of Hibernate Search.
+This section is incomplete. It will be completed during the Alpha/Beta phases of Hibernate Search 6.0.0.
 ====


### PR DESCRIPTION
Follows up on #1804 

I noticed the getting started guide didn't cover bridges at all, and those are a big part of what changed in Search 6, so we'd better add a minimum of documentation about them.