### PR TITLE
HSEARCH-3561 - transpositions is ignored for .keyword().fuzzy() queri…

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ToElasticsearch.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ToElasticsearch.java
@@ -409,6 +409,7 @@ public class ToElasticsearch {
 										.addProperty( "value", query.getTerm().text() )
 										.addProperty( "fuzziness", query.getMaxEdits() )
 										.addProperty( "prefix_length", query.getPrefixLength() )
+										.addProperty( "transpositions", query.getTranspositions() )
 										.append( boostAppender( query ) )
 						)
 				).build();

--- a/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ToElasticsearchIT.java
+++ b/integrationtest/elasticsearch/src/test/java/org/hibernate/search/elasticsearch/test/ToElasticsearchIT.java
@@ -22,6 +22,7 @@ import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.CachingWrapperQuery;
+import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.TermQuery;
@@ -170,6 +171,54 @@ public class ToElasticsearchIT extends SearchTestBase {
 			List<Letter> letters = fullTextQuery.list();
 
 			assertThat( letters ).isEmpty();
+		}
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testFuzzyQueryWithTranspositionsEnabled() {
+		boolean transpositions = true;
+		int	editDistance = 1;
+		int prefixLength = 1;
+
+		try ( Session session = openSession() ) {
+			FullTextSession fullTextSession = Search.getFullTextSession( session );
+
+			FuzzyQuery fuzzyQuery = new FuzzyQuery( new Term( "signature", "gunnra" ), editDistance, prefixLength, FuzzyQuery.defaultMaxExpansions, transpositions );
+			BooleanQuery testedQuery = new BooleanQuery.Builder().add( fuzzyQuery, Occur.SHOULD ).build();
+			FullTextQuery fullTextQuery = fullTextSession.createFullTextQuery( testedQuery, Letter.class );
+
+			String queryString = fullTextQuery.getQueryString();
+			assertJsonEquals( "{'query':{'bool':{'should':{'fuzzy':{'signature':{'value':'gunnra','fuzziness':1,'prefix_length':1,'transpositions':true}}}}}}", queryString );
+
+			List<Letter> letters = fullTextQuery.list();
+
+			assertThat( letters ).hasSize( 2 );
+			assertThat( letters.get( 0 ) ).extracting( "signature" ).containsExactly( "Gunnar Morling" );
+			assertThat( letters.get( 1 ) ).extracting( "signature" ).containsExactly( "Gunnar Morling" );
+		}
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testFuzzyQueryWithTranspositionsDisabled() {
+		boolean transpositions = false;
+		int	editDistance = 1;
+		int prefixLength = 1;
+
+		try ( Session session = openSession() ) {
+			FullTextSession fullTextSession = Search.getFullTextSession( session );
+
+			FuzzyQuery fuzzyQuery = new FuzzyQuery( new Term( "signature", "gunnra" ), editDistance, prefixLength, FuzzyQuery.defaultMaxExpansions, transpositions );
+			BooleanQuery testedQuery = new BooleanQuery.Builder().add( fuzzyQuery, Occur.SHOULD ).build();
+			FullTextQuery fullTextQuery = fullTextSession.createFullTextQuery( testedQuery, Letter.class );
+
+			String queryString = fullTextQuery.getQueryString();
+			assertJsonEquals( "{'query':{'bool':{'should':{'fuzzy':{'signature':{'value':'gunnra','fuzziness':1,'prefix_length':1,'transpositions':false}}}}}}", queryString );
+
+			List<Letter> letters = fullTextQuery.list();
+
+			assertThat( letters ).hasSize( 0 );
 		}
 	}
 


### PR DESCRIPTION
 transpositions property is ignored for .keyword().fuzzy() queries in the Elasticsearch integration