### PR TITLE
HSEARCH-3503 Add dedicated default value bridges for java.sql.Timestamp, java.sql.Date and java.sql.Time

### DIFF
--- a/documentation/src/main/asciidoc/mapper-orm-mapping.asciidoc
+++ b/documentation/src/main/asciidoc/mapper-orm-mapping.asciidoc
@@ -292,9 +292,12 @@ or <<backend-elasticsearch-field-types,Elasticsearch field types>> depending on 
 |java.time.Year|-
 |java.time.YearMonth|-
 |java.time.MonthDay|-
+|java.util.UUID|`toString()` as a `java.lang.String`
 |java.util.Calendar|A `java.time.ZonedDateTime` representing the same date/time and timezone; see <<mapper-orm-legacy-date-time-apis>>
 |java.util.Date|`toInstant()` as a `java.time.Instant`; see <<mapper-orm-legacy-date-time-apis>>
-|java.util.UUID|`toString()` as a `java.lang.String`
+|java.sql.Timestamp|`toInstant()` as a `java.time.Instant`; see <<mapper-orm-legacy-date-time-apis>>
+|java.sql.Date|`toInstant()` as a `java.time.Instant`; see <<mapper-orm-legacy-date-time-apis>>
+|java.sql.Time|`toInstant()` as a `java.time.Instant`; see <<mapper-orm-legacy-date-time-apis>>
 |====
 
 [[mapper-orm-bridge-typeandpropertybridge]]
@@ -338,9 +341,10 @@ along with the value of the document identifier, i.e. the value passed to the un
 include::todo-placeholder.asciidoc[]
 
 [[mapper-orm-legacy-date-time-apis]]
-=== Support for legacy date/time APIs
+=== Support for legacy java.util date/time APIs
 
-Using legacy date/time types such as `java.util.Calendar` or `java.util.Date` is not recommended,
+Using legacy date/time types such as `java.util.Calendar`, `java.util.Date`, `java.sql.Timestamp`, `java.sql.Date`, `java.sql.Time`
+is not recommended,
 due to their numerous quirks and shortcomings.
 The https://docs.oracle.com/javase/8/docs/api/java/time/package-summary.html[`java.time`] package introduced
 in Java 8 should generally be preferred.

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/JavaSqlDatePropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/JavaSqlDatePropertyTypeDescriptor.java
@@ -1,0 +1,140 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.testsupport.types;
+
+import java.sql.Date;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.TimeZone;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultIdentifierBridgeExpectations;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultValueBridgeExpectations;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+public class JavaSqlDatePropertyTypeDescriptor extends PropertyTypeDescriptor<Date> {
+
+	JavaSqlDatePropertyTypeDescriptor() {
+		super( Date.class );
+	}
+
+	@Override
+	public Optional<DefaultIdentifierBridgeExpectations<Date>> getDefaultIdentifierBridgeExpectations() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<DefaultValueBridgeExpectations<Date, ?>> getDefaultValueBridgeExpectations() {
+		return Optional.of( new DefaultValueBridgeExpectations<Date, Instant>() {
+			@Override
+			public Class<Date> getProjectionType() {
+				return Date.class;
+			}
+
+			@Override
+			public Class<Instant> getIndexFieldJavaType() {
+				return Instant.class;
+			}
+
+			@Override
+			public List<Date> getEntityPropertyValues() {
+				return Arrays.asList(
+						date( Long.MIN_VALUE ),
+						date( 1970, 1, 1, 0, 0, 0, 0 ),
+						date( 1970, 1, 9, 13, 28, 59, 0 ),
+						date( 2017, 11, 6, 19, 19, 0, 540 ),
+						date( Long.MAX_VALUE ),
+
+						// A february 29th on a leap year
+						date( 2000, 2, 29, 12, 0, 0, 0 ),
+						// A february 29th on a leap year in the Julian calendar (java.util), but not the Gregorian calendar (java.time)
+						date( 1500, 2, 29, 12, 0, 0, 0 )
+				);
+			}
+
+			@Override
+			public List<Instant> getDocumentFieldValues() {
+				return Arrays.asList(
+						Instant.ofEpochMilli( Long.MIN_VALUE ),
+						Instant.parse( "1970-01-01T00:00:00.00Z" ),
+						Instant.parse( "1970-01-09T13:28:59.00Z" ),
+						Instant.parse( "2017-11-06T19:19:00.54Z" ),
+						Instant.ofEpochMilli( Long.MAX_VALUE ),
+
+						Instant.parse( "2000-02-29T12:00:00.0Z" ),
+						// The Julian calendar is 10 days late at this point
+						// See https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar#Difference_between_Julian_and_proleptic_Gregorian_calendar_dates
+						Instant.parse( "1500-03-10T12:00:00.0Z" )
+				);
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge1() {
+				return TypeWithValueBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithValueBridge1(int identifier, Date propertyValue) {
+				TypeWithValueBridge1 instance = new TypeWithValueBridge1();
+				instance.id = identifier;
+				instance.myProperty = propertyValue;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge2() {
+				return TypeWithValueBridge2.class;
+			}
+		} );
+	}
+
+	private static Date date(long epochMilli) {
+		return new Date( epochMilli );
+	}
+
+	private static Date date(int year, int month, int day, int hour, int minute, int second, int millisecond) {
+		Calendar calendar = new GregorianCalendar( TimeZone.getTimeZone( "UTC" ), Locale.ROOT );
+		calendar.clear();
+		calendar.set( year, month - 1, day, hour, minute, second );
+		calendar.set( Calendar.MILLISECOND, millisecond );
+		return new Date( calendar.getTimeInMillis() );
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithValueBridge1 {
+		Integer id;
+		Date myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public Date getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithValueBridge2 {
+		Integer id;
+		Date myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public Date getMyProperty() {
+			return myProperty;
+		}
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/JavaSqlTimePropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/JavaSqlTimePropertyTypeDescriptor.java
@@ -1,0 +1,140 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.testsupport.types;
+
+import java.sql.Time;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.TimeZone;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultIdentifierBridgeExpectations;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultValueBridgeExpectations;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+public class JavaSqlTimePropertyTypeDescriptor extends PropertyTypeDescriptor<Time> {
+
+	JavaSqlTimePropertyTypeDescriptor() {
+		super( Time.class );
+	}
+
+	@Override
+	public Optional<DefaultIdentifierBridgeExpectations<Time>> getDefaultIdentifierBridgeExpectations() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<DefaultValueBridgeExpectations<Time, ?>> getDefaultValueBridgeExpectations() {
+		return Optional.of( new DefaultValueBridgeExpectations<Time, Instant>() {
+			@Override
+			public Class<Time> getProjectionType() {
+				return Time.class;
+			}
+
+			@Override
+			public Class<Instant> getIndexFieldJavaType() {
+				return Instant.class;
+			}
+
+			@Override
+			public List<Time> getEntityPropertyValues() {
+				return Arrays.asList(
+						date( Long.MIN_VALUE ),
+						date( 1970, 1, 1, 0, 0, 0, 0 ),
+						date( 1970, 1, 9, 13, 28, 59, 0 ),
+						date( 2017, 11, 6, 19, 19, 0, 540 ),
+						date( Long.MAX_VALUE ),
+
+						// A february 29th on a leap year
+						date( 2000, 2, 29, 12, 0, 0, 0 ),
+						// A february 29th on a leap year in the Julian calendar (java.util), but not the Gregorian calendar (java.time)
+						date( 1500, 2, 29, 12, 0, 0, 0 )
+				);
+			}
+
+			@Override
+			public List<Instant> getDocumentFieldValues() {
+				return Arrays.asList(
+						Instant.ofEpochMilli( Long.MIN_VALUE ),
+						Instant.parse( "1970-01-01T00:00:00.00Z" ),
+						Instant.parse( "1970-01-09T13:28:59.00Z" ),
+						Instant.parse( "2017-11-06T19:19:00.54Z" ),
+						Instant.ofEpochMilli( Long.MAX_VALUE ),
+
+						Instant.parse( "2000-02-29T12:00:00.0Z" ),
+						// The Julian calendar is 10 days late at this point
+						// See https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar#Difference_between_Julian_and_proleptic_Gregorian_calendar_dates
+						Instant.parse( "1500-03-10T12:00:00.0Z" )
+				);
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge1() {
+				return TypeWithValueBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithValueBridge1(int identifier, Time propertyValue) {
+				TypeWithValueBridge1 instance = new TypeWithValueBridge1();
+				instance.id = identifier;
+				instance.myProperty = propertyValue;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge2() {
+				return TypeWithValueBridge2.class;
+			}
+		} );
+	}
+
+	private static Time date(long epochMilli) {
+		return new Time( epochMilli );
+	}
+
+	private static Time date(int year, int month, int day, int hour, int minute, int second, int millisecond) {
+		Calendar calendar = new GregorianCalendar( TimeZone.getTimeZone( "UTC" ), Locale.ROOT );
+		calendar.clear();
+		calendar.set( year, month - 1, day, hour, minute, second );
+		calendar.set( Calendar.MILLISECOND, millisecond );
+		return new Time( calendar.getTimeInMillis() );
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithValueBridge1 {
+		Integer id;
+		Time myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public Time getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithValueBridge2 {
+		Integer id;
+		Time myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public Time getMyProperty() {
+			return myProperty;
+		}
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/JavaSqlTimestampPropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/JavaSqlTimestampPropertyTypeDescriptor.java
@@ -1,0 +1,140 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.testsupport.types;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.TimeZone;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultIdentifierBridgeExpectations;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.types.expectations.DefaultValueBridgeExpectations;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+public class JavaSqlTimestampPropertyTypeDescriptor extends PropertyTypeDescriptor<Timestamp> {
+
+	JavaSqlTimestampPropertyTypeDescriptor() {
+		super( Timestamp.class );
+	}
+
+	@Override
+	public Optional<DefaultIdentifierBridgeExpectations<Timestamp>> getDefaultIdentifierBridgeExpectations() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<DefaultValueBridgeExpectations<Timestamp, ?>> getDefaultValueBridgeExpectations() {
+		return Optional.of( new DefaultValueBridgeExpectations<Timestamp, Instant>() {
+			@Override
+			public Class<Timestamp> getProjectionType() {
+				return Timestamp.class;
+			}
+
+			@Override
+			public Class<Instant> getIndexFieldJavaType() {
+				return Instant.class;
+			}
+
+			@Override
+			public List<Timestamp> getEntityPropertyValues() {
+				return Arrays.asList(
+						date( Long.MIN_VALUE ),
+						date( 1970, 1, 1, 0, 0, 0, 0 ),
+						date( 1970, 1, 9, 13, 28, 59, 0 ),
+						date( 2017, 11, 6, 19, 19, 0, 540 ),
+						date( Long.MAX_VALUE ),
+
+						// A february 29th on a leap year
+						date( 2000, 2, 29, 12, 0, 0, 0 ),
+						// A february 29th on a leap year in the Julian calendar (java.util), but not the Gregorian calendar (java.time)
+						date( 1500, 2, 29, 12, 0, 0, 0 )
+				);
+			}
+
+			@Override
+			public List<Instant> getDocumentFieldValues() {
+				return Arrays.asList(
+						Instant.ofEpochMilli( Long.MIN_VALUE ),
+						Instant.parse( "1970-01-01T00:00:00.00Z" ),
+						Instant.parse( "1970-01-09T13:28:59.00Z" ),
+						Instant.parse( "2017-11-06T19:19:00.54Z" ),
+						Instant.ofEpochMilli( Long.MAX_VALUE ),
+
+						Instant.parse( "2000-02-29T12:00:00.0Z" ),
+						// The Julian calendar is 10 days late at this point
+						// See https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar#Difference_between_Julian_and_proleptic_Gregorian_calendar_dates
+						Instant.parse( "1500-03-10T12:00:00.0Z" )
+				);
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge1() {
+				return TypeWithValueBridge1.class;
+			}
+
+			@Override
+			public Object instantiateTypeWithValueBridge1(int identifier, Timestamp propertyValue) {
+				TypeWithValueBridge1 instance = new TypeWithValueBridge1();
+				instance.id = identifier;
+				instance.myProperty = propertyValue;
+				return instance;
+			}
+
+			@Override
+			public Class<?> getTypeWithValueBridge2() {
+				return TypeWithValueBridge2.class;
+			}
+		} );
+	}
+
+	private static Timestamp date(long epochMilli) {
+		return new Timestamp( epochMilli );
+	}
+
+	private static Timestamp date(int year, int month, int day, int hour, int minute, int second, int millisecond) {
+		Calendar calendar = new GregorianCalendar( TimeZone.getTimeZone( "UTC" ), Locale.ROOT );
+		calendar.clear();
+		calendar.set( year, month - 1, day, hour, minute, second );
+		calendar.set( Calendar.MILLISECOND, millisecond );
+		return new Timestamp( calendar.getTimeInMillis() );
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_1_INDEX_NAME)
+	public static class TypeWithValueBridge1 {
+		Integer id;
+		Timestamp myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public Timestamp getMyProperty() {
+			return myProperty;
+		}
+	}
+
+	@Indexed(index = DefaultValueBridgeExpectations.TYPE_WITH_VALUE_BRIDGE_2_INDEX_NAME)
+	public static class TypeWithValueBridge2 {
+		Integer id;
+		Timestamp myProperty;
+		@DocumentId
+		public Integer getId() {
+			return id;
+		}
+		@GenericField
+		public Timestamp getMyProperty() {
+			return myProperty;
+		}
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/PropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/PropertyTypeDescriptor.java
@@ -59,7 +59,8 @@ public abstract class PropertyTypeDescriptor<V> {
 					new JavaNetURIPropertyTypeDescriptor(),
 					new JavaNetURLPropertyTypeDescriptor(),
 					new JavaSqlDatePropertyTypeDescriptor(),
-					new JavaSqlTimestampPropertyTypeDescriptor()
+					new JavaSqlTimestampPropertyTypeDescriptor(),
+					new JavaSqlTimePropertyTypeDescriptor()
 			) );
 		}
 		return all;

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/PropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/PropertyTypeDescriptor.java
@@ -57,7 +57,8 @@ public abstract class PropertyTypeDescriptor<V> {
 					new DurationPropertyTypeDescriptor(),
 					new PeriodPropertyTypeDescriptor(),
 					new JavaNetURIPropertyTypeDescriptor(),
-					new JavaNetURLPropertyTypeDescriptor()
+					new JavaNetURLPropertyTypeDescriptor(),
+					new JavaSqlDatePropertyTypeDescriptor()
 			) );
 		}
 		return all;

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/PropertyTypeDescriptor.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/types/PropertyTypeDescriptor.java
@@ -58,7 +58,8 @@ public abstract class PropertyTypeDescriptor<V> {
 					new PeriodPropertyTypeDescriptor(),
 					new JavaNetURIPropertyTypeDescriptor(),
 					new JavaNetURLPropertyTypeDescriptor(),
-					new JavaSqlDatePropertyTypeDescriptor()
+					new JavaSqlDatePropertyTypeDescriptor(),
+					new JavaSqlTimestampPropertyTypeDescriptor()
 			) );
 		}
 		return all;

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/impl/DefaultJavaSqlDateValueBridge.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/impl/DefaultJavaSqlDateValueBridge.java
@@ -41,10 +41,7 @@ public final class DefaultJavaSqlDateValueBridge implements ValueBridge<Date, In
 
 	@Override
 	public boolean isCompatibleWith(ValueBridge<?, ?> other) {
-		if ( !getClass().equals( other.getClass() ) ) {
-			return false;
-		}
-		return true;
+		return getClass().equals( other.getClass() );
 	}
 
 	private static class PojoDefaultSqlDateFromDocumentFieldValueConverter

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/impl/DefaultJavaSqlDateValueBridge.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/impl/DefaultJavaSqlDateValueBridge.java
@@ -1,0 +1,70 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.bridge.builtin.impl;
+
+import java.sql.Date;
+import java.time.Instant;
+
+import org.hibernate.search.engine.backend.types.converter.FromDocumentFieldValueConverter;
+import org.hibernate.search.engine.backend.types.converter.runtime.FromDocumentFieldValueConvertContext;
+import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeContext;
+import org.hibernate.search.mapper.pojo.bridge.ValueBridge;
+import org.hibernate.search.mapper.pojo.bridge.binding.ValueBridgeBindingContext;
+import org.hibernate.search.mapper.pojo.bridge.runtime.ValueBridgeToIndexedValueContext;
+
+public final class DefaultJavaSqlDateValueBridge implements ValueBridge<Date, Instant> {
+
+	@Override
+	public String toString() {
+		return getClass().getSimpleName();
+	}
+
+	@Override
+	public StandardIndexFieldTypeContext<?, Instant> bind(ValueBridgeBindingContext<Date> context) {
+		return context.getTypeFactory().asInstant()
+				.projectionConverter( PojoDefaultSqlDateFromDocumentFieldValueConverter.INSTANCE );
+	}
+
+	@Override
+	public Instant toIndexedValue(Date value, ValueBridgeToIndexedValueContext context) {
+		return value == null ? null : Instant.ofEpochMilli( value.getTime() );
+	}
+
+	@Override
+	public Date cast(Object value) {
+		return (Date) value;
+	}
+
+	@Override
+	public boolean isCompatibleWith(ValueBridge<?, ?> other) {
+		if ( !getClass().equals( other.getClass() ) ) {
+			return false;
+		}
+		return true;
+	}
+
+	private static class PojoDefaultSqlDateFromDocumentFieldValueConverter
+			implements FromDocumentFieldValueConverter<Instant, Date> {
+		private static final PojoDefaultSqlDateFromDocumentFieldValueConverter INSTANCE = new PojoDefaultSqlDateFromDocumentFieldValueConverter();
+
+		@Override
+		public boolean isConvertedTypeAssignableTo(Class<?> superTypeCandidate) {
+			return superTypeCandidate.isAssignableFrom( Date.class );
+		}
+
+		@Override
+		public Date convert(Instant value, FromDocumentFieldValueConvertContext context) {
+			return value == null ? null : new Date( value.toEpochMilli() );
+		}
+
+		@Override
+		public boolean isCompatibleWith(FromDocumentFieldValueConverter<?, ?> other) {
+			return INSTANCE.equals( other );
+		}
+	}
+
+}

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/impl/DefaultJavaSqlTimeValueBridge.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/impl/DefaultJavaSqlTimeValueBridge.java
@@ -1,0 +1,70 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.bridge.builtin.impl;
+
+import java.sql.Time;
+import java.time.Instant;
+
+import org.hibernate.search.engine.backend.types.converter.FromDocumentFieldValueConverter;
+import org.hibernate.search.engine.backend.types.converter.runtime.FromDocumentFieldValueConvertContext;
+import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeContext;
+import org.hibernate.search.mapper.pojo.bridge.ValueBridge;
+import org.hibernate.search.mapper.pojo.bridge.binding.ValueBridgeBindingContext;
+import org.hibernate.search.mapper.pojo.bridge.runtime.ValueBridgeToIndexedValueContext;
+
+public final class DefaultJavaSqlTimeValueBridge implements ValueBridge<Time, Instant> {
+
+	@Override
+	public String toString() {
+		return getClass().getSimpleName();
+	}
+
+	@Override
+	public StandardIndexFieldTypeContext<?, Instant> bind(ValueBridgeBindingContext<Time> context) {
+		return context.getTypeFactory().asInstant()
+				.projectionConverter( PojoDefaultSqlDateFromDocumentFieldValueConverter.INSTANCE );
+	}
+
+	@Override
+	public Instant toIndexedValue(Time value, ValueBridgeToIndexedValueContext context) {
+		return value == null ? null : Instant.ofEpochMilli( value.getTime() );
+	}
+
+	@Override
+	public Time cast(Object value) {
+		return (Time) value;
+	}
+
+	@Override
+	public boolean isCompatibleWith(ValueBridge<?, ?> other) {
+		if ( !getClass().equals( other.getClass() ) ) {
+			return false;
+		}
+		return true;
+	}
+
+	private static class PojoDefaultSqlDateFromDocumentFieldValueConverter
+			implements FromDocumentFieldValueConverter<Instant, Time> {
+		private static final PojoDefaultSqlDateFromDocumentFieldValueConverter INSTANCE = new PojoDefaultSqlDateFromDocumentFieldValueConverter();
+
+		@Override
+		public boolean isConvertedTypeAssignableTo(Class<?> superTypeCandidate) {
+			return superTypeCandidate.isAssignableFrom( Time.class );
+		}
+
+		@Override
+		public Time convert(Instant value, FromDocumentFieldValueConvertContext context) {
+			return value == null ? null : new Time( value.toEpochMilli() );
+		}
+
+		@Override
+		public boolean isCompatibleWith(FromDocumentFieldValueConverter<?, ?> other) {
+			return INSTANCE.equals( other );
+		}
+	}
+
+}

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/impl/DefaultJavaSqlTimeValueBridge.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/impl/DefaultJavaSqlTimeValueBridge.java
@@ -41,10 +41,7 @@ public final class DefaultJavaSqlTimeValueBridge implements ValueBridge<Time, In
 
 	@Override
 	public boolean isCompatibleWith(ValueBridge<?, ?> other) {
-		if ( !getClass().equals( other.getClass() ) ) {
-			return false;
-		}
-		return true;
+		return getClass().equals( other.getClass() );
 	}
 
 	private static class PojoDefaultSqlDateFromDocumentFieldValueConverter

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/impl/DefaultJavaSqlTimestampValueBridge.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/impl/DefaultJavaSqlTimestampValueBridge.java
@@ -1,0 +1,70 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.bridge.builtin.impl;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+
+import org.hibernate.search.engine.backend.types.converter.FromDocumentFieldValueConverter;
+import org.hibernate.search.engine.backend.types.converter.runtime.FromDocumentFieldValueConvertContext;
+import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeContext;
+import org.hibernate.search.mapper.pojo.bridge.ValueBridge;
+import org.hibernate.search.mapper.pojo.bridge.binding.ValueBridgeBindingContext;
+import org.hibernate.search.mapper.pojo.bridge.runtime.ValueBridgeToIndexedValueContext;
+
+public final class DefaultJavaSqlTimestampValueBridge implements ValueBridge<Timestamp, Instant> {
+
+	@Override
+	public String toString() {
+		return getClass().getSimpleName();
+	}
+
+	@Override
+	public StandardIndexFieldTypeContext<?, Instant> bind(ValueBridgeBindingContext<Timestamp> context) {
+		return context.getTypeFactory().asInstant()
+				.projectionConverter( PojoDefaultSqlDateFromDocumentFieldValueConverter.INSTANCE );
+	}
+
+	@Override
+	public Instant toIndexedValue(Timestamp value, ValueBridgeToIndexedValueContext context) {
+		return value == null ? null : Instant.ofEpochMilli( value.getTime() );
+	}
+
+	@Override
+	public Timestamp cast(Object value) {
+		return (Timestamp) value;
+	}
+
+	@Override
+	public boolean isCompatibleWith(ValueBridge<?, ?> other) {
+		if ( !getClass().equals( other.getClass() ) ) {
+			return false;
+		}
+		return true;
+	}
+
+	private static class PojoDefaultSqlDateFromDocumentFieldValueConverter
+			implements FromDocumentFieldValueConverter<Instant, Timestamp> {
+		private static final PojoDefaultSqlDateFromDocumentFieldValueConverter INSTANCE = new PojoDefaultSqlDateFromDocumentFieldValueConverter();
+
+		@Override
+		public boolean isConvertedTypeAssignableTo(Class<?> superTypeCandidate) {
+			return superTypeCandidate.isAssignableFrom( Timestamp.class );
+		}
+
+		@Override
+		public Timestamp convert(Instant value, FromDocumentFieldValueConvertContext context) {
+			return value == null ? null : new Timestamp( value.toEpochMilli() );
+		}
+
+		@Override
+		public boolean isCompatibleWith(FromDocumentFieldValueConverter<?, ?> other) {
+			return INSTANCE.equals( other );
+		}
+	}
+
+}

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/impl/DefaultJavaSqlTimestampValueBridge.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/impl/DefaultJavaSqlTimestampValueBridge.java
@@ -41,10 +41,7 @@ public final class DefaultJavaSqlTimestampValueBridge implements ValueBridge<Tim
 
 	@Override
 	public boolean isCompatibleWith(ValueBridge<?, ?> other) {
-		if ( !getClass().equals( other.getClass() ) ) {
-			return false;
-		}
-		return true;
+		return getClass().equals( other.getClass() );
 	}
 
 	private static class PojoDefaultSqlDateFromDocumentFieldValueConverter

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/impl/DefaultJavaUtilDateValueBridge.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/impl/DefaultJavaUtilDateValueBridge.java
@@ -41,10 +41,7 @@ public final class DefaultJavaUtilDateValueBridge implements ValueBridge<Date, I
 
 	@Override
 	public boolean isCompatibleWith(ValueBridge<?, ?> other) {
-		if ( !getClass().equals( other.getClass() ) ) {
-			return false;
-		}
-		return true;
+		return getClass().equals( other.getClass() );
 	}
 
 	private static class PojoDefaultDateFromDocumentFieldValueConverter

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/impl/BridgeResolver.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/impl/BridgeResolver.java
@@ -11,6 +11,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URI;
 import java.net.URL;
+import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -46,6 +47,7 @@ import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultIntegerIdenti
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultJavaNetURIValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultJavaNetURLValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultJavaSqlDateValueBridge;
+import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultJavaSqlTimestampValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultJavaUtilCalendarValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultJavaUtilDateValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultLongIdentifierBridge;
@@ -121,6 +123,7 @@ public final class BridgeResolver {
 		addValueBridgeForExactRawType( URI.class, ignored -> BeanHolder.of( new DefaultJavaNetURIValueBridge() ) );
 		addValueBridgeForExactRawType( URL.class, ignored -> BeanHolder.of( new DefaultJavaNetURLValueBridge() ) );
 		addValueBridgeForExactRawType( java.sql.Date.class, ignored -> BeanHolder.of( new DefaultJavaSqlDateValueBridge() ) );
+		addValueBridgeForExactRawType( Timestamp.class, ignored -> BeanHolder.of( new DefaultJavaSqlTimestampValueBridge() ) );
 	}
 
 	public BridgeBuilder<? extends IdentifierBridge<?>> resolveIdentifierBridgeForType(PojoGenericTypeModel<?> sourceType) {

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/impl/BridgeResolver.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/impl/BridgeResolver.java
@@ -45,6 +45,7 @@ import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultEnumValueBrid
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultIntegerIdentifierBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultJavaNetURIValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultJavaNetURLValueBridge;
+import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultJavaSqlDateValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultJavaUtilCalendarValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultJavaUtilDateValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultLongIdentifierBridge;
@@ -119,6 +120,7 @@ public final class BridgeResolver {
 		addValueBridgeForExactRawType( Duration.class, ignored -> BeanHolder.of( new DefaultDurationValueBridge() ) );
 		addValueBridgeForExactRawType( URI.class, ignored -> BeanHolder.of( new DefaultJavaNetURIValueBridge() ) );
 		addValueBridgeForExactRawType( URL.class, ignored -> BeanHolder.of( new DefaultJavaNetURLValueBridge() ) );
+		addValueBridgeForExactRawType( java.sql.Date.class, ignored -> BeanHolder.of( new DefaultJavaSqlDateValueBridge() ) );
 	}
 
 	public BridgeBuilder<? extends IdentifierBridge<?>> resolveIdentifierBridgeForType(PojoGenericTypeModel<?> sourceType) {

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/impl/BridgeResolver.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/impl/BridgeResolver.java
@@ -11,6 +11,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URI;
 import java.net.URL;
+import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.Instant;
@@ -47,6 +48,7 @@ import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultIntegerIdenti
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultJavaNetURIValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultJavaNetURLValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultJavaSqlDateValueBridge;
+import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultJavaSqlTimeValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultJavaSqlTimestampValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultJavaUtilCalendarValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.impl.DefaultJavaUtilDateValueBridge;
@@ -124,6 +126,7 @@ public final class BridgeResolver {
 		addValueBridgeForExactRawType( URL.class, ignored -> BeanHolder.of( new DefaultJavaNetURLValueBridge() ) );
 		addValueBridgeForExactRawType( java.sql.Date.class, ignored -> BeanHolder.of( new DefaultJavaSqlDateValueBridge() ) );
 		addValueBridgeForExactRawType( Timestamp.class, ignored -> BeanHolder.of( new DefaultJavaSqlTimestampValueBridge() ) );
+		addValueBridgeForExactRawType( Time.class, ignored -> BeanHolder.of( new DefaultJavaSqlTimeValueBridge() ) );
 	}
 
 	public BridgeBuilder<? extends IdentifierBridge<?>> resolveIdentifierBridgeForType(PojoGenericTypeModel<?> sourceType) {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3503

It's incredible that `java.sql.Date` and even `java.sql.Time` behaves exact as `java.sql.Timestamp`.

The methods `java.sql.Date#toLocalDate`, ` java.sqlTimestamp#toLocalDateTime` and so on have a lot of issue relative to the default JVM timezones applied on the conversion.
Thus I avoided to use them or their reverse.

