### PR TITLE
HSEARCH-3518 Add support for Elasticsearch 6.7

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -184,7 +184,8 @@ stage('Configure') {
 			],
 			esLocal: [
 					new EsLocalITEnvironment(versionRange: '[5.6,6.0)', mavenProfile: 'elasticsearch-5.6', status: ITEnvironmentStatus.SUPPORTED),
-					new EsLocalITEnvironment(versionRange: '[6.0,6.x)', mavenProfile: 'elasticsearch-6.0', status: ITEnvironmentStatus.USED_IN_DEFAULT_BUILD),
+					new EsLocalITEnvironment(versionRange: '[6.0,6.6)', mavenProfile: 'elasticsearch-6.0', status: ITEnvironmentStatus.SUPPORTED),
+					new EsLocalITEnvironment(versionRange: '[6.7,6.7)', mavenProfile: 'elasticsearch-6.7', status: ITEnvironmentStatus.USED_IN_DEFAULT_BUILD),
 					new EsLocalITEnvironment(versionRange: '[7.0,7.x)', mavenProfile: 'elasticsearch-7.0', status: ITEnvironmentStatus.SUPPORTED)
 			],
 			esAws: [

--- a/README.md
+++ b/README.md
@@ -97,12 +97,14 @@ launching an Elasticsearch server automatically on port 9200.
 You may redefine the version to use by specifying the right profile and using the
 `test.elasticsearch.host.version` property, while disabling the default profile:
 
-    > mvn clean install -P!elasticsearch-5.6,elasticsearch-6.0 -Dtest.elasticsearch.host.version=6.0.0
+    > mvn clean install -P!elasticsearch-6.7,elasticsearch-6.0 -Dtest.elasticsearch.host.version=6.0.0
 
 The following profiles are available:
 
  * `elasticsearch-5.6` for 5.6.x and later 5.x
- * `elasticsearch-6.0` for 6.x (the default)
+ * `elasticsearch-6.0` for 6.0.x to 6.6.x
+ * `elasticsearch-6.7` for 6.7 (the default)
+ * `elasticsearch-7.0` for 7.x (the default)
 
 A list of available versions for `test.elasticsearch.host.version` can be found on
 [Maven Central](https://search.maven.org/search?q=g:org.elasticsearch%20AND%20a:elasticsearch&core=gav).
@@ -116,7 +118,7 @@ and run Elasticsearch-related tests against your own server using the
 If you want to run tests against a different Elasticsearch version  (6.x for instance),
 you will still have to select a profile among those listed above, and disable the default profile:
 
-    > mvn clean install -P!elasticsearch-5.6,elasticsearch-6.0 -Dtest.elasticsearch.host.provided=true -Dtest.elasticsearch.host.url=http://localhost:9200
+    > mvn clean install -P!elasticsearch-6.7,elasticsearch-6.0 -Dtest.elasticsearch.host.provided=true -Dtest.elasticsearch.host.url=http://localhost:9200
 
 You may also use authentication:
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchDialectName.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchDialectName.java
@@ -19,9 +19,13 @@ public enum ElasticsearchDialectName {
 	 */
 	ES_5_6("5.6"),
 	/**
-	 * Use the dialect targeting Elasticsearch 6.
+	 * Use the dialect targeting Elasticsearch 6.0 to 6.6.
 	 */
 	ES_6("6"),
+	/**
+	 * Use the dialect targeting Elasticsearch 6.7.
+	 */
+	ES_6_7("6.7"),
 	/**
 	 * Use the dialect targeting Elasticsearch 7.
 	 */

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/Elasticsearch56Dialect.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/Elasticsearch56Dialect.java
@@ -9,7 +9,7 @@ package org.hibernate.search.backend.elasticsearch.dialect.impl;
 /**
  * The dialect for Elasticsearch 5.6.
  */
-public class Elasticsearch56Dialect extends Elasticsearch6Dialect implements ElasticsearchDialect {
+public class Elasticsearch56Dialect extends Elasticsearch60Dialect implements ElasticsearchDialect {
 
 	// Nothing specific so far. This may change if we add new features that work better in later versions.
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/Elasticsearch60Dialect.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/Elasticsearch60Dialect.java
@@ -1,0 +1,24 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.dialect.impl;
+
+import org.hibernate.search.backend.elasticsearch.gson.spi.GsonProvider;
+import org.hibernate.search.backend.elasticsearch.work.builder.factory.impl.Elasticsearch60WorkBuilderFactory;
+import org.hibernate.search.backend.elasticsearch.work.builder.factory.impl.ElasticsearchWorkBuilderFactory;
+
+/**
+ * The dialect for Elasticsearch 6.0 to 6.6.
+ */
+public class Elasticsearch60Dialect extends Elasticsearch67Dialect implements ElasticsearchDialect {
+
+	@Override
+	public ElasticsearchWorkBuilderFactory createWorkBuilderFactory(GsonProvider gsonProvider) {
+		// Necessary because of the breaking changes related to type names in ES6.7/ES7
+		return new Elasticsearch60WorkBuilderFactory( gsonProvider );
+	}
+
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/Elasticsearch67Dialect.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/Elasticsearch67Dialect.java
@@ -11,7 +11,7 @@ import org.hibernate.search.backend.elasticsearch.search.query.impl.Elasticsearc
 import org.hibernate.search.backend.elasticsearch.search.query.impl.ElasticsearchSearchResultExtractorFactory;
 import org.hibernate.search.backend.elasticsearch.types.dsl.provider.impl.Elasticsearch6IndexFieldTypeFactoryContextProvider;
 import org.hibernate.search.backend.elasticsearch.types.dsl.provider.impl.ElasticsearchIndexFieldTypeFactoryContextProvider;
-import org.hibernate.search.backend.elasticsearch.work.builder.factory.impl.Elasticsearch6WorkBuilderFactory;
+import org.hibernate.search.backend.elasticsearch.work.builder.factory.impl.Elasticsearch67WorkBuilderFactory;
 import org.hibernate.search.backend.elasticsearch.work.builder.factory.impl.ElasticsearchWorkBuilderFactory;
 
 import com.google.gson.Gson;
@@ -19,12 +19,12 @@ import com.google.gson.Gson;
 /**
  * The dialect for Elasticsearch 6.
  */
-public class Elasticsearch6Dialect extends Elasticsearch7Dialect implements ElasticsearchDialect {
+public class Elasticsearch67Dialect extends Elasticsearch7Dialect implements ElasticsearchDialect {
 
 	@Override
 	public ElasticsearchWorkBuilderFactory createWorkBuilderFactory(GsonProvider gsonProvider) {
 		// Necessary because of the breaking changes related to type names in ES7
-		return new Elasticsearch6WorkBuilderFactory( gsonProvider );
+		return new Elasticsearch67WorkBuilderFactory( gsonProvider );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactory.java
@@ -26,7 +26,9 @@ public class ElasticsearchDialectFactory {
 			case ES_5_6:
 				return new Elasticsearch56Dialect();
 			case ES_6:
-				return new Elasticsearch6Dialect();
+				return new Elasticsearch60Dialect();
+			case ES_6_7:
+				return new Elasticsearch67Dialect();
 			case ES_7:
 				return new Elasticsearch7Dialect();
 			case AUTO:
@@ -50,7 +52,14 @@ public class ElasticsearchDialectFactory {
 			return ElasticsearchDialectName.ES_5_6;
 		}
 		else if ( version.getMajor() == 6 ) {
-			return ElasticsearchDialectName.ES_6;
+			if ( version.getMinor() < 7 ) {
+				return ElasticsearchDialectName.ES_6;
+			}
+			// Either the latest supported version, or a newer/unknown one
+			if ( version.getMinor() != 7 ) {
+				log.unknownElasticsearchVersion( version );
+			}
+			return ElasticsearchDialectName.ES_6_7;
 		}
 		else {
 			// Either the latest supported version, or a newer/unknown one

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/builder/factory/impl/Elasticsearch60WorkBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/builder/factory/impl/Elasticsearch60WorkBuilderFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.work.builder.factory.impl;
+
+import org.hibernate.search.backend.elasticsearch.client.impl.Paths;
+import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.RootTypeMapping;
+import org.hibernate.search.backend.elasticsearch.gson.spi.GsonProvider;
+import org.hibernate.search.backend.elasticsearch.util.spi.URLEncodedString;
+import org.hibernate.search.backend.elasticsearch.work.builder.impl.CreateIndexWorkBuilder;
+import org.hibernate.search.backend.elasticsearch.work.builder.impl.GetIndexTypeMappingWorkBuilder;
+import org.hibernate.search.backend.elasticsearch.work.builder.impl.PutIndexMappingWorkBuilder;
+import org.hibernate.search.backend.elasticsearch.work.impl.CreateIndexWork;
+import org.hibernate.search.backend.elasticsearch.work.impl.GetIndexTypeMappingWork;
+import org.hibernate.search.backend.elasticsearch.work.impl.PutIndexTypeMappingWork;
+
+/**
+ * A work builder factory for ES6.0 to ES6.6.
+ * <p>
+ * Compared to ES6.7:
+ * <ul>
+ *     <li>We do NOT set an "include_type_name=true" parameter in index creation and mapping APIs</li>
+ * </ul>
+ */
+@SuppressWarnings("deprecation") // We use Paths.DOC on purpose
+public class Elasticsearch60WorkBuilderFactory extends Elasticsearch67WorkBuilderFactory {
+
+	public Elasticsearch60WorkBuilderFactory(GsonProvider gsonProvider) {
+		super( gsonProvider );
+	}
+
+	@Override
+	public CreateIndexWorkBuilder createIndex(URLEncodedString indexName) {
+		return CreateIndexWork.Builder.forElasticsearch66AndBelow( gsonProvider, indexName, Paths.DOC );
+	}
+
+	@Override
+	public GetIndexTypeMappingWorkBuilder getIndexTypeMapping(URLEncodedString indexName) {
+		return GetIndexTypeMappingWork.Builder.forElasticsearch66AndBelow( indexName, Paths.DOC );
+	}
+
+	@Override
+	public PutIndexMappingWorkBuilder putIndexTypeMapping(URLEncodedString indexName, RootTypeMapping mapping) {
+		return PutIndexTypeMappingWork.Builder.forElasticsearch66AndBelow( gsonProvider, indexName, Paths.DOC, mapping );
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/builder/factory/impl/Elasticsearch67WorkBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/builder/factory/impl/Elasticsearch67WorkBuilderFactory.java
@@ -29,12 +29,13 @@ import com.google.gson.JsonObject;
  * <ul>
  *     <li>Mappings are assigned a "type name"; we use the hardcoded "doc" type name</li>
  *     <li>Some URLs require to include this type name instead of the "_doc" keyword used in ES7.</li>
+ *     <li>We set an "include_type_name=true" parameter in index creation and mapping APIs</li>
  * </ul>
  */
 @SuppressWarnings("deprecation") // We use Paths.DOC on purpose
-public class Elasticsearch6WorkBuilderFactory extends Elasticsearch7WorkBuilderFactory {
+public class Elasticsearch67WorkBuilderFactory extends Elasticsearch7WorkBuilderFactory {
 
-	public Elasticsearch6WorkBuilderFactory(GsonProvider gsonProvider) {
+	public Elasticsearch67WorkBuilderFactory(GsonProvider gsonProvider) {
 		super( gsonProvider );
 	}
 
@@ -46,17 +47,17 @@ public class Elasticsearch6WorkBuilderFactory extends Elasticsearch7WorkBuilderF
 
 	@Override
 	public CreateIndexWorkBuilder createIndex(URLEncodedString indexName) {
-		return CreateIndexWork.Builder.forElasticsearch6AndBelow( gsonProvider, indexName, Paths.DOC );
+		return CreateIndexWork.Builder.forElasticsearch67( gsonProvider, indexName, Paths.DOC );
 	}
 
 	@Override
 	public GetIndexTypeMappingWorkBuilder getIndexTypeMapping(URLEncodedString indexName) {
-		return GetIndexTypeMappingWork.Builder.forElasticsearch6AndBelow( indexName, Paths.DOC );
+		return GetIndexTypeMappingWork.Builder.forElasticsearch67( indexName, Paths.DOC );
 	}
 
 	@Override
 	public PutIndexMappingWorkBuilder putIndexTypeMapping(URLEncodedString indexName, RootTypeMapping mapping) {
-		return PutIndexTypeMappingWork.Builder.forElasticsearch6AndBelow( gsonProvider, indexName, Paths.DOC, mapping );
+		return PutIndexTypeMappingWork.Builder.forElasticsearch67( gsonProvider, indexName, Paths.DOC, mapping );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/CreateIndexWork.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/CreateIndexWork.java
@@ -48,23 +48,31 @@ public class CreateIndexWork extends AbstractSimpleElasticsearchWork<CreateIndex
 		private final GsonProvider gsonProvider;
 		private final URLEncodedString indexName;
 		private final URLEncodedString typeName;
+		private final Boolean includeTypeName;
 		private final JsonObject payload = new JsonObject();
 
-		public static Builder forElasticsearch6AndBelow(GsonProvider gsonProvider,
+		public static Builder forElasticsearch66AndBelow(GsonProvider gsonProvider,
 				URLEncodedString indexName, URLEncodedString typeName) {
-			return new Builder( gsonProvider, indexName, typeName );
+			return new Builder( gsonProvider, indexName, typeName, null );
+		}
+
+		public static Builder forElasticsearch67(GsonProvider gsonProvider,
+				URLEncodedString indexName, URLEncodedString typeName) {
+			return new Builder( gsonProvider, indexName, typeName, true );
 		}
 
 		public static Builder forElasticsearch7AndAbove(GsonProvider gsonProvider,
 				URLEncodedString indexName) {
-			return new Builder( gsonProvider, indexName, null );
+			return new Builder( gsonProvider, indexName, null, null );
 		}
 
-		private Builder(GsonProvider gsonProvider, URLEncodedString indexName, URLEncodedString typeName) {
+		private Builder(GsonProvider gsonProvider, URLEncodedString indexName, URLEncodedString typeName,
+				Boolean includeTypeName) {
 			super( null, DefaultElasticsearchRequestSuccessAssessor.INSTANCE );
 			this.gsonProvider = gsonProvider;
 			this.indexName = indexName;
 			this.typeName = typeName;
+			this.includeTypeName = includeTypeName;
 		}
 
 		@Override
@@ -112,7 +120,10 @@ public class CreateIndexWork extends AbstractSimpleElasticsearchWork<CreateIndex
 			ElasticsearchRequest.Builder builder =
 					ElasticsearchRequest.put()
 					.pathComponent( indexName );
-
+			// ES6.7 only
+			if ( includeTypeName != null ) {
+				builder.param( "include_type_name", includeTypeName );
+			}
 			if ( payload.size() > 0 ) {
 				builder.body( payload );
 			}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/GetIndexTypeMappingWork.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/GetIndexTypeMappingWork.java
@@ -70,19 +70,25 @@ public class GetIndexTypeMappingWork extends AbstractSimpleElasticsearchWork<Roo
 			implements GetIndexTypeMappingWorkBuilder {
 		private final URLEncodedString indexName;
 		private final URLEncodedString typeName;
+		private final Boolean includeTypeName;
 
-		public static Builder forElasticsearch6AndBelow(URLEncodedString indexName, URLEncodedString typeName) {
-			return new Builder( indexName, typeName );
+		public static Builder forElasticsearch66AndBelow(URLEncodedString indexName, URLEncodedString typeName) {
+			return new Builder( indexName, typeName, null );
+		}
+
+		public static Builder forElasticsearch67(URLEncodedString indexName, URLEncodedString typeName) {
+			return new Builder( indexName, typeName, true );
 		}
 
 		public static Builder forElasticsearch7AndAbove(URLEncodedString indexName) {
-			return new Builder( indexName, null );
+			return new Builder( indexName, null, null );
 		}
 
-		public Builder(URLEncodedString indexName, URLEncodedString typeName) {
+		private Builder(URLEncodedString indexName, URLEncodedString typeName, Boolean includeTypeName) {
 			super( null, DefaultElasticsearchRequestSuccessAssessor.INSTANCE );
 			this.indexName = indexName;
 			this.typeName = typeName;
+			this.includeTypeName = includeTypeName;
 		}
 
 		@Override
@@ -91,6 +97,10 @@ public class GetIndexTypeMappingWork extends AbstractSimpleElasticsearchWork<Roo
 					ElasticsearchRequest.get()
 					.pathComponent( indexName )
 					.pathComponent( Paths._MAPPING );
+			// ES6.7 only
+			if ( includeTypeName != null ) {
+				builder.param( "include_type_name", includeTypeName );
+			}
 			return builder.build();
 		}
 

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/client/impl/ElasticsearchClientUtilsGetElasticsearchVersionTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/client/impl/ElasticsearchClientUtilsGetElasticsearchVersionTest.java
@@ -44,6 +44,7 @@ public class ElasticsearchClientUtilsGetElasticsearchVersionTest {
 				{ "5.0.0", 5, 0, 0, null },
 				{ "5.6.6", 5, 6, 6, null },
 				{ "6.0.0", 6, 0, 0, null },
+				{ "6.7.0", 6, 7, 0, null },
 				{ "7.0.0-beta1", 7, 0, 0, "beta1" },
 				{ "7.0.0", 7, 0, 0, null }
 		};

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
@@ -93,6 +93,11 @@ public class ElasticsearchDialectFactoryTest {
 	}
 
 	@Test
+	public void es67() {
+		testSuccess( "6.7.0", ElasticsearchDialectName.ES_6, Elasticsearch6Dialect.class );
+	}
+
+	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3490")
 	public void es700beta1() throws Exception {
 		testSuccess( "7.0.0-beta1", ElasticsearchDialectName.ES_7, Elasticsearch7Dialect.class );

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
@@ -84,17 +84,24 @@ public class ElasticsearchDialectFactoryTest {
 
 	@Test
 	public void es60() {
-		testSuccess( "6.0.0", ElasticsearchDialectName.ES_6, Elasticsearch6Dialect.class );
+		testSuccess( "6.0.0", ElasticsearchDialectName.ES_6, Elasticsearch60Dialect.class );
 	}
 
 	@Test
 	public void es66() {
-		testSuccess( "6.6.0", ElasticsearchDialectName.ES_6, Elasticsearch6Dialect.class );
+		testSuccess( "6.6.0", ElasticsearchDialectName.ES_6, Elasticsearch60Dialect.class );
 	}
 
 	@Test
 	public void es67() {
-		testSuccess( "6.7.0", ElasticsearchDialectName.ES_6, Elasticsearch6Dialect.class );
+		testSuccess( "6.7.0", ElasticsearchDialectName.ES_6_7, Elasticsearch67Dialect.class );
+	}
+
+	@Test
+	public void es68() {
+		logged.expectMessage( "HSEARCH400085", "'6.8.0'" );
+		ElasticsearchDialectName dialectName = dialectFactory.getAppropriateDialectName( ElasticsearchVersion.of( "6.8.0" ) );
+		assertThat( dialectName ).isEqualTo( ElasticsearchDialectName.ES_6_7 );
 	}
 
 	@Test

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/dialect/Elasticsearch60TestDialect.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/dialect/Elasticsearch60TestDialect.java
@@ -18,7 +18,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
 @SuppressWarnings("deprecation") // We use Paths.DOC on purpose
-public class Elasticsearch6TestDialect implements ElasticsearchTestDialect {
+public class Elasticsearch60TestDialect implements ElasticsearchTestDialect {
 
 	@Override
 	public ElasticsearchDialectName getName() {
@@ -38,6 +38,11 @@ public class Elasticsearch6TestDialect implements ElasticsearchTestDialect {
 	@Override
 	public Optional<URLEncodedString> getTypeNameForMappingApi() {
 		return Optional.of( Paths.DOC );
+	}
+
+	@Override
+	public Boolean getIncludeTypeNameParameterForMappingApi() {
+		return null;
 	}
 
 	@Override

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/dialect/Elasticsearch67TestDialect.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/dialect/Elasticsearch67TestDialect.java
@@ -14,14 +14,15 @@ import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchDialectName;
 import org.hibernate.search.backend.elasticsearch.client.impl.Paths;
 import org.hibernate.search.backend.elasticsearch.util.spi.URLEncodedString;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
 @SuppressWarnings("deprecation") // We use Paths.DOC on purpose
-public class Elasticsearch5TestDialect implements ElasticsearchTestDialect {
+public class Elasticsearch67TestDialect implements ElasticsearchTestDialect {
 
 	@Override
 	public ElasticsearchDialectName getName() {
-		return ElasticsearchDialectName.ES_5_6;
+		return ElasticsearchDialectName.ES_6_7;
 	}
 
 	@Override
@@ -41,7 +42,7 @@ public class Elasticsearch5TestDialect implements ElasticsearchTestDialect {
 
 	@Override
 	public Boolean getIncludeTypeNameParameterForMappingApi() {
-		return null;
+		return true;
 	}
 
 	@Override
@@ -51,6 +52,8 @@ public class Elasticsearch5TestDialect implements ElasticsearchTestDialect {
 
 	@Override
 	public void setTemplatePattern(JsonObject object, String pattern) {
-		object.addProperty( "template", pattern );
+		JsonArray array = new JsonArray();
+		array.add( pattern );
+		object.add( "index_patterns", array );
 	}
 }

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/dialect/Elasticsearch7TestDialect.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/dialect/Elasticsearch7TestDialect.java
@@ -40,6 +40,11 @@ public class Elasticsearch7TestDialect implements ElasticsearchTestDialect {
 	}
 
 	@Override
+	public Boolean getIncludeTypeNameParameterForMappingApi() {
+		return null;
+	}
+
+	@Override
 	public List<String> getAllLocalDateDefaultMappingFormats() {
 		return Collections.singletonList( "uuuu-MM-dd" );
 	}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/dialect/ElasticsearchTestDialect.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/dialect/ElasticsearchTestDialect.java
@@ -24,6 +24,8 @@ public interface ElasticsearchTestDialect {
 
 	Optional<URLEncodedString> getTypeNameForMappingApi();
 
+	Boolean getIncludeTypeNameParameterForMappingApi();
+
 	List<String> getAllLocalDateDefaultMappingFormats();
 
 	default String getFirstLocalDateDefaultMappingFormat() {

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
         <!-- When updating the following versions you will likely need to update the
              matching test profile as well, e.g. elasticsearch-5.2 for the 5.2+ series -->
         <!-- The main version of Elasticsearch targeted by Hibernate Search, tested in the default profile -->
-        <version.org.elasticsearch.main>6.6.2</version.org.elasticsearch.main>
+        <version.org.elasticsearch.main>6.7.0</version.org.elasticsearch.main>
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently from the version of the remote cluster -->
         <version.org.elasticsearch.client>${version.org.elasticsearch.main}</version.org.elasticsearch.client>
         <documentation.org.elasticsearch.url>https://www.elastic.co/guide/en/elasticsearch/reference/${parsed-version.org.elasticsearch.main.majorVersion}.${parsed-version.org.elasticsearch.main.minorVersion}</documentation.org.elasticsearch.url>

--- a/pom.xml
+++ b/pom.xml
@@ -2306,9 +2306,33 @@
             </build>
         </profile>
 
-        <!-- Elasticsearch 6.0+ test environment (default) -->
+        <!-- Elasticsearch 6.0 to 6.6 test environment -->
         <profile>
             <id>elasticsearch-6.0</id>
+            <properties>
+                <test.elasticsearch.host.version>6.6.2</test.elasticsearch.host.version>
+                <test.elasticsearch.testdialect>org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.dialect.Elasticsearch60TestDialect</test.elasticsearch.testdialect>
+            </properties>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>com.github.alexcojocaru</groupId>
+                            <artifactId>elasticsearch-maven-plugin</artifactId>
+                            <version>${version.com.github.alexcojocaru.elasticsearch.plugin}</version>
+                            <configuration>
+                                <pathConf>${project.build.directory}/elasticsearch-maven-plugin/6.0/configuration/</pathConf>
+                                <pathInitScript>${project.build.directory}/elasticsearch-maven-plugin/6.0/init/init.script</pathInitScript>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+
+        <!-- Elasticsearch 6.7 test environment (default) -->
+        <profile>
+            <id>elasticsearch-6.7</id>
             <activation>
                 <!-- Activate by default, i.e. if test.elasticsearch.host.version has not been defined explicitly -->
                 <property>
@@ -2317,7 +2341,7 @@
             </activation>
             <properties>
                 <test.elasticsearch.host.version>${version.org.elasticsearch.main}</test.elasticsearch.host.version>
-                <test.elasticsearch.testdialect>org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.dialect.Elasticsearch6TestDialect</test.elasticsearch.testdialect>
+                <test.elasticsearch.testdialect>org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.dialect.Elasticsearch67TestDialect</test.elasticsearch.testdialect>
             </properties>
             <build>
                 <pluginManagement>


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3518

For now it's a dedicated dialect, I'll change that in https://hibernate.atlassian.net/browse/HSEARCH-3563

Full build: http://ci.hibernate.org/job/hibernate-search/job/PR-1956/4/