### PR TITLE
Search 6 groundwork - Implement the missing field types and default bridges compared to Search 5

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/impl/esnative/DataType.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/impl/esnative/DataType.java
@@ -39,6 +39,8 @@ public enum DataType {
 	DOUBLE,
 	@SerializedName("float")
 	FLOAT,
+	@SerializedName("byte")
+	BYTE,
 	@SerializedName("date")
 	DATE,
 	@SerializedName("boolean")

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/impl/esnative/DataType.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/impl/esnative/DataType.java
@@ -41,6 +41,8 @@ public enum DataType {
 	FLOAT,
 	@SerializedName("byte")
 	BYTE,
+	@SerializedName("short")
+	SHORT,
 	@SerializedName("date")
 	DATE,
 	@SerializedName("boolean")

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/gson/impl/JsonElementTypes.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/gson/impl/JsonElementTypes.java
@@ -197,6 +197,18 @@ public final class JsonElementTypes {
 		}
 	};
 
+	public static final JsonElementType<Byte> BYTE = new JsonNumberType<Byte>() {
+		@Override
+		protected Byte nullUnsafeFromNumber(JsonPrimitive primitive) {
+			return primitive.getAsByte();
+		}
+
+		@Override
+		public String toString() {
+			return JsonPrimitive.class.getSimpleName() + "(Byte)";
+		}
+	};
+
 	public static final JsonElementType<JsonNull> NULL = new JsonElementType<JsonNull>() {
 		@Override
 		protected JsonNull nullUnsafeFromElement(JsonElement element) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/gson/impl/JsonElementTypes.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/gson/impl/JsonElementTypes.java
@@ -209,6 +209,18 @@ public final class JsonElementTypes {
 		}
 	};
 
+	public static final JsonElementType<Short> SHORT = new JsonNumberType<Short>() {
+		@Override
+		protected Short nullUnsafeFromNumber(JsonPrimitive primitive) {
+			return primitive.getAsShort();
+		}
+
+		@Override
+		public String toString() {
+			return JsonPrimitive.class.getSimpleName() + "(Short)";
+		}
+	};
+
 	public static final JsonElementType<JsonNull> NULL = new JsonElementType<JsonNull>() {
 		@Override
 		protected JsonNull nullUnsafeFromElement(JsonElement element) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchByteFieldCodec.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchByteFieldCodec.java
@@ -1,0 +1,41 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.types.codec.impl;
+
+import org.hibernate.search.backend.elasticsearch.gson.impl.JsonElementTypes;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonPrimitive;
+
+public class ElasticsearchByteFieldCodec implements ElasticsearchFieldCodec<Byte> {
+	public static final ElasticsearchByteFieldCodec INSTANCE = new ElasticsearchByteFieldCodec();
+
+	private ElasticsearchByteFieldCodec() {
+	}
+
+	@Override
+	public JsonElement encode(Byte value) {
+		if ( value == null ) {
+			return JsonNull.INSTANCE;
+		}
+		return new JsonPrimitive( value );
+	}
+
+	@Override
+	public Byte decode(JsonElement element) {
+		if ( element == null || element.isJsonNull() ) {
+			return null;
+		}
+		return JsonElementTypes.BYTE.fromElement( element );
+	}
+
+	@Override
+	public boolean isCompatibleWith(ElasticsearchFieldCodec<?> other) {
+		return INSTANCE == other;
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchCharacterFieldCodec.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchCharacterFieldCodec.java
@@ -1,0 +1,43 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.types.codec.impl;
+
+import org.hibernate.search.backend.elasticsearch.gson.impl.JsonElementTypes;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonPrimitive;
+
+public class ElasticsearchCharacterFieldCodec implements ElasticsearchFieldCodec<Character> {
+	// Must be a singleton so that equals() works as required by the interface
+	public static final ElasticsearchCharacterFieldCodec INSTANCE = new ElasticsearchCharacterFieldCodec();
+
+	private ElasticsearchCharacterFieldCodec() {
+	}
+
+	@Override
+	public JsonElement encode(Character value) {
+		if ( value == null ) {
+			return JsonNull.INSTANCE;
+		}
+
+		return new JsonPrimitive( (int) value );
+	}
+
+	@Override
+	public Character decode(JsonElement element) {
+		if ( element == null || element.isJsonNull() ) {
+			return null;
+		}
+		return (char) JsonElementTypes.INTEGER.fromElement( element ).intValue();
+	}
+
+	@Override
+	public boolean isCompatibleWith(ElasticsearchFieldCodec<?> other) {
+		return INSTANCE == other;
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchDoubleFieldCodec.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchDoubleFieldCodec.java
@@ -1,0 +1,41 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.types.codec.impl;
+
+import org.hibernate.search.backend.elasticsearch.gson.impl.JsonElementTypes;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonPrimitive;
+
+public class ElasticsearchDoubleFieldCodec implements ElasticsearchFieldCodec<Double> {
+	public static final ElasticsearchDoubleFieldCodec INSTANCE = new ElasticsearchDoubleFieldCodec();
+
+	private ElasticsearchDoubleFieldCodec() {
+	}
+
+	@Override
+	public JsonElement encode(Double value) {
+		if ( value == null ) {
+			return JsonNull.INSTANCE;
+		}
+		return new JsonPrimitive( value );
+	}
+
+	@Override
+	public Double decode(JsonElement element) {
+		if ( element == null || element.isJsonNull() ) {
+			return null;
+		}
+		return JsonElementTypes.DOUBLE.fromElement( element );
+	}
+
+	@Override
+	public boolean isCompatibleWith(ElasticsearchFieldCodec<?> other) {
+		return INSTANCE == other;
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchFloatFieldCodec.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchFloatFieldCodec.java
@@ -1,0 +1,41 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.types.codec.impl;
+
+import org.hibernate.search.backend.elasticsearch.gson.impl.JsonElementTypes;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonPrimitive;
+
+public class ElasticsearchFloatFieldCodec implements ElasticsearchFieldCodec<Float> {
+	public static final ElasticsearchFloatFieldCodec INSTANCE = new ElasticsearchFloatFieldCodec();
+
+	private ElasticsearchFloatFieldCodec() {
+	}
+
+	@Override
+	public JsonElement encode(Float value) {
+		if ( value == null ) {
+			return JsonNull.INSTANCE;
+		}
+		return new JsonPrimitive( value );
+	}
+
+	@Override
+	public Float decode(JsonElement element) {
+		if ( element == null || element.isJsonNull() ) {
+			return null;
+		}
+		return JsonElementTypes.FLOAT.fromElement( element );
+	}
+
+	@Override
+	public boolean isCompatibleWith(ElasticsearchFieldCodec<?> other) {
+		return INSTANCE == other;
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchLocalDateTimeFieldCodec.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchLocalDateTimeFieldCodec.java
@@ -1,0 +1,56 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.types.codec.impl;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.hibernate.search.backend.elasticsearch.gson.impl.JsonElementTypes;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonPrimitive;
+
+public class ElasticsearchLocalDateTimeFieldCodec implements ElasticsearchFieldCodec<LocalDateTime> {
+
+	private final DateTimeFormatter formatter;
+
+	public ElasticsearchLocalDateTimeFieldCodec(DateTimeFormatter delegate) {
+		this.formatter = delegate;
+	}
+
+	@Override
+	public JsonElement encode(LocalDateTime value) {
+		if ( value == null ) {
+			return JsonNull.INSTANCE;
+		}
+		return new JsonPrimitive( formatter.format( value ) );
+	}
+
+	@Override
+	public LocalDateTime decode(JsonElement element) {
+		if ( element == null || element.isJsonNull() ) {
+			return null;
+		}
+		String stringValue = JsonElementTypes.STRING.fromElement( element );
+		return LocalDateTime.parse( stringValue, formatter );
+	}
+
+	@Override
+	public boolean isCompatibleWith(ElasticsearchFieldCodec<?> obj) {
+		if ( obj == this ) {
+			return true;
+		}
+		if ( obj.getClass() != getClass() ) {
+			return false;
+		}
+
+		ElasticsearchLocalDateTimeFieldCodec other = (ElasticsearchLocalDateTimeFieldCodec) obj;
+
+		return formatter.equals( other.formatter );
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchShortFieldCodec.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchShortFieldCodec.java
@@ -1,0 +1,41 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.types.codec.impl;
+
+import org.hibernate.search.backend.elasticsearch.gson.impl.JsonElementTypes;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonPrimitive;
+
+public class ElasticsearchShortFieldCodec implements ElasticsearchFieldCodec<Short> {
+	public static final ElasticsearchShortFieldCodec INSTANCE = new ElasticsearchShortFieldCodec();
+
+	private ElasticsearchShortFieldCodec() {
+	}
+
+	@Override
+	public JsonElement encode(Short value) {
+		if ( value == null ) {
+			return JsonNull.INSTANCE;
+		}
+		return new JsonPrimitive( value );
+	}
+
+	@Override
+	public Short decode(JsonElement element) {
+		if ( element == null || element.isJsonNull() ) {
+			return null;
+		}
+		return JsonElementTypes.SHORT.fromElement( element );
+	}
+
+	@Override
+	public boolean isCompatibleWith(ElasticsearchFieldCodec<?> other) {
+		return INSTANCE == other;
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchByteIndexFieldTypeContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchByteIndexFieldTypeContext.java
@@ -1,0 +1,47 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.types.dsl.impl;
+
+import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.DataType;
+import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.PropertyMapping;
+import org.hibernate.search.backend.elasticsearch.types.codec.impl.ElasticsearchByteFieldCodec;
+import org.hibernate.search.backend.elasticsearch.types.impl.ElasticsearchIndexFieldType;
+import org.hibernate.search.backend.elasticsearch.types.predicate.impl.ElasticsearchStandardFieldPredicateBuilderFactory;
+import org.hibernate.search.backend.elasticsearch.types.projection.impl.ElasticsearchStandardFieldProjectionBuilderFactory;
+import org.hibernate.search.backend.elasticsearch.types.sort.impl.ElasticsearchStandardFieldSortBuilderFactory;
+import org.hibernate.search.engine.backend.types.converter.FromDocumentFieldValueConverter;
+import org.hibernate.search.engine.backend.types.converter.ToDocumentFieldValueConverter;
+
+class ElasticsearchByteIndexFieldTypeContext
+		extends AbstractElasticsearchScalarFieldTypeContext<ElasticsearchByteIndexFieldTypeContext, Byte> {
+
+	ElasticsearchByteIndexFieldTypeContext(ElasticsearchIndexFieldTypeBuildContext buildContext) {
+		super( buildContext, Byte.class, DataType.BYTE );
+	}
+
+	@Override
+	protected ElasticsearchIndexFieldType<Byte> toIndexFieldType(PropertyMapping mapping) {
+		ToDocumentFieldValueConverter<?, ? extends Byte> dslToIndexConverter =
+				createDslToIndexConverter();
+		FromDocumentFieldValueConverter<? super Byte, ?> indexToProjectionConverter =
+				createIndexToProjectionConverter();
+		ElasticsearchByteFieldCodec codec = ElasticsearchByteFieldCodec.INSTANCE;
+
+		return new ElasticsearchIndexFieldType<>(
+				codec,
+				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, codec ),
+				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, codec ),
+				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec ),
+				mapping
+		);
+	}
+
+	@Override
+	protected ElasticsearchByteIndexFieldTypeContext thisAsS() {
+		return this;
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchCharacterIndexFieldTypeContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchCharacterIndexFieldTypeContext.java
@@ -1,0 +1,47 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.types.dsl.impl;
+
+import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.DataType;
+import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.PropertyMapping;
+import org.hibernate.search.backend.elasticsearch.types.codec.impl.ElasticsearchCharacterFieldCodec;
+import org.hibernate.search.backend.elasticsearch.types.impl.ElasticsearchIndexFieldType;
+import org.hibernate.search.backend.elasticsearch.types.predicate.impl.ElasticsearchStandardFieldPredicateBuilderFactory;
+import org.hibernate.search.backend.elasticsearch.types.projection.impl.ElasticsearchStandardFieldProjectionBuilderFactory;
+import org.hibernate.search.backend.elasticsearch.types.sort.impl.ElasticsearchStandardFieldSortBuilderFactory;
+import org.hibernate.search.engine.backend.types.converter.FromDocumentFieldValueConverter;
+import org.hibernate.search.engine.backend.types.converter.ToDocumentFieldValueConverter;
+
+class ElasticsearchCharacterIndexFieldTypeContext
+		extends AbstractElasticsearchScalarFieldTypeContext<ElasticsearchCharacterIndexFieldTypeContext, Character> {
+
+	ElasticsearchCharacterIndexFieldTypeContext(ElasticsearchIndexFieldTypeBuildContext buildContext) {
+		super( buildContext, Character.class, DataType.INTEGER );
+	}
+
+	@Override
+	protected ElasticsearchIndexFieldType<Character> toIndexFieldType(PropertyMapping mapping) {
+		ToDocumentFieldValueConverter<?, ? extends Character> dslToIndexConverter =
+				createDslToIndexConverter();
+		FromDocumentFieldValueConverter<? super Character, ?> indexToProjectionConverter =
+				createIndexToProjectionConverter();
+		ElasticsearchCharacterFieldCodec codec = ElasticsearchCharacterFieldCodec.INSTANCE;
+
+		return new ElasticsearchIndexFieldType<>(
+				codec,
+				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, codec ),
+				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, codec ),
+				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec ),
+				mapping
+		);
+	}
+
+	@Override
+	protected ElasticsearchCharacterIndexFieldTypeContext thisAsS() {
+		return this;
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchDoubleIndexFieldTypeContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchDoubleIndexFieldTypeContext.java
@@ -1,0 +1,47 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.types.dsl.impl;
+
+import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.DataType;
+import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.PropertyMapping;
+import org.hibernate.search.backend.elasticsearch.types.codec.impl.ElasticsearchDoubleFieldCodec;
+import org.hibernate.search.backend.elasticsearch.types.impl.ElasticsearchIndexFieldType;
+import org.hibernate.search.backend.elasticsearch.types.predicate.impl.ElasticsearchStandardFieldPredicateBuilderFactory;
+import org.hibernate.search.backend.elasticsearch.types.projection.impl.ElasticsearchStandardFieldProjectionBuilderFactory;
+import org.hibernate.search.backend.elasticsearch.types.sort.impl.ElasticsearchStandardFieldSortBuilderFactory;
+import org.hibernate.search.engine.backend.types.converter.FromDocumentFieldValueConverter;
+import org.hibernate.search.engine.backend.types.converter.ToDocumentFieldValueConverter;
+
+class ElasticsearchDoubleIndexFieldTypeContext
+		extends AbstractElasticsearchScalarFieldTypeContext<ElasticsearchDoubleIndexFieldTypeContext, Double> {
+
+	ElasticsearchDoubleIndexFieldTypeContext(ElasticsearchIndexFieldTypeBuildContext buildContext) {
+		super( buildContext, Double.class, DataType.DOUBLE );
+	}
+
+	@Override
+	protected ElasticsearchIndexFieldType<Double> toIndexFieldType(PropertyMapping mapping) {
+		ToDocumentFieldValueConverter<?, ? extends Double> dslToIndexConverter =
+				createDslToIndexConverter();
+		FromDocumentFieldValueConverter<? super Double, ?> indexToProjectionConverter =
+				createIndexToProjectionConverter();
+		ElasticsearchDoubleFieldCodec codec = ElasticsearchDoubleFieldCodec.INSTANCE;
+
+		return new ElasticsearchIndexFieldType<>(
+				codec,
+				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, codec ),
+				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, codec ),
+				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec ),
+				mapping
+		);
+	}
+
+	@Override
+	protected ElasticsearchDoubleIndexFieldTypeContext thisAsS() {
+		return this;
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchFloatIndexFieldTypeContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchFloatIndexFieldTypeContext.java
@@ -1,0 +1,47 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.types.dsl.impl;
+
+import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.DataType;
+import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.PropertyMapping;
+import org.hibernate.search.backend.elasticsearch.types.codec.impl.ElasticsearchFloatFieldCodec;
+import org.hibernate.search.backend.elasticsearch.types.impl.ElasticsearchIndexFieldType;
+import org.hibernate.search.backend.elasticsearch.types.predicate.impl.ElasticsearchStandardFieldPredicateBuilderFactory;
+import org.hibernate.search.backend.elasticsearch.types.projection.impl.ElasticsearchStandardFieldProjectionBuilderFactory;
+import org.hibernate.search.backend.elasticsearch.types.sort.impl.ElasticsearchStandardFieldSortBuilderFactory;
+import org.hibernate.search.engine.backend.types.converter.FromDocumentFieldValueConverter;
+import org.hibernate.search.engine.backend.types.converter.ToDocumentFieldValueConverter;
+
+class ElasticsearchFloatIndexFieldTypeContext
+		extends AbstractElasticsearchScalarFieldTypeContext<ElasticsearchFloatIndexFieldTypeContext, Float> {
+
+	ElasticsearchFloatIndexFieldTypeContext(ElasticsearchIndexFieldTypeBuildContext buildContext) {
+		super( buildContext, Float.class, DataType.FLOAT );
+	}
+
+	@Override
+	protected ElasticsearchIndexFieldType<Float> toIndexFieldType(PropertyMapping mapping) {
+		ToDocumentFieldValueConverter<?, ? extends Float> dslToIndexConverter =
+				createDslToIndexConverter();
+		FromDocumentFieldValueConverter<? super Float, ?> indexToProjectionConverter =
+				createIndexToProjectionConverter();
+		ElasticsearchFloatFieldCodec codec = ElasticsearchFloatFieldCodec.INSTANCE;
+
+		return new ElasticsearchIndexFieldType<>(
+				codec,
+				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, codec ),
+				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, codec ),
+				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec ),
+				mapping
+		);
+	}
+
+	@Override
+	protected ElasticsearchFloatIndexFieldTypeContext thisAsS() {
+		return this;
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchIndexFieldTypeFactoryContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchIndexFieldTypeFactoryContextImpl.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.backend.elasticsearch.types.dsl.impl;
 
 import java.lang.invoke.MethodHandles;
+import java.net.URI;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
@@ -66,6 +67,9 @@ public class ElasticsearchIndexFieldTypeFactoryContextImpl
 		else if ( GeoPoint.class.equals( inputType ) ) {
 			return (StandardIndexFieldTypeContext<?, F>) asGeoPoint();
 		}
+		else if ( URI.class.equals( inputType ) ) {
+			return (StandardIndexFieldTypeContext<?, F>) asUri();
+		}
 		else {
 			// TODO implement other types
 			throw log.cannotGuessFieldType( inputType, getEventContext() );
@@ -111,6 +115,12 @@ public class ElasticsearchIndexFieldTypeFactoryContextImpl
 	@Override
 	public StandardIndexFieldTypeContext<?, GeoPoint> asGeoPoint() {
 		return new ElasticsearchGeoPointIndexFieldTypeContext( this );
+	}
+
+	@Override
+	public StandardIndexFieldTypeContext<?, URI> asUri() {
+		// TODO implement this on backend commits within the same HSEARCH-3047 issue
+		return null;
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchIndexFieldTypeFactoryContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchIndexFieldTypeFactoryContextImpl.java
@@ -61,6 +61,9 @@ public class ElasticsearchIndexFieldTypeFactoryContextImpl
 		else if ( Byte.class.equals( inputType ) ) {
 			return (StandardIndexFieldTypeContext<?, F>) asByte();
 		}
+		else if ( Short.class.equals( inputType ) ) {
+			return (StandardIndexFieldTypeContext<?, F>) asShort();
+		}
 		else if ( LocalDate.class.equals( inputType ) ) {
 			return (StandardIndexFieldTypeContext<?, F>) asLocalDate();
 		}
@@ -110,6 +113,11 @@ public class ElasticsearchIndexFieldTypeFactoryContextImpl
 	@Override
 	public StandardIndexFieldTypeContext<?, Byte> asByte() {
 		return new ElasticsearchByteIndexFieldTypeContext( this );
+	}
+
+	@Override
+	public StandardIndexFieldTypeContext<?, Short> asShort() {
+		return new ElasticsearchShortIndexFieldTypeContext( this );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchIndexFieldTypeFactoryContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchIndexFieldTypeFactoryContextImpl.java
@@ -64,6 +64,9 @@ public class ElasticsearchIndexFieldTypeFactoryContextImpl
 		else if ( Short.class.equals( inputType ) ) {
 			return (StandardIndexFieldTypeContext<?, F>) asShort();
 		}
+		else if ( Double.class.equals( inputType ) ) {
+			return (StandardIndexFieldTypeContext<?, F>) asDouble();
+		}
 		else if ( LocalDate.class.equals( inputType ) ) {
 			return (StandardIndexFieldTypeContext<?, F>) asLocalDate();
 		}
@@ -118,6 +121,11 @@ public class ElasticsearchIndexFieldTypeFactoryContextImpl
 	@Override
 	public StandardIndexFieldTypeContext<?, Short> asShort() {
 		return new ElasticsearchShortIndexFieldTypeContext( this );
+	}
+
+	@Override
+	public StandardIndexFieldTypeContext<?, Double> asDouble() {
+		return new ElasticsearchDoubleIndexFieldTypeContext( this );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchIndexFieldTypeFactoryContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchIndexFieldTypeFactoryContextImpl.java
@@ -58,6 +58,9 @@ public class ElasticsearchIndexFieldTypeFactoryContextImpl
 		else if ( Character.class.equals( inputType ) ) {
 			return (StandardIndexFieldTypeContext<?, F>) asCharacter();
 		}
+		else if ( Byte.class.equals( inputType ) ) {
+			return (StandardIndexFieldTypeContext<?, F>) asByte();
+		}
 		else if ( LocalDate.class.equals( inputType ) ) {
 			return (StandardIndexFieldTypeContext<?, F>) asLocalDate();
 		}
@@ -102,6 +105,11 @@ public class ElasticsearchIndexFieldTypeFactoryContextImpl
 	@Override
 	public StandardIndexFieldTypeContext<?, Character> asCharacter() {
 		return new ElasticsearchCharacterIndexFieldTypeContext( this );
+	}
+
+	@Override
+	public StandardIndexFieldTypeContext<?, Byte> asByte() {
+		return new ElasticsearchByteIndexFieldTypeContext( this );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchIndexFieldTypeFactoryContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchIndexFieldTypeFactoryContextImpl.java
@@ -64,6 +64,9 @@ public class ElasticsearchIndexFieldTypeFactoryContextImpl
 		else if ( Short.class.equals( inputType ) ) {
 			return (StandardIndexFieldTypeContext<?, F>) asShort();
 		}
+		else if ( Float.class.equals( inputType ) ) {
+			return (StandardIndexFieldTypeContext<?, F>) asFloat();
+		}
 		else if ( Double.class.equals( inputType ) ) {
 			return (StandardIndexFieldTypeContext<?, F>) asDouble();
 		}
@@ -121,6 +124,11 @@ public class ElasticsearchIndexFieldTypeFactoryContextImpl
 	@Override
 	public StandardIndexFieldTypeContext<?, Short> asShort() {
 		return new ElasticsearchShortIndexFieldTypeContext( this );
+	}
+
+	@Override
+	public StandardIndexFieldTypeContext<?, Float> asFloat() {
+		return new ElasticsearchFloatIndexFieldTypeContext( this );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchIndexFieldTypeFactoryContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchIndexFieldTypeFactoryContextImpl.java
@@ -10,6 +10,7 @@ import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 
 import org.hibernate.search.backend.elasticsearch.logging.impl.Log;
@@ -72,6 +73,9 @@ public class ElasticsearchIndexFieldTypeFactoryContextImpl
 		}
 		else if ( LocalDate.class.equals( inputType ) ) {
 			return (StandardIndexFieldTypeContext<?, F>) asLocalDate();
+		}
+		else if ( LocalDateTime.class.equals( inputType ) ) {
+			return (StandardIndexFieldTypeContext<?, F>) asLocalDateTime();
 		}
 		else if ( Instant.class.equals( inputType ) ) {
 			return (StandardIndexFieldTypeContext<?, F>) asInstant();
@@ -139,6 +143,11 @@ public class ElasticsearchIndexFieldTypeFactoryContextImpl
 	@Override
 	public StandardIndexFieldTypeContext<?, LocalDate> asLocalDate() {
 		return new ElasticsearchLocalDateIndexFieldTypeContext( this );
+	}
+
+	@Override
+	public StandardIndexFieldTypeContext<?, LocalDateTime> asLocalDateTime() {
+		return new ElasticsearchLocalDateTimeIndexFieldTypeContext( this );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchIndexFieldTypeFactoryContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchIndexFieldTypeFactoryContextImpl.java
@@ -9,6 +9,7 @@ package org.hibernate.search.backend.elasticsearch.types.dsl.impl;
 import java.lang.invoke.MethodHandles;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZonedDateTime;
 
 import org.hibernate.search.backend.elasticsearch.logging.impl.Log;
 import org.hibernate.search.backend.elasticsearch.types.dsl.ElasticsearchIndexFieldTypeFactoryContext;
@@ -59,6 +60,9 @@ public class ElasticsearchIndexFieldTypeFactoryContextImpl
 		else if ( Instant.class.equals( inputType ) ) {
 			return (StandardIndexFieldTypeContext<?, F>) asInstant();
 		}
+		else if ( ZonedDateTime.class.equals( inputType ) ) {
+			return (StandardIndexFieldTypeContext<?, F>) asZonedDateTime();
+		}
 		else if ( GeoPoint.class.equals( inputType ) ) {
 			return (StandardIndexFieldTypeContext<?, F>) asGeoPoint();
 		}
@@ -96,6 +100,12 @@ public class ElasticsearchIndexFieldTypeFactoryContextImpl
 	@Override
 	public StandardIndexFieldTypeContext<?, Instant> asInstant() {
 		return new ElasticsearchInstantIndexFieldTypeContext( this );
+	}
+
+	@Override
+	public StandardIndexFieldTypeContext<?, ZonedDateTime> asZonedDateTime() {
+		// TODO implement this on backend commits within the same HSEARCH-3047 issue
+		return null;
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchIndexFieldTypeFactoryContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchIndexFieldTypeFactoryContextImpl.java
@@ -55,6 +55,9 @@ public class ElasticsearchIndexFieldTypeFactoryContextImpl
 		else if ( Boolean.class.equals( inputType ) ) {
 			return (StandardIndexFieldTypeContext<?, F>) asBoolean();
 		}
+		else if ( Character.class.equals( inputType ) ) {
+			return (StandardIndexFieldTypeContext<?, F>) asCharacter();
+		}
 		else if ( LocalDate.class.equals( inputType ) ) {
 			return (StandardIndexFieldTypeContext<?, F>) asLocalDate();
 		}
@@ -94,6 +97,11 @@ public class ElasticsearchIndexFieldTypeFactoryContextImpl
 	@Override
 	public StandardIndexFieldTypeContext<?, Boolean> asBoolean() {
 		return new ElasticsearchBooleanIndexFieldTypeContext( this );
+	}
+
+	@Override
+	public StandardIndexFieldTypeContext<?, Character> asCharacter() {
+		return new ElasticsearchCharacterIndexFieldTypeContext( this );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchLocalDateIndexFieldTypeContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchLocalDateIndexFieldTypeContext.java
@@ -11,6 +11,7 @@ import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
 import static java.time.temporal.ChronoField.YEAR;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.ResolverStyle;
 import java.time.format.SignStyle;
@@ -34,16 +35,16 @@ import org.hibernate.search.engine.backend.types.converter.ToDocumentFieldValueC
 class ElasticsearchLocalDateIndexFieldTypeContext
 		extends AbstractElasticsearchScalarFieldTypeContext<ElasticsearchLocalDateIndexFieldTypeContext, LocalDate> {
 
-	private static final ElasticsearchLocalDateFieldCodec DEFAULT_CODEC = new ElasticsearchLocalDateFieldCodec(
-					new DateTimeFormatterBuilder()
-							.appendValue( YEAR, 4, 9, SignStyle.EXCEEDS_PAD )
-							.appendLiteral( '-' )
-							.appendValue( MONTH_OF_YEAR, 2 )
-							.appendLiteral( '-' )
-							.appendValue( DAY_OF_MONTH, 2 )
-							.toFormatter( Locale.ROOT )
-							.withResolverStyle( ResolverStyle.STRICT )
-			);
+	static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
+			.appendValue( YEAR, 4, 9, SignStyle.EXCEEDS_PAD )
+			.appendLiteral( '-' )
+			.appendValue( MONTH_OF_YEAR, 2 )
+			.appendLiteral( '-' )
+			.appendValue( DAY_OF_MONTH, 2 )
+			.toFormatter( Locale.ROOT )
+			.withResolverStyle( ResolverStyle.STRICT );
+
+	private static final ElasticsearchLocalDateFieldCodec DEFAULT_CODEC = new ElasticsearchLocalDateFieldCodec( FORMATTER );
 
 	private final ElasticsearchLocalDateFieldCodec codec = DEFAULT_CODEC; // TODO add method to allow customization
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchLocalDateTimeIndexFieldTypeContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchLocalDateTimeIndexFieldTypeContext.java
@@ -1,0 +1,77 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.types.dsl.impl;
+
+import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
+import static java.time.temporal.ChronoField.NANO_OF_SECOND;
+import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.ResolverStyle;
+import java.util.Arrays;
+import java.util.Locale;
+
+import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.DataType;
+import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.PropertyMapping;
+import org.hibernate.search.backend.elasticsearch.types.codec.impl.ElasticsearchLocalDateTimeFieldCodec;
+import org.hibernate.search.backend.elasticsearch.types.impl.ElasticsearchIndexFieldType;
+import org.hibernate.search.backend.elasticsearch.types.predicate.impl.ElasticsearchStandardFieldPredicateBuilderFactory;
+import org.hibernate.search.backend.elasticsearch.types.projection.impl.ElasticsearchStandardFieldProjectionBuilderFactory;
+import org.hibernate.search.backend.elasticsearch.types.sort.impl.ElasticsearchStandardFieldSortBuilderFactory;
+import org.hibernate.search.engine.backend.types.converter.FromDocumentFieldValueConverter;
+import org.hibernate.search.engine.backend.types.converter.ToDocumentFieldValueConverter;
+
+class ElasticsearchLocalDateTimeIndexFieldTypeContext
+		extends AbstractElasticsearchScalarFieldTypeContext<ElasticsearchLocalDateTimeIndexFieldTypeContext, LocalDateTime> {
+
+	private static final ElasticsearchLocalDateTimeFieldCodec DEFAULT_CODEC = new ElasticsearchLocalDateTimeFieldCodec(
+					new DateTimeFormatterBuilder()
+							.append( ElasticsearchLocalDateIndexFieldTypeContext.FORMATTER )
+							.appendLiteral( 'T' )
+							.appendValue( HOUR_OF_DAY, 2 )
+							.appendLiteral( ':' )
+							.appendValue( MINUTE_OF_HOUR, 2 )
+							.optionalStart()
+							.appendLiteral( ':' )
+							.appendValue( SECOND_OF_MINUTE, 2 )
+							.optionalStart()
+							.appendFraction( NANO_OF_SECOND, 3, 9, true )
+							.toFormatter( Locale.ROOT )
+							.withResolverStyle( ResolverStyle.STRICT )
+			);
+
+	private final ElasticsearchLocalDateTimeFieldCodec codec = DEFAULT_CODEC; // TODO add method to allow customization
+
+	ElasticsearchLocalDateTimeIndexFieldTypeContext(ElasticsearchIndexFieldTypeBuildContext buildContext) {
+		super( buildContext, LocalDateTime.class, DataType.DATE );
+	}
+
+	@Override
+	protected ElasticsearchIndexFieldType<LocalDateTime> toIndexFieldType(PropertyMapping mapping) {
+		mapping.setFormat( Arrays.asList( "strict_date_hour_minute_second_fraction", "yyyyyyyyy-MM-dd'T'HH:mm:ss.SSS" ) );
+
+		ToDocumentFieldValueConverter<?, ? extends LocalDateTime> dslToIndexConverter =
+				createDslToIndexConverter();
+		FromDocumentFieldValueConverter<? super LocalDateTime, ?> indexToProjectionConverter =
+				createIndexToProjectionConverter();
+
+		return new ElasticsearchIndexFieldType<>(
+				codec,
+				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, codec ),
+				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, codec ),
+				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec ),
+				mapping
+		);
+	}
+
+	@Override
+	protected ElasticsearchLocalDateTimeIndexFieldTypeContext thisAsS() {
+		return this;
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchShortIndexFieldTypeContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchShortIndexFieldTypeContext.java
@@ -1,0 +1,47 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.types.dsl.impl;
+
+import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.DataType;
+import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.PropertyMapping;
+import org.hibernate.search.backend.elasticsearch.types.codec.impl.ElasticsearchShortFieldCodec;
+import org.hibernate.search.backend.elasticsearch.types.impl.ElasticsearchIndexFieldType;
+import org.hibernate.search.backend.elasticsearch.types.predicate.impl.ElasticsearchStandardFieldPredicateBuilderFactory;
+import org.hibernate.search.backend.elasticsearch.types.projection.impl.ElasticsearchStandardFieldProjectionBuilderFactory;
+import org.hibernate.search.backend.elasticsearch.types.sort.impl.ElasticsearchStandardFieldSortBuilderFactory;
+import org.hibernate.search.engine.backend.types.converter.FromDocumentFieldValueConverter;
+import org.hibernate.search.engine.backend.types.converter.ToDocumentFieldValueConverter;
+
+class ElasticsearchShortIndexFieldTypeContext
+		extends AbstractElasticsearchScalarFieldTypeContext<ElasticsearchShortIndexFieldTypeContext, Short> {
+
+	ElasticsearchShortIndexFieldTypeContext(ElasticsearchIndexFieldTypeBuildContext buildContext) {
+		super( buildContext, Short.class, DataType.SHORT );
+	}
+
+	@Override
+	protected ElasticsearchIndexFieldType<Short> toIndexFieldType(PropertyMapping mapping) {
+		ToDocumentFieldValueConverter<?, ? extends Short> dslToIndexConverter =
+				createDslToIndexConverter();
+		FromDocumentFieldValueConverter<? super Short, ?> indexToProjectionConverter =
+				createIndexToProjectionConverter();
+		ElasticsearchShortFieldCodec codec = ElasticsearchShortFieldCodec.INSTANCE;
+
+		return new ElasticsearchIndexFieldType<>(
+				codec,
+				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, codec ),
+				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, codec ),
+				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec ),
+				mapping
+		);
+	}
+
+	@Override
+	protected ElasticsearchShortIndexFieldTypeContext thisAsS() {
+		return this;
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneByteFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneByteFieldCodec.java
@@ -1,0 +1,82 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.types.codec.impl;
+
+import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.IndexableField;
+
+public final class LuceneByteFieldCodec implements LuceneNumericFieldCodec<Byte, Integer> {
+
+	private final boolean projectable;
+
+	private final boolean sortable;
+
+	public LuceneByteFieldCodec(boolean projectable, boolean sortable) {
+		this.projectable = projectable;
+		this.sortable = sortable;
+	}
+
+	@Override
+	public void encode(LuceneDocumentBuilder documentBuilder, String absoluteFieldPath, Byte value) {
+		if ( value == null ) {
+			return;
+		}
+		Integer intValue = encode( value );
+
+		if ( projectable ) {
+			documentBuilder.addField( new StoredField( absoluteFieldPath, intValue ) );
+		}
+
+		if ( sortable ) {
+			documentBuilder.addField( new NumericDocValuesField( absoluteFieldPath, intValue.longValue() ) );
+		}
+
+		documentBuilder.addField( new IntPoint( absoluteFieldPath, intValue ) );
+	}
+
+	@Override
+	public Byte decode(Document document, String absoluteFieldPath) {
+		IndexableField field = document.getField( absoluteFieldPath );
+
+		if ( field == null ) {
+			return null;
+		}
+
+		Integer integer = (Integer) field.numericValue();
+		return integer.byteValue();
+	}
+
+	@Override
+	public boolean isCompatibleWith(LuceneFieldCodec<?> obj) {
+		if ( this == obj ) {
+			return true;
+		}
+		if ( LuceneByteFieldCodec.class != obj.getClass() ) {
+			return false;
+		}
+
+		LuceneByteFieldCodec other = (LuceneByteFieldCodec) obj;
+
+		return ( projectable == other.projectable ) &&
+				( sortable == other.sortable );
+	}
+
+	@Override
+	public Integer encode(Byte value) {
+		return (int) value;
+	}
+
+	@Override
+	public LuceneNumericDomain<Integer> getDomain() {
+		return LuceneNumericDomain.INTEGER;
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneCharacterFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneCharacterFieldCodec.java
@@ -1,0 +1,82 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.types.codec.impl;
+
+import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.IndexableField;
+
+public final class LuceneCharacterFieldCodec implements LuceneNumericFieldCodec<Character, Integer> {
+
+	private final boolean projectable;
+
+	private final boolean sortable;
+
+	public LuceneCharacterFieldCodec(boolean projectable, boolean sortable) {
+		this.projectable = projectable;
+		this.sortable = sortable;
+	}
+
+	@Override
+	public void encode(LuceneDocumentBuilder documentBuilder, String absoluteFieldPath, Character value) {
+		if ( value == null ) {
+			return;
+		}
+		Integer intValue = encode( value );
+
+		if ( projectable ) {
+			documentBuilder.addField( new StoredField( absoluteFieldPath, intValue ) );
+		}
+
+		if ( sortable ) {
+			documentBuilder.addField( new NumericDocValuesField( absoluteFieldPath, intValue.longValue() ) );
+		}
+
+		documentBuilder.addField( new IntPoint( absoluteFieldPath, intValue ) );
+	}
+
+	@Override
+	public Character decode(Document document, String absoluteFieldPath) {
+		IndexableField field = document.getField( absoluteFieldPath );
+
+		if ( field == null ) {
+			return null;
+		}
+
+		Integer integer = (Integer) field.numericValue();
+		return (char) integer.intValue();
+	}
+
+	@Override
+	public boolean isCompatibleWith(LuceneFieldCodec<?> obj) {
+		if ( this == obj ) {
+			return true;
+		}
+		if ( LuceneCharacterFieldCodec.class != obj.getClass() ) {
+			return false;
+		}
+
+		LuceneCharacterFieldCodec other = (LuceneCharacterFieldCodec) obj;
+
+		return ( projectable == other.projectable ) &&
+				( sortable == other.sortable );
+	}
+
+	@Override
+	public Integer encode(Character value) {
+		return (int) value;
+	}
+
+	@Override
+	public LuceneNumericDomain<Integer> getDomain() {
+		return LuceneNumericDomain.INTEGER;
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneDoubleFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneDoubleFieldCodec.java
@@ -1,0 +1,80 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.types.codec.impl;
+
+import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.DoubleDocValuesField;
+import org.apache.lucene.document.DoublePoint;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.IndexableField;
+
+public final class LuceneDoubleFieldCodec implements LuceneNumericFieldCodec<Double, Double> {
+
+	private final boolean projectable;
+
+	private final boolean sortable;
+
+	public LuceneDoubleFieldCodec(boolean projectable, boolean sortable) {
+		this.projectable = projectable;
+		this.sortable = sortable;
+	}
+
+	@Override
+	public void encode(LuceneDocumentBuilder documentBuilder, String absoluteFieldPath, Double value) {
+		if ( value == null ) {
+			return;
+		}
+
+		if ( projectable ) {
+			documentBuilder.addField( new StoredField( absoluteFieldPath, value ) );
+		}
+
+		if ( sortable ) {
+			documentBuilder.addField( new DoubleDocValuesField( absoluteFieldPath, value ) );
+		}
+
+		documentBuilder.addField( new DoublePoint( absoluteFieldPath, value ) );
+	}
+
+	@Override
+	public Double decode(Document document, String absoluteFieldPath) {
+		IndexableField field = document.getField( absoluteFieldPath );
+
+		if ( field == null ) {
+			return null;
+		}
+
+		return (Double) field.numericValue();
+	}
+
+	@Override
+	public boolean isCompatibleWith(LuceneFieldCodec<?> obj) {
+		if ( this == obj ) {
+			return true;
+		}
+		if ( LuceneDoubleFieldCodec.class != obj.getClass() ) {
+			return false;
+		}
+
+		LuceneDoubleFieldCodec other = (LuceneDoubleFieldCodec) obj;
+
+		return ( projectable == other.projectable ) &&
+				( sortable == other.sortable );
+	}
+
+	@Override
+	public Double encode(Double value) {
+		return value;
+	}
+
+	@Override
+	public LuceneNumericDomain<Double> getDomain() {
+		return LuceneNumericDomain.DOUBLE;
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneFloatFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneFloatFieldCodec.java
@@ -1,0 +1,80 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.types.codec.impl;
+
+import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.FloatDocValuesField;
+import org.apache.lucene.document.FloatPoint;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.IndexableField;
+
+public final class LuceneFloatFieldCodec implements LuceneNumericFieldCodec<Float, Float> {
+
+	private final boolean projectable;
+
+	private final boolean sortable;
+
+	public LuceneFloatFieldCodec(boolean projectable, boolean sortable) {
+		this.projectable = projectable;
+		this.sortable = sortable;
+	}
+
+	@Override
+	public void encode(LuceneDocumentBuilder documentBuilder, String absoluteFieldPath, Float value) {
+		if ( value == null ) {
+			return;
+		}
+
+		if ( projectable ) {
+			documentBuilder.addField( new StoredField( absoluteFieldPath, value ) );
+		}
+
+		if ( sortable ) {
+			documentBuilder.addField( new FloatDocValuesField( absoluteFieldPath, value ) );
+		}
+
+		documentBuilder.addField( new FloatPoint( absoluteFieldPath, value ) );
+	}
+
+	@Override
+	public Float decode(Document document, String absoluteFieldPath) {
+		IndexableField field = document.getField( absoluteFieldPath );
+
+		if ( field == null ) {
+			return null;
+		}
+
+		return (Float) field.numericValue();
+	}
+
+	@Override
+	public boolean isCompatibleWith(LuceneFieldCodec<?> obj) {
+		if ( this == obj ) {
+			return true;
+		}
+		if ( LuceneFloatFieldCodec.class != obj.getClass() ) {
+			return false;
+		}
+
+		LuceneFloatFieldCodec other = (LuceneFloatFieldCodec) obj;
+
+		return ( projectable == other.projectable ) &&
+				( sortable == other.sortable );
+	}
+
+	@Override
+	public Float encode(Float value) {
+		return value;
+	}
+
+	@Override
+	public LuceneNumericDomain<Float> getDomain() {
+		return LuceneNumericDomain.FLOAT;
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneNumericDomain.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneNumericDomain.java
@@ -6,6 +6,9 @@
  */
 package org.hibernate.search.backend.lucene.types.codec.impl;
 
+import java.math.BigDecimal;
+
+import org.apache.lucene.document.DoublePoint;
 import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.search.Query;
@@ -105,4 +108,42 @@ public abstract class LuceneNumericDomain<E> {
 		}
 	};
 
+	public static final LuceneNumericDomain<Double> DOUBLE = new LuceneNumericDomain<Double>() {
+		@Override
+		public Double getMinValue() {
+			return Double.MIN_VALUE;
+		}
+
+		@Override
+		public Double getMaxValue() {
+			return Double.MAX_VALUE;
+		}
+
+		@Override
+		public Double getPreviousValue(Double value) {
+			return new BigDecimal( value ).subtract( BigDecimal.ONE ).doubleValue();
+		}
+
+		@Override
+		public Double getNextValue(Double value) {
+			return new BigDecimal( value ).add( BigDecimal.ONE ).doubleValue();
+		}
+
+		@Override
+		public Query createExactQuery(String absoluteFieldPath, Double value) {
+			return DoublePoint.newExactQuery( absoluteFieldPath, value );
+		}
+
+		@Override
+		public Query createRangeQuery(String absoluteFieldPath, Double lowerLimit, Double upperLimit) {
+			return DoublePoint.newRangeQuery(
+					absoluteFieldPath, lowerLimit, upperLimit
+			);
+		}
+
+		@Override
+		public SortField.Type getSortFieldType() {
+			return SortField.Type.DOUBLE;
+		}
+	};
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneNumericDomain.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneNumericDomain.java
@@ -9,6 +9,7 @@ package org.hibernate.search.backend.lucene.types.codec.impl;
 import java.math.BigDecimal;
 
 import org.apache.lucene.document.DoublePoint;
+import org.apache.lucene.document.FloatPoint;
 import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.search.Query;
@@ -105,6 +106,45 @@ public abstract class LuceneNumericDomain<E> {
 		@Override
 		public SortField.Type getSortFieldType() {
 			return SortField.Type.LONG;
+		}
+	};
+
+	public static final LuceneNumericDomain<Float> FLOAT = new LuceneNumericDomain<Float>() {
+		@Override
+		public Float getMinValue() {
+			return Float.MIN_VALUE;
+		}
+
+		@Override
+		public Float getMaxValue() {
+			return Float.MAX_VALUE;
+		}
+
+		@Override
+		public Float getPreviousValue(Float value) {
+			return new BigDecimal( value.doubleValue() ).subtract( BigDecimal.ONE ).floatValue();
+		}
+
+		@Override
+		public Float getNextValue(Float value) {
+			return new BigDecimal( value.doubleValue() ).add( BigDecimal.ONE ).floatValue();
+		}
+
+		@Override
+		public Query createExactQuery(String absoluteFieldPath, Float value) {
+			return FloatPoint.newExactQuery( absoluteFieldPath, value );
+		}
+
+		@Override
+		public Query createRangeQuery(String absoluteFieldPath, Float lowerLimit, Float upperLimit) {
+			return FloatPoint.newRangeQuery(
+					absoluteFieldPath, lowerLimit, upperLimit
+			);
+		}
+
+		@Override
+		public SortField.Type getSortFieldType() {
+			return SortField.Type.FLOAT;
 		}
 	};
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneShortFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneShortFieldCodec.java
@@ -1,0 +1,82 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.types.codec.impl;
+
+import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.IndexableField;
+
+public final class LuceneShortFieldCodec implements LuceneNumericFieldCodec<Short, Integer> {
+
+	private final boolean projectable;
+
+	private final boolean sortable;
+
+	public LuceneShortFieldCodec(boolean projectable, boolean sortable) {
+		this.projectable = projectable;
+		this.sortable = sortable;
+	}
+
+	@Override
+	public void encode(LuceneDocumentBuilder documentBuilder, String absoluteFieldPath, Short value) {
+		if ( value == null ) {
+			return;
+		}
+		Integer intValue = encode( value );
+
+		if ( projectable ) {
+			documentBuilder.addField( new StoredField( absoluteFieldPath, intValue ) );
+		}
+
+		if ( sortable ) {
+			documentBuilder.addField( new NumericDocValuesField( absoluteFieldPath, intValue.longValue() ) );
+		}
+
+		documentBuilder.addField( new IntPoint( absoluteFieldPath, intValue ) );
+	}
+
+	@Override
+	public Short decode(Document document, String absoluteFieldPath) {
+		IndexableField field = document.getField( absoluteFieldPath );
+
+		if ( field == null ) {
+			return null;
+		}
+
+		Integer integer = (Integer) field.numericValue();
+		return integer.shortValue();
+	}
+
+	@Override
+	public boolean isCompatibleWith(LuceneFieldCodec<?> obj) {
+		if ( this == obj ) {
+			return true;
+		}
+		if ( LuceneShortFieldCodec.class != obj.getClass() ) {
+			return false;
+		}
+
+		LuceneShortFieldCodec other = (LuceneShortFieldCodec) obj;
+
+		return ( projectable == other.projectable ) &&
+				( sortable == other.sortable );
+	}
+
+	@Override
+	public Integer encode(Short value) {
+		return (int) value;
+	}
+
+	@Override
+	public LuceneNumericDomain<Integer> getDomain() {
+		return LuceneNumericDomain.INTEGER;
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneByteIndexFieldTypeContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneByteIndexFieldTypeContext.java
@@ -1,0 +1,56 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.types.dsl.impl;
+
+import org.hibernate.search.backend.lucene.types.codec.impl.LuceneByteFieldCodec;
+import org.hibernate.search.backend.lucene.types.impl.LuceneIndexFieldType;
+import org.hibernate.search.backend.lucene.types.predicate.impl.LuceneNumericFieldPredicateBuilderFactory;
+import org.hibernate.search.backend.lucene.types.projection.impl.LuceneStandardFieldProjectionBuilderFactory;
+import org.hibernate.search.backend.lucene.types.sort.impl.LuceneNumericFieldSortBuilderFactory;
+import org.hibernate.search.engine.backend.types.Sortable;
+import org.hibernate.search.engine.backend.types.converter.FromDocumentFieldValueConverter;
+import org.hibernate.search.engine.backend.types.converter.ToDocumentFieldValueConverter;
+
+class LuceneByteIndexFieldTypeContext
+		extends AbstractLuceneStandardIndexFieldTypeContext<LuceneByteIndexFieldTypeContext, Byte> {
+
+	private Sortable sortable = Sortable.DEFAULT;
+
+	LuceneByteIndexFieldTypeContext(LuceneIndexFieldTypeBuildContext buildContext) {
+		super( buildContext, Byte.class );
+	}
+
+	@Override
+	public LuceneByteIndexFieldTypeContext sortable(Sortable sortable) {
+		this.sortable = sortable;
+		return this;
+	}
+
+	@Override
+	public LuceneIndexFieldType<Byte> toIndexFieldType() {
+		boolean resolvedSortable = resolveDefault( sortable );
+		boolean resolvedProjectable = resolveDefault( projectable );
+
+		ToDocumentFieldValueConverter<?, ? extends Byte> dslToIndexConverter =
+				createDslToIndexConverter();
+		FromDocumentFieldValueConverter<? super Byte, ?> indexToProjectionConverter =
+				createIndexToProjectionConverter();
+		LuceneByteFieldCodec codec = new LuceneByteFieldCodec( resolvedProjectable, resolvedSortable );
+
+		return new LuceneIndexFieldType<>(
+				codec,
+				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, codec ),
+				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, codec ),
+				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec )
+		);
+	}
+
+	@Override
+	protected LuceneByteIndexFieldTypeContext thisAsS() {
+		return this;
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneCharacterIndexFieldTypeContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneCharacterIndexFieldTypeContext.java
@@ -1,0 +1,56 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.types.dsl.impl;
+
+import org.hibernate.search.backend.lucene.types.codec.impl.LuceneCharacterFieldCodec;
+import org.hibernate.search.backend.lucene.types.impl.LuceneIndexFieldType;
+import org.hibernate.search.backend.lucene.types.predicate.impl.LuceneNumericFieldPredicateBuilderFactory;
+import org.hibernate.search.backend.lucene.types.projection.impl.LuceneStandardFieldProjectionBuilderFactory;
+import org.hibernate.search.backend.lucene.types.sort.impl.LuceneNumericFieldSortBuilderFactory;
+import org.hibernate.search.engine.backend.types.Sortable;
+import org.hibernate.search.engine.backend.types.converter.FromDocumentFieldValueConverter;
+import org.hibernate.search.engine.backend.types.converter.ToDocumentFieldValueConverter;
+
+class LuceneCharacterIndexFieldTypeContext
+		extends AbstractLuceneStandardIndexFieldTypeContext<LuceneCharacterIndexFieldTypeContext, Character> {
+
+	private Sortable sortable = Sortable.DEFAULT;
+
+	LuceneCharacterIndexFieldTypeContext(LuceneIndexFieldTypeBuildContext buildContext) {
+		super( buildContext, Character.class );
+	}
+
+	@Override
+	public LuceneCharacterIndexFieldTypeContext sortable(Sortable sortable) {
+		this.sortable = sortable;
+		return this;
+	}
+
+	@Override
+	public LuceneIndexFieldType<Character> toIndexFieldType() {
+		boolean resolvedSortable = resolveDefault( sortable );
+		boolean resolvedProjectable = resolveDefault( projectable );
+
+		ToDocumentFieldValueConverter<?, ? extends Character> dslToIndexConverter =
+				createDslToIndexConverter();
+		FromDocumentFieldValueConverter<? super Character, ?> indexToProjectionConverter =
+				createIndexToProjectionConverter();
+		LuceneCharacterFieldCodec codec = new LuceneCharacterFieldCodec( resolvedProjectable, resolvedSortable );
+
+		return new LuceneIndexFieldType<>(
+				codec,
+				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, codec ),
+				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, codec ),
+				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec )
+		);
+	}
+
+	@Override
+	protected LuceneCharacterIndexFieldTypeContext thisAsS() {
+		return this;
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneDoubleIndexFieldTypeContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneDoubleIndexFieldTypeContext.java
@@ -1,0 +1,56 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.types.dsl.impl;
+
+import org.hibernate.search.backend.lucene.types.codec.impl.LuceneDoubleFieldCodec;
+import org.hibernate.search.backend.lucene.types.impl.LuceneIndexFieldType;
+import org.hibernate.search.backend.lucene.types.predicate.impl.LuceneNumericFieldPredicateBuilderFactory;
+import org.hibernate.search.backend.lucene.types.projection.impl.LuceneStandardFieldProjectionBuilderFactory;
+import org.hibernate.search.backend.lucene.types.sort.impl.LuceneNumericFieldSortBuilderFactory;
+import org.hibernate.search.engine.backend.types.Sortable;
+import org.hibernate.search.engine.backend.types.converter.FromDocumentFieldValueConverter;
+import org.hibernate.search.engine.backend.types.converter.ToDocumentFieldValueConverter;
+
+class LuceneDoubleIndexFieldTypeContext
+		extends AbstractLuceneStandardIndexFieldTypeContext<LuceneDoubleIndexFieldTypeContext, Double> {
+
+	private Sortable sortable = Sortable.DEFAULT;
+
+	LuceneDoubleIndexFieldTypeContext(LuceneIndexFieldTypeBuildContext buildContext) {
+		super( buildContext, Double.class );
+	}
+
+	@Override
+	public LuceneDoubleIndexFieldTypeContext sortable(Sortable sortable) {
+		this.sortable = sortable;
+		return this;
+	}
+
+	@Override
+	public LuceneIndexFieldType<Double> toIndexFieldType() {
+		boolean resolvedSortable = resolveDefault( sortable );
+		boolean resolvedProjectable = resolveDefault( projectable );
+
+		ToDocumentFieldValueConverter<?, ? extends Double> dslToIndexConverter =
+				createDslToIndexConverter();
+		FromDocumentFieldValueConverter<? super Double, ?> indexToProjectionConverter =
+				createIndexToProjectionConverter();
+		LuceneDoubleFieldCodec codec = new LuceneDoubleFieldCodec( resolvedProjectable, resolvedSortable );
+
+		return new LuceneIndexFieldType<>(
+				codec,
+				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, codec ),
+				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, codec ),
+				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec )
+		);
+	}
+
+	@Override
+	protected LuceneDoubleIndexFieldTypeContext thisAsS() {
+		return this;
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneFloatIndexFieldTypeContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneFloatIndexFieldTypeContext.java
@@ -1,0 +1,56 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.types.dsl.impl;
+
+import org.hibernate.search.backend.lucene.types.codec.impl.LuceneFloatFieldCodec;
+import org.hibernate.search.backend.lucene.types.impl.LuceneIndexFieldType;
+import org.hibernate.search.backend.lucene.types.predicate.impl.LuceneNumericFieldPredicateBuilderFactory;
+import org.hibernate.search.backend.lucene.types.projection.impl.LuceneStandardFieldProjectionBuilderFactory;
+import org.hibernate.search.backend.lucene.types.sort.impl.LuceneNumericFieldSortBuilderFactory;
+import org.hibernate.search.engine.backend.types.Sortable;
+import org.hibernate.search.engine.backend.types.converter.FromDocumentFieldValueConverter;
+import org.hibernate.search.engine.backend.types.converter.ToDocumentFieldValueConverter;
+
+class LuceneFloatIndexFieldTypeContext
+		extends AbstractLuceneStandardIndexFieldTypeContext<LuceneFloatIndexFieldTypeContext, Float> {
+
+	private Sortable sortable = Sortable.DEFAULT;
+
+	LuceneFloatIndexFieldTypeContext(LuceneIndexFieldTypeBuildContext buildContext) {
+		super( buildContext, Float.class );
+	}
+
+	@Override
+	public LuceneFloatIndexFieldTypeContext sortable(Sortable sortable) {
+		this.sortable = sortable;
+		return this;
+	}
+
+	@Override
+	public LuceneIndexFieldType<Float> toIndexFieldType() {
+		boolean resolvedSortable = resolveDefault( sortable );
+		boolean resolvedProjectable = resolveDefault( projectable );
+
+		ToDocumentFieldValueConverter<?, ? extends Float> dslToIndexConverter =
+				createDslToIndexConverter();
+		FromDocumentFieldValueConverter<? super Float, ?> indexToProjectionConverter =
+				createIndexToProjectionConverter();
+		LuceneFloatFieldCodec codec = new LuceneFloatFieldCodec( resolvedProjectable, resolvedSortable );
+
+		return new LuceneIndexFieldType<>(
+				codec,
+				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, codec ),
+				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, codec ),
+				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec )
+		);
+	}
+
+	@Override
+	protected LuceneFloatIndexFieldTypeContext thisAsS() {
+		return this;
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIndexFieldTypeFactoryContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIndexFieldTypeFactoryContextImpl.java
@@ -63,6 +63,9 @@ public class LuceneIndexFieldTypeFactoryContextImpl
 		else if ( Byte.class.equals( inputType ) ) {
 			return (StandardIndexFieldTypeContext<?, F>) asByte();
 		}
+		else if ( Short.class.equals( inputType ) ) {
+			return (StandardIndexFieldTypeContext<?, F>) asShort();
+		}
 		else if ( LocalDate.class.equals( inputType ) ) {
 			return (StandardIndexFieldTypeContext<?, F>) asLocalDate();
 		}
@@ -112,6 +115,11 @@ public class LuceneIndexFieldTypeFactoryContextImpl
 	@Override
 	public StandardIndexFieldTypeContext<?, Byte> asByte() {
 		return new LuceneByteIndexFieldTypeContext( this );
+	}
+
+	@Override
+	public StandardIndexFieldTypeContext<?, Short> asShort() {
+		return new LuceneShortIndexFieldTypeContext( this );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIndexFieldTypeFactoryContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIndexFieldTypeFactoryContextImpl.java
@@ -57,6 +57,9 @@ public class LuceneIndexFieldTypeFactoryContextImpl
 		else if ( Boolean.class.equals( inputType ) ) {
 			return (StandardIndexFieldTypeContext<?, F>) asBoolean();
 		}
+		else if ( Character.class.equals( inputType ) ) {
+			return (StandardIndexFieldTypeContext<?, F>) asCharacter();
+		}
 		else if ( LocalDate.class.equals( inputType ) ) {
 			return (StandardIndexFieldTypeContext<?, F>) asLocalDate();
 		}
@@ -96,6 +99,11 @@ public class LuceneIndexFieldTypeFactoryContextImpl
 	@Override
 	public StandardIndexFieldTypeContext<?, Boolean> asBoolean() {
 		return new LuceneBooleanIndexFieldTypeContext( this );
+	}
+
+	@Override
+	public StandardIndexFieldTypeContext<?, Character> asCharacter() {
+		return new LuceneCharacterIndexFieldTypeContext( this );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIndexFieldTypeFactoryContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIndexFieldTypeFactoryContextImpl.java
@@ -60,6 +60,9 @@ public class LuceneIndexFieldTypeFactoryContextImpl
 		else if ( Character.class.equals( inputType ) ) {
 			return (StandardIndexFieldTypeContext<?, F>) asCharacter();
 		}
+		else if ( Byte.class.equals( inputType ) ) {
+			return (StandardIndexFieldTypeContext<?, F>) asByte();
+		}
 		else if ( LocalDate.class.equals( inputType ) ) {
 			return (StandardIndexFieldTypeContext<?, F>) asLocalDate();
 		}
@@ -104,6 +107,11 @@ public class LuceneIndexFieldTypeFactoryContextImpl
 	@Override
 	public StandardIndexFieldTypeContext<?, Character> asCharacter() {
 		return new LuceneCharacterIndexFieldTypeContext( this );
+	}
+
+	@Override
+	public StandardIndexFieldTypeContext<?, Byte> asByte() {
+		return new LuceneByteIndexFieldTypeContext( this );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIndexFieldTypeFactoryContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIndexFieldTypeFactoryContextImpl.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.backend.lucene.types.dsl.impl;
 
 import java.lang.invoke.MethodHandles;
+import java.net.URI;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
@@ -68,6 +69,9 @@ public class LuceneIndexFieldTypeFactoryContextImpl
 		else if ( GeoPoint.class.equals( inputType ) ) {
 			return (StandardIndexFieldTypeContext<?, F>) asGeoPoint();
 		}
+		else if ( URI.class.equals( inputType ) ) {
+			return (StandardIndexFieldTypeContext<?, F>) asUri();
+		}
 		else {
 			// TODO implement other types
 			throw log.cannotGuessFieldType( inputType, getEventContext() );
@@ -113,6 +117,12 @@ public class LuceneIndexFieldTypeFactoryContextImpl
 	@Override
 	public StandardIndexFieldTypeContext<?, GeoPoint> asGeoPoint() {
 		return new LuceneGeoPointIndexFieldTypeContext( this );
+	}
+
+	@Override
+	public StandardIndexFieldTypeContext<?, URI> asUri() {
+		// TODO implement this on backend commits within the same HSEARCH-3047 issue
+		return null;
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIndexFieldTypeFactoryContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIndexFieldTypeFactoryContextImpl.java
@@ -66,6 +66,9 @@ public class LuceneIndexFieldTypeFactoryContextImpl
 		else if ( Short.class.equals( inputType ) ) {
 			return (StandardIndexFieldTypeContext<?, F>) asShort();
 		}
+		else if ( Float.class.equals( inputType ) ) {
+			return (StandardIndexFieldTypeContext<?, F>) asFloat();
+		}
 		else if ( Double.class.equals( inputType ) ) {
 			return (StandardIndexFieldTypeContext<?, F>) asDouble();
 		}
@@ -123,6 +126,11 @@ public class LuceneIndexFieldTypeFactoryContextImpl
 	@Override
 	public StandardIndexFieldTypeContext<?, Short> asShort() {
 		return new LuceneShortIndexFieldTypeContext( this );
+	}
+
+	@Override
+	public StandardIndexFieldTypeContext<?, Float> asFloat() {
+		return new LuceneFloatIndexFieldTypeContext( this );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIndexFieldTypeFactoryContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIndexFieldTypeFactoryContextImpl.java
@@ -10,6 +10,7 @@ import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 
 import org.hibernate.search.backend.lucene.analysis.model.impl.LuceneAnalysisDefinitionRegistry;
@@ -74,6 +75,9 @@ public class LuceneIndexFieldTypeFactoryContextImpl
 		}
 		else if ( LocalDate.class.equals( inputType ) ) {
 			return (StandardIndexFieldTypeContext<?, F>) asLocalDate();
+		}
+		else if ( LocalDateTime.class.equals( inputType ) ) {
+			return (StandardIndexFieldTypeContext<?, F>) asLocalDateTime();
 		}
 		else if ( Instant.class.equals( inputType ) ) {
 			return (StandardIndexFieldTypeContext<?, F>) asInstant();
@@ -141,6 +145,11 @@ public class LuceneIndexFieldTypeFactoryContextImpl
 	@Override
 	public StandardIndexFieldTypeContext<?, LocalDate> asLocalDate() {
 		return new LuceneLocalDateIndexFieldTypeContext( this );
+	}
+
+	@Override
+	public StandardIndexFieldTypeContext<?, LocalDateTime> asLocalDateTime() {
+		return new LuceneLocalDateTimeIndexFieldTypeContext( this );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIndexFieldTypeFactoryContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIndexFieldTypeFactoryContextImpl.java
@@ -9,6 +9,7 @@ package org.hibernate.search.backend.lucene.types.dsl.impl;
 import java.lang.invoke.MethodHandles;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZonedDateTime;
 
 import org.hibernate.search.backend.lucene.analysis.model.impl.LuceneAnalysisDefinitionRegistry;
 import org.hibernate.search.backend.lucene.types.converter.LuceneFieldContributor;
@@ -61,6 +62,9 @@ public class LuceneIndexFieldTypeFactoryContextImpl
 		else if ( Instant.class.equals( inputType ) ) {
 			return (StandardIndexFieldTypeContext<?, F>) asInstant();
 		}
+		else if ( ZonedDateTime.class.equals( inputType ) ) {
+			return (StandardIndexFieldTypeContext<?, F>) asZonedDateTime();
+		}
 		else if ( GeoPoint.class.equals( inputType ) ) {
 			return (StandardIndexFieldTypeContext<?, F>) asGeoPoint();
 		}
@@ -98,6 +102,12 @@ public class LuceneIndexFieldTypeFactoryContextImpl
 	@Override
 	public StandardIndexFieldTypeContext<?, Instant> asInstant() {
 		return new LuceneInstantIndexFieldTypeContext( this );
+	}
+
+	@Override
+	public StandardIndexFieldTypeContext<?, ZonedDateTime> asZonedDateTime() {
+		// TODO implement this on backend commits within the same HSEARCH-3047 issue
+		return null;
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIndexFieldTypeFactoryContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIndexFieldTypeFactoryContextImpl.java
@@ -66,6 +66,9 @@ public class LuceneIndexFieldTypeFactoryContextImpl
 		else if ( Short.class.equals( inputType ) ) {
 			return (StandardIndexFieldTypeContext<?, F>) asShort();
 		}
+		else if ( Double.class.equals( inputType ) ) {
+			return (StandardIndexFieldTypeContext<?, F>) asDouble();
+		}
 		else if ( LocalDate.class.equals( inputType ) ) {
 			return (StandardIndexFieldTypeContext<?, F>) asLocalDate();
 		}
@@ -120,6 +123,11 @@ public class LuceneIndexFieldTypeFactoryContextImpl
 	@Override
 	public StandardIndexFieldTypeContext<?, Short> asShort() {
 		return new LuceneShortIndexFieldTypeContext( this );
+	}
+
+	@Override
+	public StandardIndexFieldTypeContext<?, Double> asDouble() {
+		return new LuceneDoubleIndexFieldTypeContext( this );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneLocalDateTimeIndexFieldTypeContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneLocalDateTimeIndexFieldTypeContext.java
@@ -1,0 +1,58 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.types.dsl.impl;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.search.backend.lucene.types.codec.impl.LuceneLocalDateTimeFieldCodec;
+import org.hibernate.search.backend.lucene.types.impl.LuceneIndexFieldType;
+import org.hibernate.search.backend.lucene.types.predicate.impl.LuceneNumericFieldPredicateBuilderFactory;
+import org.hibernate.search.backend.lucene.types.projection.impl.LuceneStandardFieldProjectionBuilderFactory;
+import org.hibernate.search.backend.lucene.types.sort.impl.LuceneNumericFieldSortBuilderFactory;
+import org.hibernate.search.engine.backend.types.Sortable;
+import org.hibernate.search.engine.backend.types.converter.FromDocumentFieldValueConverter;
+import org.hibernate.search.engine.backend.types.converter.ToDocumentFieldValueConverter;
+
+class LuceneLocalDateTimeIndexFieldTypeContext
+		extends AbstractLuceneStandardIndexFieldTypeContext<LuceneLocalDateTimeIndexFieldTypeContext, LocalDateTime> {
+
+	private Sortable sortable = Sortable.DEFAULT;
+
+	LuceneLocalDateTimeIndexFieldTypeContext(LuceneIndexFieldTypeBuildContext buildContext) {
+		super( buildContext, LocalDateTime.class );
+	}
+
+	@Override
+	public LuceneLocalDateTimeIndexFieldTypeContext sortable(Sortable sortable) {
+		this.sortable = sortable;
+		return this;
+	}
+
+	@Override
+	public LuceneIndexFieldType<LocalDateTime> toIndexFieldType() {
+		boolean resolvedSortable = resolveDefault( sortable );
+		boolean resolvedProjectable = resolveDefault( projectable );
+
+		ToDocumentFieldValueConverter<?, ? extends LocalDateTime> dslToIndexConverter =
+				createDslToIndexConverter();
+		FromDocumentFieldValueConverter<? super LocalDateTime, ?> indexToProjectionConverter =
+				createIndexToProjectionConverter();
+		LuceneLocalDateTimeFieldCodec codec = new LuceneLocalDateTimeFieldCodec( resolvedProjectable, resolvedSortable );
+
+		return new LuceneIndexFieldType<>(
+				codec,
+				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, codec ),
+				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, codec ),
+				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec )
+		);
+	}
+
+	@Override
+	protected LuceneLocalDateTimeIndexFieldTypeContext thisAsS() {
+		return this;
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneShortIndexFieldTypeContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneShortIndexFieldTypeContext.java
@@ -1,0 +1,56 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.types.dsl.impl;
+
+import org.hibernate.search.backend.lucene.types.codec.impl.LuceneShortFieldCodec;
+import org.hibernate.search.backend.lucene.types.impl.LuceneIndexFieldType;
+import org.hibernate.search.backend.lucene.types.predicate.impl.LuceneNumericFieldPredicateBuilderFactory;
+import org.hibernate.search.backend.lucene.types.projection.impl.LuceneStandardFieldProjectionBuilderFactory;
+import org.hibernate.search.backend.lucene.types.sort.impl.LuceneNumericFieldSortBuilderFactory;
+import org.hibernate.search.engine.backend.types.Sortable;
+import org.hibernate.search.engine.backend.types.converter.FromDocumentFieldValueConverter;
+import org.hibernate.search.engine.backend.types.converter.ToDocumentFieldValueConverter;
+
+class LuceneShortIndexFieldTypeContext
+		extends AbstractLuceneStandardIndexFieldTypeContext<LuceneShortIndexFieldTypeContext, Short> {
+
+	private Sortable sortable = Sortable.DEFAULT;
+
+	LuceneShortIndexFieldTypeContext(LuceneIndexFieldTypeBuildContext buildContext) {
+		super( buildContext, Short.class );
+	}
+
+	@Override
+	public LuceneShortIndexFieldTypeContext sortable(Sortable sortable) {
+		this.sortable = sortable;
+		return this;
+	}
+
+	@Override
+	public LuceneIndexFieldType<Short> toIndexFieldType() {
+		boolean resolvedSortable = resolveDefault( sortable );
+		boolean resolvedProjectable = resolveDefault( projectable );
+
+		ToDocumentFieldValueConverter<?, ? extends Short> dslToIndexConverter =
+				createDslToIndexConverter();
+		FromDocumentFieldValueConverter<? super Short, ?> indexToProjectionConverter =
+				createIndexToProjectionConverter();
+		LuceneShortFieldCodec codec = new LuceneShortFieldCodec( resolvedProjectable, resolvedSortable );
+
+		return new LuceneIndexFieldType<>(
+				codec,
+				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, codec ),
+				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, codec ),
+				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec )
+		);
+	}
+
+	@Override
+	protected LuceneShortIndexFieldTypeContext thisAsS() {
+		return this;
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/engine/backend/types/dsl/IndexFieldTypeFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/types/dsl/IndexFieldTypeFactoryContext.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.engine.backend.types.dsl;
 
+import java.net.URI;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
@@ -35,6 +36,8 @@ public interface IndexFieldTypeFactoryContext {
 	StandardIndexFieldTypeContext<?, ZonedDateTime> asZonedDateTime();
 
 	StandardIndexFieldTypeContext<?, GeoPoint> asGeoPoint();
+
+	StandardIndexFieldTypeContext<?, URI> asUri();
 
 	// TODO NumericBridgeProvider
 	// TODO JavaTimeBridgeProvider

--- a/engine/src/main/java/org/hibernate/search/engine/backend/types/dsl/IndexFieldTypeFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/types/dsl/IndexFieldTypeFactoryContext.java
@@ -31,6 +31,8 @@ public interface IndexFieldTypeFactoryContext {
 
 	StandardIndexFieldTypeContext<?, Character> asCharacter();
 
+	StandardIndexFieldTypeContext<?, Byte> asByte();
+
 	StandardIndexFieldTypeContext<?, LocalDate> asLocalDate();
 
 	StandardIndexFieldTypeContext<?, Instant> asInstant();

--- a/engine/src/main/java/org/hibernate/search/engine/backend/types/dsl/IndexFieldTypeFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/types/dsl/IndexFieldTypeFactoryContext.java
@@ -35,6 +35,8 @@ public interface IndexFieldTypeFactoryContext {
 
 	StandardIndexFieldTypeContext<?, Short> asShort();
 
+	StandardIndexFieldTypeContext<?, Float> asFloat();
+
 	StandardIndexFieldTypeContext<?, Double> asDouble();
 
 	StandardIndexFieldTypeContext<?, LocalDate> asLocalDate();

--- a/engine/src/main/java/org/hibernate/search/engine/backend/types/dsl/IndexFieldTypeFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/types/dsl/IndexFieldTypeFactoryContext.java
@@ -29,6 +29,8 @@ public interface IndexFieldTypeFactoryContext {
 
 	StandardIndexFieldTypeContext<?, Boolean> asBoolean();
 
+	StandardIndexFieldTypeContext<?, Character> asCharacter();
+
 	StandardIndexFieldTypeContext<?, LocalDate> asLocalDate();
 
 	StandardIndexFieldTypeContext<?, Instant> asInstant();

--- a/engine/src/main/java/org/hibernate/search/engine/backend/types/dsl/IndexFieldTypeFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/types/dsl/IndexFieldTypeFactoryContext.java
@@ -35,6 +35,8 @@ public interface IndexFieldTypeFactoryContext {
 
 	StandardIndexFieldTypeContext<?, Short> asShort();
 
+	StandardIndexFieldTypeContext<?, Double> asDouble();
+
 	StandardIndexFieldTypeContext<?, LocalDate> asLocalDate();
 
 	StandardIndexFieldTypeContext<?, Instant> asInstant();

--- a/engine/src/main/java/org/hibernate/search/engine/backend/types/dsl/IndexFieldTypeFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/types/dsl/IndexFieldTypeFactoryContext.java
@@ -33,6 +33,8 @@ public interface IndexFieldTypeFactoryContext {
 
 	StandardIndexFieldTypeContext<?, Byte> asByte();
 
+	StandardIndexFieldTypeContext<?, Short> asShort();
+
 	StandardIndexFieldTypeContext<?, LocalDate> asLocalDate();
 
 	StandardIndexFieldTypeContext<?, Instant> asInstant();

--- a/engine/src/main/java/org/hibernate/search/engine/backend/types/dsl/IndexFieldTypeFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/types/dsl/IndexFieldTypeFactoryContext.java
@@ -9,6 +9,7 @@ package org.hibernate.search.engine.backend.types.dsl;
 import java.net.URI;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 
 import org.hibernate.search.engine.spatial.GeoPoint;
@@ -40,6 +41,8 @@ public interface IndexFieldTypeFactoryContext {
 	StandardIndexFieldTypeContext<?, Double> asDouble();
 
 	StandardIndexFieldTypeContext<?, LocalDate> asLocalDate();
+
+	StandardIndexFieldTypeContext<?, LocalDateTime> asLocalDateTime();
 
 	StandardIndexFieldTypeContext<?, Instant> asInstant();
 

--- a/engine/src/main/java/org/hibernate/search/engine/backend/types/dsl/IndexFieldTypeFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/types/dsl/IndexFieldTypeFactoryContext.java
@@ -8,6 +8,7 @@ package org.hibernate.search.engine.backend.types.dsl;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZonedDateTime;
 
 import org.hibernate.search.engine.spatial.GeoPoint;
 
@@ -30,6 +31,8 @@ public interface IndexFieldTypeFactoryContext {
 	StandardIndexFieldTypeContext<?, LocalDate> asLocalDate();
 
 	StandardIndexFieldTypeContext<?, Instant> asInstant();
+
+	StandardIndexFieldTypeContext<?, ZonedDateTime> asZonedDateTime();
 
 	StandardIndexFieldTypeContext<?, GeoPoint> asGeoPoint();
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSearchSortIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSearchSortIT.java
@@ -10,6 +10,7 @@ import static org.hibernate.search.util.impl.integrationtest.common.assertion.Se
 import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
@@ -115,9 +116,11 @@ public class FieldSearchSortIT {
 					.hasDocRefHitsExactOrder( INDEX_NAME, EMPTY, DOCUMENT_3, DOCUMENT_2, DOCUMENT_1 );
 
 			// Explicit order with onMissingValue().use( ... )
+			// Eventually we will remove any restriction here. See the issues: HSEARCH-3254 HSEARCH-3255 and HSEARCH-3387.
 			if (
 					( TckConfiguration.get().getBackendFeatures().stringTypeOnMissingValueUse() || !String.class.equals( fieldModel.type ) )
 					&& ( TckConfiguration.get().getBackendFeatures().localDateTypeOnMissingValueUse() || !LocalDate.class.equals( fieldModel.type ) )
+					&& ( TckConfiguration.get().getBackendFeatures().localDateTypeOnMissingValueUse() || !LocalDateTime.class.equals( fieldModel.type ) )
 			) {
 				query = simpleQuery( b -> b.byField( fieldPath ).asc().onMissingValue().use( fieldModel.before1Value ) );
 				assertThat( query )
@@ -141,9 +144,11 @@ public class FieldSearchSortIT {
 			SearchQuery<DocumentReference> query;
 			String fieldPath = fieldModel.relativeFieldName;
 
+			// Eventually we will remove any restriction here. See the issues: HSEARCH-3254 HSEARCH-3255 and HSEARCH-3387.
 			if (
 					( TckConfiguration.get().getBackendFeatures().stringTypeOnMissingValueUse() || !String.class.equals( fieldModel.type ) )
 					&& ( TckConfiguration.get().getBackendFeatures().localDateTypeOnMissingValueUse() || !LocalDate.class.equals( fieldModel.type ) )
+					&& ( TckConfiguration.get().getBackendFeatures().localDateTypeOnMissingValueUse() || !LocalDateTime.class.equals( fieldModel.type ) )
 			) {
 				query = simpleQuery( b -> b.byField( fieldPath ).asc().onMissingValue()
 						.use( new ValueWrapper<>( fieldModel.before1Value ) ) );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/ByteFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/ByteFieldTypeDescriptor.java
@@ -1,0 +1,51 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.tck.testsupport.types;
+
+import java.util.Optional;
+
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldProjectionExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldSortExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.MatchPredicateExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.RangePredicateExpectations;
+
+public class ByteFieldTypeDescriptor extends FieldTypeDescriptor<Byte> {
+
+	ByteFieldTypeDescriptor() {
+		super( Byte.class );
+	}
+
+	@Override
+	public Optional<MatchPredicateExpectations<Byte>> getMatchPredicateExpectations() {
+		return Optional.of( new MatchPredicateExpectations<>(
+				(byte) 42, (byte) 67
+		) );
+	}
+
+	@Override
+	public Optional<RangePredicateExpectations<Byte>> getRangePredicateExpectations() {
+		return Optional.of( new RangePredicateExpectations<>(
+				(byte) 3, (byte) 13, (byte) 25,
+				(byte) 10, (byte) 19
+		) );
+	}
+
+	@Override
+	public Optional<FieldSortExpectations<Byte>> getFieldSortExpectations() {
+		return Optional.of( new FieldSortExpectations<>(
+				(byte) 1, (byte) 3, (byte) 5,
+				Byte.MIN_VALUE, (byte) 2, (byte) 4, Byte.MAX_VALUE
+		) );
+	}
+
+	@Override
+	public Optional<FieldProjectionExpectations<Byte>> getFieldProjectionExpectations() {
+		return Optional.of( new FieldProjectionExpectations<>(
+				(byte) 1, (byte) 3, (byte) 5
+		) );
+	}
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/CharacterFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/CharacterFieldTypeDescriptor.java
@@ -1,0 +1,51 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.tck.testsupport.types;
+
+import java.util.Optional;
+
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldProjectionExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldSortExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.MatchPredicateExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.RangePredicateExpectations;
+
+public class CharacterFieldTypeDescriptor extends FieldTypeDescriptor<Character> {
+
+	CharacterFieldTypeDescriptor() {
+		super( Character.class );
+	}
+
+	@Override
+	public Optional<MatchPredicateExpectations<Character>> getMatchPredicateExpectations() {
+		return Optional.of( new MatchPredicateExpectations<>(
+				(char) 42, (char) 67
+		) );
+	}
+
+	@Override
+	public Optional<RangePredicateExpectations<Character>> getRangePredicateExpectations() {
+		return Optional.of( new RangePredicateExpectations<>(
+				(char) 3, (char) 13, (char) 25,
+				(char) 10, (char) 19
+		) );
+	}
+
+	@Override
+	public Optional<FieldSortExpectations<Character>> getFieldSortExpectations() {
+		return Optional.of( new FieldSortExpectations<>(
+				(char) 1, (char) 3, (char) 5,
+				Character.MIN_VALUE, (char) 2, (char) 4, Character.MAX_VALUE
+		) );
+	}
+
+	@Override
+	public Optional<FieldProjectionExpectations<Character>> getFieldProjectionExpectations() {
+		return Optional.of( new FieldProjectionExpectations<>(
+				(char) 1, (char) 3, (char) 5
+		) );
+	}
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/DoubleFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/DoubleFieldTypeDescriptor.java
@@ -1,0 +1,51 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.tck.testsupport.types;
+
+import java.util.Optional;
+
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldProjectionExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldSortExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.MatchPredicateExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.RangePredicateExpectations;
+
+public class DoubleFieldTypeDescriptor extends FieldTypeDescriptor<Double> {
+
+	DoubleFieldTypeDescriptor() {
+		super( Double.class );
+	}
+
+	@Override
+	public Optional<MatchPredicateExpectations<Double>> getMatchPredicateExpectations() {
+		return Optional.of( new MatchPredicateExpectations<>(
+				42.1, 67.0
+		) );
+	}
+
+	@Override
+	public Optional<RangePredicateExpectations<Double>> getRangePredicateExpectations() {
+		return Optional.of( new RangePredicateExpectations<>(
+				3.0, 13.2, 25.79,
+				10.0, 19.101
+		) );
+	}
+
+	@Override
+	public Optional<FieldSortExpectations<Double>> getFieldSortExpectations() {
+		return Optional.of( new FieldSortExpectations<>(
+				1.01, 3.2, 5.1,
+				Double.MIN_VALUE, 2.0, 4.00001, Double.MAX_VALUE
+		) );
+	}
+
+	@Override
+	public Optional<FieldProjectionExpectations<Double>> getFieldProjectionExpectations() {
+		return Optional.of( new FieldProjectionExpectations<>(
+				1.001, 3.0, 5.1
+		) );
+	}
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/FieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/FieldTypeDescriptor.java
@@ -32,6 +32,7 @@ public abstract class FieldTypeDescriptor<F> {
 					new LongFieldTypeDescriptor(),
 					new BooleanFieldTypeDescriptor(),
 					new CharacterFieldTypeDescriptor(),
+					new ByteFieldTypeDescriptor(),
 					new InstantFieldTypeDescriptor(),
 					new LocalDateFieldTypeDescriptor(),
 					new GeoPointFieldTypeDescriptor()

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/FieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/FieldTypeDescriptor.java
@@ -38,6 +38,7 @@ public abstract class FieldTypeDescriptor<F> {
 					new DoubleFieldTypeDescriptor(),
 					new InstantFieldTypeDescriptor(),
 					new LocalDateFieldTypeDescriptor(),
+					new LocalDateTimeFieldTypeDescriptor(),
 					new GeoPointFieldTypeDescriptor()
 			) );
 		}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/FieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/FieldTypeDescriptor.java
@@ -29,6 +29,7 @@ public abstract class FieldTypeDescriptor<F> {
 					new AnalyzedStringFieldTypeDescriptor(),
 					new NormalizedStringFieldTypeDescriptor(),
 					new IntegerFieldTypeDescriptor(),
+					new FloatFieldTypeDescriptor(),
 					new LongFieldTypeDescriptor(),
 					new BooleanFieldTypeDescriptor(),
 					new CharacterFieldTypeDescriptor(),

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/FieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/FieldTypeDescriptor.java
@@ -34,6 +34,7 @@ public abstract class FieldTypeDescriptor<F> {
 					new CharacterFieldTypeDescriptor(),
 					new ByteFieldTypeDescriptor(),
 					new ShortFieldTypeDescriptor(),
+					new DoubleFieldTypeDescriptor(),
 					new InstantFieldTypeDescriptor(),
 					new LocalDateFieldTypeDescriptor(),
 					new GeoPointFieldTypeDescriptor()

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/FieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/FieldTypeDescriptor.java
@@ -31,6 +31,7 @@ public abstract class FieldTypeDescriptor<F> {
 					new IntegerFieldTypeDescriptor(),
 					new LongFieldTypeDescriptor(),
 					new BooleanFieldTypeDescriptor(),
+					new CharacterFieldTypeDescriptor(),
 					new InstantFieldTypeDescriptor(),
 					new LocalDateFieldTypeDescriptor(),
 					new GeoPointFieldTypeDescriptor()

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/FieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/FieldTypeDescriptor.java
@@ -33,6 +33,7 @@ public abstract class FieldTypeDescriptor<F> {
 					new BooleanFieldTypeDescriptor(),
 					new CharacterFieldTypeDescriptor(),
 					new ByteFieldTypeDescriptor(),
+					new ShortFieldTypeDescriptor(),
 					new InstantFieldTypeDescriptor(),
 					new LocalDateFieldTypeDescriptor(),
 					new GeoPointFieldTypeDescriptor()

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/FloatFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/FloatFieldTypeDescriptor.java
@@ -1,0 +1,51 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.tck.testsupport.types;
+
+import java.util.Optional;
+
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldProjectionExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldSortExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.MatchPredicateExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.RangePredicateExpectations;
+
+public class FloatFieldTypeDescriptor extends FieldTypeDescriptor<Float> {
+
+	FloatFieldTypeDescriptor() {
+		super( Float.class );
+	}
+
+	@Override
+	public Optional<MatchPredicateExpectations<Float>> getMatchPredicateExpectations() {
+		return Optional.of( new MatchPredicateExpectations<>(
+				42.1f, 67.0f
+		) );
+	}
+
+	@Override
+	public Optional<RangePredicateExpectations<Float>> getRangePredicateExpectations() {
+		return Optional.of( new RangePredicateExpectations<>(
+				3.0f, 13.2f, 25.79f,
+				10.0f, 19.101f
+		) );
+	}
+
+	@Override
+	public Optional<FieldSortExpectations<Float>> getFieldSortExpectations() {
+		return Optional.of( new FieldSortExpectations<>(
+				1.01f, 3.2f, 5.1f,
+				Float.MIN_VALUE, 2.0f, 4.00001f, Float.MAX_VALUE
+		) );
+	}
+
+	@Override
+	public Optional<FieldProjectionExpectations<Float>> getFieldProjectionExpectations() {
+		return Optional.of( new FieldProjectionExpectations<>(
+				1.001f, 3.0f, 5.1f
+		) );
+	}
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/LocalDateTimeFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/LocalDateTimeFieldTypeDescriptor.java
@@ -1,0 +1,67 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.tck.testsupport.types;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldProjectionExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldSortExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.MatchPredicateExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.RangePredicateExpectations;
+
+public class LocalDateTimeFieldTypeDescriptor extends FieldTypeDescriptor<LocalDateTime> {
+
+	LocalDateTimeFieldTypeDescriptor() {
+		super( LocalDateTime.class );
+	}
+
+	@Override
+	public Optional<MatchPredicateExpectations<LocalDateTime>> getMatchPredicateExpectations() {
+		return Optional.of( new MatchPredicateExpectations<>(
+				LocalDateTime.of( 1980, 10, 11, 0, 0 ),
+				LocalDateTime.of( 1984, 10, 7, 0, 0 )
+		) );
+	}
+
+	@Override
+	public Optional<RangePredicateExpectations<LocalDateTime>> getRangePredicateExpectations() {
+		return Optional.of( new RangePredicateExpectations<>(
+				// Indexed
+				LocalDateTime.of( 2018, 2, 1, 0, 0 ),
+				LocalDateTime.of( 2018, 3, 1, 0, 0 ),
+				LocalDateTime.of( 2018, 4, 1, 0, 0 ),
+				// Values around what is indexed
+				LocalDateTime.of( 2018, 2, 15, 0, 0 ),
+				LocalDateTime.of( 2018, 3, 15, 0, 0 )
+		) );
+	}
+
+	@Override
+	public Optional<FieldSortExpectations<LocalDateTime>> getFieldSortExpectations() {
+		return Optional.of( new FieldSortExpectations<>(
+				// Indexed
+				LocalDateTime.of( 2018, 2, 1, 0, 0 ),
+				LocalDateTime.of( 2018, 3, 1, 0, 0 ),
+				LocalDateTime.of( 2018, 4, 1, 0, 0 ),
+				// Values around what is indexed
+				LocalDateTime.of( 2018, 1, 1, 0, 0 ),
+				LocalDateTime.of( 2018, 2, 15, 0, 0 ),
+				LocalDateTime.of( 2018, 3, 15, 0, 0 ),
+				LocalDateTime.of( 2018, 5, 1, 0, 0 )
+		) );
+	}
+
+	@Override
+	public Optional<FieldProjectionExpectations<LocalDateTime>> getFieldProjectionExpectations() {
+		return Optional.of( new FieldProjectionExpectations<>(
+				LocalDateTime.of( 2018, 2, 1, 0, 0, 0, 1 ),
+				LocalDateTime.of( 2018, 3, 1, 0, 0 ),
+				LocalDateTime.of( 2018, 4, 1, 0, 0 )
+		) );
+	}
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/ShortFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/ShortFieldTypeDescriptor.java
@@ -1,0 +1,51 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.tck.testsupport.types;
+
+import java.util.Optional;
+
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldProjectionExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldSortExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.MatchPredicateExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.RangePredicateExpectations;
+
+public class ShortFieldTypeDescriptor extends FieldTypeDescriptor<Short> {
+
+	ShortFieldTypeDescriptor() {
+		super( Short.class );
+	}
+
+	@Override
+	public Optional<MatchPredicateExpectations<Short>> getMatchPredicateExpectations() {
+		return Optional.of( new MatchPredicateExpectations<>(
+				(short) 42, (short) 67
+		) );
+	}
+
+	@Override
+	public Optional<RangePredicateExpectations<Short>> getRangePredicateExpectations() {
+		return Optional.of( new RangePredicateExpectations<>(
+				(short) 3, (short) 13, (short) 25,
+				(short) 10, (short) 19
+		) );
+	}
+
+	@Override
+	public Optional<FieldSortExpectations<Short>> getFieldSortExpectations() {
+		return Optional.of( new FieldSortExpectations<>(
+				(short) 1, (short) 3, (short) 5,
+				Short.MIN_VALUE, (short) 2, (short) 4, Short.MAX_VALUE
+		) );
+	}
+
+	@Override
+	public Optional<FieldProjectionExpectations<Short>> getFieldProjectionExpectations() {
+		return Optional.of( new FieldProjectionExpectations<>(
+				(short) 1, (short) 3, (short) 5
+		) );
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/BigDecimalPropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/BigDecimalPropertyTypeDescriptor.java
@@ -1,0 +1,102 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.testsupport.types;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultIdentifierBridgeExpectations;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultValueBridgeExpectations;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+public class BigDecimalPropertyTypeDescriptor extends PropertyTypeDescriptor<BigDecimal> {
+
+	BigDecimalPropertyTypeDescriptor() {
+		super( BigDecimal.class );
+	}
+
+	@Override
+	public Optional<DefaultIdentifierBridgeExpectations<BigDecimal>> getDefaultIdentifierBridgeExpectations() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<DefaultValueBridgeExpectations<BigDecimal, ?>> getDefaultValueBridgeExpectations() {
+		return Optional.of( new DefaultValueBridgeExpectations<BigDecimal, BigDecimal>() {
+			@Override
+			public Class<BigDecimal> getProjectionType() {
+				return BigDecimal.class;
+			}
+
+			@Override
+			public Class<BigDecimal> getIndexFieldJavaType() {
+				return BigDecimal.class;
+			}
+
+			@Override
+			public List<BigDecimal> getEntityPropertyValues() {
+				return Arrays.asList( BigDecimal.valueOf( -100000.0 ), BigDecimal.valueOf( -1.0 ), BigDecimal.ZERO, BigDecimal.ONE, BigDecimal.TEN,
+						BigDecimal.valueOf( 100000.0 ) );
+			}
+
+			@Override
+			public List<BigDecimal> getDocumentFieldValues() {
+				return getEntityPropertyValues();
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge1() {
+				return TypeWithValueBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithValueBridge1(int identifier, BigDecimal propertyValue) {
+				TypeWithValueBridge1 instance = new TypeWithValueBridge1();
+				instance.id = identifier;
+				instance.myProperty = propertyValue;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge2() {
+				return TypeWithValueBridge2.class;
+			}
+		} );
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithValueBridge1 {
+		Integer id;
+		BigDecimal myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public BigDecimal getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithValueBridge2 {
+		Integer id;
+		BigDecimal myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public BigDecimal getMyProperty() {
+			return myProperty;
+		}
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/BigIntegerPropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/BigIntegerPropertyTypeDescriptor.java
@@ -1,0 +1,158 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.testsupport.types;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultIdentifierBridgeExpectations;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultValueBridgeExpectations;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+public class BigIntegerPropertyTypeDescriptor extends PropertyTypeDescriptor<BigInteger> {
+
+	BigIntegerPropertyTypeDescriptor() {
+		super( BigInteger.class );
+	}
+
+	@Override
+	public Optional<DefaultIdentifierBridgeExpectations<BigInteger>> getDefaultIdentifierBridgeExpectations() {
+		return Optional.of( new DefaultIdentifierBridgeExpectations<BigInteger>() {
+			@Override
+			public List<BigInteger> getEntityIdentifierValues() {
+				return Arrays.asList( BigInteger.valueOf( -10000 ), BigInteger.valueOf( -1 ), BigInteger.ZERO, BigInteger.ONE, BigInteger.TEN,
+						BigInteger.valueOf( 10000 )
+				);
+			}
+
+			@Override
+			public List<String> getDocumentIdentifierValues() {
+				return Arrays.asList(
+						"-10000", "-1", "0", "1", "10", "10000"
+				);
+			}
+
+			@Override
+			public Class<?> getTypeWithIdentifierBridge1() {
+				return TypeWithIdentifierBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithIdentifierBridge1(BigInteger identifier) {
+				TypeWithIdentifierBridge1 instance = new TypeWithIdentifierBridge1();
+				instance.id = identifier;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithIdentifierBridge2() {
+				return TypeWithIdentifierBridge2.class;
+			}
+		} );
+	}
+
+	@Override
+	public Optional<DefaultValueBridgeExpectations<BigInteger, ?>> getDefaultValueBridgeExpectations() {
+		return Optional.of( new DefaultValueBridgeExpectations<BigInteger, BigInteger>() {
+			@Override
+			public Class<BigInteger> getProjectionType() {
+				return BigInteger.class;
+			}
+
+			@Override
+			public Class<BigInteger> getIndexFieldJavaType() {
+				return BigInteger.class;
+			}
+
+			@Override
+			public List<BigInteger> getEntityPropertyValues() {
+				return Arrays.asList( BigInteger.valueOf( -10000 ), BigInteger.valueOf( -1 ), BigInteger.ZERO, BigInteger.ONE, BigInteger.TEN,
+						BigInteger.valueOf( 10000 )
+				);
+			}
+
+			@Override
+			public List<BigInteger> getDocumentFieldValues() {
+				return getEntityPropertyValues();
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge1() {
+				return TypeWithValueBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithValueBridge1(int identifier, BigInteger propertyValue) {
+				TypeWithValueBridge1 instance = new TypeWithValueBridge1();
+				instance.id = identifier;
+				instance.myProperty = propertyValue;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge2() {
+				return TypeWithValueBridge2.class;
+			}
+		} );
+	}
+
+	@Indexed(index = DefaultIdentifierBridgeExpectations.TYPE_WITH_IDENTIFIER_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithIdentifierBridge1 {
+		BigInteger id;
+
+		@DocumentId
+		public BigInteger getId() {
+			return id;
+		}
+	}
+
+	@Indexed(index = DefaultIdentifierBridgeExpectations.TYPE_WITH_IDENTIFIER_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithIdentifierBridge2 {
+		BigInteger id;
+
+		@DocumentId
+		public BigInteger getId() {
+			return id;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithValueBridge1 {
+		Integer id;
+		BigInteger myProperty;
+
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+
+		@GenericField
+		public BigInteger getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithValueBridge2 {
+		Integer id;
+		BigInteger myProperty;
+
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+
+		@GenericField
+		public BigInteger getMyProperty() {
+			return myProperty;
+		}
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/BoxedBytePropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/BoxedBytePropertyTypeDescriptor.java
@@ -1,0 +1,100 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.testsupport.types;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultIdentifierBridgeExpectations;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultValueBridgeExpectations;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+public class BoxedBytePropertyTypeDescriptor extends PropertyTypeDescriptor<Byte> {
+
+	BoxedBytePropertyTypeDescriptor() {
+		super( Byte.class );
+	}
+
+	@Override
+	public Optional<DefaultIdentifierBridgeExpectations<Byte>> getDefaultIdentifierBridgeExpectations() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<DefaultValueBridgeExpectations<Byte, ?>> getDefaultValueBridgeExpectations() {
+		return Optional.of( new DefaultValueBridgeExpectations<Byte, Byte>() {
+			@Override
+			public Class<Byte> getProjectionType() {
+				return Byte.class;
+			}
+
+			@Override
+			public Class<Byte> getIndexFieldJavaType() {
+				return Byte.class;
+			}
+
+			@Override
+			public List<Byte> getEntityPropertyValues() {
+				return Arrays.asList( Byte.MIN_VALUE, (byte)-1, (byte)0, (byte)1, (byte)42, Byte.MAX_VALUE );
+			}
+
+			@Override
+			public List<Byte> getDocumentFieldValues() {
+				return getEntityPropertyValues();
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge1() {
+				return TypeWithValueBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithValueBridge1(int identifier, Byte propertyValue) {
+				TypeWithValueBridge1 instance = new TypeWithValueBridge1();
+				instance.id = identifier;
+				instance.myProperty = propertyValue;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge2() {
+				return TypeWithValueBridge2.class;
+			}
+		} );
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithValueBridge1 {
+		Integer id;
+		Byte myProperty;
+		@DocumentId
+		public int getId() {
+			return id;
+		}
+		@GenericField
+		public Byte getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithValueBridge2 {
+		Integer id;
+		Byte myProperty;
+		@DocumentId
+		public int getId() {
+			return id;
+		}
+		@GenericField
+		public Byte getMyProperty() {
+			return myProperty;
+		}
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/BoxedCharacterPropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/BoxedCharacterPropertyTypeDescriptor.java
@@ -1,0 +1,100 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.testsupport.types;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultIdentifierBridgeExpectations;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultValueBridgeExpectations;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+public class BoxedCharacterPropertyTypeDescriptor extends PropertyTypeDescriptor<Character> {
+
+	protected BoxedCharacterPropertyTypeDescriptor() {
+		super( Character.class );
+	}
+
+	@Override
+	public Optional<DefaultIdentifierBridgeExpectations<Character>> getDefaultIdentifierBridgeExpectations() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<DefaultValueBridgeExpectations<Character, ?>> getDefaultValueBridgeExpectations() {
+		return Optional.of( new DefaultValueBridgeExpectations<Character, Character>() {
+			@Override
+			public Class<Character> getProjectionType() {
+				return Character.class;
+			}
+
+			@Override
+			public Class<Character> getIndexFieldJavaType() {
+				return Character.class;
+			}
+
+			@Override
+			public List<Character> getEntityPropertyValues() {
+				return Arrays.asList( Character.MIN_VALUE, '7', 'A', 'a', 'f', Character.MAX_VALUE );
+			}
+
+			@Override
+			public List<Character> getDocumentFieldValues() {
+				return getEntityPropertyValues();
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge1() {
+				return TypeWithValueBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithValueBridge1(int identifier, Character propertyValue) {
+				TypeWithValueBridge1 instance = new TypeWithValueBridge1();
+				instance.id = identifier;
+				instance.myProperty = propertyValue;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge2() {
+				return TypeWithValueBridge2.class;
+			}
+		} );
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithValueBridge1 {
+		Integer id;
+		Character myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public Character getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithValueBridge2 {
+		Integer id;
+		Character myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public Character getMyProperty() {
+			return myProperty;
+		}
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/BoxedDoublePropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/BoxedDoublePropertyTypeDescriptor.java
@@ -1,0 +1,100 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.testsupport.types;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultIdentifierBridgeExpectations;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultValueBridgeExpectations;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+public class BoxedDoublePropertyTypeDescriptor extends PropertyTypeDescriptor<Double> {
+
+	BoxedDoublePropertyTypeDescriptor() {
+		super( Double.class );
+	}
+
+	@Override
+	public Optional<DefaultIdentifierBridgeExpectations<Double>> getDefaultIdentifierBridgeExpectations() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<DefaultValueBridgeExpectations<Double, ?>> getDefaultValueBridgeExpectations() {
+		return Optional.of( new DefaultValueBridgeExpectations<Double, Double>() {
+			@Override
+			public Class<Double> getProjectionType() {
+				return Double.class;
+			}
+
+			@Override
+			public Class<Double> getIndexFieldJavaType() {
+				return Double.class;
+			}
+
+			@Override
+			public List<Double> getEntityPropertyValues() {
+				return Arrays.asList( Double.MIN_VALUE, -1.0, 0.0, 1.0, 42.0, Double.MAX_VALUE );
+			}
+
+			@Override
+			public List<Double> getDocumentFieldValues() {
+				return getEntityPropertyValues();
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge1() {
+				return TypeWithValueBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithValueBridge1(int identifier, Double propertyValue) {
+				TypeWithValueBridge1 instance = new TypeWithValueBridge1();
+				instance.id = identifier;
+				instance.myProperty = propertyValue;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge2() {
+				return TypeWithValueBridge2.class;
+			}
+		} );
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithValueBridge1 {
+		Integer id;
+		Double myProperty;
+		@DocumentId
+		public int getId() {
+			return id;
+		}
+		@GenericField
+		public Double getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithValueBridge2 {
+		Integer id;
+		Double myProperty;
+		@DocumentId
+		public int getId() {
+			return id;
+		}
+		@GenericField
+		public Double getMyProperty() {
+			return myProperty;
+		}
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/BoxedFloatPropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/BoxedFloatPropertyTypeDescriptor.java
@@ -1,0 +1,100 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.testsupport.types;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultIdentifierBridgeExpectations;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultValueBridgeExpectations;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+public class BoxedFloatPropertyTypeDescriptor extends PropertyTypeDescriptor<Float> {
+
+	BoxedFloatPropertyTypeDescriptor() {
+		super( Float.class );
+	}
+
+	@Override
+	public Optional<DefaultIdentifierBridgeExpectations<Float>> getDefaultIdentifierBridgeExpectations() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<DefaultValueBridgeExpectations<Float, ?>> getDefaultValueBridgeExpectations() {
+		return Optional.of( new DefaultValueBridgeExpectations<Float, Float>() {
+			@Override
+			public Class<Float> getProjectionType() {
+				return Float.class;
+			}
+
+			@Override
+			public Class<Float> getIndexFieldJavaType() {
+				return Float.class;
+			}
+
+			@Override
+			public List<Float> getEntityPropertyValues() {
+				return Arrays.asList( Float.MIN_VALUE, -1.0f, 0.0f, 1.0f, 42.0f, Float.MAX_VALUE );
+			}
+
+			@Override
+			public List<Float> getDocumentFieldValues() {
+				return getEntityPropertyValues();
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge1() {
+				return TypeWithValueBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithValueBridge1(int identifier, Float propertyValue) {
+				TypeWithValueBridge1 instance = new TypeWithValueBridge1();
+				instance.id = identifier;
+				instance.myProperty = propertyValue;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge2() {
+				return TypeWithValueBridge2.class;
+			}
+		} );
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithValueBridge1 {
+		Integer id;
+		Float myProperty;
+		@DocumentId
+		public int getId() {
+			return id;
+		}
+		@GenericField
+		public Float getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithValueBridge2 {
+		Integer id;
+		Float myProperty;
+		@DocumentId
+		public int getId() {
+			return id;
+		}
+		@GenericField
+		public Float getMyProperty() {
+			return myProperty;
+		}
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/BoxedShortPropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/BoxedShortPropertyTypeDescriptor.java
@@ -1,0 +1,148 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.testsupport.types;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultIdentifierBridgeExpectations;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultValueBridgeExpectations;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+public class BoxedShortPropertyTypeDescriptor extends PropertyTypeDescriptor<Short> {
+
+	BoxedShortPropertyTypeDescriptor() {
+		super( Short.class );
+	}
+
+	@Override
+	public Optional<DefaultIdentifierBridgeExpectations<Short>> getDefaultIdentifierBridgeExpectations() {
+		return Optional.of( new DefaultIdentifierBridgeExpectations<Short>() {
+			@Override
+			public List<Short> getEntityIdentifierValues() {
+				return Arrays.asList( Short.MIN_VALUE, (short)-1, (short)0, (short)1, (short)42, Short.MAX_VALUE );
+			}
+
+			@Override
+			public List<String> getDocumentIdentifierValues() {
+				return Arrays.asList(
+						String.valueOf( Short.MIN_VALUE ), "-1", "0", "1", "42", String.valueOf( Short.MAX_VALUE )
+				);
+			}
+
+			@Override
+			public Class<?> getTypeWithIdentifierBridge1() {
+				return TypeWithIdentifierBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithIdentifierBridge1(Short identifier) {
+				TypeWithIdentifierBridge1 instance = new TypeWithIdentifierBridge1();
+				// Implicit unboxing
+				instance.id = identifier;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithIdentifierBridge2() {
+				return TypeWithIdentifierBridge2.class;
+			}
+		} );
+	}
+
+	@Override
+	public Optional<DefaultValueBridgeExpectations<Short, ?>> getDefaultValueBridgeExpectations() {
+		return Optional.of( new DefaultValueBridgeExpectations<Short, Short>() {
+			@Override
+			public Class<Short> getProjectionType() {
+				return Short.class;
+			}
+
+			@Override
+			public Class<Short> getIndexFieldJavaType() {
+				return Short.class;
+			}
+
+			@Override
+			public List<Short> getEntityPropertyValues() {
+				return Arrays.asList( Short.MIN_VALUE, (short)-1, (short)0, (short)1, (short)42, Short.MAX_VALUE );
+			}
+
+			@Override
+			public List<Short> getDocumentFieldValues() {
+				return getEntityPropertyValues();
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge1() {
+				return TypeWithValueBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithValueBridge1(int identifier, Short propertyValue) {
+				TypeWithValueBridge1 instance = new TypeWithValueBridge1();
+				instance.id = identifier;
+				instance.myProperty = propertyValue;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge2() {
+				return TypeWithValueBridge2.class;
+			}
+		} );
+	}
+
+	@Indexed(index = DefaultIdentifierBridgeExpectations.TYPE_WITH_IDENTIFIER_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithIdentifierBridge1 {
+		Short id;
+		@DocumentId
+		public Short getId() {
+			return id;
+		}
+	}
+
+	@Indexed(index = DefaultIdentifierBridgeExpectations.TYPE_WITH_IDENTIFIER_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithIdentifierBridge2 {
+		Short id;
+		@DocumentId
+		public Short getId() {
+			return id;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithValueBridge1 {
+		Integer id;
+		Short myProperty;
+		@DocumentId
+		public int getId() {
+			return id;
+		}
+		@GenericField
+		public Short getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithValueBridge2 {
+		Integer id;
+		Short myProperty;
+		@DocumentId
+		public int getId() {
+			return id;
+		}
+		@GenericField
+		public Short getMyProperty() {
+			return myProperty;
+		}
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/DurationPropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/DurationPropertyTypeDescriptor.java
@@ -1,0 +1,107 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.testsupport.types;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultIdentifierBridgeExpectations;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultValueBridgeExpectations;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+public class DurationPropertyTypeDescriptor extends PropertyTypeDescriptor<Duration> {
+
+	DurationPropertyTypeDescriptor() {
+		super( Duration.class );
+	}
+
+	@Override
+	public Optional<DefaultIdentifierBridgeExpectations<Duration>> getDefaultIdentifierBridgeExpectations() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<DefaultValueBridgeExpectations<Duration, ?>> getDefaultValueBridgeExpectations() {
+		return Optional.of( new DefaultValueBridgeExpectations<Duration, Duration>() {
+			@Override
+			public Class<Duration> getProjectionType() {
+				return Duration.class;
+			}
+
+			@Override
+			public Class<Duration> getIndexFieldJavaType() {
+				return Duration.class;
+			}
+
+			@Override
+			public List<Duration> getEntityPropertyValues() {
+				return Arrays.asList(
+						Duration.ZERO,
+						Duration.ofNanos( 1L ),
+						Duration.ofSeconds( 1, 123L ),
+						Duration.ofHours( 3 ),
+						Duration.ofDays( 7 )
+				);
+			}
+
+			@Override
+			public List<Duration> getDocumentFieldValues() {
+				return getEntityPropertyValues();
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge1() {
+				return TypeWithValueBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithValueBridge1(int identifier, Duration propertyValue) {
+				TypeWithValueBridge1 instance = new TypeWithValueBridge1();
+				instance.id = identifier;
+				instance.myProperty = propertyValue;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge2() {
+				return TypeWithValueBridge2.class;
+			}
+		} );
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithValueBridge1 {
+		Integer id;
+		Duration myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public Duration getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithValueBridge2 {
+		Integer id;
+		Duration myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public Duration getMyProperty() {
+			return myProperty;
+		}
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/JavaNetURIPropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/JavaNetURIPropertyTypeDescriptor.java
@@ -1,0 +1,115 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.testsupport.types;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultIdentifierBridgeExpectations;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultValueBridgeExpectations;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+public class JavaNetURIPropertyTypeDescriptor extends PropertyTypeDescriptor<URI> {
+
+	JavaNetURIPropertyTypeDescriptor() {
+		super( URI.class );
+	}
+
+	@Override
+	public Optional<DefaultIdentifierBridgeExpectations<URI>> getDefaultIdentifierBridgeExpectations() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<DefaultValueBridgeExpectations<URI, ?>> getDefaultValueBridgeExpectations() {
+		return Optional.of( new DefaultValueBridgeExpectations<URI, URI>() {
+			@Override
+			public Class<URI> getProjectionType() {
+				return URI.class;
+			}
+
+			@Override
+			public Class<URI> getIndexFieldJavaType() {
+				return URI.class;
+			}
+
+			@Override
+			public List<URI> getEntityPropertyValues() {
+				List<URI> uris = Arrays.asList(
+						URI.create( "https://www.google.com" ),
+						URI.create( "https://twitter.com/Hibernate/status/1093118957194801152" ),
+						URI.create( "https://twitter.com/Hibernate/status/1092803949533507584" ),
+						URI.create( "https://access.redhat.com/" ),
+						URI.create( "https://access.redhat.com/products" ),
+						URI.create( "https://access.redhat.com/products/red-hat-fuse/" ),
+						URI.create( "https://access.redhat.com/products/red-hat-openshift-container-platform/" )
+				);
+				return uris;
+			}
+
+			@Override
+			public List<URI> getDocumentFieldValues() {
+				// same representation
+				return getEntityPropertyValues();
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge1() {
+				return TypeWithValueBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithValueBridge1(int identifier, URI propertyValue) {
+				TypeWithValueBridge1 instance = new TypeWithValueBridge1();
+				instance.id = identifier;
+				instance.myProperty = propertyValue;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge2() {
+				return TypeWithValueBridge2.class;
+			}
+		} );
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithValueBridge1 {
+		Integer id;
+		URI myProperty;
+
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+
+		@GenericField
+		public URI getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithValueBridge2 {
+		Integer id;
+		URI myProperty;
+
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+
+		@GenericField
+		public URI getMyProperty() {
+			return myProperty;
+		}
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/JavaNetURLPropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/JavaNetURLPropertyTypeDescriptor.java
@@ -1,0 +1,137 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.testsupport.types;
+
+import static org.junit.Assert.fail;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultIdentifierBridgeExpectations;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultValueBridgeExpectations;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+public class JavaNetURLPropertyTypeDescriptor extends PropertyTypeDescriptor<URL> {
+
+	JavaNetURLPropertyTypeDescriptor() {
+		super( URL.class );
+	}
+
+	@Override
+	public Optional<DefaultIdentifierBridgeExpectations<URL>> getDefaultIdentifierBridgeExpectations() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<DefaultValueBridgeExpectations<URL, ?>> getDefaultValueBridgeExpectations() {
+		return Optional.of( new DefaultValueBridgeExpectations<URL, URI>() {
+			@Override
+			public Class<URL> getProjectionType() {
+				return URL.class;
+			}
+
+			@Override
+			public Class<URI> getIndexFieldJavaType() {
+				return URI.class;
+			}
+
+			@Override
+			public List<URL> getEntityPropertyValues() {
+				List<URL> urls = Arrays.asList(
+						url( "https://www.google.com" ),
+						url( "https://twitter.com/Hibernate/status/1093118957194801152" ),
+						url( "https://twitter.com/Hibernate/status/1092803949533507584" ),
+						url( "https://access.redhat.com/" ),
+						url( "https://access.redhat.com/products" ),
+						url( "https://access.redhat.com/products/red-hat-fuse/" ),
+						url( "https://access.redhat.com/products/red-hat-openshift-container-platform/" )
+				);
+				return urls;
+			}
+
+			@Override
+			public List<URI> getDocumentFieldValues() {
+				List<URI> uris = Arrays.asList(
+						URI.create( "https://www.google.com" ),
+						URI.create( "https://twitter.com/Hibernate/status/1093118957194801152" ),
+						URI.create( "https://twitter.com/Hibernate/status/1092803949533507584" ),
+						URI.create( "https://access.redhat.com/" ),
+						URI.create( "https://access.redhat.com/products" ),
+						URI.create( "https://access.redhat.com/products/red-hat-fuse/" ),
+						URI.create( "https://access.redhat.com/products/red-hat-openshift-container-platform/" )
+				);
+				return uris;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge1() {
+				return TypeWithValueBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithValueBridge1(int identifier, URL propertyValue) {
+				TypeWithValueBridge1 instance = new TypeWithValueBridge1();
+				instance.id = identifier;
+				instance.myProperty = propertyValue;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge2() {
+				return TypeWithValueBridge2.class;
+			}
+		} );
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithValueBridge1 {
+		Integer id;
+		URL myProperty;
+
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+
+		@GenericField
+		public URL getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithValueBridge2 {
+		Integer id;
+		URL myProperty;
+
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+
+		@GenericField
+		public URL getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	private static URL url(String spec) {
+		try {
+			return new URL( spec );
+		}
+		catch (MalformedURLException e) {
+			fail( "Wrong test URL: " + e.getMessage() );
+			return null;
+		}
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/JavaUtilCalendarPropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/JavaUtilCalendarPropertyTypeDescriptor.java
@@ -1,0 +1,142 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.testsupport.types;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.TimeZone;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultIdentifierBridgeExpectations;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultValueBridgeExpectations;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+public class JavaUtilCalendarPropertyTypeDescriptor extends PropertyTypeDescriptor<Calendar> {
+
+	JavaUtilCalendarPropertyTypeDescriptor() {
+		super( Calendar.class );
+	}
+
+	@Override
+	public Optional<DefaultIdentifierBridgeExpectations<Calendar>> getDefaultIdentifierBridgeExpectations() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<DefaultValueBridgeExpectations<Calendar, ?>> getDefaultValueBridgeExpectations() {
+		return Optional.of( new DefaultValueBridgeExpectations<Calendar, ZonedDateTime>() {
+			@Override
+			public Class<Calendar> getProjectionType() {
+				return Calendar.class;
+			}
+
+			@Override
+			public Class<ZonedDateTime> getIndexFieldJavaType() {
+				return ZonedDateTime.class;
+			}
+
+			@Override
+			public List<Calendar> getEntityPropertyValues() {
+				List<Calendar> calendars = Arrays.asList(
+						calendar( "1930-01-01T00:00:00.00Z", TimeZone.getTimeZone( "GMT+18:00" ) ),
+						calendar( "1970-01-01T00:00:00.00Z", TimeZone.getTimeZone( "Europe/Paris" ) ),
+						calendar( "1970-01-09T13:28:59.00Z", TimeZone.getTimeZone( "Europe/Paris" ) ),
+						calendar( "2017-11-06T19:19:00.54Z", TimeZone.getTimeZone( "Europe/Paris" ) ),
+						calendar( "2017-11-06T19:19:00.54Z", TimeZone.getTimeZone( "America/Chicago" ) ),
+						calendar( Long.MAX_VALUE, TimeZone.getTimeZone( "Europe/Paris" ) ),
+						calendar( Long.MAX_VALUE, TimeZone.getTimeZone( "GMT-18:00" ) )
+				);
+				return calendars;
+			}
+
+			@Override
+			public List<ZonedDateTime> getDocumentFieldValues() {
+				List<ZonedDateTime> zonedDateTimes = Arrays.asList(
+						Instant.parse( "1930-01-01T00:00:00.00Z" ).atZone( ZoneId.of( "GMT+18:00" ) ),
+						Instant.parse( "1970-01-01T00:00:00.00Z" ).atZone( ZoneId.of( "Europe/Paris" ) ),
+						Instant.parse( "1970-01-09T13:28:59.00Z" ).atZone( ZoneId.of( "Europe/Paris" ) ),
+						Instant.parse( "2017-11-06T19:19:00.54Z" ).atZone( ZoneId.of( "Europe/Paris" ) ),
+						Instant.parse( "2017-11-06T19:19:00.54Z" ).atZone( ZoneId.of( "America/Chicago" ) ),
+						Instant.ofEpochMilli( Long.MAX_VALUE ).atZone( ZoneId.of( "Europe/Paris" ) ),
+						Instant.ofEpochMilli( Long.MAX_VALUE ).atZone( ZoneId.of( "GMT-18:00" ) )
+				);
+				return zonedDateTimes;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge1() {
+				return TypeWithValueBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithValueBridge1(int identifier, Calendar propertyValue) {
+				TypeWithValueBridge1 instance = new TypeWithValueBridge1();
+				instance.id = identifier;
+				instance.myProperty = propertyValue;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge2() {
+				return TypeWithValueBridge2.class;
+			}
+		} );
+	}
+
+	private static Calendar calendar(String toParse, TimeZone timeZone) {
+		return calendar( Instant.parse( toParse ).toEpochMilli(), timeZone );
+	}
+
+	private static Calendar calendar(long epochMilli, TimeZone timeZone) {
+		// Even though we generally do not want our tests to be locale-sensitive,
+		// here we indeed want to use the default Locale,
+		// because that's the locale used when creating a new calendar in the bridge.
+		// We expect this test to work regardless of the default Locale.
+		Calendar calendar = Calendar.getInstance( timeZone, Locale.getDefault() );
+		calendar.setTimeInMillis( epochMilli );
+		return calendar;
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithValueBridge1 {
+		Integer id;
+		Calendar myProperty;
+
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+
+		@GenericField
+		public Calendar getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithValueBridge2 {
+		Integer id;
+		Calendar myProperty;
+
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+
+		@GenericField
+		public Calendar getMyProperty() {
+			return myProperty;
+		}
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/LocalDateTimePropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/LocalDateTimePropertyTypeDescriptor.java
@@ -1,0 +1,108 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.testsupport.types;
+
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultIdentifierBridgeExpectations;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultValueBridgeExpectations;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+public class LocalDateTimePropertyTypeDescriptor extends PropertyTypeDescriptor<LocalDateTime> {
+
+	LocalDateTimePropertyTypeDescriptor() {
+		super( LocalDateTime.class );
+	}
+
+	@Override
+	public Optional<DefaultIdentifierBridgeExpectations<LocalDateTime>> getDefaultIdentifierBridgeExpectations() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<DefaultValueBridgeExpectations<LocalDateTime, ?>> getDefaultValueBridgeExpectations() {
+		return Optional.of( new DefaultValueBridgeExpectations<LocalDateTime, LocalDateTime>() {
+			@Override
+			public Class<LocalDateTime> getProjectionType() {
+				return LocalDateTime.class;
+			}
+
+			@Override
+			public Class<LocalDateTime> getIndexFieldJavaType() {
+				return LocalDateTime.class;
+			}
+
+			@Override
+			public List<LocalDateTime> getEntityPropertyValues() {
+				return Arrays.asList(
+						LocalDateTime.MIN,
+						LocalDateTime.of( 1970, Month.JANUARY, 1, 7, 0, 0 ),
+						LocalDateTime.of( 1970, Month.JANUARY, 9, 7, 0, 0 ),
+						LocalDateTime.of( 2017, Month.JANUARY, 9, 7, 0, 0 ),
+						LocalDateTime.MAX
+				);
+			}
+
+			@Override
+			public List<LocalDateTime> getDocumentFieldValues() {
+				return getEntityPropertyValues();
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge1() {
+				return TypeWithValueBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithValueBridge1(int identifier, LocalDateTime propertyValue) {
+				TypeWithValueBridge1 instance = new TypeWithValueBridge1();
+				instance.id = identifier;
+				instance.myProperty = propertyValue;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge2() {
+				return TypeWithValueBridge2.class;
+			}
+		} );
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithValueBridge1 {
+		Integer id;
+		LocalDateTime myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public LocalDateTime getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithValueBridge2 {
+		Integer id;
+		LocalDateTime myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public LocalDateTime getMyProperty() {
+			return myProperty;
+		}
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/LocalTimePropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/LocalTimePropertyTypeDescriptor.java
@@ -1,0 +1,107 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.testsupport.types;
+
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultIdentifierBridgeExpectations;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultValueBridgeExpectations;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+public class LocalTimePropertyTypeDescriptor extends PropertyTypeDescriptor<LocalTime> {
+
+	LocalTimePropertyTypeDescriptor() {
+		super( LocalTime.class );
+	}
+
+	@Override
+	public Optional<DefaultIdentifierBridgeExpectations<LocalTime>> getDefaultIdentifierBridgeExpectations() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<DefaultValueBridgeExpectations<LocalTime, ?>> getDefaultValueBridgeExpectations() {
+		return Optional.of( new DefaultValueBridgeExpectations<LocalTime, LocalTime>() {
+			@Override
+			public Class<LocalTime> getProjectionType() {
+				return LocalTime.class;
+			}
+
+			@Override
+			public Class<LocalTime> getIndexFieldJavaType() {
+				return LocalTime.class;
+			}
+
+			@Override
+			public List<LocalTime> getEntityPropertyValues() {
+				return Arrays.asList(
+						LocalTime.MIN,
+						LocalTime.of( 7, 0, 0 ),
+						LocalTime.of( 12, 0, 0 ),
+						LocalTime.of( 12, 0, 1 ),
+						LocalTime.MAX
+				);
+			}
+
+			@Override
+			public List<LocalTime> getDocumentFieldValues() {
+				return getEntityPropertyValues();
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge1() {
+				return TypeWithValueBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithValueBridge1(int identifier, LocalTime propertyValue) {
+				TypeWithValueBridge1 instance = new TypeWithValueBridge1();
+				instance.id = identifier;
+				instance.myProperty = propertyValue;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge2() {
+				return TypeWithValueBridge2.class;
+			}
+		} );
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithValueBridge1 {
+		Integer id;
+		LocalTime myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public LocalTime getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithValueBridge2 {
+		Integer id;
+		LocalTime myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public LocalTime getMyProperty() {
+			return myProperty;
+		}
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/MonthDayPropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/MonthDayPropertyTypeDescriptor.java
@@ -1,0 +1,108 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.testsupport.types;
+
+import java.time.Month;
+import java.time.MonthDay;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultIdentifierBridgeExpectations;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultValueBridgeExpectations;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+public class MonthDayPropertyTypeDescriptor extends PropertyTypeDescriptor<MonthDay> {
+
+	MonthDayPropertyTypeDescriptor() {
+		super( MonthDay.class );
+	}
+
+	@Override
+	public Optional<DefaultIdentifierBridgeExpectations<MonthDay>> getDefaultIdentifierBridgeExpectations() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<DefaultValueBridgeExpectations<MonthDay, ?>> getDefaultValueBridgeExpectations() {
+		return Optional.of( new DefaultValueBridgeExpectations<MonthDay, MonthDay>() {
+			@Override
+			public Class<MonthDay> getProjectionType() {
+				return MonthDay.class;
+			}
+
+			@Override
+			public Class<MonthDay> getIndexFieldJavaType() {
+				return MonthDay.class;
+			}
+
+			@Override
+			public List<MonthDay> getEntityPropertyValues() {
+				return Arrays.asList(
+						MonthDay.of( Month.JANUARY, 1 ),
+						MonthDay.of( Month.MARCH, 1 ),
+						MonthDay.of( Month.MARCH, 2 ),
+						MonthDay.of( Month.NOVEMBER, 21 ),
+						MonthDay.of( Month.DECEMBER, 31 )
+				);
+			}
+
+			@Override
+			public List<MonthDay> getDocumentFieldValues() {
+				return getEntityPropertyValues();
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge1() {
+				return TypeWithValueBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithValueBridge1(int identifier, MonthDay propertyValue) {
+				TypeWithValueBridge1 instance = new TypeWithValueBridge1();
+				instance.id = identifier;
+				instance.myProperty = propertyValue;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge2() {
+				return TypeWithValueBridge2.class;
+			}
+		} );
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithValueBridge1 {
+		Integer id;
+		MonthDay myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public MonthDay getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithValueBridge2 {
+		Integer id;
+		MonthDay myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public MonthDay getMyProperty() {
+			return myProperty;
+		}
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/OffsetDateTimePropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/OffsetDateTimePropertyTypeDescriptor.java
@@ -1,0 +1,110 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.testsupport.types;
+
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultIdentifierBridgeExpectations;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultValueBridgeExpectations;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+public class OffsetDateTimePropertyTypeDescriptor extends PropertyTypeDescriptor<OffsetDateTime> {
+
+	OffsetDateTimePropertyTypeDescriptor() {
+		super( OffsetDateTime.class );
+	}
+
+	@Override
+	public Optional<DefaultIdentifierBridgeExpectations<OffsetDateTime>> getDefaultIdentifierBridgeExpectations() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<DefaultValueBridgeExpectations<OffsetDateTime, ?>> getDefaultValueBridgeExpectations() {
+		return Optional.of( new DefaultValueBridgeExpectations<OffsetDateTime, OffsetDateTime>() {
+			@Override
+			public Class<OffsetDateTime> getProjectionType() {
+				return OffsetDateTime.class;
+			}
+
+			@Override
+			public Class<OffsetDateTime> getIndexFieldJavaType() {
+				return OffsetDateTime.class;
+			}
+
+			@Override
+			public List<OffsetDateTime> getEntityPropertyValues() {
+				return Arrays.asList(
+						OffsetDateTime.of( LocalDateTime.MIN, ZoneOffset.ofHours( 1 ) ),
+						OffsetDateTime.of( LocalDateTime.of( 1970, Month.JANUARY, 1, 7, 0, 0 ), ZoneOffset.ofHours( 1 ) ),
+						OffsetDateTime.of( LocalDateTime.of( 1999, Month.JANUARY, 1, 7, 0, 0 ), ZoneOffset.ofHours( 1 ) ),
+						OffsetDateTime.of( LocalDateTime.of( 1999, Month.JANUARY, 1, 7, 0, 0 ), ZoneOffset.ofHours( -6 ) ),
+						OffsetDateTime.of( LocalDateTime.MAX, ZoneOffset.ofHours( 1 ) )
+				);
+			}
+
+			@Override
+			public List<OffsetDateTime> getDocumentFieldValues() {
+				return getEntityPropertyValues();
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge1() {
+				return TypeWithValueBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithValueBridge1(int identifier, OffsetDateTime propertyValue) {
+				TypeWithValueBridge1 instance = new TypeWithValueBridge1();
+				instance.id = identifier;
+				instance.myProperty = propertyValue;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge2() {
+				return TypeWithValueBridge2.class;
+			}
+		} );
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithValueBridge1 {
+		Integer id;
+		OffsetDateTime myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public OffsetDateTime getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithValueBridge2 {
+		Integer id;
+		OffsetDateTime myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public OffsetDateTime getMyProperty() {
+			return myProperty;
+		}
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/OffsetTimePropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/OffsetTimePropertyTypeDescriptor.java
@@ -1,0 +1,110 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.testsupport.types;
+
+import java.time.LocalTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultIdentifierBridgeExpectations;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultValueBridgeExpectations;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+public class OffsetTimePropertyTypeDescriptor extends PropertyTypeDescriptor<OffsetTime> {
+
+	OffsetTimePropertyTypeDescriptor() {
+		super( OffsetTime.class );
+	}
+
+	@Override
+	public Optional<DefaultIdentifierBridgeExpectations<OffsetTime>> getDefaultIdentifierBridgeExpectations() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<DefaultValueBridgeExpectations<OffsetTime, ?>> getDefaultValueBridgeExpectations() {
+		return Optional.of( new DefaultValueBridgeExpectations<OffsetTime, OffsetTime>() {
+			@Override
+			public Class<OffsetTime> getProjectionType() {
+				return OffsetTime.class;
+			}
+
+			@Override
+			public Class<OffsetTime> getIndexFieldJavaType() {
+				return OffsetTime.class;
+			}
+
+			@Override
+			public List<OffsetTime> getEntityPropertyValues() {
+				return Arrays.asList(
+						OffsetTime.MIN,
+						LocalTime.of( 7, 0, 0 ).atOffset( ZoneOffset.ofHours( 1 ) ),
+						LocalTime.of( 12, 0, 0 ).atOffset( ZoneOffset.ofHours( 1 ) ),
+						LocalTime.of( 12, 0, 1 ).atOffset( ZoneOffset.ofHours( 1 ) ),
+						LocalTime.of( 12, 0, 1 ).atOffset( ZoneOffset.ofHours( -6 ) ),
+						OffsetTime.MAX
+				);
+			}
+
+			@Override
+			public List<OffsetTime> getDocumentFieldValues() {
+				return getEntityPropertyValues();
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge1() {
+				return TypeWithValueBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithValueBridge1(int identifier, OffsetTime propertyValue) {
+				TypeWithValueBridge1 instance = new TypeWithValueBridge1();
+				instance.id = identifier;
+				instance.myProperty = propertyValue;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge2() {
+				return TypeWithValueBridge2.class;
+			}
+		} );
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithValueBridge1 {
+		Integer id;
+		OffsetTime myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public OffsetTime getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithValueBridge2 {
+		Integer id;
+		OffsetTime myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public OffsetTime getMyProperty() {
+			return myProperty;
+		}
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/PeriodPropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/PeriodPropertyTypeDescriptor.java
@@ -1,0 +1,107 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.testsupport.types;
+
+import java.time.Period;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultIdentifierBridgeExpectations;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultValueBridgeExpectations;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+public class PeriodPropertyTypeDescriptor extends PropertyTypeDescriptor<Period> {
+
+	PeriodPropertyTypeDescriptor() {
+		super( Period.class );
+	}
+
+	@Override
+	public Optional<DefaultIdentifierBridgeExpectations<Period>> getDefaultIdentifierBridgeExpectations() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<DefaultValueBridgeExpectations<Period, ?>> getDefaultValueBridgeExpectations() {
+		return Optional.of( new DefaultValueBridgeExpectations<Period, Period>() {
+			@Override
+			public Class<Period> getProjectionType() {
+				return Period.class;
+			}
+
+			@Override
+			public Class<Period> getIndexFieldJavaType() {
+				return Period.class;
+			}
+
+			@Override
+			public List<Period> getEntityPropertyValues() {
+				return Arrays.asList(
+						Period.ZERO,
+						Period.ofDays( 1 ),
+						Period.ofMonths( 3 ),
+						Period.ofMonths( 4 ),
+						Period.ofYears( 100 )
+				);
+			}
+
+			@Override
+			public List<Period> getDocumentFieldValues() {
+				return getEntityPropertyValues();
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge1() {
+				return TypeWithValueBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithValueBridge1(int identifier, Period propertyValue) {
+				TypeWithValueBridge1 instance = new TypeWithValueBridge1();
+				instance.id = identifier;
+				instance.myProperty = propertyValue;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge2() {
+				return TypeWithValueBridge2.class;
+			}
+		} );
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithValueBridge1 {
+		Integer id;
+		Period myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public Period getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithValueBridge2 {
+		Integer id;
+		Period myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public Period getMyProperty() {
+			return myProperty;
+		}
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/PrimitiveBytePropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/PrimitiveBytePropertyTypeDescriptor.java
@@ -1,0 +1,106 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.testsupport.types;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultIdentifierBridgeExpectations;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultValueBridgeExpectations;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+public class PrimitiveBytePropertyTypeDescriptor extends PropertyTypeDescriptor<Byte> {
+
+	PrimitiveBytePropertyTypeDescriptor() {
+		super( byte.class );
+	}
+
+	@Override
+	public Optional<DefaultIdentifierBridgeExpectations<Byte>> getDefaultIdentifierBridgeExpectations() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<DefaultValueBridgeExpectations<Byte, ?>> getDefaultValueBridgeExpectations() {
+		return Optional.of( new DefaultValueBridgeExpectations<Byte, Byte>() {
+			@Override
+			public Class<Byte> getProjectionType() {
+				return Byte.class;
+			}
+
+			@Override
+			public Class<Byte> getIndexFieldJavaType() {
+				return Byte.class;
+			}
+
+			@Override
+			public List<Byte> getEntityPropertyValues() {
+				return Arrays.asList( Byte.MIN_VALUE, (byte)-1, (byte)0, (byte)1, (byte)42, Byte.MAX_VALUE );
+			}
+
+			@Override
+			public boolean isNullTranslatedAsNull() {
+				return false;
+			}
+
+			@Override
+			public List<Byte> getDocumentFieldValues() {
+				return getEntityPropertyValues();
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge1() {
+				return TypeWithValueBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithValueBridge1(int identifier, Byte propertyValue) {
+				TypeWithValueBridge1 instance = new TypeWithValueBridge1();
+				instance.id = identifier;
+				// Implicit unboxing
+				instance.myProperty = propertyValue;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge2() {
+				return TypeWithValueBridge2.class;
+			}
+		} );
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithValueBridge1 {
+		int id;
+		byte myProperty;
+		@DocumentId
+		public int getId() {
+			return id;
+		}
+		@GenericField
+		public byte getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithValueBridge2 {
+		int id;
+		byte myProperty;
+		@DocumentId
+		public int getId() {
+			return id;
+		}
+		@GenericField
+		public byte getMyProperty() {
+			return myProperty;
+		}
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/PrimitiveCharacterPropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/PrimitiveCharacterPropertyTypeDescriptor.java
@@ -1,0 +1,106 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.testsupport.types;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultIdentifierBridgeExpectations;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultValueBridgeExpectations;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+public class PrimitiveCharacterPropertyTypeDescriptor extends PropertyTypeDescriptor<Character> {
+
+	PrimitiveCharacterPropertyTypeDescriptor() {
+		super( char.class );
+	}
+
+	@Override
+	public Optional<DefaultIdentifierBridgeExpectations<Character>> getDefaultIdentifierBridgeExpectations() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<DefaultValueBridgeExpectations<Character, ?>> getDefaultValueBridgeExpectations() {
+		return Optional.of( new DefaultValueBridgeExpectations<Character, Character>() {
+			@Override
+			public Class<Character> getProjectionType() {
+				return Character.class;
+			}
+
+			@Override
+			public Class<Character> getIndexFieldJavaType() {
+				return Character.class;
+			}
+
+			@Override
+			public List<Character> getEntityPropertyValues() {
+				return Arrays.asList( Character.MIN_VALUE, '7', 'A', 'a', 'f', Character.MAX_VALUE );
+			}
+
+			@Override
+			public boolean isNullTranslatedAsNull() {
+				return false;
+			}
+
+			@Override
+			public List<Character> getDocumentFieldValues() {
+				return getEntityPropertyValues();
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge1() {
+				return TypeWithValueBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithValueBridge1(int identifier, Character propertyValue) {
+				TypeWithValueBridge1 instance = new TypeWithValueBridge1();
+				instance.id = identifier;
+				// Implicit unboxing
+				instance.myProperty = propertyValue;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge2() {
+				return TypeWithValueBridge2.class;
+			}
+		} );
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithValueBridge1 {
+		int id;
+		char myProperty;
+		@DocumentId
+		public int getId() {
+			return id;
+		}
+		@GenericField
+		public char getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithValueBridge2 {
+		int id;
+		char myProperty;
+		@DocumentId
+		public int getId() {
+			return id;
+		}
+		@GenericField
+		public char getMyProperty() {
+			return myProperty;
+		}
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/PrimitiveDoublePropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/PrimitiveDoublePropertyTypeDescriptor.java
@@ -1,0 +1,106 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.testsupport.types;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultIdentifierBridgeExpectations;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultValueBridgeExpectations;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+public class PrimitiveDoublePropertyTypeDescriptor extends PropertyTypeDescriptor<Double> {
+
+	PrimitiveDoublePropertyTypeDescriptor() {
+		super( double.class );
+	}
+
+	@Override
+	public Optional<DefaultIdentifierBridgeExpectations<Double>> getDefaultIdentifierBridgeExpectations() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<DefaultValueBridgeExpectations<Double, ?>> getDefaultValueBridgeExpectations() {
+		return Optional.of( new DefaultValueBridgeExpectations<Double, Double>() {
+			@Override
+			public Class<Double> getProjectionType() {
+				return Double.class;
+			}
+
+			@Override
+			public Class<Double> getIndexFieldJavaType() {
+				return Double.class;
+			}
+
+			@Override
+			public List<Double> getEntityPropertyValues() {
+				return Arrays.asList( Double.MIN_VALUE, -1.0, 0.0, 1.0, 42.0, Double.MAX_VALUE );
+			}
+
+			@Override
+			public boolean isNullTranslatedAsNull() {
+				return false;
+			}
+
+			@Override
+			public List<Double> getDocumentFieldValues() {
+				return getEntityPropertyValues();
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge1() {
+				return TypeWithValueBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithValueBridge1(int identifier, Double propertyValue) {
+				TypeWithValueBridge1 instance = new TypeWithValueBridge1();
+				instance.id = identifier;
+				// Implicit unboxing
+				instance.myProperty = propertyValue;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge2() {
+				return TypeWithValueBridge2.class;
+			}
+		} );
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithValueBridge1 {
+		int id;
+		double myProperty;
+		@DocumentId
+		public int getId() {
+			return id;
+		}
+		@GenericField
+		public double getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithValueBridge2 {
+		int id;
+		double myProperty;
+		@DocumentId
+		public int getId() {
+			return id;
+		}
+		@GenericField
+		public double getMyProperty() {
+			return myProperty;
+		}
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/PrimitiveFloatPropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/PrimitiveFloatPropertyTypeDescriptor.java
@@ -1,0 +1,106 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.testsupport.types;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultIdentifierBridgeExpectations;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultValueBridgeExpectations;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+public class PrimitiveFloatPropertyTypeDescriptor extends PropertyTypeDescriptor<Float> {
+
+	PrimitiveFloatPropertyTypeDescriptor() {
+		super( float.class );
+	}
+
+	@Override
+	public Optional<DefaultIdentifierBridgeExpectations<Float>> getDefaultIdentifierBridgeExpectations() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<DefaultValueBridgeExpectations<Float, ?>> getDefaultValueBridgeExpectations() {
+		return Optional.of( new DefaultValueBridgeExpectations<Float, Float>() {
+			@Override
+			public Class<Float> getProjectionType() {
+				return Float.class;
+			}
+
+			@Override
+			public Class<Float> getIndexFieldJavaType() {
+				return Float.class;
+			}
+
+			@Override
+			public List<Float> getEntityPropertyValues() {
+				return Arrays.asList( Float.MIN_VALUE, -1.0f, 0.0f, 1.0f, 42.0f, Float.MAX_VALUE );
+			}
+
+			@Override
+			public boolean isNullTranslatedAsNull() {
+				return false;
+			}
+
+			@Override
+			public List<Float> getDocumentFieldValues() {
+				return getEntityPropertyValues();
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge1() {
+				return TypeWithValueBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithValueBridge1(int identifier, Float propertyValue) {
+				TypeWithValueBridge1 instance = new TypeWithValueBridge1();
+				instance.id = identifier;
+				// Implicit unboxing
+				instance.myProperty = propertyValue;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge2() {
+				return TypeWithValueBridge2.class;
+			}
+		} );
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithValueBridge1 {
+		int id;
+		float myProperty;
+		@DocumentId
+		public int getId() {
+			return id;
+		}
+		@GenericField
+		public float getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithValueBridge2 {
+		int id;
+		float myProperty;
+		@DocumentId
+		public int getId() {
+			return id;
+		}
+		@GenericField
+		public float getMyProperty() {
+			return myProperty;
+		}
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/PrimitiveShortPropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/PrimitiveShortPropertyTypeDescriptor.java
@@ -1,0 +1,154 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.testsupport.types;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultIdentifierBridgeExpectations;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultValueBridgeExpectations;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+public class PrimitiveShortPropertyTypeDescriptor extends PropertyTypeDescriptor<Short> {
+
+	PrimitiveShortPropertyTypeDescriptor() {
+		super( short.class );
+	}
+
+	@Override
+	public Optional<DefaultIdentifierBridgeExpectations<Short>> getDefaultIdentifierBridgeExpectations() {
+		return Optional.of( new DefaultIdentifierBridgeExpectations<Short>() {
+			@Override
+			public List<Short> getEntityIdentifierValues() {
+				return Arrays.asList( Short.MIN_VALUE, (short)-1, (short)0, (short)1, (short)42, Short.MAX_VALUE );
+			}
+
+			@Override
+			public List<String> getDocumentIdentifierValues() {
+				return Arrays.asList(
+						String.valueOf( Short.MIN_VALUE ), "-1", "0", "1", "42", String.valueOf( Short.MAX_VALUE )
+				);
+			}
+
+			@Override
+			public Class<?> getTypeWithIdentifierBridge1() {
+				return TypeWithIdentifierBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithIdentifierBridge1(Short identifier) {
+				TypeWithIdentifierBridge1 instance = new TypeWithIdentifierBridge1();
+				// Implicit unboxing
+				instance.id = identifier;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithIdentifierBridge2() {
+				return TypeWithIdentifierBridge2.class;
+			}
+		} );
+	}
+
+	@Override
+	public Optional<DefaultValueBridgeExpectations<Short, ?>> getDefaultValueBridgeExpectations() {
+		return Optional.of( new DefaultValueBridgeExpectations<Short, Short>() {
+			@Override
+			public Class<Short> getProjectionType() {
+				return Short.class;
+			}
+
+			@Override
+			public Class<Short> getIndexFieldJavaType() {
+				return Short.class;
+			}
+
+			@Override
+			public List<Short> getEntityPropertyValues() {
+				return Arrays.asList( Short.MIN_VALUE, (short)-1, (short)0, (short)1, (short)42, Short.MAX_VALUE );
+			}
+
+			@Override
+			public boolean isNullTranslatedAsNull() {
+				return false;
+			}
+
+			@Override
+			public List<Short> getDocumentFieldValues() {
+				return getEntityPropertyValues();
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge1() {
+				return TypeWithValueBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithValueBridge1(int identifier, Short propertyValue) {
+				TypeWithValueBridge1 instance = new TypeWithValueBridge1();
+				instance.id = identifier;
+				// Implicit unboxing
+				instance.myProperty = propertyValue;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge2() {
+				return TypeWithValueBridge2.class;
+			}
+		} );
+	}
+
+	@Indexed(index = DefaultIdentifierBridgeExpectations.TYPE_WITH_IDENTIFIER_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithIdentifierBridge1 {
+		short id;
+		@DocumentId
+		public short getId() {
+			return id;
+		}
+	}
+
+	@Indexed(index = DefaultIdentifierBridgeExpectations.TYPE_WITH_IDENTIFIER_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithIdentifierBridge2 {
+		short id;
+		@DocumentId
+		public short getId() {
+			return id;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithValueBridge1 {
+		int id;
+		short myProperty;
+		@DocumentId
+		public int getId() {
+			return id;
+		}
+		@GenericField
+		public short getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithValueBridge2 {
+		int id;
+		short myProperty;
+		@DocumentId
+		public int getId() {
+			return id;
+		}
+		@GenericField
+		public short getMyProperty() {
+			return myProperty;
+		}
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/PropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/PropertyTypeDescriptor.java
@@ -41,6 +41,7 @@ public abstract class PropertyTypeDescriptor<V> {
 					new InstantPropertyTypeDescriptor(),
 					new LocalDatePropertyTypeDescriptor(),
 					new JavaUtilDatePropertyTypeDescriptor(),
+					new JavaUtilCalendarPropertyTypeDescriptor(),
 					new BigDecimalPropertyTypeDescriptor(),
 					new BigIntegerPropertyTypeDescriptor(),
 					new UUIDPropertyTypeDescriptor(),

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/PropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/PropertyTypeDescriptor.java
@@ -55,7 +55,9 @@ public abstract class PropertyTypeDescriptor<V> {
 					new ZoneOffsetPropertyTypeDescriptor(),
 					new ZoneIdPropertyTypeDescriptor(),
 					new DurationPropertyTypeDescriptor(),
-					new PeriodPropertyTypeDescriptor()
+					new PeriodPropertyTypeDescriptor(),
+					new JavaNetURIPropertyTypeDescriptor(),
+					new JavaNetURLPropertyTypeDescriptor()
 			) );
 		}
 		return all;

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/PropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/PropertyTypeDescriptor.java
@@ -43,7 +43,18 @@ public abstract class PropertyTypeDescriptor<V> {
 					new JavaUtilDatePropertyTypeDescriptor(),
 					new BigDecimalPropertyTypeDescriptor(),
 					new BigIntegerPropertyTypeDescriptor(),
-					new UUIDPropertyTypeDescriptor()
+					new UUIDPropertyTypeDescriptor(),
+					new LocalDateTimePropertyTypeDescriptor(),
+					new LocalTimePropertyTypeDescriptor(),
+					new ZonedDateTimePropertyTypeDescriptor(),
+					new YearPropertyTypeDescriptor(),
+					new MonthDayPropertyTypeDescriptor(),
+					new OffsetDateTimePropertyTypeDescriptor(),
+					new OffsetTimePropertyTypeDescriptor(),
+					new ZoneOffsetPropertyTypeDescriptor(),
+					new ZoneIdPropertyTypeDescriptor(),
+					new DurationPropertyTypeDescriptor(),
+					new PeriodPropertyTypeDescriptor()
 			) );
 		}
 		return all;

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/PropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/PropertyTypeDescriptor.java
@@ -24,13 +24,26 @@ public abstract class PropertyTypeDescriptor<V> {
 					new BoxedIntegerPropertyTypeDescriptor(),
 					new BoxedLongPropertyTypeDescriptor(),
 					new BoxedBooleanPropertyTypeDescriptor(),
+					new BoxedCharacterPropertyTypeDescriptor(),
+					new BoxedBytePropertyTypeDescriptor(),
+					new BoxedShortPropertyTypeDescriptor(),
+					new BoxedFloatPropertyTypeDescriptor(),
+					new BoxedDoublePropertyTypeDescriptor(),
 					new PrimitiveIntegerPropertyTypeDescriptor(),
 					new PrimitiveLongPropertyTypeDescriptor(),
 					new PrimitiveBooleanPropertyTypeDescriptor(),
+					new PrimitiveCharacterPropertyTypeDescriptor(),
+					new PrimitiveBytePropertyTypeDescriptor(),
+					new PrimitiveShortPropertyTypeDescriptor(),
+					new PrimitiveFloatPropertyTypeDescriptor(),
+					new PrimitiveDoublePropertyTypeDescriptor(),
 					new EnumPropertyTypeDescriptor(),
 					new InstantPropertyTypeDescriptor(),
 					new LocalDatePropertyTypeDescriptor(),
-					new JavaUtilDatePropertyTypeDescriptor()
+					new JavaUtilDatePropertyTypeDescriptor(),
+					new BigDecimalPropertyTypeDescriptor(),
+					new BigIntegerPropertyTypeDescriptor(),
+					new UUIDPropertyTypeDescriptor()
 			) );
 		}
 		return all;
@@ -50,4 +63,11 @@ public abstract class PropertyTypeDescriptor<V> {
 
 	public abstract Optional<DefaultValueBridgeExpectations<V, ?>> getDefaultValueBridgeExpectations();
 
+	@Override
+	public String toString() {
+		final StringBuilder sb = new StringBuilder( "PropertyTypeDescriptor{" );
+		sb.append( "javaType=" ).append( javaType );
+		sb.append( '}' );
+		return sb.toString();
+	}
 }

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/UUIDPropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/UUIDPropertyTypeDescriptor.java
@@ -1,0 +1,174 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.testsupport.types;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultIdentifierBridgeExpectations;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultValueBridgeExpectations;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+public class UUIDPropertyTypeDescriptor extends PropertyTypeDescriptor<UUID> {
+
+	UUIDPropertyTypeDescriptor() {
+		super( UUID.class );
+	}
+
+	@Override
+	public Optional<DefaultIdentifierBridgeExpectations<UUID>> getDefaultIdentifierBridgeExpectations() {
+		return Optional.of( new DefaultIdentifierBridgeExpectations<UUID>() {
+			@Override
+			public List<UUID> getEntityIdentifierValues() {
+				return getSequence();
+			}
+
+			@Override
+			public List<String> getDocumentIdentifierValues() {
+				return getStrings();
+			}
+
+			@Override
+			public Class<?> getTypeWithIdentifierBridge1() {
+				return TypeWithIdentifierBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithIdentifierBridge1(UUID identifier) {
+				TypeWithIdentifierBridge1 instance = new TypeWithIdentifierBridge1();
+				instance.id = identifier;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithIdentifierBridge2() {
+				return TypeWithIdentifierBridge2.class;
+			}
+		} );
+	}
+
+	@Override
+	public Optional<DefaultValueBridgeExpectations<UUID, ?>> getDefaultValueBridgeExpectations() {
+		return Optional.of( new DefaultValueBridgeExpectations<UUID, UUID>() {
+			@Override
+			public Class<UUID> getProjectionType() {
+				return UUID.class;
+			}
+
+			@Override
+			public Class<UUID> getIndexFieldJavaType() {
+				return UUID.class;
+			}
+
+			@Override
+			public List<UUID> getEntityPropertyValues() {
+				return getSequence();
+			}
+
+			@Override
+			public List<UUID> getDocumentFieldValues() {
+				return getEntityPropertyValues();
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge1() {
+				return TypeWithValueBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithValueBridge1(int identifier, UUID propertyValue) {
+				TypeWithValueBridge1 instance = new TypeWithValueBridge1();
+				instance.id = identifier;
+				instance.myProperty = propertyValue;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge2() {
+				return TypeWithValueBridge2.class;
+			}
+		} );
+	}
+
+	@Indexed(index = DefaultIdentifierBridgeExpectations.TYPE_WITH_IDENTIFIER_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithIdentifierBridge1 {
+		UUID id;
+
+		@DocumentId
+		public UUID getId() {
+			return id;
+		}
+	}
+
+	@Indexed(index = DefaultIdentifierBridgeExpectations.TYPE_WITH_IDENTIFIER_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithIdentifierBridge2 {
+		UUID id;
+
+		@DocumentId
+		public UUID getId() {
+			return id;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithValueBridge1 {
+		Integer id;
+		UUID myProperty;
+
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+
+		@GenericField
+		public UUID getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithValueBridge2 {
+		Integer id;
+		UUID myProperty;
+
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+
+		@GenericField
+		public UUID getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	public static List<UUID> getSequence() {
+		return Arrays.asList(
+				new UUID( Long.MIN_VALUE, Long.MIN_VALUE ),
+				new UUID( Long.MIN_VALUE, -1L ),
+				new UUID( Long.MIN_VALUE, 0L ),
+				new UUID( Long.MIN_VALUE, 1L ),
+				new UUID( Long.MAX_VALUE, Long.MIN_VALUE ),
+				new UUID( Long.MAX_VALUE, Long.MAX_VALUE )
+		);
+	}
+
+	public static List<String> getStrings() {
+		return Arrays.asList(
+				"80000000-0000-0000-8000-000000000000",
+				"80000000-0000-0000-ffff-ffffffffffff",
+				"80000000-0000-0000-0000-000000000000",
+				"80000000-0000-0000-0000-000000000001",
+				"7fffffff-ffff-ffff-8000-000000000000",
+				"7fffffff-ffff-ffff-7fff-ffffffffffff"
+		);
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/YearMonthPropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/YearMonthPropertyTypeDescriptor.java
@@ -1,0 +1,109 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.testsupport.types;
+
+import java.time.Month;
+import java.time.Year;
+import java.time.YearMonth;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultIdentifierBridgeExpectations;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultValueBridgeExpectations;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+public class YearMonthPropertyTypeDescriptor extends PropertyTypeDescriptor<YearMonth> {
+
+	YearMonthPropertyTypeDescriptor() {
+		super( YearMonth.class );
+	}
+
+	@Override
+	public Optional<DefaultIdentifierBridgeExpectations<YearMonth>> getDefaultIdentifierBridgeExpectations() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<DefaultValueBridgeExpectations<YearMonth, ?>> getDefaultValueBridgeExpectations() {
+		return Optional.of( new DefaultValueBridgeExpectations<YearMonth, YearMonth>() {
+			@Override
+			public Class<YearMonth> getProjectionType() {
+				return YearMonth.class;
+			}
+
+			@Override
+			public Class<YearMonth> getIndexFieldJavaType() {
+				return YearMonth.class;
+			}
+
+			@Override
+			public List<YearMonth> getEntityPropertyValues() {
+				return Arrays.asList(
+						YearMonth.of( Year.MIN_VALUE, Month.NOVEMBER ),
+						YearMonth.of( 2019, Month.JANUARY ),
+						YearMonth.of( 2019, Month.FEBRUARY ),
+						YearMonth.of( 2317, Month.NOVEMBER ),
+						YearMonth.of( Year.MAX_VALUE, Month.NOVEMBER )
+				);
+			}
+
+			@Override
+			public List<YearMonth> getDocumentFieldValues() {
+				return getEntityPropertyValues();
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge1() {
+				return TypeWithValueBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithValueBridge1(int identifier, YearMonth propertyValue) {
+				TypeWithValueBridge1 instance = new TypeWithValueBridge1();
+				instance.id = identifier;
+				instance.myProperty = propertyValue;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge2() {
+				return TypeWithValueBridge2.class;
+			}
+		} );
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithValueBridge1 {
+		Integer id;
+		YearMonth myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public YearMonth getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithValueBridge2 {
+		Integer id;
+		YearMonth myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public YearMonth getMyProperty() {
+			return myProperty;
+		}
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/YearPropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/YearPropertyTypeDescriptor.java
@@ -1,0 +1,103 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.testsupport.types;
+
+import java.time.Year;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultIdentifierBridgeExpectations;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultValueBridgeExpectations;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+public class YearPropertyTypeDescriptor extends PropertyTypeDescriptor<Year> {
+
+	YearPropertyTypeDescriptor() {
+		super( Year.class );
+	}
+
+	@Override
+	public Optional<DefaultIdentifierBridgeExpectations<Year>> getDefaultIdentifierBridgeExpectations() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<DefaultValueBridgeExpectations<Year, ?>> getDefaultValueBridgeExpectations() {
+		return Optional.of( new DefaultValueBridgeExpectations<Year, Year>() {
+			@Override
+			public Class<Year> getProjectionType() {
+				return Year.class;
+			}
+
+			@Override
+			public Class<Year> getIndexFieldJavaType() {
+				return Year.class;
+			}
+
+			@Override
+			public List<Year> getEntityPropertyValues() {
+				return Arrays.asList(
+						Year.of( Year.MIN_VALUE ), Year.of( -1 ), Year.of( 0 ), Year.of( 1 ), Year.of( 42 ), Year.of( Year.MAX_VALUE )
+				);
+			}
+
+			@Override
+			public List<Year> getDocumentFieldValues() {
+				return getEntityPropertyValues();
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge1() {
+				return TypeWithValueBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithValueBridge1(int identifier, Year propertyValue) {
+				TypeWithValueBridge1 instance = new TypeWithValueBridge1();
+				instance.id = identifier;
+				instance.myProperty = propertyValue;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge2() {
+				return TypeWithValueBridge2.class;
+			}
+		} );
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithValueBridge1 {
+		Integer id;
+		Year myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public Year getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithValueBridge2 {
+		Integer id;
+		Year myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public Year getMyProperty() {
+			return myProperty;
+		}
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/ZoneIdPropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/ZoneIdPropertyTypeDescriptor.java
@@ -1,0 +1,109 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.testsupport.types;
+
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultIdentifierBridgeExpectations;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultValueBridgeExpectations;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+public class ZoneIdPropertyTypeDescriptor extends PropertyTypeDescriptor<ZoneId> {
+
+	ZoneIdPropertyTypeDescriptor() {
+		super( ZoneId.class );
+	}
+
+	@Override
+	public Optional<DefaultIdentifierBridgeExpectations<ZoneId>> getDefaultIdentifierBridgeExpectations() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<DefaultValueBridgeExpectations<ZoneId, ?>> getDefaultValueBridgeExpectations() {
+		return Optional.of( new DefaultValueBridgeExpectations<ZoneId, ZoneId>() {
+			@Override
+			public Class<ZoneId> getProjectionType() {
+				return ZoneId.class;
+			}
+
+			@Override
+			public Class<ZoneId> getIndexFieldJavaType() {
+				return ZoneId.class;
+			}
+
+			@Override
+			public List<ZoneId> getEntityPropertyValues() {
+				return Arrays.asList(
+						ZoneOffset.MIN,
+						ZoneId.of( "America/Los_Angeles" ),
+						ZoneOffset.UTC,
+						ZoneId.of( "Europe/Paris" ),
+						ZoneOffset.ofHours( 7 ),
+						ZoneOffset.MAX
+				);
+			}
+
+			@Override
+			public List<ZoneId> getDocumentFieldValues() {
+				return getEntityPropertyValues();
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge1() {
+				return TypeWithValueBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithValueBridge1(int identifier, ZoneId propertyValue) {
+				TypeWithValueBridge1 instance = new TypeWithValueBridge1();
+				instance.id = identifier;
+				instance.myProperty = propertyValue;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge2() {
+				return TypeWithValueBridge2.class;
+			}
+		} );
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithValueBridge1 {
+		Integer id;
+		ZoneId myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public ZoneId getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithValueBridge2 {
+		Integer id;
+		ZoneId myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public ZoneId getMyProperty() {
+			return myProperty;
+		}
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/ZoneOffsetPropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/ZoneOffsetPropertyTypeDescriptor.java
@@ -1,0 +1,108 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.testsupport.types;
+
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultIdentifierBridgeExpectations;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultValueBridgeExpectations;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+public class ZoneOffsetPropertyTypeDescriptor extends PropertyTypeDescriptor<ZoneOffset> {
+
+	ZoneOffsetPropertyTypeDescriptor() {
+		super( ZoneOffset.class );
+	}
+
+	@Override
+	public Optional<DefaultIdentifierBridgeExpectations<ZoneOffset>> getDefaultIdentifierBridgeExpectations() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<DefaultValueBridgeExpectations<ZoneOffset, ?>> getDefaultValueBridgeExpectations() {
+		return Optional.of( new DefaultValueBridgeExpectations<ZoneOffset, ZoneOffset>() {
+			@Override
+			public Class<ZoneOffset> getProjectionType() {
+				return ZoneOffset.class;
+			}
+
+			@Override
+			public Class<ZoneOffset> getIndexFieldJavaType() {
+				return ZoneOffset.class;
+			}
+
+			@Override
+			public List<ZoneOffset> getEntityPropertyValues() {
+				return Arrays.asList(
+						ZoneOffset.MIN,
+						ZoneOffset.ofHours( -1 ),
+						ZoneOffset.UTC,
+						ZoneOffset.ofHours( 1 ),
+						ZoneOffset.ofHours( 7 ),
+						ZoneOffset.MAX
+				);
+			}
+
+			@Override
+			public List<ZoneOffset> getDocumentFieldValues() {
+				return getEntityPropertyValues();
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge1() {
+				return TypeWithValueBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithValueBridge1(int identifier, ZoneOffset propertyValue) {
+				TypeWithValueBridge1 instance = new TypeWithValueBridge1();
+				instance.id = identifier;
+				instance.myProperty = propertyValue;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge2() {
+				return TypeWithValueBridge2.class;
+			}
+		} );
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithValueBridge1 {
+		Integer id;
+		ZoneOffset myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public ZoneOffset getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithValueBridge2 {
+		Integer id;
+		ZoneOffset myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public ZoneOffset getMyProperty() {
+			return myProperty;
+		}
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/ZonedDateTimePropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/ZonedDateTimePropertyTypeDescriptor.java
@@ -1,0 +1,110 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.testsupport.types;
+
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultIdentifierBridgeExpectations;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultValueBridgeExpectations;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+public class ZonedDateTimePropertyTypeDescriptor extends PropertyTypeDescriptor<ZonedDateTime> {
+
+	ZonedDateTimePropertyTypeDescriptor() {
+		super( ZonedDateTime.class );
+	}
+
+	@Override
+	public Optional<DefaultIdentifierBridgeExpectations<ZonedDateTime>> getDefaultIdentifierBridgeExpectations() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<DefaultValueBridgeExpectations<ZonedDateTime, ?>> getDefaultValueBridgeExpectations() {
+		return Optional.of( new DefaultValueBridgeExpectations<ZonedDateTime, ZonedDateTime>() {
+			@Override
+			public Class<ZonedDateTime> getProjectionType() {
+				return ZonedDateTime.class;
+			}
+
+			@Override
+			public Class<ZonedDateTime> getIndexFieldJavaType() {
+				return ZonedDateTime.class;
+			}
+
+			@Override
+			public List<ZonedDateTime> getEntityPropertyValues() {
+				return Arrays.asList(
+						ZonedDateTime.of( LocalDateTime.MIN, ZoneId.of( "Europe/Paris" ) ),
+						ZonedDateTime.of( LocalDateTime.of( 1970, Month.JANUARY, 1, 7, 0, 0 ), ZoneId.of( "Europe/Paris" ) ),
+						ZonedDateTime.of( LocalDateTime.of( 1999, Month.JANUARY, 1, 7, 0, 0 ), ZoneId.of( "Europe/Paris" ) ),
+						ZonedDateTime.of( LocalDateTime.of( 1999, Month.JANUARY, 1, 7, 0, 0 ), ZoneId.of( "America/Chicago" ) ),
+						ZonedDateTime.of( LocalDateTime.MAX, ZoneId.of( "Europe/Paris" ) )
+				);
+			}
+
+			@Override
+			public List<ZonedDateTime> getDocumentFieldValues() {
+				return getEntityPropertyValues();
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge1() {
+				return TypeWithValueBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithValueBridge1(int identifier, ZonedDateTime propertyValue) {
+				TypeWithValueBridge1 instance = new TypeWithValueBridge1();
+				instance.id = identifier;
+				instance.myProperty = propertyValue;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge2() {
+				return TypeWithValueBridge2.class;
+			}
+		} );
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithValueBridge1 {
+		Integer id;
+		ZonedDateTime myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public ZonedDateTime getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithValueBridge2 {
+		Integer id;
+		ZonedDateTime myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public ZonedDateTime getMyProperty() {
+			return myProperty;
+		}
+	}
+}

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/impl/DefaultBigIntegerIdentifierBridge.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/impl/DefaultBigIntegerIdentifierBridge.java
@@ -1,0 +1,36 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.bridge.builtin.impl;
+
+import java.math.BigInteger;
+
+import org.hibernate.search.mapper.pojo.bridge.IdentifierBridge;
+import org.hibernate.search.mapper.pojo.bridge.runtime.IdentifierBridgeFromDocumentIdentifierContext;
+import org.hibernate.search.mapper.pojo.bridge.runtime.IdentifierBridgeToDocumentIdentifierContext;
+
+public final class DefaultBigIntegerIdentifierBridge implements IdentifierBridge<BigInteger> {
+
+	@Override
+	public String toDocumentIdentifier(BigInteger propertyValue, IdentifierBridgeToDocumentIdentifierContext context) {
+		return propertyValue.toString();
+	}
+
+	@Override
+	public BigInteger fromDocumentIdentifier(String documentIdentifier, IdentifierBridgeFromDocumentIdentifierContext context) {
+		return new BigInteger( documentIdentifier );
+	}
+
+	@Override
+	public BigInteger cast(Object value) {
+		return (BigInteger) value;
+	}
+
+	@Override
+	public boolean isCompatibleWith(IdentifierBridge<?> other) {
+		return getClass().equals( other.getClass() );
+	}
+}

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/impl/DefaultJavaNetURLValueBridge.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/impl/DefaultJavaNetURLValueBridge.java
@@ -1,0 +1,101 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.bridge.builtin.impl;
+
+import java.lang.invoke.MethodHandles;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.hibernate.search.engine.backend.types.converter.FromDocumentFieldValueConverter;
+import org.hibernate.search.engine.backend.types.converter.runtime.FromDocumentFieldValueConvertContext;
+import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeContext;
+import org.hibernate.search.mapper.pojo.bridge.ValueBridge;
+import org.hibernate.search.mapper.pojo.bridge.binding.ValueBridgeBindingContext;
+import org.hibernate.search.mapper.pojo.bridge.runtime.ValueBridgeToIndexedValueContext;
+import org.hibernate.search.mapper.pojo.logging.impl.Log;
+import org.hibernate.search.util.impl.common.LoggerFactory;
+
+public final class DefaultJavaNetURLValueBridge implements ValueBridge<URL, URI> {
+
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+
+	@Override
+	public String toString() {
+		return getClass().getSimpleName();
+	}
+
+	@Override
+	@SuppressWarnings("unchecked") // The bridge resolver performs the checks using reflection
+	public StandardIndexFieldTypeContext<?, URI> bind(ValueBridgeBindingContext<URL> context) {
+		return context.getTypeFactory().asUri()
+				.projectionConverter( PojoDefaultURLFromDocumentFieldValueConverter.INSTANCE );
+	}
+
+	@Override
+	public URI toIndexedValue(URL value, ValueBridgeToIndexedValueContext context) {
+		return value == null ? null : toURI( value );
+	}
+
+	@Override
+	public URL cast(Object value) {
+		return (URL) value;
+	}
+
+	@Override
+	public boolean isCompatibleWith(ValueBridge<?, ?> other) {
+		if ( !getClass().equals( other.getClass() ) ) {
+			return false;
+		}
+		return true;
+	}
+
+	private static class PojoDefaultURLFromDocumentFieldValueConverter
+			implements FromDocumentFieldValueConverter<URI, URL> {
+		private static final PojoDefaultURLFromDocumentFieldValueConverter INSTANCE = new PojoDefaultURLFromDocumentFieldValueConverter();
+
+		@Override
+		public boolean isConvertedTypeAssignableTo(Class<?> superTypeCandidate) {
+			return superTypeCandidate.isAssignableFrom( URL.class );
+		}
+
+		@Override
+		public URL convert(URI value, FromDocumentFieldValueConvertContext context) {
+			return value == null ? null : toURL( value );
+		}
+
+		@Override
+		public boolean isCompatibleWith(FromDocumentFieldValueConverter<?, ?> other) {
+			return INSTANCE.equals( other );
+		}
+	}
+
+	private static URL toURL(URI value) {
+		URL url = null;
+		try {
+			url = value.toURL();
+		}
+		catch (MalformedURLException e) {
+			log.malformedURL( value, e );
+		}
+
+		return url;
+	}
+
+	private static URI toURI(URL value) {
+		URI uri = null;
+		try {
+			uri = value.toURI();
+		}
+		catch (URISyntaxException e) {
+			log.badURISyntax( value, e );
+		}
+
+		return uri;
+	}
+}

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/impl/DefaultJavaUtilCalendarValueBridge.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/impl/DefaultJavaUtilCalendarValueBridge.java
@@ -1,0 +1,105 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.bridge.builtin.impl;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoField;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.Locale;
+import java.util.TimeZone;
+
+import org.hibernate.search.engine.backend.types.converter.FromDocumentFieldValueConverter;
+import org.hibernate.search.engine.backend.types.converter.runtime.FromDocumentFieldValueConvertContext;
+import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeContext;
+import org.hibernate.search.mapper.pojo.bridge.ValueBridge;
+import org.hibernate.search.mapper.pojo.bridge.binding.ValueBridgeBindingContext;
+import org.hibernate.search.mapper.pojo.bridge.runtime.ValueBridgeToIndexedValueContext;
+
+public final class DefaultJavaUtilCalendarValueBridge implements ValueBridge<Calendar, ZonedDateTime> {
+
+	@Override
+	public String toString() {
+		return getClass().getSimpleName();
+	}
+
+	@Override
+	@SuppressWarnings("unchecked") // The bridge resolver performs the checks using reflection
+	public StandardIndexFieldTypeContext<?, ZonedDateTime> bind(ValueBridgeBindingContext<Calendar> context) {
+		return context.getTypeFactory().asZonedDateTime()
+				.projectionConverter( PojoDefaultCalendarFromDocumentFieldValueConverter.INSTANCE );
+	}
+
+	@Override
+	public ZonedDateTime toIndexedValue(Calendar value, ValueBridgeToIndexedValueContext context) {
+		if ( value == null ) {
+			return null;
+		}
+
+		if ( value instanceof GregorianCalendar ) {
+			return ( (GregorianCalendar) value ).toZonedDateTime();
+		}
+
+		// Using any static zone id to produce the ZonedDateTime instance,
+		// since not-gregorian calendar could not contain this time zone information.
+		// We know that data stored in the backends will contain this extra non-user data,
+		// but we accept this compromise considering that Calendar is considered a Java legacy type
+		// and most of the time it is used as a GregorianCalendar implementation.
+		return value.toInstant().atZone( ZoneId.of( "UTC" ) );
+	}
+
+	@Override
+	public Calendar cast(Object value) {
+		return (Calendar) value;
+	}
+
+	@Override
+	public boolean isCompatibleWith(ValueBridge<?, ?> other) {
+		if ( !getClass().equals( other.getClass() ) ) {
+			return false;
+		}
+		return true;
+	}
+
+	private static class PojoDefaultCalendarFromDocumentFieldValueConverter
+			implements FromDocumentFieldValueConverter<ZonedDateTime, Calendar> {
+		private static final PojoDefaultCalendarFromDocumentFieldValueConverter INSTANCE = new PojoDefaultCalendarFromDocumentFieldValueConverter();
+
+		@Override
+		public boolean isConvertedTypeAssignableTo(Class<?> superTypeCandidate) {
+			return superTypeCandidate.isAssignableFrom( Calendar.class );
+		}
+
+		@Override
+		public Calendar convert(ZonedDateTime value, FromDocumentFieldValueConvertContext context) {
+			return value == null ? null : from( value );
+		}
+
+		@Override
+		public boolean isCompatibleWith(FromDocumentFieldValueConverter<?, ?> other) {
+			return INSTANCE.equals( other );
+		}
+	}
+
+	private static Calendar from(ZonedDateTime value) {
+		// We had some troubles using `GregorianCalendar.from( value )`:
+		// it seems that the method calculates firstDayOfWeek and minimalDaysInFirstWeek
+		// in a different way GregorianCalendar.getInstance does.
+		Calendar calendar = Calendar.getInstance( TimeZone.getTimeZone( value.getZone() ), Locale.getDefault() );
+		if ( calendar instanceof GregorianCalendar ) {
+			calendar.setTimeInMillis( Math.addExact( Math.multiplyExact( value.toEpochSecond(), 1000 ), value.get( ChronoField.MILLI_OF_SECOND ) ) );
+		}
+		else {
+			calendar.setTime( Date.from( value.toInstant() ) );
+		}
+
+		return calendar;
+	}
+
+}

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/impl/DefaultShortIdentifierBridge.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/impl/DefaultShortIdentifierBridge.java
@@ -1,0 +1,36 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.bridge.builtin.impl;
+
+import org.hibernate.search.mapper.pojo.bridge.IdentifierBridge;
+import org.hibernate.search.mapper.pojo.bridge.runtime.IdentifierBridgeFromDocumentIdentifierContext;
+import org.hibernate.search.mapper.pojo.bridge.runtime.IdentifierBridgeToDocumentIdentifierContext;
+
+public final class DefaultShortIdentifierBridge implements IdentifierBridge<Short> {
+
+	@Override
+	public String toDocumentIdentifier(Short propertyValue,
+			IdentifierBridgeToDocumentIdentifierContext context) {
+		return propertyValue.toString();
+	}
+
+	@Override
+	public Short fromDocumentIdentifier(String documentIdentifier, IdentifierBridgeFromDocumentIdentifierContext context) {
+		return Short.parseShort( documentIdentifier );
+	}
+
+	@Override
+	public Short cast(Object value) {
+		return (Short) value;
+	}
+
+	@Override
+	public boolean isCompatibleWith(IdentifierBridge<?> other) {
+		return getClass().equals( other.getClass() );
+	}
+
+}

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/impl/DefaultUUIDIdentifierBridge.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/impl/DefaultUUIDIdentifierBridge.java
@@ -1,0 +1,36 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.bridge.builtin.impl;
+
+import java.util.UUID;
+
+import org.hibernate.search.mapper.pojo.bridge.IdentifierBridge;
+import org.hibernate.search.mapper.pojo.bridge.runtime.IdentifierBridgeFromDocumentIdentifierContext;
+import org.hibernate.search.mapper.pojo.bridge.runtime.IdentifierBridgeToDocumentIdentifierContext;
+
+public final class DefaultUUIDIdentifierBridge implements IdentifierBridge<UUID> {
+
+	@Override
+	public String toDocumentIdentifier(UUID propertyValue, IdentifierBridgeToDocumentIdentifierContext context) {
+		return propertyValue.toString();
+	}
+
+	@Override
+	public UUID fromDocumentIdentifier(String documentIdentifier, IdentifierBridgeFromDocumentIdentifierContext context) {
+		return UUID.fromString( documentIdentifier );
+	}
+
+	@Override
+	public UUID cast(Object value) {
+		return (UUID) value;
+	}
+
+	@Override
+	public boolean isCompatibleWith(IdentifierBridge<?> other) {
+		return getClass().equals( other.getClass() );
+	}
+}

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/impl/BridgeResolver.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/impl/BridgeResolver.java
@@ -24,6 +24,7 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -38,6 +39,7 @@ import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultBigIntegerIde
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultEnumIdentifierBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultEnumValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultIntegerIdentifierBridge;
+import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultJavaUtilCalendarValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultJavaUtilDateValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultLongIdentifierBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultShortIdentifierBridge;
@@ -84,6 +86,7 @@ public final class BridgeResolver {
 		addValueBridgeForExactRawType( LocalDate.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( LocalDate.class ) ) );
 		addValueBridgeForExactRawType( Instant.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( Instant.class ) ) );
 		addValueBridgeForExactRawType( Date.class, ignored -> BeanHolder.of( new DefaultJavaUtilDateValueBridge() ) );
+		addValueBridgeForExactRawType( Calendar.class, ignored -> BeanHolder.of( new DefaultJavaUtilCalendarValueBridge() ) );
 		addValueBridgeForTypePattern( concreteEnumPattern, ignored -> BeanHolder.of( new DefaultEnumValueBridge<>() ) );
 		addValueBridgeForExactRawType( Character.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( Character.class ) ) );
 		addValueBridgeForExactRawType( Byte.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( Byte.class ) ) );

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/impl/BridgeResolver.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/impl/BridgeResolver.java
@@ -9,8 +9,20 @@ package org.hibernate.search.mapper.pojo.bridge.impl;
 import java.lang.invoke.MethodHandles;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.MonthDay;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Period;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -81,6 +93,18 @@ public final class BridgeResolver {
 		addValueBridgeForExactRawType( BigDecimal.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( BigDecimal.class ) ) );
 		addValueBridgeForExactRawType( BigInteger.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( BigInteger.class ) ) );
 		addValueBridgeForExactRawType( UUID.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( UUID.class ) ) );
+		addValueBridgeForExactRawType( LocalDateTime.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( LocalDateTime.class ) ) );
+		addValueBridgeForExactRawType( LocalTime.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( LocalTime.class ) ) );
+		addValueBridgeForExactRawType( ZonedDateTime.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( ZonedDateTime.class ) ) );
+		addValueBridgeForExactRawType( Year.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( Year.class ) ) );
+		addValueBridgeForExactRawType( YearMonth.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( YearMonth.class ) ) );
+		addValueBridgeForExactRawType( MonthDay.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( MonthDay.class ) ) );
+		addValueBridgeForExactRawType( OffsetDateTime.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( OffsetDateTime.class ) ) );
+		addValueBridgeForExactRawType( OffsetTime.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( OffsetTime.class ) ) );
+		addValueBridgeForExactRawType( ZoneOffset.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( ZoneOffset.class ) ) );
+		addValueBridgeForExactRawType( ZoneId.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( ZoneId.class ) ) );
+		addValueBridgeForExactRawType( Period.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( Period.class ) ) );
+		addValueBridgeForExactRawType( Duration.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( Duration.class ) ) );
 	}
 
 	public BridgeBuilder<? extends IdentifierBridge<?>> resolveIdentifierBridgeForType(PojoGenericTypeModel<?> sourceType) {

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/impl/BridgeResolver.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/impl/BridgeResolver.java
@@ -9,6 +9,8 @@ package org.hibernate.search.mapper.pojo.bridge.impl;
 import java.lang.invoke.MethodHandles;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.net.URI;
+import java.net.URL;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -39,6 +41,7 @@ import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultBigIntegerIde
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultEnumIdentifierBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultEnumValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultIntegerIdentifierBridge;
+import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultJavaNetURLValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultJavaUtilCalendarValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultJavaUtilDateValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultLongIdentifierBridge;
@@ -67,7 +70,6 @@ public final class BridgeResolver {
 
 	public BridgeResolver(TypePatternMatcherFactory typePatternMatcherFactory) {
 		// TODO add an extension point to override these maps, or at least to add defaults for other types
-		// TODO add defaults for other types (byte, char, Characeter, Double, double, boolean, Boolean, ...)
 
 		TypePatternMatcher concreteEnumPattern = typePatternMatcherFactory.createRawSuperTypeMatcher( Enum.class )
 				.and( typePatternMatcherFactory.createExactRawTypeMatcher( Enum.class ).negate() );
@@ -108,6 +110,8 @@ public final class BridgeResolver {
 		addValueBridgeForExactRawType( ZoneId.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( ZoneId.class ) ) );
 		addValueBridgeForExactRawType( Period.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( Period.class ) ) );
 		addValueBridgeForExactRawType( Duration.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( Duration.class ) ) );
+		addValueBridgeForExactRawType( URI.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( URI.class ) ) );
+		addValueBridgeForExactRawType( URL.class, ignored -> BeanHolder.of( new DefaultJavaNetURLValueBridge() ) );
 	}
 
 	public BridgeBuilder<? extends IdentifierBridge<?>> resolveIdentifierBridgeForType(PojoGenericTypeModel<?> sourceType) {

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/impl/BridgeResolver.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/impl/BridgeResolver.java
@@ -7,6 +7,8 @@
 package org.hibernate.search.mapper.pojo.bridge.impl;
 
 import java.lang.invoke.MethodHandles;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -15,15 +17,19 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import org.hibernate.search.engine.environment.bean.BeanHolder;
 import org.hibernate.search.mapper.pojo.bridge.ValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.IdentifierBridge;
+import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultBigIntegerIdentifierBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultEnumIdentifierBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultEnumValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultIntegerIdentifierBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultJavaUtilDateValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultLongIdentifierBridge;
+import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultShortIdentifierBridge;
+import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultUUIDIdentifierBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.PassThroughValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.mapping.BridgeBuilder;
 import org.hibernate.search.mapper.pojo.logging.impl.Log;
@@ -55,6 +61,9 @@ public final class BridgeResolver {
 		addIdentifierBridgeForExactRawType( Integer.class, ignored -> BeanHolder.of( new DefaultIntegerIdentifierBridge() ) );
 		addIdentifierBridgeForExactRawType( Long.class, ignored -> BeanHolder.of( new DefaultLongIdentifierBridge() ) );
 		addIdentifierBridgeForTypePattern( concreteEnumPattern, ignored -> BeanHolder.of( new DefaultEnumIdentifierBridge<>() ) );
+		addIdentifierBridgeForExactRawType( Short.class, ignored -> BeanHolder.of( new DefaultShortIdentifierBridge() ) );
+		addIdentifierBridgeForExactRawType( BigInteger.class, ignored -> BeanHolder.of( new DefaultBigIntegerIdentifierBridge() ) );
+		addIdentifierBridgeForExactRawType( UUID.class, ignored -> BeanHolder.of( new DefaultUUIDIdentifierBridge() ) );
 
 		addValueBridgeForExactRawType( Integer.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( Integer.class ) ) );
 		addValueBridgeForExactRawType( Long.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( Long.class ) ) );
@@ -64,6 +73,14 @@ public final class BridgeResolver {
 		addValueBridgeForExactRawType( Instant.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( Instant.class ) ) );
 		addValueBridgeForExactRawType( Date.class, ignored -> BeanHolder.of( new DefaultJavaUtilDateValueBridge() ) );
 		addValueBridgeForTypePattern( concreteEnumPattern, ignored -> BeanHolder.of( new DefaultEnumValueBridge<>() ) );
+		addValueBridgeForExactRawType( Character.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( Character.class ) ) );
+		addValueBridgeForExactRawType( Byte.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( Byte.class ) ) );
+		addValueBridgeForExactRawType( Short.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( Short.class ) ) );
+		addValueBridgeForExactRawType( Float.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( Float.class ) ) );
+		addValueBridgeForExactRawType( Double.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( Double.class ) ) );
+		addValueBridgeForExactRawType( BigDecimal.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( BigDecimal.class ) ) );
+		addValueBridgeForExactRawType( BigInteger.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( BigInteger.class ) ) );
+		addValueBridgeForExactRawType( UUID.class, ignored -> BeanHolder.of( new PassThroughValueBridge<>( UUID.class ) ) );
 	}
 
 	public BridgeBuilder<? extends IdentifierBridge<?>> resolveIdentifierBridgeForType(PojoGenericTypeModel<?> sourceType) {

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
@@ -10,6 +10,10 @@ package org.hibernate.search.mapper.pojo.logging.impl;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Member;
 import java.lang.reflect.Type;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.Set;
 
 import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeContext;
@@ -31,6 +35,8 @@ import org.hibernate.search.util.impl.common.logging.EnumFormatter;
 import org.hibernate.search.util.impl.common.logging.ToStringTreeAppendableMultilineFormatter;
 import org.hibernate.search.util.SearchException;
 import org.hibernate.search.util.impl.common.logging.TypeFormatter;
+import org.hibernate.search.util.impl.common.logging.URIFormatter;
+import org.hibernate.search.util.impl.common.logging.URLFormatter;
 
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
@@ -322,4 +328,10 @@ public interface Log extends BasicLogger {
 	)
 	SearchException invalidContainerExtractorReferencingBothBuiltinExtractorAndExplicitType(@FormatWith(EnumFormatter.class) BuiltinContainerExtractor value,
 			@FormatWith(ClassFormatter.class) Class<? extends ContainerExtractor> type);
+
+	@Message(id = ID_OFFSET_2 + 43, value = "Error on mapping back URI '%1$s' to URL.")
+	SearchException malformedURL(@FormatWith(URIFormatter.class) URI value, @Cause MalformedURLException e);
+
+	@Message(id = ID_OFFSET_2 + 44, value = "Error on mapping URL '%1$s' to URI.")
+	SearchException badURISyntax(@FormatWith(URLFormatter.class) URL value, @Cause URISyntaxException e);
 }

--- a/util/internal/common/src/main/java/org/hibernate/search/util/impl/common/logging/URIFormatter.java
+++ b/util/internal/common/src/main/java/org/hibernate/search/util/impl/common/logging/URIFormatter.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.impl.common.logging;
+
+import java.net.URI;
+
+public class URIFormatter {
+
+	private final String stringRepresentation;
+
+	public URIFormatter(URI uri) {
+		this.stringRepresentation = uri != null ? uri.toString() : null;
+	}
+
+	@Override
+	public String toString() {
+		return stringRepresentation;
+	}
+}

--- a/util/internal/common/src/main/java/org/hibernate/search/util/impl/common/logging/URLFormatter.java
+++ b/util/internal/common/src/main/java/org/hibernate/search/util/impl/common/logging/URLFormatter.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.impl.common.logging;
+
+import java.net.URL;
+
+public class URLFormatter {
+
+	private final String stringRepresentation;
+
+	public URLFormatter(URL url) {
+		this.stringRepresentation = url != null ? url.toString() : null;
+	}
+
+	@Override
+	public String toString() {
+		return stringRepresentation;
+	}
+}

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/types/dsl/impl/StubIndexFieldTypeFactoryContext.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/types/dsl/impl/StubIndexFieldTypeFactoryContext.java
@@ -8,6 +8,7 @@ package org.hibernate.search.util.impl.integrationtest.common.stub.backend.types
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZonedDateTime;
 
 import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeFactoryContext;
 import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeContext;
@@ -55,6 +56,11 @@ public class StubIndexFieldTypeFactoryContext implements IndexFieldTypeFactoryCo
 	@Override
 	public StandardIndexFieldTypeContext<?, Instant> asInstant() {
 		return as( Instant.class );
+	}
+
+	@Override
+	public StandardIndexFieldTypeContext<?, ZonedDateTime> asZonedDateTime() {
+		return as( ZonedDateTime.class );
 	}
 
 	@Override

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/types/dsl/impl/StubIndexFieldTypeFactoryContext.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/types/dsl/impl/StubIndexFieldTypeFactoryContext.java
@@ -65,6 +65,11 @@ public class StubIndexFieldTypeFactoryContext implements IndexFieldTypeFactoryCo
 	}
 
 	@Override
+	public StandardIndexFieldTypeContext<?, Float> asFloat() {
+		return as( Float.class );
+	}
+
+	@Override
 	public StandardIndexFieldTypeContext<?, Double> asDouble() {
 		return as( Double.class );
 	}

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/types/dsl/impl/StubIndexFieldTypeFactoryContext.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/types/dsl/impl/StubIndexFieldTypeFactoryContext.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.util.impl.integrationtest.common.stub.backend.types.dsl.impl;
 
+import java.net.URI;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
@@ -68,4 +69,8 @@ public class StubIndexFieldTypeFactoryContext implements IndexFieldTypeFactoryCo
 		return as( GeoPoint.class );
 	}
 
+	@Override
+	public StandardIndexFieldTypeContext<?, URI> asUri() {
+		return as( URI.class );
+	}
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/types/dsl/impl/StubIndexFieldTypeFactoryContext.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/types/dsl/impl/StubIndexFieldTypeFactoryContext.java
@@ -55,6 +55,11 @@ public class StubIndexFieldTypeFactoryContext implements IndexFieldTypeFactoryCo
 	}
 
 	@Override
+	public StandardIndexFieldTypeContext<?, Byte> asByte() {
+		return as( Byte.class );
+	}
+
+	@Override
 	public StandardIndexFieldTypeContext<?, LocalDate> asLocalDate() {
 		return as( LocalDate.class );
 	}

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/types/dsl/impl/StubIndexFieldTypeFactoryContext.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/types/dsl/impl/StubIndexFieldTypeFactoryContext.java
@@ -65,6 +65,11 @@ public class StubIndexFieldTypeFactoryContext implements IndexFieldTypeFactoryCo
 	}
 
 	@Override
+	public StandardIndexFieldTypeContext<?, Double> asDouble() {
+		return as( Double.class );
+	}
+
+	@Override
 	public StandardIndexFieldTypeContext<?, LocalDate> asLocalDate() {
 		return as( LocalDate.class );
 	}

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/types/dsl/impl/StubIndexFieldTypeFactoryContext.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/types/dsl/impl/StubIndexFieldTypeFactoryContext.java
@@ -60,6 +60,11 @@ public class StubIndexFieldTypeFactoryContext implements IndexFieldTypeFactoryCo
 	}
 
 	@Override
+	public StandardIndexFieldTypeContext<?, Short> asShort() {
+		return as( Short.class );
+	}
+
+	@Override
 	public StandardIndexFieldTypeContext<?, LocalDate> asLocalDate() {
 		return as( LocalDate.class );
 	}

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/types/dsl/impl/StubIndexFieldTypeFactoryContext.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/types/dsl/impl/StubIndexFieldTypeFactoryContext.java
@@ -9,6 +9,7 @@ package org.hibernate.search.util.impl.integrationtest.common.stub.backend.types
 import java.net.URI;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 
 import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeFactoryContext;
@@ -77,6 +78,11 @@ public class StubIndexFieldTypeFactoryContext implements IndexFieldTypeFactoryCo
 	@Override
 	public StandardIndexFieldTypeContext<?, LocalDate> asLocalDate() {
 		return as( LocalDate.class );
+	}
+
+	@Override
+	public StandardIndexFieldTypeContext<?, LocalDateTime> asLocalDateTime() {
+		return as( LocalDateTime.class );
 	}
 
 	@Override

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/types/dsl/impl/StubIndexFieldTypeFactoryContext.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/types/dsl/impl/StubIndexFieldTypeFactoryContext.java
@@ -50,6 +50,11 @@ public class StubIndexFieldTypeFactoryContext implements IndexFieldTypeFactoryCo
 	}
 
 	@Override
+	public StandardIndexFieldTypeContext<?, Character> asCharacter() {
+		return as( Character.class );
+	}
+
+	@Override
 	public StandardIndexFieldTypeContext<?, LocalDate> asLocalDate() {
 		return as( LocalDate.class );
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3047

[Type Spreadsheets](https://docs.google.com/spreadsheets/d/1kXq3gh-jqRajK5oqFC9hG3RNYisUljMdAttPjedFF-4/edit?usp=sharing)

