### PR TITLE
HSEARCH-3484 + HSEARCH-3485 + HSEARCH-3491: JDK12 compatibility on branch 5.11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,7 +158,7 @@ stage('Configure') {
 					// See http://www.oracle.com/technetwork/java/javase/eol-135779.html
 					new JdkITEnvironment(version: '8', tool: 'Oracle JDK 8', status: ITEnvironmentStatus.USED_IN_DEFAULT_BUILD),
 					new JdkITEnvironment(version: '11', tool: 'OpenJDK 11 Latest', status: ITEnvironmentStatus.SUPPORTED),
-					new JdkITEnvironment(version: '12', tool: 'OpenJDK 12 Latest', status: ITEnvironmentStatus.EXPERIMENTAL)
+					new JdkITEnvironment(version: '12', tool: 'OpenJDK 12 Latest', status: ITEnvironmentStatus.SUPPORTED)
 			],
 			database: [
 					new DatabaseITEnvironment(dbName: 'h2', mavenProfile: 'h2', status: ITEnvironmentStatus.USED_IN_DEFAULT_BUILD),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -157,7 +157,8 @@ stage('Configure') {
 					// This should not include every JDK; in particular let's not care too much about EOL'd JDKs like version 9
 					// See http://www.oracle.com/technetwork/java/javase/eol-135779.html
 					new JdkITEnvironment(version: '8', tool: 'Oracle JDK 8', status: ITEnvironmentStatus.USED_IN_DEFAULT_BUILD),
-					new JdkITEnvironment(version: '11', tool: 'OpenJDK 11 Latest', status: ITEnvironmentStatus.SUPPORTED)
+					new JdkITEnvironment(version: '11', tool: 'OpenJDK 11 Latest', status: ITEnvironmentStatus.SUPPORTED),
+					new JdkITEnvironment(version: '12', tool: 'OpenJDK 12 Latest', status: ITEnvironmentStatus.EXPERIMENTAL)
 			],
 			database: [
 					new DatabaseITEnvironment(dbName: 'h2', mavenProfile: 'h2', status: ITEnvironmentStatus.USED_IN_DEFAULT_BUILD),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -125,7 +125,7 @@ import org.hibernate.jenkins.pipeline.helpers.version.Version
  * to send coverage reports to coveralls.io. Note these credentials should be registered at the job level, not system-wide.
  */
 
-@Field final String MAVEN_TOOL = 'Apache Maven 3.5.4'
+@Field final String MAVEN_TOOL = 'Apache Maven 3.6.0'
 
 // Default node pattern, to be used for resource-intensive stages.
 // Should not include the master node.

--- a/engine/src/main/java/org/hibernate/search/query/engine/impl/QueryFilters.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/impl/QueryFilters.java
@@ -61,7 +61,7 @@ public final class QueryFilters {
 	}
 
 	/**
-	 * @return <tt>true</tt> if this contains to filters to be applied.
+	 * @return {@code true} if this contains to filters to be applied.
 	 */
 	public boolean isEmpty() {
 		return filterQueries.isEmpty();

--- a/engine/src/main/java/org/hibernate/search/query/engine/spi/HSQuery.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/spi/HSQuery.java
@@ -114,9 +114,9 @@ public interface HSQuery extends ProjectionConstants {
 
 	/**
 	 * Set the first element to retrieve. If not set, elements will be
-	 * retrieved beginning from element <tt>0</tt>.
+	 * retrieved beginning from element {@code 0}.
 	 *
-	 * @param firstResult a element number, numbered from <tt>0</tt>
+	 * @param firstResult a element number, numbered from {@code 0}
 	 * @return {@code this}  to allow for method chaining
 	 */
 	HSQuery firstResult(int firstResult);

--- a/engine/src/main/java/org/hibernate/search/util/impl/ConcurrentReferenceHashMap.java
+++ b/engine/src/main/java/org/hibernate/search/util/impl/ConcurrentReferenceHashMap.java
@@ -50,8 +50,8 @@ import java.util.concurrent.locks.ReentrantLock;
  * discarded by the garbage collector. Once a key has been discarded by the
  * collector, the corresponding entry is no longer visible to this table;
  * however, the entry may occupy space until a future table operation decides to
- * reclaim it. For this reason, summary functions such as <tt>size</tt> and
- * <tt>isEmpty</tt> might return a value greater than the observed number of
+ * reclaim it. For this reason, summary functions such as {@code size} and
+ * {@code isEmpty} might return a value greater than the observed number of
  * entries. In order to support a high level of concurrency, stale entries are
  * only reclaimed during blocking (usually mutating) operations.
  *
@@ -76,19 +76,19 @@ import java.util.concurrent.locks.ReentrantLock;
  * Just like {@link java.util.concurrent.ConcurrentHashMap}, this class obeys
  * the same functional specification as {@link java.util.Hashtable}, and
  * includes versions of methods corresponding to each method of
- * <tt>Hashtable</tt>. However, even though all operations are thread-safe,
+ * {@code Hashtable}. However, even though all operations are thread-safe,
  * retrieval operations do <em>not</em> entail locking, and there is
  * <em>not</em> any support for locking the entire table in a way that
  * prevents all access. This class is fully interoperable with
- * <tt>Hashtable</tt> in programs that rely on its thread safety but not on
+ * {@code Hashtable} in programs that rely on its thread safety but not on
  * its synchronization details.
  *
  * <p>
- * Retrieval operations (including <tt>get</tt>) generally do not block, so
- * may overlap with update operations (including <tt>put</tt> and
- * <tt>remove</tt>). Retrievals reflect the results of the most recently
+ * Retrieval operations (including {@code get}) generally do not block, so
+ * may overlap with update operations (including {@code put} and
+ * {@code remove}). Retrievals reflect the results of the most recently
  * <em>completed</em> update operations holding upon their onset. For
- * aggregate operations such as <tt>putAll</tt> and <tt>clear</tt>,
+ * aggregate operations such as {@code putAll} and {@code clear},
  * concurrent retrievals may reflect insertion or removal of only some entries.
  * Similarly, Iterators and Enumerations return elements reflecting the state of
  * the hash table at some point at or since the creation of the
@@ -98,7 +98,7 @@ import java.util.concurrent.locks.ReentrantLock;
  *
  * <p>
  * The allowed concurrency among update operations is guided by the optional
- * <tt>concurrencyLevel</tt> constructor argument (default <tt>16</tt>),
+ * {@code concurrencyLevel} constructor argument (default {@code 16}),
  * which is used as a hint for internal sizing. The table is internally
  * partitioned to try to permit the indicated number of concurrent updates
  * without contention. Because placement in hash tables is essentially random,
@@ -119,7 +119,7 @@ import java.util.concurrent.locks.ReentrantLock;
  *
  * <p>
  * Like {@link Hashtable} but unlike {@link HashMap}, this class does
- * <em>not</em> allow <tt>null</tt> to be used as a key or value.
+ * <em>not</em> allow {@code null} to be used as a key or value.
  *
  * <p>
  * This class is a member of the <a href="{@docRoot}/../technotes/guides/collections/index.html">
@@ -520,8 +520,8 @@ class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
 
 		/**
 		 * The table is rehashed when its size exceeds this threshold.
-		 * (The value of this field is always <tt>(int)(capacity *
-		 * loadFactor)</tt>.)
+		 * (The value of this field is always {@code (int)(capacity *
+		 * loadFactor)}.)
 		 */
 		transient int threshold;
 
@@ -1080,9 +1080,9 @@ class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
 	}
 
 	/**
-	 * Returns <tt>true</tt> if this map contains no key-value mappings.
+	 * Returns {@code true} if this map contains no key-value mappings.
 	 *
-	 * @return <tt>true</tt> if this map contains no key-value mappings
+	 * @return {@code true} if this map contains no key-value mappings
 	 */
 	@Override
 	public boolean isEmpty() {
@@ -1122,8 +1122,8 @@ class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
 
 	/**
 	 * Returns the number of key-value mappings in this map.  If the
-	 * map contains more than <tt>Integer.MAX_VALUE</tt> elements, returns
-	 * <tt>Integer.MAX_VALUE</tt>.
+	 * map contains more than {@code Integer.MAX_VALUE} elements, returns
+	 * {@code Integer.MAX_VALUE}.
 	 *
 	 * @return the number of key-value mappings in this map
 	 */
@@ -1201,9 +1201,9 @@ class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
 	 *
 	 * @param key possible key
 	 *
-	 * @return <tt>true</tt> if and only if the specified object
+	 * @return {@code true} if and only if the specified object
 	 *         is a key in this table, as determined by the
-	 *         <tt>equals</tt> method; <tt>false</tt> otherwise.
+	 *         {@code equals} method; {@code false} otherwise.
 	 *
 	 * @throws NullPointerException if the specified key is null
 	 */
@@ -1217,14 +1217,14 @@ class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
 	}
 
 	/**
-	 * Returns <tt>true</tt> if this map maps one or more keys to the
+	 * Returns {@code true} if this map maps one or more keys to the
 	 * specified value. Note: This method requires a full internal
 	 * traversal of the hash table, and so is much slower than
-	 * method <tt>containsKey</tt>.
+	 * method {@code containsKey}.
 	 *
 	 * @param value value whose presence in this map is to be tested
 	 *
-	 * @return <tt>true</tt> if this map maps one or more keys to the
+	 * @return {@code true} if this map maps one or more keys to the
 	 *         specified value
 	 */
 	@Override
@@ -1293,10 +1293,10 @@ class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
 	 *
 	 * @param value a value to search for
 	 *
-	 * @return <tt>true</tt> if and only if some key maps to the
-	 *         <tt>value</tt> argument in this table as
-	 *         determined by the <tt>equals</tt> method;
-	 *         <tt>false</tt> otherwise
+	 * @return {@code true} if and only if some key maps to the
+	 *         {@code value} argument in this table as
+	 *         determined by the {@code equals} method;
+	 *         {@code false} otherwise
 	 *
 	 * @throws NullPointerException if the specified value is null
 	 */
@@ -1308,14 +1308,14 @@ class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
 	 * Maps the specified key to the specified value in this table.
 	 * Neither the key nor the value can be null.
 	 *
-	 * <p> The value can be retrieved by calling the <tt>get</tt> method
+	 * <p> The value can be retrieved by calling the {@code get} method
 	 * with a key that is equal to the original key.
 	 *
 	 * @param key key with which the specified value is to be associated
 	 * @param value value to be associated with the specified key
 	 *
-	 * @return the previous value associated with <tt>key</tt>, or
-	 *         <tt>null</tt> if there was no mapping for <tt>key</tt>
+	 * @return the previous value associated with {@code key}, or
+	 *         {@code null} if there was no mapping for {@code key}
 	 *
 	 * @throws NullPointerException if the specified key or value is null
 	 */
@@ -1332,7 +1332,7 @@ class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
 	 * {@inheritDoc}
 	 *
 	 * @return the previous value associated with the specified key,
-	 *         or <tt>null</tt> if there was no mapping for the key
+	 *         or {@code null} if there was no mapping for the key
 	 *
 	 * @throws NullPointerException if the specified key or value is null
 	 */
@@ -1365,8 +1365,8 @@ class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
 	 *
 	 * @param key the key that needs to be removed
 	 *
-	 * @return the previous value associated with <tt>key</tt>, or
-	 *         <tt>null</tt> if there was no mapping for <tt>key</tt>
+	 * @return the previous value associated with {@code key}, or
+	 *         {@code null} if there was no mapping for {@code key}
 	 *
 	 * @throws NullPointerException if the specified key is null
 	 */
@@ -1411,7 +1411,7 @@ class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
 	 * {@inheritDoc}
 	 *
 	 * @return the previous value associated with the specified key,
-	 *         or <tt>null</tt> if there was no mapping for the key
+	 *         or {@code null} if there was no mapping for the key
 	 *
 	 * @throws NullPointerException if the specified key or value is null
 	 */
@@ -1457,12 +1457,12 @@ class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
 	 * The set is backed by the map, so changes to the map are
 	 * reflected in the set, and vice-versa.  The set supports element
 	 * removal, which removes the corresponding mapping from this map,
-	 * via the <tt>Iterator.remove</tt>, <tt>Set.remove</tt>,
-	 * <tt>removeAll</tt>, <tt>retainAll</tt>, and <tt>clear</tt>
-	 * operations.  It does not support the <tt>add</tt> or
-	 * <tt>addAll</tt> operations.
+	 * via the {@code Iterator.remove}, {@code Set.remove},
+	 * {@code removeAll}, {@code retainAll}, and {@code clear}
+	 * operations.  It does not support the {@code add} or
+	 * {@code addAll} operations.
 	 *
-	 * <p>The view's <tt>iterator</tt> is a "weakly consistent" iterator
+	 * <p>The view's {@code iterator} is a "weakly consistent" iterator
 	 * that will never throw {@link ConcurrentModificationException},
 	 * and guarantees to traverse elements as they existed upon
 	 * construction of the iterator, and may (but is not guaranteed to)
@@ -1479,12 +1479,12 @@ class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
 	 * The collection is backed by the map, so changes to the map are
 	 * reflected in the collection, and vice-versa.  The collection
 	 * supports element removal, which removes the corresponding
-	 * mapping from this map, via the <tt>Iterator.remove</tt>,
-	 * <tt>Collection.remove</tt>, <tt>removeAll</tt>,
-	 * <tt>retainAll</tt>, and <tt>clear</tt> operations.  It does not
-	 * support the <tt>add</tt> or <tt>addAll</tt> operations.
+	 * mapping from this map, via the {@code Iterator.remove},
+	 * {@code Collection.remove}, {@code removeAll},
+	 * {@code retainAll}, and {@code clear} operations.  It does not
+	 * support the {@code add} or {@code addAll} operations.
 	 *
-	 * <p>The view's <tt>iterator</tt> is a "weakly consistent" iterator
+	 * <p>The view's {@code iterator} is a "weakly consistent" iterator
 	 * that will never throw {@link ConcurrentModificationException},
 	 * and guarantees to traverse elements as they existed upon
 	 * construction of the iterator, and may (but is not guaranteed to)
@@ -1501,12 +1501,12 @@ class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
 	 * The set is backed by the map, so changes to the map are
 	 * reflected in the set, and vice-versa.  The set supports element
 	 * removal, which removes the corresponding mapping from the map,
-	 * via the <tt>Iterator.remove</tt>, <tt>Set.remove</tt>,
-	 * <tt>removeAll</tt>, <tt>retainAll</tt>, and <tt>clear</tt>
-	 * operations.  It does not support the <tt>add</tt> or
-	 * <tt>addAll</tt> operations.
+	 * via the {@code Iterator.remove}, {@code Set.remove},
+	 * {@code removeAll}, {@code retainAll}, and {@code clear}
+	 * operations.  It does not support the {@code add} or
+	 * {@code addAll} operations.
 	 *
-	 * <p>The view's <tt>iterator</tt> is a "weakly consistent" iterator
+	 * <p>The view's {@code iterator} is a "weakly consistent" iterator
 	 * that will never throw {@link ConcurrentModificationException},
 	 * and guarantees to traverse elements as they existed upon
 	 * construction of the iterator, and may (but is not guaranteed to)
@@ -1855,7 +1855,7 @@ class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
 	/* ---------------- Serialization Support -------------- */
 
 	/**
-	 * Save the state of the <tt>ConcurrentReferenceHashMap</tt> instance to a
+	 * Save the state of the {@code ConcurrentReferenceHashMap} instance to a
 	 * stream (i.e., serialize it).
 	 *
 	 * @param s the stream
@@ -1894,7 +1894,7 @@ class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
 	}
 
 	/**
-	 * Reconstitute the <tt>ConcurrentReferenceHashMap</tt> instance from a
+	 * Reconstitute the {@code ConcurrentReferenceHashMap} instance from a
 	 * stream (i.e., deserialize it).
 	 *
 	 * @param s the stream

--- a/engine/src/main/java/org/hibernate/search/util/impl/Executors.java
+++ b/engine/src/main/java/org/hibernate/search/util/impl/Executors.java
@@ -105,7 +105,7 @@ public final class Executors {
 	public static class BlockPolicy implements RejectedExecutionHandler {
 
 		/**
-		 * Creates a <tt>BlockPolicy</tt>.
+		 * Creates a {@code BlockPolicy}.
 		 */
 		public BlockPolicy() {
 		}

--- a/integrationtest/osgi/karaf-it/pom.xml
+++ b/integrationtest/osgi/karaf-it/pom.xml
@@ -171,6 +171,7 @@
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
+                    <skip>${failsafe.osgi.skip}</skip>
                     <systemPropertyVariables>
                         <maven.settings.localRepository>${settings.localRepository}</maven.settings.localRepository>
                         <maven.jboss.public.repo.url>${jboss.public.repo.url}</maven.jboss.public.repo.url>

--- a/integrationtest/performance/orm/pom.xml
+++ b/integrationtest/performance/orm/pom.xml
@@ -187,6 +187,34 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <skip>${failsafe.wildfly.skip}</skip>
+                    <includes>
+                        <include>**/Test*.java</include>
+                        <include>**/*Test.java</include>
+                        <include>**/*Tests.java</include>
+                        <include>**/*TestCase.java</include>
+                    </includes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
             <plugin>

--- a/integrationtest/wildfly/pom.xml
+++ b/integrationtest/wildfly/pom.xml
@@ -268,6 +268,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <skip>${failsafe.wildfly.skip}</skip>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/MassIndexingJob.java
+++ b/jsr352/core/src/main/java/org/hibernate/search/jsr352/massindexing/MassIndexingJob.java
@@ -127,10 +127,10 @@ public final class MassIndexingJob {
 		 * The string that allows to select how you want to reference the {@link EntityManagerFactory}.
 		 * Possible values are:
 		 * <ul>
-		 * <li><tt>persistence-unit-name</tt> (the default): use the persistence unit name defined
-		 * in <tt>persistence.xml</tt>.
-		 * <li><tt>session-factory-name</tt>: use the session factory name defined in the Hibernate
-		 * configuration by the <tt>hibernate.session_factory_name</tt> configuration property.
+		 * <li>{@code persistence-unit-name} (the default): use the persistence unit name defined
+		 * in {@code persistence.xml}.
+		 * <li>{@code session-factory-name}: use the session factory name defined in the Hibernate
+		 * configuration by the {@code hibernate.session_factory_name} configuration property.
 		 * </ul>
 		 *
 		 * @param namespace the name of namespace to use

--- a/orm/src/main/java/org/hibernate/search/MassIndexer.java
+++ b/orm/src/main/java/org/hibernate/search/MassIndexer.java
@@ -26,7 +26,7 @@ public interface MassIndexer {
 	 * Defaults to 1.
 	 *
 	 * @param threadsToIndexObjects  number of entity types to be indexed in parallel
-	 * @return <tt>this</tt> for method chaining
+	 * @return {@code this} for method chaining
 	 */
 	MassIndexer typesToIndexInParallel(int threadsToIndexObjects);
 
@@ -34,21 +34,21 @@ public interface MassIndexer {
 	 * Set the number of threads to be used to load
 	 * the root entities.
 	 * @param numberOfThreads the number of threads
-	 * @return <tt>this</tt> for method chaining
+	 * @return {@code this} for method chaining
 	 */
 	MassIndexer threadsToLoadObjects(int numberOfThreads);
 
 	/**
 	 * Sets the batch size used to load the root entities.
 	 * @param batchSize the batch size
-	 * @return <tt>this</tt> for method chaining
+	 * @return {@code this} for method chaining
 	 */
 	MassIndexer batchSizeToLoadObjects(int batchSize);
 
 	/**
 	 * Deprecated: value is ignored.
 	 * @param numberOfThreads the number of threads
-	 * @return <tt>this</tt> for method chaining
+	 * @return {@code this} for method chaining
 	 * @deprecated Being ignored: this method will be removed.
 	 */
 	@Deprecated
@@ -58,31 +58,31 @@ public interface MassIndexer {
 	 * Override the default <code>MassIndexerProgressMonitor</code>.
 	 *
 	 * @param monitor this instance will receive updates about the massindexing progress.
-	 * @return <tt>this</tt> for method chaining
+	 * @return {@code this} for method chaining
 	 */
 	MassIndexer progressMonitor(MassIndexerProgressMonitor monitor);
 
 	/**
 	 * Sets the cache interaction mode for the data loading tasks.
-	 * Defaults to <tt>CacheMode.IGNORE</tt>.
+	 * Defaults to {@code CacheMode.IGNORE}.
 	 * @param cacheMode the cache interaction mode
-	 * @return <tt>this</tt> for method chaining
+	 * @return {@code this} for method chaining
 	 */
 	MassIndexer cacheMode(CacheMode cacheMode);
 
 	/**
-	 * If index optimization has to be started at the end of the indexing process. Defaults to <tt>true</tt>.
+	 * If index optimization has to be started at the end of the indexing process. Defaults to {@code true}.
 	 * @param optimize {@code true} to enable the index optimization at the end of the indexing process
-	 * @return <tt>this</tt> for method chaining
+	 * @return {@code this} for method chaining
 	 */
 	MassIndexer optimizeOnFinish(boolean optimize);
 
 	/**
 	 * If index optimization should be run before starting,
-	 * after the purgeAll. Has no effect if <tt>purgeAll</tt> is set to false.
-	 * Defaults to <tt>true</tt>.
+	 * after the purgeAll. Has no effect if {@code purgeAll} is set to false.
+	 * Defaults to {@code true}.
 	 * @param optimize {@code true} to enable the index optimization after purge
-	 * @return <tt>this</tt> for method chaining
+	 * @return {@code this} for method chaining
 	 */
 	MassIndexer optimizeAfterPurge(boolean optimize);
 
@@ -92,7 +92,7 @@ public interface MassIndexer {
 	 * entities in the index: otherwise search results may be duplicated.
 	 * Defaults to true.
 	 * @param purgeAll if {@code true} all entities will be removed from the index before starting the indexing
-	 * @return <tt>this</tt> for method chaining
+	 * @return {@code this} for method chaining
 	 */
 	MassIndexer purgeAllOnStart(boolean purgeAll);
 
@@ -103,7 +103,7 @@ public interface MassIndexer {
 	 * As a results the index will not be consistent
 	 * with the database: use only for testing on an (undefined) subset of database data.
 	 * @param maximum the maximum number of objects to index
-	 * @return <tt>this</tt> for method chaining
+	 * @return {@code this} for method chaining
 	 */
 	MassIndexer limitIndexedObjectsTo(long maximum);
 
@@ -128,7 +128,7 @@ public interface MassIndexer {
 	 * for example MySQL might benefit from using {@link Integer#MIN_VALUE}
 	 * otherwise it will attempt to preload everything in memory.
 	 * @param idFetchSize the fetch size to be used when loading primary keys
-	 * @return <tt>this</tt> for method chaining
+	 * @return {@code this} for method chaining
 	 */
 	MassIndexer idFetchSize(int idFetchSize);
 

--- a/orm/src/main/java/org/hibernate/search/batchindexing/spi/MassIndexerWithTenant.java
+++ b/orm/src/main/java/org/hibernate/search/batchindexing/spi/MassIndexerWithTenant.java
@@ -19,7 +19,7 @@ public interface MassIndexerWithTenant extends MassIndexer {
 	 * Set the tenant that is associated to this {@link MassIndexer}.
 	 *
 	 * @param tenantIdentifier the identifier of the tenant associated this {@link MassIndexer}
-	 * @return <tt>this</tt> for method chaining
+	 * @return {@code this} for method chaining
 	 */
 	MassIndexerWithTenant tenantIdentifier(String tenantIdentifier);
 }

--- a/orm/src/main/java/org/hibernate/search/jpa/FullTextQuery.java
+++ b/orm/src/main/java/org/hibernate/search/jpa/FullTextQuery.java
@@ -46,7 +46,7 @@ public interface FullTextQuery extends Query, ProjectionConstants {
 
 	/**
 	 * Allows to set a single Lucene filter.
-	 * @deprecated: use the {@link org.hibernate.search.annotations.FullTextFilterDef} approach,
+	 * @deprecated use the {@link org.hibernate.search.annotations.FullTextFilterDef} approach,
 	 *     or use a {@link org.apache.lucene.search.BooleanQuery} and add a clause using
 	 *     {@link org.apache.lucene.search.BooleanClause.Occur#FILTER}.
 	 *

--- a/pom.xml
+++ b/pom.xml
@@ -323,7 +323,7 @@
         <version.surefire.plugin>2.21.0</version.surefire.plugin>
         <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
         <version.org.wildfly.build-tools>1.2.9.Final</version.org.wildfly.build-tools>
-        <version.jacoco.plugin>0.8.0</version.jacoco.plugin>
+        <version.jacoco.plugin>0.8.3</version.jacoco.plugin>
         <version.coveralls.plugin>4.3.0</version.coveralls.plugin>
         <version.org.jboss.bridger.plugin>1.5.Final</version.org.jboss.bridger.plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1520,6 +1520,7 @@
                                 <head>Experimental</head>
                             </tag>
                         </tags>
+                        <additionalOptions>${javadoc.additionalOptions.java-version}</additionalOptions>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -2058,6 +2059,8 @@
                 <failsafe.wildfly.skip>true</failsafe.wildfly.skip>
                 <!-- no specific issue was reported yet -->
                 <failsafe.osgi.skip>true</failsafe.osgi.skip>
+                <!-- https://bugs.openjdk.java.net/browse/JDK-8212233?focusedCommentId=14245762 -->
+                <javadoc.additionalOptions.java-version>-html5 -source 8</javadoc.additionalOptions.java-version>
             </properties>
         </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2012,9 +2012,9 @@
         </profile>
 
         <profile>
-            <id>jdk11</id>
+            <id>jdk11+</id>
             <activation>
-                <jdk>11</jdk>
+                <jdk>[11,)</jdk>
             </activation>
             <properties>
                 <surefire.jvm.args.java-version.lenient>

--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
         <version.com.github.tomakehurst.wiremock>2.5.1</version.com.github.tomakehurst.wiremock>
         <!-- Fixes dependency convergence within Wiremock, see below -->
         <version.com.fasterxml.jackson>2.8.6</version.com.fasterxml.jackson>
-        <version.org.jboss.byteman>4.0.4</version.org.jboss.byteman>
+        <version.org.jboss.byteman>4.0.5</version.org.jboss.byteman>
         <version.io.takari.junit>1.2.7</version.io.takari.junit>
         <version.com.h2database>1.4.178</version.com.h2database>
 

--- a/pom.xml
+++ b/pom.xml
@@ -387,6 +387,9 @@
         <surefire.jvm.args>${surefire.jvm.args.memory} ${surefire.jvm.args.java-version} ${surefire.jvm.args.jacoco}</surefire.jvm.args>
         <failsafe.jvm.args>${surefire.jvm.args.memory} ${surefire.jvm.args.java-version} ${failsafe.jvm.args.jacoco}</failsafe.jvm.args>
 
+        <failsafe.wildfly.skip>false</failsafe.wildfly.skip>
+        <failsafe.osgi.skip>false</failsafe.osgi.skip>
+
         <!--
             Should be set by submodules.
             Used by integration tests modules that execute tests from another module.
@@ -2042,6 +2045,20 @@
             <modules>
                 <module>integrationtest/jdk9-modules</module>
             </modules>
+        </profile>
+
+        <profile>
+            <id>jdk12+</id>
+            <activation>
+                <jdk>[12,)</jdk>
+            </activation>
+            <!-- Skip the OSGi and WildFly integration tests with JDK >= 12 -->
+            <properties>
+                <!-- see https://github.com/jbossas/jboss-classfilewriter/issues/18 -->
+                <failsafe.wildfly.skip>true</failsafe.wildfly.skip>
+                <!-- no specific issue was reported yet -->
+                <failsafe.osgi.skip>true</failsafe.osgi.skip>
+            </properties>
         </profile>
 
         <profile>


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3484
https://hibernate.atlassian.net//browse/HSEARCH-3485
https://hibernate.atlassian.net//browse/HSEARCH-3491
https://hibernate.atlassian.net//browse/HSEARCH-3494

Full build (including JDK12): http://ci.hibernate.org/job/hibernate-search/job/PR-1894/4/
Note that OSGi and WildFly integration tests are disabled on JDK12, because Karaf and WildFly don't work on JDK12 yet.