### PR TITLE
HSEARCH-3509 Document the limitations of the date/time conversion in the Pojo mapper for java.util.Calendar and java.util.Date

### DIFF
--- a/documentation/src/main/asciidoc/mapper-orm-mapping.asciidoc
+++ b/documentation/src/main/asciidoc/mapper-orm-mapping.asciidoc
@@ -292,8 +292,8 @@ or <<backend-elasticsearch-field-types,Elasticsearch field types>> depending on 
 |java.time.Year|-
 |java.time.YearMonth|-
 |java.time.MonthDay|-
-|java.util.Calendar|A `java.time.ZonedDateTime` representing the same date/time and timezone.
-|java.util.Date|`toInstant()` as a `java.time.Instant`
+|java.util.Calendar|A `java.time.ZonedDateTime` representing the same date/time and timezone; see <<mapper-orm-legacy-date-time-apis>>
+|java.util.Date|`toInstant()` as a `java.time.Instant`; see <<mapper-orm-legacy-date-time-apis>>
 |java.util.UUID|`toString()` as a `java.lang.String`
 |====
 
@@ -334,6 +334,69 @@ along with the value of the document identifier, i.e. the value passed to the un
 
 [[mapper-orm-bridge-routingkeybridge]]
 === Routing key bridges
+
+include::todo-placeholder.asciidoc[]
+
+[[mapper-orm-legacy-date-time-apis]]
+=== Support for legacy date/time APIs
+
+Using legacy date/time types such as `java.util.Calendar` or `java.util.Date` is not recommended,
+due to their numerous quirks and shortcomings.
+The https://docs.oracle.com/javase/8/docs/api/java/time/package-summary.html[`java.time`] package introduced
+in Java 8 should generally be preferred.
+
+That being said, integration constraints may force you to rely on the legacy date/time APIs,
+which is why Hibernate Search still attempts to support them on a best effort basis.
+
+Since Hibernate Search uses the `java.time` APIs to represent date/time internally,
+the legacy date/time types need to be converted before they can be indexed.
+Hibernate Search keeps things simple:
+`java.util.Date`, `java.util.Calendar`, etc. will be converted using their time-value (number of milliseconds since the epoch),
+which will be assumed to represent the same date/time in Java 8 APIs.
+In the case of `java.util.Calendar`, timezone information will be preserved for projections.
+
+For all dates after 1900, this will work exactly as expected.
+
+Before 1900, indexing and searching through Hibernate Search APIs will also work as expected,
+but *if you need to access the index natively*, for example through direct HTTP calls to an Elasticsearch server,
+you will notice that the indexed values are slightly "off".
+This is caused by differences in the implementation of `java.time` and legacy date/time APIs
+which lead to slight differences in the interpretation of time-values (number of milliseconds since the epoch).
+
+The "drifts" are consistent: they will also happen when building a predicate,
+and they will happen in the opposite direction when projecting.
+As a result, the differences will not be visible from an application relying on the Hibernate Search APIs exclusively.
+They will, however, be visible when accessing indexes natively.
+
+For the large majority of use cases, this will not be a problem.
+If this behavior is not acceptable for your application,
+you should look into implementing custom <<mapper-orm-bridge-valuebridge,value bridges>>
+and instructing Hibernate Search to use them by default for `java.util.Date`, `java.util.Calendar`, etc.:
+see <<mapper-orm-bridge-resolver>>.
+
+[TIP]
+====
+Technically, conversions are difficult because the `java.time` APIs
+and the legacy date/time APIs do not have the same internal calendar.
+
+In particular:
+
+* `java.time` assumes a "Local Mean Time" before 1900, while legacy date/time APIs do not support it
+(https://bugs.openjdk.java.net/browse/JDK-6281408[JDK-6281408]),
+As a result, time values (number of milliseconds since the epoch) reported by the two APIs
+will be different for dates before 1900.
+* `java.time` uses a proleptic Gregorian calendar before October 15, 1582,
+meaning it acts as if the Gregorian calendar, along with its system of leap years, had always existed.
+Legacy date/time APIs, on the other hand, use the Julian calendar before that date (by default),
+meaning the leap years are not exactly the same ones.
+As a result, some dates that are deemed valid by one API will be deemed invalid by the other,
+for example February 29, 1500.
+
+Those are the two main problems, but there may be others.
+====
+
+[[mapper-orm-bridge-resolver]]
+=== Default bridge resolver
 
 include::todo-placeholder.asciidoc[]
 

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/JavaUtilCalendarPropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/JavaUtilCalendarPropertyTypeDescriptor.java
@@ -61,6 +61,8 @@ public class JavaUtilCalendarPropertyTypeDescriptor extends PropertyTypeDescript
 
 						// A february 29th on a leap year
 						calendar( 2000, 2, 29, 12, 0, 0, 0, "UTC" ),
+						// A february 29th on a leap year in the Julian calendar (java.util), but not the Gregorian calendar (java.time)
+						calendar( 1500, 2, 29, 12, 0, 0, 0, "UTC" ),
 
 						// Two date/times that could be ambiguous due to a daylight saving time switch
 						calendar(
@@ -87,10 +89,11 @@ public class JavaUtilCalendarPropertyTypeDescriptor extends PropertyTypeDescript
 						zonedDateTime( Long.MAX_VALUE, "UTC" ),
 						zonedDateTime( Long.MAX_VALUE, "GMT-18:00" ),
 
-						// a february 29th on a leap year
 						zonedDateTime( "2000-02-29T12:00:00.00", "UTC" ),
+						// The Julian calendar is 10 days late at this point
+						// See https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar#Difference_between_Julian_and_proleptic_Gregorian_calendar_dates
+						zonedDateTime( "1500-03-10T12:00:00.00", "UTC" ),
 
-						// Two date/times that could be ambiguous due to a daylight saving time switch
 						zonedDateTime( "2011-10-30T02:50:00.00", "CET" ).withEarlierOffsetAtOverlap(),
 						zonedDateTime( "2011-10-30T02:50:00.00", "CET" ).withLaterOffsetAtOverlap()
 				);

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/JavaUtilDatePropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/JavaUtilDatePropertyTypeDescriptor.java
@@ -8,9 +8,13 @@ package org.hibernate.search.integrationtest.mapper.pojo.testsupport.types;
 
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
+import java.util.TimeZone;
 
 import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultIdentifierBridgeExpectations;
 import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultValueBridgeExpectations;
@@ -45,11 +49,11 @@ public class JavaUtilDatePropertyTypeDescriptor extends PropertyTypeDescriptor<D
 			@Override
 			public List<Date> getEntityPropertyValues() {
 				return Arrays.asList(
-						new Date( Long.MIN_VALUE ),
-						date( "1970-01-01T00:00:00.00Z" ),
-						date( "1970-01-09T13:28:59.00Z" ),
-						date( "2017-11-06T19:19:00.54Z" ),
-						new Date( Long.MAX_VALUE )
+						date( Long.MIN_VALUE ),
+						date( 1970, 1, 1, 0, 0, 0, 0 ),
+						date( 1970, 1, 9, 13, 28, 59, 0 ),
+						date( 2017, 11, 6, 19, 19, 0, 540 ),
+						date( Long.MAX_VALUE )
 				);
 			}
 
@@ -84,8 +88,16 @@ public class JavaUtilDatePropertyTypeDescriptor extends PropertyTypeDescriptor<D
 		} );
 	}
 
-	private static Date date(String toParse) {
-		return Date.from( Instant.parse( toParse ) );
+	private static Date date(long epochMilli) {
+		return new Date( epochMilli );
+	}
+
+	private static Date date(int year, int month, int day, int hour, int minute, int second, int millisecond) {
+		Calendar calendar = new GregorianCalendar( TimeZone.getTimeZone( "UTC" ), Locale.ROOT );
+		calendar.clear();
+		calendar.set( year, month - 1, day, hour, minute, second );
+		calendar.set( Calendar.MILLISECOND, millisecond );
+		return calendar.getTime();
 	}
 
 	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_1_INDEX_NAME)

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/JavaUtilDatePropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/JavaUtilDatePropertyTypeDescriptor.java
@@ -53,7 +53,12 @@ public class JavaUtilDatePropertyTypeDescriptor extends PropertyTypeDescriptor<D
 						date( 1970, 1, 1, 0, 0, 0, 0 ),
 						date( 1970, 1, 9, 13, 28, 59, 0 ),
 						date( 2017, 11, 6, 19, 19, 0, 540 ),
-						date( Long.MAX_VALUE )
+						date( Long.MAX_VALUE ),
+
+						// A february 29th on a leap year
+						date( 2000, 2, 29, 12, 0, 0, 0 ),
+						// A february 29th on a leap year in the Julian calendar (java.util), but not the Gregorian calendar (java.time)
+						date( 1500, 2, 29, 12, 0, 0, 0 )
 				);
 			}
 
@@ -64,7 +69,12 @@ public class JavaUtilDatePropertyTypeDescriptor extends PropertyTypeDescriptor<D
 						Instant.parse( "1970-01-01T00:00:00.00Z" ),
 						Instant.parse( "1970-01-09T13:28:59.00Z" ),
 						Instant.parse( "2017-11-06T19:19:00.54Z" ),
-						Instant.ofEpochMilli( Long.MAX_VALUE )
+						Instant.ofEpochMilli( Long.MAX_VALUE ),
+
+						Instant.parse( "2000-02-29T12:00:00.0Z" ),
+						// The Julian calendar is 10 days late at this point
+						// See https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar#Difference_between_Julian_and_proleptic_Gregorian_calendar_dates
+						Instant.parse( "1500-03-10T12:00:00.0Z" )
 				);
 			}
 


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3509
