### PR TITLE
Backport HSEARCH-3493 to branch 5.11 - Test compatibility with JDK13

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,7 +158,8 @@ stage('Configure') {
 					// See http://www.oracle.com/technetwork/java/javase/eol-135779.html
 					new JdkITEnvironment(version: '8', tool: 'Oracle JDK 8', status: ITEnvironmentStatus.USED_IN_DEFAULT_BUILD),
 					new JdkITEnvironment(version: '11', tool: 'OpenJDK 11 Latest', status: ITEnvironmentStatus.SUPPORTED),
-					new JdkITEnvironment(version: '12', tool: 'OpenJDK 12 Latest', status: ITEnvironmentStatus.SUPPORTED)
+					new JdkITEnvironment(version: '12', tool: 'OpenJDK 12 Latest', status: ITEnvironmentStatus.SUPPORTED),
+					new JdkITEnvironment(version: '13', tool: 'OpenJDK 13 Latest', status: ITEnvironmentStatus.EXPERIMENTAL)
 			],
 			database: [
 					new DatabaseITEnvironment(dbName: 'h2', mavenProfile: 'h2', status: ITEnvironmentStatus.USED_IN_DEFAULT_BUILD),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -159,7 +159,9 @@ stage('Configure') {
 					new JdkITEnvironment(version: '8', tool: 'Oracle JDK 8', status: ITEnvironmentStatus.USED_IN_DEFAULT_BUILD),
 					new JdkITEnvironment(version: '11', tool: 'OpenJDK 11 Latest', status: ITEnvironmentStatus.SUPPORTED),
 					new JdkITEnvironment(version: '12', tool: 'OpenJDK 12 Latest', status: ITEnvironmentStatus.SUPPORTED),
-					new JdkITEnvironment(version: '13', tool: 'OpenJDK 13 Latest', status: ITEnvironmentStatus.EXPERIMENTAL)
+					new JdkITEnvironment(version: '13', tool: 'OpenJDK 13 Latest', status: ITEnvironmentStatus.EXPERIMENTAL,
+							// Elasticsearch won't run on JDK13
+							elasticsearchTool: 'OpenJDK 11 Latest')
 			],
 			database: [
 					new DatabaseITEnvironment(dbName: 'h2', mavenProfile: 'h2', status: ITEnvironmentStatus.USED_IN_DEFAULT_BUILD),
@@ -408,9 +410,11 @@ stage('Non-default environment ITs') {
 	environments.content.jdk.enabled.each { JdkITEnvironment itEnv ->
 		executions.put(itEnv.tag, {
 			node(NODE_PATTERN_BASE) {
+				def elasticsearchJdkTool = itEnv.elasticsearchTool ? tool(name: itEnv.elasticsearchTool, type: 'jdk') : null
 				helper.withMavenWorkspace(jdk: itEnv.tool) {
 					mavenNonDefaultIT itEnv, """ \
 							clean install --fail-at-end \
+							${elasticsearchJdkTool ? "-Dtest.elasticsearch.java_home=$elasticsearchJdkTool" : ""} \
 					"""
 				}
 			}
@@ -566,6 +570,7 @@ abstract class ITEnvironment {
 class JdkITEnvironment extends ITEnvironment {
 	String version
 	String tool
+	String elasticsearchTool
 	String getTag() { "jdk-$version" }
 }
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ You will need to execute something along the lines of:
 
     > mvn integration-test -pl elasticsearch -Dtest.elasticsearch.host.provided=true -Dtest.elasticsearch.host.url=<The full URL of your Elasticsearch endpoint> -Dtest.elasticsearch.host.aws.access_key=<Your access key> -Dtest.elasticsearch.host.aws.secret_key=<Your secret key> -Dtest.elasticsearch.host.aws.region=<Your AWS region ID>
 
+When building Hibernate Search with new JDKs, you may want to run Elasticsearch with a different JDK than the one used by Maven.
+This can be done by setting a property
+(**this will only work with the profiles for Elasticsearch 5 and above**):
+
+    > mvn clean install -Dtest.elasticsearch.java_home=/path/to/my/jdk
+
+
 ## Contributing
 
 New contributors are always welcome. We collected some helpful hints on how to get started

--- a/pom.xml
+++ b/pom.xml
@@ -2424,7 +2424,7 @@
         <profile>
             <id>elasticsearch-5.0</id>
             <properties>
-                <version.elasticsearch.plugin>5.7</version.elasticsearch.plugin>
+                <version.elasticsearch.plugin>6.10</version.elasticsearch.plugin>
                 <test.elasticsearch.host.version>5.1.2</test.elasticsearch.host.version>
             </properties>
             <build>
@@ -2475,7 +2475,7 @@
                 </property>
             </activation>
             <properties>
-                <version.elasticsearch.plugin>5.7</version.elasticsearch.plugin>
+                <version.elasticsearch.plugin>6.10</version.elasticsearch.plugin>
                 <test.elasticsearch.host.version>5.6.8</test.elasticsearch.host.version>
             </properties>
             <build>

--- a/pom.xml
+++ b/pom.xml
@@ -283,6 +283,7 @@
 
         <!-- Elasticsearch tests properties -->
 
+        <test.elasticsearch.java_home>${java.home}</test.elasticsearch.java_home>
         <test.elasticsearch.host.url>http://localhost:9200</test.elasticsearch.host.url>
         <test.elasticsearch.host.username></test.elasticsearch.host.username>
         <test.elasticsearch.host.password></test.elasticsearch.host.password>
@@ -2441,6 +2442,9 @@
                                 <pathConf>${project.build.directory}/elasticsearch-maven-plugin/5.0/configuration/</pathConf>
                                 <pathInitScript>${project.build.directory}/elasticsearch-maven-plugin/5.0/init/init.script</pathInitScript>
                                 <autoCreateIndex>false</autoCreateIndex>
+                                <environmentVariables>
+                                    <JAVA_HOME>${test.elasticsearch.java_home}</JAVA_HOME>
+                                </environmentVariables>
                             </configuration>
                             <!-- Different executions from 2.x: the "start" goal has been renamed in version 5  -->
                             <executions>
@@ -2492,6 +2496,9 @@
                                 <pathConf>${project.build.directory}/elasticsearch-maven-plugin/5.0/configuration/</pathConf>
                                 <pathInitScript>${project.build.directory}/elasticsearch-maven-plugin/5.0/init/init.script</pathInitScript>
                                 <autoCreateIndex>false</autoCreateIndex>
+                                <environmentVariables>
+                                    <JAVA_HOME>${test.elasticsearch.java_home}</JAVA_HOME>
+                                </environmentVariables>
                             </configuration>
                             <!-- Different executions from 2.x: the "start" goal has been renamed in version 5  -->
                             <executions>


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3493

Backport of #1897.

Note that tests don't pass, so I kept the build as experimental (= not run on CI builds except when explicitly requested).
But all the errors seem related to Byteman not supporting JDK13 yet (see https://developer.jboss.org/message/988091).