### PR TITLE
Backport HSEARCH-3470 to branch 5.11 - Upgrade Hibernate ORM to 5.4.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
 
         <!-- Dependencies versions -->
 
-        <version.org.hibernate>5.4.0.Final</version.org.hibernate>
+        <version.org.hibernate>5.4.1.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>5.1.0.Final</version.org.hibernate.commons.annotations>
         <version.javax.persistence>2.2</version.javax.persistence>
 


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3470

No need to review, just waiting for CI.