### PR TITLE
HSEARCH-3298 Mark the accessor-based entity access API and explicit reindexing declaration API in bridges as experimental

### DIFF
--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/binding/IdentifierBridgeBindingContext.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/binding/IdentifierBridgeBindingContext.java
@@ -16,6 +16,8 @@ public interface IdentifierBridgeBindingContext<T> {
 
 	/**
 	 * @return An entry point allowing to inspect the type of values that will be passed to this bridge.
+	 * @hsearch.experimental This feature is under active development.
+	 *    You should be prepared for incompatible changes in future releases.
 	 */
 	PojoModelValue<T> getBridgedElement();
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/binding/PropertyBridgeBindingContext.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/binding/PropertyBridgeBindingContext.java
@@ -19,6 +19,8 @@ public interface PropertyBridgeBindingContext {
 
 	/**
 	 * @return An entry point allowing to declare expectations and retrieve accessors to the bridged POJO property.
+	 * @hsearch.experimental This feature is under active development.
+	 *    You should be prepared for incompatible changes in future releases.
 	 */
 	PojoModelProperty getBridgedElement();
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/binding/RoutingKeyBridgeBindingContext.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/binding/RoutingKeyBridgeBindingContext.java
@@ -17,6 +17,8 @@ public interface RoutingKeyBridgeBindingContext {
 
 	/**
 	 * @return An entry point allowing to declare expectations and retrieve accessors to the bridged POJO type.
+	 * @hsearch.experimental This feature is under active development.
+	 *    You should be prepared for incompatible changes in future releases.
 	 */
 	PojoModelType getBridgedElement();
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/binding/TypeBridgeBindingContext.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/binding/TypeBridgeBindingContext.java
@@ -19,6 +19,8 @@ public interface TypeBridgeBindingContext {
 
 	/**
 	 * @return An entry point allowing to declare expectations and retrieve accessors to the bridged POJO type.
+	 * @hsearch.experimental This feature is under active development.
+	 *    You should be prepared for incompatible changes in future releases.
 	 */
 	PojoModelType getBridgedElement();
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/binding/ValueBridgeBindingContext.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/binding/ValueBridgeBindingContext.java
@@ -17,6 +17,8 @@ public interface ValueBridgeBindingContext<V> {
 
 	/**
 	 * @return An entry point allowing to inspect the type of values that will be passed to this bridge.
+	 * @hsearch.experimental This feature is under active development.
+	 *    You should be prepared for incompatible changes in future releases.
 	 */
 	PojoModelValue<V> getBridgedElement();
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/PojoElementAccessor.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/PojoElementAccessor.java
@@ -11,6 +11,8 @@ package org.hibernate.search.mapper.pojo.model;
  * An accessor allowing to retrieve an element of a POJO, e.g. a property.
  * <p>
  * Accessors are created by {@link PojoModelCompositeElement} instances.
+ * @hsearch.experimental This type is under active development.
+ *    You should be prepared for incompatible changes in future releases.
  */
 public interface PojoElementAccessor<T> {
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/PojoModelCompositeElement.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/PojoModelCompositeElement.java
@@ -16,6 +16,8 @@ import java.util.stream.Stream;
  *
  * @see PojoModelType
  * @see PojoModelProperty
+ * @hsearch.experimental This type is under active development.
+ *    You should be prepared for incompatible changes in future releases.
  */
 public interface PojoModelCompositeElement extends PojoModelElement {
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/PojoModelElement.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/PojoModelElement.java
@@ -11,6 +11,8 @@ package org.hibernate.search.mapper.pojo.model;
  *
  * @see PojoModelType
  * @see PojoModelProperty
+ * @hsearch.experimental This type is under active development.
+ *    You should be prepared for incompatible changes in future releases.
  */
 public interface PojoModelElement {
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/PojoModelProperty.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/PojoModelProperty.java
@@ -12,6 +12,8 @@ import java.util.stream.Stream;
  * A model element representing a property bound to a bridge.
  *
  * @see org.hibernate.search.mapper.pojo.bridge.PropertyBridge
+ * @hsearch.experimental This type is under active development.
+ *    You should be prepared for incompatible changes in future releases.
  */
 public interface PojoModelProperty extends PojoModelCompositeElement {
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/PojoModelType.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/PojoModelType.java
@@ -10,6 +10,8 @@ package org.hibernate.search.mapper.pojo.model;
  * A model element representing a type bound to a bridge.
  *
  * @see org.hibernate.search.mapper.pojo.bridge.TypeBridge
+ * @hsearch.experimental This type is under active development.
+ *    You should be prepared for incompatible changes in future releases.
  */
 public interface PojoModelType extends PojoModelCompositeElement {
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/PojoModelValue.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/PojoModelValue.java
@@ -10,6 +10,8 @@ package org.hibernate.search.mapper.pojo.model;
  * A model element representing a value bound to a bridge.
  *
  * @see org.hibernate.search.mapper.pojo.bridge.ValueBridge
+ * @hsearch.experimental This type is under active development.
+ *    You should be prepared for incompatible changes in future releases.
  */
 public interface PojoModelValue<T> extends PojoModelElement {
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/dependency/PojoOtherEntityDependencyContext.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/dependency/PojoOtherEntityDependencyContext.java
@@ -9,6 +9,10 @@ package org.hibernate.search.mapper.pojo.model.dependency;
 import org.hibernate.search.mapper.pojo.model.path.PojoModelPath;
 import org.hibernate.search.mapper.pojo.model.path.PojoModelPathValueNode;
 
+/**
+ * @hsearch.experimental This type is under active development.
+ *    You should be prepared for incompatible changes in future releases.
+ */
 public interface PojoOtherEntityDependencyContext {
 
 	/**
@@ -19,6 +23,8 @@ public interface PojoOtherEntityDependencyContext {
 	 * @return {@code this}, for method chaining.
 	 * @throws org.hibernate.search.util.common.SearchException If the given path cannot be applied to the entity type.
 	 * @see #use(PojoModelPathValueNode)
+	 * @hsearch.experimental This feature is under active development.
+	 *    You should be prepared for incompatible changes in future releases.
 	 */
 	default PojoOtherEntityDependencyContext use(String pathFromOtherEntityTypeToUsedValue) {
 		return use( PojoModelPath.parse( pathFromOtherEntityTypeToUsedValue ) );
@@ -35,6 +41,8 @@ public interface PojoOtherEntityDependencyContext {
 	 * @param pathFromBridgedTypeToUsedValue The path from the entity type to the value used by the bridge.
 	 * @return {@code this}, for method chaining.
 	 * @throws org.hibernate.search.util.common.SearchException If the given path cannot be applied to the entity type.
+	 * @hsearch.experimental This feature is under active development.
+	 *    You should be prepared for incompatible changes in future releases.
 	 */
 	PojoOtherEntityDependencyContext use(PojoModelPathValueNode pathFromBridgedTypeToUsedValue);
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/dependency/PojoPropertyDependencyContext.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/dependency/PojoPropertyDependencyContext.java
@@ -105,6 +105,8 @@ public interface PojoPropertyDependencyContext {
 	 * @throws org.hibernate.search.util.common.SearchException If the bridged property does not point to an entity type,
 	 * or the given type is not an entity type,
 	 * or the given path cannot be applied to the given entity type.
+	 * @hsearch.experimental This feature is under active development.
+	 *    You should be prepared for incompatible changes in future releases.
 	 */
 	default PojoOtherEntityDependencyContext fromOtherEntity(Class<?> otherEntityType,
 			String pathFromOtherEntityTypeToBridgedType) {
@@ -126,6 +128,8 @@ public interface PojoPropertyDependencyContext {
 	 * @throws org.hibernate.search.util.common.SearchException If the bridged property does not point to an entity type,
 	 * or the given type is not an entity type,
 	 * or the given path cannot be applied to the given entity type.
+	 * @hsearch.experimental This feature is under active development.
+	 *    You should be prepared for incompatible changes in future releases.
 	 */
 	default PojoOtherEntityDependencyContext fromOtherEntity(Class<?> otherEntityType,
 			PojoModelPathValueNode pathFromOtherEntityTypeToBridgedType) {
@@ -151,6 +155,8 @@ public interface PojoPropertyDependencyContext {
 	 * or the given type is not an entity type,
 	 * or the given extractor path cannot be applied to the bridged property,
 	 * or the given path cannot be applied to the given entity type.
+	 * @hsearch.experimental This feature is under active development.
+	 *    You should be prepared for incompatible changes in future releases.
 	 */
 	PojoOtherEntityDependencyContext fromOtherEntity(ContainerExtractorPath extractorPathFromBridgedProperty,
 			Class<?> otherEntityType,

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/dependency/PojoTypeDependencyContext.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/dependency/PojoTypeDependencyContext.java
@@ -47,6 +47,8 @@ public interface PojoTypeDependencyContext {
 	 * @param pathFromBridgedTypeToUsedValue The path from the bridged type to the value used by the bridge.
 	 * @return {@code this}, for method chaining.
 	 * @throws org.hibernate.search.util.common.SearchException If the given path cannot be applied to the bridged type.
+	 * @hsearch.experimental This feature is under active development.
+	 *    You should be prepared for incompatible changes in future releases.
 	 */
 	PojoTypeDependencyContext use(PojoModelPathValueNode pathFromBridgedTypeToUsedValue);
 
@@ -66,6 +68,8 @@ public interface PojoTypeDependencyContext {
 	 * @throws org.hibernate.search.util.common.SearchException If the bridged type is not an entity type,
 	 * or the given type is not an entity type,
 	 * or the given path cannot be applied to the given entity type.
+	 * @hsearch.experimental This feature is under active development.
+	 *    You should be prepared for incompatible changes in future releases.
 	 */
 	default PojoOtherEntityDependencyContext fromOtherEntity(Class<?> otherEntityType,
 			String pathFromOtherEntityTypeToBridgedType) {
@@ -87,6 +91,8 @@ public interface PojoTypeDependencyContext {
 	 * @throws org.hibernate.search.util.common.SearchException If the bridged type is not an entity type,
 	 * or the given type is not an entity type,
 	 * or the given path cannot be applied to the given entity type.
+	 * @hsearch.experimental This feature is under active development.
+	 *    You should be prepared for incompatible changes in future releases.
 	 */
 	PojoOtherEntityDependencyContext fromOtherEntity(Class<?> otherEntityType,
 			PojoModelPathValueNode pathFromOtherEntityTypeToBridgedType);


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3298

~Based on #1962 , which should be merged first.~ => Done