### PR TITLE
HSEARCH-3351 follow-up: use executeCount() in mass indexing tests + fix a potential bug

### DIFF
--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQuery.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQuery.java
@@ -85,7 +85,7 @@ public class LuceneSearchQuery<T> implements SearchQuery<T> {
 	@Override
 	public long executeCount() {
 		LuceneQueryWork<SearchResult<T>> work = workFactory.search( new LuceneSearcher<>(
-				indexNames, readerProviders, luceneQuery, luceneSort, firstResultIndex, 0L,
+				indexNames, readerProviders, luceneQuery, luceneSort, 0L, 0L,
 				// do not add any TopDocs collector
 				( luceneCollectorBuilder -> { } ),
 				searchResultExtractor

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/SearchResultLoadingOrTransformingIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/SearchResultLoadingOrTransformingIT.java
@@ -343,6 +343,19 @@ public class SearchResultLoadingOrTransformingIT {
 				.build();
 
 		assertEquals( 1L, query.executeCount() );
+
+		// Using setFirstResult/setMaxResult should not affect the count
+		query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.matchAll().toPredicate() )
+				.build();
+
+		query.setFirstResult( 1L );
+		assertEquals( 2L, query.executeCount() );
+
+		query.setFirstResult( 0L );
+		query.setMaxResults( 1L );
+		assertEquals( 2L, query.executeCount() );
 	}
 
 	@Test

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexDocumentWorkExecutorIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexDocumentWorkExecutorIT.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.integrationtest.backend.tck.work;
 
-import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
 import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
 
 import java.util.concurrent.CompletableFuture;
@@ -25,13 +24,15 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import org.assertj.core.api.Assertions;
+
 /**
  * Verify that the {@link IndexDocumentWorkExecutor}, provided by a backend, is working properly, storing correctly the indexes.
  */
 public class IndexDocumentWorkExecutorIT {
 
 	private static final String INDEX_NAME = "lordOfTheRingsChapters";
-	public static final int NUMBER_OF_BOOKS = 200;
+	private static final int NUMBER_OF_BOOKS = 200;
 
 	@Rule
 	public SearchSetupHelper setupHelper = new SearchSetupHelper();
@@ -71,7 +72,7 @@ public class IndexDocumentWorkExecutorIT {
 				.predicate( f -> f.matchAll().toPredicate() )
 				.build();
 
-		assertThat( query ).hasHitCount( NUMBER_OF_BOOKS );
+		Assertions.assertThat( query.executeCount() ).isEqualTo( NUMBER_OF_BOOKS );
 	}
 
 	private static class IndexAccessors {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkExecutorIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkExecutorIT.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.integrationtest.backend.tck.work;
 
-import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
 import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
 
 import java.util.concurrent.CompletableFuture;
@@ -25,6 +24,8 @@ import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMap
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import org.assertj.core.api.Assertions;
 
 /**
  * Verify that the work executor operations:
@@ -123,13 +124,13 @@ public class IndexWorkExecutorIT {
 		CompletableFuture.allOf( tasks ).join();
 	}
 
-	private void assertBookNumberIsEqualsTo(Integer bookNumber, StubSessionContext sessionContext) {
+	private void assertBookNumberIsEqualsTo(long bookNumber, StubSessionContext sessionContext) {
 		SearchQuery<DocumentReference> query = indexManager.createSearchTarget().query( sessionContext )
 				.asReference()
 				.predicate( f -> f.matchAll().toPredicate() )
 				.build();
 
-		assertThat( query ).hasHitCount( bookNumber );
+		Assertions.assertThat( query.executeCount() ).isEqualTo( bookNumber );
 	}
 
 	private static class IndexAccessors {

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/dao/DocumentDao.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/dao/DocumentDao.java
@@ -81,6 +81,8 @@ public abstract class DocumentDao {
 
 	public abstract Optional<Book> getByIsbn(String isbnAsString);
 
+	public abstract long count();
+
 	public abstract List<Book> searchByMedium(String terms, BookMedium medium, int offset, int limit);
 
 	public abstract List<Document<?>> searchAroundMe(String terms, String tags,

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/dao/syntax/lambda/LambdaSyntaxDocumentDao.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/dao/syntax/lambda/LambdaSyntaxDocumentDao.java
@@ -46,6 +46,19 @@ class LambdaSyntaxDocumentDao extends DocumentDao {
 	}
 
 	@Override
+	public long count() {
+		FullTextSession fullTextSession = entityManager.unwrap( FullTextSession.class );
+
+		FullTextQuery<Book> query =
+				fullTextSession.search( Book.class ).query()
+						.asEntity()
+						.predicate( f -> f.matchAll().toPredicate() )
+						.build();
+
+		return query.getResultSize();
+	}
+
+	@Override
 	public List<Book> searchByMedium(String terms, BookMedium medium, int offset, int limit) {
 		FullTextQuery<Book> query = entityManager.search( Book.class ).query()
 				.asEntity()

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/dao/syntax/object/ObjectSyntaxDocumentDao.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/dao/syntax/object/ObjectSyntaxDocumentDao.java
@@ -52,6 +52,20 @@ class ObjectSyntaxDocumentDao extends DocumentDao {
 	}
 
 	@Override
+	public long count() {
+		FullTextSession fullTextSession = entityManager.unwrap( FullTextSession.class );
+
+		FullTextSearchTarget<Book> target = fullTextSession.search( Book.class );
+
+		FullTextQuery<Book> query = target.query()
+						.asEntity()
+						.predicate( target.predicate().matchAll().toPredicate() )
+						.build();
+
+		return query.getResultSize();
+	}
+
+	@Override
 	public List<Book> searchByMedium(String terms, BookMedium medium, int offset, int limit) {
 		FullTextSearchTarget<Book> target = entityManager.search( Book.class );
 		BooleanJunctionPredicateContext booleanBuilder = target.predicate().bool();

--- a/integrationtest/showcase/library/src/test/java/org/hibernate/search/integrationtest/showcase/ManualIndexingIT.java
+++ b/integrationtest/showcase/library/src/test/java/org/hibernate/search/integrationtest/showcase/ManualIndexingIT.java
@@ -152,12 +152,13 @@ public class ManualIndexingIT {
 		assertThat( books ).hasSize( 0 );
 	}
 
-	public void checkEverythingIsIndexed(Session session) {
+	private void checkEverythingIsIndexed(Session session) {
 		DocumentDao dao = daoFactory.createDocumentDao( session );
+
+		assertThat( dao.count() ).isEqualTo( NUMBER_OF_BOOKS );
 
 		Optional<Book> book = dao.getByIsbn( "973-0-00-000007-3" );
 		assertTrue( book.isPresent() );
 		assertThat( book.get() ).isEqualTo( session.get( Book.class, 7 ) );
-		// TODO HSEARCH-3351 Use getResultSize() to fetch the total number of indexed documents and check that it's equal to NUMBER_OF_BOOKS
 	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3351

@fax4ever I noticed that just after merging... See anything wrong with it?

Waiting for CI, I didn't run all the tests locally.