### PR TITLE
HSEARCH-3422 Use _doc to implement index order sorting on Elasticsearch

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/sort/impl/IndexOrderSortContributor.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/sort/impl/IndexOrderSortContributor.java
@@ -12,13 +12,13 @@ class IndexOrderSortContributor implements ElasticsearchSearchSortBuilder {
 
 	public static final IndexOrderSortContributor INSTANCE = new IndexOrderSortContributor();
 
-	private static final JsonPrimitive UID_SORT_KEYWORD_JSON = new JsonPrimitive( "_uid" );
+	private static final JsonPrimitive DOC_SORT_KEYWORD_JSON = new JsonPrimitive( "_doc" );
 
 	private IndexOrderSortContributor() {
 	}
 
 	@Override
 	public void buildAndAddTo(ElasticsearchSearchSortCollector collector) {
-		collector.collectSort( UID_SORT_KEYWORD_JSON );
+		collector.collectSort( DOC_SORT_KEYWORD_JSON );
 	}
 }


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/HSEARCH-3422