### PR TITLE
HSEARCH-3089 Add to the DSL the missing query predicates (excluding spatial, faceting, moreLikeThis) compared to Search 5

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
@@ -456,4 +456,8 @@ public interface Log extends BasicLogger {
 	@Message(id = ID_OFFSET_3 + 52, value = "Invalid index lifecycle strategy name: '%1$s'."
 			+ " Valid names are: %2$s.")
 	SearchException invalidIndexLifecycleStrategyName(String invalidRepresentation, List<String> validRepresentations);
+
+	@Message(id = ID_OFFSET_3 + 53,
+			value = "Text predicates (phrase, fuzzy, wildcard) are not supported by this field's type.")
+	SearchException textPredicatesNotSupportedByFieldType(@Param EventContext context);
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
@@ -458,6 +458,6 @@ public interface Log extends BasicLogger {
 	SearchException invalidIndexLifecycleStrategyName(String invalidRepresentation, List<String> validRepresentations);
 
 	@Message(id = ID_OFFSET_3 + 53,
-			value = "Text predicates (phrase, fuzzy, wildcard) are not supported by this field's type.")
+			value = "Text predicates (phrase, fuzzy, wildcard, simple query string) are not supported by this field's type.")
 	SearchException textPredicatesNotSupportedByFieldType(@Param EventContext context);
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchSearchPredicateBuilderFactoryImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchSearchPredicateBuilderFactoryImpl.java
@@ -21,6 +21,7 @@ import org.hibernate.search.engine.search.predicate.spi.MatchAllPredicateBuilder
 import org.hibernate.search.engine.search.predicate.spi.MatchIdPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.MatchPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.NestedPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.RangePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinBoundingBoxPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinCirclePredicateBuilder;
@@ -94,6 +95,13 @@ public class ElasticsearchSearchPredicateBuilderFactoryImpl implements Elasticse
 		return searchTargetModel
 				.getSchemaNodeComponent( absoluteFieldPath, PREDICATE_BUILDER_FACTORY_RETRIEVAL_STRATEGY, dslConverter )
 				.createRangePredicateBuilder( searchContext, absoluteFieldPath, dslConverter );
+	}
+
+	@Override
+	public PhrasePredicateBuilder<ElasticsearchSearchPredicateBuilder> phrase(String absoluteFieldPath) {
+		return searchTargetModel
+				.getSchemaNodeComponent( absoluteFieldPath, PREDICATE_BUILDER_FACTORY_RETRIEVAL_STRATEGY, DslConverter.DISABLED )
+				.createPhrasePredicateBuilder( absoluteFieldPath );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchSearchPredicateBuilderFactoryImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchSearchPredicateBuilderFactoryImpl.java
@@ -23,6 +23,7 @@ import org.hibernate.search.engine.search.predicate.spi.MatchPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.NestedPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.RangePredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.SimpleQueryStringPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinBoundingBoxPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinCirclePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinPolygonPredicateBuilder;
@@ -36,7 +37,7 @@ public class ElasticsearchSearchPredicateBuilderFactoryImpl implements Elasticse
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private static final PredicateBuilderFactoryRetrievalStrategy PREDICATE_BUILDER_FACTORY_RETRIEVAL_STRATEGY =
+	static final PredicateBuilderFactoryRetrievalStrategy PREDICATE_BUILDER_FACTORY_RETRIEVAL_STRATEGY =
 			new PredicateBuilderFactoryRetrievalStrategy();
 
 	private final ElasticsearchSearchContext searchContext;
@@ -102,6 +103,11 @@ public class ElasticsearchSearchPredicateBuilderFactoryImpl implements Elasticse
 		return searchTargetModel
 				.getSchemaNodeComponent( absoluteFieldPath, PREDICATE_BUILDER_FACTORY_RETRIEVAL_STRATEGY, DslConverter.DISABLED )
 				.createPhrasePredicateBuilder( absoluteFieldPath );
+	}
+
+	@Override
+	public SimpleQueryStringPredicateBuilder<ElasticsearchSearchPredicateBuilder> simpleQueryString() {
+		return new ElasticsearchSimpleQueryStringPredicateBuilder( searchTargetModel );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchSearchPredicateBuilderFactoryImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchSearchPredicateBuilderFactoryImpl.java
@@ -27,6 +27,7 @@ import org.hibernate.search.engine.search.predicate.spi.SimpleQueryStringPredica
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinBoundingBoxPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinCirclePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinPolygonPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.WildcardPredicateBuilder;
 import org.hibernate.search.util.common.reporting.EventContext;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
@@ -103,6 +104,13 @@ public class ElasticsearchSearchPredicateBuilderFactoryImpl implements Elasticse
 		return searchTargetModel
 				.getSchemaNodeComponent( absoluteFieldPath, PREDICATE_BUILDER_FACTORY_RETRIEVAL_STRATEGY, DslConverter.DISABLED )
 				.createPhrasePredicateBuilder( absoluteFieldPath );
+	}
+
+	@Override
+	public WildcardPredicateBuilder<ElasticsearchSearchPredicateBuilder> wildcard(String absoluteFieldPath) {
+		return searchTargetModel
+				.getSchemaNodeComponent( absoluteFieldPath, PREDICATE_BUILDER_FACTORY_RETRIEVAL_STRATEGY, DslConverter.DISABLED )
+				.createWildcardPredicateBuilder( absoluteFieldPath );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchSimpleQueryStringPredicateBuilder.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchSimpleQueryStringPredicateBuilder.java
@@ -1,0 +1,88 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.search.predicate.impl;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.hibernate.search.backend.elasticsearch.gson.impl.JsonAccessor;
+import org.hibernate.search.backend.elasticsearch.gson.impl.JsonObjectAccessor;
+import org.hibernate.search.backend.elasticsearch.search.impl.ElasticsearchSearchTargetModel;
+import org.hibernate.search.backend.elasticsearch.types.predicate.impl.ElasticsearchSimpleQueryStringPredicateBuilderFieldContext;
+import org.hibernate.search.engine.search.predicate.spi.DslConverter;
+import org.hibernate.search.engine.search.predicate.spi.SimpleQueryStringPredicateBuilder;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
+public class ElasticsearchSimpleQueryStringPredicateBuilder extends AbstractElasticsearchSearchPredicateBuilder
+		implements SimpleQueryStringPredicateBuilder<ElasticsearchSearchPredicateBuilder> {
+
+	private static final JsonObjectAccessor SIMPLE_QUERY_STRING_ACCESSOR = JsonAccessor.root().property( "simple_query_string" ).asObject();
+	private static final JsonAccessor<String> QUERY_ACCESSOR = JsonAccessor.root().property( "query" ).asString();
+	private static final JsonAccessor<JsonElement> DEFAULT_OPERATOR_ACCESSOR = JsonAccessor.root().property( "default_operator" );
+	private static final JsonAccessor<JsonArray> FIELDS_ACCESSOR = JsonAccessor.root().property( "fields" ).asArray();
+
+
+	private static final JsonPrimitive AND_OPERATOR_KEYWORD_JSON = new JsonPrimitive( "and" );
+	private static final JsonPrimitive OR_OPERATOR_KEYWORD_JSON = new JsonPrimitive( "or" );
+
+
+	private final ElasticsearchSearchTargetModel searchTargetModel;
+
+	private final Map<String, ElasticsearchSimpleQueryStringPredicateBuilderFieldContext> fields = new LinkedHashMap<>();
+	private JsonPrimitive defaultOperator = OR_OPERATOR_KEYWORD_JSON;
+	private String simpleQueryString;
+
+	ElasticsearchSimpleQueryStringPredicateBuilder(ElasticsearchSearchTargetModel searchTargetModel) {
+		this.searchTargetModel = searchTargetModel;
+	}
+
+	@Override
+	public void withAndAsDefaultOperator() {
+		this.defaultOperator = AND_OPERATOR_KEYWORD_JSON;
+	}
+
+	@Override
+	public FieldContext field(String absoluteFieldPath) {
+		ElasticsearchSimpleQueryStringPredicateBuilderFieldContext field = fields.get( absoluteFieldPath );
+		if ( field == null ) {
+			field = searchTargetModel.getSchemaNodeComponent(
+					absoluteFieldPath,
+					ElasticsearchSearchPredicateBuilderFactoryImpl.PREDICATE_BUILDER_FACTORY_RETRIEVAL_STRATEGY,
+					DslConverter.DISABLED
+			)
+					.createSimpleQueryStringFieldContext( absoluteFieldPath );
+			fields.put( absoluteFieldPath, field );
+		}
+		return field;
+	}
+
+	@Override
+	public void simpleQueryString(String simpleQueryString) {
+		this.simpleQueryString = simpleQueryString;
+	}
+
+	@Override
+	protected JsonObject doBuild(ElasticsearchSearchPredicateContext context,
+			JsonObject outerObject, JsonObject innerObject) {
+		QUERY_ACCESSOR.set( innerObject, simpleQueryString );
+		DEFAULT_OPERATOR_ACCESSOR.set( innerObject, defaultOperator );
+
+		JsonArray fieldArray = new JsonArray();
+		for ( ElasticsearchSimpleQueryStringPredicateBuilderFieldContext fieldContext : fields.values() ) {
+			fieldArray.add( fieldContext.build() );
+		}
+		FIELDS_ACCESSOR.set( innerObject, fieldArray );
+
+		SIMPLE_QUERY_STRING_ACCESSOR.set( outerObject, innerObject );
+		return outerObject;
+	}
+
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchStringIndexFieldTypeContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchStringIndexFieldTypeContext.java
@@ -13,7 +13,7 @@ import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.P
 import org.hibernate.search.backend.elasticsearch.logging.impl.Log;
 import org.hibernate.search.backend.elasticsearch.types.codec.impl.ElasticsearchStringFieldCodec;
 import org.hibernate.search.backend.elasticsearch.types.impl.ElasticsearchIndexFieldType;
-import org.hibernate.search.backend.elasticsearch.types.predicate.impl.ElasticsearchStandardFieldPredicateBuilderFactory;
+import org.hibernate.search.backend.elasticsearch.types.predicate.impl.ElasticsearchTextFieldPredicateBuilderFactory;
 import org.hibernate.search.backend.elasticsearch.types.projection.impl.ElasticsearchStandardFieldProjectionBuilderFactory;
 import org.hibernate.search.backend.elasticsearch.types.sort.impl.ElasticsearchStandardFieldSortBuilderFactory;
 import org.hibernate.search.engine.backend.types.Projectable;
@@ -106,7 +106,7 @@ class ElasticsearchStringIndexFieldTypeContext
 
 		return new ElasticsearchIndexFieldType<>(
 				codec,
-				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
+				new ElasticsearchTextFieldPredicateBuilderFactory( dslToIndexConverter, createRawConverter(), codec ),
 				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
 				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec ),
 				mapping

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/AbstractElasticsearchFieldPredicateBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/AbstractElasticsearchFieldPredicateBuilderFactory.java
@@ -1,0 +1,72 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.types.predicate.impl;
+
+import java.lang.invoke.MethodHandles;
+
+import org.hibernate.search.backend.elasticsearch.logging.impl.Log;
+import org.hibernate.search.backend.elasticsearch.search.predicate.impl.ElasticsearchSearchPredicateBuilder;
+import org.hibernate.search.engine.reporting.spi.EventContexts;
+import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.SpatialWithinBoundingBoxPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.SpatialWithinCirclePredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.SpatialWithinPolygonPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.WildcardPredicateBuilder;
+import org.hibernate.search.util.common.logging.impl.LoggerFactory;
+
+abstract class AbstractElasticsearchFieldPredicateBuilderFactory implements ElasticsearchFieldPredicateBuilderFactory {
+
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+
+	@Override
+	public PhrasePredicateBuilder<ElasticsearchSearchPredicateBuilder> createPhrasePredicateBuilder(
+			String absoluteFieldPath) {
+		throw log.textPredicatesNotSupportedByFieldType(
+				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
+		);
+	}
+
+	@Override
+	public WildcardPredicateBuilder<ElasticsearchSearchPredicateBuilder> createWildcardPredicateBuilder(
+			String absoluteFieldPath) {
+		throw log.textPredicatesNotSupportedByFieldType(
+				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
+		);
+	}
+
+	@Override
+	public ElasticsearchSimpleQueryStringPredicateBuilderFieldContext createSimpleQueryStringFieldContext(
+			String absoluteFieldPath) {
+		throw log.textPredicatesNotSupportedByFieldType(
+				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
+		);
+	}
+
+	@Override
+	public SpatialWithinCirclePredicateBuilder<ElasticsearchSearchPredicateBuilder> createSpatialWithinCirclePredicateBuilder(
+			String absoluteFieldPath) {
+		throw log.spatialPredicatesNotSupportedByFieldType(
+				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
+		);
+	}
+
+	@Override
+	public SpatialWithinPolygonPredicateBuilder<ElasticsearchSearchPredicateBuilder> createSpatialWithinPolygonPredicateBuilder(
+			String absoluteFieldPath) {
+		throw log.spatialPredicatesNotSupportedByFieldType(
+				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
+		);
+	}
+
+	@Override
+	public SpatialWithinBoundingBoxPredicateBuilder<ElasticsearchSearchPredicateBuilder> createSpatialWithinBoundingBoxPredicateBuilder(
+			String absoluteFieldPath) {
+		throw log.spatialPredicatesNotSupportedByFieldType(
+				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
+		);
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchFieldPredicateBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchFieldPredicateBuilderFactory.java
@@ -12,6 +12,7 @@ import org.hibernate.search.backend.elasticsearch.types.codec.impl.Elasticsearch
 import org.hibernate.search.engine.backend.types.converter.ToDocumentFieldValueConverter;
 import org.hibernate.search.engine.search.predicate.spi.DslConverter;
 import org.hibernate.search.engine.search.predicate.spi.MatchPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.RangePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinBoundingBoxPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinCirclePredicateBuilder;
@@ -55,6 +56,9 @@ public interface ElasticsearchFieldPredicateBuilderFactory {
 
 	RangePredicateBuilder<ElasticsearchSearchPredicateBuilder> createRangePredicateBuilder(
 			ElasticsearchSearchContext searchContext, String absoluteFieldPath, DslConverter dslConverter);
+
+	PhrasePredicateBuilder<ElasticsearchSearchPredicateBuilder> createPhrasePredicateBuilder(
+			String absoluteFieldPath);
 
 	SpatialWithinCirclePredicateBuilder<ElasticsearchSearchPredicateBuilder> createSpatialWithinCirclePredicateBuilder(
 			String absoluteFieldPath);

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchFieldPredicateBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchFieldPredicateBuilderFactory.java
@@ -17,6 +17,7 @@ import org.hibernate.search.engine.search.predicate.spi.RangePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinBoundingBoxPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinCirclePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinPolygonPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.WildcardPredicateBuilder;
 
 /**
  * A field-scoped factory for search predicate builders.
@@ -58,6 +59,9 @@ public interface ElasticsearchFieldPredicateBuilderFactory {
 			ElasticsearchSearchContext searchContext, String absoluteFieldPath, DslConverter dslConverter);
 
 	PhrasePredicateBuilder<ElasticsearchSearchPredicateBuilder> createPhrasePredicateBuilder(
+			String absoluteFieldPath);
+
+	WildcardPredicateBuilder<ElasticsearchSearchPredicateBuilder> createWildcardPredicateBuilder(
 			String absoluteFieldPath);
 
 	ElasticsearchSimpleQueryStringPredicateBuilderFieldContext createSimpleQueryStringFieldContext(String absoluteFieldPath);

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchFieldPredicateBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchFieldPredicateBuilderFactory.java
@@ -60,6 +60,8 @@ public interface ElasticsearchFieldPredicateBuilderFactory {
 	PhrasePredicateBuilder<ElasticsearchSearchPredicateBuilder> createPhrasePredicateBuilder(
 			String absoluteFieldPath);
 
+	ElasticsearchSimpleQueryStringPredicateBuilderFieldContext createSimpleQueryStringFieldContext(String absoluteFieldPath);
+
 	SpatialWithinCirclePredicateBuilder<ElasticsearchSearchPredicateBuilder> createSpatialWithinCirclePredicateBuilder(
 			String absoluteFieldPath);
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchGeoPointFieldPredicateBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchGeoPointFieldPredicateBuilderFactory.java
@@ -20,6 +20,7 @@ import org.hibernate.search.engine.search.predicate.spi.RangePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinBoundingBoxPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinCirclePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinPolygonPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.WildcardPredicateBuilder;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
 public class ElasticsearchGeoPointFieldPredicateBuilderFactory implements ElasticsearchFieldPredicateBuilderFactory {
@@ -56,6 +57,14 @@ public class ElasticsearchGeoPointFieldPredicateBuilderFactory implements Elasti
 
 	@Override
 	public PhrasePredicateBuilder<ElasticsearchSearchPredicateBuilder> createPhrasePredicateBuilder(
+			String absoluteFieldPath) {
+		throw log.textPredicatesNotSupportedByFieldType(
+				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
+		);
+	}
+
+	@Override
+	public WildcardPredicateBuilder<ElasticsearchSearchPredicateBuilder> createWildcardPredicateBuilder(
 			String absoluteFieldPath) {
 		throw log.textPredicatesNotSupportedByFieldType(
 				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchGeoPointFieldPredicateBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchGeoPointFieldPredicateBuilderFactory.java
@@ -15,6 +15,7 @@ import org.hibernate.search.backend.elasticsearch.types.codec.impl.Elasticsearch
 import org.hibernate.search.engine.reporting.spi.EventContexts;
 import org.hibernate.search.engine.search.predicate.spi.DslConverter;
 import org.hibernate.search.engine.search.predicate.spi.MatchPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.RangePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinBoundingBoxPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinCirclePredicateBuilder;
@@ -49,6 +50,14 @@ public class ElasticsearchGeoPointFieldPredicateBuilderFactory implements Elasti
 	public RangePredicateBuilder<ElasticsearchSearchPredicateBuilder> createRangePredicateBuilder(
 			ElasticsearchSearchContext searchContext, String absoluteFieldPath, DslConverter dslConverter) {
 		throw log.rangePredicatesNotSupportedByGeoPoint(
+				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
+		);
+	}
+
+	@Override
+	public PhrasePredicateBuilder<ElasticsearchSearchPredicateBuilder> createPhrasePredicateBuilder(
+			String absoluteFieldPath) {
+		throw log.textPredicatesNotSupportedByFieldType(
 				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
 		);
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchGeoPointFieldPredicateBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchGeoPointFieldPredicateBuilderFactory.java
@@ -15,15 +15,14 @@ import org.hibernate.search.backend.elasticsearch.types.codec.impl.Elasticsearch
 import org.hibernate.search.engine.reporting.spi.EventContexts;
 import org.hibernate.search.engine.search.predicate.spi.DslConverter;
 import org.hibernate.search.engine.search.predicate.spi.MatchPredicateBuilder;
-import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.RangePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinBoundingBoxPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinCirclePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinPolygonPredicateBuilder;
-import org.hibernate.search.engine.search.predicate.spi.WildcardPredicateBuilder;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
-public class ElasticsearchGeoPointFieldPredicateBuilderFactory implements ElasticsearchFieldPredicateBuilderFactory {
+public class ElasticsearchGeoPointFieldPredicateBuilderFactory
+		extends AbstractElasticsearchFieldPredicateBuilderFactory {
 
 	public static final ElasticsearchGeoPointFieldPredicateBuilderFactory INSTANCE = new ElasticsearchGeoPointFieldPredicateBuilderFactory();
 
@@ -51,30 +50,6 @@ public class ElasticsearchGeoPointFieldPredicateBuilderFactory implements Elasti
 	public RangePredicateBuilder<ElasticsearchSearchPredicateBuilder> createRangePredicateBuilder(
 			ElasticsearchSearchContext searchContext, String absoluteFieldPath, DslConverter dslConverter) {
 		throw log.rangePredicatesNotSupportedByGeoPoint(
-				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
-		);
-	}
-
-	@Override
-	public PhrasePredicateBuilder<ElasticsearchSearchPredicateBuilder> createPhrasePredicateBuilder(
-			String absoluteFieldPath) {
-		throw log.textPredicatesNotSupportedByFieldType(
-				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
-		);
-	}
-
-	@Override
-	public WildcardPredicateBuilder<ElasticsearchSearchPredicateBuilder> createWildcardPredicateBuilder(
-			String absoluteFieldPath) {
-		throw log.textPredicatesNotSupportedByFieldType(
-				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
-		);
-	}
-
-	@Override
-	public ElasticsearchSimpleQueryStringPredicateBuilderFieldContext createSimpleQueryStringFieldContext(
-			String absoluteFieldPath) {
-		throw log.textPredicatesNotSupportedByFieldType(
 				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
 		);
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchGeoPointFieldPredicateBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchGeoPointFieldPredicateBuilderFactory.java
@@ -63,6 +63,14 @@ public class ElasticsearchGeoPointFieldPredicateBuilderFactory implements Elasti
 	}
 
 	@Override
+	public ElasticsearchSimpleQueryStringPredicateBuilderFieldContext createSimpleQueryStringFieldContext(
+			String absoluteFieldPath) {
+		throw log.textPredicatesNotSupportedByFieldType(
+				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
+		);
+	}
+
+	@Override
 	public SpatialWithinCirclePredicateBuilder<ElasticsearchSearchPredicateBuilder> createSpatialWithinCirclePredicateBuilder(
 			String absoluteFieldPath) {
 		return new ElasticsearchGeoPointSpatialWithinCirclePredicateBuilder( absoluteFieldPath, CODEC );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchSimpleQueryStringPredicateBuilderFieldContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchSimpleQueryStringPredicateBuilderFieldContext.java
@@ -1,0 +1,36 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.types.predicate.impl;
+
+import org.hibernate.search.engine.search.predicate.spi.SimpleQueryStringPredicateBuilder;
+
+import com.google.gson.JsonPrimitive;
+
+public final class ElasticsearchSimpleQueryStringPredicateBuilderFieldContext
+		implements SimpleQueryStringPredicateBuilder.FieldContext {
+	private static final String BOOST_OPERATOR = "^";
+
+	private final String absoluteFieldPath;
+	private Float boost;
+
+	ElasticsearchSimpleQueryStringPredicateBuilderFieldContext(String absoluteFieldPath) {
+		this.absoluteFieldPath = absoluteFieldPath;
+	}
+
+	@Override
+	public void boost(float boost) {
+		this.boost = boost;
+	}
+
+	public JsonPrimitive build() {
+		StringBuilder sb = new StringBuilder( absoluteFieldPath );
+		if ( boost != null ) {
+			sb.append( BOOST_OPERATOR ).append( boost );
+		}
+		return new JsonPrimitive( sb.toString() );
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchStandardFieldPredicateBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchStandardFieldPredicateBuilderFactory.java
@@ -10,7 +10,6 @@ import java.lang.invoke.MethodHandles;
 
 import org.hibernate.search.backend.elasticsearch.logging.impl.Log;
 import org.hibernate.search.backend.elasticsearch.search.impl.ElasticsearchSearchContext;
-import org.hibernate.search.backend.elasticsearch.search.predicate.impl.ElasticsearchMatchPredicateBuilder;
 import org.hibernate.search.backend.elasticsearch.search.predicate.impl.ElasticsearchSearchPredicateBuilder;
 import org.hibernate.search.backend.elasticsearch.search.predicate.impl.ElasticsearchRangePredicateBuilder;
 import org.hibernate.search.backend.elasticsearch.types.codec.impl.ElasticsearchFieldCodec;
@@ -32,7 +31,7 @@ public class ElasticsearchStandardFieldPredicateBuilderFactory<F> implements Ela
 	protected final ToDocumentFieldValueConverter<?, ? extends F> converter;
 	protected final ToDocumentFieldValueConverter<F, ? extends F> rawConverter;
 
-	private final ElasticsearchFieldCodec<F> codec;
+	protected final ElasticsearchFieldCodec<F> codec;
 
 	public ElasticsearchStandardFieldPredicateBuilderFactory(
 			ToDocumentFieldValueConverter<?, ? extends F> converter, ToDocumentFieldValueConverter<F, ? extends F> rawConverter,
@@ -58,7 +57,7 @@ public class ElasticsearchStandardFieldPredicateBuilderFactory<F> implements Ela
 	@Override
 	public MatchPredicateBuilder<ElasticsearchSearchPredicateBuilder> createMatchPredicateBuilder(
 			ElasticsearchSearchContext searchContext, String absoluteFieldPath, DslConverter dslConverter) {
-		return new ElasticsearchMatchPredicateBuilder<>( searchContext, absoluteFieldPath, getConverter( dslConverter ), codec );
+		return new ElasticsearchStandardMatchPredicateBuilder<>( searchContext, absoluteFieldPath, getConverter( dslConverter ), codec );
 	}
 
 	@Override
@@ -99,7 +98,7 @@ public class ElasticsearchStandardFieldPredicateBuilderFactory<F> implements Ela
 		);
 	}
 
-	private ToDocumentFieldValueConverter<?, ? extends F> getConverter(DslConverter dslConverter) {
+	protected final ToDocumentFieldValueConverter<?, ? extends F> getConverter(DslConverter dslConverter) {
 		return ( dslConverter.isEnabled() ) ? converter : rawConverter;
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchStandardFieldPredicateBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchStandardFieldPredicateBuilderFactory.java
@@ -75,6 +75,14 @@ public class ElasticsearchStandardFieldPredicateBuilderFactory<F> implements Ela
 	}
 
 	@Override
+	public ElasticsearchSimpleQueryStringPredicateBuilderFieldContext createSimpleQueryStringFieldContext(
+			String absoluteFieldPath) {
+		throw log.textPredicatesNotSupportedByFieldType(
+				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
+		);
+	}
+
+	@Override
 	public SpatialWithinCirclePredicateBuilder<ElasticsearchSearchPredicateBuilder> createSpatialWithinCirclePredicateBuilder(
 			String absoluteFieldPath) {
 		throw log.spatialPredicatesNotSupportedByFieldType(

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchStandardFieldPredicateBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchStandardFieldPredicateBuilderFactory.java
@@ -6,28 +6,17 @@
  */
 package org.hibernate.search.backend.elasticsearch.types.predicate.impl;
 
-import java.lang.invoke.MethodHandles;
-
-import org.hibernate.search.backend.elasticsearch.logging.impl.Log;
 import org.hibernate.search.backend.elasticsearch.search.impl.ElasticsearchSearchContext;
-import org.hibernate.search.backend.elasticsearch.search.predicate.impl.ElasticsearchSearchPredicateBuilder;
 import org.hibernate.search.backend.elasticsearch.search.predicate.impl.ElasticsearchRangePredicateBuilder;
+import org.hibernate.search.backend.elasticsearch.search.predicate.impl.ElasticsearchSearchPredicateBuilder;
 import org.hibernate.search.backend.elasticsearch.types.codec.impl.ElasticsearchFieldCodec;
 import org.hibernate.search.engine.backend.types.converter.ToDocumentFieldValueConverter;
-import org.hibernate.search.engine.reporting.spi.EventContexts;
 import org.hibernate.search.engine.search.predicate.spi.DslConverter;
 import org.hibernate.search.engine.search.predicate.spi.MatchPredicateBuilder;
-import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.RangePredicateBuilder;
-import org.hibernate.search.engine.search.predicate.spi.SpatialWithinBoundingBoxPredicateBuilder;
-import org.hibernate.search.engine.search.predicate.spi.SpatialWithinCirclePredicateBuilder;
-import org.hibernate.search.engine.search.predicate.spi.SpatialWithinPolygonPredicateBuilder;
-import org.hibernate.search.engine.search.predicate.spi.WildcardPredicateBuilder;
-import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
-public class ElasticsearchStandardFieldPredicateBuilderFactory<F> implements ElasticsearchFieldPredicateBuilderFactory {
-
-	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+public class ElasticsearchStandardFieldPredicateBuilderFactory<F>
+		extends AbstractElasticsearchFieldPredicateBuilderFactory {
 
 	protected final ToDocumentFieldValueConverter<?, ? extends F> converter;
 	protected final ToDocumentFieldValueConverter<F, ? extends F> rawConverter;
@@ -65,54 +54,6 @@ public class ElasticsearchStandardFieldPredicateBuilderFactory<F> implements Ela
 	public RangePredicateBuilder<ElasticsearchSearchPredicateBuilder> createRangePredicateBuilder(
 			ElasticsearchSearchContext searchContext, String absoluteFieldPath, DslConverter dslConverter) {
 		return new ElasticsearchRangePredicateBuilder<>( searchContext, absoluteFieldPath, getConverter( dslConverter ), codec );
-	}
-
-	@Override
-	public PhrasePredicateBuilder<ElasticsearchSearchPredicateBuilder> createPhrasePredicateBuilder(
-			String absoluteFieldPath) {
-		throw log.textPredicatesNotSupportedByFieldType(
-				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
-		);
-	}
-
-	@Override
-	public WildcardPredicateBuilder<ElasticsearchSearchPredicateBuilder> createWildcardPredicateBuilder(
-			String absoluteFieldPath) {
-		throw log.textPredicatesNotSupportedByFieldType(
-				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
-		);
-	}
-
-	@Override
-	public ElasticsearchSimpleQueryStringPredicateBuilderFieldContext createSimpleQueryStringFieldContext(
-			String absoluteFieldPath) {
-		throw log.textPredicatesNotSupportedByFieldType(
-				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
-		);
-	}
-
-	@Override
-	public SpatialWithinCirclePredicateBuilder<ElasticsearchSearchPredicateBuilder> createSpatialWithinCirclePredicateBuilder(
-			String absoluteFieldPath) {
-		throw log.spatialPredicatesNotSupportedByFieldType(
-				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
-		);
-	}
-
-	@Override
-	public SpatialWithinPolygonPredicateBuilder<ElasticsearchSearchPredicateBuilder> createSpatialWithinPolygonPredicateBuilder(
-			String absoluteFieldPath) {
-		throw log.spatialPredicatesNotSupportedByFieldType(
-				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
-		);
-	}
-
-	@Override
-	public SpatialWithinBoundingBoxPredicateBuilder<ElasticsearchSearchPredicateBuilder> createSpatialWithinBoundingBoxPredicateBuilder(
-			String absoluteFieldPath) {
-		throw log.spatialPredicatesNotSupportedByFieldType(
-				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
-		);
 	}
 
 	protected final ToDocumentFieldValueConverter<?, ? extends F> getConverter(DslConverter dslConverter) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchStandardFieldPredicateBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchStandardFieldPredicateBuilderFactory.java
@@ -22,6 +22,7 @@ import org.hibernate.search.engine.search.predicate.spi.RangePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinBoundingBoxPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinCirclePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinPolygonPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.WildcardPredicateBuilder;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
 public class ElasticsearchStandardFieldPredicateBuilderFactory<F> implements ElasticsearchFieldPredicateBuilderFactory {
@@ -68,6 +69,14 @@ public class ElasticsearchStandardFieldPredicateBuilderFactory<F> implements Ela
 
 	@Override
 	public PhrasePredicateBuilder<ElasticsearchSearchPredicateBuilder> createPhrasePredicateBuilder(
+			String absoluteFieldPath) {
+		throw log.textPredicatesNotSupportedByFieldType(
+				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
+		);
+	}
+
+	@Override
+	public WildcardPredicateBuilder<ElasticsearchSearchPredicateBuilder> createWildcardPredicateBuilder(
 			String absoluteFieldPath) {
 		throw log.textPredicatesNotSupportedByFieldType(
 				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchStandardFieldPredicateBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchStandardFieldPredicateBuilderFactory.java
@@ -18,6 +18,7 @@ import org.hibernate.search.engine.backend.types.converter.ToDocumentFieldValueC
 import org.hibernate.search.engine.reporting.spi.EventContexts;
 import org.hibernate.search.engine.search.predicate.spi.DslConverter;
 import org.hibernate.search.engine.search.predicate.spi.MatchPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.RangePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinBoundingBoxPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinCirclePredicateBuilder;
@@ -28,8 +29,8 @@ public class ElasticsearchStandardFieldPredicateBuilderFactory<F> implements Ela
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private final ToDocumentFieldValueConverter<?, ? extends F> converter;
-	private final ToDocumentFieldValueConverter<F, ? extends F> rawConverter;
+	protected final ToDocumentFieldValueConverter<?, ? extends F> converter;
+	protected final ToDocumentFieldValueConverter<F, ? extends F> rawConverter;
 
 	private final ElasticsearchFieldCodec<F> codec;
 
@@ -64,6 +65,14 @@ public class ElasticsearchStandardFieldPredicateBuilderFactory<F> implements Ela
 	public RangePredicateBuilder<ElasticsearchSearchPredicateBuilder> createRangePredicateBuilder(
 			ElasticsearchSearchContext searchContext, String absoluteFieldPath, DslConverter dslConverter) {
 		return new ElasticsearchRangePredicateBuilder<>( searchContext, absoluteFieldPath, getConverter( dslConverter ), codec );
+	}
+
+	@Override
+	public PhrasePredicateBuilder<ElasticsearchSearchPredicateBuilder> createPhrasePredicateBuilder(
+			String absoluteFieldPath) {
+		throw log.textPredicatesNotSupportedByFieldType(
+				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
+		);
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchStandardMatchPredicateBuilder.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchStandardMatchPredicateBuilder.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.backend.elasticsearch.search.predicate.impl;
+package org.hibernate.search.backend.elasticsearch.types.predicate.impl;
 
 import java.lang.invoke.MethodHandles;
 
@@ -12,6 +12,9 @@ import org.hibernate.search.backend.elasticsearch.gson.impl.JsonAccessor;
 import org.hibernate.search.backend.elasticsearch.gson.impl.JsonObjectAccessor;
 import org.hibernate.search.backend.elasticsearch.logging.impl.Log;
 import org.hibernate.search.backend.elasticsearch.search.impl.ElasticsearchSearchContext;
+import org.hibernate.search.backend.elasticsearch.search.predicate.impl.AbstractElasticsearchSearchPredicateBuilder;
+import org.hibernate.search.backend.elasticsearch.search.predicate.impl.ElasticsearchSearchPredicateBuilder;
+import org.hibernate.search.backend.elasticsearch.search.predicate.impl.ElasticsearchSearchPredicateContext;
 import org.hibernate.search.backend.elasticsearch.types.codec.impl.ElasticsearchFieldCodec;
 import org.hibernate.search.engine.backend.types.converter.ToDocumentFieldValueConverter;
 import org.hibernate.search.engine.reporting.spi.EventContexts;
@@ -24,7 +27,7 @@ import com.google.gson.JsonObject;
 /**
  * @author Yoann Rodiere
  */
-public class ElasticsearchMatchPredicateBuilder<F> extends AbstractElasticsearchSearchPredicateBuilder
+class ElasticsearchStandardMatchPredicateBuilder<F> extends AbstractElasticsearchSearchPredicateBuilder
 		implements MatchPredicateBuilder<ElasticsearchSearchPredicateBuilder> {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
@@ -41,7 +44,7 @@ public class ElasticsearchMatchPredicateBuilder<F> extends AbstractElasticsearch
 
 	private JsonElement value;
 
-	public ElasticsearchMatchPredicateBuilder(ElasticsearchSearchContext searchContext,
+	ElasticsearchStandardMatchPredicateBuilder(ElasticsearchSearchContext searchContext,
 			String absoluteFieldPath,
 			ToDocumentFieldValueConverter<?, ? extends F> dslToIndexConverter,
 			ElasticsearchFieldCodec<F> codec) {
@@ -49,6 +52,11 @@ public class ElasticsearchMatchPredicateBuilder<F> extends AbstractElasticsearch
 		this.absoluteFieldPath = absoluteFieldPath;
 		this.dslToIndexConverter = dslToIndexConverter;
 		this.codec = codec;
+	}
+
+	@Override
+	public void fuzzy(int maxEditDistance, int exactPrefixLength) {
+		throw log.textPredicatesNotSupportedByFieldType( EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchTextFieldPredicateBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchTextFieldPredicateBuilderFactory.java
@@ -13,6 +13,7 @@ import org.hibernate.search.engine.backend.types.converter.ToDocumentFieldValueC
 import org.hibernate.search.engine.search.predicate.spi.DslConverter;
 import org.hibernate.search.engine.search.predicate.spi.MatchPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.WildcardPredicateBuilder;
 
 public class ElasticsearchTextFieldPredicateBuilderFactory
 		extends ElasticsearchStandardFieldPredicateBuilderFactory<String> {
@@ -34,6 +35,12 @@ public class ElasticsearchTextFieldPredicateBuilderFactory
 	public PhrasePredicateBuilder<ElasticsearchSearchPredicateBuilder> createPhrasePredicateBuilder(
 			String absoluteFieldPath) {
 		return new ElasticsearchTextPhrasePredicateBuilder( absoluteFieldPath );
+	}
+
+	@Override
+	public WildcardPredicateBuilder<ElasticsearchSearchPredicateBuilder> createWildcardPredicateBuilder(
+			String absoluteFieldPath) {
+		return new ElasticsearchTextWildcardPredicateBuilder( absoluteFieldPath );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchTextFieldPredicateBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchTextFieldPredicateBuilderFactory.java
@@ -35,4 +35,10 @@ public class ElasticsearchTextFieldPredicateBuilderFactory
 			String absoluteFieldPath) {
 		return new ElasticsearchTextPhrasePredicateBuilder( absoluteFieldPath );
 	}
+
+	@Override
+	public ElasticsearchSimpleQueryStringPredicateBuilderFieldContext createSimpleQueryStringFieldContext(
+			String absoluteFieldPath) {
+		return new ElasticsearchSimpleQueryStringPredicateBuilderFieldContext( absoluteFieldPath );
+	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchTextFieldPredicateBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchTextFieldPredicateBuilderFactory.java
@@ -1,0 +1,29 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.types.predicate.impl;
+
+import org.hibernate.search.backend.elasticsearch.search.predicate.impl.ElasticsearchSearchPredicateBuilder;
+import org.hibernate.search.backend.elasticsearch.types.codec.impl.ElasticsearchFieldCodec;
+import org.hibernate.search.engine.backend.types.converter.ToDocumentFieldValueConverter;
+import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
+
+public class ElasticsearchTextFieldPredicateBuilderFactory
+		extends ElasticsearchStandardFieldPredicateBuilderFactory<String> {
+
+	public ElasticsearchTextFieldPredicateBuilderFactory(
+			ToDocumentFieldValueConverter<?, ? extends String> converter,
+			ToDocumentFieldValueConverter<String, ? extends String> rawConverter,
+			ElasticsearchFieldCodec<String> codec) {
+		super( converter, rawConverter, codec );
+	}
+
+	@Override
+	public PhrasePredicateBuilder<ElasticsearchSearchPredicateBuilder> createPhrasePredicateBuilder(
+			String absoluteFieldPath) {
+		return new ElasticsearchTextPhrasePredicateBuilder( absoluteFieldPath );
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchTextFieldPredicateBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchTextFieldPredicateBuilderFactory.java
@@ -6,9 +6,12 @@
  */
 package org.hibernate.search.backend.elasticsearch.types.predicate.impl;
 
+import org.hibernate.search.backend.elasticsearch.search.impl.ElasticsearchSearchContext;
 import org.hibernate.search.backend.elasticsearch.search.predicate.impl.ElasticsearchSearchPredicateBuilder;
 import org.hibernate.search.backend.elasticsearch.types.codec.impl.ElasticsearchFieldCodec;
 import org.hibernate.search.engine.backend.types.converter.ToDocumentFieldValueConverter;
+import org.hibernate.search.engine.search.predicate.spi.DslConverter;
+import org.hibernate.search.engine.search.predicate.spi.MatchPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
 
 public class ElasticsearchTextFieldPredicateBuilderFactory
@@ -19,6 +22,12 @@ public class ElasticsearchTextFieldPredicateBuilderFactory
 			ToDocumentFieldValueConverter<String, ? extends String> rawConverter,
 			ElasticsearchFieldCodec<String> codec) {
 		super( converter, rawConverter, codec );
+	}
+
+	@Override
+	public MatchPredicateBuilder<ElasticsearchSearchPredicateBuilder> createMatchPredicateBuilder(
+			ElasticsearchSearchContext searchContext, String absoluteFieldPath, DslConverter dslConverter) {
+		return new ElasticsearchTextMatchPredicateBuilder( searchContext, absoluteFieldPath, getConverter( dslConverter ), codec );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchTextMatchPredicateBuilder.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchTextMatchPredicateBuilder.java
@@ -1,0 +1,50 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.types.predicate.impl;
+
+import org.hibernate.search.backend.elasticsearch.gson.impl.JsonAccessor;
+import org.hibernate.search.backend.elasticsearch.search.impl.ElasticsearchSearchContext;
+import org.hibernate.search.backend.elasticsearch.search.predicate.impl.ElasticsearchSearchPredicateContext;
+import org.hibernate.search.backend.elasticsearch.types.codec.impl.ElasticsearchFieldCodec;
+import org.hibernate.search.engine.backend.types.converter.ToDocumentFieldValueConverter;
+
+import com.google.gson.JsonObject;
+
+class ElasticsearchTextMatchPredicateBuilder extends ElasticsearchStandardMatchPredicateBuilder<String> {
+
+	private static final JsonAccessor<Integer> FUZZINESS_ACCESSOR = JsonAccessor.root().property( "fuzziness" ).asInteger();
+	private static final JsonAccessor<Integer> PREFIX_LENGTH_ACCESSOR = JsonAccessor.root().property( "prefix_length" ).asInteger();
+
+	private Integer fuzziness;
+	private Integer prefixLength;
+
+	ElasticsearchTextMatchPredicateBuilder(
+			ElasticsearchSearchContext searchContext,
+			String absoluteFieldPath,
+			ToDocumentFieldValueConverter<?, ? extends String> dslToIndexConverter,
+			ElasticsearchFieldCodec<String> codec) {
+		super( searchContext, absoluteFieldPath, dslToIndexConverter, codec );
+	}
+
+	@Override
+	public void fuzzy(int maxEditDistance, int exactPrefixLength) {
+		this.fuzziness = maxEditDistance;
+		this.prefixLength = exactPrefixLength;
+	}
+
+	@Override
+	protected JsonObject doBuild(ElasticsearchSearchPredicateContext context, JsonObject outerObject,
+			JsonObject innerObject) {
+		if ( fuzziness != null ) {
+			FUZZINESS_ACCESSOR.set( innerObject, fuzziness );
+		}
+		if ( prefixLength != null ) {
+			PREFIX_LENGTH_ACCESSOR.set( innerObject, prefixLength );
+		}
+		return super.doBuild( context, outerObject, innerObject );
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchTextPhrasePredicateBuilder.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchTextPhrasePredicateBuilder.java
@@ -1,0 +1,62 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.types.predicate.impl;
+
+import org.hibernate.search.backend.elasticsearch.gson.impl.JsonAccessor;
+import org.hibernate.search.backend.elasticsearch.gson.impl.JsonObjectAccessor;
+import org.hibernate.search.backend.elasticsearch.search.predicate.impl.AbstractElasticsearchSearchPredicateBuilder;
+import org.hibernate.search.backend.elasticsearch.search.predicate.impl.ElasticsearchSearchPredicateBuilder;
+import org.hibernate.search.backend.elasticsearch.search.predicate.impl.ElasticsearchSearchPredicateContext;
+import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
+class ElasticsearchTextPhrasePredicateBuilder extends AbstractElasticsearchSearchPredicateBuilder
+		implements PhrasePredicateBuilder<ElasticsearchSearchPredicateBuilder> {
+
+	private static final JsonObjectAccessor MATCH_PHRASE_ACCESSOR = JsonAccessor.root().property( "match_phrase" ).asObject();
+
+	private static final JsonAccessor<Integer> SLOP_ACCESSOR = JsonAccessor.root().property( "slop" ).asInteger();
+	private static final JsonAccessor<JsonElement> QUERY_ACCESSOR = JsonAccessor.root().property( "query" );
+
+	private final String absoluteFieldPath;
+
+	private Integer slop;
+	private JsonElement phrase;
+
+	ElasticsearchTextPhrasePredicateBuilder(String absoluteFieldPath) {
+		this.absoluteFieldPath = absoluteFieldPath;
+	}
+
+	@Override
+	public void slop(int slop) {
+		this.slop = slop;
+	}
+
+	@Override
+	public void phrase(String phrase) {
+		this.phrase = new JsonPrimitive( phrase );
+	}
+
+	@Override
+	protected JsonObject doBuild(ElasticsearchSearchPredicateContext context,
+			JsonObject outerObject, JsonObject innerObject) {
+		QUERY_ACCESSOR.set( innerObject, phrase );
+		if ( slop != null ) {
+			SLOP_ACCESSOR.set( innerObject, slop );
+		}
+
+		JsonObject middleObject = new JsonObject();
+		middleObject.add( absoluteFieldPath, innerObject );
+
+		MATCH_PHRASE_ACCESSOR.set( outerObject, middleObject );
+		return outerObject;
+	}
+
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchTextWildcardPredicateBuilder.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchTextWildcardPredicateBuilder.java
@@ -1,0 +1,52 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.types.predicate.impl;
+
+import org.hibernate.search.backend.elasticsearch.gson.impl.JsonAccessor;
+import org.hibernate.search.backend.elasticsearch.gson.impl.JsonObjectAccessor;
+import org.hibernate.search.backend.elasticsearch.search.predicate.impl.AbstractElasticsearchSearchPredicateBuilder;
+import org.hibernate.search.backend.elasticsearch.search.predicate.impl.ElasticsearchSearchPredicateBuilder;
+import org.hibernate.search.backend.elasticsearch.search.predicate.impl.ElasticsearchSearchPredicateContext;
+import org.hibernate.search.engine.search.predicate.spi.WildcardPredicateBuilder;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
+public class ElasticsearchTextWildcardPredicateBuilder extends AbstractElasticsearchSearchPredicateBuilder
+		implements WildcardPredicateBuilder<ElasticsearchSearchPredicateBuilder> {
+
+	private static final JsonObjectAccessor WILDCARD_ACCESSOR = JsonAccessor.root().property( "wildcard" ).asObject();
+
+	private static final JsonAccessor<JsonElement> VALUE_ACCESSOR = JsonAccessor.root().property( "value" );
+
+	private final String absoluteFieldPath;
+
+	private JsonElement pattern;
+
+	public ElasticsearchTextWildcardPredicateBuilder(String absoluteFieldPath) {
+		this.absoluteFieldPath = absoluteFieldPath;
+	}
+
+	@Override
+	public void pattern(String pattern) {
+		this.pattern = new JsonPrimitive( pattern );
+	}
+
+	@Override
+	protected JsonObject doBuild(ElasticsearchSearchPredicateContext context,
+			JsonObject outerObject, JsonObject innerObject) {
+		VALUE_ACCESSOR.set( innerObject, pattern );
+
+		JsonObject middleObject = new JsonObject();
+		middleObject.add( absoluteFieldPath, innerObject );
+
+		WILDCARD_ACCESSOR.set( outerObject, middleObject );
+		return outerObject;
+	}
+
+}

--- a/backend/lucene/pom.xml
+++ b/backend/lucene/pom.xml
@@ -30,6 +30,10 @@
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-queryparser</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-join</artifactId>
         </dependency>
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/analysis/impl/ScopedAnalyzer.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/analysis/impl/ScopedAnalyzer.java
@@ -10,8 +10,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.AnalyzerWrapper;
 import org.apache.lucene.analysis.DelegatingAnalyzerWrapper;
+import org.apache.lucene.analysis.core.KeywordAnalyzer;
 
 import org.hibernate.search.util.common.impl.CollectionHelper;
 
@@ -20,13 +20,12 @@ import org.hibernate.search.util.common.impl.CollectionHelper;
  */
 public final class ScopedAnalyzer extends DelegatingAnalyzerWrapper {
 
-	private final Analyzer globalAnalyzer;
+	private static final Analyzer DEFAULT_ANALYZER = new KeywordAnalyzer();
 
 	private final Map<String, Analyzer> scopedAnalyzers;
 
-	private ScopedAnalyzer(Analyzer globalAnalyzer, Map<String, Analyzer> scopedAnalyzers) {
+	private ScopedAnalyzer(Map<String, Analyzer> scopedAnalyzers) {
 		super( PER_FIELD_REUSE_STRATEGY );
-		this.globalAnalyzer = globalAnalyzer;
 		this.scopedAnalyzers = CollectionHelper.toImmutableMap( scopedAnalyzers );
 	}
 
@@ -35,7 +34,7 @@ public final class ScopedAnalyzer extends DelegatingAnalyzerWrapper {
 		Analyzer analyzer = scopedAnalyzers.get( absoluteFieldPath );
 
 		if ( analyzer == null ) {
-			return globalAnalyzer;
+			return DEFAULT_ANALYZER;
 		}
 
 		return analyzer;
@@ -43,20 +42,14 @@ public final class ScopedAnalyzer extends DelegatingAnalyzerWrapper {
 
 	public static class Builder {
 
-		private final Analyzer globalAnalyzer;
-
 		private final Map<String, Analyzer> scopedAnalyzers = new HashMap<>();
-
-		public Builder(Analyzer globalAnalyzer) {
-			this.globalAnalyzer = globalAnalyzer;
-		}
 
 		public void setAnalyzer(String absoluteFieldPath, Analyzer analyzer) {
 			this.scopedAnalyzers.put( absoluteFieldPath, analyzer );
 		}
 
 		public ScopedAnalyzer build() {
-			return new ScopedAnalyzer( globalAnalyzer, scopedAnalyzers );
+			return new ScopedAnalyzer( scopedAnalyzers );
 		}
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/analysis/impl/ScopedAnalyzer.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/analysis/impl/ScopedAnalyzer.java
@@ -11,12 +11,14 @@ import java.util.Map;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.AnalyzerWrapper;
+import org.apache.lucene.analysis.DelegatingAnalyzerWrapper;
+
 import org.hibernate.search.util.common.impl.CollectionHelper;
 
 /**
  * @author Guillaume Smet
  */
-public final class ScopedAnalyzer extends AnalyzerWrapper {
+public final class ScopedAnalyzer extends DelegatingAnalyzerWrapper {
 
 	private final Analyzer globalAnalyzer;
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/dsl/impl/LuceneIndexSchemaRootNodeBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/dsl/impl/LuceneIndexSchemaRootNodeBuilder.java
@@ -10,7 +10,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.core.KeywordAnalyzer;
 import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexModel;
 import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexSchemaFieldNode;
 import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexSchemaNodeCollector;
@@ -67,8 +66,7 @@ public class LuceneIndexSchemaRootNodeBuilder extends AbstractLuceneIndexSchemaO
 	public LuceneIndexModel build(String indexName) {
 		Map<String, LuceneIndexSchemaObjectNode> objectNodesBuilder = new HashMap<>();
 		Map<String, LuceneIndexSchemaFieldNode<?>> fieldNodesBuilder = new HashMap<>();
-		// TODO the default analyzer should be configurable, for now, we default to no analysis
-		ScopedAnalyzer.Builder scopedAnalyzerBuilder = new ScopedAnalyzer.Builder( new KeywordAnalyzer() );
+		ScopedAnalyzer.Builder scopedAnalyzerBuilder = new ScopedAnalyzer.Builder();
 
 		LuceneIndexSchemaNodeCollector collector = new LuceneIndexSchemaNodeCollector() {
 			@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
@@ -416,6 +416,6 @@ public interface Log extends BasicLogger {
 	SearchException ioExceptionOnExplain(@Cause IOException e);
 
 	@Message(id = ID_OFFSET_2 + 70,
-			value = "Text predicates (phrase, fuzzy, wildcard) are not supported by this field's type.")
+			value = "Text predicates (phrase, fuzzy, wildcard, simple query string) are not supported by this field's type.")
 	SearchException textPredicatesNotSupportedByFieldType(@Param EventContext context);
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
@@ -414,4 +414,8 @@ public interface Log extends BasicLogger {
 	@Message(id = ID_OFFSET_2 + 69,
 			value = "An IOException occurred while generating an Explanation.")
 	SearchException ioExceptionOnExplain(@Cause IOException e);
+
+	@Message(id = ID_OFFSET_2 + 70,
+			value = "Text predicates (phrase, fuzzy, wildcard) are not supported by this field's type.")
+	SearchException textPredicatesNotSupportedByFieldType(@Param EventContext context);
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/AbstractLuceneSearchPredicateBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/AbstractLuceneSearchPredicateBuilder.java
@@ -16,7 +16,7 @@ import org.apache.lucene.search.Query;
 /**
  * @author Guillaume Smet
  */
-abstract class AbstractLuceneSearchPredicateBuilder implements SearchPredicateBuilder<LuceneSearchPredicateBuilder>,
+public abstract class AbstractLuceneSearchPredicateBuilder implements SearchPredicateBuilder<LuceneSearchPredicateBuilder>,
 		LuceneSearchPredicateBuilder {
 
 	private Float boost;

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/AbstractLuceneStandardMatchPredicateBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/AbstractLuceneStandardMatchPredicateBuilder.java
@@ -47,6 +47,11 @@ public abstract class AbstractLuceneStandardMatchPredicateBuilder<F, E, C extend
 	}
 
 	@Override
+	public void fuzzy(int maxEditDistance, int exactPrefixLength) {
+		throw log.textPredicatesNotSupportedByFieldType( EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
+	}
+
+	@Override
 	public void value(Object value) {
 		try {
 			F converted = converter.convertUnknown( value, searchContext.getToDocumentFieldValueConvertContext() );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/LuceneSearchPredicateBuilderFactoryImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/LuceneSearchPredicateBuilderFactoryImpl.java
@@ -24,6 +24,7 @@ import org.hibernate.search.engine.search.predicate.spi.MatchPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.NestedPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.RangePredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.SimpleQueryStringPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinBoundingBoxPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinCirclePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinPolygonPredicateBuilder;
@@ -38,7 +39,7 @@ public class LuceneSearchPredicateBuilderFactoryImpl implements LuceneSearchPred
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private static final PredicateBuilderFactoryRetrievalStrategy PREDICATE_BUILDER_FACTORY_RETRIEVAL_STRATEGY =
+	static final PredicateBuilderFactoryRetrievalStrategy PREDICATE_BUILDER_FACTORY_RETRIEVAL_STRATEGY =
 			new PredicateBuilderFactoryRetrievalStrategy();
 
 	private final LuceneSearchContext searchContext;
@@ -103,6 +104,11 @@ public class LuceneSearchPredicateBuilderFactoryImpl implements LuceneSearchPred
 		return searchTargetModel
 				.getSchemaNodeComponent( absoluteFieldPath, PREDICATE_BUILDER_FACTORY_RETRIEVAL_STRATEGY, DslConverter.DISABLED )
 				.createPhrasePredicateBuilder( absoluteFieldPath );
+	}
+
+	@Override
+	public SimpleQueryStringPredicateBuilder<LuceneSearchPredicateBuilder> simpleQueryString() {
+		return new LuceneSimpleQueryStringPredicateBuilder( searchTargetModel );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/LuceneSearchPredicateBuilderFactoryImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/LuceneSearchPredicateBuilderFactoryImpl.java
@@ -22,6 +22,7 @@ import org.hibernate.search.engine.search.predicate.spi.MatchAllPredicateBuilder
 import org.hibernate.search.engine.search.predicate.spi.MatchIdPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.MatchPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.NestedPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.RangePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinBoundingBoxPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinCirclePredicateBuilder;
@@ -95,6 +96,13 @@ public class LuceneSearchPredicateBuilderFactoryImpl implements LuceneSearchPred
 		return searchTargetModel
 				.getSchemaNodeComponent( absoluteFieldPath, PREDICATE_BUILDER_FACTORY_RETRIEVAL_STRATEGY, dslConverter )
 				.createRangePredicateBuilder( searchContext, absoluteFieldPath, dslConverter );
+	}
+
+	@Override
+	public PhrasePredicateBuilder<LuceneSearchPredicateBuilder> phrase(String absoluteFieldPath) {
+		return searchTargetModel
+				.getSchemaNodeComponent( absoluteFieldPath, PREDICATE_BUILDER_FACTORY_RETRIEVAL_STRATEGY, DslConverter.DISABLED )
+				.createPhrasePredicateBuilder( absoluteFieldPath );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/LuceneSearchPredicateBuilderFactoryImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/LuceneSearchPredicateBuilderFactoryImpl.java
@@ -28,6 +28,7 @@ import org.hibernate.search.engine.search.predicate.spi.SimpleQueryStringPredica
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinBoundingBoxPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinCirclePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinPolygonPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.WildcardPredicateBuilder;
 import org.hibernate.search.util.common.reporting.EventContext;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
@@ -104,6 +105,13 @@ public class LuceneSearchPredicateBuilderFactoryImpl implements LuceneSearchPred
 		return searchTargetModel
 				.getSchemaNodeComponent( absoluteFieldPath, PREDICATE_BUILDER_FACTORY_RETRIEVAL_STRATEGY, DslConverter.DISABLED )
 				.createPhrasePredicateBuilder( absoluteFieldPath );
+	}
+
+	@Override
+	public WildcardPredicateBuilder<LuceneSearchPredicateBuilder> wildcard(String absoluteFieldPath) {
+		return searchTargetModel
+				.getSchemaNodeComponent( absoluteFieldPath, PREDICATE_BUILDER_FACTORY_RETRIEVAL_STRATEGY, DslConverter.DISABLED )
+				.createWildcardPredicateBuilder( absoluteFieldPath );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/LuceneSimpleQueryStringPredicateBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/LuceneSimpleQueryStringPredicateBuilder.java
@@ -1,0 +1,97 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.search.predicate.impl;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.hibernate.search.backend.lucene.analysis.impl.ScopedAnalyzer;
+import org.hibernate.search.backend.lucene.search.impl.LuceneSearchTargetModel;
+import org.hibernate.search.backend.lucene.types.predicate.impl.LuceneSimpleQueryStringPredicateBuilderFieldContext;
+import org.hibernate.search.backend.lucene.util.impl.FieldContextSimpleQueryParser;
+import org.hibernate.search.engine.search.predicate.spi.DslConverter;
+import org.hibernate.search.engine.search.predicate.spi.SimpleQueryStringPredicateBuilder;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.Query;
+
+public class LuceneSimpleQueryStringPredicateBuilder extends AbstractLuceneSearchPredicateBuilder
+		implements SimpleQueryStringPredicateBuilder<LuceneSearchPredicateBuilder> {
+
+	private final LuceneSearchTargetModel searchTargetModel;
+
+	private final Map<String, LuceneSimpleQueryStringPredicateBuilderFieldContext> fields = new LinkedHashMap<>();
+	private Occur defaultOperator = Occur.SHOULD;
+	private String simpleQueryString;
+
+	LuceneSimpleQueryStringPredicateBuilder(LuceneSearchTargetModel searchTargetModel) {
+		this.searchTargetModel = searchTargetModel;
+	}
+
+	@Override
+	public void withAndAsDefaultOperator() {
+		this.defaultOperator = Occur.MUST;
+	}
+
+	@Override
+	public FieldContext field(String absoluteFieldPath) {
+		LuceneSimpleQueryStringPredicateBuilderFieldContext field = fields.get( absoluteFieldPath );
+		if ( field == null ) {
+			field = searchTargetModel.getSchemaNodeComponent(
+					absoluteFieldPath,
+					LuceneSearchPredicateBuilderFactoryImpl.PREDICATE_BUILDER_FACTORY_RETRIEVAL_STRATEGY,
+					DslConverter.DISABLED
+			)
+					.createSimpleQueryStringFieldContext( absoluteFieldPath );
+			fields.put( absoluteFieldPath, field );
+		}
+		return field;
+	}
+
+	@Override
+	public void simpleQueryString(String simpleQueryString) {
+		this.simpleQueryString = simpleQueryString;
+	}
+
+	@Override
+	protected Query doBuild(LuceneSearchPredicateContext context) {
+		Analyzer analyzer = buildAnalyzer();
+		FieldContextSimpleQueryParser queryParser = new FieldContextSimpleQueryParser( analyzer, fields );
+		queryParser.setDefaultOperator( defaultOperator );
+
+		return queryParser.parse( simpleQueryString );
+	}
+
+	private Analyzer buildAnalyzer() {
+		if ( fields.size() == 1 ) {
+			return fields.values().iterator().next().getAnalyzer();
+		}
+		else {
+			/*
+			 * We need to build a new scoped analyzer to address the case of search queries targeting
+			 * multiple indexes, where index A defines "field1" but not "field2",
+			 * and index B defines "field2" but not "field1".
+			 * In that case, neither the scoped analyzer for index A nor the scoped analyzer for index B would work.
+			 *
+			 * An alternative exists, but I am not sure it would perform significantly better.
+			 * Let us consider that all targeted indexes are compatible for the targeted fields,
+			 * i.e. if an index defines a field, it always has the same analyzer as the same field in other indexes.
+			 * This compatibility would allow us to simply use a "chaining" analyzer,
+			 * which would hold a list of each scoped analyzer for each index,
+			 * and, when asked for the analyzer to delegate to,
+			 * would pick the first analyzer returned by any of the scoped analyzers in its list.
+			 */
+			ScopedAnalyzer.Builder builder = new ScopedAnalyzer.Builder();
+			for ( Map.Entry<String, LuceneSimpleQueryStringPredicateBuilderFieldContext> entry : fields.entrySet() ) {
+				builder.setAnalyzer( entry.getKey(), entry.getValue().getAnalyzer() );
+			}
+			return builder.build();
+		}
+	}
+
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/AbstractLuceneFieldPredicateBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/AbstractLuceneFieldPredicateBuilderFactory.java
@@ -9,44 +9,39 @@ package org.hibernate.search.backend.lucene.types.predicate.impl;
 import java.lang.invoke.MethodHandles;
 
 import org.hibernate.search.backend.lucene.logging.impl.Log;
-import org.hibernate.search.backend.lucene.search.impl.LuceneSearchContext;
 import org.hibernate.search.backend.lucene.search.predicate.impl.LuceneSearchPredicateBuilder;
 import org.hibernate.search.engine.reporting.spi.EventContexts;
-import org.hibernate.search.engine.search.predicate.spi.DslConverter;
-import org.hibernate.search.engine.search.predicate.spi.MatchPredicateBuilder;
-import org.hibernate.search.engine.search.predicate.spi.RangePredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinBoundingBoxPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinCirclePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinPolygonPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.WildcardPredicateBuilder;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
-public final class LuceneGeoPointFieldPredicateBuilderFactory
-		extends AbstractLuceneFieldPredicateBuilderFactory {
+abstract class AbstractLuceneFieldPredicateBuilderFactory
+		implements LuceneFieldPredicateBuilderFactory {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	public static final LuceneGeoPointFieldPredicateBuilderFactory INSTANCE = new LuceneGeoPointFieldPredicateBuilderFactory();
-
-	private LuceneGeoPointFieldPredicateBuilderFactory() {
-	}
-
 	@Override
-	public boolean isDslCompatibleWith(LuceneFieldPredicateBuilderFactory other, DslConverter dslConverter) {
-		return INSTANCE == other;
-	}
-
-	@Override
-	public MatchPredicateBuilder<LuceneSearchPredicateBuilder> createMatchPredicateBuilder(
-			LuceneSearchContext searchContext, String absoluteFieldPath, DslConverter dslConverter) {
-		throw log.matchPredicatesNotSupportedByGeoPoint(
+	public PhrasePredicateBuilder<LuceneSearchPredicateBuilder> createPhrasePredicateBuilder(String absoluteFieldPath) {
+		throw log.textPredicatesNotSupportedByFieldType(
 				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
 		);
 	}
 
 	@Override
-	public RangePredicateBuilder<LuceneSearchPredicateBuilder> createRangePredicateBuilder(
-			LuceneSearchContext searchContext, String absoluteFieldPath, DslConverter dslConverter) {
-		throw log.rangePredicatesNotSupportedByGeoPoint(
+	public WildcardPredicateBuilder<LuceneSearchPredicateBuilder> createWildcardPredicateBuilder(
+			String absoluteFieldPath) {
+		throw log.textPredicatesNotSupportedByFieldType(
+				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
+		);
+	}
+
+	@Override
+	public LuceneSimpleQueryStringPredicateBuilderFieldContext createSimpleQueryStringFieldContext(
+			String absoluteFieldPath) {
+		throw log.textPredicatesNotSupportedByFieldType(
 				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
 		);
 	}
@@ -54,18 +49,24 @@ public final class LuceneGeoPointFieldPredicateBuilderFactory
 	@Override
 	public SpatialWithinCirclePredicateBuilder<LuceneSearchPredicateBuilder> createSpatialWithinCirclePredicateBuilder(
 			String absoluteFieldPath) {
-		return new LuceneGeoPointSpatialWithinCirclePredicateBuilder( absoluteFieldPath );
+		throw log.spatialPredicatesNotSupportedByFieldType(
+				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
+		);
 	}
 
 	@Override
 	public SpatialWithinPolygonPredicateBuilder<LuceneSearchPredicateBuilder> createSpatialWithinPolygonPredicateBuilder(
 			String absoluteFieldPath) {
-		return new LuceneGeoPointSpatialWithinPolygonPredicateBuilder( absoluteFieldPath );
+		throw log.spatialPredicatesNotSupportedByFieldType(
+				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
+		);
 	}
 
 	@Override
 	public SpatialWithinBoundingBoxPredicateBuilder<LuceneSearchPredicateBuilder> createSpatialWithinBoundingBoxPredicateBuilder(
 			String absoluteFieldPath) {
-		return new LuceneGeoPointSpatialWithinBoundingBoxPredicateBuilder( absoluteFieldPath );
+		throw log.spatialPredicatesNotSupportedByFieldType(
+				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
+		);
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/AbstractLuceneStandardFieldPredicateBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/AbstractLuceneStandardFieldPredicateBuilderFactory.java
@@ -14,6 +14,7 @@ import org.hibernate.search.backend.lucene.types.codec.impl.LuceneStandardFieldC
 import org.hibernate.search.engine.backend.types.converter.ToDocumentFieldValueConverter;
 import org.hibernate.search.engine.reporting.spi.EventContexts;
 import org.hibernate.search.engine.search.predicate.spi.DslConverter;
+import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinBoundingBoxPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinCirclePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinPolygonPredicateBuilder;
@@ -56,6 +57,13 @@ abstract class AbstractLuceneStandardFieldPredicateBuilderFactory<F, C extends L
 			return false;
 		}
 		return !dslConverter.isEnabled() || converter.isCompatibleWith( castedOther.converter );
+	}
+
+	@Override
+	public PhrasePredicateBuilder<LuceneSearchPredicateBuilder> createPhrasePredicateBuilder(String absoluteFieldPath) {
+		throw log.textPredicatesNotSupportedByFieldType(
+				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
+		);
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/AbstractLuceneStandardFieldPredicateBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/AbstractLuceneStandardFieldPredicateBuilderFactory.java
@@ -6,21 +6,10 @@
  */
 package org.hibernate.search.backend.lucene.types.predicate.impl;
 
-import java.lang.invoke.MethodHandles;
-
-import org.hibernate.search.backend.lucene.logging.impl.Log;
-import org.hibernate.search.backend.lucene.search.predicate.impl.LuceneSearchPredicateBuilder;
 import org.hibernate.search.backend.lucene.types.codec.impl.LuceneStandardFieldCodec;
 import org.hibernate.search.engine.backend.types.converter.ToDocumentFieldValueConverter;
-import org.hibernate.search.engine.reporting.spi.EventContexts;
 import org.hibernate.search.engine.search.predicate.spi.DslConverter;
-import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
-import org.hibernate.search.engine.search.predicate.spi.SpatialWithinBoundingBoxPredicateBuilder;
-import org.hibernate.search.engine.search.predicate.spi.SpatialWithinCirclePredicateBuilder;
-import org.hibernate.search.engine.search.predicate.spi.SpatialWithinPolygonPredicateBuilder;
-import org.hibernate.search.engine.search.predicate.spi.WildcardPredicateBuilder;
 import org.hibernate.search.util.common.impl.Contracts;
-import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
 /**
  * @param <F> The field type exposed to the mapper.
@@ -28,9 +17,7 @@ import org.hibernate.search.util.common.logging.impl.LoggerFactory;
  * @see LuceneStandardFieldCodec
  */
 abstract class AbstractLuceneStandardFieldPredicateBuilderFactory<F, C extends LuceneStandardFieldCodec<F, ?>>
-		implements LuceneFieldPredicateBuilderFactory {
-
-	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+		extends AbstractLuceneFieldPredicateBuilderFactory {
 
 	private final ToDocumentFieldValueConverter<?, ? extends F> converter;
 	private final ToDocumentFieldValueConverter<F, ? extends F> rawConverter;
@@ -58,53 +45,6 @@ abstract class AbstractLuceneStandardFieldPredicateBuilderFactory<F, C extends L
 			return false;
 		}
 		return !dslConverter.isEnabled() || converter.isCompatibleWith( castedOther.converter );
-	}
-
-	@Override
-	public PhrasePredicateBuilder<LuceneSearchPredicateBuilder> createPhrasePredicateBuilder(String absoluteFieldPath) {
-		throw log.textPredicatesNotSupportedByFieldType(
-				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
-		);
-	}
-
-	@Override
-	public WildcardPredicateBuilder<LuceneSearchPredicateBuilder> createWildcardPredicateBuilder(
-			String absoluteFieldPath) {
-		throw log.textPredicatesNotSupportedByFieldType(
-				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
-		);
-	}
-
-	@Override
-	public LuceneSimpleQueryStringPredicateBuilderFieldContext createSimpleQueryStringFieldContext(
-			String absoluteFieldPath) {
-		throw log.textPredicatesNotSupportedByFieldType(
-				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
-		);
-	}
-
-	@Override
-	public SpatialWithinCirclePredicateBuilder<LuceneSearchPredicateBuilder> createSpatialWithinCirclePredicateBuilder(
-			String absoluteFieldPath) {
-		throw log.spatialPredicatesNotSupportedByFieldType(
-				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
-		);
-	}
-
-	@Override
-	public SpatialWithinPolygonPredicateBuilder<LuceneSearchPredicateBuilder> createSpatialWithinPolygonPredicateBuilder(
-			String absoluteFieldPath) {
-		throw log.spatialPredicatesNotSupportedByFieldType(
-				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
-		);
-	}
-
-	@Override
-	public SpatialWithinBoundingBoxPredicateBuilder<LuceneSearchPredicateBuilder> createSpatialWithinBoundingBoxPredicateBuilder(
-			String absoluteFieldPath) {
-		throw log.spatialPredicatesNotSupportedByFieldType(
-				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
-		);
 	}
 
 	protected ToDocumentFieldValueConverter<?, ? extends F> getConverter(DslConverter dslConverter) {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/AbstractLuceneStandardFieldPredicateBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/AbstractLuceneStandardFieldPredicateBuilderFactory.java
@@ -18,6 +18,7 @@ import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinBoundingBoxPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinCirclePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinPolygonPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.WildcardPredicateBuilder;
 import org.hibernate.search.util.common.impl.Contracts;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
@@ -61,6 +62,14 @@ abstract class AbstractLuceneStandardFieldPredicateBuilderFactory<F, C extends L
 
 	@Override
 	public PhrasePredicateBuilder<LuceneSearchPredicateBuilder> createPhrasePredicateBuilder(String absoluteFieldPath) {
+		throw log.textPredicatesNotSupportedByFieldType(
+				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
+		);
+	}
+
+	@Override
+	public WildcardPredicateBuilder<LuceneSearchPredicateBuilder> createWildcardPredicateBuilder(
+			String absoluteFieldPath) {
 		throw log.textPredicatesNotSupportedByFieldType(
 				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
 		);

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/AbstractLuceneStandardFieldPredicateBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/AbstractLuceneStandardFieldPredicateBuilderFactory.java
@@ -67,6 +67,14 @@ abstract class AbstractLuceneStandardFieldPredicateBuilderFactory<F, C extends L
 	}
 
 	@Override
+	public LuceneSimpleQueryStringPredicateBuilderFieldContext createSimpleQueryStringFieldContext(
+			String absoluteFieldPath) {
+		throw log.textPredicatesNotSupportedByFieldType(
+				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
+		);
+	}
+
+	@Override
 	public SpatialWithinCirclePredicateBuilder<LuceneSearchPredicateBuilder> createSpatialWithinCirclePredicateBuilder(
 			String absoluteFieldPath) {
 		throw log.spatialPredicatesNotSupportedByFieldType(

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneFieldPredicateBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneFieldPredicateBuilderFactory.java
@@ -59,6 +59,8 @@ public interface LuceneFieldPredicateBuilderFactory {
 	PhrasePredicateBuilder<LuceneSearchPredicateBuilder> createPhrasePredicateBuilder(
 			String absoluteFieldPath);
 
+	LuceneSimpleQueryStringPredicateBuilderFieldContext createSimpleQueryStringFieldContext(String absoluteFieldPath);
+
 	SpatialWithinCirclePredicateBuilder<LuceneSearchPredicateBuilder> createSpatialWithinCirclePredicateBuilder(
 			String absoluteFieldPath);
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneFieldPredicateBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneFieldPredicateBuilderFactory.java
@@ -17,6 +17,7 @@ import org.hibernate.search.engine.search.predicate.spi.RangePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinBoundingBoxPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinCirclePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinPolygonPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.WildcardPredicateBuilder;
 
 /**
  * A field-scoped factory for search predicate builders.
@@ -57,6 +58,9 @@ public interface LuceneFieldPredicateBuilderFactory {
 			LuceneSearchContext searchContext, String absoluteFieldPath, DslConverter dslConverter);
 
 	PhrasePredicateBuilder<LuceneSearchPredicateBuilder> createPhrasePredicateBuilder(
+			String absoluteFieldPath);
+
+	WildcardPredicateBuilder<LuceneSearchPredicateBuilder> createWildcardPredicateBuilder(
 			String absoluteFieldPath);
 
 	LuceneSimpleQueryStringPredicateBuilderFieldContext createSimpleQueryStringFieldContext(String absoluteFieldPath);

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneFieldPredicateBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneFieldPredicateBuilderFactory.java
@@ -12,6 +12,7 @@ import org.hibernate.search.backend.lucene.types.codec.impl.LuceneFieldCodec;
 import org.hibernate.search.engine.backend.types.converter.ToDocumentFieldValueConverter;
 import org.hibernate.search.engine.search.predicate.spi.DslConverter;
 import org.hibernate.search.engine.search.predicate.spi.MatchPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.RangePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinBoundingBoxPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinCirclePredicateBuilder;
@@ -54,6 +55,9 @@ public interface LuceneFieldPredicateBuilderFactory {
 
 	RangePredicateBuilder<LuceneSearchPredicateBuilder> createRangePredicateBuilder(
 			LuceneSearchContext searchContext, String absoluteFieldPath, DslConverter dslConverter);
+
+	PhrasePredicateBuilder<LuceneSearchPredicateBuilder> createPhrasePredicateBuilder(
+			String absoluteFieldPath);
 
 	SpatialWithinCirclePredicateBuilder<LuceneSearchPredicateBuilder> createSpatialWithinCirclePredicateBuilder(
 			String absoluteFieldPath);

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneGeoPointFieldPredicateBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneGeoPointFieldPredicateBuilderFactory.java
@@ -19,6 +19,7 @@ import org.hibernate.search.engine.search.predicate.spi.RangePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinBoundingBoxPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinCirclePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinPolygonPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.WildcardPredicateBuilder;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
 public final class LuceneGeoPointFieldPredicateBuilderFactory implements LuceneFieldPredicateBuilderFactory {
@@ -53,6 +54,14 @@ public final class LuceneGeoPointFieldPredicateBuilderFactory implements LuceneF
 
 	@Override
 	public PhrasePredicateBuilder<LuceneSearchPredicateBuilder> createPhrasePredicateBuilder(String absoluteFieldPath) {
+		throw log.textPredicatesNotSupportedByFieldType(
+				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
+		);
+	}
+
+	@Override
+	public WildcardPredicateBuilder<LuceneSearchPredicateBuilder> createWildcardPredicateBuilder(
+			String absoluteFieldPath) {
 		throw log.textPredicatesNotSupportedByFieldType(
 				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
 		);

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneGeoPointFieldPredicateBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneGeoPointFieldPredicateBuilderFactory.java
@@ -14,6 +14,7 @@ import org.hibernate.search.backend.lucene.search.predicate.impl.LuceneSearchPre
 import org.hibernate.search.engine.reporting.spi.EventContexts;
 import org.hibernate.search.engine.search.predicate.spi.DslConverter;
 import org.hibernate.search.engine.search.predicate.spi.MatchPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.RangePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinBoundingBoxPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinCirclePredicateBuilder;
@@ -46,6 +47,13 @@ public final class LuceneGeoPointFieldPredicateBuilderFactory implements LuceneF
 	public RangePredicateBuilder<LuceneSearchPredicateBuilder> createRangePredicateBuilder(
 			LuceneSearchContext searchContext, String absoluteFieldPath, DslConverter dslConverter) {
 		throw log.rangePredicatesNotSupportedByGeoPoint(
+				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
+		);
+	}
+
+	@Override
+	public PhrasePredicateBuilder<LuceneSearchPredicateBuilder> createPhrasePredicateBuilder(String absoluteFieldPath) {
+		throw log.textPredicatesNotSupportedByFieldType(
 				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
 		);
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneGeoPointFieldPredicateBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneGeoPointFieldPredicateBuilderFactory.java
@@ -59,6 +59,14 @@ public final class LuceneGeoPointFieldPredicateBuilderFactory implements LuceneF
 	}
 
 	@Override
+	public LuceneSimpleQueryStringPredicateBuilderFieldContext createSimpleQueryStringFieldContext(
+			String absoluteFieldPath) {
+		throw log.textPredicatesNotSupportedByFieldType(
+				EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
+		);
+	}
+
+	@Override
 	public SpatialWithinCirclePredicateBuilder<LuceneSearchPredicateBuilder> createSpatialWithinCirclePredicateBuilder(
 			String absoluteFieldPath) {
 		return new LuceneGeoPointSpatialWithinCirclePredicateBuilder( absoluteFieldPath );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneSimpleQueryStringPredicateBuilderFieldContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneSimpleQueryStringPredicateBuilderFieldContext.java
@@ -1,0 +1,44 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.types.predicate.impl;
+
+import org.hibernate.search.backend.lucene.util.impl.FieldContextSimpleQueryParser;
+import org.hibernate.search.engine.search.predicate.spi.SimpleQueryStringPredicateBuilder;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.search.BoostQuery;
+import org.apache.lucene.search.Query;
+
+public final class LuceneSimpleQueryStringPredicateBuilderFieldContext
+		implements SimpleQueryStringPredicateBuilder.FieldContext, FieldContextSimpleQueryParser.FieldContext {
+
+	private final Analyzer analyzer;
+	private Float boost;
+
+	LuceneSimpleQueryStringPredicateBuilderFieldContext(Analyzer analyzer) {
+		this.analyzer = analyzer;
+	}
+
+	@Override
+	public void boost(float boost) {
+		this.boost = boost;
+	}
+
+	@Override
+	public Query wrap(Query query) {
+		if ( boost != null ) {
+			return new BoostQuery( query, boost );
+		}
+		else {
+			return query;
+		}
+	}
+
+	public Analyzer getAnalyzer() {
+		return analyzer;
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneTextFieldPredicateBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneTextFieldPredicateBuilderFactory.java
@@ -11,9 +11,11 @@ import java.util.Objects;
 import org.apache.lucene.util.QueryBuilder;
 
 import org.hibernate.search.backend.lucene.search.impl.LuceneSearchContext;
+import org.hibernate.search.backend.lucene.search.predicate.impl.LuceneSearchPredicateBuilder;
 import org.hibernate.search.backend.lucene.types.codec.impl.LuceneTextFieldCodec;
 import org.hibernate.search.engine.backend.types.converter.ToDocumentFieldValueConverter;
 import org.hibernate.search.engine.search.predicate.spi.DslConverter;
+import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
 
 public final class LuceneTextFieldPredicateBuilderFactory<F>
 		extends AbstractLuceneStandardFieldPredicateBuilderFactory<F, LuceneTextFieldCodec<F>> {
@@ -51,5 +53,10 @@ public final class LuceneTextFieldPredicateBuilderFactory<F>
 	public LuceneTextRangePredicateBuilder<?> createRangePredicateBuilder(
 			LuceneSearchContext searchContext, String absoluteFieldPath, DslConverter dslConverter) {
 		return new LuceneTextRangePredicateBuilder<>( searchContext, absoluteFieldPath, getConverter( dslConverter ), codec );
+	}
+
+	@Override
+	public PhrasePredicateBuilder<LuceneSearchPredicateBuilder> createPhrasePredicateBuilder(String absoluteFieldPath) {
+		return new LuceneTextPhrasePredicateBuilder( absoluteFieldPath, codec, queryBuilder );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneTextFieldPredicateBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneTextFieldPredicateBuilderFactory.java
@@ -59,4 +59,12 @@ public final class LuceneTextFieldPredicateBuilderFactory<F>
 	public PhrasePredicateBuilder<LuceneSearchPredicateBuilder> createPhrasePredicateBuilder(String absoluteFieldPath) {
 		return new LuceneTextPhrasePredicateBuilder( absoluteFieldPath, codec, queryBuilder );
 	}
+
+	@Override
+	public LuceneSimpleQueryStringPredicateBuilderFieldContext createSimpleQueryStringFieldContext(
+			String absoluteFieldPath) {
+		return new LuceneSimpleQueryStringPredicateBuilderFieldContext(
+				queryBuilder == null ? null : queryBuilder.getAnalyzer()
+		);
+	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneTextFieldPredicateBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneTextFieldPredicateBuilderFactory.java
@@ -16,6 +16,7 @@ import org.hibernate.search.backend.lucene.types.codec.impl.LuceneTextFieldCodec
 import org.hibernate.search.engine.backend.types.converter.ToDocumentFieldValueConverter;
 import org.hibernate.search.engine.search.predicate.spi.DslConverter;
 import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.WildcardPredicateBuilder;
 
 public final class LuceneTextFieldPredicateBuilderFactory<F>
 		extends AbstractLuceneStandardFieldPredicateBuilderFactory<F, LuceneTextFieldCodec<F>> {
@@ -58,6 +59,12 @@ public final class LuceneTextFieldPredicateBuilderFactory<F>
 	@Override
 	public PhrasePredicateBuilder<LuceneSearchPredicateBuilder> createPhrasePredicateBuilder(String absoluteFieldPath) {
 		return new LuceneTextPhrasePredicateBuilder( absoluteFieldPath, codec, queryBuilder );
+	}
+
+	@Override
+	public WildcardPredicateBuilder<LuceneSearchPredicateBuilder> createWildcardPredicateBuilder(
+			String absoluteFieldPath) {
+		return new LuceneTextWildcardPredicateBuilder( absoluteFieldPath );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneTextPhrasePredicateBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneTextPhrasePredicateBuilder.java
@@ -1,0 +1,71 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.types.predicate.impl;
+
+import org.hibernate.search.backend.lucene.search.predicate.impl.AbstractLuceneSearchPredicateBuilder;
+import org.hibernate.search.backend.lucene.search.predicate.impl.LuceneSearchPredicateBuilder;
+import org.hibernate.search.backend.lucene.search.predicate.impl.LuceneSearchPredicateContext;
+import org.hibernate.search.backend.lucene.types.codec.impl.LuceneTextFieldCodec;
+import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.MatchNoDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.util.QueryBuilder;
+
+class LuceneTextPhrasePredicateBuilder extends AbstractLuceneSearchPredicateBuilder
+		implements PhrasePredicateBuilder<LuceneSearchPredicateBuilder> {
+
+	protected final String absoluteFieldPath;
+	protected final LuceneTextFieldCodec<?> codec;
+
+	private final QueryBuilder queryBuilder;
+
+	private int slop;
+	private String phrase;
+
+	LuceneTextPhrasePredicateBuilder(
+			String absoluteFieldPath,
+			LuceneTextFieldCodec<?> codec,
+			QueryBuilder queryBuilder) {
+		this.absoluteFieldPath = absoluteFieldPath;
+		this.codec = codec;
+		this.queryBuilder = queryBuilder;
+	}
+
+	@Override
+	public void slop(int slop) {
+		this.slop = slop;
+	}
+
+	@Override
+	public void phrase(String phrase) {
+		this.phrase = phrase;
+	}
+
+	@Override
+	protected Query doBuild(LuceneSearchPredicateContext context) {
+		if ( queryBuilder != null ) {
+			Query analyzed = queryBuilder.createPhraseQuery( absoluteFieldPath, phrase, slop );
+			if ( analyzed == null ) {
+				// Either the value was an empty string
+				// or the analysis removed all tokens (that can happen if the value contained only stopwords, for example)
+				// In any case, use the same behavior as Elasticsearch: don't match anything
+				analyzed = new MatchNoDocsQuery( "No tokens after analysis of the phrase to match" );
+			}
+			return analyzed;
+		}
+		else {
+			// we are in the case where we a have a normalizer here as the analyzer case has already been treated by
+			// the queryBuilder case above
+
+			return new TermQuery( new Term( absoluteFieldPath, codec.normalize( absoluteFieldPath, phrase ) ) );
+		}
+
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneTextWildcardPredicateBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneTextWildcardPredicateBuilder.java
@@ -1,0 +1,38 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.types.predicate.impl;
+
+import org.hibernate.search.backend.lucene.search.predicate.impl.AbstractLuceneSearchPredicateBuilder;
+import org.hibernate.search.backend.lucene.search.predicate.impl.LuceneSearchPredicateBuilder;
+import org.hibernate.search.backend.lucene.search.predicate.impl.LuceneSearchPredicateContext;
+import org.hibernate.search.engine.search.predicate.spi.WildcardPredicateBuilder;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.WildcardQuery;
+
+class LuceneTextWildcardPredicateBuilder extends AbstractLuceneSearchPredicateBuilder
+		implements WildcardPredicateBuilder<LuceneSearchPredicateBuilder> {
+
+	protected final String absoluteFieldPath;
+
+	private String pattern;
+
+	LuceneTextWildcardPredicateBuilder(String absoluteFieldPath) {
+		this.absoluteFieldPath = absoluteFieldPath;
+	}
+
+	@Override
+	public void pattern(String wildcardPattern) {
+		this.pattern = wildcardPattern;
+	}
+
+	@Override
+	protected Query doBuild(LuceneSearchPredicateContext context) {
+		return new WildcardQuery( new Term( absoluteFieldPath, pattern ) );
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/util/impl/FieldContextSimpleQueryParser.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/util/impl/FieldContextSimpleQueryParser.java
@@ -1,0 +1,91 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+package org.hibernate.search.backend.lucene.util.impl;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.queryparser.simple.SimpleQueryParser;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.FuzzyQuery;
+import org.apache.lucene.search.PrefixQuery;
+import org.apache.lucene.search.Query;
+
+/**
+ * An implementation of {@link SimpleQueryParser} that allows to wrap created queries
+ * to add boosts, constant score, ...
+ *
+ * @author Guillaume Smet
+ */
+public class FieldContextSimpleQueryParser extends SimpleQueryParser {
+
+	public interface FieldContext {
+
+		Query wrap(Query query);
+
+	}
+
+	private final Map<String, ? extends FieldContext> fieldContexts;
+
+	public FieldContextSimpleQueryParser(Analyzer analyzer, Map<String, ? extends FieldContext> fieldContexts) {
+		this( analyzer, fieldContexts, -1 );
+	}
+
+	public FieldContextSimpleQueryParser(Analyzer analyzer, Map<String, ? extends FieldContext> fieldContexts, int flags) {
+		super( analyzer, Collections.emptyMap(), flags );
+		this.fieldContexts = fieldContexts;
+	}
+
+	@Override
+	protected Query newDefaultQuery(String text) {
+		BooleanQuery.Builder bqb = new BooleanQuery.Builder();
+		for ( Map.Entry<String, ? extends FieldContext> entry : fieldContexts.entrySet() ) {
+			Query q = createBooleanQuery( entry.getKey(), text, getDefaultOperator() );
+			if ( q != null ) {
+				bqb.add( entry.getValue().wrap( q ), BooleanClause.Occur.SHOULD );
+			}
+		}
+		return simplify( bqb.build() );
+	}
+
+	@Override
+	protected Query newFuzzyQuery(String text, int fuzziness) {
+		BooleanQuery.Builder bqb = new BooleanQuery.Builder();
+		for ( Map.Entry<String, ? extends FieldContext> entry : fieldContexts.entrySet() ) {
+			Query q = new FuzzyQuery( new Term( entry.getKey(), text ), fuzziness );
+			bqb.add( entry.getValue().wrap( q ), BooleanClause.Occur.SHOULD );
+		}
+		return simplify( bqb.build() );
+	}
+
+	@Override
+	protected Query newPhraseQuery(String text, int slop) {
+		BooleanQuery.Builder bqb = new BooleanQuery.Builder();
+		for ( Map.Entry<String, ? extends FieldContext> entry : fieldContexts.entrySet() ) {
+			Query q = createPhraseQuery( entry.getKey(), text, slop );
+			if ( q != null ) {
+				bqb.add( entry.getValue().wrap( q ), BooleanClause.Occur.SHOULD );
+			}
+		}
+		return simplify( bqb.build() );
+	}
+
+	@Override
+	protected Query newPrefixQuery(String text) {
+		BooleanQuery.Builder bqb = new BooleanQuery.Builder();
+		for ( Map.Entry<String, ? extends FieldContext> entry : fieldContexts.entrySet() ) {
+			PrefixQuery prefix = new PrefixQuery( new Term( entry.getKey(), text ) );
+			bqb.add( entry.getValue().wrap( prefix ), BooleanClause.Occur.SHOULD );
+		}
+		return simplify( bqb.build() );
+	}
+
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/util/impl/FuzzyQueryBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/util/impl/FuzzyQueryBuilder.java
@@ -1,0 +1,29 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.util.impl;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.FuzzyQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.QueryBuilder;
+
+public final class FuzzyQueryBuilder extends QueryBuilder {
+	private final int maxEditDistance;
+	private final int prefixLength;
+
+	public FuzzyQueryBuilder(Analyzer analyzer, int maxEditDistance, int prefixLength) {
+		super( analyzer );
+		this.maxEditDistance = maxEditDistance;
+		this.prefixLength = prefixLength;
+	}
+
+	@Override
+	protected Query newTermQuery(Term term) {
+		return new FuzzyQuery( term, maxEditDistance, prefixLength );
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
@@ -250,4 +250,15 @@ public interface Log extends BasicLogger {
 			value = "It is not possible to use per-field boosts together with withConstantScore option"
 	)
 	SearchException perFieldBoostWithConstantScore();
+
+	@Message(id = ID_OFFSET_2 + 52,
+			value = "Invalid phrase: the phrase to match in phrase predicates must be non-null."
+					+ " Null phrase was passed to phrase predicate on fields %1$s.")
+	SearchException phrasePredicateCannotMatchNullPhrase(List<String> strings);
+
+	@Message(id = ID_OFFSET_2 + 53,
+			value = "Invalid slop: %1$d. The slop must be positive or zero.")
+	SearchException invalidPhrasePredicateSlop(int slop);
+
+
 }

--- a/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
@@ -96,14 +96,12 @@ public interface Log extends BasicLogger {
 	SearchException cannotAddMultiplePredicatesToNestedPredicate();
 
 	@Message(id = ID_OFFSET_2 + 11,
-			value = "Invalid value: the value to match in match predicates must be non-null."
-					+ " Null value was passed to match predicate on fields %1$s")
-	SearchException matchPredicateCannotMatchNullValue(List<String> strings);
+			value = "Invalid value: the value to match in match predicates must be non-null.")
+	SearchException matchPredicateCannotMatchNullValue(@Param EventContext context);
 
 	@Message(id = ID_OFFSET_2 + 12,
-			value = "Invalid value: at least one bound in range predicates must be non-null."
-					+ " Null bounds were passed to range predicate on fields %1$s")
-	SearchException rangePredicateCannotMatchNullValue(List<String> strings);
+			value = "Invalid value: at least one bound in range predicates must be non-null.")
+	SearchException rangePredicateCannotMatchNullValue(@Param EventContext context);
 
 	@Message(id = ID_OFFSET_2 + 13,
 			value = "Cannot map type '%1$s' to index '%2$s', because this type is abstract."
@@ -258,9 +256,8 @@ public interface Log extends BasicLogger {
 	SearchException perFieldBoostWithConstantScore();
 
 	@Message(id = ID_OFFSET_2 + 52,
-			value = "Invalid phrase: the phrase to match in phrase predicates must be non-null."
-					+ " Null phrase was passed to phrase predicate on fields %1$s.")
-	SearchException phrasePredicateCannotMatchNullPhrase(List<String> strings);
+			value = "Invalid phrase: the phrase to match in phrase predicates must be non-null.")
+	SearchException phrasePredicateCannotMatchNullPhrase(@Param EventContext context);
 
 	@Message(id = ID_OFFSET_2 + 53,
 			value = "Invalid slop: %1$d. The slop must be positive or zero.")
@@ -275,9 +272,8 @@ public interface Log extends BasicLogger {
 	SearchException invalidExactPrefixLength(int exactPrefixLength);
 
 	@Message(id = ID_OFFSET_2 + 56,
-			value = "Invalid pattern: the pattern to match in wildcard predicates must be non-null."
-					+ " Null pattern was passed to wildcard predicate on fields %1$s.")
-	SearchException wildcardPredicateCannotMatchNullPattern(List<String> fields);
+			value = "Invalid pattern: the pattern to match in wildcard predicates must be non-null.")
+	SearchException wildcardPredicateCannotMatchNullPattern(@Param EventContext context);
 
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
@@ -260,5 +260,13 @@ public interface Log extends BasicLogger {
 			value = "Invalid slop: %1$d. The slop must be positive or zero.")
 	SearchException invalidPhrasePredicateSlop(int slop);
 
+	@Message(id = ID_OFFSET_2 + 54,
+			value = "Invalid maximum edit distance: %1$d. The value must be 0, 1 or 2.")
+	SearchException invalidFuzzyMaximumEditDistance(int maximumEditDistance);
+
+	@Message(id = ID_OFFSET_2 + 55,
+			value = "Invalid exact prefix length: %1$d. The value must be positive or zero.")
+	SearchException invalidExactPrefixLength(int exactPrefixLength);
+
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
@@ -274,5 +274,10 @@ public interface Log extends BasicLogger {
 			value = "Invalid exact prefix length: %1$d. The value must be positive or zero.")
 	SearchException invalidExactPrefixLength(int exactPrefixLength);
 
+	@Message(id = ID_OFFSET_2 + 56,
+			value = "Invalid pattern: the pattern to match in wildcard predicates must be non-null."
+					+ " Null pattern was passed to wildcard predicate on fields %1$s.")
+	SearchException wildcardPredicateCannotMatchNullPattern(List<String> fields);
+
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
@@ -7,6 +7,7 @@
 
 package org.hibernate.search.engine.logging.impl;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.hibernate.search.engine.environment.classpath.spi.ClassLoadingException;
@@ -49,6 +50,11 @@ public interface Log extends BasicLogger {
 	@Message(id = ID_OFFSET_1 + 242,
 			value = "Hibernate Search failed to initialize component '%1$s' as class '%2$s' doesn't have a public no-arguments constructor")
 	SearchException noPublicNoArgConstructor(String componentName, @FormatWith(ClassFormatter.class) Class<?> clazz);
+
+	@Message(id = ID_OFFSET_1 + 334,
+			value = "Invalid simple query string: the string must be non-null."
+					+ " Null value was passed to simple query string predicate on fields %1$s.")
+	SearchException simpleQueryStringCannotBeNull(Collection<String> strings);
 
 	// TODO HSEARCH-3308 migrate relevant messages from Search 5 here
 

--- a/engine/src/main/java/org/hibernate/search/engine/reporting/impl/EngineEventContextMessages.java
+++ b/engine/src/main/java/org/hibernate/search/engine/reporting/impl/EngineEventContextMessages.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.engine.reporting.impl;
 
+import java.util.List;
 import java.util.Set;
 
 import org.hibernate.search.util.common.logging.impl.MessageConstants;
@@ -61,6 +62,9 @@ public interface EngineEventContextMessages {
 
 	@Message(value = "field '%1$s'")
 	String indexFieldAbsolutePath(String absolutePath);
+
+	@Message(value = "fields %1$s")
+	String indexFieldAbsolutePaths(List<String> absolutePaths);
 
 	@Message(value = "analyzer '%1$s'")
 	String analyzer(String name);

--- a/engine/src/main/java/org/hibernate/search/engine/reporting/spi/EventContexts.java
+++ b/engine/src/main/java/org/hibernate/search/engine/reporting/spi/EventContexts.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.engine.reporting.spi;
 
+import java.util.List;
 import java.util.Set;
 
 import org.hibernate.search.util.common.reporting.impl.AbstractSimpleEventContextElement;
@@ -105,6 +106,15 @@ public class EventContexts {
 			@Override
 			public String render(String param) {
 				return MESSAGES.indexFieldAbsolutePath( param );
+			}
+		} );
+	}
+
+	public static EventContext fromIndexFieldAbsolutePaths(List<String> absolutePaths) {
+		return EventContext.create( new AbstractSimpleEventContextElement<List<String>>( absolutePaths ) {
+			@Override
+			public String render(List<String> param) {
+				return MESSAGES.indexFieldAbsolutePaths( param );
 			}
 		} );
 	}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/MatchIdPredicateContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/MatchIdPredicateContext.java
@@ -11,7 +11,7 @@ import java.util.Collection;
 /**
  * The context used when defining a match on an identifier.
  */
-public interface MatchIdPredicateContext extends SearchPredicateTerminalContext {
+public interface MatchIdPredicateContext {
 
 	/**
 	 * Target the identifier with the given id.
@@ -22,7 +22,7 @@ public interface MatchIdPredicateContext extends SearchPredicateTerminalContext 
 	 * @param value the value of the id we want to match.
 	 * @return {@code this} for method chaining.
 	 */
-	MatchIdPredicateContext matching(Object value);
+	MatchIdPredicateTerminalContext matching(Object value);
 
 	/**
 	 * Target the identifiers matching any of the values in a collection.
@@ -30,8 +30,8 @@ public interface MatchIdPredicateContext extends SearchPredicateTerminalContext 
 	 * @param values the collection of identifiers to match.
 	 * @return {@code this} for method chaining.
 	 */
-	default MatchIdPredicateContext matchingAny(Collection<Object> values) {
-		MatchIdPredicateContext context = null;
+	default MatchIdPredicateTerminalContext matchingAny(Collection<Object> values) {
+		MatchIdPredicateTerminalContext context = null;
 		for ( Object value : values ) {
 			context = matching( value );
 		}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/MatchIdPredicateTerminalContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/MatchIdPredicateTerminalContext.java
@@ -1,0 +1,14 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.dsl.predicate;
+
+/**
+ * The context used when defining a match on an identifier.
+ */
+public interface MatchIdPredicateTerminalContext extends MatchIdPredicateContext, SearchPredicateTerminalContext {
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/MatchPredicateContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/MatchPredicateContext.java
@@ -12,7 +12,51 @@ package org.hibernate.search.engine.search.dsl.predicate;
  */
 public interface MatchPredicateContext extends SearchPredicateScoreContext<MatchPredicateContext> {
 
-	// TODO wildcard, fuzzy. Or maybe a separate context?
+	/**
+	 * Enable fuzziness for this match predicate; only works for text fields.
+	 * <p>
+	 * Fuzziness allows to match documents that do not contain the value to match,
+	 * but a close value, for example with one letter that differs.
+	 *
+	 * @return {@code this}, for method chaining.
+	 * @see #fuzzy(int, int)
+	 */
+	default MatchPredicateContext fuzzy() {
+		return fuzzy( 2, 0 );
+	}
+
+	/**
+	 * Enable fuzziness for this match predicate; only works for text fields.
+	 * <p>
+	 * Fuzziness allows to match documents that do not contain the value to match,
+	 * but a close value, for example with one letter that differs.
+	 *
+	 * @param maxEditDistance The maximum value of the edit distance, which defines how permissive the fuzzy predicate will be.
+	 * @return {@code this}, for method chaining.
+	 * @see #fuzzy(int, int)
+	 */
+	default MatchPredicateContext fuzzy(int maxEditDistance) {
+		return fuzzy( maxEditDistance, 0 );
+	}
+
+	/**
+	 * Enable fuzziness for this match predicate; only works for text fields.
+	 * <p>
+	 * Fuzziness allows to match documents that do not contain the value to match,
+	 * but a close value, for example with one letter that differs.
+	 *
+	 * @param maxEditDistance The maximum value of the edit distance, which defines how permissive the fuzzy predicate will be.
+	 * <p>
+	 * Roughly speaking, the edit distance is the number of changes between two terms: switching characters, removing them, ...
+	 * <p>
+	 * If zero, then fuzziness is completely disabled.
+	 * The other accepted values, {@code 1} and {@code 2}, are increasingly fuzzy.
+	 * @param exactPrefixLength Length of the prefix that has to match exactly, i.e. for which fuzziness will not be allowed.
+	 * <p>
+	 * A non-zero value is recommended if the index contains a large amount of distinct terms.
+	 * @return {@code this}, for method chaining.
+	 */
+	MatchPredicateContext fuzzy(int maxEditDistance, int exactPrefixLength);
 
 	/**
 	 * Target the given field in the match predicate.

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/PhrasePredicateContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/PhrasePredicateContext.java
@@ -1,0 +1,73 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.dsl.predicate;
+
+/**
+ * The context used when starting to define a phrase predicate.
+ */
+public interface PhrasePredicateContext extends SearchPredicateScoreContext<PhrasePredicateContext> {
+
+	// TODO HSEARCH-3312 allow analyzer/normalizer override
+
+	/**
+	 * Sets the slop, which defines how permissive the phrase predicate will be.
+	 * <p>
+	 * If zero (the default), then the predicate will only match the exact phrase given (after analysis).
+	 * Higher values are increasingly permissive, allowing unexpected words or words that switched position.
+	 * <p>
+	 * The slop represents the number of edit operations that can be applied to the phrase to match,
+	 * where each edit operation moves one word by one position.
+	 * So {@code quick fox} with a slop of 1 can become {@code quick * fox}, where {@code <word>} can be any word.
+	 * {@code quick fox} with a slop of 2 can become {@code quick <word> fox}, or {@code quick <word1> <word2> fox}
+	 * or even {@code fox quick} (two operations: moved {@code fox} to the left and {@code quick} to the right).
+	 * And similarly for higher slops and for phrases with more words.
+	 *
+	 * @param slop The slop value
+	 * @return {@code this}, for method chaining.
+	 */
+	PhrasePredicateContext withSlop(int slop);
+
+	/**
+	 * Target the given field in the phrase predicate.
+	 * <p>
+	 * Only text fields are supported.
+	 * <p>
+	 * Multiple fields may be targeted by the same predicate:
+	 * the predicate will match if <em>any</em> targeted field matches.
+	 * <p>
+	 * When targeting multiple fields, those fields must have compatible types.
+	 * See <a href="SearchPredicateFactoryContext.html#commonconcepts-parametertype">there</a> for more information.
+	 *
+	 * @param absoluteFieldPath The absolute path (from the document root) of the targeted field.
+	 * @return A {@link PhrasePredicateFieldSetContext} allowing to define field-specific settings
+	 * (such as the {@link PhrasePredicateFieldSetContext#boostedTo(float) boost}),
+	 * or simply to continue the definition of the phrase predicate
+	 * ({@link PhrasePredicateFieldSetContext#matching(String) phrase to match}, ...).
+	 */
+	default PhrasePredicateFieldSetContext onField(String absoluteFieldPath) {
+		return onFields( absoluteFieldPath );
+	}
+
+	/**
+	 * Target the given fields in the phrase predicate.
+	 * <p>
+	 * Only text fields are supported.
+	 * <p>
+	 * Equivalent to {@link #onField(String)} followed by multiple calls to
+	 * {@link PhrasePredicateFieldSetContext#orField(String)},
+	 * the only difference being that calls to {@link PhrasePredicateFieldSetContext#boostedTo(float)}
+	 * and other field-specific settings on the returned context will only need to be done once
+	 * and will apply to all the fields passed to this method.
+	 *
+	 * @param absoluteFieldPaths The absolute paths (from the document root) of the targeted fields.
+	 * @return A {@link PhrasePredicateFieldSetContext} (see {@link #onField(String)} for details).
+	 *
+	 * @see #onField(String)
+	 */
+	PhrasePredicateFieldSetContext onFields(String... absoluteFieldPaths);
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/PhrasePredicateFieldSetContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/PhrasePredicateFieldSetContext.java
@@ -1,0 +1,54 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.dsl.predicate;
+
+/**
+ * The context used when defining a phrase predicate, after at least one field was mentioned.
+ */
+public interface PhrasePredicateFieldSetContext extends MultiFieldPredicateFieldSetContext<PhrasePredicateFieldSetContext> {
+
+	/**
+	 * Target the given field in the phrase predicate,
+	 * as an alternative to the already-targeted fields.
+	 * <p>
+	 * Only text fields are supported.
+	 * <p>
+	 * See {@link PhrasePredicateContext#onField(String)} for more information on targeted fields.
+	 *
+	 * @param absoluteFieldPath The absolute path (from the document root) of the targeted field.
+	 * @return {@code this}, for method chaining.
+	 *
+	 * @see PhrasePredicateContext#onField(String)
+	 */
+	default PhrasePredicateFieldSetContext orField(String absoluteFieldPath) {
+		return orFields( absoluteFieldPath );
+	}
+
+	/**
+	 * Target the given fields in the phrase predicate,
+	 * as an alternative to the already-targeted fields.
+	 * <p>
+	 * Only text fields are supported.
+	 * <p>
+	 * See {@link PhrasePredicateContext#onFields(String...)} for more information on targeted fields.
+	 *
+	 * @param absoluteFieldPaths The absolute paths (from the document root) of the targeted fields.
+	 * @return {@code this}, for method chaining.
+	 *
+	 * @see PhrasePredicateContext#onFields(String...)
+	 */
+	PhrasePredicateFieldSetContext orFields(String... absoluteFieldPaths);
+
+	/**
+	 * Require at least one of the targeted fields to match the given phrase.
+	 *
+	 * @param phrase The phrase to match.
+	 * @return A context allowing to get the resulting predicate.
+	 */
+	SearchPredicateTerminalContext matching(String phrase);
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/SearchPredicateFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/SearchPredicateFactoryContext.java
@@ -151,6 +151,21 @@ public interface SearchPredicateFactoryContext {
 	NestedPredicateContext nested();
 
 	/**
+	 * Match documents according to a given query string,
+	 * with a simple query language adapted to end users.
+	 * <p>
+	 * Note that by default, unless the query string contains explicit operators,
+	 * documents will match if <em>any</em> term mentioned in the query string is present in the document (OR operator).
+	 * This makes sense when sorting results by relevance, but is not ideal otherwise.
+	 * See {@link SimpleQueryStringPredicateFieldSetContext#withAndAsDefaultOperator()} to change this behavior.
+	 *
+	 * @return A context allowing to define the predicate more precisely
+	 * and ultimately {@link SearchPredicateTerminalContext#toPredicate() get the resulting predicate}.
+	 * @see SimpleQueryStringPredicateContext
+	 */
+	SimpleQueryStringPredicateContext simpleQueryString();
+
+	/**
 	 * Access the different types of spatial predicates.
 	 *
 	 * @return A context allowing to define the type of spatial predicate.

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/SearchPredicateFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/SearchPredicateFactoryContext.java
@@ -84,6 +84,13 @@ public interface SearchPredicateFactoryContext {
 	 */
 	MatchAllPredicateContext matchAll();
 
+	/**
+	 * Match documents where the identifier is among the given values.
+	 *
+	 * @return A context allowing to define the predicate more precisely
+	 * and ultimately {@link SearchPredicateTerminalContext#toPredicate() get the resulting predicate}.
+	 * @see MatchIdPredicateContext
+	 */
 	MatchIdPredicateContext id();
 
 	/**

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/SearchPredicateFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/SearchPredicateFactoryContext.java
@@ -173,9 +173,6 @@ public interface SearchPredicateFactoryContext {
 	 */
 	SpatialPredicateContext spatial();
 
-	// TODO ids query (Type + list of IDs? Just IDs? See https://www.elastic.co/guide/en/elasticsearch/reference/5.5/query-dsl-ids-query.html)
-	// TODO other queries (spatial, ...)
-
 	/**
 	 * Extend the current context with the given extension,
 	 * resulting in an extended context offering different types of predicates.

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/SearchPredicateFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/SearchPredicateFactoryContext.java
@@ -147,6 +147,20 @@ public interface SearchPredicateFactoryContext {
 	PhrasePredicateContext phrase();
 
 	/**
+	 * Match documents where targeted fields contain a term that matches a given pattern,
+	 * such as {@code inter*on} or {@code pa?t}.
+	 * <p>
+	 * Note that such patterns are <strong>not analyzed</strong>,
+	 * thus any character that is not a wildcard must match exactly the content of the index
+	 * (including uppercase letters, diacritics, ...).
+	 *
+	 * @return A context allowing to define the predicate more precisely
+	 * and ultimately {@link SearchPredicateTerminalContext#toPredicate() get the resulting predicate}.
+	 * @see WildcardPredicateContext
+	 */
+	WildcardPredicateContext wildcard();
+
+	/**
 	 * Match documents where a
 	 * {@link org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage#NESTED nested object}
 	 * matches a given predicate.

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/SearchPredicateFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/SearchPredicateFactoryContext.java
@@ -131,6 +131,15 @@ public interface SearchPredicateFactoryContext {
 	RangePredicateContext range();
 
 	/**
+	 * Match documents where targeted fields have a value that contains a given phrase.
+	 *
+	 * @return A context allowing to define the predicate more precisely
+	 * and ultimately {@link SearchPredicateTerminalContext#toPredicate() get the resulting predicate}.
+	 * @see PhrasePredicateContext
+	 */
+	PhrasePredicateContext phrase();
+
+	/**
 	 * Match documents where a
 	 * {@link org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage#NESTED nested object}
 	 * matches a given predicate.

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/SimpleQueryStringPredicateContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/SimpleQueryStringPredicateContext.java
@@ -1,0 +1,55 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.dsl.predicate;
+
+/**
+ * The context used when starting to define a simple query string predicate.
+ */
+public interface SimpleQueryStringPredicateContext {
+
+	// TODO HSEARCH-3312 allow analyzer/normalizer override
+
+	/**
+	 * Target the given field in the simple query string predicate.
+	 * <p>
+	 * Only text fields are supported.
+	 * <p>
+	 * Multiple fields may be targeted by the same predicate:
+	 * the predicate will match if <em>any</em> targeted field matches.
+	 * <p>
+	 * When targeting multiple fields, those fields must have compatible types.
+	 * See <a href="SearchPredicateFactoryContext.html#commonconcepts-parametertype">there</a> for more information.
+	 *
+	 * @param absoluteFieldPath The absolute path (from the document root) of the targeted field.
+	 * @return A {@link SimpleQueryStringPredicateFieldSetContext} allowing to define field-specific settings
+	 * (such as the {@link SimpleQueryStringPredicateFieldSetContext#boostedTo(float) boost}),
+	 * or simply to continue the definition of the simpleQueryString predicate
+	 * ({@link SimpleQueryStringPredicateFieldSetContext#matching(String) simpleQueryString to match}, ...).
+	 */
+	default SimpleQueryStringPredicateFieldSetContext onField(String absoluteFieldPath) {
+		return onFields( absoluteFieldPath );
+	}
+
+	/**
+	 * Target the given fields in the simple query string predicate.
+	 * <p>
+	 * Only text fields are supported.
+	 * <p>
+	 * Equivalent to {@link #onField(String)} followed by multiple calls to
+	 * {@link SimpleQueryStringPredicateFieldSetContext#orField(String)},
+	 * the only difference being that calls to {@link SimpleQueryStringPredicateFieldSetContext#boostedTo(float)}
+	 * and other field-specific settings on the returned context will only need to be done once
+	 * and will apply to all the fields passed to this method.
+	 *
+	 * @param absoluteFieldPaths The absolute paths (from the document root) of the targeted fields.
+	 * @return A {@link SimpleQueryStringPredicateFieldSetContext} (see {@link #onField(String)} for details).
+	 *
+	 * @see #onField(String)
+	 */
+	SimpleQueryStringPredicateFieldSetContext onFields(String... absoluteFieldPaths);
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/SimpleQueryStringPredicateContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/SimpleQueryStringPredicateContext.java
@@ -9,7 +9,7 @@ package org.hibernate.search.engine.search.dsl.predicate;
 /**
  * The context used when starting to define a simple query string predicate.
  */
-public interface SimpleQueryStringPredicateContext {
+public interface SimpleQueryStringPredicateContext extends SearchPredicateScoreContext<SimpleQueryStringPredicateContext> {
 
 	// TODO HSEARCH-3312 allow analyzer/normalizer override
 

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/SimpleQueryStringPredicateFieldSetContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/SimpleQueryStringPredicateFieldSetContext.java
@@ -1,0 +1,66 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.dsl.predicate;
+
+/**
+ * The context used when defining a simple query string predicate, after at least one field was mentioned.
+ */
+public interface SimpleQueryStringPredicateFieldSetContext extends MultiFieldPredicateFieldSetContext<SimpleQueryStringPredicateFieldSetContext> {
+
+	/**
+	 * Define the default operator as AND.
+	 * <p>
+	 * By default, unless the query string contains explicit operators,
+	 * documents will match if <em>any</em> term mentioned in the query string is present in the document (OR operator).
+	 * This will change the default behavior,
+	 * making document match if <em>all</em> terms mentioned in the query string are present in the document.
+	 *
+	 * @return {@code this}, for method chaining.
+	 */
+	SimpleQueryStringPredicateFieldSetContext withAndAsDefaultOperator();
+
+	/**
+	 * Target the given field in the simple query string predicate,
+	 * as an alternative to the already-targeted fields.
+	 * <p>
+	 * Only text fields are supported.
+	 * <p>
+	 * See {@link SimpleQueryStringPredicateContext#onField(String)} for more information on targeted fields.
+	 *
+	 * @param absoluteFieldPath The absolute path (from the document root) of the targeted field.
+	 * @return {@code this}, for method chaining.
+	 *
+	 * @see SimpleQueryStringPredicateContext#onField(String)
+	 */
+	default SimpleQueryStringPredicateFieldSetContext orField(String absoluteFieldPath) {
+		return orFields( absoluteFieldPath );
+	}
+
+	/**
+	 * Target the given fields in the simple query string predicate,
+	 * as an alternative to the already-targeted fields.
+	 * <p>
+	 * Only text fields are supported.
+	 * <p>
+	 * See {@link SimpleQueryStringPredicateContext#onFields(String...)} for more information on targeted fields.
+	 *
+	 * @param absoluteFieldPaths The absolute paths (from the document root) of the targeted fields.
+	 * @return {@code this}, for method chaining.
+	 *
+	 * @see SimpleQueryStringPredicateContext#onFields(String...)
+	 */
+	SimpleQueryStringPredicateFieldSetContext orFields(String... absoluteFieldPaths);
+
+	/**
+	 * Require at least one of the targeted fields to match the given query string.
+	 *
+	 * @param simpleQueryString The query string to match.
+	 * @return A context allowing to get the resulting predicate.
+	 */
+	SearchPredicateTerminalContext matching(String simpleQueryString);
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/WildcardPredicateContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/WildcardPredicateContext.java
@@ -1,0 +1,53 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.dsl.predicate;
+
+/**
+ * The context used when starting to define a wildcard predicate.
+ */
+public interface WildcardPredicateContext extends SearchPredicateNoFieldContext<WildcardPredicateContext> {
+
+	/**
+	 * Target the given field in the wildcard predicate.
+	 * <p>
+	 * Only text fields are supported.
+	 * <p>
+	 * Multiple fields may be targeted by the same predicate:
+	 * the predicate will match if <em>any</em> targeted field matches.
+	 * <p>
+	 * When targeting multiple fields, those fields must have compatible types.
+	 * See <a href="SearchPredicateFactoryContext.html#commonconcepts-parametertype">there</a> for more information.
+	 *
+	 * @param absoluteFieldPath The absolute path (from the document root) of the targeted field.
+	 * @return A {@link WildcardPredicateFieldSetContext} allowing to define field-specific settings
+	 * (such as the {@link WildcardPredicateFieldSetContext#boostedTo(float) boost}),
+	 * or simply to continue the definition of the wildcard predicate
+	 * ({@link WildcardPredicateFieldSetContext#matching(String) wildcard to match}, ...).
+	 */
+	default WildcardPredicateFieldSetContext onField(String absoluteFieldPath) {
+		return onFields( absoluteFieldPath );
+	}
+
+	/**
+	 * Target the given fields in the wildcard predicate.
+	 * <p>
+	 * Only text fields are supported.
+	 * <p>
+	 * Equivalent to {@link #onField(String)} followed by multiple calls to
+	 * {@link WildcardPredicateFieldSetContext#orField(String)},
+	 * the only difference being that calls to {@link WildcardPredicateFieldSetContext#boostedTo(float)}
+	 * and other field-specific settings on the returned context will only need to be done once
+	 * and will apply to all the fields passed to this method.
+	 *
+	 * @param absoluteFieldPaths The absolute paths (from the document root) of the targeted fields.
+	 * @return A {@link WildcardPredicateFieldSetContext} (see {@link #onField(String)} for details).
+	 *
+	 * @see #onField(String)
+	 */
+	WildcardPredicateFieldSetContext onFields(String... absoluteFieldPaths);
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/WildcardPredicateFieldSetContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/WildcardPredicateFieldSetContext.java
@@ -1,0 +1,56 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.dsl.predicate;
+
+/**
+ * The context used when defining a wildcard predicate, after at least one field was mentioned.
+ */
+public interface WildcardPredicateFieldSetContext extends MultiFieldPredicateFieldSetContext<WildcardPredicateFieldSetContext> {
+
+	/**
+	 * Target the given field in the wildcard predicate,
+	 * as an alternative to the already-targeted fields.
+	 * <p>
+	 * Only text fields are supported.
+	 * <p>
+	 * See {@link WildcardPredicateContext#onField(String)} for more information on targeted fields.
+	 *
+	 * @param absoluteFieldPath The absolute path (from the document root) of the targeted field.
+	 * @return {@code this}, for method chaining.
+	 *
+	 * @see WildcardPredicateContext#onField(String)
+	 */
+	default WildcardPredicateFieldSetContext orField(String absoluteFieldPath) {
+		return orFields( absoluteFieldPath );
+	}
+
+	/**
+	 * Target the given fields in the wildcard predicate,
+	 * as an alternative to the already-targeted fields.
+	 * <p>
+	 * Only text fields are supported.
+	 * <p>
+	 * See {@link WildcardPredicateContext#onFields(String...)} for more information on targeted fields.
+	 *
+	 * @param absoluteFieldPaths The absolute paths (from the document root) of the targeted fields.
+	 * @return {@code this}, for method chaining.
+	 *
+	 * @see WildcardPredicateContext#onFields(String...)
+	 */
+	WildcardPredicateFieldSetContext orFields(String... absoluteFieldPaths);
+
+	/**
+	 * Require at least one of the targeted fields to match the given wildcard pattern.
+	 *
+	 * @param wildcardPattern The pattern to match. Supported wildcards are {@code *},
+	 * which matches any character sequence (including the empty one), and {@code ?},
+	 * which matches any single character. {@code \} is the escape character.
+	 * @return A context allowing to get the resulting predicate.
+	 */
+	SearchPredicateTerminalContext matching(String wildcardPattern);
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/AbstractBooleanMultiFieldPredicateCommonState.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/AbstractBooleanMultiFieldPredicateCommonState.java
@@ -18,7 +18,19 @@ import org.hibernate.search.engine.search.predicate.spi.SearchPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SearchPredicateBuilderFactory;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
-abstract class AbstractMultiFieldPredicateCommonState<B, F extends AbstractMultiFieldPredicateCommonState.FieldSetContext<B>>
+/**
+ * A common state for a multi-field predicate context
+ * that will simply create one predicate per field and a boolean query to join the predicates.
+ * <p>
+ * This abstract class is appropriate if the predicate supports targeting multiple fields at the DSL level,
+ * but not at the backend SPI level (like for range predicates, for example).
+ * Some predicate support targeting multiple fields at the backend SPI level,
+ * like the simple query string predicate.
+ *
+ * @param <B> The implementation type of builders.
+ * @param <F> The type of field set contexts.
+ */
+abstract class AbstractBooleanMultiFieldPredicateCommonState<B, F extends AbstractBooleanMultiFieldPredicateCommonState.FieldSetContext<B>>
 		extends AbstractSearchPredicateTerminalContext<B> {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
@@ -27,7 +39,7 @@ abstract class AbstractMultiFieldPredicateCommonState<B, F extends AbstractMulti
 	private Float predicateLevelBoost;
 	private boolean withConstantScore = false;
 
-	AbstractMultiFieldPredicateCommonState(SearchPredicateBuilderFactory<?, B> factory) {
+	AbstractBooleanMultiFieldPredicateCommonState(SearchPredicateBuilderFactory<?, B> factory) {
 		super( factory );
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/AbstractBooleanMultiFieldPredicateCommonState.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/AbstractBooleanMultiFieldPredicateCommonState.java
@@ -10,13 +10,16 @@ import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import org.hibernate.search.engine.logging.impl.Log;
+import org.hibernate.search.engine.reporting.spi.EventContexts;
 import org.hibernate.search.engine.search.dsl.predicate.spi.AbstractSearchPredicateTerminalContext;
 import org.hibernate.search.engine.search.predicate.spi.BooleanJunctionPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SearchPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SearchPredicateBuilderFactory;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
+import org.hibernate.search.util.common.reporting.EventContext;
 
 /**
  * A common state for a multi-field predicate context
@@ -102,7 +105,15 @@ abstract class AbstractBooleanMultiFieldPredicateCommonState<B, F extends Abstra
 		}
 	}
 
+	protected final EventContext getEventContext() {
+		return EventContexts.fromIndexFieldAbsolutePaths(
+				getFieldSetContexts().stream().flatMap( f -> f.getAbsoluteFieldPaths().stream() )
+						.collect( Collectors.toList() )
+		);
+	}
+
 	public interface FieldSetContext<B> {
+		List<String> getAbsoluteFieldPaths();
 		void contributePredicateBuilders(Consumer<B> collector);
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/DefaultSearchPredicateFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/DefaultSearchPredicateFactoryContext.java
@@ -20,6 +20,7 @@ import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryCo
 import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryContextExtension;
 import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryExtensionContext;
 import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateTerminalContext;
+import org.hibernate.search.engine.search.dsl.predicate.SimpleQueryStringPredicateContext;
 import org.hibernate.search.engine.search.dsl.predicate.SpatialPredicateContext;
 import org.hibernate.search.engine.search.predicate.spi.SearchPredicateBuilderFactory;
 
@@ -72,6 +73,11 @@ public class DefaultSearchPredicateFactoryContext<B> implements SearchPredicateF
 	@Override
 	public NestedPredicateContext nested() {
 		return new NestedPredicateContextImpl<>( factory, this );
+	}
+
+	@Override
+	public SimpleQueryStringPredicateContext simpleQueryString() {
+		throw new UnsupportedOperationException( "Not implemented yet" );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/DefaultSearchPredicateFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/DefaultSearchPredicateFactoryContext.java
@@ -14,6 +14,7 @@ import org.hibernate.search.engine.search.dsl.predicate.MatchAllPredicateContext
 import org.hibernate.search.engine.search.dsl.predicate.MatchIdPredicateContext;
 import org.hibernate.search.engine.search.dsl.predicate.MatchPredicateContext;
 import org.hibernate.search.engine.search.dsl.predicate.NestedPredicateContext;
+import org.hibernate.search.engine.search.dsl.predicate.PhrasePredicateContext;
 import org.hibernate.search.engine.search.dsl.predicate.RangePredicateContext;
 import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryContext;
 import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryContextExtension;
@@ -61,6 +62,11 @@ public class DefaultSearchPredicateFactoryContext<B> implements SearchPredicateF
 	@Override
 	public RangePredicateContext range() {
 		return new RangePredicateContextImpl<>( factory );
+	}
+
+	@Override
+	public PhrasePredicateContext phrase() {
+		throw new UnsupportedOperationException();
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/DefaultSearchPredicateFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/DefaultSearchPredicateFactoryContext.java
@@ -77,7 +77,7 @@ public class DefaultSearchPredicateFactoryContext<B> implements SearchPredicateF
 
 	@Override
 	public SimpleQueryStringPredicateContext simpleQueryString() {
-		throw new UnsupportedOperationException( "Not implemented yet" );
+		return new SimpleQueryStringPredicateContextImpl<>( factory );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/DefaultSearchPredicateFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/DefaultSearchPredicateFactoryContext.java
@@ -22,6 +22,7 @@ import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryEx
 import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateTerminalContext;
 import org.hibernate.search.engine.search.dsl.predicate.SimpleQueryStringPredicateContext;
 import org.hibernate.search.engine.search.dsl.predicate.SpatialPredicateContext;
+import org.hibernate.search.engine.search.dsl.predicate.WildcardPredicateContext;
 import org.hibernate.search.engine.search.predicate.spi.SearchPredicateBuilderFactory;
 
 
@@ -68,6 +69,11 @@ public class DefaultSearchPredicateFactoryContext<B> implements SearchPredicateF
 	@Override
 	public PhrasePredicateContext phrase() {
 		return new PhrasePredicateContextImpl<>( factory );
+	}
+
+	@Override
+	public WildcardPredicateContext wildcard() {
+		throw new UnsupportedOperationException( "Not implemented yet" );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/DefaultSearchPredicateFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/DefaultSearchPredicateFactoryContext.java
@@ -66,7 +66,7 @@ public class DefaultSearchPredicateFactoryContext<B> implements SearchPredicateF
 
 	@Override
 	public PhrasePredicateContext phrase() {
-		throw new UnsupportedOperationException();
+		return new PhrasePredicateContextImpl<>( factory );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/DefaultSearchPredicateFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/DefaultSearchPredicateFactoryContext.java
@@ -73,7 +73,7 @@ public class DefaultSearchPredicateFactoryContext<B> implements SearchPredicateF
 
 	@Override
 	public WildcardPredicateContext wildcard() {
-		throw new UnsupportedOperationException( "Not implemented yet" );
+		return new WildcardPredicateContextImpl<>( factory );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/MatchIdPredicateContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/MatchIdPredicateContextImpl.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.engine.search.dsl.predicate.impl;
 
 import org.hibernate.search.engine.search.dsl.predicate.MatchIdPredicateContext;
+import org.hibernate.search.engine.search.dsl.predicate.MatchIdPredicateTerminalContext;
 import org.hibernate.search.engine.search.dsl.predicate.spi.AbstractSearchPredicateTerminalContext;
 import org.hibernate.search.engine.search.predicate.spi.MatchIdPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SearchPredicateBuilderFactory;
@@ -14,7 +15,7 @@ import org.hibernate.search.engine.search.predicate.spi.SearchPredicateBuilderFa
 
 class MatchIdPredicateContextImpl<B>
 		extends AbstractSearchPredicateTerminalContext<B>
-		implements MatchIdPredicateContext {
+		implements MatchIdPredicateContext, MatchIdPredicateTerminalContext {
 
 	private final MatchIdPredicateBuilder<B> matchIdBuilder;
 
@@ -24,7 +25,7 @@ class MatchIdPredicateContextImpl<B>
 	}
 
 	@Override
-	public MatchIdPredicateContext matching(Object value) {
+	public MatchIdPredicateTerminalContext matching(Object value) {
 		matchIdBuilder.value( value );
 		return this;
 	}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/MatchPredicateContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/MatchPredicateContextImpl.java
@@ -23,6 +23,11 @@ class MatchPredicateContextImpl<B> implements MatchPredicateContext {
 	}
 
 	@Override
+	public MatchPredicateContext fuzzy(int maxEditDistance, int nonFuzzyPrefixLength) {
+		throw new UnsupportedOperationException( "Not implemented yet" );
+	}
+
+	@Override
 	public MatchPredicateFieldSetContext onFields(String ... absoluteFieldPaths) {
 		return new MatchPredicateFieldSetContextImpl<>( commonState, Arrays.asList( absoluteFieldPaths ), DslConverter.ENABLED );
 	}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/MatchPredicateContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/MatchPredicateContextImpl.java
@@ -23,8 +23,9 @@ class MatchPredicateContextImpl<B> implements MatchPredicateContext {
 	}
 
 	@Override
-	public MatchPredicateContext fuzzy(int maxEditDistance, int nonFuzzyPrefixLength) {
-		throw new UnsupportedOperationException( "Not implemented yet" );
+	public MatchPredicateContext fuzzy(int maxEditDistance, int exactPrefixLength) {
+		commonState.fuzzy( maxEditDistance, exactPrefixLength );
+		return this;
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/MatchPredicateFieldSetContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/MatchPredicateFieldSetContextImpl.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import org.hibernate.search.engine.logging.impl.Log;
 import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateTerminalContext;
@@ -66,6 +65,11 @@ class MatchPredicateFieldSetContextImpl<B>
 	}
 
 	@Override
+	public List<String> getAbsoluteFieldPaths() {
+		return absoluteFieldPaths;
+	}
+
+	@Override
 	public void contributePredicateBuilders(Consumer<B> collector) {
 		for ( MatchPredicateBuilder<B> predicateBuilder : predicateBuilders ) {
 			collector.accept( predicateBuilder.toImplementation() );
@@ -95,7 +99,7 @@ class MatchPredicateFieldSetContextImpl<B>
 
 		SearchPredicateTerminalContext matching(Object value) {
 			if ( value == null ) {
-				throw log.matchPredicateCannotMatchNullValue( collectAbsoluteFieldPaths() );
+				throw log.matchPredicateCannotMatchNullValue( getEventContext() );
 			}
 
 			for ( MatchPredicateFieldSetContextImpl<B> fieldSetContext : getFieldSetContexts() ) {
@@ -110,11 +114,6 @@ class MatchPredicateFieldSetContextImpl<B>
 				}
 			}
 			return this;
-		}
-
-		private List<String> collectAbsoluteFieldPaths() {
-			return getFieldSetContexts().stream().flatMap( f -> f.absoluteFieldPaths.stream() )
-					.collect( Collectors.toList() );
 		}
 
 	}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/MatchPredicateFieldSetContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/MatchPredicateFieldSetContextImpl.java
@@ -23,7 +23,7 @@ import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
 
 class MatchPredicateFieldSetContextImpl<B>
-		implements MatchPredicateFieldSetContext, AbstractMultiFieldPredicateCommonState.FieldSetContext<B> {
+		implements MatchPredicateFieldSetContext, AbstractBooleanMultiFieldPredicateCommonState.FieldSetContext<B> {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
@@ -72,7 +72,7 @@ class MatchPredicateFieldSetContextImpl<B>
 		}
 	}
 
-	static class CommonState<B> extends AbstractMultiFieldPredicateCommonState<B, MatchPredicateFieldSetContextImpl<B>>
+	static class CommonState<B> extends AbstractBooleanMultiFieldPredicateCommonState<B, MatchPredicateFieldSetContextImpl<B>>
 			implements SearchPredicateTerminalContext {
 
 		private Integer maxEditDistance;

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/PhrasePredicateContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/PhrasePredicateContextImpl.java
@@ -1,0 +1,46 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.dsl.predicate.impl;
+
+import java.util.Arrays;
+
+import org.hibernate.search.engine.search.dsl.predicate.PhrasePredicateContext;
+import org.hibernate.search.engine.search.dsl.predicate.PhrasePredicateFieldSetContext;
+import org.hibernate.search.engine.search.predicate.spi.SearchPredicateBuilderFactory;
+
+
+class PhrasePredicateContextImpl<B> implements PhrasePredicateContext {
+
+	private final PhrasePredicateFieldSetContextImpl.CommonState<B> commonState;
+
+	PhrasePredicateContextImpl(SearchPredicateBuilderFactory<?, B> factory) {
+		this.commonState = new PhrasePredicateFieldSetContextImpl.CommonState<>( factory );
+	}
+
+	@Override
+	public PhrasePredicateContext withConstantScore() {
+		commonState.withConstantScore();
+		return this;
+	}
+
+	@Override
+	public PhrasePredicateContext boostedTo(float boost) {
+		commonState.setPredicateLevelBoost( boost );
+		return this;
+	}
+
+	@Override
+	public PhrasePredicateContext withSlop(int slop) {
+		commonState.withSlop( slop );
+		return this;
+	}
+
+	@Override
+	public PhrasePredicateFieldSetContext onFields(String ... absoluteFieldPaths) {
+		return new PhrasePredicateFieldSetContextImpl<>( commonState, Arrays.asList( absoluteFieldPaths ) );
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/PhrasePredicateFieldSetContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/PhrasePredicateFieldSetContextImpl.java
@@ -22,7 +22,7 @@ import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
 
 class PhrasePredicateFieldSetContextImpl<B>
-		implements PhrasePredicateFieldSetContext, AbstractMultiFieldPredicateCommonState.FieldSetContext<B> {
+		implements PhrasePredicateFieldSetContext, AbstractBooleanMultiFieldPredicateCommonState.FieldSetContext<B> {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
@@ -66,7 +66,7 @@ class PhrasePredicateFieldSetContextImpl<B>
 		}
 	}
 
-	static class CommonState<B> extends AbstractMultiFieldPredicateCommonState<B, PhrasePredicateFieldSetContextImpl<B>>
+	static class CommonState<B> extends AbstractBooleanMultiFieldPredicateCommonState<B, PhrasePredicateFieldSetContextImpl<B>>
 			implements SearchPredicateTerminalContext {
 
 		private int slop = 0;

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/PhrasePredicateFieldSetContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/PhrasePredicateFieldSetContextImpl.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import org.hibernate.search.engine.logging.impl.Log;
 import org.hibernate.search.engine.search.dsl.predicate.PhrasePredicateFieldSetContext;
@@ -60,6 +59,11 @@ class PhrasePredicateFieldSetContextImpl<B>
 	}
 
 	@Override
+	public List<String> getAbsoluteFieldPaths() {
+		return absoluteFieldPaths;
+	}
+
+	@Override
 	public void contributePredicateBuilders(Consumer<B> collector) {
 		for ( PhrasePredicateBuilder<B> predicateBuilder : predicateBuilders ) {
 			collector.accept( predicateBuilder.toImplementation() );
@@ -84,7 +88,7 @@ class PhrasePredicateFieldSetContextImpl<B>
 
 		private SearchPredicateTerminalContext matching(String phrase) {
 			if ( phrase == null ) {
-				throw log.phrasePredicateCannotMatchNullPhrase( collectAbsoluteFieldPaths() );
+				throw log.phrasePredicateCannotMatchNullPhrase( getEventContext() );
 			}
 
 			for ( PhrasePredicateFieldSetContextImpl<B> fieldSetContext : getFieldSetContexts() ) {
@@ -97,11 +101,6 @@ class PhrasePredicateFieldSetContextImpl<B>
 				}
 			}
 			return this;
-		}
-
-		private List<String> collectAbsoluteFieldPaths() {
-			return getFieldSetContexts().stream().flatMap( f -> f.absoluteFieldPaths.stream() )
-					.collect( Collectors.toList() );
 		}
 
 	}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/PhrasePredicateFieldSetContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/PhrasePredicateFieldSetContextImpl.java
@@ -1,0 +1,109 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.dsl.predicate.impl;
+
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import org.hibernate.search.engine.logging.impl.Log;
+import org.hibernate.search.engine.search.dsl.predicate.PhrasePredicateFieldSetContext;
+import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateTerminalContext;
+import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.SearchPredicateBuilderFactory;
+import org.hibernate.search.util.common.logging.impl.LoggerFactory;
+
+
+class PhrasePredicateFieldSetContextImpl<B>
+		implements PhrasePredicateFieldSetContext, AbstractMultiFieldPredicateCommonState.FieldSetContext<B> {
+
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+
+	private final CommonState<B> commonState;
+
+	private final List<String> absoluteFieldPaths;
+	private final List<PhrasePredicateBuilder<B>> predicateBuilders = new ArrayList<>();
+
+	private Float fieldSetBoost;
+
+	PhrasePredicateFieldSetContextImpl(CommonState<B> commonState, List<String> absoluteFieldPaths) {
+		this.commonState = commonState;
+		this.commonState.add( this );
+		this.absoluteFieldPaths = absoluteFieldPaths;
+		SearchPredicateBuilderFactory<?, B> predicateFactory = commonState.getFactory();
+		for ( String absoluteFieldPath : absoluteFieldPaths ) {
+			predicateBuilders.add( predicateFactory.phrase( absoluteFieldPath ) );
+		}
+	}
+
+	@Override
+	public PhrasePredicateFieldSetContext orFields(String... absoluteFieldPaths) {
+		return new PhrasePredicateFieldSetContextImpl<>( commonState, Arrays.asList( absoluteFieldPaths ) );
+	}
+
+	@Override
+	public PhrasePredicateFieldSetContext boostedTo(float boost) {
+		this.fieldSetBoost = boost;
+		return this;
+	}
+
+	@Override
+	public SearchPredicateTerminalContext matching(String phrase) {
+		return commonState.matching( phrase );
+	}
+
+	@Override
+	public void contributePredicateBuilders(Consumer<B> collector) {
+		for ( PhrasePredicateBuilder<B> predicateBuilder : predicateBuilders ) {
+			collector.accept( predicateBuilder.toImplementation() );
+		}
+	}
+
+	static class CommonState<B> extends AbstractMultiFieldPredicateCommonState<B, PhrasePredicateFieldSetContextImpl<B>>
+			implements SearchPredicateTerminalContext {
+
+		private int slop = 0;
+
+		CommonState(SearchPredicateBuilderFactory<?, B> factory) {
+			super( factory );
+		}
+
+		void withSlop(int slop) {
+			if ( slop < 0 ) {
+				throw log.invalidPhrasePredicateSlop( slop );
+			}
+			this.slop = slop;
+		}
+
+		private SearchPredicateTerminalContext matching(String phrase) {
+			if ( phrase == null ) {
+				throw log.phrasePredicateCannotMatchNullPhrase( collectAbsoluteFieldPaths() );
+			}
+
+			for ( PhrasePredicateFieldSetContextImpl<B> fieldSetContext : getFieldSetContexts() ) {
+				for ( PhrasePredicateBuilder<B> predicateBuilder : fieldSetContext.predicateBuilders ) {
+					predicateBuilder.phrase( phrase );
+
+					// Fieldset contexts won't be accessed anymore, it's time to apply their options
+					applyBoostAndConstantScore( fieldSetContext.fieldSetBoost, predicateBuilder );
+					predicateBuilder.slop( slop );
+				}
+			}
+			return this;
+		}
+
+		private List<String> collectAbsoluteFieldPaths() {
+			return getFieldSetContexts().stream().flatMap( f -> f.absoluteFieldPaths.stream() )
+					.collect( Collectors.toList() );
+		}
+
+	}
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/RangePredicateFieldSetContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/RangePredicateFieldSetContextImpl.java
@@ -26,7 +26,7 @@ import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
 
 class RangePredicateFieldSetContextImpl<B>
-		implements RangePredicateFieldSetContext, AbstractMultiFieldPredicateCommonState.FieldSetContext<B> {
+		implements RangePredicateFieldSetContext, AbstractBooleanMultiFieldPredicateCommonState.FieldSetContext<B> {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
@@ -88,7 +88,8 @@ class RangePredicateFieldSetContextImpl<B>
 		}
 	}
 
-	static class CommonState<B> extends AbstractMultiFieldPredicateCommonState<B, RangePredicateFieldSetContextImpl<B>> implements RangePredicateTerminalContext {
+	static class CommonState<B> extends AbstractBooleanMultiFieldPredicateCommonState<B, RangePredicateFieldSetContextImpl<B>>
+			implements RangePredicateTerminalContext {
 
 		private boolean hasNonNullBound = false;
 

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/RangePredicateFieldSetContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/RangePredicateFieldSetContextImpl.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.hibernate.search.engine.logging.impl.Log;
@@ -76,6 +75,11 @@ class RangePredicateFieldSetContextImpl<B>
 	@Override
 	public RangePredicateTerminalContext below(Object value) {
 		return commonState.below( value );
+	}
+
+	@Override
+	public List<String> getAbsoluteFieldPaths() {
+		return absoluteFieldPaths;
 	}
 
 	@Override
@@ -156,11 +160,6 @@ class RangePredicateFieldSetContextImpl<B>
 			}
 		}
 
-		private List<String> collectAbsoluteFieldPaths() {
-			return getFieldSetContexts().stream().flatMap( f -> f.absoluteFieldPaths.stream() )
-					.collect( Collectors.toList() );
-		}
-
 		private void applyPerFieldSetOptions() {
 			for ( RangePredicateFieldSetContextImpl<B> fieldSetContext : getFieldSetContexts() ) {
 				for ( RangePredicateBuilder<B> predicateBuilder : fieldSetContext.predicateBuilders ) {
@@ -171,7 +170,7 @@ class RangePredicateFieldSetContextImpl<B>
 
 		private void checkHasNonNullBound() {
 			if ( !hasNonNullBound ) {
-				throw log.rangePredicateCannotMatchNullValue( collectAbsoluteFieldPaths() );
+				throw log.rangePredicateCannotMatchNullValue( getEventContext() );
 			}
 		}
 

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/SimpleQueryStringPredicateContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/SimpleQueryStringPredicateContextImpl.java
@@ -1,0 +1,40 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.dsl.predicate.impl;
+
+import java.util.Arrays;
+
+import org.hibernate.search.engine.search.dsl.predicate.SimpleQueryStringPredicateContext;
+import org.hibernate.search.engine.search.dsl.predicate.SimpleQueryStringPredicateFieldSetContext;
+import org.hibernate.search.engine.search.predicate.spi.SearchPredicateBuilderFactory;
+
+
+class SimpleQueryStringPredicateContextImpl<B> implements SimpleQueryStringPredicateContext {
+
+	private final SimpleQueryStringPredicateFieldSetContextImpl.CommonState<B> commonState;
+
+	SimpleQueryStringPredicateContextImpl(SearchPredicateBuilderFactory<?, B> factory) {
+		this.commonState = new SimpleQueryStringPredicateFieldSetContextImpl.CommonState<>( factory );
+	}
+
+	@Override
+	public SimpleQueryStringPredicateContext withConstantScore() {
+		commonState.withConstantScore();
+		return this;
+	}
+
+	@Override
+	public SimpleQueryStringPredicateContext boostedTo(float boost) {
+		commonState.boost( boost );
+		return this;
+	}
+
+	@Override
+	public SimpleQueryStringPredicateFieldSetContext onFields(String ... absoluteFieldPaths) {
+		return new SimpleQueryStringPredicateFieldSetContextImpl<>( commonState, Arrays.asList( absoluteFieldPaths ) );
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/SimpleQueryStringPredicateFieldSetContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/SimpleQueryStringPredicateFieldSetContextImpl.java
@@ -1,0 +1,116 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.dsl.predicate.impl;
+
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.hibernate.search.engine.logging.impl.Log;
+import org.hibernate.search.engine.search.dsl.predicate.SimpleQueryStringPredicateFieldSetContext;
+import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateTerminalContext;
+import org.hibernate.search.engine.search.dsl.predicate.spi.AbstractSearchPredicateTerminalContext;
+import org.hibernate.search.engine.search.predicate.spi.SimpleQueryStringPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.SearchPredicateBuilderFactory;
+import org.hibernate.search.util.common.logging.impl.LoggerFactory;
+
+
+class SimpleQueryStringPredicateFieldSetContextImpl<B>
+		implements SimpleQueryStringPredicateFieldSetContext {
+
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+
+	private final CommonState<B> commonState;
+
+	private final List<String> absoluteFieldPaths;
+	private final List<SimpleQueryStringPredicateBuilder.FieldContext> fieldContexts = new ArrayList<>();
+
+	SimpleQueryStringPredicateFieldSetContextImpl(CommonState<B> commonState, List<String> absoluteFieldPaths) {
+		this.commonState = commonState;
+		this.commonState.add( this );
+		this.absoluteFieldPaths = absoluteFieldPaths;
+		for ( String absoluteFieldPath : absoluteFieldPaths ) {
+			fieldContexts.add( commonState.field( absoluteFieldPath ) );
+		}
+	}
+
+	@Override
+	public SimpleQueryStringPredicateFieldSetContext withAndAsDefaultOperator() {
+		commonState.withAndAsDefaultOperator();
+		return this;
+	}
+
+	@Override
+	public SimpleQueryStringPredicateFieldSetContext orFields(String... absoluteFieldPaths) {
+		return new SimpleQueryStringPredicateFieldSetContextImpl<>( commonState, Arrays.asList( absoluteFieldPaths ) );
+	}
+
+	@Override
+	public SimpleQueryStringPredicateFieldSetContext boostedTo(float boost) {
+		fieldContexts.forEach( c -> c.boost( boost ) );
+		return this;
+	}
+
+	@Override
+	public SearchPredicateTerminalContext matching(String simpleQueryString) {
+		return commonState.matching( simpleQueryString );
+	}
+
+	static class CommonState<B> extends AbstractSearchPredicateTerminalContext<B>
+			implements SearchPredicateTerminalContext {
+
+		private final SimpleQueryStringPredicateBuilder<B> builder;
+
+		private final List<SimpleQueryStringPredicateFieldSetContextImpl<B>> fieldSetContexts = new ArrayList<>();
+
+		CommonState(SearchPredicateBuilderFactory<?, B> factory) {
+			super( factory );
+			this.builder = factory.simpleQueryString();
+		}
+
+		@Override
+		protected B toImplementation() {
+			return builder.toImplementation();
+		}
+
+		void withConstantScore() {
+			builder.withConstantScore();
+		}
+
+		void boost(float boost) {
+			builder.boost( boost );
+		}
+
+		void add(SimpleQueryStringPredicateFieldSetContextImpl<B> fieldSetContext) {
+			fieldSetContexts.add( fieldSetContext );
+		}
+
+		SimpleQueryStringPredicateBuilder.FieldContext field(String absoluteFieldPath) {
+			return builder.field( absoluteFieldPath );
+		}
+
+		void withAndAsDefaultOperator() {
+			builder.withAndAsDefaultOperator();
+		}
+
+		private SearchPredicateTerminalContext matching(String simpleQueryString) {
+			if ( simpleQueryString == null ) {
+				throw log.simpleQueryStringCannotBeNull( collectAbsoluteFieldPaths() );
+			}
+			builder.simpleQueryString( simpleQueryString );
+			return this;
+		}
+
+		private List<String> collectAbsoluteFieldPaths() {
+			return fieldSetContexts.stream().flatMap( f -> f.absoluteFieldPaths.stream() )
+					.collect( Collectors.toList() );
+		}
+	}
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/SpatialWithinPredicateFieldSetContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/SpatialWithinPredicateFieldSetContextImpl.java
@@ -27,7 +27,7 @@ import org.hibernate.search.util.common.impl.Contracts;
 
 
 class SpatialWithinPredicateFieldSetContextImpl<B>
-		implements SpatialWithinPredicateFieldSetContext, AbstractMultiFieldPredicateCommonState.FieldSetContext<B> {
+		implements SpatialWithinPredicateFieldSetContext, AbstractBooleanMultiFieldPredicateCommonState.FieldSetContext<B> {
 
 	private final CommonState<B> commonState;
 
@@ -109,7 +109,7 @@ class SpatialWithinPredicateFieldSetContextImpl<B>
 		}
 	}
 
-	static class CommonState<B> extends AbstractMultiFieldPredicateCommonState<B, SpatialWithinPredicateFieldSetContextImpl<B>>
+	static class CommonState<B> extends AbstractBooleanMultiFieldPredicateCommonState<B, SpatialWithinPredicateFieldSetContextImpl<B>>
 			implements SearchPredicateTerminalContext {
 
 		CommonState(SearchPredicateBuilderFactory<?, B> factory) {

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/SpatialWithinPredicateFieldSetContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/SpatialWithinPredicateFieldSetContextImpl.java
@@ -79,6 +79,11 @@ class SpatialWithinPredicateFieldSetContextImpl<B>
 	}
 
 	@Override
+	public List<String> getAbsoluteFieldPaths() {
+		return absoluteFieldPaths;
+	}
+
+	@Override
 	public void contributePredicateBuilders(Consumer<B> collector) {
 		for ( SearchPredicateBuilder<B> predicateBuilder : predicateBuilders ) {
 			collector.accept( predicateBuilder.toImplementation() );

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/WildcardPredicateContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/WildcardPredicateContextImpl.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.dsl.predicate.impl;
+
+import java.util.Arrays;
+
+import org.hibernate.search.engine.search.dsl.predicate.WildcardPredicateContext;
+import org.hibernate.search.engine.search.dsl.predicate.WildcardPredicateFieldSetContext;
+import org.hibernate.search.engine.search.predicate.spi.SearchPredicateBuilderFactory;
+
+
+class WildcardPredicateContextImpl<B> implements WildcardPredicateContext {
+
+	private final WildcardPredicateFieldSetContextImpl.CommonState<B> commonState;
+
+	WildcardPredicateContextImpl(SearchPredicateBuilderFactory<?, B> factory) {
+		this.commonState = new WildcardPredicateFieldSetContextImpl.CommonState<>( factory );
+	}
+
+	@Override
+	public WildcardPredicateContext boostedTo(float boost) {
+		commonState.setPredicateLevelBoost( boost );
+		return this;
+	}
+
+	@Override
+	public WildcardPredicateFieldSetContext onFields(String ... absoluteFieldPaths) {
+		return new WildcardPredicateFieldSetContextImpl<>( commonState, Arrays.asList( absoluteFieldPaths ) );
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/WildcardPredicateFieldSetContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/WildcardPredicateFieldSetContextImpl.java
@@ -1,0 +1,98 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.dsl.predicate.impl;
+
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import org.hibernate.search.engine.logging.impl.Log;
+import org.hibernate.search.engine.search.dsl.predicate.WildcardPredicateFieldSetContext;
+import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateTerminalContext;
+import org.hibernate.search.engine.search.predicate.spi.WildcardPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.SearchPredicateBuilderFactory;
+import org.hibernate.search.util.common.logging.impl.LoggerFactory;
+
+
+class WildcardPredicateFieldSetContextImpl<B>
+		implements WildcardPredicateFieldSetContext, AbstractBooleanMultiFieldPredicateCommonState.FieldSetContext<B> {
+
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+
+	private final CommonState<B> commonState;
+
+	private final List<String> absoluteFieldPaths;
+	private final List<WildcardPredicateBuilder<B>> predicateBuilders = new ArrayList<>();
+
+	private Float fieldSetBoost;
+
+	WildcardPredicateFieldSetContextImpl(CommonState<B> commonState, List<String> absoluteFieldPaths) {
+		this.commonState = commonState;
+		this.commonState.add( this );
+		this.absoluteFieldPaths = absoluteFieldPaths;
+		SearchPredicateBuilderFactory<?, B> predicateFactory = commonState.getFactory();
+		for ( String absoluteFieldPath : absoluteFieldPaths ) {
+			predicateBuilders.add( predicateFactory.wildcard( absoluteFieldPath ) );
+		}
+	}
+
+	@Override
+	public WildcardPredicateFieldSetContext orFields(String... absoluteFieldPaths) {
+		return new WildcardPredicateFieldSetContextImpl<>( commonState, Arrays.asList( absoluteFieldPaths ) );
+	}
+
+	@Override
+	public WildcardPredicateFieldSetContext boostedTo(float boost) {
+		this.fieldSetBoost = boost;
+		return this;
+	}
+
+	@Override
+	public SearchPredicateTerminalContext matching(String wildcard) {
+		return commonState.matching( wildcard );
+	}
+
+	@Override
+	public void contributePredicateBuilders(Consumer<B> collector) {
+		for ( WildcardPredicateBuilder<B> predicateBuilder : predicateBuilders ) {
+			collector.accept( predicateBuilder.toImplementation() );
+		}
+	}
+
+	static class CommonState<B> extends AbstractBooleanMultiFieldPredicateCommonState<B, WildcardPredicateFieldSetContextImpl<B>>
+			implements SearchPredicateTerminalContext {
+
+		CommonState(SearchPredicateBuilderFactory<?, B> factory) {
+			super( factory );
+		}
+
+		private SearchPredicateTerminalContext matching(String wildcardPattern) {
+			if ( wildcardPattern == null ) {
+				throw log.wildcardPredicateCannotMatchNullPattern( collectAbsoluteFieldPaths() );
+			}
+			for ( WildcardPredicateFieldSetContextImpl<B> fieldSetContext : getFieldSetContexts() ) {
+				for ( WildcardPredicateBuilder<B> predicateBuilder : fieldSetContext.predicateBuilders ) {
+					predicateBuilder.pattern( wildcardPattern );
+
+					// Fieldset contexts won't be accessed anymore, it's time to apply their options
+					applyBoostAndConstantScore( fieldSetContext.fieldSetBoost, predicateBuilder );
+				}
+			}
+			return this;
+		}
+
+		private List<String> collectAbsoluteFieldPaths() {
+			return getFieldSetContexts().stream().flatMap( f -> f.absoluteFieldPaths.stream() )
+					.collect( Collectors.toList() );
+		}
+
+	}
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/WildcardPredicateFieldSetContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/impl/WildcardPredicateFieldSetContextImpl.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import org.hibernate.search.engine.logging.impl.Log;
 import org.hibernate.search.engine.search.dsl.predicate.WildcardPredicateFieldSetContext;
@@ -60,6 +59,11 @@ class WildcardPredicateFieldSetContextImpl<B>
 	}
 
 	@Override
+	public List<String> getAbsoluteFieldPaths() {
+		return absoluteFieldPaths;
+	}
+
+	@Override
 	public void contributePredicateBuilders(Consumer<B> collector) {
 		for ( WildcardPredicateBuilder<B> predicateBuilder : predicateBuilders ) {
 			collector.accept( predicateBuilder.toImplementation() );
@@ -75,7 +79,7 @@ class WildcardPredicateFieldSetContextImpl<B>
 
 		private SearchPredicateTerminalContext matching(String wildcardPattern) {
 			if ( wildcardPattern == null ) {
-				throw log.wildcardPredicateCannotMatchNullPattern( collectAbsoluteFieldPaths() );
+				throw log.wildcardPredicateCannotMatchNullPattern( getEventContext() );
 			}
 			for ( WildcardPredicateFieldSetContextImpl<B> fieldSetContext : getFieldSetContexts() ) {
 				for ( WildcardPredicateBuilder<B> predicateBuilder : fieldSetContext.predicateBuilders ) {
@@ -86,11 +90,6 @@ class WildcardPredicateFieldSetContextImpl<B>
 				}
 			}
 			return this;
-		}
-
-		private List<String> collectAbsoluteFieldPaths() {
-			return getFieldSetContexts().stream().flatMap( f -> f.absoluteFieldPaths.stream() )
-					.collect( Collectors.toList() );
 		}
 
 	}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/spi/DelegatingSearchPredicateFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/spi/DelegatingSearchPredicateFactoryContext.java
@@ -19,6 +19,7 @@ import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryCo
 import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryContextExtension;
 import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryExtensionContext;
 import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateTerminalContext;
+import org.hibernate.search.engine.search.dsl.predicate.SimpleQueryStringPredicateContext;
 import org.hibernate.search.engine.search.dsl.predicate.SpatialPredicateContext;
 
 /**
@@ -72,6 +73,11 @@ public class DelegatingSearchPredicateFactoryContext implements SearchPredicateF
 	@Override
 	public NestedPredicateContext nested() {
 		return delegate.nested();
+	}
+
+	@Override
+	public SimpleQueryStringPredicateContext simpleQueryString() {
+		return delegate.simpleQueryString();
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/spi/DelegatingSearchPredicateFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/spi/DelegatingSearchPredicateFactoryContext.java
@@ -21,6 +21,7 @@ import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryEx
 import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateTerminalContext;
 import org.hibernate.search.engine.search.dsl.predicate.SimpleQueryStringPredicateContext;
 import org.hibernate.search.engine.search.dsl.predicate.SpatialPredicateContext;
+import org.hibernate.search.engine.search.dsl.predicate.WildcardPredicateContext;
 
 /**
  * A delegating {@link SearchPredicateFactoryContext}.
@@ -68,6 +69,11 @@ public class DelegatingSearchPredicateFactoryContext implements SearchPredicateF
 	@Override
 	public PhrasePredicateContext phrase() {
 		return delegate.phrase();
+	}
+
+	@Override
+	public WildcardPredicateContext wildcard() {
+		return delegate.wildcard();
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/spi/DelegatingSearchPredicateFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/spi/DelegatingSearchPredicateFactoryContext.java
@@ -13,6 +13,7 @@ import org.hibernate.search.engine.search.dsl.predicate.MatchIdPredicateContext;
 import org.hibernate.search.engine.search.dsl.predicate.BooleanJunctionPredicateContext;
 import org.hibernate.search.engine.search.dsl.predicate.MatchPredicateContext;
 import org.hibernate.search.engine.search.dsl.predicate.NestedPredicateContext;
+import org.hibernate.search.engine.search.dsl.predicate.PhrasePredicateContext;
 import org.hibernate.search.engine.search.dsl.predicate.RangePredicateContext;
 import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryContext;
 import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryContextExtension;
@@ -61,6 +62,11 @@ public class DelegatingSearchPredicateFactoryContext implements SearchPredicateF
 	@Override
 	public RangePredicateContext range() {
 		return delegate.range();
+	}
+
+	@Override
+	public PhrasePredicateContext phrase() {
+		return delegate.phrase();
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/MatchPredicateBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/MatchPredicateBuilder.java
@@ -8,6 +8,8 @@ package org.hibernate.search.engine.search.predicate.spi;
 
 public interface MatchPredicateBuilder<B> extends SearchPredicateBuilder<B> {
 
+	void fuzzy(int maxEditDistance, int exactPrefixLength);
+
 	void value(Object value);
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/PhrasePredicateBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/PhrasePredicateBuilder.java
@@ -1,0 +1,15 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.predicate.spi;
+
+public interface PhrasePredicateBuilder<B> extends SearchPredicateBuilder<B> {
+
+	void slop(int slop);
+
+	void phrase(String phrase);
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/SearchPredicateBuilderFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/SearchPredicateBuilderFactory.java
@@ -66,6 +66,8 @@ public interface SearchPredicateBuilderFactory<C, B> {
 
 	PhrasePredicateBuilder<B> phrase(String absoluteFieldPath);
 
+	WildcardPredicateBuilder<B> wildcard(String absoluteFieldPath);
+
 	NestedPredicateBuilder<B> nested(String absoluteFieldPath);
 
 	SimpleQueryStringPredicateBuilder<B> simpleQueryString();

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/SearchPredicateBuilderFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/SearchPredicateBuilderFactory.java
@@ -64,6 +64,8 @@ public interface SearchPredicateBuilderFactory<C, B> {
 
 	RangePredicateBuilder<B> range(String absoluteFieldPath, DslConverter dslConverter);
 
+	PhrasePredicateBuilder<B> phrase(String absoluteFieldPath);
+
 	NestedPredicateBuilder<B> nested(String absoluteFieldPath);
 
 	SpatialWithinCirclePredicateBuilder<B> spatialWithinCircle(String absoluteFieldPath);

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/SearchPredicateBuilderFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/SearchPredicateBuilderFactory.java
@@ -68,10 +68,11 @@ public interface SearchPredicateBuilderFactory<C, B> {
 
 	NestedPredicateBuilder<B> nested(String absoluteFieldPath);
 
+	SimpleQueryStringPredicateBuilder<B> simpleQueryString();
+
 	SpatialWithinCirclePredicateBuilder<B> spatialWithinCircle(String absoluteFieldPath);
 
 	SpatialWithinPolygonPredicateBuilder<B> spatialWithinPolygon(String absoluteFieldPath);
 
 	SpatialWithinBoundingBoxPredicateBuilder<B> spatialWithinBoundingBox(String absoluteFieldPath);
-
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/SimpleQueryStringPredicateBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/SimpleQueryStringPredicateBuilder.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.predicate.spi;
+
+public interface SimpleQueryStringPredicateBuilder<B> extends SearchPredicateBuilder<B> {
+
+	FieldContext field(String absoluteFieldPath);
+
+	void withAndAsDefaultOperator();
+
+	void simpleQueryString(String simpleQueryString);
+
+	interface FieldContext {
+
+		void boost(float boost);
+
+	}
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/WildcardPredicateBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/WildcardPredicateBuilder.java
@@ -1,0 +1,13 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.predicate.spi;
+
+public interface WildcardPredicateBuilder<B> extends SearchPredicateBuilder<B> {
+
+	void pattern(String wildcardPattern);
+
+}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
@@ -71,7 +71,7 @@ public class ElasticsearchExtensionIT {
 	public void setup() {
 		this.integration = setupHelper.withDefaultConfiguration( BACKEND_NAME )
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/fieldtype/ElasticsearchFieldTypesIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/fieldtype/ElasticsearchFieldTypesIT.java
@@ -60,7 +60,7 @@ public class ElasticsearchFieldTypesIT {
 						BACKEND_NAME, ElasticsearchBackendSpiSettings.CLIENT_FACTORY, clientSpy.getFactory()
 				)
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> new IndexAccessors( ctx.getSchemaElement() ),
 						indexManager -> {
 						}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchAnalyzerDefinitionCreationIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchAnalyzerDefinitionCreationIT.java
@@ -115,7 +115,7 @@ public class ElasticsearchAnalyzerDefinitionCreationIT {
 	private void setup() {
 		withManagementStrategyConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> { },
 						indexMapping -> { }
 				)

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchAnalyzerDefinitionMigrationIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchAnalyzerDefinitionMigrationIT.java
@@ -489,7 +489,7 @@ public class ElasticsearchAnalyzerDefinitionMigrationIT {
 	private void setup() {
 		withManagementStrategyConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> { },
 						indexMapping -> { }
 				)

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchAnalyzerDefinitionValidationIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchAnalyzerDefinitionValidationIT.java
@@ -649,7 +649,7 @@ public class ElasticsearchAnalyzerDefinitionValidationIT {
 	private void setup() {
 		withManagementStrategyConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> { },
 						indexMapping -> { }
 				)

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchIndexStatusCheckIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchIndexStatusCheckIT.java
@@ -138,7 +138,7 @@ public class ElasticsearchIndexStatusCheckIT {
 	private void setup() {
 		withManagementStrategyConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> { },
 						indexMapping -> { }
 				)

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchNormalizerDefinitionCreationIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchNormalizerDefinitionCreationIT.java
@@ -91,7 +91,7 @@ public class ElasticsearchNormalizerDefinitionCreationIT {
 	private void setup() {
 		withManagementStrategyConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> { },
 						indexMapping -> { }
 				)

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchNormalizerDefinitionMigrationIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchNormalizerDefinitionMigrationIT.java
@@ -308,7 +308,7 @@ public class ElasticsearchNormalizerDefinitionMigrationIT {
 	private void setup() {
 		withManagementStrategyConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> { },
 						indexMapping -> { }
 				)

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchNormalizerDefinitionValidationIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchNormalizerDefinitionValidationIT.java
@@ -112,7 +112,7 @@ public class ElasticsearchNormalizerDefinitionValidationIT {
 	private void setup() {
 		withManagementStrategyConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> { },
 						indexMapping -> { }
 				)

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchSchemaCreateStrategyIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchSchemaCreateStrategyIT.java
@@ -77,7 +77,7 @@ public class ElasticsearchSchemaCreateStrategyIT {
 	private void setup() {
 		setupHelper.withDefaultConfiguration( BACKEND_NAME )
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> {
 							IndexSchemaElement root = ctx.getSchemaElement();
 							root.field( "field", f -> f.asString() )

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchSchemaCreationIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchSchemaCreationIT.java
@@ -202,7 +202,7 @@ public class ElasticsearchSchemaCreationIT {
 	private void setup(Consumer<IndexModelBindingContext> mappingContributor) {
 		setupHelper.withDefaultConfiguration( BACKEND_NAME )
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						mappingContributor,
 						indexManager -> { }
 				)

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchSchemaMigrationIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchSchemaMigrationIT.java
@@ -110,7 +110,7 @@ public class ElasticsearchSchemaMigrationIT {
 
 		withManagementStrategyConfiguration()
 				.withIndex(
-						"MappedType1", INDEX1_NAME,
+						INDEX1_NAME,
 						ctx -> {
 							IndexSchemaElement root = ctx.getSchemaElement();
 							root.field( "myField", f -> f.asLocalDate() )
@@ -119,7 +119,7 @@ public class ElasticsearchSchemaMigrationIT {
 						indexManager -> { }
 				)
 				.withIndex(
-						"MappedType2", INDEX2_NAME,
+						INDEX2_NAME,
 						ctx -> {
 							IndexSchemaElement root = ctx.getSchemaElement();
 							root.field( "myField", f -> f.asBoolean() )
@@ -128,7 +128,7 @@ public class ElasticsearchSchemaMigrationIT {
 						indexManager -> { }
 				)
 				.withIndex(
-						"MappedType3", INDEX3_NAME,
+						INDEX3_NAME,
 						ctx -> {
 							IndexSchemaElement root = ctx.getSchemaElement();
 							root.field(
@@ -211,7 +211,7 @@ public class ElasticsearchSchemaMigrationIT {
 
 		withManagementStrategyConfiguration()
 				.withIndex(
-						"MappedType", INDEX1_NAME,
+						INDEX1_NAME,
 						ctx -> {
 							IndexSchemaElement root = ctx.getSchemaElement();
 							root.field( "myField", f -> f.asBoolean() )
@@ -257,7 +257,7 @@ public class ElasticsearchSchemaMigrationIT {
 
 		withManagementStrategyConfiguration()
 				.withIndex(
-						"MappedType", INDEX1_NAME,
+						INDEX1_NAME,
 						ctx -> {
 							IndexSchemaElement root = ctx.getSchemaElement();
 							root.field( "myField", f -> f.asBoolean() )
@@ -302,7 +302,7 @@ public class ElasticsearchSchemaMigrationIT {
 
 		withManagementStrategyConfiguration()
 				.withIndex(
-						"MappedType", INDEX1_NAME,
+						INDEX1_NAME,
 						ctx -> {
 							IndexSchemaElement root = ctx.getSchemaElement();
 							root.field( "myField", f -> f.asLocalDate() )
@@ -350,7 +350,7 @@ public class ElasticsearchSchemaMigrationIT {
 		setupExpectingFailure(
 				() -> withManagementStrategyConfiguration()
 						.withIndex(
-								"MappedType", INDEX1_NAME,
+								INDEX1_NAME,
 								ctx -> {
 									IndexSchemaElement root = ctx.getSchemaElement();
 									root.field( "myField", f -> f.asLocalDate() )
@@ -392,7 +392,7 @@ public class ElasticsearchSchemaMigrationIT {
 		setupExpectingFailure(
 				() -> withManagementStrategyConfiguration()
 						.withIndex(
-								"MappedType", INDEX1_NAME,
+								INDEX1_NAME,
 								ctx -> {
 									IndexSchemaElement root = ctx.getSchemaElement();
 									root.field(
@@ -437,7 +437,7 @@ public class ElasticsearchSchemaMigrationIT {
 		setupExpectingFailure(
 				() -> withManagementStrategyConfiguration()
 						.withIndex(
-								"MappedType", INDEX1_NAME,
+								INDEX1_NAME,
 								ctx -> {
 									IndexSchemaElement root = ctx.getSchemaElement();
 									root.field(

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchSchemaValidationIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchSchemaValidationIT.java
@@ -127,7 +127,7 @@ public class ElasticsearchSchemaValidationIT {
 
 		withManagementStrategyConfiguration()
 				.withIndex(
-						"MappedType1", INDEX1_NAME,
+						INDEX1_NAME,
 						ctx -> {
 							IndexSchemaElement root = ctx.getSchemaElement();
 							root.field( "myField", f -> f.asLocalDate() )
@@ -136,7 +136,7 @@ public class ElasticsearchSchemaValidationIT {
 						indexManager -> { }
 				)
 				.withIndex(
-						"MappedType2", INDEX2_NAME,
+						INDEX2_NAME,
 						ctx -> {
 							IndexSchemaElement root = ctx.getSchemaElement();
 							root.field( "myField", f -> f.asBoolean() )
@@ -145,7 +145,7 @@ public class ElasticsearchSchemaValidationIT {
 						indexManager -> { }
 				)
 				.withIndex(
-						"MappedType3", INDEX3_NAME,
+						INDEX3_NAME,
 						ctx -> {
 							IndexSchemaElement root = ctx.getSchemaElement();
 							root.field(
@@ -167,7 +167,7 @@ public class ElasticsearchSchemaValidationIT {
 		elasticSearchClient.index( INDEX1_NAME ).deleteAndCreate();
 
 		setupExpectingFailure(
-				() -> setupSimpleIndexWithLocalDateField( "MappedType1", INDEX1_NAME ),
+				() -> setupSimpleIndexWithLocalDateField( INDEX1_NAME ),
 				FailureReportUtils.buildFailureReportPattern()
 						.indexContext( INDEX1_NAME )
 						.contextLiteral( SCHEMA_VALIDATION_CONTEXT )
@@ -191,7 +191,7 @@ public class ElasticsearchSchemaValidationIT {
 				);
 
 		setupExpectingFailure(
-				() -> setupSimpleIndexWithLocalDateField( "MappedType1", INDEX1_NAME ),
+				() -> setupSimpleIndexWithLocalDateField( INDEX1_NAME ),
 				FailureReportUtils.buildFailureReportPattern()
 						.indexContext( INDEX1_NAME )
 						.contextLiteral( SCHEMA_VALIDATION_CONTEXT )
@@ -216,7 +216,7 @@ public class ElasticsearchSchemaValidationIT {
 				);
 
 		setupExpectingFailure(
-				() -> setupSimpleIndexWithLocalDateField( "MappedType1", INDEX1_NAME ),
+				() -> setupSimpleIndexWithLocalDateField( INDEX1_NAME ),
 				FailureReportUtils.buildFailureReportPattern()
 						.indexContext( INDEX1_NAME )
 						.contextLiteral( SCHEMA_VALIDATION_CONTEXT )
@@ -237,7 +237,7 @@ public class ElasticsearchSchemaValidationIT {
 				);
 
 		setupExpectingFailure(
-				() -> setupSimpleIndexWithLocalDateField( "MappedType1", INDEX1_NAME ),
+				() -> setupSimpleIndexWithLocalDateField( INDEX1_NAME ),
 				FailureReportUtils.buildFailureReportPattern()
 						.indexContext( INDEX1_NAME )
 						.contextLiteral( SCHEMA_VALIDATION_CONTEXT )
@@ -263,7 +263,7 @@ public class ElasticsearchSchemaValidationIT {
 				);
 
 		setupExpectingFailure(
-				() -> setupSimpleIndexWithLocalDateField( "MappedType1", INDEX1_NAME ),
+				() -> setupSimpleIndexWithLocalDateField( INDEX1_NAME ),
 				FailureReportUtils.buildFailureReportPattern()
 						.indexContext( INDEX1_NAME )
 						.contextLiteral( SCHEMA_VALIDATION_CONTEXT )
@@ -288,7 +288,7 @@ public class ElasticsearchSchemaValidationIT {
 				);
 
 		setupExpectingFailure(
-				() -> setupSimpleIndexWithLocalDateField( "MappedType1", INDEX1_NAME ),
+				() -> setupSimpleIndexWithLocalDateField( INDEX1_NAME ),
 				FailureReportUtils.buildFailureReportPattern()
 						.indexContext( INDEX1_NAME )
 						.contextLiteral( SCHEMA_VALIDATION_CONTEXT )
@@ -315,7 +315,7 @@ public class ElasticsearchSchemaValidationIT {
 				);
 
 		setupExpectingFailure(
-				() -> setupSimpleIndexWithLocalDateField( "MappedType1", INDEX1_NAME ),
+				() -> setupSimpleIndexWithLocalDateField( INDEX1_NAME ),
 				FailureReportUtils.buildFailureReportPattern()
 						.indexContext( INDEX1_NAME )
 						.contextLiteral( SCHEMA_VALIDATION_CONTEXT )
@@ -344,7 +344,7 @@ public class ElasticsearchSchemaValidationIT {
 		setupExpectingFailure(
 				() -> withManagementStrategyConfiguration()
 						.withIndex(
-								"MappedType1", INDEX1_NAME,
+								INDEX1_NAME,
 								ctx -> {
 									IndexSchemaElement root = ctx.getSchemaElement();
 									root.field(
@@ -385,7 +385,7 @@ public class ElasticsearchSchemaValidationIT {
 		setupExpectingFailure(
 				() -> withManagementStrategyConfiguration()
 						.withIndex(
-								"MappedType1", INDEX1_NAME,
+								INDEX1_NAME,
 								ctx -> {
 									IndexSchemaElement root = ctx.getSchemaElement();
 									root.field(
@@ -425,7 +425,7 @@ public class ElasticsearchSchemaValidationIT {
 		setupExpectingFailure(
 				() -> withManagementStrategyConfiguration()
 						.withIndex(
-								"MappedType1", INDEX1_NAME,
+								INDEX1_NAME,
 								ctx -> {
 									IndexSchemaElement root = ctx.getSchemaElement();
 									root.field( "myField", f -> f.asLocalDate() )
@@ -467,7 +467,7 @@ public class ElasticsearchSchemaValidationIT {
 		setupExpectingFailure(
 				() -> withManagementStrategyConfiguration()
 						.withIndex(
-								"MappedType1", INDEX1_NAME,
+								INDEX1_NAME,
 								ctx -> {
 									IndexSchemaElement root = ctx.getSchemaElement();
 									root.field( "myField", f -> f.asLocalDate() )
@@ -505,7 +505,7 @@ public class ElasticsearchSchemaValidationIT {
 				);
 
 		setupExpectingFailure(
-				() -> setupSimpleIndexWithLocalDateField( "MappedType1", INDEX1_NAME ),
+				() -> setupSimpleIndexWithLocalDateField( INDEX1_NAME ),
 				FailureReportUtils.buildFailureReportPattern()
 						.indexContext( INDEX1_NAME )
 						.contextLiteral( SCHEMA_VALIDATION_CONTEXT )
@@ -544,7 +544,7 @@ public class ElasticsearchSchemaValidationIT {
 
 		withManagementStrategyConfiguration()
 				.withIndex(
-						"MappedType1", INDEX1_NAME,
+						INDEX1_NAME,
 						ctx -> {
 							IndexSchemaElement root = ctx.getSchemaElement();
 							root.field( "myField", f -> f.asLong() )
@@ -586,7 +586,7 @@ public class ElasticsearchSchemaValidationIT {
 		setupExpectingFailure(
 				() -> withManagementStrategyConfiguration()
 						.withIndex(
-								"MappedTypeName", INDEX1_NAME,
+								INDEX1_NAME,
 								ctx -> {
 									IndexSchemaElement root = ctx.getSchemaElement();
 									IndexSchemaObjectField objectField =
@@ -623,7 +623,7 @@ public class ElasticsearchSchemaValidationIT {
 				);
 
 		setupExpectingFailure(
-				() -> setupSimpleIndexWithKeywordField( "MappedType1", INDEX1_NAME ),
+				() -> setupSimpleIndexWithKeywordField( INDEX1_NAME ),
 				FailureReportUtils.buildFailureReportPattern()
 						.indexContext( INDEX1_NAME )
 						.contextLiteral( SCHEMA_VALIDATION_CONTEXT )
@@ -666,7 +666,7 @@ public class ElasticsearchSchemaValidationIT {
 		setupExpectingFailure(
 				() -> withManagementStrategyConfiguration()
 						.withIndex(
-								"MappedType1", INDEX1_NAME,
+								INDEX1_NAME,
 								ctx -> {
 									IndexSchemaElement root = ctx.getSchemaElement();
 									root.field( "myField", f -> f.asString() )
@@ -675,7 +675,7 @@ public class ElasticsearchSchemaValidationIT {
 								indexManager -> { }
 						)
 						.withIndex(
-								"MappedType2", INDEX2_NAME,
+								INDEX2_NAME,
 								ctx -> {
 									IndexSchemaElement root = ctx.getSchemaElement();
 									root.field( "myField", f -> f.asString() )
@@ -828,10 +828,10 @@ public class ElasticsearchSchemaValidationIT {
 				.hasMessageMatching( failureReportRegex );
 	}
 
-	private void setupSimpleIndexWithKeywordField(String typeName, String indexName) {
+	private void setupSimpleIndexWithKeywordField(String indexName) {
 		withManagementStrategyConfiguration()
 				.withIndex(
-						typeName, indexName,
+						indexName,
 						ctx -> {
 							IndexSchemaElement root = ctx.getSchemaElement();
 							root.field( "myField", f -> f.asString() )
@@ -843,10 +843,10 @@ public class ElasticsearchSchemaValidationIT {
 				.setup();
 	}
 
-	private void setupSimpleIndexWithLocalDateField(String typeName, String indexName) {
+	private void setupSimpleIndexWithLocalDateField(String indexName) {
 		withManagementStrategyConfiguration()
 				.withIndex(
-						typeName, indexName,
+						indexName,
 						ctx -> {
 							IndexSchemaElement root = ctx.getSchemaElement();
 							root.field( "myField", f -> f.asLocalDate() )

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/search/query/ElasticsearchSearchQueryIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/search/query/ElasticsearchSearchQueryIT.java
@@ -54,7 +54,7 @@ public class ElasticsearchSearchQueryIT {
 						BACKEND_NAME, ElasticsearchBackendSpiSettings.CLIENT_FACTORY, clientSpy.getFactory()
 				)
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> new IndexAccessors( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/configuration/DefaultITAnalysisConfigurer.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/configuration/DefaultITAnalysisConfigurer.java
@@ -13,7 +13,9 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.configuratio
 public class DefaultITAnalysisConfigurer implements ElasticsearchAnalysisConfigurer {
 	@Override
 	public void configure(ElasticsearchAnalysisDefinitionContainerContext context) {
-		context.analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD.name ).type( "standard" );
+		context.analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD.name ).type( "standard" )
+				// Try to behave like Lucene, which uses English stopwords by default
+				.param( "stopwords", "_english_" );
 		context.normalizer( DefaultAnalysisDefinitions.NORMALIZER_LOWERCASE.name ).custom()
 				.withTokenFilters( "lowercase" );
 	}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/work/ElasticsearchIndexingIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/work/ElasticsearchIndexingIT.java
@@ -56,7 +56,7 @@ public class ElasticsearchIndexingIT {
 						BACKEND_NAME, ElasticsearchBackendSpiSettings.CLIENT_FACTORY, clientSpy.getFactory()
 				)
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneDocumentModelDslIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneDocumentModelDslIT.java
@@ -62,7 +62,7 @@ public class LuceneDocumentModelDslIT {
 	private void setup(Consumer<IndexModelBindingContext> mappingContributor) {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						mappingContributor,
 						indexManager -> { }
 				)

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneExtensionIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneExtensionIT.java
@@ -84,7 +84,7 @@ public class LuceneExtensionIT {
 	public void setup() {
 		this.integration = setupHelper.withDefaultConfiguration( BACKEND_NAME )
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/fieldtype/LuceneFieldContentIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/fieldtype/LuceneFieldContentIT.java
@@ -47,7 +47,7 @@ public class LuceneFieldContentIT {
 	public void setup() {
 		setupHelper.withDefaultConfiguration( "myLuceneBackend" )
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneSearchMultiIndexIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneSearchMultiIndexIT.java
@@ -69,12 +69,12 @@ public class LuceneSearchMultiIndexIT {
 	public void setup() {
 		setupHelper.withDefaultConfiguration( BACKEND_1 )
 				.withIndex(
-						"MappedType_1_1", INDEX_NAME_1_1,
+						INDEX_NAME_1_1,
 						ctx -> this.indexAccessors_1_1 = new IndexAccessors_1_1( ctx.getSchemaElement() ),
 						indexMapping -> this.indexManager_1_1 = indexMapping
 				)
 				.withIndex(
-						"MappedType_1_2", INDEX_NAME_1_2,
+						INDEX_NAME_1_2,
 						ctx -> this.indexAccessors_1_2 = new IndexAccessors_1_2( ctx.getSchemaElement() ),
 						indexMapping -> this.indexManager_1_2 = indexMapping
 				)

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneSearchSortIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneSearchSortIT.java
@@ -52,7 +52,7 @@ public class LuceneSearchSortIT {
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/DocumentModelDslIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/DocumentModelDslIT.java
@@ -496,7 +496,7 @@ public class DocumentModelDslIT {
 	private void setup(Consumer<IndexModelBindingContext> mappingContributor) {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						mappingContributor,
 						indexManager -> { }
 				)

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/IndexFieldAccessorIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/IndexFieldAccessorIT.java
@@ -55,7 +55,7 @@ public class IndexFieldAccessorIT {
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx ),
 						indexManager -> this.indexManager = indexManager
 				)

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/MultiTenancyIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/MultiTenancyIT.java
@@ -73,7 +73,7 @@ public class MultiTenancyIT {
 	public void setup() {
 		setupHelper.withConfiguration( CONFIGURATION_ID )
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)
@@ -342,7 +342,7 @@ public class MultiTenancyIT {
 
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)
@@ -360,7 +360,7 @@ public class MultiTenancyIT {
 
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", "IndexName-using_multi_tenancy_for_query_while_disabled_throws_exception",
+						"IndexName-using_multi_tenancy_for_query_while_disabled_throws_exception",
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)
@@ -383,7 +383,7 @@ public class MultiTenancyIT {
 
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", "IndexName-using_multi_tenancy_for_add_while_disabled_throws_exception",
+						"IndexName-using_multi_tenancy_for_add_while_disabled_throws_exception",
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)
@@ -411,7 +411,7 @@ public class MultiTenancyIT {
 
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", "IndexName-using_multi_tenancy_for_update_while_disabled_throws_exception",
+						"IndexName-using_multi_tenancy_for_update_while_disabled_throws_exception",
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)
@@ -439,7 +439,7 @@ public class MultiTenancyIT {
 
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", "IndexName-using_multi_tenancy_for_delete_while_disabled_throws_exception",
+						"IndexName-using_multi_tenancy_for_delete_while_disabled_throws_exception",
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/ObjectFieldStorageIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/ObjectFieldStorageIT.java
@@ -61,7 +61,7 @@ public class ObjectFieldStorageIT {
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/SmokeIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/SmokeIT.java
@@ -47,7 +47,7 @@ public class SmokeIT {
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/analysis/AnalysisCustomIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/analysis/AnalysisCustomIT.java
@@ -235,7 +235,7 @@ public class AnalysisCustomIT {
 			Function<StringIndexFieldTypeContext<?>, IndexFieldTypeTerminalContext<String>> typeContributor) {
 		setupHelper.withConfiguration( CONFIGURATION_ID )
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> {
 							IndexFieldAccessor<String> accessor = ctx.getSchemaElement().field(
 									fieldName,

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/SearchMultiIndexIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/SearchMultiIndexIT.java
@@ -89,12 +89,12 @@ public class SearchMultiIndexIT {
 	public void setup() {
 		setupHelper.withDefaultConfiguration( BACKEND_1 )
 				.withIndex(
-						"MappedType_1_1", INDEX_NAME_1_1,
+						INDEX_NAME_1_1,
 						ctx -> this.indexAccessors_1_1 = new IndexAccessors_1_1( ctx.getSchemaElement() ),
 						indexMapping -> this.indexManager_1_1 = indexMapping
 				)
 				.withIndex(
-						"MappedType_1_2", INDEX_NAME_1_2,
+						INDEX_NAME_1_2,
 						ctx -> this.indexAccessors_1_2 = new IndexAccessors_1_2( ctx.getSchemaElement() ),
 						indexMapping -> this.indexManager_1_2 = indexMapping
 				)
@@ -102,7 +102,7 @@ public class SearchMultiIndexIT {
 
 		setupHelper.withDefaultConfiguration( BACKEND_2 )
 				.withIndex(
-						"MappedType_2_1", INDEX_NAME_2_1,
+						INDEX_NAME_2_1,
 						ctx -> this.indexAccessors_2_1 = new IndexAccessors_2_1( ctx.getSchemaElement() ),
 						indexMapping -> this.indexManager_2_1 = indexMapping
 				)

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/SearchQueryIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/SearchQueryIT.java
@@ -52,7 +52,7 @@ public class SearchQueryIT {
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/SearchResultLoadingOrTransformingIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/SearchResultLoadingOrTransformingIT.java
@@ -72,7 +72,7 @@ public class SearchResultLoadingOrTransformingIT {
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/bool/BooleanSortAndRangePredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/bool/BooleanSortAndRangePredicateIT.java
@@ -66,7 +66,7 @@ public class BooleanSortAndRangePredicateIT {
 	public void before() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/BoolSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/BoolSearchPredicateIT.java
@@ -71,7 +71,7 @@ public class BoolSearchPredicateIT {
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchAllSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchAllSearchPredicateIT.java
@@ -47,7 +47,7 @@ public class MatchAllSearchPredicateIT {
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchIdSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchIdSearchPredicateIT.java
@@ -39,7 +39,7 @@ public class MatchIdSearchPredicateIT {
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> { }, // Nothing to do, we don't need any field in the mapping
 						indexManager -> this.indexManager = indexManager
 				)

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchIdWithConverterSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchIdWithConverterSearchPredicateIT.java
@@ -60,7 +60,7 @@ public class MatchIdWithConverterSearchPredicateIT {
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						(ctx) -> {
 							ctx.idDslConverter( ID_CONVERTER );
 							// Nothing else to do, we don't need any field in the mapping

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchSearchPredicateIT.java
@@ -11,32 +11,30 @@ import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldAccessor;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.index.spi.IndexWorkPlan;
 import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeFactoryContext;
 import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeContext;
-import org.hibernate.search.engine.backend.index.spi.IndexWorkPlan;
-import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.MatchPredicateExpectations;
-import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldTypeDescriptor;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingSearchTarget;
+import org.hibernate.search.engine.reporting.spi.EventContexts;
+import org.hibernate.search.engine.search.DocumentReference;
+import org.hibernate.search.engine.search.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldModelConsumer;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldTypeDescriptor;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.MatchPredicateExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.InvalidType;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.StandardFieldMapper;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.ValueWrapper;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
-import org.hibernate.search.engine.reporting.spi.EventContexts;
-import org.hibernate.search.engine.search.DocumentReference;
-import org.hibernate.search.engine.search.SearchQuery;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
+import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingSearchTarget;
 import org.hibernate.search.util.impl.test.SubTest;
 
 import org.junit.Before;
@@ -48,7 +46,7 @@ public class MatchSearchPredicateIT {
 	private static final String INDEX_NAME = "IndexName";
 	private static final String COMPATIBLE_INDEX_NAME = "IndexWithCompatibleFields";
 	private static final String RAW_FIELD_COMPATIBLE_INDEX_NAME = "IndexWithCompatibleRawFields";
-	private static final String NOT_COMPATIBLE_INDEX_NAME = "IndexWithInCompatibleFields";
+	private static final String INCOMPATIBLE_INDEX_NAME = "IndexWithIncompatibleFields";
 
 	private static final String DOCUMENT_1 = "document1";
 	private static final String DOCUMENT_2 = "document2";
@@ -62,12 +60,15 @@ public class MatchSearchPredicateIT {
 	public SearchSetupHelper setupHelper = new SearchSetupHelper();
 
 	private IndexMapping indexMapping;
-	private RawFieldCompatibleIndexMapping rawFieldCompatibleIndexMapping;
-
 	private StubMappingIndexManager indexManager;
+
+	private IndexMapping compatibleIndexMapping;
 	private StubMappingIndexManager compatibleIndexManager;
+
+	private RawFieldCompatibleIndexMapping rawFieldCompatibleIndexMapping;
 	private StubMappingIndexManager rawFieldCompatibleIndexManager;
-	private StubMappingIndexManager notCompatibleIndexManager;
+
+	private StubMappingIndexManager incompatibleIndexManager;
 
 	@Before
 	public void setup() {
@@ -79,7 +80,7 @@ public class MatchSearchPredicateIT {
 				)
 				.withIndex(
 						"CompatibleMappedType", COMPATIBLE_INDEX_NAME,
-						ctx -> new IndexMapping( ctx.getSchemaElement() ),
+						ctx -> this.compatibleIndexMapping = new IndexMapping( ctx.getSchemaElement() ),
 						indexManager -> this.compatibleIndexManager = indexManager
 				)
 				.withIndex(
@@ -88,9 +89,9 @@ public class MatchSearchPredicateIT {
 						indexManager -> this.rawFieldCompatibleIndexManager = indexManager
 				)
 				.withIndex(
-						NOT_COMPATIBLE_INDEX_NAME + "Type", NOT_COMPATIBLE_INDEX_NAME,
-						ctx -> new NotCompatibleIndexMapping( ctx.getSchemaElement() ),
-						indexManager -> this.notCompatibleIndexManager = indexManager
+						INCOMPATIBLE_INDEX_NAME + "Type", INCOMPATIBLE_INDEX_NAME,
+						ctx -> new IncompatibleIndexMapping( ctx.getSchemaElement() ),
+						indexManager -> this.incompatibleIndexManager = indexManager
 				)
 				.setup();
 
@@ -713,8 +714,8 @@ public class MatchSearchPredicateIT {
 	}
 
 	@Test
-	public void multiIndex_withNoCompatibleIndexManager_usingField() {
-		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget( notCompatibleIndexManager );
+	public void multiIndex_withIncompatibleIndexManager_usingField() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget( incompatibleIndexManager );
 
 		for ( ByTypeFieldModel<?> fieldModel : indexMapping.supportedFieldModels ) {
 			String fieldPath = fieldModel.relativeFieldName;
@@ -727,14 +728,14 @@ public class MatchSearchPredicateIT {
 					.hasMessageContaining( "Multiple conflicting types to build a predicate" )
 					.hasMessageContaining( "'" + fieldPath + "'" )
 					.satisfies( FailureReportUtils.hasContext(
-							EventContexts.fromIndexNames( INDEX_NAME, NOT_COMPATIBLE_INDEX_NAME )
+							EventContexts.fromIndexNames( INDEX_NAME, INCOMPATIBLE_INDEX_NAME )
 					) );
 		}
 	}
 
 	@Test
-	public void multiIndex_withNoCompatibleIndexManager_usingRawField() {
-		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget( notCompatibleIndexManager );
+	public void multiIndex_withIncompatibleIndexManager_usingRawField() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget( incompatibleIndexManager );
 
 		for ( ByTypeFieldModel<?> fieldModel : indexMapping.supportedFieldModels ) {
 			String fieldPath = fieldModel.relativeFieldName;
@@ -747,7 +748,7 @@ public class MatchSearchPredicateIT {
 					.hasMessageContaining( "Multiple conflicting types to build a predicate" )
 					.hasMessageContaining( "'" + fieldPath + "'" )
 					.satisfies( FailureReportUtils.hasContext(
-							EventContexts.fromIndexNames( INDEX_NAME, NOT_COMPATIBLE_INDEX_NAME )
+							EventContexts.fromIndexNames( INDEX_NAME, INCOMPATIBLE_INDEX_NAME )
 					) );
 		}
 	}
@@ -786,8 +787,8 @@ public class MatchSearchPredicateIT {
 
 		workPlan = compatibleIndexManager.createWorkPlan();
 		workPlan.add( referenceProvider( COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
-			indexMapping.supportedFieldModels.forEach( f -> f.document1Value.write( document ) );
-			indexMapping.supportedFieldWithDslConverterModels.forEach( f -> f.document1Value.write( document ) );
+			compatibleIndexMapping.supportedFieldModels.forEach( f -> f.document1Value.write( document ) );
+			compatibleIndexMapping.supportedFieldWithDslConverterModels.forEach( f -> f.document1Value.write( document ) );
 		} );
 		workPlan.execute().join();
 
@@ -798,20 +799,45 @@ public class MatchSearchPredicateIT {
 		workPlan.execute().join();
 
 		// Check that all documents are searchable
-		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
-		SearchQuery<DocumentReference> query = searchTarget.query()
+		SearchQuery<DocumentReference> query = indexManager.createSearchTarget().query()
 				.asReference()
 				.predicate( f -> f.matchAll() )
 				.build();
-		assertThat( query ).hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, EMPTY,
-				DOCUMENT_3
-		);
+		assertThat( query ).hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3, EMPTY );
+		query = compatibleIndexManager.createSearchTarget().query()
+				.asReference()
+				.predicate( f -> f.matchAll() )
+				.build();
+		assertThat( query ).hasDocRefHitsAnyOrder( COMPATIBLE_INDEX_NAME, COMPATIBLE_INDEX_DOCUMENT_1 );
+		query = rawFieldCompatibleIndexManager.createSearchTarget().query()
+				.asReference()
+				.predicate( f -> f.matchAll() )
+				.build();
+		assertThat( query ).hasDocRefHitsAnyOrder( RAW_FIELD_COMPATIBLE_INDEX_NAME, RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 );
+	}
+
+	private static void forEachTypeDescriptor(Consumer<FieldTypeDescriptor<?>> action) {
+		FieldTypeDescriptor.getAll().stream()
+				.filter( typeDescriptor -> typeDescriptor.getMatchPredicateExpectations().isPresent() )
+				.forEach( action );
+	}
+
+	private static void mapByTypeFields(IndexSchemaElement parent, String prefix,
+			Consumer<StandardIndexFieldTypeContext<?, ?>> additionalConfiguration,
+			FieldModelConsumer<MatchPredicateExpectations<?>, ByTypeFieldModel<?>> consumer) {
+		forEachTypeDescriptor( typeDescriptor -> {
+			// Safe, see forEachTypeDescriptor
+			MatchPredicateExpectations<?> expectations = typeDescriptor.getMatchPredicateExpectations().get();
+			ByTypeFieldModel<?> fieldModel = ByTypeFieldModel.mapper( typeDescriptor )
+					.map( parent, prefix + typeDescriptor.getUniqueName(), additionalConfiguration );
+			consumer.accept( typeDescriptor, expectations, fieldModel );
+		} );
 	}
 
 	private static class IndexMapping {
-		final List<ByTypeFieldModel<?>> supportedFieldModels;
-		final List<ByTypeFieldModel<?>> supportedFieldWithDslConverterModels;
-		final List<ByTypeFieldModel<?>> unsupportedFieldModels;
+		final List<ByTypeFieldModel<?>> supportedFieldModels = new ArrayList<>();
+		final List<ByTypeFieldModel<?>> supportedFieldWithDslConverterModels = new ArrayList<>();
+		final List<ByTypeFieldModel<?>> unsupportedFieldModels = new ArrayList<>();
 
 		final MainFieldModel string1Field;
 		final MainFieldModel string2Field;
@@ -822,17 +848,24 @@ public class MatchSearchPredicateIT {
 		final MainFieldModel string2FieldWithDslConverter;
 
 		IndexMapping(IndexSchemaElement root) {
-			supportedFieldModels = mapByTypeFields(
-					root, "supported_", ignored -> { },
-					MatchPredicateExpectations::isMatchPredicateSupported
+			mapByTypeFields(
+					root, "byType_", ignored -> { },
+					(typeDescriptor, expectations, model) -> {
+						if ( expectations.isMatchPredicateSupported() ) {
+							supportedFieldModels.add( model );
+						}
+						else {
+							unsupportedFieldModels.add( model );
+						}
+					}
 			);
-			supportedFieldWithDslConverterModels = mapByTypeFields(
-					root, "supported_converted_", c -> c.dslConverter( ValueWrapper.toIndexFieldConverter() ),
-					MatchPredicateExpectations::isMatchPredicateSupported
-			);
-			unsupportedFieldModels = mapByTypeFields(
-					root, "supported_converted_", ignored -> { },
-					e -> !e.isMatchPredicateSupported()
+			mapByTypeFields(
+					root, "byType_converted_", c -> c.dslConverter( ValueWrapper.toIndexFieldConverter() ),
+					(typeDescriptor, expectations, model) -> {
+						if ( expectations.isMatchPredicateSupported() ) {
+							supportedFieldWithDslConverterModels.add( model );
+						}
+					}
 			);
 			string1Field = MainFieldModel.mapper(
 					"Irving", "Auster", "Coe"
@@ -848,7 +881,7 @@ public class MatchSearchPredicateIT {
 					.map( root, "string3" );
 			analyzedStringField = MainFieldModel.mapper(
 					c -> c.asString().analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD.name ),
-					"a word", "another word", "a"
+					"quick brown fox", "another word", "a"
 			)
 					.map( root, "analyzedString" );
 			string1FieldWithDslConverter = MainFieldModel.mapper(
@@ -865,77 +898,41 @@ public class MatchSearchPredicateIT {
 	}
 
 	private static class RawFieldCompatibleIndexMapping {
-		final List<ByTypeFieldModel<?>> supportedFieldModels;
+		final List<ByTypeFieldModel<?>> supportedFieldModels = new ArrayList<>();
 
 		RawFieldCompatibleIndexMapping(IndexSchemaElement root) {
-			supportedFieldModels = mapByTypeFields(
-					root, "supported_", c -> c.dslConverter( ValueWrapper.toIndexFieldConverter() ),
-					MatchPredicateExpectations::isMatchPredicateSupported
-			);
-		}
-	}
-
-	private static class NotCompatibleIndexMapping {
-		NotCompatibleIndexMapping(IndexSchemaElement root) {
 			/*
 			 * Add fields with the same name as the supportedFieldModels from IndexMapping,
-			 * but with an incompatible type.
+			 * but with an incompatible DSL converter.
 			 */
-			mapByTypeSupportedIncompatibleFields(
-					root, "supported_",
-					(type, context) -> {
-						// Just try to pick a different, also supported type
-						if ( Integer.class.equals( type.getJavaType() ) ) {
-							return context.asLong();
-						}
-						else {
-							return context.asInteger();
+			mapByTypeFields(
+					root, "byType_", c -> c.dslConverter( ValueWrapper.toIndexFieldConverter() ),
+					(typeDescriptor, expectations, model) -> {
+						if ( expectations.isMatchPredicateSupported() ) {
+							supportedFieldModels.add( model );
 						}
 					}
 			);
 		}
 	}
 
-	private static List<ByTypeFieldModel<?>> mapByTypeFields(IndexSchemaElement root, String prefix,
-			Consumer<StandardIndexFieldTypeContext<?, ?>> additionalConfiguration,
-			Predicate<MatchPredicateExpectations<?>> predicate) {
-		return FieldTypeDescriptor.getAll().stream()
-				.filter(
-						typeDescriptor -> typeDescriptor.getMatchPredicateExpectations().isPresent()
-						&& predicate.test( typeDescriptor.getMatchPredicateExpectations().get() )
-				)
-				.map( typeDescriptor -> mapByTypeField( root, prefix, typeDescriptor, additionalConfiguration ) )
-				.collect( Collectors.toList() );
-	}
-
-	private static <F> ByTypeFieldModel<F> mapByTypeField(IndexSchemaElement parent, String prefix,
-			FieldTypeDescriptor<F> typeDescriptor,
-			Consumer<StandardIndexFieldTypeContext<?, ?>> additionalConfiguration) {
-		MatchPredicateExpectations<F> expectations = typeDescriptor.getMatchPredicateExpectations().get(); // Safe, see caller
-		return StandardFieldMapper.of(
-				typeDescriptor::configure,
-				additionalConfiguration,
-				(accessor, name) -> new ByTypeFieldModel<>( accessor, name, expectations )
-		)
-				.map( parent, prefix + typeDescriptor.getUniqueName() );
-	}
-
-	private static List<IncompatibleFieldModel<?>> mapByTypeSupportedIncompatibleFields(IndexSchemaElement root, String prefix,
-			BiFunction<FieldTypeDescriptor<?>, IndexFieldTypeFactoryContext, StandardIndexFieldTypeContext<?, ?>> configuration) {
-		return FieldTypeDescriptor.getAll().stream()
-				.filter( typeDescriptor -> typeDescriptor.getFieldProjectionExpectations().isPresent() )
-				.map( typeDescriptor -> mapByTypeIncompatibleField( root, prefix, typeDescriptor, configuration ) )
-				.collect( Collectors.toList() );
-	}
-
-	private static <F> IncompatibleFieldModel<?> mapByTypeIncompatibleField(IndexSchemaElement parent, String prefix,
-			FieldTypeDescriptor<F> typeDescriptor,
-			BiFunction<FieldTypeDescriptor<?>, IndexFieldTypeFactoryContext, StandardIndexFieldTypeContext<?, ?>> configuration) {
-		String name = prefix + typeDescriptor.getUniqueName();
-		return IncompatibleFieldModel.mapper(
-				context -> configuration.apply( typeDescriptor, context )
-		)
-				.map( parent, name );
+	private static class IncompatibleIndexMapping {
+		IncompatibleIndexMapping(IndexSchemaElement root) {
+			/*
+			 * Add fields with the same name as the supportedFieldModels from IndexMapping,
+			 * but with an incompatible type.
+			 */
+			forEachTypeDescriptor( typeDescriptor -> {
+				StandardFieldMapper<?, IncompatibleFieldModel> mapper;
+				if ( Integer.class.equals( typeDescriptor.getJavaType() ) ) {
+					mapper = IncompatibleFieldModel.mapper( context -> context.asLong() );
+				}
+				else {
+					mapper = IncompatibleFieldModel.mapper( context -> context.asInteger() );
+				}
+				mapper.map( root, "byType_" + typeDescriptor.getUniqueName() );
+			} );
+		}
 	}
 
 	private static class ValueModel<F> {
@@ -982,6 +979,15 @@ public class MatchSearchPredicateIT {
 	}
 
 	private static class ByTypeFieldModel<F> {
+		static <F> StandardFieldMapper<F, ByTypeFieldModel<F>> mapper(FieldTypeDescriptor<F> typeDescriptor) {
+			// Safe, see caller
+			MatchPredicateExpectations<F> expectations = typeDescriptor.getMatchPredicateExpectations().get();
+			return StandardFieldMapper.of(
+					typeDescriptor::configure,
+					(accessor, name) -> new ByTypeFieldModel<>( accessor, name, expectations )
+			);
+		}
+
 		final String relativeFieldName;
 		final ValueModel<F> document1Value;
 		final ValueModel<F> document2Value;
@@ -997,13 +1003,10 @@ public class MatchSearchPredicateIT {
 		}
 	}
 
-	private static class IncompatibleFieldModel<F> {
-		static <F> StandardFieldMapper<F, IncompatibleFieldModel<F>> mapper(
+	private static class IncompatibleFieldModel {
+		static <F> StandardFieldMapper<?, IncompatibleFieldModel> mapper(
 				Function<IndexFieldTypeFactoryContext, StandardIndexFieldTypeContext<?, F>> configuration) {
-			return StandardFieldMapper.of(
-					configuration,
-					(accessor, name) -> new IncompatibleFieldModel<>( name )
-			);
+			return StandardFieldMapper.of( configuration, (accessor, name) -> new IncompatibleFieldModel( name ) );
 		}
 
 		final String relativeFieldName;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchSearchPredicateIT.java
@@ -74,22 +74,22 @@ public class MatchSearchPredicateIT {
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> this.indexMapping = new IndexMapping( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)
 				.withIndex(
-						"CompatibleMappedType", COMPATIBLE_INDEX_NAME,
+						COMPATIBLE_INDEX_NAME,
 						ctx -> this.compatibleIndexMapping = new IndexMapping( ctx.getSchemaElement() ),
 						indexManager -> this.compatibleIndexManager = indexManager
 				)
 				.withIndex(
-						RAW_FIELD_COMPATIBLE_INDEX_NAME + "Type", RAW_FIELD_COMPATIBLE_INDEX_NAME,
+						RAW_FIELD_COMPATIBLE_INDEX_NAME,
 						ctx -> this.rawFieldCompatibleIndexMapping = new RawFieldCompatibleIndexMapping( ctx.getSchemaElement() ),
 						indexManager -> this.rawFieldCompatibleIndexManager = indexManager
 				)
 				.withIndex(
-						INCOMPATIBLE_INDEX_NAME + "Type", INCOMPATIBLE_INDEX_NAME,
+						INCOMPATIBLE_INDEX_NAME,
 						ctx -> new IncompatibleIndexMapping( ctx.getSchemaElement() ),
 						indexManager -> this.incompatibleIndexManager = indexManager
 				)

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchSearchPredicateIT.java
@@ -117,7 +117,7 @@ public class MatchSearchPredicateIT {
 	}
 
 	@Test
-	public void match_withDslConverter() {
+	public void withDslConverter() {
 		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
 
 		for ( ByTypeFieldModel<?> fieldModel : indexMapping.supportedFieldWithDslConverterModels ) {
@@ -135,7 +135,7 @@ public class MatchSearchPredicateIT {
 	}
 
 	@Test
-	public void match_withDslConverter_usingRawValues() {
+	public void withDslConverter_usingRawValues() {
 		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
 
 		for ( ByTypeFieldModel<?> fieldModel : indexMapping.supportedFieldWithDslConverterModels ) {
@@ -152,7 +152,7 @@ public class MatchSearchPredicateIT {
 	}
 
 	@Test
-	public void match_emptyStringBeforeAnalysis() {
+	public void emptyStringBeforeAnalysis() {
 		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
 
 		MainFieldModel fieldModel = indexMapping.analyzedStringField;
@@ -167,7 +167,7 @@ public class MatchSearchPredicateIT {
 	}
 
 	@Test
-	public void match_noTokenAfterAnalysis() {
+	public void noTokenAfterAnalysis() {
 		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
 
 		MainFieldModel fieldModel = indexMapping.analyzedStringField;
@@ -183,7 +183,7 @@ public class MatchSearchPredicateIT {
 	}
 
 	@Test
-	public void unsupported_field_types() {
+	public void error_unsupportedFieldTypes() {
 		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
 
 		for ( ByTypeFieldModel<?> fieldModel : indexMapping.unsupportedFieldModels ) {
@@ -204,7 +204,7 @@ public class MatchSearchPredicateIT {
 	}
 
 	@Test
-	public void match_error_null() {
+	public void error_null() {
 		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
 
 		for ( ByTypeFieldModel<?> fieldModel : indexMapping.supportedFieldModels ) {
@@ -469,7 +469,7 @@ public class MatchSearchPredicateIT {
 	}
 
 	@Test
-	public void multi_fields() {
+	public void multiFields() {
 		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
 
 		// onField(...).orField(...)
@@ -555,7 +555,7 @@ public class MatchSearchPredicateIT {
 	}
 
 	@Test
-	public void multiField_withDslConverter() {
+	public void multiFields_withDslConverter() {
 		SearchQuery<DocumentReference> query = indexManager.createSearchTarget().query()
 				.asReference()
 				.predicate( f -> f.match()
@@ -583,7 +583,7 @@ public class MatchSearchPredicateIT {
 	}
 
 	@Test
-	public void unknown_field() {
+	public void error_unknownField() {
 		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
 
 		SubTest.expectException(

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/NestedSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/NestedSearchPredicateIT.java
@@ -59,7 +59,7 @@ public class NestedSearchPredicateIT {
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/PhraseSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/PhraseSearchPredicateIT.java
@@ -1,0 +1,771 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.tck.search.predicate;
+
+import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.hibernate.search.engine.backend.document.DocumentElement;
+import org.hibernate.search.engine.backend.document.IndexFieldAccessor;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.index.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeFactoryContext;
+import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeContext;
+import org.hibernate.search.engine.reporting.spi.EventContexts;
+import org.hibernate.search.engine.search.DocumentReference;
+import org.hibernate.search.engine.search.SearchQuery;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldModelConsumer;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldTypeDescriptor;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.StandardFieldMapper;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.ValueWrapper;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
+import org.hibernate.search.util.common.SearchException;
+import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
+import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingSearchTarget;
+import org.hibernate.search.util.impl.test.SubTest;
+import org.hibernate.search.util.impl.test.annotation.PortedFromSearch5;
+
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class PhraseSearchPredicateIT {
+
+	private static final String INDEX_NAME = "IndexName";
+	private static final String COMPATIBLE_INDEX_NAME = "IndexWithCompatibleFields";
+	private static final String RAW_FIELD_COMPATIBLE_INDEX_NAME = "IndexWithCompatibleRawFields";
+	private static final String INCOMPATIBLE_INDEX_NAME = "IndexWithIncompatibleFields";
+
+	private static final String DOCUMENT_1 = "document1";
+	private static final String DOCUMENT_2 = "document2";
+	private static final String DOCUMENT_3 = "document3";
+	private static final String DOCUMENT_4 = "document4";
+	private static final String DOCUMENT_5 = "document5";
+	private static final String EMPTY = "empty";
+
+	private static final String PHRASE_1 = "quick fox";
+	private static final String PHRASE_1_UNIQUE_TERM = "fox";
+	private static final String PHRASE_1_TEXT_EXACT_MATCH = "Once upon a time, there was a quick fox in a big house.";
+	private static final String PHRASE_1_TEXT_SLOP_1_MATCH = "Once upon a time, there was a quick brown fox in a big house.";
+	private static final String PHRASE_1_TEXT_SLOP_2_MATCH = "Once upon a time, there was a quick, sad brown fox in a big house.";
+	private static final String PHRASE_1_TEXT_SLOP_3_MATCH = "In the big house, the fox was quick.";
+
+	private static final String PHRASE_2 = "white shark";
+	private static final String PHRASE_2_TEXT_EXACT_MATCH = "Once upon a time, there was a white shark in a small sea.";
+
+	private static final String PHRASE_3 = "sly cat";
+	private static final String PHRASE_3_TEXT_EXACT_MATCH = "Once upon a time, there was a sly cat in a dark tree.";
+
+	private static final String COMPATIBLE_INDEX_DOCUMENT_1 = "compatible_1";
+	private static final String RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 = "raw_field_compatible_1";
+
+
+	@Rule
+	public SearchSetupHelper setupHelper = new SearchSetupHelper();
+
+	private IndexMapping indexMapping;
+	private StubMappingIndexManager indexManager;
+
+	private OtherIndexMapping compatibleIndexMapping;
+	private StubMappingIndexManager compatibleIndexManager;
+
+	private OtherIndexMapping rawFieldCompatibleIndexMapping;
+	private StubMappingIndexManager rawFieldCompatibleIndexManager;
+
+	private StubMappingIndexManager incompatibleIndexManager;
+
+	@Before
+	public void setup() {
+		setupHelper.withDefaultConfiguration()
+				.withIndex(
+						INDEX_NAME,
+						ctx -> this.indexMapping = new IndexMapping( ctx.getSchemaElement() ),
+						indexManager -> this.indexManager = indexManager
+				)
+				.withIndex(
+						COMPATIBLE_INDEX_NAME,
+						ctx -> this.compatibleIndexMapping =
+								OtherIndexMapping.createCompatible( ctx.getSchemaElement() ),
+						indexManager -> this.compatibleIndexManager = indexManager
+				)
+				.withIndex(
+						RAW_FIELD_COMPATIBLE_INDEX_NAME,
+						ctx -> this.rawFieldCompatibleIndexMapping =
+								OtherIndexMapping.createRawFieldCompatible( ctx.getSchemaElement() ),
+						indexManager -> this.rawFieldCompatibleIndexManager = indexManager
+				)
+				.withIndex(
+						INCOMPATIBLE_INDEX_NAME,
+						ctx -> OtherIndexMapping.createIncompatible( ctx.getSchemaElement() ),
+						indexManager -> this.incompatibleIndexManager = indexManager
+				)
+				.setup();
+
+		initData();
+	}
+
+	@Test
+	@PortedFromSearch5(original = "org.hibernate.search.test.dsl.DSLTest.testPhraseQuery")
+	public void phrase() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.phrase().onField( absoluteFieldPath ).matching( PHRASE_1 ) )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
+	}
+
+	/**
+	 * Check that a phrase predicate can be used on a field that has a DSL converter.
+	 * The DSL converter should be ignored, and there shouldn't be any exception thrown
+	 * (the field should be considered as a text field).
+	 */
+	@Test
+	public void withDslConverter() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		String absoluteFieldPath = indexMapping.analyzedStringFieldWithDslConverter.relativeFieldName;
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.phrase().onField( absoluteFieldPath ).matching( PHRASE_1 ) )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
+	}
+
+	@Test
+	@PortedFromSearch5(original = "org.hibernate.search.test.dsl.DSLTest.testPhraseQuery")
+	public void singleTerm() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.phrase().onField( absoluteFieldPath ).matching( PHRASE_1_UNIQUE_TERM ) )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3, DOCUMENT_4 );
+	}
+
+	@Test
+	public void emptyStringBeforeAnalysis() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		MainFieldModel fieldModel = indexMapping.analyzedStringField1;
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.phrase().onField( fieldModel.relativeFieldName ).matching( "" ) )
+				.build();
+
+		assertThat( query )
+				.hasNoHits();
+	}
+
+	@Test
+	public void noTokenAfterAnalysis() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		MainFieldModel fieldModel = indexMapping.analyzedStringField1;
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				// Use stopwords, which should be removed by the analysis
+				.predicate( f -> f.phrase().onField( fieldModel.relativeFieldName ).matching( "the a" ) )
+				.build();
+
+		assertThat( query )
+				.hasNoHits();
+	}
+
+	@Test
+	public void error_unsupportedFieldType() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		for ( ByTypeFieldModel fieldModel : indexMapping.unsupportedFieldModels ) {
+			String absoluteFieldPath = fieldModel.relativeFieldName;
+
+			SubTest.expectException(
+					"phrase() predicate with unsupported type on field " + absoluteFieldPath,
+					() -> searchTarget.predicate().phrase().onField( absoluteFieldPath )
+			)
+					.assertThrown()
+					.isInstanceOf( SearchException.class )
+					.hasMessageContaining( "Text predicates" )
+					.hasMessageContaining( "are not supported by" )
+					.hasMessageContaining( "'" + absoluteFieldPath + "'" )
+					.satisfies( FailureReportUtils.hasContext(
+							EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
+					) );
+		}
+	}
+
+	@Test
+	public void error_null() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
+
+		SubTest.expectException(
+				"phrase() predicate with null value to match",
+				() -> searchTarget.predicate().phrase().onField( absoluteFieldPath ).matching( null )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Invalid phrase" )
+				.hasMessageContaining( "must be non-null" )
+				.hasMessageContaining( absoluteFieldPath );
+	}
+
+	@Test
+	@PortedFromSearch5(original = "org.hibernate.search.test.dsl.DSLTest.testPhraseQuery")
+	public void slop() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
+		Function<Integer, SearchQuery<DocumentReference>> createQuery = slop -> searchTarget.query().asReference()
+				.predicate( f -> f.phrase().withSlop( slop ).onField( absoluteFieldPath ).matching( PHRASE_1 ) )
+				.build();
+
+		assertThat( createQuery.apply( 0 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
+
+		assertThat( createQuery.apply( 1 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2 );
+
+		assertThat( createQuery.apply( 2 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
+
+		assertThat( createQuery.apply( 3 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3, DOCUMENT_4 );
+
+		assertThat( createQuery.apply( 50 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3, DOCUMENT_4 );
+	}
+
+	@Test
+	public void perFieldBoostWithConstantScore_error() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
+
+		SubTest.expectException(
+				() -> searchTarget.predicate().phrase().withConstantScore()
+						.onField( absoluteFieldPath ).boostedTo( 2.1f )
+						.matching( PHRASE_1 )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "per-field boosts together with withConstantScore option" );
+	}
+
+	@Test
+	public void fieldLevelBoost() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		String absoluteFieldPath1 = indexMapping.analyzedStringField1.relativeFieldName;
+		String absoluteFieldPath2 = indexMapping.analyzedStringField2.relativeFieldName;
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.phrase()
+						.onField( absoluteFieldPath1 ).boostedTo( 42 )
+						.orField( absoluteFieldPath2 )
+						.matching( PHRASE_1 )
+				)
+				.sort( c -> c.byScore() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_5 );
+
+		query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.phrase()
+						.onField( absoluteFieldPath1 )
+						.orField( absoluteFieldPath2 ).boostedTo( 42 )
+						.matching( PHRASE_1 )
+				)
+				.sort( c -> c.byScore() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_5, DOCUMENT_1 );
+	}
+
+	@Test
+	public void predicateLevelBoost() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		String absoluteFieldPath1 = indexMapping.analyzedStringField1.relativeFieldName;
+		String absoluteFieldPath2 = indexMapping.analyzedStringField2.relativeFieldName;
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.bool()
+						.should( f.phrase().onField( absoluteFieldPath1 )
+								.matching( PHRASE_1 )
+						)
+						.should( f.phrase().boostedTo( 7 ).onField( absoluteFieldPath2 )
+								.matching( PHRASE_1 )
+						)
+				)
+				.sort( c -> c.byScore() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_5, DOCUMENT_1 );
+
+		query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.bool()
+						.should( f.phrase().boostedTo( 39 ).onField( absoluteFieldPath1 )
+								.matching( PHRASE_1 )
+						)
+						.should( f.phrase().onField( absoluteFieldPath2 )
+								.matching( PHRASE_1 )
+						)
+				)
+				.sort( c -> c.byScore() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_5 );
+	}
+
+	@Test
+	public void predicateLevelBoost_withConstantScore() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		String absoluteFieldPath1 = indexMapping.analyzedStringField1.relativeFieldName;
+		String absoluteFieldPath2 = indexMapping.analyzedStringField2.relativeFieldName;
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.bool()
+						.should( f.phrase().withConstantScore().boostedTo( 7 )
+								.onField( absoluteFieldPath1 )
+								.matching( PHRASE_1 )
+						)
+						.should( f.phrase().withConstantScore().boostedTo( 39 )
+								.onField( absoluteFieldPath2 )
+								.matching( PHRASE_1 )
+						)
+				)
+				.sort( c -> c.byScore() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_5, DOCUMENT_1 );
+
+		query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.bool()
+						.should( f.phrase().withConstantScore().boostedTo( 39 )
+								.onField( absoluteFieldPath1 )
+								.matching( PHRASE_1 )
+						)
+						.should( f.phrase().withConstantScore().boostedTo( 7 )
+								.onField( absoluteFieldPath2 )
+								.matching( PHRASE_1 )
+						)
+				)
+				.sort( c -> c.byScore() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_5 );
+	}
+
+	@Test
+	public void multiFields() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		String absoluteFieldPath1 = indexMapping.analyzedStringField1.relativeFieldName;
+		String absoluteFieldPath2 = indexMapping.analyzedStringField2.relativeFieldName;
+		String absoluteFieldPath3 = indexMapping.analyzedStringField3.relativeFieldName;
+		Function<String, SearchQuery<DocumentReference>> createQuery;
+
+		// onField(...)
+
+		createQuery = phrase -> searchTarget.query().asReference()
+				.predicate( f -> f.phrase().onField( absoluteFieldPath1 )
+						.matching( phrase )
+				)
+				.build();
+
+		assertThat( createQuery.apply( PHRASE_1 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
+		assertThat( createQuery.apply( PHRASE_2 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_5 );
+		assertThat( createQuery.apply( PHRASE_3 ) )
+				.hasNoHits();
+
+		// onField(...).orField(...)
+
+		createQuery = phrase -> searchTarget.query().asReference()
+				.predicate( f -> f.phrase().onField( absoluteFieldPath1 )
+						.orField( absoluteFieldPath2 )
+						.matching( phrase )
+				)
+				.build();
+
+		assertThat( createQuery.apply( PHRASE_1 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_5 );
+		assertThat( createQuery.apply( PHRASE_2 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_2, DOCUMENT_5 );
+		assertThat( createQuery.apply( PHRASE_3 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_3 );
+
+		// onField().orFields(...)
+
+		createQuery = phrase -> searchTarget.query()
+				.asReference()
+				.predicate( f -> f.phrase().onField( absoluteFieldPath1 )
+						.orFields( absoluteFieldPath2, absoluteFieldPath3 )
+						.matching( phrase )
+				)
+				.build();
+
+		assertThat( createQuery.apply( PHRASE_1 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_3, DOCUMENT_5 );
+		assertThat( createQuery.apply( PHRASE_2 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_2, DOCUMENT_4, DOCUMENT_5 );
+		assertThat( createQuery.apply( PHRASE_3 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_3 );
+
+		// onFields(...)
+
+		createQuery = phrase -> searchTarget.query()
+				.asReference()
+				.predicate( f -> f.phrase()
+						.onFields( absoluteFieldPath1, absoluteFieldPath2 )
+						.matching( phrase )
+				)
+				.build();
+
+		assertThat( createQuery.apply( PHRASE_1 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_5 );
+		assertThat( createQuery.apply( PHRASE_2 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_2, DOCUMENT_5 );
+		assertThat( createQuery.apply( PHRASE_3 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_3 );
+	}
+
+	@Test
+	public void error_unknownField() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
+
+		SubTest.expectException(
+				"phrase() predicate with unknown field",
+				() -> searchTarget.predicate().phrase().onField( "unknown_field" )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Unknown field" )
+				.hasMessageContaining( "'unknown_field'" );
+
+		SubTest.expectException(
+				"phrase() predicate with unknown field",
+				() -> searchTarget.predicate().phrase()
+						.onFields( absoluteFieldPath, "unknown_field" )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Unknown field" )
+				.hasMessageContaining( "'unknown_field'" );
+
+		SubTest.expectException(
+				"phrase() predicate with unknown field",
+				() -> searchTarget.predicate().phrase().onField( absoluteFieldPath )
+						.orField( "unknown_field" )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Unknown field" )
+				.hasMessageContaining( "'unknown_field'" );
+
+		SubTest.expectException(
+				"phrase() predicate with unknown field",
+				() -> searchTarget.predicate().phrase().onField( absoluteFieldPath )
+						.orFields( "unknown_field" )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Unknown field" )
+				.hasMessageContaining( "'unknown_field'" );
+	}
+
+	@Test
+	public void error_invalidSlop() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		SubTest.expectException(
+				"phrase() predicate with negative slop",
+				() -> searchTarget.predicate().phrase().withSlop( -1 )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Invalid slop" )
+				.hasMessageContaining( "must be positive or zero" );
+
+		SubTest.expectException(
+				"phrase() predicate with negative slop",
+				() -> searchTarget.predicate().phrase().withSlop( Integer.MIN_VALUE )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Invalid slop" )
+				.hasMessageContaining( "must be positive or zero" );
+	}
+
+	@Test
+	public void multiIndex_withCompatibleIndexManager() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget(
+				compatibleIndexManager
+		);
+
+		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.phrase().onField( absoluteFieldPath ).matching( PHRASE_1 ) )
+				.build();
+
+		assertThat( query ).hasDocRefHitsAnyOrder( b -> {
+			b.doc( INDEX_NAME, DOCUMENT_1 );
+			b.doc( COMPATIBLE_INDEX_NAME, COMPATIBLE_INDEX_DOCUMENT_1 );
+		} );
+	}
+
+	@Test
+	public void multiIndex_withRawFieldCompatibleIndexManager() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget( rawFieldCompatibleIndexManager );
+
+		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.phrase().onField( absoluteFieldPath ).matching( PHRASE_1 ) )
+				.build();
+
+		assertThat( query ).hasDocRefHitsAnyOrder( b -> {
+			b.doc( INDEX_NAME, DOCUMENT_1 );
+			b.doc( RAW_FIELD_COMPATIBLE_INDEX_NAME, RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 );
+		} );
+	}
+
+	@Test
+	public void multiIndex_withIncompatibleIndexManager() {
+		// TODO HSEARCH-3307 re-enable this test once we properly take analyzer/normalizer into account when testing field compatibility for predicates in Elasticsearch
+		Assume.assumeTrue( "This feature is not implemented yet", false );
+
+		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
+
+		SubTest.expectException(
+				() -> {
+					indexManager.createSearchTarget( incompatibleIndexManager )
+							.predicate().phrase().onField( absoluteFieldPath );
+				}
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Multiple conflicting types to build a predicate" )
+				.hasMessageContaining( "'" + absoluteFieldPath + "'" )
+				.satisfies( FailureReportUtils.hasContext(
+						EventContexts.fromIndexNames( INDEX_NAME, INCOMPATIBLE_INDEX_NAME )
+				) );
+	}
+
+	private void initData() {
+		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
+		workPlan.add( referenceProvider( DOCUMENT_1 ), document -> {
+			indexMapping.analyzedStringField1.accessor.write( document, PHRASE_1_TEXT_EXACT_MATCH );
+			indexMapping.analyzedStringFieldWithDslConverter.accessor.write( document, PHRASE_1_TEXT_EXACT_MATCH );
+		} );
+		workPlan.add( referenceProvider( DOCUMENT_2 ), document -> {
+			indexMapping.analyzedStringField1.accessor.write( document, PHRASE_1_TEXT_SLOP_1_MATCH );
+			indexMapping.analyzedStringField2.accessor.write( document, PHRASE_2_TEXT_EXACT_MATCH );
+		} );
+		workPlan.add( referenceProvider( DOCUMENT_3 ), document -> {
+			indexMapping.analyzedStringField1.accessor.write( document, PHRASE_1_TEXT_SLOP_2_MATCH );
+			indexMapping.analyzedStringField2.accessor.write( document, PHRASE_3_TEXT_EXACT_MATCH );
+			indexMapping.analyzedStringField3.accessor.write( document, PHRASE_1_TEXT_EXACT_MATCH );
+		} );
+		workPlan.add( referenceProvider( DOCUMENT_4 ), document -> {
+			indexMapping.analyzedStringField1.accessor.write( document, PHRASE_1_TEXT_SLOP_3_MATCH );
+			indexMapping.analyzedStringField3.accessor.write( document, PHRASE_2_TEXT_EXACT_MATCH );
+		} );
+		workPlan.add( referenceProvider( DOCUMENT_5 ), document -> {
+			indexMapping.analyzedStringField1.accessor.write( document, PHRASE_2_TEXT_EXACT_MATCH );
+			indexMapping.analyzedStringField2.accessor.write( document, PHRASE_1_TEXT_EXACT_MATCH );
+		} );
+		workPlan.add( referenceProvider( EMPTY ), document -> {
+		} );
+		workPlan.execute().join();
+
+		workPlan = compatibleIndexManager.createWorkPlan();
+		workPlan.add( referenceProvider( COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
+			compatibleIndexMapping.analyzedStringField1.accessor.write( document, PHRASE_1_TEXT_EXACT_MATCH );
+		} );
+		workPlan.execute().join();
+
+		workPlan = rawFieldCompatibleIndexManager.createWorkPlan();
+		workPlan.add( referenceProvider( RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
+			rawFieldCompatibleIndexMapping.analyzedStringField1.accessor.write( document, PHRASE_1_TEXT_EXACT_MATCH );
+		} );
+		workPlan.execute().join();
+
+		// Check that all documents are searchable
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.matchAll() )
+				.build();
+		assertThat( query )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3, DOCUMENT_4, DOCUMENT_5, EMPTY );
+		query = compatibleIndexManager.createSearchTarget().query()
+				.asReference()
+				.predicate( f -> f.matchAll() )
+				.build();
+		assertThat( query ).hasDocRefHitsAnyOrder( COMPATIBLE_INDEX_NAME, COMPATIBLE_INDEX_DOCUMENT_1 );
+		query = rawFieldCompatibleIndexManager.createSearchTarget().query()
+				.asReference()
+				.predicate( f -> f.matchAll() )
+				.build();
+		assertThat( query ).hasDocRefHitsAnyOrder( RAW_FIELD_COMPATIBLE_INDEX_NAME, RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 );
+	}
+
+	private static void forEachTypeDescriptor(Consumer<FieldTypeDescriptor<?>> action) {
+		FieldTypeDescriptor.getAll().stream()
+				.filter( typeDescriptor -> typeDescriptor.getMatchPredicateExpectations().isPresent() )
+				.forEach( action );
+	}
+
+	private static void mapByTypeFields(IndexSchemaElement parent, String prefix,
+			FieldModelConsumer<Void, ByTypeFieldModel> consumer) {
+		forEachTypeDescriptor( typeDescriptor -> {
+			ByTypeFieldModel fieldModel = ByTypeFieldModel.mapper( typeDescriptor )
+					.map( parent, prefix + typeDescriptor.getUniqueName() );
+			consumer.accept( typeDescriptor, null, fieldModel );
+		} );
+	}
+
+	private static class IndexMapping {
+		final List<ByTypeFieldModel> unsupportedFieldModels = new ArrayList<>();
+
+		final MainFieldModel analyzedStringField1;
+		final MainFieldModel analyzedStringField2;
+		final MainFieldModel analyzedStringField3;
+		final MainFieldModel analyzedStringFieldWithDslConverter;
+
+		IndexMapping(IndexSchemaElement root) {
+			mapByTypeFields(
+					root, "byType_",
+					(typeDescriptor, ignored, model) -> {
+						if ( !String.class.equals( typeDescriptor.getJavaType() ) ) {
+							unsupportedFieldModels.add( model );
+						}
+					}
+			);
+			analyzedStringField1 = MainFieldModel.mapper(
+					c -> c.asString().analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD.name )
+			)
+					.map( root, "analyzedString1" );
+			analyzedStringField2 = MainFieldModel.mapper(
+					c -> c.asString().analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD.name )
+			)
+					.map( root, "analyzedString2" );
+			analyzedStringField3 = MainFieldModel.mapper(
+					c -> c.asString().analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD.name )
+			)
+					.map( root, "analyzedString3" );
+			analyzedStringFieldWithDslConverter = MainFieldModel.mapper(
+					c -> c.asString().analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD.name )
+							.dslConverter( ValueWrapper.toIndexFieldConverter() )
+			)
+					.map( root, "analyzedStringWithDslConverter" );
+		}
+	}
+
+	private static class OtherIndexMapping {
+		static OtherIndexMapping createCompatible(IndexSchemaElement root) {
+			return new OtherIndexMapping(
+					MainFieldModel.mapper(
+							c -> c.asString().analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD.name )
+					)
+							.map( root, "analyzedString1" )
+			);
+		}
+
+		static OtherIndexMapping createRawFieldCompatible(IndexSchemaElement root) {
+			return new OtherIndexMapping(
+					MainFieldModel.mapper(
+							c -> c.asString().analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD.name )
+									// Using a different DSL converter
+									.dslConverter( ValueWrapper.toIndexFieldConverter() )
+					)
+							.map( root, "analyzedString1" )
+			);
+		}
+
+		static OtherIndexMapping createIncompatible(IndexSchemaElement root) {
+			return new OtherIndexMapping(
+					MainFieldModel.mapper(
+							// Using a different analyzer/normalizer
+							c -> c.asString().normalizer( DefaultAnalysisDefinitions.NORMALIZER_LOWERCASE.name )
+					)
+							.map( root, "analyzedString1" )
+			);
+		}
+
+		final MainFieldModel analyzedStringField1;
+
+		private OtherIndexMapping(MainFieldModel analyzedStringField1) {
+			this.analyzedStringField1 = analyzedStringField1;
+		}
+	}
+
+	private static class MainFieldModel {
+		static StandardFieldMapper<String, MainFieldModel> mapper(
+				Function<IndexFieldTypeFactoryContext, StandardIndexFieldTypeContext<?, String>> configuration) {
+			return StandardFieldMapper.of(
+					configuration,
+					(accessor, name) -> new MainFieldModel( accessor, name )
+			);
+		}
+
+		final IndexFieldAccessor<String> accessor;
+		final String relativeFieldName;
+
+		private MainFieldModel(IndexFieldAccessor<String> accessor, String relativeFieldName) {
+			this.accessor = accessor;
+			this.relativeFieldName = relativeFieldName;
+		}
+	}
+
+	private static class ByTypeFieldModel {
+		static <F> StandardFieldMapper<F, ByTypeFieldModel> mapper(FieldTypeDescriptor<F> typeDescriptor) {
+			return StandardFieldMapper.of(
+					typeDescriptor::configure,
+					(accessor, name) -> new ByTypeFieldModel( name )
+			);
+		}
+
+		final String relativeFieldName;
+
+		private ByTypeFieldModel(String relativeFieldName) {
+			this.relativeFieldName = relativeFieldName;
+		}
+	}
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/RangeSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/RangeSearchPredicateIT.java
@@ -73,22 +73,22 @@ public class RangeSearchPredicateIT {
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> this.indexMapping = new IndexMapping( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)
 				.withIndex(
-						"CompatibleMappedType", COMPATIBLE_INDEX_NAME,
+						COMPATIBLE_INDEX_NAME,
 						ctx -> this.compatibleIndexMapping = new IndexMapping( ctx.getSchemaElement() ),
 						indexManager -> this.compatibleIndexManager = indexManager
 				)
 				.withIndex(
-						RAW_FIELD_COMPATIBLE_INDEX_NAME + "Type", RAW_FIELD_COMPATIBLE_INDEX_NAME,
+						RAW_FIELD_COMPATIBLE_INDEX_NAME,
 						ctx -> this.rawFieldCompatibleIndexMapping = new RawFieldCompatibleIndexMapping( ctx.getSchemaElement() ),
 						indexManager -> this.rawFieldCompatibleIndexManager = indexManager
 				)
 				.withIndex(
-						INCOMPATIBLE_INDEX_NAME + "Type", INCOMPATIBLE_INDEX_NAME,
+						INCOMPATIBLE_INDEX_NAME,
 						ctx -> new NotCompatibleIndexMapping( ctx.getSchemaElement() ),
 						indexManager -> this.incompatibleIndexManager = indexManager
 				)

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SearchPredicateIT.java
@@ -55,7 +55,7 @@ public class SearchPredicateIT {
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SimpleQueryStringSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SimpleQueryStringSearchPredicateIT.java
@@ -1,0 +1,799 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.tck.search.predicate;
+
+import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.hibernate.search.engine.backend.document.DocumentElement;
+import org.hibernate.search.engine.backend.document.IndexFieldAccessor;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.index.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeFactoryContext;
+import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeContext;
+import org.hibernate.search.engine.reporting.spi.EventContexts;
+import org.hibernate.search.engine.search.DocumentReference;
+import org.hibernate.search.engine.search.SearchQuery;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldModelConsumer;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldTypeDescriptor;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.StandardFieldMapper;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.ValueWrapper;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
+import org.hibernate.search.util.common.SearchException;
+import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
+import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingSearchTarget;
+import org.hibernate.search.util.impl.test.SubTest;
+import org.hibernate.search.util.impl.test.annotation.PortedFromSearch5;
+import org.hibernate.search.util.impl.test.annotation.TestForIssue;
+
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class SimpleQueryStringSearchPredicateIT {
+
+	private static final String INDEX_NAME = "IndexName";
+	private static final String COMPATIBLE_INDEX_NAME = "IndexWithCompatibleFields";
+	private static final String RAW_FIELD_COMPATIBLE_INDEX_NAME = "IndexWithCompatibleRawFields";
+	private static final String INCOMPATIBLE_INDEX_NAME = "IndexWithIncompatibleFields";
+
+	private static final String DOCUMENT_1 = "document1";
+	private static final String DOCUMENT_2 = "document2";
+	private static final String DOCUMENT_3 = "document3";
+	private static final String DOCUMENT_4 = "document4";
+	private static final String DOCUMENT_5 = "document5";
+	private static final String EMPTY = "empty";
+
+	private static final String TERM_1 = "word";
+	private static final String TERM_2 = "panda";
+	private static final String TERM_3 = "room";
+	private static final String TERM_4 = "elephant john";
+	private static final String PHRASE_WITH_TERM_2 = "panda breeding";
+	private static final String PHRASE_WITH_TERM_4 = "elephant john";
+	private static final String TEXT_TERM_1_AND_TERM_2 = "Here I was, feeding my panda, and the crowd had no word.";
+	private static final String TEXT_TERM_1_AND_TERM_3 = "Without a word, he went out of the room.";
+	private static final String TEXT_TERM_2_IN_PHRASE = "I admired her for her panda breeding expertise.";
+	private static final String TEXT_TERM_4_IN_PHRASE_SLOP_2 = "An elephant ran past John.";
+	private static final String TEXT_TERM_1_EDIT_DISTANCE_1 = "I came to the world in a dumpster.";
+
+	private static final String COMPATIBLE_INDEX_DOCUMENT_1 = "compatible_1";
+	private static final String RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 = "raw_field_compatible_1";
+
+	@Rule
+	public SearchSetupHelper setupHelper = new SearchSetupHelper();
+
+	private IndexMapping indexMapping;
+	private StubMappingIndexManager indexManager;
+
+	private OtherIndexMapping compatibleIndexMapping;
+	private StubMappingIndexManager compatibleIndexManager;
+
+	private OtherIndexMapping rawFieldCompatibleIndexMapping;
+	private StubMappingIndexManager rawFieldCompatibleIndexManager;
+
+	private StubMappingIndexManager incompatibleIndexManager;
+
+	@Before
+	public void setup() {
+		setupHelper.withDefaultConfiguration()
+				.withIndex(
+						INDEX_NAME,
+						ctx -> this.indexMapping = new IndexMapping( ctx.getSchemaElement() ),
+						indexManager -> this.indexManager = indexManager
+				)
+				.withIndex(
+						COMPATIBLE_INDEX_NAME,
+						ctx -> this.compatibleIndexMapping =
+								OtherIndexMapping.createCompatible( ctx.getSchemaElement() ),
+						indexManager -> this.compatibleIndexManager = indexManager
+				)
+				.withIndex(
+						RAW_FIELD_COMPATIBLE_INDEX_NAME,
+						ctx -> this.rawFieldCompatibleIndexMapping =
+								OtherIndexMapping.createRawFieldCompatible( ctx.getSchemaElement() ),
+						indexManager -> this.rawFieldCompatibleIndexManager = indexManager
+				)
+				.withIndex(
+						INCOMPATIBLE_INDEX_NAME,
+						ctx -> OtherIndexMapping.createIncompatible( ctx.getSchemaElement() ),
+						indexManager -> this.incompatibleIndexManager = indexManager
+				)
+				.setup();
+
+		initData();
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-2678")
+	@PortedFromSearch5(original = "org.hibernate.search.test.dsl.SimpleQueryStringDSLTest.testSimpleQueryString")
+	public void simpleQueryString() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
+		Function<String, SearchQuery<DocumentReference>> createQuery = queryString -> searchTarget.query().asReference()
+				.predicate( f -> f.simpleQueryString().onField( absoluteFieldPath ).matching( queryString ) )
+				.build();
+
+		assertThat( createQuery.apply( TERM_1 + " " + TERM_2 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
+
+		assertThat( createQuery.apply( TERM_1 + " | " + TERM_2 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
+
+		assertThat( createQuery.apply( TERM_1 + " + " + TERM_2 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
+
+		assertThat( createQuery.apply( "-" + TERM_1 + " + " + TERM_2 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_3 );
+
+		assertThat( createQuery.apply( TERM_1 + " + -" + TERM_2 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_2 );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-2678")
+	@PortedFromSearch5(original = "org.hibernate.search.test.dsl.SimpleQueryStringDSLTest.testSimpleQueryString")
+	public void withAndAsDefaultOperator() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
+		SearchQuery<DocumentReference> query;
+
+		query = searchTarget.query().asReference()
+				.predicate( f -> f.simpleQueryString().onField( absoluteFieldPath )
+						.matching( TERM_1 + " " + TERM_2 ) )
+				.build();
+		assertThat( query )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
+
+		query = searchTarget.query().asReference()
+				.predicate( f -> f.simpleQueryString().onField( absoluteFieldPath ).withAndAsDefaultOperator()
+						.matching( TERM_1 + " " + TERM_2 ) )
+				.build();
+		assertThat( query )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
+	}
+
+	/**
+	 * Check that a simple query string predicate can be used on a field that has a DSL converter.
+	 * The DSL converter should be ignored, and there shouldn't be any exception thrown
+	 * (the field should be considered as a text field).
+	 */
+	@Test
+	public void withDslConverter() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		String absoluteFieldPath = indexMapping.analyzedStringFieldWithDslConverter.relativeFieldName;
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.simpleQueryString().onField( absoluteFieldPath ).matching( TERM_1 ) )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-2700")
+	@PortedFromSearch5(original = "org.hibernate.search.test.dsl.SimpleQueryStringDSLTest.testEmptyQueryString")
+	public void emptyStringBeforeAnalysis() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		MainFieldModel fieldModel = indexMapping.analyzedStringField1;
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.simpleQueryString().onField( fieldModel.relativeFieldName ).matching( "" ) )
+				.build();
+
+		assertThat( query )
+				.hasNoHits();
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-2700")
+	@PortedFromSearch5(original = "org.hibernate.search.test.dsl.SimpleQueryStringDSLTest.testBlankQueryString")
+	public void blankStringBeforeAnalysis() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		MainFieldModel fieldModel = indexMapping.analyzedStringField1;
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.simpleQueryString().onField( fieldModel.relativeFieldName ).matching( "   " ) )
+				.build();
+
+		assertThat( query )
+				.hasNoHits();
+	}
+
+	@Test
+	public void noTokenAfterAnalysis() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		MainFieldModel fieldModel = indexMapping.analyzedStringField1;
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				// Use stopwords, which should be removed by the analysis
+				.predicate( f -> f.simpleQueryString().onField( fieldModel.relativeFieldName ).matching( "the a" ) )
+				.build();
+
+		assertThat( query )
+				.hasNoHits();
+	}
+
+	@Test
+	public void error_unsupportedFieldType() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		for ( ByTypeFieldModel fieldModel : indexMapping.unsupportedFieldModels ) {
+			String absoluteFieldPath = fieldModel.relativeFieldName;
+
+			SubTest.expectException(
+					"simpleQueryString() predicate with unsupported type on field " + absoluteFieldPath,
+					() -> searchTarget.predicate().simpleQueryString().onField( absoluteFieldPath )
+			)
+					.assertThrown()
+					.isInstanceOf( SearchException.class )
+					.hasMessageContaining( "Text predicates" )
+					.hasMessageContaining( "are not supported by" )
+					.hasMessageContaining( "'" + absoluteFieldPath + "'" )
+					.satisfies( FailureReportUtils.hasContext(
+							EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
+					) );
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-2700")
+	@PortedFromSearch5(original = "org.hibernate.search.test.dsl.SimpleQueryStringDSLTest.testNullQueryString")
+	public void error_null() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
+
+		SubTest.expectException(
+				"simpleQueryString() predicate with null value to match",
+				() -> searchTarget.predicate().simpleQueryString().onField( absoluteFieldPath ).matching( null )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Invalid simple query string" )
+				.hasMessageContaining( "must be non-null" )
+				.hasMessageContaining( absoluteFieldPath );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-2678")
+	@PortedFromSearch5(original = "org.hibernate.search.test.dsl.SimpleQueryStringDSLTest.testSimpleQueryString")
+	public void phrase() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
+		Function<String, SearchQuery<DocumentReference>> createQuery = queryString -> searchTarget.query().asReference()
+				.predicate( f -> f.simpleQueryString().onField( absoluteFieldPath ).matching( queryString ) )
+				.build();
+
+		assertThat( createQuery.apply( "\"" + PHRASE_WITH_TERM_2 + "\"" ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_3 );
+
+		assertThat( createQuery.apply( TERM_3 + " \"" + PHRASE_WITH_TERM_2 + "\"" ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_2, DOCUMENT_3 );
+
+		// Slop
+		assertThat( createQuery.apply( "\"" + PHRASE_WITH_TERM_4 + "\"" ) )
+				.hasNoHits();
+		assertThat( createQuery.apply( "\"" + PHRASE_WITH_TERM_4 + "\"~1" ) )
+				.hasNoHits();
+		assertThat( createQuery.apply( "\"" + PHRASE_WITH_TERM_4 + "\"~2" ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_4 );
+		assertThat( createQuery.apply( "\"" + PHRASE_WITH_TERM_4 + "\"~3" ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_4 );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-2678")
+	@PortedFromSearch5(original = "org.hibernate.search.test.dsl.SimpleQueryStringDSLTest.testBoost")
+	public void fieldLevelBoost() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		String absoluteFieldPath1 = indexMapping.analyzedStringField1.relativeFieldName;
+		String absoluteFieldPath2 = indexMapping.analyzedStringField2.relativeFieldName;
+		SearchQuery<DocumentReference> query;
+
+		query = searchTarget.query().asReference()
+				.predicate( f -> f.simpleQueryString()
+						.onField( absoluteFieldPath1 ).boostedTo( 5f )
+						.orField( absoluteFieldPath2 )
+						.matching( TERM_3 )
+				)
+				.sort( f -> f.byScore() )
+				.build();
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_2, DOCUMENT_1 );
+
+		query = searchTarget.query().asReference()
+				.predicate( f -> f.simpleQueryString()
+						.onField( absoluteFieldPath1 )
+						.orField( absoluteFieldPath2 ).boostedTo( 5f )
+						.matching( TERM_3 )
+				)
+				.sort( f -> f.byScore() )
+				.build();
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2 );
+	}
+
+	@Test
+	public void predicateLevelBoost() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		String absoluteFieldPath1 = indexMapping.analyzedStringField1.relativeFieldName;
+		String absoluteFieldPath2 = indexMapping.analyzedStringField2.relativeFieldName;
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.bool()
+						.should( f.simpleQueryString().onField( absoluteFieldPath1 )
+								.matching( TERM_3 )
+						)
+						.should( f.simpleQueryString().boostedTo( 7 ).onField( absoluteFieldPath2 )
+								.matching( TERM_3 )
+						)
+				)
+				.sort( c -> c.byScore() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2 );
+
+		query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.bool()
+						.should( f.simpleQueryString().boostedTo( 39 ).onField( absoluteFieldPath1 )
+								.matching( TERM_3 )
+						)
+						.should( f.simpleQueryString().onField( absoluteFieldPath2 )
+								.matching( TERM_3 )
+						)
+				)
+				.sort( c -> c.byScore() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_2, DOCUMENT_1 );
+	}
+
+	@Test
+	public void predicateLevelBoost_withConstantScore() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		String absoluteFieldPath1 = indexMapping.analyzedStringField1.relativeFieldName;
+		String absoluteFieldPath2 = indexMapping.analyzedStringField2.relativeFieldName;
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.bool()
+						.should( f.simpleQueryString().withConstantScore().boostedTo( 7 )
+								.onField( absoluteFieldPath1 )
+								.matching( TERM_3 )
+						)
+						.should( f.simpleQueryString().withConstantScore().boostedTo( 39 )
+								.onField( absoluteFieldPath2 )
+								.matching( TERM_3 )
+						)
+				)
+				.sort( c -> c.byScore() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2 );
+
+		query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.bool()
+						.should( f.simpleQueryString().withConstantScore().boostedTo( 39 )
+								.onField( absoluteFieldPath1 )
+								.matching( TERM_3 )
+						)
+						.should( f.simpleQueryString().withConstantScore().boostedTo( 7 )
+								.onField( absoluteFieldPath2 )
+								.matching( TERM_3 )
+						)
+				)
+				.sort( c -> c.byScore() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_2, DOCUMENT_1 );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-2678")
+	@PortedFromSearch5(original = "org.hibernate.search.test.dsl.SimpleQueryStringDSLTest.testFuzzy")
+	public void fuzzy() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
+		Function<String, SearchQuery<DocumentReference>> createQuery = queryString -> searchTarget.query().asReference()
+				.predicate( f -> f.simpleQueryString().onField( absoluteFieldPath ).matching( queryString ) )
+				.build();
+
+		assertThat( createQuery.apply( TERM_1 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2 );
+
+		assertThat( createQuery.apply( TERM_1 + "~1" ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_5 );
+
+		assertThat( createQuery.apply( TERM_1 + "~2" ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_5 );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-2678")
+	@PortedFromSearch5(original = "org.hibernate.search.test.dsl.SimpleQueryStringDSLTest.testFuzzy")
+	public void analyzer() {
+		// TODO HSEARCH-3312 implement this test once we allow to override the analyzer
+		// See the original test in Search 5 for examples of use
+		Assume.assumeTrue( "This feature is not implemented yet", false );
+	}
+
+	@Test
+	public void multiFields() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		String absoluteFieldPath1 = indexMapping.analyzedStringField1.relativeFieldName;
+		String absoluteFieldPath2 = indexMapping.analyzedStringField2.relativeFieldName;
+		String absoluteFieldPath3 = indexMapping.analyzedStringField3.relativeFieldName;
+		Function<String, SearchQuery<DocumentReference>> createQuery;
+
+		// onField(...)
+
+		createQuery = query -> searchTarget.query().asReference()
+				.predicate( f -> f.simpleQueryString().onField( absoluteFieldPath1 )
+						.matching( query )
+				)
+				.build();
+
+		assertThat( createQuery.apply( TERM_1 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2 );
+		assertThat( createQuery.apply( TERM_2 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_3 );
+		assertThat( createQuery.apply( TERM_3 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_2 );
+
+		// onField(...).orField(...)
+
+		createQuery = query -> searchTarget.query().asReference()
+				.predicate( f -> f.simpleQueryString().onField( absoluteFieldPath1 )
+						.orField( absoluteFieldPath2 )
+						.matching( query )
+				)
+				.build();
+
+		assertThat( createQuery.apply( TERM_1 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2 );
+		assertThat( createQuery.apply( TERM_2 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_3, DOCUMENT_4 );
+		assertThat( createQuery.apply( TERM_3 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2 );
+
+		// onField().orFields(...)
+
+		createQuery = query -> searchTarget.query()
+				.asReference()
+				.predicate( f -> f.simpleQueryString().onField( absoluteFieldPath1 )
+						.orFields( absoluteFieldPath2, absoluteFieldPath3 )
+						.matching( query )
+				)
+				.build();
+
+		assertThat( createQuery.apply( TERM_1 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_5 );
+		assertThat( createQuery.apply( TERM_2 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_3, DOCUMENT_4, DOCUMENT_5 );
+		assertThat( createQuery.apply( TERM_3 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_5 );
+
+		// onFields(...)
+
+		createQuery = query -> searchTarget.query()
+				.asReference()
+				.predicate( f -> f.simpleQueryString().onFields( absoluteFieldPath1, absoluteFieldPath2 )
+						.matching( query )
+				)
+				.build();
+
+		assertThat( createQuery.apply( TERM_1 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2 );
+		assertThat( createQuery.apply( TERM_2 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_3, DOCUMENT_4 );
+		assertThat( createQuery.apply( TERM_3 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2 );
+	}
+
+	@Test
+	public void error_unknownField() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
+
+		SubTest.expectException(
+				"simpleQueryString() predicate with unknown field",
+				() -> searchTarget.predicate().simpleQueryString().onField( "unknown_field" )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Unknown field" )
+				.hasMessageContaining( "'unknown_field'" );
+
+		SubTest.expectException(
+				"simpleQueryString() predicate with unknown field",
+				() -> searchTarget.predicate().simpleQueryString()
+						.onFields( absoluteFieldPath, "unknown_field" )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Unknown field" )
+				.hasMessageContaining( "'unknown_field'" );
+
+		SubTest.expectException(
+				"simpleQueryString() predicate with unknown field",
+				() -> searchTarget.predicate().simpleQueryString().onField( absoluteFieldPath )
+						.orField( "unknown_field" )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Unknown field" )
+				.hasMessageContaining( "'unknown_field'" );
+
+		SubTest.expectException(
+				"simpleQueryString() predicate with unknown field",
+				() -> searchTarget.predicate().simpleQueryString().onField( absoluteFieldPath )
+						.orFields( "unknown_field" )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Unknown field" )
+				.hasMessageContaining( "'unknown_field'" );
+	}
+
+	@Test
+	public void multiIndex_withCompatibleIndexManager() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget(
+				compatibleIndexManager
+		);
+		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.simpleQueryString().onField( absoluteFieldPath ).matching( TERM_1 ) )
+				.build();
+
+		assertThat( query ).hasDocRefHitsAnyOrder( b -> {
+			b.doc( INDEX_NAME, DOCUMENT_1, DOCUMENT_2 );
+			b.doc( COMPATIBLE_INDEX_NAME, COMPATIBLE_INDEX_DOCUMENT_1 );
+		} );
+	}
+
+	@Test
+	public void multiIndex_withRawFieldCompatibleIndexManager() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget( rawFieldCompatibleIndexManager );
+		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.simpleQueryString().onField( absoluteFieldPath ).matching( TERM_1 ) )
+				.build();
+
+		assertThat( query ).hasDocRefHitsAnyOrder( b -> {
+			b.doc( INDEX_NAME, DOCUMENT_1, DOCUMENT_2 );
+			b.doc( RAW_FIELD_COMPATIBLE_INDEX_NAME, RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 );
+		} );
+	}
+
+	@Test
+	public void multiIndex_withIncompatibleIndexManager() {
+		// TODO HSEARCH-3307 re-enable this test once we properly take analyzer/normalizer into account when testing field compatibility for predicates in Elasticsearch
+		Assume.assumeTrue( "This feature is not implemented yet", false );
+		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
+
+		SubTest.expectException(
+				() -> {
+					indexManager.createSearchTarget( incompatibleIndexManager )
+							.predicate().simpleQueryString().onField( absoluteFieldPath );
+				}
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Multiple conflicting types to build a predicate" )
+				.hasMessageContaining( "'" + absoluteFieldPath + "'" )
+				.satisfies( FailureReportUtils.hasContext(
+						EventContexts.fromIndexNames( INDEX_NAME, INCOMPATIBLE_INDEX_NAME )
+				) );
+	}
+
+	private void initData() {
+		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
+		workPlan.add( referenceProvider( DOCUMENT_1 ), document -> {
+			indexMapping.analyzedStringField1.accessor.write( document, TEXT_TERM_1_AND_TERM_2 );
+			indexMapping.analyzedStringFieldWithDslConverter.accessor.write( document, TEXT_TERM_1_AND_TERM_2 );
+			indexMapping.analyzedStringField2.accessor.write( document, TEXT_TERM_1_AND_TERM_3 );
+			indexMapping.analyzedStringField3.accessor.write( document, TERM_4 );
+		} );
+		workPlan.add( referenceProvider( DOCUMENT_2 ), document -> {
+			indexMapping.analyzedStringField1.accessor.write( document, TEXT_TERM_1_AND_TERM_3 );
+		} );
+		workPlan.add( referenceProvider( DOCUMENT_3 ), document -> {
+			indexMapping.analyzedStringField1.accessor.write( document, TEXT_TERM_2_IN_PHRASE );
+		} );
+		workPlan.add( referenceProvider( DOCUMENT_4 ), document -> {
+			indexMapping.analyzedStringField1.accessor.write( document, TEXT_TERM_4_IN_PHRASE_SLOP_2 );
+			indexMapping.analyzedStringField2.accessor.write( document, TEXT_TERM_2_IN_PHRASE );
+		} );
+		workPlan.add( referenceProvider( DOCUMENT_5 ), document -> {
+			indexMapping.analyzedStringField1.accessor.write( document, TEXT_TERM_1_EDIT_DISTANCE_1 );
+			indexMapping.analyzedStringField3.accessor.write( document, TEXT_TERM_2_IN_PHRASE );
+			indexMapping.analyzedStringField3.accessor.write( document, TEXT_TERM_1_AND_TERM_3 );
+		} );
+		workPlan.add( referenceProvider( EMPTY ), document -> {
+		} );
+		workPlan.execute().join();
+
+		workPlan = compatibleIndexManager.createWorkPlan();
+		workPlan.add( referenceProvider( COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
+			compatibleIndexMapping.analyzedStringField1.accessor.write( document, TEXT_TERM_1_AND_TERM_2 );
+		} );
+		workPlan.execute().join();
+
+		workPlan = rawFieldCompatibleIndexManager.createWorkPlan();
+		workPlan.add( referenceProvider( RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
+			rawFieldCompatibleIndexMapping.analyzedStringField1.accessor.write( document, TEXT_TERM_1_AND_TERM_2 );
+		} );
+		workPlan.execute().join();
+
+		// Check that all documents are searchable
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.matchAll() )
+				.build();
+		assertThat( query )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3, DOCUMENT_4, DOCUMENT_5, EMPTY );
+		query = compatibleIndexManager.createSearchTarget().query()
+				.asReference()
+				.predicate( f -> f.matchAll() )
+				.build();
+		assertThat( query ).hasDocRefHitsAnyOrder( COMPATIBLE_INDEX_NAME, COMPATIBLE_INDEX_DOCUMENT_1 );
+		query = rawFieldCompatibleIndexManager.createSearchTarget().query()
+				.asReference()
+				.predicate( f -> f.matchAll() )
+				.build();
+		assertThat( query ).hasDocRefHitsAnyOrder( RAW_FIELD_COMPATIBLE_INDEX_NAME, RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 );
+	}
+
+	private static void forEachTypeDescriptor(Consumer<FieldTypeDescriptor<?>> action) {
+		FieldTypeDescriptor.getAll().stream()
+				.filter( typeDescriptor -> typeDescriptor.getMatchPredicateExpectations().isPresent() )
+				.forEach( action );
+	}
+
+	private static void mapByTypeFields(IndexSchemaElement parent, String prefix,
+			FieldModelConsumer<Void, ByTypeFieldModel> consumer) {
+		forEachTypeDescriptor( typeDescriptor -> {
+			ByTypeFieldModel fieldModel = ByTypeFieldModel.mapper( typeDescriptor )
+					.map( parent, prefix + typeDescriptor.getUniqueName() );
+			consumer.accept( typeDescriptor, null, fieldModel );
+		} );
+	}
+
+	private static class IndexMapping {
+		final List<ByTypeFieldModel> unsupportedFieldModels = new ArrayList<>();
+
+		final MainFieldModel analyzedStringField1;
+		final MainFieldModel analyzedStringField2;
+		final MainFieldModel analyzedStringField3;
+		final MainFieldModel analyzedStringFieldWithDslConverter;
+
+		IndexMapping(IndexSchemaElement root) {
+			mapByTypeFields(
+					root, "byType_",
+					(typeDescriptor, ignored, model) -> {
+						if ( !String.class.equals( typeDescriptor.getJavaType() ) ) {
+							unsupportedFieldModels.add( model );
+						}
+					}
+			);
+			analyzedStringField1 = MainFieldModel.mapper(
+					c -> c.asString().analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD.name )
+			)
+					.map( root, "analyzedString1" );
+			analyzedStringField2 = MainFieldModel.mapper(
+					c -> c.asString().analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD.name )
+			)
+					.map( root, "analyzedString2" );
+			analyzedStringField3 = MainFieldModel.mapper(
+					c -> c.asString().analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD.name )
+			)
+					.map( root, "analyzedString3" );
+			analyzedStringFieldWithDslConverter = MainFieldModel.mapper(
+					c -> c.asString().analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD.name )
+							.dslConverter( ValueWrapper.toIndexFieldConverter() )
+			)
+					.map( root, "analyzedStringWithDslConverter" );
+		}
+	}
+
+	private static class OtherIndexMapping {
+		static OtherIndexMapping createCompatible(IndexSchemaElement root) {
+			return new OtherIndexMapping(
+					MainFieldModel.mapper(
+							c -> c.asString().analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD.name )
+					)
+							.map( root, "analyzedString1" )
+			);
+		}
+
+		static OtherIndexMapping createRawFieldCompatible(IndexSchemaElement root) {
+			return new OtherIndexMapping(
+					MainFieldModel.mapper(
+							c -> c.asString().analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD.name )
+									// Using a different DSL converter
+									.dslConverter( ValueWrapper.toIndexFieldConverter() )
+					)
+							.map( root, "analyzedString1" )
+			);
+		}
+
+		static OtherIndexMapping createIncompatible(IndexSchemaElement root) {
+			return new OtherIndexMapping(
+					MainFieldModel.mapper(
+							// Using a different analyzer/normalizer
+							c -> c.asString().normalizer( DefaultAnalysisDefinitions.NORMALIZER_LOWERCASE.name )
+					)
+							.map( root, "analyzedString1" )
+			);
+		}
+
+		final MainFieldModel analyzedStringField1;
+
+		private OtherIndexMapping(MainFieldModel analyzedStringField1) {
+			this.analyzedStringField1 = analyzedStringField1;
+		}
+	}
+
+	private static class MainFieldModel {
+		static StandardFieldMapper<String, MainFieldModel> mapper(
+				Function<IndexFieldTypeFactoryContext, StandardIndexFieldTypeContext<?, String>> configuration) {
+			return StandardFieldMapper.of(
+					configuration,
+					(accessor, name) -> new MainFieldModel( accessor, name )
+			);
+		}
+
+		final IndexFieldAccessor<String> accessor;
+		final String relativeFieldName;
+
+		private MainFieldModel(IndexFieldAccessor<String> accessor, String relativeFieldName) {
+			this.accessor = accessor;
+			this.relativeFieldName = relativeFieldName;
+		}
+	}
+
+	private static class ByTypeFieldModel {
+		static <F> StandardFieldMapper<F, ByTypeFieldModel> mapper(FieldTypeDescriptor<F> typeDescriptor) {
+			return StandardFieldMapper.of(
+					typeDescriptor::configure,
+					(accessor, name) -> new ByTypeFieldModel( name )
+			);
+		}
+
+		final String relativeFieldName;
+
+		private ByTypeFieldModel(String relativeFieldName) {
+			this.relativeFieldName = relativeFieldName;
+		}
+	}
+
+
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/WildcardSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/WildcardSearchPredicateIT.java
@@ -1,0 +1,625 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.tck.search.predicate;
+
+import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.hibernate.search.engine.backend.document.DocumentElement;
+import org.hibernate.search.engine.backend.document.IndexFieldAccessor;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.index.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeFactoryContext;
+import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeContext;
+import org.hibernate.search.engine.reporting.spi.EventContexts;
+import org.hibernate.search.engine.search.DocumentReference;
+import org.hibernate.search.engine.search.SearchQuery;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldModelConsumer;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldTypeDescriptor;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.StandardFieldMapper;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.ValueWrapper;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
+import org.hibernate.search.util.common.SearchException;
+import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
+import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingSearchTarget;
+import org.hibernate.search.util.impl.test.SubTest;
+import org.hibernate.search.util.impl.test.annotation.PortedFromSearch5;
+
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class WildcardSearchPredicateIT {
+
+	private static final String INDEX_NAME = "IndexName";
+	private static final String COMPATIBLE_INDEX_NAME = "IndexWithCompatibleFields";
+	private static final String RAW_FIELD_COMPATIBLE_INDEX_NAME = "IndexWithCompatibleRawFields";
+	private static final String INCOMPATIBLE_INDEX_NAME = "IndexWithIncompatiblFields";
+
+	private static final String DOCUMENT_1 = "document1";
+	private static final String DOCUMENT_2 = "document2";
+	private static final String DOCUMENT_3 = "document3";
+	private static final String DOCUMENT_4 = "document4";
+	private static final String DOCUMENT_5 = "document5";
+	private static final String EMPTY = "empty";
+
+	private static final String PATTERN_1 = "local*n";
+	private static final String PATTERN_2 = "inter*on";
+	private static final String PATTERN_3 = "la*d";
+	private static final String TEXT_MATCHING_PATTERN_1 = "Localization in English is a must-have.";
+	private static final String TEXT_MATCHING_PATTERN_2 = "Internationalization allows to adapt the application to multiple locales.";
+	private static final String TEXT_MATCHING_PATTERN_3 = "A had to call the landlord.";
+	private static final String TEXT_MATCHING_PATTERN_2_AND_3 = "I had some interaction with that lad.";
+
+	private static final String COMPATIBLE_INDEX_DOCUMENT_1 = "compatible_1";
+	private static final String RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 = "raw_field_compatible_1";
+
+	@Rule
+	public SearchSetupHelper setupHelper = new SearchSetupHelper();
+
+	private IndexMapping indexMapping;
+	private StubMappingIndexManager indexManager;
+
+	private OtherIndexMapping compatibleIndexMapping;
+	private StubMappingIndexManager compatibleIndexManager;
+
+	private OtherIndexMapping rawFieldCompatibleIndexMapping;
+	private StubMappingIndexManager rawFieldCompatibleIndexManager;
+
+	private StubMappingIndexManager incompatibleIndexManager;
+
+	@Before
+	public void setup() {
+		setupHelper.withDefaultConfiguration()
+				.withIndex(
+						INDEX_NAME,
+						ctx -> this.indexMapping = new IndexMapping( ctx.getSchemaElement() ),
+						indexManager -> this.indexManager = indexManager
+				)
+				.withIndex(
+						COMPATIBLE_INDEX_NAME,
+						ctx -> this.compatibleIndexMapping =
+								OtherIndexMapping.createCompatible( ctx.getSchemaElement() ),
+						indexManager -> this.compatibleIndexManager = indexManager
+				)
+				.withIndex(
+						RAW_FIELD_COMPATIBLE_INDEX_NAME,
+						ctx -> this.rawFieldCompatibleIndexMapping =
+								OtherIndexMapping.createRawFieldCompatible( ctx.getSchemaElement() ),
+						indexManager -> this.rawFieldCompatibleIndexManager = indexManager
+				)
+				.withIndex(
+						INCOMPATIBLE_INDEX_NAME,
+						ctx -> OtherIndexMapping.createIncompatible( ctx.getSchemaElement() ),
+						indexManager -> this.incompatibleIndexManager = indexManager
+				)
+				.setup();
+
+		initData();
+	}
+
+	@Test
+	@PortedFromSearch5(original = "org.hibernate.search.test.dsl.DSLTest.testWildcardQuery")
+	public void wildcard() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
+		Function<String, SearchQuery<DocumentReference>> createQuery = queryString -> searchTarget.query().asReference()
+				.predicate( f -> f.wildcard().onField( absoluteFieldPath ).matching( queryString ) )
+				.build();
+
+		assertThat( createQuery.apply( PATTERN_1 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
+
+		assertThat( createQuery.apply( PATTERN_2 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_2, DOCUMENT_4 );
+
+		assertThat( createQuery.apply( PATTERN_3 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_3, DOCUMENT_4 );
+	}
+
+	/**
+	 * Check that a wildcard predicate can be used on a field that has a DSL converter.
+	 * The DSL converter should be ignored, and there shouldn't be any exception thrown
+	 * (the field should be considered as a text field).
+	 */
+	@Test
+	public void withDslConverter() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		String absoluteFieldPath = indexMapping.analyzedStringFieldWithDslConverter.relativeFieldName;
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.wildcard().onField( absoluteFieldPath ).matching( PATTERN_1 ) )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
+	}
+
+	@Test
+	public void emptyString() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		MainFieldModel fieldModel = indexMapping.analyzedStringField1;
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.wildcard().onField( fieldModel.relativeFieldName ).matching( "" ) )
+				.build();
+
+		assertThat( query )
+				.hasNoHits();
+	}
+
+	@Test
+	public void error_unsupportedFieldType() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		for ( ByTypeFieldModel fieldModel : indexMapping.unsupportedFieldModels ) {
+			String absoluteFieldPath = fieldModel.relativeFieldName;
+
+			SubTest.expectException(
+					"wildcard() predicate with unsupported type on field " + absoluteFieldPath,
+					() -> searchTarget.predicate().wildcard().onField( absoluteFieldPath )
+			)
+					.assertThrown()
+					.isInstanceOf( SearchException.class )
+					.hasMessageContaining( "Text predicates" )
+					.hasMessageContaining( "are not supported by" )
+					.hasMessageContaining( "'" + absoluteFieldPath + "'" )
+					.satisfies( FailureReportUtils.hasContext(
+							EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath )
+					) );
+		}
+	}
+
+	@Test
+	public void error_null() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
+
+		SubTest.expectException(
+				"wildcard() predicate with null pattern",
+				() -> searchTarget.predicate().wildcard().onField( absoluteFieldPath ).matching( null )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Invalid pattern" )
+				.hasMessageContaining( "must be non-null" )
+				.hasMessageContaining( absoluteFieldPath );
+	}
+
+	@Test
+	public void fieldLevelBoost() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.wildcard()
+						.onField( indexMapping.analyzedStringField1.relativeFieldName ).boostedTo( 42 )
+						.orField( indexMapping.analyzedStringField2.relativeFieldName )
+						.matching( PATTERN_1 )
+				)
+				.sort( c -> c.byScore() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_5 );
+
+		query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.wildcard()
+						.onField( indexMapping.analyzedStringField1.relativeFieldName )
+						.orField( indexMapping.analyzedStringField2.relativeFieldName ).boostedTo( 42 )
+						.matching( PATTERN_1 )
+				)
+				.sort( c -> c.byScore() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_5, DOCUMENT_1 );
+	}
+
+	@Test
+	public void predicateLevelBoost() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.bool()
+						.should( f.wildcard().onField( indexMapping.analyzedStringField1.relativeFieldName )
+								.matching( PATTERN_1 )
+						)
+						.should( f.wildcard().boostedTo( 7 ).onField( indexMapping.analyzedStringField2.relativeFieldName )
+								.matching( PATTERN_1 )
+						)
+				)
+				.sort( c -> c.byScore() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_5, DOCUMENT_1 );
+
+		query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.bool()
+						.should( f.wildcard().boostedTo( 39 ).onField( indexMapping.analyzedStringField1.relativeFieldName )
+								.matching( PATTERN_1 )
+						)
+						.should( f.wildcard().onField( indexMapping.analyzedStringField2.relativeFieldName )
+								.matching( PATTERN_1 )
+						)
+				)
+				.sort( c -> c.byScore() )
+				.build();
+
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_5 );
+	}
+
+	@Test
+	public void multiFields() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		String absoluteFieldPath1 = indexMapping.analyzedStringField1.relativeFieldName;
+		String absoluteFieldPath2 = indexMapping.analyzedStringField2.relativeFieldName;
+		String absoluteFieldPath3 = indexMapping.analyzedStringField3.relativeFieldName;
+		Function<String, SearchQuery<DocumentReference>> createQuery;
+
+		// onField(...)
+
+		createQuery = pattern -> searchTarget.query().asReference()
+				.predicate( f -> f.wildcard().onField( absoluteFieldPath1 )
+						.matching( pattern )
+				)
+				.build();
+
+		assertThat( createQuery.apply( PATTERN_1 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
+		assertThat( createQuery.apply( PATTERN_2 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_2, DOCUMENT_4 );
+		assertThat( createQuery.apply( PATTERN_3 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_3, DOCUMENT_4 );
+
+		// onField(...).orField(...)
+
+		createQuery = pattern -> searchTarget.query().asReference()
+				.predicate( f -> f.wildcard().onField( absoluteFieldPath1 )
+						.orField( absoluteFieldPath2 )
+						.matching( pattern )
+				)
+				.build();
+
+		assertThat( createQuery.apply( PATTERN_1 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_5 );
+		assertThat( createQuery.apply( PATTERN_2 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_2, DOCUMENT_4 );
+		assertThat( createQuery.apply( PATTERN_3 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_3, DOCUMENT_4 );
+
+		// onField().orFields(...)
+
+		createQuery = pattern -> searchTarget.query()
+				.asReference()
+				.predicate( f -> f.wildcard().onField( absoluteFieldPath1 )
+						.orFields( absoluteFieldPath2, absoluteFieldPath3 )
+						.matching( pattern )
+				)
+				.build();
+
+		assertThat( createQuery.apply( PATTERN_1 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_5 );
+		assertThat( createQuery.apply( PATTERN_2 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_2, DOCUMENT_4 );
+		assertThat( createQuery.apply( PATTERN_3 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_3, DOCUMENT_4, DOCUMENT_5 );
+
+		// onFields(...)
+
+		createQuery = pattern -> searchTarget.query()
+				.asReference()
+				.predicate( f -> f.wildcard().onFields( absoluteFieldPath1, absoluteFieldPath2 )
+						.matching( pattern )
+				)
+				.build();
+
+		assertThat( createQuery.apply( PATTERN_1 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_5 );
+		assertThat( createQuery.apply( PATTERN_2 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_2, DOCUMENT_4 );
+		assertThat( createQuery.apply( PATTERN_3 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_3, DOCUMENT_4 );
+	}
+
+	@Test
+	public void error_unknownField() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
+
+		SubTest.expectException(
+				"wildcard() predicate with unknown field",
+				() -> searchTarget.predicate().wildcard().onField( "unknown_field" )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Unknown field" )
+				.hasMessageContaining( "'unknown_field'" );
+
+		SubTest.expectException(
+				"wildcard() predicate with unknown field",
+				() -> searchTarget.predicate().wildcard()
+						.onFields( absoluteFieldPath, "unknown_field" )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Unknown field" )
+				.hasMessageContaining( "'unknown_field'" );
+
+		SubTest.expectException(
+				"wildcard() predicate with unknown field",
+				() -> searchTarget.predicate().wildcard().onField( absoluteFieldPath )
+						.orField( "unknown_field" )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Unknown field" )
+				.hasMessageContaining( "'unknown_field'" );
+
+		SubTest.expectException(
+				"wildcard() predicate with unknown field",
+				() -> searchTarget.predicate().wildcard().onField( absoluteFieldPath )
+						.orFields( "unknown_field" )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Unknown field" )
+				.hasMessageContaining( "'unknown_field'" );
+	}
+
+	@Test
+	public void multiIndex_withCompatibleIndexManager() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget(
+				compatibleIndexManager
+		);
+
+		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.wildcard().onField( absoluteFieldPath ).matching( PATTERN_1 ) )
+				.build();
+
+		assertThat( query ).hasDocRefHitsAnyOrder( b -> {
+			b.doc( INDEX_NAME, DOCUMENT_1 );
+			b.doc( COMPATIBLE_INDEX_NAME, COMPATIBLE_INDEX_DOCUMENT_1 );
+		} );
+	}
+
+	@Test
+	public void multiIndex_withRawFieldCompatibleIndexManager() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget( rawFieldCompatibleIndexManager );
+
+		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
+
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.wildcard().onField( absoluteFieldPath ).matching( PATTERN_1 ) )
+				.build();
+
+		assertThat( query ).hasDocRefHitsAnyOrder( b -> {
+			b.doc( INDEX_NAME, DOCUMENT_1 );
+			b.doc( RAW_FIELD_COMPATIBLE_INDEX_NAME, RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 );
+		} );
+	}
+
+	@Test
+	public void multiIndex_withIncompatibleIndexManager() {
+		// TODO HSEARCH-3307 re-enable this test once we properly take analyzer/normalizer into account when testing field compatibility for predicates in Elasticsearch
+		Assume.assumeTrue( "This feature is not implemented yet", false );
+
+		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
+
+		SubTest.expectException(
+				() -> {
+					indexManager.createSearchTarget( incompatibleIndexManager )
+							.predicate().wildcard().onField( absoluteFieldPath );
+				}
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Multiple conflicting types to build a predicate" )
+				.hasMessageContaining( "'" + absoluteFieldPath + "'" )
+				.satisfies( FailureReportUtils.hasContext(
+						EventContexts.fromIndexNames( INDEX_NAME, INCOMPATIBLE_INDEX_NAME )
+				) );
+	}
+
+	private void initData() {
+		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
+		workPlan.add( referenceProvider( DOCUMENT_1 ), document -> {
+			indexMapping.analyzedStringField1.accessor.write( document, TEXT_MATCHING_PATTERN_1 );
+			indexMapping.analyzedStringFieldWithDslConverter.accessor.write( document, TEXT_MATCHING_PATTERN_1 );
+		} );
+		workPlan.add( referenceProvider( DOCUMENT_2 ), document -> {
+			indexMapping.analyzedStringField1.accessor.write( document, TEXT_MATCHING_PATTERN_2 );
+		} );
+		workPlan.add( referenceProvider( DOCUMENT_3 ), document -> {
+			indexMapping.analyzedStringField1.accessor.write( document, TEXT_MATCHING_PATTERN_3 );
+		} );
+		workPlan.add( referenceProvider( DOCUMENT_4 ), document -> {
+			indexMapping.analyzedStringField1.accessor.write( document, TEXT_MATCHING_PATTERN_2_AND_3 );
+		} );
+		workPlan.add( referenceProvider( DOCUMENT_5 ), document -> {
+			indexMapping.analyzedStringField2.accessor.write( document, TEXT_MATCHING_PATTERN_1 );
+			indexMapping.analyzedStringField3.accessor.write( document, TEXT_MATCHING_PATTERN_3 );
+		} );
+		workPlan.add( referenceProvider( EMPTY ), document -> {
+		} );
+		workPlan.execute().join();
+
+		workPlan = compatibleIndexManager.createWorkPlan();
+		workPlan.add( referenceProvider( COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
+			compatibleIndexMapping.analyzedStringField1.accessor.write( document, TEXT_MATCHING_PATTERN_1 );
+		} );
+		workPlan.execute().join();
+
+		workPlan = rawFieldCompatibleIndexManager.createWorkPlan();
+		workPlan.add( referenceProvider( RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
+			rawFieldCompatibleIndexMapping.analyzedStringField1.accessor.write( document, TEXT_MATCHING_PATTERN_1 );
+		} );
+		workPlan.execute().join();
+
+		// Check that all documents are searchable
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+		SearchQuery<DocumentReference> query = searchTarget.query()
+				.asReference()
+				.predicate( f -> f.matchAll() )
+				.build();
+		assertThat( query )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3, DOCUMENT_4, DOCUMENT_5, EMPTY );
+		query = compatibleIndexManager.createSearchTarget().query()
+				.asReference()
+				.predicate( f -> f.matchAll() )
+				.build();
+		assertThat( query ).hasDocRefHitsAnyOrder( COMPATIBLE_INDEX_NAME, COMPATIBLE_INDEX_DOCUMENT_1 );
+		query = rawFieldCompatibleIndexManager.createSearchTarget().query()
+				.asReference()
+				.predicate( f -> f.matchAll() )
+				.build();
+		assertThat( query ).hasDocRefHitsAnyOrder( RAW_FIELD_COMPATIBLE_INDEX_NAME, RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 );
+	}
+
+	private static void forEachTypeDescriptor(Consumer<FieldTypeDescriptor<?>> action) {
+		FieldTypeDescriptor.getAll().stream()
+				.filter( typeDescriptor -> typeDescriptor.getMatchPredicateExpectations().isPresent() )
+				.forEach( action );
+	}
+
+	private static void mapByTypeFields(IndexSchemaElement parent, String prefix,
+			FieldModelConsumer<Void, ByTypeFieldModel> consumer) {
+		forEachTypeDescriptor( typeDescriptor -> {
+			ByTypeFieldModel fieldModel = ByTypeFieldModel.mapper( typeDescriptor )
+					.map( parent, prefix + typeDescriptor.getUniqueName() );
+			consumer.accept( typeDescriptor, null, fieldModel );
+		} );
+	}
+
+	private static class IndexMapping {
+		final List<ByTypeFieldModel> unsupportedFieldModels = new ArrayList<>();
+
+		final MainFieldModel analyzedStringField1;
+		final MainFieldModel analyzedStringField2;
+		final MainFieldModel analyzedStringField3;
+		final MainFieldModel analyzedStringFieldWithDslConverter;
+
+		IndexMapping(IndexSchemaElement root) {
+			mapByTypeFields(
+					root, "byType_",
+					(typeDescriptor, ignored, model) -> {
+						if ( !String.class.equals( typeDescriptor.getJavaType() ) ) {
+							unsupportedFieldModels.add( model );
+						}
+					}
+			);
+			analyzedStringField1 = MainFieldModel.mapper(
+					c -> c.asString().analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD.name )
+			)
+					.map( root, "analyzedString1" );
+			analyzedStringField2 = MainFieldModel.mapper(
+					c -> c.asString().analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD.name )
+			)
+					.map( root, "analyzedString2" );
+			analyzedStringField3 = MainFieldModel.mapper(
+					c -> c.asString().analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD.name )
+			)
+					.map( root, "analyzedString3" );
+			analyzedStringFieldWithDslConverter = MainFieldModel.mapper(
+					c -> c.asString().analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD.name )
+							.dslConverter( ValueWrapper.toIndexFieldConverter() )
+			)
+					.map( root, "analyzedStringWithDslConverter" );
+		}
+	}
+
+	private static class OtherIndexMapping {
+		static OtherIndexMapping createCompatible(IndexSchemaElement root) {
+			return new OtherIndexMapping(
+					MainFieldModel.mapper(
+							c -> c.asString().analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD.name )
+					)
+							.map( root, "analyzedString1" )
+			);
+		}
+
+		static OtherIndexMapping createRawFieldCompatible(IndexSchemaElement root) {
+			return new OtherIndexMapping(
+					MainFieldModel.mapper(
+							c -> c.asString().analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD.name )
+									// Using a different DSL converter
+									.dslConverter( ValueWrapper.toIndexFieldConverter() )
+					)
+							.map( root, "analyzedString1" )
+			);
+		}
+
+		static OtherIndexMapping createIncompatible(IndexSchemaElement root) {
+			return new OtherIndexMapping(
+					MainFieldModel.mapper(
+							// Using a different analyzer/normalizer
+							c -> c.asString().normalizer( DefaultAnalysisDefinitions.NORMALIZER_LOWERCASE.name )
+					)
+							.map( root, "analyzedString1" )
+			);
+		}
+
+		final MainFieldModel analyzedStringField1;
+
+		private OtherIndexMapping(MainFieldModel analyzedStringField1) {
+			this.analyzedStringField1 = analyzedStringField1;
+		}
+	}
+
+	private static class MainFieldModel {
+		static StandardFieldMapper<String, MainFieldModel> mapper(
+				Function<IndexFieldTypeFactoryContext, StandardIndexFieldTypeContext<?, String>> configuration) {
+			return StandardFieldMapper.of(
+					configuration,
+					(accessor, name) -> new MainFieldModel( accessor, name )
+			);
+		}
+
+		final IndexFieldAccessor<String> accessor;
+		final String relativeFieldName;
+
+		private MainFieldModel(IndexFieldAccessor<String> accessor, String relativeFieldName) {
+			this.accessor = accessor;
+			this.relativeFieldName = relativeFieldName;
+		}
+	}
+
+	private static class ByTypeFieldModel {
+		static <F> StandardFieldMapper<F, ByTypeFieldModel> mapper(FieldTypeDescriptor<F> typeDescriptor) {
+			return StandardFieldMapper.of(
+					typeDescriptor::configure,
+					(accessor, name) -> new ByTypeFieldModel( name )
+			);
+		}
+
+		final String relativeFieldName;
+
+		private ByTypeFieldModel(String relativeFieldName) {
+			this.relativeFieldName = relativeFieldName;
+		}
+	}
+
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/CompositeSearchProjectionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/CompositeSearchProjectionIT.java
@@ -66,7 +66,7 @@ public class CompositeSearchProjectionIT {
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> this.indexMapping = new IndexMapping( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/FieldSearchProjectionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/FieldSearchProjectionIT.java
@@ -80,22 +80,22 @@ public class FieldSearchProjectionIT {
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> this.indexMapping = new IndexMapping( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)
 				.withIndex(
-						"CompatibleMappedType", COMPATIBLE_INDEX_NAME,
+						COMPATIBLE_INDEX_NAME,
 						ctx -> this.compatibleIndexMapping = new IndexMapping( ctx.getSchemaElement() ),
 						indexManager -> this.compatibleIndexManager = indexManager
 				)
 				.withIndex(
-						"MappedTypeWithIncompatibleFieldProjectionConverters", RAW_FIELD_COMPATIBLE_INDEX_NAME,
+						RAW_FIELD_COMPATIBLE_INDEX_NAME,
 						ctx -> new IncompatibleFieldProjectionConvertersIndexMapping( ctx.getSchemaElement() ),
 						indexManager -> this.rawFieldCompatibleIndexManager = indexManager
 				)
 				.withIndex(
-						"MappedTypeWithIncompatibleFieldTypes", INCOMPATIBLE_INDEX_NAME,
+						INCOMPATIBLE_INDEX_NAME,
 						ctx -> new IncompatibleFieldTypesIndexMapping( ctx.getSchemaElement() ),
 						indexManager -> this.incompatibleIndexManager = indexManager
 				)

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/SearchProjectionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/SearchProjectionIT.java
@@ -77,7 +77,7 @@ public class SearchProjectionIT {
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> this.indexMapping = new IndexMapping( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSearchSortIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSearchSortIT.java
@@ -98,22 +98,22 @@ public class FieldSearchSortIT {
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> this.indexMapping = new IndexMapping( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)
 				.withIndex(
-						"CompatibleMappedType", COMPATIBLE_INDEX_NAME,
+						COMPATIBLE_INDEX_NAME,
 						ctx -> this.compatibleIndexMapping = new IndexMapping( ctx.getSchemaElement() ),
 						indexManager -> this.compatibleIndexManager = indexManager
 				)
 				.withIndex(
-						RAW_FIELD_COMPATIBLE_INDEX_NAME + "Type", RAW_FIELD_COMPATIBLE_INDEX_NAME,
+						RAW_FIELD_COMPATIBLE_INDEX_NAME,
 						ctx -> this.rawFieldCompatibleIndexMapping = new RawFieldCompatibleIndexMapping( ctx.getSchemaElement() ),
 						indexManager -> this.rawFieldCompatibleIndexManager = indexManager
 				)
 				.withIndex(
-						INCOMPATIBLE_INDEX_NAME + "Type", INCOMPATIBLE_INDEX_NAME,
+						INCOMPATIBLE_INDEX_NAME,
 						ctx -> new IncompatibleIndexMapping( ctx.getSchemaElement() ),
 						indexManager -> this.incompatibleIndexManager = indexManager
 				)

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/SearchSortIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/SearchSortIT.java
@@ -76,7 +76,7 @@ public class SearchSortIT {
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/AbstractSpatialWithinSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/AbstractSpatialWithinSearchPredicateIT.java
@@ -53,7 +53,7 @@ public abstract class AbstractSpatialWithinSearchPredicateIT {
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/FieldModelConsumer.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/FieldModelConsumer.java
@@ -1,0 +1,13 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.tck.testsupport.types;
+
+public interface FieldModelConsumer<E, M> {
+
+	void accept(FieldTypeDescriptor<?> typeDescriptor, E expectations, M fieldModel);
+
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/rule/SearchSetupHelper.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/rule/SearchSetupHelper.java
@@ -113,6 +113,11 @@ public class SearchSetupHelper implements TestRule {
 			);
 		}
 
+		public SetupContext withIndex(String rawIndexName,
+				Consumer<IndexModelBindingContext> mappingContributor, IndexSetupListener listener) {
+			return withIndex( rawIndexName + "_Type", rawIndexName, mappingContributor, listener );
+		}
+
 		public SetupContext withIndex(String typeName, String rawIndexName,
 				Consumer<IndexModelBindingContext> mappingContributor, IndexSetupListener listener) {
 			indexDefinitions.add( new IndexDefinition( typeName, rawIndexName, mappingContributor, listener ) );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexDocumentWorkExecutorIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexDocumentWorkExecutorIT.java
@@ -48,7 +48,7 @@ public class IndexDocumentWorkExecutorIT {
 	public void before() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkExecutorIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkExecutorIT.java
@@ -59,7 +59,7 @@ public class IndexWorkExecutorIT {
 	public void runOptimizePurgeAndFlushInSequence() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)
@@ -85,7 +85,7 @@ public class IndexWorkExecutorIT {
 	public void runOptimizePurgeAndFlushWithMultiTenancy() {
 		setupHelper.withConfiguration( CONFIGURATION_ID )
 				.withIndex(
-						"MappedType", INDEX_NAME,
+						INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)

--- a/legacy/engine/src/test/java/org/hibernate/search/test/dsl/DSLTest.java
+++ b/legacy/engine/src/test/java/org/hibernate/search/test/dsl/DSLTest.java
@@ -40,6 +40,7 @@ import org.hibernate.search.query.dsl.BooleanJunction;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.query.dsl.impl.ConnectedTermMatchingContext;
 import org.hibernate.search.testsupport.TestForIssue;
+import org.hibernate.search.testsupport.junit.PortedToSearch6;
 import org.hibernate.search.testsupport.junit.SearchFactoryHolder;
 import org.hibernate.search.testsupport.junit.SearchITHelper;
 import org.hibernate.search.testsupport.junit.SkipOnElasticsearch;
@@ -637,6 +638,7 @@ public class DSLTest {
 	}
 
 	@Test
+	@Category(PortedToSearch6.class)
 	public void testPhraseQuery() throws Exception {
 		final QueryBuilder monthQb = helper.queryBuilder( Month.class );
 

--- a/legacy/engine/src/test/java/org/hibernate/search/test/dsl/DSLTest.java
+++ b/legacy/engine/src/test/java/org/hibernate/search/test/dsl/DSLTest.java
@@ -177,6 +177,7 @@ public class DSLTest {
 	}
 
 	@Test
+	@Category(PortedToSearch6.class)
 	public void testFuzzyQuery() throws Exception {
 		final QueryBuilder monthQb = helper.queryBuilder( Month.class );
 
@@ -195,6 +196,7 @@ public class DSLTest {
 	}
 
 	@Test
+	@Category(PortedToSearch6.class)
 	public void testFuzzyQueryOnMultipleFields() throws Exception {
 		final QueryBuilder monthQb = helper.queryBuilder( Month.class );
 

--- a/legacy/engine/src/test/java/org/hibernate/search/test/dsl/SimpleQueryStringDSLTest.java
+++ b/legacy/engine/src/test/java/org/hibernate/search/test/dsl/SimpleQueryStringDSLTest.java
@@ -15,11 +15,13 @@ import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.test.dsl.DSLTest.MappingFactory;
 import org.hibernate.search.testsupport.TestForIssue;
+import org.hibernate.search.testsupport.junit.PortedToSearch6;
 import org.hibernate.search.testsupport.junit.SearchFactoryHolder;
 import org.hibernate.search.testsupport.junit.SearchITHelper;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 
 /**
@@ -42,6 +44,7 @@ public class SimpleQueryStringDSLTest {
 
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-2678")
+	@Category(PortedToSearch6.class)
 	public void testSimpleQueryString() {
 		QueryBuilder qb = getCoffeeQueryBuilder();
 
@@ -83,6 +86,7 @@ public class SimpleQueryStringDSLTest {
 
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-2678")
+	@Category(PortedToSearch6.class)
 	public void testBoost() {
 		QueryBuilder qb = getCoffeeQueryBuilder();
 
@@ -109,6 +113,7 @@ public class SimpleQueryStringDSLTest {
 
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-2678")
+	@Category(PortedToSearch6.class)
 	public void testFuzzy() {
 		QueryBuilder qb = getCoffeeQueryBuilder();
 
@@ -125,6 +130,7 @@ public class SimpleQueryStringDSLTest {
 
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-2678")
+	@Category(PortedToSearch6.class)
 	public void testAnalyzer() {
 		QueryBuilder qb = getBookQueryBuilder();
 
@@ -165,6 +171,7 @@ public class SimpleQueryStringDSLTest {
 	}
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-2700")
+	@Category(PortedToSearch6.class)
 	public void testNullQueryString() {
 		QueryBuilder qb = getCoffeeQueryBuilder();
 
@@ -181,6 +188,7 @@ public class SimpleQueryStringDSLTest {
 
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-2700")
+	@Category(PortedToSearch6.class)
 	public void testEmptyQueryString() {
 		QueryBuilder qb = getCoffeeQueryBuilder();
 
@@ -197,6 +205,7 @@ public class SimpleQueryStringDSLTest {
 
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-2700")
+	@Category(PortedToSearch6.class)
 	public void testBlankQueryString() {
 		QueryBuilder qb = getCoffeeQueryBuilder();
 

--- a/pom.xml
+++ b/pom.xml
@@ -741,6 +741,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-queryparser</artifactId>
+                <version>${version.org.apache.lucene}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.lucene</groupId>
                 <artifactId>lucene-join</artifactId>
                 <version>${version.org.apache.lucene}</version>
             </dependency>

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubPredicateBuilder.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubPredicateBuilder.java
@@ -13,6 +13,7 @@ import org.hibernate.search.engine.search.predicate.spi.MatchPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.NestedPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.RangePredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.SimpleQueryStringPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinBoundingBoxPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinCirclePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinPolygonPredicateBuilder;
@@ -27,6 +28,7 @@ public class StubPredicateBuilder implements MatchAllPredicateBuilder<StubPredic
 		MatchPredicateBuilder<StubPredicateBuilder>,
 		RangePredicateBuilder<StubPredicateBuilder>,
 		PhrasePredicateBuilder<StubPredicateBuilder>,
+		SimpleQueryStringPredicateBuilder<StubPredicateBuilder>,
 		NestedPredicateBuilder<StubPredicateBuilder>,
 		SpatialWithinCirclePredicateBuilder<StubPredicateBuilder>,
 		SpatialWithinPolygonPredicateBuilder<StubPredicateBuilder>,
@@ -109,6 +111,21 @@ public class StubPredicateBuilder implements MatchAllPredicateBuilder<StubPredic
 	}
 
 	@Override
+	public FieldContext field(String absoluteFieldPath) {
+		return new StubFieldContext();
+	}
+
+	@Override
+	public void withAndAsDefaultOperator() {
+		// No-op
+	}
+
+	@Override
+	public void simpleQueryString(String simpleQueryString) {
+		// No-op
+	}
+
+	@Override
 	public void boost(float boost) {
 		// No-op
 	}
@@ -140,6 +157,14 @@ public class StubPredicateBuilder implements MatchAllPredicateBuilder<StubPredic
 
 	void simulateBuild() {
 		// No-op, just simulates a call on this object
+	}
+
+	private static class StubFieldContext implements SimpleQueryStringPredicateBuilder.FieldContext {
+
+		@Override
+		public void boost(float boost) {
+			// No-op
+		}
 	}
 
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubPredicateBuilder.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubPredicateBuilder.java
@@ -11,6 +11,7 @@ import org.hibernate.search.engine.search.predicate.spi.MatchAllPredicateBuilder
 import org.hibernate.search.engine.search.predicate.spi.MatchIdPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.MatchPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.NestedPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.RangePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinBoundingBoxPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinCirclePredicateBuilder;
@@ -25,6 +26,7 @@ public class StubPredicateBuilder implements MatchAllPredicateBuilder<StubPredic
 		MatchIdPredicateBuilder<StubPredicateBuilder>,
 		MatchPredicateBuilder<StubPredicateBuilder>,
 		RangePredicateBuilder<StubPredicateBuilder>,
+		PhrasePredicateBuilder<StubPredicateBuilder>,
 		NestedPredicateBuilder<StubPredicateBuilder>,
 		SpatialWithinCirclePredicateBuilder<StubPredicateBuilder>,
 		SpatialWithinPolygonPredicateBuilder<StubPredicateBuilder>,
@@ -88,6 +90,16 @@ public class StubPredicateBuilder implements MatchAllPredicateBuilder<StubPredic
 
 	@Override
 	public void excludeUpperLimit() {
+		// No-op
+	}
+
+	@Override
+	public void slop(int slop) {
+		// No-op
+	}
+
+	@Override
+	public void phrase(String phrase) {
 		// No-op
 	}
 

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubPredicateBuilder.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubPredicateBuilder.java
@@ -17,6 +17,7 @@ import org.hibernate.search.engine.search.predicate.spi.SimpleQueryStringPredica
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinBoundingBoxPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinCirclePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SpatialWithinPolygonPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.WildcardPredicateBuilder;
 import org.hibernate.search.engine.spatial.DistanceUnit;
 import org.hibernate.search.engine.spatial.GeoBoundingBox;
 import org.hibernate.search.engine.spatial.GeoPoint;
@@ -28,6 +29,7 @@ public class StubPredicateBuilder implements MatchAllPredicateBuilder<StubPredic
 		MatchPredicateBuilder<StubPredicateBuilder>,
 		RangePredicateBuilder<StubPredicateBuilder>,
 		PhrasePredicateBuilder<StubPredicateBuilder>,
+		WildcardPredicateBuilder<StubPredicateBuilder>,
 		SimpleQueryStringPredicateBuilder<StubPredicateBuilder>,
 		NestedPredicateBuilder<StubPredicateBuilder>,
 		SpatialWithinCirclePredicateBuilder<StubPredicateBuilder>,
@@ -107,6 +109,11 @@ public class StubPredicateBuilder implements MatchAllPredicateBuilder<StubPredic
 
 	@Override
 	public void phrase(String phrase) {
+		// No-op
+	}
+
+	@Override
+	public void pattern(String wildcardPattern) {
 		// No-op
 	}
 

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubPredicateBuilder.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubPredicateBuilder.java
@@ -69,6 +69,11 @@ public class StubPredicateBuilder implements MatchAllPredicateBuilder<StubPredic
 	}
 
 	@Override
+	public void fuzzy(int maxEditDistance, int exactPrefixLength) {
+		// No-op
+	}
+
+	@Override
 	public void value(Object value) {
 		// No-op
 	}

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubSearchPredicateBuilderFactory.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubSearchPredicateBuilderFactory.java
@@ -9,6 +9,7 @@ package org.hibernate.search.util.impl.integrationtest.common.stub.backend.searc
 import org.hibernate.search.engine.search.predicate.spi.DslConverter;
 import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.SimpleQueryStringPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.WildcardPredicateBuilder;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.StubQueryElementCollector;
 import org.hibernate.search.engine.search.SearchPredicate;
 import org.hibernate.search.engine.search.predicate.spi.MatchAllPredicateBuilder;
@@ -68,6 +69,11 @@ public class StubSearchPredicateBuilderFactory
 
 	@Override
 	public PhrasePredicateBuilder<StubPredicateBuilder> phrase(String absoluteFieldPath) {
+		return new StubPredicateBuilder();
+	}
+
+	@Override
+	public WildcardPredicateBuilder<StubPredicateBuilder> wildcard(String absoluteFieldPath) {
 		return new StubPredicateBuilder();
 	}
 

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubSearchPredicateBuilderFactory.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubSearchPredicateBuilderFactory.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.predicate.impl;
 
 import org.hibernate.search.engine.search.predicate.spi.DslConverter;
+import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.StubQueryElementCollector;
 import org.hibernate.search.engine.search.SearchPredicate;
 import org.hibernate.search.engine.search.predicate.spi.MatchAllPredicateBuilder;
@@ -61,6 +62,11 @@ public class StubSearchPredicateBuilderFactory
 
 	@Override
 	public RangePredicateBuilder<StubPredicateBuilder> range(String absoluteFieldPath, DslConverter dslConverter) {
+		return new StubPredicateBuilder();
+	}
+
+	@Override
+	public PhrasePredicateBuilder<StubPredicateBuilder> phrase(String absoluteFieldPath) {
 		return new StubPredicateBuilder();
 	}
 

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubSearchPredicateBuilderFactory.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubSearchPredicateBuilderFactory.java
@@ -8,6 +8,7 @@ package org.hibernate.search.util.impl.integrationtest.common.stub.backend.searc
 
 import org.hibernate.search.engine.search.predicate.spi.DslConverter;
 import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.SimpleQueryStringPredicateBuilder;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.StubQueryElementCollector;
 import org.hibernate.search.engine.search.SearchPredicate;
 import org.hibernate.search.engine.search.predicate.spi.MatchAllPredicateBuilder;
@@ -67,6 +68,11 @@ public class StubSearchPredicateBuilderFactory
 
 	@Override
 	public PhrasePredicateBuilder<StubPredicateBuilder> phrase(String absoluteFieldPath) {
+		return new StubPredicateBuilder();
+	}
+
+	@Override
+	public SimpleQueryStringPredicateBuilder<StubPredicateBuilder> simpleQueryString() {
 		return new StubPredicateBuilder();
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3089

Waiting for HSEARCH-3256 (#1902), I will probably have to make some change to rebase on that PR.

Also requires #1904 .