### PR TITLE
HSEARCH-3515 Upgraded maven-checkstyle-plugin to 3.0.0

### DIFF
--- a/build-config/src/main/resources/checkstyle.xml
+++ b/build-config/src/main/resources/checkstyle.xml
@@ -10,6 +10,8 @@
 
 <module name="Checker">
 
+    <property name="cacheFile" value="${checkstyle.cache.file}" />
+
     <module name="Header">
         <property name="header" value="/*\n * Hibernate Search, full-text search for your domain model\n *\n * License: GNU Lesser General Public License (LGPL), version 2.1 or later\n * See the lgpl.txt file in the root directory or &lt;http://www.gnu.org/licenses/lgpl-2.1.html&gt;.\n */"/>
         <property name="fileExtensions" value="java"/>
@@ -21,7 +23,6 @@
     </module>
 
     <module name="TreeWalker">
-        <property name="cacheFile" value="${checkstyle.cache.file}" />
 
         <module name="SuppressionCommentFilter" />
 

--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,7 @@
             overridden by a CI job of the Checkstyle project so that they can
             check for regressions. Which is obviously good for us, too.
          -->
-        <puppycrawl.checkstyle.version>8.8</puppycrawl.checkstyle.version>
+        <puppycrawl.checkstyle.version>8.18</puppycrawl.checkstyle.version>
 
         <!-- Asciidoctor -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
 
         <version.assembly.plugin>3.1.0</version.assembly.plugin>
         <version.buildhelper.plugin>3.0.0</version.buildhelper.plugin>
-        <version.checkstyle.plugin>2.17</version.checkstyle.plugin>
+        <version.checkstyle.plugin>3.0.0</version.checkstyle.plugin>
         <version.bundle.plugin>3.3.0</version.bundle.plugin>
         <version.clean.plugin>3.0.0</version.clean.plugin>
         <version.copy.plugin>0.0.5</version.copy.plugin>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3515

This PR is being created because we are removing the deprecated field `cacheFile` from TreeWalker. Checker still supports it.
PR: checkstyle/checkstyle#6553
Issue: checkstyle/checkstyle#2883

Maven-checkstyle-plugin needs to be upgraded because the old versions still tried to set the `cacheFile` field even if it wasn't declared in the config.

Feel free to ask any questions.
Thanks.