### PR TITLE
HSEARCH-3561 transpositions is ignored for .keyword().fuzzy() queries in the Elasticsearch integration

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ToElasticsearch.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ToElasticsearch.java
@@ -409,6 +409,7 @@ public class ToElasticsearch {
 										.addProperty( "value", query.getTerm().text() )
 										.addProperty( "fuzziness", query.getMaxEdits() )
 										.addProperty( "prefix_length", query.getPrefixLength() )
+										.addProperty( "transpositions", query.getTranspositions() )
 										.append( boostAppender( query ) )
 						)
 				).build();

--- a/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ToElasticsearchIT.java
+++ b/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ToElasticsearchIT.java
@@ -172,7 +172,7 @@ public class ToElasticsearchIT extends SearchTestBase {
 	@SuppressWarnings("unchecked")
 	public void testFuzzyQueryWithTranspositionsEnabled() {
 		boolean transpositions = true;
-		int	editDistance = 1;
+		int editDistance = 1;
 		int prefixLength = 1;
 
 		try ( Session session = openSession() ) {
@@ -197,7 +197,7 @@ public class ToElasticsearchIT extends SearchTestBase {
 	@SuppressWarnings("unchecked")
 	public void testFuzzyQueryWithTranspositionsDisabled() {
 		boolean transpositions = false;
-		int	editDistance = 1;
+		int editDistance = 1;
 		int prefixLength = 1;
 
 		try ( Session session = openSession() ) {


### PR DESCRIPTION
Is it correct to fix this in 5.10.x ?

Will it get auto-merged up to 5.11.x ?