### PR TITLE
HSEARCH-3542 + HSEARCH-3543 Spatial-related fixes

### DIFF
--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BridgeUsingPropertyMarkerAccessIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BridgeUsingPropertyMarkerAccessIT.java
@@ -11,6 +11,7 @@ import javax.persistence.Id;
 
 import org.hibernate.SessionFactory;
 import org.hibernate.search.engine.backend.types.Projectable;
+import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.engine.spatial.GeoPoint;
 import org.hibernate.search.mapper.pojo.bridge.builtin.spatial.annotation.GeoPointBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.spatial.annotation.Latitude;
@@ -72,7 +73,8 @@ public class BridgeUsingPropertyMarkerAccessIT<TIndexed> {
 	@Before
 	public void setup() {
 		backendMock.expectSchema( INDEX_NAME, b -> b
-				.field( "location", GeoPoint.class, b2 -> b2.projectable( Projectable.DEFAULT ) )
+				.field( "location", GeoPoint.class,
+						b2 -> b2.projectable( Projectable.DEFAULT ).sortable( Sortable.DEFAULT ) )
 		);
 		sessionFactory = ormSetupHelper.withBackendMock( backendMock )
 				.setup( modelPrimitives.getModelClass() );

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/spatial/AnnotationMappingGeoPointBridgeIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/spatial/AnnotationMappingGeoPointBridgeIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.pojo.spatial;
 
 import org.hibernate.search.engine.backend.types.Projectable;
+import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.engine.spatial.GeoPoint;
 import org.hibernate.search.integrationtest.mapper.pojo.testsupport.util.rule.JavaBeanMappingSetupHelper;
 import org.hibernate.search.mapper.javabean.JavaBeanMapping;
@@ -38,16 +39,16 @@ public class AnnotationMappingGeoPointBridgeIT {
 	@Before
 	public void setup() {
 		backendMock.expectSchema( GeoPointOnTypeEntity.INDEX, b -> b
-				.field( "homeLocation", GeoPoint.class, b2 -> b2.projectable( Projectable.YES ) )
-				.field( "workLocation", GeoPoint.class, b2 -> b2.projectable( Projectable.DEFAULT ) )
+				.field( "homeLocation", GeoPoint.class, b2 -> b2.projectable( Projectable.YES ).sortable( Sortable.YES ) )
+				.field( "workLocation", GeoPoint.class, b2 -> b2.projectable( Projectable.DEFAULT ).sortable( Sortable.DEFAULT ) )
 		);
 		backendMock.expectSchema( GeoPointOnCoordinatesPropertyEntity.INDEX, b -> b
-				.field( "coord", GeoPoint.class, b2 -> b2.projectable( Projectable.DEFAULT ) )
-				.field( "location", GeoPoint.class, b2 -> b2.projectable( Projectable.NO ) )
+				.field( "coord", GeoPoint.class, b2 -> b2.projectable( Projectable.DEFAULT ).sortable( Sortable.DEFAULT ) )
+				.field( "location", GeoPoint.class, b2 -> b2.projectable( Projectable.NO ).sortable( Sortable.DEFAULT ) )
 		);
 		backendMock.expectSchema( GeoPointOnCustomCoordinatesPropertyEntity.INDEX, b -> b
-				.field( "coord", GeoPoint.class, b2 -> b2.projectable( Projectable.DEFAULT ) )
-				.field( "location", GeoPoint.class, b2 -> b2.projectable( Projectable.DEFAULT ) )
+				.field( "coord", GeoPoint.class, b2 -> b2.projectable( Projectable.DEFAULT ).sortable( Sortable.DEFAULT ) )
+				.field( "location", GeoPoint.class, b2 -> b2.projectable( Projectable.DEFAULT ).sortable( Sortable.DEFAULT ) )
 		);
 
 		mapping = setupHelper.withBackendMock( backendMock )
@@ -124,7 +125,7 @@ public class AnnotationMappingGeoPointBridgeIT {
 	}
 
 	@Indexed(index = GeoPointOnTypeEntity.INDEX)
-	@GeoPointBridge(fieldName = "homeLocation", markerSet = "home", projectable = Projectable.YES)
+	@GeoPointBridge(fieldName = "homeLocation", markerSet = "home", projectable = Projectable.YES, sortable = Sortable.YES)
 	@GeoPointBridge(fieldName = "workLocation", markerSet = "work")
 	public static final class GeoPointOnTypeEntity {
 

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/spatial/ProgrammaticMappingGeoPointBridgeIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/spatial/ProgrammaticMappingGeoPointBridgeIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.pojo.spatial;
 
 import org.hibernate.search.engine.backend.types.Projectable;
+import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.mapper.javabean.JavaBeanMapping;
 import org.hibernate.search.mapper.pojo.bridge.builtin.spatial.GeoPointBridgeBuilder;
 import org.hibernate.search.mapper.javabean.session.SearchSession;
@@ -36,16 +37,16 @@ public class ProgrammaticMappingGeoPointBridgeIT {
 	@Before
 	public void setup() {
 		backendMock.expectSchema( GeoPointOnTypeEntity.INDEX, b -> b
-				.field( "homeLocation", GeoPoint.class, b2 -> b2.projectable( Projectable.YES ) )
-				.field( "workLocation", GeoPoint.class, b2 -> b2.projectable( Projectable.DEFAULT ) )
+				.field( "homeLocation", GeoPoint.class, b2 -> b2.projectable( Projectable.YES ).sortable( Sortable.YES ) )
+				.field( "workLocation", GeoPoint.class, b2 -> b2.projectable( Projectable.DEFAULT ).sortable( Sortable.DEFAULT ) )
 		);
 		backendMock.expectSchema( GeoPointOnCoordinatesPropertyEntity.INDEX, b -> b
-				.field( "coord", GeoPoint.class, b2 -> b2.projectable( Projectable.DEFAULT ) )
-				.field( "location", GeoPoint.class, b2 -> b2.projectable( Projectable.NO ) )
+				.field( "coord", GeoPoint.class, b2 -> b2.projectable( Projectable.DEFAULT ).sortable( Sortable.DEFAULT ) )
+				.field( "location", GeoPoint.class, b2 -> b2.projectable( Projectable.NO ).sortable( Sortable.DEFAULT ) )
 		);
 		backendMock.expectSchema( GeoPointOnCustomCoordinatesPropertyEntity.INDEX, b -> b
-				.field( "coord", GeoPoint.class, b2 -> b2.projectable( Projectable.DEFAULT ) )
-				.field( "location", GeoPoint.class, b2 -> b2.projectable( Projectable.DEFAULT ) )
+				.field( "coord", GeoPoint.class, b2 -> b2.projectable( Projectable.DEFAULT ).sortable( Sortable.DEFAULT ) )
+				.field( "location", GeoPoint.class, b2 -> b2.projectable( Projectable.DEFAULT ).sortable( Sortable.DEFAULT ) )
 		);
 
 		mapping = setupHelper.withBackendMock( backendMock )
@@ -63,6 +64,7 @@ public class ProgrammaticMappingGeoPointBridgeIT {
 									.fieldName( "homeLocation" )
 									.markerSet( "home" )
 									.projectable( Projectable.YES )
+									.sortable( Sortable.YES )
 							)
 							.bridge(
 							GeoPointBridgeBuilder.forType()

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/model/Library.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/model/Library.java
@@ -31,7 +31,7 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordFie
  */
 @Entity
 @Indexed(index = Library.INDEX)
-@GeoPointBridge(fieldName = "location")
+@GeoPointBridge(fieldName = "location", sortable = Sortable.YES)
 public class Library extends AbstractEntity<Integer> {
 
 	static final String INDEX = "Library";

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchDocumentRepositoryImpl.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchDocumentRepositoryImpl.java
@@ -134,7 +134,13 @@ public class IndexSearchDocumentRepositoryImpl implements IndexSearchDocumentRep
 					}
 				} ) )
 				// TODO facets (tag, medium, library in particular)
-				.sort( b -> b.byScore() )
+				.sort( b -> {
+					if ( myLocation != null ) {
+						// TODO HSEARCH-2254 sort by distance once we implement nested support for sorts ("copies" is a nested object field)
+						//b.byDistance( "copies.library.location", myLocation );
+					}
+					b.byScore();
+				} )
 				.toQuery();
 
 		return query.fetchHits( limit, offset );

--- a/integrationtest/showcase/library/src/test/java/org/hibernate/search/integrationtest/showcase/library/OrmLibraryShowcaseIT.java
+++ b/integrationtest/showcase/library/src/test/java/org/hibernate/search/integrationtest/showcase/library/OrmLibraryShowcaseIT.java
@@ -220,7 +220,8 @@ public class OrmLibraryShowcaseIT {
 				0, 10
 		);
 		// Should only include content from university
-		assertThat( documents ).extracting( Document::getId ).containsExactly(
+		// TODO HSEARCH-2254 check results are sorted by distance once we do sort them (see the query implementation)
+		assertThat( documents ).extracting( Document::getId ).containsExactlyInAnyOrder(
 				INDONESIAN_ECONOMY_ID,
 				JAVA_FOR_DUMMIES_ID,
 				ART_OF_COMPUTER_PROG_ID,
@@ -234,7 +235,8 @@ public class OrmLibraryShowcaseIT {
 				0, 10
 		);
 		// Should only include content from suburb1 or university
-		assertThat( documents ).extracting( Document::getId ).containsExactly(
+		// TODO HSEARCH-2254 check results are sorted by distance once we do sort them (see the query implementation)
+		assertThat( documents ).extracting( Document::getId ).containsExactlyInAnyOrder(
 				CALLIGRAPHY_ID,
 				INDONESIAN_ECONOMY_ID,
 				JAVA_FOR_DUMMIES_ID,
@@ -249,7 +251,8 @@ public class OrmLibraryShowcaseIT {
 				0, 10
 		);
 		// Should only include content from suburb1 or university with "calligraphy" in it
-		assertThat( documents ).extracting( Document::getId ).containsExactly(
+		// TODO HSEARCH-2254 check results are sorted by distance once we do sort them (see the query implementation)
+		assertThat( documents ).extracting( Document::getId ).containsExactlyInAnyOrder(
 				CALLIGRAPHY_ID
 		);
 
@@ -261,7 +264,8 @@ public class OrmLibraryShowcaseIT {
 				0, 10
 		);
 		// Should only include content from university
-		assertThat( documents ).extracting( Document::getId ).containsExactly(
+		// TODO HSEARCH-2254 check results are sorted by distance once we do sort them (see the query implementation)
+		assertThat( documents ).extracting( Document::getId ).containsExactlyInAnyOrder(
 				INDONESIAN_ECONOMY_ID,
 				JAVA_FOR_DUMMIES_ID,
 				ART_OF_COMPUTER_PROG_ID,

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/spatial/GeoPointBridgeBuilder.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/spatial/GeoPointBridgeBuilder.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.mapper.pojo.bridge.builtin.spatial;
 
 import org.hibernate.search.engine.backend.types.Projectable;
+import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.mapper.pojo.bridge.PropertyBridge;
 import org.hibernate.search.mapper.pojo.bridge.TypeBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.spatial.impl.GeoPointBridge;
@@ -19,6 +20,8 @@ public interface GeoPointBridgeBuilder<B> extends BridgeBuilder<B> {
 	GeoPointBridgeBuilder<B> fieldName(String fieldName);
 
 	GeoPointBridgeBuilder<B> projectable(Projectable projectable);
+
+	GeoPointBridgeBuilder<B> sortable(Sortable sortable);
 
 	GeoPointBridgeBuilder<B> markerSet(String markerSet);
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/spatial/annotation/GeoPointBridge.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/spatial/annotation/GeoPointBridge.java
@@ -14,6 +14,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.hibernate.search.engine.backend.types.Projectable;
+import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.mapper.pojo.bridge.declaration.PropertyBridgeMapping;
 import org.hibernate.search.mapper.pojo.bridge.declaration.PropertyBridgeRef;
 import org.hibernate.search.mapper.pojo.bridge.declaration.TypeBridgeMapping;
@@ -89,6 +90,12 @@ public @interface GeoPointBridge {
 	 * field. Defaults to {@code Projectable.DEFAULT}.
 	 */
 	Projectable projectable() default Projectable.DEFAULT;
+
+	/**
+	 * @return Returns an instance of the {@link Sortable} enum, indicating whether sorts are enabled for this
+	 * field. Defaults to {@code Sortable.DEFAULT}.
+	 */
+	Sortable sortable() default Sortable.DEFAULT;
 
 	/**
 	 * @return The name of the marker set this spatial should look into

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/spatial/impl/GeoPointBridge.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/spatial/impl/GeoPointBridge.java
@@ -15,6 +15,7 @@ import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.types.Projectable;
+import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeFactoryContext;
 import org.hibernate.search.engine.environment.bean.BeanHolder;
 import org.hibernate.search.mapper.pojo.bridge.PropertyBridge;
@@ -46,6 +47,7 @@ public class GeoPointBridge implements TypeBridge, PropertyBridge {
 
 		private String fieldName;
 		private Projectable projectable = Projectable.DEFAULT;
+		private Sortable sortable = Sortable.DEFAULT;
 		private String markerSet;
 
 		@Override
@@ -54,6 +56,7 @@ public class GeoPointBridge implements TypeBridge, PropertyBridge {
 			fieldName( annotation.fieldName() );
 			markerSet( annotation.markerSet() );
 			projectable( annotation.projectable() );
+			sortable( annotation.sortable() );
 		}
 
 		@Override
@@ -69,6 +72,12 @@ public class GeoPointBridge implements TypeBridge, PropertyBridge {
 		}
 
 		@Override
+		public Builder sortable(Sortable sortable) {
+			this.sortable = sortable;
+			return this;
+		}
+
+		@Override
 		public Builder markerSet(String markerSet) {
 			this.markerSet = markerSet;
 			return this;
@@ -76,12 +85,13 @@ public class GeoPointBridge implements TypeBridge, PropertyBridge {
 
 		@Override
 		public BeanHolder<? extends GeoPointBridge> build(BridgeBuildContext buildContext) {
-			return BeanHolder.of( new GeoPointBridge( fieldName, projectable, markerSet ) );
+			return BeanHolder.of( new GeoPointBridge( fieldName, projectable, sortable, markerSet ) );
 		}
 	}
 
 	private final String fieldName;
 	private final Projectable projectable;
+	private final Sortable sortable;
 	private final String markerSet;
 
 	private IndexFieldReference<GeoPoint> indexFieldReference;
@@ -90,9 +100,10 @@ public class GeoPointBridge implements TypeBridge, PropertyBridge {
 	/**
 	 * Private constructor, use {@link GeoPointBridgeBuilder#forType()} or {@link GeoPointBridgeBuilder#forProperty()} instead.
 	 */
-	private GeoPointBridge(String fieldName, Projectable projectable, String markerSet) {
+	private GeoPointBridge(String fieldName, Projectable projectable, Sortable sortable, String markerSet) {
 		this.fieldName = fieldName;
 		this.projectable = projectable;
+		this.sortable = sortable;
 		this.markerSet = markerSet;
 	}
 
@@ -123,7 +134,7 @@ public class GeoPointBridge implements TypeBridge, PropertyBridge {
 			PojoModelCompositeElement bridgedPojoModelElement) {
 		indexFieldReference = indexSchemaElement.field(
 				defaultedFieldName,
-				typeFactoryContext.asGeoPoint().projectable( projectable ).toIndexFieldType()
+				typeFactoryContext.asGeoPoint().projectable( projectable ).sortable( sortable ).toIndexFieldType()
 		)
 				.toReference();
 


### PR DESCRIPTION
[HSEARCH-3542](https://hibernate.atlassian.net//browse/HSEARCH-3542): Fix transient failures in OrmLibraryShowcaseIT#searchAroundMe_spatial
[HSEARCH-3543](https://hibernate.atlassian.net//browse/HSEARCH-3543): Allow to set GeoPointBridges as sortable to enable distance sorts

I need this in particular because the transient failures affect integration tests when testing against an AWS Elasticsearch service (and I'm trying to restore support for the AWS integration).

