### PR TITLE
HSEARCH-3548 + HSEARCH-3549 + HSEARCH-3555 + HSEARCH-3557 Tests and fixes for indexing problems in Elasticsearch and Lucene

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchMonthDayFieldCodec.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchMonthDayFieldCodec.java
@@ -6,17 +6,39 @@
  */
 package org.hibernate.search.backend.elasticsearch.types.codec.impl;
 
+import java.time.LocalDate;
 import java.time.MonthDay;
 import java.time.format.DateTimeFormatter;
 
 public class ElasticsearchMonthDayFieldCodec extends AbstractElasticsearchJavaTimeFieldCodec<MonthDay> {
+
+	/**
+	 * Elasticsearch cannot store a monthday, it always stores an actual date.
+	 * If we omit the year, it's automatically set to 1970.
+	 * 1970 is not a leap year, so this would prevent us from indexing february 29th.
+	 * Thus we explicitly set the year to a leap year for all indexed values.
+	 * <p>
+	 * Note we must do it consistently for all indexed values, not just february 29th,
+	 * otherwise range predicates and sorts would not work correctly.
+	 * <p>
+	 * WARNING: changing this value will force applications to reindex all data
+	 * to avoid problems with sorts and range predicates.
+	 */
+	private static final int LEAP_YEAR = 0; // Year 0 exists in the proleptic gregorian calendar and is a leap year.
 
 	public ElasticsearchMonthDayFieldCodec(DateTimeFormatter delegate) {
 		super( delegate );
 	}
 
 	@Override
+	protected String nullUnsafeFormat(MonthDay value) {
+		LocalDate date = value.atYear( LEAP_YEAR );
+		return formatter.format( date );
+	}
+
+	@Override
 	protected MonthDay nullUnsafeParse(String stringValue) {
-		return MonthDay.parse( stringValue, formatter );
+		LocalDate date = LocalDate.parse( stringValue, formatter );
+		return MonthDay.from( date );
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchZonedDateTimeFieldCodec.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchZonedDateTimeFieldCodec.java
@@ -9,6 +9,8 @@ package org.hibernate.search.backend.elasticsearch.types.codec.impl;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
+import org.hibernate.search.util.common.impl.TimeHelper;
+
 public class ElasticsearchZonedDateTimeFieldCodec extends AbstractElasticsearchJavaTimeFieldCodec<ZonedDateTime> {
 
 	public ElasticsearchZonedDateTimeFieldCodec(DateTimeFormatter delegate) {
@@ -17,6 +19,6 @@ public class ElasticsearchZonedDateTimeFieldCodec extends AbstractElasticsearchJ
 
 	@Override
 	protected ZonedDateTime nullUnsafeParse(String stringValue) {
-		return ZonedDateTime.parse( stringValue, formatter );
+		return TimeHelper.parseZoneDateTime( stringValue, formatter );
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/AbstractElasticsearchTemporalIndexFieldTypeContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/AbstractElasticsearchTemporalIndexFieldTypeContext.java
@@ -8,7 +8,6 @@ package org.hibernate.search.backend.elasticsearch.types.dsl.impl;
 
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
-
 import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.DataType;
 import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.PropertyMapping;
 import org.hibernate.search.backend.elasticsearch.types.format.impl.ElasticsearchDefaultFieldFormatProvider;

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchMonthDayIndexFieldTypeContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchMonthDayIndexFieldTypeContext.java
@@ -26,7 +26,8 @@ class ElasticsearchMonthDayIndexFieldTypeContext
 	}
 
 	@Override
-	protected ElasticsearchIndexFieldType<MonthDay> toIndexFieldType(PropertyMapping mapping, DateTimeFormatter formatter) {
+	protected ElasticsearchIndexFieldType<MonthDay> toIndexFieldType(PropertyMapping mapping,
+			DateTimeFormatter formatter) {
 		ElasticsearchMonthDayFieldCodec codec = new ElasticsearchMonthDayFieldCodec( formatter );
 
 		ToDocumentFieldValueConverter<?, ? extends MonthDay> dslToIndexConverter =

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/format/impl/Elasticsearch6DefaultFieldFormatProvider.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/format/impl/Elasticsearch6DefaultFieldFormatProvider.java
@@ -58,8 +58,17 @@ public class Elasticsearch6DefaultFieldFormatProvider implements ElasticsearchDe
 		map.put( LocalDateTime.class, asImmutableList( "yyyy-MM-dd'T'HH:mm:ss.SSS", "yyyyyyyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS" ) );
 		map.put( OffsetTime.class, asImmutableList( "HH:mm:ss.SSSZZ", "HH:mm:ss.SSSSSSSSSZZ" ) );
 		map.put( OffsetDateTime.class, asImmutableList( "yyyy-MM-dd'T'HH:mm:ss.SSSZZ", "yyyyyyyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSZZ" ) );
-		// ZoneRegionId is optional for ZonedDateTime, but we need the offset to handle ambiguous date/times at DST overlap
-		map.put( ZonedDateTime.class, asImmutableList( "yyyy-MM-dd'T'HH:mm:ss.SSSZZ'['ZZZ']'", "yyyyyyyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSZZ'['ZZZ']'" ) );
+		/*
+		 * ZoneRegionId is optional for ZonedDateTime, but we need the offset to handle ambiguous date/times at DST overlap.
+		 *
+		 * Also, in some cases the ZoneId might actually be a ZoneOffset (since ZoneOffset extends ZoneId),
+		 * so we need an alternative format to support this.
+		 */
+		map.put( ZonedDateTime.class, asImmutableList(
+				"yyyy-MM-dd'T'HH:mm:ss.SSSZZ'['ZZZ']'",
+				"yyyyyyyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSZZ'['ZZZ']'",
+				"yyyyyyyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSZZ'['ZZ']'"
+		) );
 		map.put( Year.class, asImmutableList( "yyyy", "yyyyyyyyy" ) );
 		map.put( YearMonth.class, asImmutableList( "yyyy-MM", "yyyyyyyyy-MM" ) );
 		// MonthDays are formatted as a LocalDate, with a forced year, to support February 29th. See ElasticsearchMonthDayFieldCodec.

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/format/impl/Elasticsearch6DefaultFieldFormatProvider.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/format/impl/Elasticsearch6DefaultFieldFormatProvider.java
@@ -62,11 +62,8 @@ public class Elasticsearch6DefaultFieldFormatProvider implements ElasticsearchDe
 		map.put( ZonedDateTime.class, asImmutableList( "yyyy-MM-dd'T'HH:mm:ss.SSSZZ'['ZZZ']'", "yyyyyyyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSZZ'['ZZZ']'" ) );
 		map.put( Year.class, asImmutableList( "yyyy", "yyyyyyyyy" ) );
 		map.put( YearMonth.class, asImmutableList( "yyyy-MM", "yyyyyyyyy-MM" ) );
-		/*
-		 * This seems to be the ISO-8601 format for dates without year.
-		 * It's also the default format for Java's MonthDay, see MonthDay.PARSER.
-		 */
-		map.put( MonthDay.class, asImmutableList( "--MM-dd" ) );
+		// MonthDays are formatted as a LocalDate, with a forced year, to support February 29th. See ElasticsearchMonthDayFieldCodec.
+		map.put( MonthDay.class, asImmutableList( "yyyy-MM-dd" ) );
 		ELASTICSEARCH_6_FORMAT_PATTERNS_BY_TYPE = Collections.unmodifiableMap( map );
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/format/impl/Elasticsearch7DefaultFieldFormatProvider.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/format/impl/Elasticsearch7DefaultFieldFormatProvider.java
@@ -52,11 +52,8 @@ public class Elasticsearch7DefaultFieldFormatProvider implements ElasticsearchDe
 		map.put( ZonedDateTime.class, "uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSSZZZZZ'['VV']'" );
 		map.put( Year.class, "uuuu" );
 		map.put( YearMonth.class, "uuuu-MM" );
-		/*
-		 * This seems to be the ISO-8601 format for dates without year.
-		 * It's also the default format for Java's MonthDay, see MonthDay.PARSER.
-		 */
-		map.put( MonthDay.class, "--MM-dd" );
+		// MonthDays are formatted as a LocalDate, with a forced year, to support February 29th. See ElasticsearchMonthDayFieldCodec.
+		map.put( MonthDay.class, "uuuu-MM-dd" );
 		JAVA_TIME_FORMAT_PATTERN_BY_TYPE = Collections.unmodifiableMap( map );
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneZonedDateTimeFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneZonedDateTimeFieldCodec.java
@@ -13,6 +13,7 @@ import java.time.format.ResolverStyle;
 import java.util.Locale;
 
 import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
+import org.hibernate.search.util.common.impl.TimeHelper;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.LongPoint;
@@ -76,7 +77,7 @@ public final class LuceneZonedDateTimeFieldCodec implements LuceneNumericFieldCo
 			return null;
 		}
 
-		return ZonedDateTime.parse( value, FORMATTER );
+		return TimeHelper.parseZoneDateTime( value, FORMATTER );
 	}
 
 	@Override

--- a/build-config/src/main/resources/forbidden-runtime.txt
+++ b/build-config/src/main/resources/forbidden-runtime.txt
@@ -43,3 +43,8 @@ org.hibernate.search.util.SearchException#<init>(java.lang.Throwable)
 org.hibernate.search.util.SearchException#<init>(java.lang.String, java.lang.Throwable, org.hibernate.search.util.EventContext)
 org.hibernate.search.util.SearchException#<init>(java.lang.String, org.hibernate.search.util.EventContext)
 org.hibernate.search.util.SearchException#<init>(java.lang.Throwable, org.hibernate.search.util.EventContext)
+
+################################################################################################################
+@defaultMessage ZonedDateTime.parse is buggy, use TimeHelper.parseZoneDateTime instead. See https://bugs.openjdk.java.net/browse/JDK-8066982
+java.time.ZonedDateTime#parse(java.lang.CharSequence)
+java.time.ZonedDateTime#parse(java.lang.CharSequence, java.time.format.DateTimeFormatter)

--- a/documentation/src/main/asciidoc/backend-elasticsearch.asciidoc
+++ b/documentation/src/main/asciidoc/backend-elasticsearch.asciidoc
@@ -368,7 +368,9 @@ or `yyyy\|\|yyyyyyyyy` (ES6 and below)
 |java.time.YearMonth|`date` with format
 `uuuu-MM` (ES7 and above)
 or `yyyy-MM\|\|yyyyyyyyy-MM` (ES6 and below)
-|java.time.MonthDay|`date` with format `--MM-dd`
+|java.time.MonthDay|`date` with format `uuuu-MM-dd` (ES7 and above)
+or `yyyy-MM-dd` (ES6 and below).
+**The year is always set to 0**.
 |org.hibernate.search.engine.spatial.GeoPoint|`geo_point`
 |====
 

--- a/documentation/src/main/asciidoc/backend-elasticsearch.asciidoc
+++ b/documentation/src/main/asciidoc/backend-elasticsearch.asciidoc
@@ -374,6 +374,14 @@ or `yyyy-MM-dd` (ES6 and below).
 |org.hibernate.search.engine.spatial.GeoPoint|`geo_point`
 |====
 
+[NOTE]
+====
+The Elasticsearch `date` type does not support the whole range of years that can be modeled in `java.time` types:
+
+* `java.time` supports years ranging from `-999.999.999` to `999.999.999`.
+* Elasticsearch supports years ranging from `-292.275.054` to `292.278.993`.
+====
+
 // TODO also document "extension" types
 
 [[backend-elasticsearch-analysis]]

--- a/documentation/src/main/asciidoc/backend-elasticsearch.asciidoc
+++ b/documentation/src/main/asciidoc/backend-elasticsearch.asciidoc
@@ -355,7 +355,7 @@ or `HH:mm:ss.SSS\|\|HH:mm:ss.SSSSSSSSS` (ES6 and below)
 or `yyyy-MM-dd'T'HH:mm:ss.SSS\|\|yyyyyyyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS` (ES6 and below)
 |java.time.ZonedDateTime|`date` with format
 `uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSSZZZZZ'['VV']'` (ES7 and above)
-or `yyyy-MM-dd'T'HH:mm:ss.SSSZZ'['ZZZ']'\|\|yyyyyyyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSZZ'['ZZZ']'` (ES6 and below)
+or `yyyy-MM-dd'T'HH:mm:ss.SSSZZ'['ZZZ']'\|\|yyyyyyyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSZZ'['ZZZ']'\|\|yyyyyyyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSZZ'['ZZ']'` (ES6 and below)
 |java.time.OffsetDateTime|`date` with format
 `uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSSZZZZZ` (ES7 and above)
 or `yyyy-MM-dd'T'HH:mm:ss.SSSZZ\|\|yyyyyyyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSZZ` (ES6 and below)

--- a/documentation/src/main/asciidoc/backend-lucene.asciidoc
+++ b/documentation/src/main/asciidoc/backend-lucene.asciidoc
@@ -117,6 +117,14 @@ See <<mapper-orm-bridge-valuebridge-builtin>> for more information.
 |org.hibernate.search.engine.spatial.GeoPoint
 |====
 
+[NOTE]
+====
+Date/time types do not support the whole range of years that can be represented in `java.time` types:
+
+* `java.time` can represent years ranging from `-999.999.999` to `999.999.999`.
+* The Lucene backend supports dates ranging from year `-292.275.054` to year `292.278.993`.
+====
+
 // TODO also document "extension" types
 
 [[backend-lucene-analysis]]

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/AnalyzedStringFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/AnalyzedStringFieldTypeDescriptor.java
@@ -13,6 +13,7 @@ import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeConte
 import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldProjectionExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldSortExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.IndexingExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.MatchPredicateExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.RangePredicateExpectations;
 
@@ -25,6 +26,18 @@ public class AnalyzedStringFieldTypeDescriptor extends FieldTypeDescriptor<Strin
 	@Override
 	public StandardIndexFieldTypeContext<?, String> configure(IndexFieldTypeFactoryContext fieldContext) {
 		return fieldContext.asString().analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD_ENGLISH.name );
+	}
+
+	@Override
+	public Optional<IndexingExpectations<String>> getIndexingExpectations() {
+		return Optional.of( new IndexingExpectations<>(
+				"several tokens",
+				"onetoken",
+				"to the", // Only stopwords
+				"    trailingspaces   ",
+				"      ",
+				""
+		) );
 	}
 
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/BooleanFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/BooleanFieldTypeDescriptor.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldProjectionExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldSortExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.IndexingExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.MatchPredicateExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.RangePredicateExpectations;
 
@@ -17,6 +18,17 @@ public class BooleanFieldTypeDescriptor extends FieldTypeDescriptor<Boolean> {
 
 	BooleanFieldTypeDescriptor() {
 		super( Boolean.class );
+	}
+
+	@Override
+	public Optional<IndexingExpectations<Boolean>> getIndexingExpectations() {
+		return Optional.of( new IndexingExpectations<>(
+				true,
+				false,
+				// This is ugly, but we test it on purpose
+				new Boolean( true ),
+				new Boolean( false )
+		) );
 	}
 
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/ByteFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/ByteFieldTypeDescriptor.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldProjectionExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldSortExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.IndexingExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.MatchPredicateExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.RangePredicateExpectations;
 
@@ -17,6 +18,16 @@ public class ByteFieldTypeDescriptor extends FieldTypeDescriptor<Byte> {
 
 	ByteFieldTypeDescriptor() {
 		super( Byte.class );
+	}
+
+	@Override
+	public Optional<IndexingExpectations<Byte>> getIndexingExpectations() {
+		return Optional.of( new IndexingExpectations<>(
+				Byte.MIN_VALUE, Byte.MAX_VALUE,
+				(byte) -42, (byte) -1, (byte) 0, (byte) 1, (byte) 3, (byte) 42,
+				// This is ugly, but we test it on purpose
+				new Byte( (byte) 44 )
+		) );
 	}
 
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/DoubleFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/DoubleFieldTypeDescriptor.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldProjectionExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldSortExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.IndexingExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.MatchPredicateExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.RangePredicateExpectations;
 
@@ -17,6 +18,24 @@ public class DoubleFieldTypeDescriptor extends FieldTypeDescriptor<Double> {
 
 	DoubleFieldTypeDescriptor() {
 		super( Double.class );
+	}
+
+	@Override
+	public Optional<IndexingExpectations<Double>> getIndexingExpectations() {
+		return Optional.of( new IndexingExpectations<>(
+				Double.MIN_VALUE, Double.MAX_VALUE,
+				- Double.MIN_VALUE, - Double.MAX_VALUE,
+				// Elasticsearch doesn't support these: it fails when parsing them
+				//Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NaN,
+				0.0,
+				-0.0, // Negative 0 is a different double
+				Math.nextDown( 0.0 ),
+				Math.nextUp( 0.0 ),
+				42.42,
+				1584514514.000000184,
+				// This is ugly, but we test it on purpose
+				new Double( 44.0 )
+		) );
 	}
 
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/FieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/FieldTypeDescriptor.java
@@ -15,6 +15,7 @@ import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeFactoryContex
 import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeContext;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldProjectionExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldSortExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.IndexingExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.MatchPredicateExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.RangePredicateExpectations;
 
@@ -63,6 +64,11 @@ public abstract class FieldTypeDescriptor<F> {
 		this.uniqueName = uniqueName;
 	}
 
+	@Override
+	public String toString() {
+		return getClass().getSimpleName() + "[javaType=" + javaType + "]";
+	}
+
 	public final Class<F> getJavaType() {
 		return javaType;
 	}
@@ -74,6 +80,8 @@ public abstract class FieldTypeDescriptor<F> {
 	public StandardIndexFieldTypeContext<?, F> configure(IndexFieldTypeFactoryContext fieldContext) {
 		return fieldContext.as( javaType );
 	}
+
+	public abstract Optional<IndexingExpectations<F>> getIndexingExpectations();
 
 	public abstract Optional<MatchPredicateExpectations<F>> getMatchPredicateExpectations();
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/FloatFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/FloatFieldTypeDescriptor.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldProjectionExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldSortExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.IndexingExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.MatchPredicateExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.RangePredicateExpectations;
 
@@ -17,6 +18,24 @@ public class FloatFieldTypeDescriptor extends FieldTypeDescriptor<Float> {
 
 	FloatFieldTypeDescriptor() {
 		super( Float.class );
+	}
+
+	@Override
+	public Optional<IndexingExpectations<Float>> getIndexingExpectations() {
+		return Optional.of( new IndexingExpectations<>(
+				Float.MIN_VALUE, Float.MAX_VALUE,
+				- Float.MIN_VALUE, - Float.MAX_VALUE,
+				// Elasticsearch doesn't support these: it fails when parsing them
+				//Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY, Float.NaN,
+				0.0f,
+				-0.0f, // Negative 0 is a different float
+				Math.nextDown( 0.0f ),
+				Math.nextUp( 0.0f ),
+				42.42f,
+				1584514514.000000184f,
+				// This is ugly, but we test it on purpose
+				new Float( 44.0f )
+		) );
 	}
 
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/GeoPointFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/GeoPointFieldTypeDescriptor.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 import org.hibernate.search.engine.spatial.GeoPoint;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldProjectionExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldSortExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.IndexingExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.MatchPredicateExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.RangePredicateExpectations;
 
@@ -18,6 +19,24 @@ public class GeoPointFieldTypeDescriptor extends FieldTypeDescriptor<GeoPoint> {
 
 	GeoPointFieldTypeDescriptor() {
 		super( GeoPoint.class );
+	}
+
+	@Override
+	public Optional<IndexingExpectations<GeoPoint>> getIndexingExpectations() {
+		return Optional.of( new IndexingExpectations<>(
+				GeoPoint.of( 0.0, 0.0 ),
+				// Negative 0 is a thing with doubles.
+				GeoPoint.of( 0.0, -0.0 ),
+				GeoPoint.of( -0.0, 0.0 ),
+				GeoPoint.of( -0.0, -0.0 ),
+				GeoPoint.of( 90.0, 0.0 ),
+				GeoPoint.of( 90.0, 180.0 ),
+				GeoPoint.of( 90.0, -180.0 ),
+				GeoPoint.of( -90.0, 0.0 ),
+				GeoPoint.of( -90.0, 180.0 ),
+				GeoPoint.of( -90.0, -180.0 ),
+				GeoPoint.of( 42.0, -42.0 )
+		) );
 	}
 
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/InstantFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/InstantFieldTypeDescriptor.java
@@ -7,10 +7,14 @@
 package org.hibernate.search.integrationtest.backend.tck.testsupport.types;
 
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldProjectionExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldSortExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.IndexingExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.MatchPredicateExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.RangePredicateExpectations;
 
@@ -18,6 +22,16 @@ public class InstantFieldTypeDescriptor extends FieldTypeDescriptor<Instant> {
 
 	InstantFieldTypeDescriptor() {
 		super( Instant.class );
+	}
+
+	@Override
+	public Optional<IndexingExpectations<Instant>> getIndexingExpectations() {
+		List<Instant> values = new ArrayList<>();
+		LocalDateTimeFieldTypeDescriptor.getValuesForIndexingExpectations().forEach( localDateTime -> {
+			values.add( localDateTime.atOffset( ZoneOffset.UTC ).toInstant() );
+		} );
+		values.add( Instant.EPOCH );
+		return Optional.of( new IndexingExpectations<>( values ) );
 	}
 
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/IntegerFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/IntegerFieldTypeDescriptor.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldProjectionExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldSortExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.IndexingExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.MatchPredicateExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.RangePredicateExpectations;
 
@@ -17,6 +18,16 @@ public class IntegerFieldTypeDescriptor extends FieldTypeDescriptor<Integer> {
 
 	IntegerFieldTypeDescriptor() {
 		super( Integer.class );
+	}
+
+	@Override
+	public Optional<IndexingExpectations<Integer>> getIndexingExpectations() {
+		return Optional.of( new IndexingExpectations<>(
+				Integer.MIN_VALUE, Integer.MAX_VALUE,
+				-251_484_254, -42, -1, 0, 1, 3, 42, 151_484_254,
+				// This is ugly, but we test it on purpose
+				new Integer( 44 )
+		) );
 	}
 
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/KeywordStringFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/KeywordStringFieldTypeDescriptor.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldProjectionExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldSortExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.IndexingExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.MatchPredicateExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.RangePredicateExpectations;
 
@@ -17,6 +18,18 @@ public class KeywordStringFieldTypeDescriptor extends FieldTypeDescriptor<String
 
 	KeywordStringFieldTypeDescriptor() {
 		super( String.class, "keywordString" );
+	}
+
+	@Override
+	public Optional<IndexingExpectations<String>> getIndexingExpectations() {
+		return Optional.of( new IndexingExpectations<>(
+				"several tokens",
+				"onetoken",
+				"to the", // Only stopwords
+				"    trailingspaces   ",
+				"      ",
+				""
+		) );
 	}
 
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/LocalDateFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/LocalDateFieldTypeDescriptor.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldProjectionExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldSortExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.IndexingExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.MatchPredicateExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.RangePredicateExpectations;
 
@@ -18,6 +19,21 @@ public class LocalDateFieldTypeDescriptor extends FieldTypeDescriptor<LocalDate>
 
 	LocalDateFieldTypeDescriptor() {
 		super( LocalDate.class );
+	}
+
+	@Override
+	public Optional<IndexingExpectations<LocalDate>> getIndexingExpectations() {
+		return Optional.of( new IndexingExpectations<>(
+				LocalDate.of( 1970, 1, 1 ),
+				LocalDate.of( 1980, 1, 1 ),
+				LocalDate.of( 2017, 7, 7 ),
+				LocalDate.of( 1980, 12, 31 ),
+				LocalDate.of( 2004, 2, 29 ),
+				LocalDate.of( 1900, 1, 1 ),
+				LocalDate.of( 1600, 2, 28 ),
+				LocalDate.of( -52, 10, 11 ),
+				LocalDate.of( 22500, 10, 11 )
+		) );
 	}
 
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/LocalDateTimeFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/LocalDateTimeFieldTypeDescriptor.java
@@ -7,17 +7,41 @@
 package org.hibernate.search.integrationtest.backend.tck.testsupport.types;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldProjectionExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldSortExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.IndexingExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.MatchPredicateExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.RangePredicateExpectations;
 
 public class LocalDateTimeFieldTypeDescriptor extends FieldTypeDescriptor<LocalDateTime> {
 
+	static List<LocalDateTime> getValuesForIndexingExpectations() {
+		return Arrays.asList(
+				LocalDateTime.of( 1970, 1, 1, 0, 0, 0, 0 ),
+				LocalDateTime.of( 1980, 1, 1, 0, 0, 0, 0 ),
+				LocalDateTime.of( 1985, 5, 13, 10, 15, 30, 0 ),
+				LocalDateTime.of( 2017, 7, 7, 11, 15, 30, 555_000_000 ),
+				LocalDateTime.of( 1980, 10, 5, 12, 0, 0, 0 ),
+				LocalDateTime.of( 1980, 12, 31, 23, 59, 59, 999_000_000 ),
+				LocalDateTime.of( 2004, 2, 29, 1, 0, 0, 0 ),
+				LocalDateTime.of( 1900, 1, 1, 0, 0, 0, 0 ),
+				LocalDateTime.of( 1600, 2, 28, 13, 0, 23, 0 ),
+				LocalDateTime.of( -52, 10, 11, 10, 15, 30, 0 ),
+				LocalDateTime.of( 22500, 10, 11, 17, 44, 0, 0 )
+		);
+	}
+
 	LocalDateTimeFieldTypeDescriptor() {
 		super( LocalDateTime.class );
+	}
+
+	@Override
+	public Optional<IndexingExpectations<LocalDateTime>> getIndexingExpectations() {
+		return Optional.of( new IndexingExpectations<>( getValuesForIndexingExpectations() ) );
 	}
 
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/LocalDateTimeFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/LocalDateTimeFieldTypeDescriptor.java
@@ -31,7 +31,14 @@ public class LocalDateTimeFieldTypeDescriptor extends FieldTypeDescriptor<LocalD
 				LocalDateTime.of( 1900, 1, 1, 0, 0, 0, 0 ),
 				LocalDateTime.of( 1600, 2, 28, 13, 0, 23, 0 ),
 				LocalDateTime.of( -52, 10, 11, 10, 15, 30, 0 ),
-				LocalDateTime.of( 22500, 10, 11, 17, 44, 0, 0 )
+				LocalDateTime.of( 22500, 10, 11, 17, 44, 0, 0 ),
+				/*
+				 * Minimum and maximum years that can be represented as number of millisecond since the epoch in a long.
+				 * The minimum and maximum dates that can be represented are slightly before/after,
+				 * but there's no point telling users these years are supported if not all months are supported.
+				 */
+				LocalDateTime.of( -292_275_054, 1, 1, 0, 0, 0, 0 ),
+				LocalDateTime.of( 292_278_993, 12, 31, 23, 59, 59, 999_000_000 )
 		);
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/LocalTimeFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/LocalTimeFieldTypeDescriptor.java
@@ -7,26 +7,41 @@
 package org.hibernate.search.integrationtest.backend.tck.testsupport.types;
 
 import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldProjectionExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldSortExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.IndexingExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.MatchPredicateExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.RangePredicateExpectations;
 
 public class LocalTimeFieldTypeDescriptor extends FieldTypeDescriptor<LocalTime> {
 
-	public static final int ONE_MILLION = 1000000;
+	static List<LocalTime> getValuesForIndexingExpectations() {
+		return Arrays.asList(
+				LocalTime.of( 0, 0, 0, 0 ),
+				LocalTime.of( 10, 15, 30, 0 ),
+				LocalTime.of( 11, 15, 30, 555_000_000 ),
+				LocalTime.of( 23, 59, 59, 999_000_000 )
+		);
+	}
 
 	LocalTimeFieldTypeDescriptor() {
 		super( LocalTime.class );
 	}
 
 	@Override
+	public Optional<IndexingExpectations<LocalTime>> getIndexingExpectations() {
+		return Optional.of( new IndexingExpectations<>( getValuesForIndexingExpectations() ) );
+	}
+
+	@Override
 	public Optional<MatchPredicateExpectations<LocalTime>> getMatchPredicateExpectations() {
 		return Optional.of( new MatchPredicateExpectations<>(
-				LocalTime.of( 10, 10, 10, 123 * ONE_MILLION ),
-				LocalTime.of( 10, 10, 10, 122 * ONE_MILLION )
+				LocalTime.of( 10, 10, 10, 123_000_000 ),
+				LocalTime.of( 10, 10, 10, 122_000_000 )
 		) );
 	}
 
@@ -61,9 +76,9 @@ public class LocalTimeFieldTypeDescriptor extends FieldTypeDescriptor<LocalTime>
 	@Override
 	public Optional<FieldProjectionExpectations<LocalTime>> getFieldProjectionExpectations() {
 		return Optional.of( new FieldProjectionExpectations<>(
-				LocalTime.of( 10, 10, 10, 123000000 ),
-				LocalTime.of( 11, 10, 10, 123450000 ),
-				LocalTime.of( 12, 10, 10, 123456789 )
+				LocalTime.of( 10, 10, 10, 123_000_000 ),
+				LocalTime.of( 11, 10, 10, 123_450_000 ),
+				LocalTime.of( 12, 10, 10, 123_456_789 )
 		) );
 	}
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/LongFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/LongFieldTypeDescriptor.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldProjectionExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldSortExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.IndexingExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.MatchPredicateExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.RangePredicateExpectations;
 
@@ -17,6 +18,17 @@ public class LongFieldTypeDescriptor extends FieldTypeDescriptor<Long> {
 
 	LongFieldTypeDescriptor() {
 		super( Long.class );
+	}
+
+	@Override
+	public Optional<IndexingExpectations<Long>> getIndexingExpectations() {
+		return Optional.of( new IndexingExpectations<>(
+				Long.MIN_VALUE, Long.MAX_VALUE,
+				(long) Integer.MIN_VALUE, (long) Integer.MAX_VALUE,
+				-251_484_254L, -42L, -1L, 0L, 1L, 3L, 42L, 151_484_254L,
+				// This is ugly, but we test it on purpose
+				new Long( 44L )
+		) );
 	}
 
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/MonthDayFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/MonthDayFieldTypeDescriptor.java
@@ -38,6 +38,7 @@ public class MonthDayFieldTypeDescriptor extends FieldTypeDescriptor<MonthDay> {
 		Collections.addAll(
 				values,
 				MonthDay.of( Month.FEBRUARY, 28 ),
+				MonthDay.of( Month.FEBRUARY, 29 ), // HSEARCH-3549
 				MonthDay.of( Month.JUNE, 30 ),
 				MonthDay.of( Month.DECEMBER, 31 )
 		);

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/MonthDayFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/MonthDayFieldTypeDescriptor.java
@@ -8,10 +8,15 @@ package org.hibernate.search.integrationtest.backend.tck.testsupport.types;
 
 import java.time.Month;
 import java.time.MonthDay;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldProjectionExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldSortExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.IndexingExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.MatchPredicateExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.RangePredicateExpectations;
 
@@ -19,6 +24,24 @@ public class MonthDayFieldTypeDescriptor extends FieldTypeDescriptor<MonthDay> {
 
 	MonthDayFieldTypeDescriptor() {
 		super( MonthDay.class );
+	}
+
+	@Override
+	public Optional<IndexingExpectations<MonthDay>> getIndexingExpectations() {
+		List<MonthDay> values = new ArrayList<>();
+		Arrays.stream( Month.values() ).forEach( month -> {
+			values.add( MonthDay.of( month, 1 ) );
+			values.add( MonthDay.of( month, 3 ) );
+			values.add( MonthDay.of( month, 14 ) );
+			values.add( MonthDay.of( month, 28 ) );
+		} );
+		Collections.addAll(
+				values,
+				MonthDay.of( Month.FEBRUARY, 28 ),
+				MonthDay.of( Month.JUNE, 30 ),
+				MonthDay.of( Month.DECEMBER, 31 )
+		);
+		return Optional.of( new IndexingExpectations<>( values ) );
 	}
 
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/NormalizedStringFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/NormalizedStringFieldTypeDescriptor.java
@@ -13,6 +13,7 @@ import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeConte
 import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldProjectionExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldSortExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.IndexingExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.MatchPredicateExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.RangePredicateExpectations;
 
@@ -25,6 +26,18 @@ public class NormalizedStringFieldTypeDescriptor extends FieldTypeDescriptor<Str
 	@Override
 	public StandardIndexFieldTypeContext<?, String> configure(IndexFieldTypeFactoryContext fieldContext) {
 		return fieldContext.asString().normalizer( DefaultAnalysisDefinitions.NORMALIZER_LOWERCASE.name );
+	}
+
+	@Override
+	public Optional<IndexingExpectations<String>> getIndexingExpectations() {
+		return Optional.of( new IndexingExpectations<>(
+				"several tokens",
+				"onetoken",
+				"to the", // Only stopwords
+				"    trailingspaces   ",
+				"      ",
+				""
+		) );
 	}
 
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/OffsetDateTimeFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/OffsetDateTimeFieldTypeDescriptor.java
@@ -9,17 +9,45 @@ package org.hibernate.search.integrationtest.backend.tck.testsupport.types;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldProjectionExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldSortExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.IndexingExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.MatchPredicateExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.RangePredicateExpectations;
 
 public class OffsetDateTimeFieldTypeDescriptor extends FieldTypeDescriptor<OffsetDateTime> {
 
+	static List<ZoneOffset> getOffsetsForIndexingExpectations() {
+		return Arrays.asList(
+				ZoneOffset.UTC,
+				ZoneOffset.ofHoursMinutes( -8, 0 ),
+				ZoneOffset.ofHoursMinutes( -2, -30 ),
+				ZoneOffset.ofHoursMinutes( -2, 0 ),
+				ZoneOffset.ofHoursMinutes( 2, 0 ),
+				ZoneOffset.ofHoursMinutes( 2, 30 ),
+				ZoneOffset.ofHoursMinutes( 10, 0 ),
+				ZoneOffset.ofHoursMinutesSeconds( 10, 0, 24 )
+		);
+	}
+
 	OffsetDateTimeFieldTypeDescriptor() {
 		super( OffsetDateTime.class );
+	}
+
+	@Override
+	public Optional<IndexingExpectations<OffsetDateTime>> getIndexingExpectations() {
+		List<OffsetDateTime> values = new ArrayList<>();
+		LocalDateTimeFieldTypeDescriptor.getValuesForIndexingExpectations().forEach( localDateTime -> {
+			getOffsetsForIndexingExpectations().forEach( offset -> {
+				values.add( localDateTime.atOffset( offset ) );
+			} );
+		} );
+		return Optional.of( new IndexingExpectations<>( values ) );
 	}
 
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/OffsetTimeFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/OffsetTimeFieldTypeDescriptor.java
@@ -9,10 +9,13 @@ package org.hibernate.search.integrationtest.backend.tck.testsupport.types;
 import java.time.LocalTime;
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldProjectionExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldSortExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.IndexingExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.MatchPredicateExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.RangePredicateExpectations;
 
@@ -20,6 +23,17 @@ public class OffsetTimeFieldTypeDescriptor extends FieldTypeDescriptor<OffsetTim
 
 	OffsetTimeFieldTypeDescriptor() {
 		super( OffsetTime.class );
+	}
+
+	@Override
+	public Optional<IndexingExpectations<OffsetTime>> getIndexingExpectations() {
+		List<OffsetTime> values = new ArrayList<>();
+		LocalTimeFieldTypeDescriptor.getValuesForIndexingExpectations().forEach( localTime -> {
+			OffsetDateTimeFieldTypeDescriptor.getOffsetsForIndexingExpectations().forEach( offset -> {
+				values.add( localTime.atOffset( offset ) );
+			} );
+		} );
+		return Optional.of( new IndexingExpectations<>( values ) );
 	}
 
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/ShortFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/ShortFieldTypeDescriptor.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldProjectionExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldSortExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.IndexingExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.MatchPredicateExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.RangePredicateExpectations;
 
@@ -17,6 +18,16 @@ public class ShortFieldTypeDescriptor extends FieldTypeDescriptor<Short> {
 
 	ShortFieldTypeDescriptor() {
 		super( Short.class );
+	}
+
+	@Override
+	public Optional<IndexingExpectations<Short>> getIndexingExpectations() {
+		return Optional.of( new IndexingExpectations<>(
+				Short.MIN_VALUE, Short.MAX_VALUE,
+				(short) -25435, (short) -42, (short) -1, (short) 0, (short) 1, (short) 3, (short) 42, (short) 18353,
+				// This is ugly, but we test it on purpose
+				new Short( (short) 47 )
+		) );
 	}
 
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/YearFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/YearFieldTypeDescriptor.java
@@ -28,7 +28,14 @@ public class YearFieldTypeDescriptor extends FieldTypeDescriptor<Year> {
 				Year.of( 1999 ),
 				Year.of( 2000 ),
 				Year.of( 2019 ),
-				Year.of( 2050 )
+				Year.of( 2050 ),
+				/*
+				 * Minimum and maximum years that can be represented as number of millisecond since the epoch in a long.
+				 * The minimum and maximum dates that can be represented are slightly before/after,
+				 * but there's no point telling users these years are supported if not all months are supported.
+				 */
+				Year.of( -292_275_054 ),
+				Year.of( 292_278_993 )
 		);
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/YearFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/YearFieldTypeDescriptor.java
@@ -7,17 +7,38 @@
 package org.hibernate.search.integrationtest.backend.tck.testsupport.types;
 
 import java.time.Year;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldProjectionExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldSortExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.IndexingExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.MatchPredicateExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.RangePredicateExpectations;
 
 public class YearFieldTypeDescriptor extends FieldTypeDescriptor<Year> {
 
+	static List<Year> getValuesForIndexingExpectations() {
+		return Arrays.asList(
+				Year.of( -25435 ), Year.of( -42 ), Year.of( -1 ),
+				Year.of( 0 ),
+				Year.of( 1 ), Year.of( 3 ), Year.of( 42 ), Year.of( 18353 ),
+				Year.of( 1989 ),
+				Year.of( 1999 ),
+				Year.of( 2000 ),
+				Year.of( 2019 ),
+				Year.of( 2050 )
+		);
+	}
+
 	YearFieldTypeDescriptor() {
 		super( Year.class );
+	}
+
+	@Override
+	public Optional<IndexingExpectations<Year>> getIndexingExpectations() {
+		return Optional.of( new IndexingExpectations<>( getValuesForIndexingExpectations() ) );
 	}
 
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/YearMonthFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/YearMonthFieldTypeDescriptor.java
@@ -8,10 +8,14 @@ package org.hibernate.search.integrationtest.backend.tck.testsupport.types;
 
 import java.time.Month;
 import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldProjectionExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldSortExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.IndexingExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.MatchPredicateExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.RangePredicateExpectations;
 
@@ -19,6 +23,17 @@ public class YearMonthFieldTypeDescriptor extends FieldTypeDescriptor<YearMonth>
 
 	YearMonthFieldTypeDescriptor() {
 		super( YearMonth.class );
+	}
+
+	@Override
+	public Optional<IndexingExpectations<YearMonth>> getIndexingExpectations() {
+		List<YearMonth> values = new ArrayList<>();
+		YearFieldTypeDescriptor.getValuesForIndexingExpectations().forEach( year -> {
+			Arrays.stream( Month.values() ).forEach( month -> {
+				values.add( year.atMonth( month ) );
+			} );
+		} );
+		return Optional.of( new IndexingExpectations<>( values ) );
 	}
 
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/ZonedDateTimeFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/ZonedDateTimeFieldTypeDescriptor.java
@@ -28,7 +28,12 @@ public class ZonedDateTimeFieldTypeDescriptor extends FieldTypeDescriptor<ZonedD
 				ZoneId.of( "UTC" ),
 				ZoneId.of( "Europe/Paris" ),
 				ZoneId.of( "Europe/Amsterdam" ),
-				ZoneId.of( "America/Los_Angeles" )
+				ZoneId.of( "America/Los_Angeles" ),
+				// HSEARCH-3548: also test ZoneOffsets used as ZoneIds
+				ZoneOffset.UTC, // Strangely, this is not the same as ZoneId.of( "UTC" )
+				ZoneOffset.ofHoursMinutes( -2, 0 ),
+				ZoneOffset.ofHoursMinutes( 2, 30 ),
+				ZoneOffset.ofHoursMinutesSeconds( 10, 0, 24 )
 		);
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/ZonedDateTimeFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/ZonedDateTimeFieldTypeDescriptor.java
@@ -8,18 +8,43 @@ package org.hibernate.search.integrationtest.backend.tck.testsupport.types;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldProjectionExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldSortExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.IndexingExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.MatchPredicateExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.RangePredicateExpectations;
 
 public class ZonedDateTimeFieldTypeDescriptor extends FieldTypeDescriptor<ZonedDateTime> {
 
+	private static List<ZoneId> getZoneIdsForIndexingExpectations() {
+		return Arrays.asList(
+				ZoneId.of( "UTC" ),
+				ZoneId.of( "Europe/Paris" ),
+				ZoneId.of( "Europe/Amsterdam" ),
+				ZoneId.of( "America/Los_Angeles" )
+		);
+	}
+
 	ZonedDateTimeFieldTypeDescriptor() {
 		super( ZonedDateTime.class );
+	}
+
+	@Override
+	public Optional<IndexingExpectations<ZonedDateTime>> getIndexingExpectations() {
+		List<ZonedDateTime> values = new ArrayList<>();
+		LocalDateTimeFieldTypeDescriptor.getValuesForIndexingExpectations().forEach( localDateTime -> {
+			getZoneIdsForIndexingExpectations().forEach( zoneId -> {
+				values.add( localDateTime.atZone( zoneId ) );
+			} );
+		} );
+		return Optional.of( new IndexingExpectations<>( values ) );
 	}
 
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/ZonedDateTimeFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/ZonedDateTimeFieldTypeDescriptor.java
@@ -12,6 +12,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -49,6 +50,14 @@ public class ZonedDateTimeFieldTypeDescriptor extends FieldTypeDescriptor<ZonedD
 				values.add( localDateTime.atZone( zoneId ) );
 			} );
 		} );
+		// HSEARCH-3557: Two date/times that could be ambiguous due to a daylight saving time switch
+		Collections.addAll(
+				values,
+				LocalDateTime.parse( "2011-10-30T02:50:00.00" ).atZone( ZoneId.of( "CET" ) )
+						.withEarlierOffsetAtOverlap(),
+				LocalDateTime.parse( "2011-10-30T02:50:00.00" ).atZone( ZoneId.of( "CET" ) )
+						.withLaterOffsetAtOverlap()
+		);
 		return Optional.of( new IndexingExpectations<>( values ) );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/expectations/IndexingExpectations.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/expectations/IndexingExpectations.java
@@ -1,0 +1,29 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class IndexingExpectations<F> {
+
+	private final List<F> values;
+
+	@SafeVarargs
+	public IndexingExpectations(F ... values) {
+		this( Arrays.asList( values ) );
+	}
+
+	public IndexingExpectations(List<F> values) {
+		this.values = values;
+	}
+
+	public List<F> getValues() {
+		return values;
+	}
+
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexingIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexingIT.java
@@ -1,0 +1,183 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.tck.work;
+
+import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.hibernate.search.engine.backend.document.DocumentElement;
+import org.hibernate.search.engine.backend.document.IndexFieldReference;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.index.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.types.Projectable;
+import org.hibernate.search.engine.search.query.spi.IndexSearchQuery;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldTypeDescriptor;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.IndexingExpectations;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.StandardFieldMapper;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingSearchScope;
+
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+/**
+ * Test indexing with various values.
+ * <p>
+ * Useful to test corner cases: 0, Integer.MAX_VALUE, empty string, date at epoch, february 29th, ...
+ *
+ * @param <F> The type of field values.
+ */
+@RunWith(Parameterized.class)
+public class IndexingIT<F> {
+
+	private static final String INDEX_NAME = "IndexName";
+
+	@Parameterized.Parameters(name = "{0}")
+	public static Object[] types() {
+		return FieldTypeDescriptor.getAll().stream()
+				.map( typeDescriptor -> new Object[] { typeDescriptor, typeDescriptor.getIndexingExpectations() } )
+				.toArray();
+	}
+
+	@Rule
+	public SearchSetupHelper setupHelper = new SearchSetupHelper();
+
+	private final FieldTypeDescriptor<F> typeDescriptor;
+	private final IndexingExpectations<F> expectations;
+
+	private IndexMapping indexMapping;
+	private StubMappingIndexManager indexManager;
+
+	public IndexingIT(FieldTypeDescriptor<F> typeDescriptor, Optional<IndexingExpectations<F>> expectations) {
+		Assume.assumeTrue(
+				"Type " + typeDescriptor + " does not define indexing expectations", expectations.isPresent()
+		);
+		this.typeDescriptor = typeDescriptor;
+		this.expectations = expectations.get();
+	}
+
+	@Before
+	public void setup() {
+		setupHelper.withDefaultConfiguration()
+				.withIndex(
+						INDEX_NAME,
+						ctx -> this.indexMapping = new IndexMapping( ctx.getSchemaElement() ),
+						indexManager -> this.indexManager = indexManager
+				)
+				.setup();
+	}
+
+	@Test
+	public void index() {
+		List<F> values = new ArrayList<>( expectations.getValues() );
+		values.add( null ); // Also test null
+		List<IdAndValue<F>> expectedDocuments = new ArrayList<>();
+
+		// Index all values, each in its own document
+		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
+		for ( int i = 0; i < values.size(); i++ ) {
+			String documentId = "document_" + i;
+			F value = values.get( i );
+			workPlan.add( referenceProvider( documentId ), document -> {
+				document.addValue( indexMapping.fieldModel.reference, value );
+			} );
+			expectedDocuments.add( new IdAndValue<>( documentId, value ) );
+		}
+		workPlan.execute().join();
+
+		// If we get here, indexing went well.
+		// However, it may have failed silently... Let's check the documents are there, with the right value.
+
+		StubMappingSearchScope scope = indexManager.createSearchScope();
+		String absoluteFieldPath = indexMapping.fieldModel.relativeFieldName;
+
+		for ( int i = 0; i < values.size(); i++ ) {
+			IndexSearchQuery<IdAndValue<F>> query = scope.query()
+					.asProjection( f -> f.composite(
+							(ref, val) -> new IdAndValue<>( ref.getId(), val ),
+							f.reference(),
+							f.field( absoluteFieldPath, typeDescriptor.getJavaType() )
+					) )
+					.predicate( f -> f.matchAll() )
+					.toQuery();
+
+			assertThat( query ).hasHitsAnyOrder( expectedDocuments );
+		}
+	}
+
+	private class IndexMapping {
+		final FieldModel<F> fieldModel;
+
+		IndexMapping(IndexSchemaElement root) {
+			this.fieldModel = FieldModel.mapper( typeDescriptor )
+					.map( root, "field_" + typeDescriptor.getUniqueName(), c -> c.projectable( Projectable.YES ) );
+		}
+	}
+
+	private static class FieldModel<F> {
+		static <F> StandardFieldMapper<F, FieldModel<F>> mapper(FieldTypeDescriptor<F> typeDescriptor) {
+			return StandardFieldMapper.of(
+					typeDescriptor::configure,
+					FieldModel::new
+			);
+		}
+
+		final IndexFieldReference<F> reference;
+		final String relativeFieldName;
+
+		private FieldModel(IndexFieldReference<F> reference, String relativeFieldName) {
+			this.reference = reference;
+			this.relativeFieldName = relativeFieldName;
+		}
+	}
+
+	private static class IdAndValue<F> {
+		final String documentId;
+		final F fieldValue;
+
+		private IdAndValue(String documentId, F fieldValue) {
+			this.documentId = documentId;
+			this.fieldValue = fieldValue;
+		}
+
+		@Override
+		public String toString() {
+			return "IdAndValue{" +
+					"documentId='" + documentId + '\'' +
+					", fieldValue=" + fieldValue +
+					'}';
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			IdAndValue<?> that = (IdAndValue<?>) o;
+			return Objects.equals( documentId, that.documentId ) &&
+					Objects.equals( fieldValue, that.fieldValue );
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( documentId, fieldValue );
+		}
+	}
+}

--- a/util/common/src/main/java/org/hibernate/search/util/common/impl/TimeHelper.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/impl/TimeHelper.java
@@ -1,0 +1,62 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.common.impl;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
+
+/**
+ * Helpers for classes in java.time.*
+ */
+public final class TimeHelper {
+
+	private TimeHelper() {
+		// not allowed
+	}
+
+	/**
+	 * Workaround for https://bugs.openjdk.java.net/browse/JDK-8066982,
+	 * which at the moment has only been solved for JDK9.
+	 *
+	 * <p>Tested against TCKDTFParsedInstant in
+	 * http://hg.openjdk.java.net/jdk9/dev/jdk/rev/f371bdfb7875
+	 * with both JDK8b101 and JDK9 (early access - build 137).
+	 *
+	 * @param value The value to be parsed
+	 * @param formatter The formatter to use when parsing
+	 * @return The parsed {@link ZonedDateTime}
+	 */
+	public static ZonedDateTime parseZoneDateTime(String value, DateTimeFormatter formatter) {
+		TemporalAccessor temporal = formatter.parse( value );
+		if ( !temporal.isSupported( ChronoField.OFFSET_SECONDS ) ) {
+			// No need for a workaround
+			return ZonedDateTime.from( temporal );
+		}
+		/*
+		 * Rationale
+		 *
+		 * The bug lies in the way epoch seconds are retrieved: the date is interpreted as being
+		 * expressed in the default offset for the timezone, instead of using the given offset.
+		 * ZonedDateTime.from uses these epoch seconds in priority when retrieving the local date/time,
+		 * and falls back to using the epoch day and nano of day.
+		 * We work around the bug by bypassing ZonedDateTime.from and not using the epoch seconds,
+		 * but instead directly retrieving the LocalDateTime using LocalDateTime.from. This method
+		 * relies on ChronoField.EPOCH_DAY and ChronoField.NANO_OF_DAY, which (strangely) seem
+		 * unaffected by the bug.
+		 */
+		ZoneId zone = ZoneId.from( temporal );
+		ZoneOffset offset = ZoneOffset.from( temporal );
+		LocalDateTime ldt = LocalDateTime.from( temporal );
+		return ZonedDateTime.ofInstant( ldt, offset, zone );
+	}
+
+}


### PR DESCRIPTION
* [HSEARCH-3548](https://hibernate.atlassian.net//browse/HSEARCH-3548): ZonedDateTime with zone = ZoneOffset.UTC fails when indexing in Elasticsearch 5.6
* [HSEARCH-3549](https://hibernate.atlassian.net//browse/HSEARCH-3549): Indexing MonthDay.of( 2, 29 ) fails on Elasticsearch 5.6
* [HSEARCH-3555](https://hibernate.atlassian.net//browse/HSEARCH-3555): Indexing Year.of( Year.MAX_VALUE ) fails with Elasticsearch 5
* [HSEARCH-3557](https://hibernate.atlassian.net//browse/HSEARCH-3557): ZonedDateTime at later offset during DST change gets parsed incorrectly

