### PR TITLE
HSEARCH-3512 throw an exception when the field is non projectable due to the bridge

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
@@ -460,4 +460,8 @@ public interface Log extends BasicLogger {
 	@Message(id = ID_OFFSET_3 + 53,
 			value = "Text predicates (phrase, fuzzy, wildcard, simple query string) are not supported by this field's type.")
 	SearchException textPredicatesNotSupportedByFieldType(@Param EventContext context);
+
+	@Message(id = ID_OFFSET_3 + 54, value = "Projection on field `%1$s` is not allowed, since bridge did not specify a bind back for this field. " +
+			"Please define a projection converter or use .rawField(`%1$s`) to extract the raw values bypassing the bridge.")
+	SearchException projectionConverterRequired(String absoluteFieldPath, @Param EventContext context);
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchSearchProjectionBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchSearchProjectionBuilderFactory.java
@@ -19,6 +19,7 @@ import org.hibernate.search.backend.elasticsearch.search.impl.IndexSchemaFieldNo
 import org.hibernate.search.backend.elasticsearch.types.projection.impl.ElasticsearchFieldProjectionBuilderFactory;
 import org.hibernate.search.engine.search.SearchProjection;
 import org.hibernate.search.engine.search.predicate.spi.DslConverter;
+import org.hibernate.search.engine.search.predicate.spi.ProjectionConverter;
 import org.hibernate.search.engine.search.projection.spi.CompositeProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.DistanceToFieldProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.DocumentReferenceProjectionBuilder;
@@ -57,10 +58,10 @@ public class ElasticsearchSearchProjectionBuilderFactory implements SearchProjec
 	}
 
 	@Override
-	public <T> FieldProjectionBuilder<T> field(String absoluteFieldPath, Class<T> expectedType) {
+	public <T> FieldProjectionBuilder<T> field(String absoluteFieldPath, Class<T> expectedType, ProjectionConverter projectionConverter) {
 		return searchTargetModel
 				.getSchemaNodeComponent( absoluteFieldPath, PROJECTION_BUILDER_FACTORY_RETRIEVAL_STRATEGY )
-				.createFieldValueProjectionBuilder( absoluteFieldPath, expectedType );
+				.createFieldValueProjectionBuilder( absoluteFieldPath, expectedType, projectionConverter );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/AbstractElasticsearchIndexFieldTypeConverterContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/AbstractElasticsearchIndexFieldTypeConverterContext.java
@@ -57,9 +57,8 @@ abstract class AbstractElasticsearchIndexFieldTypeConverterContext<S extends Abs
 
 	final FromDocumentFieldValueConverter<? super F, ?> createIndexToProjectionConverter() {
 		/*
-		 * TODO HSEARCH-3257 when no projection converter is configured, create a projection converter that will throw an exception
-		 * with an explicit message.
-		 * Currently we create a pass-through converter because users have no way to bypass the converter.
+		 * TODO HSEARCH-3512 Throw an exception when the field is non projectable due to the bridge.
+		 * E.g. if the field is bridged and the bridge did not specify a "FromIndexFieldValueConverter".
 		 */
 		return indexToProjectionConverter == null ? createFromDocumentRawConverter() : indexToProjectionConverter;
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/AbstractElasticsearchIndexFieldTypeConverterContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/AbstractElasticsearchIndexFieldTypeConverterContext.java
@@ -56,11 +56,18 @@ abstract class AbstractElasticsearchIndexFieldTypeConverterContext<S extends Abs
 	}
 
 	final FromDocumentFieldValueConverter<? super F, ?> createIndexToProjectionConverter() {
-		/*
-		 * TODO HSEARCH-3512 Throw an exception when the field is non projectable due to the bridge.
-		 * E.g. if the field is bridged and the bridge did not specify a "FromIndexFieldValueConverter".
-		 */
-		return indexToProjectionConverter == null ? createFromDocumentRawConverter() : indexToProjectionConverter;
+		if ( indexToProjectionConverter != null ) {
+			// this case corresponds to a two-way bridge
+			return indexToProjectionConverter;
+		}
+
+		if ( dslToIndexConverter != null ) {
+			// this case corresponds to a one-way bridge
+			return null;
+		}
+
+		// this case corresponds to no bridge
+		return createFromDocumentRawConverter();
 	}
 
 	final FromDocumentFieldValueConverter<? super F, F> createFromDocumentRawConverter() {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/AbstractElasticsearchIndexFieldTypeConverterContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/AbstractElasticsearchIndexFieldTypeConverterContext.java
@@ -48,10 +48,10 @@ abstract class AbstractElasticsearchIndexFieldTypeConverterContext<S extends Abs
 	}
 
 	final ToDocumentFieldValueConverter<?, ? extends F> createDslToIndexConverter() {
-		return dslToIndexConverter == null ? createRawConverter() : dslToIndexConverter;
+		return dslToIndexConverter == null ? createToDocumentRawConverter() : dslToIndexConverter;
 	}
 
-	final ToDocumentFieldValueConverter<F, ? extends F> createRawConverter() {
+	final ToDocumentFieldValueConverter<F, ? extends F> createToDocumentRawConverter() {
 		return new PassThroughToDocumentFieldValueConverter<>( fieldType );
 	}
 
@@ -61,7 +61,10 @@ abstract class AbstractElasticsearchIndexFieldTypeConverterContext<S extends Abs
 		 * with an explicit message.
 		 * Currently we create a pass-through converter because users have no way to bypass the converter.
 		 */
-		return indexToProjectionConverter == null ? new PassThroughFromDocumentFieldValueConverter<>( fieldType )
-				: indexToProjectionConverter;
+		return indexToProjectionConverter == null ? createFromDocumentRawConverter() : indexToProjectionConverter;
+	}
+
+	final FromDocumentFieldValueConverter<? super F, F> createFromDocumentRawConverter() {
+		return new PassThroughFromDocumentFieldValueConverter<>( fieldType );
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchBooleanIndexFieldTypeContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchBooleanIndexFieldTypeContext.java
@@ -33,9 +33,9 @@ class ElasticsearchBooleanIndexFieldTypeContext
 
 		return new ElasticsearchIndexFieldType<>(
 				codec,
-				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec ),
+				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec ),
 				mapping
 		);
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchByteIndexFieldTypeContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchByteIndexFieldTypeContext.java
@@ -33,9 +33,9 @@ class ElasticsearchByteIndexFieldTypeContext
 
 		return new ElasticsearchIndexFieldType<>(
 				codec,
-				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec ),
+				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec ),
 				mapping
 		);
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchDoubleIndexFieldTypeContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchDoubleIndexFieldTypeContext.java
@@ -33,9 +33,9 @@ class ElasticsearchDoubleIndexFieldTypeContext
 
 		return new ElasticsearchIndexFieldType<>(
 				codec,
-				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter ,createRawConverter(), codec ),
-				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec ),
+				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter , createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec ),
 				mapping
 		);
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchFloatIndexFieldTypeContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchFloatIndexFieldTypeContext.java
@@ -33,9 +33,9 @@ class ElasticsearchFloatIndexFieldTypeContext
 
 		return new ElasticsearchIndexFieldType<>(
 				codec,
-				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec ),
+				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec ),
 				mapping
 		);
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchGeoPointIndexFieldTypeContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchGeoPointIndexFieldTypeContext.java
@@ -37,7 +37,7 @@ class ElasticsearchGeoPointIndexFieldTypeContext
 				codec,
 				ElasticsearchGeoPointFieldPredicateBuilderFactory.INSTANCE,
 				new ElasticsearchGeoPointFieldSortBuilderFactory( resolvedSortable ),
-				new ElasticsearchGeoPointFieldProjectionBuilderFactory( resolvedProjectable, indexToProjectionConverter, codec ),
+				new ElasticsearchGeoPointFieldProjectionBuilderFactory( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec ),
 				mapping
 		);
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchInstantIndexFieldTypeContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchInstantIndexFieldTypeContext.java
@@ -43,9 +43,9 @@ class ElasticsearchInstantIndexFieldTypeContext
 
 		return new ElasticsearchIndexFieldType<>(
 				codec,
-				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec ),
+				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec ),
 				mapping
 		);
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchIntegerIndexFieldTypeContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchIntegerIndexFieldTypeContext.java
@@ -37,9 +37,9 @@ class ElasticsearchIntegerIndexFieldTypeContext
 
 		return new ElasticsearchIndexFieldType<>(
 				codec,
-				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec ),
+				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec ),
 				mapping
 		);
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchJsonStringIndexFieldTypeContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchJsonStringIndexFieldTypeContextImpl.java
@@ -53,9 +53,9 @@ class ElasticsearchJsonStringIndexFieldTypeContextImpl
 
 		return new ElasticsearchIndexFieldType<>(
 				codec,
-				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldSortBuilderFactory<>( true, dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldProjectionBuilderFactory<>( true, indexToProjectionConverter, codec ),
+				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldSortBuilderFactory<>( true, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldProjectionBuilderFactory<>( true, indexToProjectionConverter, createFromDocumentRawConverter(), codec ),
 				mapping
 		);
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchLocalDateIndexFieldTypeContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchLocalDateIndexFieldTypeContext.java
@@ -58,9 +58,9 @@ class ElasticsearchLocalDateIndexFieldTypeContext
 
 		return new ElasticsearchIndexFieldType<>(
 				codec,
-				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec ),
+				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec ),
 				mapping
 		);
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchLocalDateTimeIndexFieldTypeContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchLocalDateTimeIndexFieldTypeContext.java
@@ -52,9 +52,9 @@ class ElasticsearchLocalDateTimeIndexFieldTypeContext
 
 		return new ElasticsearchIndexFieldType<>(
 				codec,
-				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec ),
+				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec ),
 				mapping
 		);
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchLocalTimeIndexFieldTypeContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchLocalTimeIndexFieldTypeContext.java
@@ -62,9 +62,9 @@ class ElasticsearchLocalTimeIndexFieldTypeContext
 
 		return new ElasticsearchIndexFieldType<>(
 				codec,
-				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec ),
+				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec ),
 				mapping
 		);
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchLongIndexFieldTypeContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchLongIndexFieldTypeContext.java
@@ -33,9 +33,9 @@ class ElasticsearchLongIndexFieldTypeContext
 
 		return new ElasticsearchIndexFieldType<>(
 				codec,
-				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec ),
+				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec ),
 				mapping
 		);
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchMonthDayIndexFieldTypeContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchMonthDayIndexFieldTypeContext.java
@@ -60,9 +60,9 @@ class ElasticsearchMonthDayIndexFieldTypeContext
 
 		return new ElasticsearchIndexFieldType<>(
 				codec,
-				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec ),
+				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec ),
 				mapping
 		);
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchOffsetDateTimeIndexFieldTypeContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchOffsetDateTimeIndexFieldTypeContext.java
@@ -52,9 +52,9 @@ class ElasticsearchOffsetDateTimeIndexFieldTypeContext
 
 		return new ElasticsearchIndexFieldType<>(
 				codec,
-				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(),codec ),
-				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec ),
+				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(),codec ),
+				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec ),
 				mapping
 		);
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchOffsetTimeIndexFieldTypeContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchOffsetTimeIndexFieldTypeContext.java
@@ -52,9 +52,9 @@ class ElasticsearchOffsetTimeIndexFieldTypeContext
 
 		return new ElasticsearchIndexFieldType<>(
 				codec,
-				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec ),
+				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec ),
 				mapping
 		);
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchShortIndexFieldTypeContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchShortIndexFieldTypeContext.java
@@ -33,9 +33,9 @@ class ElasticsearchShortIndexFieldTypeContext
 
 		return new ElasticsearchIndexFieldType<>(
 				codec,
-				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec ),
+				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec ),
 				mapping
 		);
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchStringIndexFieldTypeContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchStringIndexFieldTypeContext.java
@@ -106,9 +106,9 @@ class ElasticsearchStringIndexFieldTypeContext
 
 		return new ElasticsearchIndexFieldType<>(
 				codec,
-				new ElasticsearchTextFieldPredicateBuilderFactory( dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec ),
+				new ElasticsearchTextFieldPredicateBuilderFactory( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec ),
 				mapping
 		);
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchYearIndexFieldTypeContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchYearIndexFieldTypeContext.java
@@ -53,9 +53,9 @@ class ElasticsearchYearIndexFieldTypeContext
 
 		return new ElasticsearchIndexFieldType<>(
 				codec,
-				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec ),
+				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec ),
 				mapping
 		);
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchYearMonthIndexFieldTypeContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchYearMonthIndexFieldTypeContext.java
@@ -54,9 +54,9 @@ class ElasticsearchYearMonthIndexFieldTypeContext
 
 		return new ElasticsearchIndexFieldType<>(
 				codec,
-				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter,createRawConverter(), codec ),
-				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec ),
+				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec ),
 				mapping
 		);
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchZonedDateTimeIndexFieldTypeContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchZonedDateTimeIndexFieldTypeContext.java
@@ -56,9 +56,9 @@ class ElasticsearchZonedDateTimeIndexFieldTypeContext
 
 		return new ElasticsearchIndexFieldType<>(
 				codec,
-				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec ),
+				new ElasticsearchStandardFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new ElasticsearchStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec ),
 				mapping
 		);
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/ElasticsearchFieldProjectionBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/ElasticsearchFieldProjectionBuilderFactory.java
@@ -8,6 +8,7 @@ package org.hibernate.search.backend.elasticsearch.types.projection.impl;
 
 import org.hibernate.search.backend.elasticsearch.types.codec.impl.ElasticsearchFieldCodec;
 import org.hibernate.search.engine.backend.types.converter.FromDocumentFieldValueConverter;
+import org.hibernate.search.engine.search.predicate.spi.ProjectionConverter;
 import org.hibernate.search.engine.search.projection.spi.DistanceToFieldProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.FieldProjectionBuilder;
 import org.hibernate.search.engine.spatial.GeoPoint;
@@ -25,7 +26,7 @@ import org.hibernate.search.engine.spatial.GeoPoint;
 public interface ElasticsearchFieldProjectionBuilderFactory {
 
 	<T> FieldProjectionBuilder<T> createFieldValueProjectionBuilder(String absoluteFieldPath,
-			Class<T> expectedType);
+			Class<T> expectedType, ProjectionConverter projectionConverter);
 
 	DistanceToFieldProjectionBuilder createDistanceProjectionBuilder(String absoluteFieldPath, GeoPoint center);
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/ElasticsearchGeoPointFieldProjectionBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/ElasticsearchGeoPointFieldProjectionBuilderFactory.java
@@ -45,6 +45,11 @@ public class ElasticsearchGeoPointFieldProjectionBuilderFactory implements Elast
 			Class<T> expectedType, ProjectionConverter projectionConverter) {
 		checkProjectable( absoluteFieldPath, projectable );
 
+		if ( projectionConverter.isEnabled() && converter == null ) {
+			throw log.projectionConverterRequired( absoluteFieldPath,
+					EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
+		}
+
 		if ( projectionConverter.isEnabled() && !converter.isConvertedTypeAssignableTo( expectedType ) ) {
 			throw log.invalidProjectionInvalidType( absoluteFieldPath, expectedType,
 					EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/ElasticsearchGeoPointFieldProjectionBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/ElasticsearchGeoPointFieldProjectionBuilderFactory.java
@@ -26,13 +26,18 @@ public class ElasticsearchGeoPointFieldProjectionBuilderFactory implements Elast
 	private final boolean projectable;
 
 	private final FromDocumentFieldValueConverter<? super GeoPoint, ?> converter;
+
+	// TODO passing rawConverter to the projection builder
+	private final FromDocumentFieldValueConverter<? super GeoPoint, GeoPoint> rawConverter;
+
 	private final ElasticsearchFieldCodec<GeoPoint> codec;
 
 	public ElasticsearchGeoPointFieldProjectionBuilderFactory(boolean projectable,
-			FromDocumentFieldValueConverter<? super GeoPoint, ?> converter,
+			FromDocumentFieldValueConverter<? super GeoPoint, ?> converter, FromDocumentFieldValueConverter<? super GeoPoint, GeoPoint> rawConverter,
 			ElasticsearchFieldCodec<GeoPoint> codec) {
 		this.projectable = projectable;
 		this.converter = converter;
+		this.rawConverter = rawConverter;
 		this.codec = codec;
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/ElasticsearchStandardFieldProjectionBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/ElasticsearchStandardFieldProjectionBuilderFactory.java
@@ -45,6 +45,11 @@ public class ElasticsearchStandardFieldProjectionBuilderFactory<F> implements El
 			Class<T> expectedType, ProjectionConverter projectionConverter) {
 		checkProjectable( absoluteFieldPath, projectable );
 
+		if ( projectionConverter.isEnabled() && converter == null ) {
+			throw log.projectionConverterRequired( absoluteFieldPath,
+					EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
+		}
+
 		if ( projectionConverter.isEnabled() && !converter.isConvertedTypeAssignableTo( expectedType ) ) {
 			throw log.invalidProjectionInvalidType( absoluteFieldPath, expectedType,
 					EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/ElasticsearchStandardFieldProjectionBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/ElasticsearchStandardFieldProjectionBuilderFactory.java
@@ -25,13 +25,18 @@ public class ElasticsearchStandardFieldProjectionBuilderFactory<F> implements El
 	private final boolean projectable;
 
 	private final FromDocumentFieldValueConverter<? super F, ?> converter;
+
+	// TODO passing rawConverter to the projection builder
+	private final FromDocumentFieldValueConverter<? super F, F> rawConverter;
+
 	private final ElasticsearchFieldCodec<F> codec;
 
 	public ElasticsearchStandardFieldProjectionBuilderFactory(boolean projectable,
-			FromDocumentFieldValueConverter<? super F, ?> converter,
+			FromDocumentFieldValueConverter<? super F, ?> converter, FromDocumentFieldValueConverter<? super F, F> rawConverter,
 			ElasticsearchFieldCodec<F> codec) {
 		this.projectable = projectable;
 		this.converter = converter;
+		this.rawConverter = rawConverter;
 		this.codec = codec;
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/ElasticsearchStandardFieldProjectionBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/projection/impl/ElasticsearchStandardFieldProjectionBuilderFactory.java
@@ -13,6 +13,7 @@ import org.hibernate.search.backend.elasticsearch.search.projection.impl.Elastic
 import org.hibernate.search.backend.elasticsearch.types.codec.impl.ElasticsearchFieldCodec;
 import org.hibernate.search.engine.backend.types.converter.FromDocumentFieldValueConverter;
 import org.hibernate.search.engine.reporting.spi.EventContexts;
+import org.hibernate.search.engine.search.predicate.spi.ProjectionConverter;
 import org.hibernate.search.engine.search.projection.spi.DistanceToFieldProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.FieldProjectionBuilder;
 import org.hibernate.search.engine.spatial.GeoPoint;
@@ -25,8 +26,6 @@ public class ElasticsearchStandardFieldProjectionBuilderFactory<F> implements El
 	private final boolean projectable;
 
 	private final FromDocumentFieldValueConverter<? super F, ?> converter;
-
-	// TODO passing rawConverter to the projection builder
 	private final FromDocumentFieldValueConverter<? super F, F> rawConverter;
 
 	private final ElasticsearchFieldCodec<F> codec;
@@ -43,15 +42,15 @@ public class ElasticsearchStandardFieldProjectionBuilderFactory<F> implements El
 	@Override
 	@SuppressWarnings("unchecked") // We check the cast is legal by asking the converter
 	public <T> FieldProjectionBuilder<T> createFieldValueProjectionBuilder(String absoluteFieldPath,
-			Class<T> expectedType) {
+			Class<T> expectedType, ProjectionConverter projectionConverter) {
 		checkProjectable( absoluteFieldPath, projectable );
 
-		if ( !converter.isConvertedTypeAssignableTo( expectedType ) ) {
+		if ( projectionConverter.isEnabled() && !converter.isConvertedTypeAssignableTo( expectedType ) ) {
 			throw log.invalidProjectionInvalidType( absoluteFieldPath, expectedType,
 					EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
 		}
 
-		return (FieldProjectionBuilder<T>) new ElasticsearchFieldProjectionBuilder<>( absoluteFieldPath, converter, codec );
+		return (FieldProjectionBuilder<T>) new ElasticsearchFieldProjectionBuilder<>( absoluteFieldPath, getConverter( projectionConverter ), codec );
 	}
 
 	@Override
@@ -83,5 +82,9 @@ public class ElasticsearchStandardFieldProjectionBuilderFactory<F> implements El
 				throw log.nonProjectableField( absoluteFieldPath,
 						EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
 		}
+	}
+
+	private FromDocumentFieldValueConverter<? super F, ?> getConverter(ProjectionConverter projectionConverter) {
+		return ( projectionConverter.isEnabled() ) ? converter : rawConverter;
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
@@ -418,4 +418,8 @@ public interface Log extends BasicLogger {
 	@Message(id = ID_OFFSET_2 + 70,
 			value = "Text predicates (phrase, fuzzy, wildcard, simple query string) are not supported by this field's type.")
 	SearchException textPredicatesNotSupportedByFieldType(@Param EventContext context);
+
+	@Message(id = ID_OFFSET_2 + 71, value = "Projection on field `%1$s` is not allowed, since bridge did not specify a bind back for this field. " +
+			"Please define a projection converter or use .rawField(`%1$s`) to extract the raw values bypassing the bridge.")
+	SearchException projectionConverterRequired(String absoluteFieldPath, @Param EventContext context);
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneSearchProjectionBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneSearchProjectionBuilderFactory.java
@@ -19,6 +19,7 @@ import org.hibernate.search.backend.lucene.search.impl.LuceneSearchTargetModel;
 import org.hibernate.search.backend.lucene.types.projection.impl.LuceneFieldProjectionBuilderFactory;
 import org.hibernate.search.engine.search.SearchProjection;
 import org.hibernate.search.engine.search.predicate.spi.DslConverter;
+import org.hibernate.search.engine.search.predicate.spi.ProjectionConverter;
 import org.hibernate.search.engine.search.projection.spi.CompositeProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.DistanceToFieldProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.DocumentReferenceProjectionBuilder;
@@ -56,10 +57,10 @@ public class LuceneSearchProjectionBuilderFactory implements SearchProjectionBui
 	}
 
 	@Override
-	public <T> FieldProjectionBuilder<T> field(String absoluteFieldPath, Class<T> expectedType) {
+	public <T> FieldProjectionBuilder<T> field(String absoluteFieldPath, Class<T> expectedType, ProjectionConverter projectionConverter) {
 		return searchTargetModel
 				.getSchemaNodeComponent( absoluteFieldPath, PROJECTION_BUILDER_FACTORY_RETRIEVAL_STRATEGY )
-				.createFieldValueProjectionBuilder( absoluteFieldPath, expectedType );
+				.createFieldValueProjectionBuilder( absoluteFieldPath, expectedType, projectionConverter );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/AbstractLuceneStandardIndexFieldTypeContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/AbstractLuceneStandardIndexFieldTypeContext.java
@@ -76,11 +76,18 @@ abstract class AbstractLuceneStandardIndexFieldTypeContext<S extends AbstractLuc
 	}
 
 	protected final FromDocumentFieldValueConverter<? super F, ?> createIndexToProjectionConverter() {
-		/*
-		 * TODO HSEARCH-3512 Throw an exception when the field is non projectable due to the bridge.
-		 * E.g. if the field is bridged and the bridge did not specify a "FromIndexFieldValueConverter".
-		 */
-		return indexToProjectionConverter == null ? createFromDocumentRawConverter() : indexToProjectionConverter;
+		if ( indexToProjectionConverter != null ) {
+			// this case corresponds to a two-way bridge
+			return indexToProjectionConverter;
+		}
+
+		if ( dslToIndexConverter != null ) {
+			// this case corresponds to a one-way bridge
+			return null;
+		}
+
+		// this case corresponds to no bridge
+		return createFromDocumentRawConverter();
 	}
 
 	protected final FromDocumentFieldValueConverter<? super F, F> createFromDocumentRawConverter() {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/AbstractLuceneStandardIndexFieldTypeContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/AbstractLuceneStandardIndexFieldTypeContext.java
@@ -68,10 +68,10 @@ abstract class AbstractLuceneStandardIndexFieldTypeContext<S extends AbstractLuc
 	}
 
 	protected final ToDocumentFieldValueConverter<?, ? extends F> createDslToIndexConverter() {
-		return dslToIndexConverter == null ? createRawConverter() : dslToIndexConverter;
+		return dslToIndexConverter == null ? createToDocumentRawConverter() : dslToIndexConverter;
 	}
 
-	protected final ToDocumentFieldValueConverter<F, ? extends F> createRawConverter() {
+	protected final ToDocumentFieldValueConverter<F, ? extends F> createToDocumentRawConverter() {
 		return new PassThroughToDocumentFieldValueConverter<>( fieldType );
 	}
 
@@ -81,8 +81,11 @@ abstract class AbstractLuceneStandardIndexFieldTypeContext<S extends AbstractLuc
 		 * with an explicit message.
 		 * Currently we create a pass-through converter because users have no way to bypass the converter.
 		 */
-		return indexToProjectionConverter == null ? new PassThroughFromDocumentFieldValueConverter<>( fieldType )
-				: indexToProjectionConverter;
+		return indexToProjectionConverter == null ? createFromDocumentRawConverter() : indexToProjectionConverter;
+	}
+
+	protected final FromDocumentFieldValueConverter<? super F, F> createFromDocumentRawConverter() {
+		return new PassThroughFromDocumentFieldValueConverter<>( fieldType );
 	}
 
 	protected static boolean resolveDefault(Projectable projectable) {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/AbstractLuceneStandardIndexFieldTypeContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/AbstractLuceneStandardIndexFieldTypeContext.java
@@ -77,9 +77,8 @@ abstract class AbstractLuceneStandardIndexFieldTypeContext<S extends AbstractLuc
 
 	protected final FromDocumentFieldValueConverter<? super F, ?> createIndexToProjectionConverter() {
 		/*
-		 * TODO HSEARCH-3257 when no projection converter is configured, create a projection converter that will throw an exception
-		 * with an explicit message.
-		 * Currently we create a pass-through converter because users have no way to bypass the converter.
+		 * TODO HSEARCH-3512 Throw an exception when the field is non projectable due to the bridge.
+		 * E.g. if the field is bridged and the bridge did not specify a "FromIndexFieldValueConverter".
 		 */
 		return indexToProjectionConverter == null ? createFromDocumentRawConverter() : indexToProjectionConverter;
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneBooleanIndexFieldTypeContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneBooleanIndexFieldTypeContext.java
@@ -43,9 +43,9 @@ class LuceneBooleanIndexFieldTypeContext
 
 		return new LuceneIndexFieldType<>(
 				codec,
-				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec )
+				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec )
 		);
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneByteIndexFieldTypeContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneByteIndexFieldTypeContext.java
@@ -43,9 +43,9 @@ class LuceneByteIndexFieldTypeContext
 
 		return new LuceneIndexFieldType<>(
 				codec,
-				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec )
+				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec )
 		);
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneDoubleIndexFieldTypeContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneDoubleIndexFieldTypeContext.java
@@ -43,9 +43,9 @@ class LuceneDoubleIndexFieldTypeContext
 
 		return new LuceneIndexFieldType<>(
 				codec,
-				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec )
+				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec )
 		);
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneFieldIndexFieldTypeContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneFieldIndexFieldTypeContext.java
@@ -22,7 +22,7 @@ import org.hibernate.search.engine.backend.types.IndexFieldType;
 class LuceneFieldIndexFieldTypeContext<F>
 		implements IndexFieldTypeTerminalContext<F> {
 
-	private final FromDocumentFieldValueConverter<? super F, ?> indexToProjectionConverter;
+	private final FromDocumentFieldValueConverter<? super F, F> indexToProjectionConverter;
 	private final LuceneFieldContributor<F> fieldContributor;
 	private final LuceneFieldValueExtractor<F> fieldValueExtractor;
 
@@ -41,7 +41,7 @@ class LuceneFieldIndexFieldTypeContext<F>
 				codec,
 				null,
 				null,
-				new LuceneStandardFieldProjectionBuilderFactory<>( fieldValueExtractor != null, indexToProjectionConverter, codec )
+				new LuceneStandardFieldProjectionBuilderFactory<>( fieldValueExtractor != null, indexToProjectionConverter, indexToProjectionConverter, codec )
 		);
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneFloatIndexFieldTypeContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneFloatIndexFieldTypeContext.java
@@ -43,9 +43,9 @@ class LuceneFloatIndexFieldTypeContext
 
 		return new LuceneIndexFieldType<>(
 				codec,
-				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec )
+				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec )
 		);
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneGeoPointIndexFieldTypeContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneGeoPointIndexFieldTypeContext.java
@@ -48,7 +48,7 @@ class LuceneGeoPointIndexFieldTypeContext
 				codec,
 				LuceneGeoPointFieldPredicateBuilderFactory.INSTANCE,
 				new LuceneGeoPointFieldSortBuilderFactory( resolvedSortable ),
-				new LuceneGeoPointFieldProjectionBuilderFactory( resolvedProjectable, codec, indexToProjectionConverter )
+				new LuceneGeoPointFieldProjectionBuilderFactory( resolvedProjectable, codec, indexToProjectionConverter, createFromDocumentRawConverter() )
 		);
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneInstantIndexFieldTypeContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneInstantIndexFieldTypeContext.java
@@ -45,9 +45,9 @@ class LuceneInstantIndexFieldTypeContext
 
 		return new LuceneIndexFieldType<>(
 				codec,
-				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec )
+				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec )
 		);
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIntegerIndexFieldTypeContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIntegerIndexFieldTypeContext.java
@@ -46,9 +46,9 @@ class LuceneIntegerIndexFieldTypeContext
 
 		return new LuceneIndexFieldType<>(
 				codec,
-				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec )
+				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec )
 		);
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneLocalDateIndexFieldTypeContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneLocalDateIndexFieldTypeContext.java
@@ -48,9 +48,9 @@ class LuceneLocalDateIndexFieldTypeContext
 
 		return new LuceneIndexFieldType<>(
 				codec,
-				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec )
+				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec )
 		);
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneLocalDateTimeIndexFieldTypeContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneLocalDateTimeIndexFieldTypeContext.java
@@ -45,9 +45,9 @@ class LuceneLocalDateTimeIndexFieldTypeContext
 
 		return new LuceneIndexFieldType<>(
 				codec,
-				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec )
+				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec )
 		);
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneLocalTimeIndexFieldTypeContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneLocalTimeIndexFieldTypeContext.java
@@ -45,9 +45,9 @@ class LuceneLocalTimeIndexFieldTypeContext
 
 		return new LuceneIndexFieldType<>(
 				codec,
-				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec )
+				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec )
 		);
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneLongIndexFieldTypeContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneLongIndexFieldTypeContext.java
@@ -43,9 +43,9 @@ class LuceneLongIndexFieldTypeContext
 
 		return new LuceneIndexFieldType<>(
 				codec,
-				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec )
+				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec )
 		);
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneMonthDayIndexFieldTypeContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneMonthDayIndexFieldTypeContext.java
@@ -45,9 +45,9 @@ class LuceneMonthDayIndexFieldTypeContext
 
 		return new LuceneIndexFieldType<>(
 				codec,
-				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec )
+				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec )
 		);
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneOffsetDateTimeIndexFieldTypeContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneOffsetDateTimeIndexFieldTypeContext.java
@@ -45,9 +45,9 @@ class LuceneOffsetDateTimeIndexFieldTypeContext
 
 		return new LuceneIndexFieldType<>(
 				codec,
-				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec )
+				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec )
 		);
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneOffsetTimeIndexFieldTypeContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneOffsetTimeIndexFieldTypeContext.java
@@ -45,9 +45,9 @@ class LuceneOffsetTimeIndexFieldTypeContext
 
 		return new LuceneIndexFieldType<>(
 				codec,
-				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec )
+				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec )
 		);
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneShortIndexFieldTypeContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneShortIndexFieldTypeContext.java
@@ -43,9 +43,9 @@ class LuceneShortIndexFieldTypeContext
 
 		return new LuceneIndexFieldType<>(
 				codec,
-				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec )
+				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec )
 		);
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneStringIndexFieldTypeContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneStringIndexFieldTypeContext.java
@@ -102,9 +102,9 @@ class LuceneStringIndexFieldTypeContext
 
 		return new LuceneIndexFieldType<>(
 				codec,
-				new LuceneTextFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec, queryBuilder ),
-				new LuceneTextFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec ),
+				new LuceneTextFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec, queryBuilder ),
+				new LuceneTextFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec ),
 				analyzerOrNormalizer
 		);
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneYearIndexFieldTypeContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneYearIndexFieldTypeContext.java
@@ -45,9 +45,9 @@ class LuceneYearIndexFieldTypeContext
 
 		return new LuceneIndexFieldType<>(
 				codec,
-				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec )
+				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec )
 		);
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneYearMonthIndexFieldTypeContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneYearMonthIndexFieldTypeContext.java
@@ -45,9 +45,9 @@ class LuceneYearMonthIndexFieldTypeContext
 
 		return new LuceneIndexFieldType<>(
 				codec,
-				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec )
+				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec )
 		);
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneZonedDateTimeIndexFieldTypeContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneZonedDateTimeIndexFieldTypeContext.java
@@ -45,9 +45,9 @@ class LuceneZonedDateTimeIndexFieldTypeContext
 
 		return new LuceneIndexFieldType<>(
 				codec,
-				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createRawConverter(), codec ),
-				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, codec )
+				new LuceneNumericFieldPredicateBuilderFactory<>( dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneNumericFieldSortBuilderFactory<>( resolvedSortable, dslToIndexConverter, createToDocumentRawConverter(), codec ),
+				new LuceneStandardFieldProjectionBuilderFactory<>( resolvedProjectable, indexToProjectionConverter, createFromDocumentRawConverter(), codec )
 		);
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/LuceneFieldProjectionBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/LuceneFieldProjectionBuilderFactory.java
@@ -9,6 +9,7 @@ package org.hibernate.search.backend.lucene.types.projection.impl;
 import org.hibernate.search.backend.lucene.types.codec.impl.LuceneFieldCodec;
 import org.hibernate.search.backend.lucene.types.predicate.impl.LuceneFieldPredicateBuilderFactory;
 import org.hibernate.search.engine.backend.types.converter.FromDocumentFieldValueConverter;
+import org.hibernate.search.engine.search.predicate.spi.ProjectionConverter;
 import org.hibernate.search.engine.search.projection.spi.DistanceToFieldProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.FieldProjectionBuilder;
 import org.hibernate.search.engine.spatial.GeoPoint;
@@ -26,7 +27,7 @@ import org.hibernate.search.engine.spatial.GeoPoint;
 public interface LuceneFieldProjectionBuilderFactory {
 
 	<U> FieldProjectionBuilder<U> createFieldValueProjectionBuilder(String absoluteFieldPath,
-			Class<U> expectedType);
+			Class<U> expectedType, ProjectionConverter projectionConverter);
 
 	DistanceToFieldProjectionBuilder createDistanceProjectionBuilder(String absoluteFieldPath, GeoPoint center);
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/LuceneGeoPointFieldProjectionBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/LuceneGeoPointFieldProjectionBuilderFactory.java
@@ -26,13 +26,18 @@ public class LuceneGeoPointFieldProjectionBuilderFactory implements LuceneFieldP
 	private final boolean projectable;
 
 	private final FromDocumentFieldValueConverter<? super GeoPoint, ?> converter;
+
+	// TODO passing rawConverter to the projection builder
+	private final FromDocumentFieldValueConverter<? super GeoPoint, GeoPoint> rawConverter;
+
 	private final LuceneFieldCodec<GeoPoint> codec;
 
 	public LuceneGeoPointFieldProjectionBuilderFactory(boolean projectable,
 			LuceneFieldCodec<GeoPoint> codec,
-			FromDocumentFieldValueConverter<? super GeoPoint, ?> converter) {
+			FromDocumentFieldValueConverter<? super GeoPoint, ?> converter, FromDocumentFieldValueConverter<? super GeoPoint, GeoPoint> rawConverter) {
 		this.projectable = projectable;
 		this.converter = converter;
+		this.rawConverter = rawConverter;
 		this.codec = codec;
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/LuceneGeoPointFieldProjectionBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/LuceneGeoPointFieldProjectionBuilderFactory.java
@@ -45,6 +45,11 @@ public class LuceneGeoPointFieldProjectionBuilderFactory implements LuceneFieldP
 			Class<T> expectedType, ProjectionConverter projectionConverter) {
 		checkProjectable( absoluteFieldPath, projectable );
 
+		if ( projectionConverter.isEnabled() && converter == null ) {
+			throw log.projectionConverterRequired( absoluteFieldPath,
+					EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
+		}
+
 		if ( projectionConverter.isEnabled() && !converter.isConvertedTypeAssignableTo( expectedType ) ) {
 			throw log.invalidProjectionInvalidType( absoluteFieldPath, expectedType,
 					EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/LuceneStandardFieldProjectionBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/LuceneStandardFieldProjectionBuilderFactory.java
@@ -29,13 +29,18 @@ public class LuceneStandardFieldProjectionBuilderFactory<F> implements LuceneFie
 	private final boolean projectable;
 
 	private final FromDocumentFieldValueConverter<? super F, ?> converter;
+
+	// TODO passing rawConverter to the projection builder
+	private final FromDocumentFieldValueConverter<? super F, F> rawConverter;
+
 	private final LuceneFieldCodec<F> codec;
 
 	public LuceneStandardFieldProjectionBuilderFactory(boolean projectable,
-			FromDocumentFieldValueConverter<? super F, ?> converter,
+			FromDocumentFieldValueConverter<? super F, ?> converter, FromDocumentFieldValueConverter<? super F, F> rawConverter,
 			LuceneFieldCodec<F> codec) {
 		this.projectable = projectable;
 		this.converter = converter;
+		this.rawConverter = rawConverter;
 		this.codec = codec;
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/LuceneStandardFieldProjectionBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/LuceneStandardFieldProjectionBuilderFactory.java
@@ -49,6 +49,11 @@ public class LuceneStandardFieldProjectionBuilderFactory<F> implements LuceneFie
 			Class<T> expectedType, ProjectionConverter projectionConverter) {
 		checkProjectable( absoluteFieldPath, projectable );
 
+		if ( projectionConverter.isEnabled() && converter == null ) {
+			throw log.projectionConverterRequired( absoluteFieldPath,
+					EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
+		}
+
 		if ( projectionConverter.isEnabled() && !converter.isConvertedTypeAssignableTo( expectedType ) ) {
 			throw log.invalidProjectionInvalidType( absoluteFieldPath, expectedType,
 					EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/LuceneStandardFieldProjectionBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/projection/impl/LuceneStandardFieldProjectionBuilderFactory.java
@@ -13,6 +13,7 @@ import org.hibernate.search.backend.lucene.search.projection.impl.LuceneFieldPro
 import org.hibernate.search.backend.lucene.types.codec.impl.LuceneFieldCodec;
 import org.hibernate.search.engine.backend.types.converter.FromDocumentFieldValueConverter;
 import org.hibernate.search.engine.reporting.spi.EventContexts;
+import org.hibernate.search.engine.search.predicate.spi.ProjectionConverter;
 import org.hibernate.search.engine.search.projection.spi.DistanceToFieldProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.FieldProjectionBuilder;
 import org.hibernate.search.engine.spatial.GeoPoint;
@@ -29,8 +30,6 @@ public class LuceneStandardFieldProjectionBuilderFactory<F> implements LuceneFie
 	private final boolean projectable;
 
 	private final FromDocumentFieldValueConverter<? super F, ?> converter;
-
-	// TODO passing rawConverter to the projection builder
 	private final FromDocumentFieldValueConverter<? super F, F> rawConverter;
 
 	private final LuceneFieldCodec<F> codec;
@@ -47,15 +46,15 @@ public class LuceneStandardFieldProjectionBuilderFactory<F> implements LuceneFie
 	@Override
 	@SuppressWarnings("unchecked") // We check the cast is legal by asking the converter
 	public <T> FieldProjectionBuilder<T> createFieldValueProjectionBuilder(String absoluteFieldPath,
-			Class<T> expectedType) {
+			Class<T> expectedType, ProjectionConverter projectionConverter) {
 		checkProjectable( absoluteFieldPath, projectable );
 
-		if ( !converter.isConvertedTypeAssignableTo( expectedType ) ) {
+		if ( projectionConverter.isEnabled() && !converter.isConvertedTypeAssignableTo( expectedType ) ) {
 			throw log.invalidProjectionInvalidType( absoluteFieldPath, expectedType,
 					EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
 		}
 
-		return (FieldProjectionBuilder<T>) new LuceneFieldProjectionBuilder<>( absoluteFieldPath, converter, codec );
+		return (FieldProjectionBuilder<T>) new LuceneFieldProjectionBuilder<>( absoluteFieldPath, getConverter( projectionConverter ), codec );
 	}
 
 	@Override
@@ -87,5 +86,9 @@ public class LuceneStandardFieldProjectionBuilderFactory<F> implements LuceneFie
 			throw log.nonProjectableField( absoluteFieldPath,
 					EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
 		}
+	}
+
+	private FromDocumentFieldValueConverter<? super F, ?> getConverter(ProjectionConverter projectionConverter) {
+		return ( projectionConverter.isEnabled() ) ? converter : rawConverter;
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/SearchProjectionFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/SearchProjectionFactoryContext.java
@@ -73,6 +73,30 @@ public interface SearchProjectionFactoryContext<R, O> {
 	FieldProjectionContext<Object> field(String absoluteFieldPath);
 
 	/**
+	 * Project to a field of the indexed document.
+	 *
+	 * Unlike {@link #field(String, Class)} this method bypass any {@code DslConverter} defined on the field,
+	 * so that the values will be provided exactly as they are stored in the backend.
+	 *
+	 * @param absoluteFieldPath The absolute path of the field.
+	 * @param type The resulting type of the projection.
+	 * @param <T> The resulting type of the projection.
+	 * @return A context allowing to define the projection more precisely.
+	 */
+	<T> FieldProjectionContext<T> rawField(String absoluteFieldPath, Class<T> type);
+
+	/**
+	 * Project to a field of the indexed document without specifying a type.
+	 *
+	 * Unlike {@link #field(String)} this method bypass any {@code DslConverter} defined on the field,
+	 * so that the values will be provided exactly as they are stored in the backend.
+	 *
+	 * @param absoluteFieldPath The absolute path of the field.
+	 * @return A context allowing to define the projection more precisely.
+	 */
+	FieldProjectionContext<Object> rawField(String absoluteFieldPath);
+
+	/**
 	 * Project on the score of the hit.
 	 *
 	 * @return A context allowing to define the projection more precisely.

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/impl/DefaultSearchProjectionFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/impl/DefaultSearchProjectionFactoryContext.java
@@ -22,6 +22,7 @@ import org.hibernate.search.engine.search.dsl.projection.ScoreProjectionContext;
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContext;
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContextExtension;
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryExtensionContext;
+import org.hibernate.search.engine.search.predicate.spi.ProjectionConverter;
 import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilderFactory;
 import org.hibernate.search.engine.spatial.GeoPoint;
 import org.hibernate.search.util.common.function.TriFunction;
@@ -45,11 +46,23 @@ public class DefaultSearchProjectionFactoryContext<R, O> implements SearchProjec
 	public <T> FieldProjectionContext<T> field(String absoluteFieldPath, Class<T> clazz) {
 		Contracts.assertNotNull( clazz, "clazz" );
 
-		return new FieldProjectionContextImpl<>( factory, absoluteFieldPath, clazz );
+		return new FieldProjectionContextImpl<>( factory, absoluteFieldPath, clazz, ProjectionConverter.ENABLED );
 	}
 
 	@Override
 	public FieldProjectionContext<Object> field(String absoluteFieldPath) {
+		return field( absoluteFieldPath, Object.class );
+	}
+
+	@Override
+	public <T> FieldProjectionContext<T> rawField(String absoluteFieldPath, Class<T> clazz) {
+		Contracts.assertNotNull( clazz, "clazz" );
+
+		return new FieldProjectionContextImpl<>( factory, absoluteFieldPath, clazz, ProjectionConverter.DISABLED );
+	}
+
+	@Override
+	public FieldProjectionContext<Object> rawField(String absoluteFieldPath) {
 		return field( absoluteFieldPath, Object.class );
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/impl/FieldProjectionContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/impl/FieldProjectionContextImpl.java
@@ -17,9 +17,8 @@ public class FieldProjectionContextImpl<T> implements FieldProjectionContext<T> 
 
 	private final FieldProjectionBuilder<T> fieldProjectionBuilder;
 
-	FieldProjectionContextImpl(SearchProjectionBuilderFactory factory, String absoluteFieldPath, Class<T> clazz) {
-		// TODO handle DslConverter option here
-		this.fieldProjectionBuilder = factory.field( absoluteFieldPath, clazz, ProjectionConverter.ENABLED );
+	FieldProjectionContextImpl(SearchProjectionBuilderFactory factory, String absoluteFieldPath, Class<T> clazz, ProjectionConverter dslConverter) {
+		this.fieldProjectionBuilder = factory.field( absoluteFieldPath, clazz, dslConverter );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/impl/FieldProjectionContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/impl/FieldProjectionContextImpl.java
@@ -8,6 +8,7 @@ package org.hibernate.search.engine.search.dsl.projection.impl;
 
 import org.hibernate.search.engine.search.SearchProjection;
 import org.hibernate.search.engine.search.dsl.projection.FieldProjectionContext;
+import org.hibernate.search.engine.search.predicate.spi.ProjectionConverter;
 import org.hibernate.search.engine.search.projection.spi.FieldProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilderFactory;
 
@@ -17,7 +18,8 @@ public class FieldProjectionContextImpl<T> implements FieldProjectionContext<T> 
 	private final FieldProjectionBuilder<T> fieldProjectionBuilder;
 
 	FieldProjectionContextImpl(SearchProjectionBuilderFactory factory, String absoluteFieldPath, Class<T> clazz) {
-		this.fieldProjectionBuilder = factory.field( absoluteFieldPath, clazz );
+		// TODO handle DslConverter option here
+		this.fieldProjectionBuilder = factory.field( absoluteFieldPath, clazz, ProjectionConverter.ENABLED );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/spi/DelegatingSearchProjectionFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/spi/DelegatingSearchProjectionFactoryContext.java
@@ -58,6 +58,16 @@ public class DelegatingSearchProjectionFactoryContext<R, O> implements SearchPro
 	}
 
 	@Override
+	public <T> FieldProjectionContext<T> rawField(String absoluteFieldPath, Class<T> type) {
+		return delegate.rawField( absoluteFieldPath, type );
+	}
+
+	@Override
+	public FieldProjectionContext<Object> rawField(String absoluteFieldPath) {
+		return delegate.rawField( absoluteFieldPath );
+	}
+
+	@Override
 	public ScoreProjectionContext score() {
 		return delegate.score();
 	}

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/ProjectionConverter.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/ProjectionConverter.java
@@ -1,0 +1,16 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.predicate.spi;
+
+public enum ProjectionConverter {
+
+	ENABLED, DISABLED;
+
+	public boolean isEnabled() {
+		return this.equals( ENABLED );
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/projection/spi/SearchProjectionBuilderFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/projection/spi/SearchProjectionBuilderFactory.java
@@ -11,6 +11,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.hibernate.search.engine.search.SearchProjection;
+import org.hibernate.search.engine.search.predicate.spi.ProjectionConverter;
 import org.hibernate.search.engine.spatial.GeoPoint;
 import org.hibernate.search.util.common.function.TriFunction;
 
@@ -24,7 +25,7 @@ public interface SearchProjectionBuilderFactory {
 
 	DocumentReferenceProjectionBuilder documentReference();
 
-	<T> FieldProjectionBuilder<T> field(String absoluteFieldPath, Class<T> clazz);
+	<T> FieldProjectionBuilder<T> field(String absoluteFieldPath, Class<T> clazz, ProjectionConverter projectionConverter);
 
 	<O> ObjectProjectionBuilder<O> object();
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/FieldSearchProjectionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/FieldSearchProjectionIT.java
@@ -266,6 +266,29 @@ public class FieldSearchProjectionIT {
 	}
 
 	@Test
+	public void withProjectionConverters_rawValues() {
+		StubMappingSearchTarget searchTarget = indexManager.createSearchTarget();
+
+		for ( FieldModel<?> fieldModel : indexMapping.supportedFieldWithProjectionConverterModels ) {
+			SubTest.expectSuccess( fieldModel, model -> {
+				String fieldPath = model.relativeFieldName;
+
+				assertThat(
+						searchTarget.query()
+								.asProjection( f -> f.rawField( fieldPath, model.type ) )
+								.predicate( f -> f.matchAll() )
+								.build()
+				).hasHitsAnyOrder(
+						model.document1Value.indexedValue,
+						model.document2Value.indexedValue,
+						model.document3Value.indexedValue,
+						null // Empty document
+				);
+			} );
+		}
+	}
+
+	@Test
 	public void error_invalidProjectionType_withProjectionConverter() {
 		FieldModel<?> fieldModel = indexMapping.supportedFieldWithProjectionConverterModels.get( 0 );
 

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubSearchProjectionBuilderFactory.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubSearchProjectionBuilderFactory.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 
 import org.hibernate.search.engine.search.DocumentReference;
 import org.hibernate.search.engine.search.SearchProjection;
+import org.hibernate.search.engine.search.predicate.spi.ProjectionConverter;
 import org.hibernate.search.engine.search.projection.spi.CompositeProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.DistanceToFieldProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.DocumentReferenceProjectionBuilder;
@@ -48,7 +49,7 @@ public class StubSearchProjectionBuilderFactory implements SearchProjectionBuild
 	}
 
 	@Override
-	public <T> FieldProjectionBuilder<T> field(String absoluteFieldPath, Class<T> clazz) {
+	public <T> FieldProjectionBuilder<T> field(String absoluteFieldPath, Class<T> clazz, ProjectionConverter projectionConverter) {
 		StubFieldConverter<?> converter = targetModel.getFieldConverter( absoluteFieldPath );
 		return new FieldProjectionBuilder<T>() {
 			@Override


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3512
Based on top of https://github.com/hibernate/hibernate-search/pull/1907.
Issue is scoped on commits having comments having prefix `HSEARCH-3512`.

This is the way I understood the HSEARCH-3512.
@yrodiere, I would like to present this solution, even if it is probably wrong :P