### PR TITLE
HSEARCH-3493 Test compatibility with JDK13

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -172,7 +172,8 @@ stage('Configure') {
 					// See http://www.oracle.com/technetwork/java/javase/eol-135779.html
 					new JdkITEnvironment(version: '8', tool: 'Oracle JDK 8', status: ITEnvironmentStatus.USED_IN_DEFAULT_BUILD),
 					new JdkITEnvironment(version: '11', tool: 'OpenJDK 11 Latest', status: ITEnvironmentStatus.SUPPORTED),
-					new JdkITEnvironment(version: '12', tool: 'OpenJDK 12 Latest', status: ITEnvironmentStatus.SUPPORTED)
+					new JdkITEnvironment(version: '12', tool: 'OpenJDK 12 Latest', status: ITEnvironmentStatus.SUPPORTED),
+					new JdkITEnvironment(version: '13', tool: 'OpenJDK 13 Latest', status: ITEnvironmentStatus.EXPERIMENTAL)
 			],
 			database: [
 					new DatabaseITEnvironment(dbName: 'h2', mavenProfile: 'h2', status: ITEnvironmentStatus.USED_IN_DEFAULT_BUILD),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -173,7 +173,9 @@ stage('Configure') {
 					new JdkITEnvironment(version: '8', tool: 'Oracle JDK 8', status: ITEnvironmentStatus.USED_IN_DEFAULT_BUILD),
 					new JdkITEnvironment(version: '11', tool: 'OpenJDK 11 Latest', status: ITEnvironmentStatus.SUPPORTED),
 					new JdkITEnvironment(version: '12', tool: 'OpenJDK 12 Latest', status: ITEnvironmentStatus.SUPPORTED),
-					new JdkITEnvironment(version: '13', tool: 'OpenJDK 13 Latest', status: ITEnvironmentStatus.EXPERIMENTAL)
+					new JdkITEnvironment(version: '13', tool: 'OpenJDK 13 Latest', status: ITEnvironmentStatus.EXPERIMENTAL,
+							// Elasticsearch won't run on JDK13
+							elasticsearchTool: 'OpenJDK 11 Latest')
 			],
 			database: [
 					new DatabaseITEnvironment(dbName: 'h2', mavenProfile: 'h2', status: ITEnvironmentStatus.USED_IN_DEFAULT_BUILD),
@@ -459,9 +461,11 @@ stage('Non-default environment ITs') {
 	environments.content.jdk.enabled.each { JdkITEnvironment itEnv ->
 		executions.put(itEnv.tag, {
 			node(NODE_PATTERN_BASE) {
+				def elasticsearchJdkTool = itEnv.elasticsearchTool ? tool(name: itEnv.elasticsearchTool, type: 'jdk') : null
 				helper.withMavenWorkspace(jdk: itEnv.tool) {
 					mavenNonDefaultIT itEnv, """ \
 							clean install --fail-at-end \
+							${elasticsearchJdkTool ? "-Dtest.elasticsearch.java_home=$elasticsearchJdkTool" : ""} \
 					"""
 				}
 			}
@@ -614,6 +618,7 @@ abstract class ITEnvironment {
 class JdkITEnvironment extends ITEnvironment {
 	String version
 	String tool
+	String elasticsearchTool
 	String getTag() { "jdk-$version" }
 }
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ You will need to execute something along the lines of:
 
     > mvn integration-test -pl elasticsearch -Dtest.elasticsearch.host.provided=true -Dtest.elasticsearch.host.url=<The full URL of your Elasticsearch endpoint> -Dtest.elasticsearch.host.aws.access_key=<Your access key> -Dtest.elasticsearch.host.aws.secret_key=<Your secret key> -Dtest.elasticsearch.host.aws.region=<Your AWS region ID>
 
+When building Hibernate Search with new JDKs, you may want to run Elasticsearch with a different JDK than the one used by Maven.
+This can be done by setting a property
+(**this will only work with the profiles for Elasticsearch 5 and above**):
+
+    > mvn clean install -Dtest.elasticsearch.java_home=/path/to/my/jdk
+
 ## Contributing
 
 New contributors are always welcome. We collected some helpful hints on how to get started

--- a/README.md
+++ b/README.md
@@ -122,11 +122,11 @@ You may also use authentication:
 
     > mvn clean install -Dtest.elasticsearch.host.provided=true -Dtest.elasticsearch.host.url=https://localhost:9200 -Dtest.elasticsearch.host.username=ironman -Dtest.elasticsearch.host.password=j@rV1s
 
-Also, the elasticsearch module (and only this one) can execute its integration tests
+Also, the elasticsearch integration tests can be executed
 against an Elasticsearch service on AWS.
 You will need to execute something along the lines of:
 
-    > mvn integration-test -pl elasticsearch -Dtest.elasticsearch.host.provided=true -Dtest.elasticsearch.host.url=<The full URL of your Elasticsearch endpoint> -Dtest.elasticsearch.host.aws.access_key=<Your access key> -Dtest.elasticsearch.host.aws.secret_key=<Your secret key> -Dtest.elasticsearch.host.aws.region=<Your AWS region ID>
+    > mvn clean install -Dtest.elasticsearch.host.provided=true -Dtest.elasticsearch.host.url=<The full URL of your Elasticsearch endpoint> -Dtest.elasticsearch.host.aws.access_key=<Your access key> -Dtest.elasticsearch.host.aws.secret_key=<Your secret key> -Dtest.elasticsearch.host.aws.region=<Your AWS region ID>
 
 When building Hibernate Search with new JDKs, you may want to run Elasticsearch with a different JDK than the one used by Maven.
 This can be done by setting a property

--- a/pom.xml
+++ b/pom.xml
@@ -261,6 +261,7 @@
         <version.coveralls.plugin>4.3.0</version.coveralls.plugin>
         <version.org.jboss.bridger.plugin>1.5.Final</version.org.jboss.bridger.plugin>
         <version.com.buschmais.jqassistant.plugin>1.5.0</version.com.buschmais.jqassistant.plugin>
+        <version.com.github.alexcojocaru.elasticsearch.plugin>6.9</version.com.github.alexcojocaru.elasticsearch.plugin>
 
         <!--
             Please don't change the name of this property, it may be used and
@@ -1503,11 +1504,32 @@
                 <plugin>
                     <groupId>com.github.alexcojocaru</groupId>
                     <artifactId>elasticsearch-maven-plugin</artifactId>
-                    <version>${version.elasticsearch.plugin}</version>
+                    <version>${version.com.github.alexcojocaru.elasticsearch.plugin}</version>
                     <configuration>
+                        <skip>${test.elasticsearch.host.provided}</skip>
                         <clusterName>hsearchEsTestCluster</clusterName>
                         <httpPort>9200</httpPort>
+                        <version>${test.elasticsearch.host.version}</version>
+                        <timeout>90</timeout><!-- Make it work on our slow CI -->
+                        <autoCreateIndex>false</autoCreateIndex>
                     </configuration>
+                    <!-- Different executions from 2.x: the "start" goal has been renamed in version 5  -->
+                    <executions>
+                        <execution>
+                            <id>start-elasticsearch</id>
+                            <phase>pre-integration-test</phase>
+                            <goals>
+                                <goal>runforked</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>stop-elasticsearch</id>
+                            <phase>post-integration-test</phase>
+                            <goals>
+                                <goal>stop</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.wildfly.build</groupId>
@@ -2180,7 +2202,6 @@
         <profile>
             <id>elasticsearch-5.6</id>
             <properties>
-                <test.elasticsearch.mavenPlugin.version>5.7</test.elasticsearch.mavenPlugin.version>
                 <test.elasticsearch.host.version>5.6.8</test.elasticsearch.host.version>
             </properties>
             <build>
@@ -2189,33 +2210,11 @@
                         <plugin>
                             <groupId>com.github.alexcojocaru</groupId>
                             <artifactId>elasticsearch-maven-plugin</artifactId>
-                            <version>${test.elasticsearch.mavenPlugin.version}</version>
+                            <version>${version.com.github.alexcojocaru.elasticsearch.plugin}</version>
                             <configuration>
-                                <skip>${test.elasticsearch.host.provided}</skip>
-                                <version>${test.elasticsearch.host.version}</version>
-                                <clusterName>hsearchEsTestCluster</clusterName>
-                                <timeout>90</timeout><!-- Make it work on our slow CI -->
                                 <pathConf>${project.build.directory}/elasticsearch-maven-plugin/5.0/configuration/</pathConf>
                                 <pathInitScript>${project.build.directory}/elasticsearch-maven-plugin/5.0/init/init.script</pathInitScript>
-                                <autoCreateIndex>false</autoCreateIndex>
                             </configuration>
-                            <!-- Different executions from 2.x: the "start" goal has been renamed in version 5  -->
-                            <executions>
-                                <execution >
-                                    <id>start-elasticsearch</id>
-                                    <phase>pre-integration-test</phase>
-                                    <goals>
-                                        <goal>runforked</goal>
-                                    </goals>
-                                </execution>
-                                <execution>
-                                    <id>stop-elasticsearch</id>
-                                    <phase>post-integration-test</phase>
-                                    <goals>
-                                        <goal>stop</goal>
-                                    </goals>
-                                </execution>
-                            </executions>
                         </plugin>
                     </plugins>
                 </pluginManagement>
@@ -2232,7 +2231,6 @@
                 </property>
             </activation>
             <properties>
-                <test.elasticsearch.mavenPlugin.version>6.9</test.elasticsearch.mavenPlugin.version>
                 <test.elasticsearch.host.version>${version.org.elasticsearch.main}</test.elasticsearch.host.version>
             </properties>
             <build>
@@ -2241,32 +2239,11 @@
                         <plugin>
                             <groupId>com.github.alexcojocaru</groupId>
                             <artifactId>elasticsearch-maven-plugin</artifactId>
-                            <version>${test.elasticsearch.mavenPlugin.version}</version>
+                            <version>${version.com.github.alexcojocaru.elasticsearch.plugin}</version>
                             <configuration>
-                                <skip>${test.elasticsearch.host.provided}</skip>
-                                <version>${test.elasticsearch.host.version}</version>
-                                <timeout>90</timeout><!-- Make it work on our slow CI -->
                                 <pathConf>${project.build.directory}/elasticsearch-maven-plugin/6.0/configuration/</pathConf>
                                 <pathInitScript>${project.build.directory}/elasticsearch-maven-plugin/6.0/init/init.script</pathInitScript>
-                                <autoCreateIndex>false</autoCreateIndex>
                             </configuration>
-                            <!-- Different executions from 2.x: the "start" goal has been renamed in version 5  -->
-                            <executions>
-                                <execution >
-                                    <id>start-elasticsearch</id>
-                                    <phase>pre-integration-test</phase>
-                                    <goals>
-                                        <goal>runforked</goal>
-                                    </goals>
-                                </execution>
-                                <execution>
-                                    <id>stop-elasticsearch</id>
-                                    <phase>post-integration-test</phase>
-                                    <goals>
-                                        <goal>stop</goal>
-                                    </goals>
-                                </execution>
-                            </executions>
                         </plugin>
                     </plugins>
                 </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,7 @@
         <version.coveralls.plugin>4.3.0</version.coveralls.plugin>
         <version.org.jboss.bridger.plugin>1.5.Final</version.org.jboss.bridger.plugin>
         <version.com.buschmais.jqassistant.plugin>1.5.0</version.com.buschmais.jqassistant.plugin>
-        <version.com.github.alexcojocaru.elasticsearch.plugin>6.9</version.com.github.alexcojocaru.elasticsearch.plugin>
+        <version.com.github.alexcojocaru.elasticsearch.plugin>6.10</version.com.github.alexcojocaru.elasticsearch.plugin>
 
         <!--
             Please don't change the name of this property, it may be used and

--- a/pom.xml
+++ b/pom.xml
@@ -409,6 +409,7 @@
 
         <!-- Elasticsearch tests properties -->
 
+        <test.elasticsearch.java_home>${java.home}</test.elasticsearch.java_home>
         <test.elasticsearch.host.url>http://localhost:9200</test.elasticsearch.host.url>
         <test.elasticsearch.host.username></test.elasticsearch.host.username>
         <test.elasticsearch.host.password></test.elasticsearch.host.password>
@@ -1512,6 +1513,9 @@
                         <version>${test.elasticsearch.host.version}</version>
                         <timeout>90</timeout><!-- Make it work on our slow CI -->
                         <autoCreateIndex>false</autoCreateIndex>
+                        <environmentVariables>
+                            <JAVA_HOME>${test.elasticsearch.java_home}</JAVA_HOME>
+                        </environmentVariables>
                     </configuration>
                     <!-- Different executions from 2.x: the "start" goal has been renamed in version 5  -->
                     <executions>


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3493

I only had to submit a PR to the elasticsearch-maven-plugin so that we can run Elasticsearch with a different JDK. Fortunately it was accepted and released right away, so here is a fully compatible build: everything else already worked.

~I'll start a full build soon to demonstrate that it works.~ => Done, see here: http://ci.hibernate.org/blue/organizations/jenkins/hibernate-search/detail/PR-1897/2/pipeline

For now, I'd rather keep the JDK13 as experimental (= not run on master) and run a separate weekly job to check compatibility, because I expect most of the breaking changes in JDK13 are still to come.