### PR TITLE
HSEARCH-3058 Search 6 groundwork - Add generic type parameters to PropertyHandle

### DIFF
--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/model/impl/JavaBeanBootstrapIntrospector.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/model/impl/JavaBeanBootstrapIntrospector.java
@@ -87,7 +87,7 @@ public class JavaBeanBootstrapIntrospector implements PojoBootstrapIntrospector 
 		return annotationHelper.getAnnotationsByMetaAnnotationType( annotatedElement, metaAnnotationType );
 	}
 
-	PropertyHandle createPropertyHandle(String name, Method method) throws IllegalAccessException {
+	PropertyHandle<?> createPropertyHandle(String name, Method method) throws IllegalAccessException {
 		return propertyHandleFactory.createForMethod( name, method );
 	}
 

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/model/impl/JavaBeanPropertyModel.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/model/impl/JavaBeanPropertyModel.java
@@ -29,7 +29,7 @@ class JavaBeanPropertyModel<T> implements PojoPropertyModel<T> {
 	private final PropertyDescriptor descriptor;
 
 	private PojoGenericTypeModel<T> typeModel;
-	private PropertyHandle handle;
+	private PropertyHandle<T> handle;
 
 	JavaBeanPropertyModel(JavaBeanBootstrapIntrospector introspector, JavaBeanTypeModel<?> parentTypeModel,
 			PropertyDescriptor descriptor) {
@@ -102,10 +102,11 @@ class JavaBeanPropertyModel<T> implements PojoPropertyModel<T> {
 	}
 
 	@Override
-	public PropertyHandle getHandle() {
+	@SuppressWarnings("unchecked") // By construction, we know the member returns values of type T
+	public PropertyHandle<T> getHandle() {
 		if ( handle == null ) {
 			try {
-				handle = introspector.createPropertyHandle( getName(), descriptor.getReadMethod() );
+				handle = (PropertyHandle<T>) introspector.createPropertyHandle( getName(), descriptor.getReadMethod() );
 			}
 			catch (IllegalAccessException | RuntimeException e) {
 				throw log.errorRetrievingPropertyTypeModel( getName(), parentTypeModel, e );

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmBootstrapIntrospector.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmBootstrapIntrospector.java
@@ -232,7 +232,7 @@ public class HibernateOrmBootstrapIntrospector implements PojoBootstrapIntrospec
 				.filter( annotation -> annotationHelper.isMetaAnnotated( annotation, metaAnnotationType ) );
 	}
 
-	PropertyHandle createPropertyHandle(String name, Member member) throws IllegalAccessException {
+	PropertyHandle<?> createPropertyHandle(String name, Member member) throws IllegalAccessException {
 		if ( member instanceof Method ) {
 			Method method = (Method) member;
 			setAccessible( method );

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmPropertyModel.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmPropertyModel.java
@@ -39,7 +39,7 @@ class HibernateOrmPropertyModel<T> implements PojoPropertyModel<T> {
  	 */
 	private final List<XProperty> declaredXProperties;
 
-	private PropertyHandle handle;
+	private PropertyHandle<T> handle;
 	private PojoGenericTypeModel<T> typeModel;
 
 	HibernateOrmPropertyModel(HibernateOrmBootstrapIntrospector introspector, HibernateOrmRawTypeModel<?> holderTypeModel,
@@ -90,10 +90,11 @@ class HibernateOrmPropertyModel<T> implements PojoPropertyModel<T> {
 	}
 
 	@Override
-	public PropertyHandle getHandle() {
+	@SuppressWarnings("unchecked") // By construction, we know the member returns values of type T
+	public PropertyHandle<T> getHandle() {
 		if ( handle == null ) {
 			try {
-				handle = introspector.createPropertyHandle( name, member );
+				handle = (PropertyHandle<T>) introspector.createPropertyHandle( name, member );
 			}
 			catch (IllegalAccessException | RuntimeException e) {
 				throw log.errorRetrievingPropertyTypeModel( getName(), holderTypeModel, e );

--- a/mapper/orm/src/test/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmBootstrapIntrospectorAccessTypeTest.java
+++ b/mapper/orm/src/test/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmBootstrapIntrospectorAccessTypeTest.java
@@ -189,7 +189,7 @@ public class HibernateOrmBootstrapIntrospectorAccessTypeTest {
 		 * If they return the correct value, we know they work correctly,
 		 * because the types are designed in such a way that any other access type wouldn't work.
 		 */
-		PropertyHandle propertyHandle = typeModel.getProperty( "propertyWithDefaultFieldAccess" ).getHandle();
+		PropertyHandle<?> propertyHandle = typeModel.getProperty( "propertyWithDefaultFieldAccess" ).getHandle();
 		assertThat( propertyHandle.get( entity ) ).isEqualTo( entity.propertyWithDefaultFieldAccess );
 		propertyHandle = typeModel.getProperty( "idWithDefaultFieldAccess" ).getHandle();
 		assertThat( propertyHandle.get( entity ) ).isEqualTo( entity.idWithDefaultFieldAccess );
@@ -207,7 +207,7 @@ public class HibernateOrmBootstrapIntrospectorAccessTypeTest {
 		 * If they return the correct value, we know they work correctly,
 		 * because the types are designed in such a way that any other access type wouldn't work.
 		 */
-		PropertyHandle propertyHandle = typeModel.getProperty( "propertyWithDefaultMethodAccess" ).getHandle();
+		PropertyHandle<?> propertyHandle = typeModel.getProperty( "propertyWithDefaultMethodAccess" ).getHandle();
 		assertThat( propertyHandle.get( entity ) ).isEqualTo( entity.getPropertyWithDefaultMethodAccess() );
 		propertyHandle = typeModel.getProperty( "idWithDefaultMethodAccess" ).getHandle();
 		assertThat( propertyHandle.get( entity ) ).isEqualTo( entity.getIdWithDefaultMethodAccess() );
@@ -225,7 +225,7 @@ public class HibernateOrmBootstrapIntrospectorAccessTypeTest {
 		 * If they return the correct value, we know they work correctly,
 		 * because the types are designed in such a way that any other access type wouldn't work.
 		 */
-		PropertyHandle propertyHandle = typeModel.getProperty( "propertyWithDefaultFieldAccess" ).getHandle();
+		PropertyHandle<?> propertyHandle = typeModel.getProperty( "propertyWithDefaultFieldAccess" ).getHandle();
 		assertThat( propertyHandle.get( embeddable ) ).isEqualTo( embeddable.propertyWithDefaultFieldAccess );
 		propertyHandle = typeModel.getProperty( "propertyWithNonDefaultMethodAccess" ).getHandle();
 		assertThat( propertyHandle.get( embeddable ) ).isEqualTo( embeddable.getPropertyWithNonDefaultMethodAccess() );
@@ -252,7 +252,7 @@ public class HibernateOrmBootstrapIntrospectorAccessTypeTest {
 		 * If they return the correct value, we know they work correctly,
 		 * because the types are designed in such a way that any other access type wouldn't work.
 		 */
-		PropertyHandle propertyHandle = typeModel.getProperty( "propertyWithDefaultMethodAccess" ).getHandle();
+		PropertyHandle<?> propertyHandle = typeModel.getProperty( "propertyWithDefaultMethodAccess" ).getHandle();
 		assertThat( propertyHandle.get( embeddable ) ).isEqualTo( embeddable.getPropertyWithDefaultMethodAccess() );
 		propertyHandle = typeModel.getProperty( "propertyWithNonDefaultFieldAccess" ).getHandle();
 		assertThat( propertyHandle.get( embeddable ) ).isEqualTo( embeddable.propertyWithNonDefaultFieldAccess );

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/dirtiness/building/impl/AbstractPojoImplicitReindexingResolverTypeNodeBuilder.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/dirtiness/building/impl/AbstractPojoImplicitReindexingResolverTypeNodeBuilder.java
@@ -118,7 +118,7 @@ abstract class AbstractPojoImplicitReindexingResolverTypeNodeBuilder<T, U>
 
 	private PojoImplicitReindexingResolverPropertyNodeBuilder<U, ?> createPropertyBuilder(String propertyName) {
 		checkNotFrozen();
-		PropertyHandle handle = modelPath.getTypeModel().getProperty( propertyName ).getHandle();
+		PropertyHandle<?> handle = modelPath.getTypeModel().getProperty( propertyName ).getHandle();
 		return new PojoImplicitReindexingResolverPropertyNodeBuilder<>(
 				modelPath.property( handle ), buildingHelper
 		);

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/dirtiness/building/impl/PojoAssociationPathInverter.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/dirtiness/building/impl/PojoAssociationPathInverter.java
@@ -189,7 +189,7 @@ public final class PojoAssociationPathInverter {
 				inverseSideTypeAdditionalMetadata.getPropertiesAdditionalMetadata().entrySet() ) {
 			String inverseSidePropertyName = propertyEntry.getKey();
 			PojoPropertyModel<?> inverseSidePropertyModel = inverseSideTypeModel.getProperty( inverseSidePropertyName );
-			PropertyHandle propertyHandle = inverseSidePropertyModel.getHandle();
+			PropertyHandle<?> propertyHandle = inverseSidePropertyModel.getHandle();
 			BoundPojoModelPathPropertyNode<?, ?> inverseSidePathPropertyNode =
 					inverseSidePathTypeNode.property( propertyHandle );
 			PojoPropertyAdditionalMetadata inverseSidePropertyAdditionalMetadata = propertyEntry.getValue();

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/dirtiness/building/impl/PojoIndexingDependencyCollectorTypeNode.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/dirtiness/building/impl/PojoIndexingDependencyCollectorTypeNode.java
@@ -79,7 +79,7 @@ public class PojoIndexingDependencyCollectorTypeNode<T> extends AbstractPojoInde
 	 * Thus applying the same property handle results in the same property type.
 	 */
 	@SuppressWarnings({"unchecked", "rawtypes"})
-	public PojoIndexingDependencyCollectorPropertyNode<T, ?> property(PropertyHandle propertyHandle) {
+	public PojoIndexingDependencyCollectorPropertyNode<T, ?> property(PropertyHandle<?> propertyHandle) {
 		return new PojoIndexingDependencyCollectorPropertyNode<>(
 				this,
 				modelPathFromCurrentNode.property( propertyHandle ),

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/dirtiness/impl/PojoImplicitReindexingResolverPropertyNode.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/dirtiness/impl/PojoImplicitReindexingResolverPropertyNode.java
@@ -28,10 +28,10 @@ import org.hibernate.search.util.common.impl.ToStringTreeBuilder;
  */
 public class PojoImplicitReindexingResolverPropertyNode<T, S, P> extends PojoImplicitReindexingResolverNode<T, S> {
 
-	private final PropertyHandle handle;
+	private final PropertyHandle<P> handle;
 	private final Collection<PojoImplicitReindexingResolverNode<? super P, S>> nestedNodes;
 
-	public PojoImplicitReindexingResolverPropertyNode(PropertyHandle handle,
+	public PojoImplicitReindexingResolverPropertyNode(PropertyHandle<P> handle,
 			Collection<PojoImplicitReindexingResolverNode<? super P, S>> nestedNodes) {
 		this.handle = handle;
 		this.nestedNodes = nestedNodes;
@@ -58,9 +58,7 @@ public class PojoImplicitReindexingResolverPropertyNode<T, S, P> extends PojoImp
 	@Override
 	public void resolveEntitiesToReindex(PojoReindexingCollector collector,
 			PojoRuntimeIntrospector runtimeIntrospector, T dirty, S dirtinessState) {
-		// TODO HSEARCH-3058 add generic type parameters to property handles
-		@SuppressWarnings("unchecked")
-		P propertyValue = (P) handle.get( dirty );
+		P propertyValue = handle.get( dirty );
 		if ( propertyValue != null ) {
 			for ( PojoImplicitReindexingResolverNode<? super P, S> node : nestedNodes ) {
 				node.resolveEntitiesToReindex( collector, runtimeIntrospector, propertyValue, dirtinessState );

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/InitialPropertyMappingContext.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/InitialPropertyMappingContext.java
@@ -33,12 +33,12 @@ public class InitialPropertyMappingContext
 		implements PropertyMappingContext, PojoTypeMetadataContributor {
 
 	private final TypeMappingContext parent;
-	private final PropertyHandle propertyHandle;
+	private final PropertyHandle<?> propertyHandle;
 
 	private final ErrorCollectingPojoPropertyMetadataContributor children =
 			new ErrorCollectingPojoPropertyMetadataContributor();
 
-	InitialPropertyMappingContext(TypeMappingContext parent, PropertyHandle propertyHandle) {
+	InitialPropertyMappingContext(TypeMappingContext parent, PropertyHandle<?> propertyHandle) {
 		this.parent = parent;
 		this.propertyHandle = propertyHandle;
 	}

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/TypeMappingContextImpl.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/TypeMappingContextImpl.java
@@ -118,7 +118,7 @@ public class TypeMappingContextImpl
 	@Override
 	public PropertyMappingContext property(String propertyName) {
 		PojoPropertyModel<?> propertyModel = typeModel.getProperty( propertyName );
-		PropertyHandle propertyHandle = propertyModel.getHandle();
+		PropertyHandle<?> propertyHandle = propertyModel.getHandle();
 		InitialPropertyMappingContext child = new InitialPropertyMappingContext( this, propertyHandle );
 		children.add( child );
 		return child;

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PropertyIdentifierMapping.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PropertyIdentifierMapping.java
@@ -22,10 +22,10 @@ import org.hibernate.search.util.common.impl.Closer;
 public class PropertyIdentifierMapping<I, E> implements IdentifierMapping<I, E> {
 
 	private final PojoCaster<? super I> caster;
-	private final PropertyHandle<? super I> property;
+	private final PropertyHandle<I> property;
 	private final BeanHolder<? extends IdentifierBridge<I>> bridgeHolder;
 
-	public PropertyIdentifierMapping(PojoCaster<? super I> caster, PropertyHandle<? super I> property,
+	public PropertyIdentifierMapping(PojoCaster<? super I> caster, PropertyHandle<I> property,
 			BeanHolder<? extends IdentifierBridge<I>> bridgeHolder) {
 		this.caster = caster;
 		this.property = property;
@@ -46,10 +46,7 @@ public class PropertyIdentifierMapping<I, E> implements IdentifierMapping<I, E> 
 		if ( providedId != null ) {
 			return (I) caster.cast( providedId );
 		}
-
-		Object id = property.get( entitySupplier.get() );
-		// TODO avoid this cast? By construction, the property handle should always return type I
-		return (I) caster.cast( id );
+		return property.get( entitySupplier.get() );
 	}
 
 	@Override

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PropertyIdentifierMapping.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PropertyIdentifierMapping.java
@@ -22,10 +22,10 @@ import org.hibernate.search.util.common.impl.Closer;
 public class PropertyIdentifierMapping<I, E> implements IdentifierMapping<I, E> {
 
 	private final PojoCaster<? super I> caster;
-	private final PropertyHandle property;
+	private final PropertyHandle<? super I> property;
 	private final BeanHolder<? extends IdentifierBridge<I>> bridgeHolder;
 
-	public PropertyIdentifierMapping(PojoCaster<? super I> caster, PropertyHandle property,
+	public PropertyIdentifierMapping(PojoCaster<? super I> caster, PropertyHandle<? super I> property,
 			BeanHolder<? extends IdentifierBridge<I>> bridgeHolder) {
 		this.caster = caster;
 		this.property = property;

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/impl/PojoModelNestedCompositeElement.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/impl/PojoModelNestedCompositeElement.java
@@ -71,7 +71,7 @@ class PojoModelNestedCompositeElement<T, P> extends AbstractPojoModelCompositeEl
 		return modelPath.type();
 	}
 
-	PropertyHandle getHandle() {
+	PropertyHandle<P> getHandle() {
 		return modelPath.getParent().getPropertyHandle();
 	}
 }

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/impl/PojoModelPropertyElementAccessor.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/impl/PojoModelPropertyElementAccessor.java
@@ -16,20 +16,18 @@ import org.hibernate.search.mapper.pojo.model.spi.PropertyHandle;
 class PojoModelPropertyElementAccessor<P> implements PojoModelElementAccessor<P> {
 
 	private final PojoModelElementAccessor<?> parent;
-	private final PropertyHandle handle;
+	private final PropertyHandle<P> handle;
 
-	PojoModelPropertyElementAccessor(PojoModelElementAccessor<?> parent, PropertyHandle handle) {
+	PojoModelPropertyElementAccessor(PojoModelElementAccessor<?> parent, PropertyHandle<P> handle) {
 		this.parent = parent;
 		this.handle = handle;
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public P read(PojoElement bridgedElement) {
 		Object parentValue = parent.read( bridgedElement );
 		if ( parentValue != null ) {
-			// TODO HSEARCH-3058 add generic type parameters to property handles
-			return (P) handle.get( parentValue );
+			return handle.get( parentValue );
 		}
 		else {
 			return null;

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/path/impl/BoundPojoModelPathPropertyNode.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/path/impl/BoundPojoModelPathPropertyNode.java
@@ -21,10 +21,10 @@ import org.hibernate.search.mapper.pojo.model.spi.PropertyHandle;
 public class BoundPojoModelPathPropertyNode<T, P> extends BoundPojoModelPath {
 
 	private final BoundPojoModelPathTypeNode<T> parent;
-	private final PropertyHandle propertyHandle;
+	private final PropertyHandle<P> propertyHandle;
 	private final PojoPropertyModel<P> propertyModel;
 
-	BoundPojoModelPathPropertyNode(BoundPojoModelPathTypeNode<T> parent, PropertyHandle propertyHandle,
+	BoundPojoModelPathPropertyNode(BoundPojoModelPathTypeNode<T> parent, PropertyHandle<P> propertyHandle,
 			PojoPropertyModel<P> propertyModel) {
 		this.parent = parent;
 		this.propertyHandle = propertyHandle;
@@ -61,7 +61,7 @@ public class BoundPojoModelPathPropertyNode<T, P> extends BoundPojoModelPath {
 		return new BoundPojoModelPathValueNode<>( this, extractorPath );
 	}
 
-	public PropertyHandle getPropertyHandle() {
+	public PropertyHandle<P> getPropertyHandle() {
 		return propertyHandle;
 	}
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/path/impl/BoundPojoModelPathTypeNode.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/path/impl/BoundPojoModelPathTypeNode.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.mapper.pojo.model.path.impl;
 
 import org.hibernate.search.mapper.pojo.model.path.PojoModelPathValueNode;
+import org.hibernate.search.mapper.pojo.model.spi.PojoPropertyModel;
 import org.hibernate.search.mapper.pojo.model.spi.PojoTypeModel;
 import org.hibernate.search.mapper.pojo.model.spi.PropertyHandle;
 
@@ -29,9 +30,11 @@ public abstract class BoundPojoModelPathTypeNode<T> extends BoundPojoModelPath {
 		}
 	}
 
-	public BoundPojoModelPathPropertyNode<T, ?> property(PropertyHandle propertyHandle) {
+	@SuppressWarnings("unchecked") // TODO HSEARCH-3318 This is an approximation, ideally we should not pass a propertyHandle but a name and access type
+	public <P> BoundPojoModelPathPropertyNode<T, P> property(PropertyHandle<P> propertyHandle) {
 		return new BoundPojoModelPathPropertyNode<>(
-				this, propertyHandle, getTypeModel().getProperty( propertyHandle.getName() )
+				this, propertyHandle,
+				(PojoPropertyModel<P>) getTypeModel().getProperty( propertyHandle.getName() )
 		);
 	}
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/spi/FieldPropertyHandle.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/spi/FieldPropertyHandle.java
@@ -12,7 +12,7 @@ import java.lang.reflect.Field;
 import org.hibernate.search.mapper.pojo.logging.impl.Log;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
-final class FieldPropertyHandle implements PropertyHandle {
+final class FieldPropertyHandle<T> implements PropertyHandle<T> {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
@@ -35,9 +35,9 @@ final class FieldPropertyHandle implements PropertyHandle {
 	}
 
 	@Override
-	public Object get(Object thiz) {
+	public T get(Object thiz) {
 		try {
-			return field.get( thiz );
+			return (T) field.get( thiz );
 		}
 		catch (Error e) {
 			throw e;
@@ -60,7 +60,7 @@ final class FieldPropertyHandle implements PropertyHandle {
 		if ( obj == null || !obj.getClass().equals( getClass() ) ) {
 			return false;
 		}
-		FieldPropertyHandle other = (FieldPropertyHandle) obj;
+		FieldPropertyHandle<?> other = (FieldPropertyHandle) obj;
 		return name.equals( other.name ) && field.equals( other.field );
 	}
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/spi/GenericContextAwarePojoGenericTypeModel.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/spi/GenericContextAwarePojoGenericTypeModel.java
@@ -154,7 +154,7 @@ public final class GenericContextAwarePojoGenericTypeModel<T> implements PojoGen
 		GenericContextAwarePojoGenericTypeModel<? extends U> genericPropertyTypeModel =
 				new GenericContextAwarePojoGenericTypeModel<>( helper, propertyGenericTypeContext );
 		PojoPropertyModel<? extends U> propertyModel =
-				new GenericContextAwarePojoPropertyMode<>( rawPropertyModel, genericPropertyTypeModel );
+				new GenericContextAwarePojoPropertyModel<>( rawPropertyModel, genericPropertyTypeModel );
 		genericPropertyCache.put( cacheKey, propertyModel );
 		return propertyModel;
 	}

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/spi/GenericContextAwarePojoPropertyMode.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/spi/GenericContextAwarePojoPropertyMode.java
@@ -43,7 +43,8 @@ final class GenericContextAwarePojoPropertyMode<T> implements PojoPropertyModel<
 	}
 
 	@Override
-	public PropertyHandle getHandle() {
-		return rawPropertyModel.getHandle();
+	@SuppressWarnings("unchecked") // We know that, in the current generic context, this cast is legal
+	public PropertyHandle<T> getHandle() {
+		return (PropertyHandle<T>) rawPropertyModel.getHandle();
 	}
 }

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/spi/GenericContextAwarePojoPropertyModel.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/spi/GenericContextAwarePojoPropertyModel.java
@@ -9,12 +9,12 @@ package org.hibernate.search.mapper.pojo.model.spi;
 import java.lang.annotation.Annotation;
 import java.util.stream.Stream;
 
-final class GenericContextAwarePojoPropertyMode<T> implements PojoPropertyModel<T> {
+final class GenericContextAwarePojoPropertyModel<T> implements PojoPropertyModel<T> {
 
 	private final PojoPropertyModel<? super T> rawPropertyModel;
 	private final GenericContextAwarePojoGenericTypeModel<T> genericPropertyTypeModel;
 
-	GenericContextAwarePojoPropertyMode(
+	GenericContextAwarePojoPropertyModel(
 			PojoPropertyModel<? super T> rawPropertyModel,
 			GenericContextAwarePojoGenericTypeModel<T> genericPropertyTypeModel) {
 		this.rawPropertyModel = rawPropertyModel;

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/spi/MemberPropertyHandleFactory.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/spi/MemberPropertyHandleFactory.java
@@ -11,12 +11,12 @@ import java.lang.reflect.Method;
 
 final class MemberPropertyHandleFactory implements PropertyHandleFactory {
 	@Override
-	public PropertyHandle createForField(String propertyName, Field field) {
+	public PropertyHandle<?> createForField(String propertyName, Field field) {
 		return new FieldPropertyHandle( propertyName, field );
 	}
 
 	@Override
-	public PropertyHandle createForMethod(String propertyName, Method method) {
+	public PropertyHandle<?> createForMethod(String propertyName, Method method) {
 		return new MethodPropertyHandle( propertyName, method );
 	}
 }

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/spi/MethodHandlePropertyHandle.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/spi/MethodHandlePropertyHandle.java
@@ -16,7 +16,7 @@ import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 /**
  * @author Yoann Rodiere
  */
-public final class MethodHandlePropertyHandle implements PropertyHandle {
+public final class MethodHandlePropertyHandle<T> implements PropertyHandle<T> {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
@@ -41,9 +41,9 @@ public final class MethodHandlePropertyHandle implements PropertyHandle {
 	}
 
 	@Override
-	public Object get(Object thiz) {
+	public T get(Object thiz) {
 		try {
-			return getter.invoke( thiz );
+			return (T) getter.invoke( thiz );
 		}
 		catch (Error e) {
 			throw e;
@@ -66,7 +66,7 @@ public final class MethodHandlePropertyHandle implements PropertyHandle {
 		if ( obj == null || !obj.getClass().equals( getClass() ) ) {
 			return false;
 		}
-		MethodHandlePropertyHandle other = (MethodHandlePropertyHandle) obj;
+		MethodHandlePropertyHandle<?> other = (MethodHandlePropertyHandle) obj;
 		return name.equals( other.name ) && member.equals( other.member );
 	}
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/spi/MethodHandlePropertyHandleFactory.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/spi/MethodHandlePropertyHandleFactory.java
@@ -19,12 +19,12 @@ final class MethodHandlePropertyHandleFactory implements PropertyHandleFactory {
 	}
 
 	@Override
-	public PropertyHandle createForField(String propertyName, Field field) throws IllegalAccessException {
+	public PropertyHandle<?> createForField(String propertyName, Field field) throws IllegalAccessException {
 		return new MethodHandlePropertyHandle( propertyName, field, lookup.unreflectGetter( field ) );
 	}
 
 	@Override
-	public PropertyHandle createForMethod(String propertyName, Method method) throws IllegalAccessException {
+	public PropertyHandle<?> createForMethod(String propertyName, Method method) throws IllegalAccessException {
 		return new MethodHandlePropertyHandle( propertyName, method, lookup.unreflect( method ) );
 	}
 }

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/spi/MethodPropertyHandle.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/spi/MethodPropertyHandle.java
@@ -12,7 +12,7 @@ import java.lang.reflect.Method;
 import org.hibernate.search.mapper.pojo.logging.impl.Log;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
-final class MethodPropertyHandle implements PropertyHandle {
+final class MethodPropertyHandle<T> implements PropertyHandle<T> {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
@@ -35,9 +35,9 @@ final class MethodPropertyHandle implements PropertyHandle {
 	}
 
 	@Override
-	public Object get(Object thiz) {
+	public T get(Object thiz) {
 		try {
-			return method.invoke( thiz );
+			return (T) method.invoke( thiz );
 		}
 		catch (Error e) {
 			throw e;
@@ -60,7 +60,7 @@ final class MethodPropertyHandle implements PropertyHandle {
 		if ( obj == null || !obj.getClass().equals( getClass() ) ) {
 			return false;
 		}
-		MethodPropertyHandle other = (MethodPropertyHandle) obj;
+		MethodPropertyHandle<?> other = (MethodPropertyHandle) obj;
 		return name.equals( other.name ) && method.equals( other.method );
 	}
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/spi/PojoPropertyModel.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/spi/PojoPropertyModel.java
@@ -23,6 +23,6 @@ public interface PojoPropertyModel<T> {
 	 */
 	PojoGenericTypeModel<T> getTypeModel();
 
-	PropertyHandle getHandle();
+	PropertyHandle<T> getHandle();
 
 }

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/spi/PropertyHandle.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/spi/PropertyHandle.java
@@ -8,12 +8,14 @@ package org.hibernate.search.mapper.pojo.model.spi;
 
 /**
  * A handle to a property of a POJO, allowing to get the value of that property from a POJO instance.
+ *
+ * @param <T> The property type.
  */
-public interface PropertyHandle {
+public interface PropertyHandle<T> {
 
 	String getName();
 
-	Object get(Object thiz);
+	T get(Object thiz);
 
 	/**
 	 * @return {@code true} if {@code obj} is a {@link PropertyHandle} referencing the exact same property

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/spi/PropertyHandleFactory.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/spi/PropertyHandleFactory.java
@@ -12,9 +12,9 @@ import java.lang.reflect.Method;
 
 public interface PropertyHandleFactory {
 
-	PropertyHandle createForField(String propertyName, Field field) throws IllegalAccessException;
+	PropertyHandle<?> createForField(String propertyName, Field field) throws IllegalAccessException;
 
-	PropertyHandle createForMethod(String propertyName, Method method) throws IllegalAccessException;
+	PropertyHandle<?> createForMethod(String propertyName, Method method) throws IllegalAccessException;
 
 	/**
 	 * @return A factory producing property handles that rely on {@code java.lang.reflect} to get the value of a property,

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/processing/building/impl/PojoIndexingProcessorTypeNodeBuilder.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/processing/building/impl/PojoIndexingProcessorTypeNodeBuilder.java
@@ -51,7 +51,7 @@ public class PojoIndexingProcessorTypeNodeBuilder<T> extends AbstractPojoProcess
 	private BoundRoutingKeyBridge<T> boundRoutingKeyBridge;
 	private final Collection<BoundTypeBridge<T>> boundBridges = new ArrayList<>();
 	// Use a LinkedHashMap for deterministic iteration
-	private final Map<PropertyHandle, PojoIndexingProcessorPropertyNodeBuilder<T, ?>> propertyNodeBuilders =
+	private final Map<PropertyHandle<?>, PojoIndexingProcessorPropertyNodeBuilder<T, ?>> propertyNodeBuilders =
 			new LinkedHashMap<>();
 
 	public PojoIndexingProcessorTypeNodeBuilder(
@@ -84,11 +84,11 @@ public class PojoIndexingProcessorTypeNodeBuilder<T> extends AbstractPojoProcess
 	public PojoMappingCollectorPropertyNode property(String propertyName) {
 		// TODO HSEARCH-3318 also pass an access type ("default" if not mentioned by the user, method/field otherwise) and take it into account to retrieve the right property model/handle
 		PojoPropertyModel<?> propertyModel = getModelPath().getTypeModel().getProperty( propertyName );
-		PropertyHandle propertyHandle = propertyModel.getHandle();
+		PropertyHandle<?> propertyHandle = propertyModel.getHandle();
 		return propertyNodeBuilders.computeIfAbsent( propertyHandle, this::createPropertyNodeBuilder );
 	}
 
-	private PojoIndexingProcessorPropertyNodeBuilder<T, ?> createPropertyNodeBuilder(PropertyHandle propertyHandle) {
+	private PojoIndexingProcessorPropertyNodeBuilder<T, ?> createPropertyNodeBuilder(PropertyHandle<?> propertyHandle) {
 		return new PojoIndexingProcessorPropertyNodeBuilder<>(
 				modelPath.property( propertyHandle ),
 				mappingHelper, bindingContext, identityMappingCollector

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/processing/impl/PojoIndexingProcessorPropertyNode.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/processing/impl/PojoIndexingProcessorPropertyNode.java
@@ -27,11 +27,11 @@ import org.hibernate.search.util.common.impl.ToStringTreeBuilder;
  */
 public class PojoIndexingProcessorPropertyNode<T, P> extends PojoIndexingProcessor<T> {
 
-	private final PropertyHandle handle;
+	private final PropertyHandle<P> handle;
 	private final Collection<BeanHolder<? extends PropertyBridge>> propertyBridgeHolders;
 	private final Collection<PojoIndexingProcessor<? super P>> nestedNodes;
 
-	public PojoIndexingProcessorPropertyNode(PropertyHandle handle,
+	public PojoIndexingProcessorPropertyNode(PropertyHandle<P> handle,
 			Collection<BeanHolder<? extends PropertyBridge>> propertyBridgeHolders,
 			Collection<PojoIndexingProcessor<? super P>> nestedNodes) {
 		this.handle = handle;
@@ -66,9 +66,7 @@ public class PojoIndexingProcessorPropertyNode<T, P> extends PojoIndexingProcess
 
 	@Override
 	public final void process(DocumentElement target, T source, AbstractPojoSessionContextImplementor sessionContext) {
-		// TODO HSEARCH-3058 add generic type parameters to property handles
-		@SuppressWarnings("unchecked")
-		P propertyValue = (P) handle.get( source );
+		P propertyValue = handle.get( source );
 		if ( !propertyBridgeHolders.isEmpty() ) {
 			PojoElement bridgedElement = new PojoElementImpl( propertyValue );
 			for ( BeanHolder<? extends PropertyBridge> bridgeHolder : propertyBridgeHolders ) {

--- a/mapper/pojo/src/test/java/org/hibernate/search/mapper/pojo/dirtiness/building/impl/PojoAssociationPathInverterTest.java
+++ b/mapper/pojo/src/test/java/org/hibernate/search/mapper/pojo/dirtiness/building/impl/PojoAssociationPathInverterTest.java
@@ -69,7 +69,7 @@ public class PojoAssociationPathInverterTest extends EasyMockSupport {
 
 		PojoGenericTypeModel<?> originalSidePropertyTypeMock =
 				createMock( "originalSidePropertyTypeMock", PojoGenericTypeModel.class );
-		PropertyHandle originalSidePropertyHandleMock = setupPropertyStub(
+		PropertyHandle<?> originalSidePropertyHandleMock = setupPropertyStub(
 				originalSideEntityTypeMock, originalSidePropertyName, originalSidePropertyTypeMock
 		);
 
@@ -187,9 +187,9 @@ public class PojoAssociationPathInverterTest extends EasyMockSupport {
 		}
 	}
 
-	private PropertyHandle setupPropertyStub(PojoTypeModel<?> holdingTypeMock, String propertyName,
+	private PropertyHandle<?> setupPropertyStub(PojoTypeModel<?> holdingTypeMock, String propertyName,
 			PojoGenericTypeModel<?> propertyTypeMock) {
-		PropertyHandle propertyHandleMock =
+		PropertyHandle<?> propertyHandleMock =
 				createMock( propertyName + "HandleMock", PropertyHandle.class );
 		PojoPropertyModel<?> propertyModelMock =
 				createMock( propertyName + "ModelMock", PojoPropertyModel.class );
@@ -197,7 +197,7 @@ public class PojoAssociationPathInverterTest extends EasyMockSupport {
 				.andStubReturn( (PojoPropertyModel) propertyModelMock );
 		EasyMock.expect( propertyHandleMock.getName() ).andStubReturn( propertyName );
 		EasyMock.expect( propertyModelMock.getName() ).andStubReturn( propertyName );
-		EasyMock.expect( propertyModelMock.getHandle() ).andStubReturn( propertyHandleMock );
+		EasyMock.expect( propertyModelMock.getHandle() ).andStubReturn( (PropertyHandle) propertyHandleMock );
 		EasyMock.expect( propertyModelMock.getTypeModel() )
 				.andStubReturn( (PojoGenericTypeModel) propertyTypeMock );
 		return propertyHandleMock;

--- a/mapper/pojo/src/test/java/org/hibernate/search/mapper/pojo/model/spi/PropertyHandleTest.java
+++ b/mapper/pojo/src/test/java/org/hibernate/search/mapper/pojo/model/spi/PropertyHandleTest.java
@@ -107,7 +107,7 @@ public class PropertyHandleTest {
 		Field otherField = EntityType.class.getDeclaredField( "otherField" );
 		setAccessible( otherField );
 
-		PropertyHandle propertyHandle = factory.createForField( propertyName, field );
+		PropertyHandle<?> propertyHandle = factory.createForField( propertyName, field );
 
 		assertThat( propertyHandle.getName() ).isEqualTo( propertyName );
 		assertThat( propertyHandle.get( new EntityType() ) ).isEqualTo( expectedValue );
@@ -116,9 +116,9 @@ public class PropertyHandleTest {
 				.contains( propertyHandle.getClass().getSimpleName() )
 				.contains( field.toString() );
 
-		PropertyHandle equalPropertyHandle = factory.createForField( propertyName, field );
-		PropertyHandle differentNamePropertyHandle = factory.createForField( propertyName + "foo", field );
-		PropertyHandle differentFieldPropertyHandle = factory.createForField( propertyName, otherField );
+		PropertyHandle<?> equalPropertyHandle = factory.createForField( propertyName, field );
+		PropertyHandle<?> differentNamePropertyHandle = factory.createForField( propertyName + "foo", field );
+		PropertyHandle<?> differentFieldPropertyHandle = factory.createForField( propertyName, otherField );
 		assertThat( propertyHandle ).isEqualTo( equalPropertyHandle );
 		assertThat( propertyHandle.hashCode() ).isEqualTo( equalPropertyHandle.hashCode() );
 		assertThat( propertyHandle ).isNotEqualTo( differentNamePropertyHandle );
@@ -133,7 +133,7 @@ public class PropertyHandleTest {
 		Method otherMethod = EntityType.class.getDeclaredMethod( "otherMethod" );
 		setAccessible( otherMethod );
 
-		PropertyHandle propertyHandle = factory.createForMethod( propertyName, method );
+		PropertyHandle<?> propertyHandle = factory.createForMethod( propertyName, method );
 		assertThat( propertyHandle.getName() ).isEqualTo( propertyName );
 		assertThat( propertyHandle.get( new EntityType() ) ).isEqualTo( expectedValue );
 
@@ -141,9 +141,9 @@ public class PropertyHandleTest {
 				.contains( propertyHandle.getClass().getSimpleName() )
 				.contains( method.toString() );
 
-		PropertyHandle equalPropertyHandle = factory.createForMethod( propertyName, method );
-		PropertyHandle differentNamePropertyHandle = factory.createForMethod( propertyName + "foo", method );
-		PropertyHandle differentMethodPropertyHandle = factory.createForMethod( propertyName + "foo", otherMethod );
+		PropertyHandle<?> equalPropertyHandle = factory.createForMethod( propertyName, method );
+		PropertyHandle<?> differentNamePropertyHandle = factory.createForMethod( propertyName + "foo", method );
+		PropertyHandle<?> differentMethodPropertyHandle = factory.createForMethod( propertyName + "foo", otherMethod );
 		assertThat( propertyHandle ).isEqualTo( equalPropertyHandle );
 		assertThat( propertyHandle.hashCode() ).isEqualTo( equalPropertyHandle.hashCode() );
 		assertThat( propertyHandle ).isNotEqualTo( differentNamePropertyHandle );


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3058

Actually I'm not sure whether it is a good idea to make the method `PojoPropertyModel#getHandle` return a `PropertyHandle<? super T>` instead of just `PropertyHandle<T>`.

This was my first choice, since the field `GenericContextAwarePojoPropertyMode#rawPropertyModel` has a type `PojoPropertyModel<? super T>`. On the other hand, I'm not sure about the solution I applied.