### PR TITLE
HSEARCH-3467 Add tests for all the attributes validated by the Elasticsearch schema validator

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/impl/esnative/PropertyMapping.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/impl/esnative/PropertyMapping.java
@@ -69,9 +69,6 @@ public class PropertyMapping extends AbstractTypeMapping {
 
 	private String analyzer;
 
-	@SerializedName("fielddata")
-	private Boolean fieldData;
-
 	/*
 	 * Keyword datatype
 	 * https://www.elastic.co/guide/en/elasticsearch/reference/current/keyword.html
@@ -174,13 +171,5 @@ public class PropertyMapping extends AbstractTypeMapping {
 
 	public void setNormalizer(String normalizer) {
 		this.normalizer = normalizer;
-	}
-
-	public Boolean getFieldData() {
-		return fieldData;
-	}
-
-	public void setFieldData(Boolean fieldData) {
-		this.fieldData = fieldData;
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/impl/esnative/PropertyMapping.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/impl/esnative/PropertyMapping.java
@@ -33,8 +33,6 @@ public class PropertyMapping extends AbstractTypeMapping {
 	 * Attributes common to multiple datatypes
 	 */
 
-	private Float boost;
-
 	private Boolean index;
 
 	private Boolean norms;
@@ -101,14 +99,6 @@ public class PropertyMapping extends AbstractTypeMapping {
 
 	public void setFormat(List<String> format) {
 		this.format = format;
-	}
-
-	public Float getBoost() {
-		return boost;
-	}
-
-	public void setBoost(Float boost) {
-		this.boost = boost;
 	}
 
 	public Boolean getIndex() {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/impl/esnative/PropertyMappingJsonAdapterFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/impl/esnative/PropertyMappingJsonAdapterFactory.java
@@ -21,7 +21,6 @@ public class PropertyMappingJsonAdapterFactory extends AbstractTypeMappingJsonAd
 	protected <T> void addFields(Builder<T> builder) {
 		super.addFields( builder );
 		builder.add( "type", DataType.class );
-		builder.add( "boost", Float.class );
 		builder.add( "index", Boolean.class );
 		builder.add( "norms", Boolean.class );
 		builder.add( "docValues", Boolean.class );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/impl/esnative/PropertyMappingJsonAdapterFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/impl/esnative/PropertyMappingJsonAdapterFactory.java
@@ -28,7 +28,6 @@ public class PropertyMappingJsonAdapterFactory extends AbstractTypeMappingJsonAd
 		builder.add( "nullValue", JsonPrimitive.class );
 		builder.add( "fields", FIELD_MAP_TYPE_TOKEN );
 		builder.add( "analyzer", String.class );
-		builder.add( "fieldData", Boolean.class );
 		builder.add( "normalizer", String.class );
 		builder.add( "format", new ElasticsearchFormatJsonAdapter() );
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/admin/impl/ElasticsearchSchemaValidatorImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/admin/impl/ElasticsearchSchemaValidatorImpl.java
@@ -538,8 +538,6 @@ public class ElasticsearchSchemaValidatorImpl implements ElasticsearchSchemaVali
 					? DEFAULT_DATE_FORMAT : Collections.emptyList();
 			validateFormatWithDefault( errorCollector, "format", expectedMapping.getFormat(), actualMapping.getFormat(), formatDefault );
 
-			validateEqualWithDefault( errorCollector, "boost", expectedMapping.getBoost(), actualMapping.getBoost(), DEFAULT_FLOAT_DELTA, 1.0f );
-
 			validateIndexOptions( errorCollector, expectedMapping, actualMapping );
 
 			Boolean expectedStore = expectedMapping.getStore();

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/admin/impl/ElasticsearchSchemaValidatorImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/admin/impl/ElasticsearchSchemaValidatorImpl.java
@@ -575,11 +575,8 @@ public class ElasticsearchSchemaValidatorImpl implements ElasticsearchSchemaVali
 
 		Boolean expectedDocValues = expectedMapping.getDocValues();
 		if ( Boolean.TRUE.equals( expectedDocValues ) ) { // If we don't need doc_values, we don't care
-			/*
-			 * Elasticsearch documentation (2.3) says doc_values is true by default on fields
-			 * supporting it, but tests show it's wrong.
-			 */
-			validateEqualWithDefault( errorCollector, "doc_values", expectedDocValues, actualMapping.getDocValues(), false );
+			// From ES 5.0 on, all indexable doc_values is true by default
+			validateEqualWithDefault( errorCollector, "doc_values", expectedDocValues, actualMapping.getDocValues(), true );
 		}
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/admin/impl/ElasticsearchSchemaValidatorImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/admin/impl/ElasticsearchSchemaValidatorImpl.java
@@ -573,11 +573,6 @@ public class ElasticsearchSchemaValidatorImpl implements ElasticsearchSchemaVali
 			validateEqualWithDefault( errorCollector, "norms", expectedNorms, actualMapping.getNorms(), normsDefault );
 		}
 
-		Boolean expectedFieldData = expectedMapping.getFieldData();
-		if ( Boolean.TRUE.equals( expectedFieldData ) ) { // If we don't need an index, we don't care
-			validateEqualWithDefault( errorCollector, "fielddata", expectedFieldData, actualMapping.getFieldData(), false );
-		}
-
 		Boolean expectedDocValues = expectedMapping.getDocValues();
 		if ( Boolean.TRUE.equals( expectedDocValues ) ) { // If we don't need doc_values, we don't care
 			/*

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/bootstrap/ElasticsearchBootstrapIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/bootstrap/ElasticsearchBootstrapIT.java
@@ -52,8 +52,7 @@ public class ElasticsearchBootstrapIT {
 				)
 				.withIndex(
 						"EmptyIndexName",
-						ctx -> { },
-						indexManager -> { }
+						ctx -> { }
 				)
 				.setupFirstPhaseOnly();
 

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/fieldtype/ElasticsearchFieldTypesIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/fieldtype/ElasticsearchFieldTypesIT.java
@@ -64,9 +64,7 @@ public class ElasticsearchFieldTypesIT {
 				)
 				.withIndex(
 						INDEX_NAME,
-						ctx -> new IndexMapping( ctx.getSchemaElement() ),
-						indexManager -> {
-						}
+						ctx -> new IndexMapping( ctx.getSchemaElement() )
 				)
 				.setup();
 

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchAnalyzerDefinitionCreationIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchAnalyzerDefinitionCreationIT.java
@@ -116,8 +116,7 @@ public class ElasticsearchAnalyzerDefinitionCreationIT {
 		withManagementStrategyConfiguration()
 				.withIndex(
 						INDEX_NAME,
-						ctx -> { },
-						indexMapping -> { }
+						ctx -> { }
 				)
 				.setup();
 	}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchAnalyzerDefinitionMigrationIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchAnalyzerDefinitionMigrationIT.java
@@ -490,8 +490,7 @@ public class ElasticsearchAnalyzerDefinitionMigrationIT {
 		withManagementStrategyConfiguration()
 				.withIndex(
 						INDEX_NAME,
-						ctx -> { },
-						indexMapping -> { }
+						ctx -> { }
 				)
 				.setup();
 	}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchAnalyzerDefinitionValidationIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchAnalyzerDefinitionValidationIT.java
@@ -650,8 +650,7 @@ public class ElasticsearchAnalyzerDefinitionValidationIT {
 		withManagementStrategyConfiguration()
 				.withIndex(
 						INDEX_NAME,
-						ctx -> { },
-						indexMapping -> { }
+						ctx -> { }
 				)
 				.setup();
 	}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchIndexStatusCheckIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchIndexStatusCheckIT.java
@@ -139,8 +139,7 @@ public class ElasticsearchIndexStatusCheckIT {
 		withManagementStrategyConfiguration()
 				.withIndex(
 						INDEX_NAME,
-						ctx -> { },
-						indexMapping -> { }
+						ctx -> { }
 				)
 				.setup();
 	}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchNormalizerDefinitionCreationIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchNormalizerDefinitionCreationIT.java
@@ -92,8 +92,7 @@ public class ElasticsearchNormalizerDefinitionCreationIT {
 		withManagementStrategyConfiguration()
 				.withIndex(
 						INDEX_NAME,
-						ctx -> { },
-						indexMapping -> { }
+						ctx -> { }
 				)
 				.setup();
 	}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchNormalizerDefinitionMigrationIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchNormalizerDefinitionMigrationIT.java
@@ -309,8 +309,7 @@ public class ElasticsearchNormalizerDefinitionMigrationIT {
 		withManagementStrategyConfiguration()
 				.withIndex(
 						INDEX_NAME,
-						ctx -> { },
-						indexMapping -> { }
+						ctx -> { }
 				)
 				.setup();
 	}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchNormalizerDefinitionValidationIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchNormalizerDefinitionValidationIT.java
@@ -113,8 +113,7 @@ public class ElasticsearchNormalizerDefinitionValidationIT {
 		withManagementStrategyConfiguration()
 				.withIndex(
 						INDEX_NAME,
-						ctx -> { },
-						indexMapping -> { }
+						ctx -> { }
 				)
 				.setup();
 	}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchSchemaAttributeValidationIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchSchemaAttributeValidationIT.java
@@ -1,0 +1,783 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.elasticsearch.management;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurer;
+import org.hibernate.search.backend.elasticsearch.analysis.model.dsl.ElasticsearchAnalysisDefinitionContainerContext;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexLifecycleStrategyName;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.types.Projectable;
+import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.TestElasticsearchClient;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
+import org.hibernate.search.util.common.SearchException;
+import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
+import org.hibernate.search.util.impl.test.SubTest;
+
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ElasticsearchSchemaAttributeValidationIT {
+
+	private static final String BACKEND_NAME = "myElasticsearchBackend";
+	private static final String INDEX_NAME = "IndexName";
+	private static final String SCHEMA_VALIDATION_CONTEXT = "schema validation";
+
+	@Rule
+	public SearchSetupHelper setupHelper = new SearchSetupHelper();
+
+	@Rule
+	public TestElasticsearchClient elasticSearchClient = new TestElasticsearchClient();
+
+	@Test
+	public void attribute_dynamic_missing() {
+		elasticSearchClient.index( INDEX_NAME ).deleteAndCreate();
+		elasticSearchClient.index( INDEX_NAME ).type().putMapping(
+				"{"
+					+ "'properties': {"
+							+ "'myField': {"
+									+ "'type': 'integer',"
+									+ "'index': true"
+							+ "}"
+					+ "}"
+				+ "}"
+		);
+
+		SubTest.expectException( () ->
+				validateSchemaConfig()
+						.withIndex( INDEX_NAME, ctx -> {
+									IndexSchemaElement root = ctx.getSchemaElement();
+									root.field( "myField", f -> f.asInteger() ).toReference();
+								}
+						)
+						.setup() )
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.indexContext( INDEX_NAME )
+						.contextLiteral( SCHEMA_VALIDATION_CONTEXT )
+						.failure( "Invalid value for attribute 'dynamic'. Expected 'STRICT', actual is 'null'" )
+						.build() );
+	}
+
+	@Test
+	public void attribute_dynamic_invalid() {
+		elasticSearchClient.index( INDEX_NAME ).deleteAndCreate();
+		elasticSearchClient.index( INDEX_NAME ).type().putMapping(
+				"{"
+					+ "'dynamic': false,"
+					+ "'properties': {"
+							+ "'myField': {"
+									+ "'type': 'integer',"
+									+ "'index': true"
+							+ "}"
+					+ "}"
+				+ "}"
+		);
+
+		SubTest.expectException( () ->
+				validateSchemaConfig()
+						.withIndex( INDEX_NAME, ctx -> {
+									IndexSchemaElement root = ctx.getSchemaElement();
+									root.field( "myField", f -> f.asInteger() ).toReference();
+								}
+						)
+						.setup() )
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.indexContext( INDEX_NAME )
+						.contextLiteral( SCHEMA_VALIDATION_CONTEXT )
+						.failure( "Invalid value for attribute 'dynamic'. Expected 'STRICT', actual is 'FALSE'" )
+						.build() );
+
+	}
+
+	@Test
+	public void attribute_properties_missing() {
+		elasticSearchClient.index( INDEX_NAME ).deleteAndCreate();
+		elasticSearchClient.index( INDEX_NAME ).type().putMapping(
+				"{"
+					+ "'dynamic': 'strict'"
+				+ "}"
+		);
+
+
+		SubTest.expectException( () ->
+				validateSchemaConfig()
+						.withIndex( INDEX_NAME, ctx -> {
+									IndexSchemaElement root = ctx.getSchemaElement();
+									root.field( "myField", f -> f.asInteger() ).toReference();
+								}
+						)
+						.setup() )
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.indexContext( INDEX_NAME )
+						.contextLiteral( SCHEMA_VALIDATION_CONTEXT )
+						.indexFieldContext( "myField" )
+						.failure( "Missing property mapping" )
+						.build() );
+	}
+
+	@Test
+	public void attribute_properties_empty() {
+		elasticSearchClient.index( INDEX_NAME ).deleteAndCreate();
+		elasticSearchClient.index( INDEX_NAME ).type().putMapping(
+				"{"
+					+ "'dynamic': 'strict',"
+					+ "'properties': {"
+					+ "}"
+				+ "}"
+		);
+
+
+		SubTest.expectException( () ->
+				validateSchemaConfig()
+						.withIndex( INDEX_NAME, ctx -> {
+									IndexSchemaElement root = ctx.getSchemaElement();
+									root.field( "myField", f -> f.asInteger() ).toReference();
+								}
+						)
+						.setup() )
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.indexContext( INDEX_NAME )
+						.contextLiteral( SCHEMA_VALIDATION_CONTEXT )
+						.indexFieldContext( "myField" )
+						.failure( "Missing property mapping" )
+						.build() );
+	}
+
+	@Test
+	public void attribute_type_invalid() {
+		elasticSearchClient.index( INDEX_NAME ).deleteAndCreate();
+		elasticSearchClient.index( INDEX_NAME ).type().putMapping(
+				"{"
+					+ "'dynamic': 'strict',"
+					+ "'properties': {"
+							+ "'myField': {"
+									+ "'type': 'keyword',"
+									+ "'index': true"
+							+ "}"
+					+ "}"
+				+ "}"
+		);
+
+		SubTest.expectException( () ->
+				validateSchemaConfig()
+						.withIndex( INDEX_NAME, ctx -> {
+									IndexSchemaElement root = ctx.getSchemaElement();
+									root.field( "myField", f -> f.asInteger() ).toReference();
+								}
+						)
+						.setup() )
+				.assertThrown()
+				.isInstanceOf( Exception.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.indexContext( INDEX_NAME )
+						.contextLiteral( SCHEMA_VALIDATION_CONTEXT )
+						.indexFieldContext( "myField" )
+						.failure( "Invalid value for attribute 'type'. Expected 'INTEGER', actual is 'KEYWORD'" )
+						.build() );
+	}
+
+	@Test
+	public void attribute_index_missing() {
+		elasticSearchClient.index( INDEX_NAME ).deleteAndCreate();
+		elasticSearchClient.index( INDEX_NAME ).type().putMapping(
+				"{"
+					+ "'dynamic': 'strict',"
+					+ "'properties': {"
+							+ "'myField': {"
+									+ "'type': 'integer'"
+							+ "}"
+					+ "}"
+				+ "}"
+		);
+
+		// the expected value true is the default
+		validateSchemaConfig()
+				.withIndex( INDEX_NAME, ctx -> {
+							IndexSchemaElement root = ctx.getSchemaElement();
+							root.field( "myField", f -> f.asInteger() ).toReference();
+						}
+				)
+				.setup();
+	}
+
+	@Test
+	public void attribute_index_invalid() {
+		elasticSearchClient.index( INDEX_NAME ).deleteAndCreate();
+		elasticSearchClient.index( INDEX_NAME ).type().putMapping(
+				"{"
+					+ "'dynamic': 'strict',"
+					+ "'properties': {"
+							+ "'myField': {"
+									+ "'type': 'integer',"
+									+ "'index': false"
+							+ "}"
+					+ "}"
+				+ "}"
+		);
+
+		SubTest.expectException( () ->
+				validateSchemaConfig()
+						.withIndex( INDEX_NAME, ctx -> {
+									IndexSchemaElement root = ctx.getSchemaElement();
+									root.field( "myField", f -> f.asInteger() ).toReference();
+								}
+						)
+						.setup() )
+				.assertThrown()
+				.isInstanceOf( Exception.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.indexContext( INDEX_NAME )
+						.contextLiteral( SCHEMA_VALIDATION_CONTEXT )
+						.indexFieldContext( "myField" )
+						.failure( "Invalid value for attribute 'index'. Expected 'true', actual is 'false'" )
+						.build() );
+	}
+
+	@Test
+	public void attribute_format_missing() {
+		List<String> allFormats = elasticSearchClient.getDialect().getAllLocalDateDefaultMappingFormats();
+
+		elasticSearchClient.index( INDEX_NAME ).deleteAndCreate();
+		elasticSearchClient.index( INDEX_NAME ).type().putMapping(
+				"{"
+					+ "'dynamic': 'strict',"
+					+ "'properties': {"
+							+ "'myField': {"
+									+ "'type': 'date'"
+							+ "}"
+					+ "}"
+				+ "}"
+		);
+
+		SubTest.expectException( () ->
+				validateSchemaConfig()
+						.withIndex( INDEX_NAME, ctx -> {
+									IndexSchemaElement root = ctx.getSchemaElement();
+									root.field( "myField", f -> f.asLocalDate() ).toReference();
+								}
+						)
+						.setup() )
+				.assertThrown()
+				.isInstanceOf( Exception.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.indexContext( INDEX_NAME )
+						.contextLiteral( SCHEMA_VALIDATION_CONTEXT )
+						.indexFieldContext( "myField" )
+						.failure( "The output format (the first format in the 'format' attribute) is invalid." )
+						.failure(
+								"Invalid formats for attribute 'format'",
+								"missing elements are '" + allFormats + "'"
+						)
+						.build() );
+	}
+
+	@Test
+	public void attribute_format_valid() {
+		String allFormats = elasticSearchClient.getDialect().getConcatenatedLocalDateDefaultMappingFormats();
+
+		elasticSearchClient.index( INDEX_NAME ).deleteAndCreate();
+		elasticSearchClient.index( INDEX_NAME ).type().putMapping(
+				"{"
+					+ "'dynamic': 'strict',"
+					+ "'properties': {"
+							+ "'myField': {"
+									+ "'type': 'date',"
+									+ "'format': '" + allFormats + "'"
+							+ "}"
+					+ "}"
+				+ "}"
+		);
+
+		validateSchemaConfig()
+				.withIndex( INDEX_NAME, ctx -> {
+							IndexSchemaElement root = ctx.getSchemaElement();
+							root.field( "myField", f -> f.asLocalDate() ).toReference();
+						}
+				)
+				.setup();
+	}
+
+	@Test
+	public void attribute_format_incomplete() {
+		String firstFormat = elasticSearchClient.getDialect().getFirstLocalDateDefaultMappingFormat();
+		List<String> nextFormats = elasticSearchClient.getDialect().getAllLocalDateDefaultMappingFormats()
+				.stream().skip( 1 ).collect( Collectors.toList() );
+		Assume.assumeFalse(
+				"Skipping this test as we don't have a type with multiple default formats in " + elasticSearchClient.getDialect(),
+				nextFormats.isEmpty()
+		);
+
+		elasticSearchClient.index( INDEX_NAME ).deleteAndCreate();
+		elasticSearchClient.index( INDEX_NAME ).type().putMapping(
+				"{"
+					+ "'dynamic': 'strict',"
+					+ "'properties': {"
+							+ "'myField': {"
+									+ "'type': 'date',"
+									+ "'format': '" + firstFormat + "'"
+							+ "}"
+					+ "}"
+				+ "}"
+		);
+
+		SubTest.expectException( () ->
+				validateSchemaConfig()
+						.withIndex( INDEX_NAME, ctx -> {
+									IndexSchemaElement root = ctx.getSchemaElement();
+									root.field( "myField", f -> f.asLocalDate() ).toReference();
+								}
+						)
+						.setup() )
+				.assertThrown()
+				.isInstanceOf( Exception.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.indexContext( INDEX_NAME )
+						.contextLiteral( SCHEMA_VALIDATION_CONTEXT )
+						.indexFieldContext( "myField" )
+						.failure(
+								"Invalid formats for attribute 'format'",
+								"missing elements are '" + nextFormats + "'"
+						)
+						.build() );
+	}
+
+	@Test
+	public void attribute_format_exceeding() {
+		String allFormats = elasticSearchClient.getDialect().getConcatenatedLocalDateDefaultMappingFormats();
+
+		elasticSearchClient.index( INDEX_NAME ).deleteAndCreate();
+		elasticSearchClient.index( INDEX_NAME ).type().putMapping(
+				"{"
+					+ "'dynamic': 'strict',"
+					+ "'properties': {"
+							+ "'myField': {"
+									+ "'type': 'date',"
+									+ "'format': '" + allFormats + "||yyyy" + "'"
+							+ "}"
+					+ "}"
+				+ "}"
+		);
+
+		SubTest.expectException( () ->
+				validateSchemaConfig()
+						.withIndex( INDEX_NAME, ctx -> {
+									IndexSchemaElement root = ctx.getSchemaElement();
+									root.field( "myField", f -> f.asLocalDate() ).toReference();
+								}
+						)
+						.setup() )
+				.assertThrown()
+				.isInstanceOf( Exception.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.indexContext( INDEX_NAME )
+						.contextLiteral( SCHEMA_VALIDATION_CONTEXT )
+						.indexFieldContext( "myField" )
+						.failure(
+								"Invalid formats for attribute 'format'",
+								"unexpected elements are '[yyyy]'"
+						)
+						.build() );
+	}
+
+	@Test
+	public void attribute_format_wrong() {
+		elasticSearchClient.index( INDEX_NAME ).deleteAndCreate();
+		elasticSearchClient.index( INDEX_NAME ).type().putMapping(
+				"{"
+					+ "'dynamic': 'strict',"
+					+ "'properties': {"
+							+ "'myField': {"
+									+ "'type': 'date',"
+									+ "'format': 'epoch_millis||strict_date_time'"
+							+ "}"
+					+ "}"
+				+ "}"
+		);
+
+		SubTest.expectException( () ->
+				validateSchemaConfig()
+						.withIndex( INDEX_NAME, ctx -> {
+									IndexSchemaElement root = ctx.getSchemaElement();
+									root.field( "myField", f -> f.asLocalDate() ).toReference();
+								}
+						)
+						.setup() )
+				.assertThrown()
+				.isInstanceOf( Exception.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.indexContext( INDEX_NAME )
+						.contextLiteral( SCHEMA_VALIDATION_CONTEXT )
+						.indexFieldContext( "myField" )
+						.failure(
+								"The output format (the first format in the 'format' attribute) is invalid. Expected '"
+										+ elasticSearchClient.getDialect().getFirstLocalDateDefaultMappingFormat()
+										+ "', actual is 'epoch_millis'"
+						)
+						.build() );
+	}
+
+	@Test
+	public void attribute_analyzer_missing() {
+		elasticSearchClient.index( INDEX_NAME ).deleteAndCreate();
+		elasticSearchClient.index( INDEX_NAME ).type().putMapping(
+				"{"
+					+ "'dynamic': 'strict',"
+					+ "'properties': {"
+							+ "'myField': {"
+									+ "'type': 'text',"
+									+ "'index': true"
+							+ "}"
+					+ "}"
+				+ "}"
+		);
+
+		SubTest.expectException( () ->
+				validateSchemaConfig()
+						.withIndex( INDEX_NAME, ctx -> {
+									IndexSchemaElement root = ctx.getSchemaElement();
+									root.field( "myField", f -> f.asString().analyzer( "keyword" ) ).toReference();
+								}
+						)
+						.setup() )
+				.assertThrown()
+				.isInstanceOf( Exception.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.indexContext( INDEX_NAME )
+						.contextLiteral( SCHEMA_VALIDATION_CONTEXT )
+						.indexFieldContext( "myField" )
+						.failure( "Invalid value for attribute 'analyzer'. Expected 'keyword', actual is 'null'" )
+						.build() );
+	}
+
+	@Test
+	public void attribute_analyzer_valid() {
+		elasticSearchClient.index( INDEX_NAME ).deleteAndCreate();
+		elasticSearchClient.index( INDEX_NAME ).type().putMapping(
+				"{"
+					+ "'dynamic': 'strict',"
+					+ "'properties': {"
+							+ "'myField': {"
+									+ "'type': 'text',"
+									+ "'index': true,"
+									+ "'analyzer': 'keyword'"
+							+ "}"
+					+ "}"
+				+ "}"
+		);
+
+		validateSchemaConfig()
+				.withIndex( INDEX_NAME, ctx -> {
+							IndexSchemaElement root = ctx.getSchemaElement();
+							root.field( "myField", f -> f.asString().analyzer( "keyword" ) ).toReference();
+						}
+				)
+				.setup();
+	}
+
+	@Test
+	public void attribute_analyzer_invalid() {
+		elasticSearchClient.index( INDEX_NAME ).deleteAndCreate();
+		elasticSearchClient.index( INDEX_NAME ).type().putMapping(
+				"{"
+					+ "'dynamic': 'strict',"
+					+ "'properties': {"
+							+ "'myField': {"
+									+ "'type': 'text',"
+									+ "'index': true,"
+									+ "'analyzer': 'keyword'"
+							+ "}"
+					+ "}"
+				+ "}"
+		);
+
+		SubTest.expectException( () ->
+				validateSchemaConfig()
+						.withIndex( INDEX_NAME, ctx -> {
+									IndexSchemaElement root = ctx.getSchemaElement();
+									root.field( "myField", f -> f.asString().analyzer( "default" ) ).toReference();
+								}
+						)
+						.setup() )
+				.assertThrown()
+				.isInstanceOf( Exception.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.indexContext( INDEX_NAME )
+						.contextLiteral( SCHEMA_VALIDATION_CONTEXT )
+						.indexFieldContext( "myField" )
+						.failure( "Invalid value for attribute 'analyzer'. Expected 'default', actual is 'keyword'" )
+						.build() );
+	}
+
+	// TODO HSEARCH-3048: test attribute norm (same pattern: missing, valid, invalid)
+	@Test
+	public void property_norms_invalid() throws Exception {
+		Assume.assumeTrue( "Norms configuration is not supported yet; see HSEARCH-3048", false );
+
+		elasticSearchClient.index( INDEX_NAME ).deleteAndCreate();
+		elasticSearchClient.index( INDEX_NAME ).type().putMapping(
+				"{"
+					+ "'dynamic': 'strict',"
+					+ "'properties': {"
+							+ "'myField': {"
+									+ "'type': 'text',"
+									+ "'norms': false"
+							+ "}"
+					+ "}"
+				+ "}"
+		);
+
+		SubTest.expectException( () ->
+				validateSchemaConfig()
+						.withIndex( INDEX_NAME, ctx -> {
+									IndexSchemaElement root = ctx.getSchemaElement();
+									// TODO disable norms once the APIs allow it; see HSEARCH-3048
+									root.field( "myField", f -> f.asString().analyzer( "default" ) ).toReference();
+								}
+						)
+						.setup() )
+				.assertThrown()
+				.isInstanceOf( Exception.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.indexContext( INDEX_NAME )
+						.contextLiteral( SCHEMA_VALIDATION_CONTEXT )
+						.indexFieldContext( "myField" )
+						.failure( "Invalid value for attribute 'norms'. Expected 'true', actual is 'false'" )
+						.build()
+		);
+	}
+	@Test
+	public void attribute_store_true() {
+		elasticSearchClient.index( INDEX_NAME ).deleteAndCreate();
+		elasticSearchClient.index( INDEX_NAME ).type().putMapping(
+				"{"
+					+ "'dynamic': 'strict',"
+					+ "'properties': {"
+							+ "'myField': {"
+									+ "'type': 'keyword',"
+									+ "'store': true"
+							+ "}"
+					+ "}"
+				+ "}"
+		);
+
+		validateSchemaConfig()
+				.withIndex( INDEX_NAME, ctx -> {
+							IndexSchemaElement root = ctx.getSchemaElement();
+							root.field( "myField", f -> f.asString().projectable( Projectable.YES ) ).toReference();
+						}
+				)
+				.setup();
+	}
+
+	@Test
+	public void attribute_store_default() {
+		elasticSearchClient.index( INDEX_NAME ).deleteAndCreate();
+		elasticSearchClient.index( INDEX_NAME ).type().putMapping(
+				"{"
+					+ "'dynamic': 'strict',"
+					+ "'properties': {"
+							+ "'myField': {"
+									+ "'type': 'keyword'"
+							+ "}"
+					+ "}"
+				+ "}"
+		);
+
+		validateSchemaConfig()
+				.withIndex( INDEX_NAME, ctx -> {
+							IndexSchemaElement root = ctx.getSchemaElement();
+							root.field( "myField", f -> f.asString().projectable( Projectable.DEFAULT ) ).toReference();
+						}
+				)
+				.setup();
+	}
+
+	@Test
+	public void attribute_store_invalid() {
+		elasticSearchClient.index( INDEX_NAME ).deleteAndCreate();
+		elasticSearchClient.index( INDEX_NAME ).type().putMapping(
+				"{"
+					+ "'dynamic': 'strict',"
+					+ "'properties': {"
+							+ "'myField': {"
+									+ "'type': 'keyword',"
+									+ "'store': false"
+							+ "}"
+					+ "}"
+				+ "}"
+		);
+
+		SubTest.expectException( () -> validateSchemaConfig()
+				.withIndex( INDEX_NAME, ctx -> {
+							IndexSchemaElement root = ctx.getSchemaElement();
+							root.field( "myField", f -> f.asString().projectable( Projectable.YES ) ).toReference();
+						}
+				)
+				.setup() )
+				.assertThrown()
+				.isInstanceOf( Exception.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.indexContext( INDEX_NAME )
+						.contextLiteral( SCHEMA_VALIDATION_CONTEXT )
+						.indexFieldContext( "myField" )
+						.failure( "Invalid value for attribute 'store'. Expected 'true', actual is 'null'" )
+						.build() );
+	}
+
+	@Test
+	public void attribute_nullValue_valid() {
+		elasticSearchClient.index( INDEX_NAME ).deleteAndCreate();
+		elasticSearchClient.index( INDEX_NAME ).type().putMapping(
+				"{"
+					+ "'dynamic': 'strict',"
+					+ "'properties': {"
+							+ "'myField': {"
+									+ "'type': 'integer',"
+									+ "'null_value': 739"
+							+ "}"
+					+ "}"
+				+ "}"
+		);
+
+		validateSchemaConfig()
+				.withIndex( INDEX_NAME, ctx -> {
+							IndexSchemaElement root = ctx.getSchemaElement();
+							root.field( "myField", f -> f.asInteger().indexNullAs( 739 ) ).toReference();
+						}
+				)
+				.setup();
+	}
+
+	@Test
+	public void attribute_nullValue_missing() {
+		elasticSearchClient.index( INDEX_NAME ).deleteAndCreate();
+		elasticSearchClient.index( INDEX_NAME ).type().putMapping(
+				"{"
+					+ "'dynamic': 'strict',"
+					+ "'properties': {"
+							+ "'myField': {"
+									+ "'type': 'integer'"
+							+ "}"
+					+ "}"
+				+ "}"
+		);
+
+		SubTest.expectException( () -> validateSchemaConfig()
+				.withIndex( INDEX_NAME, ctx -> {
+							IndexSchemaElement root = ctx.getSchemaElement();
+							root.field( "myField", f -> f.asInteger().indexNullAs( 739 ) ).toReference();
+						}
+				)
+				.setup() )
+				.assertThrown()
+				.isInstanceOf( Exception.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.indexContext( INDEX_NAME )
+						.contextLiteral( SCHEMA_VALIDATION_CONTEXT )
+						.indexFieldContext( "myField" )
+						.failure( "Invalid value for attribute 'null_value'. Expected '739', actual is 'null'" )
+						.build() );
+	}
+
+	@Test
+	public void attribute_nullValue_invalid() {
+		elasticSearchClient.index( INDEX_NAME ).deleteAndCreate();
+		elasticSearchClient.index( INDEX_NAME ).type().putMapping(
+				"{"
+					+ "'dynamic': 'strict',"
+					+ "'properties': {"
+							+ "'myField': {"
+									+ "'type': 'integer',"
+									+ "'null_value': 777"
+							+ "}"
+					+ "}"
+				+ "}"
+		);
+
+		SubTest.expectException( () -> validateSchemaConfig()
+				.withIndex( INDEX_NAME, ctx -> {
+							IndexSchemaElement root = ctx.getSchemaElement();
+							root.field( "myField", f -> f.asInteger().indexNullAs( 739 ) ).toReference();
+						}
+				)
+				.setup() )
+				.assertThrown()
+				.isInstanceOf( Exception.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.indexContext( INDEX_NAME )
+						.contextLiteral( SCHEMA_VALIDATION_CONTEXT )
+						.indexFieldContext( "myField" )
+						.failure( "Invalid value for attribute 'null_value'. Expected '739', actual is '777'" )
+						.build() );
+	}
+
+	@Test
+	public void attribute_normalizer_missing() {
+		elasticSearchClient.index( INDEX_NAME ).deleteAndCreate();
+		elasticSearchClient.index( INDEX_NAME ).type().putMapping(
+				"{"
+					+ "'dynamic': 'strict',"
+					+ "'properties': {"
+							+ "'myField': {"
+									+ "'type': 'keyword',"
+									+ "'index': true"
+							+ "}"
+					+ "}"
+				+ "}"
+		);
+
+		SubTest.expectException( () ->
+				validateSchemaConfig()
+						.withIndex( INDEX_NAME, ctx -> {
+									IndexSchemaElement root = ctx.getSchemaElement();
+									root.field( "myField", f -> f.asString().normalizer( "default" ) ).toReference();
+								}
+						)
+						.setup() )
+				.assertThrown()
+				.isInstanceOf( Exception.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.indexContext( INDEX_NAME )
+						.contextLiteral( SCHEMA_VALIDATION_CONTEXT )
+						.indexFieldContext( "myField" )
+						.failure( "Invalid value for attribute 'normalizer'. Expected 'default', actual is 'null'" )
+						.build() );
+	}
+
+	private SearchSetupHelper.SetupContext validateSchemaConfig() {
+		return setupHelper.withDefaultConfiguration( BACKEND_NAME )
+				.withIndexDefaultsProperty(
+						BACKEND_NAME,
+						ElasticsearchIndexSettings.LIFECYCLE_STRATEGY,
+						ElasticsearchIndexLifecycleStrategyName.VALIDATE.getExternalRepresentation()
+				)
+				.withBackendProperty(
+						BACKEND_NAME,
+						// Don't contribute any analysis definitions, migration of those is tested in another test class
+						ElasticsearchBackendSettings.ANALYSIS_CONFIGURER,
+						new ElasticsearchAnalysisConfigurer() {
+							@Override
+							public void configure(ElasticsearchAnalysisDefinitionContainerContext context) {
+								// No-op
+							}
+						}
+				);
+	}
+}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchSchemaCreateStrategyIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchSchemaCreateStrategyIT.java
@@ -82,8 +82,7 @@ public class ElasticsearchSchemaCreateStrategyIT {
 							IndexSchemaElement root = ctx.getSchemaElement();
 							root.field( "field", f -> f.asString() )
 									.toReference();
-						},
-						indexManager -> { }
+						}
 				)
 				.withIndexDefaultsProperty(
 						BACKEND_NAME,

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchSchemaCreationIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchSchemaCreationIT.java
@@ -203,8 +203,7 @@ public class ElasticsearchSchemaCreationIT {
 		setupHelper.withDefaultConfiguration( BACKEND_NAME )
 				.withIndex(
 						INDEX_NAME,
-						mappingContributor,
-						indexManager -> { }
+						mappingContributor
 				)
 				.withIndexDefaultsProperty(
 						BACKEND_NAME,

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchSchemaMigrationIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchSchemaMigrationIT.java
@@ -115,8 +115,7 @@ public class ElasticsearchSchemaMigrationIT {
 							IndexSchemaElement root = ctx.getSchemaElement();
 							root.field( "myField", f -> f.asLocalDate() )
 									.toReference();
-						},
-						indexManager -> { }
+						}
 				)
 				.withIndex(
 						INDEX2_NAME,
@@ -124,8 +123,7 @@ public class ElasticsearchSchemaMigrationIT {
 							IndexSchemaElement root = ctx.getSchemaElement();
 							root.field( "myField", f -> f.asBoolean() )
 									.toReference();
-						},
-						indexManager -> { }
+						}
 				)
 				.withIndex(
 						INDEX3_NAME,
@@ -146,8 +144,7 @@ public class ElasticsearchSchemaMigrationIT {
 									f -> f.asString().normalizer( "customNormalizer" )
 							)
 									.toReference();
-						},
-						indexManager -> { }
+						}
 				)
 				.setup();
 
@@ -216,8 +213,7 @@ public class ElasticsearchSchemaMigrationIT {
 							IndexSchemaElement root = ctx.getSchemaElement();
 							root.field( "myField", f -> f.asBoolean() )
 									.toReference();
-						},
-						indexManager -> { }
+						}
 				)
 				.setup();
 
@@ -262,8 +258,7 @@ public class ElasticsearchSchemaMigrationIT {
 							IndexSchemaElement root = ctx.getSchemaElement();
 							root.field( "myField", f -> f.asBoolean() )
 									.toReference();
-						},
-						indexManager -> { }
+						}
 				)
 				.setup();
 
@@ -307,8 +302,7 @@ public class ElasticsearchSchemaMigrationIT {
 							IndexSchemaElement root = ctx.getSchemaElement();
 							root.field( "myField", f -> f.asLocalDate() )
 									.toReference();
-						},
-						indexManager -> { }
+						}
 				)
 				.setup();
 
@@ -355,8 +349,7 @@ public class ElasticsearchSchemaMigrationIT {
 									IndexSchemaElement root = ctx.getSchemaElement();
 									root.field( "myField", f -> f.asLocalDate() )
 											.toReference();
-								},
-								indexManager -> { }
+								}
 						)
 						.setup(),
 				FailureReportUtils.buildFailureReportPattern()
@@ -400,8 +393,7 @@ public class ElasticsearchSchemaMigrationIT {
 											f -> f.asString().analyzer( "customAnalyzer" )
 									)
 											.toReference();
-								},
-								indexManager -> { }
+								}
 						)
 						.setup(),
 				FailureReportUtils.buildFailureReportPattern()
@@ -445,8 +437,7 @@ public class ElasticsearchSchemaMigrationIT {
 											f -> f.asString().normalizer( "customNormalizer" )
 									)
 											.toReference();
-								},
-								indexManager -> { }
+								}
 						)
 						.setup(),
 				FailureReportUtils.buildFailureReportPattern()

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchSchemaValidationIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/management/ElasticsearchSchemaValidationIT.java
@@ -135,8 +135,7 @@ public class ElasticsearchSchemaValidationIT {
 							IndexSchemaElement root = ctx.getSchemaElement();
 							root.field( "myField", f -> f.asLocalDate() )
 									.toReference();
-						},
-						indexManager -> { }
+						}
 				)
 				.withIndex(
 						INDEX2_NAME,
@@ -144,8 +143,7 @@ public class ElasticsearchSchemaValidationIT {
 							IndexSchemaElement root = ctx.getSchemaElement();
 							root.field( "myField", f -> f.asBoolean() )
 									.toReference();
-						},
-						indexManager -> { }
+						}
 				)
 				.withIndex(
 						INDEX3_NAME,
@@ -156,8 +154,7 @@ public class ElasticsearchSchemaValidationIT {
 									f -> f.asString().analyzer( "default" )
 							)
 									.toReference();
-						},
-						indexManager -> { }
+						}
 				)
 				.setup();
 		// TODO add an index with a faceted field once we restore support for faceting; see HSEARCH-3271
@@ -359,8 +356,7 @@ public class ElasticsearchSchemaValidationIT {
 											f -> f.asString().analyzer( "default" )
 									)
 											.toReference();
-								},
-								indexManager -> { }
+								}
 						)
 						.setup(),
 				FailureReportUtils.buildFailureReportPattern()
@@ -401,8 +397,7 @@ public class ElasticsearchSchemaValidationIT {
 											// TODO disable norms once the APIs allow it; see HSEARCH-3048
 									)
 											.toReference();
-								},
-								indexManager -> { }
+								}
 						)
 						.setup(),
 				FailureReportUtils.buildFailureReportPattern()
@@ -437,8 +432,6 @@ public class ElasticsearchSchemaValidationIT {
 									IndexSchemaElement root = ctx.getSchemaElement();
 									root.field( "myField", f -> f.asLocalDate() )
 											.toReference();
-								},
-								indexManager -> {
 								}
 						)
 						.setup(),
@@ -491,8 +484,6 @@ public class ElasticsearchSchemaValidationIT {
 									IndexSchemaElement root = ctx.getSchemaElement();
 									root.field( "myField", f -> f.asLocalDate() )
 											.toReference();
-								},
-								indexManager -> {
 								}
 						)
 						.setup(),
@@ -570,8 +561,6 @@ public class ElasticsearchSchemaValidationIT {
 									.toReference();
 							root.field( "myTextField", f -> f.asString().analyzer( "default" ) )
 									.toReference();
-						},
-						indexManager -> {
 						}
 				)
 				.setup();
@@ -613,8 +602,6 @@ public class ElasticsearchSchemaValidationIT {
 									objectField.field( "myField", f -> f.asLocalDate() )
 											.toReference();
 									objectField.toReference();
-								},
-								indexManager -> {
 								}
 						)
 						.setup(),
@@ -690,8 +677,7 @@ public class ElasticsearchSchemaValidationIT {
 									IndexSchemaElement root = ctx.getSchemaElement();
 									root.field( "myField", f -> f.asString() )
 											.toReference();
-								},
-								indexManager -> { }
+								}
 						)
 						.withIndex(
 								INDEX2_NAME,
@@ -699,8 +685,7 @@ public class ElasticsearchSchemaValidationIT {
 									IndexSchemaElement root = ctx.getSchemaElement();
 									root.field( "myField", f -> f.asString() )
 											.toReference();
-								},
-								indexManager -> { }
+								}
 						)
 						.setup(),
 				FailureReportUtils.buildFailureReportPattern()
@@ -855,8 +840,6 @@ public class ElasticsearchSchemaValidationIT {
 							IndexSchemaElement root = ctx.getSchemaElement();
 							root.field( "myField", f -> f.asString() )
 									.toReference();
-						},
-						indexManager -> {
 						}
 				)
 				.setup();
@@ -870,8 +853,6 @@ public class ElasticsearchSchemaValidationIT {
 							IndexSchemaElement root = ctx.getSchemaElement();
 							root.field( "myField", f -> f.asLocalDate() )
 									.toReference();
-						},
-						indexManager -> {
 						}
 				)
 				.setup();

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneDocumentModelDslIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneDocumentModelDslIT.java
@@ -63,8 +63,7 @@ public class LuceneDocumentModelDslIT {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
 						INDEX_NAME,
-						mappingContributor,
-						indexManager -> { }
+						mappingContributor
 				)
 				.setup();
 	}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/DocumentModelDslIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/DocumentModelDslIT.java
@@ -497,8 +497,7 @@ public class DocumentModelDslIT {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
 						INDEX_NAME,
-						mappingContributor,
-						indexManager -> { }
+						mappingContributor
 				)
 				.setup();
 	}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/rule/SearchSetupHelper.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/rule/SearchSetupHelper.java
@@ -123,6 +123,10 @@ public class SearchSetupHelper implements TestRule {
 			return withIndex( rawIndexName, ignored -> { }, mappingContributor, listener );
 		}
 
+		public SetupContext withIndex(String rawIndexName, Consumer<? super IndexedEntityBindingContext> mappingContributor) {
+			return withIndex( rawIndexName, mappingContributor, ignored -> { } );
+		}
+
 		public SetupContext withIndex(String rawIndexName,
 				Consumer<? super StubIndexMappingContext> optionsContributor,
 				Consumer<? super IndexedEntityBindingContext> mappingContributor, IndexSetupListener listener) {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3467

~~Still in preview, since several attributes have not been tested yet:~~ done

1. Property type attributes: ~~boots~~ removed!, ~~store, null_value, fielddata, doc_values, normalizer~~ done!.
2. ~~Normalizer definition attributes: char_filter, token_filter.~~ already exists
2. ~~Analyzer definition attributes: char_filter, token_filter, tokenizer.~~ already exists