### PR TITLE
Backport HSEARCH-3535 to branch 5.11 - Parameters are inverted in minimumShouldMatch error message

### DIFF
--- a/engine/src/main/java/org/hibernate/search/query/dsl/impl/MinimumShouldMatchContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/impl/MinimumShouldMatchContextImpl.java
@@ -74,7 +74,7 @@ final class MinimumShouldMatchContextImpl {
 			}
 
 			if ( minimum < 1 || minimum > totalShouldClauseNumber ) {
-				throw log.minimumShouldMatchMinimumOutOfBounds( minimum, totalShouldClauseNumber );
+				throw log.minimumShouldMatchMinimumOutOfBounds( totalShouldClauseNumber, minimum );
 			}
 
 			return minimum;

--- a/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/util/logging/impl/Log.java
@@ -1015,9 +1015,11 @@ public interface Log extends BaseHibernateSearchLogger {
 	@Message(id = 350, value = "'%1$s' must be positive or zero.")
 	IllegalArgumentException mustBePositiveOrZero(String objectDescription);
 
-	@Message(id = 351, value = "Computed minimum for minimumShouldMatch constraint is out of bounds:"
-			+ " expected a number between 1 and '%1$s', got '%2$s'.")
-	SearchException minimumShouldMatchMinimumOutOfBounds(int minimum, int totalShouldClauseNumber);
+	@Message(id = 351,
+			value = "Computed minimum for minimumShouldMatch constraint is out of bounds:"
+					+ " expected a number between '1' and '%1$s', got '%2$s'.")
+	SearchException minimumShouldMatchMinimumOutOfBounds(int totalShouldClauseNumber, int minimum);
+
 
 	@Message(id = 352, value = "Multiple conflicting minimumShouldMatch constraints")
 	SearchException minimumShouldMatchConflictingConstraints();

--- a/engine/src/test/java/org/hibernate/search/test/dsl/BoolDSLTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/dsl/BoolDSLTest.java
@@ -12,6 +12,7 @@ import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.hibernate.search.query.engine.spi.HSQuery;
+import org.hibernate.search.testsupport.TestForIssue;
 import org.hibernate.search.testsupport.junit.SearchFactoryHolder;
 import org.hibernate.search.testsupport.junit.SearchITHelper;
 
@@ -490,6 +491,21 @@ public class BoolDSLTest {
 		thrown.expectMessage( "Multiple conflicting minimumShouldMatch constraints" );
 
 		queryBuilder.bool().minimumShouldMatchNumber( -1 ).minimumShouldMatchPercent( 100 );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-3535")
+	public void minimumShouldMatch_error_outOfBounds() {
+		QueryBuilder queryBuilder = helper.queryBuilder( IndexedEntity.class );
+
+		thrown.expect( SearchException.class );
+		thrown.expectMessage( "Computed minimum for minimumShouldMatch constraint is out of bounds" );
+		thrown.expectMessage( "expected a number between '1' and '1', got '3'" );
+
+		queryBuilder.bool()
+				.should( queryBuilder.all().createQuery() )
+				.minimumShouldMatchNumber( 3 )
+				.createQuery();
 	}
 
 	private void initData() {


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3535

Just waiting for CI.

Backport of #1944 , but just the part about HSEARCH-3535. The other part breaks backward compatibility so I'd rather not.