### PR TITLE
HSEARCH-3453 Execute blocking search result processing in another thread than the one used for HTTP requests

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/impl/ElasticsearchSearchQueryElementCollector.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/impl/ElasticsearchSearchQueryElementCollector.java
@@ -9,10 +9,9 @@ package org.hibernate.search.backend.elasticsearch.search.impl;
 import java.util.Map;
 
 import org.hibernate.search.backend.elasticsearch.search.predicate.impl.ElasticsearchSearchPredicateCollector;
-import org.hibernate.search.backend.elasticsearch.search.projection.impl.SearchProjectionExecutionContext;
-import org.hibernate.search.backend.elasticsearch.search.projection.impl.SearchProjectionExecutionContext.DistanceSortKey;
+import org.hibernate.search.backend.elasticsearch.search.projection.impl.SearchProjectionExtractContext;
+import org.hibernate.search.backend.elasticsearch.search.projection.impl.SearchProjectionExtractContext.DistanceSortKey;
 import org.hibernate.search.backend.elasticsearch.search.sort.impl.ElasticsearchSearchSortCollector;
-import org.hibernate.search.engine.mapper.session.context.spi.SessionContextImplementor;
 import org.hibernate.search.engine.spatial.GeoPoint;
 import org.hibernate.search.util.impl.common.CollectionHelper;
 
@@ -69,7 +68,7 @@ public class ElasticsearchSearchQueryElementCollector
 		return jsonSort;
 	}
 
-	public SearchProjectionExecutionContext toSearchProjectionExecutionContext(SessionContextImplementor sessionContext) {
-		return new SearchProjectionExecutionContext( sessionContext, distanceSorts );
+	public SearchProjectionExtractContext toSearchProjectionExecutionContext() {
+		return new SearchProjectionExtractContext( distanceSorts );
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchCompositeBiFunctionProjection.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchCompositeBiFunctionProjection.java
@@ -33,25 +33,26 @@ public class ElasticsearchCompositeBiFunctionProjection<P1, P2, T> implements
 
 	@Override
 	public void contributeRequest(JsonObject requestBody,
-			SearchProjectionExecutionContext searchProjectionExecutionContext) {
-		projection1.contributeRequest( requestBody, searchProjectionExecutionContext );
-		projection2.contributeRequest( requestBody, searchProjectionExecutionContext );
+			SearchProjectionExtractContext context) {
+		projection1.contributeRequest( requestBody, context );
+		projection2.contributeRequest( requestBody, context );
 	}
 
 	@Override
 	public Object[] extract(ProjectionHitMapper<?, ?> projectionHitMapper, JsonObject responseBody, JsonObject hit,
-			SearchProjectionExecutionContext searchProjectionExecutionContext) {
+			SearchProjectionExtractContext context) {
 		return new Object[] {
-				projection1.extract( projectionHitMapper, responseBody, hit, searchProjectionExecutionContext ),
-				projection2.extract( projectionHitMapper, responseBody, hit, searchProjectionExecutionContext )
+				projection1.extract( projectionHitMapper, responseBody, hit, context ),
+				projection2.extract( projectionHitMapper, responseBody, hit, context )
 		};
 	}
 
 	@Override
-	public T transform(LoadingResult<?> loadingResult, Object[] extractedData) {
+	public T transform(LoadingResult<?> loadingResult, Object[] extractedData,
+			SearchProjectionTransformContext context) {
 		return transformer.apply(
-				transformUnsafe( projection1, loadingResult, extractedData[0] ),
-				transformUnsafe( projection2, loadingResult, extractedData[1] )
+				transformUnsafe( projection1, loadingResult, extractedData[0], context ),
+				transformUnsafe( projection2, loadingResult, extractedData[1], context )
 		);
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchCompositeFunctionProjection.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchCompositeFunctionProjection.java
@@ -27,19 +27,19 @@ public class ElasticsearchCompositeFunctionProjection<E, P, T> implements Elasti
 
 	@Override
 	public void contributeRequest(JsonObject requestBody,
-			SearchProjectionExecutionContext searchProjectionExecutionContext) {
-		projection.contributeRequest( requestBody, searchProjectionExecutionContext );
+			SearchProjectionExtractContext context) {
+		projection.contributeRequest( requestBody, context );
 	}
 
 	@Override
 	public E extract(ProjectionHitMapper<?, ?> projectionHitMapper, JsonObject responseBody, JsonObject hit,
-			SearchProjectionExecutionContext searchProjectionExecutionContext) {
-		return projection.extract( projectionHitMapper, responseBody, hit, searchProjectionExecutionContext );
+			SearchProjectionExtractContext context) {
+		return projection.extract( projectionHitMapper, responseBody, hit, context );
 	}
 
 	@Override
-	public T transform(LoadingResult<?> loadingResult, E extractedData) {
-		return transformer.apply( projection.transform( loadingResult, extractedData ) );
+	public T transform(LoadingResult<?> loadingResult, E extractedData, SearchProjectionTransformContext context) {
+		return transformer.apply( projection.transform( loadingResult, extractedData, context ) );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchCompositeListProjection.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchCompositeListProjection.java
@@ -31,29 +31,30 @@ public class ElasticsearchCompositeListProjection<T> implements ElasticsearchCom
 
 	@Override
 	public void contributeRequest(JsonObject requestBody,
-			SearchProjectionExecutionContext searchProjectionExecutionContext) {
+			SearchProjectionExtractContext context) {
 		for ( ElasticsearchSearchProjection<?, ?> child : children ) {
-			child.contributeRequest( requestBody, searchProjectionExecutionContext );
+			child.contributeRequest( requestBody, context );
 		}
 	}
 
 	@Override
 	public List<Object> extract(ProjectionHitMapper<?, ?> projectionHitMapper, JsonObject responseBody, JsonObject hit,
-			SearchProjectionExecutionContext searchProjectionExecutionContext) {
+			SearchProjectionExtractContext context) {
 		List<Object> extractedData = new ArrayList<>( children.size() );
 
 		for ( ElasticsearchSearchProjection<?, ?> child : children ) {
 			extractedData
-					.add( child.extract( projectionHitMapper, responseBody, hit, searchProjectionExecutionContext ) );
+					.add( child.extract( projectionHitMapper, responseBody, hit, context ) );
 		}
 
 		return extractedData;
 	}
 
 	@Override
-	public T transform(LoadingResult<?> loadingResult, List<Object> extractedData) {
+	public T transform(LoadingResult<?> loadingResult, List<Object> extractedData,
+			SearchProjectionTransformContext context) {
 		for ( int i = 0; i < extractedData.size(); i++ ) {
-			extractedData.set( i, transformUnsafe( children.get( i ), loadingResult, extractedData.get( i ) ) );
+			extractedData.set( i, transformUnsafe( children.get( i ), loadingResult, extractedData.get( i ), context ) );
 		}
 
 		return transformer.apply( extractedData );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchCompositeTriFunctionProjection.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchCompositeTriFunctionProjection.java
@@ -36,28 +36,29 @@ public class ElasticsearchCompositeTriFunctionProjection<P1, P2, P3, T> implemen
 
 	@Override
 	public void contributeRequest(JsonObject requestBody,
-			SearchProjectionExecutionContext searchProjectionExecutionContext) {
-		projection1.contributeRequest( requestBody, searchProjectionExecutionContext );
-		projection2.contributeRequest( requestBody, searchProjectionExecutionContext );
-		projection3.contributeRequest( requestBody, searchProjectionExecutionContext );
+			SearchProjectionExtractContext context) {
+		projection1.contributeRequest( requestBody, context );
+		projection2.contributeRequest( requestBody, context );
+		projection3.contributeRequest( requestBody, context );
 	}
 
 	@Override
 	public Object[] extract(ProjectionHitMapper<?, ?> projectionHitMapper, JsonObject responseBody, JsonObject hit,
-			SearchProjectionExecutionContext searchProjectionExecutionContext) {
+			SearchProjectionExtractContext context) {
 		return new Object[] {
-				projection1.extract( projectionHitMapper, responseBody, hit, searchProjectionExecutionContext ),
-				projection2.extract( projectionHitMapper, responseBody, hit, searchProjectionExecutionContext ),
-				projection3.extract( projectionHitMapper, responseBody, hit, searchProjectionExecutionContext )
+				projection1.extract( projectionHitMapper, responseBody, hit, context ),
+				projection2.extract( projectionHitMapper, responseBody, hit, context ),
+				projection3.extract( projectionHitMapper, responseBody, hit, context )
 		};
 	}
 
 	@Override
-	public T transform(LoadingResult<?> loadingResult, Object[] extractedData) {
+	public T transform(LoadingResult<?> loadingResult, Object[] extractedData,
+			SearchProjectionTransformContext context) {
 		return transformer.apply(
-				transformUnsafe( projection1, loadingResult, extractedData[0] ),
-				transformUnsafe( projection2, loadingResult, extractedData[1] ),
-				transformUnsafe( projection3, loadingResult, extractedData[2] )
+				transformUnsafe( projection1, loadingResult, extractedData[0], context ),
+				transformUnsafe( projection2, loadingResult, extractedData[1], context ),
+				transformUnsafe( projection3, loadingResult, extractedData[2], context )
 		);
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchDistanceToFieldProjection.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchDistanceToFieldProjection.java
@@ -44,8 +44,8 @@ class ElasticsearchDistanceToFieldProjection implements ElasticsearchSearchProje
 	}
 
 	@Override
-	public void contributeRequest(JsonObject requestBody, SearchProjectionExecutionContext searchProjectionExecutionContext) {
-		if ( searchProjectionExecutionContext.getDistanceSortIndex( absoluteFieldPath, center ) == null ) {
+	public void contributeRequest(JsonObject requestBody, SearchProjectionExtractContext context) {
+		if ( context.getDistanceSortIndex( absoluteFieldPath, center ) == null ) {
 			// we rely on a script to compute the distance
 			SCRIPT_FIELDS_ACCESSOR
 					.property( scriptFieldName ).asObject()
@@ -56,10 +56,10 @@ class ElasticsearchDistanceToFieldProjection implements ElasticsearchSearchProje
 
 	@Override
 	public Double extract(ProjectionHitMapper<?, ?> projectionHitMapper, JsonObject responseBody, JsonObject hit,
-			SearchProjectionExecutionContext searchProjectionExecutionContext) {
+			SearchProjectionExtractContext context) {
 		Optional<Double> distance;
 
-		Integer distanceSortIndex = searchProjectionExecutionContext.getDistanceSortIndex( absoluteFieldPath, center );
+		Integer distanceSortIndex = context.getDistanceSortIndex( absoluteFieldPath, center );
 
 		if ( distanceSortIndex == null ) {
 			// we extract the value from the fields computed by the script_fields
@@ -89,7 +89,8 @@ class ElasticsearchDistanceToFieldProjection implements ElasticsearchSearchProje
 	}
 
 	@Override
-	public Double transform(LoadingResult<?> loadingResult, Double extractedData) {
+	public Double transform(LoadingResult<?> loadingResult, Double extractedData,
+			SearchProjectionTransformContext context) {
 		return extractedData;
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchDocumentReferenceProjection.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchDocumentReferenceProjection.java
@@ -22,18 +22,19 @@ class ElasticsearchDocumentReferenceProjection
 	}
 
 	@Override
-	public void contributeRequest(JsonObject requestBody, SearchProjectionExecutionContext searchProjectionExecutionContext) {
+	public void contributeRequest(JsonObject requestBody, SearchProjectionExtractContext context) {
 		helper.contributeRequest( requestBody );
 	}
 
 	@Override
 	public DocumentReference extract(ProjectionHitMapper<?, ?> projectionHitMapper, JsonObject responseBody, JsonObject hit,
-			SearchProjectionExecutionContext searchProjectionExecutionContext) {
+			SearchProjectionExtractContext context) {
 		return helper.extractDocumentReference( hit );
 	}
 
 	@Override
-	public DocumentReference transform(LoadingResult<?> loadingResult, DocumentReference extractedData) {
+	public DocumentReference transform(LoadingResult<?> loadingResult, DocumentReference extractedData,
+			SearchProjectionTransformContext context) {
 		return extractedData;
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchExplanationProjection.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchExplanationProjection.java
@@ -26,20 +26,21 @@ class ElasticsearchExplanationProjection implements ElasticsearchSearchProjectio
 	}
 
 	@Override
-	public void contributeRequest(JsonObject requestBody, SearchProjectionExecutionContext searchProjectionExecutionContext) {
+	public void contributeRequest(JsonObject requestBody, SearchProjectionExtractContext context) {
 		REQUEST_EXPLAIN_ACCESSOR.set( requestBody, true );
 	}
 
 	@SuppressWarnings("unchecked")
 	@Override
 	public String extract(ProjectionHitMapper<?, ?> projectionHitMapper, JsonObject responseBody, JsonObject hit,
-			SearchProjectionExecutionContext searchProjectionExecutionContext) {
+			SearchProjectionExtractContext context) {
 		// We expect the optional to always be non-empty.
 		return gson.toJson( HIT_EXPLANATION_ACCESSOR.get( hit ).get() );
 	}
 
 	@Override
-	public String transform(LoadingResult<?> loadingResult, String extractedData) {
+	public String transform(LoadingResult<?> loadingResult, String extractedData,
+			SearchProjectionTransformContext context) {
 		return extractedData;
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchObjectProjection.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchObjectProjection.java
@@ -20,19 +20,20 @@ public class ElasticsearchObjectProjection<O> implements ElasticsearchSearchProj
 	}
 
 	@Override
-	public void contributeRequest(JsonObject requestBody, SearchProjectionExecutionContext searchProjectionExecutionContext) {
+	public void contributeRequest(JsonObject requestBody, SearchProjectionExtractContext context) {
 		helper.contributeRequest( requestBody );
 	}
 
 	@Override
 	public Object extract(ProjectionHitMapper<?, ?> projectionHitMapper, JsonObject responseBody, JsonObject hit,
-			SearchProjectionExecutionContext searchProjectionExecutionContext) {
+			SearchProjectionExtractContext context) {
 		return projectionHitMapper.planLoading( helper.extractDocumentReference( hit ) );
 	}
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public O transform(LoadingResult<?> loadingResult, Object extractedData) {
+	public O transform(LoadingResult<?> loadingResult, Object extractedData,
+			SearchProjectionTransformContext context) {
 		return (O) loadingResult.getLoaded( extractedData );
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchReferenceProjection.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchReferenceProjection.java
@@ -20,19 +20,20 @@ public class ElasticsearchReferenceProjection<R> implements ElasticsearchSearchP
 	}
 
 	@Override
-	public void contributeRequest(JsonObject requestBody, SearchProjectionExecutionContext searchProjectionExecutionContext) {
+	public void contributeRequest(JsonObject requestBody, SearchProjectionExtractContext context) {
 		helper.contributeRequest( requestBody );
 	}
 
 	@SuppressWarnings("unchecked")
 	@Override
 	public R extract(ProjectionHitMapper<?, ?> projectionHitMapper, JsonObject responseBody, JsonObject hit,
-			SearchProjectionExecutionContext searchProjectionExecutionContext) {
+			SearchProjectionExtractContext context) {
 		return (R) projectionHitMapper.convertReference( helper.extractDocumentReference( hit ) );
 	}
 
 	@Override
-	public R transform(LoadingResult<?> loadingResult, R extractedData) {
+	public R transform(LoadingResult<?> loadingResult, R extractedData,
+			SearchProjectionTransformContext context) {
 		return extractedData;
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchScoreProjection.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchScoreProjection.java
@@ -21,18 +21,19 @@ class ElasticsearchScoreProjection implements ElasticsearchSearchProjection<Floa
 	}
 
 	@Override
-	public void contributeRequest(JsonObject requestBody, SearchProjectionExecutionContext searchProjectionExecutionContext) {
+	public void contributeRequest(JsonObject requestBody, SearchProjectionExtractContext context) {
 		TRACK_SCORES_ACCESSOR.set( requestBody, true );
 	}
 
 	@Override
 	public Float extract(ProjectionHitMapper<?, ?> projectionHitMapper, JsonObject responseBody, JsonObject hit,
-			SearchProjectionExecutionContext searchProjectionExecutionContext) {
+			SearchProjectionExtractContext context) {
 		return hit.get( "_score" ).getAsFloat();
 	}
 
 	@Override
-	public Float transform(LoadingResult<?> loadingResult, Float extractedData) {
+	public Float transform(LoadingResult<?> loadingResult, Float extractedData,
+			SearchProjectionTransformContext context) {
 		return extractedData;
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchSourceProjection.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchSourceProjection.java
@@ -32,7 +32,7 @@ class ElasticsearchSourceProjection implements ElasticsearchSearchProjection<Str
 	}
 
 	@Override
-	public void contributeRequest(JsonObject requestBody, SearchProjectionExecutionContext searchProjectionExecutionContext) {
+	public void contributeRequest(JsonObject requestBody, SearchProjectionExtractContext context) {
 		JsonArray source = REQUEST_SOURCE_ACCESSOR.getOrCreate( requestBody, JsonArray::new );
 		if ( !source.contains( WILDCARD_ALL ) ) {
 			source.add( WILDCARD_ALL );
@@ -42,7 +42,7 @@ class ElasticsearchSourceProjection implements ElasticsearchSearchProjection<Str
 	@SuppressWarnings("unchecked")
 	@Override
 	public String extract(ProjectionHitMapper<?, ?> projectionHitMapper, JsonObject responseBody, JsonObject hit,
-			SearchProjectionExecutionContext searchProjectionExecutionContext) {
+			SearchProjectionExtractContext context) {
 		Optional<JsonObject> sourceElement = HIT_SOURCE_ACCESSOR.get( hit );
 		if ( sourceElement.isPresent() ) {
 			return gson.toJson( sourceElement.get() );
@@ -53,7 +53,8 @@ class ElasticsearchSourceProjection implements ElasticsearchSearchProjection<Str
 	}
 
 	@Override
-	public String transform(LoadingResult<?> loadingResult, String extractedData) {
+	public String transform(LoadingResult<?> loadingResult, String extractedData,
+			SearchProjectionTransformContext context) {
 		return extractedData;
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/SearchProjectionExtractContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/SearchProjectionExtractContext.java
@@ -10,24 +10,14 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
-import org.hibernate.search.engine.backend.document.converter.runtime.FromDocumentFieldValueConvertContext;
-import org.hibernate.search.engine.backend.document.converter.runtime.spi.FromDocumentFieldValueConvertContextImpl;
-import org.hibernate.search.engine.mapper.session.context.spi.SessionContextImplementor;
 import org.hibernate.search.engine.spatial.GeoPoint;
 
-public class SearchProjectionExecutionContext {
+public class SearchProjectionExtractContext {
 
-	private final FromDocumentFieldValueConvertContext fromDocumentFieldValueConvertContext;
 	private final Map<DistanceSortKey, Integer> distanceSorts;
 
-	public SearchProjectionExecutionContext(SessionContextImplementor sessionContext,
-			Map<DistanceSortKey, Integer> distanceSorts) {
-		this.fromDocumentFieldValueConvertContext = new FromDocumentFieldValueConvertContextImpl( sessionContext );
+	public SearchProjectionExtractContext(Map<DistanceSortKey, Integer> distanceSorts) {
 		this.distanceSorts = distanceSorts != null ? Collections.unmodifiableMap( distanceSorts ) : null;
-	}
-
-	FromDocumentFieldValueConvertContext getFromDocumentFieldValueConvertContext() {
-		return fromDocumentFieldValueConvertContext;
 	}
 
 	Integer getDistanceSortIndex(String absoluteFieldPath, GeoPoint location) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/SearchProjectionTransformContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/SearchProjectionTransformContext.java
@@ -1,0 +1,24 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.search.projection.impl;
+
+import org.hibernate.search.engine.backend.document.converter.runtime.FromDocumentFieldValueConvertContext;
+import org.hibernate.search.engine.backend.document.converter.runtime.spi.FromDocumentFieldValueConvertContextImpl;
+import org.hibernate.search.engine.mapper.session.context.spi.SessionContextImplementor;
+
+public class SearchProjectionTransformContext {
+
+	private final FromDocumentFieldValueConvertContext fromDocumentFieldValueConvertContext;
+
+	public SearchProjectionTransformContext(SessionContextImplementor sessionContext) {
+		this.fromDocumentFieldValueConvertContext = new FromDocumentFieldValueConvertContextImpl( sessionContext );
+	}
+
+	FromDocumentFieldValueConvertContext getFromDocumentFieldValueConvertContext() {
+		return fromDocumentFieldValueConvertContext;
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchLoadableSearchResult.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchLoadableSearchResult.java
@@ -1,0 +1,64 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.search.query.impl;
+
+import static org.hibernate.search.backend.elasticsearch.search.projection.impl.ElasticsearchSearchProjection.transformUnsafe;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.hibernate.search.backend.elasticsearch.search.projection.impl.ElasticsearchSearchProjection;
+import org.hibernate.search.engine.search.SearchResult;
+import org.hibernate.search.engine.search.query.spi.LoadingResult;
+import org.hibernate.search.engine.search.query.spi.ProjectionHitMapper;
+import org.hibernate.search.engine.search.spi.SimpleSearchResult;
+
+/**
+ * A search result from the backend that offers a method to load data from the mapper.
+ * <p>
+ * Allows to run loading in the user thread, and not in the backend HTTP request threads.
+ * <p>
+ * <strong>WARNING:</strong> loading should only be triggered once.
+ * <p>
+ * <strong>WARNING:</strong> this class is not thread-safe.
+ *
+ * @param <T> The type of hits in the search result.
+ */
+public class ElasticsearchLoadableSearchResult<T> {
+	private final ProjectionHitMapper<?, ?> projectionHitMapper;
+	private final ElasticsearchSearchProjection<?, T> rootProjection;
+
+	private final long hitCount;
+	private List<Object> extractedData;
+
+	ElasticsearchLoadableSearchResult(ProjectionHitMapper<?, ?> projectionHitMapper,
+			ElasticsearchSearchProjection<?, T> rootProjection,
+			long hitCount, List<Object> extractedData) {
+		this.projectionHitMapper = projectionHitMapper;
+		this.rootProjection = rootProjection;
+		this.hitCount = hitCount;
+		this.extractedData = extractedData;
+	}
+
+	SearchResult<T> loadBlocking() {
+		LoadingResult<?> loadingResult = projectionHitMapper.loadBlocking();
+
+		for ( int i = 0; i < extractedData.size(); i++ ) {
+			T transformed = transformUnsafe( rootProjection, loadingResult, extractedData.get( i ) );
+			extractedData.set( i, transformed );
+		}
+
+		// The cast is safe, since all elements extend T and we make the list unmodifiable
+		@SuppressWarnings("unchecked")
+		List<T> loadedHits = Collections.unmodifiableList( (List<? extends T>) extractedData );
+
+		// Make sure that if someone uses this object incorrectly, it will always fail, and will fail early.
+		extractedData = null;
+
+		return new SimpleSearchResult<>( hitCount, loadedHits );
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchLoadableSearchResult.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchLoadableSearchResult.java
@@ -12,6 +12,8 @@ import java.util.Collections;
 import java.util.List;
 
 import org.hibernate.search.backend.elasticsearch.search.projection.impl.ElasticsearchSearchProjection;
+import org.hibernate.search.backend.elasticsearch.search.projection.impl.SearchProjectionTransformContext;
+import org.hibernate.search.engine.mapper.session.context.spi.SessionContextImplementor;
 import org.hibernate.search.engine.search.SearchResult;
 import org.hibernate.search.engine.search.query.spi.LoadingResult;
 import org.hibernate.search.engine.search.query.spi.ProjectionHitMapper;
@@ -44,11 +46,13 @@ public class ElasticsearchLoadableSearchResult<T> {
 		this.extractedData = extractedData;
 	}
 
-	SearchResult<T> loadBlocking() {
+	SearchResult<T> loadBlocking(SessionContextImplementor sessionContext) {
+		SearchProjectionTransformContext transformContext = new SearchProjectionTransformContext( sessionContext );
+
 		LoadingResult<?> loadingResult = projectionHitMapper.loadBlocking();
 
 		for ( int i = 0; i < extractedData.size(); i++ ) {
-			T transformed = transformUnsafe( rootProjection, loadingResult, extractedData.get( i ) );
+			T transformed = transformUnsafe( rootProjection, loadingResult, extractedData.get( i ), transformContext );
 			extractedData.set( i, transformed );
 		}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchQuery.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchQuery.java
@@ -15,6 +15,7 @@ import org.hibernate.search.backend.elasticsearch.orchestration.impl.Elasticsear
 import org.hibernate.search.backend.elasticsearch.work.impl.ElasticsearchWork;
 import org.hibernate.search.backend.elasticsearch.work.impl.ElasticsearchWorkFactory;
 import org.hibernate.search.backend.elasticsearch.work.impl.ElasticsearchSearchResultExtractor;
+import org.hibernate.search.engine.mapper.session.context.spi.SessionContextImplementor;
 import org.hibernate.search.engine.search.SearchQuery;
 import org.hibernate.search.engine.search.SearchResult;
 
@@ -29,6 +30,7 @@ public class ElasticsearchSearchQuery<T> implements SearchQuery<T> {
 	private final ElasticsearchWorkFactory workFactory;
 	private final ElasticsearchWorkOrchestrator queryOrchestrator;
 	private final Set<URLEncodedString> indexNames;
+	private final SessionContextImplementor sessionContext;
 	private final Set<String> routingKeys;
 	private final JsonObject payload;
 	private final ElasticsearchSearchResultExtractor<T> searchResultExtractor;
@@ -38,11 +40,14 @@ public class ElasticsearchSearchQuery<T> implements SearchQuery<T> {
 
 	public ElasticsearchSearchQuery(ElasticsearchWorkFactory workFactory,
 			ElasticsearchWorkOrchestrator queryOrchestrator,
-			Set<URLEncodedString> indexNames, Set<String> routingKeys,
+			Set<URLEncodedString> indexNames,
+			SessionContextImplementor sessionContext,
+			Set<String> routingKeys,
 			JsonObject payload, ElasticsearchSearchResultExtractor<T> searchResultExtractor) {
 		this.workFactory = workFactory;
 		this.queryOrchestrator = queryOrchestrator;
 		this.indexNames = indexNames;
+		this.sessionContext = sessionContext;
 		this.routingKeys = routingKeys;
 		this.payload = payload;
 		this.searchResultExtractor = searchResultExtractor;
@@ -82,7 +87,7 @@ public class ElasticsearchSearchQuery<T> implements SearchQuery<T> {
 				 * This method may not be easy to implement for blocking mappers,
 				 * so we may choose to throw exceptions for those.
 				 */
-				.loadBlocking();
+				.loadBlocking( sessionContext );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchQueryBuilder.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchQueryBuilder.java
@@ -14,7 +14,7 @@ import org.hibernate.search.backend.elasticsearch.multitenancy.impl.MultiTenancy
 import org.hibernate.search.backend.elasticsearch.orchestration.impl.ElasticsearchWorkOrchestrator;
 import org.hibernate.search.backend.elasticsearch.search.impl.ElasticsearchSearchQueryElementCollector;
 import org.hibernate.search.backend.elasticsearch.search.projection.impl.ElasticsearchSearchProjection;
-import org.hibernate.search.backend.elasticsearch.search.projection.impl.SearchProjectionExecutionContext;
+import org.hibernate.search.backend.elasticsearch.search.projection.impl.SearchProjectionExtractContext;
 import org.hibernate.search.backend.elasticsearch.util.spi.URLEncodedString;
 import org.hibernate.search.backend.elasticsearch.work.impl.ElasticsearchWorkFactory;
 import org.hibernate.search.backend.elasticsearch.work.impl.ElasticsearchSearchResultExtractor;
@@ -85,8 +85,8 @@ class ElasticsearchSearchQueryBuilder<T>
 			payload.add( "sort", jsonSort );
 		}
 
-		SearchProjectionExecutionContext searchProjectionExecutionContext = elementCollector
-				.toSearchProjectionExecutionContext( sessionContext );
+		SearchProjectionExtractContext searchProjectionExecutionContext = elementCollector
+				.toSearchProjectionExecutionContext();
 
 		rootProjection.contributeRequest( payload, searchProjectionExecutionContext );
 
@@ -95,7 +95,7 @@ class ElasticsearchSearchQueryBuilder<T>
 
 		return new ElasticsearchSearchQuery<>(
 				workFactory, queryOrchestrator,
-				indexNames, routingKeys,
+				indexNames, sessionContext, routingKeys,
 				payload,
 				searchResultExtractor
 		);

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchResultExtractorImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchResultExtractorImpl.java
@@ -82,7 +82,7 @@ public class ElasticsearchSearchResultExtractorImpl<T> implements ElasticsearchS
 					searchProjectionExecutionContext ) );
 		}
 
-		LoadingResult<?> loadingResult = projectionHitMapper.load();
+		LoadingResult<?> loadingResult = projectionHitMapper.loadBlocking();
 
 		for ( int i = 0; i < hits.size(); i++ ) {
 			hits.set( i, transformUnsafe( rootProjection, loadingResult, hits.get( i ) ) );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchResultExtractorImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchResultExtractorImpl.java
@@ -13,7 +13,7 @@ import java.util.List;
 import org.hibernate.search.backend.elasticsearch.gson.impl.JsonAccessor;
 import org.hibernate.search.backend.elasticsearch.gson.impl.JsonObjectAccessor;
 import org.hibernate.search.backend.elasticsearch.search.projection.impl.ElasticsearchSearchProjection;
-import org.hibernate.search.backend.elasticsearch.search.projection.impl.SearchProjectionExecutionContext;
+import org.hibernate.search.backend.elasticsearch.search.projection.impl.SearchProjectionExtractContext;
 import org.hibernate.search.backend.elasticsearch.work.impl.ElasticsearchSearchResultExtractor;
 import org.hibernate.search.engine.search.query.spi.ProjectionHitMapper;
 
@@ -35,12 +35,12 @@ public class ElasticsearchSearchResultExtractorImpl<T> implements ElasticsearchS
 	private final ProjectionHitMapper<?, ?> projectionHitMapper;
 	private final ElasticsearchSearchProjection<?, T> rootProjection;
 
-	private final SearchProjectionExecutionContext searchProjectionExecutionContext;
+	private final SearchProjectionExtractContext searchProjectionExecutionContext;
 
 	public ElasticsearchSearchResultExtractorImpl(
 			ProjectionHitMapper<?, ?> projectionHitMapper,
 			ElasticsearchSearchProjection<?, T> rootProjection,
-			SearchProjectionExecutionContext searchProjectionExecutionContext) {
+			SearchProjectionExtractContext searchProjectionExecutionContext) {
 		this.projectionHitMapper = projectionHitMapper;
 		this.rootProjection = rootProjection;
 		this.searchProjectionExecutionContext = searchProjectionExecutionContext;

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/ElasticsearchSearchResultExtractor.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/ElasticsearchSearchResultExtractor.java
@@ -6,12 +6,12 @@
  */
 package org.hibernate.search.backend.elasticsearch.work.impl;
 
-import org.hibernate.search.engine.search.SearchResult;
+import org.hibernate.search.backend.elasticsearch.search.query.impl.ElasticsearchLoadableSearchResult;
 
 import com.google.gson.JsonObject;
 
 public interface ElasticsearchSearchResultExtractor<T> {
 
-	SearchResult<T> extract(JsonObject responseBody);
+	ElasticsearchLoadableSearchResult<T> extract(JsonObject responseBody);
 
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/ElasticsearchStubWorkFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/ElasticsearchStubWorkFactory.java
@@ -14,10 +14,10 @@ import org.hibernate.search.backend.elasticsearch.client.impl.Paths;
 import org.hibernate.search.backend.elasticsearch.gson.impl.JsonAccessor;
 import org.hibernate.search.backend.elasticsearch.index.settings.impl.esnative.IndexSettings;
 import org.hibernate.search.backend.elasticsearch.multitenancy.impl.MultiTenancyStrategy;
+import org.hibernate.search.backend.elasticsearch.search.query.impl.ElasticsearchLoadableSearchResult;
 import org.hibernate.search.backend.elasticsearch.util.spi.URLEncodedString;
 import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.RootTypeMapping;
 import org.hibernate.search.backend.elasticsearch.gson.spi.GsonProvider;
-import org.hibernate.search.engine.search.SearchResult;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -145,7 +145,7 @@ public class ElasticsearchStubWorkFactory implements ElasticsearchWorkFactory {
 	}
 
 	@Override
-	public <T> ElasticsearchWork<SearchResult<T>> search(Set<URLEncodedString> indexNames, Set<String> routingKeys,
+	public <T> ElasticsearchWork<ElasticsearchLoadableSearchResult<T>> search(Set<URLEncodedString> indexNames, Set<String> routingKeys,
 			JsonObject payload, ElasticsearchSearchResultExtractor<T> searchResultExtractor,
 			Long offset, Long limit) {
 		ElasticsearchRequest.Builder builder = ElasticsearchRequest.post()

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/ElasticsearchWorkFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/ElasticsearchWorkFactory.java
@@ -9,9 +9,9 @@ package org.hibernate.search.backend.elasticsearch.work.impl;
 import java.util.Set;
 
 import org.hibernate.search.backend.elasticsearch.index.settings.impl.esnative.IndexSettings;
+import org.hibernate.search.backend.elasticsearch.search.query.impl.ElasticsearchLoadableSearchResult;
 import org.hibernate.search.backend.elasticsearch.util.spi.URLEncodedString;
 import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.RootTypeMapping;
-import org.hibernate.search.engine.search.SearchResult;
 
 import com.google.gson.JsonObject;
 
@@ -38,7 +38,7 @@ public interface ElasticsearchWorkFactory {
 
 	ElasticsearchWork<?> optimize(URLEncodedString indexName);
 
-	<T> ElasticsearchWork<SearchResult<T>> search(Set<URLEncodedString> indexNames, Set<String> routingKeys,
+	<T> ElasticsearchWork<ElasticsearchLoadableSearchResult<T>> search(Set<URLEncodedString> indexNames, Set<String> routingKeys,
 			JsonObject payload, ElasticsearchSearchResultExtractor<T> searchResultExtractor,
 			Long offset, Long limit);
 

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/DistanceToFieldSearchProjectionTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/DistanceToFieldSearchProjectionTest.java
@@ -9,7 +9,6 @@ package org.hibernate.search.backend.elasticsearch.search.projection.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.hibernate.search.backend.elasticsearch.search.impl.ElasticsearchSearchQueryElementCollector;
-import org.hibernate.search.engine.mapper.session.context.spi.SessionContextImplementor;
 import org.hibernate.search.engine.spatial.DistanceUnit;
 import org.hibernate.search.engine.spatial.GeoPoint;
 import org.junit.Test;
@@ -32,12 +31,10 @@ public class DistanceToFieldSearchProjectionTest extends EasyMockSupport {
 
 		JsonObject requestBody = new JsonObject();
 
-		SessionContextImplementor sessionContext = createMock( SessionContextImplementor.class );
-
 		resetAll();
 		replayAll();
-		SearchProjectionExecutionContext searchProjectionExecutionContext =
-				elementCollector.toSearchProjectionExecutionContext( sessionContext );
+		SearchProjectionExtractContext searchProjectionExecutionContext =
+				elementCollector.toSearchProjectionExecutionContext();
 		projection.contributeRequest( requestBody, searchProjectionExecutionContext );
 		verifyAll();
 
@@ -56,12 +53,10 @@ public class DistanceToFieldSearchProjectionTest extends EasyMockSupport {
 
 		JsonObject requestBody = new JsonObject();
 
-		SessionContextImplementor sessionContext = createMock( SessionContextImplementor.class );
-
 		resetAll();
 		replayAll();
-		SearchProjectionExecutionContext searchProjectionExecutionContext =
-				elementCollector.toSearchProjectionExecutionContext( sessionContext );
+		SearchProjectionExtractContext searchProjectionExecutionContext =
+				elementCollector.toSearchProjectionExecutionContext();
 		projection.contributeRequest( requestBody, searchProjectionExecutionContext );
 		verifyAll();
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneCompositeBiFunctionProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneCompositeBiFunctionProjection.java
@@ -45,7 +45,7 @@ public class LuceneCompositeBiFunctionProjection<P1, P2, T> implements LuceneCom
 
 	@Override
 	public Object[] extract(ProjectionHitMapper<?, ?> projectionHitMapper, LuceneResult luceneResult,
-			SearchProjectionExecutionContext context) {
+			SearchProjectionExtractContext context) {
 		return new Object[] {
 				projection1.extract( projectionHitMapper, luceneResult, context ),
 				projection2.extract( projectionHitMapper, luceneResult, context )
@@ -53,10 +53,11 @@ public class LuceneCompositeBiFunctionProjection<P1, P2, T> implements LuceneCom
 	}
 
 	@Override
-	public T transform(LoadingResult<?> loadingResult, Object[] extractedData) {
+	public T transform(LoadingResult<?> loadingResult, Object[] extractedData,
+			SearchProjectionTransformContext context) {
 		return transformer.apply(
-				transformUnsafe( projection1, loadingResult, extractedData[0] ),
-				transformUnsafe( projection2, loadingResult, extractedData[1] )
+				transformUnsafe( projection1, loadingResult, extractedData[0], context ),
+				transformUnsafe( projection2, loadingResult, extractedData[1], context )
 		);
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneCompositeFunctionProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneCompositeFunctionProjection.java
@@ -38,13 +38,14 @@ public class LuceneCompositeFunctionProjection<E, P, T> implements LuceneComposi
 
 	@Override
 	public E extract(ProjectionHitMapper<?, ?> projectionHitMapper, LuceneResult luceneResult,
-			SearchProjectionExecutionContext context) {
+			SearchProjectionExtractContext context) {
 		return projection.extract( projectionHitMapper, luceneResult, context );
 	}
 
 	@Override
-	public T transform(LoadingResult<?> loadingResult, E extractedData) {
-		return transformer.apply( projection.transform( loadingResult, extractedData ) );
+	public T transform(LoadingResult<?> loadingResult, E extractedData,
+			SearchProjectionTransformContext context) {
+		return transformer.apply( projection.transform( loadingResult, extractedData, context ) );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneCompositeListProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneCompositeListProjection.java
@@ -46,7 +46,7 @@ public class LuceneCompositeListProjection<T> implements LuceneCompositeProjecti
 
 	@Override
 	public List<Object> extract(ProjectionHitMapper<?, ?> mapper, LuceneResult documentResult,
-			SearchProjectionExecutionContext context) {
+			SearchProjectionExtractContext context) {
 		List<Object> extractedData = new ArrayList<>( children.size() );
 
 		for ( LuceneSearchProjection<?, ?> child : children ) {
@@ -57,9 +57,10 @@ public class LuceneCompositeListProjection<T> implements LuceneCompositeProjecti
 	}
 
 	@Override
-	public T transform(LoadingResult<?> loadingResult, List<Object> extractedData) {
+	public T transform(LoadingResult<?> loadingResult, List<Object> extractedData,
+			SearchProjectionTransformContext context) {
 		for ( int i = 0; i < extractedData.size(); i++ ) {
-			extractedData.set( i, transformUnsafe( children.get( i ), loadingResult, extractedData.get( i ) ) );
+			extractedData.set( i, transformUnsafe( children.get( i ), loadingResult, extractedData.get( i ), context ) );
 		}
 
 		return transformer.apply( extractedData );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneCompositeTriFunctionProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneCompositeTriFunctionProjection.java
@@ -51,7 +51,7 @@ public class LuceneCompositeTriFunctionProjection<P1, P2, P3, T> implements Luce
 
 	@Override
 	public Object[] extract(ProjectionHitMapper<?, ?> projectionHitMapper, LuceneResult luceneResult,
-			SearchProjectionExecutionContext context) {
+			SearchProjectionExtractContext context) {
 		return new Object[] {
 				projection1.extract( projectionHitMapper, luceneResult, context ),
 				projection2.extract( projectionHitMapper, luceneResult, context ),
@@ -60,11 +60,12 @@ public class LuceneCompositeTriFunctionProjection<P1, P2, P3, T> implements Luce
 	}
 
 	@Override
-	public T transform(LoadingResult<?> loadingResult, Object[] extractedData) {
+	public T transform(LoadingResult<?> loadingResult, Object[] extractedData,
+			SearchProjectionTransformContext context) {
 		return transformer.apply(
-				transformUnsafe( projection1, loadingResult, extractedData[0] ),
-				transformUnsafe( projection2, loadingResult, extractedData[1] ),
-				transformUnsafe( projection3, loadingResult, extractedData[2] )
+				transformUnsafe( projection1, loadingResult, extractedData[0], context ),
+				transformUnsafe( projection2, loadingResult, extractedData[1], context ),
+				transformUnsafe( projection3, loadingResult, extractedData[2], context )
 		);
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneDistanceToFieldProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneDistanceToFieldProjection.java
@@ -43,12 +43,13 @@ class LuceneDistanceToFieldProjection implements LuceneSearchProjection<Double, 
 
 	@Override
 	public Double extract(ProjectionHitMapper<?, ?> mapper, LuceneResult documentResult,
-			SearchProjectionExecutionContext context) {
+			SearchProjectionExtractContext context) {
 		return unit.fromMeters( distanceCollector.getDistance( documentResult.getDocId() ) );
 	}
 
 	@Override
-	public Double transform(LoadingResult<?> loadingResult, Double extractedData) {
+	public Double transform(LoadingResult<?> loadingResult, Double extractedData,
+			SearchProjectionTransformContext context) {
 		return extractedData;
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneDocumentProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneDocumentProjection.java
@@ -37,12 +37,13 @@ class LuceneDocumentProjection implements LuceneSearchProjection<Document, Docum
 
 	@Override
 	public Document extract(ProjectionHitMapper<?, ?> mapper, LuceneResult documentResult,
-			SearchProjectionExecutionContext context) {
+			SearchProjectionExtractContext context) {
 		return documentResult.getDocument();
 	}
 
 	@Override
-	public Document transform(LoadingResult<?> loadingResult, Document extractedData) {
+	public Document transform(LoadingResult<?> loadingResult, Document extractedData,
+			SearchProjectionTransformContext context) {
 		return extractedData;
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneDocumentReferenceProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneDocumentReferenceProjection.java
@@ -37,12 +37,13 @@ class LuceneDocumentReferenceProjection implements LuceneSearchProjection<Docume
 
 	@Override
 	public DocumentReference extract(ProjectionHitMapper<?, ?> mapper, LuceneResult documentResult,
-			SearchProjectionExecutionContext context) {
+			SearchProjectionExtractContext context) {
 		return DocumentReferenceExtractorHelper.extractDocumentReference( documentResult );
 	}
 
 	@Override
-	public DocumentReference transform(LoadingResult<?> loadingResult, DocumentReference extractedData) {
+	public DocumentReference transform(LoadingResult<?> loadingResult, DocumentReference extractedData,
+			SearchProjectionTransformContext context) {
 		return extractedData;
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneExplanationProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneExplanationProjection.java
@@ -37,12 +37,13 @@ class LuceneExplanationProjection implements LuceneSearchProjection<Explanation,
 
 	@Override
 	public Explanation extract(ProjectionHitMapper<?, ?> mapper, LuceneResult documentResult,
-			SearchProjectionExecutionContext context) {
+			SearchProjectionExtractContext context) {
 		return context.explain( documentResult.getDocId() );
 	}
 
 	@Override
-	public Explanation transform(LoadingResult<?> loadingResult, Explanation extractedData) {
+	public Explanation transform(LoadingResult<?> loadingResult, Explanation extractedData,
+			SearchProjectionTransformContext context) {
 		return extractedData;
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneFieldProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneFieldProjection.java
@@ -15,7 +15,7 @@ import org.hibernate.search.engine.backend.document.converter.runtime.FromDocume
 import org.hibernate.search.engine.search.query.spi.LoadingResult;
 import org.hibernate.search.engine.search.query.spi.ProjectionHitMapper;
 
-class LuceneFieldProjection<F, T> implements LuceneSearchProjection<T, T> {
+class LuceneFieldProjection<F, T> implements LuceneSearchProjection<F, T> {
 
 	private final String absoluteFieldPath;
 
@@ -47,16 +47,16 @@ class LuceneFieldProjection<F, T> implements LuceneSearchProjection<T, T> {
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public T extract(ProjectionHitMapper<?, ?> mapper, LuceneResult documentResult,
-			SearchProjectionExecutionContext context) {
-		F rawValue = codec.decode( documentResult.getDocument(), absoluteFieldPath );
-		FromDocumentFieldValueConvertContext convertContext = context.getFromDocumentFieldValueConvertContext();
-		return converter.convert( rawValue, convertContext );
+	public F extract(ProjectionHitMapper<?, ?> mapper, LuceneResult documentResult,
+			SearchProjectionExtractContext context) {
+		return codec.decode( documentResult.getDocument(), absoluteFieldPath );
 	}
 
 	@Override
-	public T transform(LoadingResult<?> loadingResult, T extractedData) {
-		return extractedData;
+	public T transform(LoadingResult<?> loadingResult, F extractedData,
+			SearchProjectionTransformContext context) {
+		FromDocumentFieldValueConvertContext convertContext = context.getFromDocumentFieldValueConvertContext();
+		return converter.convert( extractedData, convertContext );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneObjectProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneObjectProjection.java
@@ -38,13 +38,14 @@ public class LuceneObjectProjection<O> implements LuceneSearchProjection<Object,
 
 	@Override
 	public Object extract(ProjectionHitMapper<?, ?> mapper, LuceneResult documentResult,
-			SearchProjectionExecutionContext context) {
+			SearchProjectionExtractContext context) {
 		return mapper.planLoading( DocumentReferenceExtractorHelper.extractDocumentReference( documentResult ) );
 	}
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public O transform(LoadingResult<?> loadingResult, Object extractedData) {
+	public O transform(LoadingResult<?> loadingResult, Object extractedData,
+			SearchProjectionTransformContext context) {
 		return (O) loadingResult.getLoaded( extractedData );
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneReferenceProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneReferenceProjection.java
@@ -39,12 +39,13 @@ public class LuceneReferenceProjection<R> implements LuceneSearchProjection<R, R
 	@SuppressWarnings("unchecked")
 	@Override
 	public R extract(ProjectionHitMapper<?, ?> mapper, LuceneResult documentResult,
-			SearchProjectionExecutionContext context) {
+			SearchProjectionExtractContext context) {
 		return (R) mapper.convertReference( DocumentReferenceExtractorHelper.extractDocumentReference( documentResult ) );
 	}
 
 	@Override
-	public R transform(LoadingResult<?> loadingResult, R extractedData) {
+	public R transform(LoadingResult<?> loadingResult, R extractedData,
+			SearchProjectionTransformContext context) {
 		return extractedData;
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneScoreProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneScoreProjection.java
@@ -35,12 +35,13 @@ class LuceneScoreProjection implements LuceneSearchProjection<Float, Float> {
 
 	@Override
 	public Float extract(ProjectionHitMapper<?, ?> mapper, LuceneResult documentResult,
-			SearchProjectionExecutionContext context) {
+			SearchProjectionExtractContext context) {
 		return documentResult.getScore();
 	}
 
 	@Override
-	public Float transform(LoadingResult<?> loadingResult, Float extractedData) {
+	public Float transform(LoadingResult<?> loadingResult, Float extractedData,
+			SearchProjectionTransformContext context) {
 		return extractedData;
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/SearchProjectionExtractContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/SearchProjectionExtractContext.java
@@ -10,34 +10,22 @@ import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 
 import org.hibernate.search.backend.lucene.logging.impl.Log;
-import org.hibernate.search.engine.backend.document.converter.runtime.FromDocumentFieldValueConvertContext;
-import org.hibernate.search.engine.backend.document.converter.runtime.spi.FromDocumentFieldValueConvertContextImpl;
-import org.hibernate.search.engine.mapper.session.context.spi.SessionContextImplementor;
 import org.hibernate.search.util.impl.common.LoggerFactory;
 
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 
-public class SearchProjectionExecutionContext {
+public class SearchProjectionExtractContext {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
-
-	private final FromDocumentFieldValueConvertContext fromDocumentFieldValueConvertContext;
 
 	private final IndexSearcher indexSearcher;
 	private final Query luceneQuery;
 
-	public SearchProjectionExecutionContext(SessionContextImplementor sessionContext,
-			IndexSearcher indexSearcher,
-			Query luceneQuery) {
-		this.fromDocumentFieldValueConvertContext = new FromDocumentFieldValueConvertContextImpl( sessionContext );
+	public SearchProjectionExtractContext(IndexSearcher indexSearcher, Query luceneQuery) {
 		this.indexSearcher = indexSearcher;
 		this.luceneQuery = luceneQuery;
-	}
-
-	FromDocumentFieldValueConvertContext getFromDocumentFieldValueConvertContext() {
-		return fromDocumentFieldValueConvertContext;
 	}
 
 	public Explanation explain(int docId) {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/SearchProjectionTransformContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/SearchProjectionTransformContext.java
@@ -1,0 +1,24 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.search.projection.impl;
+
+import org.hibernate.search.engine.backend.document.converter.runtime.FromDocumentFieldValueConvertContext;
+import org.hibernate.search.engine.backend.document.converter.runtime.spi.FromDocumentFieldValueConvertContextImpl;
+import org.hibernate.search.engine.mapper.session.context.spi.SessionContextImplementor;
+
+public class SearchProjectionTransformContext {
+
+	private final FromDocumentFieldValueConvertContext fromDocumentFieldValueConvertContext;
+
+	public SearchProjectionTransformContext(SessionContextImplementor sessionContext) {
+		this.fromDocumentFieldValueConvertContext = new FromDocumentFieldValueConvertContextImpl( sessionContext );
+	}
+
+	FromDocumentFieldValueConvertContext getFromDocumentFieldValueConvertContext() {
+		return fromDocumentFieldValueConvertContext;
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneLoadableSearchResult.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneLoadableSearchResult.java
@@ -12,6 +12,8 @@ import java.util.Collections;
 import java.util.List;
 
 import org.hibernate.search.backend.lucene.search.projection.impl.LuceneSearchProjection;
+import org.hibernate.search.backend.lucene.search.projection.impl.SearchProjectionTransformContext;
+import org.hibernate.search.engine.mapper.session.context.spi.SessionContextImplementor;
 import org.hibernate.search.engine.search.SearchResult;
 import org.hibernate.search.engine.search.query.spi.LoadingResult;
 import org.hibernate.search.engine.search.query.spi.ProjectionHitMapper;
@@ -48,11 +50,13 @@ public class LuceneLoadableSearchResult<T> {
 		return hitCount;
 	}
 
-	SearchResult<T> loadBlocking() {
+	SearchResult<T> loadBlocking(SessionContextImplementor sessionContext) {
+		SearchProjectionTransformContext transformContext = new SearchProjectionTransformContext( sessionContext );
+
 		LoadingResult<?> loadingResult = projectionHitMapper.loadBlocking();
 
 		for ( int i = 0; i < extractedData.size(); i++ ) {
-			T transformed = transformUnsafe( rootProjection, loadingResult, extractedData.get( i ) );
+			T transformed = transformUnsafe( rootProjection, loadingResult, extractedData.get( i ), transformContext );
 			extractedData.set( i, transformed );
 		}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneLoadableSearchResult.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneLoadableSearchResult.java
@@ -1,0 +1,68 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.search.query.impl;
+
+import static org.hibernate.search.backend.lucene.search.projection.impl.LuceneSearchProjection.transformUnsafe;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.hibernate.search.backend.lucene.search.projection.impl.LuceneSearchProjection;
+import org.hibernate.search.engine.search.SearchResult;
+import org.hibernate.search.engine.search.query.spi.LoadingResult;
+import org.hibernate.search.engine.search.query.spi.ProjectionHitMapper;
+import org.hibernate.search.engine.search.spi.SimpleSearchResult;
+
+/**
+ * A search result from the backend that offers a method to load data from the mapper.
+ * <p>
+ * Allows to run loading in the user thread, and not in the backend HTTP request threads.
+ * <p>
+ * <strong>WARNING:</strong> loading should only be triggered once.
+ * <p>
+ * <strong>WARNING:</strong> this class is not thread-safe.
+ *
+ * @param <T> The type of hits in the search result.
+ */
+public class LuceneLoadableSearchResult<T> {
+	private final ProjectionHitMapper<?, ?> projectionHitMapper;
+	private final LuceneSearchProjection<?, T> rootProjection;
+
+	private final long hitCount;
+	private List<Object> extractedData;
+
+	LuceneLoadableSearchResult(ProjectionHitMapper<?, ?> projectionHitMapper,
+			LuceneSearchProjection<?, T> rootProjection,
+			long hitCount, List<Object> extractedData) {
+		this.projectionHitMapper = projectionHitMapper;
+		this.rootProjection = rootProjection;
+		this.hitCount = hitCount;
+		this.extractedData = extractedData;
+	}
+
+	long getHitCount() {
+		return hitCount;
+	}
+
+	SearchResult<T> loadBlocking() {
+		LoadingResult<?> loadingResult = projectionHitMapper.loadBlocking();
+
+		for ( int i = 0; i < extractedData.size(); i++ ) {
+			T transformed = transformUnsafe( rootProjection, loadingResult, extractedData.get( i ) );
+			extractedData.set( i, transformed );
+		}
+
+		// The cast is safe, since all elements extend T and we make the list unmodifiable
+		@SuppressWarnings("unchecked")
+		List<T> loadedHits = Collections.unmodifiableList( (List<? extends T>) extractedData );
+
+		// Make sure that if someone uses this object incorrectly, it will always fail, and will fail early.
+		extractedData = null;
+
+		return new SimpleSearchResult<>( hitCount, loadedHits );
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQuery.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQuery.java
@@ -84,8 +84,7 @@ public class LuceneSearchQuery<T> implements SearchQuery<T> {
 						luceneQuery, luceneSort,
 						firstResultIndex, maxResultsCount,
 						luceneCollectorProvider, searchResultExtractor
-				),
-				sessionContext
+				)
 		);
 		return queryOrchestrator.submit( work ).join()
 				/*
@@ -95,7 +94,7 @@ public class LuceneSearchQuery<T> implements SearchQuery<T> {
 				 * This method may not be easy to implement for blocking mappers,
 				 * so we may choose to throw exceptions for those.
 				 */
-				.loadBlocking();
+				.loadBlocking( sessionContext );
 	}
 
 	@Override
@@ -109,8 +108,7 @@ public class LuceneSearchQuery<T> implements SearchQuery<T> {
 						// do not add any TopDocs collector
 						( luceneCollectorBuilder -> { } ),
 						searchResultExtractor
-				),
-				sessionContext
+				)
 		);
 		return queryOrchestrator.submit( work ).join().getHitCount();
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchResultExtractor.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchResultExtractor.java
@@ -16,7 +16,7 @@ import org.hibernate.search.engine.search.SearchResult;
 
 public interface LuceneSearchResultExtractor<T> {
 
-	SearchResult<T> extract(IndexSearcher indexSearcher, long totalHits, TopDocs topDocs,
+	LuceneLoadableSearchResult<T> extract(IndexSearcher indexSearcher, long totalHits, TopDocs topDocs,
 			SearchProjectionExecutionContext projectionExecutionContext) throws IOException;
 
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchResultExtractor.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchResultExtractor.java
@@ -11,12 +11,11 @@ import java.io.IOException;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.TopDocs;
 
-import org.hibernate.search.backend.lucene.search.projection.impl.SearchProjectionExecutionContext;
-import org.hibernate.search.engine.search.SearchResult;
+import org.hibernate.search.backend.lucene.search.projection.impl.SearchProjectionExtractContext;
 
 public interface LuceneSearchResultExtractor<T> {
 
 	LuceneLoadableSearchResult<T> extract(IndexSearcher indexSearcher, long totalHits, TopDocs topDocs,
-			SearchProjectionExecutionContext projectionExecutionContext) throws IOException;
+			SearchProjectionExtractContext projectionExecutionContext) throws IOException;
 
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchResultExtractorImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchResultExtractorImpl.java
@@ -76,7 +76,7 @@ class LuceneSearchResultExtractorImpl<T> implements LuceneSearchResultExtractor<
 			hits.add( rootProjection.extract( projectionHitMapper, luceneResult, projectionExecutionContext ) );
 		}
 
-		LoadingResult<?> loadingResult = projectionHitMapper.load();
+		LoadingResult<?> loadingResult = projectionHitMapper.loadBlocking();
 
 		for ( int i = 0; i < hits.size(); i++ ) {
 			hits.set( i, transformUnsafe( rootProjection, loadingResult, hits.get( i ) ) );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchResultExtractorImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchResultExtractorImpl.java
@@ -18,7 +18,7 @@ import org.apache.lucene.search.TopDocs;
 import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneResult;
 import org.hibernate.search.backend.lucene.search.extraction.impl.ReusableDocumentStoredFieldVisitor;
 import org.hibernate.search.backend.lucene.search.projection.impl.LuceneSearchProjection;
-import org.hibernate.search.backend.lucene.search.projection.impl.SearchProjectionExecutionContext;
+import org.hibernate.search.backend.lucene.search.projection.impl.SearchProjectionExtractContext;
 import org.hibernate.search.engine.search.query.spi.ProjectionHitMapper;
 
 class LuceneSearchResultExtractorImpl<T> implements LuceneSearchResultExtractor<T> {
@@ -38,7 +38,7 @@ class LuceneSearchResultExtractorImpl<T> implements LuceneSearchResultExtractor<
 
 	@Override
 	public LuceneLoadableSearchResult<T> extract(IndexSearcher indexSearcher, long totalHits, TopDocs topDocs,
-			SearchProjectionExecutionContext projectionExecutionContext) throws IOException {
+			SearchProjectionExtractContext projectionExecutionContext) throws IOException {
 		List<Object> extractedData = extractHits( indexSearcher, topDocs, projectionExecutionContext );
 
 		return new LuceneLoadableSearchResult<>(
@@ -49,7 +49,7 @@ class LuceneSearchResultExtractorImpl<T> implements LuceneSearchResultExtractor<
 
 	@SuppressWarnings("unchecked")
 	private List<Object> extractHits(IndexSearcher indexSearcher, TopDocs topDocs,
-			SearchProjectionExecutionContext projectionExecutionContext) throws IOException {
+			SearchProjectionExtractContext projectionExecutionContext) throws IOException {
 		if ( topDocs == null ) {
 			return Collections.emptyList();
 		}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearcher.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearcher.java
@@ -16,11 +16,9 @@ import org.hibernate.search.backend.lucene.index.spi.ReaderProvider;
 import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneCollectorProvider;
 import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneCollectors;
 import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneCollectorsBuilder;
-import org.hibernate.search.backend.lucene.search.projection.impl.SearchProjectionExecutionContext;
+import org.hibernate.search.backend.lucene.search.projection.impl.SearchProjectionExtractContext;
 import org.hibernate.search.backend.lucene.search.reader.impl.MultiReaderFactory;
 import org.hibernate.search.engine.logging.spi.EventContexts;
-import org.hibernate.search.engine.mapper.session.context.spi.SessionContextImplementor;
-import org.hibernate.search.engine.search.SearchResult;
 import org.hibernate.search.util.EventContext;
 
 /**
@@ -58,7 +56,7 @@ public class LuceneSearcher<T> implements AutoCloseable {
 		this.searchResultExtractor = searchResultExtractor;
 	}
 
-	public LuceneLoadableSearchResult<T> execute(SessionContextImplementor sessionContext) throws IOException {
+	public LuceneLoadableSearchResult<T> execute() throws IOException {
 		// TODO GSM implement timeout handling by wrapping the collector with the timeout limiting one
 
 		LuceneCollectorsBuilder luceneCollectorsBuilder = new LuceneCollectorsBuilder( luceneSort, getMaxDocs() );
@@ -67,8 +65,8 @@ public class LuceneSearcher<T> implements AutoCloseable {
 
 		indexSearcher.search( luceneQuery, luceneCollectors.getCompositeCollector() );
 
-		SearchProjectionExecutionContext projectionExecutionContext =
-				new SearchProjectionExecutionContext( sessionContext, indexSearcher, luceneQuery );
+		SearchProjectionExtractContext projectionExecutionContext =
+				new SearchProjectionExtractContext( indexSearcher, luceneQuery );
 
 		return searchResultExtractor.extract(
 				indexSearcher, luceneCollectors.getTotalHits(),

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearcher.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearcher.java
@@ -58,7 +58,7 @@ public class LuceneSearcher<T> implements AutoCloseable {
 		this.searchResultExtractor = searchResultExtractor;
 	}
 
-	public SearchResult<T> execute(SessionContextImplementor sessionContext) throws IOException {
+	public LuceneLoadableSearchResult<T> execute(SessionContextImplementor sessionContext) throws IOException {
 		// TODO GSM implement timeout handling by wrapping the collector with the timeout limiting one
 
 		LuceneCollectorsBuilder luceneCollectorsBuilder = new LuceneCollectorsBuilder( luceneSort, getMaxDocs() );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneExecuteQueryWork.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneExecuteQueryWork.java
@@ -13,8 +13,6 @@ import java.util.concurrent.CompletableFuture;
 import org.hibernate.search.backend.lucene.logging.impl.Log;
 import org.hibernate.search.backend.lucene.search.query.impl.LuceneLoadableSearchResult;
 import org.hibernate.search.backend.lucene.search.query.impl.LuceneSearcher;
-import org.hibernate.search.engine.mapper.session.context.spi.SessionContextImplementor;
-import org.hibernate.search.engine.search.SearchResult;
 import org.hibernate.search.util.impl.common.Futures;
 import org.hibernate.search.util.impl.common.LoggerFactory;
 
@@ -26,12 +24,9 @@ public class LuceneExecuteQueryWork<T> implements LuceneQueryWork<LuceneLoadable
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private final LuceneSearcher<T> searcher;
-	private final SessionContextImplementor sessionContext;
 
-	public LuceneExecuteQueryWork(LuceneSearcher<T> searcher,
-			SessionContextImplementor sessionContext) {
+	public LuceneExecuteQueryWork(LuceneSearcher<T> searcher) {
 		this.searcher = searcher;
-		this.sessionContext = sessionContext;
 	}
 
 	@Override
@@ -42,7 +37,7 @@ public class LuceneExecuteQueryWork<T> implements LuceneQueryWork<LuceneLoadable
 
 	private LuceneLoadableSearchResult<T> executeQuery(LuceneSearcher<T> searcher) {
 		try {
-			return searcher.execute( sessionContext );
+			return searcher.execute();
 		}
 		catch (IOException e) {
 			throw log.ioExceptionOnQueryExecution( searcher.getLuceneQuery(), searcher.getEventContext(), e );
@@ -57,7 +52,6 @@ public class LuceneExecuteQueryWork<T> implements LuceneQueryWork<LuceneLoadable
 		StringBuilder sb = new StringBuilder( getClass().getSimpleName() )
 				.append( "[" )
 				.append( "searcher=" ).append( searcher )
-				.append( ", sessionContext=" ).append( sessionContext )
 				.append( "]" );
 		return sb.toString();
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneExecuteQueryWork.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneExecuteQueryWork.java
@@ -11,6 +11,7 @@ import java.lang.invoke.MethodHandles;
 import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.search.backend.lucene.logging.impl.Log;
+import org.hibernate.search.backend.lucene.search.query.impl.LuceneLoadableSearchResult;
 import org.hibernate.search.backend.lucene.search.query.impl.LuceneSearcher;
 import org.hibernate.search.engine.mapper.session.context.spi.SessionContextImplementor;
 import org.hibernate.search.engine.search.SearchResult;
@@ -20,7 +21,7 @@ import org.hibernate.search.util.impl.common.LoggerFactory;
 /**
  * @author Guillaume Smet
  */
-public class LuceneExecuteQueryWork<T> implements LuceneQueryWork<SearchResult<T>> {
+public class LuceneExecuteQueryWork<T> implements LuceneQueryWork<LuceneLoadableSearchResult<T>> {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
@@ -34,12 +35,12 @@ public class LuceneExecuteQueryWork<T> implements LuceneQueryWork<SearchResult<T
 	}
 
 	@Override
-	public CompletableFuture<SearchResult<T>> execute(LuceneQueryWorkExecutionContext context) {
+	public CompletableFuture<LuceneLoadableSearchResult<T>> execute(LuceneQueryWorkExecutionContext context) {
 		// FIXME for now everything is blocking here, we need a non blocking wrapper on top of the IndexWriter
 		return Futures.create( () -> CompletableFuture.completedFuture( executeQuery( searcher ) ) );
 	}
 
-	private SearchResult<T> executeQuery(LuceneSearcher<T> searcher) {
+	private LuceneLoadableSearchResult<T> executeQuery(LuceneSearcher<T> searcher) {
 		try {
 			return searcher.execute( sessionContext );
 		}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneStubWorkFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneStubWorkFactory.java
@@ -9,7 +9,6 @@ package org.hibernate.search.backend.lucene.work.impl;
 import org.hibernate.search.backend.lucene.document.impl.LuceneIndexEntry;
 import org.hibernate.search.backend.lucene.multitenancy.impl.MultiTenancyStrategy;
 import org.hibernate.search.backend.lucene.search.query.impl.LuceneSearcher;
-import org.hibernate.search.engine.mapper.session.context.spi.SessionContextImplementor;
 
 
 /**
@@ -60,7 +59,7 @@ public class LuceneStubWorkFactory implements LuceneWorkFactory {
 	}
 
 	@Override
-	public <T> LuceneExecuteQueryWork<T> search(LuceneSearcher<T> luceneSearcher, SessionContextImplementor sessionContext) {
-		return new LuceneExecuteQueryWork<>( luceneSearcher, sessionContext );
+	public <T> LuceneExecuteQueryWork<T> search(LuceneSearcher<T> luceneSearcher) {
+		return new LuceneExecuteQueryWork<>( luceneSearcher );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneWorkFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneWorkFactory.java
@@ -8,7 +8,6 @@ package org.hibernate.search.backend.lucene.work.impl;
 
 import org.hibernate.search.backend.lucene.document.impl.LuceneIndexEntry;
 import org.hibernate.search.backend.lucene.search.query.impl.LuceneSearcher;
-import org.hibernate.search.engine.mapper.session.context.spi.SessionContextImplementor;
 
 /**
  * @author Guillaume Smet
@@ -30,5 +29,5 @@ public interface LuceneWorkFactory {
 
 	LuceneIndexWork<?> optimize(String indexName);
 
-	<T> LuceneExecuteQueryWork<T> search(LuceneSearcher<T> luceneSearcher, SessionContextImplementor sessionContext);
+	<T> LuceneExecuteQueryWork<T> search(LuceneSearcher<T> luceneSearcher);
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/loading/spi/IdentityObjectLoader.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/loading/spi/IdentityObjectLoader.java
@@ -18,7 +18,7 @@ class IdentityObjectLoader<T> implements ObjectLoader<T, T> {
 	}
 
 	@Override
-	public List<T> load(List<T> references) {
+	public List<T> loadBlocking(List<T> references) {
 		return references;
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/loading/spi/ObjectLoader.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/loading/spi/ObjectLoader.java
@@ -17,11 +17,13 @@ import java.util.List;
 public interface ObjectLoader<R, O> {
 
 	/**
+	 * Loads the entities corresponding to the given references, blocking the current thread while doing so.
+	 *
 	 * @param references A list of references to the objects to load.
 	 * @return A list of loaded objects, in the same order the references were given.
 	 * {@code null} is inserted when an object is not found.
 	 */
-	List<O> load(List<R> references);
+	List<O> loadBlocking(List<R> references);
 
 	static <T> ObjectLoader<T, T> identity() {
 		return IdentityObjectLoader.get();

--- a/engine/src/main/java/org/hibernate/search/engine/search/query/impl/DefaultProjectionHitMapper.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/query/impl/DefaultProjectionHitMapper.java
@@ -41,8 +41,8 @@ public class DefaultProjectionHitMapper<R, O> implements ProjectionHitMapper<R, 
 	}
 
 	@Override
-	public LoadingResult<O> load() {
-		return new DefaultLoadingResult<>( objectLoader.load( referencesToLoad ) );
+	public LoadingResult<O> loadBlocking() {
+		return new DefaultLoadingResult<>( objectLoader.loadBlocking( referencesToLoad ) );
 	}
 
 	private static class DefaultLoadingResult<O> implements LoadingResult<O> {

--- a/engine/src/main/java/org/hibernate/search/engine/search/query/impl/NoLoadingProjectionHitMapper.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/query/impl/NoLoadingProjectionHitMapper.java
@@ -32,7 +32,7 @@ public class NoLoadingProjectionHitMapper<R> implements ProjectionHitMapper<R, V
 	}
 
 	@Override
-	public LoadingResult<Void> load() {
+	public LoadingResult<Void> loadBlocking() {
 		return UnusableLoadingResult.INSTANCE;
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/search/query/spi/ProjectionHitMapper.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/query/spi/ProjectionHitMapper.java
@@ -30,9 +30,9 @@ public interface ProjectionHitMapper<R, O> {
 	Object planLoading(DocumentReference reference);
 
 	/**
-	 * Loads the entities planned for loading in one go.
+	 * Loads the entities planned for loading in one go, blocking the current thread while doing so.
 	 *
 	 * @return The loaded entities.
 	 */
-	LoadingResult<O> load();
+	LoadingResult<O> loadBlocking();
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/spi/SimpleSearchResult.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/spi/SimpleSearchResult.java
@@ -1,0 +1,39 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.spi;
+
+import java.util.List;
+
+import org.hibernate.search.engine.search.SearchResult;
+
+public final class SimpleSearchResult<T> implements SearchResult<T> {
+	private final long hitCount;
+	private final List<T> hits;
+
+	public SimpleSearchResult(long hitCount, List<T> hits) {
+		this.hitCount = hitCount;
+		this.hits = hits;
+	}
+
+	@Override
+	public long getHitCount() {
+		return hitCount;
+	}
+
+	@Override
+	public List<T> getHits() {
+		return hits;
+	}
+
+	@Override
+	public String toString() {
+		return getClass().getSimpleName() + "["
+				+ "hitCount=" + hitCount
+				+ ", hits=" + hits
+				+ "]";
+	}
+}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/HibernateOrmByTypeObjectLoader.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/HibernateOrmByTypeObjectLoader.java
@@ -29,7 +29,7 @@ public class HibernateOrmByTypeObjectLoader<O, T> implements ObjectLoader<PojoRe
 	}
 
 	@Override
-	public List<T> load(List<PojoReference> references) {
+	public List<T> loadBlocking(List<PojoReference> references) {
 		LinkedHashMap<PojoReference, T> objectsByReference = new LinkedHashMap<>( references.size() );
 		Map<HibernateOrmComposableObjectLoader<PojoReference, ? extends T>, List<PojoReference>> referencesByDelegate = new HashMap<>();
 
@@ -46,7 +46,7 @@ public class HibernateOrmByTypeObjectLoader<O, T> implements ObjectLoader<PojoRe
 				referencesByDelegate.entrySet() ) {
 			HibernateOrmComposableObjectLoader<PojoReference, ? extends T> delegate = entry.getKey();
 			List<PojoReference> referencesForDelegate = entry.getValue();
-			delegate.load( referencesForDelegate, objectsByReference );
+			delegate.loadBlocking( referencesForDelegate, objectsByReference );
 		}
 
 		// Re-create the list of objects in the same order

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/HibernateOrmComposableObjectLoader.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/HibernateOrmComposableObjectLoader.java
@@ -22,7 +22,8 @@ interface HibernateOrmComposableObjectLoader<R, O> extends ObjectLoader<R, O> {
 
 	/**
 	 * For each reference in the given list,
-	 * loads the corresponding object and puts it as a value in the given map.
+	 * loads the corresponding object and puts it as a value in the given map,
+	 * blocking the current thread while doing so.
 	 * <p>
 	 * When an object cannot be found, the map is not altered.
 	 *
@@ -30,6 +31,6 @@ interface HibernateOrmComposableObjectLoader<R, O> extends ObjectLoader<R, O> {
 	 * @param objectsByReference A map with references as keys and objects as values.
 	 * Initial values are undefined and the loader must not rely on them.
 	 */
-	void load(List<R> references, Map<? super R, ? super O> objectsByReference);
+	void loadBlocking(List<R> references, Map<? super R, ? super O> objectsByReference);
 
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/HibernateOrmSingleTypeByIdObjectLoader.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/HibernateOrmSingleTypeByIdObjectLoader.java
@@ -38,7 +38,7 @@ class HibernateOrmSingleTypeByIdObjectLoader<O, T> implements HibernateOrmCompos
 	}
 
 	@Override
-	public List<T> load(List<PojoReference> references) {
+	public List<T> loadBlocking(List<PojoReference> references) {
 		List<O> loadedObjects = loadEntities( references );
 
 		// TODO avoid creating this list when the transformer is the identity; maybe cast the list in that case, or tranform in-place all the time?
@@ -46,7 +46,7 @@ class HibernateOrmSingleTypeByIdObjectLoader<O, T> implements HibernateOrmCompos
 	}
 
 	@Override
-	public void load(List<PojoReference> references, Map<? super PojoReference, ? super T> objectsByReference) {
+	public void loadBlocking(List<PojoReference> references, Map<? super PojoReference, ? super T> objectsByReference) {
 		List<O> loadedObjects = loadEntities( references );
 		Iterator<PojoReference> referencesIterator = references.iterator();
 		Iterator<O> loadedObjectIterator = loadedObjects.iterator();

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/SearchWorkCall.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/SearchWorkCall.java
@@ -83,7 +83,7 @@ class SearchWorkCall<T> extends Call<SearchWorkCall<?>> {
 					actualRootProjection.extract( actualProjectionHitMapper, rawHit, actualConvertContext ) );
 		}
 
-		LoadingResult<?> loadingResult = actualProjectionHitMapper.load();
+		LoadingResult<?> loadingResult = actualProjectionHitMapper.loadBlocking();
 
 		List<U> results = new ArrayList<>( rawHits.size() );
 

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/SearchWorkCall.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/SearchWorkCall.java
@@ -16,6 +16,7 @@ import org.hibernate.search.engine.backend.document.converter.runtime.FromDocume
 import org.hibernate.search.engine.search.SearchResult;
 import org.hibernate.search.engine.search.query.spi.LoadingResult;
 import org.hibernate.search.engine.search.query.spi.ProjectionHitMapper;
+import org.hibernate.search.engine.search.spi.SimpleSearchResult;
 import org.hibernate.search.util.impl.integrationtest.common.assertion.StubSearchWorkAssert;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.StubSearchWork;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.projection.impl.StubSearchProjection;
@@ -63,8 +64,15 @@ class SearchWorkCall<T> extends Call<SearchWorkCall<?>> {
 
 		long totalHitCount = behavior.getTotalHitCount();
 
-		return new SearchResultFromMock<>( totalHitCount, getResults( actualCall.convertContext,
-				actualCall.projectionHitMapper, actualCall.rootProjection, behavior.getRawHits() ) );
+		return new SimpleSearchResult<>(
+				totalHitCount,
+				getResults(
+						actualCall.convertContext,
+						actualCall.projectionHitMapper,
+						actualCall.rootProjection,
+						behavior.getRawHits()
+				)
+		);
 	}
 
 	@Override
@@ -97,35 +105,6 @@ class SearchWorkCall<T> extends Call<SearchWorkCall<?>> {
 	@Override
 	public String toString() {
 		return "search work execution on indexes '" + indexNames + "'; work = " + work;
-	}
-
-	private static final class SearchResultFromMock<T> implements SearchResult<T> {
-
-		private final long totalHitCount;
-		private final List<T> hits;
-
-		public SearchResultFromMock(long totalHitCount, List<T> hits) {
-			this.totalHitCount = totalHitCount;
-			this.hits = hits;
-		}
-
-		@Override
-		public long getHitCount() {
-			return totalHitCount;
-		}
-
-		@Override
-		public List<T> getHits() {
-			return hits;
-		}
-
-		@Override
-		public String toString() {
-			return getClass().getSimpleName() + "{" +
-					"totalHitCount=" + totalHitCount +
-					", hits=" + hits +
-					'}';
-		}
 	}
 
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/StubMapperUtils.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/StubMapperUtils.java
@@ -43,7 +43,7 @@ public final class StubMapperUtils {
 		LoadingDefinitionContext<R, O> context = new LoadingDefinitionContext<>();
 		loadingDefinition.accept( context );
 
-		EasyMock.expect( objectLoaderMock.load(
+		EasyMock.expect( objectLoaderMock.loadBlocking(
 				EasyMockUtils.collectionAnyOrderMatcher( new ArrayList<>( context.loadingMap.keySet() ) )
 		) )
 				.andAnswer(


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3453

~Based on #1855 and #1837 , which should be merged first.~ => Done

I only addressed the most pressing matter, i.e. the fact we were executing blocking operations in the backend threads (it's no longer the case). Solutions for asynchronous query execution will have to wait until [HSEARCH-3322](https://hibernate.atlassian.net/browse/HSEARCH-3322).

In the future, I suspect we will want to keep multiple methods in `SearchQuery` for each operation: a blocking method relying on the user thread, and an asynchronous, non-blocking method that either returns an incomplete result (to be loaded in the user thread) or executes loading in a dedicated thread pool (not ideal).