### PR TITLE
HSEARCH-3086 Search 6 groundwork - Add the missing non-field projections compared to Search 5

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchBackendFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchBackendFactory.java
@@ -46,6 +46,7 @@ import org.hibernate.search.util.EventContext;
 import org.hibernate.search.util.impl.common.LoggerFactory;
 import org.hibernate.search.util.impl.common.SuppressingCloser;
 
+import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 
@@ -100,6 +101,8 @@ public class ElasticsearchBackendFactory implements BackendFactory {
 					DefaultGsonProvider.create( this::createES5GsonBuilderBase, logPrettyPrinting );
 			client.init( dialectSpecificGsonProvider );
 
+			Gson userFacingGson = new Gson();
+
 			MultiTenancyStrategy multiTenancyStrategy = getMultiTenancyStrategy( name, propertySource );
 			ElasticsearchWorkFactory workFactory = new ElasticsearchStubWorkFactory( dialectSpecificGsonProvider, multiTenancyStrategy );
 
@@ -107,7 +110,7 @@ public class ElasticsearchBackendFactory implements BackendFactory {
 					getAnalysisDefinitionRegistry( backendContext, buildContext, propertySource );
 
 			return new ElasticsearchBackendImpl(
-					client, name, workFactory,
+					client, name, workFactory, userFacingGson,
 					analysisDefinitionRegistry,
 					multiTenancyStrategy
 			);

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchBackendFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchBackendFactory.java
@@ -101,7 +101,7 @@ public class ElasticsearchBackendFactory implements BackendFactory {
 					DefaultGsonProvider.create( this::createES5GsonBuilderBase, logPrettyPrinting );
 			client.init( dialectSpecificGsonProvider );
 
-			Gson userFacingGson = new Gson();
+			Gson userFacingGson = new GsonBuilder().setPrettyPrinting().create();
 
 			MultiTenancyStrategy multiTenancyStrategy = getMultiTenancyStrategy( name, propertySource );
 			ElasticsearchWorkFactory workFactory = new ElasticsearchStubWorkFactory( dialectSpecificGsonProvider, multiTenancyStrategy );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchBackendImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchBackendImpl.java
@@ -36,6 +36,8 @@ import org.hibernate.search.engine.logging.spi.EventContexts;
 import org.hibernate.search.util.impl.common.Closer;
 import org.hibernate.search.util.impl.common.LoggerFactory;
 
+import com.google.gson.Gson;
+
 
 /**
  * @author Yoann Rodiere
@@ -63,6 +65,7 @@ class ElasticsearchBackendImpl implements BackendImplementor<ElasticsearchDocume
 	private final SearchBackendContext searchContext;
 
 	ElasticsearchBackendImpl(ElasticsearchClientImplementor client, String name, ElasticsearchWorkFactory workFactory,
+			Gson userFacingGson,
 			ElasticsearchAnalysisDefinitionRegistry analysisDefinitionRegistry,
 			MultiTenancyStrategy multiTenancyStrategy) {
 		this.client = client;
@@ -77,7 +80,7 @@ class ElasticsearchBackendImpl implements BackendImplementor<ElasticsearchDocume
 				eventContext, client, workFactory, multiTenancyStrategy, streamOrchestrator
 		);
 		this.searchContext = new SearchBackendContext(
-				eventContext, workFactory,
+				eventContext, workFactory, userFacingGson,
 				new Function<String, String>() {
 					@Override
 					public String apply(String elasticsearchIndexName) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/projection/ElasticsearchSearchProjectionFactoryContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/projection/ElasticsearchSearchProjectionFactoryContext.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.backend.elasticsearch.search.dsl.projection;
 
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContext;
+import org.hibernate.search.engine.search.dsl.projection.SearchProjectionTerminalContext;
 
 /**
  * A DSL context allowing to create a projection, with some Elasticsearch-specific methods.
@@ -16,4 +17,11 @@ import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactory
  * @see SearchProjectionFactoryContext
  */
 public interface ElasticsearchSearchProjectionFactoryContext<R, O> extends SearchProjectionFactoryContext<R, O> {
+
+	/**
+	 * Project to a string representing the JSON document as stored in Elasticsearch.
+	 * @return A context allowing to define the projection more precisely.
+	 */
+	SearchProjectionTerminalContext<String> source();
+
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/projection/ElasticsearchSearchProjectionFactoryContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/projection/ElasticsearchSearchProjectionFactoryContext.java
@@ -1,0 +1,19 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.search.dsl.projection;
+
+import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContext;
+
+/**
+ * A DSL context allowing to create a projection, with some Elasticsearch-specific methods.
+ *
+ * @param <R> The type of references.
+ * @param <O> The type of loaded objects.
+ * @see SearchProjectionFactoryContext
+ */
+public interface ElasticsearchSearchProjectionFactoryContext<R, O> extends SearchProjectionFactoryContext<R, O> {
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/projection/ElasticsearchSearchProjectionFactoryContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/projection/ElasticsearchSearchProjectionFactoryContext.java
@@ -24,4 +24,14 @@ public interface ElasticsearchSearchProjectionFactoryContext<R, O> extends Searc
 	 */
 	SearchProjectionTerminalContext<String> source();
 
+	/**
+	 * Project to a string representing a JSON object describing the score computation for the hit.
+	 * <p>
+	 * This feature is relatively expensive, do not use unless you return a limited
+	 * amount of objects (using pagination).
+	 *
+	 * @return A context allowing to define the projection more precisely.
+	 */
+	SearchProjectionTerminalContext<String> explanation();
+
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/projection/impl/ElasticsearchExplanationProjectionContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/projection/impl/ElasticsearchExplanationProjectionContext.java
@@ -1,0 +1,25 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.search.dsl.projection.impl;
+
+import org.hibernate.search.backend.elasticsearch.search.projection.impl.ElasticsearchSearchProjectionBuilderFactory;
+import org.hibernate.search.engine.search.SearchProjection;
+import org.hibernate.search.engine.search.dsl.projection.SearchProjectionTerminalContext;
+import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilder;
+
+public class ElasticsearchExplanationProjectionContext implements SearchProjectionTerminalContext<String> {
+	private final SearchProjectionBuilder<String> builder;
+
+	ElasticsearchExplanationProjectionContext(ElasticsearchSearchProjectionBuilderFactory factory) {
+		this.builder = factory.explanation();
+	}
+
+	@Override
+	public SearchProjection<String> toProjection() {
+		return builder.build();
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/projection/impl/ElasticsearchSearchProjectionFactoryContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/projection/impl/ElasticsearchSearchProjectionFactoryContextImpl.java
@@ -9,6 +9,7 @@ package org.hibernate.search.backend.elasticsearch.search.dsl.projection.impl;
 import org.hibernate.search.backend.elasticsearch.search.dsl.projection.ElasticsearchSearchProjectionFactoryContext;
 import org.hibernate.search.backend.elasticsearch.search.projection.impl.ElasticsearchSearchProjectionBuilderFactory;
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContext;
+import org.hibernate.search.engine.search.dsl.projection.SearchProjectionTerminalContext;
 import org.hibernate.search.engine.search.dsl.projection.spi.DelegatingSearchProjectionFactoryContext;
 
 public class ElasticsearchSearchProjectionFactoryContextImpl<R, O>
@@ -21,5 +22,10 @@ public class ElasticsearchSearchProjectionFactoryContextImpl<R, O>
 			ElasticsearchSearchProjectionBuilderFactory factory) {
 		super( delegate );
 		this.factory = factory;
+	}
+
+	@Override
+	public SearchProjectionTerminalContext<String> source() {
+		return new ElasticsearchSourceProjectionContext( factory );
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/projection/impl/ElasticsearchSearchProjectionFactoryContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/projection/impl/ElasticsearchSearchProjectionFactoryContextImpl.java
@@ -1,0 +1,25 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.search.dsl.projection.impl;
+
+import org.hibernate.search.backend.elasticsearch.search.dsl.projection.ElasticsearchSearchProjectionFactoryContext;
+import org.hibernate.search.backend.elasticsearch.search.projection.impl.ElasticsearchSearchProjectionBuilderFactory;
+import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContext;
+import org.hibernate.search.engine.search.dsl.projection.spi.DelegatingSearchProjectionFactoryContext;
+
+public class ElasticsearchSearchProjectionFactoryContextImpl<R, O>
+		extends DelegatingSearchProjectionFactoryContext<R, O>
+		implements ElasticsearchSearchProjectionFactoryContext<R, O> {
+
+	private final ElasticsearchSearchProjectionBuilderFactory factory;
+
+	public ElasticsearchSearchProjectionFactoryContextImpl(SearchProjectionFactoryContext<R, O> delegate,
+			ElasticsearchSearchProjectionBuilderFactory factory) {
+		super( delegate );
+		this.factory = factory;
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/projection/impl/ElasticsearchSearchProjectionFactoryContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/projection/impl/ElasticsearchSearchProjectionFactoryContextImpl.java
@@ -28,4 +28,9 @@ public class ElasticsearchSearchProjectionFactoryContextImpl<R, O>
 	public SearchProjectionTerminalContext<String> source() {
 		return new ElasticsearchSourceProjectionContext( factory );
 	}
+
+	@Override
+	public SearchProjectionTerminalContext<String> explanation() {
+		return new ElasticsearchExplanationProjectionContext( factory );
+	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/projection/impl/ElasticsearchSourceProjectionContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/projection/impl/ElasticsearchSourceProjectionContext.java
@@ -1,0 +1,25 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.search.dsl.projection.impl;
+
+import org.hibernate.search.backend.elasticsearch.search.projection.impl.ElasticsearchSearchProjectionBuilderFactory;
+import org.hibernate.search.engine.search.SearchProjection;
+import org.hibernate.search.engine.search.dsl.projection.SearchProjectionTerminalContext;
+import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilder;
+
+public class ElasticsearchSourceProjectionContext implements SearchProjectionTerminalContext<String> {
+	private final SearchProjectionBuilder<String> builder;
+
+	ElasticsearchSourceProjectionContext(ElasticsearchSearchProjectionBuilderFactory factory) {
+		this.builder = factory.source();
+	}
+
+	@Override
+	public SearchProjection<String> toProjection() {
+		return builder.build();
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/impl/ElasticsearchSearchContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/impl/ElasticsearchSearchContext.java
@@ -12,15 +12,20 @@ import org.hibernate.search.engine.backend.document.converter.runtime.spi.ToDocu
 import org.hibernate.search.engine.backend.document.converter.runtime.spi.ToDocumentIdentifierValueConvertContextImpl;
 import org.hibernate.search.engine.mapper.mapping.context.spi.MappingContextImplementor;
 
+import com.google.gson.Gson;
+
 public final class ElasticsearchSearchContext {
 
 	private final ToDocumentIdentifierValueConvertContext toDocumentIdentifierValueConvertContext;
 
 	private final ToDocumentFieldValueConvertContext toDocumentFieldValueConvertContext;
 
-	public ElasticsearchSearchContext(MappingContextImplementor mappingContext) {
+	private final Gson userFacingGson;
+
+	public ElasticsearchSearchContext(MappingContextImplementor mappingContext, Gson userFacingGson) {
 		this.toDocumentIdentifierValueConvertContext = new ToDocumentIdentifierValueConvertContextImpl( mappingContext );
 		this.toDocumentFieldValueConvertContext = new ToDocumentFieldValueConvertContextImpl( mappingContext );
+		this.userFacingGson = userFacingGson;
 	}
 
 	public ToDocumentIdentifierValueConvertContext getToDocumentIdentifierValueConvertContext() {
@@ -29,5 +34,9 @@ public final class ElasticsearchSearchContext {
 
 	public ToDocumentFieldValueConvertContext getToDocumentFieldValueConvertContext() {
 		return toDocumentFieldValueConvertContext;
+	}
+
+	public Gson getUserFacingGson() {
+		return userFacingGson;
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchSearchPredicateBuilderFactoryImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchSearchPredicateBuilderFactoryImpl.java
@@ -28,8 +28,6 @@ import org.hibernate.search.util.EventContext;
 import org.hibernate.search.util.SearchException;
 import org.hibernate.search.util.impl.common.LoggerFactory;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 
 /**
@@ -39,8 +37,6 @@ import com.google.gson.JsonObject;
 public class ElasticsearchSearchPredicateBuilderFactoryImpl implements ElasticsearchSearchPredicateBuilderFactory {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
-
-	private static final Gson GSON = new GsonBuilder().create();
 
 	private static final PredicateBuilderFactoryRetrievalStrategy PREDICATE_BUILDER_FACTORY_RETRIEVAL_STRATEGY =
 			new PredicateBuilderFactoryRetrievalStrategy();
@@ -135,7 +131,9 @@ public class ElasticsearchSearchPredicateBuilderFactoryImpl implements Elasticse
 
 	@Override
 	public ElasticsearchSearchPredicateBuilder fromJsonString(String jsonString) {
-		return new ElasticsearchUserProvidedJsonPredicateContributor( GSON.fromJson( jsonString, JsonObject.class ) );
+		return new ElasticsearchUserProvidedJsonPredicateContributor(
+				searchContext.getUserFacingGson().fromJson( jsonString, JsonObject.class )
+		);
 	}
 
 	private static class PredicateBuilderFactoryRetrievalStrategy

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchExplanationProjection.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchExplanationProjection.java
@@ -1,0 +1,51 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.search.projection.impl;
+
+import org.hibernate.search.backend.elasticsearch.gson.impl.JsonAccessor;
+import org.hibernate.search.backend.elasticsearch.gson.impl.JsonObjectAccessor;
+import org.hibernate.search.engine.search.query.spi.LoadingResult;
+import org.hibernate.search.engine.search.query.spi.ProjectionHitMapper;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+class ElasticsearchExplanationProjection implements ElasticsearchSearchProjection<String, String> {
+
+	private static final JsonAccessor<Boolean> REQUEST_EXPLAIN_ACCESSOR = JsonAccessor.root().property( "explain" ).asBoolean();
+	private static final JsonObjectAccessor HIT_EXPLANATION_ACCESSOR = JsonAccessor.root().property( "_explanation" ).asObject();
+
+	private final Gson gson;
+
+	ElasticsearchExplanationProjection(Gson gson) {
+		this.gson = gson;
+	}
+
+	@Override
+	public void contributeRequest(JsonObject requestBody, SearchProjectionExecutionContext searchProjectionExecutionContext) {
+		REQUEST_EXPLAIN_ACCESSOR.set( requestBody, true );
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public String extract(ProjectionHitMapper<?, ?> projectionHitMapper, JsonObject responseBody, JsonObject hit,
+			SearchProjectionExecutionContext searchProjectionExecutionContext) {
+		// We expect the optional to always be non-empty.
+		return gson.toJson( HIT_EXPLANATION_ACCESSOR.get( hit ).get() );
+	}
+
+	@Override
+	public String transform(LoadingResult<?> loadingResult, String extractedData) {
+		return extractedData;
+	}
+
+	@Override
+	public String toString() {
+		return getClass().getSimpleName();
+	}
+
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchExplanationProjectionBuilder.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchExplanationProjectionBuilder.java
@@ -1,0 +1,27 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.search.projection.impl;
+
+import org.hibernate.search.engine.search.SearchProjection;
+import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilder;
+
+import com.google.gson.Gson;
+
+
+class ElasticsearchExplanationProjectionBuilder implements SearchProjectionBuilder<String> {
+
+	private final ElasticsearchExplanationProjection projection;
+
+	ElasticsearchExplanationProjectionBuilder(Gson gson) {
+		this.projection = new ElasticsearchExplanationProjection( gson );
+	}
+
+	@Override
+	public SearchProjection<String> build() {
+		return projection;
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchSearchProjectionBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchSearchProjectionBuilderFactory.java
@@ -25,6 +25,7 @@ import org.hibernate.search.engine.search.projection.spi.FieldProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.ObjectProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.ReferenceProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.ScoreProjectionBuilder;
+import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilderFactory;
 import org.hibernate.search.engine.spatial.GeoPoint;
 import org.hibernate.search.util.EventContext;
@@ -120,6 +121,10 @@ public class ElasticsearchSearchProjectionBuilderFactory implements SearchProjec
 				new ElasticsearchCompositeTriFunctionProjection<>( transformer, toImplementation( projection1 ),
 						toImplementation( projection2 ), toImplementation( projection3 ) )
 		);
+	}
+
+	public SearchProjectionBuilder<String> source() {
+		return searchProjectionBackendContext.getSourceProjectionBuilder();
 	}
 
 	@SuppressWarnings("unchecked")

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchSearchProjectionBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchSearchProjectionBuilderFactory.java
@@ -127,6 +127,10 @@ public class ElasticsearchSearchProjectionBuilderFactory implements SearchProjec
 		return searchProjectionBackendContext.getSourceProjectionBuilder();
 	}
 
+	public SearchProjectionBuilder<String> explanation() {
+		return searchProjectionBackendContext.getExplanationProjectionBuilder();
+	}
+
 	@SuppressWarnings("unchecked")
 	public <T> ElasticsearchSearchProjection<?, T> toImplementation(SearchProjection<T> projection) {
 		if ( !( projection instanceof ElasticsearchSearchProjection ) ) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchSourceProjection.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchSourceProjection.java
@@ -1,0 +1,65 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.search.projection.impl;
+
+import java.util.Optional;
+
+import org.hibernate.search.backend.elasticsearch.gson.impl.JsonAccessor;
+import org.hibernate.search.backend.elasticsearch.gson.impl.JsonArrayAccessor;
+import org.hibernate.search.backend.elasticsearch.gson.impl.JsonObjectAccessor;
+import org.hibernate.search.engine.search.query.spi.LoadingResult;
+import org.hibernate.search.engine.search.query.spi.ProjectionHitMapper;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
+class ElasticsearchSourceProjection implements ElasticsearchSearchProjection<String, String> {
+
+	private static final JsonArrayAccessor REQUEST_SOURCE_ACCESSOR = JsonAccessor.root().property( "_source" ).asArray();
+	private static final JsonObjectAccessor HIT_SOURCE_ACCESSOR = JsonAccessor.root().property( "_source" ).asObject();
+	private static final JsonPrimitive WILDCARD_ALL = new JsonPrimitive( "*" );
+
+	private final Gson gson;
+
+	ElasticsearchSourceProjection(Gson gson) {
+		this.gson = gson;
+	}
+
+	@Override
+	public void contributeRequest(JsonObject requestBody, SearchProjectionExecutionContext searchProjectionExecutionContext) {
+		JsonArray source = REQUEST_SOURCE_ACCESSOR.getOrCreate( requestBody, JsonArray::new );
+		if ( !source.contains( WILDCARD_ALL ) ) {
+			source.add( WILDCARD_ALL );
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public String extract(ProjectionHitMapper<?, ?> projectionHitMapper, JsonObject responseBody, JsonObject hit,
+			SearchProjectionExecutionContext searchProjectionExecutionContext) {
+		Optional<JsonObject> sourceElement = HIT_SOURCE_ACCESSOR.get( hit );
+		if ( sourceElement.isPresent() ) {
+			return gson.toJson( sourceElement.get() );
+		}
+		else {
+			return null;
+		}
+	}
+
+	@Override
+	public String transform(LoadingResult<?> loadingResult, String extractedData) {
+		return extractedData;
+	}
+
+	@Override
+	public String toString() {
+		return getClass().getSimpleName();
+	}
+
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchSourceProjectionBuilder.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchSourceProjectionBuilder.java
@@ -1,0 +1,27 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.search.projection.impl;
+
+import org.hibernate.search.engine.search.SearchProjection;
+import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilder;
+
+import com.google.gson.Gson;
+
+
+class ElasticsearchSourceProjectionBuilder implements SearchProjectionBuilder<String> {
+
+	private final ElasticsearchSourceProjection projection;
+
+	ElasticsearchSourceProjectionBuilder(Gson gson) {
+		this.projection = new ElasticsearchSourceProjection( gson );
+	}
+
+	@Override
+	public SearchProjection<String> build() {
+		return projection;
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/SearchProjectionBackendContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/SearchProjectionBackendContext.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.backend.elasticsearch.search.projection.impl;
 
+import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilder;
+
 import com.google.gson.Gson;
 
 public class SearchProjectionBackendContext {
@@ -17,6 +19,7 @@ public class SearchProjectionBackendContext {
 	private final ElasticsearchReferenceProjectionBuilder referenceProjectionBuilder;
 	private final ElasticsearchScoreProjectionBuilder scoreProjectionBuilder;
 	private final ElasticsearchSourceProjectionBuilder sourceProjectionBuilder;
+	private final ElasticsearchExplanationProjectionBuilder explanationProjectionBuilder;
 
 	@SuppressWarnings("rawtypes")
 	public SearchProjectionBackendContext(DocumentReferenceExtractorHelper documentReferenceExtractorHelper,
@@ -26,6 +29,7 @@ public class SearchProjectionBackendContext {
 		this.referenceProjectionBuilder = new ElasticsearchReferenceProjectionBuilder( documentReferenceExtractorHelper );
 		this.scoreProjectionBuilder = new ElasticsearchScoreProjectionBuilder();
 		this.sourceProjectionBuilder = new ElasticsearchSourceProjectionBuilder( userFacingGson );
+		this.explanationProjectionBuilder = new ElasticsearchExplanationProjectionBuilder( userFacingGson );
 	}
 
 	ElasticsearchDocumentReferenceProjectionBuilder getDocumentReferenceProjectionBuilder() {
@@ -48,5 +52,9 @@ public class SearchProjectionBackendContext {
 
 	ElasticsearchSourceProjectionBuilder getSourceProjectionBuilder() {
 		return sourceProjectionBuilder;
+	}
+
+	public SearchProjectionBuilder<String> getExplanationProjectionBuilder() {
+		return explanationProjectionBuilder;
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/SearchProjectionBackendContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/SearchProjectionBackendContext.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.backend.elasticsearch.search.projection.impl;
 
+import com.google.gson.Gson;
+
 public class SearchProjectionBackendContext {
 
 	private final ElasticsearchDocumentReferenceProjectionBuilder documentReferenceProjectionBuilder;
@@ -14,13 +16,16 @@ public class SearchProjectionBackendContext {
 	@SuppressWarnings("rawtypes")
 	private final ElasticsearchReferenceProjectionBuilder referenceProjectionBuilder;
 	private final ElasticsearchScoreProjectionBuilder scoreProjectionBuilder;
+	private final ElasticsearchSourceProjectionBuilder sourceProjectionBuilder;
 
 	@SuppressWarnings("rawtypes")
-	public SearchProjectionBackendContext(DocumentReferenceExtractorHelper documentReferenceExtractorHelper) {
+	public SearchProjectionBackendContext(DocumentReferenceExtractorHelper documentReferenceExtractorHelper,
+			Gson userFacingGson) {
 		this.documentReferenceProjectionBuilder = new ElasticsearchDocumentReferenceProjectionBuilder( documentReferenceExtractorHelper );
 		this.objectProjectionBuilder = new ElasticsearchObjectProjectionBuilder( documentReferenceExtractorHelper );
 		this.referenceProjectionBuilder = new ElasticsearchReferenceProjectionBuilder( documentReferenceExtractorHelper );
 		this.scoreProjectionBuilder = new ElasticsearchScoreProjectionBuilder();
+		this.sourceProjectionBuilder = new ElasticsearchSourceProjectionBuilder( userFacingGson );
 	}
 
 	ElasticsearchDocumentReferenceProjectionBuilder getDocumentReferenceProjectionBuilder() {
@@ -39,5 +44,9 @@ public class SearchProjectionBackendContext {
 
 	ElasticsearchScoreProjectionBuilder getScoreProjectionBuilder() {
 		return scoreProjectionBuilder;
+	}
+
+	ElasticsearchSourceProjectionBuilder getSourceProjectionBuilder() {
+		return sourceProjectionBuilder;
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchTargetContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchTargetContext.java
@@ -28,7 +28,8 @@ public class ElasticsearchSearchTargetContext
 			MappingContextImplementor mappingContext,
 			SearchBackendContext searchBackendContext,
 			ElasticsearchSearchTargetModel searchTargetModel) {
-		ElasticsearchSearchContext searchContext = new ElasticsearchSearchContext( mappingContext );
+		ElasticsearchSearchContext searchContext =
+				new ElasticsearchSearchContext( mappingContext, searchBackendContext.getUserFacingGson() );
 		this.searchTargetModel = searchTargetModel;
 		this.searchPredicateFactory = new ElasticsearchSearchPredicateBuilderFactoryImpl( searchContext, searchTargetModel );
 		this.searchSortFactory = new ElasticsearchSearchSortBuilderFactoryImpl( searchContext, searchTargetModel );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/SearchBackendContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/SearchBackendContext.java
@@ -20,10 +20,13 @@ import org.hibernate.search.engine.mapper.session.context.spi.SessionContextImpl
 import org.hibernate.search.engine.search.query.spi.ProjectionHitMapper;
 import org.hibernate.search.util.EventContext;
 
+import com.google.gson.Gson;
+
 public class SearchBackendContext {
 	private final EventContext eventContext;
 
 	private final ElasticsearchWorkFactory workFactory;
+	private final Gson userFacingGson;
 	private final MultiTenancyStrategy multiTenancyStrategy;
 
 	private final ElasticsearchWorkOrchestrator orchestrator;
@@ -34,11 +37,13 @@ public class SearchBackendContext {
 
 	public SearchBackendContext(EventContext eventContext,
 			ElasticsearchWorkFactory workFactory,
+			Gson userFacingGson,
 			Function<String, String> indexNameConverter,
 			MultiTenancyStrategy multiTenancyStrategy,
 			ElasticsearchWorkOrchestrator orchestrator) {
 		this.eventContext = eventContext;
 		this.workFactory = workFactory;
+		this.userFacingGson = userFacingGson;
 		this.multiTenancyStrategy = multiTenancyStrategy;
 		this.orchestrator = orchestrator;
 
@@ -55,6 +60,10 @@ public class SearchBackendContext {
 
 	public EventContext getEventContext() {
 		return eventContext;
+	}
+
+	Gson getUserFacingGson() {
+		return userFacingGson;
 	}
 
 	DocumentReferenceExtractorHelper getDocumentReferenceExtractorHelper() {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/SearchBackendContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/SearchBackendContext.java
@@ -50,7 +50,10 @@ public class SearchBackendContext {
 		this.documentReferenceExtractorHelper =
 				new DocumentReferenceExtractorHelper( indexNameConverter, multiTenancyStrategy );
 
-		this.searchProjectionBackendContext = new SearchProjectionBackendContext( documentReferenceExtractorHelper );
+		this.searchProjectionBackendContext = new SearchProjectionBackendContext(
+				documentReferenceExtractorHelper,
+				userFacingGson
+		);
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/sort/impl/ElasticsearchSearchSortBuilderFactoryImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/sort/impl/ElasticsearchSearchSortBuilderFactoryImpl.java
@@ -26,8 +26,6 @@ import org.hibernate.search.util.EventContext;
 import org.hibernate.search.util.SearchException;
 import org.hibernate.search.util.impl.common.LoggerFactory;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 
 /**
@@ -37,8 +35,6 @@ import com.google.gson.JsonObject;
 public class ElasticsearchSearchSortBuilderFactoryImpl implements ElasticsearchSearchSortBuilderFactory {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
-
-	private static final Gson GSON = new GsonBuilder().create();
 
 	private static final SortBuilderFactoryRetrievalStrategy SORT_BUILDER_FACTORY_RETRIEVAL_STRATEGY =
 			new SortBuilderFactoryRetrievalStrategy();
@@ -103,7 +99,9 @@ public class ElasticsearchSearchSortBuilderFactoryImpl implements ElasticsearchS
 
 	@Override
 	public ElasticsearchSearchSortBuilder fromJsonString(String jsonString) {
-		return new ElasticsearchUserProvidedJsonSortBuilder( GSON.fromJson( jsonString, JsonObject.class ) );
+		return new ElasticsearchUserProvidedJsonSortBuilder(
+				searchContext.getUserFacingGson().fromJson( jsonString, JsonObject.class )
+		);
 	}
 
 	private static class SortBuilderFactoryRetrievalStrategy

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/LuceneExtension.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/LuceneExtension.java
@@ -11,6 +11,9 @@ import java.util.Optional;
 
 import org.hibernate.search.backend.lucene.search.dsl.predicate.LuceneSearchPredicateFactoryContext;
 import org.hibernate.search.backend.lucene.search.dsl.predicate.impl.LuceneSearchPredicateFactoryContextImpl;
+import org.hibernate.search.backend.lucene.search.dsl.projection.LuceneSearchProjectionFactoryContext;
+import org.hibernate.search.backend.lucene.search.dsl.projection.impl.LuceneSearchProjectionFactoryContextImpl;
+import org.hibernate.search.backend.lucene.search.projection.impl.LuceneSearchProjectionBuilderFactory;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldContext;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldContextExtension;
 import org.hibernate.search.backend.lucene.document.model.dsl.LuceneIndexSchemaFieldContext;
@@ -22,10 +25,13 @@ import org.hibernate.search.backend.lucene.search.sort.impl.LuceneSearchSortBuil
 import org.hibernate.search.backend.lucene.search.sort.impl.LuceneSearchSortBuilderFactory;
 import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryContext;
 import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryContextExtension;
+import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContext;
+import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContextExtension;
 import org.hibernate.search.engine.search.dsl.sort.SearchSortContainerContext;
 import org.hibernate.search.engine.search.dsl.sort.SearchSortContainerContextExtension;
 import org.hibernate.search.engine.search.dsl.sort.spi.SearchSortDslContext;
 import org.hibernate.search.engine.search.predicate.spi.SearchPredicateBuilderFactory;
+import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilderFactory;
 import org.hibernate.search.engine.search.sort.spi.SearchSortBuilderFactory;
 import org.hibernate.search.util.impl.common.LoggerFactory;
 
@@ -35,18 +41,27 @@ import org.hibernate.search.util.impl.common.LoggerFactory;
  * <strong>WARNING:</strong> while this type is API, because instances should be manipulated by users,
  * all of its methods are considered SPIs and therefore should never be called directly by users.
  * In short, users are only expected to get instances of this type from an API and pass it to another API.
+ *
+ * @param <R> The reference type for projections.
+ * Users should not have to care about this, as the parameter will automatically take the appropriate value when calling
+ * {@code .extension( LuceneExtension.get() }.
+ * @param <O> The loaded object type for projections.
+ * Users should not have to care about this, as the parameter will automatically take the appropriate value when calling
+ * {@code .extension( LuceneExtension.get() }.
  */
-public final class LuceneExtension
+public final class LuceneExtension<R, O>
 		implements SearchPredicateFactoryContextExtension<LuceneSearchPredicateFactoryContext>,
 		SearchSortContainerContextExtension<LuceneSearchSortContainerContext>,
+		SearchProjectionFactoryContextExtension<LuceneSearchProjectionFactoryContext<R, O>, R, O>,
 		IndexSchemaFieldContextExtension<LuceneIndexSchemaFieldContext> {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private static final LuceneExtension INSTANCE = new LuceneExtension();
+	private static final LuceneExtension<Object, Object> INSTANCE = new LuceneExtension<>();
 
-	public static LuceneExtension get() {
-		return INSTANCE;
+	@SuppressWarnings("unchecked") // The instance works for any R and O
+	public static <R, O> LuceneExtension<R, O> get() {
+		return (LuceneExtension<R, O>) INSTANCE;
 	}
 
 	private LuceneExtension() {
@@ -78,6 +93,22 @@ public final class LuceneExtension
 			SearchSortDslContext<? super B> dslContext) {
 		if ( factory instanceof LuceneSearchSortBuilderFactory ) {
 			return Optional.of( extendUnsafe( original, (LuceneSearchSortBuilderFactory) factory, dslContext ) );
+		}
+		else {
+			return Optional.empty();
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Optional<LuceneSearchProjectionFactoryContext<R, O>> extendOptional(
+			SearchProjectionFactoryContext<R, O> original, SearchProjectionBuilderFactory factory) {
+		if ( factory instanceof LuceneSearchProjectionBuilderFactory ) {
+			return Optional.of( new LuceneSearchProjectionFactoryContextImpl<>(
+					original, (LuceneSearchProjectionBuilderFactory) factory
+			) );
 		}
 		else {
 			return Optional.empty();

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
@@ -412,4 +412,8 @@ public interface Log extends BasicLogger {
 			value = "Multiple conflicting types for identifier: '%1$s' vs. '%2$s'.")
 	SearchException conflictingIdentifierTypesForPredicate(ToDocumentIdentifierValueConverter<?> component1,
 			ToDocumentIdentifierValueConverter<?> component2, @Param EventContext context);
+
+	@Message(id = ID_OFFSET_2 + 69,
+			value = "An IOException occurred while generating an Explanation.")
+	SearchException ioExceptionOnExplain(@Cause IOException e);
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/projection/LuceneSearchProjectionFactoryContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/projection/LuceneSearchProjectionFactoryContext.java
@@ -1,0 +1,19 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.search.dsl.projection;
+
+import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContext;
+
+/**
+ * A DSL context allowing to create a projection, with some Lucene-specific methods.
+ *
+ * @param <R> The type of references.
+ * @param <O> The type of loaded objects.
+ * @see SearchProjectionFactoryContext
+ */
+public interface LuceneSearchProjectionFactoryContext<R, O> extends SearchProjectionFactoryContext<R, O> {
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/projection/LuceneSearchProjectionFactoryContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/projection/LuceneSearchProjectionFactoryContext.java
@@ -10,6 +10,7 @@ import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactory
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionTerminalContext;
 
 import org.apache.lucene.document.Document;
+import org.apache.lucene.search.Explanation;
 
 /**
  * A DSL context allowing to create a projection, with some Lucene-specific methods.
@@ -30,5 +31,15 @@ public interface LuceneSearchProjectionFactoryContext<R, O> extends SearchProjec
 	 * @return A context allowing to define the projection more precisely.
 	 */
 	SearchProjectionTerminalContext<Document> document();
+
+	/**
+	 * Project to a Lucene {@link Explanation} describing the score computation for the hit.
+	 * <p>
+	 * This feature is relatively expensive, do not use unless you return a limited
+	 * amount of objects (using pagination).
+	 *
+	 * @return A context allowing to define the projection more precisely.
+	 */
+	SearchProjectionTerminalContext<Explanation> explanation();
 
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/projection/LuceneSearchProjectionFactoryContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/projection/LuceneSearchProjectionFactoryContext.java
@@ -7,6 +7,9 @@
 package org.hibernate.search.backend.lucene.search.dsl.projection;
 
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContext;
+import org.hibernate.search.engine.search.dsl.projection.SearchProjectionTerminalContext;
+
+import org.apache.lucene.document.Document;
 
 /**
  * A DSL context allowing to create a projection, with some Lucene-specific methods.
@@ -16,4 +19,16 @@ import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactory
  * @see SearchProjectionFactoryContext
  */
 public interface LuceneSearchProjectionFactoryContext<R, O> extends SearchProjectionFactoryContext<R, O> {
+
+	/**
+	 * Project to a Lucene {@link Document} containing all the stored fields.
+	 * <p>
+	 * Note that only stored fields are returned: fields that are not marked as
+	 * {@link org.hibernate.search.engine.backend.document.model.dsl.Projectable#YES projectable}
+	 * may be missing.
+	 *
+	 * @return A context allowing to define the projection more precisely.
+	 */
+	SearchProjectionTerminalContext<Document> document();
+
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/projection/impl/LuceneDocumentProjectionContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/projection/impl/LuceneDocumentProjectionContext.java
@@ -1,0 +1,27 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.search.dsl.projection.impl;
+
+import org.hibernate.search.backend.lucene.search.projection.impl.LuceneSearchProjectionBuilderFactory;
+import org.hibernate.search.engine.search.SearchProjection;
+import org.hibernate.search.engine.search.dsl.projection.SearchProjectionTerminalContext;
+import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilder;
+
+import org.apache.lucene.document.Document;
+
+final class LuceneDocumentProjectionContext implements SearchProjectionTerminalContext<Document> {
+	private final SearchProjectionBuilder<Document> builder;
+
+	LuceneDocumentProjectionContext(LuceneSearchProjectionBuilderFactory factory) {
+		this.builder = factory.document();
+	}
+
+	@Override
+	public SearchProjection<Document> toProjection() {
+		return builder.build();
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/projection/impl/LuceneExplanationProjectionContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/projection/impl/LuceneExplanationProjectionContext.java
@@ -1,0 +1,27 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.search.dsl.projection.impl;
+
+import org.hibernate.search.backend.lucene.search.projection.impl.LuceneSearchProjectionBuilderFactory;
+import org.hibernate.search.engine.search.SearchProjection;
+import org.hibernate.search.engine.search.dsl.projection.SearchProjectionTerminalContext;
+import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilder;
+
+import org.apache.lucene.search.Explanation;
+
+final class LuceneExplanationProjectionContext implements SearchProjectionTerminalContext<Explanation> {
+	private final SearchProjectionBuilder<Explanation> builder;
+
+	LuceneExplanationProjectionContext(LuceneSearchProjectionBuilderFactory factory) {
+		this.builder = factory.explanation();
+	}
+
+	@Override
+	public SearchProjection<Explanation> toProjection() {
+		return builder.build();
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/projection/impl/LuceneSearchProjectionFactoryContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/projection/impl/LuceneSearchProjectionFactoryContextImpl.java
@@ -9,7 +9,10 @@ package org.hibernate.search.backend.lucene.search.dsl.projection.impl;
 import org.hibernate.search.backend.lucene.search.dsl.projection.LuceneSearchProjectionFactoryContext;
 import org.hibernate.search.backend.lucene.search.projection.impl.LuceneSearchProjectionBuilderFactory;
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContext;
+import org.hibernate.search.engine.search.dsl.projection.SearchProjectionTerminalContext;
 import org.hibernate.search.engine.search.dsl.projection.spi.DelegatingSearchProjectionFactoryContext;
+
+import org.apache.lucene.document.Document;
 
 public class LuceneSearchProjectionFactoryContextImpl<R, O>
 		extends DelegatingSearchProjectionFactoryContext<R, O>
@@ -21,5 +24,10 @@ public class LuceneSearchProjectionFactoryContextImpl<R, O>
 			LuceneSearchProjectionBuilderFactory factory) {
 		super( delegate );
 		this.factory = factory;
+	}
+
+	@Override
+	public SearchProjectionTerminalContext<Document> document() {
+		return new LuceneDocumentProjectionContext( factory );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/projection/impl/LuceneSearchProjectionFactoryContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/projection/impl/LuceneSearchProjectionFactoryContextImpl.java
@@ -13,6 +13,7 @@ import org.hibernate.search.engine.search.dsl.projection.SearchProjectionTermina
 import org.hibernate.search.engine.search.dsl.projection.spi.DelegatingSearchProjectionFactoryContext;
 
 import org.apache.lucene.document.Document;
+import org.apache.lucene.search.Explanation;
 
 public class LuceneSearchProjectionFactoryContextImpl<R, O>
 		extends DelegatingSearchProjectionFactoryContext<R, O>
@@ -29,5 +30,10 @@ public class LuceneSearchProjectionFactoryContextImpl<R, O>
 	@Override
 	public SearchProjectionTerminalContext<Document> document() {
 		return new LuceneDocumentProjectionContext( factory );
+	}
+
+	@Override
+	public SearchProjectionTerminalContext<Explanation> explanation() {
+		return new LuceneExplanationProjectionContext( factory );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/projection/impl/LuceneSearchProjectionFactoryContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/projection/impl/LuceneSearchProjectionFactoryContextImpl.java
@@ -1,0 +1,25 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.search.dsl.projection.impl;
+
+import org.hibernate.search.backend.lucene.search.dsl.projection.LuceneSearchProjectionFactoryContext;
+import org.hibernate.search.backend.lucene.search.projection.impl.LuceneSearchProjectionBuilderFactory;
+import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContext;
+import org.hibernate.search.engine.search.dsl.projection.spi.DelegatingSearchProjectionFactoryContext;
+
+public class LuceneSearchProjectionFactoryContextImpl<R, O>
+		extends DelegatingSearchProjectionFactoryContext<R, O>
+		implements LuceneSearchProjectionFactoryContext<R, O> {
+
+	private final LuceneSearchProjectionBuilderFactory factory;
+
+	public LuceneSearchProjectionFactoryContextImpl(SearchProjectionFactoryContext<R, O> delegate,
+			LuceneSearchProjectionBuilderFactory factory) {
+		super( delegate );
+		this.factory = factory;
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/extraction/impl/DocumentReferenceExtractorHelper.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/extraction/impl/DocumentReferenceExtractorHelper.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.search.backend.lucene.search.extraction.impl;
 
-import java.util.Set;
-
 import org.hibernate.search.backend.lucene.search.impl.LuceneDocumentReference;
 import org.hibernate.search.backend.lucene.util.impl.LuceneFields;
 import org.hibernate.search.engine.search.DocumentReference;
@@ -21,9 +19,9 @@ public final class DocumentReferenceExtractorHelper {
 		luceneCollectorBuilder.requireTopDocsCollector();
 	}
 
-	public static void contributeFields(Set<String> absoluteFieldPaths) {
-		absoluteFieldPaths.add( LuceneFields.indexFieldName() );
-		absoluteFieldPaths.add( LuceneFields.idFieldName() );
+	public static void contributeFields(LuceneDocumentStoredFieldVisitorBuilder builder) {
+		builder.add( LuceneFields.indexFieldName() );
+		builder.add( LuceneFields.idFieldName() );
 	}
 
 	public static DocumentReference extractDocumentReference(LuceneResult documentResult) {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/extraction/impl/LuceneDocumentStoredFieldVisitorBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/extraction/impl/LuceneDocumentStoredFieldVisitorBuilder.java
@@ -1,0 +1,29 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.search.extraction.impl;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+public class LuceneDocumentStoredFieldVisitorBuilder {
+
+	private Set<String> explicitlyRequired = new HashSet<>();
+
+	public void add(String absoluteFieldPath) {
+		explicitlyRequired.add( absoluteFieldPath );
+	}
+
+	public void addAll(Collection<String> absoluteFieldPaths) {
+		explicitlyRequired.addAll( absoluteFieldPaths );
+	}
+
+	public ReusableDocumentStoredFieldVisitor build() {
+		return new ReusableDocumentStoredFieldVisitor( explicitlyRequired );
+	}
+
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/extraction/impl/LuceneDocumentStoredFieldVisitorBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/extraction/impl/LuceneDocumentStoredFieldVisitorBuilder.java
@@ -12,18 +12,33 @@ import java.util.Set;
 
 public class LuceneDocumentStoredFieldVisitorBuilder {
 
+	private boolean entireDocumentRequired = false;
 	private Set<String> explicitlyRequired = new HashSet<>();
 
+	public void addEntireDocument() {
+		entireDocumentRequired = true;
+		explicitlyRequired.clear();
+	}
+
 	public void add(String absoluteFieldPath) {
-		explicitlyRequired.add( absoluteFieldPath );
+		if ( !entireDocumentRequired ) {
+			explicitlyRequired.add( absoluteFieldPath );
+		}
 	}
 
 	public void addAll(Collection<String> absoluteFieldPaths) {
-		explicitlyRequired.addAll( absoluteFieldPaths );
+		if ( !entireDocumentRequired ) {
+			explicitlyRequired.addAll( absoluteFieldPaths );
+		}
 	}
 
 	public ReusableDocumentStoredFieldVisitor build() {
-		return new ReusableDocumentStoredFieldVisitor( explicitlyRequired );
+		if ( entireDocumentRequired ) {
+			return new ReusableDocumentStoredFieldVisitor();
+		}
+		else {
+			return new ReusableDocumentStoredFieldVisitor( explicitlyRequired );
+		}
 	}
 
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/extraction/impl/ReusableDocumentStoredFieldVisitor.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/extraction/impl/ReusableDocumentStoredFieldVisitor.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.backend.lucene.search.query.impl;
+package org.hibernate.search.backend.lucene.search.extraction.impl;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/extraction/impl/ReusableDocumentStoredFieldVisitor.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/extraction/impl/ReusableDocumentStoredFieldVisitor.java
@@ -44,6 +44,18 @@ public final class ReusableDocumentStoredFieldVisitor extends StoredFieldVisitor
 	//This field needs to be reset to the value of totalFields when the doc field is changed.
 	private int missingFields;
 
+	/**
+	 * Create a visitor that collects all fields.
+	 */
+	public ReusableDocumentStoredFieldVisitor() {
+		this.rootAcceptor = null;
+		this.totalFields = 0; // Shouldn't be used
+		this.missingFields = totalFields;
+	}
+
+	/**
+	 * Create a visitor that collects only some specified fields.
+	 */
 	public ReusableDocumentStoredFieldVisitor(Set<String> fieldsToLoad) {
 		FieldAcceptor previous = NOT_ACCEPT;
 		for ( String fieldName : fieldsToLoad ) {
@@ -90,6 +102,10 @@ public final class ReusableDocumentStoredFieldVisitor extends StoredFieldVisitor
 
 	@Override
 	public Status needsField(FieldInfo fieldInfo) throws IOException {
+		if ( rootAcceptor == null ) {
+			// We need all fields
+			return Status.YES;
+		}
 		if ( missingFields == 0 ) {
 			// An aggressive STOP could prevent unnecessary I/O !
 			return Status.STOP;

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneCompositeBiFunctionProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneCompositeBiFunctionProjection.java
@@ -8,11 +8,11 @@ package org.hibernate.search.backend.lucene.search.projection.impl;
 
 import static org.hibernate.search.backend.lucene.search.projection.impl.LuceneSearchProjection.transformUnsafe;
 
-import java.util.Set;
 import java.util.function.BiFunction;
 
 import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneCollectorsBuilder;
 import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneResult;
+import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneDocumentStoredFieldVisitorBuilder;
 import org.hibernate.search.engine.search.query.spi.LoadingResult;
 import org.hibernate.search.engine.search.query.spi.ProjectionHitMapper;
 
@@ -38,9 +38,9 @@ public class LuceneCompositeBiFunctionProjection<P1, P2, T> implements LuceneCom
 	}
 
 	@Override
-	public void contributeFields(Set<String> absoluteFieldPaths) {
-		projection1.contributeFields( absoluteFieldPaths );
-		projection2.contributeFields( absoluteFieldPaths );
+	public void contributeFields(LuceneDocumentStoredFieldVisitorBuilder builder) {
+		projection1.contributeFields( builder );
+		projection2.contributeFields( builder );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneCompositeFunctionProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneCompositeFunctionProjection.java
@@ -6,11 +6,11 @@
  */
 package org.hibernate.search.backend.lucene.search.projection.impl;
 
-import java.util.Set;
 import java.util.function.Function;
 
 import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneCollectorsBuilder;
 import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneResult;
+import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneDocumentStoredFieldVisitorBuilder;
 import org.hibernate.search.engine.search.query.spi.LoadingResult;
 import org.hibernate.search.engine.search.query.spi.ProjectionHitMapper;
 
@@ -32,8 +32,8 @@ public class LuceneCompositeFunctionProjection<E, P, T> implements LuceneComposi
 	}
 
 	@Override
-	public void contributeFields(Set<String> absoluteFieldPaths) {
-		projection.contributeFields( absoluteFieldPaths );
+	public void contributeFields(LuceneDocumentStoredFieldVisitorBuilder builder) {
+		projection.contributeFields( builder );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneCompositeListProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneCompositeListProjection.java
@@ -10,11 +10,11 @@ import static org.hibernate.search.backend.lucene.search.projection.impl.LuceneS
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Function;
 
 import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneCollectorsBuilder;
 import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneResult;
+import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneDocumentStoredFieldVisitorBuilder;
 import org.hibernate.search.engine.search.query.spi.LoadingResult;
 import org.hibernate.search.engine.search.query.spi.ProjectionHitMapper;
 
@@ -38,9 +38,9 @@ public class LuceneCompositeListProjection<T> implements LuceneCompositeProjecti
 	}
 
 	@Override
-	public void contributeFields(Set<String> absoluteFieldPaths) {
+	public void contributeFields(LuceneDocumentStoredFieldVisitorBuilder builder) {
 		for ( LuceneSearchProjection<?, ?> child : children ) {
-			child.contributeFields( absoluteFieldPaths );
+			child.contributeFields( builder );
 		}
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneCompositeTriFunctionProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneCompositeTriFunctionProjection.java
@@ -9,10 +9,9 @@ package org.hibernate.search.backend.lucene.search.projection.impl;
 
 import static org.hibernate.search.backend.lucene.search.projection.impl.LuceneSearchProjection.transformUnsafe;
 
-import java.util.Set;
-
 import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneCollectorsBuilder;
 import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneResult;
+import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneDocumentStoredFieldVisitorBuilder;
 import org.hibernate.search.engine.search.query.spi.LoadingResult;
 import org.hibernate.search.engine.search.query.spi.ProjectionHitMapper;
 import org.hibernate.search.util.function.TriFunction;
@@ -44,10 +43,10 @@ public class LuceneCompositeTriFunctionProjection<P1, P2, P3, T> implements Luce
 	}
 
 	@Override
-	public void contributeFields(Set<String> absoluteFieldPaths) {
-		projection1.contributeFields( absoluteFieldPaths );
-		projection2.contributeFields( absoluteFieldPaths );
-		projection3.contributeFields( absoluteFieldPaths );
+	public void contributeFields(LuceneDocumentStoredFieldVisitorBuilder builder) {
+		projection1.contributeFields( builder );
+		projection2.contributeFields( builder );
+		projection3.contributeFields( builder );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneDistanceToFieldProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneDistanceToFieldProjection.java
@@ -6,11 +6,10 @@
  */
 package org.hibernate.search.backend.lucene.search.projection.impl;
 
-import java.util.Set;
-
 import org.hibernate.search.backend.lucene.search.extraction.impl.DistanceCollector;
 import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneCollectorsBuilder;
 import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneResult;
+import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneDocumentStoredFieldVisitorBuilder;
 import org.hibernate.search.engine.search.query.spi.LoadingResult;
 import org.hibernate.search.engine.search.query.spi.ProjectionHitMapper;
 import org.hibernate.search.engine.spatial.DistanceUnit;
@@ -38,8 +37,8 @@ class LuceneDistanceToFieldProjection implements LuceneSearchProjection<Double, 
 	}
 
 	@Override
-	public void contributeFields(Set<String> absoluteFieldPaths) {
-		absoluteFieldPaths.add( absoluteFieldPath );
+	public void contributeFields(LuceneDocumentStoredFieldVisitorBuilder builder) {
+		builder.add( absoluteFieldPath );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneDocumentProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneDocumentProjection.java
@@ -1,0 +1,54 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.search.projection.impl;
+
+import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneCollectorsBuilder;
+import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneDocumentStoredFieldVisitorBuilder;
+import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneResult;
+import org.hibernate.search.engine.search.query.spi.LoadingResult;
+import org.hibernate.search.engine.search.query.spi.ProjectionHitMapper;
+
+import org.apache.lucene.document.Document;
+
+class LuceneDocumentProjection implements LuceneSearchProjection<Document, Document> {
+
+	private static final LuceneDocumentProjection INSTANCE = new LuceneDocumentProjection();
+
+	static LuceneDocumentProjection get() {
+		return INSTANCE;
+	}
+
+	private LuceneDocumentProjection() {
+	}
+
+	@Override
+	public void contributeCollectors(LuceneCollectorsBuilder luceneCollectorBuilder) {
+		luceneCollectorBuilder.requireTopDocsCollector();
+	}
+
+	@Override
+	public void contributeFields(LuceneDocumentStoredFieldVisitorBuilder builder) {
+		builder.addEntireDocument();
+	}
+
+	@Override
+	public Document extract(ProjectionHitMapper<?, ?> mapper, LuceneResult documentResult,
+			SearchProjectionExecutionContext context) {
+		return documentResult.getDocument();
+	}
+
+	@Override
+	public Document transform(LoadingResult<?> loadingResult, Document extractedData) {
+		return extractedData;
+	}
+
+	@Override
+	public String toString() {
+		return getClass().getSimpleName();
+	}
+
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneDocumentProjectionBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneDocumentProjectionBuilder.java
@@ -1,0 +1,30 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.search.projection.impl;
+
+import org.hibernate.search.engine.search.SearchProjection;
+import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilder;
+
+import org.apache.lucene.document.Document;
+
+
+public class LuceneDocumentProjectionBuilder implements SearchProjectionBuilder<Document> {
+
+	private static final LuceneDocumentProjectionBuilder INSTANCE = new LuceneDocumentProjectionBuilder();
+
+	public static LuceneDocumentProjectionBuilder get() {
+		return INSTANCE;
+	}
+
+	private LuceneDocumentProjectionBuilder() {
+	}
+
+	@Override
+	public SearchProjection<Document> build() {
+		return LuceneDocumentProjection.get();
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneDocumentReferenceProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneDocumentReferenceProjection.java
@@ -6,11 +6,10 @@
  */
 package org.hibernate.search.backend.lucene.search.projection.impl;
 
-import java.util.Set;
-
 import org.hibernate.search.backend.lucene.search.extraction.impl.DocumentReferenceExtractorHelper;
 import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneResult;
 import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneCollectorsBuilder;
+import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneDocumentStoredFieldVisitorBuilder;
 import org.hibernate.search.engine.search.DocumentReference;
 import org.hibernate.search.engine.search.query.spi.LoadingResult;
 import org.hibernate.search.engine.search.query.spi.ProjectionHitMapper;
@@ -32,8 +31,8 @@ class LuceneDocumentReferenceProjection implements LuceneSearchProjection<Docume
 	}
 
 	@Override
-	public void contributeFields(Set<String> absoluteFieldPaths) {
-		DocumentReferenceExtractorHelper.contributeFields( absoluteFieldPaths );
+	public void contributeFields(LuceneDocumentStoredFieldVisitorBuilder builder) {
+		DocumentReferenceExtractorHelper.contributeFields( builder );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneExplanationProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneExplanationProjection.java
@@ -1,0 +1,54 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.search.projection.impl;
+
+import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneCollectorsBuilder;
+import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneDocumentStoredFieldVisitorBuilder;
+import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneResult;
+import org.hibernate.search.engine.search.query.spi.LoadingResult;
+import org.hibernate.search.engine.search.query.spi.ProjectionHitMapper;
+
+import org.apache.lucene.search.Explanation;
+
+class LuceneExplanationProjection implements LuceneSearchProjection<Explanation, Explanation> {
+
+	private static final LuceneExplanationProjection INSTANCE = new LuceneExplanationProjection();
+
+	static LuceneExplanationProjection get() {
+		return INSTANCE;
+	}
+
+	private LuceneExplanationProjection() {
+	}
+
+	@Override
+	public void contributeCollectors(LuceneCollectorsBuilder luceneCollectorBuilder) {
+		luceneCollectorBuilder.requireTopDocsCollector();
+	}
+
+	@Override
+	public void contributeFields(LuceneDocumentStoredFieldVisitorBuilder builder) {
+		builder.addEntireDocument();
+	}
+
+	@Override
+	public Explanation extract(ProjectionHitMapper<?, ?> mapper, LuceneResult documentResult,
+			SearchProjectionExecutionContext context) {
+		return context.explain( documentResult.getDocId() );
+	}
+
+	@Override
+	public Explanation transform(LoadingResult<?> loadingResult, Explanation extractedData) {
+		return extractedData;
+	}
+
+	@Override
+	public String toString() {
+		return getClass().getSimpleName();
+	}
+
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneExplanationProjectionBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneExplanationProjectionBuilder.java
@@ -1,0 +1,30 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.search.projection.impl;
+
+import org.hibernate.search.engine.search.SearchProjection;
+import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilder;
+
+import org.apache.lucene.search.Explanation;
+
+
+public class LuceneExplanationProjectionBuilder implements SearchProjectionBuilder<Explanation> {
+
+	private static final LuceneExplanationProjectionBuilder INSTANCE = new LuceneExplanationProjectionBuilder();
+
+	public static LuceneExplanationProjectionBuilder get() {
+		return INSTANCE;
+	}
+
+	private LuceneExplanationProjectionBuilder() {
+	}
+
+	@Override
+	public SearchProjection<Explanation> build() {
+		return LuceneExplanationProjection.get();
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneFieldProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneFieldProjection.java
@@ -6,10 +6,9 @@
  */
 package org.hibernate.search.backend.lucene.search.projection.impl;
 
-import java.util.Set;
-
 import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneCollectorsBuilder;
 import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneResult;
+import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneDocumentStoredFieldVisitorBuilder;
 import org.hibernate.search.backend.lucene.types.codec.impl.LuceneFieldCodec;
 import org.hibernate.search.engine.backend.document.converter.FromDocumentFieldValueConverter;
 import org.hibernate.search.engine.backend.document.converter.runtime.FromDocumentFieldValueConvertContext;
@@ -37,12 +36,12 @@ class LuceneFieldProjection<F, T> implements LuceneSearchProjection<T, T> {
 	}
 
 	@Override
-	public void contributeFields(Set<String> absoluteFieldPaths) {
+	public void contributeFields(LuceneDocumentStoredFieldVisitorBuilder builder) {
 		if ( codec.getOverriddenStoredFields().isEmpty() ) {
-			absoluteFieldPaths.add( absoluteFieldPath );
+			builder.add( absoluteFieldPath );
 		}
 		else {
-			absoluteFieldPaths.addAll( codec.getOverriddenStoredFields() );
+			builder.addAll( codec.getOverriddenStoredFields() );
 		}
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneObjectProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneObjectProjection.java
@@ -6,11 +6,10 @@
  */
 package org.hibernate.search.backend.lucene.search.projection.impl;
 
-import java.util.Set;
-
 import org.hibernate.search.backend.lucene.search.extraction.impl.DocumentReferenceExtractorHelper;
 import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneCollectorsBuilder;
 import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneResult;
+import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneDocumentStoredFieldVisitorBuilder;
 import org.hibernate.search.engine.search.query.spi.LoadingResult;
 import org.hibernate.search.engine.search.query.spi.ProjectionHitMapper;
 
@@ -33,8 +32,8 @@ public class LuceneObjectProjection<O> implements LuceneSearchProjection<Object,
 	}
 
 	@Override
-	public void contributeFields(Set<String> absoluteFieldPaths) {
-		DocumentReferenceExtractorHelper.contributeFields( absoluteFieldPaths );
+	public void contributeFields(LuceneDocumentStoredFieldVisitorBuilder builder) {
+		DocumentReferenceExtractorHelper.contributeFields( builder );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneReferenceProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneReferenceProjection.java
@@ -6,11 +6,10 @@
  */
 package org.hibernate.search.backend.lucene.search.projection.impl;
 
-import java.util.Set;
-
 import org.hibernate.search.backend.lucene.search.extraction.impl.DocumentReferenceExtractorHelper;
 import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneCollectorsBuilder;
 import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneResult;
+import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneDocumentStoredFieldVisitorBuilder;
 import org.hibernate.search.engine.search.query.spi.LoadingResult;
 import org.hibernate.search.engine.search.query.spi.ProjectionHitMapper;
 
@@ -33,8 +32,8 @@ public class LuceneReferenceProjection<R> implements LuceneSearchProjection<R, R
 	}
 
 	@Override
-	public void contributeFields(Set<String> absoluteFieldPaths) {
-		DocumentReferenceExtractorHelper.contributeFields( absoluteFieldPaths );
+	public void contributeFields(LuceneDocumentStoredFieldVisitorBuilder builder) {
+		DocumentReferenceExtractorHelper.contributeFields( builder );
 	}
 
 	@SuppressWarnings("unchecked")

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneScoreProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneScoreProjection.java
@@ -6,10 +6,9 @@
  */
 package org.hibernate.search.backend.lucene.search.projection.impl;
 
-import java.util.Set;
-
 import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneResult;
 import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneCollectorsBuilder;
+import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneDocumentStoredFieldVisitorBuilder;
 import org.hibernate.search.engine.search.query.spi.LoadingResult;
 import org.hibernate.search.engine.search.query.spi.ProjectionHitMapper;
 
@@ -30,7 +29,7 @@ class LuceneScoreProjection implements LuceneSearchProjection<Float, Float> {
 	}
 
 	@Override
-	public void contributeFields(Set<String> absoluteFieldPaths) {
+	public void contributeFields(LuceneDocumentStoredFieldVisitorBuilder builder) {
 		// Nothing to contribute
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneSearchProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneSearchProjection.java
@@ -29,7 +29,7 @@ public interface LuceneSearchProjection<E, T> extends SearchProjection<T>, Lucen
 	 *
 	 * @param projectionHitMapper The projection hit mapper used to transform hits to entities.
 	 * @param luceneResult A wrapper on top of the Lucene document extracted from the index.
-	 * @param searchProjectionExecutionContext An execution context for the search projections.
+	 * @param context An execution context for the search projections.
 	 * @return The element extracted from the hit. Might be a key referring to an object that will be loaded by the
 	 * {@link ProjectionHitMapper}. This returned object will be passed to {@link #transform(LoadingResult, Object)}.
 	 */

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneSearchProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneSearchProjection.java
@@ -6,10 +6,9 @@
  */
 package org.hibernate.search.backend.lucene.search.projection.impl;
 
-import java.util.Set;
-
 import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneCollectorProvider;
 import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneResult;
+import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneDocumentStoredFieldVisitorBuilder;
 import org.hibernate.search.engine.search.SearchProjection;
 import org.hibernate.search.engine.search.query.spi.LoadingResult;
 import org.hibernate.search.engine.search.query.spi.ProjectionHitMapper;
@@ -20,9 +19,9 @@ public interface LuceneSearchProjection<E, T> extends SearchProjection<T>, Lucen
 	 * Contributes to the list of fields extracted from the Lucene document. Some fields might require the extraction of
 	 * other fields e.g. if the stored fields have different names.
 	 *
-	 * @param absoluteFieldPaths The set of absolute field paths contributed.
+	 * @param builder The builder allowing to set expectations regarding collected fields.
 	 */
-	void contributeFields(Set<String> absoluteFieldPaths);
+	void contributeFields(LuceneDocumentStoredFieldVisitorBuilder builder);
 
 	/**
 	 * Perform hit extraction.

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneSearchProjectionBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneSearchProjectionBuilderFactory.java
@@ -34,6 +34,7 @@ import org.hibernate.search.util.function.TriFunction;
 import org.hibernate.search.util.impl.common.LoggerFactory;
 
 import org.apache.lucene.document.Document;
+import org.apache.lucene.search.Explanation;
 
 public class LuceneSearchProjectionBuilderFactory implements SearchProjectionBuilderFactory {
 
@@ -131,6 +132,10 @@ public class LuceneSearchProjectionBuilderFactory implements SearchProjectionBui
 
 	public SearchProjectionBuilder<Document> document() {
 		return LuceneDocumentProjectionBuilder.get();
+	}
+
+	public SearchProjectionBuilder<Explanation> explanation() {
+		return LuceneExplanationProjectionBuilder.get();
 	}
 
 	private static class ProjectionBuilderFactoryRetrievalStrategy

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneSearchProjectionBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneSearchProjectionBuilderFactory.java
@@ -25,12 +25,15 @@ import org.hibernate.search.engine.search.projection.spi.FieldProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.ObjectProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.ReferenceProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.ScoreProjectionBuilder;
+import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilderFactory;
 import org.hibernate.search.engine.spatial.GeoPoint;
 import org.hibernate.search.util.EventContext;
 import org.hibernate.search.util.SearchException;
 import org.hibernate.search.util.function.TriFunction;
 import org.hibernate.search.util.impl.common.LoggerFactory;
+
+import org.apache.lucene.document.Document;
 
 public class LuceneSearchProjectionBuilderFactory implements SearchProjectionBuilderFactory {
 
@@ -124,6 +127,10 @@ public class LuceneSearchProjectionBuilderFactory implements SearchProjectionBui
 			throw log.cannotMixLuceneSearchQueryWithOtherProjections( projection );
 		}
 		return (LuceneSearchProjection<?, T>) projection;
+	}
+
+	public SearchProjectionBuilder<Document> document() {
+		return LuceneDocumentProjectionBuilder.get();
 	}
 
 	private static class ProjectionBuilderFactoryRetrievalStrategy

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/SearchProjectionExecutionContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/SearchProjectionExecutionContext.java
@@ -6,19 +6,46 @@
  */
 package org.hibernate.search.backend.lucene.search.projection.impl;
 
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+
+import org.hibernate.search.backend.lucene.logging.impl.Log;
 import org.hibernate.search.engine.backend.document.converter.runtime.FromDocumentFieldValueConvertContext;
 import org.hibernate.search.engine.backend.document.converter.runtime.spi.FromDocumentFieldValueConvertContextImpl;
 import org.hibernate.search.engine.mapper.session.context.spi.SessionContextImplementor;
+import org.hibernate.search.util.impl.common.LoggerFactory;
+
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
 
 public class SearchProjectionExecutionContext {
 
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+
 	private final FromDocumentFieldValueConvertContext fromDocumentFieldValueConvertContext;
 
-	public SearchProjectionExecutionContext(SessionContextImplementor sessionContext) {
+	private final IndexSearcher indexSearcher;
+	private final Query luceneQuery;
+
+	public SearchProjectionExecutionContext(SessionContextImplementor sessionContext,
+			IndexSearcher indexSearcher,
+			Query luceneQuery) {
 		this.fromDocumentFieldValueConvertContext = new FromDocumentFieldValueConvertContextImpl( sessionContext );
+		this.indexSearcher = indexSearcher;
+		this.luceneQuery = luceneQuery;
 	}
 
 	FromDocumentFieldValueConvertContext getFromDocumentFieldValueConvertContext() {
 		return fromDocumentFieldValueConvertContext;
+	}
+
+	public Explanation explain(int docId) {
+		try {
+			return indexSearcher.explain( luceneQuery, docId );
+		}
+		catch (IOException e) {
+			throw log.ioExceptionOnExplain( e );
+		}
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryBuilder.java
@@ -17,7 +17,6 @@ import org.hibernate.search.backend.lucene.search.impl.LuceneQueries;
 import org.hibernate.search.backend.lucene.search.impl.LuceneSearchQueryElementCollector;
 import org.hibernate.search.backend.lucene.search.impl.LuceneSearchTargetModel;
 import org.hibernate.search.backend.lucene.search.projection.impl.LuceneSearchProjection;
-import org.hibernate.search.backend.lucene.search.projection.impl.SearchProjectionExecutionContext;
 import org.hibernate.search.backend.lucene.work.impl.LuceneWorkFactory;
 import org.hibernate.search.engine.mapper.session.context.spi.SessionContextImplementor;
 import org.hibernate.search.engine.search.SearchQuery;
@@ -72,22 +71,22 @@ class LuceneSearchQueryBuilder<T> implements SearchQueryBuilder<T, LuceneSearchQ
 	}
 
 	private SearchQuery<T> build() {
-		SearchProjectionExecutionContext projectionExecutionContext =
-				new SearchProjectionExecutionContext( sessionContext );
-
 		LuceneSearchResultExtractor<T> searchResultExtractor = new LuceneSearchResultExtractorImpl<>(
-				storedFieldVisitor, rootProjection, projectionHitMapper, projectionExecutionContext
+				storedFieldVisitor, rootProjection, projectionHitMapper
 		);
 
 		BooleanQuery.Builder luceneQueryBuilder = new BooleanQuery.Builder();
 		luceneQueryBuilder.add( elementCollector.toLuceneQueryPredicate(), Occur.MUST );
 		luceneQueryBuilder.add( LuceneQueries.mainDocumentQuery(), Occur.FILTER );
 
-		return new LuceneSearchQuery<>( queryOrchestrator, workFactory,
+		return new LuceneSearchQuery<>(
+				queryOrchestrator, workFactory,
 				searchTargetModel.getIndexNames(), searchTargetModel.getReaderProviders(),
+				sessionContext,
 				multiTenancyStrategy.decorateLuceneQuery( luceneQueryBuilder.build(), sessionContext.getTenantIdentifier() ),
 				elementCollector.toLuceneSort(),
-				rootProjection, searchResultExtractor );
+				rootProjection, searchResultExtractor
+		);
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryBuilder.java
@@ -12,6 +12,7 @@ import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.hibernate.search.backend.lucene.multitenancy.impl.MultiTenancyStrategy;
 import org.hibernate.search.backend.lucene.orchestration.impl.LuceneQueryWorkOrchestrator;
+import org.hibernate.search.backend.lucene.search.extraction.impl.ReusableDocumentStoredFieldVisitor;
 import org.hibernate.search.backend.lucene.search.impl.LuceneQueries;
 import org.hibernate.search.backend.lucene.search.impl.LuceneSearchQueryElementCollector;
 import org.hibernate.search.backend.lucene.search.impl.LuceneSearchTargetModel;

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchResultExtractor.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchResultExtractor.java
@@ -10,10 +10,13 @@ import java.io.IOException;
 
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.TopDocs;
+
+import org.hibernate.search.backend.lucene.search.projection.impl.SearchProjectionExecutionContext;
 import org.hibernate.search.engine.search.SearchResult;
 
 public interface LuceneSearchResultExtractor<T> {
 
-	SearchResult<T> extract(IndexSearcher indexSearcher, long totalHits, TopDocs topDocs) throws IOException;
+	SearchResult<T> extract(IndexSearcher indexSearcher, long totalHits, TopDocs topDocs,
+			SearchProjectionExecutionContext projectionExecutionContext) throws IOException;
 
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchResultExtractorImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchResultExtractorImpl.java
@@ -18,6 +18,7 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneResult;
+import org.hibernate.search.backend.lucene.search.extraction.impl.ReusableDocumentStoredFieldVisitor;
 import org.hibernate.search.backend.lucene.search.projection.impl.LuceneSearchProjection;
 import org.hibernate.search.backend.lucene.search.projection.impl.SearchProjectionExecutionContext;
 import org.hibernate.search.engine.search.SearchResult;

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/SearchBackendContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/SearchBackendContext.java
@@ -6,11 +6,9 @@
  */
 package org.hibernate.search.backend.lucene.search.query.impl;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import org.hibernate.search.backend.lucene.multitenancy.impl.MultiTenancyStrategy;
 import org.hibernate.search.backend.lucene.orchestration.impl.LuceneQueryWorkOrchestrator;
+import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneDocumentStoredFieldVisitorBuilder;
 import org.hibernate.search.backend.lucene.search.impl.LuceneSearchTargetModel;
 import org.hibernate.search.backend.lucene.search.projection.impl.LuceneSearchProjection;
 import org.hibernate.search.backend.lucene.work.impl.LuceneWorkFactory;
@@ -52,8 +50,8 @@ public class SearchBackendContext {
 			LuceneSearchProjection<?, T> rootProjection) {
 		multiTenancyStrategy.checkTenantId( sessionContext.getTenantIdentifier(), eventContext );
 
-		Set<String> storedFields = new HashSet<>();
-		rootProjection.contributeFields( storedFields );
+		LuceneDocumentStoredFieldVisitorBuilder storedFieldFilterBuilder = new LuceneDocumentStoredFieldVisitorBuilder();
+		rootProjection.contributeFields( storedFieldFilterBuilder );
 
 		return new LuceneSearchQueryBuilder<>(
 				workFactory,
@@ -61,7 +59,7 @@ public class SearchBackendContext {
 				multiTenancyStrategy,
 				searchTargetModel,
 				sessionContext,
-				new ReusableDocumentStoredFieldVisitor( storedFields ),
+				storedFieldFilterBuilder.build(),
 				projectionHitMapper,
 				rootProjection
 		);

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneExecuteQueryWork.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneExecuteQueryWork.java
@@ -12,6 +12,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.search.backend.lucene.logging.impl.Log;
 import org.hibernate.search.backend.lucene.search.query.impl.LuceneSearcher;
+import org.hibernate.search.engine.mapper.session.context.spi.SessionContextImplementor;
 import org.hibernate.search.engine.search.SearchResult;
 import org.hibernate.search.util.impl.common.Futures;
 import org.hibernate.search.util.impl.common.LoggerFactory;
@@ -24,9 +25,12 @@ public class LuceneExecuteQueryWork<T> implements LuceneQueryWork<SearchResult<T
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private final LuceneSearcher<T> searcher;
+	private final SessionContextImplementor sessionContext;
 
-	public LuceneExecuteQueryWork(LuceneSearcher<T> searcher) {
+	public LuceneExecuteQueryWork(LuceneSearcher<T> searcher,
+			SessionContextImplementor sessionContext) {
 		this.searcher = searcher;
+		this.sessionContext = sessionContext;
 	}
 
 	@Override
@@ -37,7 +41,7 @@ public class LuceneExecuteQueryWork<T> implements LuceneQueryWork<SearchResult<T
 
 	private SearchResult<T> executeQuery(LuceneSearcher<T> searcher) {
 		try {
-			return searcher.execute();
+			return searcher.execute( sessionContext );
 		}
 		catch (IOException e) {
 			throw log.ioExceptionOnQueryExecution( searcher.getLuceneQuery(), searcher.getEventContext(), e );
@@ -52,6 +56,7 @@ public class LuceneExecuteQueryWork<T> implements LuceneQueryWork<SearchResult<T
 		StringBuilder sb = new StringBuilder( getClass().getSimpleName() )
 				.append( "[" )
 				.append( "searcher=" ).append( searcher )
+				.append( ", sessionContext=" ).append( sessionContext )
 				.append( "]" );
 		return sb.toString();
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneStubWorkFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneStubWorkFactory.java
@@ -9,6 +9,7 @@ package org.hibernate.search.backend.lucene.work.impl;
 import org.hibernate.search.backend.lucene.document.impl.LuceneIndexEntry;
 import org.hibernate.search.backend.lucene.multitenancy.impl.MultiTenancyStrategy;
 import org.hibernate.search.backend.lucene.search.query.impl.LuceneSearcher;
+import org.hibernate.search.engine.mapper.session.context.spi.SessionContextImplementor;
 
 
 /**
@@ -59,7 +60,7 @@ public class LuceneStubWorkFactory implements LuceneWorkFactory {
 	}
 
 	@Override
-	public <T> LuceneExecuteQueryWork<T> search(LuceneSearcher<T> luceneSearcher) {
-		return new LuceneExecuteQueryWork<T>( luceneSearcher );
+	public <T> LuceneExecuteQueryWork<T> search(LuceneSearcher<T> luceneSearcher, SessionContextImplementor sessionContext) {
+		return new LuceneExecuteQueryWork<>( luceneSearcher, sessionContext );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneWorkFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneWorkFactory.java
@@ -8,6 +8,7 @@ package org.hibernate.search.backend.lucene.work.impl;
 
 import org.hibernate.search.backend.lucene.document.impl.LuceneIndexEntry;
 import org.hibernate.search.backend.lucene.search.query.impl.LuceneSearcher;
+import org.hibernate.search.engine.mapper.session.context.spi.SessionContextImplementor;
 
 /**
  * @author Guillaume Smet
@@ -29,5 +30,5 @@ public interface LuceneWorkFactory {
 
 	LuceneIndexWork<?> optimize(String indexName);
 
-	<T> LuceneExecuteQueryWork<T> search(LuceneSearcher<T> luceneSearcher);
+	<T> LuceneExecuteQueryWork<T> search(LuceneSearcher<T> luceneSearcher, SessionContextImplementor sessionContext);
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/SearchPredicateFactoryContextExtension.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/SearchPredicateFactoryContextExtension.java
@@ -33,8 +33,8 @@ public interface SearchPredicateFactoryContextExtension<T> {
 	 * <p>
 	 * <strong>WARNING:</strong> this method is not API, see comments at the type level.
 	 *
-	 * @param <C> The type of query element collector for the given DSL context.
-	 * @param <B> The implementation type of builders for the given DSL context.
+	 * @param <C> The type of query element collector for the given predicate builder factory.
+	 * @param <B> The implementation type of builders for the given predicate builder factory.
 	 * @param original The original, non-extended {@link SearchPredicateFactoryContext}.
 	 * @param factory A {@link SearchPredicateBuilderFactory}.
 	 * @return An optional containing the extended search predicate factory context ({@link T}) in case

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/SearchPredicateFactoryExtensionContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/SearchPredicateFactoryExtensionContext.java
@@ -22,7 +22,7 @@ public interface SearchPredicateFactoryExtensionContext {
 	 * If the given extension is supported, and none of the previous extensions passed to
 	 * {@link #ifSupported(SearchPredicateFactoryContextExtension, Function)}
 	 * was supported, extend the current context with this extension,
-	 * and apply the given consumer to the extended context.
+	 * apply the given function to the extended context, and store the resulting predicate for later retrieval.
 	 * <p>
 	 * This method cannot be called after {@link #orElse(Function)} or {@link #orElseFail()}.
 	 *
@@ -40,18 +40,21 @@ public interface SearchPredicateFactoryExtensionContext {
 	/**
 	 * If no extension passed to {@link #ifSupported(SearchPredicateFactoryContextExtension, Function)}
 	 * was supported so far, apply the given consumer to the current (non-extended) {@link SearchPredicateFactoryContext};
-	 * otherwise do nothing.
+	 * otherwise return the predicate created in the first succeeding {@code ifSupported} call.
 	 *
 	 * @param predicateContributor A function that will use the (non-extended) context passed in parameter to create a {@link SearchPredicate},
 	 * if the extension is successfully applied.
 	 * Should generally be a lambda expression.
+	 * @return The created predicate.
 	 */
 	SearchPredicate orElse(Function<SearchPredicateFactoryContext, SearchPredicate> predicateContributor);
 
 	/**
 	 * If no extension passed to {@link #ifSupported(SearchPredicateFactoryContextExtension, Function)}
-	 * was supported so far, throw an exception; otherwise do nothing.
+	 * was supported so far, throw an exception;
+	 * otherwise return the predicate created in the first succeeding {@code ifSupported} call.
 	 *
+	 * @return The created predicate.
 	 * @throws org.hibernate.search.util.SearchException If none of the previously passed extensions was supported.
 	 */
 	SearchPredicate orElseFail();

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/SearchProjectionFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/SearchProjectionFactoryContext.java
@@ -212,4 +212,30 @@ public interface SearchProjectionFactoryContext<R, O> {
 				terminalContext1.toProjection(), terminalContext2.toProjection(), terminalContext3.toProjection()
 		);
 	}
+
+	/**
+	 * Extend the current context with the given extension,
+	 * resulting in an extended context offering different types of projections.
+	 *
+	 * @param extension The extension to the projection DSL.
+	 * @param <T> The type of context provided by the extension.
+	 * @return The extended context.
+	 * @throws org.hibernate.search.util.SearchException If the extension cannot be applied (wrong underlying backend, ...).
+	 */
+	<T> T extension(SearchProjectionFactoryContextExtension<T, R, O> extension);
+
+	/**
+	 * Create a context allowing to try to apply multiple extensions one after the other,
+	 * failing only if <em>none</em> of the extensions is supported.
+	 * <p>
+	 * If you only need to apply a single extension and fail if it is not supported,
+	 * use the simpler {@link #extension(SearchProjectionFactoryContextExtension)} method instead.
+	 * <p>
+	 * This method is generic, and you should set the generic type explicitly to the expected projected type,
+	 * e.g. {@code .<MyProjectedType>extension()}.
+	 *
+	 * @param <T> The expected projected type.
+	 * @return A context allowing to define the extensions to attempt, and the corresponding projections.
+	 */
+	<T> SearchProjectionFactoryExtensionContext<T, R, O> extension();
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/SearchProjectionFactoryContextExtension.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/SearchProjectionFactoryContextExtension.java
@@ -1,0 +1,46 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.dsl.projection;
+
+
+import java.util.Optional;
+
+import org.hibernate.search.engine.search.dsl.projection.spi.DelegatingSearchProjectionFactoryContext;
+import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilderFactory;
+
+/**
+ * An extension to the search query DSL, allowing to add non-standard predicates to a query.
+ * <p>
+ * <strong>WARNING:</strong> while this type is API, because instances should be manipulated by users,
+ * all of its methods are considered SPIs and therefore should never be called or implemented directly by users.
+ * In short, users are only expected to get instances of this type from an API ({@code SomeExtension.get()})
+ * and pass it to another API.
+ *
+ * @param <T> The type of extended search factory contexts. Should generally extend
+ * {@link SearchProjectionFactoryContext}.
+ * @param <R> The type of references in the original {@link SearchProjectionFactoryContext}.
+ * @param <O> The type of loaded objects in the original {@link SearchProjectionFactoryContext}.
+ *
+ * @see SearchProjectionFactoryContext#extension(SearchProjectionFactoryContextExtension)
+ * @see DelegatingSearchProjectionFactoryContext
+ */
+public interface SearchProjectionFactoryContextExtension<T, R, O> {
+
+	/**
+	 * Attempt to extend a given context, returning an empty {@link Optional} in case of failure.
+	 * <p>
+	 * <strong>WARNING:</strong> this method is not API, see comments at the type level.
+	 *
+	 * @param original The original, non-extended {@link SearchProjectionFactoryContext}.
+	 * @param factory A {@link SearchProjectionBuilderFactory}.
+	 * @return An optional containing the extended search predicate factory context ({@link T}) in case
+	 * of success, or an empty optional otherwise.
+	 */
+	Optional<T> extendOptional(SearchProjectionFactoryContext<R, O> original,
+			SearchProjectionBuilderFactory factory);
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/SearchProjectionFactoryExtensionContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/SearchProjectionFactoryExtensionContext.java
@@ -1,0 +1,67 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.dsl.projection;
+
+import java.util.function.Function;
+
+import org.hibernate.search.engine.search.SearchProjection;
+
+/**
+ * The context used when attempting to apply multiple extensions
+ * to a {@link SearchProjectionFactoryContext}.
+ *
+ * @param <R> The type of references in the parent {@link SearchProjectionFactoryContext}.
+ * @param <O> The type of loaded objects in the parent {@link SearchProjectionFactoryContext}.
+ * @param <P> The resulting projection type.
+ *
+ * @see SearchProjectionFactoryContext#extension()
+ */
+public interface SearchProjectionFactoryExtensionContext<P, R, O> {
+
+	/**
+	 * If the given extension is supported, and none of the previous extensions passed to
+	 * {@link #ifSupported(SearchProjectionFactoryContextExtension, Function)}
+	 * was supported, extend the current context with this extension,
+	 * apply the given function to the extended context, and store the resulting projection for later retrieval.
+	 * <p>
+	 * This method cannot be called after {@link #orElse(Function)} or {@link #orElseFail()}.
+	 *
+	 * @param extension The extension to apply.
+	 * @param projectionContributor A function that will use the (extended) context passed in parameter to create a {@link SearchProjection},
+	 * if the extension is successfully applied.
+	 * Should generally be a lambda expression.
+	 * @param <T> The type of the extended context.
+	 * @return {@code this}, for method chaining.
+	 */
+	<T> SearchProjectionFactoryExtensionContext<P, R, O> ifSupported(
+			SearchProjectionFactoryContextExtension<T, R, O> extension,
+			Function<T, SearchProjection<P>> projectionContributor
+	);
+
+	/**
+	 * If no extension passed to {@link #ifSupported(SearchProjectionFactoryContextExtension, Function)}
+	 * was supported so far, apply the given function to the current (non-extended) {@link SearchProjectionFactoryContext};
+	 * otherwise return the projection created in the first succeeding {@code ifSupported} call.
+	 *
+	 * @param projectionContributor A function that will use the (non-extended) context passed in parameter to create a {@link SearchProjection},
+	 * if the extension is successfully applied.
+	 * Should generally be a lambda expression.
+	 * @return The created projection.
+	 */
+	SearchProjection<P> orElse(Function<SearchProjectionFactoryContext<R, O>, SearchProjection<P>> projectionContributor);
+
+	/**
+	 * If no extension passed to {@link #ifSupported(SearchProjectionFactoryContextExtension, Function)}
+	 * was supported so far, throw an exception;
+	 * otherwise return the projection created in the first succeeding {@code ifSupported} call.
+	 *
+	 * @return The created projection.
+	 * @throws org.hibernate.search.util.SearchException If none of the previously passed extensions was supported.
+	 */
+	SearchProjection<P> orElseFail();
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/impl/DefaultSearchProjectionFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/impl/DefaultSearchProjectionFactoryContext.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import org.hibernate.search.engine.common.dsl.spi.DslExtensionState;
 import org.hibernate.search.engine.search.SearchProjection;
 import org.hibernate.search.engine.search.dsl.projection.CompositeProjectionContext;
 import org.hibernate.search.engine.search.dsl.projection.DistanceToFieldProjectionContext;
@@ -19,6 +20,8 @@ import org.hibernate.search.engine.search.dsl.projection.ObjectProjectionContext
 import org.hibernate.search.engine.search.dsl.projection.ReferenceProjectionContext;
 import org.hibernate.search.engine.search.dsl.projection.ScoreProjectionContext;
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContext;
+import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContextExtension;
+import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryExtensionContext;
 import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilderFactory;
 import org.hibernate.search.engine.spatial.GeoPoint;
 import org.hibernate.search.util.function.TriFunction;
@@ -108,5 +111,17 @@ public class DefaultSearchProjectionFactoryContext<R, O> implements SearchProjec
 		Contracts.assertNotNull( projection3, "projection3" );
 
 		return new CompositeProjectionContextImpl<>( factory, transformer, projection1, projection2, projection3 );
+	}
+
+	@Override
+	public <T> T extension(SearchProjectionFactoryContextExtension<T, R, O> extension) {
+		return DslExtensionState.returnIfSupported(
+				extension, extension.extendOptional( this, factory )
+		);
+	}
+
+	@Override
+	public <T> SearchProjectionFactoryExtensionContext<T, R, O> extension() {
+		return new SearchProjectionFactoryExtensionContextImpl<>( this, factory );
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/impl/SearchProjectionFactoryExtensionContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/impl/SearchProjectionFactoryExtensionContextImpl.java
@@ -1,0 +1,47 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.dsl.projection.impl;
+
+import java.util.function.Function;
+
+import org.hibernate.search.engine.common.dsl.spi.DslExtensionState;
+import org.hibernate.search.engine.search.SearchProjection;
+import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContext;
+import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContextExtension;
+import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryExtensionContext;
+import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilderFactory;
+
+public class SearchProjectionFactoryExtensionContextImpl<P, R, O> implements SearchProjectionFactoryExtensionContext<P, R, O> {
+
+	private final SearchProjectionFactoryContext<R, O> parent;
+	private final SearchProjectionBuilderFactory factory;
+
+	private final DslExtensionState<SearchProjection<P>> state = new DslExtensionState<>();
+
+	SearchProjectionFactoryExtensionContextImpl(SearchProjectionFactoryContext<R, O> parent,
+			SearchProjectionBuilderFactory factory) {
+		this.parent = parent;
+		this.factory = factory;
+	}
+
+	@Override
+	public <T> SearchProjectionFactoryExtensionContext<P, R, O> ifSupported(
+			SearchProjectionFactoryContextExtension<T, R, O> extension, Function<T, SearchProjection<P>> projectionContributor) {
+		state.ifSupported( extension, extension.extendOptional( parent, factory ), projectionContributor );
+		return this;
+	}
+
+	@Override
+	public SearchProjection<P> orElse(Function<SearchProjectionFactoryContext<R, O>, SearchProjection<P>> projectionContributor) {
+		return state.orElse( parent, projectionContributor );
+	}
+
+	@Override
+	public SearchProjection<P> orElseFail() {
+		return state.orElseFail();
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/spi/DelegatingSearchProjectionFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/spi/DelegatingSearchProjectionFactoryContext.java
@@ -1,0 +1,102 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.dsl.projection.spi;
+
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import org.hibernate.search.engine.search.SearchProjection;
+import org.hibernate.search.engine.search.dsl.projection.CompositeProjectionContext;
+import org.hibernate.search.engine.search.dsl.projection.DistanceToFieldProjectionContext;
+import org.hibernate.search.engine.search.dsl.projection.DocumentReferenceProjectionContext;
+import org.hibernate.search.engine.search.dsl.projection.FieldProjectionContext;
+import org.hibernate.search.engine.search.dsl.projection.ObjectProjectionContext;
+import org.hibernate.search.engine.search.dsl.projection.ReferenceProjectionContext;
+import org.hibernate.search.engine.search.dsl.projection.ScoreProjectionContext;
+import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContext;
+import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContextExtension;
+import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryExtensionContext;
+import org.hibernate.search.engine.spatial.GeoPoint;
+import org.hibernate.search.util.function.TriFunction;
+
+public class DelegatingSearchProjectionFactoryContext<R, O> implements SearchProjectionFactoryContext<R, O> {
+
+	private final SearchProjectionFactoryContext<R, O> delegate;
+
+	public DelegatingSearchProjectionFactoryContext(SearchProjectionFactoryContext<R, O> delegate) {
+		this.delegate = delegate;
+	}
+
+	@Override
+	public DocumentReferenceProjectionContext documentReference() {
+		return delegate.documentReference();
+	}
+
+	@Override
+	public ReferenceProjectionContext<R> reference() {
+		return delegate.reference();
+	}
+
+	@Override
+	public ObjectProjectionContext<O> object() {
+		return delegate.object();
+	}
+
+	@Override
+	public <T> FieldProjectionContext<T> field(String absoluteFieldPath, Class<T> type) {
+		return delegate.field( absoluteFieldPath, type );
+	}
+
+	@Override
+	public FieldProjectionContext<Object> field(String absoluteFieldPath) {
+		return delegate.field( absoluteFieldPath );
+	}
+
+	@Override
+	public ScoreProjectionContext score() {
+		return delegate.score();
+	}
+
+	@Override
+	public DistanceToFieldProjectionContext distance(String absoluteFieldPath, GeoPoint center) {
+		return delegate.distance( absoluteFieldPath, center );
+	}
+
+	@Override
+	public <T> CompositeProjectionContext<T> composite(Function<List<?>, T> transformer,
+			SearchProjection<?>... projections) {
+		return delegate.composite( transformer, projections );
+	}
+
+	@Override
+	public <P, T> CompositeProjectionContext<T> composite(Function<P, T> transformer, SearchProjection<P> projection) {
+		return delegate.composite( transformer, projection );
+	}
+
+	@Override
+	public <P1, P2, T> CompositeProjectionContext<T> composite(BiFunction<P1, P2, T> transformer,
+			SearchProjection<P1> projection1, SearchProjection<P2> projection2) {
+		return delegate.composite( transformer, projection1, projection2 );
+	}
+
+	@Override
+	public <P1, P2, P3, T> CompositeProjectionContext<T> composite(TriFunction<P1, P2, P3, T> transformer,
+			SearchProjection<P1> projection1, SearchProjection<P2> projection2, SearchProjection<P3> projection3) {
+		return delegate.composite( transformer, projection1, projection2, projection3 );
+	}
+
+	@Override
+	public <T> T extension(SearchProjectionFactoryContextExtension<T, R, O> extension) {
+		return delegate.extension( extension );
+	}
+
+	@Override
+	public <P> SearchProjectionFactoryExtensionContext<P, R, O> extension() {
+		return delegate.extension();
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/sort/SearchSortContainerContextExtension.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/sort/SearchSortContainerContextExtension.java
@@ -37,13 +37,12 @@ public interface SearchSortContainerContextExtension<T> {
 	 * @param original The original, non-extended {@link SearchSortContainerContext}.
 	 * @param factory A {@link SearchSortBuilderFactory}.
 	 * @param dslContext A {@link SearchSortDslContext}.
-	 * @param <C> The type of query element collector for the given DSL context.
-	 * @param <B> The implementation type of builders for the given DSL context.
+	 * @param <C> The type of query element collector for the given sort builder factory.
+	 * @param <B> The implementation type of builders for the given sort builder factory.
 	 * @return An optional containing the extended search predicate container context ({@link T}) in case
 	 * of success, or an empty optional otherwise.
 	 */
-	<C, B> Optional<T> extendOptional(
-			SearchSortContainerContext original,
+	<C, B> Optional<T> extendOptional(SearchSortContainerContext original,
 			SearchSortBuilderFactory<C, B> factory, SearchSortDslContext<? super B> dslContext);
 
 }

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
@@ -38,7 +38,7 @@ import org.assertj.core.api.Assertions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
 
-public class ExtensionIT {
+public class ElasticsearchExtensionIT {
 
 	private static final String BACKEND_NAME = "myElasticsearchBackend";
 	private static final String INDEX_NAME = "IndexName";

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
@@ -312,6 +312,23 @@ public class ElasticsearchExtensionIT {
 	}
 
 	@Test
+	public void projection_explanation() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		SearchQuery<String> query = searchTarget.query()
+				.asProjection( f -> f.extension( ElasticsearchExtension.get() ).explanation().toProjection() )
+				.predicate( f -> f.id().matching( FIRST_ID ).toPredicate() )
+				.build();
+
+		List<String> result = query.execute().getHits();
+		Assertions.assertThat( result ).hasSize( 1 );
+		Assertions.assertThat( result.get( 0 ) )
+				.asString()
+				.contains( "\"description\":" )
+				.contains( "\"details\":" );
+	}
+
+	@Test
 	public void backend_unwrap() {
 		Backend backend = integration.getBackend( BACKEND_NAME );
 		Assertions.assertThat( backend.unwrap( ElasticsearchBackend.class ) )

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneExtensionIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneExtensionIT.java
@@ -52,7 +52,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-public class ExtensionIT {
+public class LuceneExtensionIT {
 
 	private static final String BACKEND_NAME = "myLuceneBackend";
 	private static final String INDEX_NAME = "IndexName";
@@ -477,15 +477,15 @@ public class ExtensionIT {
 					.createAccessor();
 			nativeField = root.field( "nativeField" )
 					.extension( LuceneExtension.get() )
-					.asLuceneField( Integer.class, ExtensionIT::contributeNativeField, ExtensionIT::fromNativeField )
+					.asLuceneField( Integer.class, LuceneExtensionIT::contributeNativeField, LuceneExtensionIT::fromNativeField )
 					.createAccessor();
 			nativeField_unsupportedProjection = root.field( "nativeField_unsupportedProjection" )
 					.extension( LuceneExtension.get() )
-					.asLuceneField( Integer.class, ExtensionIT::contributeNativeField )
+					.asLuceneField( Integer.class, LuceneExtensionIT::contributeNativeField )
 					.createAccessor();
 			nativeField_invalidFieldPath = root.field( "nativeField_invalidFieldPath" )
 					.extension( LuceneExtension.get() )
-					.asLuceneField( Integer.class, ExtensionIT::contributeNativeFieldInvalidFieldPath )
+					.asLuceneField( Integer.class, LuceneExtensionIT::contributeNativeFieldInvalidFieldPath )
 					.createAccessor();
 
 			sort1 = root.field( "sort1" )

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneExtensionIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneExtensionIT.java
@@ -22,6 +22,7 @@ import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.SortField.Type;
@@ -429,6 +430,22 @@ public class LuceneExtensionIT {
 								.hasField( "nativeField_unsupportedProjection", "37" )
 								.andOnlyInternalFields()
 				) );
+	}
+
+	@Test
+	public void projection_explanation() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		SearchQuery<Explanation> query = searchTarget.query()
+				.asProjection( f -> f.extension( LuceneExtension.get() ).explanation().toProjection() )
+				.predicate( f -> f.id().matching( FIRST_ID ).toPredicate() )
+				.build();
+
+		List<Explanation> result = query.execute().getHits();
+		Assertions.assertThat( result ).hasSize( 1 );
+		Assertions.assertThat( result.get( 0 ) ).isInstanceOf( Explanation.class );
+		Assertions.assertThat( result.get( 0 ).toString() )
+				.contains( LuceneFields.idFieldName() );
 	}
 
 	@Test

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/testsupport/util/DocumentAssert.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/testsupport/util/DocumentAssert.java
@@ -1,0 +1,108 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.lucene.testsupport.util;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import org.hibernate.search.backend.lucene.util.impl.LuceneFields;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.util.BytesRef;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Condition;
+import org.assertj.core.api.ListAssert;
+import org.assertj.core.api.iterable.Extractor;
+
+public class DocumentAssert {
+	private static final String INTERNAL_FIELDS_PREFIX = "__HSEARCH_";
+
+	private final Document actual;
+	private String name;
+
+	private Set<String> allCheckedPaths = new HashSet<>();
+
+	public DocumentAssert(Document actual) {
+		this.actual = actual;
+	}
+
+	public DocumentAssert as(String name) {
+		this.name = name;
+		return this;
+	}
+
+	private ListAssert<IndexableField> asFields() {
+		return Assertions.assertThat( actual.getFields() );
+	}
+
+	public DocumentAssert hasField(String absoluteFieldPath, String ... values) {
+		return hasField( "string", absoluteFieldPath, values );
+	}
+
+	public DocumentAssert hasField(String absoluteFieldPath, Number ... values) {
+		return hasField( "numeric", absoluteFieldPath, values );
+	}
+
+	public DocumentAssert hasInternalField(String absoluteFieldPath, String ... values) {
+		return hasField( INTERNAL_FIELDS_PREFIX + absoluteFieldPath, values );
+	}
+
+	public DocumentAssert hasInternalField(String absoluteFieldPath, Number ... values) {
+		return hasField( INTERNAL_FIELDS_PREFIX + absoluteFieldPath, values );
+	}
+
+	@SafeVarargs
+	private final <T> DocumentAssert hasField(String type, String absoluteFieldPath, T ... values) {
+		String fieldDescription = "field of document '" + name + "' at path '" + absoluteFieldPath + "'"
+				+ " with type '" + type + "' and values '" + Arrays.toString( values ) + "'";
+		Predicate<IndexableField> predicate = field -> absoluteFieldPath.equals( field.name() );
+		asFields()
+				.areAtLeastOne( new Condition<>( predicate, fieldDescription ) )
+				.filteredOn( predicate )
+				.extracting( (Extractor<IndexableField, Object>) f -> {
+					// We can't just return everything and then exclude nulls,
+					// since .stringValue() converts a number to a string automatically...
+					Number number = f.numericValue();
+					if ( number != null ) {
+						return number;
+					}
+					BytesRef bytesRef = f.binaryValue();
+					if ( bytesRef != null ) {
+						return bytesRef.bytes;
+					}
+					String string = f.stringValue();
+					if ( string != null ) {
+						return string;
+					}
+					return null;
+				} )
+				.filteredOn( Objects::nonNull )
+				.as( fieldDescription )
+				.containsExactlyInAnyOrder( values );
+		allCheckedPaths.add( absoluteFieldPath );
+		return this;
+	}
+
+	public void andOnlyInternalFields() {
+		Set<String> allowedPaths = new HashSet<>( allCheckedPaths );
+		allowedPaths.add( LuceneFields.idFieldName() );
+		allowedPaths.add( LuceneFields.indexFieldName() );
+		allowedPaths.add( LuceneFields.typeFieldName() );
+		allowedPaths.add( LuceneFields.tenantIdFieldName() );
+		allowedPaths.add( LuceneFields.rootIdFieldName() );
+		allowedPaths.add( LuceneFields.rootIndexFieldName() );
+		asFields().are( new Condition<>(
+				field -> allowedPaths.contains( field.name() ),
+				"exclusively fields with path " + allCheckedPaths
+						+ " or prefixed with " + INTERNAL_FIELDS_PREFIX + " , and no other path"
+		) );
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3086
