### PR TITLE
HSEARCH-3470 Upgrade Hibernate ORM to 5.4.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
         <version.com.google.code.gson>2.8.5</version.com.google.code.gson>
 
         <!-- >>> ORM -->
-        <version.org.hibernate>5.4.0.Final</version.org.hibernate>
+        <version.org.hibernate>5.4.1.Final</version.org.hibernate>
         <javadoc.org.hibernate.url>http://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.majorVersion}.${parsed-version.org.hibernate.minorVersion}/javadocs/</javadoc.org.hibernate.url>
         <version.org.hibernate.commons.annotations>5.1.0.Final</version.org.hibernate.commons.annotations>
         <version.javax.persistence>2.2</version.javax.persistence>


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/HSEARCH-3470

To be backported to 5.11.