### PR TITLE
HSEARCH-2908 Incorrect mapping for 'java.lang.Short and java.lang.Byte' fields with Elasticsearch.

### DIFF
--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/fieldtype/ElasticsearchFieldTypesIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/fieldtype/ElasticsearchFieldTypesIT.java
@@ -10,7 +10,7 @@ import org.hibernate.search.backend.elasticsearch.cfg.spi.ElasticsearchBackendSp
 import org.hibernate.search.backend.elasticsearch.client.spi.ElasticsearchRequest;
 import org.hibernate.search.backend.elasticsearch.util.spi.URLEncodedString;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
-import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchClientMock;
+import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchClientSpy;
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchRequestAssertionMode;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 
@@ -32,22 +32,22 @@ public class ElasticsearchFieldTypesIT {
 	public SearchSetupHelper setupHelper = new SearchSetupHelper();
 
 	@Rule
-	public ElasticsearchClientMock clientMock = new ElasticsearchClientMock();
+	public ElasticsearchClientSpy clientSpy = new ElasticsearchClientSpy();
 
 	@Rule
 	public ExpectedException thrown = ExpectedException.none();
 
 	@Test
 	public void addUpdateDelete_routing() {
-		clientMock.expectNext(
+		clientSpy.expectNext(
 				ElasticsearchRequest.get().build(), ElasticsearchRequestAssertionMode.STRICT
 		);
 
-		clientMock.expectNext(
+		clientSpy.expectNext(
 				ElasticsearchRequest.head().pathComponent( URLEncodedString.fromString( INDEX_NAME ) ).build(), ElasticsearchRequestAssertionMode.STRICT
 		);
 
-		clientMock.expectNext(
+		clientSpy.expectNext(
 				ElasticsearchRequest.put()
 						.pathComponent( URLEncodedString.fromString( INDEX_NAME ) )
 						.body( indexCreationPayload() )
@@ -57,7 +57,7 @@ public class ElasticsearchFieldTypesIT {
 
 		setupHelper.withDefaultConfiguration( BACKEND_NAME )
 				.withBackendProperty(
-						BACKEND_NAME, ElasticsearchBackendSpiSettings.CLIENT_FACTORY, clientMock.getFactory()
+						BACKEND_NAME, ElasticsearchBackendSpiSettings.CLIENT_FACTORY, clientSpy.getFactory()
 				)
 				.withIndex(
 						"MappedType", INDEX_NAME,
@@ -67,7 +67,7 @@ public class ElasticsearchFieldTypesIT {
 				)
 				.setup();
 
-		clientMock.verifyExpectationsMet();
+		clientSpy.verifyExpectationsMet();
 	}
 
 	private JsonObject indexCreationPayload() {

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/fieldtype/ElasticsearchFieldTypesIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/fieldtype/ElasticsearchFieldTypesIT.java
@@ -1,0 +1,121 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.elasticsearch.fieldtype;
+
+import org.hibernate.search.backend.elasticsearch.cfg.spi.ElasticsearchBackendSpiSettings;
+import org.hibernate.search.backend.elasticsearch.client.spi.ElasticsearchRequest;
+import org.hibernate.search.backend.elasticsearch.util.spi.URLEncodedString;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchClientMock;
+import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchRequestAssertionMode;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import com.google.gson.JsonObject;
+
+/**
+ * Test the property types defined on Elasticsearch server
+ */
+public class ElasticsearchFieldTypesIT {
+
+	private static final String BACKEND_NAME = "myElasticsearchBackend";
+	private static final String INDEX_NAME = "indexname";
+
+	@Rule
+	public SearchSetupHelper setupHelper = new SearchSetupHelper();
+
+	@Rule
+	public ElasticsearchClientMock clientMock = new ElasticsearchClientMock();
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void addUpdateDelete_routing() {
+		clientMock.expectNext(
+				ElasticsearchRequest.get().build(), ElasticsearchRequestAssertionMode.STRICT
+		);
+
+		clientMock.expectNext(
+				ElasticsearchRequest.head().pathComponent( URLEncodedString.fromString( INDEX_NAME ) ).build(), ElasticsearchRequestAssertionMode.STRICT
+		);
+
+		clientMock.expectNext(
+				ElasticsearchRequest.put()
+						.pathComponent( URLEncodedString.fromString( INDEX_NAME ) )
+						.body( indexCreationPayload() )
+						.build(),
+				ElasticsearchRequestAssertionMode.EXTENSIBLE
+		);
+
+		setupHelper.withDefaultConfiguration( BACKEND_NAME )
+				.withBackendProperty(
+						BACKEND_NAME, ElasticsearchBackendSpiSettings.CLIENT_FACTORY, clientMock.getFactory()
+				)
+				.withIndex(
+						"MappedType", INDEX_NAME,
+						ctx -> new IndexAccessors( ctx.getSchemaElement() ),
+						indexManager -> {
+						}
+				)
+				.setup();
+
+		clientMock.verifyExpectationsMet();
+	}
+
+	private JsonObject indexCreationPayload() {
+		JsonObject payload = new JsonObject();
+
+		JsonObject mappings = new JsonObject();
+		payload.add( "mappings", mappings );
+
+		JsonObject doc = new JsonObject();
+		mappings.add( "doc", doc );
+
+		JsonObject properties = new JsonObject();
+		doc.add( "properties", properties );
+
+		properties.add( "keyword", type( "keyword" ) );
+		properties.add( "text", type( "text" ) );
+		properties.add( "integer", type( "integer" ) );
+		properties.add( "long", type( "long" ) );
+		properties.add( "boolean", type( "boolean" ) );
+		properties.add( "byte", type( "byte" ) );
+		properties.add( "short", type( "short" ) );
+		properties.add( "float", type( "float" ) );
+		properties.add( "double", type( "double" ) );
+
+		return payload;
+	}
+
+	private static JsonObject type(String type) {
+		JsonObject field = new JsonObject();
+		field.addProperty( "type", type );
+		return field;
+	}
+
+	private static class IndexAccessors {
+		IndexAccessors(IndexSchemaElement root) {
+			// string type + not analyzed => keyword
+			root.field( "keyword", f -> f.asString() ).createAccessor();
+
+			// string type + analyzed => text
+			root.field( "text", f -> f.asString().analyzer( "standard" ) ).createAccessor();
+
+			root.field( "integer", f -> f.asInteger() ).createAccessor();
+			root.field( "long", f -> f.asLong() ).createAccessor();
+			root.field( "boolean", f -> f.asBoolean() ).createAccessor();
+			root.field( "byte", f -> f.asByte() ).createAccessor();
+			root.field( "short", f -> f.asShort() ).createAccessor();
+			root.field( "float", f -> f.asFloat() ).createAccessor();
+			root.field( "double", f -> f.asDouble() ).createAccessor();
+		}
+	}
+}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/search/query/ElasticsearchSearchQueryIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/search/query/ElasticsearchSearchQueryIT.java
@@ -14,7 +14,7 @@ import org.hibernate.search.engine.backend.document.IndexFieldAccessor;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.types.Projectable;
 import org.hibernate.search.engine.search.SearchQuery;
-import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchClientMock;
+import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchClientSpy;
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchRequestAssertionMode;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
@@ -40,7 +40,7 @@ public class ElasticsearchSearchQueryIT {
 	public SearchSetupHelper setupHelper = new SearchSetupHelper();
 
 	@Rule
-	public ElasticsearchClientMock clientMock = new ElasticsearchClientMock();
+	public ElasticsearchClientSpy clientSpy = new ElasticsearchClientSpy();
 
 	@Rule
 	public ExpectedException thrown = ExpectedException.none();
@@ -51,7 +51,7 @@ public class ElasticsearchSearchQueryIT {
 	public void setup() {
 		setupHelper.withDefaultConfiguration( BACKEND_NAME )
 				.withBackendProperty(
-						BACKEND_NAME, ElasticsearchBackendSpiSettings.CLIENT_FACTORY, clientMock.getFactory()
+						BACKEND_NAME, ElasticsearchBackendSpiSettings.CLIENT_FACTORY, clientSpy.getFactory()
 				)
 				.withIndex(
 						"MappedType", INDEX_NAME,
@@ -70,7 +70,7 @@ public class ElasticsearchSearchQueryIT {
 				.predicate( f -> f.matchAll() )
 				.build();
 
-		clientMock.expectNext(
+		clientSpy.expectNext(
 				ElasticsearchRequest.post()
 						.pathComponent( URLEncodedString.fromString( INDEX_NAME ) )
 						.pathComponent( Paths._SEARCH )
@@ -94,7 +94,7 @@ public class ElasticsearchSearchQueryIT {
 				.routing( routingKey )
 				.build();
 
-		clientMock.expectNext(
+		clientSpy.expectNext(
 				ElasticsearchRequest.post()
 						.pathComponent( URLEncodedString.fromString( INDEX_NAME ) )
 						.pathComponent( Paths._SEARCH )

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchClientSpy.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchClientSpy.java
@@ -23,7 +23,7 @@ import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
-public class ElasticsearchClientMock implements TestRule {
+public class ElasticsearchClientSpy implements TestRule {
 	private final CallQueue<ElasticsearchClientSubmitCall> expectations = new CallQueue<>();
 
 	@Override

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/work/ElasticsearchIndexingIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/work/ElasticsearchIndexingIT.java
@@ -16,7 +16,7 @@ import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldAccessor;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.index.spi.IndexWorkPlan;
-import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchClientMock;
+import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchClientSpy;
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchRequestAssertionMode;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
@@ -41,7 +41,7 @@ public class ElasticsearchIndexingIT {
 	public SearchSetupHelper setupHelper = new SearchSetupHelper();
 
 	@Rule
-	public ElasticsearchClientMock clientMock = new ElasticsearchClientMock();
+	public ElasticsearchClientSpy clientSpy = new ElasticsearchClientSpy();
 
 	@Rule
 	public ExpectedException thrown = ExpectedException.none();
@@ -53,7 +53,7 @@ public class ElasticsearchIndexingIT {
 	public void setup() {
 		setupHelper.withDefaultConfiguration( BACKEND_NAME )
 				.withBackendProperty(
-						BACKEND_NAME, ElasticsearchBackendSpiSettings.CLIENT_FACTORY, clientMock.getFactory()
+						BACKEND_NAME, ElasticsearchBackendSpiSettings.CLIENT_FACTORY, clientSpy.getFactory()
 				)
 				.withIndex(
 						"MappedType", INDEX_NAME,
@@ -71,7 +71,7 @@ public class ElasticsearchIndexingIT {
 		workPlan.add( referenceProvider( "1", routingKey ), document -> {
 			indexAccessors.string.write( document, "text1" );
 		} );
-		clientMock.expectNext(
+		clientSpy.expectNext(
 				ElasticsearchRequest.put()
 						.pathComponent( URLEncodedString.fromString( INDEX_NAME ) )
 						.pathComponent( TYPE_NAME )
@@ -82,12 +82,12 @@ public class ElasticsearchIndexingIT {
 				ElasticsearchRequestAssertionMode.EXTENSIBLE
 		);
 		workPlan.execute().join();
-		clientMock.verifyExpectationsMet();
+		clientSpy.verifyExpectationsMet();
 
 		workPlan.update( referenceProvider( "1", routingKey ), document -> {
 			indexAccessors.string.write( document, "text2" );
 		} );
-		clientMock.expectNext(
+		clientSpy.expectNext(
 				ElasticsearchRequest.put()
 						.pathComponent( URLEncodedString.fromString( INDEX_NAME ) )
 						.pathComponent( TYPE_NAME )
@@ -98,10 +98,10 @@ public class ElasticsearchIndexingIT {
 				ElasticsearchRequestAssertionMode.EXTENSIBLE
 		);
 		workPlan.execute().join();
-		clientMock.verifyExpectationsMet();
+		clientSpy.verifyExpectationsMet();
 
 		workPlan.delete( referenceProvider( "1", routingKey ) );
-		clientMock.expectNext(
+		clientSpy.expectNext(
 				ElasticsearchRequest.delete()
 						.pathComponent( URLEncodedString.fromString( INDEX_NAME ) )
 						.pathComponent( TYPE_NAME )
@@ -111,7 +111,7 @@ public class ElasticsearchIndexingIT {
 				ElasticsearchRequestAssertionMode.EXTENSIBLE
 		);
 		workPlan.execute().join();
-		clientMock.verifyExpectationsMet();
+		clientSpy.verifyExpectationsMet();
 	}
 
 	private static class IndexAccessors {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2908

Based on top of https://github.com/hibernate/hibernate-search/pull/1889.
Thus we need to merge https://github.com/hibernate/hibernate-search/pull/1889 first.