### PR TITLE
HSEARCH-3502 Upgrade to Byteman 4.0.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
         <version.com.github.tomakehurst.wiremock>2.5.1</version.com.github.tomakehurst.wiremock>
         <!-- Fixes dependency convergence within Wiremock, see below -->
         <version.com.fasterxml.jackson>2.8.6</version.com.fasterxml.jackson>
-        <version.org.jboss.byteman>4.0.5</version.org.jboss.byteman>
+        <version.org.jboss.byteman>4.0.6</version.org.jboss.byteman>
         <version.io.takari.junit>1.2.7</version.io.takari.junit>
         <version.com.h2database>1.4.178</version.com.h2database>
 


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3502

It fixes the JDK13 build: http://ci.hibernate.org/blue/organizations/jenkins/hibernate-search-yoann/detail/tracking-jdk13-5.11/6/pipeline