### PR TITLE
HSEARCH-3573 Use consistent naming for hits and projections

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/ElasticsearchExtension.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/ElasticsearchExtension.java
@@ -54,7 +54,7 @@ import org.hibernate.search.util.common.logging.impl.LoggerFactory;
  * all of its methods are considered SPIs and therefore should never be called directly by users.
  * In short, users are only expected to get instances of this type from an API and pass it to another API.
  *
- * @param <T> The type of query hits.
+ * @param <H> The type of query hits.
  * Users should not have to care about this, as the parameter will automatically take the appropriate value when calling
  * @param <R> The reference type for projections.
  * Users should not have to care about this, as the parameter will automatically take the appropriate value when calling
@@ -63,9 +63,9 @@ import org.hibernate.search.util.common.logging.impl.LoggerFactory;
  * Users should not have to care about this, as the parameter will automatically take the appropriate value when calling
  * {@code .extension( ElasticsearchExtension.get() }.
  */
-public final class ElasticsearchExtension<T, R, E>
+public final class ElasticsearchExtension<H, R, E>
 		implements SearchQueryContextExtension<ElasticsearchSearchQueryResultDefinitionContext<R, E>, R, E>,
-		SearchQueryExtension<ElasticsearchSearchQuery<T>, T>,
+		SearchQueryExtension<ElasticsearchSearchQuery<H>, H>,
 		SearchPredicateFactoryContextExtension<ElasticsearchSearchPredicateFactoryContext>,
 		SearchSortContainerContextExtension<ElasticsearchSearchSortContainerContext>,
 		SearchProjectionFactoryContextExtension<ElasticsearchSearchProjectionFactoryContext<R, E>, R, E>,
@@ -75,7 +75,7 @@ public final class ElasticsearchExtension<T, R, E>
 
 	private static final ElasticsearchExtension<Object, Object, Object> INSTANCE = new ElasticsearchExtension<>();
 
-	@SuppressWarnings("unchecked") // The instance works for any T, R and E
+	@SuppressWarnings("unchecked") // The instance works for any H, R and E
 	public static <Q, R, E> ElasticsearchExtension<Q, R, E> get() {
 		return (ElasticsearchExtension<Q, R, E>) INSTANCE;
 	}
@@ -107,10 +107,10 @@ public final class ElasticsearchExtension<T, R, E>
 	 * {@inheritDoc}
 	 */
 	@Override
-	public Optional<ElasticsearchSearchQuery<T>> extendOptional(SearchQuery<T> original,
+	public Optional<ElasticsearchSearchQuery<H>> extendOptional(SearchQuery<H> original,
 			LoadingContext<?, ?> loadingContext) {
 		if ( original instanceof ElasticsearchSearchQuery ) {
-			return Optional.of( (ElasticsearchSearchQuery<T>) original );
+			return Optional.of( (ElasticsearchSearchQuery<H>) original );
 		}
 		else {
 			return Optional.empty();

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/ElasticsearchExtension.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/ElasticsearchExtension.java
@@ -59,7 +59,7 @@ import org.hibernate.search.util.common.logging.impl.LoggerFactory;
  * @param <R> The reference type for projections.
  * Users should not have to care about this, as the parameter will automatically take the appropriate value when calling
  * {@code .extension( ElasticsearchExtension.get() }.
- * @param <O> The loaded object type for projections.
+ * @param <O> The entity type for projections.
  * Users should not have to care about this, as the parameter will automatically take the appropriate value when calling
  * {@code .extension( ElasticsearchExtension.get() }.
  */

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/ElasticsearchExtension.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/ElasticsearchExtension.java
@@ -59,25 +59,25 @@ import org.hibernate.search.util.common.logging.impl.LoggerFactory;
  * @param <R> The reference type for projections.
  * Users should not have to care about this, as the parameter will automatically take the appropriate value when calling
  * {@code .extension( ElasticsearchExtension.get() }.
- * @param <O> The entity type for projections.
+ * @param <E> The entity type for projections.
  * Users should not have to care about this, as the parameter will automatically take the appropriate value when calling
  * {@code .extension( ElasticsearchExtension.get() }.
  */
-public final class ElasticsearchExtension<T, R, O>
-		implements SearchQueryContextExtension<ElasticsearchSearchQueryResultDefinitionContext<R, O>, R, O>,
+public final class ElasticsearchExtension<T, R, E>
+		implements SearchQueryContextExtension<ElasticsearchSearchQueryResultDefinitionContext<R, E>, R, E>,
 		SearchQueryExtension<ElasticsearchSearchQuery<T>, T>,
 		SearchPredicateFactoryContextExtension<ElasticsearchSearchPredicateFactoryContext>,
 		SearchSortContainerContextExtension<ElasticsearchSearchSortContainerContext>,
-		SearchProjectionFactoryContextExtension<ElasticsearchSearchProjectionFactoryContext<R, O>, R, O>,
+		SearchProjectionFactoryContextExtension<ElasticsearchSearchProjectionFactoryContext<R, E>, R, E>,
 		IndexFieldTypeFactoryContextExtension<ElasticsearchIndexFieldTypeFactoryContext> {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private static final ElasticsearchExtension<Object, Object, Object> INSTANCE = new ElasticsearchExtension<>();
 
-	@SuppressWarnings("unchecked") // The instance works for any T, R and O
-	public static <Q, R, O> ElasticsearchExtension<Q, R, O> get() {
-		return (ElasticsearchExtension<Q, R, O>) INSTANCE;
+	@SuppressWarnings("unchecked") // The instance works for any T, R and E
+	public static <Q, R, E> ElasticsearchExtension<Q, R, E> get() {
+		return (ElasticsearchExtension<Q, R, E>) INSTANCE;
 	}
 
 	private ElasticsearchExtension() {
@@ -88,11 +88,11 @@ public final class ElasticsearchExtension<T, R, O>
 	 * {@inheritDoc}
 	 */
 	@Override
-	public Optional<ElasticsearchSearchQueryResultDefinitionContext<R, O>> extendOptional(
-			SearchQueryResultDefinitionContext<R, O, ?> original,
+	public Optional<ElasticsearchSearchQueryResultDefinitionContext<R, E>> extendOptional(
+			SearchQueryResultDefinitionContext<R, E, ?> original,
 			IndexSearchScope<?> indexSearchScope,
 			SessionContextImplementor sessionContext,
-			LoadingContextBuilder<R, O> loadingContextBuilder) {
+			LoadingContextBuilder<R, E> loadingContextBuilder) {
 		if ( indexSearchScope instanceof ElasticsearchIndexSearchScope ) {
 			return Optional.of( new ElasticsearchSearchQueryResultDefinitionContextImpl<>(
 					(ElasticsearchIndexSearchScope) indexSearchScope, sessionContext, loadingContextBuilder
@@ -152,8 +152,8 @@ public final class ElasticsearchExtension<T, R, O>
 	 * {@inheritDoc}
 	 */
 	@Override
-	public Optional<ElasticsearchSearchProjectionFactoryContext<R, O>> extendOptional(
-			SearchProjectionFactoryContext<R, O> original, SearchProjectionBuilderFactory factory) {
+	public Optional<ElasticsearchSearchProjectionFactoryContext<R, E>> extendOptional(
+			SearchProjectionFactoryContext<R, E> original, SearchProjectionBuilderFactory factory) {
 		if ( factory instanceof ElasticsearchSearchProjectionBuilderFactory ) {
 			return Optional.of( new ElasticsearchSearchProjectionFactoryContextImpl<>(
 					original, (ElasticsearchSearchProjectionBuilderFactory) factory

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/projection/ElasticsearchSearchProjectionFactoryContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/projection/ElasticsearchSearchProjectionFactoryContext.java
@@ -13,10 +13,10 @@ import org.hibernate.search.engine.search.dsl.projection.SearchProjectionTermina
  * A DSL context allowing to create a projection, with some Elasticsearch-specific methods.
  *
  * @param <R> The type of references.
- * @param <O> The type of entities.
+ * @param <E> The type of entities.
  * @see SearchProjectionFactoryContext
  */
-public interface ElasticsearchSearchProjectionFactoryContext<R, O> extends SearchProjectionFactoryContext<R, O> {
+public interface ElasticsearchSearchProjectionFactoryContext<R, E> extends SearchProjectionFactoryContext<R, E> {
 
 	/**
 	 * Project to a string representing the JSON document as stored in Elasticsearch.

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/projection/ElasticsearchSearchProjectionFactoryContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/projection/ElasticsearchSearchProjectionFactoryContext.java
@@ -13,7 +13,7 @@ import org.hibernate.search.engine.search.dsl.projection.SearchProjectionTermina
  * A DSL context allowing to create a projection, with some Elasticsearch-specific methods.
  *
  * @param <R> The type of references.
- * @param <O> The type of loaded objects.
+ * @param <O> The type of entities.
  * @see SearchProjectionFactoryContext
  */
 public interface ElasticsearchSearchProjectionFactoryContext<R, O> extends SearchProjectionFactoryContext<R, O> {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/projection/impl/ElasticsearchSearchProjectionFactoryContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/projection/impl/ElasticsearchSearchProjectionFactoryContextImpl.java
@@ -12,13 +12,13 @@ import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactory
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionTerminalContext;
 import org.hibernate.search.engine.search.dsl.projection.spi.DelegatingSearchProjectionFactoryContext;
 
-public class ElasticsearchSearchProjectionFactoryContextImpl<R, O>
-		extends DelegatingSearchProjectionFactoryContext<R, O>
-		implements ElasticsearchSearchProjectionFactoryContext<R, O> {
+public class ElasticsearchSearchProjectionFactoryContextImpl<R, E>
+		extends DelegatingSearchProjectionFactoryContext<R, E>
+		implements ElasticsearchSearchProjectionFactoryContext<R, E> {
 
 	private final ElasticsearchSearchProjectionBuilderFactory factory;
 
-	public ElasticsearchSearchProjectionFactoryContextImpl(SearchProjectionFactoryContext<R, O> delegate,
+	public ElasticsearchSearchProjectionFactoryContextImpl(SearchProjectionFactoryContext<R, E> delegate,
 			ElasticsearchSearchProjectionBuilderFactory factory) {
 		super( delegate );
 		this.factory = factory;

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/query/ElasticsearchSearchQueryContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/query/ElasticsearchSearchQueryContext.java
@@ -10,9 +10,9 @@ import org.hibernate.search.backend.elasticsearch.search.dsl.sort.ElasticsearchS
 import org.hibernate.search.backend.elasticsearch.search.query.ElasticsearchSearchQuery;
 import org.hibernate.search.engine.search.dsl.query.SearchQueryContext;
 
-public interface ElasticsearchSearchQueryContext<T>
-		extends SearchQueryContext<ElasticsearchSearchQueryContext<T>, T, ElasticsearchSearchSortContainerContext> {
+public interface ElasticsearchSearchQueryContext<H>
+		extends SearchQueryContext<ElasticsearchSearchQueryContext<H>, H, ElasticsearchSearchSortContainerContext> {
 
 	@Override
-	ElasticsearchSearchQuery<T> toQuery();
+	ElasticsearchSearchQuery<H> toQuery();
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/query/ElasticsearchSearchQueryResultContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/query/ElasticsearchSearchQueryResultContext.java
@@ -9,7 +9,7 @@ package org.hibernate.search.backend.elasticsearch.search.dsl.query;
 import org.hibernate.search.backend.elasticsearch.search.dsl.predicate.ElasticsearchSearchPredicateFactoryContext;
 import org.hibernate.search.engine.search.dsl.query.SearchQueryResultContext;
 
-public interface ElasticsearchSearchQueryResultContext<T>
-		extends SearchQueryResultContext<ElasticsearchSearchQueryContext<T>, T, ElasticsearchSearchPredicateFactoryContext> {
+public interface ElasticsearchSearchQueryResultContext<H>
+		extends SearchQueryResultContext<ElasticsearchSearchQueryContext<H>, H, ElasticsearchSearchPredicateFactoryContext> {
 
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/query/ElasticsearchSearchQueryResultDefinitionContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/query/ElasticsearchSearchQueryResultDefinitionContext.java
@@ -14,18 +14,18 @@ import org.hibernate.search.engine.search.SearchProjection;
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionTerminalContext;
 import org.hibernate.search.engine.search.dsl.query.SearchQueryResultDefinitionContext;
 
-public interface ElasticsearchSearchQueryResultDefinitionContext<R, O>
-		extends SearchQueryResultDefinitionContext<R, O, ElasticsearchSearchProjectionFactoryContext<R, O>> {
+public interface ElasticsearchSearchQueryResultDefinitionContext<R, E>
+		extends SearchQueryResultDefinitionContext<R, E, ElasticsearchSearchProjectionFactoryContext<R, E>> {
 
 	@Override
-	ElasticsearchSearchQueryResultContext<O> asEntity();
+	ElasticsearchSearchQueryResultContext<E> asEntity();
 
 	@Override
 	ElasticsearchSearchQueryResultContext<R> asReference();
 
 	@Override
 	<P> ElasticsearchSearchQueryResultContext<P> asProjection(
-			Function<? super ElasticsearchSearchProjectionFactoryContext<R, O>, ? extends SearchProjectionTerminalContext<P>> projectionContributor);
+			Function<? super ElasticsearchSearchProjectionFactoryContext<R, E>, ? extends SearchProjectionTerminalContext<P>> projectionContributor);
 
 	@Override
 	<P> ElasticsearchSearchQueryResultContext<P> asProjection(SearchProjection<P> projection);

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/query/impl/ElasticsearchSearchQueryContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/query/impl/ElasticsearchSearchQueryContextImpl.java
@@ -19,31 +19,31 @@ import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryCo
 import org.hibernate.search.engine.search.dsl.query.spi.AbstractSearchQueryContext;
 import org.hibernate.search.engine.search.dsl.sort.SearchSortContainerContext;
 
-class ElasticsearchSearchQueryContextImpl<T>
+class ElasticsearchSearchQueryContextImpl<H>
 		extends AbstractSearchQueryContext<
-				ElasticsearchSearchQueryContext<T>,
-				T,
+				ElasticsearchSearchQueryContext<H>,
+				H,
 				ElasticsearchSearchPredicateFactoryContext,
 				ElasticsearchSearchSortContainerContext,
 				ElasticsearchSearchQueryElementCollector
 		>
-		implements ElasticsearchSearchQueryResultContext<T>, ElasticsearchSearchQueryContext<T> {
+		implements ElasticsearchSearchQueryResultContext<H>, ElasticsearchSearchQueryContext<H> {
 
-	private final ElasticsearchSearchQueryBuilder<T> searchQueryBuilder;
+	private final ElasticsearchSearchQueryBuilder<H> searchQueryBuilder;
 
 	ElasticsearchSearchQueryContextImpl(ElasticsearchIndexSearchScope indexSearchScope,
-			ElasticsearchSearchQueryBuilder<T> searchQueryBuilder) {
+			ElasticsearchSearchQueryBuilder<H> searchQueryBuilder) {
 		super( indexSearchScope, searchQueryBuilder );
 		this.searchQueryBuilder = searchQueryBuilder;
 	}
 
 	@Override
-	public ElasticsearchSearchQuery<T> toQuery() {
+	public ElasticsearchSearchQuery<H> toQuery() {
 		return searchQueryBuilder.build();
 	}
 
 	@Override
-	protected ElasticsearchSearchQueryContextImpl<T> thisAsS() {
+	protected ElasticsearchSearchQueryContextImpl<H> thisAsS() {
 		return this;
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/query/impl/ElasticsearchSearchQueryResultDefinitionContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/query/impl/ElasticsearchSearchQueryResultDefinitionContextImpl.java
@@ -46,7 +46,7 @@ public class ElasticsearchSearchQueryResultDefinitionContextImpl<R, O>
 	@Override
 	public ElasticsearchSearchQueryResultContext<O> asEntity() {
 		ElasticsearchSearchQueryBuilder<O> builder = indexSearchScope.getSearchQueryBuilderFactory()
-				.asObject( sessionContext, loadingContextBuilder );
+				.asEntity( sessionContext, loadingContextBuilder );
 		return createSearchQueryContext( builder );
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/query/impl/ElasticsearchSearchQueryResultDefinitionContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/query/impl/ElasticsearchSearchQueryResultDefinitionContextImpl.java
@@ -95,7 +95,7 @@ public class ElasticsearchSearchQueryResultDefinitionContextImpl<R, E>
 		return loadingContextBuilder;
 	}
 
-	private <T> ElasticsearchSearchQueryResultContext<T> createSearchQueryContext(ElasticsearchSearchQueryBuilder<T> builder) {
+	private <H> ElasticsearchSearchQueryResultContext<H> createSearchQueryContext(ElasticsearchSearchQueryBuilder<H> builder) {
 		return new ElasticsearchSearchQueryContextImpl<>( indexSearchScope, builder );
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/query/impl/ElasticsearchSearchQueryResultDefinitionContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/query/impl/ElasticsearchSearchQueryResultDefinitionContextImpl.java
@@ -22,30 +22,30 @@ import org.hibernate.search.engine.search.dsl.projection.SearchProjectionTermina
 import org.hibernate.search.engine.search.dsl.query.spi.AbstractSearchQueryResultDefinitionContext;
 import org.hibernate.search.engine.search.loading.context.spi.LoadingContextBuilder;
 
-public class ElasticsearchSearchQueryResultDefinitionContextImpl<R, O>
+public class ElasticsearchSearchQueryResultDefinitionContextImpl<R, E>
 		extends AbstractSearchQueryResultDefinitionContext<
 				R,
-				O,
-				ElasticsearchSearchProjectionFactoryContext<R, O>,
+				E,
+				ElasticsearchSearchProjectionFactoryContext<R, E>,
 				ElasticsearchSearchQueryElementCollector
 		>
-		implements ElasticsearchSearchQueryResultDefinitionContext<R, O> {
+		implements ElasticsearchSearchQueryResultDefinitionContext<R, E> {
 
 	private final ElasticsearchIndexSearchScope indexSearchScope;
 	private final SessionContextImplementor sessionContext;
-	private final LoadingContextBuilder<R, O> loadingContextBuilder;
+	private final LoadingContextBuilder<R, E> loadingContextBuilder;
 
 	public ElasticsearchSearchQueryResultDefinitionContextImpl(ElasticsearchIndexSearchScope indexSearchScope,
 			SessionContextImplementor sessionContext,
-			LoadingContextBuilder<R, O> loadingContextBuilder) {
+			LoadingContextBuilder<R, E> loadingContextBuilder) {
 		this.indexSearchScope = indexSearchScope;
 		this.sessionContext = sessionContext;
 		this.loadingContextBuilder = loadingContextBuilder;
 	}
 
 	@Override
-	public ElasticsearchSearchQueryResultContext<O> asEntity() {
-		ElasticsearchSearchQueryBuilder<O> builder = indexSearchScope.getSearchQueryBuilderFactory()
+	public ElasticsearchSearchQueryResultContext<E> asEntity() {
+		ElasticsearchSearchQueryBuilder<E> builder = indexSearchScope.getSearchQueryBuilderFactory()
 				.asEntity( sessionContext, loadingContextBuilder );
 		return createSearchQueryContext( builder );
 	}
@@ -59,8 +59,8 @@ public class ElasticsearchSearchQueryResultDefinitionContextImpl<R, O>
 
 	@Override
 	public <P> ElasticsearchSearchQueryResultContext<P> asProjection(
-			Function<? super ElasticsearchSearchProjectionFactoryContext<R, O>, ? extends SearchProjectionTerminalContext<P>> projectionContributor) {
-		ElasticsearchSearchProjectionFactoryContext<R, O> factoryContext =
+			Function<? super ElasticsearchSearchProjectionFactoryContext<R, E>, ? extends SearchProjectionTerminalContext<P>> projectionContributor) {
+		ElasticsearchSearchProjectionFactoryContext<R, E> factoryContext =
 				createDefaultProjectionFactoryContext().extension( ElasticsearchExtension.get() );
 		SearchProjection<P> projection = projectionContributor.apply( factoryContext ).toProjection();
 		return asProjection( projection );
@@ -91,7 +91,7 @@ public class ElasticsearchSearchQueryResultDefinitionContextImpl<R, O>
 	}
 
 	@Override
-	protected LoadingContextBuilder<R, O> getLoadingContextBuilder() {
+	protected LoadingContextBuilder<R, E> getLoadingContextBuilder() {
 		return loadingContextBuilder;
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchCompositeBiFunctionProjection.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchCompositeBiFunctionProjection.java
@@ -15,16 +15,16 @@ import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 
 import com.google.gson.JsonObject;
 
-public class ElasticsearchCompositeBiFunctionProjection<P1, P2, T> implements
-		ElasticsearchCompositeProjection<Object[], T> {
+public class ElasticsearchCompositeBiFunctionProjection<P1, P2, P> implements
+		ElasticsearchCompositeProjection<Object[], P> {
 
-	private final BiFunction<P1, P2, T> transformer;
+	private final BiFunction<P1, P2, P> transformer;
 
 	private final ElasticsearchSearchProjection<?, P1> projection1;
 
 	private final ElasticsearchSearchProjection<?, P2> projection2;
 
-	public ElasticsearchCompositeBiFunctionProjection(BiFunction<P1, P2, T> transformer,
+	public ElasticsearchCompositeBiFunctionProjection(BiFunction<P1, P2, P> transformer,
 			ElasticsearchSearchProjection<?, P1> projection1, ElasticsearchSearchProjection<?, P2> projection2) {
 		this.transformer = transformer;
 		this.projection1 = projection1;
@@ -48,7 +48,7 @@ public class ElasticsearchCompositeBiFunctionProjection<P1, P2, T> implements
 	}
 
 	@Override
-	public T transform(LoadingResult<?> loadingResult, Object[] extractedData,
+	public P transform(LoadingResult<?> loadingResult, Object[] extractedData,
 			SearchProjectionTransformContext context) {
 		return transformer.apply(
 				transformUnsafe( projection1, loadingResult, extractedData[0], context ),

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchCompositeFunctionProjection.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchCompositeFunctionProjection.java
@@ -13,14 +13,14 @@ import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 
 import com.google.gson.JsonObject;
 
-public class ElasticsearchCompositeFunctionProjection<E, P, T> implements ElasticsearchCompositeProjection<E, T> {
+public class ElasticsearchCompositeFunctionProjection<E, P1, P> implements ElasticsearchCompositeProjection<E, P> {
 
-	private final Function<P, T> transformer;
+	private final Function<P1, P> transformer;
 
-	private final ElasticsearchSearchProjection<E, P> projection;
+	private final ElasticsearchSearchProjection<E, P1> projection;
 
-	public ElasticsearchCompositeFunctionProjection(Function<P, T> transformer,
-			ElasticsearchSearchProjection<E, P> projection) {
+	public ElasticsearchCompositeFunctionProjection(Function<P1, P> transformer,
+			ElasticsearchSearchProjection<E, P1> projection) {
 		this.transformer = transformer;
 		this.projection = projection;
 	}
@@ -38,7 +38,7 @@ public class ElasticsearchCompositeFunctionProjection<E, P, T> implements Elasti
 	}
 
 	@Override
-	public T transform(LoadingResult<?> loadingResult, E extractedData, SearchProjectionTransformContext context) {
+	public P transform(LoadingResult<?> loadingResult, E extractedData, SearchProjectionTransformContext context) {
 		return transformer.apply( projection.transform( loadingResult, extractedData, context ) );
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchCompositeListProjection.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchCompositeListProjection.java
@@ -17,13 +17,13 @@ import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 
 import com.google.gson.JsonObject;
 
-public class ElasticsearchCompositeListProjection<T> implements ElasticsearchCompositeProjection<List<Object>, T> {
+public class ElasticsearchCompositeListProjection<P> implements ElasticsearchCompositeProjection<List<Object>, P> {
 
-	private final Function<List<?>, T> transformer;
+	private final Function<List<?>, P> transformer;
 
 	private final List<ElasticsearchSearchProjection<?, ?>> children;
 
-	public ElasticsearchCompositeListProjection(Function<List<?>, T> transformer,
+	public ElasticsearchCompositeListProjection(Function<List<?>, P> transformer,
 			List<ElasticsearchSearchProjection<?, ?>> children) {
 		this.transformer = transformer;
 		this.children = children;
@@ -51,7 +51,7 @@ public class ElasticsearchCompositeListProjection<T> implements ElasticsearchCom
 	}
 
 	@Override
-	public T transform(LoadingResult<?> loadingResult, List<Object> extractedData,
+	public P transform(LoadingResult<?> loadingResult, List<Object> extractedData,
 			SearchProjectionTransformContext context) {
 		for ( int i = 0; i < extractedData.size(); i++ ) {
 			extractedData.set( i, transformUnsafe( children.get( i ), loadingResult, extractedData.get( i ), context ) );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchCompositeProjection.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchCompositeProjection.java
@@ -6,6 +6,6 @@
  */
 package org.hibernate.search.backend.elasticsearch.search.projection.impl;
 
-public interface ElasticsearchCompositeProjection<E, T> extends ElasticsearchSearchProjection<E, T> {
+public interface ElasticsearchCompositeProjection<E, P> extends ElasticsearchSearchProjection<E, P> {
 
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchCompositeProjectionBuilder.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchCompositeProjectionBuilder.java
@@ -10,16 +10,16 @@ import org.hibernate.search.engine.search.SearchProjection;
 import org.hibernate.search.engine.search.projection.spi.CompositeProjectionBuilder;
 
 
-class ElasticsearchCompositeProjectionBuilder<T> implements CompositeProjectionBuilder<T> {
+class ElasticsearchCompositeProjectionBuilder<P> implements CompositeProjectionBuilder<P> {
 
-	private final ElasticsearchCompositeProjection<?, T> projection;
+	private final ElasticsearchCompositeProjection<?, P> projection;
 
-	ElasticsearchCompositeProjectionBuilder(ElasticsearchCompositeProjection<?, T> projection) {
+	ElasticsearchCompositeProjectionBuilder(ElasticsearchCompositeProjection<?, P> projection) {
 		this.projection = projection;
 	}
 
 	@Override
-	public SearchProjection<T> build() {
+	public SearchProjection<P> build() {
 		return projection;
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchCompositeTriFunctionProjection.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchCompositeTriFunctionProjection.java
@@ -14,10 +14,10 @@ import org.hibernate.search.util.common.function.TriFunction;
 
 import com.google.gson.JsonObject;
 
-public class ElasticsearchCompositeTriFunctionProjection<P1, P2, P3, T> implements
-		ElasticsearchCompositeProjection<Object[], T> {
+public class ElasticsearchCompositeTriFunctionProjection<P1, P2, P3, P> implements
+		ElasticsearchCompositeProjection<Object[], P> {
 
-	private final TriFunction<P1, P2, P3, T> transformer;
+	private final TriFunction<P1, P2, P3, P> transformer;
 
 	private final ElasticsearchSearchProjection<?, P1> projection1;
 
@@ -25,7 +25,7 @@ public class ElasticsearchCompositeTriFunctionProjection<P1, P2, P3, T> implemen
 
 	private final ElasticsearchSearchProjection<?, P3> projection3;
 
-	public ElasticsearchCompositeTriFunctionProjection(TriFunction<P1, P2, P3, T> transformer,
+	public ElasticsearchCompositeTriFunctionProjection(TriFunction<P1, P2, P3, P> transformer,
 			ElasticsearchSearchProjection<?, P1> projection1, ElasticsearchSearchProjection<?, P2> projection2,
 			ElasticsearchSearchProjection<?, P3> projection3) {
 		this.transformer = transformer;
@@ -53,7 +53,7 @@ public class ElasticsearchCompositeTriFunctionProjection<P1, P2, P3, T> implemen
 	}
 
 	@Override
-	public T transform(LoadingResult<?> loadingResult, Object[] extractedData,
+	public P transform(LoadingResult<?> loadingResult, Object[] extractedData,
 			SearchProjectionTransformContext context) {
 		return transformer.apply(
 				transformUnsafe( projection1, loadingResult, extractedData[0], context ),

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchEntityProjection.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchEntityProjection.java
@@ -11,7 +11,7 @@ import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 
 import com.google.gson.JsonObject;
 
-public class ElasticsearchEntityProjection<O> implements ElasticsearchSearchProjection<Object, O> {
+public class ElasticsearchEntityProjection<E> implements ElasticsearchSearchProjection<Object, E> {
 
 	private final DocumentReferenceExtractorHelper helper;
 
@@ -32,9 +32,9 @@ public class ElasticsearchEntityProjection<O> implements ElasticsearchSearchProj
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public O transform(LoadingResult<?> loadingResult, Object extractedData,
+	public E transform(LoadingResult<?> loadingResult, Object extractedData,
 			SearchProjectionTransformContext context) {
-		return (O) loadingResult.getLoaded( extractedData );
+		return (E) loadingResult.getLoaded( extractedData );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchEntityProjection.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchEntityProjection.java
@@ -11,11 +11,11 @@ import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 
 import com.google.gson.JsonObject;
 
-public class ElasticsearchObjectProjection<O> implements ElasticsearchSearchProjection<Object, O> {
+public class ElasticsearchEntityProjection<O> implements ElasticsearchSearchProjection<Object, O> {
 
 	private final DocumentReferenceExtractorHelper helper;
 
-	public ElasticsearchObjectProjection(DocumentReferenceExtractorHelper helper) {
+	public ElasticsearchEntityProjection(DocumentReferenceExtractorHelper helper) {
 		this.helper = helper;
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchEntityProjectionBuilder.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchEntityProjectionBuilder.java
@@ -7,15 +7,15 @@
 package org.hibernate.search.backend.elasticsearch.search.projection.impl;
 
 import org.hibernate.search.engine.search.SearchProjection;
-import org.hibernate.search.engine.search.projection.spi.ObjectProjectionBuilder;
+import org.hibernate.search.engine.search.projection.spi.EntityProjectionBuilder;
 
 
-class ElasticsearchObjectProjectionBuilder<O> implements ObjectProjectionBuilder<O> {
+class ElasticsearchEntityProjectionBuilder<O> implements EntityProjectionBuilder<O> {
 
-	private final ElasticsearchObjectProjection<O> projection;
+	private final ElasticsearchEntityProjection<O> projection;
 
-	ElasticsearchObjectProjectionBuilder(DocumentReferenceExtractorHelper helper) {
-		this.projection = new ElasticsearchObjectProjection<>( helper );
+	ElasticsearchEntityProjectionBuilder(DocumentReferenceExtractorHelper helper) {
+		this.projection = new ElasticsearchEntityProjection<>( helper );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchEntityProjectionBuilder.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchEntityProjectionBuilder.java
@@ -10,16 +10,16 @@ import org.hibernate.search.engine.search.SearchProjection;
 import org.hibernate.search.engine.search.projection.spi.EntityProjectionBuilder;
 
 
-class ElasticsearchEntityProjectionBuilder<O> implements EntityProjectionBuilder<O> {
+class ElasticsearchEntityProjectionBuilder<E> implements EntityProjectionBuilder<E> {
 
-	private final ElasticsearchEntityProjection<O> projection;
+	private final ElasticsearchEntityProjection<E> projection;
 
 	ElasticsearchEntityProjectionBuilder(DocumentReferenceExtractorHelper helper) {
 		this.projection = new ElasticsearchEntityProjection<>( helper );
 	}
 
 	@Override
-	public SearchProjection<O> build() {
+	public SearchProjection<E> build() {
 		return projection;
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchFieldProjection.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchFieldProjection.java
@@ -23,7 +23,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 
-class ElasticsearchFieldProjection<F, T> implements ElasticsearchSearchProjection<F, T> {
+class ElasticsearchFieldProjection<F, V> implements ElasticsearchSearchProjection<F, V> {
 
 	private static final JsonArrayAccessor REQUEST_SOURCE_ACCESSOR = JsonAccessor.root().property( "_source" ).asArray();
 	private static final JsonObjectAccessor HIT_SOURCE_ACCESSOR = JsonAccessor.root().property( "_source" ).asObject();
@@ -31,11 +31,11 @@ class ElasticsearchFieldProjection<F, T> implements ElasticsearchSearchProjectio
 	private final String absoluteFieldPath;
 	private final UnknownTypeJsonAccessor hitFieldValueAccessor;
 
-	private final FromDocumentFieldValueConverter<? super F, T> converter;
+	private final FromDocumentFieldValueConverter<? super F, V> converter;
 	private final ElasticsearchFieldCodec<F> codec;
 
 	ElasticsearchFieldProjection(String absoluteFieldPath,
-			FromDocumentFieldValueConverter<? super F, T> converter,
+			FromDocumentFieldValueConverter<? super F, V> converter,
 			ElasticsearchFieldCodec<F> codec) {
 		this.absoluteFieldPath = absoluteFieldPath;
 		this.hitFieldValueAccessor = HIT_SOURCE_ACCESSOR.path( absoluteFieldPath );
@@ -65,7 +65,7 @@ class ElasticsearchFieldProjection<F, T> implements ElasticsearchSearchProjectio
 	}
 
 	@Override
-	public T transform(LoadingResult<?> loadingResult, F extractedData, SearchProjectionTransformContext context) {
+	public V transform(LoadingResult<?> loadingResult, F extractedData, SearchProjectionTransformContext context) {
 		FromDocumentFieldValueConvertContext convertContext = context.getFromDocumentFieldValueConvertContext();
 		return converter.convert( extractedData, convertContext );
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchFieldProjectionBuilder.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchFieldProjectionBuilder.java
@@ -12,15 +12,15 @@ import org.hibernate.search.engine.search.SearchProjection;
 import org.hibernate.search.engine.search.projection.spi.FieldProjectionBuilder;
 
 
-public class ElasticsearchFieldProjectionBuilder<F, T> implements FieldProjectionBuilder<T> {
+public class ElasticsearchFieldProjectionBuilder<F, V> implements FieldProjectionBuilder<V> {
 
 	private final String absoluteFieldPath;
 
-	private final FromDocumentFieldValueConverter<? super F, T> converter;
+	private final FromDocumentFieldValueConverter<? super F, V> converter;
 	private final ElasticsearchFieldCodec<F> codec;
 
 	public ElasticsearchFieldProjectionBuilder(String absoluteFieldPath,
-			FromDocumentFieldValueConverter<? super F, T> converter,
+			FromDocumentFieldValueConverter<? super F, V> converter,
 			ElasticsearchFieldCodec<F> codec) {
 		this.absoluteFieldPath = absoluteFieldPath;
 		this.converter = converter;
@@ -28,7 +28,7 @@ public class ElasticsearchFieldProjectionBuilder<F, T> implements FieldProjectio
 	}
 
 	@Override
-	public SearchProjection<T> build() {
+	public SearchProjection<V> build() {
 		return new ElasticsearchFieldProjection<>( absoluteFieldPath, converter, codec );
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchSearchProjection.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchSearchProjection.java
@@ -12,7 +12,7 @@ import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 
 import com.google.gson.JsonObject;
 
-public interface ElasticsearchSearchProjection<E, T> extends SearchProjection<T> {
+public interface ElasticsearchSearchProjection<E, P> extends SearchProjection<P> {
 
 	/**
 	 * Contribute to the request, making sure that the requirements for this projection are met.
@@ -51,7 +51,7 @@ public interface ElasticsearchSearchProjection<E, T> extends SearchProjection<T>
 	 * @param context An execution context for the transforming.
 	 * @return The final result considered as a hit.
 	 */
-	T transform(LoadingResult<?> loadingResult, E extractedData, SearchProjectionTransformContext context);
+	P transform(LoadingResult<?> loadingResult, E extractedData, SearchProjectionTransformContext context);
 
 	/**
 	 * Transform the extracted data and cast it to the right type.

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchSearchProjectionBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchSearchProjectionBuilderFactory.java
@@ -69,7 +69,7 @@ public class ElasticsearchSearchProjectionBuilderFactory implements SearchProjec
 	}
 
 	@Override
-	public <O> EntityProjectionBuilder<O> entity() {
+	public <E> EntityProjectionBuilder<E> entity() {
 		return searchProjectionBackendContext.getEntityProjectionBuilder();
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchSearchProjectionBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchSearchProjectionBuilderFactory.java
@@ -91,7 +91,7 @@ public class ElasticsearchSearchProjectionBuilderFactory implements SearchProjec
 	}
 
 	@Override
-	public <T> CompositeProjectionBuilder<T> composite(Function<List<?>, T> transformer,
+	public <P> CompositeProjectionBuilder<P> composite(Function<List<?>, P> transformer,
 			SearchProjection<?>... projections) {
 		List<ElasticsearchSearchProjection<?, ?>> typedProjections = new ArrayList<>( projections.length );
 		for ( SearchProjection<?> projection : projections ) {
@@ -104,15 +104,15 @@ public class ElasticsearchSearchProjectionBuilderFactory implements SearchProjec
 	}
 
 	@Override
-	public <P, T> CompositeProjectionBuilder<T> composite(Function<P, T> transformer,
-			SearchProjection<P> projection) {
+	public <P1, P> CompositeProjectionBuilder<P> composite(Function<P1, P> transformer,
+			SearchProjection<P1> projection) {
 		return new ElasticsearchCompositeProjectionBuilder<>(
 				new ElasticsearchCompositeFunctionProjection<>( transformer, toImplementation( projection ) )
 		);
 	}
 
 	@Override
-	public <P1, P2, T> CompositeProjectionBuilder<T> composite(BiFunction<P1, P2, T> transformer,
+	public <P1, P2, P> CompositeProjectionBuilder<P> composite(BiFunction<P1, P2, P> transformer,
 			SearchProjection<P1> projection1, SearchProjection<P2> projection2) {
 		return new ElasticsearchCompositeProjectionBuilder<>(
 				new ElasticsearchCompositeBiFunctionProjection<>( transformer, toImplementation( projection1 ),
@@ -121,7 +121,7 @@ public class ElasticsearchSearchProjectionBuilderFactory implements SearchProjec
 	}
 
 	@Override
-	public <P1, P2, P3, T> CompositeProjectionBuilder<T> composite(TriFunction<P1, P2, P3, T> transformer,
+	public <P1, P2, P3, P> CompositeProjectionBuilder<P> composite(TriFunction<P1, P2, P3, P> transformer,
 			SearchProjection<P1> projection1, SearchProjection<P2> projection2, SearchProjection<P3> projection3) {
 		return new ElasticsearchCompositeProjectionBuilder<>(
 				new ElasticsearchCompositeTriFunctionProjection<>( transformer, toImplementation( projection1 ),

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchSearchProjectionBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchSearchProjectionBuilderFactory.java
@@ -24,7 +24,7 @@ import org.hibernate.search.engine.search.projection.spi.CompositeProjectionBuil
 import org.hibernate.search.engine.search.projection.spi.DistanceToFieldProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.DocumentReferenceProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.FieldProjectionBuilder;
-import org.hibernate.search.engine.search.projection.spi.ObjectProjectionBuilder;
+import org.hibernate.search.engine.search.projection.spi.EntityProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.ReferenceProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.ScoreProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilder;
@@ -69,8 +69,8 @@ public class ElasticsearchSearchProjectionBuilderFactory implements SearchProjec
 	}
 
 	@Override
-	public <O> ObjectProjectionBuilder<O> object() {
-		return searchProjectionBackendContext.getObjectProjectionBuilder();
+	public <O> EntityProjectionBuilder<O> entity() {
+		return searchProjectionBackendContext.getEntityProjectionBuilder();
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/SearchProjectionBackendContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/SearchProjectionBackendContext.java
@@ -14,7 +14,7 @@ public class SearchProjectionBackendContext {
 
 	private final ElasticsearchDocumentReferenceProjectionBuilder documentReferenceProjectionBuilder;
 	@SuppressWarnings("rawtypes")
-	private final ElasticsearchObjectProjectionBuilder objectProjectionBuilder;
+	private final ElasticsearchEntityProjectionBuilder objectProjectionBuilder;
 	@SuppressWarnings("rawtypes")
 	private final ElasticsearchReferenceProjectionBuilder referenceProjectionBuilder;
 	private final ElasticsearchScoreProjectionBuilder scoreProjectionBuilder;
@@ -25,7 +25,7 @@ public class SearchProjectionBackendContext {
 	public SearchProjectionBackendContext(DocumentReferenceExtractorHelper documentReferenceExtractorHelper,
 			Gson userFacingGson) {
 		this.documentReferenceProjectionBuilder = new ElasticsearchDocumentReferenceProjectionBuilder( documentReferenceExtractorHelper );
-		this.objectProjectionBuilder = new ElasticsearchObjectProjectionBuilder( documentReferenceExtractorHelper );
+		this.objectProjectionBuilder = new ElasticsearchEntityProjectionBuilder( documentReferenceExtractorHelper );
 		this.referenceProjectionBuilder = new ElasticsearchReferenceProjectionBuilder( documentReferenceExtractorHelper );
 		this.scoreProjectionBuilder = new ElasticsearchScoreProjectionBuilder();
 		this.sourceProjectionBuilder = new ElasticsearchSourceProjectionBuilder( userFacingGson );
@@ -37,7 +37,7 @@ public class SearchProjectionBackendContext {
 	}
 
 	@SuppressWarnings("unchecked")
-	<O> ElasticsearchObjectProjectionBuilder<O> getObjectProjectionBuilder() {
+	<O> ElasticsearchEntityProjectionBuilder<O> getEntityProjectionBuilder() {
 		return objectProjectionBuilder;
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/SearchProjectionBackendContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/SearchProjectionBackendContext.java
@@ -37,7 +37,7 @@ public class SearchProjectionBackendContext {
 	}
 
 	@SuppressWarnings("unchecked")
-	<O> ElasticsearchEntityProjectionBuilder<O> getEntityProjectionBuilder() {
+	<E> ElasticsearchEntityProjectionBuilder<E> getEntityProjectionBuilder() {
 		return objectProjectionBuilder;
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/ElasticsearchSearchQuery.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/ElasticsearchSearchQuery.java
@@ -8,5 +8,5 @@ package org.hibernate.search.backend.elasticsearch.search.query;
 
 import org.hibernate.search.engine.search.query.ExtendedSearchQuery;
 
-public interface ElasticsearchSearchQuery<T> extends ExtendedSearchQuery<T, ElasticsearchSearchResult<T>> {
+public interface ElasticsearchSearchQuery<H> extends ExtendedSearchQuery<H, ElasticsearchSearchResult<H>> {
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/ElasticsearchSearchResult.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/ElasticsearchSearchResult.java
@@ -8,5 +8,5 @@ package org.hibernate.search.backend.elasticsearch.search.query;
 
 import org.hibernate.search.engine.search.query.SearchResult;
 
-public interface ElasticsearchSearchResult<T> extends SearchResult<T> {
+public interface ElasticsearchSearchResult<H> extends SearchResult<H> {
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/Elasticsearch6SearchResultExtractor.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/Elasticsearch6SearchResultExtractor.java
@@ -21,14 +21,14 @@ import com.google.gson.JsonObject;
  *     <li>The total hit count is retrieved from hits.total instead of hits.total.value</li>
  * </ul>
  */
-class Elasticsearch6SearchResultExtractor<T> extends Elasticsearch7SearchResultExtractor<T> {
+class Elasticsearch6SearchResultExtractor<H> extends Elasticsearch7SearchResultExtractor<H> {
 
 	private static final JsonAccessor<Long> HITS_TOTAL_ACCESSOR =
 			HITS_ACCESSOR.property( "total" ).asLong();
 
 	Elasticsearch6SearchResultExtractor(
 			LoadingContext<?, ?> loadingContext,
-			ElasticsearchSearchProjection<?, T> rootProjection,
+			ElasticsearchSearchProjection<?, H> rootProjection,
 			SearchProjectionExtractContext searchProjectionExecutionContext) {
 		super( loadingContext, rootProjection, searchProjectionExecutionContext );
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/Elasticsearch6SearchResultExtractorFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/Elasticsearch6SearchResultExtractorFactory.java
@@ -13,8 +13,8 @@ import org.hibernate.search.engine.search.loading.context.spi.LoadingContext;
 
 public class Elasticsearch6SearchResultExtractorFactory implements ElasticsearchSearchResultExtractorFactory {
 	@Override
-	public <T> ElasticsearchSearchResultExtractor<T> createResultExtractor(LoadingContext<?, ?> loadingContext,
-			ElasticsearchSearchProjection<?, T> rootProjection,
+	public <H> ElasticsearchSearchResultExtractor<H> createResultExtractor(LoadingContext<?, ?> loadingContext,
+			ElasticsearchSearchProjection<?, H> rootProjection,
 			SearchProjectionExtractContext searchProjectionExecutionContext) {
 		return new Elasticsearch6SearchResultExtractor<>( loadingContext, rootProjection,
 				searchProjectionExecutionContext );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/Elasticsearch7SearchResultExtractor.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/Elasticsearch7SearchResultExtractor.java
@@ -22,7 +22,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
-class Elasticsearch7SearchResultExtractor<T> implements ElasticsearchSearchResultExtractor<T> {
+class Elasticsearch7SearchResultExtractor<H> implements ElasticsearchSearchResultExtractor<H> {
 
 	protected static final JsonObjectAccessor HITS_ACCESSOR =
 			JsonAccessor.root().property( "hits" ).asObject();
@@ -34,13 +34,13 @@ class Elasticsearch7SearchResultExtractor<T> implements ElasticsearchSearchResul
 			HITS_ACCESSOR.property( "total" ).property( "value" ).asLong();
 
 	private final LoadingContext<?, ?> loadingContext;
-	private final ElasticsearchSearchProjection<?, T> rootProjection;
+	private final ElasticsearchSearchProjection<?, H> rootProjection;
 
 	private final SearchProjectionExtractContext searchProjectionExecutionContext;
 
 	Elasticsearch7SearchResultExtractor(
 			LoadingContext<?, ?> loadingContext,
-			ElasticsearchSearchProjection<?, T> rootProjection,
+			ElasticsearchSearchProjection<?, H> rootProjection,
 			SearchProjectionExtractContext searchProjectionExecutionContext) {
 		this.loadingContext = loadingContext;
 		this.rootProjection = rootProjection;
@@ -48,7 +48,7 @@ class Elasticsearch7SearchResultExtractor<T> implements ElasticsearchSearchResul
 	}
 
 	@Override
-	public ElasticsearchLoadableSearchResult<T> extract(JsonObject responseBody) {
+	public ElasticsearchLoadableSearchResult<H> extract(JsonObject responseBody) {
 		ProjectionHitMapper<?, ?> hitMapper = loadingContext.getProjectionHitMapper();
 
 		long hitCount = extractHitCount( responseBody );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/Elasticsearch7SearchResultExtractorFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/Elasticsearch7SearchResultExtractorFactory.java
@@ -13,8 +13,8 @@ import org.hibernate.search.engine.search.loading.context.spi.LoadingContext;
 
 public class Elasticsearch7SearchResultExtractorFactory implements ElasticsearchSearchResultExtractorFactory {
 	@Override
-	public <T> ElasticsearchSearchResultExtractor<T> createResultExtractor(LoadingContext<?, ?> loadingContext,
-			ElasticsearchSearchProjection<?, T> rootProjection,
+	public <H> ElasticsearchSearchResultExtractor<H> createResultExtractor(LoadingContext<?, ?> loadingContext,
+			ElasticsearchSearchProjection<?, H> rootProjection,
 			SearchProjectionExtractContext searchProjectionExecutionContext) {
 		return new Elasticsearch7SearchResultExtractor<>( loadingContext, rootProjection,
 				searchProjectionExecutionContext );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchLoadableSearchResult.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchLoadableSearchResult.java
@@ -27,17 +27,17 @@ import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
  * <p>
  * <strong>WARNING:</strong> this class is not thread-safe.
  *
- * @param <T> The type of hits in the search result.
+ * @param <H> The type of hits in the search result.
  */
-public class ElasticsearchLoadableSearchResult<T> {
+public class ElasticsearchLoadableSearchResult<H> {
 	private final ProjectionHitMapper<?, ?> projectionHitMapper;
-	private final ElasticsearchSearchProjection<?, T> rootProjection;
+	private final ElasticsearchSearchProjection<?, H> rootProjection;
 
 	private final long hitCount;
 	private List<Object> extractedData;
 
 	ElasticsearchLoadableSearchResult(ProjectionHitMapper<?, ?> projectionHitMapper,
-			ElasticsearchSearchProjection<?, T> rootProjection,
+			ElasticsearchSearchProjection<?, H> rootProjection,
 			long hitCount, List<Object> extractedData) {
 		this.projectionHitMapper = projectionHitMapper;
 		this.rootProjection = rootProjection;
@@ -45,19 +45,19 @@ public class ElasticsearchLoadableSearchResult<T> {
 		this.extractedData = extractedData;
 	}
 
-	ElasticsearchSearchResult<T> loadBlocking(SessionContextImplementor sessionContext) {
+	ElasticsearchSearchResult<H> loadBlocking(SessionContextImplementor sessionContext) {
 		SearchProjectionTransformContext transformContext = new SearchProjectionTransformContext( sessionContext );
 
 		LoadingResult<?> loadingResult = projectionHitMapper.loadBlocking();
 
 		for ( int i = 0; i < extractedData.size(); i++ ) {
-			T transformed = transformUnsafe( rootProjection, loadingResult, extractedData.get( i ), transformContext );
+			H transformed = transformUnsafe( rootProjection, loadingResult, extractedData.get( i ), transformContext );
 			extractedData.set( i, transformed );
 		}
 
-		// The cast is safe, since all elements extend T and we make the list unmodifiable
+		// The cast is safe, since all elements extend H and we make the list unmodifiable
 		@SuppressWarnings("unchecked")
-		List<T> loadedHits = Collections.unmodifiableList( (List<? extends T>) extractedData );
+		List<H> loadedHits = Collections.unmodifiableList( (List<? extends H>) extractedData );
 
 		// Make sure that if someone uses this object incorrectly, it will always fail, and will fail early.
 		extractedData = null;

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchQueryBuilder.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchQueryBuilder.java
@@ -26,8 +26,8 @@ import org.hibernate.search.engine.search.query.spi.SearchQueryBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
-public class ElasticsearchSearchQueryBuilder<T>
-		implements SearchQueryBuilder<T, ElasticsearchSearchQueryElementCollector> {
+public class ElasticsearchSearchQueryBuilder<H>
+		implements SearchQueryBuilder<H, ElasticsearchSearchQueryElementCollector> {
 
 	private final ElasticsearchWorkBuilderFactory workFactory;
 	private final ElasticsearchSearchResultExtractorFactory searchResultExtractorFactory;
@@ -40,7 +40,7 @@ public class ElasticsearchSearchQueryBuilder<T>
 
 	private final ElasticsearchSearchQueryElementCollector elementCollector;
 	private final LoadingContextBuilder<?, ?> loadingContextBuilder;
-	private final ElasticsearchSearchProjection<?, T> rootProjection;
+	private final ElasticsearchSearchProjection<?, H> rootProjection;
 
 	ElasticsearchSearchQueryBuilder(
 			ElasticsearchWorkBuilderFactory workFactory,
@@ -50,7 +50,7 @@ public class ElasticsearchSearchQueryBuilder<T>
 			Set<URLEncodedString> indexNames,
 			SessionContextImplementor sessionContext,
 			LoadingContextBuilder<?, ?> loadingContextBuilder,
-			ElasticsearchSearchProjection<?, T> rootProjection) {
+			ElasticsearchSearchProjection<?, H> rootProjection) {
 		this.workFactory = workFactory;
 		this.searchResultExtractorFactory = searchResultExtractorFactory;
 		this.queryOrchestrator = queryOrchestrator;
@@ -76,7 +76,7 @@ public class ElasticsearchSearchQueryBuilder<T>
 	}
 
 	@Override
-	public ElasticsearchSearchQuery<T> build() {
+	public ElasticsearchSearchQuery<H> build() {
 		JsonObject payload = new JsonObject();
 
 		JsonObject jsonQuery = getJsonQuery();
@@ -96,7 +96,7 @@ public class ElasticsearchSearchQueryBuilder<T>
 
 		LoadingContext<?, ?> loadingContext = loadingContextBuilder.build();
 
-		ElasticsearchSearchResultExtractor<T> searchResultExtractor =
+		ElasticsearchSearchResultExtractor<H> searchResultExtractor =
 				searchResultExtractorFactory.createResultExtractor(
 						loadingContext,
 						rootProjection, searchProjectionExecutionContext

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchQueryBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchQueryBuilderFactory.java
@@ -39,8 +39,8 @@ public class ElasticsearchSearchQueryBuilderFactory
 	}
 
 	@Override
-	public <O> ElasticsearchSearchQueryBuilder<O> asEntity(
-			SessionContextImplementor sessionContext, LoadingContextBuilder<?, O> loadingContextBuilder) {
+	public <E> ElasticsearchSearchQueryBuilder<E> asEntity(
+			SessionContextImplementor sessionContext, LoadingContextBuilder<?, E> loadingContextBuilder) {
 		return createSearchQueryBuilder(
 				sessionContext, loadingContextBuilder,
 				new ElasticsearchEntityProjection<>( searchBackendContext.getDocumentReferenceExtractorHelper() )

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchQueryBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchQueryBuilderFactory.java
@@ -13,7 +13,7 @@ import java.util.function.Function;
 import org.hibernate.search.backend.elasticsearch.search.impl.ElasticsearchSearchQueryElementCollector;
 import org.hibernate.search.backend.elasticsearch.search.impl.ElasticsearchSearchScopeModel;
 import org.hibernate.search.backend.elasticsearch.search.projection.impl.ElasticsearchCompositeListProjection;
-import org.hibernate.search.backend.elasticsearch.search.projection.impl.ElasticsearchObjectProjection;
+import org.hibernate.search.backend.elasticsearch.search.projection.impl.ElasticsearchEntityProjection;
 import org.hibernate.search.backend.elasticsearch.search.projection.impl.ElasticsearchReferenceProjection;
 import org.hibernate.search.backend.elasticsearch.search.projection.impl.ElasticsearchSearchProjection;
 import org.hibernate.search.backend.elasticsearch.search.projection.impl.ElasticsearchSearchProjectionBuilderFactory;
@@ -39,11 +39,11 @@ public class ElasticsearchSearchQueryBuilderFactory
 	}
 
 	@Override
-	public <O> ElasticsearchSearchQueryBuilder<O> asObject(
+	public <O> ElasticsearchSearchQueryBuilder<O> asEntity(
 			SessionContextImplementor sessionContext, LoadingContextBuilder<?, O> loadingContextBuilder) {
 		return createSearchQueryBuilder(
 				sessionContext, loadingContextBuilder,
-				new ElasticsearchObjectProjection<>( searchBackendContext.getDocumentReferenceExtractorHelper() )
+				new ElasticsearchEntityProjection<>( searchBackendContext.getDocumentReferenceExtractorHelper() )
 		);
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchQueryBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchQueryBuilderFactory.java
@@ -83,9 +83,9 @@ public class ElasticsearchSearchQueryBuilderFactory
 		return new ElasticsearchCompositeListProjection<>( Function.identity(), children );
 	}
 
-	private <T> ElasticsearchSearchQueryBuilder<T> createSearchQueryBuilder(
+	private <H> ElasticsearchSearchQueryBuilder<H> createSearchQueryBuilder(
 			SessionContextImplementor sessionContext, LoadingContextBuilder<?, ?> loadingContextBuilder,
-			ElasticsearchSearchProjection<?, T> rootProjection) {
+			ElasticsearchSearchProjection<?, H> rootProjection) {
 		return searchBackendContext.createSearchQueryBuilder(
 				scopeModel.getElasticsearchIndexNames(),
 				sessionContext,

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchQueryBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchQueryBuilderFactory.java
@@ -48,8 +48,8 @@ public class ElasticsearchSearchQueryBuilderFactory
 	}
 
 	@Override
-	public <T> ElasticsearchSearchQueryBuilder<T> asReference(
-			SessionContextImplementor sessionContext, LoadingContextBuilder<T, ?> loadingContextBuilder) {
+	public <R> ElasticsearchSearchQueryBuilder<R> asReference(
+			SessionContextImplementor sessionContext, LoadingContextBuilder<R, ?> loadingContextBuilder) {
 		return createSearchQueryBuilder(
 				sessionContext, loadingContextBuilder,
 				new ElasticsearchReferenceProjection<>( searchBackendContext.getDocumentReferenceExtractorHelper() )
@@ -57,9 +57,9 @@ public class ElasticsearchSearchQueryBuilderFactory
 	}
 
 	@Override
-	public <T> ElasticsearchSearchQueryBuilder<T> asProjection(
+	public <P> ElasticsearchSearchQueryBuilder<P> asProjection(
 			SessionContextImplementor sessionContext, LoadingContextBuilder<?, ?> loadingContextBuilder,
-			SearchProjection<T> projection) {
+			SearchProjection<P> projection) {
 		return createSearchQueryBuilder(
 				sessionContext, loadingContextBuilder,
 				searchProjectionFactory.toImplementation( projection )

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchQueryImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchQueryImpl.java
@@ -93,7 +93,7 @@ public class ElasticsearchSearchQueryImpl<T> extends AbstractSearchQuery<T, Elas
 				/*
 				 * WARNING: the following call must run in the user thread.
 				 * If we introduce async query execution, we will have to add a loadAsync method here,
-				 * as well as in ProjectionHitMapper and ObjectLoader.
+				 * as well as in ProjectionHitMapper and EntityLoader.
 				 * This method may not be easy to implement for blocking mappers,
 				 * so we may choose to throw exceptions for those.
 				 */

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchQueryImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchQueryImpl.java
@@ -30,8 +30,8 @@ import com.google.gson.JsonObject;
 /**
  * @author Yoann Rodiere
  */
-public class ElasticsearchSearchQueryImpl<T> extends AbstractSearchQuery<T, ElasticsearchSearchResult<T>>
-		implements ElasticsearchSearchQuery<T> {
+public class ElasticsearchSearchQueryImpl<H> extends AbstractSearchQuery<H, ElasticsearchSearchResult<H>>
+		implements ElasticsearchSearchQuery<H> {
 
 	/**
 	 * ES default limit for (limit + offset); any search query beyond that limit will be rejected.
@@ -45,7 +45,7 @@ public class ElasticsearchSearchQueryImpl<T> extends AbstractSearchQuery<T, Elas
 	private final LoadingContext<?, ?> loadingContext;
 	private final Set<String> routingKeys;
 	private final JsonObject payload;
-	private final ElasticsearchSearchResultExtractor<T> searchResultExtractor;
+	private final ElasticsearchSearchResultExtractor<H> searchResultExtractor;
 
 	ElasticsearchSearchQueryImpl(ElasticsearchWorkBuilderFactory workFactory,
 			ElasticsearchWorkOrchestrator queryOrchestrator,
@@ -53,7 +53,7 @@ public class ElasticsearchSearchQueryImpl<T> extends AbstractSearchQuery<T, Elas
 			SessionContextImplementor sessionContext,
 			LoadingContext<?, ?> loadingContext,
 			Set<String> routingKeys,
-			JsonObject payload, ElasticsearchSearchResultExtractor<T> searchResultExtractor) {
+			JsonObject payload, ElasticsearchSearchResultExtractor<H> searchResultExtractor) {
 		this.workFactory = workFactory;
 		this.queryOrchestrator = queryOrchestrator;
 		this.indexNames = indexNames;
@@ -75,16 +75,16 @@ public class ElasticsearchSearchQueryImpl<T> extends AbstractSearchQuery<T, Elas
 	}
 
 	@Override
-	public <Q> Q extension(SearchQueryExtension<Q, T> extension) {
+	public <Q> Q extension(SearchQueryExtension<Q, H> extension) {
 		return DslExtensionState.returnIfSupported(
 				extension, extension.extendOptional( this, loadingContext )
 		);
 	}
 
 	@Override
-	public ElasticsearchSearchResult<T> fetch(Long limit, Long offset) {
+	public ElasticsearchSearchResult<H> fetch(Long limit, Long offset) {
 		// TODO restore scrolling support. See HSEARCH-3323
-		ElasticsearchWork<ElasticsearchLoadableSearchResult<T>> work = workFactory.search( payload, searchResultExtractor )
+		ElasticsearchWork<ElasticsearchLoadableSearchResult<H>> work = workFactory.search( payload, searchResultExtractor )
 				.indexes( indexNames )
 				.paging( defaultedLimit( limit, offset ), offset )
 				.routingKeys( routingKeys ).build();

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchResultImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchResultImpl.java
@@ -11,9 +11,9 @@ import java.util.List;
 import org.hibernate.search.backend.elasticsearch.search.query.ElasticsearchSearchResult;
 import org.hibernate.search.engine.search.query.spi.SimpleSearchResult;
 
-class ElasticsearchSearchResultImpl<T> extends SimpleSearchResult<T>
-		implements ElasticsearchSearchResult<T> {
-	ElasticsearchSearchResultImpl(long hitCount, List<T> hits) {
+class ElasticsearchSearchResultImpl<H> extends SimpleSearchResult<H>
+		implements ElasticsearchSearchResult<H> {
+	ElasticsearchSearchResultImpl(long hitCount, List<H> hits) {
 		super( hitCount, hits );
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/SearchBackendContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/SearchBackendContext.java
@@ -79,11 +79,11 @@ public class SearchBackendContext {
 		return new ElasticsearchSearchContext( mappingContext, userFacingGson, multiTenancyStrategy );
 	}
 
-	<T> ElasticsearchSearchQueryBuilder<T> createSearchQueryBuilder(
+	<H> ElasticsearchSearchQueryBuilder<H> createSearchQueryBuilder(
 			Set<URLEncodedString> indexNames,
 			SessionContextImplementor sessionContext,
 			LoadingContextBuilder<?, ?> loadingContextBuilder,
-			ElasticsearchSearchProjection<?, T> rootProjection) {
+			ElasticsearchSearchProjection<?, H> rootProjection) {
 		multiTenancyStrategy.checkTenantId( sessionContext.getTenantIdentifier(), eventContext );
 		return new ElasticsearchSearchQueryBuilder<>(
 				link.getWorkBuilderFactory(), link.getSearchResultExtractorFactory(), orchestrator, multiTenancyStrategy,

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/builder/impl/ScrollWorkBuilder.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/builder/impl/ScrollWorkBuilder.java
@@ -12,6 +12,6 @@ import org.hibernate.search.backend.elasticsearch.work.impl.ElasticsearchWork;
 /**
  * @author Yoann Rodiere
  */
-public interface ScrollWorkBuilder<T> extends ElasticsearchWorkBuilder<ElasticsearchWork<ElasticsearchLoadableSearchResult<T>>> {
+public interface ScrollWorkBuilder<H> extends ElasticsearchWorkBuilder<ElasticsearchWork<ElasticsearchLoadableSearchResult<H>>> {
 
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/ElasticsearchSearchResultExtractor.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/ElasticsearchSearchResultExtractor.java
@@ -10,8 +10,8 @@ import org.hibernate.search.backend.elasticsearch.search.query.impl.Elasticsearc
 
 import com.google.gson.JsonObject;
 
-public interface ElasticsearchSearchResultExtractor<T> {
+public interface ElasticsearchSearchResultExtractor<H> {
 
-	ElasticsearchLoadableSearchResult<T> extract(JsonObject responseBody);
+	ElasticsearchLoadableSearchResult<H> extract(JsonObject responseBody);
 
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/ScrollWork.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/ScrollWork.java
@@ -17,29 +17,29 @@ import com.google.gson.JsonObject;
 /**
  * @author Yoann Rodiere
  */
-public class ScrollWork<T> extends AbstractSimpleElasticsearchWork<ElasticsearchLoadableSearchResult<T>> {
+public class ScrollWork<H> extends AbstractSimpleElasticsearchWork<ElasticsearchLoadableSearchResult<H>> {
 
-	private final ElasticsearchSearchResultExtractor<T> resultExtractor;
+	private final ElasticsearchSearchResultExtractor<H> resultExtractor;
 
-	protected ScrollWork(Builder<T> builder) {
+	protected ScrollWork(Builder<H> builder) {
 		super( builder );
 		this.resultExtractor = builder.resultExtractor;
 	}
 
 	@Override
-	protected ElasticsearchLoadableSearchResult<T> generateResult(ElasticsearchWorkExecutionContext context, ElasticsearchResponse response) {
+	protected ElasticsearchLoadableSearchResult<H> generateResult(ElasticsearchWorkExecutionContext context, ElasticsearchResponse response) {
 		JsonObject body = response.getBody();
 		return resultExtractor.extract( body );
 	}
 
-	public static class Builder<T>
-			extends AbstractBuilder<Builder<T>>
-			implements ScrollWorkBuilder<T> {
+	public static class Builder<H>
+			extends AbstractBuilder<Builder<H>>
+			implements ScrollWorkBuilder<H> {
 		private final String scrollId;
 		private final String scrollTimeout;
-		private final ElasticsearchSearchResultExtractor<T> resultExtractor;
+		private final ElasticsearchSearchResultExtractor<H> resultExtractor;
 
-		public Builder(String scrollId, String scrollTimeout, ElasticsearchSearchResultExtractor<T> resultExtractor) {
+		public Builder(String scrollId, String scrollTimeout, ElasticsearchSearchResultExtractor<H> resultExtractor) {
 			super( null, DefaultElasticsearchRequestSuccessAssessor.INSTANCE );
 			this.scrollId = scrollId;
 			this.scrollTimeout = scrollTimeout;
@@ -62,7 +62,7 @@ public class ScrollWork<T> extends AbstractSimpleElasticsearchWork<Elasticsearch
 		}
 
 		@Override
-		public ScrollWork<T> build() {
+		public ScrollWork<H> build() {
 			return new ScrollWork<>( this );
 		}
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/SearchWork.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/SearchWork.java
@@ -26,13 +26,13 @@ import com.google.gson.JsonObject;
 /**
  * @author Yoann Rodiere
  */
-public class SearchWork<T> extends AbstractSimpleElasticsearchWork<ElasticsearchLoadableSearchResult<T>> {
+public class SearchWork<H> extends AbstractSimpleElasticsearchWork<ElasticsearchLoadableSearchResult<H>> {
 
 	private static final Log QUERY_LOG = LoggerFactory.make( Log.class, DefaultLogCategories.QUERY );
 
-	private final ElasticsearchSearchResultExtractor<T> resultExtractor;
+	private final ElasticsearchSearchResultExtractor<H> resultExtractor;
 
-	protected SearchWork(Builder<T> builder) {
+	protected SearchWork(Builder<H> builder) {
 		super( builder );
 		this.resultExtractor = builder.resultExtractor;
 	}
@@ -48,14 +48,14 @@ public class SearchWork<T> extends AbstractSimpleElasticsearchWork<Elasticsearch
 	}
 
 	@Override
-	protected ElasticsearchLoadableSearchResult<T> generateResult(ElasticsearchWorkExecutionContext context, ElasticsearchResponse response) {
+	protected ElasticsearchLoadableSearchResult<H> generateResult(ElasticsearchWorkExecutionContext context, ElasticsearchResponse response) {
 		JsonObject body = response.getBody();
 		return resultExtractor.extract( body );
 	}
 
-	public static class Builder<T>
-			extends AbstractBuilder<Builder<T>>
-			implements SearchWorkBuilder<T> {
+	public static class Builder<H>
+			extends AbstractBuilder<Builder<H>>
+			implements SearchWorkBuilder<H> {
 
 		public static <T> Builder<T> forElasticsearch6AndBelow(JsonObject payload, ElasticsearchSearchResultExtractor<T> resultExtractor) {
 			// No "track_total_hits": this parameter does not exist in ES6 and below, and total hits are always tracked
@@ -68,7 +68,7 @@ public class SearchWork<T> extends AbstractSimpleElasticsearchWork<Elasticsearch
 		}
 
 		private final JsonObject payload;
-		private final ElasticsearchSearchResultExtractor<T> resultExtractor;
+		private final ElasticsearchSearchResultExtractor<H> resultExtractor;
 		private final Boolean trackTotalHits;
 		private final Set<URLEncodedString> indexes = new HashSet<>();
 
@@ -78,7 +78,7 @@ public class SearchWork<T> extends AbstractSimpleElasticsearchWork<Elasticsearch
 		private String scrollTimeout;
 		private Set<String> routingKeys;
 
-		private Builder(JsonObject payload, ElasticsearchSearchResultExtractor<T> resultExtractor, Boolean trackTotalHits) {
+		private Builder(JsonObject payload, ElasticsearchSearchResultExtractor<H> resultExtractor, Boolean trackTotalHits) {
 			super( null, DefaultElasticsearchRequestSuccessAssessor.INSTANCE );
 			this.payload = payload;
 			this.resultExtractor = resultExtractor;
@@ -86,27 +86,27 @@ public class SearchWork<T> extends AbstractSimpleElasticsearchWork<Elasticsearch
 		}
 
 		@Override
-		public Builder<T> indexes(Collection<URLEncodedString> indexNames) {
+		public Builder<H> indexes(Collection<URLEncodedString> indexNames) {
 			indexes.addAll( indexNames );
 			return this;
 		}
 
 		@Override
-		public Builder<T> paging(Long limit, Long offset) {
+		public Builder<H> paging(Long limit, Long offset) {
 			this.from = offset;
 			this.size = limit;
 			return this;
 		}
 
 		@Override
-		public Builder<T> scrolling(long scrollSize, String scrollTimeout) {
+		public Builder<H> scrolling(long scrollSize, String scrollTimeout) {
 			this.scrollSize = scrollSize;
 			this.scrollTimeout = scrollTimeout;
 			return this;
 		}
 
 		@Override
-		public SearchWorkBuilder<T> routingKeys(Set<String> routingKeys) {
+		public SearchWorkBuilder<H> routingKeys(Set<String> routingKeys) {
 			this.routingKeys = routingKeys;
 			return this;
 		}
@@ -144,7 +144,7 @@ public class SearchWork<T> extends AbstractSimpleElasticsearchWork<Elasticsearch
 		}
 
 		@Override
-		public SearchWork<T> build() {
+		public SearchWork<H> build() {
 			return new SearchWork<>( this );
 		}
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/LuceneExtension.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/LuceneExtension.java
@@ -54,7 +54,7 @@ import org.hibernate.search.util.common.logging.impl.LoggerFactory;
  * all of its methods are considered SPIs and therefore should never be called directly by users.
  * In short, users are only expected to get instances of this type from an API and pass it to another API.
  *
- * @param <T> The type of query hits.
+ * @param <H> The type of query hits.
  * Users should not have to care about this, as the parameter will automatically take the appropriate value when calling
  * {@code .extension( LuceneExtension.get() }.
  * @param <R> The reference type for projections.
@@ -64,9 +64,9 @@ import org.hibernate.search.util.common.logging.impl.LoggerFactory;
  * Users should not have to care about this, as the parameter will automatically take the appropriate value when calling
  * {@code .extension( LuceneExtension.get() }.
  */
-public final class LuceneExtension<T, R, E>
+public final class LuceneExtension<H, R, E>
 		implements SearchQueryContextExtension<LuceneSearchQueryResultDefinitionContext<R, E>, R, E>,
-		SearchQueryExtension<LuceneSearchQuery<T>, T>,
+		SearchQueryExtension<LuceneSearchQuery<H>, H>,
 		SearchPredicateFactoryContextExtension<LuceneSearchPredicateFactoryContext>,
 		SearchSortContainerContextExtension<LuceneSearchSortContainerContext>,
 		SearchProjectionFactoryContextExtension<LuceneSearchProjectionFactoryContext<R, E>, R, E>,
@@ -76,9 +76,9 @@ public final class LuceneExtension<T, R, E>
 
 	private static final LuceneExtension<Object, Object, Object> INSTANCE = new LuceneExtension<>();
 
-	@SuppressWarnings("unchecked") // The instance works for any T, R and E
-	public static <Q, R, E> LuceneExtension<Q, R, E> get() {
-		return (LuceneExtension<Q, R, E>) INSTANCE;
+	@SuppressWarnings("unchecked") // The instance works for any H, R and E
+	public static <H, R, E> LuceneExtension<H, R, E> get() {
+		return (LuceneExtension<H, R, E>) INSTANCE;
 	}
 
 	private LuceneExtension() {
@@ -108,10 +108,10 @@ public final class LuceneExtension<T, R, E>
 	 * {@inheritDoc}
 	 */
 	@Override
-	public Optional<LuceneSearchQuery<T>> extendOptional(SearchQuery<T> original,
+	public Optional<LuceneSearchQuery<H>> extendOptional(SearchQuery<H> original,
 			LoadingContext<?, ?> loadingContext) {
 		if ( original instanceof LuceneSearchQuery ) {
-			return Optional.of( (LuceneSearchQuery<T>) original );
+			return Optional.of( (LuceneSearchQuery<H>) original );
 		}
 		else {
 			return Optional.empty();

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/LuceneExtension.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/LuceneExtension.java
@@ -60,25 +60,25 @@ import org.hibernate.search.util.common.logging.impl.LoggerFactory;
  * @param <R> The reference type for projections.
  * Users should not have to care about this, as the parameter will automatically take the appropriate value when calling
  * {@code .extension( LuceneExtension.get() }.
- * @param <O> entity type for projections.
+ * @param <E> entity type for projections.
  * Users should not have to care about this, as the parameter will automatically take the appropriate value when calling
  * {@code .extension( LuceneExtension.get() }.
  */
-public final class LuceneExtension<T, R, O>
-		implements SearchQueryContextExtension<LuceneSearchQueryResultDefinitionContext<R, O>, R, O>,
+public final class LuceneExtension<T, R, E>
+		implements SearchQueryContextExtension<LuceneSearchQueryResultDefinitionContext<R, E>, R, E>,
 		SearchQueryExtension<LuceneSearchQuery<T>, T>,
 		SearchPredicateFactoryContextExtension<LuceneSearchPredicateFactoryContext>,
 		SearchSortContainerContextExtension<LuceneSearchSortContainerContext>,
-		SearchProjectionFactoryContextExtension<LuceneSearchProjectionFactoryContext<R, O>, R, O>,
+		SearchProjectionFactoryContextExtension<LuceneSearchProjectionFactoryContext<R, E>, R, E>,
 		IndexFieldTypeFactoryContextExtension<LuceneIndexFieldTypeFactoryContext> {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private static final LuceneExtension<Object, Object, Object> INSTANCE = new LuceneExtension<>();
 
-	@SuppressWarnings("unchecked") // The instance works for any T, R and O
-	public static <Q, R, O> LuceneExtension<Q, R, O> get() {
-		return (LuceneExtension<Q, R, O>) INSTANCE;
+	@SuppressWarnings("unchecked") // The instance works for any T, R and E
+	public static <Q, R, E> LuceneExtension<Q, R, E> get() {
+		return (LuceneExtension<Q, R, E>) INSTANCE;
 	}
 
 	private LuceneExtension() {
@@ -89,11 +89,11 @@ public final class LuceneExtension<T, R, O>
 	 * {@inheritDoc}
 	 */
 	@Override
-	public Optional<LuceneSearchQueryResultDefinitionContext<R, O>> extendOptional(
-			SearchQueryResultDefinitionContext<R, O, ?> original,
+	public Optional<LuceneSearchQueryResultDefinitionContext<R, E>> extendOptional(
+			SearchQueryResultDefinitionContext<R, E, ?> original,
 			IndexSearchScope<?> indexSearchScope,
 			SessionContextImplementor sessionContext,
-			LoadingContextBuilder<R, O> loadingContextBuilder) {
+			LoadingContextBuilder<R, E> loadingContextBuilder) {
 		if ( indexSearchScope instanceof LuceneIndexSearchScope ) {
 			return Optional.of( new LuceneSearchQueryResultDefinitionContextImpl<>(
 					(LuceneIndexSearchScope) indexSearchScope, sessionContext, loadingContextBuilder
@@ -153,8 +153,8 @@ public final class LuceneExtension<T, R, O>
 	 * {@inheritDoc}
 	 */
 	@Override
-	public Optional<LuceneSearchProjectionFactoryContext<R, O>> extendOptional(
-			SearchProjectionFactoryContext<R, O> original, SearchProjectionBuilderFactory factory) {
+	public Optional<LuceneSearchProjectionFactoryContext<R, E>> extendOptional(
+			SearchProjectionFactoryContext<R, E> original, SearchProjectionBuilderFactory factory) {
 		if ( factory instanceof LuceneSearchProjectionBuilderFactory ) {
 			return Optional.of( new LuceneSearchProjectionFactoryContextImpl<>(
 					original, (LuceneSearchProjectionBuilderFactory) factory

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/LuceneExtension.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/LuceneExtension.java
@@ -60,7 +60,7 @@ import org.hibernate.search.util.common.logging.impl.LoggerFactory;
  * @param <R> The reference type for projections.
  * Users should not have to care about this, as the parameter will automatically take the appropriate value when calling
  * {@code .extension( LuceneExtension.get() }.
- * @param <O> The loaded object type for projections.
+ * @param <O> entity type for projections.
  * Users should not have to care about this, as the parameter will automatically take the appropriate value when calling
  * {@code .extension( LuceneExtension.get() }.
  */

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/projection/LuceneSearchProjectionFactoryContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/projection/LuceneSearchProjectionFactoryContext.java
@@ -16,10 +16,10 @@ import org.apache.lucene.search.Explanation;
  * A DSL context allowing to create a projection, with some Lucene-specific methods.
  *
  * @param <R> The type of references.
- * @param <O> The type of entities.
+ * @param <E> The type of entities.
  * @see SearchProjectionFactoryContext
  */
-public interface LuceneSearchProjectionFactoryContext<R, O> extends SearchProjectionFactoryContext<R, O> {
+public interface LuceneSearchProjectionFactoryContext<R, E> extends SearchProjectionFactoryContext<R, E> {
 
 	/**
 	 * Project to a Lucene {@link Document} containing all the stored fields.

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/projection/LuceneSearchProjectionFactoryContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/projection/LuceneSearchProjectionFactoryContext.java
@@ -16,7 +16,7 @@ import org.apache.lucene.search.Explanation;
  * A DSL context allowing to create a projection, with some Lucene-specific methods.
  *
  * @param <R> The type of references.
- * @param <O> The type of loaded objects.
+ * @param <O> The type of entities.
  * @see SearchProjectionFactoryContext
  */
 public interface LuceneSearchProjectionFactoryContext<R, O> extends SearchProjectionFactoryContext<R, O> {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/projection/impl/LuceneSearchProjectionFactoryContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/projection/impl/LuceneSearchProjectionFactoryContextImpl.java
@@ -15,13 +15,13 @@ import org.hibernate.search.engine.search.dsl.projection.spi.DelegatingSearchPro
 import org.apache.lucene.document.Document;
 import org.apache.lucene.search.Explanation;
 
-public class LuceneSearchProjectionFactoryContextImpl<R, O>
-		extends DelegatingSearchProjectionFactoryContext<R, O>
-		implements LuceneSearchProjectionFactoryContext<R, O> {
+public class LuceneSearchProjectionFactoryContextImpl<R, E>
+		extends DelegatingSearchProjectionFactoryContext<R, E>
+		implements LuceneSearchProjectionFactoryContext<R, E> {
 
 	private final LuceneSearchProjectionBuilderFactory factory;
 
-	public LuceneSearchProjectionFactoryContextImpl(SearchProjectionFactoryContext<R, O> delegate,
+	public LuceneSearchProjectionFactoryContextImpl(SearchProjectionFactoryContext<R, E> delegate,
 			LuceneSearchProjectionBuilderFactory factory) {
 		super( delegate );
 		this.factory = factory;

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/query/LuceneSearchQueryContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/query/LuceneSearchQueryContext.java
@@ -10,10 +10,10 @@ import org.hibernate.search.backend.lucene.search.dsl.sort.LuceneSearchSortConta
 import org.hibernate.search.backend.lucene.search.query.LuceneSearchQuery;
 import org.hibernate.search.engine.search.dsl.query.SearchQueryContext;
 
-public interface LuceneSearchQueryContext<T>
-		extends SearchQueryContext<LuceneSearchQueryContext<T>, T, LuceneSearchSortContainerContext> {
+public interface LuceneSearchQueryContext<H>
+		extends SearchQueryContext<LuceneSearchQueryContext<H>, H, LuceneSearchSortContainerContext> {
 
 	@Override
-	LuceneSearchQuery<T> toQuery();
+	LuceneSearchQuery<H> toQuery();
 
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/query/LuceneSearchQueryResultContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/query/LuceneSearchQueryResultContext.java
@@ -9,7 +9,7 @@ package org.hibernate.search.backend.lucene.search.dsl.query;
 import org.hibernate.search.backend.lucene.search.dsl.predicate.LuceneSearchPredicateFactoryContext;
 import org.hibernate.search.engine.search.dsl.query.SearchQueryResultContext;
 
-public interface LuceneSearchQueryResultContext<T>
-		extends SearchQueryResultContext<LuceneSearchQueryContext<T>, T, LuceneSearchPredicateFactoryContext> {
+public interface LuceneSearchQueryResultContext<H>
+		extends SearchQueryResultContext<LuceneSearchQueryContext<H>, H, LuceneSearchPredicateFactoryContext> {
 
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/query/LuceneSearchQueryResultDefinitionContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/query/LuceneSearchQueryResultDefinitionContext.java
@@ -14,18 +14,18 @@ import org.hibernate.search.engine.search.SearchProjection;
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionTerminalContext;
 import org.hibernate.search.engine.search.dsl.query.SearchQueryResultDefinitionContext;
 
-public interface LuceneSearchQueryResultDefinitionContext<R, O>
-		extends SearchQueryResultDefinitionContext<R, O, LuceneSearchProjectionFactoryContext<R, O>> {
+public interface LuceneSearchQueryResultDefinitionContext<R, E>
+		extends SearchQueryResultDefinitionContext<R, E, LuceneSearchProjectionFactoryContext<R, E>> {
 
 	@Override
-	LuceneSearchQueryResultContext<O> asEntity();
+	LuceneSearchQueryResultContext<E> asEntity();
 
 	@Override
 	LuceneSearchQueryResultContext<R> asReference();
 
 	@Override
 	<P> LuceneSearchQueryResultContext<P> asProjection(
-			Function<? super LuceneSearchProjectionFactoryContext<R, O>, ? extends SearchProjectionTerminalContext<P>> projectionContributor);
+			Function<? super LuceneSearchProjectionFactoryContext<R, E>, ? extends SearchProjectionTerminalContext<P>> projectionContributor);
 
 	@Override
 	<P> LuceneSearchQueryResultContext<P> asProjection(SearchProjection<P> projection);

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/query/impl/LuceneSearchQueryContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/query/impl/LuceneSearchQueryContextImpl.java
@@ -19,31 +19,31 @@ import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryCo
 import org.hibernate.search.engine.search.dsl.query.spi.AbstractSearchQueryContext;
 import org.hibernate.search.engine.search.dsl.sort.SearchSortContainerContext;
 
-class LuceneSearchQueryContextImpl<T>
+class LuceneSearchQueryContextImpl<H>
 		extends AbstractSearchQueryContext<
-		LuceneSearchQueryContext<T>,
-		T,
+		LuceneSearchQueryContext<H>,
+		H,
 		LuceneSearchPredicateFactoryContext,
 		LuceneSearchSortContainerContext,
 		LuceneSearchQueryElementCollector
 		>
-		implements LuceneSearchQueryResultContext<T>, LuceneSearchQueryContext<T> {
+		implements LuceneSearchQueryResultContext<H>, LuceneSearchQueryContext<H> {
 
-	private final LuceneSearchQueryBuilder<T> searchQueryBuilder;
+	private final LuceneSearchQueryBuilder<H> searchQueryBuilder;
 
 	LuceneSearchQueryContextImpl(LuceneIndexSearchScope indexSearchScope,
-			LuceneSearchQueryBuilder<T> searchQueryBuilder) {
+			LuceneSearchQueryBuilder<H> searchQueryBuilder) {
 		super( indexSearchScope, searchQueryBuilder );
 		this.searchQueryBuilder = searchQueryBuilder;
 	}
 
 	@Override
-	public LuceneSearchQuery<T> toQuery() {
+	public LuceneSearchQuery<H> toQuery() {
 		return searchQueryBuilder.build();
 	}
 
 	@Override
-	protected LuceneSearchQueryContextImpl<T> thisAsS() {
+	protected LuceneSearchQueryContextImpl<H> thisAsS() {
 		return this;
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/query/impl/LuceneSearchQueryResultDefinitionContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/query/impl/LuceneSearchQueryResultDefinitionContextImpl.java
@@ -22,30 +22,30 @@ import org.hibernate.search.engine.search.dsl.projection.SearchProjectionTermina
 import org.hibernate.search.engine.search.dsl.query.spi.AbstractSearchQueryResultDefinitionContext;
 import org.hibernate.search.engine.search.loading.context.spi.LoadingContextBuilder;
 
-public class LuceneSearchQueryResultDefinitionContextImpl<R, O>
+public class LuceneSearchQueryResultDefinitionContextImpl<R, E>
 		extends AbstractSearchQueryResultDefinitionContext<
 				R,
-				O,
-				LuceneSearchProjectionFactoryContext<R, O>,
+				E,
+				LuceneSearchProjectionFactoryContext<R, E>,
 				LuceneSearchQueryElementCollector
 		>
-		implements LuceneSearchQueryResultDefinitionContext<R, O> {
+		implements LuceneSearchQueryResultDefinitionContext<R, E> {
 
 	private final LuceneIndexSearchScope indexSearchScope;
 	private final SessionContextImplementor sessionContext;
-	private final LoadingContextBuilder<R, O> loadingContextBuilder;
+	private final LoadingContextBuilder<R, E> loadingContextBuilder;
 
 	public LuceneSearchQueryResultDefinitionContextImpl(LuceneIndexSearchScope indexSearchScope,
 			SessionContextImplementor sessionContext,
-			LoadingContextBuilder<R, O> loadingContextBuilder) {
+			LoadingContextBuilder<R, E> loadingContextBuilder) {
 		this.indexSearchScope = indexSearchScope;
 		this.sessionContext = sessionContext;
 		this.loadingContextBuilder = loadingContextBuilder;
 	}
 
 	@Override
-	public LuceneSearchQueryResultContext<O> asEntity() {
-		LuceneSearchQueryBuilder<O> builder = indexSearchScope.getSearchQueryBuilderFactory()
+	public LuceneSearchQueryResultContext<E> asEntity() {
+		LuceneSearchQueryBuilder<E> builder = indexSearchScope.getSearchQueryBuilderFactory()
 				.asEntity( sessionContext, loadingContextBuilder );
 		return createSearchQueryContext( builder );
 	}
@@ -59,8 +59,8 @@ public class LuceneSearchQueryResultDefinitionContextImpl<R, O>
 
 	@Override
 	public <P> LuceneSearchQueryResultContext<P> asProjection(
-			Function<? super LuceneSearchProjectionFactoryContext<R, O>, ? extends SearchProjectionTerminalContext<P>> projectionContributor) {
-		LuceneSearchProjectionFactoryContext<R, O> factoryContext =
+			Function<? super LuceneSearchProjectionFactoryContext<R, E>, ? extends SearchProjectionTerminalContext<P>> projectionContributor) {
+		LuceneSearchProjectionFactoryContext<R, E> factoryContext =
 				createDefaultProjectionFactoryContext().extension( LuceneExtension.get() );
 		SearchProjection<P> projection = projectionContributor.apply( factoryContext ).toProjection();
 		return asProjection( projection );
@@ -91,7 +91,7 @@ public class LuceneSearchQueryResultDefinitionContextImpl<R, O>
 	}
 
 	@Override
-	protected LoadingContextBuilder<R, O> getLoadingContextBuilder() {
+	protected LoadingContextBuilder<R, E> getLoadingContextBuilder() {
 		return loadingContextBuilder;
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/query/impl/LuceneSearchQueryResultDefinitionContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/query/impl/LuceneSearchQueryResultDefinitionContextImpl.java
@@ -95,7 +95,7 @@ public class LuceneSearchQueryResultDefinitionContextImpl<R, E>
 		return loadingContextBuilder;
 	}
 
-	private <T> LuceneSearchQueryResultContext<T> createSearchQueryContext(LuceneSearchQueryBuilder<T> builder) {
+	private <H> LuceneSearchQueryResultContext<H> createSearchQueryContext(LuceneSearchQueryBuilder<H> builder) {
 		return new LuceneSearchQueryContextImpl<>( indexSearchScope, builder );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/query/impl/LuceneSearchQueryResultDefinitionContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/query/impl/LuceneSearchQueryResultDefinitionContextImpl.java
@@ -46,7 +46,7 @@ public class LuceneSearchQueryResultDefinitionContextImpl<R, O>
 	@Override
 	public LuceneSearchQueryResultContext<O> asEntity() {
 		LuceneSearchQueryBuilder<O> builder = indexSearchScope.getSearchQueryBuilderFactory()
-				.asObject( sessionContext, loadingContextBuilder );
+				.asEntity( sessionContext, loadingContextBuilder );
 		return createSearchQueryContext( builder );
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneCompositeBiFunctionProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneCompositeBiFunctionProjection.java
@@ -16,15 +16,15 @@ import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneDocument
 import org.hibernate.search.engine.search.loading.spi.LoadingResult;
 import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 
-public class LuceneCompositeBiFunctionProjection<P1, P2, T> implements LuceneCompositeProjection<Object[], T> {
+public class LuceneCompositeBiFunctionProjection<P1, P2, P> implements LuceneCompositeProjection<Object[], P> {
 
-	private final BiFunction<P1, P2, T> transformer;
+	private final BiFunction<P1, P2, P> transformer;
 
 	private final LuceneSearchProjection<?, P1> projection1;
 
 	private final LuceneSearchProjection<?, P2> projection2;
 
-	public LuceneCompositeBiFunctionProjection(BiFunction<P1, P2, T> transformer,
+	public LuceneCompositeBiFunctionProjection(BiFunction<P1, P2, P> transformer,
 			LuceneSearchProjection<?, P1> projection1, LuceneSearchProjection<?, P2> projection2) {
 		this.transformer = transformer;
 		this.projection1 = projection1;
@@ -53,7 +53,7 @@ public class LuceneCompositeBiFunctionProjection<P1, P2, T> implements LuceneCom
 	}
 
 	@Override
-	public T transform(LoadingResult<?> loadingResult, Object[] extractedData,
+	public P transform(LoadingResult<?> loadingResult, Object[] extractedData,
 			SearchProjectionTransformContext context) {
 		return transformer.apply(
 				transformUnsafe( projection1, loadingResult, extractedData[0], context ),

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneCompositeFunctionProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneCompositeFunctionProjection.java
@@ -14,14 +14,14 @@ import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneDocument
 import org.hibernate.search.engine.search.loading.spi.LoadingResult;
 import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 
-public class LuceneCompositeFunctionProjection<E, P, T> implements LuceneCompositeProjection<E, T> {
+public class LuceneCompositeFunctionProjection<E, P1, P> implements LuceneCompositeProjection<E, P> {
 
-	private final Function<P, T> transformer;
+	private final Function<P1, P> transformer;
 
-	private final LuceneSearchProjection<E, P> projection;
+	private final LuceneSearchProjection<E, P1> projection;
 
-	public LuceneCompositeFunctionProjection(Function<P, T> transformer,
-			LuceneSearchProjection<E, P> projection) {
+	public LuceneCompositeFunctionProjection(Function<P1, P> transformer,
+			LuceneSearchProjection<E, P1> projection) {
 		this.transformer = transformer;
 		this.projection = projection;
 	}
@@ -43,7 +43,7 @@ public class LuceneCompositeFunctionProjection<E, P, T> implements LuceneComposi
 	}
 
 	@Override
-	public T transform(LoadingResult<?> loadingResult, E extractedData,
+	public P transform(LoadingResult<?> loadingResult, E extractedData,
 			SearchProjectionTransformContext context) {
 		return transformer.apply( projection.transform( loadingResult, extractedData, context ) );
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneCompositeListProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneCompositeListProjection.java
@@ -18,13 +18,13 @@ import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneDocument
 import org.hibernate.search.engine.search.loading.spi.LoadingResult;
 import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 
-public class LuceneCompositeListProjection<T> implements LuceneCompositeProjection<List<Object>, T> {
+public class LuceneCompositeListProjection<P> implements LuceneCompositeProjection<List<Object>, P> {
 
-	private final Function<List<?>, T> transformer;
+	private final Function<List<?>, P> transformer;
 
 	private final List<LuceneSearchProjection<?, ?>> children;
 
-	public LuceneCompositeListProjection(Function<List<?>, T> transformer,
+	public LuceneCompositeListProjection(Function<List<?>, P> transformer,
 			List<LuceneSearchProjection<?, ?>> children) {
 		this.transformer = transformer;
 		this.children = children;
@@ -57,7 +57,7 @@ public class LuceneCompositeListProjection<T> implements LuceneCompositeProjecti
 	}
 
 	@Override
-	public T transform(LoadingResult<?> loadingResult, List<Object> extractedData,
+	public P transform(LoadingResult<?> loadingResult, List<Object> extractedData,
 			SearchProjectionTransformContext context) {
 		for ( int i = 0; i < extractedData.size(); i++ ) {
 			extractedData.set( i, transformUnsafe( children.get( i ), loadingResult, extractedData.get( i ), context ) );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneCompositeProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneCompositeProjection.java
@@ -6,6 +6,6 @@
  */
 package org.hibernate.search.backend.lucene.search.projection.impl;
 
-public interface LuceneCompositeProjection<E, T> extends LuceneSearchProjection<E, T> {
+public interface LuceneCompositeProjection<E, P> extends LuceneSearchProjection<E, P> {
 
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneCompositeProjectionBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneCompositeProjectionBuilder.java
@@ -10,16 +10,16 @@ import org.hibernate.search.engine.search.SearchProjection;
 import org.hibernate.search.engine.search.projection.spi.CompositeProjectionBuilder;
 
 
-class LuceneCompositeProjectionBuilder<T> implements CompositeProjectionBuilder<T> {
+class LuceneCompositeProjectionBuilder<P> implements CompositeProjectionBuilder<P> {
 
-	private final LuceneCompositeProjection<?, T> projection;
+	private final LuceneCompositeProjection<?, P> projection;
 
-	LuceneCompositeProjectionBuilder(LuceneCompositeProjection<?, T> projection) {
+	LuceneCompositeProjectionBuilder(LuceneCompositeProjection<?, P> projection) {
 		this.projection = projection;
 	}
 
 	@Override
-	public SearchProjection<T> build() {
+	public SearchProjection<P> build() {
 		return projection;
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneCompositeTriFunctionProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneCompositeTriFunctionProjection.java
@@ -16,9 +16,9 @@ import org.hibernate.search.engine.search.loading.spi.LoadingResult;
 import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 import org.hibernate.search.util.common.function.TriFunction;
 
-public class LuceneCompositeTriFunctionProjection<P1, P2, P3, T> implements LuceneCompositeProjection<Object[], T> {
+public class LuceneCompositeTriFunctionProjection<P1, P2, P3, P> implements LuceneCompositeProjection<Object[], P> {
 
-	private final TriFunction<P1, P2, P3, T> transformer;
+	private final TriFunction<P1, P2, P3, P> transformer;
 
 	private final LuceneSearchProjection<?, P1> projection1;
 
@@ -26,7 +26,7 @@ public class LuceneCompositeTriFunctionProjection<P1, P2, P3, T> implements Luce
 
 	private final LuceneSearchProjection<?, P3> projection3;
 
-	public LuceneCompositeTriFunctionProjection(TriFunction<P1, P2, P3, T> transformer,
+	public LuceneCompositeTriFunctionProjection(TriFunction<P1, P2, P3, P> transformer,
 			LuceneSearchProjection<?, P1> projection1, LuceneSearchProjection<?, P2> projection2,
 			LuceneSearchProjection<?, P3> projection3) {
 		this.transformer = transformer;
@@ -60,7 +60,7 @@ public class LuceneCompositeTriFunctionProjection<P1, P2, P3, T> implements Luce
 	}
 
 	@Override
-	public T transform(LoadingResult<?> loadingResult, Object[] extractedData,
+	public P transform(LoadingResult<?> loadingResult, Object[] extractedData,
 			SearchProjectionTransformContext context) {
 		return transformer.apply(
 				transformUnsafe( projection1, loadingResult, extractedData[0], context ),

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneEntityProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneEntityProjection.java
@@ -13,7 +13,7 @@ import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneDocument
 import org.hibernate.search.engine.search.loading.spi.LoadingResult;
 import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 
-public class LuceneEntityProjection<O> implements LuceneSearchProjection<Object, O> {
+public class LuceneEntityProjection<E> implements LuceneSearchProjection<Object, E> {
 
 	@SuppressWarnings("rawtypes")
 	private static final LuceneEntityProjection INSTANCE = new LuceneEntityProjection();
@@ -44,9 +44,9 @@ public class LuceneEntityProjection<O> implements LuceneSearchProjection<Object,
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public O transform(LoadingResult<?> loadingResult, Object extractedData,
+	public E transform(LoadingResult<?> loadingResult, Object extractedData,
 			SearchProjectionTransformContext context) {
-		return (O) loadingResult.getLoaded( extractedData );
+		return (E) loadingResult.getLoaded( extractedData );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneEntityProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneEntityProjection.java
@@ -13,17 +13,17 @@ import org.hibernate.search.backend.lucene.search.extraction.impl.LuceneDocument
 import org.hibernate.search.engine.search.loading.spi.LoadingResult;
 import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 
-public class LuceneObjectProjection<O> implements LuceneSearchProjection<Object, O> {
+public class LuceneEntityProjection<O> implements LuceneSearchProjection<Object, O> {
 
 	@SuppressWarnings("rawtypes")
-	private static final LuceneObjectProjection INSTANCE = new LuceneObjectProjection();
+	private static final LuceneEntityProjection INSTANCE = new LuceneEntityProjection();
 
 	@SuppressWarnings("unchecked")
-	public static <T> LuceneObjectProjection<T> get() {
+	public static <T> LuceneEntityProjection<T> get() {
 		return INSTANCE;
 	}
 
-	private LuceneObjectProjection() {
+	private LuceneEntityProjection() {
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneEntityProjectionBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneEntityProjectionBuilder.java
@@ -7,24 +7,24 @@
 package org.hibernate.search.backend.lucene.search.projection.impl;
 
 import org.hibernate.search.engine.search.SearchProjection;
-import org.hibernate.search.engine.search.projection.spi.ObjectProjectionBuilder;
+import org.hibernate.search.engine.search.projection.spi.EntityProjectionBuilder;
 
 
-public class LuceneObjectProjectionBuilder<O> implements ObjectProjectionBuilder<O> {
+public class LuceneEntityProjectionBuilder<O> implements EntityProjectionBuilder<O> {
 
 	@SuppressWarnings("rawtypes")
-	private static final LuceneObjectProjectionBuilder INSTANCE = new LuceneObjectProjectionBuilder();
+	private static final LuceneEntityProjectionBuilder INSTANCE = new LuceneEntityProjectionBuilder();
 
 	@SuppressWarnings("unchecked")
-	public static <T> LuceneObjectProjectionBuilder<T> get() {
+	public static <T> LuceneEntityProjectionBuilder<T> get() {
 		return INSTANCE;
 	}
 
-	private LuceneObjectProjectionBuilder() {
+	private LuceneEntityProjectionBuilder() {
 	}
 
 	@Override
 	public SearchProjection<O> build() {
-		return LuceneObjectProjection.get();
+		return LuceneEntityProjection.get();
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneEntityProjectionBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneEntityProjectionBuilder.java
@@ -10,7 +10,7 @@ import org.hibernate.search.engine.search.SearchProjection;
 import org.hibernate.search.engine.search.projection.spi.EntityProjectionBuilder;
 
 
-public class LuceneEntityProjectionBuilder<O> implements EntityProjectionBuilder<O> {
+public class LuceneEntityProjectionBuilder<E> implements EntityProjectionBuilder<E> {
 
 	@SuppressWarnings("rawtypes")
 	private static final LuceneEntityProjectionBuilder INSTANCE = new LuceneEntityProjectionBuilder();
@@ -24,7 +24,7 @@ public class LuceneEntityProjectionBuilder<O> implements EntityProjectionBuilder
 	}
 
 	@Override
-	public SearchProjection<O> build() {
+	public SearchProjection<E> build() {
 		return LuceneEntityProjection.get();
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneFieldProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneFieldProjection.java
@@ -15,16 +15,16 @@ import org.hibernate.search.engine.backend.types.converter.runtime.FromDocumentF
 import org.hibernate.search.engine.search.loading.spi.LoadingResult;
 import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 
-class LuceneFieldProjection<F, T> implements LuceneSearchProjection<F, T> {
+class LuceneFieldProjection<F, V> implements LuceneSearchProjection<F, V> {
 
 	private final String absoluteFieldPath;
 
 	private final LuceneFieldCodec<F> codec;
 
-	private final FromDocumentFieldValueConverter<? super F, T> converter;
+	private final FromDocumentFieldValueConverter<? super F, V> converter;
 
 	LuceneFieldProjection(String absoluteFieldPath, LuceneFieldCodec<F> codec,
-			FromDocumentFieldValueConverter<? super F, T> converter) {
+			FromDocumentFieldValueConverter<? super F, V> converter) {
 		this.absoluteFieldPath = absoluteFieldPath;
 		this.codec = codec;
 		this.converter = converter;
@@ -47,7 +47,7 @@ class LuceneFieldProjection<F, T> implements LuceneSearchProjection<F, T> {
 	}
 
 	@Override
-	public T transform(LoadingResult<?> loadingResult, F extractedData,
+	public V transform(LoadingResult<?> loadingResult, F extractedData,
 			SearchProjectionTransformContext context) {
 		FromDocumentFieldValueConvertContext convertContext = context.getFromDocumentFieldValueConvertContext();
 		return converter.convert( extractedData, convertContext );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneFieldProjectionBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneFieldProjectionBuilder.java
@@ -11,15 +11,15 @@ import org.hibernate.search.engine.backend.types.converter.FromDocumentFieldValu
 import org.hibernate.search.engine.search.SearchProjection;
 import org.hibernate.search.engine.search.projection.spi.FieldProjectionBuilder;
 
-public class LuceneFieldProjectionBuilder<F, T> implements FieldProjectionBuilder<T> {
+public class LuceneFieldProjectionBuilder<F, V> implements FieldProjectionBuilder<V> {
 
 	private final String absoluteFieldPath;
 
-	private final FromDocumentFieldValueConverter<? super F, T> converter;
+	private final FromDocumentFieldValueConverter<? super F, V> converter;
 	private final LuceneFieldCodec<F> codec;
 
 	public LuceneFieldProjectionBuilder(String absoluteFieldPath,
-			FromDocumentFieldValueConverter<? super F, T> converter,
+			FromDocumentFieldValueConverter<? super F, V> converter,
 			LuceneFieldCodec<F> codec) {
 		this.absoluteFieldPath = absoluteFieldPath;
 		this.converter = converter;
@@ -27,7 +27,7 @@ public class LuceneFieldProjectionBuilder<F, T> implements FieldProjectionBuilde
 	}
 
 	@Override
-	public SearchProjection<T> build() {
+	public SearchProjection<V> build() {
 		return new LuceneFieldProjection<>( absoluteFieldPath, codec, converter );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneSearchProjection.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneSearchProjection.java
@@ -13,7 +13,7 @@ import org.hibernate.search.engine.search.SearchProjection;
 import org.hibernate.search.engine.search.loading.spi.LoadingResult;
 import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 
-public interface LuceneSearchProjection<E, T> extends SearchProjection<T>, LuceneCollectorProvider {
+public interface LuceneSearchProjection<E, P> extends SearchProjection<P>, LuceneCollectorProvider {
 
 	/**
 	 * Contributes to the list of fields extracted from the Lucene document. Some fields might require the extraction of
@@ -50,7 +50,7 @@ public interface LuceneSearchProjection<E, T> extends SearchProjection<T>, Lucen
 	 * @param context An execution context for the transforming.
 	 * @return The final result considered as a hit.
 	 */
-	T transform(LoadingResult<?> loadingResult, E extractedData,
+	P transform(LoadingResult<?> loadingResult, E extractedData,
 			SearchProjectionTransformContext context);
 
 	/**

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneSearchProjectionBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneSearchProjectionBuilderFactory.java
@@ -68,7 +68,7 @@ public class LuceneSearchProjectionBuilderFactory implements SearchProjectionBui
 	}
 
 	@Override
-	public <O> EntityProjectionBuilder<O> entity() {
+	public <E> EntityProjectionBuilder<E> entity() {
 		return LuceneEntityProjectionBuilder.get();
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneSearchProjectionBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneSearchProjectionBuilderFactory.java
@@ -24,7 +24,7 @@ import org.hibernate.search.engine.search.projection.spi.CompositeProjectionBuil
 import org.hibernate.search.engine.search.projection.spi.DistanceToFieldProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.DocumentReferenceProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.FieldProjectionBuilder;
-import org.hibernate.search.engine.search.projection.spi.ObjectProjectionBuilder;
+import org.hibernate.search.engine.search.projection.spi.EntityProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.ReferenceProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.ScoreProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilder;
@@ -68,8 +68,8 @@ public class LuceneSearchProjectionBuilderFactory implements SearchProjectionBui
 	}
 
 	@Override
-	public <O> ObjectProjectionBuilder<O> object() {
-		return LuceneObjectProjectionBuilder.get();
+	public <O> EntityProjectionBuilder<O> entity() {
+		return LuceneEntityProjectionBuilder.get();
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneSearchProjectionBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/projection/impl/LuceneSearchProjectionBuilderFactory.java
@@ -90,7 +90,7 @@ public class LuceneSearchProjectionBuilderFactory implements SearchProjectionBui
 	}
 
 	@Override
-	public <T> CompositeProjectionBuilder<T> composite(Function<List<?>, T> transformer,
+	public <P> CompositeProjectionBuilder<P> composite(Function<List<?>, P> transformer,
 			SearchProjection<?>... projections) {
 		List<LuceneSearchProjection<?, ?>> typedProjections = new ArrayList<>( projections.length );
 		for ( SearchProjection<?> projection : projections ) {
@@ -103,15 +103,15 @@ public class LuceneSearchProjectionBuilderFactory implements SearchProjectionBui
 	}
 
 	@Override
-	public <P, T> CompositeProjectionBuilder<T> composite(Function<P, T> transformer,
-			SearchProjection<P> projection) {
+	public <P1, P> CompositeProjectionBuilder<P> composite(Function<P1, P> transformer,
+			SearchProjection<P1> projection) {
 		return new LuceneCompositeProjectionBuilder<>(
 				new LuceneCompositeFunctionProjection<>( transformer, toImplementation( projection ) )
 		);
 	}
 
 	@Override
-	public <P1, P2, T> CompositeProjectionBuilder<T> composite(BiFunction<P1, P2, T> transformer,
+	public <P1, P2, P> CompositeProjectionBuilder<P> composite(BiFunction<P1, P2, P> transformer,
 			SearchProjection<P1> projection1, SearchProjection<P2> projection2) {
 		return new LuceneCompositeProjectionBuilder<>(
 				new LuceneCompositeBiFunctionProjection<>( transformer, toImplementation( projection1 ),
@@ -120,7 +120,7 @@ public class LuceneSearchProjectionBuilderFactory implements SearchProjectionBui
 	}
 
 	@Override
-	public <P1, P2, P3, T> CompositeProjectionBuilder<T> composite(TriFunction<P1, P2, P3, T> transformer,
+	public <P1, P2, P3, P> CompositeProjectionBuilder<P> composite(TriFunction<P1, P2, P3, P> transformer,
 			SearchProjection<P1> projection1, SearchProjection<P2> projection2, SearchProjection<P3> projection3) {
 		return new LuceneCompositeProjectionBuilder<>(
 				new LuceneCompositeTriFunctionProjection<>( transformer, toImplementation( projection1 ),

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/LuceneSearchQuery.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/LuceneSearchQuery.java
@@ -8,5 +8,5 @@ package org.hibernate.search.backend.lucene.search.query;
 
 import org.hibernate.search.engine.search.query.ExtendedSearchQuery;
 
-public interface LuceneSearchQuery<T> extends ExtendedSearchQuery<T, LuceneSearchResult<T>> {
+public interface LuceneSearchQuery<H> extends ExtendedSearchQuery<H, LuceneSearchResult<H>> {
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/LuceneSearchResult.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/LuceneSearchResult.java
@@ -8,5 +8,5 @@ package org.hibernate.search.backend.lucene.search.query;
 
 import org.hibernate.search.engine.search.query.SearchResult;
 
-public interface LuceneSearchResult<T> extends SearchResult<T> {
+public interface LuceneSearchResult<H> extends SearchResult<H> {
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneLoadableSearchResult.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneLoadableSearchResult.java
@@ -27,17 +27,17 @@ import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
  * <p>
  * <strong>WARNING:</strong> this class is not thread-safe.
  *
- * @param <T> The type of hits in the search result.
+ * @param <H> The type of hits in the search result.
  */
-public class LuceneLoadableSearchResult<T> {
+public class LuceneLoadableSearchResult<H> {
 	private final ProjectionHitMapper<?, ?> projectionHitMapper;
-	private final LuceneSearchProjection<?, T> rootProjection;
+	private final LuceneSearchProjection<?, H> rootProjection;
 
 	private final long hitCount;
 	private List<Object> extractedData;
 
 	LuceneLoadableSearchResult(ProjectionHitMapper<?, ?> projectionHitMapper,
-			LuceneSearchProjection<?, T> rootProjection,
+			LuceneSearchProjection<?, H> rootProjection,
 			long hitCount, List<Object> extractedData) {
 		this.projectionHitMapper = projectionHitMapper;
 		this.rootProjection = rootProjection;
@@ -49,19 +49,19 @@ public class LuceneLoadableSearchResult<T> {
 		return hitCount;
 	}
 
-	LuceneSearchResult<T> loadBlocking(SessionContextImplementor sessionContext) {
+	LuceneSearchResult<H> loadBlocking(SessionContextImplementor sessionContext) {
 		SearchProjectionTransformContext transformContext = new SearchProjectionTransformContext( sessionContext );
 
 		LoadingResult<?> loadingResult = projectionHitMapper.loadBlocking();
 
 		for ( int i = 0; i < extractedData.size(); i++ ) {
-			T transformed = transformUnsafe( rootProjection, loadingResult, extractedData.get( i ), transformContext );
+			H transformed = transformUnsafe( rootProjection, loadingResult, extractedData.get( i ), transformContext );
 			extractedData.set( i, transformed );
 		}
 
-		// The cast is safe, since all elements extend T and we make the list unmodifiable
+		// The cast is safe, since all elements extend H and we make the list unmodifiable
 		@SuppressWarnings("unchecked")
-		List<T> loadedHits = Collections.unmodifiableList( (List<? extends T>) extractedData );
+		List<H> loadedHits = Collections.unmodifiableList( (List<? extends H>) extractedData );
 
 		// Make sure that if someone uses this object incorrectly, it will always fail, and will fail early.
 		extractedData = null;

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryBuilder.java
@@ -22,7 +22,7 @@ import org.hibernate.search.engine.search.loading.context.spi.LoadingContext;
 import org.hibernate.search.engine.search.loading.context.spi.LoadingContextBuilder;
 import org.hibernate.search.engine.search.query.spi.SearchQueryBuilder;
 
-public class LuceneSearchQueryBuilder<T> implements SearchQueryBuilder<T, LuceneSearchQueryElementCollector> {
+public class LuceneSearchQueryBuilder<H> implements SearchQueryBuilder<H, LuceneSearchQueryElementCollector> {
 
 	private final LuceneWorkFactory workFactory;
 	private final LuceneQueryWorkOrchestrator queryOrchestrator;
@@ -33,7 +33,7 @@ public class LuceneSearchQueryBuilder<T> implements SearchQueryBuilder<T, Lucene
 
 	private final ReusableDocumentStoredFieldVisitor storedFieldVisitor;
 	private final LoadingContextBuilder<?, ?> loadingContextBuilder;
-	private final LuceneSearchProjection<?, T> rootProjection;
+	private final LuceneSearchProjection<?, H> rootProjection;
 	private final LuceneSearchQueryElementCollector elementCollector;
 
 	LuceneSearchQueryBuilder(
@@ -44,7 +44,7 @@ public class LuceneSearchQueryBuilder<T> implements SearchQueryBuilder<T, Lucene
 			SessionContextImplementor sessionContext,
 			ReusableDocumentStoredFieldVisitor storedFieldVisitor,
 			LoadingContextBuilder<?, ?> loadingContextBuilder,
-			LuceneSearchProjection<?, T> rootProjection) {
+			LuceneSearchProjection<?, H> rootProjection) {
 		this.workFactory = workFactory;
 		this.queryOrchestrator = queryOrchestrator;
 		this.multiTenancyStrategy = multiTenancyStrategy;
@@ -70,10 +70,10 @@ public class LuceneSearchQueryBuilder<T> implements SearchQueryBuilder<T, Lucene
 	}
 
 	@Override
-	public LuceneSearchQuery<T> build() {
+	public LuceneSearchQuery<H> build() {
 		LoadingContext<?, ?> loadingContext = loadingContextBuilder.build();
 
-		LuceneSearchResultExtractor<T> searchResultExtractor = new LuceneSearchResultExtractorImpl<>(
+		LuceneSearchResultExtractor<H> searchResultExtractor = new LuceneSearchResultExtractorImpl<>(
 				storedFieldVisitor, rootProjection, loadingContext
 		);
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryBuilderFactory.java
@@ -76,9 +76,9 @@ public class LuceneSearchQueryBuilderFactory
 		return new LuceneCompositeListProjection<>( Function.identity(), children );
 	}
 
-	private <T> LuceneSearchQueryBuilder<T> createSearchQueryBuilder(
+	private <H> LuceneSearchQueryBuilder<H> createSearchQueryBuilder(
 			SessionContextImplementor sessionContext, LoadingContextBuilder<?, ?> loadingContextBuilder,
-			LuceneSearchProjection<?, T> rootProjection) {
+			LuceneSearchProjection<?, H> rootProjection) {
 		return searchBackendContext.createSearchQueryBuilder(
 				scopeModel, sessionContext, loadingContextBuilder, rootProjection
 		);

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryBuilderFactory.java
@@ -15,7 +15,7 @@ import org.hibernate.search.backend.lucene.search.impl.LuceneSearchScopeModel;
 import org.hibernate.search.backend.lucene.search.projection.impl.LuceneCompositeListProjection;
 import org.hibernate.search.backend.lucene.search.projection.impl.LuceneSearchProjection;
 import org.hibernate.search.backend.lucene.search.projection.impl.LuceneSearchProjectionBuilderFactory;
-import org.hibernate.search.backend.lucene.search.projection.impl.LuceneObjectProjection;
+import org.hibernate.search.backend.lucene.search.projection.impl.LuceneEntityProjection;
 import org.hibernate.search.backend.lucene.search.projection.impl.LuceneReferenceProjection;
 import org.hibernate.search.engine.mapper.session.context.spi.SessionContextImplementor;
 import org.hibernate.search.engine.search.SearchProjection;
@@ -40,9 +40,9 @@ public class LuceneSearchQueryBuilderFactory
 	}
 
 	@Override
-	public <O> LuceneSearchQueryBuilder<O> asObject(
+	public <O> LuceneSearchQueryBuilder<O> asEntity(
 			SessionContextImplementor sessionContext, LoadingContextBuilder<?, O> loadingContextBuilder) {
-		return createSearchQueryBuilder( sessionContext, loadingContextBuilder, LuceneObjectProjection.get() );
+		return createSearchQueryBuilder( sessionContext, loadingContextBuilder, LuceneEntityProjection.get() );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryBuilderFactory.java
@@ -40,8 +40,8 @@ public class LuceneSearchQueryBuilderFactory
 	}
 
 	@Override
-	public <O> LuceneSearchQueryBuilder<O> asEntity(
-			SessionContextImplementor sessionContext, LoadingContextBuilder<?, O> loadingContextBuilder) {
+	public <E> LuceneSearchQueryBuilder<E> asEntity(
+			SessionContextImplementor sessionContext, LoadingContextBuilder<?, E> loadingContextBuilder) {
 		return createSearchQueryBuilder( sessionContext, loadingContextBuilder, LuceneEntityProjection.get() );
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryBuilderFactory.java
@@ -46,15 +46,15 @@ public class LuceneSearchQueryBuilderFactory
 	}
 
 	@Override
-	public <T> LuceneSearchQueryBuilder<T> asReference(
-			SessionContextImplementor sessionContext, LoadingContextBuilder<T, ?> loadingContextBuilder) {
+	public <R> LuceneSearchQueryBuilder<R> asReference(
+			SessionContextImplementor sessionContext, LoadingContextBuilder<R, ?> loadingContextBuilder) {
 		return createSearchQueryBuilder( sessionContext, loadingContextBuilder, LuceneReferenceProjection.get() );
 	}
 
 	@Override
-	public <T> LuceneSearchQueryBuilder<T> asProjection(
+	public <P> LuceneSearchQueryBuilder<P> asProjection(
 			SessionContextImplementor sessionContext, LoadingContextBuilder<?, ?> loadingContextBuilder,
-			SearchProjection<T> projection) {
+			SearchProjection<P> projection) {
 		return createSearchQueryBuilder( sessionContext, loadingContextBuilder,
 				searchProjectionFactory.toImplementation( projection ) );
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryImpl.java
@@ -28,8 +28,8 @@ import org.apache.lucene.search.Sort;
 /**
  * @author Guillaume Smet
  */
-public class LuceneSearchQueryImpl<T> extends AbstractSearchQuery<T, LuceneSearchResult<T>>
-		implements LuceneSearchQuery<T> {
+public class LuceneSearchQueryImpl<H> extends AbstractSearchQuery<H, LuceneSearchResult<H>>
+		implements LuceneSearchQuery<H> {
 
 	private final LuceneQueryWorkOrchestrator queryOrchestrator;
 	private final LuceneWorkFactory workFactory;
@@ -40,14 +40,14 @@ public class LuceneSearchQueryImpl<T> extends AbstractSearchQuery<T, LuceneSearc
 	private final Query luceneQuery;
 	private final Sort luceneSort;
 	private final LuceneCollectorProvider luceneCollectorProvider;
-	private final LuceneSearchResultExtractor<T> searchResultExtractor;
+	private final LuceneSearchResultExtractor<H> searchResultExtractor;
 
 	LuceneSearchQueryImpl(LuceneQueryWorkOrchestrator queryOrchestrator,
 			LuceneWorkFactory workFactory, Set<String> indexNames, Set<ReaderProvider> readerProviders,
 			SessionContextImplementor sessionContext,
 			LoadingContext<?, ?> loadingContext,
 			Query luceneQuery, Sort luceneSort,
-			LuceneCollectorProvider luceneCollectorProvider, LuceneSearchResultExtractor<T> searchResultExtractor) {
+			LuceneCollectorProvider luceneCollectorProvider, LuceneSearchResultExtractor<H> searchResultExtractor) {
 		this.queryOrchestrator = queryOrchestrator;
 		this.workFactory = workFactory;
 		this.indexNames = indexNames;
@@ -71,15 +71,15 @@ public class LuceneSearchQueryImpl<T> extends AbstractSearchQuery<T, LuceneSearc
 	}
 
 	@Override
-	public <Q> Q extension(SearchQueryExtension<Q, T> extension) {
+	public <Q> Q extension(SearchQueryExtension<Q, H> extension) {
 		return DslExtensionState.returnIfSupported(
 				extension, extension.extendOptional( this, loadingContext )
 		);
 	}
 
 	@Override
-	public LuceneSearchResult<T> fetch(Long limit, Long offset) {
-		LuceneQueryWork<LuceneLoadableSearchResult<T>> work = workFactory.search(
+	public LuceneSearchResult<H> fetch(Long limit, Long offset) {
+		LuceneQueryWork<LuceneLoadableSearchResult<H>> work = workFactory.search(
 				new LuceneSearcher<>(
 						indexNames,
 						readerProviders,
@@ -101,7 +101,7 @@ public class LuceneSearchQueryImpl<T> extends AbstractSearchQuery<T, LuceneSearc
 
 	@Override
 	public long fetchTotalHitCount() {
-		LuceneQueryWork<LuceneLoadableSearchResult<T>> work = workFactory.search(
+		LuceneQueryWork<LuceneLoadableSearchResult<H>> work = workFactory.search(
 				new LuceneSearcher<>(
 						indexNames,
 						readerProviders,

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryImpl.java
@@ -92,7 +92,7 @@ public class LuceneSearchQueryImpl<T> extends AbstractSearchQuery<T, LuceneSearc
 				/*
 				 * WARNING: the following call must run in the user thread.
 				 * If we introduce async processing, we will have to add a loadAsync method here,
-				 * as well as in ProjectionHitMapper and ObjectLoader.
+				 * as well as in ProjectionHitMapper and EntityLoader.
 				 * This method may not be easy to implement for blocking mappers,
 				 * so we may choose to throw exceptions for those.
 				 */

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchResultExtractor.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchResultExtractor.java
@@ -13,9 +13,9 @@ import org.apache.lucene.search.TopDocs;
 
 import org.hibernate.search.backend.lucene.search.projection.impl.SearchProjectionExtractContext;
 
-public interface LuceneSearchResultExtractor<T> {
+public interface LuceneSearchResultExtractor<H> {
 
-	LuceneLoadableSearchResult<T> extract(IndexSearcher indexSearcher, long totalHits, TopDocs topDocs,
+	LuceneLoadableSearchResult<H> extract(IndexSearcher indexSearcher, long totalHits, TopDocs topDocs,
 			SearchProjectionExtractContext projectionExecutionContext) throws IOException;
 
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchResultExtractorImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchResultExtractorImpl.java
@@ -22,15 +22,15 @@ import org.hibernate.search.backend.lucene.search.projection.impl.SearchProjecti
 import org.hibernate.search.engine.search.loading.context.spi.LoadingContext;
 import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 
-class LuceneSearchResultExtractorImpl<T> implements LuceneSearchResultExtractor<T> {
+class LuceneSearchResultExtractorImpl<H> implements LuceneSearchResultExtractor<H> {
 
 	private final ReusableDocumentStoredFieldVisitor storedFieldVisitor;
-	private final LuceneSearchProjection<?, T> rootProjection;
+	private final LuceneSearchProjection<?, H> rootProjection;
 	private final LoadingContext<?, ?> loadingContext;
 
 	LuceneSearchResultExtractorImpl(
 			ReusableDocumentStoredFieldVisitor storedFieldVisitor,
-			LuceneSearchProjection<?, T> rootProjection,
+			LuceneSearchProjection<?, H> rootProjection,
 			LoadingContext<?, ?> loadingContext) {
 		this.storedFieldVisitor = storedFieldVisitor;
 		this.rootProjection = rootProjection;
@@ -38,7 +38,7 @@ class LuceneSearchResultExtractorImpl<T> implements LuceneSearchResultExtractor<
 	}
 
 	@Override
-	public LuceneLoadableSearchResult<T> extract(IndexSearcher indexSearcher, long totalHits, TopDocs topDocs,
+	public LuceneLoadableSearchResult<H> extract(IndexSearcher indexSearcher, long totalHits, TopDocs topDocs,
 			SearchProjectionExtractContext projectionExecutionContext) throws IOException {
 		ProjectionHitMapper<?, ?> projectionHitMapper = loadingContext.getProjectionHitMapper();
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchResultImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchResultImpl.java
@@ -11,9 +11,9 @@ import java.util.List;
 import org.hibernate.search.backend.lucene.search.query.LuceneSearchResult;
 import org.hibernate.search.engine.search.query.spi.SimpleSearchResult;
 
-class LuceneSearchResultImpl<T> extends SimpleSearchResult<T>
-		implements LuceneSearchResult<T> {
-	LuceneSearchResultImpl(long hitCount, List<T> hits) {
+class LuceneSearchResultImpl<H> extends SimpleSearchResult<H>
+		implements LuceneSearchResult<H> {
+	LuceneSearchResultImpl(long hitCount, List<H> hits) {
 		super( hitCount, hits );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearcher.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearcher.java
@@ -22,9 +22,9 @@ import org.hibernate.search.engine.reporting.spi.EventContexts;
 import org.hibernate.search.util.common.reporting.EventContext;
 
 /**
- * @author Guillaume Smet
+ * @param <H> The type of query hits.
  */
-public class LuceneSearcher<T> implements AutoCloseable {
+public class LuceneSearcher<H> implements AutoCloseable {
 
 	private final Set<String> indexNames;
 	private final IndexSearcher indexSearcher;
@@ -36,7 +36,7 @@ public class LuceneSearcher<T> implements AutoCloseable {
 	private final Long limit;
 
 	private final LuceneCollectorProvider luceneCollectorProvider;
-	private final LuceneSearchResultExtractor<T> searchResultExtractor;
+	private final LuceneSearchResultExtractor<H> searchResultExtractor;
 
 	public LuceneSearcher(Set<String> indexNames,
 			Set<ReaderProvider> readerProviders,
@@ -45,7 +45,7 @@ public class LuceneSearcher<T> implements AutoCloseable {
 			Long offset,
 			Long limit,
 			LuceneCollectorProvider luceneCollectorProvider,
-			LuceneSearchResultExtractor<T> searchResultExtractor) {
+			LuceneSearchResultExtractor<H> searchResultExtractor) {
 		this.indexNames = indexNames;
 		this.indexSearcher = new IndexSearcher( MultiReaderFactory.openReader( indexNames, readerProviders ) );
 		this.luceneQuery = luceneQuery;
@@ -56,7 +56,7 @@ public class LuceneSearcher<T> implements AutoCloseable {
 		this.searchResultExtractor = searchResultExtractor;
 	}
 
-	public LuceneLoadableSearchResult<T> execute() throws IOException {
+	public LuceneLoadableSearchResult<H> execute() throws IOException {
 		// TODO GSM implement timeout handling by wrapping the collector with the timeout limiting one
 
 		LuceneCollectorsBuilder luceneCollectorsBuilder = new LuceneCollectorsBuilder( luceneSort, getMaxDocs() );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/SearchBackendContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/SearchBackendContext.java
@@ -50,11 +50,11 @@ public class SearchBackendContext {
 		return analysisDefinitionRegistry;
 	}
 
-	<T> LuceneSearchQueryBuilder<T> createSearchQueryBuilder(
+	<H> LuceneSearchQueryBuilder<H> createSearchQueryBuilder(
 			LuceneSearchScopeModel scopeModel,
 			SessionContextImplementor sessionContext,
 			LoadingContextBuilder<?, ?> loadingContextBuilder,
-			LuceneSearchProjection<?, T> rootProjection) {
+			LuceneSearchProjection<?, H> rootProjection) {
 		multiTenancyStrategy.checkTenantId( sessionContext.getTenantIdentifier(), eventContext );
 
 		LuceneDocumentStoredFieldVisitorBuilder storedFieldFilterBuilder = new LuceneDocumentStoredFieldVisitorBuilder();

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneExecuteQueryWork.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneExecuteQueryWork.java
@@ -19,23 +19,23 @@ import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 /**
  * @author Guillaume Smet
  */
-public class LuceneExecuteQueryWork<T> implements LuceneQueryWork<LuceneLoadableSearchResult<T>> {
+public class LuceneExecuteQueryWork<H> implements LuceneQueryWork<LuceneLoadableSearchResult<H>> {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private final LuceneSearcher<T> searcher;
+	private final LuceneSearcher<H> searcher;
 
-	public LuceneExecuteQueryWork(LuceneSearcher<T> searcher) {
+	public LuceneExecuteQueryWork(LuceneSearcher<H> searcher) {
 		this.searcher = searcher;
 	}
 
 	@Override
-	public CompletableFuture<LuceneLoadableSearchResult<T>> execute(LuceneQueryWorkExecutionContext context) {
+	public CompletableFuture<LuceneLoadableSearchResult<H>> execute(LuceneQueryWorkExecutionContext context) {
 		// FIXME for now everything is blocking here, we need a non blocking wrapper on top of the IndexWriter
 		return Futures.create( () -> CompletableFuture.completedFuture( executeQuery( searcher ) ) );
 	}
 
-	private LuceneLoadableSearchResult<T> executeQuery(LuceneSearcher<T> searcher) {
+	private LuceneLoadableSearchResult<H> executeQuery(LuceneSearcher<H> searcher) {
 		try {
 			return searcher.execute();
 		}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneStubWorkFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneStubWorkFactory.java
@@ -59,7 +59,7 @@ public class LuceneStubWorkFactory implements LuceneWorkFactory {
 	}
 
 	@Override
-	public <T> LuceneExecuteQueryWork<T> search(LuceneSearcher<T> luceneSearcher) {
+	public <H> LuceneExecuteQueryWork<H> search(LuceneSearcher<H> luceneSearcher) {
 		return new LuceneExecuteQueryWork<>( luceneSearcher );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneWorkFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneWorkFactory.java
@@ -29,5 +29,5 @@ public interface LuceneWorkFactory {
 
 	LuceneIndexWork<?> optimize(String indexName);
 
-	<T> LuceneExecuteQueryWork<T> search(LuceneSearcher<T> luceneSearcher);
+	<H> LuceneExecuteQueryWork<H> search(LuceneSearcher<H> luceneSearcher);
 }

--- a/documentation/src/main/asciidoc/concepts.asciidoc
+++ b/documentation/src/main/asciidoc/concepts.asciidoc
@@ -9,6 +9,7 @@
 == Mapping
 
 // TODO maybe explain what we mean by "mapping"?
+// TODO explain what an "entity" is and what it implies
 
 [[concepts-analysis]]
 == Analysis

--- a/documentation/src/main/asciidoc/internals.asciidoc
+++ b/documentation/src/main/asciidoc/internals.asciidoc
@@ -176,8 +176,8 @@ such as `SearchPredicateFactory` or `FieldSortBuilder`.
 
 Note that the APIs implemented by the engine include ways for the mapper to wrap the resulting search query
 (`SearchQueryWrappingDefinitionResultContext#asWrappedQuery`).
-Also, the SPIs implemented by backends allow mappers to inject an "object loader" (see `SearchQueryBuilderFactory.asObject`)
-that will essentially transform document references into the object that was initially indexed.
+Also, the SPIs implemented by backends allow mappers to inject a "loading context" (see `SearchQueryBuilderFactory.asEntity`)
+that will essentially transform document references into the entity that was initially indexed.
 
 == POJO mapper
 

--- a/documentation/src/main/asciidoc/internals.asciidoc
+++ b/documentation/src/main/asciidoc/internals.asciidoc
@@ -174,8 +174,6 @@ Those generic APIs are mostly implemented in the engine.
 The implementation itself relies on lower-level, less "user-focused" SPIs implemented by backends,
 such as `SearchPredicateFactory` or `FieldSortBuilder`.
 
-Note that the APIs implemented by the engine include ways for the mapper to wrap the resulting search query
-(`SearchQueryWrappingDefinitionResultContext#asWrappedQuery`).
 Also, the SPIs implemented by backends allow mappers to inject a "loading context" (see `SearchQueryBuilderFactory.asEntity`)
 that will essentially transform document references into the entity that was initially indexed.
 

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/directfieldmapping/HibernateOrmSimpleMappingIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/directfieldmapping/HibernateOrmSimpleMappingIT.java
@@ -160,7 +160,7 @@ public class HibernateOrmSimpleMappingIT {
 			SearchQuery<MyEntityAndScoreBean<Book>> query = searchSession.search( Book.class )
 					.asProjection( f -> f.composite(
 							MyEntityAndScoreBean::new,
-							f.object(),
+							f.entity(),
 							f.score()
 					) )
 					.predicate( f -> f.matchAll() )

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/MappedIndexManagerImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/MappedIndexManagerImpl.java
@@ -47,7 +47,7 @@ class MappedIndexManagerImpl<D extends DocumentElement> implements MappedIndexMa
 	}
 
 	@Override
-	public <R, O> MappedIndexSearchScopeBuilder<R, O> createSearchScopeBuilder(MappingContextImplementor mappingContext) {
+	public <R, E> MappedIndexSearchScopeBuilder<R, E> createSearchScopeBuilder(MappingContextImplementor mappingContext) {
 		return new MappedIndexSearchScopeBuilderImpl<>(
 				implementor, mappingContext
 		);

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/MappedIndexSearchScopeBuilderImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/MappedIndexSearchScopeBuilderImpl.java
@@ -12,7 +12,7 @@ import org.hibernate.search.engine.mapper.mapping.context.spi.MappingContextImpl
 import org.hibernate.search.engine.mapper.mapping.spi.MappedIndexSearchScope;
 import org.hibernate.search.engine.mapper.mapping.spi.MappedIndexSearchScopeBuilder;
 
-class MappedIndexSearchScopeBuilderImpl<R, O> implements MappedIndexSearchScopeBuilder<R, O> {
+class MappedIndexSearchScopeBuilderImpl<R, E> implements MappedIndexSearchScopeBuilder<R, E> {
 	private final IndexSearchScopeBuilder delegate;
 
 	MappedIndexSearchScopeBuilderImpl(IndexManagerImplementor<?> firstIndexManager,
@@ -25,7 +25,7 @@ class MappedIndexSearchScopeBuilderImpl<R, O> implements MappedIndexSearchScopeB
 	}
 
 	@Override
-	public MappedIndexSearchScope<R, O> build() {
+	public MappedIndexSearchScope<R, E> build() {
 		return new MappedIndexSearchScopeImpl<>( delegate.build() );
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/MappedIndexSearchScopeImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/MappedIndexSearchScopeImpl.java
@@ -19,7 +19,7 @@ import org.hibernate.search.engine.search.dsl.sort.impl.DefaultSearchSortContain
 import org.hibernate.search.engine.search.dsl.spi.IndexSearchScope;
 import org.hibernate.search.engine.search.loading.context.spi.LoadingContextBuilder;
 
-class MappedIndexSearchScopeImpl<C, R, O> implements MappedIndexSearchScope<R, O> {
+class MappedIndexSearchScopeImpl<C, R, E> implements MappedIndexSearchScope<R, E> {
 
 	private final IndexSearchScope<C> delegate;
 
@@ -37,9 +37,9 @@ class MappedIndexSearchScopeImpl<C, R, O> implements MappedIndexSearchScope<R, O
 	}
 
 	@Override
-	public SearchQueryResultDefinitionContext<R, O, SearchProjectionFactoryContext<R, O>> search(
+	public SearchQueryResultDefinitionContext<R, E, SearchProjectionFactoryContext<R, E>> search(
 			SessionContextImplementor sessionContext,
-			LoadingContextBuilder<R, O> loadingContextBuilder) {
+			LoadingContextBuilder<R, E> loadingContextBuilder) {
 		return new DefaultSearchQueryResultDefinitionContext<>( delegate, sessionContext, loadingContextBuilder );
 	}
 
@@ -54,7 +54,7 @@ class MappedIndexSearchScopeImpl<C, R, O> implements MappedIndexSearchScope<R, O
 	}
 
 	@Override
-	public SearchProjectionFactoryContext<R, O> projection() {
+	public SearchProjectionFactoryContext<R, E> projection() {
 		return new DefaultSearchProjectionFactoryContext<>( delegate.getSearchProjectionFactory() );
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/spi/MappedIndexManager.java
+++ b/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/spi/MappedIndexManager.java
@@ -30,7 +30,7 @@ public interface MappedIndexManager<D extends DocumentElement> {
 
 	IndexWorkExecutor createWorkExecutor();
 
-	<R, O> MappedIndexSearchScopeBuilder<R, O> createSearchScopeBuilder(MappingContextImplementor mappingContext);
+	<R, E> MappedIndexSearchScopeBuilder<R, E> createSearchScopeBuilder(MappingContextImplementor mappingContext);
 
 	void addTo(MappedIndexSearchScopeBuilder<?, ?> builder);
 }

--- a/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/spi/MappedIndexSearchScope.java
+++ b/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/spi/MappedIndexSearchScope.java
@@ -17,15 +17,15 @@ import org.hibernate.search.engine.search.loading.context.spi.LoadingContextBuil
  * @param <R> The type of references, i.e. the type of hits returned by
  * {@link SearchQueryResultDefinitionContext#asReference() reference queries},
  * or the type of objects returned for {@link SearchProjectionFactoryContext#reference() reference projections}.
- * @param <O> The type of loaded objects, i.e. the type of hits returned by
- * {@link SearchQueryResultDefinitionContext#asEntity() loaded object queries}
- * or the type of objects returned for {@link SearchProjectionFactoryContext#object() loaded object projections}.
+ * @param <O> The type of entities, i.e. the type of hits returned by
+ * {@link SearchQueryResultDefinitionContext#asEntity() entity queries}
+ * or the type of objects returned for {@link SearchProjectionFactoryContext#entity() entity projections}.
  */
 public interface MappedIndexSearchScope<R, O> {
 
 	/*
 	 * IMPLEMENTATION NOTE: we *must* only accept a loading context with the same R/O type parameters as this class,
-	 * otherwise some casts in ObjectProjectionContextImpl and ReferenceProjectionContextImpl
+	 * otherwise some casts in EntityProjectionContextImpl and ReferenceProjectionContextImpl
 	 * will be wrong.
 	 * In particular, we cannot accept a LoadingContextBuilder<R, T> with any T.
 	 */
@@ -39,7 +39,7 @@ public interface MappedIndexSearchScope<R, O> {
 
 	/*
 	 * IMPLEMENTATION NOTE: we *must* return a factory with the same R/O type arguments as this class,
-	 * otherwise some casts in ObjectProjectionContextImpl and ReferenceProjectionContextImpl
+	 * otherwise some casts in EntityProjectionContextImpl and ReferenceProjectionContextImpl
 	 * will be wrong.
 	 */
 	SearchProjectionFactoryContext<R, O> projection();

--- a/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/spi/MappedIndexSearchScope.java
+++ b/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/spi/MappedIndexSearchScope.java
@@ -17,31 +17,31 @@ import org.hibernate.search.engine.search.loading.context.spi.LoadingContextBuil
  * @param <R> The type of references, i.e. the type of hits returned by
  * {@link SearchQueryResultDefinitionContext#asReference() reference queries},
  * or the type of objects returned for {@link SearchProjectionFactoryContext#reference() reference projections}.
- * @param <O> The type of entities, i.e. the type of hits returned by
+ * @param <E> The type of entities, i.e. the type of hits returned by
  * {@link SearchQueryResultDefinitionContext#asEntity() entity queries}
  * or the type of objects returned for {@link SearchProjectionFactoryContext#entity() entity projections}.
  */
-public interface MappedIndexSearchScope<R, O> {
+public interface MappedIndexSearchScope<R, E> {
 
 	/*
-	 * IMPLEMENTATION NOTE: we *must* only accept a loading context with the same R/O type parameters as this class,
+	 * IMPLEMENTATION NOTE: we *must* only accept a loading context with the same R/E type parameters as this class,
 	 * otherwise some casts in EntityProjectionContextImpl and ReferenceProjectionContextImpl
 	 * will be wrong.
 	 * In particular, we cannot accept a LoadingContextBuilder<R, T> with any T.
 	 */
-	SearchQueryResultDefinitionContext<R, O, SearchProjectionFactoryContext<R, O>> search(
+	SearchQueryResultDefinitionContext<R, E, SearchProjectionFactoryContext<R, E>> search(
 			SessionContextImplementor sessionContext,
-			LoadingContextBuilder<R, O> loadingContextBuilder);
+			LoadingContextBuilder<R, E> loadingContextBuilder);
 
 	SearchPredicateFactoryContext predicate();
 
 	SearchSortContainerContext sort();
 
 	/*
-	 * IMPLEMENTATION NOTE: we *must* return a factory with the same R/O type arguments as this class,
+	 * IMPLEMENTATION NOTE: we *must* return a factory with the same R/E type arguments as this class,
 	 * otherwise some casts in EntityProjectionContextImpl and ReferenceProjectionContextImpl
 	 * will be wrong.
 	 */
-	SearchProjectionFactoryContext<R, O> projection();
+	SearchProjectionFactoryContext<R, E> projection();
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/spi/MappedIndexSearchScopeBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/spi/MappedIndexSearchScopeBuilder.java
@@ -9,8 +9,8 @@ package org.hibernate.search.engine.mapper.mapping.spi;
 /**
  * @author Yoann Rodiere
  */
-public interface MappedIndexSearchScopeBuilder<R, O> {
+public interface MappedIndexSearchScopeBuilder<R, E> {
 
-	MappedIndexSearchScope<R, O> build();
+	MappedIndexSearchScope<R, E> build();
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/SearchProjection.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/SearchProjection.java
@@ -12,7 +12,7 @@ package org.hibernate.search.engine.search;
  * Implementations of this interface are provided to users by Hibernate Search. Users must not try to implement this
  * interface.
  *
- * @param <T> The type of the element returned by the projection.
+ * @param <P> The type of the element returned by the projection.
  */
-public interface SearchProjection<T> {
+public interface SearchProjection<P> {
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/EntityProjectionContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/EntityProjectionContext.java
@@ -7,8 +7,8 @@
 package org.hibernate.search.engine.search.dsl.projection;
 
 /**
- * The context used when starting to define an object projection.
+ * The context used when starting to define an entity projection.
  */
-public interface ObjectProjectionContext<O> extends SearchProjectionTerminalContext<O> {
+public interface EntityProjectionContext<O> extends SearchProjectionTerminalContext<O> {
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/EntityProjectionContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/EntityProjectionContext.java
@@ -9,6 +9,6 @@ package org.hibernate.search.engine.search.dsl.projection;
 /**
  * The context used when starting to define an entity projection.
  */
-public interface EntityProjectionContext<O> extends SearchProjectionTerminalContext<O> {
+public interface EntityProjectionContext<E> extends SearchProjectionTerminalContext<E> {
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/SearchProjectionFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/SearchProjectionFactoryContext.java
@@ -21,10 +21,10 @@ import org.hibernate.search.util.common.function.TriFunction;
  * A context allowing to create a projection.
  *
  * @param <R> The type of references, i.e. the type of objects returned for {@link #reference() reference projections}.
- * @param <O> The type of entities, i.e. the type of objects returned for
+ * @param <E> The type of entities, i.e. the type of objects returned for
  * {@link #entity() entity projections}.
  */
-public interface SearchProjectionFactoryContext<R, O> {
+public interface SearchProjectionFactoryContext<R, E> {
 
 	/**
 	 * Project the match to a {@link DocumentReference}.
@@ -52,7 +52,7 @@ public interface SearchProjectionFactoryContext<R, O> {
 	 *
 	 * @return A context allowing to define the projection more precisely.
 	 */
-	EntityProjectionContext<O> entity();
+	EntityProjectionContext<E> entity();
 
 	/**
 	 * Project to the value of a field in the indexed document.
@@ -279,7 +279,7 @@ public interface SearchProjectionFactoryContext<R, O> {
 	 * @return The extended context.
 	 * @throws SearchException If the extension cannot be applied (wrong underlying backend, ...).
 	 */
-	<T> T extension(SearchProjectionFactoryContextExtension<T, R, O> extension);
+	<T> T extension(SearchProjectionFactoryContextExtension<T, R, E> extension);
 
 	/**
 	 * Create a context allowing to try to apply multiple extensions one after the other,
@@ -294,5 +294,5 @@ public interface SearchProjectionFactoryContext<R, O> {
 	 * @param <T> The expected projected type.
 	 * @return A context allowing to define the extensions to attempt, and the corresponding projections.
 	 */
-	<T> SearchProjectionFactoryExtensionContext<T, R, O> extension();
+	<T> SearchProjectionFactoryExtensionContext<T, R, E> extension();
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/SearchProjectionFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/SearchProjectionFactoryContext.java
@@ -21,8 +21,8 @@ import org.hibernate.search.util.common.function.TriFunction;
  * A context allowing to create a projection.
  *
  * @param <R> The type of references, i.e. the type of objects returned for {@link #reference() reference projections}.
- * @param <O> The type of loaded objects, i.e. the type of objects returned for
- * {@link #object() object projections}.
+ * @param <O> The type of entities, i.e. the type of objects returned for
+ * {@link #entity() entity projections}.
  */
 public interface SearchProjectionFactoryContext<R, O> {
 
@@ -37,23 +37,22 @@ public interface SearchProjectionFactoryContext<R, O> {
 	 * Project to a reference to the match.
 	 * <p>
 	 * The actual type of the reference depends on the mapper used to create the query:
-	 * a POJO mapper may return a class/identifier couple, for example.
+	 * the ORM mapper will return a class/identifier pair, for example.
 	 *
 	 * @return A context allowing to define the projection more precisely.
 	 */
 	ReferenceProjectionContext<R> reference();
 
 	/**
-	 * Project to an object representing the match.
+	 * Project to an entity representing the match.
 	 * <p>
-	 * The actual type of the object depends on the entry point
-	 * for your query: an {@link org.hibernate.search.engine.backend.index.IndexManager}
-	 * will return a Java representation of the document,
-	 * but a mapper may return a Java representation of the mapped object.
+	 * The actual type of the entity depends on the mapper used to create the query
+	 * and on the indexes targeted by your query:
+	 * the ORM mapper will return a managed entity loaded from the database, for example.
 	 *
 	 * @return A context allowing to define the projection more precisely.
 	 */
-	ObjectProjectionContext<O> object();
+	EntityProjectionContext<O> entity();
 
 	/**
 	 * Project to the value of a field in the indexed document.

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/SearchProjectionFactoryContextExtension.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/SearchProjectionFactoryContextExtension.java
@@ -23,7 +23,7 @@ import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilder
  * @param <T> The type of extended search factory contexts. Should generally extend
  * {@link SearchProjectionFactoryContext}.
  * @param <R> The type of references in the original {@link SearchProjectionFactoryContext}.
- * @param <O> The type of loaded objects in the original {@link SearchProjectionFactoryContext}.
+ * @param <O> The type of entities in the original {@link SearchProjectionFactoryContext}.
  *
  * @see SearchProjectionFactoryContext#extension(SearchProjectionFactoryContextExtension)
  * @see DelegatingSearchProjectionFactoryContext

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/SearchProjectionFactoryContextExtension.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/SearchProjectionFactoryContextExtension.java
@@ -23,12 +23,12 @@ import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilder
  * @param <T> The type of extended search factory contexts. Should generally extend
  * {@link SearchProjectionFactoryContext}.
  * @param <R> The type of references in the original {@link SearchProjectionFactoryContext}.
- * @param <O> The type of entities in the original {@link SearchProjectionFactoryContext}.
+ * @param <E> The type of entities in the original {@link SearchProjectionFactoryContext}.
  *
  * @see SearchProjectionFactoryContext#extension(SearchProjectionFactoryContextExtension)
  * @see DelegatingSearchProjectionFactoryContext
  */
-public interface SearchProjectionFactoryContextExtension<T, R, O> {
+public interface SearchProjectionFactoryContextExtension<T, R, E> {
 
 	/**
 	 * Attempt to extend a given context, returning an empty {@link Optional} in case of failure.
@@ -40,7 +40,7 @@ public interface SearchProjectionFactoryContextExtension<T, R, O> {
 	 * @return An optional containing the extended search projection factory context ({@link T}) in case
 	 * of success, or an empty optional otherwise.
 	 */
-	Optional<T> extendOptional(SearchProjectionFactoryContext<R, O> original,
+	Optional<T> extendOptional(SearchProjectionFactoryContext<R, E> original,
 			SearchProjectionBuilderFactory factory);
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/SearchProjectionFactoryExtensionContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/SearchProjectionFactoryExtensionContext.java
@@ -15,12 +15,12 @@ import org.hibernate.search.util.common.SearchException;
  * to a {@link SearchProjectionFactoryContext}.
  *
  * @param <R> The type of references in the parent {@link SearchProjectionFactoryContext}.
- * @param <O> The type of entities in the parent {@link SearchProjectionFactoryContext}.
+ * @param <E> The type of entities in the parent {@link SearchProjectionFactoryContext}.
  * @param <P> The resulting projection type.
  *
  * @see SearchProjectionFactoryContext#extension()
  */
-public interface SearchProjectionFactoryExtensionContext<P, R, O> {
+public interface SearchProjectionFactoryExtensionContext<P, R, E> {
 
 	/**
 	 * If the given extension is supported, and none of the previous extensions passed to
@@ -38,8 +38,8 @@ public interface SearchProjectionFactoryExtensionContext<P, R, O> {
 	 * @param <T> The type of the extended context.
 	 * @return {@code this}, for method chaining.
 	 */
-	<T> SearchProjectionFactoryExtensionContext<P, R, O> ifSupported(
-			SearchProjectionFactoryContextExtension<T, R, O> extension,
+	<T> SearchProjectionFactoryExtensionContext<P, R, E> ifSupported(
+			SearchProjectionFactoryContextExtension<T, R, E> extension,
 			Function<T, ? extends SearchProjectionTerminalContext<P>> projectionContributor
 	);
 
@@ -54,7 +54,7 @@ public interface SearchProjectionFactoryExtensionContext<P, R, O> {
 	 * Should generally be a lambda expression.
 	 * @return The created projection.
 	 */
-	SearchProjectionTerminalContext<P> orElse(Function<SearchProjectionFactoryContext<R, O>, ? extends SearchProjectionTerminalContext<P>> projectionContributor);
+	SearchProjectionTerminalContext<P> orElse(Function<SearchProjectionFactoryContext<R, E>, ? extends SearchProjectionTerminalContext<P>> projectionContributor);
 
 	/**
 	 * If no extension passed to {@link #ifSupported(SearchProjectionFactoryContextExtension, Function)}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/SearchProjectionFactoryExtensionContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/SearchProjectionFactoryExtensionContext.java
@@ -15,7 +15,7 @@ import org.hibernate.search.util.common.SearchException;
  * to a {@link SearchProjectionFactoryContext}.
  *
  * @param <R> The type of references in the parent {@link SearchProjectionFactoryContext}.
- * @param <O> The type of loaded objects in the parent {@link SearchProjectionFactoryContext}.
+ * @param <O> The type of entities in the parent {@link SearchProjectionFactoryContext}.
  * @param <P> The resulting projection type.
  *
  * @see SearchProjectionFactoryContext#extension()

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/impl/DefaultSearchProjectionFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/impl/DefaultSearchProjectionFactoryContext.java
@@ -16,7 +16,7 @@ import org.hibernate.search.engine.search.dsl.projection.CompositeProjectionCont
 import org.hibernate.search.engine.search.dsl.projection.DistanceToFieldProjectionContext;
 import org.hibernate.search.engine.search.dsl.projection.DocumentReferenceProjectionContext;
 import org.hibernate.search.engine.search.dsl.projection.FieldProjectionContext;
-import org.hibernate.search.engine.search.dsl.projection.ObjectProjectionContext;
+import org.hibernate.search.engine.search.dsl.projection.EntityProjectionContext;
 import org.hibernate.search.engine.search.dsl.projection.ReferenceProjectionContext;
 import org.hibernate.search.engine.search.dsl.projection.ScoreProjectionContext;
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContext;
@@ -60,8 +60,8 @@ public class DefaultSearchProjectionFactoryContext<R, O> implements SearchProjec
 	}
 
 	@Override
-	public ObjectProjectionContext<O> object() {
-		return new ObjectProjectionContextImpl<>( factory );
+	public EntityProjectionContext<O> entity() {
+		return new EntityProjectionContextImpl<>( factory );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/impl/DefaultSearchProjectionFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/impl/DefaultSearchProjectionFactoryContext.java
@@ -29,7 +29,7 @@ import org.hibernate.search.util.common.function.TriFunction;
 import org.hibernate.search.util.common.impl.Contracts;
 
 
-public class DefaultSearchProjectionFactoryContext<R, O> implements SearchProjectionFactoryContext<R, O> {
+public class DefaultSearchProjectionFactoryContext<R, E> implements SearchProjectionFactoryContext<R, E> {
 
 	private final SearchProjectionBuilderFactory factory;
 
@@ -60,7 +60,7 @@ public class DefaultSearchProjectionFactoryContext<R, O> implements SearchProjec
 	}
 
 	@Override
-	public EntityProjectionContext<O> entity() {
+	public EntityProjectionContext<E> entity() {
 		return new EntityProjectionContextImpl<>( factory );
 	}
 
@@ -115,14 +115,14 @@ public class DefaultSearchProjectionFactoryContext<R, O> implements SearchProjec
 	}
 
 	@Override
-	public <T> T extension(SearchProjectionFactoryContextExtension<T, R, O> extension) {
+	public <T> T extension(SearchProjectionFactoryContextExtension<T, R, E> extension) {
 		return DslExtensionState.returnIfSupported(
 				extension, extension.extendOptional( this, factory )
 		);
 	}
 
 	@Override
-	public <T> SearchProjectionFactoryExtensionContext<T, R, O> extension() {
+	public <T> SearchProjectionFactoryExtensionContext<T, R, E> extension() {
 		return new SearchProjectionFactoryExtensionContextImpl<>( this, factory );
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/impl/EntityProjectionContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/impl/EntityProjectionContextImpl.java
@@ -7,28 +7,28 @@
 package org.hibernate.search.engine.search.dsl.projection.impl;
 
 import org.hibernate.search.engine.search.SearchProjection;
-import org.hibernate.search.engine.search.dsl.projection.ObjectProjectionContext;
-import org.hibernate.search.engine.search.projection.spi.ObjectProjectionBuilder;
+import org.hibernate.search.engine.search.dsl.projection.EntityProjectionContext;
+import org.hibernate.search.engine.search.projection.spi.EntityProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilderFactory;
 
 
-public class ObjectProjectionContextImpl<O> implements ObjectProjectionContext<O> {
+public class EntityProjectionContextImpl<O> implements EntityProjectionContext<O> {
 
-	private final ObjectProjectionBuilder<O> objectProjectionBuilder;
+	private final EntityProjectionBuilder<O> entityProjectionBuilder;
 
-	ObjectProjectionContextImpl(SearchProjectionBuilderFactory factory) {
-		this.objectProjectionBuilder = factory.object();
+	EntityProjectionContextImpl(SearchProjectionBuilderFactory factory) {
+		this.entityProjectionBuilder = factory.entity();
 	}
 
 	@Override
 	/*
-	 * The backend has no control over the type of loaded objects.
+	 * The backend has no control over the type of entities.
 	 * This cast is only safe because we make sure to only use SearchProjectionFactoryContext
 	 * with generic type arguments that are consistent with the type of object loaders.
 	 * See comments in MappedIndexSearchScope.
 	 */
 	public SearchProjection<O> toProjection() {
-		return objectProjectionBuilder.build();
+		return entityProjectionBuilder.build();
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/impl/EntityProjectionContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/impl/EntityProjectionContextImpl.java
@@ -24,7 +24,7 @@ public class EntityProjectionContextImpl<O> implements EntityProjectionContext<O
 	/*
 	 * The backend has no control over the type of entities.
 	 * This cast is only safe because we make sure to only use SearchProjectionFactoryContext
-	 * with generic type arguments that are consistent with the type of object loaders.
+	 * with generic type arguments that are consistent with the type of entity loaders.
 	 * See comments in MappedIndexSearchScope.
 	 */
 	public SearchProjection<O> toProjection() {

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/impl/EntityProjectionContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/impl/EntityProjectionContextImpl.java
@@ -12,9 +12,9 @@ import org.hibernate.search.engine.search.projection.spi.EntityProjectionBuilder
 import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilderFactory;
 
 
-public class EntityProjectionContextImpl<O> implements EntityProjectionContext<O> {
+public class EntityProjectionContextImpl<E> implements EntityProjectionContext<E> {
 
-	private final EntityProjectionBuilder<O> entityProjectionBuilder;
+	private final EntityProjectionBuilder<E> entityProjectionBuilder;
 
 	EntityProjectionContextImpl(SearchProjectionBuilderFactory factory) {
 		this.entityProjectionBuilder = factory.entity();
@@ -27,7 +27,7 @@ public class EntityProjectionContextImpl<O> implements EntityProjectionContext<O
 	 * with generic type arguments that are consistent with the type of entity loaders.
 	 * See comments in MappedIndexSearchScope.
 	 */
-	public SearchProjection<O> toProjection() {
+	public SearchProjection<E> toProjection() {
 		return entityProjectionBuilder.build();
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/impl/ReferenceProjectionContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/impl/ReferenceProjectionContextImpl.java
@@ -24,7 +24,7 @@ public class ReferenceProjectionContextImpl<R> implements ReferenceProjectionCon
 	/*
 	 * The backend has no control over the type of entities.
 	 * This cast is only safe because we make sure to only use SearchProjectionFactoryContext
-	 * with generic type arguments that are consistent with the type of object loaders.
+	 * with generic type arguments that are consistent with the type of entity loaders.
 	 * See comments in MappedIndexSearchScope.
 	 */
 	public SearchProjection<R> toProjection() {

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/impl/ReferenceProjectionContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/impl/ReferenceProjectionContextImpl.java
@@ -22,7 +22,7 @@ public class ReferenceProjectionContextImpl<R> implements ReferenceProjectionCon
 
 	@Override
 	/*
-	 * The backend has no control over the type of loaded objects.
+	 * The backend has no control over the type of entities.
 	 * This cast is only safe because we make sure to only use SearchProjectionFactoryContext
 	 * with generic type arguments that are consistent with the type of object loaders.
 	 * See comments in MappedIndexSearchScope.

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/impl/SearchProjectionFactoryExtensionContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/impl/SearchProjectionFactoryExtensionContextImpl.java
@@ -15,22 +15,22 @@ import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactory
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionTerminalContext;
 import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilderFactory;
 
-public class SearchProjectionFactoryExtensionContextImpl<P, R, O> implements SearchProjectionFactoryExtensionContext<P, R, O> {
+public class SearchProjectionFactoryExtensionContextImpl<P, R, E> implements SearchProjectionFactoryExtensionContext<P, R, E> {
 
-	private final SearchProjectionFactoryContext<R, O> parent;
+	private final SearchProjectionFactoryContext<R, E> parent;
 	private final SearchProjectionBuilderFactory factory;
 
 	private final DslExtensionState<SearchProjectionTerminalContext<P>> state = new DslExtensionState<>();
 
-	SearchProjectionFactoryExtensionContextImpl(SearchProjectionFactoryContext<R, O> parent,
+	SearchProjectionFactoryExtensionContextImpl(SearchProjectionFactoryContext<R, E> parent,
 			SearchProjectionBuilderFactory factory) {
 		this.parent = parent;
 		this.factory = factory;
 	}
 
 	@Override
-	public <T> SearchProjectionFactoryExtensionContext<P, R, O> ifSupported(
-			SearchProjectionFactoryContextExtension<T, R, O> extension,
+	public <T> SearchProjectionFactoryExtensionContext<P, R, E> ifSupported(
+			SearchProjectionFactoryContextExtension<T, R, E> extension,
 			Function<T, ? extends SearchProjectionTerminalContext<P>> projectionContributor) {
 		state.ifSupported( extension, extension.extendOptional( parent, factory ), projectionContributor );
 		return this;
@@ -38,7 +38,7 @@ public class SearchProjectionFactoryExtensionContextImpl<P, R, O> implements Sea
 
 	@Override
 	public SearchProjectionTerminalContext<P> orElse(
-			Function<SearchProjectionFactoryContext<R, O>, ? extends SearchProjectionTerminalContext<P>> projectionContributor) {
+			Function<SearchProjectionFactoryContext<R, E>, ? extends SearchProjectionTerminalContext<P>> projectionContributor) {
 		return state.orElse( parent, projectionContributor );
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/spi/DelegatingSearchProjectionFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/spi/DelegatingSearchProjectionFactoryContext.java
@@ -14,8 +14,8 @@ import org.hibernate.search.engine.search.SearchProjection;
 import org.hibernate.search.engine.search.dsl.projection.CompositeProjectionContext;
 import org.hibernate.search.engine.search.dsl.projection.DistanceToFieldProjectionContext;
 import org.hibernate.search.engine.search.dsl.projection.DocumentReferenceProjectionContext;
+import org.hibernate.search.engine.search.dsl.projection.EntityProjectionContext;
 import org.hibernate.search.engine.search.dsl.projection.FieldProjectionContext;
-import org.hibernate.search.engine.search.dsl.projection.ObjectProjectionContext;
 import org.hibernate.search.engine.search.dsl.projection.ReferenceProjectionContext;
 import org.hibernate.search.engine.search.dsl.projection.ScoreProjectionContext;
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContext;
@@ -44,8 +44,8 @@ public class DelegatingSearchProjectionFactoryContext<R, O> implements SearchPro
 	}
 
 	@Override
-	public ObjectProjectionContext<O> object() {
-		return delegate.object();
+	public EntityProjectionContext<O> entity() {
+		return delegate.entity();
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/spi/DelegatingSearchProjectionFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/projection/spi/DelegatingSearchProjectionFactoryContext.java
@@ -25,11 +25,11 @@ import org.hibernate.search.engine.search.projection.ProjectionConverter;
 import org.hibernate.search.engine.spatial.GeoPoint;
 import org.hibernate.search.util.common.function.TriFunction;
 
-public class DelegatingSearchProjectionFactoryContext<R, O> implements SearchProjectionFactoryContext<R, O> {
+public class DelegatingSearchProjectionFactoryContext<R, E> implements SearchProjectionFactoryContext<R, E> {
 
-	private final SearchProjectionFactoryContext<R, O> delegate;
+	private final SearchProjectionFactoryContext<R, E> delegate;
 
-	public DelegatingSearchProjectionFactoryContext(SearchProjectionFactoryContext<R, O> delegate) {
+	public DelegatingSearchProjectionFactoryContext(SearchProjectionFactoryContext<R, E> delegate) {
 		this.delegate = delegate;
 	}
 
@@ -44,7 +44,7 @@ public class DelegatingSearchProjectionFactoryContext<R, O> implements SearchPro
 	}
 
 	@Override
-	public EntityProjectionContext<O> entity() {
+	public EntityProjectionContext<E> entity() {
 		return delegate.entity();
 	}
 
@@ -92,12 +92,12 @@ public class DelegatingSearchProjectionFactoryContext<R, O> implements SearchPro
 	}
 
 	@Override
-	public <T> T extension(SearchProjectionFactoryContextExtension<T, R, O> extension) {
+	public <T> T extension(SearchProjectionFactoryContextExtension<T, R, E> extension) {
 		return delegate.extension( extension );
 	}
 
 	@Override
-	public <P> SearchProjectionFactoryExtensionContext<P, R, O> extension() {
+	public <P> SearchProjectionFactoryExtensionContext<P, R, E> extension() {
 		return delegate.extension();
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/SearchQueryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/SearchQueryContext.java
@@ -18,12 +18,12 @@ import org.hibernate.search.engine.search.query.SearchQuery;
  * The context used when building a query, after the search predicate has been defined.
  *
  * @param <S> The type actually exposed to the user for this context (may be a subtype of SearchQueryContext, with more exposed methods).
- * @param <T> The type of hits for the created query.
+ * @param <H> The type of hits for the created query.
  * @param <SC> The type of contexts used to create sorts in {@link #sort(Consumer)}.
  */
 public interface SearchQueryContext<
-		S extends SearchQueryContext<? extends S, T, SC>,
-		T,
+		S extends SearchQueryContext<? extends S, H, SC>,
+		H,
 		SC extends SearchSortContainerContext
 		> {
 
@@ -35,6 +35,6 @@ public interface SearchQueryContext<
 
 	S sort(Consumer<? super SC> sortContributor);
 
-	SearchQuery<T> toQuery();
+	SearchQuery<H> toQuery();
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/SearchQueryContextExtension.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/SearchQueryContextExtension.java
@@ -28,7 +28,7 @@ import org.hibernate.search.engine.search.loading.context.spi.LoadingContextBuil
  * @param <R> The reference type.
  * Users should not have to care about this, as the parameter will automatically take the appropriate value when calling
  * {@code .extension( ElasticsearchExtension.get() }.
- * @param <O> The loaded object type.
+ * @param <O> The entity type.
  * Users should not have to care about this, as the parameter will automatically take the appropriate value when calling
  *
  * @see SearchQueryResultDefinitionContext#extension(SearchQueryContextExtension)

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/SearchQueryContextExtension.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/SearchQueryContextExtension.java
@@ -28,13 +28,13 @@ import org.hibernate.search.engine.search.loading.context.spi.LoadingContextBuil
  * @param <R> The reference type.
  * Users should not have to care about this, as the parameter will automatically take the appropriate value when calling
  * {@code .extension( ElasticsearchExtension.get() }.
- * @param <O> The entity type.
+ * @param <E> The entity type.
  * Users should not have to care about this, as the parameter will automatically take the appropriate value when calling
  *
  * @see SearchQueryResultDefinitionContext#extension(SearchQueryContextExtension)
  * @see AbstractSearchQueryContext
  */
-public interface SearchQueryContextExtension<T, R, O> {
+public interface SearchQueryContextExtension<T, R, E> {
 
 	/**
 	 * Attempt to extend a given context, returning an empty {@link Optional} in case of failure.
@@ -48,9 +48,9 @@ public interface SearchQueryContextExtension<T, R, O> {
 	 * @return An optional containing the extended search query context ({@link T}) in case
 	 * of success, or an empty optional otherwise.
 	 */
-	Optional<T> extendOptional(SearchQueryResultDefinitionContext<R, O, ?> original,
+	Optional<T> extendOptional(SearchQueryResultDefinitionContext<R, E, ?> original,
 			IndexSearchScope<?> indexSearchScope,
 			SessionContextImplementor sessionContext,
-			LoadingContextBuilder<R, O> loadingContextBuilder);
+			LoadingContextBuilder<R, E> loadingContextBuilder);
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/SearchQueryResultContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/SearchQueryResultContext.java
@@ -16,12 +16,12 @@ import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateTerminalC
  * The context used when building a query, after the search result type has been defined.
  *
  * @param <N> The type of the next context, returned after a predicate is defined.
- * @param <T> The type of hits for the created query.
+ * @param <H> The type of hits for the created query.
  * @param <PC> The type of contexts used to create predicates in {@link #predicate(Function)}.
  */
 public interface SearchQueryResultContext<
-		N extends SearchQueryContext<? extends N, T, ?>,
-		T,
+		N extends SearchQueryContext<? extends N, H, ?>,
+		H,
 		PC extends SearchPredicateFactoryContext
 		> {
 

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/SearchQueryResultDefinitionContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/SearchQueryResultDefinitionContext.java
@@ -21,9 +21,9 @@ import org.hibernate.search.util.common.SearchException;
  * @param <R> The type of references, i.e. the type of hits returned by
  * {@link #asReference() reference queries},
  * or the type of objects returned for {@link SearchProjectionFactoryContext#reference() reference projections}.
- * @param <O> The type of loaded objects, i.e. the type of hits returned by
+ * @param <O> The type of entities, i.e. the type of hits returned by
  * {@link #asEntity() entity queries},
- * or the type of objects returned for {@link SearchProjectionFactoryContext#object() loaded object projections}.
+ * or the type of objects returned for {@link SearchProjectionFactoryContext#entity() entity projections}.
  * @param <PC> The type of contexts used to create projections in {@link #asProjection(Function)}.
  */
 public interface SearchQueryResultDefinitionContext<R, O, PC extends SearchProjectionFactoryContext<R, O>> {

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/SearchQueryResultDefinitionContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/SearchQueryResultDefinitionContext.java
@@ -21,12 +21,12 @@ import org.hibernate.search.util.common.SearchException;
  * @param <R> The type of references, i.e. the type of hits returned by
  * {@link #asReference() reference queries},
  * or the type of objects returned for {@link SearchProjectionFactoryContext#reference() reference projections}.
- * @param <O> The type of entities, i.e. the type of hits returned by
+ * @param <E> The type of entities, i.e. the type of hits returned by
  * {@link #asEntity() entity queries},
  * or the type of objects returned for {@link SearchProjectionFactoryContext#entity() entity projections}.
  * @param <PC> The type of contexts used to create projections in {@link #asProjection(Function)}.
  */
-public interface SearchQueryResultDefinitionContext<R, O, PC extends SearchProjectionFactoryContext<R, O>> {
+public interface SearchQueryResultDefinitionContext<R, E, PC extends SearchProjectionFactoryContext<R, E>> {
 
 	/**
 	 * Define the query results as the entity was originally indexed, loaded from an external source (database, ...).
@@ -34,7 +34,7 @@ public interface SearchQueryResultDefinitionContext<R, O, PC extends SearchProje
 	 * @return A context allowing to define the query further.
 	 * @see SearchQueryResultContext
 	 */
-	SearchQueryResultContext<?, O, ?> asEntity();
+	SearchQueryResultContext<?, E, ?> asEntity();
 
 	/**
 	 * Define the query results as a reference to entity that was originally indexed.
@@ -91,6 +91,6 @@ public interface SearchQueryResultDefinitionContext<R, O, PC extends SearchProje
 	 * @return The extended context.
 	 * @throws SearchException If the extension cannot be applied (wrong underlying backend, ...).
 	 */
-	<T> T extension(SearchQueryContextExtension<T, R, O> extension);
+	<T> T extension(SearchQueryContextExtension<T, R, E> extension);
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/impl/DefaultSearchQueryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/impl/DefaultSearchQueryContext.java
@@ -14,18 +14,18 @@ import org.hibernate.search.engine.search.dsl.sort.SearchSortContainerContext;
 import org.hibernate.search.engine.search.dsl.spi.IndexSearchScope;
 import org.hibernate.search.engine.search.query.spi.SearchQueryBuilder;
 
-final class DefaultSearchQueryContext<T, C>
+final class DefaultSearchQueryContext<H, C>
 		extends AbstractSearchQueryContext<
-						DefaultSearchQueryContext<T, C>,
-						T,
+						DefaultSearchQueryContext<H, C>,
+		H,
 						SearchPredicateFactoryContext,
 						SearchSortContainerContext,
 						C
 				>
-		implements SearchQueryResultContext<DefaultSearchQueryContext<T, C>, T, SearchPredicateFactoryContext>,
-				SearchQueryContext<DefaultSearchQueryContext<T, C>, T, SearchSortContainerContext> {
+		implements SearchQueryResultContext<DefaultSearchQueryContext<H, C>, H, SearchPredicateFactoryContext>,
+				SearchQueryContext<DefaultSearchQueryContext<H, C>, H, SearchSortContainerContext> {
 
-	DefaultSearchQueryContext(IndexSearchScope<C> indexSearchScope, SearchQueryBuilder<T, C> searchQueryBuilder) {
+	DefaultSearchQueryContext(IndexSearchScope<C> indexSearchScope, SearchQueryBuilder<H, C> searchQueryBuilder) {
 		super( indexSearchScope, searchQueryBuilder );
 	}
 
@@ -43,7 +43,7 @@ final class DefaultSearchQueryContext<T, C>
 	}
 
 	@Override
-	protected DefaultSearchQueryContext<T, C> thisAsS() {
+	protected DefaultSearchQueryContext<H, C> thisAsS() {
 		return this;
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/impl/DefaultSearchQueryResultDefinitionContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/impl/DefaultSearchQueryResultDefinitionContext.java
@@ -37,7 +37,7 @@ public final class DefaultSearchQueryResultDefinitionContext<R, O, C>
 	@Override
 	public SearchQueryResultContext<?, O, ?> asEntity() {
 		SearchQueryBuilder<O, C> builder = indexSearchScope.getSearchQueryBuilderFactory()
-				.asObject( sessionContext, loadingContextBuilder );
+				.asEntity( sessionContext, loadingContextBuilder );
 		return new DefaultSearchQueryContext<>( indexSearchScope, builder );
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/impl/DefaultSearchQueryResultDefinitionContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/impl/DefaultSearchQueryResultDefinitionContext.java
@@ -19,24 +19,24 @@ import org.hibernate.search.engine.search.dsl.spi.IndexSearchScope;
 import org.hibernate.search.engine.search.loading.context.spi.LoadingContextBuilder;
 import org.hibernate.search.engine.search.query.spi.SearchQueryBuilder;
 
-public final class DefaultSearchQueryResultDefinitionContext<R, O, C>
-		extends AbstractSearchQueryResultDefinitionContext<R, O, SearchProjectionFactoryContext<R, O>, C> {
+public final class DefaultSearchQueryResultDefinitionContext<R, E, C>
+		extends AbstractSearchQueryResultDefinitionContext<R, E, SearchProjectionFactoryContext<R, E>, C> {
 
 	private final IndexSearchScope<C> indexSearchScope;
 	private final SessionContextImplementor sessionContext;
-	private final LoadingContextBuilder<R, O> loadingContextBuilder;
+	private final LoadingContextBuilder<R, E> loadingContextBuilder;
 
 	public DefaultSearchQueryResultDefinitionContext(IndexSearchScope<C> indexSearchScope,
 			SessionContextImplementor sessionContext,
-			LoadingContextBuilder<R, O> loadingContextBuilder) {
+			LoadingContextBuilder<R, E> loadingContextBuilder) {
 		this.indexSearchScope = indexSearchScope;
 		this.sessionContext = sessionContext;
 		this.loadingContextBuilder = loadingContextBuilder;
 	}
 
 	@Override
-	public SearchQueryResultContext<?, O, ?> asEntity() {
-		SearchQueryBuilder<O, C> builder = indexSearchScope.getSearchQueryBuilderFactory()
+	public SearchQueryResultContext<?, E, ?> asEntity() {
+		SearchQueryBuilder<E, C> builder = indexSearchScope.getSearchQueryBuilderFactory()
 				.asEntity( sessionContext, loadingContextBuilder );
 		return new DefaultSearchQueryContext<>( indexSearchScope, builder );
 	}
@@ -50,8 +50,8 @@ public final class DefaultSearchQueryResultDefinitionContext<R, O, C>
 
 	@Override
 	public <P> SearchQueryResultContext<?, P, ?> asProjection(
-			Function<? super SearchProjectionFactoryContext<R, O>, ? extends SearchProjectionTerminalContext<P>> projectionContributor) {
-		SearchProjectionFactoryContext<R, O> factoryContext = createDefaultProjectionFactoryContext();
+			Function<? super SearchProjectionFactoryContext<R, E>, ? extends SearchProjectionTerminalContext<P>> projectionContributor) {
+		SearchProjectionFactoryContext<R, E> factoryContext = createDefaultProjectionFactoryContext();
 		SearchProjection<P> projection = projectionContributor.apply( factoryContext ).toProjection();
 		return asProjection( projection );
 	}
@@ -81,7 +81,7 @@ public final class DefaultSearchQueryResultDefinitionContext<R, O, C>
 	}
 
 	@Override
-	protected LoadingContextBuilder<R, O> getLoadingContextBuilder() {
+	protected LoadingContextBuilder<R, E> getLoadingContextBuilder() {
 		return loadingContextBuilder;
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/spi/AbstractDelegatingSearchQueryResultDefinitionContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/spi/AbstractDelegatingSearchQueryResultDefinitionContext.java
@@ -16,17 +16,17 @@ import org.hibernate.search.engine.search.dsl.query.SearchQueryContextExtension;
 import org.hibernate.search.engine.search.dsl.query.SearchQueryResultContext;
 import org.hibernate.search.engine.search.dsl.query.SearchQueryResultDefinitionContext;
 
-public abstract class AbstractDelegatingSearchQueryResultDefinitionContext<R, O>
-		implements SearchQueryResultDefinitionContext<R, O, SearchProjectionFactoryContext<R, O>> {
+public abstract class AbstractDelegatingSearchQueryResultDefinitionContext<R, E>
+		implements SearchQueryResultDefinitionContext<R, E, SearchProjectionFactoryContext<R, E>> {
 
-	private final SearchQueryResultDefinitionContext<R, O, ?> delegate;
+	private final SearchQueryResultDefinitionContext<R, E, ?> delegate;
 
-	public AbstractDelegatingSearchQueryResultDefinitionContext(SearchQueryResultDefinitionContext<R, O, ?> delegate) {
+	public AbstractDelegatingSearchQueryResultDefinitionContext(SearchQueryResultDefinitionContext<R, E, ?> delegate) {
 		this.delegate = delegate;
 	}
 
 	@Override
-	public SearchQueryResultContext<?, O, ?> asEntity() {
+	public SearchQueryResultContext<?, E, ?> asEntity() {
 		return delegate.asEntity();
 	}
 
@@ -37,7 +37,7 @@ public abstract class AbstractDelegatingSearchQueryResultDefinitionContext<R, O>
 
 	@Override
 	public <P> SearchQueryResultContext<?, P, ?> asProjection(
-			Function<? super SearchProjectionFactoryContext<R, O>, ? extends SearchProjectionTerminalContext<P>> projectionContributor) {
+			Function<? super SearchProjectionFactoryContext<R, E>, ? extends SearchProjectionTerminalContext<P>> projectionContributor) {
 		return delegate.asProjection( projectionContributor );
 	}
 
@@ -53,7 +53,7 @@ public abstract class AbstractDelegatingSearchQueryResultDefinitionContext<R, O>
 	}
 
 	@Override
-	public <T> T extension(SearchQueryContextExtension<T, R, O> extension) {
+	public <T> T extension(SearchQueryContextExtension<T, R, E> extension) {
 		return delegate.extension( extension );
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/spi/AbstractSearchQueryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/spi/AbstractSearchQueryContext.java
@@ -27,19 +27,19 @@ import org.hibernate.search.engine.search.query.spi.SearchQueryBuilder;
 import org.hibernate.search.engine.search.sort.spi.SearchSortBuilderFactory;
 
 public abstract class AbstractSearchQueryContext<
-		S extends SearchQueryContext<S, T, SC>,
-		T,
+		S extends SearchQueryContext<S, H, SC>,
+		H,
 		PC extends SearchPredicateFactoryContext,
 		SC extends SearchSortContainerContext,
 		C
 		>
-		implements SearchQueryResultContext<S, T, PC>, SearchQueryContext<S, T, SC> {
+		implements SearchQueryResultContext<S, H, PC>, SearchQueryContext<S, H, SC> {
 
 	private final IndexSearchScope<C> indexSearchScope;
-	private final SearchQueryBuilder<T, C> searchQueryBuilder;
+	private final SearchQueryBuilder<H, C> searchQueryBuilder;
 
 	public AbstractSearchQueryContext(IndexSearchScope<C> indexSearchScope,
-			SearchQueryBuilder<T, C> searchQueryBuilder) {
+			SearchQueryBuilder<H, C> searchQueryBuilder) {
 		this.indexSearchScope = indexSearchScope;
 		this.searchQueryBuilder = searchQueryBuilder;
 	}
@@ -87,7 +87,7 @@ public abstract class AbstractSearchQueryContext<
 	}
 
 	@Override
-	public SearchQuery<T> toQuery() {
+	public SearchQuery<H> toQuery() {
 		return searchQueryBuilder.build();
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/spi/AbstractSearchQueryResultDefinitionContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/spi/AbstractSearchQueryResultDefinitionContext.java
@@ -15,11 +15,11 @@ import org.hibernate.search.engine.search.dsl.query.SearchQueryResultDefinitionC
 import org.hibernate.search.engine.search.dsl.spi.IndexSearchScope;
 import org.hibernate.search.engine.search.loading.context.spi.LoadingContextBuilder;
 
-public abstract class AbstractSearchQueryResultDefinitionContext<R, O, PC extends SearchProjectionFactoryContext<R, O>, C>
-		implements SearchQueryResultDefinitionContext<R, O, PC> {
+public abstract class AbstractSearchQueryResultDefinitionContext<R, E, PC extends SearchProjectionFactoryContext<R, E>, C>
+		implements SearchQueryResultDefinitionContext<R, E, PC> {
 
 	@Override
-	public <T> T extension(SearchQueryContextExtension<T, R, O> extension) {
+	public <T> T extension(SearchQueryContextExtension<T, R, E> extension) {
 		return DslExtensionState.returnIfSupported(
 				extension,
 				extension.extendOptional(
@@ -28,7 +28,7 @@ public abstract class AbstractSearchQueryResultDefinitionContext<R, O, PC extend
 		);
 	}
 
-	protected final SearchProjectionFactoryContext<R, O> createDefaultProjectionFactoryContext() {
+	protected final SearchProjectionFactoryContext<R, E> createDefaultProjectionFactoryContext() {
 		return new DefaultSearchProjectionFactoryContext<>( getIndexSearchScope().getSearchProjectionFactory() );
 	}
 
@@ -36,5 +36,5 @@ public abstract class AbstractSearchQueryResultDefinitionContext<R, O, PC extend
 
 	protected abstract SessionContextImplementor getSessionContext();
 
-	protected abstract LoadingContextBuilder<R, O> getLoadingContextBuilder();
+	protected abstract LoadingContextBuilder<R, E> getLoadingContextBuilder();
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/loading/context/spi/LoadingContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/loading/context/spi/LoadingContext.java
@@ -12,11 +12,11 @@ import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
  * An execution context for queries,
  * providing components allowing to load data from an external source (relational database, ...).
  *
- * @param <R> The type of object references.
- * @param <O> The type of loaded objects.
+ * @param <R> The type of entity references.
+ * @param <E> The type of loaded entities.
  */
-public interface LoadingContext<R, O> {
+public interface LoadingContext<R, E> {
 
-	ProjectionHitMapper<R, O> getProjectionHitMapper();
+	ProjectionHitMapper<R, E> getProjectionHitMapper();
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/loading/context/spi/LoadingContextBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/loading/context/spi/LoadingContextBuilder.java
@@ -10,11 +10,11 @@ package org.hibernate.search.engine.search.loading.context.spi;
  * A builder for {@link LoadingContext},
  * allowing to change the parameters of object loading while a query is being built.
  *
- * @param <R> The type of object references.
- * @param <O> The type of loaded objects.
+ * @param <R> The type of entity references.
+ * @param <E> The type of loaded entities.
  */
-public interface LoadingContextBuilder<R, O> {
+public interface LoadingContextBuilder<R, E> {
 
-	LoadingContext<R, O> build();
+	LoadingContext<R, E> build();
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/loading/spi/DefaultProjectionHitMapper.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/loading/spi/DefaultProjectionHitMapper.java
@@ -16,12 +16,12 @@ import org.hibernate.search.util.common.impl.CollectionHelper;
 public final class DefaultProjectionHitMapper<R, O> implements ProjectionHitMapper<R, O> {
 
 	private final Function<DocumentReference, R> documentReferenceTransformer;
-	private final ObjectLoader<R, O> objectLoader;
+	private final EntityLoader<R, O> objectLoader;
 
 	private final List<R> referencesToLoad = new ArrayList<>();
 
 	public DefaultProjectionHitMapper(Function<DocumentReference, R> documentReferenceTransformer,
-			ObjectLoader<R, O> objectLoader) {
+			EntityLoader<R, O> objectLoader) {
 		this.documentReferenceTransformer = documentReferenceTransformer;
 		this.objectLoader = objectLoader;
 	}

--- a/engine/src/main/java/org/hibernate/search/engine/search/loading/spi/DefaultProjectionHitMapper.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/loading/spi/DefaultProjectionHitMapper.java
@@ -44,9 +44,9 @@ public final class DefaultProjectionHitMapper<R, O> implements ProjectionHitMapp
 
 	private static class DefaultLoadingResult<O> implements LoadingResult<O> {
 
-		private final List<O> loadedObjects;
+		private final List<? extends O> loadedObjects;
 
-		private DefaultLoadingResult(List<O> loadedObjects) {
+		private DefaultLoadingResult(List<? extends O> loadedObjects) {
 			this.loadedObjects = CollectionHelper.toImmutableList( loadedObjects );
 		}
 

--- a/engine/src/main/java/org/hibernate/search/engine/search/loading/spi/DefaultProjectionHitMapper.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/loading/spi/DefaultProjectionHitMapper.java
@@ -13,15 +13,15 @@ import java.util.function.Function;
 import org.hibernate.search.engine.search.DocumentReference;
 import org.hibernate.search.util.common.impl.CollectionHelper;
 
-public final class DefaultProjectionHitMapper<R, O> implements ProjectionHitMapper<R, O> {
+public final class DefaultProjectionHitMapper<R, E> implements ProjectionHitMapper<R, E> {
 
 	private final Function<DocumentReference, R> documentReferenceTransformer;
-	private final EntityLoader<R, O> objectLoader;
+	private final EntityLoader<R, E> objectLoader;
 
 	private final List<R> referencesToLoad = new ArrayList<>();
 
 	public DefaultProjectionHitMapper(Function<DocumentReference, R> documentReferenceTransformer,
-			EntityLoader<R, O> objectLoader) {
+			EntityLoader<R, E> objectLoader) {
 		this.documentReferenceTransformer = documentReferenceTransformer;
 		this.objectLoader = objectLoader;
 	}
@@ -38,20 +38,20 @@ public final class DefaultProjectionHitMapper<R, O> implements ProjectionHitMapp
 	}
 
 	@Override
-	public LoadingResult<O> loadBlocking() {
+	public LoadingResult<E> loadBlocking() {
 		return new DefaultLoadingResult<>( objectLoader.loadBlocking( referencesToLoad ) );
 	}
 
-	private static class DefaultLoadingResult<O> implements LoadingResult<O> {
+	private static class DefaultLoadingResult<E> implements LoadingResult<E> {
 
-		private final List<? extends O> loadedObjects;
+		private final List<? extends E> loadedObjects;
 
-		private DefaultLoadingResult(List<? extends O> loadedObjects) {
+		private DefaultLoadingResult(List<? extends E> loadedObjects) {
 			this.loadedObjects = CollectionHelper.toImmutableList( loadedObjects );
 		}
 
 		@Override
-		public O getLoaded(Object key) {
+		public E getLoaded(Object key) {
 			return loadedObjects.get( (int) key );
 		}
 	}

--- a/engine/src/main/java/org/hibernate/search/engine/search/loading/spi/EntityLoader.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/loading/spi/EntityLoader.java
@@ -14,7 +14,7 @@ import java.util.List;
  * @param <R> The expected reference type (input)
  * @param <O> The resulting entity type (output)
  */
-public interface ObjectLoader<R, O> {
+public interface EntityLoader<R, O> {
 
 	/**
 	 * Loads the entities corresponding to the given references, blocking the current thread while doing so.
@@ -25,8 +25,8 @@ public interface ObjectLoader<R, O> {
 	 */
 	List<O> loadBlocking(List<R> references);
 
-	static <T> ObjectLoader<T, T> identity() {
-		return IdentityObjectLoader.get();
+	static <T> EntityLoader<T, T> identity() {
+		return IdentityEntityLoader.get();
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/loading/spi/EntityLoader.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/loading/spi/EntityLoader.java
@@ -12,9 +12,9 @@ import java.util.List;
  * Loads objects into memory using a reference and implementation-specific context.
  *
  * @param <R> The expected reference type (input)
- * @param <O> The resulting entity type (output)
+ * @param <E> The resulting entity type (output)
  */
-public interface EntityLoader<R, O> {
+public interface EntityLoader<R, E> {
 
 	/**
 	 * Loads the entities corresponding to the given references, blocking the current thread while doing so.
@@ -23,7 +23,7 @@ public interface EntityLoader<R, O> {
 	 * @return A list of entities, in the same order the references were given.
 	 * {@code null} is inserted when an object is not found.
 	 */
-	List<? extends O> loadBlocking(List<R> references);
+	List<? extends E> loadBlocking(List<R> references);
 
 	static <T> EntityLoader<T, T> identity() {
 		return IdentityEntityLoader.get();

--- a/engine/src/main/java/org/hibernate/search/engine/search/loading/spi/EntityLoader.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/loading/spi/EntityLoader.java
@@ -23,7 +23,7 @@ public interface EntityLoader<R, O> {
 	 * @return A list of entities, in the same order the references were given.
 	 * {@code null} is inserted when an object is not found.
 	 */
-	List<O> loadBlocking(List<R> references);
+	List<? extends O> loadBlocking(List<R> references);
 
 	static <T> EntityLoader<T, T> identity() {
 		return IdentityEntityLoader.get();

--- a/engine/src/main/java/org/hibernate/search/engine/search/loading/spi/IdentityEntityLoader.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/loading/spi/IdentityEntityLoader.java
@@ -9,11 +9,11 @@ package org.hibernate.search.engine.search.loading.spi;
 import java.util.List;
 
 @SuppressWarnings({ "unchecked", "rawtypes" }) // This implementation works for any T
-class IdentityObjectLoader<T> implements ObjectLoader<T, T> {
+class IdentityEntityLoader<T> implements EntityLoader<T, T> {
 
-	private static final IdentityObjectLoader INSTANCE = new IdentityObjectLoader();
+	private static final IdentityEntityLoader INSTANCE = new IdentityEntityLoader();
 
-	public static <T> IdentityObjectLoader<T> get() {
+	public static <T> IdentityEntityLoader<T> get() {
 		return INSTANCE;
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/search/loading/spi/IdentityEntityLoader.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/loading/spi/IdentityEntityLoader.java
@@ -8,17 +8,17 @@ package org.hibernate.search.engine.search.loading.spi;
 
 import java.util.List;
 
-@SuppressWarnings({ "unchecked", "rawtypes" }) // This implementation works for any T
-class IdentityEntityLoader<T> implements EntityLoader<T, T> {
+@SuppressWarnings({ "unchecked", "rawtypes" }) // This implementation works for any E
+class IdentityEntityLoader<E> implements EntityLoader<E, E> {
 
 	private static final IdentityEntityLoader INSTANCE = new IdentityEntityLoader();
 
-	public static <T> IdentityEntityLoader<T> get() {
+	public static <E> IdentityEntityLoader<E> get() {
 		return INSTANCE;
 	}
 
 	@Override
-	public List<T> loadBlocking(List<T> references) {
+	public List<E> loadBlocking(List<E> references) {
 		return references;
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/loading/spi/LoadingResult.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/loading/spi/LoadingResult.java
@@ -12,13 +12,13 @@ import org.hibernate.search.engine.search.DocumentReference;
 /**
  * The result of the loading of the entities by the {@link ProjectionHitMapper}.
  *
- * @param <O> The type of entities.
+ * @param <E> The type of entities.
  */
-public interface LoadingResult<O> {
+public interface LoadingResult<E> {
 
 	/**
 	 * @param key The key that was previously returned by {@link ProjectionHitMapper#planLoading(DocumentReference)}.
 	 * @return The loaded entity corresponding to the key.
 	 */
-	O getLoaded(Object key);
+	E getLoaded(Object key);
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/loading/spi/LoadingResult.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/loading/spi/LoadingResult.java
@@ -12,7 +12,7 @@ import org.hibernate.search.engine.search.DocumentReference;
 /**
  * The result of the loading of the entities by the {@link ProjectionHitMapper}.
  *
- * @param <O> The type of the loaded objects.
+ * @param <O> The type of entities.
  */
 public interface LoadingResult<O> {
 

--- a/engine/src/main/java/org/hibernate/search/engine/search/loading/spi/ObjectLoader.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/loading/spi/ObjectLoader.java
@@ -12,7 +12,7 @@ import java.util.List;
  * Loads objects into memory using a reference and implementation-specific context.
  *
  * @param <R> The expected reference type (input)
- * @param <O> The resulting object type (output)
+ * @param <O> The resulting entity type (output)
  */
 public interface ObjectLoader<R, O> {
 
@@ -20,7 +20,7 @@ public interface ObjectLoader<R, O> {
 	 * Loads the entities corresponding to the given references, blocking the current thread while doing so.
 	 *
 	 * @param references A list of references to the objects to load.
-	 * @return A list of loaded objects, in the same order the references were given.
+	 * @return A list of entities, in the same order the references were given.
 	 * {@code null} is inserted when an object is not found.
 	 */
 	List<O> loadBlocking(List<R> references);

--- a/engine/src/main/java/org/hibernate/search/engine/search/loading/spi/ProjectionHitMapper.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/loading/spi/ProjectionHitMapper.java
@@ -11,10 +11,10 @@ import org.hibernate.search.engine.search.DocumentReference;
 /**
  * Contract binding result hits and the mapper.
  *
- * @param <R> The type of object references.
- * @param <O> The type of entities.
+ * @param <R> The type of entity references.
+ * @param <E> The type of entities.
  */
-public interface ProjectionHitMapper<R, O> {
+public interface ProjectionHitMapper<R, E> {
 
 	/**
 	 * Convert a document reference to the reference specific to the mapper.
@@ -37,6 +37,6 @@ public interface ProjectionHitMapper<R, O> {
 	 *
 	 * @return The loaded entities.
 	 */
-	LoadingResult<O> loadBlocking();
+	LoadingResult<E> loadBlocking();
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/loading/spi/ProjectionHitMapper.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/loading/spi/ProjectionHitMapper.java
@@ -12,7 +12,7 @@ import org.hibernate.search.engine.search.DocumentReference;
  * Contract binding result hits and the mapper.
  *
  * @param <R> The type of object references.
- * @param <O> The type of loaded objects.
+ * @param <O> The type of entities.
  */
 public interface ProjectionHitMapper<R, O> {
 

--- a/engine/src/main/java/org/hibernate/search/engine/search/projection/spi/EntityProjectionBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/projection/spi/EntityProjectionBuilder.java
@@ -6,6 +6,6 @@
  */
 package org.hibernate.search.engine.search.projection.spi;
 
-public interface EntityProjectionBuilder<O> extends SearchProjectionBuilder<O> {
+public interface EntityProjectionBuilder<E> extends SearchProjectionBuilder<E> {
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/projection/spi/EntityProjectionBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/projection/spi/EntityProjectionBuilder.java
@@ -6,6 +6,6 @@
  */
 package org.hibernate.search.engine.search.projection.spi;
 
-public interface ObjectProjectionBuilder<O> extends SearchProjectionBuilder<O> {
+public interface EntityProjectionBuilder<O> extends SearchProjectionBuilder<O> {
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/projection/spi/SearchProjectionBuilderFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/projection/spi/SearchProjectionBuilderFactory.java
@@ -35,13 +35,13 @@ public interface SearchProjectionBuilderFactory {
 
 	DistanceToFieldProjectionBuilder distance(String absoluteFieldPath, GeoPoint center);
 
-	<T> CompositeProjectionBuilder<T> composite(Function<List<?>, T> transformer, SearchProjection<?>... projections);
+	<P> CompositeProjectionBuilder<P> composite(Function<List<?>, P> transformer, SearchProjection<?>... projections);
 
-	<P, T> CompositeProjectionBuilder<T> composite(Function<P, T> transformer, SearchProjection<P> projection);
+	<P1, P> CompositeProjectionBuilder<P> composite(Function<P1, P> transformer, SearchProjection<P1> projection);
 
-	<P1, P2, T> CompositeProjectionBuilder<T> composite(BiFunction<P1, P2, T> transformer,
+	<P1, P2, P> CompositeProjectionBuilder<P> composite(BiFunction<P1, P2, P> transformer,
 			SearchProjection<P1> projection1, SearchProjection<P2> projection2);
 
-	<P1, P2, P3, T> CompositeProjectionBuilder<T> composite(TriFunction<P1, P2, P3, T> transformer,
+	<P1, P2, P3, P> CompositeProjectionBuilder<P> composite(TriFunction<P1, P2, P3, P> transformer,
 			SearchProjection<P1> projection1, SearchProjection<P2> projection2, SearchProjection<P3> projection3);
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/projection/spi/SearchProjectionBuilderFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/projection/spi/SearchProjectionBuilderFactory.java
@@ -27,7 +27,7 @@ public interface SearchProjectionBuilderFactory {
 
 	<T> FieldProjectionBuilder<T> field(String absoluteFieldPath, Class<T> clazz, ProjectionConverter projectionConverter);
 
-	<O> ObjectProjectionBuilder<O> object();
+	<O> EntityProjectionBuilder<O> entity();
 
 	<R> ReferenceProjectionBuilder<R> reference();
 

--- a/engine/src/main/java/org/hibernate/search/engine/search/projection/spi/SearchProjectionBuilderFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/projection/spi/SearchProjectionBuilderFactory.java
@@ -27,7 +27,7 @@ public interface SearchProjectionBuilderFactory {
 
 	<T> FieldProjectionBuilder<T> field(String absoluteFieldPath, Class<T> clazz, ProjectionConverter projectionConverter);
 
-	<O> EntityProjectionBuilder<O> entity();
+	<E> EntityProjectionBuilder<E> entity();
 
 	<R> ReferenceProjectionBuilder<R> reference();
 

--- a/engine/src/main/java/org/hibernate/search/engine/search/query/ExtendedSearchQuery.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/query/ExtendedSearchQuery.java
@@ -10,10 +10,10 @@ package org.hibernate.search.engine.search.query;
  * A base interface for subtypes of {@link SearchQuery} allowing to
  * easily override the result type for all relevant methods.
  *
- * @param <T> The type of query hits.
+ * @param <H> The type of query hits.
  * @param <R> The result type (extending {@link SearchResult}).
  */
-public interface ExtendedSearchQuery<T, R extends SearchResult<T>> extends SearchQuery<T> {
+public interface ExtendedSearchQuery<H, R extends SearchResult<H>> extends SearchQuery<H> {
 
 	@Override
 	R fetch();

--- a/engine/src/main/java/org/hibernate/search/engine/search/query/SearchQuery.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/query/SearchQuery.java
@@ -14,9 +14,9 @@ import org.hibernate.search.util.common.SearchException;
 /**
  * A search query, allowing to fetch search results.
  *
- * @param <T> The type of query hits.
+ * @param <H> The type of query hits.
  */
-public interface SearchQuery<T> {
+public interface SearchQuery<H> {
 
 	/**
 	 * Execute the query and return the {@link SearchResult}.
@@ -26,18 +26,7 @@ public interface SearchQuery<T> {
 	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
 	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
 	 */
-	SearchResult<T> fetch();
-
-	/**
-	 * Execute the query and return the {@link SearchResult}.
-	 *
-	 * @param limit The maximum number of hits to be included in the {@link SearchResult}. {@code null} means no limit.
-	 * @return The {@link SearchResult}.
-	 * @throws SearchException If something goes wrong while executing the query.
-	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
-	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
-	 */
-	SearchResult<T> fetch(Long limit);
+	SearchResult<H> fetch();
 
 	/**
 	 * Execute the query and return the {@link SearchResult}.
@@ -48,19 +37,18 @@ public interface SearchQuery<T> {
 	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
 	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
 	 */
-	SearchResult<T> fetch(Integer limit);
+	SearchResult<H> fetch(Long limit);
 
 	/**
 	 * Execute the query and return the {@link SearchResult}.
 	 *
 	 * @param limit The maximum number of hits to be included in the {@link SearchResult}. {@code null} means no limit.
-	 * @param offset The number of hits to skip before adding the hits to the {@link SearchResult}. {@code null} means no offset.
 	 * @return The {@link SearchResult}.
 	 * @throws SearchException If something goes wrong while executing the query.
 	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
 	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
 	 */
-	SearchResult<T> fetch(Long limit, Long offset);
+	SearchResult<H> fetch(Integer limit);
 
 	/**
 	 * Execute the query and return the {@link SearchResult}.
@@ -72,7 +60,19 @@ public interface SearchQuery<T> {
 	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
 	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
 	 */
-	SearchResult<T> fetch(Integer limit, Integer offset);
+	SearchResult<H> fetch(Long limit, Long offset);
+
+	/**
+	 * Execute the query and return the {@link SearchResult}.
+	 *
+	 * @param limit The maximum number of hits to be included in the {@link SearchResult}. {@code null} means no limit.
+	 * @param offset The number of hits to skip before adding the hits to the {@link SearchResult}. {@code null} means no offset.
+	 * @return The {@link SearchResult}.
+	 * @throws SearchException If something goes wrong while executing the query.
+	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
+	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
+	 */
+	SearchResult<H> fetch(Integer limit, Integer offset);
 
 	/**
 	 * Execute the query and return the hits as a {@link List}.
@@ -82,7 +82,7 @@ public interface SearchQuery<T> {
 	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
 	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
 	 */
-	List<T> fetchHits();
+	List<H> fetchHits();
 
 	/**
 	 * Execute the query and return the hits as a {@link List}.
@@ -93,7 +93,7 @@ public interface SearchQuery<T> {
 	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
 	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
 	 */
-	List<T> fetchHits(Long limit);
+	List<H> fetchHits(Long limit);
 
 	/**
 	 * Execute the query and return the hits as a {@link List}.
@@ -104,7 +104,7 @@ public interface SearchQuery<T> {
 	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
 	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
 	 */
-	List<T> fetchHits(Integer limit);
+	List<H> fetchHits(Integer limit);
 
 	/**
 	 * Execute the query and return the hits as a {@link List}.
@@ -116,7 +116,7 @@ public interface SearchQuery<T> {
 	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
 	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
 	 */
-	List<T> fetchHits(Long limit, Long offset);
+	List<H> fetchHits(Long limit, Long offset);
 
 	/**
 	 * Execute the query and return the hits as a {@link List}.
@@ -128,7 +128,7 @@ public interface SearchQuery<T> {
 	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
 	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
 	 */
-	List<T> fetchHits(Integer limit, Integer offset);
+	List<H> fetchHits(Integer limit, Integer offset);
 
 	/**
 	 * Execute the query and return the hits as a single, optional element.
@@ -139,7 +139,7 @@ public interface SearchQuery<T> {
 	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
 	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
 	 */
-	Optional<T> fetchSingleHit();
+	Optional<H> fetchSingleHit();
 
 	/**
 	 * Execute the query and return the total hit count.
@@ -163,6 +163,6 @@ public interface SearchQuery<T> {
 	 * @return The extended query.
 	 * @throws SearchException If the extension cannot be applied (wrong underlying backend, ...).
 	 */
-	<Q> Q extension(SearchQueryExtension<Q, T> extension);
+	<Q> Q extension(SearchQueryExtension<Q, H> extension);
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/query/SearchQueryExtension.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/query/SearchQueryExtension.java
@@ -20,11 +20,11 @@ import org.hibernate.search.engine.search.loading.context.spi.LoadingContext;
  * and pass it to another API.
  *
  * @param <Q> The type of search queries wrappers created by this extension.
- * @param <T> The type of hits in the query to be wrapped.
+ * @param <H> The type of hits in the query to be wrapped.
  *
  * @see org.hibernate.search.engine.search.query.SearchQuery#extension(SearchQueryExtension)
  */
-public interface SearchQueryExtension<Q, T> {
+public interface SearchQueryExtension<Q, H> {
 
 	/**
 	 * Attempt to extend a given query, returning an empty {@link Optional} in case of failure.
@@ -36,6 +36,6 @@ public interface SearchQueryExtension<Q, T> {
 	 * @return An optional containing the extended search query ({@link Q}) in case
 	 * of success, or an empty optional otherwise.
 	 */
-	Optional<Q> extendOptional(SearchQuery<T> original, LoadingContext<?, ?> loadingContext);
+	Optional<Q> extendOptional(SearchQuery<H> original, LoadingContext<?, ?> loadingContext);
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/query/SearchResult.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/query/SearchResult.java
@@ -9,9 +9,9 @@ package org.hibernate.search.engine.search.query;
 import java.util.List;
 
 /**
- * @param <T> The type of results.
+ * @param <H> The type of hits.
  */
-public interface SearchResult<T> {
+public interface SearchResult<H> {
 
 	/**
 	 * @return The total number of matching entities, ignoring pagination settings.
@@ -21,6 +21,6 @@ public interface SearchResult<T> {
 	/**
 	 * @return The hits as a {@link List} containing one element for each matched entity.
 	 */
-	List<T> getHits();
+	List<H> getHits();
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/query/spi/AbstractSearchQuery.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/query/spi/AbstractSearchQuery.java
@@ -18,10 +18,10 @@ import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 /**
  * An abstract base for implementations of {@link SearchQuery}.
  *
- * @param <T> The type of query hits.
+ * @param <H> The type of query hits.
  * @param <R> The result type (extending {@link SearchResult}).
  */
-public abstract class AbstractSearchQuery<T, R extends SearchResult<T>> implements SearchQuery<T> {
+public abstract class AbstractSearchQuery<H, R extends SearchResult<H>> implements SearchQuery<H> {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
@@ -54,35 +54,35 @@ public abstract class AbstractSearchQuery<T, R extends SearchResult<T>> implemen
 	}
 
 	@Override
-	public List<T> fetchHits() {
+	public List<H> fetchHits() {
 		return fetchHits( (Long) null, null );
 	}
 
 	@Override
-	public List<T> fetchHits(Long limit) {
+	public List<H> fetchHits(Long limit) {
 		return fetchHits( limit, null );
 	}
 
 	@Override
-	public List<T> fetchHits(Integer limit) {
+	public List<H> fetchHits(Integer limit) {
 		return fetchHits( limit == null ? null : limit.longValue(), null );
 	}
 
 	@Override
-	public List<T> fetchHits(Long limit, Long offset) {
+	public List<H> fetchHits(Long limit, Long offset) {
 		return fetch( limit, offset ).getHits();
 	}
 
 	@Override
-	public List<T> fetchHits(Integer limit, Integer offset) {
+	public List<H> fetchHits(Integer limit, Integer offset) {
 		return fetchHits( limit == null ? null : (long) limit, offset == null ? null : (long) offset );
 	}
 
 	@Override
-	public Optional<T> fetchSingleHit() {
+	public Optional<H> fetchSingleHit() {
 		// We don't need to fetch more than two elements to detect a problem
 		R result = fetch( 2L );
-		List<T> hits = result.getHits();
+		List<H> hits = result.getHits();
 		int fetchedHitCount = result.getHits().size();
 		if ( fetchedHitCount == 0 ) {
 			return Optional.empty();

--- a/engine/src/main/java/org/hibernate/search/engine/search/query/spi/SearchQueryBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/query/spi/SearchQueryBuilder.java
@@ -11,10 +11,10 @@ import org.hibernate.search.engine.search.query.SearchQuery;
 /**
  * A builder for search queries.
  *
- * @param <T> The type of query results
+ * @param <H> The type of query results
  * @param <C> The type of query element collector
  */
-public interface SearchQueryBuilder<T, C> {
+public interface SearchQueryBuilder<H, C> {
 
 	C getQueryElementCollector();
 
@@ -22,6 +22,6 @@ public interface SearchQueryBuilder<T, C> {
 
 	// TODO add more arguments, such as faceting options
 
-	SearchQuery<T> build();
+	SearchQuery<H> build();
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/query/spi/SearchQueryBuilderFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/query/spi/SearchQueryBuilderFactory.java
@@ -25,11 +25,11 @@ public interface SearchQueryBuilderFactory<C> {
 	<E> SearchQueryBuilder<E, C> asEntity(SessionContextImplementor sessionContext,
 			LoadingContextBuilder<?, E> loadingContextBuilder);
 
-	<T> SearchQueryBuilder<T, C> asReference(SessionContextImplementor sessionContext,
-			LoadingContextBuilder<T, ?> loadingContextBuilder);
+	<R> SearchQueryBuilder<R, C> asReference(SessionContextImplementor sessionContext,
+			LoadingContextBuilder<R, ?> loadingContextBuilder);
 
-	<T> SearchQueryBuilder<T, C> asProjection(SessionContextImplementor sessionContext,
-			LoadingContextBuilder<?, ?> loadingContextBuilder, SearchProjection<T> projection);
+	<P> SearchQueryBuilder<P, C> asProjection(SessionContextImplementor sessionContext,
+			LoadingContextBuilder<?, ?> loadingContextBuilder, SearchProjection<P> projection);
 
 	SearchQueryBuilder<List<?>, C> asProjections(SessionContextImplementor sessionContext,
 			LoadingContextBuilder<?, ?> loadingContextBuilder, SearchProjection<?>... projections);

--- a/engine/src/main/java/org/hibernate/search/engine/search/query/spi/SearchQueryBuilderFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/query/spi/SearchQueryBuilderFactory.java
@@ -22,8 +22,8 @@ import org.hibernate.search.engine.search.loading.context.spi.LoadingContextBuil
  */
 public interface SearchQueryBuilderFactory<C> {
 
-	<O> SearchQueryBuilder<O, C> asEntity(SessionContextImplementor sessionContext,
-			LoadingContextBuilder<?, O> loadingContextBuilder);
+	<E> SearchQueryBuilder<E, C> asEntity(SessionContextImplementor sessionContext,
+			LoadingContextBuilder<?, E> loadingContextBuilder);
 
 	<T> SearchQueryBuilder<T, C> asReference(SessionContextImplementor sessionContext,
 			LoadingContextBuilder<T, ?> loadingContextBuilder);

--- a/engine/src/main/java/org/hibernate/search/engine/search/query/spi/SearchQueryBuilderFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/query/spi/SearchQueryBuilderFactory.java
@@ -22,7 +22,7 @@ import org.hibernate.search.engine.search.loading.context.spi.LoadingContextBuil
  */
 public interface SearchQueryBuilderFactory<C> {
 
-	<O> SearchQueryBuilder<O, C> asObject(SessionContextImplementor sessionContext,
+	<O> SearchQueryBuilder<O, C> asEntity(SessionContextImplementor sessionContext,
 			LoadingContextBuilder<?, O> loadingContextBuilder);
 
 	<T> SearchQueryBuilder<T, C> asReference(SessionContextImplementor sessionContext,

--- a/engine/src/main/java/org/hibernate/search/engine/search/query/spi/SimpleSearchResult.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/query/spi/SimpleSearchResult.java
@@ -10,11 +10,11 @@ import java.util.List;
 
 import org.hibernate.search.engine.search.query.SearchResult;
 
-public class SimpleSearchResult<T> implements SearchResult<T> {
+public class SimpleSearchResult<H> implements SearchResult<H> {
 	private final long hitCount;
-	private final List<T> hits;
+	private final List<H> hits;
 
-	public SimpleSearchResult(long hitCount, List<T> hits) {
+	public SimpleSearchResult(long hitCount, List<H> hits) {
 		this.hitCount = hitCount;
 		this.hits = hits;
 	}
@@ -25,7 +25,7 @@ public class SimpleSearchResult<T> implements SearchResult<T> {
 	}
 
 	@Override
-	public List<T> getHits() {
+	public List<H> getHits() {
 		return hits;
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/SearchProjectionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/SearchProjectionIT.java
@@ -119,7 +119,7 @@ public class SearchProjectionIT extends EasyMockSupport {
 		SearchProjection<DocumentReference> referenceProjection =
 				scope.projection().reference().toProjection();
 		SearchProjection<DocumentReference> objectProjection =
-				scope.projection().object().toProjection();
+				scope.projection().entity().toProjection();
 
 		query = scope.query()
 				.asProjections(
@@ -138,7 +138,7 @@ public class SearchProjectionIT extends EasyMockSupport {
 	}
 
 	/**
-	 * Test documentReference/reference/object projections as they are likely to be used by mappers,
+	 * Test documentReference/reference/entity projections as they are likely to be used by mappers,
 	 * i.e. with a custom reference transformer and a custom object loader.
 	 */
 	@Test
@@ -179,7 +179,7 @@ public class SearchProjectionIT extends EasyMockSupport {
 		SearchProjection<StubTransformedReference> referenceProjection =
 				scope.projection().reference().toProjection();
 		SearchProjection<StubLoadedObject> objectProjection =
-				scope.projection().object().toProjection();
+				scope.projection().entity().toProjection();
 		query = scope.query( loadingContextMock )
 				.asProjections(
 						documentReferenceProjection,
@@ -195,7 +195,7 @@ public class SearchProjectionIT extends EasyMockSupport {
 				loadingContextMock, referenceTransformerMock, objectLoaderMock,
 				/*
 				 * Expect each reference to be transformed because of the reference projection,
-				 * but also loaded because of the object projection.
+				 * but also loaded because of the entity projection.
 				 */
 				c -> c
 						.reference( document1Reference, document1TransformedReference )

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/SearchProjectionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/SearchProjectionIT.java
@@ -497,10 +497,10 @@ public class SearchProjectionIT extends EasyMockSupport {
 		}
 	}
 
-	private static class SupportedExtension<R, O>
-			implements SearchProjectionFactoryContextExtension<MyExtendedContext<R, O>, R, O> {
+	private static class SupportedExtension<R, E>
+			implements SearchProjectionFactoryContextExtension<MyExtendedContext<R, E>, R, E> {
 		@Override
-		public Optional<MyExtendedContext<R, O>> extendOptional(SearchProjectionFactoryContext<R, O> original,
+		public Optional<MyExtendedContext<R, E>> extendOptional(SearchProjectionFactoryContext<R, E> original,
 				SearchProjectionBuilderFactory factory) {
 			Assertions.assertThat( original ).isNotNull();
 			Assertions.assertThat( factory ).isNotNull();
@@ -508,10 +508,10 @@ public class SearchProjectionIT extends EasyMockSupport {
 		}
 	}
 
-	private static class UnSupportedExtension<R, O>
-			implements SearchProjectionFactoryContextExtension<MyExtendedContext<R, O>, R, O> {
+	private static class UnSupportedExtension<R, E>
+			implements SearchProjectionFactoryContextExtension<MyExtendedContext<R, E>, R, E> {
 		@Override
-		public Optional<MyExtendedContext<R, O>> extendOptional(SearchProjectionFactoryContext<R, O> original,
+		public Optional<MyExtendedContext<R, E>> extendOptional(SearchProjectionFactoryContext<R, E> original,
 				SearchProjectionBuilderFactory factory) {
 			Assertions.assertThat( original ).isNotNull();
 			Assertions.assertThat( factory ).isNotNull();
@@ -519,10 +519,10 @@ public class SearchProjectionIT extends EasyMockSupport {
 		}
 	}
 
-	private static class MyExtendedContext<R, O> {
-		private final SearchProjectionFactoryContext<R, O> delegate;
+	private static class MyExtendedContext<R, E> {
+		private final SearchProjectionFactoryContext<R, E> delegate;
 
-		MyExtendedContext(SearchProjectionFactoryContext<R, O> delegate) {
+		MyExtendedContext(SearchProjectionFactoryContext<R, E> delegate) {
 			this.delegate = delegate;
 		}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/SearchProjectionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/SearchProjectionIT.java
@@ -29,12 +29,12 @@ import org.hibernate.search.engine.search.query.SearchResult;
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContext;
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContextExtension;
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionTerminalContext;
-import org.hibernate.search.engine.search.loading.spi.ObjectLoader;
+import org.hibernate.search.engine.search.loading.spi.EntityLoader;
 import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilderFactory;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.stub.StubDocumentReferenceTransformer;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.stub.StubEntityLoader;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.stub.StubLoadedObject;
-import org.hibernate.search.integrationtest.backend.tck.testsupport.stub.StubObjectLoader;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.stub.StubTransformedReference;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.StandardFieldMapper;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
@@ -139,7 +139,7 @@ public class SearchProjectionIT extends EasyMockSupport {
 
 	/**
 	 * Test documentReference/reference/entity projections as they are likely to be used by mappers,
-	 * i.e. with a custom reference transformer and a custom object loader.
+	 * i.e. with a custom reference transformer and a custom entity loader.
 	 */
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3395")
@@ -161,8 +161,8 @@ public class SearchProjectionIT extends EasyMockSupport {
 				createMock( LoadingContext.class );
 		Function<DocumentReference, StubTransformedReference> referenceTransformerMock =
 				createMock( StubDocumentReferenceTransformer.class );
-		ObjectLoader<StubTransformedReference, StubLoadedObject> objectLoaderMock =
-				createMock( StubObjectLoader.class );
+		EntityLoader<StubTransformedReference, StubLoadedObject> objectLoaderMock =
+				createMock( StubEntityLoader.class );
 
 		resetAll();
 		// No call expected on the mocks

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryBaseIT.java
@@ -186,11 +186,11 @@ public class SearchQueryBaseIT {
 		}
 	}
 
-	private static class SupportedQueryDslExtension<R, O> implements SearchQueryContextExtension<MyExtendedDslContext<R>, R, O> {
+	private static class SupportedQueryDslExtension<R, E> implements SearchQueryContextExtension<MyExtendedDslContext<R>, R, E> {
 		@Override
-		public Optional<MyExtendedDslContext<R>> extendOptional(SearchQueryResultDefinitionContext<R, O, ?> original,
+		public Optional<MyExtendedDslContext<R>> extendOptional(SearchQueryResultDefinitionContext<R, E, ?> original,
 				IndexSearchScope<?> indexSearchScope, SessionContextImplementor sessionContext,
-				LoadingContextBuilder<R, O> loadingContextBuilder) {
+				LoadingContextBuilder<R, E> loadingContextBuilder) {
 			Assertions.assertThat( original ).isNotNull();
 			Assertions.assertThat( indexSearchScope ).isNotNull();
 			Assertions.assertThat( sessionContext ).isNotNull();
@@ -199,11 +199,11 @@ public class SearchQueryBaseIT {
 		}
 	}
 
-	private static class UnSupportedQueryDslExtension<R, O> implements SearchQueryContextExtension<MyExtendedDslContext<R>, R, O> {
+	private static class UnSupportedQueryDslExtension<R, E> implements SearchQueryContextExtension<MyExtendedDslContext<R>, R, E> {
 		@Override
-		public Optional<MyExtendedDslContext<R>> extendOptional(SearchQueryResultDefinitionContext<R, O, ?> original,
+		public Optional<MyExtendedDslContext<R>> extendOptional(SearchQueryResultDefinitionContext<R, E, ?> original,
 				IndexSearchScope<?> indexSearchScope, SessionContextImplementor sessionContext,
-				LoadingContextBuilder<R, O> loadingContextBuilder) {
+				LoadingContextBuilder<R, E> loadingContextBuilder) {
 			Assertions.assertThat( original ).isNotNull();
 			Assertions.assertThat( indexSearchScope ).isNotNull();
 			Assertions.assertThat( sessionContext ).isNotNull();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryBaseIT.java
@@ -154,21 +154,21 @@ public class SearchQueryBaseIT {
 		}
 	}
 
-	private static class QueryWrapper<T> {
-		private final SearchQuery<T> query;
+	private static class QueryWrapper<H> {
+		private final SearchQuery<H> query;
 
-		private QueryWrapper(SearchQuery<T> query) {
+		private QueryWrapper(SearchQuery<H> query) {
 			this.query = query;
 		}
 
-		public SearchResult<T> extendedFetch() {
+		public SearchResult<H> extendedFetch() {
 			return query.fetch();
 		}
 	}
 
-	private static class SupportedQueryExtension<T> implements SearchQueryExtension<QueryWrapper<T>, T> {
+	private static class SupportedQueryExtension<H> implements SearchQueryExtension<QueryWrapper<H>, H> {
 		@Override
-		public Optional<QueryWrapper<T>> extendOptional(SearchQuery<T> original,
+		public Optional<QueryWrapper<H>> extendOptional(SearchQuery<H> original,
 				LoadingContext<?, ?> loadingContext) {
 			Assertions.assertThat( original ).isNotNull();
 			Assertions.assertThat( loadingContext ).isNotNull().isInstanceOf( StubLoadingContext.class );
@@ -176,9 +176,9 @@ public class SearchQueryBaseIT {
 		}
 	}
 
-	private static class UnSupportedQueryExtension<T> implements SearchQueryExtension<QueryWrapper<T>, T> {
+	private static class UnSupportedQueryExtension<H> implements SearchQueryExtension<QueryWrapper<H>, H> {
 		@Override
-		public Optional<QueryWrapper<T>> extendOptional(SearchQuery<T> original,
+		public Optional<QueryWrapper<H>> extendOptional(SearchQuery<H> original,
 				LoadingContext<?, ?> loadingContext) {
 			Assertions.assertThat( original ).isNotNull();
 			Assertions.assertThat( loadingContext ).isNotNull().isInstanceOf( StubLoadingContext.class );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryResultLoadingOrTransformingIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryResultLoadingOrTransformingIT.java
@@ -28,13 +28,13 @@ import org.hibernate.search.engine.backend.index.spi.IndexWorkPlan;
 import org.hibernate.search.engine.search.DocumentReference;
 import org.hibernate.search.engine.search.loading.context.spi.LoadingContext;
 import org.hibernate.search.engine.search.loading.spi.DefaultProjectionHitMapper;
+import org.hibernate.search.engine.search.loading.spi.EntityLoader;
 import org.hibernate.search.engine.search.query.SearchQuery;
-import org.hibernate.search.engine.search.loading.spi.ObjectLoader;
 import org.hibernate.search.engine.spatial.GeoPoint;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.stub.StubDocumentReferenceTransformer;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.stub.StubEntityLoader;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.stub.StubHitTransformer;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.stub.StubLoadedObject;
-import org.hibernate.search.integrationtest.backend.tck.testsupport.stub.StubObjectLoader;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.stub.StubTransformedHit;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.stub.StubTransformedReference;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
@@ -124,8 +124,8 @@ public class SearchQueryResultLoadingOrTransformingIT extends EasyMockSupport {
 				createMock( LoadingContext.class );
 		Function<DocumentReference, StubTransformedReference> referenceTransformerMock =
 				createMock( StubDocumentReferenceTransformer.class );
-		ObjectLoader<StubTransformedReference, StubLoadedObject> objectLoaderMock =
-				createMock( StubObjectLoader.class );
+		EntityLoader<StubTransformedReference, StubLoadedObject> objectLoaderMock =
+				createMock( StubEntityLoader.class );
 
 		resetAll();
 		// No calls expected on the mocks
@@ -168,8 +168,8 @@ public class SearchQueryResultLoadingOrTransformingIT extends EasyMockSupport {
 				createMock( LoadingContext.class );
 		Function<DocumentReference, StubTransformedReference> referenceTransformerMock =
 				createMock( StubDocumentReferenceTransformer.class );
-		ObjectLoader<StubTransformedReference, StubLoadedObject> objectLoaderMock =
-				createMock( StubObjectLoader.class );
+		EntityLoader<StubTransformedReference, StubLoadedObject> objectLoaderMock =
+				createMock( StubEntityLoader.class );
 
 		resetAll();
 		// No calls expected on the mocks
@@ -212,8 +212,8 @@ public class SearchQueryResultLoadingOrTransformingIT extends EasyMockSupport {
 				createMock( LoadingContext.class );
 		Function<DocumentReference, StubTransformedReference> referenceTransformerMock =
 				createMock( StubDocumentReferenceTransformer.class );
-		ObjectLoader<StubTransformedReference, StubLoadedObject> objectLoaderMock =
-				createMock( StubObjectLoader.class );
+		EntityLoader<StubTransformedReference, StubLoadedObject> objectLoaderMock =
+				createMock( StubEntityLoader.class );
 
 		resetAll();
 		// No calls expected on the mocks
@@ -321,8 +321,8 @@ public class SearchQueryResultLoadingOrTransformingIT extends EasyMockSupport {
 				createMock( LoadingContext.class );
 		Function<DocumentReference, StubTransformedReference> referenceTransformerMock =
 				createMock( StubDocumentReferenceTransformer.class );
-		ObjectLoader<StubTransformedReference, StubLoadedObject> objectLoaderMock =
-				createMock( StubObjectLoader.class );
+		EntityLoader<StubTransformedReference, StubLoadedObject> objectLoaderMock =
+				createMock( StubEntityLoader.class );
 		Function<List<?>, StubTransformedHit> hitTransformerMock = createMock( StubHitTransformer.class );
 
 		resetAll();
@@ -449,7 +449,7 @@ public class SearchQueryResultLoadingOrTransformingIT extends EasyMockSupport {
 
 		resetAll();
 		expect( loadingContextMock.getProjectionHitMapper() )
-				.andReturn( new DefaultProjectionHitMapper<>( Function.identity(), ObjectLoader.identity() ) );
+				.andReturn( new DefaultProjectionHitMapper<>( Function.identity(), EntityLoader.identity() ) );
 		replayAll();
 		query.fetch();
 		verifyAll();
@@ -457,7 +457,7 @@ public class SearchQueryResultLoadingOrTransformingIT extends EasyMockSupport {
 		// Second query execution to make sure the backend doesn't try to cache the projection hit mapper...
 		resetAll();
 		expect( loadingContextMock.getProjectionHitMapper() )
-				.andReturn( new DefaultProjectionHitMapper<>( Function.identity(), ObjectLoader.identity() ) );
+				.andReturn( new DefaultProjectionHitMapper<>( Function.identity(), EntityLoader.identity() ) );
 		replayAll();
 		query.fetch();
 		verifyAll();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryResultLoadingOrTransformingIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryResultLoadingOrTransformingIT.java
@@ -102,7 +102,7 @@ public class SearchQueryResultLoadingOrTransformingIT extends EasyMockSupport {
 	}
 
 	@Test
-	public void entities_noObjectLoading() {
+	public void entities_noEntityLoading() {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
@@ -156,7 +156,7 @@ public class SearchQueryResultLoadingOrTransformingIT extends EasyMockSupport {
 	}
 
 	@Test
-	public void entities_referencesTransformer_objectLoading() {
+	public void entities_referencesTransformer_entityLoading() {
 		DocumentReference mainReference = reference( INDEX_NAME, MAIN_ID );
 		DocumentReference emptyReference = reference( INDEX_NAME, EMPTY_ID );
 		StubTransformedReference mainTransformedReference = new StubTransformedReference( mainReference );
@@ -200,7 +200,7 @@ public class SearchQueryResultLoadingOrTransformingIT extends EasyMockSupport {
 	}
 
 	@Test
-	public void projection_referencesTransformer_objectLoading() {
+	public void projection_referencesTransformer_entityLoading() {
 		DocumentReference mainReference = reference( INDEX_NAME, MAIN_ID );
 		DocumentReference emptyReference = reference( INDEX_NAME, EMPTY_ID );
 		StubTransformedReference mainTransformedReference = new StubTransformedReference( mainReference );
@@ -226,7 +226,7 @@ public class SearchQueryResultLoadingOrTransformingIT extends EasyMockSupport {
 								f.field( "string", String.class ),
 								f.documentReference(),
 								f.reference(),
-								f.object()
+								f.entity()
 						)
 				)
 				.predicate( f -> f.matchAll() )
@@ -243,7 +243,7 @@ public class SearchQueryResultLoadingOrTransformingIT extends EasyMockSupport {
 				loadingContextMock, referenceTransformerMock, objectLoaderMock,
 				/*
 				 * Expect each reference to be transformed because of the reference projection,
-				 * but also loaded because of the object projection.
+				 * but also loaded because of the entity projection.
 				 */
 				c -> c
 						.reference( mainReference, mainTransformedReference )
@@ -283,7 +283,7 @@ public class SearchQueryResultLoadingOrTransformingIT extends EasyMockSupport {
 								f.field( "geoPoint", GeoPoint.class ).toProjection(),
 								f.documentReference().toProjection(),
 								f.reference().toProjection(),
-								f.object().toProjection()
+								f.entity().toProjection()
 						)
 				)
 				.predicate( f -> f.matchAll() )
@@ -307,7 +307,7 @@ public class SearchQueryResultLoadingOrTransformingIT extends EasyMockSupport {
 	}
 
 	@Test
-	public void projections_hitTransformer_referencesTransformer_objectLoading() {
+	public void projections_hitTransformer_referencesTransformer_entityLoading() {
 		DocumentReference mainReference = reference( INDEX_NAME, MAIN_ID );
 		DocumentReference emptyReference = reference( INDEX_NAME, EMPTY_ID );
 		StubTransformedHit mainTransformedHit = new StubTransformedHit( mainReference );
@@ -337,7 +337,7 @@ public class SearchQueryResultLoadingOrTransformingIT extends EasyMockSupport {
 								f.field( "string", String.class ).toProjection(),
 								f.documentReference().toProjection(),
 								f.reference().toProjection(),
-								f.object().toProjection()
+								f.entity().toProjection()
 						)
 				)
 				.predicate( f -> f.matchAll() )
@@ -354,7 +354,7 @@ public class SearchQueryResultLoadingOrTransformingIT extends EasyMockSupport {
 				loadingContextMock, referenceTransformerMock, objectLoaderMock,
 				/*
 				 * Expect each reference to be transformed because of the reference projection,
-				 * but also loaded because of the object projection.
+				 * but also loaded because of the entity projection.
 				 */
 				c -> c
 						.reference( mainReference, mainTransformedReference )

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/stub/StubEntityLoader.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/stub/StubEntityLoader.java
@@ -6,11 +6,11 @@
  */
 package org.hibernate.search.integrationtest.backend.tck.testsupport.stub;
 
-import org.hibernate.search.engine.search.loading.spi.ObjectLoader;
+import org.hibernate.search.engine.search.loading.spi.EntityLoader;
 
 /**
  * The only purpose of this class is to avoid unchecked cast warnings when creating mocks.
  */
-public interface StubObjectLoader
-		extends ObjectLoader<StubTransformedReference, StubLoadedObject> {
+public interface StubEntityLoader
+		extends EntityLoader<StubTransformedReference, StubLoadedObject> {
 }

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/SearchQueryIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/SearchQueryIT.java
@@ -211,7 +211,7 @@ public class SearchQueryIT {
 									Book_Author_Score::new,
 									f.composite(
 											Book_Author::new,
-											f.object().toProjection(),
+											f.entity().toProjection(),
 											f.field( "author", String.class ).toProjection()
 									).toProjection(),
 									f.score().toProjection()
@@ -259,7 +259,7 @@ public class SearchQueryIT {
 									Book_Author_Score::new,
 									f.composite(
 											Book_Author::new,
-											f.object(),
+											f.entity(),
 											f.field( "author", String.class )
 									),
 									f.score()

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/log/impl/Log.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/log/impl/Log.java
@@ -46,7 +46,7 @@ public interface Log extends BasicLogger {
 	@Message(id = ID_OFFSET_1 + 5,
 			value = "The JavaBean mapper cannot load entities,"
 					+ " but there was an attempt to load the entity corresponding to document '%1$s'."
-					+ " There is probably an object projection in the query definition: it should be removed."
+					+ " There is probably an entity projection in the query definition: it should be removed."
 	)
 	SearchException cannotLoadEntity(DocumentReference reference);
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/Search.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/Search.java
@@ -84,10 +84,10 @@ public final class Search {
 	 * for example when integrating to an external library that expects JPA queries.
 	 *
 	 * @param searchQuery The search query to convert.
-	 * @param <T> The type of query hits.
+	 * @param <H> The type of query hits.
 	 * @return A representation of the given query as a JPA query.
 	 */
-	public static <T> TypedQuery<T> toJpaQuery(SearchQuery<T> searchQuery) {
+	public static <H> TypedQuery<H> toJpaQuery(SearchQuery<H> searchQuery) {
 		return HibernateOrmSearchQueryAdapter.create( searchQuery );
 	}
 
@@ -101,10 +101,10 @@ public final class Search {
 	 * for example when integrating to an external library that expects Hibernate ORM queries.
 	 *
 	 * @param searchQuery The search query to convert.
-	 * @param <T> The type of query hits.
+	 * @param <H> The type of query hits.
 	 * @return A representation of the given query as a Hibernate ORM query.
 	 */
-	public static <T> Query<T> toOrmQuery(SearchQuery<T> searchQuery) {
+	public static <H> Query<H> toOrmQuery(SearchQuery<H> searchQuery) {
 		return HibernateOrmSearchQueryAdapter.create( searchQuery );
 	}
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/event/impl/HibernateSearchEventListener.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/event/impl/HibernateSearchEventListener.java
@@ -119,7 +119,7 @@ public final class HibernateSearchEventListener implements PostDeleteEventListen
 
 	/**
 	 * Make sure the indexes are updated right after the hibernate flush,
-	 * avoiding object loading during a flush. Not needed during transactions.
+	 * avoiding entity loading during a flush. Not needed during transactions.
 	 */
 	@Override
 	public void onFlush(FlushEvent event) {

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/IdentifierConsumerDocumentProducer.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/IdentifierConsumerDocumentProducer.java
@@ -134,7 +134,7 @@ public class IdentifierConsumerDocumentProducer implements Runnable {
 
 	/**
 	 * Loads a list of entities of defined type using their identifiers.
-	 * The loaded objects are then transformed into Lucene Documents
+	 * entities are then transformed into Lucene Documents
 	 * and forwarded to the indexing backend.
 	 *
 	 * @param listIds the list of entity identifiers (of type

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/SearchScope.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/SearchScope.java
@@ -25,9 +25,9 @@ import org.hibernate.search.mapper.pojo.search.PojoReference;
  * allowing to build search-related objects (query, predicate, ...)
  * taking into account the relevant indexes and their metadata (underlying technology, field types, ...).
  *
- * @param <T> A supertype of all types in this scope.
+ * @param <E> A supertype of all types in this scope.
  */
-public interface SearchScope<T> {
+public interface SearchScope<E> {
 
 	/**
 	 * Initiate the building of a search query.
@@ -38,7 +38,7 @@ public interface SearchScope<T> {
 	 * and ultimately {@link SearchQueryContext#toQuery() get the resulting query}.
 	 * @see HibernateOrmSearchQueryResultDefinitionContext
 	 */
-	HibernateOrmSearchQueryResultDefinitionContext<T> search();
+	HibernateOrmSearchQueryResultDefinitionContext<E> search();
 
 	/**
 	 * Initiate the building of a search predicate.
@@ -89,6 +89,6 @@ public interface SearchScope<T> {
 	 * and ultimately {@link SearchProjectionTerminalContext#toProjection() get the resulting projection}.
 	 * @see SearchProjectionFactoryContext
 	 */
-	SearchProjectionFactoryContext<PojoReference, T> projection();
+	SearchProjectionFactoryContext<PojoReference, E> projection();
 
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/dsl/query/HibernateOrmSearchQueryResultDefinitionContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/dsl/query/HibernateOrmSearchQueryResultDefinitionContext.java
@@ -11,11 +11,11 @@ import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactory
 import org.hibernate.search.engine.search.dsl.query.SearchQueryResultDefinitionContext;
 import org.hibernate.search.mapper.pojo.search.PojoReference;
 
-public interface HibernateOrmSearchQueryResultDefinitionContext<O>
+public interface HibernateOrmSearchQueryResultDefinitionContext<E>
 		extends SearchQueryResultDefinitionContext<
 				PojoReference,
-				O,
-				SearchProjectionFactoryContext<PojoReference, O>
+				E,
+				SearchProjectionFactoryContext<PojoReference, E>
 				> {
 
 	/**
@@ -25,6 +25,6 @@ public interface HibernateOrmSearchQueryResultDefinitionContext<O>
 	 * @return {@code this} for method chaining.
 	 * @see Query#setFetchSize(int)
 	 */
-	HibernateOrmSearchQueryResultDefinitionContext<O> fetchSize(int fetchSize);
+	HibernateOrmSearchQueryResultDefinitionContext<E> fetchSize(int fetchSize);
 
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/dsl/query/impl/HibernateOrmSearchQueryResultDefinitionContextImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/dsl/query/impl/HibernateOrmSearchQueryResultDefinitionContextImpl.java
@@ -12,20 +12,20 @@ import org.hibernate.search.mapper.orm.search.dsl.query.HibernateOrmSearchQueryR
 import org.hibernate.search.mapper.orm.search.loading.impl.MutableEntityLoadingOptions;
 import org.hibernate.search.mapper.pojo.search.PojoReference;
 
-public class HibernateOrmSearchQueryResultDefinitionContextImpl<O>
-		extends AbstractDelegatingSearchQueryResultDefinitionContext<PojoReference, O>
-		implements HibernateOrmSearchQueryResultDefinitionContext<O> {
+public class HibernateOrmSearchQueryResultDefinitionContextImpl<E>
+		extends AbstractDelegatingSearchQueryResultDefinitionContext<PojoReference, E>
+		implements HibernateOrmSearchQueryResultDefinitionContext<E> {
 	private final MutableEntityLoadingOptions loadingOptions;
 
 	public HibernateOrmSearchQueryResultDefinitionContextImpl(
-			SearchQueryResultDefinitionContext<PojoReference, O, ?> delegate,
+			SearchQueryResultDefinitionContext<PojoReference, E, ?> delegate,
 			MutableEntityLoadingOptions loadingOptions) {
 		super( delegate );
 		this.loadingOptions = loadingOptions;
 	}
 
 	@Override
-	public HibernateOrmSearchQueryResultDefinitionContext<O> fetchSize(int fetchSize) {
+	public HibernateOrmSearchQueryResultDefinitionContext<E> fetchSize(int fetchSize) {
 		loadingOptions.setFetchSize( fetchSize );
 		return this;
 	}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/dsl/query/impl/HibernateOrmSearchQueryResultDefinitionContextImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/dsl/query/impl/HibernateOrmSearchQueryResultDefinitionContextImpl.java
@@ -9,17 +9,17 @@ package org.hibernate.search.mapper.orm.search.dsl.query.impl;
 import org.hibernate.search.engine.search.dsl.query.SearchQueryResultDefinitionContext;
 import org.hibernate.search.engine.search.dsl.query.spi.AbstractDelegatingSearchQueryResultDefinitionContext;
 import org.hibernate.search.mapper.orm.search.dsl.query.HibernateOrmSearchQueryResultDefinitionContext;
-import org.hibernate.search.mapper.orm.search.loading.impl.MutableObjectLoadingOptions;
+import org.hibernate.search.mapper.orm.search.loading.impl.MutableEntityLoadingOptions;
 import org.hibernate.search.mapper.pojo.search.PojoReference;
 
 public class HibernateOrmSearchQueryResultDefinitionContextImpl<O>
 		extends AbstractDelegatingSearchQueryResultDefinitionContext<PojoReference, O>
 		implements HibernateOrmSearchQueryResultDefinitionContext<O> {
-	private final MutableObjectLoadingOptions loadingOptions;
+	private final MutableEntityLoadingOptions loadingOptions;
 
 	public HibernateOrmSearchQueryResultDefinitionContextImpl(
 			SearchQueryResultDefinitionContext<PojoReference, O, ?> delegate,
-			MutableObjectLoadingOptions loadingOptions) {
+			MutableEntityLoadingOptions loadingOptions) {
 		super( delegate );
 		this.loadingOptions = loadingOptions;
 	}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/impl/SearchScopeImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/impl/SearchScopeImpl.java
@@ -19,23 +19,23 @@ import org.hibernate.search.mapper.orm.search.loading.impl.MutableEntityLoadingO
 import org.hibernate.search.mapper.pojo.search.PojoReference;
 import org.hibernate.search.mapper.pojo.search.spi.PojoSearchScopeDelegate;
 
-public class SearchScopeImpl<O> implements SearchScope<O> {
+public class SearchScopeImpl<E> implements SearchScope<E> {
 
-	private final PojoSearchScopeDelegate<O, O> delegate;
+	private final PojoSearchScopeDelegate<E, E> delegate;
 	private final SessionImplementor sessionImplementor;
 
-	public SearchScopeImpl(PojoSearchScopeDelegate<O, O> delegate,
+	public SearchScopeImpl(PojoSearchScopeDelegate<E, E> delegate,
 			SessionImplementor sessionImplementor) {
 		this.delegate = delegate;
 		this.sessionImplementor = sessionImplementor;
 	}
 
 	@Override
-	public HibernateOrmSearchQueryResultDefinitionContext<O> search() {
-		EntityLoaderBuilder<O> entityLoaderBuilder =
+	public HibernateOrmSearchQueryResultDefinitionContext<E> search() {
+		EntityLoaderBuilder<E> entityLoaderBuilder =
 				new EntityLoaderBuilder<>( sessionImplementor, delegate.getIncludedIndexedTypes() );
 		MutableEntityLoadingOptions loadingOptions = new MutableEntityLoadingOptions();
-		HibernateOrmLoadingContext.Builder<O> loadingContextBuilder = new HibernateOrmLoadingContext.Builder<>(
+		HibernateOrmLoadingContext.Builder<E> loadingContextBuilder = new HibernateOrmLoadingContext.Builder<>(
 				sessionImplementor, delegate, entityLoaderBuilder, loadingOptions
 		);
 		return new HibernateOrmSearchQueryResultDefinitionContextImpl<>(
@@ -55,7 +55,7 @@ public class SearchScopeImpl<O> implements SearchScope<O> {
 	}
 
 	@Override
-	public SearchProjectionFactoryContext<PojoReference, O> projection() {
+	public SearchProjectionFactoryContext<PojoReference, E> projection() {
 		return delegate.projection();
 	}
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/impl/SearchScopeImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/impl/SearchScopeImpl.java
@@ -14,8 +14,8 @@ import org.hibernate.search.mapper.orm.search.SearchScope;
 import org.hibernate.search.mapper.orm.search.dsl.query.HibernateOrmSearchQueryResultDefinitionContext;
 import org.hibernate.search.mapper.orm.search.dsl.query.impl.HibernateOrmSearchQueryResultDefinitionContextImpl;
 import org.hibernate.search.mapper.orm.search.loading.context.impl.HibernateOrmLoadingContext;
-import org.hibernate.search.mapper.orm.search.loading.impl.MutableObjectLoadingOptions;
-import org.hibernate.search.mapper.orm.search.loading.impl.ObjectLoaderBuilder;
+import org.hibernate.search.mapper.orm.search.loading.impl.EntityLoaderBuilder;
+import org.hibernate.search.mapper.orm.search.loading.impl.MutableEntityLoadingOptions;
 import org.hibernate.search.mapper.pojo.search.PojoReference;
 import org.hibernate.search.mapper.pojo.search.spi.PojoSearchScopeDelegate;
 
@@ -32,11 +32,11 @@ public class SearchScopeImpl<O> implements SearchScope<O> {
 
 	@Override
 	public HibernateOrmSearchQueryResultDefinitionContext<O> search() {
-		ObjectLoaderBuilder<O> objectLoaderBuilder =
-				new ObjectLoaderBuilder<>( sessionImplementor, delegate.getIncludedIndexedTypes() );
-		MutableObjectLoadingOptions loadingOptions = new MutableObjectLoadingOptions();
+		EntityLoaderBuilder<O> entityLoaderBuilder =
+				new EntityLoaderBuilder<>( sessionImplementor, delegate.getIncludedIndexedTypes() );
+		MutableEntityLoadingOptions loadingOptions = new MutableEntityLoadingOptions();
 		HibernateOrmLoadingContext.Builder<O> loadingContextBuilder = new HibernateOrmLoadingContext.Builder<>(
-				sessionImplementor, delegate, objectLoaderBuilder, loadingOptions
+				sessionImplementor, delegate, entityLoaderBuilder, loadingOptions
 		);
 		return new HibernateOrmSearchQueryResultDefinitionContextImpl<>(
 				delegate.search( loadingContextBuilder ),

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/context/impl/HibernateOrmLoadingContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/context/impl/HibernateOrmLoadingContext.java
@@ -20,18 +20,18 @@ import org.hibernate.search.mapper.pojo.search.PojoReference;
 import org.hibernate.search.mapper.pojo.search.spi.PojoSearchScopeDelegate;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
-public final class HibernateOrmLoadingContext<O> implements LoadingContext<PojoReference, O> {
+public final class HibernateOrmLoadingContext<E> implements LoadingContext<PojoReference, E> {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private final SessionImplementor sessionImplementor;
 
-	private final ProjectionHitMapper<PojoReference, O> projectionHitMapper;
+	private final ProjectionHitMapper<PojoReference, E> projectionHitMapper;
 
 	private final MutableEntityLoadingOptions loadingOptions;
 
 	private HibernateOrmLoadingContext(SessionImplementor sessionImplementor,
-			ProjectionHitMapper<PojoReference, O> projectionHitMapper,
+			ProjectionHitMapper<PojoReference, E> projectionHitMapper,
 			MutableEntityLoadingOptions loadingOptions) {
 		this.sessionImplementor = sessionImplementor;
 		this.projectionHitMapper = projectionHitMapper;
@@ -39,7 +39,7 @@ public final class HibernateOrmLoadingContext<O> implements LoadingContext<PojoR
 	}
 
 	@Override
-	public ProjectionHitMapper<PojoReference, O> getProjectionHitMapper() {
+	public ProjectionHitMapper<PojoReference, E> getProjectionHitMapper() {
 		try {
 			sessionImplementor.checkOpen();
 		}
@@ -58,15 +58,15 @@ public final class HibernateOrmLoadingContext<O> implements LoadingContext<PojoR
 		return loadingOptions;
 	}
 
-	public static final class Builder<O> implements LoadingContextBuilder<PojoReference, O> {
+	public static final class Builder<E> implements LoadingContextBuilder<PojoReference, E> {
 		private final SessionImplementor sessionImplementor;
 		private final PojoSearchScopeDelegate<?, ?> scopeDelegate;
-		private final EntityLoaderBuilder<O> entityLoaderBuilder;
+		private final EntityLoaderBuilder<E> entityLoaderBuilder;
 		private final MutableEntityLoadingOptions loadingOptions;
 
 		public Builder(SessionImplementor sessionImplementor,
 				PojoSearchScopeDelegate<?, ?> scopeDelegate,
-				EntityLoaderBuilder<O> entityLoaderBuilder,
+				EntityLoaderBuilder<E> entityLoaderBuilder,
 				MutableEntityLoadingOptions loadingOptions) {
 			this.sessionImplementor = sessionImplementor;
 			this.scopeDelegate = scopeDelegate;
@@ -75,8 +75,8 @@ public final class HibernateOrmLoadingContext<O> implements LoadingContext<PojoR
 		}
 
 		@Override
-		public LoadingContext<PojoReference, O> build() {
-			ProjectionHitMapper<PojoReference, O> projectionHitMapper = new DefaultProjectionHitMapper<>(
+		public LoadingContext<PojoReference, E> build() {
+			ProjectionHitMapper<PojoReference, E> projectionHitMapper = new DefaultProjectionHitMapper<>(
 					scopeDelegate::toPojoReference,
 					entityLoaderBuilder.build( loadingOptions )
 			);

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/context/impl/HibernateOrmLoadingContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/context/impl/HibernateOrmLoadingContext.java
@@ -14,8 +14,8 @@ import org.hibernate.search.engine.search.loading.context.spi.LoadingContextBuil
 import org.hibernate.search.engine.search.loading.spi.DefaultProjectionHitMapper;
 import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 import org.hibernate.search.mapper.orm.logging.impl.Log;
-import org.hibernate.search.mapper.orm.search.loading.impl.MutableObjectLoadingOptions;
-import org.hibernate.search.mapper.orm.search.loading.impl.ObjectLoaderBuilder;
+import org.hibernate.search.mapper.orm.search.loading.impl.EntityLoaderBuilder;
+import org.hibernate.search.mapper.orm.search.loading.impl.MutableEntityLoadingOptions;
 import org.hibernate.search.mapper.pojo.search.PojoReference;
 import org.hibernate.search.mapper.pojo.search.spi.PojoSearchScopeDelegate;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
@@ -28,11 +28,11 @@ public final class HibernateOrmLoadingContext<O> implements LoadingContext<PojoR
 
 	private final ProjectionHitMapper<PojoReference, O> projectionHitMapper;
 
-	private final MutableObjectLoadingOptions loadingOptions;
+	private final MutableEntityLoadingOptions loadingOptions;
 
 	private HibernateOrmLoadingContext(SessionImplementor sessionImplementor,
 			ProjectionHitMapper<PojoReference, O> projectionHitMapper,
-			MutableObjectLoadingOptions loadingOptions) {
+			MutableEntityLoadingOptions loadingOptions) {
 		this.sessionImplementor = sessionImplementor;
 		this.projectionHitMapper = projectionHitMapper;
 		this.loadingOptions = loadingOptions;
@@ -54,23 +54,23 @@ public final class HibernateOrmLoadingContext<O> implements LoadingContext<PojoR
 		return sessionImplementor;
 	}
 
-	public MutableObjectLoadingOptions getLoadingOptions() {
+	public MutableEntityLoadingOptions getLoadingOptions() {
 		return loadingOptions;
 	}
 
 	public static final class Builder<O> implements LoadingContextBuilder<PojoReference, O> {
 		private final SessionImplementor sessionImplementor;
 		private final PojoSearchScopeDelegate<?, ?> scopeDelegate;
-		private final ObjectLoaderBuilder<O> objectLoaderBuilder;
-		private final MutableObjectLoadingOptions loadingOptions;
+		private final EntityLoaderBuilder<O> entityLoaderBuilder;
+		private final MutableEntityLoadingOptions loadingOptions;
 
 		public Builder(SessionImplementor sessionImplementor,
 				PojoSearchScopeDelegate<?, ?> scopeDelegate,
-				ObjectLoaderBuilder<O> objectLoaderBuilder,
-				MutableObjectLoadingOptions loadingOptions) {
+				EntityLoaderBuilder<O> entityLoaderBuilder,
+				MutableEntityLoadingOptions loadingOptions) {
 			this.sessionImplementor = sessionImplementor;
 			this.scopeDelegate = scopeDelegate;
-			this.objectLoaderBuilder = objectLoaderBuilder;
+			this.entityLoaderBuilder = entityLoaderBuilder;
 			this.loadingOptions = loadingOptions;
 		}
 
@@ -78,7 +78,7 @@ public final class HibernateOrmLoadingContext<O> implements LoadingContext<PojoR
 		public LoadingContext<PojoReference, O> build() {
 			ProjectionHitMapper<PojoReference, O> projectionHitMapper = new DefaultProjectionHitMapper<>(
 					scopeDelegate::toPojoReference,
-					objectLoaderBuilder.build( loadingOptions )
+					entityLoaderBuilder.build( loadingOptions )
 			);
 			return new HibernateOrmLoadingContext<>( sessionImplementor, projectionHitMapper, loadingOptions );
 		}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/EntityLoaderBuilder.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/EntityLoaderBuilder.java
@@ -9,25 +9,24 @@ package org.hibernate.search.mapper.orm.search.loading.impl;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 
 import org.hibernate.Session;
 import org.hibernate.search.engine.search.loading.spi.EntityLoader;
 import org.hibernate.search.mapper.pojo.search.PojoReference;
 
-public class EntityLoaderBuilder<O> {
+public class EntityLoaderBuilder<E> {
 
 	private final Session session;
-	private final Set<Class<? extends O>> concreteIndexedClasses;
+	private final Set<Class<? extends E>> concreteIndexedClasses;
 
-	public EntityLoaderBuilder(Session session, Set<Class<? extends O>> concreteIndexedClasses) {
+	public EntityLoaderBuilder(Session session, Set<Class<? extends E>> concreteIndexedClasses) {
 		this.session = session;
 		this.concreteIndexedClasses = concreteIndexedClasses;
 	}
 
-	public EntityLoader<PojoReference, O> build(MutableEntityLoadingOptions mutableLoadingOptions) {
+	public EntityLoader<PojoReference, E> build(MutableEntityLoadingOptions mutableLoadingOptions) {
 		if ( concreteIndexedClasses.size() == 1 ) {
-			Class<? extends O> concreteIndexedType = concreteIndexedClasses.iterator().next();
+			Class<? extends E> concreteIndexedType = concreteIndexedClasses.iterator().next();
 			return buildForSingleType( mutableLoadingOptions, concreteIndexedType );
 		}
 		else {
@@ -35,22 +34,22 @@ public class EntityLoaderBuilder<O> {
 		}
 	}
 
-	private HibernateOrmComposableEntityLoader<PojoReference, O> buildForSingleType(
-			MutableEntityLoadingOptions mutableLoadingOptions, Class<? extends O> concreteIndexedType) {
+	private HibernateOrmComposableEntityLoader<PojoReference, E> buildForSingleType(
+			MutableEntityLoadingOptions mutableLoadingOptions, Class<? extends E> concreteIndexedType) {
 		// TODO Add support for entities whose document ID is not the entity ID (natural ID, or other)
 		// TODO Add support for other types of database retrieval and object lookup? See HSearch 5: org.hibernate.search.engine.query.hibernate.impl.EntityLoaderBuilder#getObjectInitializer
 		return new HibernateOrmSingleTypeByIdEntityLoader<>( session, concreteIndexedType, mutableLoadingOptions );
 	}
 
-	private EntityLoader<PojoReference, O> buildForMultipleTypes(MutableEntityLoadingOptions mutableLoadingOptions) {
+	private EntityLoader<PojoReference, E> buildForMultipleTypes(MutableEntityLoadingOptions mutableLoadingOptions) {
 		/*
 		 * TODO Group together entity types from a same hierarchy, so as to optimize loads
 		 * (one query per entity hierarchy, and not one query per index).
 		 */
-		Map<Class<? extends O>, HibernateOrmComposableEntityLoader<PojoReference, ? extends O>> delegateByConcreteType =
+		Map<Class<? extends E>, HibernateOrmComposableEntityLoader<PojoReference, ? extends E>> delegateByConcreteType =
 				new HashMap<>( concreteIndexedClasses.size() );
-		for ( Class<? extends O> concreteIndexedClass : concreteIndexedClasses ) {
-			HibernateOrmComposableEntityLoader<PojoReference, O> delegate =
+		for ( Class<? extends E> concreteIndexedClass : concreteIndexedClasses ) {
+			HibernateOrmComposableEntityLoader<PojoReference, E> delegate =
 					buildForSingleType( mutableLoadingOptions, concreteIndexedClass );
 			delegateByConcreteType.put( concreteIndexedClass, delegate );
 		}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/HibernateOrmByTypeEntityLoader.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/HibernateOrmByTypeEntityLoader.java
@@ -18,13 +18,13 @@ import org.hibernate.search.mapper.pojo.search.PojoReference;
 import org.hibernate.search.engine.search.loading.spi.EntityLoader;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
-public class HibernateOrmByTypeEntityLoader<O, T> implements EntityLoader<PojoReference, T> {
+public class HibernateOrmByTypeEntityLoader<E, T> implements EntityLoader<PojoReference, T> {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private final Map<Class<? extends O>, HibernateOrmComposableEntityLoader<PojoReference, ? extends T>> delegatesByConcreteType;
+	private final Map<Class<? extends E>, HibernateOrmComposableEntityLoader<PojoReference, ? extends T>> delegatesByConcreteType;
 
-	public HibernateOrmByTypeEntityLoader(Map<Class<? extends O>, HibernateOrmComposableEntityLoader<PojoReference, ? extends T>> delegatesByConcreteType) {
+	public HibernateOrmByTypeEntityLoader(Map<Class<? extends E>, HibernateOrmComposableEntityLoader<PojoReference, ? extends T>> delegatesByConcreteType) {
 		this.delegatesByConcreteType = delegatesByConcreteType;
 	}
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/HibernateOrmComposableEntityLoader.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/HibernateOrmComposableEntityLoader.java
@@ -9,16 +9,16 @@ package org.hibernate.search.mapper.orm.search.loading.impl;
 import java.util.List;
 import java.util.Map;
 
-import org.hibernate.search.engine.search.loading.spi.ObjectLoader;
+import org.hibernate.search.engine.search.loading.spi.EntityLoader;
 
 /**
- * An {@link ObjectLoader} that can be easily composed with others object loaders.
+ * An {@link EntityLoader} that can be easily composed with others entity loaders.
  * <p>
- * See {@link HibernateOrmByTypeObjectLoader} for uses.
+ * See {@link HibernateOrmByTypeEntityLoader} for uses.
  * @param <R>
  * @param <O>
  */
-interface HibernateOrmComposableObjectLoader<R, O> extends ObjectLoader<R, O> {
+interface HibernateOrmComposableEntityLoader<R, O> extends EntityLoader<R, O> {
 
 	/**
 	 * For each reference in the given list,

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/HibernateOrmComposableEntityLoader.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/HibernateOrmComposableEntityLoader.java
@@ -16,9 +16,9 @@ import org.hibernate.search.engine.search.loading.spi.EntityLoader;
  * <p>
  * See {@link HibernateOrmByTypeEntityLoader} for uses.
  * @param <R>
- * @param <O>
+ * @param <E>
  */
-interface HibernateOrmComposableEntityLoader<R, O> extends EntityLoader<R, O> {
+interface HibernateOrmComposableEntityLoader<R, E> extends EntityLoader<R, E> {
 
 	/**
 	 * For each reference in the given list,
@@ -31,6 +31,6 @@ interface HibernateOrmComposableEntityLoader<R, O> extends EntityLoader<R, O> {
 	 * @param objectsByReference A map with references as keys and objects as values.
 	 * Initial values are undefined and the loader must not rely on them.
 	 */
-	void loadBlocking(List<R> references, Map<? super R, ? super O> objectsByReference);
+	void loadBlocking(List<R> references, Map<? super R, ? super E> objectsByReference);
 
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/HibernateOrmSingleTypeByIdEntityLoader.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/HibernateOrmSingleTypeByIdEntityLoader.java
@@ -16,16 +16,16 @@ import org.hibernate.MultiIdentifierLoadAccess;
 import org.hibernate.Session;
 import org.hibernate.search.mapper.pojo.search.PojoReference;
 
-class HibernateOrmSingleTypeByIdEntityLoader<O> implements HibernateOrmComposableEntityLoader<PojoReference, O> {
+class HibernateOrmSingleTypeByIdEntityLoader<E> implements HibernateOrmComposableEntityLoader<PojoReference, E> {
 	private final Session session;
-	private final Class<? extends O> entityType;
+	private final Class<? extends E> entityType;
 	private final MutableEntityLoadingOptions loadingOptions;
 
-	private MultiIdentifierLoadAccess<? extends O> multiAccess;
+	private MultiIdentifierLoadAccess<? extends E> multiAccess;
 
 	public HibernateOrmSingleTypeByIdEntityLoader(
 			Session session,
-			Class<? extends O> entityType,
+			Class<? extends E> entityType,
 			MutableEntityLoadingOptions loadingOptions) {
 		this.session = session;
 		this.entityType = entityType;
@@ -33,25 +33,25 @@ class HibernateOrmSingleTypeByIdEntityLoader<O> implements HibernateOrmComposabl
 	}
 
 	@Override
-	public List<? extends O> loadBlocking(List<PojoReference> references) {
+	public List<? extends E> loadBlocking(List<PojoReference> references) {
 		return loadEntities( references );
 	}
 
 	@Override
-	public void loadBlocking(List<PojoReference> references, Map<? super PojoReference, ? super O> objectsByReference) {
-		List<? extends O> loadedObjects = loadEntities( references );
+	public void loadBlocking(List<PojoReference> references, Map<? super PojoReference, ? super E> objectsByReference) {
+		List<? extends E> loadedObjects = loadEntities( references );
 		Iterator<PojoReference> referencesIterator = references.iterator();
-		Iterator<? extends O> loadedObjectIterator = loadedObjects.iterator();
+		Iterator<? extends E> loadedObjectIterator = loadedObjects.iterator();
 		while ( referencesIterator.hasNext() ) {
 			PojoReference reference = referencesIterator.next();
-			O loadedObject = loadedObjectIterator.next();
+			E loadedObject = loadedObjectIterator.next();
 			if ( loadedObject != null ) {
 				objectsByReference.put( reference, loadedObject );
 			}
 		}
 	}
 
-	private List<? extends O> loadEntities(List<PojoReference> references) {
+	private List<? extends E> loadEntities(List<PojoReference> references) {
 		List<Serializable> ids = new ArrayList<>( references.size() );
 		for ( PojoReference reference : references ) {
 			ids.add( (Serializable) reference.getId() );
@@ -60,7 +60,7 @@ class HibernateOrmSingleTypeByIdEntityLoader<O> implements HibernateOrmComposabl
 		return getMultiAccess().multiLoad( ids );
 	}
 
-	private MultiIdentifierLoadAccess<? extends O> getMultiAccess() {
+	private MultiIdentifierLoadAccess<? extends E> getMultiAccess() {
 		if ( multiAccess == null ) {
 			multiAccess = session.byMultipleIds( entityType );
 		}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/HibernateOrmSingleTypeByIdEntityLoader.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/HibernateOrmSingleTypeByIdEntityLoader.java
@@ -18,18 +18,18 @@ import org.hibernate.MultiIdentifierLoadAccess;
 import org.hibernate.Session;
 import org.hibernate.search.mapper.pojo.search.PojoReference;
 
-class HibernateOrmSingleTypeByIdObjectLoader<O, T> implements HibernateOrmComposableObjectLoader<PojoReference, T> {
+class HibernateOrmSingleTypeByIdEntityLoader<O, T> implements HibernateOrmComposableEntityLoader<PojoReference, T> {
 	private final Session session;
 	private final Class<O> entityType;
-	private final MutableObjectLoadingOptions loadingOptions;
+	private final MutableEntityLoadingOptions loadingOptions;
 	private final Function<? super O, T> hitTransformer;
 
 	private MultiIdentifierLoadAccess<O> multiAccess;
 
-	public HibernateOrmSingleTypeByIdObjectLoader(
+	public HibernateOrmSingleTypeByIdEntityLoader(
 			Session session,
 			Class<O> entityType,
-			MutableObjectLoadingOptions loadingOptions,
+			MutableEntityLoadingOptions loadingOptions,
 			Function<? super O, T> hitTransformer) {
 		this.session = session;
 		this.entityType = entityType;

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/MutableEntityLoadingOptions.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/MutableEntityLoadingOptions.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.mapper.orm.search.loading.impl;
 
-public class MutableObjectLoadingOptions {
+public class MutableEntityLoadingOptions {
 	private int fetchSize;
 
 	public int getFetchSize() {

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/query/impl/HibernateOrmSearchQueryAdapter.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/query/impl/HibernateOrmSearchQueryAdapter.java
@@ -31,7 +31,7 @@ import org.hibernate.query.internal.ParameterMetadataImpl;
 import org.hibernate.query.spi.QueryParameterBindings;
 import org.hibernate.query.spi.ScrollableResultsImplementor;
 import org.hibernate.search.engine.search.query.SearchQuery;
-import org.hibernate.search.mapper.orm.search.loading.impl.MutableObjectLoadingOptions;
+import org.hibernate.search.mapper.orm.search.loading.impl.MutableEntityLoadingOptions;
 import org.hibernate.transform.ResultTransformer;
 import org.hibernate.type.Type;
 
@@ -42,13 +42,13 @@ public final class HibernateOrmSearchQueryAdapter<R> extends AbstractProducedQue
 	}
 
 	private final SearchQuery<R> delegate;
-	private final MutableObjectLoadingOptions loadingOptions;
+	private final MutableEntityLoadingOptions loadingOptions;
 
 	private Integer firstResult;
 	private Integer maxResults;
 
 	HibernateOrmSearchQueryAdapter(SearchQuery<R> delegate, SessionImplementor sessionImplementor,
-			MutableObjectLoadingOptions loadingOptions) {
+			MutableEntityLoadingOptions loadingOptions) {
 		super( sessionImplementor, new ParameterMetadataImpl( null, null ) );
 		this.delegate = delegate;
 		this.loadingOptions = loadingOptions;

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/query/impl/HibernateOrmSearchQueryAdapterExtension.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/query/impl/HibernateOrmSearchQueryAdapterExtension.java
@@ -14,17 +14,17 @@ import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.engine.search.query.SearchQueryExtension;
 import org.hibernate.search.mapper.orm.search.loading.context.impl.HibernateOrmLoadingContext;
 
-final class HibernateOrmSearchQueryAdapterExtension<T> implements
-		SearchQueryExtension<HibernateOrmSearchQueryAdapter<T>, T> {
+final class HibernateOrmSearchQueryAdapterExtension<H> implements
+		SearchQueryExtension<HibernateOrmSearchQueryAdapter<H>, H> {
 	private static final HibernateOrmSearchQueryAdapterExtension<Object> INSTANCE = new HibernateOrmSearchQueryAdapterExtension<>();
 
-	@SuppressWarnings("unchecked") // The instance works for any T
-	static <T> HibernateOrmSearchQueryAdapterExtension<T> get() {
-		return (HibernateOrmSearchQueryAdapterExtension<T>) INSTANCE;
+	@SuppressWarnings("unchecked") // The instance works for any H
+	static <H> HibernateOrmSearchQueryAdapterExtension<H> get() {
+		return (HibernateOrmSearchQueryAdapterExtension<H>) INSTANCE;
 	}
 
 	@Override
-	public Optional<HibernateOrmSearchQueryAdapter<T>> extendOptional(SearchQuery<T> original, LoadingContext<?, ?> loadingContext) {
+	public Optional<HibernateOrmSearchQueryAdapter<H>> extendOptional(SearchQuery<H> original, LoadingContext<?, ?> loadingContext) {
 		if ( loadingContext instanceof HibernateOrmLoadingContext ) {
 			HibernateOrmLoadingContext<?> castedLoadingContext = (HibernateOrmLoadingContext<?>) loadingContext;
 			return Optional.of( new HibernateOrmSearchQueryAdapter<>(

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoIndexedTypeManager.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoIndexedTypeManager.java
@@ -135,7 +135,7 @@ public class PojoIndexedTypeManager<I, E, D extends DocumentElement> implements 
 		);
 	}
 
-	<R, O> MappedIndexSearchScopeBuilder<R, O> createSearchScopeBuilder(MappingContextImplementor mappingContext) {
+	<R, E2> MappedIndexSearchScopeBuilder<R, E2> createSearchScopeBuilder(MappingContextImplementor mappingContext) {
 		return indexManager.createSearchScopeBuilder( mappingContext );
 	}
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoSearchScopeDelegateImpl.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoSearchScopeDelegateImpl.java
@@ -25,12 +25,12 @@ import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactory
 import org.hibernate.search.engine.search.dsl.sort.SearchSortContainerContext;
 import org.hibernate.search.util.common.AssertionFailure;
 
-class PojoSearchScopeDelegateImpl<E, O> implements PojoSearchScopeDelegate<E, O> {
+class PojoSearchScopeDelegateImpl<E, E2> implements PojoSearchScopeDelegate<E, E2> {
 
 	private final PojoIndexedTypeManagerContainer typeManagers;
 	private final Set<PojoIndexedTypeManager<?, ? extends E, ?>> targetedTypeManagers;
 	private final AbstractPojoSessionContextImplementor sessionContext;
-	private MappedIndexSearchScope<PojoReference, O> delegate;
+	private MappedIndexSearchScope<PojoReference, E2> delegate;
 
 	PojoSearchScopeDelegateImpl(PojoIndexedTypeManagerContainer typeManagers,
 			Set<PojoIndexedTypeManager<?, ? extends E, ?>> targetedTypeManagers,
@@ -58,8 +58,8 @@ class PojoSearchScopeDelegateImpl<E, O> implements PojoSearchScopeDelegate<E, O>
 	}
 
 	@Override
-	public SearchQueryResultDefinitionContext<PojoReference, O, SearchProjectionFactoryContext<PojoReference, O>> search(
-			LoadingContextBuilder<PojoReference, O> loadingContextBuilder) {
+	public SearchQueryResultDefinitionContext<PojoReference, E2, SearchProjectionFactoryContext<PojoReference, E2>> search(
+			LoadingContextBuilder<PojoReference, E2> loadingContextBuilder) {
 		return getDelegate().search( sessionContext, loadingContextBuilder );
 	}
 
@@ -74,15 +74,15 @@ class PojoSearchScopeDelegateImpl<E, O> implements PojoSearchScopeDelegate<E, O>
 	}
 
 	@Override
-	public SearchProjectionFactoryContext<PojoReference, O> projection() {
+	public SearchProjectionFactoryContext<PojoReference, E2> projection() {
 		return getDelegate().projection();
 	}
 
-	private MappedIndexSearchScope<PojoReference, O> getDelegate() {
+	private MappedIndexSearchScope<PojoReference, E2> getDelegate() {
 		AbstractPojoMappingContextImplementor mappingContext = sessionContext.getMappingContext();
 		if ( delegate == null ) {
 			Iterator<PojoIndexedTypeManager<?, ? extends E, ?>> iterator = targetedTypeManagers.iterator();
-			MappedIndexSearchScopeBuilder<PojoReference, O> builder = iterator.next().createSearchScopeBuilder(
+			MappedIndexSearchScopeBuilder<PojoReference, E2> builder = iterator.next().createSearchScopeBuilder(
 					mappingContext
 			);
 			while ( iterator.hasNext() ) {

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoSearchSessionDelegateImpl.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoSearchSessionDelegateImpl.java
@@ -38,7 +38,7 @@ class PojoSearchSessionDelegateImpl implements PojoSearchSessionDelegate {
 	}
 
 	@Override
-	public <E, O> PojoSearchScopeDelegate<E, O> createPojoSearchScope(
+	public <E, E2> PojoSearchScopeDelegate<E, E2> createPojoSearchScope(
 			Collection<? extends Class<? extends E>> targetedTypes) {
 		if ( targetedTypes.isEmpty() ) {
 			throw log.cannotSearchOnEmptyTarget();

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/search/spi/PojoSearchScopeDelegate.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/search/spi/PojoSearchScopeDelegate.java
@@ -18,22 +18,22 @@ import org.hibernate.search.mapper.pojo.search.PojoReference;
 
 /**
  * @param <E> A common supertype of the indexed types included in this scope.
- * @param <O> The type of entities, i.e. the type of hits returned by
+ * @param <E2> The type of loaded entities, i.e. the type of hits returned by
  * {@link SearchQueryResultDefinitionContext#asEntity() entity queries},
  * or the type of objects returned for {@link SearchProjectionFactoryContext#entity() entity projections}.
  */
-public interface PojoSearchScopeDelegate<E, O> {
+public interface PojoSearchScopeDelegate<E, E2> {
 	Set<Class<? extends E>> getIncludedIndexedTypes();
 
 	PojoReference toPojoReference(DocumentReference documentReference);
 
-	SearchQueryResultDefinitionContext<PojoReference, O, SearchProjectionFactoryContext<PojoReference, O>> search(
-			LoadingContextBuilder<PojoReference, O> loadingContextBuilder);
+	SearchQueryResultDefinitionContext<PojoReference, E2, SearchProjectionFactoryContext<PojoReference, E2>> search(
+			LoadingContextBuilder<PojoReference, E2> loadingContextBuilder);
 
 	SearchPredicateFactoryContext predicate();
 
 	SearchSortContainerContext sort();
 
-	SearchProjectionFactoryContext<PojoReference, O> projection();
+	SearchProjectionFactoryContext<PojoReference, E2> projection();
 
 }

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/search/spi/PojoSearchScopeDelegate.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/search/spi/PojoSearchScopeDelegate.java
@@ -18,9 +18,9 @@ import org.hibernate.search.mapper.pojo.search.PojoReference;
 
 /**
  * @param <E> A common supertype of the indexed types included in this scope.
- * @param <O> The type of loaded objects, i.e. the type of hits returned by
+ * @param <O> The type of entities, i.e. the type of hits returned by
  * {@link SearchQueryResultDefinitionContext#asEntity() entity queries} when not using any hit transformer,
- * or the type of objects returned for {@link SearchProjectionFactoryContext#object() loaded object projections}.
+ * or the type of objects returned for {@link SearchProjectionFactoryContext#entity() entity projections}.
  */
 public interface PojoSearchScopeDelegate<E, O> {
 	Set<Class<? extends E>> getIncludedIndexedTypes();

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/search/spi/PojoSearchScopeDelegate.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/search/spi/PojoSearchScopeDelegate.java
@@ -19,7 +19,7 @@ import org.hibernate.search.mapper.pojo.search.PojoReference;
 /**
  * @param <E> A common supertype of the indexed types included in this scope.
  * @param <O> The type of entities, i.e. the type of hits returned by
- * {@link SearchQueryResultDefinitionContext#asEntity() entity queries} when not using any hit transformer,
+ * {@link SearchQueryResultDefinitionContext#asEntity() entity queries},
  * or the type of objects returned for {@link SearchProjectionFactoryContext#entity() entity projections}.
  */
 public interface PojoSearchScopeDelegate<E, O> {

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/session/spi/PojoSearchSessionDelegate.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/session/spi/PojoSearchSessionDelegate.java
@@ -15,7 +15,7 @@ import org.hibernate.search.mapper.pojo.work.spi.PojoSessionWorkExecutor;
 
 public interface PojoSearchSessionDelegate {
 
-	<E, O> PojoSearchScopeDelegate<E, O> createPojoSearchScope(Collection<? extends Class<? extends E>> targetedTypes);
+	<E, E2> PojoSearchScopeDelegate<E, E2> createPojoSearchScope(Collection<? extends Class<? extends E>> targetedTypes);
 
 	PojoWorkPlan createWorkPlan(DocumentRefreshStrategy refreshStrategy);
 

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/assertion/SearchHitsAssert.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/assertion/SearchHitsAssert.java
@@ -20,74 +20,74 @@ import org.assertj.core.api.ListAssert;
 import org.assertj.core.error.BasicErrorMessageFactory;
 import org.assertj.core.internal.Failures;
 
-public class SearchHitsAssert<T> {
+public class SearchHitsAssert<H> {
 
-	public static <T> SearchHitsAssert<T> assertThat(List<? extends T> actual) {
+	public static <H> SearchHitsAssert<H> assertThat(List<? extends H> actual) {
 		return new SearchHitsAssert<>( actual );
 	}
 
-	private final List<? extends T> actual;
+	private final List<? extends H> actual;
 	private String description = "<unknown>";
 
-	private SearchHitsAssert(List<? extends T> actual) {
+	private SearchHitsAssert(List<? extends H> actual) {
 		this.actual = actual;
 	}
 
-	public SearchHitsAssert<T> fromQuery(SearchQuery<?> query) {
+	public SearchHitsAssert<H> fromQuery(SearchQuery<?> query) {
 		return as( "Hits of " + query.toString() );
 	}
 
-	public SearchHitsAssert<T> as(String description) {
+	public SearchHitsAssert<H> as(String description) {
 		this.description = description;
 		return this;
 	}
 
-	public SearchHitsAssert<T> isEmpty() {
-		Assertions.<T>assertThat( actual )
+	public SearchHitsAssert<H> isEmpty() {
+		Assertions.<H>assertThat( actual )
 				.as( description )
 				.isEmpty();
 		return this;
 	}
 
 	@SafeVarargs
-	public final SearchHitsAssert<T> hasHitsExactOrder(T... hits) {
-		Assertions.<T>assertThat( actual )
+	public final SearchHitsAssert<H> hasHitsExactOrder(H... hits) {
+		Assertions.<H>assertThat( actual )
 				.as( description )
 				.containsExactly( hits );
 		return this;
 	}
 
 	@SafeVarargs
-	public final SearchHitsAssert<T> hasHitsAnyOrder(T... hits) {
-		Assertions.<T>assertThat( actual )
+	public final SearchHitsAssert<H> hasHitsAnyOrder(H... hits) {
+		Assertions.<H>assertThat( actual )
 				.as( description )
 				.containsExactlyInAnyOrder( hits );
 		return this;
 	}
 
 	@SuppressWarnings("unchecked")
-	public final SearchHitsAssert<T> hasHitsExactOrder(Collection<T> hits) {
-		return hasHitsExactOrder( (T[]) hits.toArray() );
+	public final SearchHitsAssert<H> hasHitsExactOrder(Collection<H> hits) {
+		return hasHitsExactOrder( (H[]) hits.toArray() );
 	}
 
 	@SuppressWarnings("unchecked")
-	public final SearchHitsAssert<T> hasHitsAnyOrder(Collection<T> hits) {
-		return hasHitsAnyOrder( (T[]) hits.toArray() );
+	public final SearchHitsAssert<H> hasHitsAnyOrder(Collection<H> hits) {
+		return hasHitsAnyOrder( (H[]) hits.toArray() );
 	}
 
-	public SearchHitsAssert<T> hasDocRefHitsExactOrder(String indexName, String firstId, String... otherIds) {
+	public SearchHitsAssert<H> hasDocRefHitsExactOrder(String indexName, String firstId, String... otherIds) {
 		return hasDocRefHitsExactOrder( ctx -> {
 			ctx.doc( indexName, firstId, otherIds );
 		} );
 	}
 
-	public SearchHitsAssert<T> hasDocRefHitsAnyOrder(String indexName, String firstId, String... otherIds) {
+	public SearchHitsAssert<H> hasDocRefHitsAnyOrder(String indexName, String firstId, String... otherIds) {
 		return hasDocRefHitsAnyOrder( ctx -> {
 			ctx.doc( indexName, firstId, otherIds );
 		} );
 	}
 
-	public SearchHitsAssert<T> hasDocRefHitsExactOrder(Consumer<DocumentReferenceHitsBuilder> expectation) {
+	public SearchHitsAssert<H> hasDocRefHitsExactOrder(Consumer<DocumentReferenceHitsBuilder> expectation) {
 		DocumentReferenceHitsBuilder context = new DocumentReferenceHitsBuilder();
 		expectation.accept( context );
 		Assertions.assertThat( getNormalizedActualDocumentReferencesHits() )
@@ -96,7 +96,7 @@ public class SearchHitsAssert<T> {
 		return this;
 	}
 
-	public SearchHitsAssert<T> hasDocRefHitsAnyOrder(Consumer<DocumentReferenceHitsBuilder> expectation) {
+	public SearchHitsAssert<H> hasDocRefHitsAnyOrder(Consumer<DocumentReferenceHitsBuilder> expectation) {
 		DocumentReferenceHitsBuilder context = new DocumentReferenceHitsBuilder();
 		expectation.accept( context );
 		Assertions.assertThat( getNormalizedActualDocumentReferencesHits() )
@@ -105,7 +105,7 @@ public class SearchHitsAssert<T> {
 		return this;
 	}
 
-	public SearchHitsAssert<T> hasListHitsExactOrder(Consumer<ListHitsBuilder> expectation) {
+	public SearchHitsAssert<H> hasListHitsExactOrder(Consumer<ListHitsBuilder> expectation) {
 		ListHitsBuilder context = new ListHitsBuilder();
 		expectation.accept( context );
 		Assertions.assertThat( getNormalizedActualListHits() )
@@ -114,7 +114,7 @@ public class SearchHitsAssert<T> {
 		return this;
 	}
 
-	public SearchHitsAssert<T> hasListHitsAnyOrder(Consumer<ListHitsBuilder> expectation) {
+	public SearchHitsAssert<H> hasListHitsAnyOrder(Consumer<ListHitsBuilder> expectation) {
 		ListHitsBuilder context = new ListHitsBuilder();
 		expectation.accept( context );
 		Assertions.assertThat( getNormalizedActualListHits() )

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/assertion/SearchResultAssert.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/assertion/SearchResultAssert.java
@@ -15,38 +15,38 @@ import org.hibernate.search.engine.search.query.SearchResult;
 
 import org.assertj.core.api.Assertions;
 
-public class SearchResultAssert<T> {
+public class SearchResultAssert<H> {
 
-	public static <T> SearchResultAssert<T> assertThat(SearchQuery<? extends T> searchQuery) {
-		return SearchResultAssert.<T>assertThat( searchQuery.fetch() ).fromQuery( searchQuery );
+	public static <H> SearchResultAssert<H> assertThat(SearchQuery<? extends H> searchQuery) {
+		return SearchResultAssert.<H>assertThat( searchQuery.fetch() ).fromQuery( searchQuery );
 	}
 
-	public static <T> SearchResultAssert<T> assertThat(SearchResult<? extends T> actual) {
+	public static <H> SearchResultAssert<H> assertThat(SearchResult<? extends H> actual) {
 		return new SearchResultAssert<>( actual );
 	}
 
-	public static <T> SearchHitsAssert<T> assertThat(List<? extends T> actual) {
+	public static <H> SearchHitsAssert<H> assertThat(List<? extends H> actual) {
 		return SearchHitsAssert.assertThat( actual );
 	}
 
-	private final SearchResult<? extends T> actual;
+	private final SearchResult<? extends H> actual;
 	private String queryDescription = "<unknown>";
 
-	private SearchResultAssert(SearchResult<? extends T> actual) {
+	private SearchResultAssert(SearchResult<? extends H> actual) {
 		this.actual = actual;
 	}
 
-	public SearchResultAssert<T> fromQuery(SearchQuery<?> query) {
+	public SearchResultAssert<H> fromQuery(SearchQuery<?> query) {
 		this.queryDescription = query.toString();
 		return this;
 	}
 
-	public SearchResultAssert<T> hasNoHits() {
+	public SearchResultAssert<H> hasNoHits() {
 		assertHits().isEmpty();
 		return this;
 	}
 
-	public SearchResultAssert<T> hasTotalHitCount(long expected) {
+	public SearchResultAssert<H> hasTotalHitCount(long expected) {
 		Assertions.assertThat( actual.getTotalHitCount() )
 				.as( "Total hit count of " + queryDescription )
 				.isEqualTo( expected );
@@ -54,59 +54,59 @@ public class SearchResultAssert<T> {
 	}
 
 	@SafeVarargs
-	public final SearchResultAssert<T> hasHitsExactOrder(T... hits) {
+	public final SearchResultAssert<H> hasHitsExactOrder(H... hits) {
 		assertHits().hasHitsExactOrder( hits );
 		return this;
 	}
 
 	@SafeVarargs
-	public final SearchResultAssert<T> hasHitsAnyOrder(T... hits) {
+	public final SearchResultAssert<H> hasHitsAnyOrder(H... hits) {
 		assertHits().hasHitsAnyOrder( hits );
 		return this;
 	}
 
-	public final SearchResultAssert<T> hasHitsExactOrder(Collection<T> hits) {
+	public final SearchResultAssert<H> hasHitsExactOrder(Collection<H> hits) {
 		assertHits().hasHitsExactOrder( hits );
 		return this;
 	}
 
-	public final SearchResultAssert<T> hasHitsAnyOrder(Collection<T> hits) {
+	public final SearchResultAssert<H> hasHitsAnyOrder(Collection<H> hits) {
 		assertHits().hasHitsAnyOrder( hits );
 		return this;
 	}
 
-	public SearchResultAssert<T> hasDocRefHitsExactOrder(String indexName, String firstId, String... otherIds) {
+	public SearchResultAssert<H> hasDocRefHitsExactOrder(String indexName, String firstId, String... otherIds) {
 		assertHits().hasDocRefHitsExactOrder( indexName, firstId, otherIds );
 		return this;
 	}
 
-	public SearchResultAssert<T> hasDocRefHitsAnyOrder(String indexName, String firstId, String... otherIds) {
+	public SearchResultAssert<H> hasDocRefHitsAnyOrder(String indexName, String firstId, String... otherIds) {
 		assertHits().hasDocRefHitsAnyOrder( indexName, firstId, otherIds );
 		return this;
 	}
 
-	public SearchResultAssert<T> hasDocRefHitsExactOrder(Consumer<DocumentReferenceHitsBuilder> expectation) {
+	public SearchResultAssert<H> hasDocRefHitsExactOrder(Consumer<DocumentReferenceHitsBuilder> expectation) {
 		assertHits().hasDocRefHitsExactOrder( expectation );
 		return this;
 	}
 
-	public SearchResultAssert<T> hasDocRefHitsAnyOrder(Consumer<DocumentReferenceHitsBuilder> expectation) {
+	public SearchResultAssert<H> hasDocRefHitsAnyOrder(Consumer<DocumentReferenceHitsBuilder> expectation) {
 		assertHits().hasDocRefHitsAnyOrder( expectation );
 		return this;
 	}
 
-	public SearchResultAssert<T> hasListHitsExactOrder(Consumer<ListHitsBuilder> expectation) {
+	public SearchResultAssert<H> hasListHitsExactOrder(Consumer<ListHitsBuilder> expectation) {
 		assertHits().hasListHitsExactOrder( expectation );
 		return this;
 	}
 
-	public SearchResultAssert<T> hasListHitsAnyOrder(Consumer<ListHitsBuilder> expectation) {
+	public SearchResultAssert<H> hasListHitsAnyOrder(Consumer<ListHitsBuilder> expectation) {
 		assertHits().hasListHitsAnyOrder( expectation );
 		return this;
 	}
 
-	private SearchHitsAssert<T> assertHits() {
-		return SearchHitsAssert.<T>assertThat( actual.getHits() ).as( "Hits of " + queryDescription );
+	private SearchHitsAssert<H> assertHits() {
+		return SearchHitsAssert.<H>assertThat( actual.getHits() ).as( "Hits of " + queryDescription );
 	}
 
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubSearchQueryBuilderFactory.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubSearchQueryBuilderFactory.java
@@ -46,8 +46,8 @@ class StubSearchQueryBuilderFactory implements SearchQueryBuilderFactory<StubQue
 	}
 
 	@Override
-	public <T> SearchQueryBuilder<T, StubQueryElementCollector> asReference(SessionContextImplementor sessionContext,
-			LoadingContextBuilder<T, ?> loadingContextBuilder) {
+	public <R> SearchQueryBuilder<R, StubQueryElementCollector> asReference(SessionContextImplementor sessionContext,
+			LoadingContextBuilder<R, ?> loadingContextBuilder) {
 		return new StubSearchQueryBuilder<>(
 				backend, scopeModel, StubSearchWork.ResultType.REFERENCES,
 				new FromDocumentFieldValueConvertContextImpl( sessionContext ),
@@ -57,13 +57,13 @@ class StubSearchQueryBuilderFactory implements SearchQueryBuilderFactory<StubQue
 	}
 
 	@Override
-	public <T> SearchQueryBuilder<T, StubQueryElementCollector> asProjection(SessionContextImplementor sessionContext,
-			LoadingContextBuilder<?, ?> loadingContextBuilder, SearchProjection<T> projection) {
+	public <P> SearchQueryBuilder<P, StubQueryElementCollector> asProjection(SessionContextImplementor sessionContext,
+			LoadingContextBuilder<?, ?> loadingContextBuilder, SearchProjection<P> projection) {
 		return new StubSearchQueryBuilder<>(
 				backend, scopeModel, StubSearchWork.ResultType.PROJECTIONS,
 				new FromDocumentFieldValueConvertContextImpl( sessionContext ),
 				loadingContextBuilder,
-				(StubSearchProjection<T>) projection
+				(StubSearchProjection<P>) projection
 		);
 	}
 

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubSearchQueryBuilderFactory.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubSearchQueryBuilderFactory.java
@@ -35,8 +35,8 @@ class StubSearchQueryBuilderFactory implements SearchQueryBuilderFactory<StubQue
 	}
 
 	@Override
-	public <O> SearchQueryBuilder<O, StubQueryElementCollector> asEntity(SessionContextImplementor sessionContext,
-			LoadingContextBuilder<?, O> loadingContextBuilder) {
+	public <E> SearchQueryBuilder<E, StubQueryElementCollector> asEntity(SessionContextImplementor sessionContext,
+			LoadingContextBuilder<?, E> loadingContextBuilder) {
 		return new StubSearchQueryBuilder<>(
 				backend, scopeModel, StubSearchWork.ResultType.OBJECTS,
 				new FromDocumentFieldValueConvertContextImpl( sessionContext ),

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubSearchQueryBuilderFactory.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubSearchQueryBuilderFactory.java
@@ -21,7 +21,7 @@ import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.StubSearchWork;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.impl.StubSearchScopeModel;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.projection.impl.StubCompositeListSearchProjection;
-import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.projection.impl.StubObjectSearchProjection;
+import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.projection.impl.StubEntitySearchProjection;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.projection.impl.StubReferenceSearchProjection;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.projection.impl.StubSearchProjection;
 
@@ -35,13 +35,13 @@ class StubSearchQueryBuilderFactory implements SearchQueryBuilderFactory<StubQue
 	}
 
 	@Override
-	public <O> SearchQueryBuilder<O, StubQueryElementCollector> asObject(SessionContextImplementor sessionContext,
+	public <O> SearchQueryBuilder<O, StubQueryElementCollector> asEntity(SessionContextImplementor sessionContext,
 			LoadingContextBuilder<?, O> loadingContextBuilder) {
 		return new StubSearchQueryBuilder<>(
 				backend, scopeModel, StubSearchWork.ResultType.OBJECTS,
 				new FromDocumentFieldValueConvertContextImpl( sessionContext ),
 				loadingContextBuilder,
-				StubObjectSearchProjection.get()
+				StubEntitySearchProjection.get()
 		);
 	}
 

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/StubSearchQuery.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/StubSearchQuery.java
@@ -18,19 +18,19 @@ import org.hibernate.search.engine.search.query.SearchResult;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.index.impl.StubBackend;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.projection.impl.StubSearchProjection;
 
-final class StubSearchQuery<T> extends AbstractSearchQuery<T, SearchResult<T>>
-		implements SearchQuery<T> {
+final class StubSearchQuery<H> extends AbstractSearchQuery<H, SearchResult<H>>
+		implements SearchQuery<H> {
 
 	private final StubBackend backend;
 	private final List<String> indexNames;
 	private final StubSearchWork.Builder workBuilder;
 	private final FromDocumentFieldValueConvertContext convertContext;
 	private final LoadingContext<?, ?> loadingContext;
-	private final StubSearchProjection<T> rootProjection;
+	private final StubSearchProjection<H> rootProjection;
 
 	StubSearchQuery(StubBackend backend, List<String> indexNames, StubSearchWork.Builder workBuilder,
 			FromDocumentFieldValueConvertContext convertContext,
-			LoadingContext<?, ?> loadingContext, StubSearchProjection<T> rootProjection) {
+			LoadingContext<?, ?> loadingContext, StubSearchProjection<H> rootProjection) {
 		this.backend = backend;
 		this.indexNames = indexNames;
 		this.workBuilder = workBuilder;
@@ -45,14 +45,14 @@ final class StubSearchQuery<T> extends AbstractSearchQuery<T, SearchResult<T>>
 	}
 
 	@Override
-	public <Q> Q extension(SearchQueryExtension<Q, T> extension) {
+	public <Q> Q extension(SearchQueryExtension<Q, H> extension) {
 		return DslExtensionState.returnIfSupported(
 				extension, extension.extendOptional( this, loadingContext )
 		);
 	}
 
 	@Override
-	public SearchResult<T> fetch(Long limit, Long offset) {
+	public SearchResult<H> fetch(Long limit, Long offset) {
 		workBuilder.limit( limit ).offset( offset );
 		return backend.getBehavior().executeSearchWork(
 				indexNames, workBuilder.build(), convertContext, loadingContext, rootProjection

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/StubSearchQueryBuilder.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/StubSearchQueryBuilder.java
@@ -14,19 +14,19 @@ import org.hibernate.search.util.impl.integrationtest.common.stub.backend.index.
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.impl.StubSearchScopeModel;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.projection.impl.StubSearchProjection;
 
-public class StubSearchQueryBuilder<T> implements SearchQueryBuilder<T, StubQueryElementCollector> {
+public class StubSearchQueryBuilder<H> implements SearchQueryBuilder<H, StubQueryElementCollector> {
 
 	private final StubBackend backend;
 	private final StubSearchScopeModel scopeModel;
 	private final StubSearchWork.Builder workBuilder;
 	private final FromDocumentFieldValueConvertContext convertContext;
 	private final LoadingContextBuilder<?, ?> loadingContextBuilder;
-	private final StubSearchProjection<T> rootProjection;
+	private final StubSearchProjection<H> rootProjection;
 
 	public StubSearchQueryBuilder(StubBackend backend, StubSearchScopeModel scopeModel,
 			StubSearchWork.ResultType resultType,
 			FromDocumentFieldValueConvertContext convertContext,
-			LoadingContextBuilder<?, ?> loadingContextBuilder, StubSearchProjection<T> rootProjection) {
+			LoadingContextBuilder<?, ?> loadingContextBuilder, StubSearchProjection<H> rootProjection) {
 		this.backend = backend;
 		this.scopeModel = scopeModel;
 		this.workBuilder = StubSearchWork.builder( resultType );
@@ -46,7 +46,7 @@ public class StubSearchQueryBuilder<T> implements SearchQueryBuilder<T, StubQuer
 	}
 
 	@Override
-	public SearchQuery<T> build() {
+	public SearchQuery<H> build() {
 		return new StubSearchQuery<>(
 				backend, scopeModel.getIndexNames(), workBuilder, convertContext,
 				loadingContextBuilder.build(), rootProjection

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubCompositeBiFunctionSearchProjection.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubCompositeBiFunctionSearchProjection.java
@@ -13,15 +13,15 @@ import org.hibernate.search.engine.backend.types.converter.runtime.FromDocumentF
 import org.hibernate.search.engine.search.loading.spi.LoadingResult;
 import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 
-public class StubCompositeBiFunctionSearchProjection<P1, P2, T> implements StubCompositeSearchProjection<T> {
+public class StubCompositeBiFunctionSearchProjection<P1, P2, P> implements StubCompositeSearchProjection<P> {
 
-	private final BiFunction<P1, P2, T> transformer;
+	private final BiFunction<P1, P2, P> transformer;
 
 	private final StubSearchProjection<P1> projection1;
 
 	private final StubSearchProjection<P2> projection2;
 
-	public StubCompositeBiFunctionSearchProjection(BiFunction<P1, P2, T> transformer,
+	public StubCompositeBiFunctionSearchProjection(BiFunction<P1, P2, P> transformer,
 			StubSearchProjection<P1> projection1, StubSearchProjection<P2> projection2) {
 		this.transformer = transformer;
 		this.projection1 = projection1;
@@ -40,7 +40,7 @@ public class StubCompositeBiFunctionSearchProjection<P1, P2, T> implements StubC
 	}
 
 	@Override
-	public T transform(LoadingResult<?> loadingResult, Object extractedData) {
+	public P transform(LoadingResult<?> loadingResult, Object extractedData) {
 		Object[] extractedElements = (Object[]) extractedData;
 
 		return transformer.apply(

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubCompositeFunctionSearchProjection.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubCompositeFunctionSearchProjection.java
@@ -12,14 +12,14 @@ import org.hibernate.search.engine.backend.types.converter.runtime.FromDocumentF
 import org.hibernate.search.engine.search.loading.spi.LoadingResult;
 import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 
-public class StubCompositeFunctionSearchProjection<P, T> implements StubCompositeSearchProjection<T> {
+public class StubCompositeFunctionSearchProjection<P1, P> implements StubCompositeSearchProjection<P> {
 
-	private final Function<P, T> transformer;
+	private final Function<P1, P> transformer;
 
-	private final StubSearchProjection<P> projection;
+	private final StubSearchProjection<P1> projection;
 
-	public StubCompositeFunctionSearchProjection(Function<P, T> transformer,
-			StubSearchProjection<P> projection) {
+	public StubCompositeFunctionSearchProjection(Function<P1, P> transformer,
+			StubSearchProjection<P1> projection) {
 		this.transformer = transformer;
 		this.projection = projection;
 	}
@@ -31,7 +31,7 @@ public class StubCompositeFunctionSearchProjection<P, T> implements StubComposit
 	}
 
 	@Override
-	public T transform(LoadingResult<?> loadingResult, Object extractedData) {
+	public P transform(LoadingResult<?> loadingResult, Object extractedData) {
 		return transformer.apply( projection.transform( loadingResult, extractedData ) );
 	}
 

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubCompositeListSearchProjection.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubCompositeListSearchProjection.java
@@ -14,13 +14,13 @@ import org.hibernate.search.engine.backend.types.converter.runtime.FromDocumentF
 import org.hibernate.search.engine.search.loading.spi.LoadingResult;
 import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 
-public class StubCompositeListSearchProjection<T> implements StubCompositeSearchProjection<T> {
+public class StubCompositeListSearchProjection<P> implements StubCompositeSearchProjection<P> {
 
-	private final Function<List<?>, T> transformer;
+	private final Function<List<?>, P> transformer;
 
 	private final List<StubSearchProjection<?>> children;
 
-	public StubCompositeListSearchProjection(Function<List<?>, T> transformer,
+	public StubCompositeListSearchProjection(Function<List<?>, P> transformer,
 			List<StubSearchProjection<?>> children) {
 		this.transformer = transformer;
 		this.children = children;
@@ -41,7 +41,7 @@ public class StubCompositeListSearchProjection<T> implements StubCompositeSearch
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public T transform(LoadingResult<?> loadingResult, Object extractedData) {
+	public P transform(LoadingResult<?> loadingResult, Object extractedData) {
 		List<Object> extractedElements = (List<Object>) extractedData;
 		List<Object> results = new ArrayList<>( extractedElements.size() );
 

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubCompositeSearchProjection.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubCompositeSearchProjection.java
@@ -6,6 +6,6 @@
  */
 package org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.projection.impl;
 
-public interface StubCompositeSearchProjection<T> extends StubSearchProjection<T> {
+public interface StubCompositeSearchProjection<P> extends StubSearchProjection<P> {
 
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubCompositeTriFunctionSearchProjection.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubCompositeTriFunctionSearchProjection.java
@@ -13,9 +13,9 @@ import org.hibernate.search.engine.search.loading.spi.LoadingResult;
 import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 import org.hibernate.search.util.common.function.TriFunction;
 
-public class StubCompositeTriFunctionSearchProjection<P1, P2, P3, T> implements StubCompositeSearchProjection<T> {
+public class StubCompositeTriFunctionSearchProjection<P1, P2, P3, P> implements StubCompositeSearchProjection<P> {
 
-	private final TriFunction<P1, P2, P3, T> transformer;
+	private final TriFunction<P1, P2, P3, P> transformer;
 
 	private final StubSearchProjection<P1> projection1;
 
@@ -23,7 +23,7 @@ public class StubCompositeTriFunctionSearchProjection<P1, P2, P3, T> implements 
 
 	private final StubSearchProjection<P3> projection3;
 
-	public StubCompositeTriFunctionSearchProjection(TriFunction<P1, P2, P3, T> transformer,
+	public StubCompositeTriFunctionSearchProjection(TriFunction<P1, P2, P3, P> transformer,
 			StubSearchProjection<P1> projection1, StubSearchProjection<P2> projection2,
 			StubSearchProjection<P3> projection3) {
 		this.transformer = transformer;
@@ -45,7 +45,7 @@ public class StubCompositeTriFunctionSearchProjection<P1, P2, P3, T> implements 
 	}
 
 	@Override
-	public T transform(LoadingResult<?> loadingResult, Object extractedData) {
+	public P transform(LoadingResult<?> loadingResult, Object extractedData) {
 		Object[] extractedElements = (Object[]) extractedData;
 
 		return transformer.apply(

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubEntitySearchProjection.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubEntitySearchProjection.java
@@ -11,17 +11,17 @@ import org.hibernate.search.engine.search.DocumentReference;
 import org.hibernate.search.engine.search.loading.spi.LoadingResult;
 import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 
-public class StubObjectSearchProjection<T> implements StubSearchProjection<T> {
+public class StubEntitySearchProjection<T> implements StubSearchProjection<T> {
 
 	@SuppressWarnings("rawtypes")
-	private static final StubSearchProjection INSTANCE = new StubObjectSearchProjection();
+	private static final StubSearchProjection INSTANCE = new StubEntitySearchProjection();
 
 	@SuppressWarnings("unchecked")
-	public static <T> StubObjectSearchProjection<T> get() {
-		return (StubObjectSearchProjection<T>) INSTANCE;
+	public static <T> StubEntitySearchProjection<T> get() {
+		return (StubEntitySearchProjection<T>) INSTANCE;
 	}
 
-	private StubObjectSearchProjection() {
+	private StubEntitySearchProjection() {
 	}
 
 	@Override

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubSearchProjection.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubSearchProjection.java
@@ -11,10 +11,10 @@ import org.hibernate.search.engine.search.SearchProjection;
 import org.hibernate.search.engine.search.loading.spi.LoadingResult;
 import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 
-public interface StubSearchProjection<T> extends SearchProjection<T> {
+public interface StubSearchProjection<P> extends SearchProjection<P> {
 
 	Object extract(ProjectionHitMapper<?, ?> projectionHitMapper, Object projectionFromIndex,
 			FromDocumentFieldValueConvertContext context);
 
-	T transform(LoadingResult<?> loadingResult, Object extractedData);
+	P transform(LoadingResult<?> loadingResult, Object extractedData);
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubSearchProjectionBuilderFactory.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubSearchProjectionBuilderFactory.java
@@ -19,7 +19,7 @@ import org.hibernate.search.engine.search.projection.spi.CompositeProjectionBuil
 import org.hibernate.search.engine.search.projection.spi.DistanceToFieldProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.DocumentReferenceProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.FieldProjectionBuilder;
-import org.hibernate.search.engine.search.projection.spi.ObjectProjectionBuilder;
+import org.hibernate.search.engine.search.projection.spi.EntityProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.ReferenceProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.ScoreProjectionBuilder;
 import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilderFactory;
@@ -60,11 +60,11 @@ public class StubSearchProjectionBuilderFactory implements SearchProjectionBuild
 	}
 
 	@Override
-	public <O> ObjectProjectionBuilder<O> object() {
-		return new ObjectProjectionBuilder<O>() {
+	public <O> EntityProjectionBuilder<O> entity() {
+		return new EntityProjectionBuilder<O>() {
 			@Override
 			public SearchProjection<O> build() {
-				return StubObjectSearchProjection.get();
+				return StubEntitySearchProjection.get();
 			}
 		};
 	}

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubSearchProjectionBuilderFactory.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/projection/impl/StubSearchProjectionBuilderFactory.java
@@ -60,10 +60,10 @@ public class StubSearchProjectionBuilderFactory implements SearchProjectionBuild
 	}
 
 	@Override
-	public <O> EntityProjectionBuilder<O> entity() {
-		return new EntityProjectionBuilder<O>() {
+	public <E> EntityProjectionBuilder<E> entity() {
+		return new EntityProjectionBuilder<E>() {
 			@Override
-			public SearchProjection<O> build() {
+			public SearchProjection<E> build() {
 				return StubEntitySearchProjection.get();
 			}
 		};

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/GenericStubMappingSearchScope.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/GenericStubMappingSearchScope.java
@@ -19,21 +19,21 @@ import org.hibernate.search.util.impl.integrationtest.common.stub.StubSessionCon
  * A wrapper around {@link MappedIndexSearchScope} providing some syntactic sugar,
  * such as methods that do not force to provide a session context.
  */
-public class GenericStubMappingSearchScope<R, O> {
+public class GenericStubMappingSearchScope<R, E> {
 
-	private final MappedIndexSearchScope<R, O> delegate;
+	private final MappedIndexSearchScope<R, E> delegate;
 
-	GenericStubMappingSearchScope(MappedIndexSearchScope<R, O> delegate) {
+	GenericStubMappingSearchScope(MappedIndexSearchScope<R, E> delegate) {
 		this.delegate = delegate;
 	}
 
-	public SearchQueryResultDefinitionContext<R, O, ?> query(LoadingContext<R, O> loadingContext) {
+	public SearchQueryResultDefinitionContext<R, E, ?> query(LoadingContext<R, E> loadingContext) {
 		return query( new StubSessionContext(), loadingContext );
 	}
 
-	public SearchQueryResultDefinitionContext<R, O, ?> query(StubSessionContext sessionContext,
-			LoadingContext<R, O> loadingContext) {
-		LoadingContextBuilder<R, O> loadingContextBuilder = () -> loadingContext;
+	public SearchQueryResultDefinitionContext<R, E, ?> query(StubSessionContext sessionContext,
+			LoadingContext<R, E> loadingContext) {
+		LoadingContextBuilder<R, E> loadingContextBuilder = () -> loadingContext;
 		return delegate.search( sessionContext, loadingContextBuilder );
 	}
 
@@ -45,7 +45,7 @@ public class GenericStubMappingSearchScope<R, O> {
 		return delegate.sort();
 	}
 
-	public SearchProjectionFactoryContext<R, O> projection() {
+	public SearchProjectionFactoryContext<R, E> projection() {
 		return delegate.projection();
 	}
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/StubLoadingContext.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/StubLoadingContext.java
@@ -11,14 +11,14 @@ import java.util.function.Function;
 import org.hibernate.search.engine.search.DocumentReference;
 import org.hibernate.search.engine.search.loading.context.spi.LoadingContext;
 import org.hibernate.search.engine.search.loading.spi.DefaultProjectionHitMapper;
-import org.hibernate.search.engine.search.loading.spi.ObjectLoader;
+import org.hibernate.search.engine.search.loading.spi.EntityLoader;
 import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 
 public class StubLoadingContext implements LoadingContext<DocumentReference, DocumentReference> {
 	private final ProjectionHitMapper<DocumentReference, DocumentReference> projectionHitMapper;
 
 	StubLoadingContext() {
-		this.projectionHitMapper = new DefaultProjectionHitMapper<>( Function.identity(), ObjectLoader.identity() );
+		this.projectionHitMapper = new DefaultProjectionHitMapper<>( Function.identity(), EntityLoader.identity() );
 	}
 
 	@Override

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/StubMapperUtils.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/StubMapperUtils.java
@@ -47,7 +47,7 @@ public final class StubMapperUtils {
 	 * @param <R> The reference type.
 	 * @param <O> The entity type.
 	 */
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	public static <R, O> void expectHitMapping(
 			LoadingContext<R, O> loadingContextMock,
 			Function<DocumentReference, R> referenceTransformerMock,
@@ -77,7 +77,8 @@ public final class StubMapperUtils {
 				EasyMockUtils.collectionAnyOrderMatcher( new ArrayList<>( context.loadingMap.keySet() ) )
 		) )
 				.andAnswer(
-						() -> ( (List<R>) EasyMock.getCurrentArguments()[0] ).stream()
+						// We need to cast to a raw type to conform to List<? extends O>
+						() -> (List) ( (List<R>) EasyMock.getCurrentArguments()[0] ).stream()
 						.map( context.loadingMap::get )
 						.collect( Collectors.toList() )
 				);

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/StubMapperUtils.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/StubMapperUtils.java
@@ -45,14 +45,14 @@ public final class StubMapperUtils {
 	 * @param objectLoaderMock The EasyMock mock for the entity loader.
 	 * @param hitMappingDefinition A definition of the reference -> entity mapping.
 	 * @param <R> The reference type.
-	 * @param <O> The entity type.
+	 * @param <E> The entity type.
 	 */
 	@SuppressWarnings({"unchecked", "rawtypes"})
-	public static <R, O> void expectHitMapping(
-			LoadingContext<R, O> loadingContextMock,
+	public static <R, E> void expectHitMapping(
+			LoadingContext<R, E> loadingContextMock,
 			Function<DocumentReference, R> referenceTransformerMock,
-			EntityLoader<R, O> objectLoaderMock,
-			Consumer<HitMappingDefinitionContext<R, O>> hitMappingDefinition) {
+			EntityLoader<R, E> objectLoaderMock,
+			Consumer<HitMappingDefinitionContext<R, E>> hitMappingDefinition) {
 		/*
 		 * We expect getProjectionHitMapper to be called *every time* a load is performed,
 		 * so that the mapper can check its state (session is open in ORM, for example).
@@ -63,7 +63,7 @@ public final class StubMapperUtils {
 						objectLoaderMock
 				) );
 
-		HitMappingDefinitionContext<R, O> context = new HitMappingDefinitionContext<>();
+		HitMappingDefinitionContext<R, E> context = new HitMappingDefinitionContext<>();
 		hitMappingDefinition.accept( context );
 
 		for ( Map.Entry<DocumentReference, List<R>> entry : context.referenceMap.entrySet() ) {
@@ -77,24 +77,24 @@ public final class StubMapperUtils {
 				EasyMockUtils.collectionAnyOrderMatcher( new ArrayList<>( context.loadingMap.keySet() ) )
 		) )
 				.andAnswer(
-						// We need to cast to a raw type to conform to List<? extends O>
+						// We need to cast to a raw type to conform to List<? extends E>
 						() -> (List) ( (List<R>) EasyMock.getCurrentArguments()[0] ).stream()
 						.map( context.loadingMap::get )
 						.collect( Collectors.toList() )
 				);
 	}
 
-	public static class HitMappingDefinitionContext<R, O> {
+	public static class HitMappingDefinitionContext<R, E> {
 		private final Map<DocumentReference, List<R>> referenceMap = new HashMap<>();
-		private final Map<R, O> loadingMap = new HashMap<>();
+		private final Map<R, E> loadingMap = new HashMap<>();
 
-		public HitMappingDefinitionContext<R, O> reference(DocumentReference documentReference, R transformedReference) {
+		public HitMappingDefinitionContext<R, E> reference(DocumentReference documentReference, R transformedReference) {
 			referenceMap.computeIfAbsent( documentReference, ignored -> new ArrayList<>() )
 					.add( transformedReference );
 			return this;
 		}
 
-		public HitMappingDefinitionContext<R, O> load(DocumentReference documentReference, R transformedReference, O loadedObject) {
+		public HitMappingDefinitionContext<R, E> load(DocumentReference documentReference, R transformedReference, E loadedObject) {
 			// For each load, the backend must first transform the reference
 			reference( documentReference, transformedReference );
 			// Then it will need to trigger loading

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/StubMapperUtils.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/StubMapperUtils.java
@@ -43,9 +43,9 @@ public final class StubMapperUtils {
 	 * @param loadingContextMock The EasyMock mock for the loading context.
 	 * @param referenceTransformerMock The EasyMock mock for the reference transformer.
 	 * @param objectLoaderMock The EasyMock mock for the object loader.
-	 * @param hitMappingDefinition A definition of the reference -> loaded object mapping.
+	 * @param hitMappingDefinition A definition of the reference -> entity mapping.
 	 * @param <R> The reference type.
-	 * @param <O> The loaded object type.
+	 * @param <O> The entity type.
 	 */
 	@SuppressWarnings("unchecked")
 	public static <R, O> void expectHitMapping(

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/StubMapperUtils.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/StubMapperUtils.java
@@ -21,7 +21,7 @@ import org.hibernate.search.engine.backend.index.spi.DocumentReferenceProvider;
 import org.hibernate.search.engine.search.DocumentReference;
 import org.hibernate.search.engine.search.loading.context.spi.LoadingContext;
 import org.hibernate.search.engine.search.loading.spi.DefaultProjectionHitMapper;
-import org.hibernate.search.engine.search.loading.spi.ObjectLoader;
+import org.hibernate.search.engine.search.loading.spi.EntityLoader;
 import org.hibernate.search.util.impl.integrationtest.common.EasyMockUtils;
 
 import org.easymock.EasyMock;
@@ -42,7 +42,7 @@ public final class StubMapperUtils {
 	/**
 	 * @param loadingContextMock The EasyMock mock for the loading context.
 	 * @param referenceTransformerMock The EasyMock mock for the reference transformer.
-	 * @param objectLoaderMock The EasyMock mock for the object loader.
+	 * @param objectLoaderMock The EasyMock mock for the entity loader.
 	 * @param hitMappingDefinition A definition of the reference -> entity mapping.
 	 * @param <R> The reference type.
 	 * @param <O> The entity type.
@@ -51,7 +51,7 @@ public final class StubMapperUtils {
 	public static <R, O> void expectHitMapping(
 			LoadingContext<R, O> loadingContextMock,
 			Function<DocumentReference, R> referenceTransformerMock,
-			ObjectLoader<R, O> objectLoaderMock,
+			EntityLoader<R, O> objectLoaderMock,
 			Consumer<HitMappingDefinitionContext<R, O>> hitMappingDefinition) {
 		/*
 		 * We expect getProjectionHitMapper to be called *every time* a load is performed,

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/StubMappingIndexManager.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/StubMappingIndexManager.java
@@ -78,8 +78,8 @@ public class StubMappingIndexManager {
 	/**
 	 * @return A search target scoped to this index and the given other indexes.
 	 */
-	public <R, O> GenericStubMappingSearchScope<R, O> createGenericSearchScope(StubMappingIndexManager... others) {
-		MappedIndexSearchScopeBuilder<R, O> builder =
+	public <R, E> GenericStubMappingSearchScope<R, E> createGenericSearchScope(StubMappingIndexManager... others) {
+		MappedIndexSearchScopeBuilder<R, E> builder =
 				indexManager.createSearchScopeBuilder( new StubMappingContext() );
 		for ( StubMappingIndexManager other : others ) {
 			other.indexManager.addTo( builder );


### PR DESCRIPTION
[HSEARCH-3573](https://hibernate.atlassian.net//browse/HSEARCH-3573): Use consistent naming for hits and projections

~Based on #1971 , which should be merged first.~ => Done

This is strictly about method and generic type parameter names. There's a lot of changes, but very few of them are significant. I just need to know if the idea seems sound: maybe you can determine that from the commit messages? I don't want to force you to go through the entire diff...

The only significant change is the renaming of the `object()` projection to `entity()`, to be consistent with the wording of `asEntity()` when creating a query.