### PR TITLE
HSEARCH-3091 Search 6 groundwork - Add to the predicate DSL the missing per-predicate options compared to Search 5

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/AbstractElasticsearchSearchPredicateBuilder.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/AbstractElasticsearchSearchPredicateBuilder.java
@@ -22,10 +22,16 @@ public abstract class AbstractElasticsearchSearchPredicateBuilder
 	private static final JsonAccessor<Float> BOOST_ACCESSOR = JsonAccessor.root().property( "boost" ).asFloat();
 
 	private Float boost;
+	private boolean withConstantScore = false;
 
 	@Override
 	public void boost(float boost) {
 		this.boost = boost;
+	}
+
+	@Override
+	public void withConstantScore() {
+		this.withConstantScore = true;
 	}
 
 	@Override
@@ -37,6 +43,8 @@ public abstract class AbstractElasticsearchSearchPredicateBuilder
 	public final JsonObject build(ElasticsearchSearchPredicateContext context) {
 		JsonObject outerObject = new JsonObject();
 		JsonObject innerObject = new JsonObject();
+
+		// TODO handle withConstantScore value here!
 
 		if ( boost != null ) {
 			BOOST_ACCESSOR.set( innerObject, boost );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/AbstractElasticsearchSearchPredicateBuilder.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/AbstractElasticsearchSearchPredicateBuilder.java
@@ -44,15 +44,28 @@ public abstract class AbstractElasticsearchSearchPredicateBuilder
 		JsonObject outerObject = new JsonObject();
 		JsonObject innerObject = new JsonObject();
 
-		// TODO handle withConstantScore value here!
-
-		if ( boost != null ) {
+		// in case of withConstantScore boots is set by constant_score clause
+		if ( boost != null && !withConstantScore ) {
 			BOOST_ACCESSOR.set( innerObject, boost );
 		}
 
-		return doBuild( context, outerObject, innerObject );
+		JsonObject result = doBuild( context, outerObject, innerObject );
+		return ( withConstantScore ) ? applyConstantScore( result ) : result;
 	}
 
 	protected abstract JsonObject doBuild(ElasticsearchSearchPredicateContext context,
 			JsonObject outerObject, JsonObject innerObject);
+
+	private JsonObject applyConstantScore(JsonObject filter) {
+		JsonObject constantScore = new JsonObject();
+		constantScore.add( "filter", filter );
+		if ( boost != null ) {
+			BOOST_ACCESSOR.set( constantScore, boost );
+		}
+
+		JsonObject result = new JsonObject();
+		result.add( "constant_score", constantScore );
+
+		return result;
+	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/AbstractLuceneSearchPredicateBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/AbstractLuceneSearchPredicateBuilder.java
@@ -19,10 +19,16 @@ abstract class AbstractLuceneSearchPredicateBuilder implements SearchPredicateBu
 		LuceneSearchPredicateBuilder {
 
 	private Float boost;
+	private boolean withConstantScore;
 
 	@Override
 	public void boost(float boost) {
 		this.boost = boost;
+	}
+
+	@Override
+	public void withConstantScore() {
+		this.withConstantScore = true;
 	}
 
 	@Override
@@ -32,6 +38,9 @@ abstract class AbstractLuceneSearchPredicateBuilder implements SearchPredicateBu
 
 	@Override
 	public final Query build(LuceneSearchPredicateContext context) {
+
+		// TODO handle withConstantScore value here!
+
 		if ( boost != null ) {
 			return new BoostQuery( doBuild( context ), boost );
 		}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/AbstractLuceneSearchPredicateBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/AbstractLuceneSearchPredicateBuilder.java
@@ -9,6 +9,7 @@ package org.hibernate.search.backend.lucene.search.predicate.impl;
 import org.hibernate.search.engine.search.predicate.spi.SearchPredicateBuilder;
 
 import org.apache.lucene.search.BoostQuery;
+import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.Query;
 
 
@@ -38,15 +39,18 @@ abstract class AbstractLuceneSearchPredicateBuilder implements SearchPredicateBu
 
 	@Override
 	public final Query build(LuceneSearchPredicateContext context) {
+		Query query = doBuild( context );
 
-		// TODO handle withConstantScore value here!
-
+		// the boost should be applied on top of the constant score,
+		// otherwise the boost will simply be ignored
+		if ( withConstantScore ) {
+			query = new ConstantScoreQuery( query );
+		}
 		if ( boost != null ) {
-			return new BoostQuery( doBuild( context ), boost );
+			query = new BoostQuery( query, boost );
 		}
-		else {
-			return doBuild( context );
-		}
+
+		return query;
 	}
 
 	protected abstract Query doBuild(LuceneSearchPredicateContext context);

--- a/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
@@ -245,4 +245,9 @@ public interface Log extends BasicLogger {
 					+ " Set the property '%2$s' to a supported value or set '%3$s' to set a default value for all indexes."
 	)
 	SearchException indexBackendCannotBeNullOrEmpty(String indexName, String key, String defaultKey);
+
+	@Message(id = ID_OFFSET_2 + 51,
+			value = "It is not possible to use per-field boosts together with withConstantScore option"
+	)
+	SearchException perFieldBoostWithConstantScore();
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/BooleanJunctionPredicateContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/BooleanJunctionPredicateContext.java
@@ -63,7 +63,7 @@ import org.hibernate.search.engine.search.SearchPredicate;
  * Matching "should" clauses are taken into account in score computation.
  */
 public interface BooleanJunctionPredicateContext extends
-		SearchPredicateNoFieldContext<BooleanJunctionPredicateContext>, SearchPredicateTerminalContext {
+		SearchPredicateScoreContext<BooleanJunctionPredicateContext>, SearchPredicateTerminalContext {
 
 	/**
 	 * Add a <a href="#must">"must" clause</a> based on a previously-built {@link SearchPredicate}.

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/MatchPredicateContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/MatchPredicateContext.java
@@ -10,7 +10,7 @@ package org.hibernate.search.engine.search.dsl.predicate;
 /**
  * The context used when starting to define a match predicate.
  */
-public interface MatchPredicateContext {
+public interface MatchPredicateContext extends SearchPredicateNoFieldContext<MatchPredicateContext> {
 
 	// TODO wildcard, fuzzy. Or maybe a separate context?
 

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/MatchPredicateContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/MatchPredicateContext.java
@@ -10,7 +10,7 @@ package org.hibernate.search.engine.search.dsl.predicate;
 /**
  * The context used when starting to define a match predicate.
  */
-public interface MatchPredicateContext extends SearchPredicateNoFieldContext<MatchPredicateContext> {
+public interface MatchPredicateContext extends SearchPredicateScoreContext<MatchPredicateContext> {
 
 	// TODO wildcard, fuzzy. Or maybe a separate context?
 

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/MultiFieldPredicateFieldSetContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/MultiFieldPredicateFieldSetContext.java
@@ -23,8 +23,7 @@ public interface MultiFieldPredicateFieldSetContext<S> {
 	 */
 	S boostedTo(float boost);
 
-	// TODO other methods from QueryCustomization/FieldCustomization
-//	S withConstantScore();
-//	S withFilter();
+	// TODO HSEARCH-3312 add field customization method: S ignoreAnalyzer();
+	// TODO HSEARCH-3257 add field customization method: S ignoreFieldBridge();
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/RangePredicateContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/RangePredicateContext.java
@@ -10,7 +10,7 @@ package org.hibernate.search.engine.search.dsl.predicate;
 /**
  * The context used when starting to define a range predicate.
  */
-public interface RangePredicateContext {
+public interface RangePredicateContext extends SearchPredicateNoFieldContext<RangePredicateContext> {
 
 	/**
 	 * Target the given field in the range predicate.

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/SearchPredicateNoFieldContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/SearchPredicateNoFieldContext.java
@@ -23,8 +23,4 @@ public interface SearchPredicateNoFieldContext<S> {
 	 */
 	S boostedTo(float boost);
 
-	// TODO other methods from QueryCustomization
-//	S withConstantScore();
-//	S withFilter();
-
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/SearchPredicateScoreContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/SearchPredicateScoreContext.java
@@ -1,0 +1,19 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.dsl.predicate;
+
+
+/**
+ * Context for predicates that could generate a score different from constant.
+ *
+ * @param <S> The "self" type (the actual type of this context)
+ */
+public interface SearchPredicateScoreContext<S> extends SearchPredicateNoFieldContext<S> {
+
+	S withConstantScore();
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/SpatialPredicateContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/SpatialPredicateContext.java
@@ -10,7 +10,7 @@ package org.hibernate.search.engine.search.dsl.predicate;
 /**
  * The terminal context of the predicate DSL.
  */
-public interface SpatialPredicateContext {
+public interface SpatialPredicateContext extends SearchPredicateNoFieldContext<SpatialPredicateContext> {
 
 	/**
 	 * Match documents where targeted fields point to a location within given bounds:

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/AbstractMultiFieldPredicateCommonState.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/AbstractMultiFieldPredicateCommonState.java
@@ -6,17 +6,22 @@
  */
 package org.hibernate.search.engine.search.dsl.predicate.impl;
 
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
+import org.hibernate.search.engine.logging.impl.Log;
 import org.hibernate.search.engine.search.dsl.predicate.spi.AbstractSearchPredicateTerminalContext;
 import org.hibernate.search.engine.search.predicate.spi.BooleanJunctionPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SearchPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SearchPredicateBuilderFactory;
+import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
 abstract class AbstractMultiFieldPredicateCommonState<B, F extends AbstractMultiFieldPredicateCommonState.FieldSetContext<B>>
 		extends AbstractSearchPredicateTerminalContext<B> {
+
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private final List<F> fieldSetContexts = new ArrayList<>();
 	private Float predicateLevelBoost;
@@ -53,6 +58,11 @@ abstract class AbstractMultiFieldPredicateCommonState<B, F extends AbstractMulti
 	}
 
 	void applyBoostAndConstantScore(Float fieldBoost, SearchPredicateBuilder predicateBuilder) {
+		if ( fieldBoost != null && withConstantScore ) {
+			// another good option would be the one to simply ignore the fieldBoost
+			// when the option withConstantScore is defined
+			throw log.perFieldBoostWithConstantScore();
+		}
 		if ( predicateLevelBoost != null && fieldBoost != null ) {
 			predicateBuilder.boost( predicateLevelBoost * fieldBoost );
 		}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/AbstractMultiFieldPredicateCommonState.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/AbstractMultiFieldPredicateCommonState.java
@@ -20,6 +20,7 @@ abstract class AbstractMultiFieldPredicateCommonState<B, F extends AbstractMulti
 
 	private final List<F> fieldSetContexts = new ArrayList<>();
 	private Float predicateLevelBoost;
+	private boolean withConstantScore = false;
 
 	AbstractMultiFieldPredicateCommonState(SearchPredicateBuilderFactory<?, B> factory) {
 		super( factory );
@@ -41,13 +42,17 @@ abstract class AbstractMultiFieldPredicateCommonState<B, F extends AbstractMulti
 		this.predicateLevelBoost = boost;
 	}
 
-	void applyPredicateAndFieldBoosts(Float fieldBoost, List<? extends SearchPredicateBuilder> predicateBuilders) {
+	void applyBoostAndConstantScore(Float fieldBoost, List<? extends SearchPredicateBuilder> predicateBuilders) {
 		for ( SearchPredicateBuilder predicateBuilder : predicateBuilders ) {
-			applyPredicateAndFieldBoosts( fieldBoost, predicateBuilder );
+			applyBoostAndConstantScore( fieldBoost, predicateBuilder );
 		}
 	}
 
-	void applyPredicateAndFieldBoosts(Float fieldBoost, SearchPredicateBuilder predicateBuilder) {
+	void withConstantScore() {
+		withConstantScore = true;
+	}
+
+	void applyBoostAndConstantScore(Float fieldBoost, SearchPredicateBuilder predicateBuilder) {
 		if ( predicateLevelBoost != null && fieldBoost != null ) {
 			predicateBuilder.boost( predicateLevelBoost * fieldBoost );
 		}
@@ -56,6 +61,10 @@ abstract class AbstractMultiFieldPredicateCommonState<B, F extends AbstractMulti
 		}
 		else if ( fieldBoost != null ) {
 			predicateBuilder.boost( fieldBoost );
+		}
+
+		if ( withConstantScore ) {
+			predicateBuilder.withConstantScore();
 		}
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/AbstractMultiFieldPredicateCommonState.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/AbstractMultiFieldPredicateCommonState.java
@@ -12,12 +12,14 @@ import java.util.function.Consumer;
 
 import org.hibernate.search.engine.search.dsl.predicate.spi.AbstractSearchPredicateTerminalContext;
 import org.hibernate.search.engine.search.predicate.spi.BooleanJunctionPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.SearchPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SearchPredicateBuilderFactory;
 
 abstract class AbstractMultiFieldPredicateCommonState<B, F extends AbstractMultiFieldPredicateCommonState.FieldSetContext<B>>
 		extends AbstractSearchPredicateTerminalContext<B> {
 
 	private final List<F> fieldSetContexts = new ArrayList<>();
+	private Float predicateLevelBoost;
 
 	AbstractMultiFieldPredicateCommonState(SearchPredicateBuilderFactory<?, B> factory) {
 		super( factory );
@@ -33,6 +35,28 @@ abstract class AbstractMultiFieldPredicateCommonState<B, F extends AbstractMulti
 
 	List<F> getFieldSetContexts() {
 		return fieldSetContexts;
+	}
+
+	void setPredicateLevelBoost(Float boost) {
+		this.predicateLevelBoost = boost;
+	}
+
+	void applyPredicateAndFieldBoosts(Float fieldBoost, List<? extends SearchPredicateBuilder> predicateBuilders) {
+		for ( SearchPredicateBuilder predicateBuilder : predicateBuilders ) {
+			applyPredicateAndFieldBoosts( fieldBoost, predicateBuilder );
+		}
+	}
+
+	void applyPredicateAndFieldBoosts(Float fieldBoost, SearchPredicateBuilder predicateBuilder) {
+		if ( predicateLevelBoost != null && fieldBoost != null ) {
+			predicateBuilder.boost( predicateLevelBoost * fieldBoost );
+		}
+		else if ( predicateLevelBoost != null ) {
+			predicateBuilder.boost( predicateLevelBoost );
+		}
+		else if ( fieldBoost != null ) {
+			predicateBuilder.boost( fieldBoost );
+		}
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/BooleanJunctionPredicateContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/BooleanJunctionPredicateContextImpl.java
@@ -43,6 +43,12 @@ class BooleanJunctionPredicateContextImpl<B>
 	}
 
 	@Override
+	public BooleanJunctionPredicateContext withConstantScore() {
+		builder.withConstantScore();
+		return this;
+	}
+
+	@Override
 	public BooleanJunctionPredicateContext must(SearchPredicate searchPredicate) {
 		builder.must( factory.toImplementation( searchPredicate ) );
 		return this;

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/MatchPredicateContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/MatchPredicateContextImpl.java
@@ -25,4 +25,10 @@ class MatchPredicateContextImpl<B> implements MatchPredicateContext {
 	public MatchPredicateFieldSetContext onFields(String ... absoluteFieldPaths) {
 		return new MatchPredicateFieldSetContextImpl<>( commonState, Arrays.asList( absoluteFieldPaths ) );
 	}
+
+	@Override
+	public MatchPredicateContextImpl boostedTo(float boost) {
+		this.commonState.setPredicateLevelBoost( boost );
+		return this;
+	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/MatchPredicateContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/MatchPredicateContextImpl.java
@@ -31,4 +31,10 @@ class MatchPredicateContextImpl<B> implements MatchPredicateContext {
 		this.commonState.setPredicateLevelBoost( boost );
 		return this;
 	}
+
+	@Override
+	public MatchPredicateContext withConstantScore() {
+		this.commonState.withConstantScore();
+		return this;
+	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/MatchPredicateFieldSetContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/MatchPredicateFieldSetContextImpl.java
@@ -57,7 +57,7 @@ class MatchPredicateFieldSetContextImpl<B>
 
 	@Override
 	public SearchPredicateTerminalContext matching(Object value) {
-		commonState.applyPredicateAndFieldBoosts( boost, predicateBuilders );
+		commonState.applyBoostAndConstantScore( boost, predicateBuilders );
 		return commonState.matching( value );
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/MatchPredicateFieldSetContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/MatchPredicateFieldSetContextImpl.java
@@ -32,6 +32,8 @@ class MatchPredicateFieldSetContextImpl<B>
 	private final List<String> absoluteFieldPaths;
 	private final List<MatchPredicateBuilder<B>> predicateBuilders = new ArrayList<>();
 
+	private Float boost;
+
 	MatchPredicateFieldSetContextImpl(CommonState<B> commonState, List<String> absoluteFieldPaths) {
 		this.commonState = commonState;
 		this.commonState.add( this );
@@ -49,12 +51,13 @@ class MatchPredicateFieldSetContextImpl<B>
 
 	@Override
 	public MatchPredicateFieldSetContext boostedTo(float boost) {
-		predicateBuilders.forEach( b -> b.boost( boost ) );
+		this.boost = boost;
 		return this;
 	}
 
 	@Override
 	public SearchPredicateTerminalContext matching(Object value) {
+		commonState.applyPredicateAndFieldBoosts( boost, predicateBuilders );
 		return commonState.matching( value );
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/RangePredicateContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/RangePredicateContextImpl.java
@@ -12,7 +12,6 @@ import org.hibernate.search.engine.search.dsl.predicate.RangePredicateContext;
 import org.hibernate.search.engine.search.dsl.predicate.RangePredicateFieldSetContext;
 import org.hibernate.search.engine.search.predicate.spi.SearchPredicateBuilderFactory;
 
-
 class RangePredicateContextImpl<B> implements RangePredicateContext {
 
 	private final RangePredicateFieldSetContextImpl.CommonState<B> commonState;
@@ -26,4 +25,9 @@ class RangePredicateContextImpl<B> implements RangePredicateContext {
 		return new RangePredicateFieldSetContextImpl<>( commonState, Arrays.asList( absoluteFieldPaths ) );
 	}
 
+	@Override
+	public RangePredicateContextImpl boostedTo(float boost) {
+		this.commonState.setPredicateLevelBoost( boost );
+		return this;
+	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/RangePredicateFieldSetContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/RangePredicateFieldSetContextImpl.java
@@ -35,6 +35,8 @@ class RangePredicateFieldSetContextImpl<B>
 	private final List<String> absoluteFieldPaths;
 	private final List<RangePredicateBuilder<B>> predicateBuilders = new ArrayList<>();
 
+	private Float boost;
+
 	RangePredicateFieldSetContextImpl(CommonState<B> commonState, List<String> absoluteFieldPaths) {
 		this.commonState = commonState;
 		this.commonState.add( this );
@@ -53,22 +55,25 @@ class RangePredicateFieldSetContextImpl<B>
 
 	@Override
 	public RangePredicateFieldSetContext boostedTo(float boost) {
-		predicateBuilders.forEach( b -> b.boost( boost ) );
+		this.boost = boost;
 		return this;
 	}
 
 	@Override
 	public RangePredicateFromContext from(Object value) {
+		commonState.applyPredicateAndFieldBoosts( boost, predicateBuilders );
 		return fromContext.from( value );
 	}
 
 	@Override
 	public RangePredicateTerminalContext above(Object value) {
+		commonState.applyPredicateAndFieldBoosts( boost, predicateBuilders );
 		return commonState.above( value );
 	}
 
 	@Override
 	public RangePredicateTerminalContext below(Object value) {
+		commonState.applyPredicateAndFieldBoosts( boost, predicateBuilders );
 		return commonState.below( value );
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/RangePredicateFieldSetContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/RangePredicateFieldSetContextImpl.java
@@ -61,19 +61,19 @@ class RangePredicateFieldSetContextImpl<B>
 
 	@Override
 	public RangePredicateFromContext from(Object value) {
-		commonState.applyPredicateAndFieldBoosts( boost, predicateBuilders );
+		commonState.applyBoostAndConstantScore( boost, predicateBuilders );
 		return fromContext.from( value );
 	}
 
 	@Override
 	public RangePredicateTerminalContext above(Object value) {
-		commonState.applyPredicateAndFieldBoosts( boost, predicateBuilders );
+		commonState.applyBoostAndConstantScore( boost, predicateBuilders );
 		return commonState.above( value );
 	}
 
 	@Override
 	public RangePredicateTerminalContext below(Object value) {
-		commonState.applyPredicateAndFieldBoosts( boost, predicateBuilders );
+		commonState.applyBoostAndConstantScore( boost, predicateBuilders );
 		return commonState.below( value );
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/SpatialPredicateContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/SpatialPredicateContextImpl.java
@@ -13,6 +13,7 @@ import org.hibernate.search.engine.search.predicate.spi.SearchPredicateBuilderFa
 class SpatialPredicateContextImpl<B> implements SpatialPredicateContext {
 
 	private final SearchPredicateBuilderFactory<?, B> factory;
+	private Float boost;
 
 	SpatialPredicateContextImpl(SearchPredicateBuilderFactory<?, B> factory) {
 		this.factory = factory;
@@ -20,7 +21,12 @@ class SpatialPredicateContextImpl<B> implements SpatialPredicateContext {
 
 	@Override
 	public SpatialWithinPredicateContext within() {
-		return new SpatialWithinPredicateContextImpl<>( factory );
+		return new SpatialWithinPredicateContextImpl<>( factory, boost );
 	}
 
+	@Override
+	public SpatialPredicateContext boostedTo(float boost) {
+		this.boost = boost;
+		return this;
+	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/SpatialWithinPredicateContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/SpatialWithinPredicateContextImpl.java
@@ -17,8 +17,9 @@ class SpatialWithinPredicateContextImpl<B> implements SpatialWithinPredicateCont
 
 	private final SpatialWithinPredicateFieldSetContextImpl.CommonState<B> commonState;
 
-	SpatialWithinPredicateContextImpl(SearchPredicateBuilderFactory<?, B> factory) {
+	SpatialWithinPredicateContextImpl(SearchPredicateBuilderFactory<?, B> factory, Float boost) {
 		this.commonState = new SpatialWithinPredicateFieldSetContextImpl.CommonState<>( factory );
+		this.commonState.setPredicateLevelBoost( boost );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/SpatialWithinPredicateFieldSetContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/SpatialWithinPredicateFieldSetContextImpl.java
@@ -89,7 +89,7 @@ class SpatialWithinPredicateFieldSetContextImpl<B>
 		for ( String absoluteFieldPath : absoluteFieldPaths ) {
 			SpatialWithinCirclePredicateBuilder<B> predicateBuilder = commonState.getFactory().spatialWithinCircle( absoluteFieldPath );
 			predicateBuilder.circle( center, radius, unit );
-			commonState.applyPredicateAndFieldBoosts( boost, predicateBuilder );
+			commonState.applyBoostAndConstantScore( boost, predicateBuilder );
 			predicateBuilders.add( predicateBuilder );
 		}
 	}
@@ -98,7 +98,7 @@ class SpatialWithinPredicateFieldSetContextImpl<B>
 		for ( String absoluteFieldPath : absoluteFieldPaths ) {
 			SpatialWithinPolygonPredicateBuilder<B> predicateBuilder = commonState.getFactory().spatialWithinPolygon( absoluteFieldPath );
 			predicateBuilder.polygon( polygon );
-			commonState.applyPredicateAndFieldBoosts( boost, predicateBuilder );
+			commonState.applyBoostAndConstantScore( boost, predicateBuilder );
 			predicateBuilders.add( predicateBuilder );
 		}
 	}
@@ -107,7 +107,7 @@ class SpatialWithinPredicateFieldSetContextImpl<B>
 		for ( String absoluteFieldPath : absoluteFieldPaths ) {
 			SpatialWithinBoundingBoxPredicateBuilder<B> predicateBuilder = commonState.getFactory().spatialWithinBoundingBox( absoluteFieldPath );
 			predicateBuilder.boundingBox( boundingBox );
-			commonState.applyPredicateAndFieldBoosts( boost, predicateBuilder );
+			commonState.applyBoostAndConstantScore( boost, predicateBuilder );
 			predicateBuilders.add( predicateBuilder );
 		}
 	}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/SpatialWithinPredicateFieldSetContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/SpatialWithinPredicateFieldSetContextImpl.java
@@ -89,9 +89,7 @@ class SpatialWithinPredicateFieldSetContextImpl<B>
 		for ( String absoluteFieldPath : absoluteFieldPaths ) {
 			SpatialWithinCirclePredicateBuilder<B> predicateBuilder = commonState.getFactory().spatialWithinCircle( absoluteFieldPath );
 			predicateBuilder.circle( center, radius, unit );
-			if ( boost != null ) {
-				predicateBuilder.boost( boost );
-			}
+			commonState.applyPredicateAndFieldBoosts( boost, predicateBuilder );
 			predicateBuilders.add( predicateBuilder );
 		}
 	}
@@ -100,9 +98,7 @@ class SpatialWithinPredicateFieldSetContextImpl<B>
 		for ( String absoluteFieldPath : absoluteFieldPaths ) {
 			SpatialWithinPolygonPredicateBuilder<B> predicateBuilder = commonState.getFactory().spatialWithinPolygon( absoluteFieldPath );
 			predicateBuilder.polygon( polygon );
-			if ( boost != null ) {
-				predicateBuilder.boost( boost );
-			}
+			commonState.applyPredicateAndFieldBoosts( boost, predicateBuilder );
 			predicateBuilders.add( predicateBuilder );
 		}
 	}
@@ -111,9 +107,7 @@ class SpatialWithinPredicateFieldSetContextImpl<B>
 		for ( String absoluteFieldPath : absoluteFieldPaths ) {
 			SpatialWithinBoundingBoxPredicateBuilder<B> predicateBuilder = commonState.getFactory().spatialWithinBoundingBox( absoluteFieldPath );
 			predicateBuilder.boundingBox( boundingBox );
-			if ( boost != null ) {
-				predicateBuilder.boost( boost );
-			}
+			commonState.applyPredicateAndFieldBoosts( boost, predicateBuilder );
 			predicateBuilders.add( predicateBuilder );
 		}
 	}

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/SearchPredicateBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/SearchPredicateBuilder.java
@@ -17,6 +17,8 @@ public interface SearchPredicateBuilder<B> {
 
 	void boost(float boost);
 
+	void withConstantScore();
+
 	/**
 	 * @return An implementation-specific view of this builder,
 	 * allowing the backend to call a {@code build()} method in particular.

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/BoolSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/BoolSearchPredicateIT.java
@@ -407,6 +407,70 @@ public class BoolSearchPredicateIT {
 	}
 
 	@Test
+	public void withConstantScore() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.bool()
+						// 0.287682
+						.should( f.bool().must( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) ) )
+
+						// withConstantScore 0.287682 => 1
+						.should( f.bool().withConstantScore().must( f.match().onField( "field1" ).matching( FIELD1_VALUE3 ) ) )
+				)
+				.sort( c -> c.byScore() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_3, DOCUMENT_1 );
+
+		query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.bool()
+						// withConstantScore 0.287682 => 1
+						.should( f.bool().withConstantScore().must( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) ) )
+
+						// 0.287682
+						.should( f.bool().must( f.match().onField( "field1" ).matching( FIELD1_VALUE3 ) ) )
+				)
+				.sort( c -> c.byScore() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_3 );
+	}
+
+	@Test
+	public void predicateLevelBoost_withConstantScore() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.bool()
+						.should( f.bool().withConstantScore().boostedTo( 7 ).must( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) ) )
+						.should( f.bool().withConstantScore().boostedTo( 39 ).must( f.match().onField( "field1" ).matching( FIELD1_VALUE3 ) ) )
+				)
+				.sort( c -> c.byScore() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_3, DOCUMENT_1 );
+
+		query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.bool()
+						.should( f.bool().withConstantScore().boostedTo( 39 ).must( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) ) )
+						.should( f.bool().withConstantScore().boostedTo( 7 ).must( f.match().onField( "field1" ).matching( FIELD1_VALUE3 ) ) )
+				)
+				.sort( c -> c.byScore() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_3 );
+	}
+
+	@Test
 	public void must_should() {
 		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchSearchPredicateIT.java
@@ -315,6 +315,84 @@ public class MatchSearchPredicateIT {
 	}
 
 	@Test
+	public void withConstantScore() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( root -> root.bool()
+						// 0.287682
+						.should( f -> f.match().onField( indexMapping.string1Field.relativeFieldName )
+								.matching( indexMapping.string1Field.document1Value.indexedValue )
+						)
+						// withConstantScore 0.287682 => 1
+						.should( f -> f.match().withConstantScore().onField( indexMapping.string1Field.relativeFieldName )
+								.matching( indexMapping.string1Field.document3Value.indexedValue )
+						)
+				)
+				.sort( c -> c.byScore() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_3, DOCUMENT_1 );
+
+		query = searchTarget.query()
+				.asReference()
+				.predicate( root -> root.bool()
+						// withConstantScore 0.287682 => 1
+						.should( f -> f.match().withConstantScore().onField( indexMapping.string1Field.relativeFieldName )
+								.matching( indexMapping.string1Field.document1Value.indexedValue )
+						)
+						// 0.287682
+						.should( f -> f.match().onField( indexMapping.string1Field.relativeFieldName )
+								.matching( indexMapping.string1Field.document3Value.indexedValue )
+						)
+				)
+				.sort( c -> c.byScore() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_3 );
+	}
+
+	@Test
+	public void predicateLevelBoost_withConstantScore() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( root -> root.bool()
+						.should( f -> f.match().withConstantScore().boostedTo( 7 ).onField( indexMapping.string1Field.relativeFieldName )
+								.matching( indexMapping.string1Field.document1Value.indexedValue )
+						)
+						.should( f -> f.match().withConstantScore().boostedTo( 39 ).onField( indexMapping.string1Field.relativeFieldName )
+								.matching( indexMapping.string1Field.document3Value.indexedValue )
+						)
+				)
+				.sort( c -> c.byScore() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_3, DOCUMENT_1 );
+
+		query = searchTarget.query()
+				.asReference()
+				.predicate( root -> root.bool()
+						.should( f -> f.match().withConstantScore().boostedTo( 39 ).onField( indexMapping.string1Field.relativeFieldName )
+								.matching( indexMapping.string1Field.document1Value.indexedValue )
+						)
+						.should( f -> f.match().withConstantScore().boostedTo( 7 ).onField( indexMapping.string1Field.relativeFieldName )
+								.matching( indexMapping.string1Field.document3Value.indexedValue )
+						)
+				)
+				.sort( c -> c.byScore() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_3 );
+	}
+
+	@Test
 	public void multi_fields() {
 		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchSearchPredicateIT.java
@@ -187,6 +187,19 @@ public class MatchSearchPredicateIT {
 	}
 
 	@Test
+	public void perFieldBoostWithConstantScore_error() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		SubTest.expectException(
+				"HSEARCH000551: It is not possible to use per-field boosts together with withConstantScore option",
+				() -> searchTarget.predicate().match().withConstantScore().onField( indexMapping.string1Field.relativeFieldName ).boostedTo( 2.1f )
+						.matching( indexMapping.string1Field.document1Value.indexedValue )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class );
+	}
+
+	@Test
 	public void fieldLevelBoost() {
 		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/SpatialWithinBoundingBoxSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/SpatialWithinBoundingBoxSearchPredicateIT.java
@@ -127,7 +127,7 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 	}
 
 	@Test
-	public void boost() {
+	public void fieldLevelBoost() {
 		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
 
 		SearchQuery<DocumentReference> query = searchTarget.query()
@@ -146,6 +146,35 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.spatial().within().onField( "geoPoint" ).boostedTo( 42 ).boundingBox( CHEZ_MARGOTTE_BOUNDING_BOX ) )
+						.should( f.match().onField( "string" ).matching( OURSON_QUI_BOIT_STRING ) )
+				)
+				.sort( c -> c.byScore() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, CHEZ_MARGOTTE_ID, OURSON_QUI_BOIT_ID );
+	}
+
+	@Test
+	public void predicateLevelBoost() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.bool()
+						.should( f.spatial().within().onField( "geoPoint" ).boundingBox( CHEZ_MARGOTTE_BOUNDING_BOX ) )
+						.should( f.match().boostedTo( 7 ).onField( "string" ).matching( OURSON_QUI_BOIT_STRING ) )
+				)
+				.sort( c -> c.byScore() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, CHEZ_MARGOTTE_ID );
+
+		query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.bool()
+						.should( f.spatial().boostedTo( 39 ).within().onField( "geoPoint" ).boundingBox( CHEZ_MARGOTTE_BOUNDING_BOX ) )
 						.should( f.match().onField( "string" ).matching( OURSON_QUI_BOIT_STRING ) )
 				)
 				.sort( c -> c.byScore() )

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/SpatialWithinCircleSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/SpatialWithinCircleSearchPredicateIT.java
@@ -111,7 +111,7 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 	}
 
 	@Test
-	public void boost() {
+	public void fieldLevelBoost() {
 		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
 
 		SearchQuery<DocumentReference> query = searchTarget.query()
@@ -137,6 +137,47 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 				.predicate( f -> f.bool()
 						.should( f.spatial().within()
 								.onField( "geoPoint" ).boostedTo( 42 )
+								.circle( METRO_GARIBALDI, 400 )
+						)
+						.should( f.match()
+								.onField( "string" )
+								.matching( OURSON_QUI_BOIT_STRING )
+						)
+				)
+				.sort( c -> c.byScore() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, CHEZ_MARGOTTE_ID, OURSON_QUI_BOIT_ID );
+	}
+
+	@Test
+	public void predicateLevelBoost() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.bool()
+						.should( f.spatial().boostedTo( 0.123f ).within()
+								.onField( "geoPoint" )
+								.circle( METRO_GARIBALDI, 400 )
+						)
+						.should( f.match()
+								.onField( "string" )
+								.matching( OURSON_QUI_BOIT_STRING )
+						)
+				)
+				.sort( c -> c.byScore() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, CHEZ_MARGOTTE_ID );
+
+		query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.bool()
+						.should( f.spatial().boostedTo( 39 ).within()
+								.onField( "geoPoint" )
 								.circle( METRO_GARIBALDI, 400 )
 						)
 						.should( f.match()

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/SpatialWithinCircleSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/SpatialWithinCircleSearchPredicateIT.java
@@ -193,6 +193,51 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 	}
 
 	@Test
+	public void predicateLevelBoost_andFieldLevelBoost() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.bool()
+						// 0.123 * 4 => boost x0.492
+						.should( f.spatial().boostedTo( 0.123f ).within()
+								.onField( "geoPoint" ).boostedTo( 4 )
+								.circle( METRO_GARIBALDI, 400 )
+						)
+						// 1 * 1 => boost x1
+						.should( f.match()
+								.onField( "string" )
+								.matching( OURSON_QUI_BOIT_STRING )
+						)
+				)
+				.sort( c -> c.byScore() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, CHEZ_MARGOTTE_ID );
+
+		query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.bool()
+						// 39 * 7 => boost x273
+						.should( f.spatial().boostedTo( 39 ).within()
+								.onField( "geoPoint" ).boostedTo( 7 )
+								.circle( METRO_GARIBALDI, 400 )
+						)
+						// 10 * 10 => boost x100
+						.should( f.match().boostedTo( 10 )
+								.onField( "string" ).boostedTo( 10 )
+								.matching( OURSON_QUI_BOIT_STRING )
+						)
+				)
+				.sort( c -> c.byScore() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, CHEZ_MARGOTTE_ID, OURSON_QUI_BOIT_ID );
+	}
+
+	@Test
 	public void multi_fields() {
 		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/SpatialWithinPolygonSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/SpatialWithinPolygonSearchPredicateIT.java
@@ -92,7 +92,7 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 	}
 
 	@Test
-	public void boost() {
+	public void fieldLevelBoost() {
 		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
 
 		SearchQuery<DocumentReference> query = searchTarget.query()
@@ -111,6 +111,35 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.spatial().within().onField( "geoPoint" ).boostedTo( 42 ).polygon( CHEZ_MARGOTTE_POLYGON ) )
+						.should( f.match().onField( "string" ).matching( OURSON_QUI_BOIT_STRING ) )
+				)
+				.sort( c -> c.byScore() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, CHEZ_MARGOTTE_ID, OURSON_QUI_BOIT_ID );
+	}
+
+	@Test
+	public void predicateLevelBoost() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.bool()
+						.should( f.spatial().boostedTo( 0.1f ).within().onField( "geoPoint" ).polygon( CHEZ_MARGOTTE_POLYGON ) )
+						.should( f.match().onField( "string" ).matching( OURSON_QUI_BOIT_STRING ) )
+				)
+				.sort( c -> c.byScore() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, CHEZ_MARGOTTE_ID );
+
+		query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.bool()
+						.should( f.spatial().boostedTo( 39 ).within().onField( "geoPoint" ).polygon( CHEZ_MARGOTTE_POLYGON ) )
 						.should( f.match().onField( "string" ).matching( OURSON_QUI_BOIT_STRING ) )
 				)
 				.sort( c -> c.byScore() )

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubPredicateBuilder.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubPredicateBuilder.java
@@ -97,6 +97,11 @@ public class StubPredicateBuilder implements MatchAllPredicateBuilder<StubPredic
 	}
 
 	@Override
+	public void withConstantScore() {
+		// No-op
+	}
+
+	@Override
 	public void circle(GeoPoint center, double radius, DistanceUnit unit) {
 		// No-op
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3091

The assessment of missed predicate options is here: [Hibernate Search 6 - Query Predicates Comparison](https://docs.google.com/spreadsheets/d/1tLVyp5irn5SV_wVX6LKn2BxmqHewSGKsBv9a2gMlwKk/edit?usp=sharing)

~~I know I did too many commits, if you want, we could merge:~~ done!
* ~~HSEARCH-3091 Test predicate-level * with range predicate ( as one )~~
* ~~HSEARCH-3091 Handle constantScore in multi field predicates with the previous one.~~