### PR TITLE
HSEARCH-3541 + HSEARCH-3568 Upgrade to Elasticsearch 7.0.0 (release) and 6.7.1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -185,8 +185,8 @@ stage('Configure') {
 			esLocal: [
 					new EsLocalITEnvironment(versionRange: '[5.6,6.0)', mavenProfile: 'elasticsearch-5.6', status: ITEnvironmentStatus.SUPPORTED),
 					new EsLocalITEnvironment(versionRange: '[6.0,6.7)', mavenProfile: 'elasticsearch-6.0', status: ITEnvironmentStatus.SUPPORTED),
-					new EsLocalITEnvironment(versionRange: '[6.7,7.0)', mavenProfile: 'elasticsearch-6.7', status: ITEnvironmentStatus.USED_IN_DEFAULT_BUILD),
-					new EsLocalITEnvironment(versionRange: '[7.0,7.x)', mavenProfile: 'elasticsearch-7.0', status: ITEnvironmentStatus.SUPPORTED)
+					new EsLocalITEnvironment(versionRange: '[6.7,7.0)', mavenProfile: 'elasticsearch-6.7', status: ITEnvironmentStatus.SUPPORTED),
+					new EsLocalITEnvironment(versionRange: '[7.0,7.x)', mavenProfile: 'elasticsearch-7.0', status: ITEnvironmentStatus.USED_IN_DEFAULT_BUILD)
 			],
 			esAws: [
 					new EsAwsITEnvironment(version: '5.6', mavenProfile: 'elasticsearch-5.6', status: ITEnvironmentStatus.SUPPORTED),

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ The following profiles are available:
 
  * `elasticsearch-5.6` for 5.6.x and later 5.x
  * `elasticsearch-6.0` for 6.0.x to 6.6.x
- * `elasticsearch-6.7` for 6.7 (the default)
- * `elasticsearch-7.0` for 7.x
+ * `elasticsearch-6.7` for 6.7
+ * `elasticsearch-7.0` for 7.x (the default)
 
 A list of available versions for `test.elasticsearch.host.version` can be found on
 [Maven Central](https://search.maven.org/search?q=g:org.elasticsearch%20AND%20a:elasticsearch&core=gav).

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/impl/ElasticsearchClientFactoryImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/impl/ElasticsearchClientFactoryImpl.java
@@ -139,13 +139,6 @@ public class ElasticsearchClientFactoryImpl implements ElasticsearchClientFactor
 		ServerUris hosts = ServerUris.fromStrings( HOST.get( propertySource ) );
 
 		return RestClient.builder( hosts.asHostsArray() )
-				/*
-				 * Note: this timeout is currently only used on retries,
-				 * but should we start using the synchronous methods of RestClient,
-				 * it would be applied to synchronous requests too.
-				 * See https://github.com/elastic/elasticsearch/issues/21789#issuecomment-287399115
-				 */
-				.setMaxRetryTimeoutMillis( maxRetryTimeoutMillis )
 				.setRequestConfigCallback( b -> customizeRequestConfig( b, propertySource ) )
 				.setHttpClientConfigCallback(
 						b -> customizeHttpClientConfig( b, httpClientConfigurers, propertySource, hosts )

--- a/pom.xml
+++ b/pom.xml
@@ -2372,7 +2372,7 @@
         <profile>
             <id>elasticsearch-7.0</id>
             <properties>
-                <test.elasticsearch.host.version>7.0.0-beta1</test.elasticsearch.host.version>
+                <test.elasticsearch.host.version>7.0.0</test.elasticsearch.host.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.dialect.Elasticsearch7TestDialect</test.elasticsearch.testdialect>
             </properties>
             <build>

--- a/pom.xml
+++ b/pom.xml
@@ -2342,7 +2342,7 @@
         <profile>
             <id>elasticsearch-6.7</id>
             <properties>
-                <test.elasticsearch.host.version>6.7.0</test.elasticsearch.host.version>
+                <test.elasticsearch.host.version>6.7.1</test.elasticsearch.host.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.dialect.Elasticsearch67TestDialect</test.elasticsearch.testdialect>
             </properties>
             <build>

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
         <!-- When updating the following versions you will likely need to update the
              matching test profile as well, e.g. elasticsearch-5.2 for the 5.2+ series -->
         <!-- The main version of Elasticsearch targeted by Hibernate Search, tested in the default profile -->
-        <version.org.elasticsearch.main>6.7.0</version.org.elasticsearch.main>
+        <version.org.elasticsearch.main>7.0.0</version.org.elasticsearch.main>
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently from the version of the remote cluster -->
         <version.org.elasticsearch.client>${version.org.elasticsearch.main}</version.org.elasticsearch.client>
         <documentation.org.elasticsearch.url>https://www.elastic.co/guide/en/elasticsearch/reference/${parsed-version.org.elasticsearch.main.majorVersion}.${parsed-version.org.elasticsearch.main.minorVersion}</documentation.org.elasticsearch.url>
@@ -2338,17 +2338,11 @@
             </build>
         </profile>
 
-        <!-- Elasticsearch 6.7 test environment (default) -->
+        <!-- Elasticsearch 6.7 test environment -->
         <profile>
             <id>elasticsearch-6.7</id>
-            <activation>
-                <!-- Activate by default, i.e. if test.elasticsearch.host.version has not been defined explicitly -->
-                <property>
-                    <name>!test.elasticsearch.host.version</name>
-                </property>
-            </activation>
             <properties>
-                <test.elasticsearch.host.version>${version.org.elasticsearch.main}</test.elasticsearch.host.version>
+                <test.elasticsearch.host.version>6.7.0</test.elasticsearch.host.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.dialect.Elasticsearch67TestDialect</test.elasticsearch.testdialect>
             </properties>
             <build>
@@ -2368,11 +2362,17 @@
             </build>
         </profile>
 
-        <!-- Elasticsearch 7.0+ test environment -->
+        <!-- Elasticsearch 7.0+ test environment (default) -->
         <profile>
             <id>elasticsearch-7.0</id>
+            <activation>
+                <!-- Activate by default, i.e. if test.elasticsearch.host.version has not been defined explicitly -->
+                <property>
+                    <name>!test.elasticsearch.host.version</name>
+                </property>
+            </activation>
             <properties>
-                <test.elasticsearch.host.version>7.0.0</test.elasticsearch.host.version>
+                <test.elasticsearch.host.version>${version.org.elasticsearch.main}</test.elasticsearch.host.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.dialect.Elasticsearch7TestDialect</test.elasticsearch.testdialect>
             </properties>
             <build>


### PR DESCRIPTION
* [HSEARCH-3541](https://hibernate.atlassian.net//browse/HSEARCH-3541): Upgrade to Elasticsearch 7.0.0 (release)
* [HSEARCH-3568](https://hibernate.atlassian.net//browse/HSEARCH-3568): Upgrade to Elasticsearch 6.7.1

Full build: http://ci.hibernate.org/blue/organizations/jenkins/hibernate-search/detail/PR-1964/2
