### PR TITLE
HSEARCH-3536 Use Analyzer.normalize instead of our own code for normalization

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchSimpleQueryStringPredicateBuilder.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchSimpleQueryStringPredicateBuilder.java
@@ -17,7 +17,7 @@ import org.hibernate.search.backend.elasticsearch.search.impl.ElasticsearchSearc
 import org.hibernate.search.backend.elasticsearch.search.impl.ElasticsearchSucceedingCompatibilityChecker;
 import org.hibernate.search.backend.elasticsearch.types.predicate.impl.ElasticsearchFieldPredicateBuilderFactory;
 import org.hibernate.search.backend.elasticsearch.types.predicate.impl.ElasticsearchSimpleQueryStringPredicateBuilderFieldContext;
-import org.hibernate.search.backend.elasticsearch.util.impl.AnalyzerUtils;
+import org.hibernate.search.backend.elasticsearch.util.impl.AnalyzerConstants;
 import org.hibernate.search.engine.search.predicate.spi.SimpleQueryStringPredicateBuilder;
 
 import com.google.gson.JsonArray;
@@ -80,7 +80,7 @@ public class ElasticsearchSimpleQueryStringPredicateBuilder extends AbstractElas
 
 	@Override
 	public void skipAnalysis() {
-		analyzer( AnalyzerUtils.KEYWORD_ANALYZER );
+		analyzer( AnalyzerConstants.KEYWORD_ANALYZER );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchTextMatchPredicateBuilder.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchTextMatchPredicateBuilder.java
@@ -15,7 +15,7 @@ import org.hibernate.search.backend.elasticsearch.search.impl.ElasticsearchCompa
 import org.hibernate.search.backend.elasticsearch.search.impl.ElasticsearchSearchContext;
 import org.hibernate.search.backend.elasticsearch.search.predicate.impl.ElasticsearchSearchPredicateContext;
 import org.hibernate.search.backend.elasticsearch.types.codec.impl.ElasticsearchFieldCodec;
-import org.hibernate.search.backend.elasticsearch.util.impl.AnalyzerUtils;
+import org.hibernate.search.backend.elasticsearch.util.impl.AnalyzerConstants;
 import org.hibernate.search.engine.backend.types.converter.ToDocumentFieldValueConverter;
 import org.hibernate.search.engine.reporting.spi.EventContexts;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
@@ -65,7 +65,7 @@ class ElasticsearchTextMatchPredicateBuilder extends ElasticsearchStandardMatchP
 			throw log.skipAnalysisOnKeywordField( absoluteFieldPath, EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
 		}
 
-		analyzer( AnalyzerUtils.KEYWORD_ANALYZER );
+		analyzer( AnalyzerConstants.KEYWORD_ANALYZER );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchTextPhrasePredicateBuilder.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchTextPhrasePredicateBuilder.java
@@ -12,7 +12,7 @@ import org.hibernate.search.backend.elasticsearch.search.impl.ElasticsearchCompa
 import org.hibernate.search.backend.elasticsearch.search.predicate.impl.AbstractElasticsearchSearchPredicateBuilder;
 import org.hibernate.search.backend.elasticsearch.search.predicate.impl.ElasticsearchSearchPredicateBuilder;
 import org.hibernate.search.backend.elasticsearch.search.predicate.impl.ElasticsearchSearchPredicateContext;
-import org.hibernate.search.backend.elasticsearch.util.impl.AnalyzerUtils;
+import org.hibernate.search.backend.elasticsearch.util.impl.AnalyzerConstants;
 import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
 
 import com.google.gson.JsonElement;
@@ -57,7 +57,7 @@ class ElasticsearchTextPhrasePredicateBuilder extends AbstractElasticsearchSearc
 
 	@Override
 	public void skipAnalysis() {
-		analyzer( AnalyzerUtils.KEYWORD_ANALYZER );
+		analyzer( AnalyzerConstants.KEYWORD_ANALYZER );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/util/impl/AnalyzerConstants.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/util/impl/AnalyzerConstants.java
@@ -6,11 +6,11 @@
  */
 package org.hibernate.search.backend.elasticsearch.util.impl;
 
-public final class AnalyzerUtils {
+public final class AnalyzerConstants {
 
 	public static final String KEYWORD_ANALYZER = "keyword";
 
-	private AnalyzerUtils() {
+	private AnalyzerConstants() {
 		// Not used
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/analysis/impl/ScopedAnalyzer.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/analysis/impl/ScopedAnalyzer.java
@@ -12,7 +12,7 @@ import java.util.Map;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.DelegatingAnalyzerWrapper;
 
-import org.hibernate.search.backend.lucene.util.impl.AnalyzerUtils;
+import org.hibernate.search.backend.lucene.util.impl.AnalyzerConstants;
 import org.hibernate.search.util.common.impl.CollectionHelper;
 
 /**
@@ -32,7 +32,7 @@ public final class ScopedAnalyzer extends DelegatingAnalyzerWrapper {
 		Analyzer analyzer = scopedAnalyzers.get( absoluteFieldPath );
 
 		if ( analyzer == null ) {
-			return AnalyzerUtils.KEYWORD_ANALYZER;
+			return AnalyzerConstants.KEYWORD_ANALYZER;
 		}
 
 		return analyzer;

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/analysis/impl/TokenizerChain.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/analysis/impl/TokenizerChain.java
@@ -55,6 +55,25 @@ final class TokenizerChain extends Analyzer {
 	}
 
 	@Override
+	protected Reader initReaderForNormalization(String fieldName, Reader reader) {
+		// same as Lucene8's CustomAnalyzer
+		for ( CharFilterFactory charFilter : charFilters ) {
+			reader = charFilter.normalize( reader );
+		}
+		return reader;
+	}
+
+	@Override
+	protected TokenStream normalize(String fieldName, TokenStream in) {
+		// same as Lucene8's CustomAnalyzer
+		TokenStream result = in;
+		for ( TokenFilterFactory filter : filters ) {
+			result = filter.normalize( result );
+		}
+		return result;
+	}
+
+	@Override
 	public String toString() {
 		final StringBuilder sb = new StringBuilder( "TokenizerChain(" );
 		for ( CharFilterFactory filter : charFilters ) {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/LuceneSimpleQueryStringPredicateBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/LuceneSimpleQueryStringPredicateBuilder.java
@@ -20,7 +20,7 @@ import org.hibernate.search.backend.lucene.search.impl.LuceneSearchScopeModel;
 import org.hibernate.search.backend.lucene.search.impl.LuceneSucceedingCompatibilityChecker;
 import org.hibernate.search.backend.lucene.types.predicate.impl.LuceneFieldPredicateBuilderFactory;
 import org.hibernate.search.backend.lucene.types.predicate.impl.LuceneSimpleQueryStringPredicateBuilderFieldContext;
-import org.hibernate.search.backend.lucene.util.impl.AnalyzerUtils;
+import org.hibernate.search.backend.lucene.util.impl.AnalyzerConstants;
 import org.hibernate.search.backend.lucene.util.impl.FieldContextSimpleQueryParser;
 import org.hibernate.search.engine.reporting.spi.EventContexts;
 import org.hibernate.search.engine.search.predicate.spi.SimpleQueryStringPredicateBuilder;
@@ -101,7 +101,7 @@ public class LuceneSimpleQueryStringPredicateBuilder extends AbstractLuceneSearc
 
 	private Analyzer buildAnalyzer() {
 		if ( ignoreAnalyzer ) {
-			return AnalyzerUtils.KEYWORD_ANALYZER;
+			return AnalyzerConstants.KEYWORD_ANALYZER;
 		}
 		if ( overrideAnalyzer != null ) {
 			return overrideAnalyzer;

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneStringFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneStringFieldCodec.java
@@ -52,10 +52,7 @@ public final class LuceneStringFieldCodec implements LuceneTextFieldCodec<String
 		documentBuilder.addField( new Field( absoluteFieldPath, value, fieldType ) );
 
 		if ( sortable ) {
-			documentBuilder.addField( new SortedDocValuesField(
-					absoluteFieldPath,
-					new BytesRef( normalize( absoluteFieldPath, value ) )
-			) );
+			documentBuilder.addField( new SortedDocValuesField( absoluteFieldPath, normalize( absoluteFieldPath, value ) ) );
 		}
 
 		if ( !sortable && fieldType.omitNorms() ) {
@@ -103,13 +100,13 @@ public final class LuceneStringFieldCodec implements LuceneTextFieldCodec<String
 	}
 
 	@Override
-	public String normalize(String absoluteFieldPath, String value) {
+	public BytesRef normalize(String absoluteFieldPath, String value) {
 		if ( value == null ) {
 			return null;
 		}
-
-		return analyzerOrNormalizer != null
-				? analyzerOrNormalizer.normalize( absoluteFieldPath, value ).utf8ToString()
-				: value;
+		if ( analyzerOrNormalizer == null ) {
+			return new BytesRef( value );
+		}
+		return analyzerOrNormalizer.normalize( absoluteFieldPath, value );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneStringFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneStringFieldCodec.java
@@ -20,7 +20,6 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
 import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
-import org.hibernate.search.backend.lucene.util.impl.AnalyzerUtils;
 import org.hibernate.search.backend.lucene.util.impl.LuceneFields;
 
 public final class LuceneStringFieldCodec implements LuceneTextFieldCodec<String> {
@@ -110,7 +109,7 @@ public final class LuceneStringFieldCodec implements LuceneTextFieldCodec<String
 		}
 
 		return analyzerOrNormalizer != null
-				? AnalyzerUtils.normalize( analyzerOrNormalizer, absoluteFieldPath, value )
+				? analyzerOrNormalizer.normalize( absoluteFieldPath, value ).utf8ToString()
 				: value;
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneTextFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneTextFieldCodec.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.backend.lucene.types.codec.impl;
 
+import org.apache.lucene.util.BytesRef;
+
 /**
  * @param <F> The field type exposed to the mapper.
  */
@@ -18,7 +20,8 @@ public interface LuceneTextFieldCodec<F> extends LuceneStandardFieldCodec<F, Str
 	 *
 	 * @param absoluteFieldPath The absolute path of the field.
 	 * @param value The value to encode.
+	 * @return the BytesRef normalized value
 	 */
-	String normalize(String absoluteFieldPath, String value);
+	BytesRef normalize(String absoluteFieldPath, String value);
 
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneTextMatchPredicateBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneTextMatchPredicateBuilder.java
@@ -23,7 +23,7 @@ import org.hibernate.search.backend.lucene.search.impl.LuceneSearchContext;
 import org.hibernate.search.backend.lucene.search.predicate.impl.AbstractLuceneStandardMatchPredicateBuilder;
 import org.hibernate.search.backend.lucene.search.predicate.impl.LuceneSearchPredicateContext;
 import org.hibernate.search.backend.lucene.types.codec.impl.LuceneTextFieldCodec;
-import org.hibernate.search.backend.lucene.util.impl.AnalyzerUtils;
+import org.hibernate.search.backend.lucene.util.impl.AnalyzerConstants;
 import org.hibernate.search.backend.lucene.util.impl.FuzzyQueryBuilder;
 import org.hibernate.search.engine.backend.types.converter.ToDocumentFieldValueConverter;
 import org.hibernate.search.engine.reporting.spi.EventContexts;
@@ -72,7 +72,7 @@ class LuceneTextMatchPredicateBuilder<F>
 
 	@Override
 	public void skipAnalysis() {
-		this.analyzer = AnalyzerUtils.KEYWORD_ANALYZER;
+		this.analyzer = AnalyzerConstants.KEYWORD_ANALYZER;
 		this.analyzerOverridden = true;
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneTextPhrasePredicateBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneTextPhrasePredicateBuilder.java
@@ -16,7 +16,7 @@ import org.hibernate.search.backend.lucene.search.predicate.impl.AbstractLuceneS
 import org.hibernate.search.backend.lucene.search.predicate.impl.LuceneSearchPredicateBuilder;
 import org.hibernate.search.backend.lucene.search.predicate.impl.LuceneSearchPredicateContext;
 import org.hibernate.search.backend.lucene.types.codec.impl.LuceneTextFieldCodec;
-import org.hibernate.search.backend.lucene.util.impl.AnalyzerUtils;
+import org.hibernate.search.backend.lucene.util.impl.AnalyzerConstants;
 import org.hibernate.search.engine.reporting.spi.EventContexts;
 import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
@@ -77,7 +77,7 @@ class LuceneTextPhrasePredicateBuilder extends AbstractLuceneSearchPredicateBuil
 
 	@Override
 	public void skipAnalysis() {
-		this.analyzer = AnalyzerUtils.KEYWORD_ANALYZER;
+		this.analyzer = AnalyzerConstants.KEYWORD_ANALYZER;
 		this.analyzerOverridden = true;
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneTextRangePredicateBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneTextRangePredicateBuilder.java
@@ -33,7 +33,7 @@ class LuceneTextRangePredicateBuilder<F>
 		// and we should even consider forcing having a normalizer here, instead of supporting
 		// range queries on analyzed fields.
 
-		return TermRangeQuery.newStringRange(
+		return new TermRangeQuery(
 				absoluteFieldPath,
 				codec.normalize( absoluteFieldPath, lowerLimit ),
 				codec.normalize( absoluteFieldPath, upperLimit ),

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/LuceneTextFieldSortBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/sort/impl/LuceneTextFieldSortBuilder.java
@@ -27,7 +27,7 @@ public class LuceneTextFieldSortBuilder<F>
 
 	@Override
 	protected Object encodeMissingAs(F converted) {
-		return codec.normalize( absoluteFieldPath, codec.encode( converted ) );
+		return codec.normalize( absoluteFieldPath, codec.encode( converted ) ).utf8ToString();
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/util/impl/AnalyzerConstants.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/util/impl/AnalyzerConstants.java
@@ -9,16 +9,11 @@ package org.hibernate.search.backend.lucene.util.impl;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.core.KeywordAnalyzer;
 
-/**
- * Analysis helpers that have no reason to be exposed publicly.
- *
- * @author Yoann Rodiere
- */
-public final class AnalyzerUtils {
+public final class AnalyzerConstants {
 
 	public static final Analyzer KEYWORD_ANALYZER = new KeywordAnalyzer();
 
-	private AnalyzerUtils() {
+	private AnalyzerConstants() {
 		// Not used
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/util/impl/AnalyzerUtils.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/util/impl/AnalyzerUtils.java
@@ -6,17 +6,8 @@
  */
 package org.hibernate.search.backend.lucene.util.impl;
 
-import java.io.IOException;
-import java.io.StringReader;
-import java.lang.invoke.MethodHandles;
-
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.core.KeywordAnalyzer;
-import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
-import org.hibernate.search.backend.lucene.logging.impl.Log;
-import org.hibernate.search.util.common.SearchException;
-import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
 /**
  * Analysis helpers that have no reason to be exposed publicly.
@@ -27,40 +18,7 @@ public final class AnalyzerUtils {
 
 	public static final Analyzer KEYWORD_ANALYZER = new KeywordAnalyzer();
 
-	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
-
 	private AnalyzerUtils() {
 		// Not used
-	}
-
-	/**
-	 * Returns the first token resulting from the analysis, logging a warning if there are more than one token.
-	 *
-	 * @param analyzer the Lucene analyzer to use
-	 * @param fieldName the name of the field: might affect the analyzer behavior
-	 * @param text the value to analyze
-	 * @return the first token resulting from the analysis
-	 *
-	 * @throws SearchException if a problem occurs when analyzing the sortable field's value.
-	 */
-	public static String normalize(Analyzer analyzer, String fieldName, String text) {
-		try ( TokenStream stream = analyzer.tokenStream( fieldName, new StringReader( text ) ) ) {
-			String firstToken = null;
-			CharTermAttribute term = stream.addAttribute( CharTermAttribute.class );
-			stream.reset();
-			if ( stream.incrementToken() ) {
-				firstToken = new String( term.buffer(), 0, term.length() );
-				if ( stream.incrementToken() ) {
-					log.multipleTermsDetectedDuringNormalization( fieldName );
-				}
-				else {
-					stream.end();
-				}
-			}
-			return firstToken;
-		}
-		catch (SearchException | IOException e) {
-			throw log.couldNotNormalizeField( fieldName, e );
-		}
 	}
 }

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/configuration/AnalysisCustomITAnalysisConfigurer.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/configuration/AnalysisCustomITAnalysisConfigurer.java
@@ -13,9 +13,15 @@ import org.hibernate.search.integrationtest.backend.tck.analysis.AnalysisCustomI
 public class AnalysisCustomITAnalysisConfigurer implements ElasticsearchAnalysisConfigurer {
 	@Override
 	public void configure(ElasticsearchAnalysisDefinitionContainerContext context) {
+		String charFilterName = AnalysisCustomIT.AnalysisDefinitions.ANALYZER_PATTERNS_STOPWORD.name + "_charFilter";
+		String tokenizerName = AnalysisCustomIT.AnalysisDefinitions.ANALYZER_PATTERNS_STOPWORD.name + "_tokenizer";
+		String tokenFilterName = AnalysisCustomIT.AnalysisDefinitions.ANALYZER_PATTERNS_STOPWORD.name + "_tokenFilter";
+
 		context.normalizer( AnalysisCustomIT.AnalysisDefinitions.NORMALIZER_NOOP.name ).custom();
 		context.normalizer( AnalysisCustomIT.AnalysisDefinitions.NORMALIZER_LOWERCASE.name ).custom()
 				.withTokenFilters( "lowercase" );
+		context.normalizer( AnalysisCustomIT.AnalysisDefinitions.NORMALIZER_PATTERN_REPLACING.name ).custom()
+				.withCharFilters( charFilterName );
 
 		context.analyzer( AnalysisCustomIT.AnalysisDefinitions.ANALYZER_NOOP.name ).custom()
 				.withTokenizer( "keyword" );
@@ -23,9 +29,6 @@ public class AnalysisCustomITAnalysisConfigurer implements ElasticsearchAnalysis
 				.withTokenizer( "whitespace" )
 				.withTokenFilters( "lowercase" );
 
-		String charFilterName = AnalysisCustomIT.AnalysisDefinitions.ANALYZER_PATTERNS_STOPWORD.name + "_charFilter";
-		String tokenizerName = AnalysisCustomIT.AnalysisDefinitions.ANALYZER_PATTERNS_STOPWORD.name + "_tokenizer";
-		String tokenFilterName = AnalysisCustomIT.AnalysisDefinitions.ANALYZER_PATTERNS_STOPWORD.name + "_tokenFilter";
 		context.analyzer( AnalysisCustomIT.AnalysisDefinitions.ANALYZER_PATTERNS_STOPWORD.name ).custom()
 				.withTokenizer( tokenizerName )
 				.withCharFilters( charFilterName )

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/testsupport/configuration/AnalysisCustomITAnalysisConfigurer.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/testsupport/configuration/AnalysisCustomITAnalysisConfigurer.java
@@ -23,6 +23,10 @@ public class AnalysisCustomITAnalysisConfigurer implements LuceneAnalysisConfigu
 		context.normalizer( AnalysisCustomIT.AnalysisDefinitions.NORMALIZER_NOOP.name ).custom();
 		context.normalizer( AnalysisCustomIT.AnalysisDefinitions.NORMALIZER_LOWERCASE.name ).custom()
 				.tokenFilter( LowerCaseFilterFactory.class );
+		context.normalizer( AnalysisCustomIT.AnalysisDefinitions.NORMALIZER_PATTERN_REPLACING.name ).custom()
+				.charFilter( PatternReplaceCharFilterFactory.class )
+				.param( "pattern", "\\s+" )
+				.param( "replacement", "," );
 
 		context.analyzer( AnalysisCustomIT.AnalysisDefinitions.ANALYZER_NOOP.name ).custom()
 				.tokenizer( KeywordTokenizerFactory.class );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/analysis/AnalysisCustomIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/analysis/AnalysisCustomIT.java
@@ -55,6 +55,10 @@ public class AnalysisCustomIT {
 		 */
 		NORMALIZER_LOWERCASE("normalizer_lowercase"),
 		/**
+		 * Normalizer with a pattern-replacing char filter replacing "\s+" with ",".
+		 */
+		NORMALIZER_PATTERN_REPLACING("normalizer_pattern_replacing"),
+		/**
 		 * No-op analyzer.
 		 */
 		ANALYZER_NOOP("analyzer_noop"),
@@ -134,6 +138,29 @@ public class AnalysisCustomIT {
 				.hasDocRefHitsAnyOrder( INDEX_NAME, "3" );
 		assertMatchQuery( "WorD Word" )
 				.hasDocRefHitsAnyOrder( INDEX_NAME, "4" );
+	}
+
+	@Test
+	public void normalizer_pattern_replacing() {
+		setupWithNormalizer( AnalysisDefinitions.NORMALIZER_PATTERN_REPLACING );
+		initData( b -> {
+			b.document( "empty" );
+			b.document( "1", "word" );
+			b.document( "2", "WORD" );
+			b.document( "3", "wôrd" );
+			b.document( "4", "word word" );
+			b.document( "5", "word,word" );
+		} );
+
+		// We expect any ',' will be treated as a space character
+		assertMatchQuery( "word" )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, "1" );
+		assertMatchQuery( "WORD" )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, "2" );
+		assertMatchQuery( "wôrd" )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, "3" );
+		assertMatchQuery( "word word" )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, "4", "5" );
 	}
 
 	@Test


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3536

@yrodiere as you found out Analyzer.normalize method works only if we use the Lucene's 'CustomAnalyzer.builder'.
I think that our analyzers don't. So they have to override them to work as 'CustomAnalyzer' does.

In a second commit I renamed the utility classes, we can drop it.
