### PR TITLE
HSEARCH-3507 Improve consistency of naming for methods related to native Elasticsearch/Lucene features (fromJsonString, etc.)

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/predicate/ElasticsearchSearchPredicateFactoryContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/predicate/ElasticsearchSearchPredicateFactoryContext.java
@@ -14,6 +14,6 @@ import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateTerminalC
  */
 public interface ElasticsearchSearchPredicateFactoryContext extends SearchPredicateFactoryContext {
 
-	SearchPredicateTerminalContext fromJsonString(String jsonString);
+	SearchPredicateTerminalContext fromJson(String jsonString);
 
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/predicate/ElasticsearchSearchPredicateFactoryContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/predicate/ElasticsearchSearchPredicateFactoryContext.java
@@ -14,6 +14,14 @@ import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateTerminalC
  */
 public interface ElasticsearchSearchPredicateFactoryContext extends SearchPredicateFactoryContext {
 
+	/**
+	 * Create a predicate from JSON.
+	 *
+	 * @param jsonString A string representing an Elasticsearch query as a JSON object.
+	 * The JSON object must be a syntactically correct Elasticsearch query.
+	 * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html">the Elasticsearch documentation</a>.
+	 * @return A context allowing to get the resulting predicate.
+	 */
 	SearchPredicateTerminalContext fromJson(String jsonString);
 
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/predicate/impl/ElasticsearchJsonStringPredicateContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/predicate/impl/ElasticsearchJsonStringPredicateContext.java
@@ -18,7 +18,7 @@ final class ElasticsearchJsonStringPredicateContext
 
 	ElasticsearchJsonStringPredicateContext(ElasticsearchSearchPredicateBuilderFactory factory, String jsonString) {
 		super( factory );
-		this.builder = factory.fromJsonString( jsonString );
+		this.builder = factory.fromJson( jsonString );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/predicate/impl/ElasticsearchSearchPredicateFactoryContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/predicate/impl/ElasticsearchSearchPredicateFactoryContextImpl.java
@@ -26,7 +26,7 @@ public class ElasticsearchSearchPredicateFactoryContextImpl
 	}
 
 	@Override
-	public SearchPredicateTerminalContext fromJsonString(String jsonString) {
+	public SearchPredicateTerminalContext fromJson(String jsonString) {
 		return new ElasticsearchJsonStringPredicateContext( factory, jsonString );
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/sort/ElasticsearchSearchSortContainerContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/sort/ElasticsearchSearchSortContainerContext.java
@@ -14,6 +14,6 @@ import org.hibernate.search.engine.search.dsl.sort.SearchSortContainerContext;
  */
 public interface ElasticsearchSearchSortContainerContext extends SearchSortContainerContext {
 
-	NonEmptySortContext fromJsonString(String jsonString);
+	NonEmptySortContext fromJson(String jsonString);
 
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/sort/ElasticsearchSearchSortContainerContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/sort/ElasticsearchSearchSortContainerContext.java
@@ -8,12 +8,22 @@ package org.hibernate.search.backend.elasticsearch.search.dsl.sort;
 
 import org.hibernate.search.engine.search.dsl.sort.NonEmptySortContext;
 import org.hibernate.search.engine.search.dsl.sort.SearchSortContainerContext;
+import org.hibernate.search.engine.search.dsl.sort.SearchSortTerminalContext;
 
 /**
  * A DSL context allowing to specify the sort order, with some Elasticsearch-specific methods.
  */
 public interface ElasticsearchSearchSortContainerContext extends SearchSortContainerContext {
 
+	/**
+	 * Order elements according to a JSON sort definition.
+	 *
+	 * @param jsonString A string representing an Elasticsearch sort as a JSON object.
+	 * The JSON object must be represent a syntactically correct Elasticsearch sort.
+	 * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html">the Elasticsearch documentation</a>.
+	 * @return A context allowing to {@link NonEmptySortContext#then() chain other sorts}
+	 * or {@link SearchSortTerminalContext#toSort() get the resulting sort}.
+	 */
 	NonEmptySortContext fromJson(String jsonString);
 
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/sort/impl/ElasticsearchSearchSortContainerContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/sort/impl/ElasticsearchSearchSortContainerContextImpl.java
@@ -33,8 +33,8 @@ public class ElasticsearchSearchSortContainerContextImpl
 	}
 
 	@Override
-	public NonEmptySortContext fromJsonString(String jsonString) {
-		dslContext.addChild( factory.fromJsonString( jsonString ) );
+	public NonEmptySortContext fromJson(String jsonString) {
+		dslContext.addChild( factory.fromJson( jsonString ) );
 		return nonEmptyContext();
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchSearchPredicateBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchSearchPredicateBuilderFactory.java
@@ -12,6 +12,6 @@ public interface ElasticsearchSearchPredicateBuilderFactory
 		extends
 		SearchPredicateBuilderFactory<ElasticsearchSearchPredicateCollector, ElasticsearchSearchPredicateBuilder> {
 
-	ElasticsearchSearchPredicateBuilder fromJsonString(String jsonString);
+	ElasticsearchSearchPredicateBuilder fromJson(String jsonString);
 
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchSearchPredicateBuilderFactoryImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchSearchPredicateBuilderFactoryImpl.java
@@ -149,7 +149,7 @@ public class ElasticsearchSearchPredicateBuilderFactoryImpl implements Elasticse
 	}
 
 	@Override
-	public ElasticsearchSearchPredicateBuilder fromJsonString(String jsonString) {
+	public ElasticsearchSearchPredicateBuilder fromJson(String jsonString) {
 		return new ElasticsearchUserProvidedJsonPredicateContributor(
 				searchContext.getUserFacingGson().fromJson( jsonString, JsonObject.class )
 		);

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/sort/impl/ElasticsearchSearchSortBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/sort/impl/ElasticsearchSearchSortBuilderFactory.java
@@ -11,6 +11,6 @@ import org.hibernate.search.engine.search.sort.spi.SearchSortBuilderFactory;
 public interface ElasticsearchSearchSortBuilderFactory
 		extends SearchSortBuilderFactory<ElasticsearchSearchSortCollector, ElasticsearchSearchSortBuilder> {
 
-	ElasticsearchSearchSortBuilder fromJsonString(String jsonString);
+	ElasticsearchSearchSortBuilder fromJson(String jsonString);
 
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/sort/impl/ElasticsearchSearchSortBuilderFactoryImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/sort/impl/ElasticsearchSearchSortBuilderFactoryImpl.java
@@ -90,7 +90,7 @@ public class ElasticsearchSearchSortBuilderFactoryImpl implements ElasticsearchS
 	}
 
 	@Override
-	public ElasticsearchSearchSortBuilder fromJsonString(String jsonString) {
+	public ElasticsearchSearchSortBuilder fromJson(String jsonString) {
 		return new ElasticsearchUserProvidedJsonSortBuilder(
 				searchContext.getUserFacingGson().fromJson( jsonString, JsonObject.class )
 		);

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/ElasticsearchIndexFieldTypeFactoryContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/ElasticsearchIndexFieldTypeFactoryContext.java
@@ -14,6 +14,6 @@ import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeFactoryContex
  */
 public interface ElasticsearchIndexFieldTypeFactoryContext extends IndexFieldTypeFactoryContext {
 
-	ElasticsearchJsonStringIndexFieldTypeContext<?> asJsonString(String mappingJsonString);
+	ElasticsearchJsonStringIndexFieldTypeContext<?> asNative(String mappingJsonString);
 
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/ElasticsearchIndexFieldTypeFactoryContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/ElasticsearchIndexFieldTypeFactoryContext.java
@@ -14,6 +14,28 @@ import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeFactoryContex
  */
 public interface ElasticsearchIndexFieldTypeFactoryContext extends IndexFieldTypeFactoryContext {
 
+	/**
+	 * Define a native field type.
+	 * <p>
+	 * A native field type has the following characteristics:
+	 * <ul>
+	 *     <li>Hibernate Search doesn't know its exact type, so it must be entirely defined as a JSON object,
+	 *     provided as the {@code mappingJsonString} parameter</li>
+	 *     <li>When indexing, fields of this type must be populated with JSON.
+	 *     The field has a string type, but the string is interpreted as JSON, so it can contain a boolean, an integer,
+	 *     or even an object.</li>
+	 *     <li>The predicate/sort/projection DSLs have only limited support for fields of this type.
+	 *     Some features may not work and throw an exception, such as phrase predicates.
+	 *     It is recommended to create the predicate/sort/projections targeting these fields from JSON
+	 *     using {@link org.hibernate.search.backend.elasticsearch.search.dsl.predicate.ElasticsearchSearchPredicateFactoryContext#fromJson(String)}
+	 *     or {@link org.hibernate.search.backend.elasticsearch.search.dsl.sort.ElasticsearchSearchSortContainerContext#fromJson(String)}</li>
+	 * </ul>
+	 *
+	 * @param mappingJsonString A string representing an Elasticsearch field mapping as a JSON object.
+	 * The JSON object must be a syntactically correct Elasticsearch field mapping.
+	 * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html">the Elasticsearch documentation</a>.
+	 * @return A context allowing to get the resulting predicate.
+	 */
 	ElasticsearchJsonStringIndexFieldTypeContext<?> asNative(String mappingJsonString);
 
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchIndexFieldTypeFactoryContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchIndexFieldTypeFactoryContextImpl.java
@@ -212,7 +212,7 @@ public class ElasticsearchIndexFieldTypeFactoryContextImpl
 	}
 
 	@Override
-	public ElasticsearchJsonStringIndexFieldTypeContext<?> asJsonString(String mappingJsonString) {
+	public ElasticsearchJsonStringIndexFieldTypeContext<?> asNative(String mappingJsonString) {
 		return new ElasticsearchJsonStringIndexFieldTypeContextImpl( this, mappingJsonString );
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/predicate/LuceneSearchPredicateFactoryContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/predicate/LuceneSearchPredicateFactoryContext.java
@@ -15,5 +15,11 @@ import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateTerminalC
  */
 public interface LuceneSearchPredicateFactoryContext extends SearchPredicateFactoryContext {
 
+	/**
+	 * Create a predicate from a Lucene {@link Query}.
+	 *
+	 * @param query A Lucene query.
+	 * @return A context allowing to get the resulting predicate.
+	 */
 	SearchPredicateTerminalContext fromLuceneQuery(Query query);
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/sort/LuceneSearchSortContainerContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/sort/LuceneSearchSortContainerContext.java
@@ -10,14 +10,29 @@ import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.hibernate.search.engine.search.dsl.sort.NonEmptySortContext;
 import org.hibernate.search.engine.search.dsl.sort.SearchSortContainerContext;
+import org.hibernate.search.engine.search.dsl.sort.SearchSortTerminalContext;
 
 /**
  * A DSL context allowing to specify the sort order, with some Lucene-specific methods.
  */
 public interface LuceneSearchSortContainerContext extends SearchSortContainerContext {
 
+	/**
+	 * Order elements by a given Lucene {@link SortField}.
+	 *
+	 * @param luceneSortField A Lucene sort field.
+	 * @return A context allowing to {@link NonEmptySortContext#then() chain other sorts}
+	 * or {@link SearchSortTerminalContext#toSort() get the resulting sort}.
+	 */
 	NonEmptySortContext fromLuceneSortField(SortField luceneSortField);
 
+	/**
+	 * Order elements by a given Lucene {@link Sort}.
+	 *
+	 * @param luceneSort A Lucene sort.
+	 * @return A context allowing to {@link NonEmptySortContext#then() chain other sorts}
+	 * or {@link SearchSortTerminalContext#toSort() get the resulting sort}.
+	 */
 	NonEmptySortContext fromLuceneSort(Sort luceneSort);
 
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/LuceneIndexFieldTypeFactoryContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/LuceneIndexFieldTypeFactoryContext.java
@@ -11,6 +11,9 @@ import org.hibernate.search.backend.lucene.types.converter.LuceneFieldContributo
 import org.hibernate.search.backend.lucene.types.converter.LuceneFieldValueExtractor;
 import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeTerminalContext;
 
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.Sort;
+
 
 /**
  * @author Guillaume Smet
@@ -18,7 +21,23 @@ import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeTerminalConte
 public interface LuceneIndexFieldTypeFactoryContext extends IndexFieldTypeFactoryContext {
 
 	/**
-	 * Declares a native field, on which projection is allowed.
+	 * Define a native field type.
+	 * <p>
+	 * A native field type has the following characteristics:
+	 * <ul>
+	 *     <li>Hibernate Search doesn't know its exact type, so it cannot be configured precisely,
+	 *     except through the parameters passed to this method</li>
+	 *     <li>When indexing, fields values will be passed to the {@link LuceneFieldContributor field contributor}.
+	 *     This contributor will translate the value into {@link org.apache.lucene.index.IndexableField} instances
+	 *     which will be added to the document.</li>
+	 *     <li>The predicate/sort DSLs cannot be used on fields of this type.
+	 *     It is recommended to create the predicate/sort/projections targeting these fields from native Lucene objects
+	 *     using {@link org.hibernate.search.backend.lucene.search.dsl.predicate.LuceneSearchPredicateFactoryContext#fromLuceneQuery(Query)}
+	 *     or {@link org.hibernate.search.backend.lucene.search.dsl.sort.LuceneSearchSortContainerContext#fromLuceneSort(Sort)}</li>
+	 *     <li>The projection DSL can only be used on fields of this type of {@code fieldValueExtractor} is non-null.
+	 *     When projecting, the value extractor will be passed the {@link org.apache.lucene.index.IndexableField}
+	 *     and will return the corresponding projected value of type {@code F}.</li>
+	 * </ul>
 	 *
 	 * @param valueType The type of the value.
 	 * @param fieldContributor The field contributor.
@@ -31,7 +50,9 @@ public interface LuceneIndexFieldTypeFactoryContext extends IndexFieldTypeFactor
 			LuceneFieldValueExtractor<F> fieldValueExtractor);
 
 	/**
-	 * Declares a native field on which projection is not allowed.
+	 * Define a native field type on which projection is not allowed.
+	 * <p>
+	 * See {@link #asNative(Class, LuceneFieldContributor, LuceneFieldValueExtractor)}.
 	 *
 	 * @param valueType The type of the value.
 	 * @param fieldContributor The field contributor.

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/LuceneIndexFieldTypeFactoryContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/LuceneIndexFieldTypeFactoryContext.java
@@ -26,7 +26,7 @@ public interface LuceneIndexFieldTypeFactoryContext extends IndexFieldTypeFactor
 	 * @param <F> The type of the value.
 	 * @return The DSL context.
 	 */
-	<F> IndexFieldTypeTerminalContext<F> asLuceneField(Class<F> valueType,
+	<F> IndexFieldTypeTerminalContext<F> asNative(Class<F> valueType,
 			LuceneFieldContributor<F> fieldContributor,
 			LuceneFieldValueExtractor<F> fieldValueExtractor);
 
@@ -38,9 +38,9 @@ public interface LuceneIndexFieldTypeFactoryContext extends IndexFieldTypeFactor
 	 * @param <F> The type of the value.
 	 * @return The DSL context.
 	 */
-	default <F> IndexFieldTypeTerminalContext<F> asLuceneField(Class<F> valueType,
+	default <F> IndexFieldTypeTerminalContext<F> asNative(Class<F> valueType,
 			LuceneFieldContributor<F> fieldContributor) {
-		return asLuceneField( valueType, fieldContributor, null );
+		return asNative( valueType, fieldContributor, null );
 	}
 
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIndexFieldTypeFactoryContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneIndexFieldTypeFactoryContextImpl.java
@@ -210,7 +210,7 @@ public class LuceneIndexFieldTypeFactoryContextImpl
 	}
 
 	@Override
-	public <F> IndexFieldTypeTerminalContext<F> asLuceneField(Class<F> indexFieldType,
+	public <F> IndexFieldTypeTerminalContext<F> asNative(Class<F> indexFieldType,
 			LuceneFieldContributor<F> fieldContributor,
 			LuceneFieldValueExtractor<F> fieldValueExtractor) {
 		return new LuceneFieldIndexFieldTypeContext<>(

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
@@ -466,56 +466,56 @@ public class ElasticsearchExtensionIT {
 			integer = root.field(
 					"integer",
 					f -> f.extension( ElasticsearchExtension.get() )
-							.asJsonString( "{'type': 'integer'}" )
+							.asNative( "{'type': 'integer'}" )
 			)
 					.toReference();
 			string = root.field(
 					"string",
 					f -> f.extension( ElasticsearchExtension.get() )
-							.asJsonString( "{'type': 'keyword'}" )
+							.asNative( "{'type': 'keyword'}" )
 			)
 					.toReference();
 			geoPoint = root.field(
 					"geoPoint",
 					f -> f.extension( ElasticsearchExtension.get() )
-							.asJsonString( "{'type': 'geo_point'}" )
+							.asNative( "{'type': 'geo_point'}" )
 			)
 					.toReference();
 			dateWithColons = root.field(
 					"dateWithColons",
 					f -> f.extension( ElasticsearchExtension.get() )
-							.asJsonString( "{'type': 'date', 'format': 'yyyy:MM:dd'}" )
+							.asNative( "{'type': 'date', 'format': 'yyyy:MM:dd'}" )
 			)
 					.toReference();
 
 			sort1 = root.field(
 					"sort1",
 					f -> f.extension( ElasticsearchExtension.get() )
-							.asJsonString( "{'type': 'keyword', 'doc_values': true}" )
+							.asNative( "{'type': 'keyword', 'doc_values': true}" )
 			)
 					.toReference();
 			sort2 = root.field(
 					"sort2",
 					f -> f.extension( ElasticsearchExtension.get() )
-							.asJsonString( "{'type': 'keyword', 'doc_values': true}" )
+							.asNative( "{'type': 'keyword', 'doc_values': true}" )
 			)
 					.toReference();
 			sort3 = root.field(
 					"sort3",
 					f -> f.extension( ElasticsearchExtension.get() )
-							.asJsonString( "{'type': 'keyword', 'doc_values': true}" )
+							.asNative( "{'type': 'keyword', 'doc_values': true}" )
 			)
 					.toReference();
 			sort4 = root.field(
 					"sort4",
 					f -> f.extension( ElasticsearchExtension.get() )
-							.asJsonString( "{'type': 'keyword', 'doc_values': true}" )
+							.asNative( "{'type': 'keyword', 'doc_values': true}" )
 			)
 					.toReference();
 			sort5 = root.field(
 					"sort5",
 					f -> f.extension( ElasticsearchExtension.get() )
-							.asJsonString( "{'type': 'keyword', 'doc_values': true}" )
+							.asNative( "{'type': 'keyword', 'doc_values': true}" )
 			)
 					.toReference();
 		}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
@@ -81,20 +81,20 @@ public class ElasticsearchExtensionIT {
 	}
 
 	@Test
-	public void predicate_fromJsonString() {
+	public void predicate_fromJson() {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		IndexSearchQuery<DocumentReference> query = scope.query()
 				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.extension( ElasticsearchExtension.get() )
-								.fromJsonString( "{'match': {'string': 'text 1'}}" )
+								.fromJson( "{'match': {'string': 'text 1'}}" )
 						)
 						.should( f.extension( ElasticsearchExtension.get() )
-								.fromJsonString( "{'match': {'integer': 2}}" )
+								.fromJson( "{'match': {'integer': 2}}" )
 						)
 						.should( f.extension( ElasticsearchExtension.get() )
-								.fromJsonString(
+								.fromJson(
 										"{"
 											+ "'geo_distance': {"
 												+ "'distance': '200km',"
@@ -116,15 +116,15 @@ public class ElasticsearchExtensionIT {
 	}
 
 	@Test
-	public void predicate_fromJsonString_separatePredicate() {
+	public void predicate_fromJson_separatePredicate() {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchPredicate predicate1 = scope.predicate().extension( ElasticsearchExtension.get() )
-				.fromJsonString( "{'match': {'string': 'text 1'}}" ).toPredicate();
+				.fromJson( "{'match': {'string': 'text 1'}}" ).toPredicate();
 		SearchPredicate predicate2 = scope.predicate().extension( ElasticsearchExtension.get() )
-				.fromJsonString( "{'match': {'integer': 2}}" ).toPredicate();
+				.fromJson( "{'match': {'integer': 2}}" ).toPredicate();
 		SearchPredicate predicate3 = scope.predicate().extension( ElasticsearchExtension.get() )
-				.fromJsonString(
+				.fromJson(
 						"{"
 							+ "'geo_distance': {"
 								+ "'distance': '200km',"
@@ -156,7 +156,7 @@ public class ElasticsearchExtensionIT {
 	}
 
 	@Test
-	public void sort_fromJsonString() {
+	public void sort_fromJson() {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		IndexSearchQuery<DocumentReference> query = scope.query()
@@ -164,11 +164,11 @@ public class ElasticsearchExtensionIT {
 				.predicate( f -> f.matchAll() )
 				.sort( c -> c
 						.extension( ElasticsearchExtension.get() )
-								.fromJsonString( "{'sort1': 'asc'}" )
+								.fromJson( "{'sort1': 'asc'}" )
 						.then().extension( ElasticsearchExtension.get() )
-								.fromJsonString( "{'sort2': 'asc'}" )
+								.fromJson( "{'sort2': 'asc'}" )
 						.then().extension( ElasticsearchExtension.get() )
-								.fromJsonString( "{'sort3': 'asc'}" )
+								.fromJson( "{'sort3': 'asc'}" )
 						// Also test using the standard DSL on a field defined with the extension
 						.then().byField( "sort4" ).asc().onMissingValue().sortLast()
 						.then().byField( "sort5" ).asc().onMissingValue().sortFirst()
@@ -184,11 +184,11 @@ public class ElasticsearchExtensionIT {
 				.predicate( f -> f.matchAll() )
 				.sort( c -> c
 						.extension( ElasticsearchExtension.get() )
-								.fromJsonString( "{'sort1': 'desc'}" )
+								.fromJson( "{'sort1': 'desc'}" )
 						.then().extension( ElasticsearchExtension.get() )
-								.fromJsonString( "{'sort2': 'desc'}" )
+								.fromJson( "{'sort2': 'desc'}" )
 						.then().extension( ElasticsearchExtension.get() )
-								.fromJsonString( "{'sort3': 'desc'}" )
+								.fromJson( "{'sort3': 'desc'}" )
 						.then().byField( "sort4" ).desc().onMissingValue().sortLast()
 						.then().byField( "sort5" ).asc().onMissingValue().sortFirst()
 				)
@@ -200,17 +200,17 @@ public class ElasticsearchExtensionIT {
 	}
 
 	@Test
-	public void sort_fromJsonString_separateSort() {
+	public void sort_fromJson_separateSort() {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchSort sort1Asc = scope.sort().extension( ElasticsearchExtension.get() )
-				.fromJsonString( "{'sort1': 'asc'}" )
+				.fromJson( "{'sort1': 'asc'}" )
 				.toSort();
 		SearchSort sort2Asc = scope.sort().extension( ElasticsearchExtension.get() )
-				.fromJsonString( "{'sort2': 'asc'}" )
+				.fromJson( "{'sort2': 'asc'}" )
 				.toSort();
 		SearchSort sort3Asc = scope.sort().extension( ElasticsearchExtension.get() )
-				.fromJsonString( "{'sort3': 'asc'}" )
+				.fromJson( "{'sort3': 'asc'}" )
 				.toSort();
 		// Also test using the standard DSL on a field defined with the extension
 		SearchSort sort4Asc = scope.sort()
@@ -227,13 +227,13 @@ public class ElasticsearchExtensionIT {
 				.hasDocRefHitsExactOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID, FOURTH_ID, EMPTY_ID, FIFTH_ID );
 
 		SearchSort sort1Desc = scope.sort().extension( ElasticsearchExtension.get() )
-				.fromJsonString( "{'sort1': 'desc'}" )
+				.fromJson( "{'sort1': 'desc'}" )
 				.toSort();
 		SearchSort sort2Desc = scope.sort().extension( ElasticsearchExtension.get() )
-				.fromJsonString( "{'sort2': 'desc'}" )
+				.fromJson( "{'sort2': 'desc'}" )
 				.toSort();
 		SearchSort sort3Desc = scope.sort().extension( ElasticsearchExtension.get() )
-				.fromJsonString( "{'sort3': 'desc'}" )
+				.fromJson( "{'sort3': 'desc'}" )
 				.toSort();
 		SearchSort sort4Desc = scope.sort()
 				.byField( "sort4" ).desc().onMissingValue().sortLast()

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneExtensionIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneExtensionIT.java
@@ -592,19 +592,19 @@ public class LuceneExtensionIT {
 			nativeField = root.field(
 					"nativeField",
 					f -> f.extension( LuceneExtension.get() )
-							.asLuceneField( Integer.class, LuceneExtensionIT::contributeNativeField, LuceneExtensionIT::fromNativeField )
+							.asNative( Integer.class, LuceneExtensionIT::contributeNativeField, LuceneExtensionIT::fromNativeField )
 			)
 					.toReference();
 			nativeField_unsupportedProjection = root.field(
 					"nativeField_unsupportedProjection",
 					f -> f.extension( LuceneExtension.get() )
-							.asLuceneField( Integer.class, LuceneExtensionIT::contributeNativeField )
+							.asNative( Integer.class, LuceneExtensionIT::contributeNativeField )
 			)
 					.toReference();
 			nativeField_invalidFieldPath = root.field(
 					"nativeField_invalidFieldPath",
 					f -> f.extension( LuceneExtension.get() )
-							.asLuceneField( Integer.class, LuceneExtensionIT::contributeNativeFieldInvalidFieldPath )
+							.asNative( Integer.class, LuceneExtensionIT::contributeNativeFieldInvalidFieldPath )
 			)
 					.toReference();
 


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3507

I ended up going for minimal changes, so I did not fix *everything* that was mentioned in the ticket. But I think it's the best compromise between consistency and user-friendliness (because `fromJson` is definitely clearer than `byNative`, for example).