### PR TITLE
HSEARCH-3571 Extra type name parameters trigger warnings in ES6.7+

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/builder/factory/impl/Elasticsearch60WorkBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/builder/factory/impl/Elasticsearch60WorkBuilderFactory.java
@@ -12,9 +12,11 @@ import org.hibernate.search.backend.elasticsearch.gson.spi.GsonProvider;
 import org.hibernate.search.backend.elasticsearch.util.spi.URLEncodedString;
 import org.hibernate.search.backend.elasticsearch.work.builder.impl.CreateIndexWorkBuilder;
 import org.hibernate.search.backend.elasticsearch.work.builder.impl.GetIndexTypeMappingWorkBuilder;
+import org.hibernate.search.backend.elasticsearch.work.builder.impl.IndexExistsWorkBuilder;
 import org.hibernate.search.backend.elasticsearch.work.builder.impl.PutIndexMappingWorkBuilder;
 import org.hibernate.search.backend.elasticsearch.work.impl.CreateIndexWork;
 import org.hibernate.search.backend.elasticsearch.work.impl.GetIndexTypeMappingWork;
+import org.hibernate.search.backend.elasticsearch.work.impl.IndexExistsWork;
 import org.hibernate.search.backend.elasticsearch.work.impl.PutIndexTypeMappingWork;
 
 /**
@@ -35,6 +37,11 @@ public class Elasticsearch60WorkBuilderFactory extends Elasticsearch67WorkBuilde
 	@Override
 	public CreateIndexWorkBuilder createIndex(URLEncodedString indexName) {
 		return CreateIndexWork.Builder.forElasticsearch66AndBelow( gsonProvider, indexName, Paths.DOC );
+	}
+
+	@Override
+	public IndexExistsWorkBuilder indexExists(URLEncodedString indexName) {
+		return IndexExistsWork.Builder.forElasticsearch66AndBelow( indexName );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/builder/factory/impl/Elasticsearch67WorkBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/builder/factory/impl/Elasticsearch67WorkBuilderFactory.java
@@ -11,15 +11,19 @@ import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.R
 import org.hibernate.search.backend.elasticsearch.gson.spi.GsonProvider;
 import org.hibernate.search.backend.elasticsearch.util.spi.URLEncodedString;
 import org.hibernate.search.backend.elasticsearch.work.builder.impl.CreateIndexWorkBuilder;
+import org.hibernate.search.backend.elasticsearch.work.builder.impl.DeleteWorkBuilder;
 import org.hibernate.search.backend.elasticsearch.work.builder.impl.GetIndexTypeMappingWorkBuilder;
 import org.hibernate.search.backend.elasticsearch.work.builder.impl.IndexExistsWorkBuilder;
+import org.hibernate.search.backend.elasticsearch.work.builder.impl.IndexWorkBuilder;
 import org.hibernate.search.backend.elasticsearch.work.builder.impl.PutIndexMappingWorkBuilder;
 import org.hibernate.search.backend.elasticsearch.work.builder.impl.SearchWorkBuilder;
 import org.hibernate.search.backend.elasticsearch.work.impl.CreateIndexWork;
+import org.hibernate.search.backend.elasticsearch.work.impl.DeleteWork;
 import org.hibernate.search.backend.elasticsearch.work.impl.ElasticsearchSearchResultExtractor;
 import org.hibernate.search.backend.elasticsearch.work.impl.ElasticsearchSearchWork;
 import org.hibernate.search.backend.elasticsearch.work.impl.GetIndexTypeMappingWork;
 import org.hibernate.search.backend.elasticsearch.work.impl.IndexExistsWork;
+import org.hibernate.search.backend.elasticsearch.work.impl.IndexWork;
 import org.hibernate.search.backend.elasticsearch.work.impl.PutIndexTypeMappingWork;
 
 import com.google.gson.JsonObject;
@@ -39,6 +43,16 @@ public class Elasticsearch67WorkBuilderFactory extends Elasticsearch7WorkBuilder
 
 	public Elasticsearch67WorkBuilderFactory(GsonProvider gsonProvider) {
 		super( gsonProvider );
+	}
+
+	@Override
+	public IndexWorkBuilder index(URLEncodedString indexName, URLEncodedString id, String routingKey, JsonObject document) {
+		return IndexWork.Builder.forElasticsearch67AndBelow( indexName, Paths.DOC, id, routingKey, document );
+	}
+
+	@Override
+	public DeleteWorkBuilder delete(URLEncodedString indexName, URLEncodedString id, String routingKey) {
+		return DeleteWork.Builder.forElasticsearch67AndBelow( indexName, Paths.DOC, id, routingKey );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/builder/factory/impl/Elasticsearch67WorkBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/builder/factory/impl/Elasticsearch67WorkBuilderFactory.java
@@ -12,12 +12,14 @@ import org.hibernate.search.backend.elasticsearch.gson.spi.GsonProvider;
 import org.hibernate.search.backend.elasticsearch.util.spi.URLEncodedString;
 import org.hibernate.search.backend.elasticsearch.work.builder.impl.CreateIndexWorkBuilder;
 import org.hibernate.search.backend.elasticsearch.work.builder.impl.GetIndexTypeMappingWorkBuilder;
+import org.hibernate.search.backend.elasticsearch.work.builder.impl.IndexExistsWorkBuilder;
 import org.hibernate.search.backend.elasticsearch.work.builder.impl.PutIndexMappingWorkBuilder;
 import org.hibernate.search.backend.elasticsearch.work.builder.impl.SearchWorkBuilder;
 import org.hibernate.search.backend.elasticsearch.work.impl.CreateIndexWork;
 import org.hibernate.search.backend.elasticsearch.work.impl.ElasticsearchSearchResultExtractor;
 import org.hibernate.search.backend.elasticsearch.work.impl.ElasticsearchSearchWork;
 import org.hibernate.search.backend.elasticsearch.work.impl.GetIndexTypeMappingWork;
+import org.hibernate.search.backend.elasticsearch.work.impl.IndexExistsWork;
 import org.hibernate.search.backend.elasticsearch.work.impl.PutIndexTypeMappingWork;
 
 import com.google.gson.JsonObject;
@@ -48,6 +50,11 @@ public class Elasticsearch67WorkBuilderFactory extends Elasticsearch7WorkBuilder
 	@Override
 	public CreateIndexWorkBuilder createIndex(URLEncodedString indexName) {
 		return CreateIndexWork.Builder.forElasticsearch67( gsonProvider, indexName, Paths.DOC );
+	}
+
+	@Override
+	public IndexExistsWorkBuilder indexExists(URLEncodedString indexName) {
+		return IndexExistsWork.Builder.forElasticsearch67( indexName );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/builder/factory/impl/Elasticsearch67WorkBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/builder/factory/impl/Elasticsearch67WorkBuilderFactory.java
@@ -12,6 +12,7 @@ import org.hibernate.search.backend.elasticsearch.gson.spi.GsonProvider;
 import org.hibernate.search.backend.elasticsearch.util.spi.URLEncodedString;
 import org.hibernate.search.backend.elasticsearch.work.builder.impl.CreateIndexWorkBuilder;
 import org.hibernate.search.backend.elasticsearch.work.builder.impl.DeleteWorkBuilder;
+import org.hibernate.search.backend.elasticsearch.work.builder.impl.ExplainWorkBuilder;
 import org.hibernate.search.backend.elasticsearch.work.builder.impl.GetIndexTypeMappingWorkBuilder;
 import org.hibernate.search.backend.elasticsearch.work.builder.impl.IndexExistsWorkBuilder;
 import org.hibernate.search.backend.elasticsearch.work.builder.impl.IndexWorkBuilder;
@@ -21,6 +22,7 @@ import org.hibernate.search.backend.elasticsearch.work.impl.CreateIndexWork;
 import org.hibernate.search.backend.elasticsearch.work.impl.DeleteWork;
 import org.hibernate.search.backend.elasticsearch.work.impl.ElasticsearchSearchResultExtractor;
 import org.hibernate.search.backend.elasticsearch.work.impl.ElasticsearchSearchWork;
+import org.hibernate.search.backend.elasticsearch.work.impl.ExplainWork;
 import org.hibernate.search.backend.elasticsearch.work.impl.GetIndexTypeMappingWork;
 import org.hibernate.search.backend.elasticsearch.work.impl.IndexExistsWork;
 import org.hibernate.search.backend.elasticsearch.work.impl.IndexWork;
@@ -62,6 +64,11 @@ public class Elasticsearch67WorkBuilderFactory extends Elasticsearch7WorkBuilder
 	}
 
 	@Override
+	public ExplainWorkBuilder explain(URLEncodedString indexName, URLEncodedString id, JsonObject payload) {
+		return ExplainWork.Builder.forElasticsearch67AndBelow( indexName, Paths.DOC, id, payload );
+	}
+
+	@Override
 	public CreateIndexWorkBuilder createIndex(URLEncodedString indexName) {
 		return CreateIndexWork.Builder.forElasticsearch67( gsonProvider, indexName, Paths.DOC );
 	}
@@ -79,10 +86,5 @@ public class Elasticsearch67WorkBuilderFactory extends Elasticsearch7WorkBuilder
 	@Override
 	public PutIndexMappingWorkBuilder putIndexTypeMapping(URLEncodedString indexName, RootTypeMapping mapping) {
 		return PutIndexTypeMappingWork.Builder.forElasticsearch67( gsonProvider, indexName, Paths.DOC, mapping );
-	}
-
-	@Override
-	protected URLEncodedString getTypeKeyword() {
-		return Paths.DOC;
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/builder/factory/impl/Elasticsearch67WorkBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/builder/factory/impl/Elasticsearch67WorkBuilderFactory.java
@@ -21,7 +21,7 @@ import org.hibernate.search.backend.elasticsearch.work.builder.impl.SearchWorkBu
 import org.hibernate.search.backend.elasticsearch.work.impl.CreateIndexWork;
 import org.hibernate.search.backend.elasticsearch.work.impl.DeleteWork;
 import org.hibernate.search.backend.elasticsearch.work.impl.ElasticsearchSearchResultExtractor;
-import org.hibernate.search.backend.elasticsearch.work.impl.ElasticsearchSearchWork;
+import org.hibernate.search.backend.elasticsearch.work.impl.SearchWork;
 import org.hibernate.search.backend.elasticsearch.work.impl.ExplainWork;
 import org.hibernate.search.backend.elasticsearch.work.impl.GetIndexTypeMappingWork;
 import org.hibernate.search.backend.elasticsearch.work.impl.IndexExistsWork;
@@ -60,7 +60,7 @@ public class Elasticsearch67WorkBuilderFactory extends Elasticsearch7WorkBuilder
 	@Override
 	public <T> SearchWorkBuilder<T> search(JsonObject payload,
 			ElasticsearchSearchResultExtractor<T> searchResultExtractor) {
-		return ElasticsearchSearchWork.Builder.forElasticsearch6AndBelow( payload, searchResultExtractor );
+		return SearchWork.Builder.forElasticsearch6AndBelow( payload, searchResultExtractor );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/builder/factory/impl/Elasticsearch7WorkBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/builder/factory/impl/Elasticsearch7WorkBuilderFactory.java
@@ -74,12 +74,12 @@ public class Elasticsearch7WorkBuilderFactory implements ElasticsearchWorkBuilde
 
 	@Override
 	public IndexWorkBuilder index(URLEncodedString indexName, URLEncodedString id, String routingKey, JsonObject document) {
-		return new IndexWork.Builder( indexName, getTypeKeyword(), id, routingKey, document );
+		return IndexWork.Builder.forElasticsearch7AndAbove( indexName, id, routingKey, document );
 	}
 
 	@Override
 	public DeleteWorkBuilder delete(URLEncodedString indexName, URLEncodedString id, String routingKey) {
-		return new DeleteWork.Builder( indexName, getTypeKeyword(), id, routingKey );
+		return DeleteWork.Builder.forElasticsearch7AndAbove( indexName, id, routingKey );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/builder/factory/impl/Elasticsearch7WorkBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/builder/factory/impl/Elasticsearch7WorkBuilderFactory.java
@@ -154,7 +154,7 @@ public class Elasticsearch7WorkBuilderFactory implements ElasticsearchWorkBuilde
 
 	@Override
 	public IndexExistsWorkBuilder indexExists(URLEncodedString indexName) {
-		return new IndexExistsWork.Builder( indexName );
+		return IndexExistsWork.Builder.forElasticsearch7AndAbove( indexName );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/builder/factory/impl/Elasticsearch7WorkBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/builder/factory/impl/Elasticsearch7WorkBuilderFactory.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexStatus;
-import org.hibernate.search.backend.elasticsearch.client.impl.Paths;
 import org.hibernate.search.backend.elasticsearch.document.model.impl.esnative.RootTypeMapping;
 import org.hibernate.search.backend.elasticsearch.gson.spi.GsonProvider;
 import org.hibernate.search.backend.elasticsearch.index.settings.impl.esnative.IndexSettings;
@@ -59,7 +58,7 @@ import org.hibernate.search.backend.elasticsearch.work.impl.PutIndexSettingsWork
 import org.hibernate.search.backend.elasticsearch.work.impl.PutIndexTypeMappingWork;
 import org.hibernate.search.backend.elasticsearch.work.impl.RefreshWork;
 import org.hibernate.search.backend.elasticsearch.work.impl.ScrollWork;
-import org.hibernate.search.backend.elasticsearch.work.impl.ElasticsearchSearchWork;
+import org.hibernate.search.backend.elasticsearch.work.impl.SearchWork;
 import org.hibernate.search.backend.elasticsearch.work.impl.WaitForIndexStatusWork;
 
 import com.google.gson.JsonObject;
@@ -109,7 +108,7 @@ public class Elasticsearch7WorkBuilderFactory implements ElasticsearchWorkBuilde
 
 	@Override
 	public <T> SearchWorkBuilder<T> search(JsonObject payload, ElasticsearchSearchResultExtractor<T> searchResultExtractor) {
-		return ElasticsearchSearchWork.Builder.forElasticsearch7AndAbove( payload, searchResultExtractor );
+		return SearchWork.Builder.forElasticsearch7AndAbove( payload, searchResultExtractor );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/builder/factory/impl/Elasticsearch7WorkBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/builder/factory/impl/Elasticsearch7WorkBuilderFactory.java
@@ -119,7 +119,7 @@ public class Elasticsearch7WorkBuilderFactory implements ElasticsearchWorkBuilde
 
 	@Override
 	public ExplainWorkBuilder explain(URLEncodedString indexName, URLEncodedString id, JsonObject payload) {
-		return new ExplainWork.Builder( indexName, getTypeKeyword(), id, payload );
+		return ExplainWork.Builder.forElasticsearch7AndAbove( indexName, id, payload );
 	}
 
 	@Override
@@ -180,10 +180,6 @@ public class Elasticsearch7WorkBuilderFactory implements ElasticsearchWorkBuilde
 	@Override
 	public WaitForIndexStatusWorkBuilder waitForIndexStatusWork(URLEncodedString indexName, ElasticsearchIndexStatus requiredStatus, String timeout) {
 		return new WaitForIndexStatusWork.Builder( indexName, requiredStatus, timeout );
-	}
-
-	protected URLEncodedString getTypeKeyword() {
-		return Paths._DOC;
 	}
 
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/ExplainWork.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/ExplainWork.java
@@ -39,7 +39,17 @@ public class ExplainWork extends AbstractSimpleElasticsearchWork<ExplainResult> 
 		private final URLEncodedString id;
 		private final JsonObject payload;
 
-		public Builder(URLEncodedString indexName, URLEncodedString typeName, URLEncodedString id, JsonObject payload) {
+		public static Builder forElasticsearch67AndBelow(URLEncodedString indexName, URLEncodedString typeName,
+				URLEncodedString id, JsonObject payload) {
+			return new Builder( indexName, typeName, id, payload );
+		}
+
+		public static Builder forElasticsearch7AndAbove(URLEncodedString indexName,
+				URLEncodedString id, JsonObject payload) {
+			return new Builder( indexName, null, id, payload );
+		}
+
+		private Builder(URLEncodedString indexName, URLEncodedString typeName, URLEncodedString id, JsonObject payload) {
 			super( null, DefaultElasticsearchRequestSuccessAssessor.INSTANCE );
 			this.indexName = indexName;
 			this.typeName = typeName;
@@ -52,7 +62,7 @@ public class ExplainWork extends AbstractSimpleElasticsearchWork<ExplainResult> 
 			ElasticsearchRequest.Builder builder =
 					ElasticsearchRequest.get()
 					.pathComponent( indexName )
-					.pathComponent( typeName )
+					.pathComponent( typeName != null ? typeName : Paths._DOC ) // _doc for ES7+
 					.pathComponent( id )
 					.pathComponent( Paths._EXPLAIN )
 					.body( payload );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/PutIndexTypeMappingWork.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/PutIndexTypeMappingWork.java
@@ -46,6 +46,12 @@ public class PutIndexTypeMappingWork extends AbstractSimpleElasticsearchWork<Voi
 
 		public static Builder forElasticsearch67(GsonProvider gsonProvider,
 				URLEncodedString indexName, URLEncodedString typeName, RootTypeMapping typeMapping) {
+			/*
+			 * Pushing the mapping with a type name will trigger a warning,
+			 * but that's the only way to keep the index similar to what it was in 6.6,
+			 * i.e. to avoid changing the index when a user migrates from 6.6 to 6.7.
+			 * So we'll accept this single warning for now.
+			 */
 			return new Builder( gsonProvider, indexName, typeName, true, typeMapping );
 		}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/SearchWork.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/SearchWork.java
@@ -26,13 +26,13 @@ import com.google.gson.JsonObject;
 /**
  * @author Yoann Rodiere
  */
-public class ElasticsearchSearchWork<T> extends AbstractSimpleElasticsearchWork<ElasticsearchLoadableSearchResult<T>> {
+public class SearchWork<T> extends AbstractSimpleElasticsearchWork<ElasticsearchLoadableSearchResult<T>> {
 
 	private static final Log QUERY_LOG = LoggerFactory.make( Log.class, DefaultLogCategories.QUERY );
 
 	private final ElasticsearchSearchResultExtractor<T> resultExtractor;
 
-	protected ElasticsearchSearchWork(Builder<T> builder) {
+	protected SearchWork(Builder<T> builder) {
 		super( builder );
 		this.resultExtractor = builder.resultExtractor;
 	}
@@ -144,8 +144,8 @@ public class ElasticsearchSearchWork<T> extends AbstractSimpleElasticsearchWork<
 		}
 
 		@Override
-		public ElasticsearchSearchWork<T> build() {
-			return new ElasticsearchSearchWork<>( this );
+		public SearchWork<T> build() {
+			return new SearchWork<>( this );
 		}
 	}
 }

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/fieldtype/ElasticsearchFieldTypesIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/fieldtype/ElasticsearchFieldTypesIT.java
@@ -47,7 +47,8 @@ public class ElasticsearchFieldTypesIT {
 		);
 
 		clientSpy.expectNext(
-				ElasticsearchRequest.head().pathComponent( URLEncodedString.fromString( INDEX_NAME ) ).build(), ElasticsearchRequestAssertionMode.STRICT
+				ElasticsearchRequest.head().pathComponent( URLEncodedString.fromString( INDEX_NAME ) ).build(),
+				ElasticsearchRequestAssertionMode.EXTENSIBLE
 		);
 
 		clientSpy.expectNext(


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3571

I checked that the warnings are gone in the logs of this full build: http://ci.hibernate.org/view/Search/job/hibernate-search-yoann/job/HSEARCH-3571/6/

The only remaining warnings in Elasticsearch logs are the one we can't get rid of on ES 6.7 (see last commit), and some unrelated warnings about "minimumShouldMatch", which I think are false positives from Elasticsearch.