### PR TITLE
HSEARCH-3508 test against JDK11 regularly on branch 5.10

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -157,7 +157,6 @@ stage('Configure') {
 					// This should not include every JDK; in particular let's not care too much about EOL'd JDKs like version 9
 					// See http://www.oracle.com/technetwork/java/javase/eol-135779.html
 					new JdkITEnvironment(version: '8', tool: 'Oracle JDK 8', status: ITEnvironmentStatus.USED_IN_DEFAULT_BUILD),
-					new JdkITEnvironment(version: '10', tool: 'Oracle JDK 10.0.1', status: ITEnvironmentStatus.SUPPORTED),
 					new JdkITEnvironment(version: '11', tool: 'OpenJDK 11 Latest', status: ITEnvironmentStatus.SUPPORTED)
 			],
 			database: [

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,8 +158,7 @@ stage('Configure') {
 					// See http://www.oracle.com/technetwork/java/javase/eol-135779.html
 					new JdkITEnvironment(version: '8', tool: 'Oracle JDK 8', status: ITEnvironmentStatus.USED_IN_DEFAULT_BUILD),
 					new JdkITEnvironment(version: '10', tool: 'Oracle JDK 10.0.1', status: ITEnvironmentStatus.SUPPORTED),
-					// TODO HSEARCH-3238 (and maybe more) to support JDK11 builds
-					new JdkITEnvironment(version: '11', tool: 'OpenJDK 11 Latest', status: ITEnvironmentStatus.EXPERIMENTAL)
+					new JdkITEnvironment(version: '11', tool: 'OpenJDK 11 Latest', status: ITEnvironmentStatus.SUPPORTED)
 			],
 			database: [
 					new DatabaseITEnvironment(dbName: 'h2', mavenProfile: 'h2', status: ITEnvironmentStatus.USED_IN_DEFAULT_BUILD),

--- a/integrationtest/osgi/karaf-it/pom.xml
+++ b/integrationtest/osgi/karaf-it/pom.xml
@@ -171,6 +171,7 @@
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
+                    <skip>${failsafe.osgi.skip}</skip>
                     <systemPropertyVariables>
                         <maven.settings.localRepository>${settings.localRepository}</maven.settings.localRepository>
                         <maven.jboss.public.repo.url>${jboss.public.repo.url}</maven.jboss.public.repo.url>

--- a/integrationtest/performance/orm/pom.xml
+++ b/integrationtest/performance/orm/pom.xml
@@ -196,6 +196,34 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <skip>${failsafe.wildfly.skip}</skip>
+                    <includes>
+                        <include>**/Test*.java</include>
+                        <include>**/*Test.java</include>
+                        <include>**/*Tests.java</include>
+                        <include>**/*TestCase.java</include>
+                    </includes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
             <plugin>

--- a/integrationtest/wildfly/pom.xml
+++ b/integrationtest/wildfly/pom.xml
@@ -277,6 +277,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <skip>${failsafe.wildfly.skip}</skip>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -398,6 +398,9 @@
         <surefire.jvm.args>${surefire.jvm.args.memory} ${surefire.jvm.args.java-version} ${surefire.jvm.args.jacoco}</surefire.jvm.args>
         <failsafe.jvm.args>${surefire.jvm.args.memory} ${surefire.jvm.args.java-version} ${failsafe.jvm.args.jacoco}</failsafe.jvm.args>
 
+        <failsafe.wildfly.skip>false</failsafe.wildfly.skip>
+        <failsafe.osgi.skip>false</failsafe.osgi.skip>
+
         <!--
             Should be set by submodules.
             Used by integration tests modules that execute tests from another module.
@@ -2052,6 +2055,9 @@
                 <arquillian.wildfly.jvm.args.java-version>
                     -Djdk.attach.allowAttachSelf=true
                 </arquillian.wildfly.jvm.args.java-version>
+                <!-- Skip the OSGi and WildFly integration tests with JDK 11 -->
+                <failsafe.wildfly.skip>true</failsafe.wildfly.skip>
+                <failsafe.osgi.skip>true</failsafe.osgi.skip>
             </properties>
             <modules>
                 <module>integrationtest/jdk9-modules</module>

--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@
         <version.org.jboss.arquillian>1.1.11.Final</version.org.jboss.arquillian>
         <version.org.jboss.shrinkwrap.resolver>2.2.2</version.org.jboss.shrinkwrap.resolver>
         <version.org.wildfly.arquillian>2.0.0.Final</version.org.wildfly.arquillian>
-        <version.org.springframework.boot>1.5.3.RELEASE</version.org.springframework.boot>
+        <version.org.springframework.boot>2.1.0.RELEASE</version.org.springframework.boot>
         <version.org.apache.karaf>4.2.1</version.org.apache.karaf>
         <version.org.ops4j.pax.exam>4.12.0</version.org.ops4j.pax.exam>
         <version.org.ops4j.pax.url>2.5.4</version.org.ops4j.pax.url>

--- a/pom.xml
+++ b/pom.xml
@@ -2063,6 +2063,7 @@
                 </surefire.jvm.args.java-version.strict>
                 <arquillian.wildfly.jvm.args.java-version>
                     -Djdk.attach.allowAttachSelf=true
+                    --add-modules=java.se
                 </arquillian.wildfly.jvm.args.java-version>
                 <!-- Skip the OSGi and WildFly integration tests with JDK 11 -->
                 <failsafe.wildfly.skip>true</failsafe.wildfly.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -1653,14 +1653,17 @@
                                      <bundledSignature>jdk-unsafe-1.8</bundledSignature>
                                      <bundledSignature>jdk-unsafe-9</bundledSignature>
                                      <bundledSignature>jdk-unsafe-10</bundledSignature>
+                                     <bundledSignature>jdk-unsafe-11</bundledSignature>
 
                                      <bundledSignature>jdk-deprecated-1.8</bundledSignature>
                                      <bundledSignature>jdk-deprecated-9</bundledSignature>
                                      <bundledSignature>jdk-deprecated-10</bundledSignature>
+                                     <bundledSignature>jdk-deprecated-11</bundledSignature>
 
                                      <bundledSignature>jdk-internal-1.8</bundledSignature>
                                      <bundledSignature>jdk-internal-9</bundledSignature>
                                      <bundledSignature>jdk-internal-10</bundledSignature>
+                                     <bundledSignature>jdk-internal-11</bundledSignature>
                                  </bundledSignatures>
                                  <failOnMissingClasses>false</failOnMissingClasses>
                                  <failOnUnresolvableSignatures>false</failOnUnresolvableSignatures>

--- a/pom.xml
+++ b/pom.xml
@@ -314,7 +314,7 @@
         <version.deploy.plugin>2.8.2</version.deploy.plugin>
         <version.org.eclipse.m2e.lifecycle-mapping>1.0.0</version.org.eclipse.m2e.lifecycle-mapping>
         <version.enforcer.plugin>3.0.0-M1</version.enforcer.plugin>
-        <version.forbiddenapis.plugin>2.5</version.forbiddenapis.plugin>
+        <version.forbiddenapis.plugin>2.6</version.forbiddenapis.plugin>
         <version.help.plugin>2.2</version.help.plugin>
         <version.install.plugin>2.5.2</version.install.plugin>
         <version.japicmp.plugin>0.9.3</version.japicmp.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -356,7 +356,7 @@
         <!-- JBoss public repository -->
 
         <jboss.public.repo.id>jboss-public-repository-group</jboss.public.repo.id>
-        <jboss.public.repo.url>https://repository.jboss.org/nexus/content/groups/public-jboss/</jboss.public.repo.url>
+        <jboss.public.repo.url>http://repository.jboss.org/nexus/content/groups/public-jboss/</jboss.public.repo.url>
 
         <!-- Repository Deployment URLs -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -2048,9 +2048,18 @@
                     -Djdk.attach.allowAttachSelf=true
                     -Dcom.sun.xml.bind.v2.bytecode.ClassTailor.noOptimize=true
                 </surefire.jvm.args.java-version.lenient>
+                <!--
+                     When we use illegal-access=deny,
+                     we have to open the java.lang package to EasyMock,
+                     because cglib (used by EasyMock) requires to execute setAccessible(true)
+                     on ClassLoader.defineClass(...).
+                     See https://github.com/easymock/easymock/issues/235
+                     See https://hibernate.atlassian.net/browse/HSEARCH-3419
+                 -->
                 <surefire.jvm.args.java-version.strict>
                     ${surefire.jvm.args.java-version.lenient}
                     --illegal-access=deny
+                    --add-opens java.base/java.lang=ALL-UNNAMED
                 </surefire.jvm.args.java-version.strict>
                 <arquillian.wildfly.jvm.args.java-version>
                     -Djdk.attach.allowAttachSelf=true


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3508

Backports:

* https://hibernate.atlassian.net//browse/HSEARCH-3238
* https://hibernate.atlassian.net//browse/HSEARCH-3420

I just launched a full build: http://ci.hibernate.org/blue/organizations/jenkins/hibernate-search/detail/PR-1905/4/pipeline
