### PR TITLE
HSEARCH-3521 Move index-specific configuration properties below the hibernate.search.backends.<backend name>.indexes property

### DIFF
--- a/documentation/src/main/asciidoc/configuration.asciidoc
+++ b/documentation/src/main/asciidoc/configuration.asciidoc
@@ -72,14 +72,6 @@ For ORM entities, the default index name is the name of the indexed class, witho
 Index names can be customized in the mapping.
 
 +
-Notable properties:
-
-* `hibernate.search.indexes.<index name>.backend`: the backend to use for this index.
-Set this to the name of your backend.
-Note that you do not need to set this explicitly for each index,
-you can simply set the global property `hibernate.search.default_backend` (see above).
-
-+
 Examples:
 
 * `hibernate.search.backends.myBackend.index_defaults.lifecycle.strategy = validate`

--- a/documentation/src/main/asciidoc/configuration.asciidoc
+++ b/documentation/src/main/asciidoc/configuration.asciidoc
@@ -63,10 +63,11 @@ These properties affect either one or multiple indexes, depending on the root.
 +
 With the root `hibernate.search.backends.<backend name>.index_defaults`,
 they set defaults for all indexes of the referenced backend.
+The backend name must match the name defined in the mapping.
 +
-With the root `hibernate.search.indexes.<index name>`,
+With the root `hibernate.search.backends.<backend name>.indexes.<index name>`,
 they set the value for a specific index, overriding the defaults (if any).
-The index name must match the name defined in the mapping.
+The backend and index names must match the names defined in the mapping.
 For ORM entities, the default index name is the name of the indexed class, without the package:
 `org.mycompany.Book` will have `Book` as its default index name.
 Index names can be customized in the mapping.

--- a/engine/src/main/java/org/hibernate/search/engine/backend/spi/BackendFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/spi/BackendFactory.java
@@ -21,7 +21,7 @@ public interface BackendFactory {
 	 * doesn't need to care about Hibernate Search prefixes (hibernate.search.*, etc.). All the properties
 	 * can be accessed at the root.
 	 * <strong>CAUTION:</strong> the property keys listed in {@link BackendSettings},
-	 * in particular {@value BackendSettings#TYPE} and {@value BackendSettings#INDEX_DEFAULTS},
+	 * in particular {@value BackendSettings#TYPE}, {@value BackendSettings#INDEXES} and {@value BackendSettings#INDEX_DEFAULTS},
 	 * are reserved for use by the engine.
 	 * @return A backend.
 	 */

--- a/engine/src/main/java/org/hibernate/search/engine/backend/spi/BackendImplementor.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/spi/BackendImplementor.java
@@ -43,8 +43,7 @@ public interface BackendImplementor<D extends DocumentElement> extends AutoClose
 	 * @param propertySource A configuration property source, appropriately masked so that the backend
 	 * doesn't need to care about Hibernate Search prefixes (hibernate.search.*, etc.). All the properties
 	 * can be accessed at the root.
-	 * <strong>CAUTION:</strong> the property keys listed in {@link IndexSettings},
-	 * in particular {@value IndexSettings#BACKEND},
+	 * <strong>CAUTION:</strong> the property keys listed in {@link IndexSettings}
 	 * are reserved for use by the engine.
 	 * @return A builder for index managers targeting this backend.
 	 */

--- a/engine/src/main/java/org/hibernate/search/engine/cfg/BackendSettings.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/BackendSettings.java
@@ -33,4 +33,9 @@ public final class BackendSettings {
 	 */
 	public static final String INDEX_DEFAULTS = "index_defaults";
 
+	/**
+	 * The root property whose children are index names, e.g. {@code indexes.myIndex.<some index-scoped property> = bar}.
+	 */
+	public static final String INDEXES = "indexes";
+
 }

--- a/engine/src/main/java/org/hibernate/search/engine/cfg/EngineSettings.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/EngineSettings.java
@@ -19,7 +19,7 @@ public final class EngineSettings {
 	 * <p>
 	 * Expects a String.
 	 * <p>
-	 * Defaults to no value, meaning a backend must be {@link IndexSettings#BACKEND set for every single index}.
+	 * Defaults to no value, meaning a backend must be set in the mapping for every single index.
 	 */
 	public static final String DEFAULT_BACKEND = "default_backend";
 

--- a/engine/src/main/java/org/hibernate/search/engine/cfg/EngineSettings.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/EngineSettings.java
@@ -29,11 +29,6 @@ public final class EngineSettings {
 	public static final String BACKENDS = "backends";
 
 	/**
-	 * The root property whose children are index names, e.g. "indexes.myIndex.backend = myBackend".
-	 */
-	public static final String INDEXES = "indexes";
-
-	/**
 	 * Default values for the different settings if no values are given.
 	 */
 	public static final class Defaults {

--- a/engine/src/main/java/org/hibernate/search/engine/cfg/IndexSettings.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/IndexSettings.java
@@ -11,7 +11,7 @@ package org.hibernate.search.engine.cfg;
  * <p>
  * Constants in this class are to be appended to a prefix to form a property key.
  * The exact prefix will depend on the integration, but should generally look like
- * either "{@code hibernate.search.indexes.<index name>.}" (for per-index settings)
+ * either "{@code hibernate.search.backend.<backend name>.indexes.<index name>.}" (for per-index settings)
  * or "{@code hibernate.search.backends.<backend name>.index_defaults.}" (for default index settings).
  */
 public final class IndexSettings {

--- a/engine/src/main/java/org/hibernate/search/engine/cfg/IndexSettings.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/IndexSettings.java
@@ -19,13 +19,4 @@ public final class IndexSettings {
 	private IndexSettings() {
 	}
 
-	/**
-	 * The name of the backend to create the index in.
-	 * <p>
-	 * Expects a String.
-	 * <p>
-	 * Defaults to the name of the {@link EngineSettings#DEFAULT_BACKEND default backend}.
-	 */
-	public static final String BACKEND = "backend";
-
 }

--- a/engine/src/main/java/org/hibernate/search/engine/cfg/impl/EngineConfigurationUtils.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/impl/EngineConfigurationUtils.java
@@ -19,17 +19,13 @@ public final class EngineConfigurationUtils {
 		return engineSource.withMask( EngineSettings.BACKENDS ).withMask( backendName );
 	}
 
-	public static ConfigurationPropertySource getIndexWithoutDefaults(ConfigurationPropertySource engineSource, String indexName) {
-		return engineSource.withMask( EngineSettings.INDEXES ).withMask( indexName );
+	public static ConfigurationPropertySource getIndex(ConfigurationPropertySource backendSource,
+			ConfigurationPropertySource indexDefaultsSource, String indexName) {
+		return backendSource.withMask( BackendSettings.INDEXES ).withMask( indexName ).withFallback( indexDefaultsSource );
 	}
 
 	public static ConfigurationPropertySource getIndexDefaults(ConfigurationPropertySource backendSource) {
 		return backendSource.withMask( BackendSettings.INDEX_DEFAULTS );
-	}
-
-	public static ConfigurationPropertySource addIndexDefaults(ConfigurationPropertySource indexSource,
-			ConfigurationPropertySource indexDefaultsSource) {
-		return indexSource.withFallback( indexDefaultsSource );
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/IndexManagerBuildingStateHolder.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/IndexManagerBuildingStateHolder.java
@@ -131,6 +131,7 @@ class IndexManagerBuildingStateHolder {
 	class BackendInitialBuildState<D extends DocumentElement> {
 		private final String backendName;
 		private final BackendBuildContext backendBuildContext;
+		private final ConfigurationPropertySource backendPropertySource;
 		private final ConfigurationPropertySource defaultIndexPropertySource;
 		private final BackendImplementor<D> backend;
 
@@ -141,6 +142,7 @@ class IndexManagerBuildingStateHolder {
 				BackendImplementor<D> backend) {
 			this.backendName = backendName;
 			this.backendBuildContext = backendBuildContext;
+			this.backendPropertySource = backendPropertySource;
 			this.defaultIndexPropertySource =
 					EngineConfigurationUtils.getIndexDefaults( backendPropertySource );
 			this.backend = backend;
@@ -151,12 +153,10 @@ class IndexManagerBuildingStateHolder {
 			IndexManagerInitialBuildState<?> state = indexManagerBuildStateByName.get( indexName );
 			if ( state == null ) {
 				ConfigurationPropertySource indexPropertySource =
-						EngineConfigurationUtils.getIndexWithoutDefaults( propertySource, indexName );
-				ConfigurationPropertySource defaultedIndexPropertySource =
-						EngineConfigurationUtils.addIndexDefaults( indexPropertySource, defaultIndexPropertySource );
+						EngineConfigurationUtils.getIndex( backendPropertySource, defaultIndexPropertySource, indexName );
 
 				IndexManagerBuilder<D> builder = backend.createIndexManagerBuilder(
-						indexName, multiTenancyEnabled, backendBuildContext, defaultedIndexPropertySource
+						indexName, multiTenancyEnabled, backendBuildContext, indexPropertySource
 				);
 				IndexSchemaRootNodeBuilder schemaRootNodeBuilder = builder.getSchemaRootNodeBuilder();
 				IndexedEntityBindingContext bindingContext = new IndexedEntityBindingContextImpl( schemaRootNodeBuilder );

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/IndexManagerPartialBuildState.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/IndexManagerPartialBuildState.java
@@ -34,12 +34,13 @@ class IndexManagerPartialBuildState {
 			ConfigurationPropertySource rootPropertySource) {
 		ContextualFailureCollector indexFailureCollector =
 				rootFailureCollector.withContext( EventContexts.fromIndexName( indexName ) );
+		ConfigurationPropertySource backendPropertySource =
+				EngineConfigurationUtils.getBackend( rootPropertySource, backendName );
 		ConfigurationPropertySource indexPropertySource =
-				EngineConfigurationUtils.addIndexDefaults(
-						EngineConfigurationUtils.getIndexWithoutDefaults( rootPropertySource, indexName ),
-						EngineConfigurationUtils.getIndexDefaults(
-								EngineConfigurationUtils.getBackend( rootPropertySource, backendName )
-						)
+				EngineConfigurationUtils.getIndex(
+						backendPropertySource,
+						EngineConfigurationUtils.getIndexDefaults( backendPropertySource ),
+						indexName
 				);
 		IndexManagerStartContextImpl startContext = new IndexManagerStartContextImpl(
 				indexFailureCollector, indexPropertySource

--- a/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
@@ -235,10 +235,11 @@ public interface Log extends BasicLogger {
 	SearchException backendTypeCannotBeNullOrEmpty(String backendName, String key);
 
 	@Message(id = ID_OFFSET_2 + 50,
-			value = "Missing backend reference for index '%1$s'."
-					+ " Set the property '%2$s' to a supported value or set '%3$s' to set a default value for all indexes."
+			value = "The name of the default backend is not set."
+					+ " Set it through the configuration property '%1$s',"
+					+ " or set the backend name explicitly for each indexed type in your mapping."
 	)
-	SearchException indexBackendCannotBeNullOrEmpty(String indexName, String key, String defaultKey);
+	SearchException defaultBackendNameNotSet(String defaultKey);
 
 	@Message(id = ID_OFFSET_2 + 51,
 			value = "It is not possible to use per-field boosts together with withConstantScore option"

--- a/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/building/spi/MappingConfigurationCollector.java
+++ b/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/building/spi/MappingConfigurationCollector.java
@@ -13,7 +13,7 @@ import org.hibernate.search.engine.mapper.model.spi.MappableTypeModel;
  */
 public interface MappingConfigurationCollector<C> {
 
-	void mapToIndex(MappableTypeModel typeModel, String indexName);
+	void mapToIndex(MappableTypeModel typeModel, String backendName, String indexName);
 
 	void collectContributor(MappableTypeModel typeModel, C contributor);
 

--- a/engine/src/test/java/org/hibernate/search/engine/common/impl/IndexManagerBuildingStateHolderTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/common/impl/IndexManagerBuildingStateHolderTest.java
@@ -38,28 +38,24 @@ public class IndexManagerBuildingStateHolderTest extends EasyMockSupport {
 			new IndexManagerBuildingStateHolder( beanProviderMock, configurationSourceMock, rootBuildContextMock );
 
 	@Test
-	public void error_missingIndexBackend_emptyOptional() {
+	public void error_missingBackend_nullName() {
 		String keyPrefix = "somePrefix.";
 		resetAll();
-		EasyMock.expect( configurationSourceMock.get( "indexes.indexName.backend" ) )
-				.andReturn( Optional.empty() );
-		EasyMock.expect( configurationSourceMock.resolve( "indexes.indexName.backend" ) )
-				.andReturn( Optional.of( keyPrefix + "indexes.indexName.backend" ) );
 		EasyMock.expect( configurationSourceMock.get( "default_backend" ) )
 				.andReturn( Optional.empty() );
 		EasyMock.expect( configurationSourceMock.resolve( "default_backend" ) )
 				.andReturn( Optional.of( keyPrefix + "default_backend" ) );
 		replayAll();
 		thrown.expect( SearchException.class );
-		thrown.expectMessage( "Missing backend reference for index 'indexName'" );
-		thrown.expectMessage( "Set the property 'somePrefix.indexes.indexName.backend' to a supported value" );
-		thrown.expectMessage( "or set 'somePrefix.default_backend' to set a default value for all indexes" );
-		holder.startBuilding( "indexName", false );
+		thrown.expectMessage( "The name of the default backend is not set" );
+		thrown.expectMessage( "Set it through the configuration property 'somePrefix.default_backend'" );
+		thrown.expectMessage( "or set the backend name explicitly for each indexed type in your mapping" );
+		holder.getBackend( null );
 		verifyAll();
 	}
 
 	@Test
-	public void error_missingIndexBackend_emptyString() {
+	public void error_missingIndexBackend_emptyName() {
 		String keyPrefix = "somePrefix.";
 		resetAll();
 		EasyMock.expect( configurationSourceMock.get( "indexes.indexName.backend" ) )
@@ -72,19 +68,17 @@ public class IndexManagerBuildingStateHolderTest extends EasyMockSupport {
 				.andReturn( Optional.of( keyPrefix + "default_backend" ) );
 		replayAll();
 		thrown.expect( SearchException.class );
-		thrown.expectMessage( "Missing backend reference for index 'indexName'" );
-		thrown.expectMessage( "Set the property 'somePrefix.indexes.indexName.backend' to a supported value" );
-		thrown.expectMessage( "or set 'somePrefix.default_backend' to set a default value for all indexes" );
-		holder.startBuilding( "indexName", false );
+		thrown.expectMessage( "The name of the default backend is not set" );
+		thrown.expectMessage( "Set it through the configuration property 'somePrefix.default_backend'" );
+		thrown.expectMessage( "or set the backend name explicitly for each indexed type in your mapping" );
+		holder.getBackend( "" );
 		verifyAll();
 	}
 
 	@Test
-	public void error_missingBackendType_emptyOptional() {
+	public void error_missingBackendType_nullType() {
 		String keyPrefix = "somePrefix.";
 		resetAll();
-		EasyMock.expect( configurationSourceMock.get( "indexes.indexName.backend" ) )
-				.andReturn( (Optional) Optional.of( "backendName" ) );
 		EasyMock.expect( configurationSourceMock.get( "backends.backendName.type" ) )
 				.andReturn( Optional.empty() );
 		EasyMock.expect( configurationSourceMock.resolve( "backends.backendName.type" ) )
@@ -93,16 +87,14 @@ public class IndexManagerBuildingStateHolderTest extends EasyMockSupport {
 		thrown.expect( SearchException.class );
 		thrown.expectMessage( "Missing backend type for backend 'backendName'" );
 		thrown.expectMessage( "Set the property 'somePrefix.backends.backendName.type' to a supported value" );
-		holder.startBuilding( "indexName", false );
+		holder.getBackend( "backendName" );
 		verifyAll();
 	}
 
 	@Test
-	public void error_missingBackendType_emptyString() {
+	public void error_missingBackendType_emptyType() {
 		String keyPrefix = "somePrefix.";
 		resetAll();
-		EasyMock.expect( configurationSourceMock.get( "indexes.indexName.backend" ) )
-				.andReturn( (Optional) Optional.of( "backendName" ) );
 		EasyMock.expect( configurationSourceMock.get( "backends.backendName.type" ) )
 				.andReturn( (Optional) Optional.of( "" ) );
 		EasyMock.expect( configurationSourceMock.resolve( "backends.backendName.type" ) )
@@ -111,7 +103,7 @@ public class IndexManagerBuildingStateHolderTest extends EasyMockSupport {
 		thrown.expect( SearchException.class );
 		thrown.expectMessage( "Missing backend type for backend 'backendName'" );
 		thrown.expectMessage( "Set the property 'somePrefix.backends.backendName.type' to a supported value" );
-		holder.startBuilding( "indexName", false );
+		holder.getBackend( "backendName" );
 		verifyAll();
 	}
 

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/analysis/ElasticsearchAnalysisConfigurerIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/analysis/ElasticsearchAnalysisConfigurerIT.java
@@ -352,7 +352,8 @@ public class ElasticsearchAnalysisConfigurerIT {
 						analysisConfigurer
 				)
 				.withIndex(
-						MAPPED_TYPE_NAME, INDEX_NAME,
+						INDEX_NAME,
+						c -> c.mappedType( MAPPED_TYPE_NAME ),
 						mappingContributor,
 						indexManager -> { }
 				)

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/analysis/LuceneAnalysisConfigurerIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/analysis/LuceneAnalysisConfigurerIT.java
@@ -192,7 +192,8 @@ public class LuceneAnalysisConfigurerIT {
 						analysisConfigurer
 				)
 				.withIndex(
-						MAPPED_TYPE_NAME, INDEX_NAME,
+						INDEX_NAME,
+						c -> c.mappedType( MAPPED_TYPE_NAME ),
 						mappingContributor,
 						indexManager -> { }
 				)

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/IndexedIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/IndexedIT.java
@@ -24,7 +24,13 @@ import org.junit.Test;
 public class IndexedIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock defaultBackendMock = new BackendMock( "defaultBackend" );
+
+	@Rule
+	public BackendMock backend2Mock = new BackendMock( "backend2" );
+
+	@Rule
+	public BackendMock backend3Mock = new BackendMock( "backend3" );
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = new JavaBeanMappingSetupHelper( MethodHandles.lookup() );
@@ -45,12 +51,12 @@ public class IndexedIT {
 			}
 		}
 
-		backendMock.expectSchema( IndexedEntity.class.getName(), b -> b
+		defaultBackendMock.expectSchema( IndexedEntity.class.getName(), b -> b
 				.field( "text", String.class )
 		);
-		setupHelper.withBackendMock( backendMock )
+		setupHelper.withBackendMock( defaultBackendMock )
 				.setup( IndexedEntity.class );
-		backendMock.verifyExpectationsMet();
+		defaultBackendMock.verifyExpectationsMet();
 	}
 
 	@Test
@@ -69,12 +75,79 @@ public class IndexedIT {
 			}
 		}
 
-		backendMock.expectSchema( "explicitIndexName", b -> b
+		defaultBackendMock.expectSchema( "explicitIndexName", b -> b
 				.field( "text", String.class )
 		);
-		setupHelper.withBackendMock( backendMock )
+		setupHelper.withBackendMock( defaultBackendMock )
 				.setup( IndexedEntity.class );
-		backendMock.verifyExpectationsMet();
+		defaultBackendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void nonDefaultBackend() {
+		@Indexed(index = "index", backend = "backend2")
+		class IndexedEntity {
+			Integer id;
+			String text;
+			@DocumentId
+			public Integer getId() {
+				return id;
+			}
+			@GenericField
+			public String getText() {
+				throw new UnsupportedOperationException( "Should not be called" );
+			}
+		}
+
+		backend2Mock.expectSchema( "index", b -> b
+				.field( "text", String.class )
+		);
+		setupHelper.withBackendMock( defaultBackendMock )
+				.withBackendMock( backend2Mock )
+				.setup( IndexedEntity.class );
+		defaultBackendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void multiBackend() {
+		@Indexed(index = "index1", backend = "backend2")
+		class IndexedEntity1 {
+			Integer id;
+			String text1;
+			@DocumentId
+			public Integer getId() {
+				return id;
+			}
+			@GenericField
+			public String getText1() {
+				throw new UnsupportedOperationException( "Should not be called" );
+			}
+		}
+		@Indexed(index = "index2", backend = "backend3")
+		class IndexedEntity2 {
+			Integer id;
+			String text2;
+			@DocumentId
+			public Integer getId() {
+				return id;
+			}
+			@GenericField
+			public String getText2() {
+				throw new UnsupportedOperationException( "Should not be called" );
+			}
+		}
+
+		backend2Mock.expectSchema( "index1", b -> b
+				.field( "text1", String.class )
+		);
+		backend3Mock.expectSchema( "index2", b -> b
+				.field( "text2", String.class )
+		);
+		setupHelper.withBackendMock( defaultBackendMock )
+				.withBackendMock( backend2Mock )
+				.withBackendMock( backend3Mock )
+				.setup( IndexedEntity1.class, IndexedEntity2.class );
+		defaultBackendMock.verifyExpectationsMet();
 	}
 
 	@Test
@@ -93,7 +166,7 @@ public class IndexedIT {
 			}
 		}
 		SubTest.expectException(
-				() -> setupHelper.withBackendMock( backendMock )
+				() -> setupHelper.withBackendMock( defaultBackendMock )
 						// Do not mention the type is an entity type here, on purpose, to trigger the failure
 						.withAnnotatedTypes( IndexedWithoutEntityMetadata.class )
 						.setup()
@@ -123,7 +196,7 @@ public class IndexedIT {
 			}
 		}
 		SubTest.expectException(
-				() -> setupHelper.withBackendMock( backendMock ).setup( AbstractIndexedEntity.class )
+				() -> setupHelper.withBackendMock( defaultBackendMock ).setup( AbstractIndexedEntity.class )
 		)
 				.assertThrown()
 				.isInstanceOf( SearchException.class )
@@ -148,7 +221,7 @@ public class IndexedIT {
 			}
 		}
 		SubTest.expectException(
-				() -> setupHelper.withBackendMock( backendMock )
+				() -> setupHelper.withBackendMock( defaultBackendMock )
 						.withConfiguration( builder -> {
 							builder.setAnnotatedTypeDiscoveryEnabled( false );
 							builder.addEntityType( AbstractIndexedEntity.class );

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/Indexed.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/Indexed.java
@@ -20,6 +20,16 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Indexed {
 
+	/**
+	 * @return The name of the backend.
+	 * Defaults to the {@link org.hibernate.search.engine.cfg.EngineSettings#DEFAULT_BACKEND default backend}.
+	 */
+	String backend() default "";
+
+	/**
+	 * @return The name of the index.
+	 * Defaults to the simple name of the entity class.
+	 */
 	String index() default "";
 
 }

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/impl/AnnotationMappingDefinitionContextImpl.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/impl/AnnotationMappingDefinitionContextImpl.java
@@ -80,12 +80,13 @@ public class AnnotationMappingDefinitionContextImpl implements AnnotationMapping
 				.forEach( typeModel -> {
 					Optional<Indexed> indexedAnnotation = typeModel.getAnnotationByType( Indexed.class );
 					if ( indexedAnnotation.isPresent() ) {
+						String backendName = indexedAnnotation.get().backend();
 						String defaultedIndexName = indexedAnnotation.get().index();
 						if ( defaultedIndexName.isEmpty() ) {
 							defaultedIndexName = typeModel.getJavaClass().getName();
 						}
 						try {
-							collector.mapToIndex( typeModel, defaultedIndexName );
+							collector.mapToIndex( typeModel, backendName, defaultedIndexName );
 						}
 						catch (RuntimeException e) {
 							failureCollector.withContext( PojoEventContexts.fromType( typeModel ) )

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/TypeMappingContext.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/TypeMappingContext.java
@@ -20,6 +20,8 @@ public interface TypeMappingContext {
 
 	TypeMappingContext indexed(String indexName);
 
+	TypeMappingContext indexed(String backendName, String indexName);
+
 	/**
 	 * @param bridgeClass The class of the bridge to use.
 	 * @return {@code this}, for method chaining.

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/TypeMappingContextImpl.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/TypeMappingContextImpl.java
@@ -30,6 +30,7 @@ public class TypeMappingContextImpl
 
 	private final PojoRawTypeModel<?> typeModel;
 
+	private String backendName;
 	private String indexName;
 
 	private final ErrorCollectingPojoTypeMetadataContributor children = new ErrorCollectingPojoTypeMetadataContributor();
@@ -43,7 +44,7 @@ public class TypeMappingContextImpl
 			MappingConfigurationCollector<PojoTypeMetadataContributor> configurationCollector) {
 		if ( indexName != null ) {
 			try {
-				configurationCollector.mapToIndex( typeModel, indexName );
+				configurationCollector.mapToIndex( typeModel, backendName, indexName );
 			}
 			catch (RuntimeException e) {
 				buildContext.getFailureCollector()
@@ -71,6 +72,13 @@ public class TypeMappingContextImpl
 
 	@Override
 	public TypeMappingContext indexed(String indexName) {
+		this.indexName = indexName;
+		return this;
+	}
+
+	@Override
+	public TypeMappingContext indexed(String backendName, String indexName) {
+		this.backendName = backendName;
 		this.indexName = indexName;
 		return this;
 	}

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/MappingSetupHelper.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/MappingSetupHelper.java
@@ -29,7 +29,7 @@ public abstract class MappingSetupHelper<C extends MappingSetupHelper<C, B, R>.A
 	public C withBackendMock(BackendMock backendMock) {
 		String backendName = backendMock.getBackendName();
 		return createSetupContext()
-				.withBackendProperty( backendName, "type", StubBackendFactory.class.getName() )
+				.withBackendMock( backendMock )
 				.withPropertyRadical( EngineSettings.DEFAULT_BACKEND, backendName );
 	}
 
@@ -75,6 +75,11 @@ public abstract class MappingSetupHelper<C extends MappingSetupHelper<C, B, R>.A
 		private final List<Configuration<B, R>> configurations = new ArrayList<>();
 
 		protected AbstractSetupContext() {
+		}
+
+		public C withBackendMock(BackendMock backendMock) {
+			String backendName = backendMock.getBackendName();
+			return withBackendProperty( backendName, "type", StubBackendFactory.class.getName() );
 		}
 
 		protected abstract C withPropertyRadical(String keyRadical, Object value);

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/StubMappingInitiator.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/StubMappingInitiator.java
@@ -26,8 +26,10 @@ public class StubMappingInitiator implements MappingInitiator<StubTypeMetadataCo
 		this.multiTenancyEnabled = multiTenancyEnabled;
 	}
 
-	public void add(String typeIdentifier, String indexName, Consumer<? super IndexedEntityBindingContext> mappingContributor) {
-		mappingContributors.add( new StubTypeMetadataContributor( new StubTypeModel( typeIdentifier ), indexName, mappingContributor ) );
+	public void add(String typeIdentifier, String backendName, String indexName,
+			Consumer<? super IndexedEntityBindingContext> mappingContributor) {
+		mappingContributors.add( new StubTypeMetadataContributor( new StubTypeModel( typeIdentifier ), backendName,
+				indexName, mappingContributor ) );
 	}
 
 	@Override

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/StubTypeMetadataContributor.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/StubTypeMetadataContributor.java
@@ -15,18 +15,21 @@ import org.hibernate.search.engine.mapper.mapping.building.spi.IndexedEntityBind
 class StubTypeMetadataContributor {
 
 	private final StubTypeModel typeIdentifier;
+	private final String backendName;
 	private final String indexName;
 	private final Consumer<? super IndexedEntityBindingContext> delegate;
 
-	StubTypeMetadataContributor(StubTypeModel typeIdentifier, String indexName, Consumer<? super IndexedEntityBindingContext> delegate) {
+	StubTypeMetadataContributor(StubTypeModel typeIdentifier, String backendName, String indexName,
+			Consumer<? super IndexedEntityBindingContext> delegate) {
 		this.typeIdentifier = typeIdentifier;
+		this.backendName = backendName;
 		this.indexName = indexName;
 		this.delegate = delegate;
 	}
 
 	final void contribute(MappingConfigurationCollector<StubTypeMetadataContributor> collector) {
 		if ( indexName != null ) {
-			collector.mapToIndex( typeIdentifier, indexName );
+			collector.mapToIndex( typeIdentifier, backendName, indexName );
 		}
 		collector.collectContributor( typeIdentifier, this );
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3521
