### PR TITLE
HSEARCH-3431 Upgrade to Hibernate ORM 5.3.7.Final (master branch)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
         <version.com.google.code.gson>2.8.5</version.com.google.code.gson>
 
         <!-- >>> ORM -->
-        <version.org.hibernate>5.3.6.Final</version.org.hibernate>
+        <version.org.hibernate>5.3.7.Final</version.org.hibernate>
         <javadoc.org.hibernate.url>http://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.majorVersion}.${parsed-version.org.hibernate.minorVersion}/javadocs/</javadoc.org.hibernate.url>
         <version.org.hibernate.commons.annotations>5.0.5.Final</version.org.hibernate.commons.annotations>
         <version.javax.persistence>2.2</version.javax.persistence>


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3431

Same as #1816 , but for master (6.0) instead of 5.10.