### PR TITLE
HSEARCH-3458 ClassCastException: Cannot cast ScopedElasticsearchAnalyzerReference to LuceneAnalyzerReference

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/logging/impl/Log.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SortField;
 import org.hibernate.search.analyzer.spi.AnalyzerReference;
+import org.hibernate.search.elasticsearch.analyzer.impl.ElasticsearchAnalyzerReference;
 import org.hibernate.search.elasticsearch.cfg.ElasticsearchEnvironment;
 import org.hibernate.search.elasticsearch.client.impl.ElasticsearchRequest;
 import org.hibernate.search.elasticsearch.client.impl.ElasticsearchResponse;
@@ -528,4 +529,9 @@ public interface Log extends BaseHibernateSearchLogger {
 					+ " when used in the Elasticsearch integration."
 	)
 	SearchException booleanBridgeMustImplementTwoWayStringBridge(IndexedTypeIdentifier typeIdentifier, String staticAbsolutePath);
+
+	@Message(id = ES_BACKEND_MESSAGES_START_ID + 96, value = "This analyzer is defined as an Elasticsearch analyzer,"
+			+ " and cannot be used with any other technology (Lucene in particular)."
+			+ " Analyzer reference: %s")
+	SearchException invalidConversionFromElasticsearchAnalyzer(ElasticsearchAnalyzerReference reference, @Cause Exception cause);
 }

--- a/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
@@ -1024,4 +1024,9 @@ public interface Log extends BaseHibernateSearchLogger {
 
 	@Message(id = 353, value = "Unknown analyzer: '%1$s'. Make sure you defined this analyzer.")
 	SearchException unknownAnalyzerForOverride(String analyzerName);
+
+	@Message(id = 354, value = "This analyzer is defined as an embedded Lucene analyzer,"
+			+ " and cannot be used with any other technology (Elasticsearch in particular)."
+			+ " Analyzer reference: %s")
+	SearchException invalidConversionFromLuceneAnalyzer(LuceneAnalyzerReference reference, @Cause Exception cause);
 }

--- a/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/CombiningLuceneAndElasticsearchIT.java
+++ b/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/CombiningLuceneAndElasticsearchIT.java
@@ -6,27 +6,35 @@
  */
 package org.hibernate.search.elasticsearch.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
+
 import java.util.List;
 import java.util.Map;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
 
-import org.apache.lucene.queryparser.classic.QueryParser;
-import org.apache.lucene.search.MatchAllDocsQuery;
-import org.apache.lucene.search.Query;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.elasticsearch.ElasticsearchQueries;
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.query.engine.spi.QueryDescriptor;
 import org.hibernate.search.test.SearchTestBase;
 import org.hibernate.search.testsupport.TestConstants;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Fail.fail;
+import org.apache.lucene.queryparser.classic.QueryParser;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
 
 
 /**
@@ -41,11 +49,11 @@ public class CombiningLuceneAndElasticsearchIT extends SearchTestBase {
 		Session s = openSession();
 		Transaction tx = s.beginTransaction();
 
-		ResearchPaper paper = new ResearchPaper( "important research", "latest findings", "Once upon a time...", 100 );
+		ElasticsearchIndexedEntity paper = new ElasticsearchIndexedEntity( "important research" );
 		s.persist( paper );
 
-		ComicBook comicBook = new ComicBook( "The tales of Bob", "Once upon a time..." );
-		s.persist( comicBook );
+		LuceneIndexedEntity luceneIndexedEntity = new LuceneIndexedEntity( "The tales of Bob" );
+		s.persist( luceneIndexedEntity );
 
 		tx.commit();
 		s.close();
@@ -59,14 +67,14 @@ public class CombiningLuceneAndElasticsearchIT extends SearchTestBase {
 
 		List<?> result = session.createFullTextQuery(
 				ElasticsearchQueries.fromQueryString( "title:important" ),
-				ResearchPaper.class
+				ElasticsearchIndexedEntity.class
 		).list();
 
 		assertThat( result ).extracting( "title" ).containsExactly( "important research" );
 
 		result = session.createFullTextQuery(
 				queryParser.parse( "title:tales" ),
-				ComicBook.class
+				LuceneIndexedEntity.class
 		).list();
 
 		assertThat( result ).extracting( "title" ).containsExactly( "The tales of Bob" );
@@ -84,7 +92,7 @@ public class CombiningLuceneAndElasticsearchIT extends SearchTestBase {
 		try {
 			session.createFullTextQuery(
 					ElasticsearchQueries.fromQueryString( "title:tales" ),
-					ComicBook.class
+					LuceneIndexedEntity.class
 			).list();
 
 			fail( "Expected exception wasn't raised" );
@@ -105,7 +113,7 @@ public class CombiningLuceneAndElasticsearchIT extends SearchTestBase {
 		Transaction tx = s.beginTransaction();
 
 		try {
-			session.createFullTextQuery( new NotTranslatableQuery(), ResearchPaper.class ).list();
+			session.createFullTextQuery( new NotTranslatableQuery(), ElasticsearchIndexedEntity.class ).list();
 			fail( "Expected exception wasn't raised" );
 		}
 		catch (SearchException se) {
@@ -124,13 +132,13 @@ public class CombiningLuceneAndElasticsearchIT extends SearchTestBase {
 		Transaction tx = s.beginTransaction();
 
 		QueryDescriptor query = ElasticsearchQueries.fromJson( "{ 'query': { 'match_all' : {} } }" );
-		List<?> result = session.createFullTextQuery( query, ResearchPaper.class ).list();
+		List<?> result = session.createFullTextQuery( query, ElasticsearchIndexedEntity.class ).list();
 
 		for ( Object entity : result ) {
 			session.delete( entity );
 		}
 
-		result = session.createFullTextQuery( new MatchAllDocsQuery(), ComicBook.class ).list();
+		result = session.createFullTextQuery( new MatchAllDocsQuery(), LuceneIndexedEntity.class ).list();
 
 		for ( Object entity : result ) {
 			session.delete( entity );
@@ -143,14 +151,14 @@ public class CombiningLuceneAndElasticsearchIT extends SearchTestBase {
 
 	@Override
 	public Class<?>[] getAnnotatedClasses() {
-		return new Class[] { ResearchPaper.class, ComicBook.class };
+		return new Class[] { ElasticsearchIndexedEntity.class, LuceneIndexedEntity.class };
 	}
 
 	@Override
 	public void configure(Map<String, Object> settings) {
 		// default is ES
-		settings.put( "hibernate.search.comic_book.indexmanager", "directory-based" );
-		settings.put( "hibernate.search.comic_book.directory_provider", "local-heap" );
+		settings.put( "hibernate.search.luceneIndex.indexmanager", "directory-based" );
+		settings.put( "hibernate.search.luceneIndex.directory_provider", "local-heap" );
 	}
 
 	private static class NotTranslatableQuery extends Query {
@@ -161,4 +169,78 @@ public class CombiningLuceneAndElasticsearchIT extends SearchTestBase {
 		}
 
 	}
+
+	@Entity
+	@Indexed(index = "elasticsearchIndex")
+	public static class ElasticsearchIndexedEntity {
+
+		@Id
+		@GeneratedValue
+		@DocumentId
+		private Long id;
+
+		@Field
+		private String title;
+
+		ElasticsearchIndexedEntity() {
+		}
+
+		public ElasticsearchIndexedEntity(String title) {
+			this.title = title;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getTitle() {
+			return title;
+		}
+
+		public void setTitle(String title) {
+			this.title = title;
+		}
+	}
+
+	@Entity
+	@Indexed(index = "luceneIndex")
+	public static class LuceneIndexedEntity {
+
+		@Id
+		@GeneratedValue
+		@DocumentId
+		private Long id;
+
+		@Field
+		private String title;
+
+		LuceneIndexedEntity() {
+		}
+
+		public LuceneIndexedEntity(String title) {
+			this.title = title;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getTitle() {
+			return title;
+		}
+
+		public void setTitle(String title) {
+			this.title = title;
+		}
+	}
+
+
 }

--- a/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/CombiningLuceneAndElasticsearchIT.java
+++ b/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/CombiningLuceneAndElasticsearchIT.java
@@ -125,6 +125,17 @@ public class CombiningLuceneAndElasticsearchIT extends SearchTestBase {
 		}
 	}
 
+	@Test
+	public void cannotRetrieveElasticsearchAnalyzerAsLuceneAnalyzer() throws Exception {
+		try {
+			getSearchFactory().getAnalyzer( ElasticsearchIndexedEntity.class );
+			fail( "Expected exception wasn't raised" );
+		}
+		catch (SearchException se) {
+			assertThat( se.getMessage() ).contains( "HSEARCH400096" );
+		}
+	}
+
 	@After
 	public void deleteTestData() {
 		Session s = openSession();

--- a/orm/src/main/java/org/hibernate/search/SearchFactory.java
+++ b/orm/src/main/java/org/hibernate/search/SearchFactory.java
@@ -58,6 +58,8 @@ public interface SearchFactory {
 	 *
 	 * @throws java.lang.IllegalArgumentException in case {@code clazz == null} or the specified
 	 * class is not an indexed entity.
+	 * @throws org.hibernate.search.exception.SearchException if the entity is not indexed with Lucene,
+	 * but with an alternative technology such as Elasticsearch.
 	 */
 	Analyzer getAnalyzer(Class<?> clazz);
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3458

This will only document the limitation and enhance the error messages. The core of the problem cannot be solved in Search 5.