### PR TITLE
Hsearch 2534 Allow using query-only analyzer definitions with Elasticsearch

### DIFF
--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/configuration/AnalysisOverrideITAnalysisConfigurer.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/configuration/AnalysisOverrideITAnalysisConfigurer.java
@@ -21,5 +21,14 @@ public class AnalysisOverrideITAnalysisConfigurer extends DefaultITAnalysisConfi
 		context.analyzer( OverrideAnalysisDefinitions.ANALYZER_WHITESPACE_LOWERCASE.name ).custom()
 				.withTokenizer( "whitespace" )
 				.withTokenFilters( "lowercase" );
+
+		String tokenizerName = OverrideAnalysisDefinitions.ANALYZER_NGRAM.name + "_tokenizer";
+		context.analyzer( OverrideAnalysisDefinitions.ANALYZER_NGRAM.name ).custom()
+				.withTokenizer( tokenizerName );
+
+		context.tokenizer( tokenizerName )
+				.type( "ngram" )
+				.param( "min_gram", 5 )
+				.param( "max_gram", 6 );
 	}
 }

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/testsupport/configuration/AnalysisOverrideITAnalysisConfigurer.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/testsupport/configuration/AnalysisOverrideITAnalysisConfigurer.java
@@ -11,6 +11,7 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.configuratio
 
 import org.apache.lucene.analysis.core.LowerCaseFilterFactory;
 import org.apache.lucene.analysis.core.WhitespaceTokenizerFactory;
+import org.apache.lucene.analysis.ngram.NGramTokenizerFactory;
 
 public class AnalysisOverrideITAnalysisConfigurer extends DefaultITAnalysisConfigurer {
 
@@ -24,5 +25,10 @@ public class AnalysisOverrideITAnalysisConfigurer extends DefaultITAnalysisConfi
 		context.analyzer( OverrideAnalysisDefinitions.ANALYZER_WHITESPACE_LOWERCASE.name ).custom()
 				.tokenizer( WhitespaceTokenizerFactory.class )
 				.tokenFilter( LowerCaseFilterFactory.class );
+
+		context.analyzer( OverrideAnalysisDefinitions.ANALYZER_NGRAM.name ).custom()
+				.tokenizer( NGramTokenizerFactory.class )
+					.param( "minGramSize", "5" )
+					.param( "maxGramSize", "6" );
 	}
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchSearchPredicateIT.java
@@ -40,6 +40,7 @@ import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMap
 import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingSearchScope;
 import org.hibernate.search.util.impl.test.SubTest;
 import org.hibernate.search.util.impl.test.annotation.PortedFromSearch5;
+import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -930,6 +931,29 @@ public class MatchSearchPredicateIT {
 
 		assertThat( query )
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_2, DOCUMENT_3 );
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HSEARCH-2534" )
+	public void analyzerOverride_queryOnlyAnalyzer() {
+		StubMappingSearchScope scope = indexManager.createSearchScope();
+		String absoluteFieldPath = indexMapping.whitespaceLowercaseAnalyzedField.relativeFieldName;
+
+		IndexSearchQuery<DocumentReference> query = scope.query()
+				.asReference()
+				.predicate( f -> f.match().onField( absoluteFieldPath ).matching( "worldofwordcraft" ) )
+				.toQuery();
+
+		assertThat( query ).hasNoHits();
+
+		query = scope.query()
+				.asReference()
+				.predicate( f -> f.match().onField( absoluteFieldPath ).matching( "worldofwordcraft" )
+						.analyzer( OverrideAnalysisDefinitions.ANALYZER_NGRAM.name ) )
+				.toQuery();
+
+		assertThat( query )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
 	}
 
 	@Test

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/configuration/OverrideAnalysisDefinitions.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/configuration/OverrideAnalysisDefinitions.java
@@ -21,7 +21,12 @@ public enum OverrideAnalysisDefinitions {
 	/**
 	 * Analyzer with a tokenizer on whitespaces and a lowercase token filter.
 	 */
-	ANALYZER_WHITESPACE_LOWERCASE("analyzer_whitespace_lowercase");
+	ANALYZER_WHITESPACE_LOWERCASE("analyzer_whitespace_lowercase"),
+
+	/**
+	 * Ngram analyzer defined for query only.
+	 */
+	ANALYZER_NGRAM("analyzer_ngram");
 
 	public final String name;
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2534

~~Based on https://github.com/hibernate/hibernate-search/pull/1938.~~ not anymore
This PR just adds a test.