### PR TITLE
HSEARCH-3412 Projection DSL should detect (and prevent) projections on fields that have a different projection converter on the targeted indexes

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/MatchPredicateBuilderImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/MatchPredicateBuilderImpl.java
@@ -48,7 +48,7 @@ public class MatchPredicateBuilderImpl extends AbstractSearchPredicateBuilder
 	public void value(Object value) {
 		JsonElement element;
 		try {
-			element = converter.convertFromDsl( value, searchContext.getToIndexFieldValueConvertContext() );
+			element = converter.convertDslToIndex( value, searchContext.getToIndexFieldValueConvertContext() );
 		}
 		catch (RuntimeException e) {
 			throw log.cannotConvertDslParameter(

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/RangePredicateBuilderImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/RangePredicateBuilderImpl.java
@@ -55,7 +55,7 @@ public class RangePredicateBuilderImpl extends AbstractSearchPredicateBuilder
 	@Override
 	public void lowerLimit(Object value) {
 		try {
-			this.lowerLimit = converter.convertFromDsl( value, searchContext.getToIndexFieldValueConvertContext() );
+			this.lowerLimit = converter.convertDslToIndex( value, searchContext.getToIndexFieldValueConvertContext() );
 		}
 		catch (RuntimeException e) {
 			throw log.cannotConvertDslParameter(
@@ -72,7 +72,7 @@ public class RangePredicateBuilderImpl extends AbstractSearchPredicateBuilder
 	@Override
 	public void upperLimit(Object value) {
 		try {
-			this.upperLimit = converter.convertFromDsl( value, searchContext.getToIndexFieldValueConvertContext() );
+			this.upperLimit = converter.convertDslToIndex( value, searchContext.getToIndexFieldValueConvertContext() );
 		}
 		catch (RuntimeException e) {
 			throw log.cannotConvertDslParameter(

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/FieldSearchProjectionImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/FieldSearchProjectionImpl.java
@@ -55,7 +55,7 @@ class FieldSearchProjectionImpl<T> implements ElasticsearchSearchProjection<T, T
 			SearchProjectionExecutionContext searchProjectionExecutionContext) {
 		JsonElement fieldValue = hitFieldValueAccessor.get( hit ).orElse( null );
 		FromIndexFieldValueConvertContext context = searchProjectionExecutionContext.getFromIndexFieldValueConvertContext();
-		return (T) converter.convertFromProjection( fieldValue, context );
+		return (T) converter.convertIndexToProjection( fieldValue, context );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/sort/impl/FieldSortBuilderImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/sort/impl/FieldSortBuilderImpl.java
@@ -55,7 +55,7 @@ public class FieldSortBuilderImpl extends AbstractSearchSortBuilder
 	public void missingAs(Object value) {
 		JsonElement element;
 		try {
-			element = converter.convertFromDsl( value, searchContext.getToIndexFieldValueConvertContext() );
+			element = converter.convertDslToIndex( value, searchContext.getToIndexFieldValueConvertContext() );
 		}
 		catch (RuntimeException e) {
 			throw log.cannotConvertDslParameter(

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/converter/impl/ElasticsearchFieldConverter.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/converter/impl/ElasticsearchFieldConverter.java
@@ -25,7 +25,7 @@ public interface ElasticsearchFieldConverter {
 	 * @return A value of the type used internally when querying this field.
 	 * @throws RuntimeException If the value does not match the expected type.
 	 */
-	JsonElement convertFromDsl(Object value,
+	JsonElement convertDslToIndex(Object value,
 			ToIndexFieldValueConvertContext context);
 
 	/**
@@ -33,33 +33,33 @@ public interface ElasticsearchFieldConverter {
 	 * @param context The context to use when converting.
 	 * @return A value of the type expected by users when projecting.
 	 */
-	Object convertFromProjection(JsonElement value, FromIndexFieldValueConvertContext context);
+	Object convertIndexToProjection(JsonElement value, FromIndexFieldValueConvertContext context);
 
 	/**
-	 * Determine whether another converter's {@link #convertFromDsl(Object, ToIndexFieldValueConvertContext)}
+	 * Determine whether another converter's {@link #convertDslToIndex(Object, ToIndexFieldValueConvertContext)}
 	 * method is compatible with this one's.
 	 * <p>
-	 * @see org.hibernate.search.engine.backend.document.spi.UserIndexFieldConverter#isConvertFromDslCompatibleWith(UserIndexFieldConverter)
+	 * @see org.hibernate.search.engine.backend.document.spi.UserIndexFieldConverter#isConvertDslToIndexCompatibleWith(UserIndexFieldConverter)
 	 *
 	 * @param other Another {@link ElasticsearchFieldConverter}, never {@code null}.
 	 * @return {@code true} if the given converter's
-	 * {@link #convertFromDsl(Object, ToIndexFieldValueConvertContext)} method is compatible.
+	 * {@link #convertDslToIndex(Object, ToIndexFieldValueConvertContext)} method is compatible.
 	 * {@code false} otherwise, or when in doubt.
 	 */
-	boolean isConvertFromDslCompatibleWith(ElasticsearchFieldConverter other);
+	boolean isConvertDslToIndexCompatibleWith(ElasticsearchFieldConverter other);
 
 	/**
-	 * Determine whether another converter's {@link #convertFromProjection(JsonElement, FromIndexFieldValueConvertContext)}
+	 * Determine whether another converter's {@link #convertIndexToProjection(JsonElement, FromIndexFieldValueConvertContext)}
 	 * method is compatible with this one's.
 	 * <p>
-	 * @see org.hibernate.search.engine.backend.document.spi.UserIndexFieldConverter#isConvertFromProjectionCompatibleWith(UserIndexFieldConverter)
+	 * @see org.hibernate.search.engine.backend.document.spi.UserIndexFieldConverter#isConvertIndexToProjectionCompatibleWith(UserIndexFieldConverter)
 	 *
 	 * @param other Another {@link ElasticsearchFieldConverter}, never {@code null}.
 	 * @return {@code true} if the given converter's
-	 * {@link #convertFromProjection(JsonElement, FromIndexFieldValueConvertContext)} method is compatible.
+	 * {@link #convertIndexToProjection(JsonElement, FromIndexFieldValueConvertContext)} method is compatible.
 	 * {@code false} otherwise, or when in doubt.
 	 */
-	boolean isConvertFromProjectionCompatibleWith(ElasticsearchFieldConverter other);
+	boolean isConvertIndexToProjectionCompatibleWith(ElasticsearchFieldConverter other);
 
 	/**
 	 * Determine whether the given projection type is compatible with this converter.

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/converter/impl/ElasticsearchFieldConverter.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/converter/impl/ElasticsearchFieldConverter.java
@@ -36,21 +36,36 @@ public interface ElasticsearchFieldConverter {
 	Object convertFromProjection(JsonElement value, FromIndexFieldValueConvertContext context);
 
 	/**
-	 * Determine whether another converter is DSL-compatible with this one.
-	 *
-	 * @see org.hibernate.search.engine.backend.document.spi.UserIndexFieldConverter#isDslCompatibleWith(UserIndexFieldConverter)
+	 * Determine whether another converter's {@link #convertFromDsl(Object, ToIndexFieldValueConvertContext)}
+	 * method is compatible with this one's.
+	 * <p>
+	 * @see org.hibernate.search.engine.backend.document.spi.UserIndexFieldConverter#isConvertFromDslCompatibleWith(UserIndexFieldConverter)
 	 *
 	 * @param other Another {@link ElasticsearchFieldConverter}, never {@code null}.
-	 * @return {@code true} if the given converter is DSL-compatible.
+	 * @return {@code true} if the given converter's
+	 * {@link #convertFromDsl(Object, ToIndexFieldValueConvertContext)} method is compatible.
 	 * {@code false} otherwise, or when in doubt.
 	 */
-	boolean isDslCompatibleWith(ElasticsearchFieldConverter other);
+	boolean isConvertFromDslCompatibleWith(ElasticsearchFieldConverter other);
+
+	/**
+	 * Determine whether another converter's {@link #convertFromProjection(JsonElement, FromIndexFieldValueConvertContext)}
+	 * method is compatible with this one's.
+	 * <p>
+	 * @see org.hibernate.search.engine.backend.document.spi.UserIndexFieldConverter#isConvertFromProjectionCompatibleWith(UserIndexFieldConverter)
+	 *
+	 * @param other Another {@link ElasticsearchFieldConverter}, never {@code null}.
+	 * @return {@code true} if the given converter's
+	 * {@link #convertFromProjection(JsonElement, FromIndexFieldValueConvertContext)} method is compatible.
+	 * {@code false} otherwise, or when in doubt.
+	 */
+	boolean isConvertFromProjectionCompatibleWith(ElasticsearchFieldConverter other);
 
 	/**
 	 * Determine whether the given projection type is compatible with this converter.
 	 *
 	 * @param projectionType The projection type.
-	 * @return {@code true} if the given projection type is compatible. {@code false} otherwise
+	 * @return {@code true} if the given projection type is compatible. {@code false} otherwise.
 	 */
 	boolean isProjectionCompatibleWith(Class<?> projectionType);
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/converter/impl/StandardFieldConverter.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/converter/impl/StandardFieldConverter.java
@@ -41,12 +41,22 @@ public final class StandardFieldConverter<F> implements ElasticsearchFieldConver
 	}
 
 	@Override
-	public boolean isDslCompatibleWith(ElasticsearchFieldConverter other) {
+	public boolean isConvertFromDslCompatibleWith(ElasticsearchFieldConverter other) {
 		if ( !getClass().equals( other.getClass() ) ) {
 			return false;
 		}
 		StandardFieldConverter<?> castedOther = (StandardFieldConverter<?>) other;
-		return userConverter.isDslCompatibleWith( castedOther.userConverter )
+		return userConverter.isConvertFromDslCompatibleWith( castedOther.userConverter )
+				&& codec.isCompatibleWith( castedOther.codec );
+	}
+
+	@Override
+	public boolean isConvertFromProjectionCompatibleWith(ElasticsearchFieldConverter other) {
+		if ( !getClass().equals( other.getClass() ) ) {
+			return false;
+		}
+		StandardFieldConverter<?> castedOther = (StandardFieldConverter<?>) other;
+		return userConverter.isConvertFromProjectionCompatibleWith( castedOther.userConverter )
 				&& codec.isCompatibleWith( castedOther.codec );
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/converter/impl/StandardFieldConverter.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/converter/impl/StandardFieldConverter.java
@@ -29,34 +29,34 @@ public final class StandardFieldConverter<F> implements ElasticsearchFieldConver
 	}
 
 	@Override
-	public JsonElement convertFromDsl(Object value, ToIndexFieldValueConvertContext context) {
-		F rawValue = userConverter.convertFromDsl( value, context );
+	public JsonElement convertDslToIndex(Object value, ToIndexFieldValueConvertContext context) {
+		F rawValue = userConverter.convertDslToIndex( value, context );
 		return codec.encode( rawValue );
 	}
 
 	@Override
-	public Object convertFromProjection(JsonElement element, FromIndexFieldValueConvertContext context) {
+	public Object convertIndexToProjection(JsonElement element, FromIndexFieldValueConvertContext context) {
 		F rawValue = codec.decode( element );
-		return userConverter.convertFromProjection( rawValue, context );
+		return userConverter.convertIndexToProjection( rawValue, context );
 	}
 
 	@Override
-	public boolean isConvertFromDslCompatibleWith(ElasticsearchFieldConverter other) {
+	public boolean isConvertDslToIndexCompatibleWith(ElasticsearchFieldConverter other) {
 		if ( !getClass().equals( other.getClass() ) ) {
 			return false;
 		}
 		StandardFieldConverter<?> castedOther = (StandardFieldConverter<?>) other;
-		return userConverter.isConvertFromDslCompatibleWith( castedOther.userConverter )
+		return userConverter.isConvertDslToIndexCompatibleWith( castedOther.userConverter )
 				&& codec.isCompatibleWith( castedOther.codec );
 	}
 
 	@Override
-	public boolean isConvertFromProjectionCompatibleWith(ElasticsearchFieldConverter other) {
+	public boolean isConvertIndexToProjectionCompatibleWith(ElasticsearchFieldConverter other) {
 		if ( !getClass().equals( other.getClass() ) ) {
 			return false;
 		}
 		StandardFieldConverter<?> castedOther = (StandardFieldConverter<?>) other;
-		return userConverter.isConvertFromProjectionCompatibleWith( castedOther.userConverter )
+		return userConverter.isConvertIndexToProjectionCompatibleWith( castedOther.userConverter )
 				&& codec.isCompatibleWith( castedOther.codec );
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchFieldPredicateBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchFieldPredicateBuilderFactory.java
@@ -38,7 +38,7 @@ public interface ElasticsearchFieldPredicateBuilderFactory {
 	 * Determine whether another predicate builder factory is DSL-compatible with this one,
 	 * i.e. whether it creates builders that behave the same way.
 	 *
-	 * @see ElasticsearchFieldConverter#isConvertFromDslCompatibleWith(ElasticsearchFieldConverter)
+	 * @see ElasticsearchFieldConverter#isConvertDslToIndexCompatibleWith(ElasticsearchFieldConverter)
 	 *
 	 * @param other Another {@link ElasticsearchFieldPredicateBuilderFactory}, never {@code null}.
 	 * @return {@code true} if the given predicate builder factory is DSL-compatible.

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchFieldPredicateBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchFieldPredicateBuilderFactory.java
@@ -38,7 +38,7 @@ public interface ElasticsearchFieldPredicateBuilderFactory {
 	 * Determine whether another predicate builder factory is DSL-compatible with this one,
 	 * i.e. whether it creates builders that behave the same way.
 	 *
-	 * @see ElasticsearchFieldConverter#isDslCompatibleWith(ElasticsearchFieldConverter)
+	 * @see ElasticsearchFieldConverter#isConvertFromDslCompatibleWith(ElasticsearchFieldConverter)
 	 *
 	 * @param other Another {@link ElasticsearchFieldPredicateBuilderFactory}, never {@code null}.
 	 * @return {@code true} if the given predicate builder factory is DSL-compatible.

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/StandardFieldPredicateBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/StandardFieldPredicateBuilderFactory.java
@@ -38,7 +38,7 @@ public class StandardFieldPredicateBuilderFactory implements ElasticsearchFieldP
 			return false;
 		}
 		StandardFieldPredicateBuilderFactory castedOther = (StandardFieldPredicateBuilderFactory) other;
-		return converter.isDslCompatibleWith( castedOther.converter );
+		return converter.isConvertFromDslCompatibleWith( castedOther.converter );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/StandardFieldPredicateBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/StandardFieldPredicateBuilderFactory.java
@@ -38,7 +38,7 @@ public class StandardFieldPredicateBuilderFactory implements ElasticsearchFieldP
 			return false;
 		}
 		StandardFieldPredicateBuilderFactory castedOther = (StandardFieldPredicateBuilderFactory) other;
-		return converter.isConvertFromDslCompatibleWith( castedOther.converter );
+		return converter.isConvertDslToIndexCompatibleWith( castedOther.converter );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/ElasticsearchFieldProjectionBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/ElasticsearchFieldProjectionBuilderFactory.java
@@ -32,7 +32,7 @@ public interface ElasticsearchFieldProjectionBuilderFactory {
 	 * Determine whether another projection builder factory is DSL-compatible with this one,
 	 * i.e. whether it creates builders that behave the same way.
 	 *
-	 * @see ElasticsearchFieldConverter#isDslCompatibleWith(ElasticsearchFieldConverter)
+	 * @see ElasticsearchFieldConverter#isConvertFromDslCompatibleWith(ElasticsearchFieldConverter)
 	 *
 	 * @param other Another {@link ElasticsearchFieldProjectionBuilderFactory}, never {@code null}.
 	 * @return {@code true} if the given predicate builder factory is DSL-compatible.

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/ElasticsearchFieldProjectionBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/ElasticsearchFieldProjectionBuilderFactory.java
@@ -32,7 +32,7 @@ public interface ElasticsearchFieldProjectionBuilderFactory {
 	 * Determine whether another projection builder factory is DSL-compatible with this one,
 	 * i.e. whether it creates builders that behave the same way.
 	 *
-	 * @see ElasticsearchFieldConverter#isConvertFromDslCompatibleWith(ElasticsearchFieldConverter)
+	 * @see ElasticsearchFieldConverter#isConvertDslToIndexCompatibleWith(ElasticsearchFieldConverter)
 	 *
 	 * @param other Another {@link ElasticsearchFieldProjectionBuilderFactory}, never {@code null}.
 	 * @return {@code true} if the given predicate builder factory is DSL-compatible.

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/GeoPointFieldProjectionBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/GeoPointFieldProjectionBuilderFactory.java
@@ -64,7 +64,7 @@ public class GeoPointFieldProjectionBuilderFactory implements ElasticsearchField
 		GeoPointFieldProjectionBuilderFactory other = (GeoPointFieldProjectionBuilderFactory) obj;
 
 		return projectable == other.projectable &&
-				converter.isDslCompatibleWith( other.converter );
+				converter.isConvertFromProjectionCompatibleWith( other.converter );
 	}
 
 	private static void checkProjectable(String absoluteFieldPath, boolean projectable) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/GeoPointFieldProjectionBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/GeoPointFieldProjectionBuilderFactory.java
@@ -64,7 +64,7 @@ public class GeoPointFieldProjectionBuilderFactory implements ElasticsearchField
 		GeoPointFieldProjectionBuilderFactory other = (GeoPointFieldProjectionBuilderFactory) obj;
 
 		return projectable == other.projectable &&
-				converter.isConvertFromProjectionCompatibleWith( other.converter );
+				converter.isConvertIndexToProjectionCompatibleWith( other.converter );
 	}
 
 	private static void checkProjectable(String absoluteFieldPath, boolean projectable) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/StandardFieldProjectionBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/StandardFieldProjectionBuilderFactory.java
@@ -63,7 +63,7 @@ public class StandardFieldProjectionBuilderFactory implements ElasticsearchField
 		StandardFieldProjectionBuilderFactory other = (StandardFieldProjectionBuilderFactory) obj;
 
 		return projectable == other.projectable &&
-				converter.isConvertFromProjectionCompatibleWith( other.converter );
+				converter.isConvertIndexToProjectionCompatibleWith( other.converter );
 	}
 
 	private static void checkProjectable(String absoluteFieldPath, boolean projectable) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/StandardFieldProjectionBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/StandardFieldProjectionBuilderFactory.java
@@ -63,7 +63,7 @@ public class StandardFieldProjectionBuilderFactory implements ElasticsearchField
 		StandardFieldProjectionBuilderFactory other = (StandardFieldProjectionBuilderFactory) obj;
 
 		return projectable == other.projectable &&
-				converter.isDslCompatibleWith( other.converter );
+				converter.isConvertFromProjectionCompatibleWith( other.converter );
 	}
 
 	private static void checkProjectable(String absoluteFieldPath, boolean projectable) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/sort/impl/ElasticsearchFieldSortBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/sort/impl/ElasticsearchFieldSortBuilderFactory.java
@@ -41,7 +41,7 @@ public interface ElasticsearchFieldSortBuilderFactory {
 	 * Determine whether another sort builder factory is DSL-compatible with this one,
 	 * i.e. whether it creates builders that behave the same way.
 	 *
-	 * @see ElasticsearchFieldConverter#isConvertFromDslCompatibleWith(ElasticsearchFieldConverter)
+	 * @see ElasticsearchFieldConverter#isConvertDslToIndexCompatibleWith(ElasticsearchFieldConverter)
 	 *
 	 * @param other Another {@link ElasticsearchFieldSortBuilderFactory}, never {@code null}.
 	 * @return {@code true} if the given sort builder factory is DSL-compatible.

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/sort/impl/ElasticsearchFieldSortBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/sort/impl/ElasticsearchFieldSortBuilderFactory.java
@@ -41,7 +41,7 @@ public interface ElasticsearchFieldSortBuilderFactory {
 	 * Determine whether another sort builder factory is DSL-compatible with this one,
 	 * i.e. whether it creates builders that behave the same way.
 	 *
-	 * @see ElasticsearchFieldConverter#isDslCompatibleWith(ElasticsearchFieldConverter)
+	 * @see ElasticsearchFieldConverter#isConvertFromDslCompatibleWith(ElasticsearchFieldConverter)
 	 *
 	 * @param other Another {@link ElasticsearchFieldSortBuilderFactory}, never {@code null}.
 	 * @return {@code true} if the given sort builder factory is DSL-compatible.

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/sort/impl/StandardFieldSortBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/sort/impl/StandardFieldSortBuilderFactory.java
@@ -61,7 +61,7 @@ public class StandardFieldSortBuilderFactory implements ElasticsearchFieldSortBu
 		StandardFieldSortBuilderFactory other = (StandardFieldSortBuilderFactory) obj;
 
 		return sortable == other.sortable &&
-				converter.isConvertFromDslCompatibleWith( other.converter );
+				converter.isConvertDslToIndexCompatibleWith( other.converter );
 	}
 
 	private static void checkSortable(String absoluteFieldPath, boolean sortable) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/sort/impl/StandardFieldSortBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/sort/impl/StandardFieldSortBuilderFactory.java
@@ -61,7 +61,7 @@ public class StandardFieldSortBuilderFactory implements ElasticsearchFieldSortBu
 		StandardFieldSortBuilderFactory other = (StandardFieldSortBuilderFactory) obj;
 
 		return sortable == other.sortable &&
-				converter.isDslCompatibleWith( other.converter );
+				converter.isConvertFromDslCompatibleWith( other.converter );
 	}
 
 	private static void checkSortable(String absoluteFieldPath, boolean sortable) {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/AbstractMatchPredicateBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/AbstractMatchPredicateBuilder.java
@@ -38,7 +38,7 @@ public abstract class AbstractMatchPredicateBuilder<F, T> extends AbstractSearch
 	@Override
 	public void value(Object value) {
 		try {
-			this.value = converter.convertFromDsl( value, searchContext.getToIndexFieldValueConvertContext() );
+			this.value = converter.convertDslToIndex( value, searchContext.getToIndexFieldValueConvertContext() );
 		}
 		catch (RuntimeException e) {
 			throw log.cannotConvertDslParameter(

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/AbstractRangePredicateBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/AbstractRangePredicateBuilder.java
@@ -46,7 +46,7 @@ public abstract class AbstractRangePredicateBuilder<F> extends AbstractSearchPre
 	@Override
 	public void lowerLimit(Object value) {
 		try {
-			lowerLimit = converter.convertFromDsl( value, searchContext.getToIndexFieldValueConvertContext() );
+			lowerLimit = converter.convertDslToIndex( value, searchContext.getToIndexFieldValueConvertContext() );
 		}
 		catch (RuntimeException e) {
 			throw log.cannotConvertDslParameter(
@@ -63,7 +63,7 @@ public abstract class AbstractRangePredicateBuilder<F> extends AbstractSearchPre
 	@Override
 	public void upperLimit(Object value) {
 		try {
-			upperLimit = converter.convertFromDsl( value, searchContext.getToIndexFieldValueConvertContext() );
+			upperLimit = converter.convertDslToIndex( value, searchContext.getToIndexFieldValueConvertContext() );
 		}
 		catch (RuntimeException e) {
 			throw log.cannotConvertDslParameter(

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/FieldSearchProjectionImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/FieldSearchProjectionImpl.java
@@ -52,7 +52,7 @@ class FieldSearchProjectionImpl<F, T> implements LuceneSearchProjection<T, T> {
 			SearchProjectionExecutionContext context) {
 		F rawValue = codec.decode( documentResult.getDocument(), absoluteFieldPath );
 		FromIndexFieldValueConvertContext convertContext = context.getFromIndexFieldValueConvertContext();
-		return (T) converter.convertFromProjection( rawValue, convertContext );
+		return (T) converter.convertIndexToProjection( rawValue, convertContext );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/converter/impl/AbstractFieldConverter.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/converter/impl/AbstractFieldConverter.java
@@ -23,26 +23,26 @@ abstract class AbstractFieldConverter<F, T> implements LuceneFieldConverter<F, T
 	}
 
 	@Override
-	public Object convertFromProjection(F value, FromIndexFieldValueConvertContext context) {
-		return userConverter.convertFromProjection( value, context );
+	public Object convertIndexToProjection(F indexValue, FromIndexFieldValueConvertContext context) {
+		return userConverter.convertIndexToProjection( indexValue, context );
 	}
 
 	@Override
-	public boolean isConvertFromDslCompatibleWith(LuceneFieldConverter<?, ?> other) {
+	public boolean isConvertDslToIndexCompatibleWith(LuceneFieldConverter<?, ?> other) {
 		if ( !getClass().equals( other.getClass() ) ) {
 			return false;
 		}
 		AbstractFieldConverter<?, ?> castedOther = (AbstractFieldConverter<?, ?>) other;
-		return userConverter.isConvertFromDslCompatibleWith( castedOther.userConverter );
+		return userConverter.isConvertDslToIndexCompatibleWith( castedOther.userConverter );
 	}
 
 	@Override
-	public boolean isConvertFromProjectionCompatibleWith(LuceneFieldConverter<?, ?> other) {
+	public boolean isConvertIndexToProjectionCompatibleWith(LuceneFieldConverter<?, ?> other) {
 		if ( !getClass().equals( other.getClass() ) ) {
 			return false;
 		}
 		AbstractFieldConverter<?, ?> castedOther = (AbstractFieldConverter<?, ?>) other;
-		return userConverter.isConvertFromProjectionCompatibleWith( castedOther.userConverter );
+		return userConverter.isConvertIndexToProjectionCompatibleWith( castedOther.userConverter );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/converter/impl/AbstractFieldConverter.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/converter/impl/AbstractFieldConverter.java
@@ -28,12 +28,21 @@ abstract class AbstractFieldConverter<F, T> implements LuceneFieldConverter<F, T
 	}
 
 	@Override
-	public boolean isDslCompatibleWith(LuceneFieldConverter<?, ?> other) {
+	public boolean isConvertFromDslCompatibleWith(LuceneFieldConverter<?, ?> other) {
 		if ( !getClass().equals( other.getClass() ) ) {
 			return false;
 		}
 		AbstractFieldConverter<?, ?> castedOther = (AbstractFieldConverter<?, ?>) other;
-		return userConverter.isDslCompatibleWith( castedOther.userConverter );
+		return userConverter.isConvertFromDslCompatibleWith( castedOther.userConverter );
+	}
+
+	@Override
+	public boolean isConvertFromProjectionCompatibleWith(LuceneFieldConverter<?, ?> other) {
+		if ( !getClass().equals( other.getClass() ) ) {
+			return false;
+		}
+		AbstractFieldConverter<?, ?> castedOther = (AbstractFieldConverter<?, ?>) other;
+		return userConverter.isConvertFromProjectionCompatibleWith( castedOther.userConverter );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/converter/impl/BooleanFieldConverter.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/converter/impl/BooleanFieldConverter.java
@@ -16,9 +16,9 @@ public final class BooleanFieldConverter extends AbstractFieldConverter<Boolean,
 	}
 
 	@Override
-	public Integer convertFromDsl(Object value,
+	public Integer convertDslToIndex(Object value,
 			ToIndexFieldValueConvertContext context) {
-		Boolean rawValue = userConverter.convertFromDsl( value, context );
+		Boolean rawValue = userConverter.convertDslToIndex( value, context );
 		if ( value == null ) {
 			return null;
 		}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/converter/impl/InstantFieldConverter.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/converter/impl/InstantFieldConverter.java
@@ -18,9 +18,9 @@ public final class InstantFieldConverter extends AbstractFieldConverter<Instant,
 	}
 
 	@Override
-	public Long convertFromDsl(Object value,
+	public Long convertDslToIndex(Object value,
 			ToIndexFieldValueConvertContext context) {
-		Instant rawValue = userConverter.convertFromDsl( value, context );
+		Instant rawValue = userConverter.convertDslToIndex( value, context );
 		if ( value == null ) {
 			return null;
 		}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/converter/impl/LocalDateFieldConverter.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/converter/impl/LocalDateFieldConverter.java
@@ -18,9 +18,9 @@ public final class LocalDateFieldConverter extends AbstractFieldConverter<LocalD
 	}
 
 	@Override
-	public Long convertFromDsl(Object value,
+	public Long convertDslToIndex(Object value,
 			ToIndexFieldValueConvertContext context) {
-		LocalDate rawValue = userConverter.convertFromDsl( value, context );
+		LocalDate rawValue = userConverter.convertDslToIndex( value, context );
 		if ( value == null ) {
 			return null;
 		}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/converter/impl/LuceneFieldConverter.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/converter/impl/LuceneFieldConverter.java
@@ -27,40 +27,40 @@ public interface LuceneFieldConverter<F, T> {
 	 * @return A value of the type used internally when querying this field.
 	 * @throws RuntimeException If the value does not match the expected type.
 	 */
-	T convertFromDsl(Object value, ToIndexFieldValueConvertContext context);
+	T convertDslToIndex(Object value, ToIndexFieldValueConvertContext context);
 
 	/**
-	 * @param value The projected value returned by the codec.
+	 * @param indexValue The projected value returned by the codec.
 	 * @param context The context to use when converting.
 	 * @return A value of the type expected by users when projecting.
 	 */
-	Object convertFromProjection(F value, FromIndexFieldValueConvertContext context);
+	Object convertIndexToProjection(F indexValue, FromIndexFieldValueConvertContext context);
 
 	/**
-	 * Determine whether another converter's {@link #convertFromDsl(Object, ToIndexFieldValueConvertContext)}
+	 * Determine whether another converter's {@link #convertDslToIndex(Object, ToIndexFieldValueConvertContext)}
 	 * method is compatible with this one's.
 	 * <p>
-	 * @see org.hibernate.search.engine.backend.document.spi.UserIndexFieldConverter#isConvertFromDslCompatibleWith(UserIndexFieldConverter)
+	 * @see org.hibernate.search.engine.backend.document.spi.UserIndexFieldConverter#isConvertDslToIndexCompatibleWith(UserIndexFieldConverter)
 	 *
 	 * @param other Another {@link LuceneFieldConverter}, never {@code null}.
 	 * @return {@code true} if the given converter's
-	 * {@link #convertFromDsl(Object, ToIndexFieldValueConvertContext)} method is compatible.
+	 * {@link #convertDslToIndex(Object, ToIndexFieldValueConvertContext)} method is compatible.
 	 * {@code false} otherwise, or when in doubt.
 	 */
-	boolean isConvertFromDslCompatibleWith(LuceneFieldConverter<?, ?> other);
+	boolean isConvertDslToIndexCompatibleWith(LuceneFieldConverter<?, ?> other);
 
 	/**
-	 * Determine whether another converter's {@link #convertFromProjection(Object, FromIndexFieldValueConvertContext)}
+	 * Determine whether another converter's {@link #convertIndexToProjection(Object, FromIndexFieldValueConvertContext)}
 	 * method is compatible with this one's.
 	 * <p>
-	 * @see org.hibernate.search.engine.backend.document.spi.UserIndexFieldConverter#isConvertFromProjectionCompatibleWith(UserIndexFieldConverter)
+	 * @see org.hibernate.search.engine.backend.document.spi.UserIndexFieldConverter#isConvertIndexToProjectionCompatibleWith(UserIndexFieldConverter)
 	 *
 	 * @param other Another {@link LuceneFieldConverter}, never {@code null}.
 	 * @return {@code true} if the given converter's
-	 * {@link #convertFromProjection(Object, FromIndexFieldValueConvertContext)} method is compatible.
+	 * {@link #convertIndexToProjection(Object, FromIndexFieldValueConvertContext)} method is compatible.
 	 * {@code false} otherwise, or when in doubt.
 	 */
-	boolean isConvertFromProjectionCompatibleWith(LuceneFieldConverter<?, ?> other);
+	boolean isConvertIndexToProjectionCompatibleWith(LuceneFieldConverter<?, ?> other);
 
 	/**
 	 * Determine whether the given projection type is compatible with this converter.

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/converter/impl/LuceneFieldConverter.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/converter/impl/LuceneFieldConverter.java
@@ -37,21 +37,36 @@ public interface LuceneFieldConverter<F, T> {
 	Object convertFromProjection(F value, FromIndexFieldValueConvertContext context);
 
 	/**
-	 * Determine whether another converter is DSL-compatible with this one.
-	 *
-	 * @see org.hibernate.search.engine.backend.document.spi.UserIndexFieldConverter#isDslCompatibleWith(UserIndexFieldConverter)
+	 * Determine whether another converter's {@link #convertFromDsl(Object, ToIndexFieldValueConvertContext)}
+	 * method is compatible with this one's.
+	 * <p>
+	 * @see org.hibernate.search.engine.backend.document.spi.UserIndexFieldConverter#isConvertFromDslCompatibleWith(UserIndexFieldConverter)
 	 *
 	 * @param other Another {@link LuceneFieldConverter}, never {@code null}.
-	 * @return {@code true} if the given converter is DSL-compatible.
+	 * @return {@code true} if the given converter's
+	 * {@link #convertFromDsl(Object, ToIndexFieldValueConvertContext)} method is compatible.
 	 * {@code false} otherwise, or when in doubt.
 	 */
-	boolean isDslCompatibleWith(LuceneFieldConverter<?, ?> other);
+	boolean isConvertFromDslCompatibleWith(LuceneFieldConverter<?, ?> other);
+
+	/**
+	 * Determine whether another converter's {@link #convertFromProjection(Object, FromIndexFieldValueConvertContext)}
+	 * method is compatible with this one's.
+	 * <p>
+	 * @see org.hibernate.search.engine.backend.document.spi.UserIndexFieldConverter#isConvertFromProjectionCompatibleWith(UserIndexFieldConverter)
+	 *
+	 * @param other Another {@link LuceneFieldConverter}, never {@code null}.
+	 * @return {@code true} if the given converter's
+	 * {@link #convertFromProjection(Object, FromIndexFieldValueConvertContext)} method is compatible.
+	 * {@code false} otherwise, or when in doubt.
+	 */
+	boolean isConvertFromProjectionCompatibleWith(LuceneFieldConverter<?, ?> other);
 
 	/**
 	 * Determine whether the given projection type is compatible with this converter.
 	 *
 	 * @param projectionType The projection type.
-	 * @return {@code true} if the given projection type is compatible. {@code false} otherwise
+	 * @return {@code true} if the given projection type is compatible. {@code false} otherwise.
 	 */
 	boolean isProjectionCompatibleWith(Class<?> projectionType);
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/converter/impl/StandardFieldConverter.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/converter/impl/StandardFieldConverter.java
@@ -16,8 +16,8 @@ public final class StandardFieldConverter<F> extends AbstractFieldConverter<F, F
 	}
 
 	@Override
-	public F convertFromDsl(Object value,
+	public F convertDslToIndex(Object value,
 			ToIndexFieldValueConvertContext context) {
-		return userConverter.convertFromDsl( value, context );
+		return userConverter.convertDslToIndex( value, context );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/converter/impl/StringFieldConverter.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/converter/impl/StringFieldConverter.java
@@ -29,14 +29,14 @@ public final class StringFieldConverter extends AbstractFieldConverter<String, S
 	}
 
 	@Override
-	public String convertFromDsl(Object value,
+	public String convertDslToIndex(Object value,
 			ToIndexFieldValueConvertContext context) {
-		return userConverter.convertFromDsl( value, context );
+		return userConverter.convertDslToIndex( value, context );
 	}
 
 	@Override
-	public boolean isConvertFromDslCompatibleWith(LuceneFieldConverter<?, ?> other) {
-		if ( !super.isConvertFromDslCompatibleWith( other ) ) {
+	public boolean isConvertDslToIndexCompatibleWith(LuceneFieldConverter<?, ?> other) {
+		if ( !super.isConvertDslToIndexCompatibleWith( other ) ) {
 			return false;
 		}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/converter/impl/StringFieldConverter.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/converter/impl/StringFieldConverter.java
@@ -35,8 +35,8 @@ public final class StringFieldConverter extends AbstractFieldConverter<String, S
 	}
 
 	@Override
-	public boolean isDslCompatibleWith(LuceneFieldConverter<?, ?> other) {
-		if ( !super.isDslCompatibleWith( other ) ) {
+	public boolean isConvertFromDslCompatibleWith(LuceneFieldConverter<?, ?> other) {
+		if ( !super.isConvertFromDslCompatibleWith( other ) ) {
 			return false;
 		}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/AbstractStandardLuceneFieldPredicateBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/AbstractStandardLuceneFieldPredicateBuilderFactory.java
@@ -37,7 +37,7 @@ abstract class AbstractStandardLuceneFieldPredicateBuilderFactory<C extends Luce
 		}
 		AbstractStandardLuceneFieldPredicateBuilderFactory<?> castedOther =
 				(AbstractStandardLuceneFieldPredicateBuilderFactory<?>) other;
-		return converter.isDslCompatibleWith( castedOther.converter );
+		return converter.isConvertFromDslCompatibleWith( castedOther.converter );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/AbstractStandardLuceneFieldPredicateBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/AbstractStandardLuceneFieldPredicateBuilderFactory.java
@@ -37,7 +37,7 @@ abstract class AbstractStandardLuceneFieldPredicateBuilderFactory<C extends Luce
 		}
 		AbstractStandardLuceneFieldPredicateBuilderFactory<?> castedOther =
 				(AbstractStandardLuceneFieldPredicateBuilderFactory<?>) other;
-		return converter.isConvertFromDslCompatibleWith( castedOther.converter );
+		return converter.isConvertDslToIndexCompatibleWith( castedOther.converter );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneFieldPredicateBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneFieldPredicateBuilderFactory.java
@@ -37,7 +37,7 @@ public interface LuceneFieldPredicateBuilderFactory {
 	 * Determine whether another predicate builder factory is DSL-compatible with this one,
 	 * i.e. whether it creates builders that behave the same way.
 	 *
-	 * @see LuceneFieldConverter#isConvertFromDslCompatibleWith(LuceneFieldConverter)
+	 * @see LuceneFieldConverter#isConvertDslToIndexCompatibleWith(LuceneFieldConverter)
 	 *
 	 * @param other Another {@link LuceneFieldPredicateBuilderFactory}, never {@code null}.
 	 * @return {@code true} if the given predicate builder factory is DSL-compatible.

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneFieldPredicateBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneFieldPredicateBuilderFactory.java
@@ -37,7 +37,7 @@ public interface LuceneFieldPredicateBuilderFactory {
 	 * Determine whether another predicate builder factory is DSL-compatible with this one,
 	 * i.e. whether it creates builders that behave the same way.
 	 *
-	 * @see LuceneFieldConverter#isDslCompatibleWith(LuceneFieldConverter)
+	 * @see LuceneFieldConverter#isConvertFromDslCompatibleWith(LuceneFieldConverter)
 	 *
 	 * @param other Another {@link LuceneFieldPredicateBuilderFactory}, never {@code null}.
 	 * @return {@code true} if the given predicate builder factory is DSL-compatible.

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/GeoPointFieldProjectionBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/GeoPointFieldProjectionBuilderFactory.java
@@ -70,7 +70,7 @@ public class GeoPointFieldProjectionBuilderFactory<T> implements LuceneFieldProj
 
 		return projectable == other.projectable &&
 				codec.isCompatibleWith( other.codec ) &&
-				converter.isConvertFromProjectionCompatibleWith( other.converter );
+				converter.isConvertIndexToProjectionCompatibleWith( other.converter );
 	}
 
 	private static void checkProjectable(String absoluteFieldPath, boolean projectable) {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/GeoPointFieldProjectionBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/GeoPointFieldProjectionBuilderFactory.java
@@ -70,7 +70,7 @@ public class GeoPointFieldProjectionBuilderFactory<T> implements LuceneFieldProj
 
 		return projectable == other.projectable &&
 				codec.isCompatibleWith( other.codec ) &&
-				converter.isDslCompatibleWith( other.converter );
+				converter.isConvertFromProjectionCompatibleWith( other.converter );
 	}
 
 	private static void checkProjectable(String absoluteFieldPath, boolean projectable) {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/LuceneFieldProjectionBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/LuceneFieldProjectionBuilderFactory.java
@@ -34,7 +34,7 @@ public interface LuceneFieldProjectionBuilderFactory {
 	 * Determine whether another projection builder factory is DSL-compatible with this one,
 	 * i.e. whether it creates builders that behave the same way.
 	 *
-	 * @see LuceneFieldConverter#isDslCompatibleWith(LuceneFieldConverter)
+	 * @see LuceneFieldConverter#isConvertFromProjectionCompatibleWith(LuceneFieldConverter)
 	 * @see LuceneFieldCodec#isCompatibleWith(LuceneFieldCodec)
 	 *
 	 * @param other Another {@link LuceneFieldPredicateBuilderFactory}, never {@code null}.

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/LuceneFieldProjectionBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/LuceneFieldProjectionBuilderFactory.java
@@ -34,7 +34,7 @@ public interface LuceneFieldProjectionBuilderFactory {
 	 * Determine whether another projection builder factory is DSL-compatible with this one,
 	 * i.e. whether it creates builders that behave the same way.
 	 *
-	 * @see LuceneFieldConverter#isConvertFromProjectionCompatibleWith(LuceneFieldConverter)
+	 * @see LuceneFieldConverter#isConvertIndexToProjectionCompatibleWith(LuceneFieldConverter)
 	 * @see LuceneFieldCodec#isCompatibleWith(LuceneFieldCodec)
 	 *
 	 * @param other Another {@link LuceneFieldPredicateBuilderFactory}, never {@code null}.

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/StandardFieldProjectionBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/StandardFieldProjectionBuilderFactory.java
@@ -69,7 +69,7 @@ public class StandardFieldProjectionBuilderFactory<T> implements LuceneFieldProj
 
 		return projectable == other.projectable &&
 				codec.isCompatibleWith( other.codec ) &&
-				converter.isConvertFromProjectionCompatibleWith( other.converter );
+				converter.isConvertIndexToProjectionCompatibleWith( other.converter );
 	}
 
 	private static void checkProjectable(String absoluteFieldPath, boolean projectable) {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/StandardFieldProjectionBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/StandardFieldProjectionBuilderFactory.java
@@ -69,7 +69,7 @@ public class StandardFieldProjectionBuilderFactory<T> implements LuceneFieldProj
 
 		return projectable == other.projectable &&
 				codec.isCompatibleWith( other.codec ) &&
-				converter.isDslCompatibleWith( other.converter );
+				converter.isConvertFromProjectionCompatibleWith( other.converter );
 	}
 
 	private static void checkProjectable(String absoluteFieldPath, boolean projectable) {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/AbstractFieldSortBuilderImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/AbstractFieldSortBuilderImpl.java
@@ -60,7 +60,7 @@ abstract class AbstractFieldSortBuilderImpl extends AbstractSearchSortBuilder
 	@Override
 	public void missingAs(Object value) {
 		try {
-			missingValue = converter.convertFromDsl( value, searchContext.getToIndexFieldValueConvertContext() );
+			missingValue = converter.convertDslToIndex( value, searchContext.getToIndexFieldValueConvertContext() );
 		}
 		catch (RuntimeException e) {
 			throw log.cannotConvertDslParameter(

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/AbstractStandardLuceneFieldSortBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/AbstractStandardLuceneFieldSortBuilderFactory.java
@@ -49,7 +49,7 @@ abstract class AbstractStandardLuceneFieldSortBuilderFactory<T> implements Lucen
 		AbstractStandardLuceneFieldSortBuilderFactory<?> other = (AbstractStandardLuceneFieldSortBuilderFactory<?>) obj;
 
 		return sortable == other.sortable &&
-				converter.isDslCompatibleWith( other.converter );
+				converter.isConvertFromDslCompatibleWith( other.converter );
 	}
 
 	protected void checkSortable(String absoluteFieldPath) {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/AbstractStandardLuceneFieldSortBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/AbstractStandardLuceneFieldSortBuilderFactory.java
@@ -49,7 +49,7 @@ abstract class AbstractStandardLuceneFieldSortBuilderFactory<T> implements Lucen
 		AbstractStandardLuceneFieldSortBuilderFactory<?> other = (AbstractStandardLuceneFieldSortBuilderFactory<?>) obj;
 
 		return sortable == other.sortable &&
-				converter.isConvertFromDslCompatibleWith( other.converter );
+				converter.isConvertDslToIndexCompatibleWith( other.converter );
 	}
 
 	protected void checkSortable(String absoluteFieldPath) {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/LuceneFieldSortBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/LuceneFieldSortBuilderFactory.java
@@ -42,7 +42,7 @@ public interface LuceneFieldSortBuilderFactory {
 	 * Determine whether another sort builder factory is DSL-compatible with this one,
 	 * i.e. whether it creates builders that behave the same way.
 	 *
-	 * @see LuceneFieldConverter#isConvertFromDslCompatibleWith(LuceneFieldConverter)
+	 * @see LuceneFieldConverter#isConvertDslToIndexCompatibleWith(LuceneFieldConverter)
 	 * @see LuceneFieldCodec#isCompatibleWith(LuceneFieldCodec)
 	 *
 	 * @param other Another {@link LuceneFieldSortBuilderFactory}, never {@code null}.

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/LuceneFieldSortBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/LuceneFieldSortBuilderFactory.java
@@ -42,7 +42,7 @@ public interface LuceneFieldSortBuilderFactory {
 	 * Determine whether another sort builder factory is DSL-compatible with this one,
 	 * i.e. whether it creates builders that behave the same way.
 	 *
-	 * @see LuceneFieldConverter#isDslCompatibleWith(LuceneFieldConverter)
+	 * @see LuceneFieldConverter#isConvertFromDslCompatibleWith(LuceneFieldConverter)
 	 * @see LuceneFieldCodec#isCompatibleWith(LuceneFieldCodec)
 	 *
 	 * @param other Another {@link LuceneFieldSortBuilderFactory}, never {@code null}.

--- a/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withhsearch/withanalysis/GettingStartedWithAnalysisIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withhsearch/withanalysis/GettingStartedWithAnalysisIT.java
@@ -93,7 +93,7 @@ public class GettingStartedWithAnalysisIT {
 			// end::searching[]
 
 			assertThat( result ).extracting( "id" )
-					.containsOnly( bookIdHolder.get() );
+					.containsExactlyInAnyOrder( bookIdHolder.get() );
 		} );
 
 		// Also test the other terms mentioned in the getting started guide
@@ -112,7 +112,7 @@ public class GettingStartedWithAnalysisIT {
 				List<Book> result = query.getResultList();
 				assertThat( result ).as( "Result of searching for '" + term + "'" )
 						.extracting( "id" )
-						.containsOnly( bookIdHolder.get() );
+						.containsExactlyInAnyOrder( bookIdHolder.get() );
 			}
 		} );
 	}

--- a/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withhsearch/withoutanalysis/GettingStartedWithoutAnalysisIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withhsearch/withoutanalysis/GettingStartedWithoutAnalysisIT.java
@@ -100,7 +100,7 @@ public class GettingStartedWithoutAnalysisIT {
 			// end::searching-objects[]
 
 			assertThat( result ).extracting( "id" )
-					.containsOnly( bookIdHolder.get() );
+					.containsExactlyInAnyOrder( bookIdHolder.get() );
 		} );
 
 		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
@@ -122,7 +122,7 @@ public class GettingStartedWithoutAnalysisIT {
 			// end::searching-lambdas[]
 
 			assertThat( result ).extracting( "id" )
-					.containsOnly( bookIdHolder.get() );
+					.containsExactlyInAnyOrder( bookIdHolder.get() );
 		} );
 	}
 

--- a/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withouthsearch/GettingStartedWithoutHibernateSearchIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withouthsearch/GettingStartedWithoutHibernateSearchIT.java
@@ -62,7 +62,7 @@ public class GettingStartedWithoutHibernateSearchIT {
 			List<Book> result = query.getResultList();
 
 			assertThat( result ).extracting( "id" )
-					.containsOnly( bookIdHolder.get() );
+					.containsExactlyInAnyOrder( bookIdHolder.get() );
 		} );
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/backend/document/converter/FromIndexFieldValueConverter.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/document/converter/FromIndexFieldValueConverter.java
@@ -37,4 +37,15 @@ public interface FromIndexFieldValueConverter<F, V> {
 	 */
 	V convert(F value, FromIndexFieldValueConvertContext context);
 
+	/**
+	 * @param other Another {@link ToIndexFieldValueConverter}, never {@code null}.
+	 * @return {@code true} if the given object behaves exactly the same as this object,
+	 * i.e. its {@link #isConvertedTypeAssignableTo(Class)} and {@link #convert(Object, FromIndexFieldValueConvertContext)}
+	 * methods are guaranteed to always return the same value as this object's
+	 * when given the same input. {@code false} otherwise, or when in doubt.
+	 */
+	default boolean isCompatibleWith(FromIndexFieldValueConverter<?, ?> other) {
+		return equals( other );
+	}
+
 }

--- a/engine/src/main/java/org/hibernate/search/engine/backend/document/converter/spi/PassThroughFromIndexFieldValueConverter.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/document/converter/spi/PassThroughFromIndexFieldValueConverter.java
@@ -26,4 +26,13 @@ public final class PassThroughFromIndexFieldValueConverter<F> implements FromInd
 	public boolean isConvertedTypeAssignableTo(Class<?> superTypeCandidate) {
 		return superTypeCandidate.isAssignableFrom( fieldType );
 	}
+
+	@Override
+	public boolean isCompatibleWith(FromIndexFieldValueConverter<?, ?> other) {
+		if ( !getClass().equals( other.getClass() ) ) {
+			return false;
+		}
+		PassThroughFromIndexFieldValueConverter<?> castedOther = (PassThroughFromIndexFieldValueConverter<?>) other;
+		return fieldType.equals( castedOther.fieldType );
+	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/backend/document/spi/IndexSchemaFieldDefinitionHelper.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/document/spi/IndexSchemaFieldDefinitionHelper.java
@@ -33,7 +33,7 @@ public final class IndexSchemaFieldDefinitionHelper<F> {
 	private final Class<F> indexFieldType;
 
 	private ToIndexFieldValueConverter<?, ? extends F> dslToIndexConverter;
-	private FromIndexFieldValueConverter<? super F, ?> projectionFromIndexConverter;
+	private FromIndexFieldValueConverter<? super F, ?> indexToProjectionConverter;
 
 	private boolean accessorCreated = false;
 
@@ -48,7 +48,7 @@ public final class IndexSchemaFieldDefinitionHelper<F> {
 		this.schemaContext = schemaContext;
 		this.indexFieldType = indexFieldType;
 		this.dslToIndexConverter = identityToIndexConverter;
-		this.projectionFromIndexConverter = null;
+		this.indexToProjectionConverter = null;
 	}
 
 	public IndexSchemaContext getSchemaContext() {
@@ -62,7 +62,7 @@ public final class IndexSchemaFieldDefinitionHelper<F> {
 
 	public void projectionConverter(FromIndexFieldValueConverter<? super F, ?> fromIndexConverter) {
 		Contracts.assertNotNull( fromIndexConverter, "fromIndexConverter" );
-		this.projectionFromIndexConverter = fromIndexConverter;
+		this.indexToProjectionConverter = fromIndexConverter;
 	}
 
 	/**
@@ -85,7 +85,7 @@ public final class IndexSchemaFieldDefinitionHelper<F> {
 		return new UserIndexFieldConverter<>(
 				indexFieldType,
 				dslToIndexConverter,
-				projectionFromIndexConverter
+				indexToProjectionConverter
 		);
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/backend/document/spi/UserIndexFieldConverter.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/document/spi/UserIndexFieldConverter.java
@@ -56,24 +56,51 @@ public final class UserIndexFieldConverter<F> {
 	}
 
 	/**
-	 * Determine whether another converter is DSL-compatible with this one,
-	 * i.e. its {@link #convertFromDsl(Object, ToIndexFieldValueConvertContext)} method is guaranteed
-	 * to always return the same value as this converter's when given the same input.
+	 * Determine whether another converter's {@link #convertFromDsl(Object, ToIndexFieldValueConvertContext)}
+	 * method is compatible with this one's,
+	 * i.e. the method is guaranteed to always return the same value as this converter's when given the same input.
 	 * <p>
-	 * Note: this method is separate from {@link #equals(Object)} because it might return true for two different objects,
-	 * e.g. two objects that implement {@link #convertFromProjection(Object, FromIndexFieldValueConvertContext)} differently.
+	 * Note: this method is separate from {@link #equals(Object)} because it might return {@code true} for two different objects,
+	 * e.g. two objects that implement {@link #convertFromProjection(Object, FromIndexFieldValueConvertContext)} differently,
+	 * but still implement {@link #convertFromDsl(Object, ToIndexFieldValueConvertContext)} in a compatible way.
 	 *
 	 * @param other Another {@link UserIndexFieldConverter}.
-	 * @return {@code true} if the given converter is DSL-compatible.
+	 * @return {@code true} if the given converter's
+	 * {@link #convertFromDsl(Object, ToIndexFieldValueConvertContext)} method is compatible.
 	 * {@code false} otherwise, or when in doubt.
 	 */
-	public boolean isDslCompatibleWith(UserIndexFieldConverter<?> other) {
+	public boolean isConvertFromDslCompatibleWith(UserIndexFieldConverter<?> other) {
 		if ( other == null ) {
 			return false;
 		}
 		return dslToIndexConverter.isCompatibleWith( other.dslToIndexConverter );
 	}
 
+	/**
+	 * Determine whether another converter's {@link #convertFromProjection(Object, FromIndexFieldValueConvertContext)}
+	 * method is compatible with this one's,
+	 * i.e. the method is guaranteed to always return the same value as this converter's when given the same input.
+	 * <p>
+	 * Note: this method is separate from {@link #equals(Object)} because it might return {@code true} for two different objects,
+	 * e.g. two objects that implement {@link #convertFromDsl(Object, ToIndexFieldValueConvertContext)} differently,
+	 * but still implement {@link #convertFromProjection(Object, FromIndexFieldValueConvertContext)} in a compatible way.
+	 *
+	 * @param other Another {@link UserIndexFieldConverter}.
+	 * @return {@code true} if the given converter's
+	 * {@link #convertFromProjection(Object, FromIndexFieldValueConvertContext)} method is compatible.
+	 * {@code false} otherwise, or when in doubt.
+	 */
+	public boolean isConvertFromProjectionCompatibleWith(UserIndexFieldConverter<?> other) {
+		if ( other == null ) {
+			return false;
+		}
+		if ( projectionFromIndexConverter == null || other.projectionFromIndexConverter == null ) {
+			// If one projection converter is null, then both must be null in order to be compatible
+			return projectionFromIndexConverter == null && other.projectionFromIndexConverter == null;
+		}
+
+		return projectionFromIndexConverter.isCompatibleWith( other.projectionFromIndexConverter );
+	}
 
 	/**
 	 * Determine whether the given projection type is compatible with this converter.

--- a/engine/src/main/java/org/hibernate/search/engine/backend/document/spi/UserIndexFieldConverter.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/document/spi/UserIndexFieldConverter.java
@@ -26,50 +26,50 @@ public final class UserIndexFieldConverter<F> {
 
 	private final Class<F> indexFieldType;
 	private final ToIndexFieldValueConverter<?, ? extends F> dslToIndexConverter;
-	private final FromIndexFieldValueConverter<? super F, ?> projectionFromIndexConverter;
+	private final FromIndexFieldValueConverter<? super F, ?> indexToProjectionConverter;
 
 	UserIndexFieldConverter(Class<F> indexFieldType, ToIndexFieldValueConverter<?,? extends F> dslToIndexConverter,
-			FromIndexFieldValueConverter<? super F,?> projectionFromIndexConverter) {
+			FromIndexFieldValueConverter<? super F,?> indexToProjectionConverter) {
 		this.indexFieldType = indexFieldType;
 		this.dslToIndexConverter = dslToIndexConverter;
-		this.projectionFromIndexConverter = projectionFromIndexConverter;
+		this.indexToProjectionConverter = indexToProjectionConverter;
 	}
 
 	@Override
 	public String toString() {
 		return getClass().getName() + "["
 				+ "dslToIndexConverter=" + dslToIndexConverter
-				+ ", projectionFromIndexConverter=" + projectionFromIndexConverter
+				+ ", indexToProjectionConverter=" + indexToProjectionConverter
 				+ "]";
 	}
 
-	public F convertFromDsl(Object value, ToIndexFieldValueConvertContext context) {
+	public F convertDslToIndex(Object value, ToIndexFieldValueConvertContext context) {
 		return dslToIndexConverter.convertUnknown( value, context );
 	}
 
-	public Object convertFromProjection(F projection, FromIndexFieldValueConvertContext context) {
-		if ( projectionFromIndexConverter == null ) {
+	public Object convertIndexToProjection(F indexValue, FromIndexFieldValueConvertContext context) {
+		if ( indexToProjectionConverter == null ) {
 			// FIXME detect this when the projection is configured and throw an exception with an explicit message instead. A converter set to null means we don't want to enable projections.
-			return projection;
+			return indexValue;
 		}
-		return projectionFromIndexConverter.convert( projection, context );
+		return indexToProjectionConverter.convert( indexValue, context );
 	}
 
 	/**
-	 * Determine whether another converter's {@link #convertFromDsl(Object, ToIndexFieldValueConvertContext)}
+	 * Determine whether another converter's {@link #convertDslToIndex(Object, ToIndexFieldValueConvertContext)}
 	 * method is compatible with this one's,
 	 * i.e. the method is guaranteed to always return the same value as this converter's when given the same input.
 	 * <p>
 	 * Note: this method is separate from {@link #equals(Object)} because it might return {@code true} for two different objects,
-	 * e.g. two objects that implement {@link #convertFromProjection(Object, FromIndexFieldValueConvertContext)} differently,
-	 * but still implement {@link #convertFromDsl(Object, ToIndexFieldValueConvertContext)} in a compatible way.
+	 * e.g. two objects that implement {@link #convertIndexToProjection(Object, FromIndexFieldValueConvertContext)} differently,
+	 * but still implement {@link #convertDslToIndex(Object, ToIndexFieldValueConvertContext)} in a compatible way.
 	 *
 	 * @param other Another {@link UserIndexFieldConverter}.
 	 * @return {@code true} if the given converter's
-	 * {@link #convertFromDsl(Object, ToIndexFieldValueConvertContext)} method is compatible.
+	 * {@link #convertDslToIndex(Object, ToIndexFieldValueConvertContext)} method is compatible.
 	 * {@code false} otherwise, or when in doubt.
 	 */
-	public boolean isConvertFromDslCompatibleWith(UserIndexFieldConverter<?> other) {
+	public boolean isConvertDslToIndexCompatibleWith(UserIndexFieldConverter<?> other) {
 		if ( other == null ) {
 			return false;
 		}
@@ -77,29 +77,29 @@ public final class UserIndexFieldConverter<F> {
 	}
 
 	/**
-	 * Determine whether another converter's {@link #convertFromProjection(Object, FromIndexFieldValueConvertContext)}
+	 * Determine whether another converter's {@link #convertIndexToProjection(Object, FromIndexFieldValueConvertContext)}
 	 * method is compatible with this one's,
 	 * i.e. the method is guaranteed to always return the same value as this converter's when given the same input.
 	 * <p>
 	 * Note: this method is separate from {@link #equals(Object)} because it might return {@code true} for two different objects,
-	 * e.g. two objects that implement {@link #convertFromDsl(Object, ToIndexFieldValueConvertContext)} differently,
-	 * but still implement {@link #convertFromProjection(Object, FromIndexFieldValueConvertContext)} in a compatible way.
+	 * e.g. two objects that implement {@link #convertDslToIndex(Object, ToIndexFieldValueConvertContext)} differently,
+	 * but still implement {@link #convertIndexToProjection(Object, FromIndexFieldValueConvertContext)} in a compatible way.
 	 *
 	 * @param other Another {@link UserIndexFieldConverter}.
 	 * @return {@code true} if the given converter's
-	 * {@link #convertFromProjection(Object, FromIndexFieldValueConvertContext)} method is compatible.
+	 * {@link #convertIndexToProjection(Object, FromIndexFieldValueConvertContext)} method is compatible.
 	 * {@code false} otherwise, or when in doubt.
 	 */
-	public boolean isConvertFromProjectionCompatibleWith(UserIndexFieldConverter<?> other) {
+	public boolean isConvertIndexToProjectionCompatibleWith(UserIndexFieldConverter<?> other) {
 		if ( other == null ) {
 			return false;
 		}
-		if ( projectionFromIndexConverter == null || other.projectionFromIndexConverter == null ) {
+		if ( indexToProjectionConverter == null || other.indexToProjectionConverter == null ) {
 			// If one projection converter is null, then both must be null in order to be compatible
-			return projectionFromIndexConverter == null && other.projectionFromIndexConverter == null;
+			return indexToProjectionConverter == null && other.indexToProjectionConverter == null;
 		}
 
-		return projectionFromIndexConverter.isCompatibleWith( other.projectionFromIndexConverter );
+		return indexToProjectionConverter.isCompatibleWith( other.indexToProjectionConverter );
 	}
 
 	/**
@@ -109,10 +109,10 @@ public final class UserIndexFieldConverter<F> {
 	 * @return {@code true} if the given projection type is compatible. {@code false} otherwise
 	 */
 	public boolean isProjectionCompatibleWith(Class<?> projectionType) {
-		if ( projectionFromIndexConverter == null ) {
+		if ( indexToProjectionConverter == null ) {
 			return projectionType.isAssignableFrom( indexFieldType );
 		}
 
-		return projectionFromIndexConverter.isConvertedTypeAssignableTo( projectionType );
+		return indexToProjectionConverter.isConvertedTypeAssignableTo( projectionType );
 	}
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/FieldSearchProjectionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/FieldSearchProjectionIT.java
@@ -248,6 +248,9 @@ public class FieldSearchProjectionIT {
 		searchTarget.projection().field( fieldModel.relativeFieldName, String.class ).toProjection();
 	}
 
+	/**
+	 * Test that mentioning the same projection twice works as expected.
+	 */
 	@Test
 	public void duplicated() {
 		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
@@ -258,14 +261,17 @@ public class FieldSearchProjectionIT {
 
 				assertThat(
 						searchTarget.query()
-								.asProjection( searchTarget.projection().field( fieldPath, model.type ).toProjection() )
+								.asProjections(
+										searchTarget.projection().field( fieldPath, model.type ).toProjection(),
+										searchTarget.projection().field( fieldPath, model.type ).toProjection()
+								)
 								.predicate( f -> f.matchAll().toPredicate() )
 								.build()
 				).hasHitsAnyOrder(
-					model.document1Value.indexedValue,
-					model.document2Value.indexedValue,
-					model.document3Value.indexedValue,
-					null // Empty document
+						Arrays.asList( model.document1Value.indexedValue, model.document1Value.indexedValue ),
+						Arrays.asList( model.document2Value.indexedValue, model.document2Value.indexedValue ),
+						Arrays.asList( model.document3Value.indexedValue, model.document3Value.indexedValue ),
+						Arrays.asList( null, null ) // Empty document
 				);
 			} );
 		}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/FieldSearchProjectionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/FieldSearchProjectionIT.java
@@ -1,0 +1,530 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.tck.search.projection;
+
+import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.hibernate.search.engine.backend.document.DocumentElement;
+import org.hibernate.search.engine.backend.document.IndexFieldAccessor;
+import org.hibernate.search.engine.backend.document.IndexObjectFieldAccessor;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldContext;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectField;
+import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
+import org.hibernate.search.engine.backend.document.model.dsl.Projectable;
+import org.hibernate.search.engine.backend.document.model.dsl.StandardIndexSchemaFieldTypedContext;
+import org.hibernate.search.engine.backend.index.spi.IndexWorkPlan;
+import org.hibernate.search.engine.search.DocumentReference;
+import org.hibernate.search.engine.search.SearchQuery;
+import org.hibernate.search.engine.spatial.GeoPoint;
+import org.hibernate.search.integrationtest.backend.tck.configuration.DefaultAnalysisDefinitions;
+import org.hibernate.search.integrationtest.backend.tck.util.StandardFieldMapper;
+import org.hibernate.search.integrationtest.backend.tck.util.ValueWrapper;
+import org.hibernate.search.integrationtest.backend.tck.util.rule.SearchSetupHelper;
+import org.hibernate.search.util.SearchException;
+import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingSearchTarget;
+import org.hibernate.search.util.impl.test.SubTest;
+
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class FieldSearchProjectionIT {
+
+	private static final String INDEX_NAME = "IndexName";
+
+	private static final String DOCUMENT_1 = "1";
+	private static final String DOCUMENT_2 = "2";
+	private static final String DOCUMENT_3 = "3";
+	private static final String EMPTY = "empty";
+
+	@Rule
+	public SearchSetupHelper setupHelper = new SearchSetupHelper();
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	private IndexMapping indexMapping;
+	private StubMappingIndexManager indexManager;
+
+	@Before
+	public void setup() {
+		setupHelper.withDefaultConfiguration()
+				.withIndex(
+						"MappedType", INDEX_NAME,
+						ctx -> this.indexMapping = new IndexMapping( ctx.getSchemaElement() ),
+						indexManager -> this.indexManager = indexManager
+				)
+				.setup();
+
+		initData();
+	}
+
+	@Test
+	public void simple() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		for ( FieldModel<?> fieldModel : indexMapping.supportedFieldModels ) {
+			SubTest.expectSuccess( fieldModel, model -> {
+				String fieldPath = model.relativeFieldName;
+
+				assertThat(
+						searchTarget.query()
+								.asProjection( searchTarget.projection().field( fieldPath, model.type ).toProjection() )
+								.predicate( f -> f.matchAll().toPredicate() )
+								.build()
+				).hasHitsAnyOrder(
+						model.document1Value.indexedValue,
+						model.document2Value.indexedValue,
+						model.document3Value.indexedValue,
+						null // Empty document
+				);
+			} );
+		}
+	}
+
+	@Test
+	public void noClass() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		for ( FieldModel<?> fieldModel : indexMapping.supportedFieldModels ) {
+			SearchQuery<Object> query;
+			String fieldPath = fieldModel.relativeFieldName;
+
+			query = searchTarget.query()
+					.asProjection( searchTarget.projection().field( fieldPath ).toProjection() )
+					.predicate( f -> f.matchAll().toPredicate() )
+					.build();
+			assertThat( query ).hasHitsAnyOrder(
+					fieldModel.document1Value.indexedValue,
+					fieldModel.document2Value.indexedValue,
+					fieldModel.document3Value.indexedValue,
+					null // Empty document
+			);
+		}
+	}
+
+	@Test
+	public void validSuperClass() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		SearchQuery<CharSequence> query = searchTarget.query()
+				.asProjection( searchTarget.projection()
+						.field( indexMapping.string1Field.relativeFieldName, CharSequence.class ).toProjection() )
+				.predicate( f -> f.matchAll().toPredicate() )
+				.build();
+
+		assertThat( query ).hasHitsAnyOrder(
+				indexMapping.string1Field.document1Value.indexedValue,
+				indexMapping.string1Field.document2Value.indexedValue,
+				indexMapping.string1Field.document3Value.indexedValue,
+				null // Empty document
+		);
+	}
+
+	@Test
+	public void error_nullClass() {
+		thrown.expect( IllegalArgumentException.class );
+		thrown.expectMessage( "must not be null" );
+		thrown.expectMessage( "clazz" );
+
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		searchTarget.projection().field( indexMapping.string1Field.relativeFieldName, null ).toProjection();
+	}
+
+	@Test
+	public void error_invalidProjectionType() {
+		thrown.expect( SearchException.class );
+		thrown.expectMessage( "Invalid type" );
+		thrown.expectMessage( "for projection on field" );
+		thrown.expectMessage( indexMapping.string1Field.relativeFieldName );
+
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		searchTarget.projection().field( indexMapping.string1Field.relativeFieldName, Integer.class ).toProjection();
+	}
+
+	@Test
+	public void error_unknownField() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		thrown.expect( SearchException.class );
+		thrown.expectMessage( "Unknown field" );
+		thrown.expectMessage( "unknownField" );
+		thrown.expectMessage( INDEX_NAME );
+
+		searchTarget.projection().field( "unknownField", Object.class );
+	}
+
+	@Test
+	public void error_objectField_nested() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		thrown.expect( SearchException.class );
+		thrown.expectMessage( "Unknown field" );
+		thrown.expectMessage( "nestedObject" );
+		thrown.expectMessage( INDEX_NAME );
+
+		searchTarget.projection().field( "nestedObject", Object.class );
+	}
+
+	@Test
+	public void error_objectField_flattened() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		thrown.expect( SearchException.class );
+		thrown.expectMessage( "Unknown field" );
+		thrown.expectMessage( "flattenedObject" );
+		thrown.expectMessage( INDEX_NAME );
+
+		searchTarget.projection().field( "flattenedObject", Object.class );
+	}
+
+	@Test
+	public void error_nonProjectable() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		for ( FieldModel<?> fieldModel : indexMapping.nonProjectableSupportedFieldModels ) {
+			String fieldPath = fieldModel.relativeFieldName;
+			Class<?> fieldType = fieldModel.type;
+
+			SubTest.expectException( () -> {
+				searchTarget.projection().field( fieldPath, fieldType ).toProjection();
+			} ).assertThrown()
+					.isInstanceOf( SearchException.class )
+					.hasMessageContaining( "Projections are not enabled for field" )
+					.hasMessageContaining( fieldPath );
+		}
+	}
+
+	@Test
+	public void withProjectionConverters() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		for ( FieldModel<?> fieldModel : indexMapping.supportedFieldWithProjectionConverterModels ) {
+			SearchQuery<ValueWrapper> query;
+			String fieldPath = fieldModel.relativeFieldName;
+
+			query = searchTarget.query()
+					.asProjection( searchTarget.projection().field( fieldPath, ValueWrapper.class ).toProjection() )
+					.predicate( f -> f.matchAll().toPredicate() )
+					.build();
+			assertThat( query ).hasHitsAnyOrder(
+				new ValueWrapper<>( fieldModel.document1Value.indexedValue ),
+				new ValueWrapper<>( fieldModel.document2Value.indexedValue ),
+				new ValueWrapper<>( fieldModel.document3Value.indexedValue ),
+				new ValueWrapper<>( null )
+			);
+		}
+	}
+
+	@Test
+	public void error_invalidProjectionType_withProjectionConverter() {
+		FieldModel<?> fieldModel = indexMapping.supportedFieldWithProjectionConverterModels.get( 0 );
+
+		thrown.expect( SearchException.class );
+		thrown.expectMessage( "Invalid type" );
+		thrown.expectMessage( "for projection on field" );
+		thrown.expectMessage( fieldModel.relativeFieldName );
+
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		searchTarget.projection().field( fieldModel.relativeFieldName, String.class ).toProjection();
+	}
+
+	@Test
+	public void duplicated() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		for ( FieldModel<?> fieldModel : indexMapping.supportedFieldModels ) {
+			SubTest.expectSuccess( fieldModel, model -> {
+				String fieldPath = model.relativeFieldName;
+
+				assertThat(
+						searchTarget.query()
+								.asProjection( searchTarget.projection().field( fieldPath, model.type ).toProjection() )
+								.predicate( f -> f.matchAll().toPredicate() )
+								.build()
+				).hasHitsAnyOrder(
+					model.document1Value.indexedValue,
+					model.document2Value.indexedValue,
+					model.document3Value.indexedValue,
+					null // Empty document
+				);
+			} );
+		}
+	}
+
+	@Test
+	public void inFlattenedObject() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		for ( FieldModel<?> fieldModel : indexMapping.flattenedObject.supportedFieldModels ) {
+			SubTest.expectSuccess( fieldModel, model -> {
+				String fieldPath = indexMapping.flattenedObject.relativeFieldName + "." + model.relativeFieldName;
+
+				assertThat(
+						searchTarget.query()
+								.asProjection(
+										searchTarget.projection().field( fieldPath, model.type ).toProjection() )
+								.predicate( f -> f.matchAll().toPredicate() )
+								.build()
+				).hasHitsAnyOrder(
+						model.document1Value.indexedValue,
+						model.document2Value.indexedValue,
+						model.document3Value.indexedValue,
+						null // Empty document
+				);
+			} );
+		}
+	}
+
+	@Test
+	public void inNestedObject() {
+		Assume.assumeTrue( "Projections on fields within nested object fields are not supported yet", false );
+		// TODO HSEARCH-3062 support projections on fields within nested object fields
+
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		for ( FieldModel<?> fieldModel : indexMapping.nestedObject.supportedFieldModels ) {
+			SubTest.expectSuccess( fieldModel, model -> {
+				String fieldPath = indexMapping.nestedObject.relativeFieldName + "." + model.relativeFieldName;
+
+				assertThat(
+						searchTarget.query()
+								.asProjection( searchTarget.projection().field( fieldPath, model.type ).toProjection() )
+								.predicate( f -> f.matchAll().toPredicate() )
+								.build()
+				).hasHitsAnyOrder(
+						model.document1Value.indexedValue,
+						model.document2Value.indexedValue,
+						model.document3Value.indexedValue,
+						null // Empty document
+				);
+			} );
+		}
+	}
+
+	@Test
+	public void multivalued() {
+		Assume.assumeTrue( "Multi-valued projections are not supported yet", false );
+		// TODO support multi-valued projections
+
+		// TODO Project on multi-valued field
+
+		// TODO Project on fields within a multi-valued flattened object
+
+		// TODO Project on fields within a multi-valued nested object
+	}
+
+	private void initData() {
+		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
+		workPlan.add( referenceProvider( DOCUMENT_1 ), document -> {
+			indexMapping.supportedFieldModels.forEach( f -> f.document1Value.write( document ) );
+			indexMapping.supportedFieldWithProjectionConverterModels.forEach( f -> f.document1Value.write( document ) );
+
+			indexMapping.string1Field.document1Value.write( document );
+
+			// Note: this object must be single-valued for these tests
+			DocumentElement flattenedObject = indexMapping.flattenedObject.self.add( document );
+			indexMapping.flattenedObject.supportedFieldModels.forEach( f -> f.document1Value.write( flattenedObject ) );
+
+			// Note: this object must be single-valued for these tests
+			DocumentElement nestedObject = indexMapping.nestedObject.self.add( document );
+			indexMapping.nestedObject.supportedFieldModels.forEach( f -> f.document1Value.write( nestedObject ) );
+		} );
+		workPlan.add( referenceProvider( DOCUMENT_2 ), document -> {
+			indexMapping.supportedFieldModels.forEach( f -> f.document2Value.write( document ) );
+			indexMapping.supportedFieldWithProjectionConverterModels.forEach( f -> f.document2Value.write( document ) );
+
+			indexMapping.string1Field.document2Value.write( document );
+
+			// Note: this object must be single-valued for these tests
+			DocumentElement flattenedObject = indexMapping.flattenedObject.self.add( document );
+			indexMapping.flattenedObject.supportedFieldModels.forEach( f -> f.document2Value.write( flattenedObject ) );
+
+			// Note: this object must be single-valued for these tests
+			DocumentElement nestedObject = indexMapping.nestedObject.self.add( document );
+			indexMapping.nestedObject.supportedFieldModels.forEach( f -> f.document2Value.write( nestedObject ) );
+		} );
+		workPlan.add( referenceProvider( DOCUMENT_3 ), document -> {
+			indexMapping.supportedFieldModels.forEach( f -> f.document3Value.write( document ) );
+			indexMapping.supportedFieldWithProjectionConverterModels.forEach( f -> f.document3Value.write( document ) );
+
+			indexMapping.string1Field.document3Value.write( document );
+
+			// Note: this object must be single-valued for these tests
+			DocumentElement flattenedObject = indexMapping.flattenedObject.self.add( document );
+			indexMapping.flattenedObject.supportedFieldModels.forEach( f -> f.document3Value.write( flattenedObject ) );
+
+			// Note: this object must be single-valued for these tests
+			DocumentElement nestedObject = indexMapping.nestedObject.self.add( document );
+			indexMapping.nestedObject.supportedFieldModels.forEach( f -> f.document3Value.write( nestedObject ) );
+		} );
+		workPlan.add( referenceProvider( EMPTY ), document -> { } );
+
+		workPlan.execute().join();
+
+		// Check that all documents are searchable
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.matchAll().toPredicate() )
+				.build();
+		assertThat( query )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3, EMPTY );
+	}
+
+	private static class IndexMapping {
+		final List<FieldModel<?>> supportedFieldModels;
+		final List<FieldModel<?>> supportedFieldWithProjectionConverterModels;
+		final List<FieldModel<?>> nonProjectableSupportedFieldModels;
+
+		final FieldModel<String> string1Field;
+
+		final ObjectMapping flattenedObject;
+		final ObjectMapping nestedObject;
+
+		IndexMapping(IndexSchemaElement root) {
+			supportedFieldModels = mapSupportedFields( root, "", ignored -> { } );
+			supportedFieldWithProjectionConverterModels = mapSupportedFields(
+					root, "converted_", c -> c.projectionConverter( ValueWrapper.fromIndexFieldConverter() )
+			);
+			nonProjectableSupportedFieldModels = mapSupportedFields( root, "nonProjectable_",
+					c -> c.projectable( Projectable.NO ) );
+
+			string1Field = FieldModel.mapper( String.class, "ccc", "mmm", "xxx" )
+					.map( root, "string1" );
+
+			flattenedObject = new ObjectMapping( root, "flattenedObject", ObjectFieldStorage.FLATTENED );
+			nestedObject = new ObjectMapping( root, "nestedObject", ObjectFieldStorage.NESTED );
+		}
+	}
+
+	private static class ObjectMapping {
+		final String relativeFieldName;
+		final IndexObjectFieldAccessor self;
+		final List<FieldModel<?>> supportedFieldModels;
+
+		ObjectMapping(IndexSchemaElement parent, String relativeFieldName, ObjectFieldStorage storage) {
+			this.relativeFieldName = relativeFieldName;
+			IndexSchemaObjectField objectField = parent.objectField( relativeFieldName, storage );
+			self = objectField.createAccessor();
+			supportedFieldModels = mapSupportedFields( objectField, "", ignored -> { } );
+		}
+	}
+
+	private static List<FieldModel<?>> mapSupportedFields(IndexSchemaElement root, String prefix,
+			Consumer<StandardIndexSchemaFieldTypedContext<?, ?>> additionalConfiguration) {
+		return Arrays.asList(
+				FieldModel
+						// Mix capitalized and non-capitalized text on purpose
+						.mapper( String.class,
+								c -> c.asString().normalizer( DefaultAnalysisDefinitions.NORMALIZER_LOWERCASE.name ),
+								"Aaron", "george", "Zach" )
+						.map( root, prefix + "normalizedString", additionalConfiguration ),
+				FieldModel.mapper( String.class, "aaron", "george", "zach" )
+						.map( root, prefix + "nonAnalyzedString", additionalConfiguration ),
+				FieldModel.mapper( Integer.class, 1, 3, 5 )
+						.map( root, prefix + "integer", additionalConfiguration ),
+				FieldModel.mapper( Long.class, 1L, 3L, 5L )
+						.map( root, prefix + "long", additionalConfiguration ),
+				FieldModel.mapper( Boolean.class, false, true, false )
+						.map( root, prefix + "boolean", additionalConfiguration ),
+				FieldModel.mapper(
+						LocalDate.class,
+						LocalDate.of( 2018, 2, 1 ),
+						LocalDate.of( 2018, 3, 1 ),
+						LocalDate.of( 2018, 4, 1 )
+				)
+						.map( root, prefix + "localDate", additionalConfiguration ),
+				FieldModel.mapper(
+						Instant.class,
+						Instant.parse( "2018-02-01T10:15:30.00Z" ),
+						Instant.parse( "2018-03-01T10:15:30.00Z" ),
+						Instant.parse( "2018-04-01T10:15:30.00Z" )
+				)
+						.map( root, prefix + "instant", additionalConfiguration ),
+				FieldModel.mapper(
+						GeoPoint.class,
+						GeoPoint.of( 40, 70 ),
+						GeoPoint.of( 40, 75 ),
+						GeoPoint.of( 40, 80 )
+				)
+						.map( root, prefix + "geoPoint", additionalConfiguration )
+		);
+	}
+
+	private static class ValueModel<F> {
+		private final IndexFieldAccessor<F> accessor;
+		final F indexedValue;
+
+		private ValueModel(IndexFieldAccessor<F> accessor, F indexedValue) {
+			this.accessor = accessor;
+			this.indexedValue = indexedValue;
+		}
+
+		public void write(DocumentElement target) {
+			accessor.write( target, indexedValue );
+		}
+	}
+
+	private static class FieldModel<F> {
+		static <F> StandardFieldMapper<F, FieldModel<F>> mapper(Class<F> type,
+				F document1Value, F document2Value, F document3Value) {
+			return mapper(
+					type,
+					c -> (StandardIndexSchemaFieldTypedContext<?, F>) c.as( type ),
+					document1Value, document2Value, document3Value
+			);
+		}
+
+		static <F> StandardFieldMapper<F, FieldModel<F>> mapper(Class<F> type,
+				Function<IndexSchemaFieldContext, StandardIndexSchemaFieldTypedContext<?, F>> configuration,
+				F document1Value, F document2Value, F document3Value) {
+			return (parent, name, additionalConfiguration) -> {
+				IndexSchemaFieldContext untypedContext = parent.field( name );
+				StandardIndexSchemaFieldTypedContext<?, F> context = configuration.apply( untypedContext );
+				context.projectable( Projectable.YES );
+				additionalConfiguration.accept( context );
+				IndexFieldAccessor<F> accessor = context.createAccessor();
+				return new FieldModel<>(
+						accessor, name, type,
+						document1Value, document2Value, document3Value
+				);
+			};
+		}
+
+		final String relativeFieldName;
+		final Class<F> type;
+
+		final ValueModel<F> document1Value;
+		final ValueModel<F> document2Value;
+		final ValueModel<F> document3Value;
+
+		private FieldModel(IndexFieldAccessor<F> accessor, String relativeFieldName, Class<F> type,
+				F document1Value, F document2Value, F document3Value) {
+			this.relativeFieldName = relativeFieldName;
+			this.type = type;
+			this.document1Value = new ValueModel<>( accessor, document1Value );
+			this.document2Value = new ValueModel<>( accessor, document2Value );
+			this.document3Value = new ValueModel<>( accessor, document3Value );
+		}
+	}
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/util/ValueWrapper.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/util/ValueWrapper.java
@@ -22,6 +22,7 @@ import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldTy
 public final class ValueWrapper<T> {
 	public static <T> ToIndexFieldValueConverter<ValueWrapper<T>, T> toIndexFieldConverter() {
 		return new ToIndexFieldValueConverter<ValueWrapper<T>, T>() {
+
 			@Override
 			public T convert(ValueWrapper<T> value, ToIndexFieldValueConvertContext context) {
 				return value.getValue();
@@ -42,7 +43,6 @@ public final class ValueWrapper<T> {
 
 	public static <T> FromIndexFieldValueConverter<T, ValueWrapper<T>> fromIndexFieldConverter() {
 		return new FromIndexFieldValueConverter<T, ValueWrapper<T>>() {
-
 			@Override
 			public boolean isConvertedTypeAssignableTo(Class<?> superTypeCandidate) {
 				return superTypeCandidate.isAssignableFrom( ValueWrapper.class );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/util/ValueWrapper.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/util/ValueWrapper.java
@@ -32,6 +32,11 @@ public final class ValueWrapper<T> {
 			public T convertUnknown(Object value, ToIndexFieldValueConvertContext context) {
 				return ( (ValueWrapper<T>) value ).getValue();
 			}
+
+			@Override
+			public boolean isCompatibleWith(ToIndexFieldValueConverter<?, ?> other) {
+				return other != null && getClass().equals( other.getClass() );
+			}
 		};
 	}
 
@@ -46,7 +51,12 @@ public final class ValueWrapper<T> {
 			@Override
 			public ValueWrapper<T> convert(T indexedValue,
 					FromIndexFieldValueConvertContext context) {
-				return new ValueWrapper<T>( indexedValue );
+				return new ValueWrapper<>( indexedValue );
+			}
+
+			@Override
+			public boolean isCompatibleWith(FromIndexFieldValueConverter<?, ?> other) {
+				return other != null && getClass().equals( other.getClass() );
 			}
 		};
 	}

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/bridge/ISBNBridge.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/bridge/ISBNBridge.java
@@ -17,14 +17,11 @@ import org.hibernate.search.mapper.pojo.bridge.runtime.ValueBridgeToIndexedValue
 
 public class ISBNBridge implements ValueBridge<ISBN, String> {
 
-	private static final ISBNFromIndexFieldValueConverter FROM_INDEX_FIELD_VALUE_CONVERTER =
-			new ISBNFromIndexFieldValueConverter();
-
 	@Override
 	public StandardIndexSchemaFieldTypedContext<?, String> bind(ValueBridgeBindingContext<ISBN> context) {
 		return context.getIndexSchemaFieldContext().asString()
 				.normalizer( LibraryAnalysisConfigurer.NORMALIZER_ISBN )
-				.projectionConverter( FROM_INDEX_FIELD_VALUE_CONVERTER );
+				.projectionConverter( ISBNFromIndexFieldValueConverter.INSTANCE );
 	}
 
 	@Override
@@ -45,6 +42,9 @@ public class ISBNBridge implements ValueBridge<ISBN, String> {
 
 	private static class ISBNFromIndexFieldValueConverter implements FromIndexFieldValueConverter<String, ISBN> {
 
+		private static final ISBNFromIndexFieldValueConverter INSTANCE =
+				new ISBNFromIndexFieldValueConverter();
+
 		@Override
 		public boolean isConvertedTypeAssignableTo(Class<?> superTypeCandidate) {
 			return superTypeCandidate.isAssignableFrom( ISBN.class );
@@ -53,6 +53,11 @@ public class ISBNBridge implements ValueBridge<ISBN, String> {
 		@Override
 		public ISBN convert(String indexedValue, FromIndexFieldValueConvertContext context) {
 			return indexedValue == null ? null : new ISBN( indexedValue );
+		}
+
+		@Override
+		public boolean isCompatibleWith(FromIndexFieldValueConverter<?, ?> other) {
+			return INSTANCE.equals( other );
 		}
 	}
 }

--- a/integrationtest/showcase/library/src/test/java/org/hibernate/search/integrationtest/showcase/OrmElasticsearchLibraryShowcaseIT.java
+++ b/integrationtest/showcase/library/src/test/java/org/hibernate/search/integrationtest/showcase/OrmElasticsearchLibraryShowcaseIT.java
@@ -299,14 +299,14 @@ public class OrmElasticsearchLibraryShowcaseIT {
 			List<Book> books = dao.searchByMedium(
 					"java", BookMedium.DEMATERIALIZED, 0, 10
 			);
-			assertThat( books ).containsOnly(
+			assertThat( books ).containsExactlyInAnyOrder(
 					session.get( Book.class, JAVA_FOR_DUMMIES_ID )
 			);
 
 			books = dao.searchByMedium(
 					"java", BookMedium.HARDCOPY, 0, 10
 			);
-			assertThat( books ).containsOnly(
+			assertThat( books ).containsExactlyInAnyOrder(
 					session.get( Book.class, JAVA_FOR_DUMMIES_ID ),
 					session.get( Book.class, INDONESIAN_ECONOMY_ID )
 			);
@@ -392,7 +392,7 @@ public class OrmElasticsearchLibraryShowcaseIT {
 					Collections.singletonList( LibraryService.DISABLED_ACCESS ),
 					0, 10
 			);
-			assertThat( documents ).containsOnly(
+			assertThat( documents ).containsExactlyInAnyOrder(
 					session.get( Book.class, JAVA_FOR_DUMMIES_ID ),
 					session.get( Video.class, JAVA_DANCING_ID ),
 					session.get( Book.class, INDONESIAN_ECONOMY_ID )
@@ -404,7 +404,7 @@ public class OrmElasticsearchLibraryShowcaseIT {
 					Collections.singletonList( LibraryService.READING_ROOMS ),
 					0, 10
 			);
-			assertThat( documents ).containsOnly(
+			assertThat( documents ).containsExactlyInAnyOrder(
 					session.get( Book.class, JAVA_FOR_DUMMIES_ID ),
 					session.get( Video.class, JAVA_DANCING_ID ),
 					session.get( Book.class, INDONESIAN_ECONOMY_ID )
@@ -421,7 +421,7 @@ public class OrmElasticsearchLibraryShowcaseIT {
 			 * which is present in a library with disabled access and in a library with reading rooms,
 			 * but not in a library with both.
 			 */
-			assertThat( documents ).containsOnly(
+			assertThat( documents ).containsExactlyInAnyOrder(
 					session.get( Book.class, JAVA_FOR_DUMMIES_ID ),
 					session.get( Video.class, JAVA_DANCING_ID )
 			);
@@ -441,7 +441,7 @@ public class OrmElasticsearchLibraryShowcaseIT {
 					null,
 					0, 10
 			);
-			assertThat( documents ).containsOnly(
+			assertThat( documents ).containsExactlyInAnyOrder(
 					session.get( Video.class, JAVA_DANCING_ID ),
 					session.get( Book.class, JAVA_FOR_DUMMIES_ID ),
 					session.get( Book.class, INDONESIAN_ECONOMY_ID ),
@@ -454,7 +454,7 @@ public class OrmElasticsearchLibraryShowcaseIT {
 					null,
 					0, 10
 			);
-			assertThat( documents ).containsOnly(
+			assertThat( documents ).containsExactlyInAnyOrder(
 					session.get( Book.class, JAVA_FOR_DUMMIES_ID ),
 					session.get( Book.class, ART_OF_COMPUTER_PROG_ID )
 			);
@@ -465,7 +465,7 @@ public class OrmElasticsearchLibraryShowcaseIT {
 					null,
 					0, 10
 			);
-			assertThat( documents ).containsOnly(
+			assertThat( documents ).containsExactlyInAnyOrder(
 					session.get( Book.class, JAVA_FOR_DUMMIES_ID )
 			);
 		} );

--- a/legacy/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/processor/impl/DefaultContextualErrorHandlerTest.java
+++ b/legacy/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/processor/impl/DefaultContextualErrorHandlerTest.java
@@ -84,7 +84,7 @@ public class DefaultContextualErrorHandlerTest {
 		ErrorContext errorContext = capture.getValue();
 		assertThat( errorContext.getThrowable() ).isSameAs( throwable );
 		assertThat( errorContext.getOperationAtFault() ).isSameAs( luceneWork1 );
-		assertThat( errorContext.getFailingOperations() ).containsOnly( luceneWork1, luceneWork2, luceneWork3 );
+		assertThat( errorContext.getFailingOperations() ).containsExactlyInAnyOrder( luceneWork1, luceneWork2, luceneWork3 );
 	}
 
 	@Test
@@ -134,7 +134,7 @@ public class DefaultContextualErrorHandlerTest {
 		ErrorContext errorContext = capture.getValue();
 		assertThat( errorContext.getThrowable() ).isSameAs( throwable );
 		assertThat( errorContext.getOperationAtFault() ).isNull();
-		assertThat( errorContext.getFailingOperations() ).containsOnly( luceneWork1, luceneWork2, luceneWork3 );
+		assertThat( errorContext.getFailingOperations() ).containsExactlyInAnyOrder( luceneWork1, luceneWork2, luceneWork3 );
 	}
 
 	@Test
@@ -166,9 +166,9 @@ public class DefaultContextualErrorHandlerTest {
 		verify();
 		ErrorContext errorContext = capture.getValue();
 		assertThat( errorContext.getThrowable() ).isSameAs( throwable1 );
-		assertThat( throwable1.getSuppressed() ).containsOnly( throwable2 );
+		assertThat( throwable1.getSuppressed() ).containsExactlyInAnyOrder( throwable2 );
 		assertThat( errorContext.getOperationAtFault() ).isIn( luceneWork1, luceneWork2 );
-		assertThat( errorContext.getFailingOperations() ).containsOnly( luceneWork1, luceneWork2, luceneWork3 );
+		assertThat( errorContext.getFailingOperations() ).containsExactlyInAnyOrder( luceneWork1, luceneWork2, luceneWork3 );
 	}
 
 	@Test
@@ -205,9 +205,9 @@ public class DefaultContextualErrorHandlerTest {
 		verify();
 		ErrorContext errorContext = capture.getValue();
 		assertThat( errorContext.getThrowable() ).isSameAs( throwable1 );
-		assertThat( throwable1.getSuppressed() ).containsOnly( throwable2 );
+		assertThat( throwable1.getSuppressed() ).containsExactlyInAnyOrder( throwable2 );
 		assertThat( errorContext.getOperationAtFault() ).isSameAs( luceneWork1 );
-		assertThat( errorContext.getFailingOperations() ).containsOnly( luceneWork1, luceneWork2, luceneWork3 );
+		assertThat( errorContext.getFailingOperations() ).containsExactlyInAnyOrder( luceneWork1, luceneWork2, luceneWork3 );
 	}
 
 	private void reset() {

--- a/legacy/engine/src/test/java/org/hibernate/search/test/analyzer/analyzerdef/AnalyzerDefAnnotationTest.java
+++ b/legacy/engine/src/test/java/org/hibernate/search/test/analyzer/analyzerdef/AnalyzerDefAnnotationTest.java
@@ -73,10 +73,10 @@ public class AnalyzerDefAnnotationTest {
 		IndexManagerType indexManagerType = factory.getIndexBindings().get( Sample.class ).getIndexManagerType();
 		Map<String, AnalyzerReference> analyzerReferences =
 				factory.getIntegration( indexManagerType ).getAnalyzerRegistry().getNamedAnalyzerReferences();
-		assertThat( analyzerReferences.keySet() ).containsOnly( "package-analyzer", "class-analyzer" );
+		assertThat( analyzerReferences.keySet() ).containsExactlyInAnyOrder( "package-analyzer", "class-analyzer" );
 		Map<String, AnalyzerReference> normalizerReferences =
 				factory.getIntegration( indexManagerType ).getNormalizerRegistry().getNamedNormalizerReferences();
-		assertThat( normalizerReferences.keySet() ).containsOnly( "package-normalizer", "class-normalizer" );
+		assertThat( normalizerReferences.keySet() ).containsExactlyInAnyOrder( "package-normalizer", "class-normalizer" );
 	}
 
 	@Test

--- a/legacy/engine/src/test/java/org/hibernate/search/test/configuration/IndexNameOverrideTest.java
+++ b/legacy/engine/src/test/java/org/hibernate/search/test/configuration/IndexNameOverrideTest.java
@@ -49,7 +49,7 @@ public class IndexNameOverrideTest {
 				)
 				.extracting( "indexName" )
 				.as( "Index names for entity " + NoAnnotationIndexNameOverrideEntity.class )
-				.containsOnly( NoAnnotationIndexNameOverrideEntity.class.getName() );
+				.containsExactlyInAnyOrder( NoAnnotationIndexNameOverrideEntity.class.getName() );
 
 		NoAnnotationIndexNameOverrideEntity entity = new NoAnnotationIndexNameOverrideEntity();
 		entity.id = 1L;
@@ -69,7 +69,7 @@ public class IndexNameOverrideTest {
 				)
 				.extracting( "indexName" )
 				.as( "Index names for entity " + IndexedAnnotationIndexNameOverriddeEntity.class )
-				.containsOnly( INDEXED_ANNOTATION_OVERRIDDEN_INDEX_NAME );
+				.containsExactlyInAnyOrder( INDEXED_ANNOTATION_OVERRIDDEN_INDEX_NAME );
 
 		IndexedAnnotationIndexNameOverriddeEntity entity = new IndexedAnnotationIndexNameOverriddeEntity();
 		entity.id = 1L;
@@ -98,7 +98,7 @@ public class IndexNameOverrideTest {
 				)
 				.extracting( "indexName" )
 				.as( "Index names for entity " + NoAnnotationIndexNameOverrideEntity.class )
-				.containsOnly( NoAnnotationIndexNameOverrideEntity.class.getName() );
+				.containsExactlyInAnyOrder( NoAnnotationIndexNameOverrideEntity.class.getName() );
 
 		NoAnnotationIndexNameOverrideEntity entity = new NoAnnotationIndexNameOverrideEntity();
 		entity.id = 1L;
@@ -127,7 +127,7 @@ public class IndexNameOverrideTest {
 				)
 				.extracting( "indexName" )
 				.as( "Index names for entity " + IndexedAnnotationIndexNameOverriddeEntity.class )
-				.containsOnly( INDEXED_ANNOTATION_OVERRIDDEN_INDEX_NAME );
+				.containsExactlyInAnyOrder( INDEXED_ANNOTATION_OVERRIDDEN_INDEX_NAME );
 
 		IndexedAnnotationIndexNameOverriddeEntity entity = new IndexedAnnotationIndexNameOverriddeEntity();
 		entity.id = 1L;

--- a/legacy/engine/src/test/java/org/hibernate/search/test/configuration/TypeMetadataTest.java
+++ b/legacy/engine/src/test/java/org/hibernate/search/test/configuration/TypeMetadataTest.java
@@ -70,10 +70,10 @@ public class TypeMetadataTest {
 		TypeMetadata metadata = metadataProvider.getTypeMetadataFor( Bar.class, LuceneEmbeddedIndexManagerType.INSTANCE );
 
 		Set<SortableFieldMetadata> fieldMetadata = metadata.getPropertyMetadataForProperty( "name" ).getSortableFieldMetadata();
-		assertThat( fieldMetadata ).extracting( "absoluteName" ).containsOnly( "name" );
+		assertThat( fieldMetadata ).extracting( "absoluteName" ).containsExactlyInAnyOrder( "name" );
 
 		fieldMetadata = metadata.getPropertyMetadataForProperty( "age" ).getSortableFieldMetadata();
-		assertThat( fieldMetadata ).extracting( "absoluteName" ).containsOnly( "ageForStringSorting", "ageForIntSorting" );
+		assertThat( fieldMetadata ).extracting( "absoluteName" ).containsExactlyInAnyOrder( "ageForStringSorting", "ageForIntSorting" );
 	}
 
 	@Indexed

--- a/legacy/engine/src/test/java/org/hibernate/search/test/engine/numeric/NumericFieldTest.java
+++ b/legacy/engine/src/test/java/org/hibernate/search/test/engine/numeric/NumericFieldTest.java
@@ -177,7 +177,7 @@ public class NumericFieldTest {
 				.getIndexedFields();
 
 		assertThat( fields ).extracting( "name" )
-				.containsOnly( "rating", "ratingNumericPrecision1", "ratingNumericPrecision2" );
+				.containsExactlyInAnyOrder( "rating", "ratingNumericPrecision1", "ratingNumericPrecision2" );
 
 		for ( FieldDescriptor field : fields ) {
 			if ( "ratingNumericPrecision1".equals( field.getName() ) ) {

--- a/legacy/engine/src/test/java/org/hibernate/search/testsupport/junit/SearchITHelper.java
+++ b/legacy/engine/src/test/java/org/hibernate/search/testsupport/junit/SearchITHelper.java
@@ -315,13 +315,13 @@ public class SearchITHelper {
 		@SafeVarargs
 		public final AssertHSQueryContext matchesUnorderedIds(Serializable ... expectedIds) {
 			Object[] objectArray = Arrays.stream( expectedIds ).toArray();
-			asResultIds().containsOnly( objectArray );
+			asResultIds().containsExactlyInAnyOrder( objectArray );
 			return this;
 		}
 
 		public final AssertHSQueryContext matchesUnorderedIds(int[] expectedIds) {
 			Object[] objectArray = Arrays.stream( expectedIds ).mapToObj( i -> i ).toArray();
-			asResultIds().containsOnly( objectArray );
+			asResultIds().containsExactlyInAnyOrder( objectArray );
 			return this;
 		}
 
@@ -348,7 +348,7 @@ public class SearchITHelper {
 			Object[] objectArray = Arrays.stream( expectedProjections )
 					.map( Arrays::asList ) // Take advantage of List.equals
 					.toArray();
-			asResultProjectionsAsLists().containsOnly( objectArray );
+			asResultProjectionsAsLists().containsExactlyInAnyOrder( objectArray );
 			return this;
 		}
 
@@ -357,7 +357,7 @@ public class SearchITHelper {
 			Object[] objectArray = Arrays.stream( expectedSingleElementProjections )
 					.map( p -> Arrays.asList( p ) ) // Take advantage of List.equals
 					.toArray();
-			asResultProjectionsAsLists().containsOnly( objectArray );
+			asResultProjectionsAsLists().containsExactlyInAnyOrder( objectArray );
 			return this;
 		}
 

--- a/legacy/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchClassBridgeIT.java
+++ b/legacy/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchClassBridgeIT.java
@@ -90,11 +90,11 @@ public class ElasticsearchClassBridgeIT extends SearchTestBase {
 
 		QueryDescriptor query = ElasticsearchQueries.fromQueryString( "fullName:\"Klaus Hergesheimer\"" );
 		List<?> result = session.createFullTextQuery( query, GolfPlayer.class ).list();
-		assertThat( result ).extracting( "id" ).describedAs( "Class-bridge provided string field" ).containsOnly( 1L );
+		assertThat( result ).extracting( "id" ).describedAs( "Class-bridge provided string field" ).containsExactlyInAnyOrder( 1L );
 
 		query = ElasticsearchQueries.fromQueryString( "age:34" );
 		result = session.createFullTextQuery( query, GolfPlayer.class ).list();
-		assertThat( result ).extracting( "id" ).describedAs( "Class-bridge provided numeric field" ).containsOnly( 1L );
+		assertThat( result ).extracting( "id" ).describedAs( "Class-bridge provided numeric field" ).containsExactlyInAnyOrder( 1L );
 
 		tx.commit();
 		s.close();

--- a/legacy/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIT.java
+++ b/legacy/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchIT.java
@@ -164,7 +164,7 @@ public class ElasticsearchIT extends SearchTestBase {
 		QueryDescriptor query = ElasticsearchQueries.fromJson( "{ 'query': { 'match' : { 'abstract' : 'Hibernate' } } }" );
 		List<?> result = session.createFullTextQuery( query, ScientificArticle.class ).list();
 
-		assertThat( result ).extracting( "title" ).containsOnly(
+		assertThat( result ).extracting( "title" ).containsExactlyInAnyOrder(
 				"Latest in ORM",
 				"ORM for dummies",
 				"High-performance ORM",
@@ -183,7 +183,7 @@ public class ElasticsearchIT extends SearchTestBase {
 		QueryDescriptor query = ElasticsearchQueries.fromJson( "{ 'query': { 'range' : { 'wordCount' : { 'gte' : 8, 'lt' : 10 } } } }" );
 		List<?> result = session.createFullTextQuery( query ).list();
 
-		assertThat( result ).extracting( "title" ).containsOnly( "Latest in ORM", "ORM for beginners" );
+		assertThat( result ).extracting( "title" ).containsExactlyInAnyOrder( "Latest in ORM", "ORM for beginners" );
 		tx.commit();
 		s.close();
 	}
@@ -200,7 +200,7 @@ public class ElasticsearchIT extends SearchTestBase {
 				.setSort( new Sort( new SortField( "id", SortField.Type.STRING ) ) )
 				.list();
 
-		assertThat( result ).extracting( "firstName" ).containsOnly( "Klaus" );
+		assertThat( result ).extracting( "firstName" ).containsExactlyInAnyOrder( "Klaus" );
 		tx.commit();
 		s.close();
 	}
@@ -344,7 +344,7 @@ public class ElasticsearchIT extends SearchTestBase {
 		QueryDescriptor query = ElasticsearchQueries.fromJson( "{ 'query': { 'match' : { 'title' : 'findings' } } }" );
 		List<?> result = session.createFullTextQuery( query, MasterThesis.class, BachelorThesis.class ).list();
 
-		assertThat( result ).extracting( "title" ).containsOnly( "Great findings", "Latest findings" );
+		assertThat( result ).extracting( "title" ).containsExactlyInAnyOrder( "Great findings", "Latest findings" );
 		tx.commit();
 		s.close();
 	}
@@ -358,7 +358,7 @@ public class ElasticsearchIT extends SearchTestBase {
 		QueryDescriptor query = ElasticsearchQueries.fromJson( "{ 'query': { 'match' : { 'abstract' : 'Hibernate' } } }" );
 		List<?> result = session.createFullTextQuery( query, ResearchPaper.class ).list();
 
-		assertThat( result ).extracting( "title" ).containsOnly( "Very important research on Hibernate", "Some research" );
+		assertThat( result ).extracting( "title" ).containsExactlyInAnyOrder( "Very important research on Hibernate", "Some research" );
 		tx.commit();
 		s.close();
 	}
@@ -376,7 +376,7 @@ public class ElasticsearchIT extends SearchTestBase {
 				.setSort( new Sort( new SortField( "id", SortField.Type.STRING, false ) ) )
 				.list();
 
-		assertThat( result ).extracting( "title" ).containsOnly( "Latest in ORM", "High-performance ORM" );
+		assertThat( result ).extracting( "title" ).containsExactlyInAnyOrder( "Latest in ORM", "High-performance ORM" );
 		tx.commit();
 		s.close();
 	}
@@ -530,7 +530,7 @@ public class ElasticsearchIT extends SearchTestBase {
 		QueryDescriptor query = ElasticsearchQueries.fromQueryString( "abstract:Hibernate" );
 		List<?> result = session.createFullTextQuery( query, ScientificArticle.class ).list();
 
-		assertThat( result ).extracting( "title" ).containsOnly(
+		assertThat( result ).extracting( "title" ).containsExactlyInAnyOrder(
 				"Latest in ORM",
 				"ORM for dummies",
 				"High-performance ORM",
@@ -540,7 +540,7 @@ public class ElasticsearchIT extends SearchTestBase {
 		query = ElasticsearchQueries.fromQueryString( "abstract:important OR title:important" );
 		result = session.createFullTextQuery( query, ResearchPaper.class ).list();
 
-		assertThat( result ).extracting( "title" ).containsOnly(
+		assertThat( result ).extracting( "title" ).containsExactlyInAnyOrder(
 				"Very important research on Hibernate",
 				"Some research"
 		);
@@ -548,7 +548,7 @@ public class ElasticsearchIT extends SearchTestBase {
 		query = ElasticsearchQueries.fromQueryString( "wordCount:[8 TO 10}" );
 		result = session.createFullTextQuery( query, ScientificArticle.class ).list();
 
-		assertThat( result ).extracting( "title" ).containsOnly( "Latest in ORM", "ORM for beginners" );
+		assertThat( result ).extracting( "title" ).containsExactlyInAnyOrder( "Latest in ORM", "ORM for beginners" );
 
 		tx.commit();
 		s.close();
@@ -624,7 +624,7 @@ public class ElasticsearchIT extends SearchTestBase {
 
 		List<?> result = session.createFullTextQuery( query, ScientificArticle.class ).list();
 
-		assertThat( result ).extracting( "title" ).containsOnly(
+		assertThat( result ).extracting( "title" ).containsExactlyInAnyOrder(
 				"ORM for dummies",
 				"ORM for beginners"
 		);
@@ -632,7 +632,7 @@ public class ElasticsearchIT extends SearchTestBase {
 		query = ElasticsearchQueries.fromQueryString( "_id:1 OR _id:3" );
 		result = session.createFullTextQuery( query, ScientificArticle.class ).list();
 
-		assertThat( result ).extracting( "title" ).containsOnly(
+		assertThat( result ).extracting( "title" ).containsExactlyInAnyOrder(
 				"ORM for dummies",
 				"ORM for beginners"
 		);

--- a/legacy/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchNullValueIT.java
+++ b/legacy/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchNullValueIT.java
@@ -85,19 +85,19 @@ public class ElasticsearchNullValueIT extends SearchTestBase {
 
 		QueryDescriptor query = ElasticsearchQueries.fromQueryString( "firstName:&lt;NULL&gt;" );
 		List<?> result = session.createFullTextQuery( query, GolfPlayer.class ).list();
-		assertThat( result ).extracting( "id" ).describedAs( "Querying null-encoded String" ).containsOnly( 2L );
+		assertThat( result ).extracting( "id" ).describedAs( "Querying null-encoded String" ).containsExactlyInAnyOrder( 2L );
 
 		query = ElasticsearchQueries.fromQueryString( "dateOfBirth:1970-01-01" );
 		result = session.createFullTextQuery( query, GolfPlayer.class ).list();
-		assertThat( result ).extracting( "id" ).describedAs( "Querying null-encoded Date" ).containsOnly( 2L );
+		assertThat( result ).extracting( "id" ).describedAs( "Querying null-encoded Date" ).containsExactlyInAnyOrder( 2L );
 
 		query = ElasticsearchQueries.fromQueryString( "active:false" );
 		result = session.createFullTextQuery( query, GolfPlayer.class ).list();
-		assertThat( result ).extracting( "id" ).describedAs( "Querying null-encoded Boolean" ).containsOnly( 2L );
+		assertThat( result ).extracting( "id" ).describedAs( "Querying null-encoded Boolean" ).containsExactlyInAnyOrder( 2L );
 
 		query = ElasticsearchQueries.fromQueryString( "driveWidth:\\-1" );
 		result = session.createFullTextQuery( query, GolfPlayer.class ).list();
-		assertThat( result ).extracting( "id" ).describedAs( "Querying null-encoded Integer" ).containsOnly( 2L );
+		assertThat( result ).extracting( "id" ).describedAs( "Querying null-encoded Integer" ).containsExactlyInAnyOrder( 2L );
 
 		tx.commit();
 		s.close();

--- a/legacy/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchSpatialIT.java
+++ b/legacy/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ElasticsearchSpatialIT.java
@@ -99,7 +99,7 @@ public class ElasticsearchSpatialIT extends SearchTestBase {
 		List<?> result = session.createFullTextQuery( query, POI.class )
 				.setSort( new Sort( new DistanceSortField( 24, 32, "location" ) ) )
 				.list();
-		assertThat( result ).extracting( "id" ).describedAs( "Geo distance query" ).containsOnly( 1, 2, 3 );
+		assertThat( result ).extracting( "id" ).describedAs( "Geo distance query" ).containsExactlyInAnyOrder( 1, 2, 3 );
 
 		tx.commit();
 		s.close();
@@ -136,7 +136,7 @@ public class ElasticsearchSpatialIT extends SearchTestBase {
 
 		QueryDescriptor query = ElasticsearchQueries.fromJson( boundingBoxQuery );
 		List<?> result = session.createFullTextQuery( query, POI.class ).list();
-		assertThat( result ).extracting( "id" ).describedAs( "Geo distance query" ).containsOnly( 1, 2, 3, 4 );
+		assertThat( result ).extracting( "id" ).describedAs( "Geo distance query" ).containsExactlyInAnyOrder( 1, 2, 3, 4 );
 
 		tx.commit();
 		s.close();

--- a/legacy/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/deletebyquery/DeleteByQueryIT.java
+++ b/legacy/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/deletebyquery/DeleteByQueryIT.java
@@ -102,7 +102,7 @@ public class DeleteByQueryIT extends SearchTestBase {
 		@SuppressWarnings("unchecked")
 		List<HockeyPlayer> result = session.createFullTextQuery( query, HockeyPlayer.class ).list();
 
-		assertThat( result ).extracting( "name" ).containsOnly( "Hergesheimer", "Brand" );
+		assertThat( result ).extracting( "name" ).containsExactlyInAnyOrder( "Hergesheimer", "Brand" );
 
 		tx.commit();
 		s.close();

--- a/legacy/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/deletebyquery/DeleteByQueryMultiTenancyIT.java
+++ b/legacy/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/deletebyquery/DeleteByQueryMultiTenancyIT.java
@@ -156,7 +156,7 @@ public class DeleteByQueryMultiTenancyIT extends SearchTestBase {
 		@SuppressWarnings("unchecked")
 		List<HockeyPlayer> result = session.createFullTextQuery( query, HockeyPlayer.class ).list();
 
-		assertThat( result ).extracting( "name" ).containsOnly( "Hergesheimer", "Brand" );
+		assertThat( result ).extracting( "name" ).containsExactlyInAnyOrder( "Hergesheimer", "Brand" );
 
 		tx.commit();
 
@@ -179,7 +179,7 @@ public class DeleteByQueryMultiTenancyIT extends SearchTestBase {
 		assertThat( result )
 			.describedAs( "Running delete-by-query for other tenant should not affect entities of this entity" )
 			.extracting( "name" )
-			.containsOnly( "Metz", "Plenty" );
+			.containsExactlyInAnyOrder( "Metz", "Plenty" );
 
 		tx.commit();
 		s.close();

--- a/legacy/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/filter/ElasticsearchFilterIT.java
+++ b/legacy/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/filter/ElasticsearchFilterIT.java
@@ -44,13 +44,13 @@ public class ElasticsearchFilterIT extends SearchTestBase {
 		FullTextQuery ftQuery = fullTextSession.createFullTextQuery( ElasticsearchQueries.fromJson( "{ 'query': { 'match_all': {} } }" ), Driver.class );
 		ftQuery.enableFullTextFilter( "bestDriver" );
 
-		assertThat( ftQuery.list() ).extracting( "name" ).containsOnly( "Liz", "Emmanuel" );
+		assertThat( ftQuery.list() ).extracting( "name" ).containsExactlyInAnyOrder( "Liz", "Emmanuel" );
 
 		TermQuery termQuery = new TermQuery( new Term( "name", "liz" ) );
 		Filter termFilter = new QueryWrapperFilter( termQuery );
 		ftQuery.setFilter( termFilter );
 
-		assertThat( ftQuery.list() ).extracting( "name" ).containsOnly( "Liz" );
+		assertThat( ftQuery.list() ).extracting( "name" ).containsExactlyInAnyOrder( "Liz" );
 
 		tx.commit();
 		s.close();
@@ -66,7 +66,7 @@ public class ElasticsearchFilterIT extends SearchTestBase {
 		ftQuery.enableFullTextFilter( "namedDriver" )
 				.setParameter( "name", "liz" );
 
-		assertThat( ftQuery.list() ).extracting( "name" ).containsOnly( "Liz" );
+		assertThat( ftQuery.list() ).extracting( "name" ).containsExactlyInAnyOrder( "Liz" );
 
 		tx.commit();
 		s.close();
@@ -85,7 +85,7 @@ public class ElasticsearchFilterIT extends SearchTestBase {
 				.setParameter( "field", "teacher" )
 				.setParameter( "value", "andre" );
 
-		assertThat( ftQuery.list() ).extracting( "name" ).containsOnly( "Emmanuel" );
+		assertThat( ftQuery.list() ).extracting( "name" ).containsExactlyInAnyOrder( "Emmanuel" );
 
 		tx.commit();
 		s.close();

--- a/legacy/integrationtest/spring/src/test/java/org/hibernate/search/test/integration/spring/injection/SpringInjectionIT.java
+++ b/legacy/integrationtest/spring/src/test/java/org/hibernate/search/test/integration/spring/injection/SpringInjectionIT.java
@@ -50,24 +50,24 @@ public class SpringInjectionIT {
 		EntityWithSpringAwareBridges entity = new EntityWithSpringAwareBridges();
 		entity.setInternationalizedValue( InternationalizedValue.HELLO );
 		dao.create( entity );
-		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "hello" ) ).extracting( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "hallo" ) ).extracting( "id" ).containsOnly( entity.getId() );
+		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).containsExactlyInAnyOrder( entity.getId() );
+		assertThat( search.apply( "hello" ) ).extracting( "id" ).containsExactlyInAnyOrder( entity.getId() );
+		assertThat( search.apply( "hallo" ) ).extracting( "id" ).containsExactlyInAnyOrder( entity.getId() );
 		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).isEmpty();
 
 		EntityWithSpringAwareBridges entity2 = new EntityWithSpringAwareBridges();
 		entity2.setInternationalizedValue( InternationalizedValue.GOODBYE );
 		dao.create( entity2 );
-		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "hello" ) ).extracting( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "hallo" ) ).extracting( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).containsOnly( entity2.getId() );
+		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).containsExactlyInAnyOrder( entity.getId() );
+		assertThat( search.apply( "hello" ) ).extracting( "id" ).containsExactlyInAnyOrder( entity.getId() );
+		assertThat( search.apply( "hallo" ) ).extracting( "id" ).containsExactlyInAnyOrder( entity.getId() );
+		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).containsExactlyInAnyOrder( entity2.getId() );
 
 		dao.delete( entity );
 		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).isEmpty();
 		assertThat( search.apply( "hello" ) ).extracting( "id" ).isEmpty();
 		assertThat( search.apply( "hallo" ) ).extracting( "id" ).isEmpty();
-		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).containsOnly( entity2.getId() );
+		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).containsExactlyInAnyOrder( entity2.getId() );
 	}
 
 	@Test
@@ -82,24 +82,24 @@ public class SpringInjectionIT {
 		EntityWithSpringAwareBridges entity = new EntityWithSpringAwareBridges();
 		entity.setInternationalizedValue( InternationalizedValue.HELLO );
 		dao.create( entity );
-		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "hello" ) ).extracting( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "hallo" ) ).extracting( "id" ).containsOnly( entity.getId() );
+		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).containsExactlyInAnyOrder( entity.getId() );
+		assertThat( search.apply( "hello" ) ).extracting( "id" ).containsExactlyInAnyOrder( entity.getId() );
+		assertThat( search.apply( "hallo" ) ).extracting( "id" ).containsExactlyInAnyOrder( entity.getId() );
 		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).isEmpty();
 
 		EntityWithSpringAwareBridges entity2 = new EntityWithSpringAwareBridges();
 		entity2.setInternationalizedValue( InternationalizedValue.GOODBYE );
 		dao.create( entity2 );
-		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "hello" ) ).extracting( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "hallo" ) ).extracting( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).containsOnly( entity2.getId() );
+		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).containsExactlyInAnyOrder( entity.getId() );
+		assertThat( search.apply( "hello" ) ).extracting( "id" ).containsExactlyInAnyOrder( entity.getId() );
+		assertThat( search.apply( "hallo" ) ).extracting( "id" ).containsExactlyInAnyOrder( entity.getId() );
+		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).containsExactlyInAnyOrder( entity2.getId() );
 
 		dao.delete( entity );
 		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).isEmpty();
 		assertThat( search.apply( "hello" ) ).extracting( "id" ).isEmpty();
 		assertThat( search.apply( "hallo" ) ).extracting( "id" ).isEmpty();
-		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).containsOnly( entity2.getId() );
+		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).containsExactlyInAnyOrder( entity2.getId() );
 	}
 
 	@Test
@@ -111,6 +111,6 @@ public class SpringInjectionIT {
 		EntityWithSpringAwareBridges entity = new EntityWithSpringAwareBridges();
 		entity.setInternationalizedValue( InternationalizedValue.HELLO );
 		dao.create( entity );
-		assertThat( search.apply( NonSpringBridge.PREFIX + InternationalizedValue.HELLO.name() ) ).extracting( "id" ).containsOnly( entity.getId() );
+		assertThat( search.apply( NonSpringBridge.PREFIX + InternationalizedValue.HELLO.name() ) ).extracting( "id" ).containsExactlyInAnyOrder( entity.getId() );
 	}
 }

--- a/legacy/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/wildfly/cdi/CDIInjectionIT.java
+++ b/legacy/integrationtest/wildfly/src/test/java/org/hibernate/search/test/integration/wildfly/cdi/CDIInjectionIT.java
@@ -99,24 +99,24 @@ public class CDIInjectionIT {
 		EntityWithCDIAwareBridges entity = new EntityWithCDIAwareBridges();
 		entity.setInternationalizedValue( InternationalizedValue.HELLO );
 		dao.create( entity );
-		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "hello" ) ).extracting( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "hallo" ) ).extracting( "id" ).containsOnly( entity.getId() );
+		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).containsExactlyInAnyOrder( entity.getId() );
+		assertThat( search.apply( "hello" ) ).extracting( "id" ).containsExactlyInAnyOrder( entity.getId() );
+		assertThat( search.apply( "hallo" ) ).extracting( "id" ).containsExactlyInAnyOrder( entity.getId() );
 		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).isEmpty();
 
 		EntityWithCDIAwareBridges entity2 = new EntityWithCDIAwareBridges();
 		entity2.setInternationalizedValue( InternationalizedValue.GOODBYE );
 		dao.create( entity2 );
-		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "hello" ) ).extracting( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "hallo" ) ).extracting( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).containsOnly( entity2.getId() );
+		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).containsExactlyInAnyOrder( entity.getId() );
+		assertThat( search.apply( "hello" ) ).extracting( "id" ).containsExactlyInAnyOrder( entity.getId() );
+		assertThat( search.apply( "hallo" ) ).extracting( "id" ).containsExactlyInAnyOrder( entity.getId() );
+		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).containsExactlyInAnyOrder( entity2.getId() );
 
 		dao.delete( entity );
 		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).isEmpty();
 		assertThat( search.apply( "hello" ) ).extracting( "id" ).isEmpty();
 		assertThat( search.apply( "hallo" ) ).extracting( "id" ).isEmpty();
-		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).containsOnly( entity2.getId() );
+		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).containsExactlyInAnyOrder( entity2.getId() );
 	}
 
 	@Test
@@ -131,23 +131,23 @@ public class CDIInjectionIT {
 		EntityWithCDIAwareBridges entity = new EntityWithCDIAwareBridges();
 		entity.setInternationalizedValue( InternationalizedValue.HELLO );
 		dao.create( entity );
-		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "hello" ) ).extracting( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "hallo" ) ).extracting( "id" ).containsOnly( entity.getId() );
+		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).containsExactlyInAnyOrder( entity.getId() );
+		assertThat( search.apply( "hello" ) ).extracting( "id" ).containsExactlyInAnyOrder( entity.getId() );
+		assertThat( search.apply( "hallo" ) ).extracting( "id" ).containsExactlyInAnyOrder( entity.getId() );
 		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).isEmpty();
 
 		EntityWithCDIAwareBridges entity2 = new EntityWithCDIAwareBridges();
 		entity2.setInternationalizedValue( InternationalizedValue.GOODBYE );
 		dao.create( entity2 );
-		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "hello" ) ).extracting( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "hallo" ) ).extracting( "id" ).containsOnly( entity.getId() );
-		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).containsOnly( entity2.getId() );
+		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).containsExactlyInAnyOrder( entity.getId() );
+		assertThat( search.apply( "hello" ) ).extracting( "id" ).containsExactlyInAnyOrder( entity.getId() );
+		assertThat( search.apply( "hallo" ) ).extracting( "id" ).containsExactlyInAnyOrder( entity.getId() );
+		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).containsExactlyInAnyOrder( entity2.getId() );
 
 		dao.delete( entity );
 		assertThat( search.apply( "bonjour" ) ).extracting( "id" ).isEmpty();
 		assertThat( search.apply( "hello" ) ).extracting( "id" ).isEmpty();
 		assertThat( search.apply( "hallo" ) ).extracting( "id" ).isEmpty();
-		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).containsOnly( entity2.getId() );
+		assertThat( search.apply( "au revoir" ) ).extracting( "id" ).containsExactlyInAnyOrder( entity2.getId() );
 	}
 }

--- a/legacy/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/impl/util/SerializationUtilTest.java
+++ b/legacy/jsr352/core/src/test/java/org/hibernate/search/jsr352/massindexing/impl/util/SerializationUtilTest.java
@@ -144,12 +144,12 @@ public class SerializationUtilTest {
 		 * methods #equals and #hashCode, so the equality-by-value is actually equality-by-reference.
 		 * Enable the following lines to see what happens.
 		 */
-//		assertThat( actualCriteria ).containsOnly( criterion1, criterion2 );
+//		assertThat( actualCriteria ).containsExactlyInAnyOrder( criterion1, criterion2 );
 
 		Set<String> actualCriteriaAsStrings = actualCriteria.stream()
 				.map( Object::toString )
 				.collect( Collectors.toSet() );
-		assertThat( actualCriteriaAsStrings ).containsOnly( criterion1.toString(), criterion2.toString() );
+		assertThat( actualCriteriaAsStrings ).containsExactlyInAnyOrder( criterion1.toString(), criterion2.toString() );
 	}
 
 }

--- a/legacy/orm/src/test/java/org/hibernate/search/test/batchindexing/DatabaseMultitenancyTest.java
+++ b/legacy/orm/src/test/java/org/hibernate/search/test/batchindexing/DatabaseMultitenancyTest.java
@@ -91,21 +91,21 @@ public class DatabaseMultitenancyTest extends SearchTestBase {
 	public void shouldOnlyFindMetamecModels() throws Exception {
 		List<Clock> list = searchAll( METAMEC_TID );
 		assertThat( list ).isNotEmpty();
-		assertThat( list ).containsOnly( METAMEC_MODELS );
+		assertThat( list ).containsExactlyInAnyOrder( METAMEC_MODELS );
 	}
 
 	@Test
 	public void shouldOnlyFindGeochronModels() throws Exception {
 		List<Clock> list = searchAll( GEOCHRON_TID );
 		assertThat( list ).isNotEmpty();
-		assertThat( list ).containsOnly( GEOCHRON_MODELS );
+		assertThat( list ).containsExactlyInAnyOrder( GEOCHRON_MODELS );
 	}
 
 	@Test
 	public void shouldMatchOnlyElementsFromOneTenant() throws Exception {
 		List<Clock> list = searchModel( "model", GEOCHRON_TID );
 		assertThat( list ).isNotEmpty();
-		assertThat( list ).containsOnly( GEOCHRON_MODELS );
+		assertThat( list ).containsExactlyInAnyOrder( GEOCHRON_MODELS );
 	}
 
 	@Test
@@ -116,7 +116,7 @@ public class DatabaseMultitenancyTest extends SearchTestBase {
 		assertThat( listg ).isEmpty();
 		List<Clock> listm = searchAll( METAMEC_TID );
 		assertThat( listm ).isNotEmpty();
-		assertThat( listm ).containsOnly( METAMEC_MODELS );
+		assertThat( listm ).containsExactlyInAnyOrder( METAMEC_MODELS );
 	}
 
 	@Test
@@ -127,7 +127,7 @@ public class DatabaseMultitenancyTest extends SearchTestBase {
 
 		List<Clock> listg = searchAll( GEOCHRON_TID );
 		assertThat( listg ).isNotEmpty();
-		assertThat( listg ).containsOnly( GEOCHRON_MODELS );
+		assertThat( listg ).containsExactlyInAnyOrder( GEOCHRON_MODELS );
 		List<Clock> listm = searchAll( METAMEC_TID );
 		assertThat( listm ).isEmpty();
 	}
@@ -137,7 +137,7 @@ public class DatabaseMultitenancyTest extends SearchTestBase {
 		purgeAll( Clock.class, GEOCHRON_TID );
 
 		List<Clock> list = searchAll( METAMEC_TID );
-		assertThat( list ).containsOnly( METAMEC_MODELS );
+		assertThat( list ).containsExactlyInAnyOrder( METAMEC_MODELS );
 	}
 
 	@Test
@@ -146,10 +146,10 @@ public class DatabaseMultitenancyTest extends SearchTestBase {
 		rebuildIndexWithMassIndexer( Clock.class, GEOCHRON_TID );
 
 		List<Clock> metamecList = searchAll( METAMEC_TID );
-		assertThat( metamecList ).containsOnly( METAMEC_MODELS );
+		assertThat( metamecList ).containsExactlyInAnyOrder( METAMEC_MODELS );
 
 		List<Clock> geochronList = searchAll( GEOCHRON_TID );
-		assertThat( geochronList ).containsOnly( GEOCHRON_MODELS );
+		assertThat( geochronList ).containsExactlyInAnyOrder( GEOCHRON_MODELS );
 	}
 
 	@Test

--- a/legacy/orm/src/test/java/org/hibernate/search/test/filter/fulltextfilterdef/FullTextFilterDefAnnotationTest.java
+++ b/legacy/orm/src/test/java/org/hibernate/search/test/filter/fulltextfilterdef/FullTextFilterDefAnnotationTest.java
@@ -53,9 +53,9 @@ public class FullTextFilterDefAnnotationTest {
 	}
 
 	@Test
-	public void shouldContainsOnlyTheDefinedFilters() throws Exception {
+	public void shouldcontainsExactlyInAnyOrderTheDefinedFilters() throws Exception {
 		Map<String, FilterDef> filterDefinitions = ( (SearchFactoryState) sfHolder.getSearchFactory() ).getFilterDefinitions();
-		assertThat( filterDefinitions.keySet() ).containsOnly( "package-filter", "class-filter" );
+		assertThat( filterDefinitions.keySet() ).containsExactlyInAnyOrder( "package-filter", "class-filter" );
 	}
 
 	@Test

--- a/legacy/orm/src/test/java/org/hibernate/search/test/filter/fulltextfilterdefs/FullTextFilterDefsAnnotationTest.java
+++ b/legacy/orm/src/test/java/org/hibernate/search/test/filter/fulltextfilterdefs/FullTextFilterDefsAnnotationTest.java
@@ -56,7 +56,7 @@ public class FullTextFilterDefsAnnotationTest {
 	}
 
 	@Test
-	public void shouldContainsOnlyTheDefinedFilters() throws Exception {
+	public void shouldcontainsExactlyInAnyOrderTheDefinedFilters() throws Exception {
 		Map<String, FilterDef> filterDefinitions = ( (SearchFactoryState) sfHolder.getSearchFactory() ).getFilterDefinitions();
 		assertThat( filterDefinitions.keySet() ).contains( "package-filter-1", "package-filter-2", "class-filter-1", "class-filter-2" );
 	}

--- a/legacy/orm/src/test/java/org/hibernate/search/test/query/initandlookup/CriteriaObjectInitializerAndHierarchyInheritanceTest.java
+++ b/legacy/orm/src/test/java/org/hibernate/search/test/query/initandlookup/CriteriaObjectInitializerAndHierarchyInheritanceTest.java
@@ -105,19 +105,19 @@ public class CriteriaObjectInitializerAndHierarchyInheritanceTest extends Search
 		FullTextSession session = Search.getFullTextSession( s );
 
 		List<?> results = getResults( session, AAA.class );
-		assertThat( results ).extracting( "name" ).containsOnly( "A AA AAA" );
+		assertThat( results ).extracting( "name" ).containsExactlyInAnyOrder( "A AA AAA" );
 		assertThat( byteman.consumeNextRecordedEvent() ).isEqualTo( AAA.class.getName() );
 
 		results = getResults( session, AAA.class, AAB.class );
-		assertThat( results ).extracting( "name" ).containsOnly( "A AA AAA", "A AA AAB" );
+		assertThat( results ).extracting( "name" ).containsExactlyInAnyOrder( "A AA AAA", "A AA AAB" );
 		assertThat( byteman.consumeNextRecordedEvent() ).isEqualTo( AA.class.getName() );
 
 		results = getResults( session, AAA.class, AB.class );
-		assertThat( results ).extracting( "name" ).containsOnly( "A AA AAA", "A AB", "A AB ABA" );
+		assertThat( results ).extracting( "name" ).containsExactlyInAnyOrder( "A AA AAA", "A AB", "A AB ABA" );
 		assertThat( byteman.consumeNextRecordedEvent() ).isEqualTo( A.class.getName() );
 
 		results = getResults( session, AAA.class, BA.class );
-		assertThat( results ).extracting( "name" ).containsOnly( "A AA AAA", "B BA" );
+		assertThat( results ).extracting( "name" ).containsExactlyInAnyOrder( "A AA AAA", "B BA" );
 		// here, we have 2 Criterias returned: we only test the first one
 		assertThat( byteman.consumeNextRecordedEvent() ).isIn( AAA.class.getName(), BA.class.getName() );
 

--- a/legacy/orm/src/test/java/org/hibernate/search/test/query/objectloading/mixedhierarchy/ObjectLoadingCrossHierarchyTest.java
+++ b/legacy/orm/src/test/java/org/hibernate/search/test/query/objectloading/mixedhierarchy/ObjectLoadingCrossHierarchyTest.java
@@ -99,7 +99,7 @@ public class ObjectLoadingCrossHierarchyTest extends SearchTestBase {
 		assertThat( results )
 				.extracting( "name" )
 				.describedAs( "Can load results originating from different id spaces, using different id types and names" )
-				.containsOnly(
+				.containsExactlyInAnyOrder(
 				"Southern Florida College of Golf",
 				"Wogharts",
 				"St. Lucie Community College",

--- a/legacy/orm/src/test/java/org/hibernate/search/test/query/sorting/SortTest.java
+++ b/legacy/orm/src/test/java/org/hibernate/search/test/query/sorting/SortTest.java
@@ -262,7 +262,7 @@ public class SortTest extends SearchTestBase {
 		List<Book> result = hibQuery.list();
 
 		assertNotNull( result );
-		assertThat( result ).extracting( "id" ).containsOnly( 1, 2, 3, 10 );
+		assertThat( result ).extracting( "id" ).containsExactlyInAnyOrder( 1, 2, 3, 10 );
 
 		tx.commit();
 	}

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/impl/DefaultEnumValueBridge.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/impl/DefaultEnumValueBridge.java
@@ -27,7 +27,7 @@ public final class DefaultEnumValueBridge<V extends Enum<V>> implements ValueBri
 	public StandardIndexSchemaFieldTypedContext<?, String> bind(ValueBridgeBindingContext<V> context) {
 		this.enumType = (Class<V>) context.getBridgedElement().getRawType();
 		return context.getIndexSchemaFieldContext().asString()
-				.projectionConverter( new DefaultEnumFromIndexFieldValueConverter() );
+				.projectionConverter( new DefaultEnumFromIndexFieldValueConverter<>( enumType ) );
 	}
 
 	@Override
@@ -50,7 +50,14 @@ public final class DefaultEnumValueBridge<V extends Enum<V>> implements ValueBri
 		return enumType.equals( castedOther.enumType );
 	}
 
-	private class DefaultEnumFromIndexFieldValueConverter implements FromIndexFieldValueConverter<String, V> {
+	private static class DefaultEnumFromIndexFieldValueConverter<V extends Enum<V>>
+			implements FromIndexFieldValueConverter<String, V> {
+
+		private final Class<V> enumType;
+
+		private DefaultEnumFromIndexFieldValueConverter(Class<V> enumType) {
+			this.enumType = enumType;
+		}
 
 		@Override
 		public boolean isConvertedTypeAssignableTo(Class<?> superTypeCandidate) {
@@ -60,6 +67,15 @@ public final class DefaultEnumValueBridge<V extends Enum<V>> implements ValueBri
 		@Override
 		public V convert(String indexedValue, FromIndexFieldValueConvertContext context) {
 			return indexedValue == null ? null : Enum.valueOf( enumType, indexedValue );
+		}
+
+		@Override
+		public boolean isCompatibleWith(FromIndexFieldValueConverter<?, ?> other) {
+			if ( !getClass().equals( other.getClass() ) ) {
+				return false;
+			}
+			DefaultEnumFromIndexFieldValueConverter<?> castedOther = (DefaultEnumFromIndexFieldValueConverter<?>) other;
+			return enumType.equals( castedOther.enumType );
 		}
 	}
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/impl/DefaultJavaUtilDateValueBridge.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/impl/DefaultJavaUtilDateValueBridge.java
@@ -60,6 +60,11 @@ public final class DefaultJavaUtilDateValueBridge implements ValueBridge<Date, I
 		public Date convert(Instant value, FromIndexFieldValueConvertContext context) {
 			return value == null ? null : Date.from( value );
 		}
+
+		@Override
+		public boolean isCompatibleWith(FromIndexFieldValueConverter<?, ?> other) {
+			return INSTANCE.equals( other );
+		}
 	}
 
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/assertion/SearchResultAssert.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/assertion/SearchResultAssert.java
@@ -73,7 +73,7 @@ public class SearchResultAssert<T> {
 	public final SearchResultAssert<T> hasHitsAnyOrder(T... hits) {
 		Assertions.<T>assertThat( actual.getHits() )
 				.as( "Hits of " + queryDescription )
-				.containsOnly( hits );
+				.containsExactlyInAnyOrder( hits );
 		return this;
 	}
 
@@ -111,7 +111,7 @@ public class SearchResultAssert<T> {
 		expectation.accept( context );
 		Assertions.assertThat( getNormalizedActualDocumentReferencesHits() )
 				.as( "Hits of " + queryDescription )
-				.containsOnly( context.getExpectedHits() );
+				.containsExactlyInAnyOrder( context.getExpectedHits() );
 		return this;
 	}
 
@@ -129,7 +129,7 @@ public class SearchResultAssert<T> {
 		expectation.accept( context );
 		Assertions.assertThat( getNormalizedActualListHits() )
 				.as( "Hits of " + queryDescription )
-				.containsOnly( context.getExpectedHits() );
+				.containsExactlyInAnyOrder( context.getExpectedHits() );
 		return this;
 	}
 

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/impl/StubSearchTargetModel.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/impl/StubSearchTargetModel.java
@@ -42,7 +42,7 @@ public class StubSearchTargetModel {
 			if ( result == null ) {
 				result = converter;
 			}
-			else if ( !result.isDslCompatibleWith( converter ) ) {
+			else if ( !result.isConvertFromProjectionCompatibleWith( converter ) ) {
 				throw new IllegalStateException(
 						"Reference to field '" + absoluteFieldPath
 								+ "' on indexes " + indexNames

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/impl/StubSearchTargetModel.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/impl/StubSearchTargetModel.java
@@ -42,7 +42,7 @@ public class StubSearchTargetModel {
 			if ( result == null ) {
 				result = converter;
 			}
-			else if ( !result.isConvertFromProjectionCompatibleWith( converter ) ) {
+			else if ( !result.isConvertIndexToProjectionCompatibleWith( converter ) ) {
 				throw new IllegalStateException(
 						"Reference to field '" + absoluteFieldPath
 								+ "' on indexes " + indexNames

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubFieldSearchProjection.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubFieldSearchProjection.java
@@ -23,7 +23,7 @@ class StubFieldSearchProjection<T> implements StubSearchProjection<T> {
 	@Override
 	public Object extract(ProjectionHitMapper<?, ?> projectionHitMapper, Object projectionFromIndex,
 			FromIndexFieldValueConvertContext context) {
-		return converter.convertFromProjection( projectionFromIndex, context );
+		return converter.convertIndexToProjection( projectionFromIndex, context );
 	}
 
 	@Override

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/types/converter/impl/StubFieldConverter.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/types/converter/impl/StubFieldConverter.java
@@ -22,7 +22,7 @@ public class StubFieldConverter<F> {
 		return userConverter.convertFromProjection( type.cast( projection ), context );
 	}
 
-	public boolean isDslCompatibleWith(StubFieldConverter<?> other) {
-		return userConverter.isDslCompatibleWith( other.userConverter );
+	public boolean isConvertFromProjectionCompatibleWith(StubFieldConverter<?> other) {
+		return userConverter.isConvertFromProjectionCompatibleWith( other.userConverter );
 	}
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/types/converter/impl/StubFieldConverter.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/types/converter/impl/StubFieldConverter.java
@@ -18,11 +18,11 @@ public class StubFieldConverter<F> {
 		this.userConverter = userConverter;
 	}
 
-	public Object convertFromProjection(Object projection, FromIndexFieldValueConvertContext context) {
-		return userConverter.convertFromProjection( type.cast( projection ), context );
+	public Object convertIndexToProjection(Object indexValue, FromIndexFieldValueConvertContext context) {
+		return userConverter.convertIndexToProjection( type.cast( indexValue ), context );
 	}
 
-	public boolean isConvertFromProjectionCompatibleWith(StubFieldConverter<?> other) {
-		return userConverter.isConvertFromProjectionCompatibleWith( other.userConverter );
+	public boolean isConvertIndexToProjectionCompatibleWith(StubFieldConverter<?> other) {
+		return userConverter.isConvertIndexToProjectionCompatibleWith( other.userConverter );
 	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3412

Most of this PR is about tests, the actual fix is in commit "HSEARCH-3412 Correctly detect incompatible field types for projection [...]". Essentially we just make sure to ultimately rely on the projection converter to check for compatibility of projections, not on the DSL converter like we do for predicates and sorts.