### PR TITLE
HSEARCH-3442 Search 6 groundwork - Properly handle missing backend / backend type in configuration properties

### DIFF
--- a/engine/src/main/java/org/hibernate/search/engine/cfg/impl/AbstractConfigurationProperty.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/impl/AbstractConfigurationProperty.java
@@ -38,7 +38,7 @@ abstract class AbstractConfigurationProperty<T> implements ConfigurationProperty
 	abstract <R> R convert(Optional<?> rawValue, Function<T, R> transform);
 
 	<R> R doGet(ConfigurationPropertySource source, Function<T, R> transform) {
-		Optional<?> rawValue = source.get( key );
+		Optional<?> rawValue = source.get( key ).map( ConvertUtils::trimIfString );
 		try {
 			return convert( rawValue, transform );
 		}

--- a/engine/src/main/java/org/hibernate/search/engine/cfg/impl/DefaultedConfigurationProperty.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/impl/DefaultedConfigurationProperty.java
@@ -12,10 +12,10 @@ import java.util.function.Supplier;
 
 final class DefaultedConfigurationProperty<T> extends AbstractConfigurationProperty<T> {
 
-	private final Function<Object, Optional<T>> converter;
+	private final Function<Object, T> converter;
 	private final Supplier<T> defaultValueSupplier;
 
-	DefaultedConfigurationProperty(String key, Function<Object, Optional<T>> converter, Supplier<T> defaultValueSupplier) {
+	DefaultedConfigurationProperty(String key, Function<Object, T> converter, Supplier<T> defaultValueSupplier) {
 		super( key );
 		this.converter = converter;
 		this.defaultValueSupplier = defaultValueSupplier;
@@ -23,7 +23,7 @@ final class DefaultedConfigurationProperty<T> extends AbstractConfigurationPrope
 
 	@Override
 	<R> R convert(Optional<?> rawValue, Function<T, R> transform) {
-		T defaultedValue = rawValue.flatMap( converter ).orElseGet( defaultValueSupplier );
+		T defaultedValue = rawValue.map( converter ).orElseGet( defaultValueSupplier );
 		return transform.apply( defaultedValue );
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/cfg/impl/DefaultedPropertyContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/impl/DefaultedPropertyContextImpl.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.engine.cfg.impl;
 
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -15,10 +14,10 @@ import org.hibernate.search.engine.cfg.spi.DefaultedPropertyContext;
 
 final class DefaultedPropertyContextImpl<T> implements DefaultedPropertyContext<T> {
 	private final String key;
-	private final Function<Object, Optional<T>> converter;
+	private final Function<Object, T> converter;
 	private final Supplier<T> defaultValueSupplier;
 
-	DefaultedPropertyContextImpl(String key, Function<Object, Optional<T>> converter, Supplier<T> defaultValueSupplier) {
+	DefaultedPropertyContextImpl(String key, Function<Object, T> converter, Supplier<T> defaultValueSupplier) {
 		this.key = key;
 		this.converter = converter;
 		this.defaultValueSupplier = defaultValueSupplier;

--- a/engine/src/main/java/org/hibernate/search/engine/cfg/impl/OptionalConfigurationPropertyImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/impl/OptionalConfigurationPropertyImpl.java
@@ -15,9 +15,9 @@ import org.hibernate.search.engine.cfg.spi.OptionalConfigurationProperty;
 final class OptionalConfigurationPropertyImpl<T> extends AbstractConfigurationProperty<Optional<T>>
 		implements OptionalConfigurationProperty<T> {
 
-	private final Function<Object, Optional<T>> converter;
+	private final Function<Object, T> converter;
 
-	OptionalConfigurationPropertyImpl(String key, Function<Object, Optional<T>> converter) {
+	OptionalConfigurationPropertyImpl(String key, Function<Object, T> converter) {
 		super( key );
 		this.converter = converter;
 	}
@@ -34,7 +34,7 @@ final class OptionalConfigurationPropertyImpl<T> extends AbstractConfigurationPr
 
 	@Override
 	<R> R convert(Optional<?> rawValue, Function<Optional<T>, R> transform) {
-		return transform.apply( rawValue.flatMap( converter ) );
+		return transform.apply( rawValue.map( converter ) );
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/cfg/impl/OptionalConfigurationPropertyImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/impl/OptionalConfigurationPropertyImpl.java
@@ -33,6 +33,13 @@ final class OptionalConfigurationPropertyImpl<T> extends AbstractConfigurationPr
 	}
 
 	@Override
+	public <R> R getAndMapOrThrow(ConfigurationPropertySource source, Function<T, R> transform,
+			Function<String, RuntimeException> exceptionFunction) {
+		return getAndTransform( source, optional -> optional.map( transform ) )
+				.orElseThrow( () -> exceptionFunction.apply( resolveOrRaw( source ) ) );
+	}
+
+	@Override
 	<R> R convert(Optional<?> rawValue, Function<Optional<T>, R> transform) {
 		return transform.apply( rawValue.map( converter ) );
 	}

--- a/engine/src/main/java/org/hibernate/search/engine/cfg/impl/OptionalPropertyContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/impl/OptionalPropertyContextImpl.java
@@ -7,7 +7,6 @@
 package org.hibernate.search.engine.cfg.impl;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
@@ -19,9 +18,9 @@ import org.hibernate.search.engine.cfg.spi.OptionalPropertyContext;
 final class OptionalPropertyContextImpl<T> implements OptionalPropertyContext<T> {
 
 	private final String key;
-	private final Function<Object, Optional<T>> converter;
+	private final Function<Object, T> converter;
 
-	OptionalPropertyContextImpl(String key, Function<Object, Optional<T>> converter) {
+	OptionalPropertyContextImpl(String key, Function<Object, T> converter) {
 		this.key = key;
 		this.converter = converter;
 	}

--- a/engine/src/main/java/org/hibernate/search/engine/cfg/spi/ConfigurationProperty.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/spi/ConfigurationProperty.java
@@ -29,6 +29,8 @@ public interface ConfigurationProperty<T> {
 	 * such as the {@link #resolveOrRaw(ConfigurationPropertySource) resolved key} for this property.
 	 *
 	 * @param source A configuration source.
+	 * @param transform A transform function to be applied to the value of this configuration property
+	 * before returning the result.
 	 * @return The value of this property according to the given source.
 	 */
 	<R> R getAndTransform(ConfigurationPropertySource source, Function<T, R> transform);

--- a/engine/src/main/java/org/hibernate/search/engine/cfg/spi/OptionalConfigurationProperty.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/spi/OptionalConfigurationProperty.java
@@ -24,6 +24,8 @@ public interface OptionalConfigurationProperty<T> extends ConfigurationProperty<
 	 * such as the {@link #resolveOrRaw(ConfigurationPropertySource) resolved key} for this property.
 	 *
 	 * @param source A configuration source.
+	 * @param transform A transform function to be applied to the value of this configuration property
+	 * before returning the result.
 	 * @return The value of this property according to the given source.
 	 */
 	<R> Optional<R> getAndMap(ConfigurationPropertySource source, Function<T, R> transform);
@@ -37,5 +39,21 @@ public interface OptionalConfigurationProperty<T> extends ConfigurationProperty<
 	 * @return The value of this property according to the given source.
 	 */
 	T getOrThrow(ConfigurationPropertySource source, Function<String, RuntimeException> exceptionFunction);
+
+	/**
+	 * Get and transform the value of this configuration property, throwing an exception if the value is not present.
+	 * <p>
+	 * Any exception occurring during transformation will be wrapped in another exception adding some context,
+	 * such as the {@link #resolveOrRaw(ConfigurationPropertySource) resolved key} for this property.
+	 *
+	 * @param source A configuration source.
+	 * @param transform A transform function to be applied to the value of this configuration property
+	 * before returning the result.
+	 * @param exceptionFunction A function that will be called with the property key as a parameter
+	 * to create an exception if the value is missing.
+	 * @return The value of this property according to the given source.
+	 */
+	<R> R getAndMapOrThrow(ConfigurationPropertySource source, Function<T, R> transform,
+			Function<String, RuntimeException> exceptionFunction);
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/IndexManagerBuildingStateHolder.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/IndexManagerBuildingStateHolder.java
@@ -46,17 +46,19 @@ class IndexManagerBuildingStateHolder {
 	private static final OptionalConfigurationProperty<BeanReference<? extends BackendFactory>> BACKEND_TYPE =
 			ConfigurationProperty.forKey( "type" ).asBeanReference( BackendFactory.class ).build();
 
-	private final RootBuildContext rootBuildContext;
+	private final BeanProvider beanProvider;
 	private final ConfigurationPropertySource propertySource;
+	private final RootBuildContext rootBuildContext;
 	private final ConfigurationPropertySource defaultIndexPropertySource;
 
 	private final Map<String, BackendBuildingState<?>> backendBuildingStateByName = new HashMap<>();
 	private final Map<String, IndexManagerBuildingStateImpl<?>> indexManagerBuildingStateByName = new HashMap<>();
 
-	IndexManagerBuildingStateHolder(RootBuildContext rootBuildContext,
-			ConfigurationPropertySource propertySource) {
-		this.rootBuildContext = rootBuildContext;
+	IndexManagerBuildingStateHolder(BeanProvider beanProvider, ConfigurationPropertySource propertySource,
+			RootBuildContext rootBuildContext) {
+		this.beanProvider = beanProvider;
 		this.propertySource = propertySource;
+		this.rootBuildContext = rootBuildContext;
 		this.defaultIndexPropertySource = propertySource.withMask( "indexes.default" );
 	}
 
@@ -107,7 +109,6 @@ class IndexManagerBuildingStateHolder {
 
 	private BackendBuildingState<?> createBackend(String backendName) {
 		ConfigurationPropertySource backendPropertySource = propertySource.withMask( "backends." + backendName );
-		BeanProvider beanProvider = rootBuildContext.getServiceManager().getBeanProvider();
 		try ( BeanHolder<? extends BackendFactory> backendFactoryHolder =
 				BACKEND_TYPE.getAndMapOrThrow(
 						backendPropertySource,

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/SearchIntegrationBuilderImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/SearchIntegrationBuilderImpl.java
@@ -163,7 +163,7 @@ public class SearchIntegrationBuilderImpl implements SearchIntegrationBuilder {
 			ServiceManager serviceManager = new ServiceManagerImpl( classResolver, resourceResolver, beanProvider );
 			RootBuildContext rootBuildContext = new RootBuildContext( serviceManager, failureCollector );
 
-			indexManagerBuildingStateHolder = new IndexManagerBuildingStateHolder( rootBuildContext, propertySource );
+			indexManagerBuildingStateHolder = new IndexManagerBuildingStateHolder( beanProvider, propertySource, rootBuildContext );
 
 			// First phase: collect configuration for all mappings
 			for ( Map.Entry<MappingKey<?>, MappingInitiator<?, ?>> entry : mappingInitiators.entrySet() ) {

--- a/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
@@ -238,4 +238,16 @@ public interface Log extends BasicLogger {
 	SearchException invalidBeanType(
 			@FormatWith(ClassFormatter.class) Class<?> expectedSuperType,
 			@FormatWith(ClassFormatter.class) Class<?> actualType);
+
+	@Message(id = ID_OFFSET_2 + 49,
+			value = "Missing backend type for backend '%1$s'."
+					+ " Set the property '%2$s' to a supported value."
+	)
+	SearchException backendTypeCannotBeNullOrEmpty(String backendName, String key);
+
+	@Message(id = ID_OFFSET_2 + 50,
+			value = "Missing backend reference for index '%1$s'."
+					+ " Set the property '%2$s' to a supported value or set '%3$s' to set a default value for all indexes."
+	)
+	SearchException indexBackendCannotBeNullOrEmpty(String indexName, String key, String defaultKey);
 }

--- a/engine/src/test/java/org/hibernate/search/engine/cfg/spi/ConfigurationPropertyBeanReferenceTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/cfg/spi/ConfigurationPropertyBeanReferenceTest.java
@@ -19,6 +19,7 @@ import org.hibernate.search.engine.cfg.ConfigurationPropertySource;
 import org.hibernate.search.engine.environment.bean.BeanHolder;
 import org.hibernate.search.engine.environment.bean.BeanProvider;
 import org.hibernate.search.engine.environment.bean.BeanReference;
+import org.hibernate.search.engine.test.util.AbstractBeanProviderPartialMock;
 import org.hibernate.search.util.impl.test.SubTest;
 
 import org.junit.Test;
@@ -29,13 +30,7 @@ import org.easymock.EasyMockSupport;
 public class ConfigurationPropertyBeanReferenceTest extends EasyMockSupport {
 
 	private final ConfigurationPropertySource sourceMock = createMock( ConfigurationPropertySource.class );
-	/*
-	  * Use a partial mock, so that getBean(BeanReference) just uses its default implementation.
-	  *
-	  * Note we have to mock using an abstract class, otherwise we get an exception
-	  * with message "Partial mocking doesn't make sense for interface"
-	  */
-	private final BeanProvider beanProviderMock = partialMockBuilder( AbstractBeanProviderMock.class ).createMock();
+	private final BeanProvider beanProviderMock = partialMockBuilder( AbstractBeanProviderPartialMock.class ).createMock();
 
 	@Test
 	public void withDefault() {
@@ -374,6 +369,4 @@ public class ConfigurationPropertyBeanReferenceTest extends EasyMockSupport {
 	private class SimulatedFailure extends RuntimeException {
 	}
 
-	private abstract class AbstractBeanProviderMock implements BeanProvider {
-	}
 }

--- a/engine/src/test/java/org/hibernate/search/engine/cfg/spi/ConfigurationPropertyValidMissingValuesTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/cfg/spi/ConfigurationPropertyValidMissingValuesTest.java
@@ -1,0 +1,295 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.cfg.spi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+
+import org.hibernate.search.engine.cfg.ConfigurationPropertySource;
+import org.hibernate.search.util.impl.test.SubTest;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.easymock.EasyMock;
+import org.easymock.EasyMockSupport;
+
+@RunWith(Parameterized.class)
+// We have to use raw types to mock methods returning generic types with wildcards
+@SuppressWarnings({ "unchecked", "rawtypes" })
+public class ConfigurationPropertyValidMissingValuesTest<T> extends EasyMockSupport {
+
+	@Parameterized.Parameters(name = "{2}")
+	public static Object[][] data() {
+		return new Object[][] {
+				params( KeyContext::asString, "string", "string" ),
+				params( KeyContext::asInteger, "42", 42 ),
+				params( KeyContext::asLong, "3000000000042", 3000000000042L ),
+				params( KeyContext::asBoolean, "true", true ),
+				params( KeyContext::asBoolean, "false", false ),
+				params(
+						c -> c.as( MyPropertyType.class, MyPropertyType::new ),
+						"string", new MyPropertyType( "string" )
+				)
+		};
+	}
+
+	private static <T> Object[] params(Function<KeyContext, OptionalPropertyContext<T>> testedMethod,
+			String stringValue, T expectedValue) {
+		return new Object[] { testedMethod, stringValue, expectedValue };
+	}
+
+	private final Function<KeyContext, OptionalPropertyContext<T>> testedMethod;
+	private final String stringValue;
+	private final T expectedValue;
+
+	private final ConfigurationPropertySource sourceMock = createMock( ConfigurationPropertySource.class );
+
+	public ConfigurationPropertyValidMissingValuesTest(Function<KeyContext, OptionalPropertyContext<T>> testedMethod,
+			String stringValue, T expectedValue) {
+		this.testedMethod = testedMethod;
+		this.stringValue = stringValue;
+		this.expectedValue = expectedValue;
+	}
+
+	@Test
+	public void withDefault() {
+		String key = "withDefault";
+		ConfigurationProperty<T> property =
+				testedMethod.apply(
+						ConfigurationProperty.forKey( key )
+				)
+						.withDefault( expectedValue )
+						.build();
+
+		T result;
+
+		// No value
+		resetAll();
+		EasyMock.expect( sourceMock.get( key ) ).andReturn( Optional.empty() );
+		replayAll();
+		result = property.get( sourceMock );
+		verifyAll();
+		assertThat( result ).isEqualTo( expectedValue );
+
+		// String value
+		resetAll();
+		EasyMock.expect( sourceMock.get( key ) ).andReturn( (Optional) Optional.of( stringValue ) );
+		replayAll();
+		result = property.get( sourceMock );
+		verifyAll();
+		assertThat( result ).isEqualTo( expectedValue );
+
+		// Typed value
+		resetAll();
+		EasyMock.expect( sourceMock.get( key ) ).andReturn( (Optional) Optional.of( expectedValue ) );
+		replayAll();
+		result = property.get( sourceMock );
+		verifyAll();
+		assertThat( result ).isEqualTo( expectedValue );
+	}
+
+	@Test
+	public void withoutDefault() {
+		String key = "withoutDefault";
+		ConfigurationProperty<Optional<T>> property =
+				testedMethod.apply(
+						ConfigurationProperty.forKey( key )
+				)
+						.build();
+
+		Optional<T> result;
+
+		// No value
+		resetAll();
+		EasyMock.expect( sourceMock.get( key ) ).andReturn( Optional.empty() );
+		replayAll();
+		result = property.get( sourceMock );
+		verifyAll();
+		assertThat( result ).isEmpty();
+
+		// String value
+		resetAll();
+		EasyMock.expect( sourceMock.get( key ) ).andReturn( (Optional) Optional.of( stringValue ) );
+		replayAll();
+		result = property.get( sourceMock );
+		verifyAll();
+		assertThat( result ).isNotEmpty();
+		assertThat( result.get() ).isEqualTo( expectedValue );
+
+		// Typed value
+		resetAll();
+		EasyMock.expect( sourceMock.get( key ) ).andReturn( (Optional) Optional.of( expectedValue ) );
+		replayAll();
+		result = property.get( sourceMock );
+		verifyAll();
+		assertThat( result ).isNotEmpty();
+		assertThat( result.get() ).isEqualTo( expectedValue );
+	}
+
+	@Test
+	public void withoutDefault_getOrThrow() {
+		String key = "withoutDefault_getOrThrow";
+		String resolvedKey = "some.prefix." + key;
+		OptionalConfigurationProperty<T> property =
+				testedMethod.apply(
+						ConfigurationProperty.forKey( key )
+				)
+						.build();
+
+		// No value -> exception
+		resetAll();
+		EasyMock.expect( sourceMock.get( key ) ).andReturn( Optional.empty() );
+		EasyMock.expect( sourceMock.resolve( key ) ).andReturn( Optional.of( resolvedKey ) );
+		replayAll();
+		SubTest.expectException( () -> property.getOrThrow( sourceMock, SimulatedFailure::new ) )
+				.assertThrown()
+				.isInstanceOf( SimulatedFailure.class )
+				.hasMessage( resolvedKey );
+		verifyAll();
+
+		// Valid value -> no exception
+		resetAll();
+		EasyMock.expect( sourceMock.get( key ) ).andReturn( (Optional) Optional.of( expectedValue ) );
+		replayAll();
+		T result = property.getOrThrow( sourceMock, SimulatedFailure::new );
+		verifyAll();
+		assertThat( result ).isEqualTo( expectedValue );
+	}
+
+	@Test
+	public void blankCharacters() {
+		String key = "extraBlankCharacters";
+		ConfigurationProperty<T> property =
+				testedMethod.apply(
+						ConfigurationProperty.forKey( key )
+				)
+						.withDefault( expectedValue )
+						.build();
+
+		T result;
+
+		// Empty string value
+		resetAll();
+		EasyMock.expect( sourceMock.get( key ) ).andReturn( (Optional) Optional.of( "" ) );
+		replayAll();
+		result = property.get( sourceMock );
+		verifyAll();
+		assertThat( result ).isEqualTo( expectedValue );
+
+		// Blank string value
+		resetAll();
+		EasyMock.expect( sourceMock.get( key ) ).andReturn( (Optional) Optional.of( "    " ) );
+		replayAll();
+		result = property.get( sourceMock );
+		verifyAll();
+		assertThat( result ).isEqualTo( expectedValue );
+
+		// String value with extra blank characters
+		resetAll();
+		EasyMock.expect( sourceMock.get( key ) ).andReturn( (Optional) Optional.of( "   " + stringValue + "   " ) );
+		replayAll();
+		result = property.get( sourceMock );
+		verifyAll();
+		assertThat( result ).isEqualTo( expectedValue );
+	}
+
+	@Test
+	public void multiValued() {
+		String key = "multiValued";
+		ConfigurationProperty<Optional<List<T>>> property =
+				testedMethod.apply(
+						ConfigurationProperty.forKey( key )
+				)
+						.multivalued( Pattern.compile( " " ) )
+						.build();
+
+		Optional<List<T>> result;
+
+		// String value - one
+		resetAll();
+		EasyMock.expect( sourceMock.get( key ) ).andReturn( (Optional) Optional.of( stringValue ) );
+		replayAll();
+		result = property.get( sourceMock );
+		verifyAll();
+		assertThat( result ).isNotEmpty();
+		assertThat( result.get() ).containsExactly( expectedValue );
+
+		// String value - multiple
+		resetAll();
+		EasyMock.expect( sourceMock.get( key ) ).andReturn( (Optional) Optional.of( stringValue + " " + stringValue ) );
+		replayAll();
+		result = property.get( sourceMock );
+		verifyAll();
+		assertThat( result ).isNotEmpty();
+		assertThat( result.get() ).containsExactly( expectedValue, expectedValue );
+
+		// Typed value - one
+		resetAll();
+		EasyMock.expect( sourceMock.get( key ) ).andReturn( (Optional) Optional.of( createCollection( expectedValue ) ) );
+		replayAll();
+		result = property.get( sourceMock );
+		verifyAll();
+		assertThat( result ).isNotEmpty();
+		assertThat( result.get() ).containsExactly( expectedValue );
+
+		// Typed value - multiple
+		resetAll();
+		EasyMock.expect( sourceMock.get( key ) ).andReturn( (Optional) Optional.of( createCollection( expectedValue, expectedValue ) ) );
+		replayAll();
+		result = property.get( sourceMock );
+		verifyAll();
+		assertThat( result ).isNotEmpty();
+		assertThat( result.get() ).containsExactly( expectedValue );
+	}
+
+	@SafeVarargs
+	private static <T> Collection<T> createCollection(T... values) {
+		// Don't create a List, that would be too easy.
+		Collection<T> collection = new LinkedHashSet<>();
+		Collections.addAll( collection, values );
+		return collection;
+	}
+
+	private static class MyPropertyType {
+		private final String value;
+
+		private MyPropertyType(String value) {
+			this.value = value;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if ( obj == null || getClass() != obj.getClass() ) {
+				return false;
+			}
+			MyPropertyType other = (MyPropertyType) obj;
+			return Objects.equals( value, other.value );
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( value );
+		}
+	}
+
+	private static class SimulatedFailure extends RuntimeException {
+		SimulatedFailure(String message) {
+			super( message );
+		}
+	}
+
+}

--- a/engine/src/test/java/org/hibernate/search/engine/common/impl/IndexManagerBuildingStateHolderTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/common/impl/IndexManagerBuildingStateHolderTest.java
@@ -1,0 +1,118 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.common.impl;
+
+import java.util.Optional;
+
+import org.hibernate.search.engine.cfg.ConfigurationPropertySource;
+import org.hibernate.search.engine.environment.bean.BeanProvider;
+import org.hibernate.search.engine.test.util.AbstractBeanProviderPartialMock;
+import org.hibernate.search.engine.test.util.AbstractConfigurationPropertySourcePartialMock;
+import org.hibernate.search.util.SearchException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.easymock.EasyMock;
+import org.easymock.EasyMockSupport;
+
+// We have to use raw types to mock methods returning generic types with wildcards
+@SuppressWarnings({ "unchecked", "rawtypes" })
+public class IndexManagerBuildingStateHolderTest extends EasyMockSupport {
+
+	@Rule
+	public final ExpectedException thrown = ExpectedException.none();
+
+	private RootBuildContext rootBuildContextMock = createMock( RootBuildContext.class );
+	private ConfigurationPropertySource configurationSourceMock =
+			partialMockBuilder( AbstractConfigurationPropertySourcePartialMock.class ).mock();
+	private BeanProvider beanProviderMock =
+			partialMockBuilder( AbstractBeanProviderPartialMock.class ).mock();
+
+	private IndexManagerBuildingStateHolder holder =
+			new IndexManagerBuildingStateHolder( beanProviderMock, configurationSourceMock, rootBuildContextMock );
+
+	@Test
+	public void error_missingIndexBackend_emptyOptional() {
+		String keyPrefix = "somePrefix.";
+		resetAll();
+		EasyMock.expect( configurationSourceMock.get( "indexes.indexName.backend" ) )
+				.andReturn( Optional.empty() );
+		EasyMock.expect( configurationSourceMock.resolve( "indexes.indexName.backend" ) )
+				.andReturn( Optional.of( keyPrefix + "indexes.indexName.backend" ) );
+		EasyMock.expect( configurationSourceMock.get( "indexes.default.backend" ) )
+				.andReturn( Optional.empty() );
+		EasyMock.expect( configurationSourceMock.resolve( "indexes.default.backend" ) )
+				.andReturn( Optional.of( keyPrefix + "indexes.default.backend" ) );
+		replayAll();
+		thrown.expect( SearchException.class );
+		thrown.expectMessage( "Missing backend reference for index 'indexName'" );
+		thrown.expectMessage( "Set the property 'somePrefix.indexes.indexName.backend' to a supported value" );
+		thrown.expectMessage( "or set 'somePrefix.indexes.default.backend' to set a default value for all indexes" );
+		holder.startBuilding( "indexName", false );
+		verifyAll();
+	}
+
+	@Test
+	public void error_missingIndexBackend_emptyString() {
+		String keyPrefix = "somePrefix.";
+		resetAll();
+		EasyMock.expect( configurationSourceMock.get( "indexes.indexName.backend" ) )
+				.andReturn( (Optional) Optional.of( "" ) );
+		EasyMock.expect( configurationSourceMock.resolve( "indexes.indexName.backend" ) )
+				.andReturn( Optional.of( keyPrefix + "indexes.indexName.backend" ) );
+		EasyMock.expect( configurationSourceMock.get( "indexes.default.backend" ) )
+				.andReturn( (Optional) Optional.of( "" ) );
+		EasyMock.expect( configurationSourceMock.resolve( "indexes.default.backend" ) )
+				.andReturn( Optional.of( keyPrefix + "indexes.default.backend" ) );
+		replayAll();
+		thrown.expect( SearchException.class );
+		thrown.expectMessage( "Missing backend reference for index 'indexName'" );
+		thrown.expectMessage( "Set the property 'somePrefix.indexes.indexName.backend' to a supported value" );
+		thrown.expectMessage( "or set 'somePrefix.indexes.default.backend' to set a default value for all indexes" );
+		holder.startBuilding( "indexName", false );
+		verifyAll();
+	}
+
+	@Test
+	public void error_missingBackendType_emptyOptional() {
+		String keyPrefix = "somePrefix.";
+		resetAll();
+		EasyMock.expect( configurationSourceMock.get( "indexes.indexName.backend" ) )
+				.andReturn( (Optional) Optional.of( "backendName" ) );
+		EasyMock.expect( configurationSourceMock.get( "backends.backendName.type" ) )
+				.andReturn( Optional.empty() );
+		EasyMock.expect( configurationSourceMock.resolve( "backends.backendName.type" ) )
+				.andReturn( Optional.of( keyPrefix + "backends.backendName.type" ) );
+		replayAll();
+		thrown.expect( SearchException.class );
+		thrown.expectMessage( "Missing backend type for backend 'backendName'" );
+		thrown.expectMessage( "Set the property 'somePrefix.backends.backendName.type' to a supported value" );
+		holder.startBuilding( "indexName", false );
+		verifyAll();
+	}
+
+	@Test
+	public void error_missingBackendType_emptyString() {
+		String keyPrefix = "somePrefix.";
+		resetAll();
+		EasyMock.expect( configurationSourceMock.get( "indexes.indexName.backend" ) )
+				.andReturn( (Optional) Optional.of( "backendName" ) );
+		EasyMock.expect( configurationSourceMock.get( "backends.backendName.type" ) )
+				.andReturn( (Optional) Optional.of( "" ) );
+		EasyMock.expect( configurationSourceMock.resolve( "backends.backendName.type" ) )
+				.andReturn( Optional.of( keyPrefix + "backends.backendName.type" ) );
+		replayAll();
+		thrown.expect( SearchException.class );
+		thrown.expectMessage( "Missing backend type for backend 'backendName'" );
+		thrown.expectMessage( "Set the property 'somePrefix.backends.backendName.type' to a supported value" );
+		holder.startBuilding( "indexName", false );
+		verifyAll();
+	}
+
+}

--- a/engine/src/test/java/org/hibernate/search/engine/test/util/AbstractBeanProviderPartialMock.java
+++ b/engine/src/test/java/org/hibernate/search/engine/test/util/AbstractBeanProviderPartialMock.java
@@ -1,0 +1,18 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.test.util;
+
+import org.hibernate.search.engine.environment.bean.BeanProvider;
+
+/**
+ * Used for partial mocks, to benefit from default methods and mock the rest.
+ * <p>
+ * We have to base partial mocks on an abstract class,
+ * otherwise we get an exception with message "Partial mocking doesn't make sense for interface"
+ */
+public abstract class AbstractBeanProviderPartialMock implements BeanProvider {
+}

--- a/engine/src/test/java/org/hibernate/search/engine/test/util/AbstractConfigurationPropertySourcePartialMock.java
+++ b/engine/src/test/java/org/hibernate/search/engine/test/util/AbstractConfigurationPropertySourcePartialMock.java
@@ -1,0 +1,17 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.test.util;
+
+import org.hibernate.search.engine.cfg.ConfigurationPropertySource;
+
+/**
+ * Used for partial mocks, to benefit from default methods and mock the rest.
+ *
+ * @see AbstractBeanProviderPartialMock
+ */
+public abstract class AbstractConfigurationPropertySourcePartialMock implements ConfigurationPropertySource {
+}


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3442

~Based on #1828 which should be merged first.~ => Done

@fax4ever As discussed, this could be a nice start if you want to review PRs on Search. Just mind the fact that the first commits are from another PRs and should not be considered.