### PR TITLE
HSEARCH-3324 Keep track of which field may be multi-valued and force bridges to declare fields as such

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/impl/ElasticsearchDocumentObjectBuilder.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/impl/ElasticsearchDocumentObjectBuilder.java
@@ -49,6 +49,9 @@ public class ElasticsearchDocumentObjectBuilder implements DocumentElement {
 
 		ElasticsearchIndexSchemaFieldNode<F> fieldSchemaNode = elasticsearchFieldReference.getSchemaNode();
 		checkTreeConsistency( fieldSchemaNode.getParent() );
+		if ( !fieldSchemaNode.isMultiValued() && elasticsearchFieldReference.hasValueIn( content ) ) {
+			throw log.multipleValuesForSingleValuedField( fieldSchemaNode.getAbsolutePath() );
+		}
 
 		elasticsearchFieldReference.addTo( content, value );
 	}
@@ -62,6 +65,9 @@ public class ElasticsearchDocumentObjectBuilder implements DocumentElement {
 
 		ElasticsearchIndexSchemaObjectNode fieldSchemaNode = elasticsearchFieldReference.getSchemaNode();
 		checkTreeConsistency( fieldSchemaNode.getParent() );
+		if ( !fieldSchemaNode.isMultiValued() && elasticsearchFieldReference.hasValueIn( content ) ) {
+			throw log.multipleValuesForSingleValuedField( fieldSchemaNode.getAbsolutePath() );
+		}
 
 		JsonObject jsonObject = new JsonObject();
 		elasticsearchFieldReference.addTo( content, jsonObject );
@@ -78,6 +84,9 @@ public class ElasticsearchDocumentObjectBuilder implements DocumentElement {
 
 		ElasticsearchIndexSchemaObjectNode fieldSchemaNode = elasticsearchFieldReference.getSchemaNode();
 		checkTreeConsistency( fieldSchemaNode.getParent() );
+		if ( !fieldSchemaNode.isMultiValued() && elasticsearchFieldReference.hasValueIn( content ) ) {
+			throw log.multipleValuesForSingleValuedField( fieldSchemaNode.getAbsolutePath() );
+		}
 
 		elasticsearchFieldReference.addTo( content, null );
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/impl/ElasticsearchIndexFieldReference.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/impl/ElasticsearchIndexFieldReference.java
@@ -44,4 +44,8 @@ public class ElasticsearchIndexFieldReference<F> implements IndexFieldReference<
 	void addTo(JsonObject parent, F value) {
 		relativeAccessor.add( parent, schemaNode.getCodec().encode( value ) );
 	}
+
+	boolean hasValueIn(JsonObject parent) {
+		return relativeAccessor.hasExplicitValue( parent );
+	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/impl/ElasticsearchIndexObjectFieldReference.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/impl/ElasticsearchIndexObjectFieldReference.java
@@ -38,4 +38,8 @@ public class ElasticsearchIndexObjectFieldReference implements IndexObjectFieldR
 	void addTo(JsonObject parent, JsonObject value) {
 		relativeAccessor.add( parent, value );
 	}
+
+	boolean hasValueIn(JsonObject parent) {
+		return relativeAccessor.hasExplicitValue( parent );
+	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/dsl/impl/AbstractElasticsearchIndexSchemaObjectNodeBuilder.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/dsl/impl/AbstractElasticsearchIndexSchemaObjectNodeBuilder.java
@@ -12,7 +12,7 @@ import java.util.Map;
 
 import org.hibernate.search.backend.elasticsearch.types.impl.ElasticsearchIndexFieldType;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
-import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldTerminalContext;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldContext;
 import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
 import org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaObjectFieldNodeBuilder;
 import org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaObjectNodeBuilder;
@@ -40,7 +40,7 @@ public abstract class AbstractElasticsearchIndexSchemaObjectNodeBuilder implemen
 	}
 
 	@Override
-	public <F> IndexSchemaFieldTerminalContext<IndexFieldReference<F>> addField(
+	public <F> IndexSchemaFieldContext<?, IndexFieldReference<F>> addField(
 			String relativeFieldName, IndexFieldType<F> indexFieldType) {
 		ElasticsearchIndexFieldType<F> elasticsearchIndexFieldType = (ElasticsearchIndexFieldType<F>) indexFieldType;
 		ElasticsearchIndexSchemaFieldNodeBuilder<F> childBuilder = new ElasticsearchIndexSchemaFieldNodeBuilder<>(
@@ -51,7 +51,7 @@ public abstract class AbstractElasticsearchIndexSchemaObjectNodeBuilder implemen
 	}
 
 	@Override
-	public <F> IndexSchemaFieldTerminalContext<IndexFieldReference<F>> createExcludedField(
+	public <F> IndexSchemaFieldContext<?, IndexFieldReference<F>> createExcludedField(
 			String relativeFieldName, IndexFieldType<F> indexFieldType) {
 		ElasticsearchIndexFieldType<F> elasticsearchIndexFieldType = (ElasticsearchIndexFieldType<F>) indexFieldType;
 		return new ElasticsearchIndexSchemaFieldNodeBuilder<>(

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/dsl/impl/ElasticsearchIndexSchemaFieldNodeBuilder.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/dsl/impl/ElasticsearchIndexSchemaFieldNodeBuilder.java
@@ -37,6 +37,7 @@ class ElasticsearchIndexSchemaFieldNodeBuilder<F>
 	private final String relativeFieldName;
 	private final String absoluteFieldPath;
 	private final ElasticsearchIndexFieldType<F> type;
+	private boolean multiValued = false;
 
 	private ElasticsearchIndexFieldReference<F> reference;
 
@@ -56,7 +57,7 @@ class ElasticsearchIndexSchemaFieldNodeBuilder<F>
 
 	@Override
 	public ElasticsearchIndexSchemaFieldNodeBuilder<F> multiValued() {
-		// FIXME HSEARCH-3324 store and use this information
+		this.multiValued = true;
 		return this;
 	}
 
@@ -78,7 +79,9 @@ class ElasticsearchIndexSchemaFieldNodeBuilder<F>
 			throw log.incompleteFieldDefinition( getEventContext() );
 		}
 
-		ElasticsearchIndexSchemaFieldNode<F> fieldNode = type.addField( collector, parentNode, parentMapping, relativeFieldName );
+		ElasticsearchIndexSchemaFieldNode<F> fieldNode = type.addField(
+				collector, parentNode, parentMapping, relativeFieldName, multiValued
+		);
 		reference.enable( fieldNode );
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/dsl/impl/ElasticsearchIndexSchemaFieldNodeBuilder.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/dsl/impl/ElasticsearchIndexSchemaFieldNodeBuilder.java
@@ -19,7 +19,7 @@ import org.hibernate.search.backend.elasticsearch.logging.impl.Log;
 import org.hibernate.search.backend.elasticsearch.types.impl.ElasticsearchIndexFieldType;
 import org.hibernate.search.backend.elasticsearch.util.impl.ElasticsearchFields;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
-import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldTerminalContext;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldContext;
 import org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaBuildContext;
 import org.hibernate.search.engine.reporting.spi.EventContexts;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
@@ -28,7 +28,7 @@ import org.hibernate.search.util.common.reporting.EventContext;
 import com.google.gson.JsonElement;
 
 class ElasticsearchIndexSchemaFieldNodeBuilder<F>
-		implements IndexSchemaFieldTerminalContext<IndexFieldReference<F>>,
+		implements IndexSchemaFieldContext<ElasticsearchIndexSchemaFieldNodeBuilder<F>, IndexFieldReference<F>>,
 		ElasticsearchIndexSchemaNodeContributor,
 		IndexSchemaBuildContext {
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
@@ -52,6 +52,12 @@ class ElasticsearchIndexSchemaFieldNodeBuilder<F>
 	public EventContext getEventContext() {
 		return parent.getRootNodeBuilder().getIndexEventContext()
 				.append( EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
+	}
+
+	@Override
+	public ElasticsearchIndexSchemaFieldNodeBuilder<F> multiValued() {
+		// FIXME HSEARCH-3324 store and use this information
+		return this;
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/dsl/impl/ElasticsearchIndexSchemaObjectFieldNodeBuilder.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/dsl/impl/ElasticsearchIndexSchemaObjectFieldNodeBuilder.java
@@ -35,6 +35,7 @@ class ElasticsearchIndexSchemaObjectFieldNodeBuilder extends AbstractElasticsear
 	private final String absoluteFieldPath;
 	private final String relativeFieldName;
 	private final ObjectFieldStorage storage;
+	private boolean multiValued = false;
 
 	private ElasticsearchIndexObjectFieldReference reference;
 
@@ -56,7 +57,7 @@ class ElasticsearchIndexSchemaObjectFieldNodeBuilder extends AbstractElasticsear
 
 	@Override
 	public void multiValued() {
-		// FIXME HSEARCH-3324 store and use this information
+		this.multiValued = true;
 	}
 
 	@Override
@@ -77,7 +78,7 @@ class ElasticsearchIndexSchemaObjectFieldNodeBuilder extends AbstractElasticsear
 		}
 
 		ElasticsearchIndexSchemaObjectNode fieldNode =
-				new ElasticsearchIndexSchemaObjectNode( parentNode, absoluteFieldPath, storage );
+				new ElasticsearchIndexSchemaObjectNode( parentNode, absoluteFieldPath, storage, multiValued );
 		collector.collect( absoluteFieldPath, fieldNode );
 
 		reference.enable( fieldNode );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/dsl/impl/ElasticsearchIndexSchemaObjectFieldNodeBuilder.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/dsl/impl/ElasticsearchIndexSchemaObjectFieldNodeBuilder.java
@@ -55,6 +55,11 @@ class ElasticsearchIndexSchemaObjectFieldNodeBuilder extends AbstractElasticsear
 	}
 
 	@Override
+	public void multiValued() {
+		// FIXME HSEARCH-3324 store and use this information
+	}
+
+	@Override
 	public IndexObjectFieldReference toReference() {
 		if ( reference != null ) {
 			throw log.cannotCreateReferenceMultipleTimes( getEventContext() );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/impl/ElasticsearchIndexSchemaFieldNode.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/impl/ElasticsearchIndexSchemaFieldNode.java
@@ -18,6 +18,10 @@ public class ElasticsearchIndexSchemaFieldNode<F> {
 
 	private final ElasticsearchIndexSchemaObjectNode parent;
 
+	private final String absolutePath;
+
+	private final boolean multiValued;
+
 	private final ElasticsearchFieldCodec<F> codec;
 
 	private final ElasticsearchFieldPredicateBuilderFactory predicateBuilderFactory;
@@ -26,20 +30,34 @@ public class ElasticsearchIndexSchemaFieldNode<F> {
 
 	private final ElasticsearchFieldProjectionBuilderFactory projectionBuilderFactory;
 
-	public ElasticsearchIndexSchemaFieldNode(ElasticsearchIndexSchemaObjectNode parent,
+	public ElasticsearchIndexSchemaFieldNode(ElasticsearchIndexSchemaObjectNode parent, String relativeFieldName,
+			boolean multiValued,
 			ElasticsearchFieldCodec<F> codec,
 			ElasticsearchFieldPredicateBuilderFactory predicateBuilderFactory,
 			ElasticsearchFieldSortBuilderFactory sortBuilderFactory,
 			ElasticsearchFieldProjectionBuilderFactory projectionBuilderFactory) {
 		this.parent = parent;
+		this.absolutePath = parent.getAbsolutePath( relativeFieldName );
 		this.codec = codec;
 		this.predicateBuilderFactory = predicateBuilderFactory;
 		this.sortBuilderFactory = sortBuilderFactory;
 		this.projectionBuilderFactory = projectionBuilderFactory;
+		this.multiValued = multiValued;
 	}
 
 	public ElasticsearchIndexSchemaObjectNode getParent() {
 		return parent;
+	}
+
+	public String getAbsolutePath() {
+		return absolutePath;
+	}
+
+	/**
+	 * @return {@code true} if this node is multi-valued in its parent object.
+	 */
+	public boolean isMultiValued() {
+		return multiValued;
 	}
 
 	public ElasticsearchFieldCodec<F> getCodec() {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/impl/ElasticsearchIndexSchemaObjectNode.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/impl/ElasticsearchIndexSchemaObjectNode.java
@@ -14,7 +14,7 @@ import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage
 public class ElasticsearchIndexSchemaObjectNode {
 
 	private static final ElasticsearchIndexSchemaObjectNode ROOT =
-			new ElasticsearchIndexSchemaObjectNode( null, null, null );
+			new ElasticsearchIndexSchemaObjectNode( null, null, null, false );
 
 	public static ElasticsearchIndexSchemaObjectNode root() {
 		return ROOT;
@@ -26,11 +26,15 @@ public class ElasticsearchIndexSchemaObjectNode {
 
 	private final ObjectFieldStorage storage;
 
+	private final boolean multiValued;
+
 	public ElasticsearchIndexSchemaObjectNode(ElasticsearchIndexSchemaObjectNode parent, String absolutePath,
-			ObjectFieldStorage storage) {
+			ObjectFieldStorage storage,
+			boolean multiValued) {
 		this.parent = parent;
 		this.absolutePath = absolutePath;
-		this.storage = storage;
+		this.storage = ObjectFieldStorage.DEFAULT.equals( storage ) ? ObjectFieldStorage.FLATTENED : storage;
+		this.multiValued = multiValued;
 	}
 
 	@Override
@@ -52,5 +56,12 @@ public class ElasticsearchIndexSchemaObjectNode {
 
 	public ObjectFieldStorage getStorage() {
 		return storage;
+	}
+
+	/**
+	 * @return {@code true} if this node is multi-valued in its parent object.
+	 */
+	public boolean isMultiValued() {
+		return multiValued;
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/gson/impl/AbstractCrawlingJsonAccessor.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/gson/impl/AbstractCrawlingJsonAccessor.java
@@ -30,12 +30,18 @@ abstract class AbstractCrawlingJsonAccessor<P extends JsonElement> extends Abstr
 	protected JsonCompositeAccessor<P> getParentAccessor() {
 		return (JsonCompositeAccessor<P>) super.getParentAccessor();
 	}
+
 	@Override
 	public Optional<JsonElement> get(JsonObject root) throws UnexpectedJsonElementTypeException {
 		return getParentAccessor().get( root ).map( this::doGet );
 	}
 
 	protected abstract JsonElement doGet(P parent);
+
+	@Override
+	public boolean hasExplicitValue(JsonObject root) {
+		return getParentAccessor().get( root ).map( this::doGet ).isPresent();
+	}
 
 	@Override
 	public void set(JsonObject root, JsonElement newValue) throws UnexpectedJsonElementTypeException {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/gson/impl/AbstractTypingJsonAccessor.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/gson/impl/AbstractTypingJsonAccessor.java
@@ -32,6 +32,11 @@ abstract class AbstractTypingJsonAccessor<T> extends AbstractNonRootJsonAccessor
 	}
 
 	@Override
+	public boolean hasExplicitValue(JsonObject root) {
+		return getParentAccessor().hasExplicitValue( root );
+	}
+
+	@Override
 	public void set(JsonObject root, T newValue) throws UnexpectedJsonElementTypeException {
 		getParentAccessor().set( root, toElement( newValue ) );
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/gson/impl/JsonAccessor.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/gson/impl/JsonAccessor.java
@@ -36,6 +36,21 @@ public interface JsonAccessor<T> {
 	Optional<T> get(JsonObject root) throws UnexpectedJsonElementTypeException;
 
 	/**
+	 * Detects whether the element this accessor points to for the given {@code root} has an explicit value.
+	 * <p>
+	 * This method is slightly different from {@code get(root).isPresent()} in that it will return true
+	 * if the current value is {@link JsonNull#INSTANCE}, as it is considered as an explicit value.
+	 * Also, it will work fine if the leaf value has the wrong type (array of objects instead of object, for example).
+	 *
+	 * @param root The root to be accessed.
+	 * @return {@code true} if there is an explicit value (be it {@link JsonNull#INSTANCE} or a non-null value),
+	 * {@code false} otherwise.
+	 * @throws UnexpectedJsonElementTypeException If an element in the path has unexpected type,
+	 * preventing access to the element this accessor points to.
+	 */
+	boolean hasExplicitValue(JsonObject root);
+
+	/**
 	 * Set the given value on the element this accessor points to for the given {@code root}.
 	 *
 	 * @param root The root to be accessed.

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/gson/impl/RootJsonAccessor.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/gson/impl/RootJsonAccessor.java
@@ -31,6 +31,12 @@ class RootJsonAccessor implements JsonCompositeAccessor<JsonElement> {
 		return Optional.of( requireRoot( root ) );
 	}
 
+	@Override
+	public boolean hasExplicitValue(JsonObject root) {
+		requireRoot( root );
+		return true;
+	}
+
 	private JsonObject requireRoot(JsonObject root) {
 		if ( root == null ) {
 			throw new AssertionFailure( "A null root was encountered" );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
@@ -494,4 +494,10 @@ public interface Log extends BasicLogger {
 
 	@Message(id = ID_OFFSET_3 + 62, value = "Index-null-as option is not supported on analyzed field. Trying to define the analyzer: '%1$s' together with index null as: '%2$s'.")
 	SearchException cannotUseIndexNullAsAndAnalyzer(String analyzerName, String indexNullAs, @Param EventContext context);
+
+	@Message(id = ID_OFFSET_3 + 63,
+			value = "Multiple values were added to single-valued field '%1$s'."
+					+ " Declare the field as multi-valued in order to allow this."
+	)
+	SearchException multipleValuesForSingleValuedField(String absolutePath);
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/impl/ElasticsearchIndexFieldType.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/impl/ElasticsearchIndexFieldType.java
@@ -38,9 +38,11 @@ public class ElasticsearchIndexFieldType<F> implements IndexFieldType<F> {
 
 	public ElasticsearchIndexSchemaFieldNode<F> addField(ElasticsearchIndexSchemaNodeCollector collector,
 			ElasticsearchIndexSchemaObjectNode parentNode, AbstractTypeMapping parentMapping,
-			String relativeFieldName) {
+			String relativeFieldName, boolean multiValued) {
 		ElasticsearchIndexSchemaFieldNode<F> schemaNode = new ElasticsearchIndexSchemaFieldNode<>(
 				parentNode,
+				relativeFieldName,
+				multiValued,
 				codec,
 				predicateBuilderFactory,
 				sortBuilderFactory,

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/AbstractLuceneDocumentBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/AbstractLuceneDocumentBuilder.java
@@ -49,6 +49,9 @@ abstract class AbstractLuceneDocumentBuilder implements LuceneDocumentBuilder {
 
 		LuceneIndexSchemaFieldNode<F> fieldSchemaNode = luceneFieldReference.getSchemaNode();
 		checkTreeConsistency( fieldSchemaNode.getParent() );
+		if ( !fieldSchemaNode.isMultiValued() ) {
+			checkNoValueYetForSingleValued( fieldSchemaNode.getAbsoluteFieldPath() );
+		}
 
 		fieldSchemaNode.getCodec().encode( this, fieldSchemaNode.getAbsoluteFieldPath(), value );
 	}
@@ -62,6 +65,9 @@ abstract class AbstractLuceneDocumentBuilder implements LuceneDocumentBuilder {
 
 		LuceneIndexSchemaObjectNode fieldSchemaNode = luceneFieldReference.getSchemaNode();
 		checkTreeConsistency( fieldSchemaNode.getParent() );
+		if ( !fieldSchemaNode.isMultiValued() ) {
+			checkNoValueYetForSingleValued( fieldSchemaNode.getAbsolutePath() );
+		}
 
 		switch ( luceneFieldReference.getStorage() ) {
 			case NESTED:
@@ -78,8 +84,21 @@ abstract class AbstractLuceneDocumentBuilder implements LuceneDocumentBuilder {
 
 	@Override
 	public void addNullObject(IndexObjectFieldReference fieldReference) {
-		// we ignore the null objects
+		LuceneIndexObjectFieldReference luceneFieldReference = (LuceneIndexObjectFieldReference) fieldReference;
+		if ( !luceneFieldReference.isEnabled() ) {
+			return;
+		}
+
+		LuceneIndexSchemaObjectNode fieldSchemaNode = luceneFieldReference.getSchemaNode();
+		checkTreeConsistency( fieldSchemaNode.getParent() );
+		if ( !fieldSchemaNode.isMultiValued() ) {
+			checkNoValueYetForSingleValued( fieldSchemaNode.getAbsolutePath() );
+		}
+
+		// We do not add any value for null objects
 	}
+
+	abstract void checkNoValueYetForSingleValued(String absoluteFieldPath);
 
 	private void addNestedObjectDocumentBuilder(LuceneNestedObjectDocumentBuilder nestedObjectDocumentBuilder) {
 		if ( nestedObjectDocumentBuilders == null ) {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/AbstractLuceneDocumentBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/AbstractLuceneDocumentBuilder.java
@@ -26,7 +26,7 @@ import org.apache.lucene.document.Document;
 /**
  * @author Guillaume Smet
  */
-public abstract class AbstractLuceneDocumentBuilder implements LuceneDocumentBuilder {
+abstract class AbstractLuceneDocumentBuilder implements LuceneDocumentBuilder {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
@@ -36,7 +36,7 @@ public abstract class AbstractLuceneDocumentBuilder implements LuceneDocumentBui
 
 	private List<LuceneNestedObjectDocumentBuilder> nestedObjectDocumentBuilders;
 
-	protected AbstractLuceneDocumentBuilder(LuceneIndexSchemaObjectNode schemaNode) {
+	AbstractLuceneDocumentBuilder(LuceneIndexSchemaObjectNode schemaNode) {
 		this.schemaNode = schemaNode;
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/AbstractLuceneNonFlattenedDocumentBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/AbstractLuceneNonFlattenedDocumentBuilder.java
@@ -1,0 +1,56 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.document.impl;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexSchemaObjectNode;
+import org.hibernate.search.backend.lucene.multitenancy.impl.MultiTenancyStrategy;
+import org.hibernate.search.backend.lucene.util.impl.LuceneFields;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.IndexableField;
+
+/**
+ * @author Guillaume Smet
+ */
+abstract class AbstractLuceneNonFlattenedDocumentBuilder extends AbstractLuceneDocumentBuilder
+		implements LuceneDocumentBuilder {
+
+	final Document document = new Document();
+	private final Set<String> fieldNames = new HashSet<>();
+
+	AbstractLuceneNonFlattenedDocumentBuilder(LuceneIndexSchemaObjectNode schemaNode) {
+		super( schemaNode );
+	}
+
+	@Override
+	public void addField(IndexableField field) {
+		document.add( field );
+	}
+
+	@Override
+	public void addFieldName(String absoluteFieldPath) {
+		fieldNames.add( absoluteFieldPath );
+	}
+
+	@Override
+	void contribute(String rootIndexName, MultiTenancyStrategy multiTenancyStrategy, String tenantId, String rootId,
+			Document currentDocument, List<Document> nestedDocuments) {
+		for ( String fieldName : fieldNames ) {
+			document.add( new StringField( LuceneFields.fieldNamesFieldName(), fieldName, Field.Store.NO ) );
+		}
+
+		multiTenancyStrategy.contributeToIndexedDocument( document, tenantId );
+
+		super.contribute( rootIndexName, multiTenancyStrategy, tenantId, rootId, currentDocument, nestedDocuments );
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneFlattenedObjectDocumentBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneFlattenedObjectDocumentBuilder.java
@@ -6,7 +6,13 @@
  */
 package org.hibernate.search.backend.lucene.document.impl;
 
+import java.lang.invoke.MethodHandles;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexSchemaObjectNode;
+import org.hibernate.search.backend.lucene.logging.impl.Log;
+import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
 import org.apache.lucene.index.IndexableField;
 
@@ -15,7 +21,11 @@ import org.apache.lucene.index.IndexableField;
  */
 class LuceneFlattenedObjectDocumentBuilder extends AbstractLuceneDocumentBuilder {
 
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+
 	private final AbstractLuceneDocumentBuilder parent;
+
+	private final Set<String> encounteredFields = new HashSet<>();
 
 	LuceneFlattenedObjectDocumentBuilder(LuceneIndexSchemaObjectNode schemaNode, AbstractLuceneDocumentBuilder parent) {
 		super( schemaNode );
@@ -30,5 +40,13 @@ class LuceneFlattenedObjectDocumentBuilder extends AbstractLuceneDocumentBuilder
 	@Override
 	public void addFieldName(String absoluteFieldPath) {
 		parent.addFieldName( absoluteFieldPath );
+	}
+
+	@Override
+	void checkNoValueYetForSingleValued(String absoluteFieldPath) {
+		boolean firstEncounter = encounteredFields.add( absoluteFieldPath );
+		if ( !firstEncounter ) {
+			throw log.multipleValuesForSingleValuedField( absoluteFieldPath );
+		}
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneNestedObjectDocumentBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneNestedObjectDocumentBuilder.java
@@ -6,14 +6,11 @@
  */
 package org.hibernate.search.backend.lucene.document.impl;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field.Store;
 import org.apache.lucene.document.StringField;
-import org.apache.lucene.index.IndexableField;
 import org.hibernate.search.backend.lucene.util.impl.LuceneFields;
 import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexSchemaObjectNode;
 import org.hibernate.search.backend.lucene.multitenancy.impl.MultiTenancyStrategy;
@@ -21,41 +18,22 @@ import org.hibernate.search.backend.lucene.multitenancy.impl.MultiTenancyStrateg
 /**
  * @author Guillaume Smet
  */
-class LuceneNestedObjectDocumentBuilder extends AbstractLuceneDocumentBuilder {
-
-	private final Document nestedDocument = new Document();
-	private final Set<String> fieldNames = new HashSet<>();
+class LuceneNestedObjectDocumentBuilder extends AbstractLuceneNonFlattenedDocumentBuilder {
 
 	LuceneNestedObjectDocumentBuilder(LuceneIndexSchemaObjectNode schemaNode) {
 		super( schemaNode );
 	}
 
 	@Override
-	public void addField(IndexableField field) {
-		nestedDocument.add( field );
-	}
-
-	@Override
-	public void addFieldName(String absoluteFieldPath) {
-		fieldNames.add( absoluteFieldPath );
-	}
-
-	@Override
 	void contribute(String rootIndexName, MultiTenancyStrategy multiTenancyStrategy, String tenantId, String rootId, Document currentDocument,
 			List<Document> nestedDocuments) {
-		nestedDocument.add( new StringField( LuceneFields.typeFieldName(), LuceneFields.TYPE_CHILD_DOCUMENT, Store.YES ) );
-		nestedDocument.add( new StringField( LuceneFields.rootIndexFieldName(), rootIndexName, Store.YES ) );
-		nestedDocument.add( new StringField( LuceneFields.rootIdFieldName(), rootId, Store.YES ) );
-		nestedDocument.add( new StringField( LuceneFields.nestedDocumentPathFieldName(), schemaNode.getAbsolutePath(), Store.YES ) );
-
-		for ( String fieldName : fieldNames ) {
-			nestedDocument.add( new StringField( LuceneFields.fieldNamesFieldName(), fieldName, Store.NO ) );
-		}
-
-		multiTenancyStrategy.contributeToIndexedDocument( nestedDocument, tenantId );
+		document.add( new StringField( LuceneFields.typeFieldName(), LuceneFields.TYPE_CHILD_DOCUMENT, Store.YES ) );
+		document.add( new StringField( LuceneFields.rootIndexFieldName(), rootIndexName, Store.YES ) );
+		document.add( new StringField( LuceneFields.rootIdFieldName(), rootId, Store.YES ) );
+		document.add( new StringField( LuceneFields.nestedDocumentPathFieldName(), schemaNode.getAbsolutePath(), Store.YES ) );
 
 		// all the ancestors of a subdocument must be added after it
-		super.contribute( rootIndexName, multiTenancyStrategy, tenantId, rootId, nestedDocument, nestedDocuments );
-		nestedDocuments.add( nestedDocument );
+		super.contribute( rootIndexName, multiTenancyStrategy, tenantId, rootId, document, nestedDocuments );
+		nestedDocuments.add( document );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/dsl/impl/AbstractLuceneIndexSchemaObjectNodeBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/dsl/impl/AbstractLuceneIndexSchemaObjectNodeBuilder.java
@@ -16,7 +16,7 @@ import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexSchema
 import org.hibernate.search.backend.lucene.logging.impl.Log;
 import org.hibernate.search.backend.lucene.types.impl.LuceneIndexFieldType;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
-import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldTerminalContext;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldContext;
 import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
 import org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaBuildContext;
 import org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaObjectFieldNodeBuilder;
@@ -41,7 +41,7 @@ abstract class AbstractLuceneIndexSchemaObjectNodeBuilder
 	}
 
 	@Override
-	public <F> IndexSchemaFieldTerminalContext<IndexFieldReference<F>> addField(
+	public <F> IndexSchemaFieldContext<?, IndexFieldReference<F>> addField(
 			String relativeFieldName, IndexFieldType<F> indexFieldType) {
 		LuceneIndexFieldType<F> luceneIndexFieldType = (LuceneIndexFieldType<F>) indexFieldType;
 		LuceneIndexSchemaFieldNodeBuilder<F> childBuilder = new LuceneIndexSchemaFieldNodeBuilder<>(
@@ -52,7 +52,7 @@ abstract class AbstractLuceneIndexSchemaObjectNodeBuilder
 	}
 
 	@Override
-	public <F> IndexSchemaFieldTerminalContext<IndexFieldReference<F>> createExcludedField(
+	public <F> IndexSchemaFieldContext<?, IndexFieldReference<F>> createExcludedField(
 			String relativeFieldName, IndexFieldType<F> indexFieldType) {
 		LuceneIndexFieldType<F> luceneIndexFieldType = (LuceneIndexFieldType<F>) indexFieldType;
 		return new LuceneIndexSchemaFieldNodeBuilder<>(

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/dsl/impl/LuceneIndexSchemaFieldNodeBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/dsl/impl/LuceneIndexSchemaFieldNodeBuilder.java
@@ -17,14 +17,14 @@ import org.hibernate.search.backend.lucene.logging.impl.Log;
 import org.hibernate.search.backend.lucene.types.impl.LuceneIndexFieldType;
 import org.hibernate.search.backend.lucene.util.impl.LuceneFields;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
-import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldTerminalContext;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldContext;
 import org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaBuildContext;
 import org.hibernate.search.engine.reporting.spi.EventContexts;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 import org.hibernate.search.util.common.reporting.EventContext;
 
 class LuceneIndexSchemaFieldNodeBuilder<F>
-		implements IndexSchemaFieldTerminalContext<IndexFieldReference<F>>,
+		implements IndexSchemaFieldContext<LuceneIndexSchemaFieldNodeBuilder<F>, IndexFieldReference<F>>,
 		LuceneIndexSchemaNodeContributor, IndexSchemaBuildContext {
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
@@ -47,6 +47,12 @@ class LuceneIndexSchemaFieldNodeBuilder<F>
 	public EventContext getEventContext() {
 		return parent.getRootNodeBuilder().getIndexEventContext()
 				.append( EventContexts.fromIndexFieldAbsolutePath( absoluteFieldPath ) );
+	}
+
+	@Override
+	public LuceneIndexSchemaFieldNodeBuilder<F> multiValued() {
+		// FIXME HSEARCH-3324 store and use this information
+		return this;
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/dsl/impl/LuceneIndexSchemaFieldNodeBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/dsl/impl/LuceneIndexSchemaFieldNodeBuilder.java
@@ -32,6 +32,7 @@ class LuceneIndexSchemaFieldNodeBuilder<F>
 	private final String relativeFieldName;
 	private final String absoluteFieldPath;
 	private final LuceneIndexFieldType<F> type;
+	private boolean multiValued = false;
 
 	private LuceneIndexFieldReference<F> reference;
 
@@ -51,7 +52,7 @@ class LuceneIndexSchemaFieldNodeBuilder<F>
 
 	@Override
 	public LuceneIndexSchemaFieldNodeBuilder<F> multiValued() {
-		// FIXME HSEARCH-3324 store and use this information
+		this.multiValued = true;
 		return this;
 	}
 
@@ -69,7 +70,9 @@ class LuceneIndexSchemaFieldNodeBuilder<F>
 		if ( reference == null ) {
 			throw log.incompleteFieldDefinition( getEventContext() );
 		}
-		LuceneIndexSchemaFieldNode<F> fieldNode = type.addField( collector, parentNode, relativeFieldName );
+		LuceneIndexSchemaFieldNode<F> fieldNode = type.addField(
+				collector, parentNode, relativeFieldName, multiValued
+		);
 		reference.enable( fieldNode );
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/dsl/impl/LuceneIndexSchemaObjectFieldNodeBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/dsl/impl/LuceneIndexSchemaObjectFieldNodeBuilder.java
@@ -45,6 +45,11 @@ class LuceneIndexSchemaObjectFieldNodeBuilder extends AbstractLuceneIndexSchemaO
 	}
 
 	@Override
+	public void multiValued() {
+		// FIXME HSEARCH-3324 store and use this information
+	}
+
+	@Override
 	public IndexObjectFieldReference toReference() {
 		if ( reference != null ) {
 			throw log.cannotCreateReferenceMultipleTimes( getEventContext() );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/dsl/impl/LuceneIndexSchemaObjectFieldNodeBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/dsl/impl/LuceneIndexSchemaObjectFieldNodeBuilder.java
@@ -28,6 +28,7 @@ class LuceneIndexSchemaObjectFieldNodeBuilder extends AbstractLuceneIndexSchemaO
 	private final AbstractLuceneIndexSchemaObjectNodeBuilder parent;
 	private final String absoluteFieldPath;
 	private final ObjectFieldStorage storage;
+	private boolean multiValued = false;
 
 	private LuceneIndexObjectFieldReference reference;
 
@@ -46,7 +47,7 @@ class LuceneIndexSchemaObjectFieldNodeBuilder extends AbstractLuceneIndexSchemaO
 
 	@Override
 	public void multiValued() {
-		// FIXME HSEARCH-3324 store and use this information
+		this.multiValued = true;
 	}
 
 	@Override
@@ -64,7 +65,9 @@ class LuceneIndexSchemaObjectFieldNodeBuilder extends AbstractLuceneIndexSchemaO
 			throw log.incompleteFieldDefinition( getEventContext() );
 		}
 
-		LuceneIndexSchemaObjectNode node = new LuceneIndexSchemaObjectNode( parentNode, absoluteFieldPath, storage );
+		LuceneIndexSchemaObjectNode node = new LuceneIndexSchemaObjectNode(
+				parentNode, absoluteFieldPath, storage, multiValued
+		);
 		collector.collectObjectNode( absoluteFieldPath, node );
 
 		reference.enable( node );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/impl/LuceneIndexSchemaFieldNode.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/impl/LuceneIndexSchemaFieldNode.java
@@ -30,6 +30,8 @@ public class LuceneIndexSchemaFieldNode<F> {
 
 	private final String absoluteFieldPath;
 
+	private final boolean multiValued;
+
 	private final LuceneFieldCodec<F> codec;
 
 	private final LuceneFieldPredicateBuilderFactory predicateBuilderFactory;
@@ -39,6 +41,7 @@ public class LuceneIndexSchemaFieldNode<F> {
 	private final LuceneFieldProjectionBuilderFactory projectionBuilderFactory;
 
 	public LuceneIndexSchemaFieldNode(LuceneIndexSchemaObjectNode parent, String relativeFieldName,
+			boolean multiValued,
 			LuceneFieldCodec<F> codec,
 			LuceneFieldPredicateBuilderFactory predicateBuilderFactory,
 			LuceneFieldSortBuilderFactory sortBuilderFactory,
@@ -46,6 +49,7 @@ public class LuceneIndexSchemaFieldNode<F> {
 		this.parent = parent;
 		this.relativeFieldName = relativeFieldName;
 		this.absoluteFieldPath = parent.getAbsolutePath( relativeFieldName );
+		this.multiValued = multiValued;
 		this.codec = codec;
 		this.predicateBuilderFactory = predicateBuilderFactory;
 		this.sortBuilderFactory = sortBuilderFactory;
@@ -58,6 +62,13 @@ public class LuceneIndexSchemaFieldNode<F> {
 
 	public String getAbsoluteFieldPath() {
 		return absoluteFieldPath;
+	}
+
+	/**
+	 * @return {@code true} if this node is multi-valued in its parent object.
+	 */
+	public boolean isMultiValued() {
+		return multiValued;
 	}
 
 	public LuceneFieldPredicateBuilderFactory getPredicateBuilderFactory() {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/impl/LuceneIndexSchemaObjectNode.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/impl/LuceneIndexSchemaObjectNode.java
@@ -14,7 +14,8 @@ import org.hibernate.search.backend.lucene.util.impl.LuceneFields;
  */
 public class LuceneIndexSchemaObjectNode {
 
-	private static final LuceneIndexSchemaObjectNode ROOT = new LuceneIndexSchemaObjectNode( null, null, null );
+	private static final LuceneIndexSchemaObjectNode ROOT =
+			new LuceneIndexSchemaObjectNode( null, null, null, false );
 
 	public static LuceneIndexSchemaObjectNode root() {
 		return ROOT;
@@ -26,11 +27,14 @@ public class LuceneIndexSchemaObjectNode {
 
 	private final ObjectFieldStorage storage;
 
+	private final boolean multiValued;
+
 	public LuceneIndexSchemaObjectNode(LuceneIndexSchemaObjectNode parent, String absolutePath,
-			ObjectFieldStorage storage) {
+			ObjectFieldStorage storage, boolean multiValued) {
 		this.parent = parent;
 		this.absolutePath = absolutePath;
 		this.storage = storage;
+		this.multiValued = multiValued;
 	}
 
 	public LuceneIndexSchemaObjectNode getParent() {
@@ -49,8 +53,15 @@ public class LuceneIndexSchemaObjectNode {
 		return storage;
 	}
 
+	/**
+	 * @return {@code true} if this node is multi-valued in its parent object.
+	 */
+	public boolean isMultiValued() {
+		return multiValued;
+	}
+
 	@Override
-		public String toString() {
-			return getClass().getSimpleName() + "[absolutePath=" + absolutePath + ", storage=" + storage + "]";
+	public String toString() {
+		return getClass().getSimpleName() + "[absolutePath=" + absolutePath + ", storage=" + storage + "]";
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
@@ -431,4 +431,10 @@ public interface Log extends BasicLogger {
 
 	@Message(id = ID_OFFSET_2 + 73, value = "Index-null-as option is not supported on analyzed field. Trying to define the analyzer: '%1$s' together with index null as: '%2$s'.")
 	SearchException cannotUseIndexNullAsAndAnalyzer(String analyzerName, String indexNullAs, @Param EventContext context);
+
+	@Message(id = ID_OFFSET_2 + 74,
+			value = "Multiple values were added to single-valued field '%1$s'."
+					+ " Declare the field as multi-valued in order to allow this."
+	)
+	SearchException multipleValuesForSingleValuedField(String absoluteFieldPath);
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/impl/LuceneIndexFieldType.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/impl/LuceneIndexFieldType.java
@@ -24,7 +24,8 @@ public class LuceneIndexFieldType<F> implements IndexFieldType<F> {
 	private final LuceneFieldProjectionBuilderFactory projectionBuilderFactory;
 	private final Analyzer analyzerOrNormalizer;
 
-	public LuceneIndexFieldType(LuceneFieldCodec<F> codec,
+	public LuceneIndexFieldType(
+			LuceneFieldCodec<F> codec,
 			LuceneFieldPredicateBuilderFactory predicateBuilderFactory,
 			LuceneFieldSortBuilderFactory sortBuilderFactory,
 			LuceneFieldProjectionBuilderFactory projectionBuilderFactory) {
@@ -44,10 +45,11 @@ public class LuceneIndexFieldType<F> implements IndexFieldType<F> {
 	}
 
 	public LuceneIndexSchemaFieldNode<F> addField(LuceneIndexSchemaNodeCollector collector,
-			LuceneIndexSchemaObjectNode parentNode, String relativeFieldName) {
+			LuceneIndexSchemaObjectNode parentNode, String relativeFieldName, boolean multiValued) {
 		LuceneIndexSchemaFieldNode<F> schemaNode = new LuceneIndexSchemaFieldNode<>(
 				parentNode,
 				relativeFieldName,
+				multiValued,
 				codec,
 				predicateBuilderFactory,
 				sortBuilderFactory,

--- a/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/IndexSchemaElement.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/IndexSchemaElement.java
@@ -27,7 +27,7 @@ public interface IndexSchemaElement {
 	 * @param <F> The type of values held by the field.
 	 * @return A context allowing to get the reference to that new field.
 	 */
-	<F> IndexSchemaFieldTerminalContext<IndexFieldReference<F>> field(
+	<F> IndexSchemaFieldContext<?, IndexFieldReference<F>> field(
 			String relativeFieldName, IndexFieldType<F> type);
 
 	/**
@@ -38,7 +38,7 @@ public interface IndexSchemaElement {
 	 * @param <F> The type of values held by the field.
 	 * @return A context allowing to get the reference to that new field.
 	 */
-	default <F> IndexSchemaFieldTerminalContext<IndexFieldReference<F>> field(
+	default <F> IndexSchemaFieldContext<?, IndexFieldReference<F>> field(
 			String relativeFieldName, IndexFieldTypeTerminalContext<F> terminalContext) {
 		return field( relativeFieldName, terminalContext.toIndexFieldType() );
 	}
@@ -55,7 +55,7 @@ public interface IndexSchemaElement {
 	 * @param <F> The type of accessors for the new field.
 	 * @return A context allowing to get the reference to that new field.
 	 */
-	<F> IndexSchemaFieldTerminalContext<IndexFieldReference<F>> field(String relativeFieldName,
+	<F> IndexSchemaFieldContext<?, IndexFieldReference<F>> field(String relativeFieldName,
 			Function<? super IndexFieldTypeFactoryContext, ? extends IndexFieldTypeTerminalContext<F>> typeContributor);
 
 	/**

--- a/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/IndexSchemaFieldContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/IndexSchemaFieldContext.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.backend.document.model.dsl;
+
+/**
+ * @param <S> The exposed type for this context.
+ * @param <R> The reference type.
+ */
+public interface IndexSchemaFieldContext<S extends IndexSchemaFieldContext<?, R>, R> extends IndexSchemaFieldTerminalContext<R> {
+
+	/**
+	 * Mark the field as multi-valued.
+	 * <p>
+	 * This informs the backend that this field may contain multiple values for a single parent document or object.
+	 * @return {@code this}, for method chaining.
+	 */
+	S multiValued();
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/IndexSchemaObjectField.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/IndexSchemaObjectField.java
@@ -9,6 +9,6 @@ package org.hibernate.search.engine.backend.document.model.dsl;
 import org.hibernate.search.engine.backend.document.IndexObjectFieldReference;
 
 public interface IndexSchemaObjectField
-		extends IndexSchemaElement, IndexSchemaFieldTerminalContext<IndexObjectFieldReference> {
+		extends IndexSchemaElement, IndexSchemaFieldContext<IndexSchemaObjectField, IndexObjectFieldReference> {
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/impl/IndexSchemaElementImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/impl/IndexSchemaElementImpl.java
@@ -11,7 +11,7 @@ import java.util.function.Function;
 
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
-import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldTerminalContext;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldContext;
 import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeFactoryContext;
 import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectField;
@@ -48,7 +48,7 @@ public class IndexSchemaElementImpl<B extends IndexSchemaObjectNodeBuilder> impl
 	}
 
 	@Override
-	public <F> IndexSchemaFieldTerminalContext<IndexFieldReference<F>> field(
+	public <F> IndexSchemaFieldContext<?, IndexFieldReference<F>> field(
 			String relativeFieldName, IndexFieldType<F> type) {
 		checkRelativeFieldName( relativeFieldName );
 		return nestingContext.nest(
@@ -61,7 +61,7 @@ public class IndexSchemaElementImpl<B extends IndexSchemaObjectNodeBuilder> impl
 	}
 
 	@Override
-	public <F> IndexSchemaFieldTerminalContext<IndexFieldReference<F>> field(String relativeFieldName,
+	public <F> IndexSchemaFieldContext<?, IndexFieldReference<F>> field(String relativeFieldName,
 			Function<? super IndexFieldTypeFactoryContext, ? extends IndexFieldTypeTerminalContext<F>> typeContributor) {
 		return field( relativeFieldName, typeContributor.apply( typeFactoryContext ) );
 	}

--- a/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/impl/IndexSchemaObjectFieldImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/impl/IndexSchemaObjectFieldImpl.java
@@ -16,8 +16,9 @@ class IndexSchemaObjectFieldImpl extends IndexSchemaElementImpl<IndexSchemaObjec
 
 	IndexSchemaObjectFieldImpl(IndexFieldTypeFactoryContext typeFactoryContext,
 			IndexSchemaObjectFieldNodeBuilder objectFieldBuilder,
-			IndexSchemaNestingContext nestingContext) {
-		super( typeFactoryContext, objectFieldBuilder, nestingContext );
+			IndexSchemaNestingContext nestingContext,
+			boolean directChildrenAreMultiValuedByDefault) {
+		super( typeFactoryContext, objectFieldBuilder, nestingContext, directChildrenAreMultiValuedByDefault );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/impl/IndexSchemaObjectFieldImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/impl/IndexSchemaObjectFieldImpl.java
@@ -21,6 +21,12 @@ class IndexSchemaObjectFieldImpl extends IndexSchemaElementImpl<IndexSchemaObjec
 	}
 
 	@Override
+	public IndexSchemaObjectField multiValued() {
+		objectNodeBuilder.multiValued();
+		return this;
+	}
+
+	@Override
 	public IndexObjectFieldReference toReference() {
 		return objectNodeBuilder.toReference();
 	}

--- a/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/spi/IndexSchemaObjectFieldNodeBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/spi/IndexSchemaObjectFieldNodeBuilder.java
@@ -10,6 +10,12 @@ import org.hibernate.search.engine.backend.document.IndexObjectFieldReference;
 
 public interface IndexSchemaObjectFieldNodeBuilder extends IndexSchemaObjectNodeBuilder {
 
-	IndexObjectFieldReference toReference();
+	/**
+	 * Mark the current node as multi-valued.
+	 * <p>
+	 * This informs the backend that this field may contain multiple objects for a single document.
+	 */
+	void multiValued();
 
+	IndexObjectFieldReference toReference();
 }

--- a/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/spi/IndexSchemaObjectNodeBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/spi/IndexSchemaObjectNodeBuilder.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.engine.backend.document.model.dsl.spi;
 
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
-import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldTerminalContext;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldContext;
 import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
 import org.hibernate.search.engine.backend.types.IndexFieldType;
 
@@ -21,7 +21,7 @@ public interface IndexSchemaObjectNodeBuilder extends IndexSchemaBuildContext {
 	 * @param <F> The type of values for the new field
 	 * @return A context allowing to define the new field
 	 */
-	<F> IndexSchemaFieldTerminalContext<IndexFieldReference<F>> addField(String relativeFieldName, IndexFieldType<F> indexFieldType);
+	<F> IndexSchemaFieldContext<?, IndexFieldReference<F>> addField(String relativeFieldName, IndexFieldType<F> indexFieldType);
 
 	/**
 	 * Create a new field, but do not add it to the current builder.
@@ -34,7 +34,7 @@ public interface IndexSchemaObjectNodeBuilder extends IndexSchemaBuildContext {
 	 * @param <F> The type of values for the new field
 	 * @return A context allowing to define the new field
 	 */
-	<F> IndexSchemaFieldTerminalContext<IndexFieldReference<F>> createExcludedField(String relativeFieldName, IndexFieldType<F> indexFieldType);
+	<F> IndexSchemaFieldContext<?, IndexFieldReference<F>> createExcludedField(String relativeFieldName, IndexFieldType<F> indexFieldType);
 
 	/**
 	 * Create a new object field and add it to the current builder.

--- a/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/building/impl/IndexedEmbeddedBindingContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/building/impl/IndexedEmbeddedBindingContextImpl.java
@@ -20,12 +20,16 @@ class IndexedEmbeddedBindingContextImpl
 		implements IndexedEmbeddedBindingContext {
 	private final Collection<IndexObjectFieldReference> parentIndexObjectReferences;
 
+	private final boolean parentMultivaluedAndWithoutObjectField;
+
 	IndexedEmbeddedBindingContextImpl(IndexSchemaRootNodeBuilder indexSchemaRootNodeBuilder,
 			IndexSchemaObjectNodeBuilder indexSchemaObjectNodeBuilder,
 			Collection<IndexObjectFieldReference> parentIndexObjectReferences,
-			ConfiguredIndexSchemaNestingContext nestingContext) {
+			ConfiguredIndexSchemaNestingContext nestingContext,
+			boolean parentMultivaluedAndWithoutObjectField) {
 		super( indexSchemaRootNodeBuilder, indexSchemaObjectNodeBuilder, nestingContext );
 		this.parentIndexObjectReferences = Collections.unmodifiableCollection( parentIndexObjectReferences );
+		this.parentMultivaluedAndWithoutObjectField = parentMultivaluedAndWithoutObjectField;
 	}
 
 	@Override
@@ -41,5 +45,10 @@ class IndexedEmbeddedBindingContextImpl
 	@Override
 	public Set<String> getEncounteredFieldPaths() {
 		return nestingContext.getEncounteredFieldPaths();
+	}
+
+	@Override
+	boolean isParentMultivaluedAndWithoutObjectField() {
+		return parentMultivaluedAndWithoutObjectField;
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/building/impl/IndexedEntityBindingContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/building/impl/IndexedEntityBindingContextImpl.java
@@ -26,4 +26,10 @@ public class IndexedEntityBindingContextImpl extends AbstractIndexBindingContext
 	public void idDslConverter(ToDocumentIdentifierValueConverter<?> idConverter) {
 		indexSchemaObjectNodeBuilder.idDslConverter( idConverter );
 	}
+
+	@Override
+	boolean isParentMultivaluedAndWithoutObjectField() {
+		// The root has no parent
+		return false;
+	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/building/spi/IndexBindingContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/building/spi/IndexBindingContext.java
@@ -42,12 +42,15 @@ public interface IndexBindingContext {
 
 	/**
 	 * @param parentTypeModel The model representing the type holding the property with an indexed-embedded.
+	 * @param multiValued Whether the property with an indexed-embedded is to be considered as multi-valued
+	 * (i.e. multiple indexed-embedded objects may be processed for a single "embedding" object).
 	 * @param relativePrefix The prefix to apply to all index fields created in the context of the indexed-embedded.
 	 * @param storage The storage type to use for all object fields created as part of the {@code relativePrefix}.
 	 * @param maxDepth The maximum depth beyond which all created fields will be ignored. {@code null} for no limit.
 	 * @param includePaths The exhaustive list of paths of fields that are to be included. {@code null} for no limit.
 	 * @return The element in the index schema that this context points to.
 	 */
-	Optional<IndexedEmbeddedBindingContext> addIndexedEmbeddedIfIncluded(MappableTypeModel parentTypeModel,
+	Optional<IndexedEmbeddedBindingContext> addIndexedEmbeddedIfIncluded(
+			MappableTypeModel parentTypeModel, boolean multiValued,
 			String relativePrefix, ObjectFieldStorage storage, Integer maxDepth, Set<String> includePaths);
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/DocumentElementIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/DocumentElementIT.java
@@ -36,7 +36,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 /**
- * Test the behavior of implementations of implementations of {@link DocumentElement}.
+ * Test the behavior of implementations of {@link DocumentElement}.
  */
 public class DocumentElementIT {
 
@@ -287,7 +287,7 @@ public class DocumentElementIT {
 
 			// Simulate an embedded context which excludes every subfield
 			IndexedEmbeddedBindingContext excludingEmbeddedContext = ctx.addIndexedEmbeddedIfIncluded(
-					new StubTypeModel( "embedded" ),
+					new StubTypeModel( "embedded" ), true,
 					"excludingObject.", ObjectFieldStorage.FLATTENED,
 					null, Collections.singleton( "pathThatDoesNotMatchAnything" )
 			).get();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/DocumentElementIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/DocumentElementIT.java
@@ -278,9 +278,11 @@ public class DocumentElementIT {
 		IndexMapping(IndexBindingContext ctx) {
 			super( ctx.getSchemaElement() );
 			IndexSchemaElement root = ctx.getSchemaElement();
-			IndexSchemaObjectField flattenedObjectField = root.objectField( "flattenedObject", ObjectFieldStorage.FLATTENED );
+			IndexSchemaObjectField flattenedObjectField = root.objectField( "flattenedObject", ObjectFieldStorage.FLATTENED )
+					.multiValued();
 			flattenedObject = new FirstLevelObjectMapping( flattenedObjectField );
-			IndexSchemaObjectField nestedObjectField = root.objectField( "nestedObject", ObjectFieldStorage.NESTED );
+			IndexSchemaObjectField nestedObjectField = root.objectField( "nestedObject", ObjectFieldStorage.NESTED )
+					.multiValued();
 			nestedObject = new FirstLevelObjectMapping( nestedObjectField );
 
 			// Simulate an embedded context which excludes every subfield
@@ -309,9 +311,11 @@ public class DocumentElementIT {
 		FirstLevelObjectMapping(IndexSchemaElement objectField, IndexObjectFieldReference objectFieldReference) {
 			super( objectField );
 			self = objectFieldReference;
-			IndexSchemaObjectField flattenedObjectField = objectField.objectField( "flattenedObject", ObjectFieldStorage.FLATTENED );
+			IndexSchemaObjectField flattenedObjectField = objectField.objectField( "flattenedObject", ObjectFieldStorage.FLATTENED )
+					.multiValued();
 			flattenedObject = new SecondLevelObjectMapping( flattenedObjectField );
-			IndexSchemaObjectField nestedObjectField = objectField.objectField( "nestedObject", ObjectFieldStorage.NESTED );
+			IndexSchemaObjectField nestedObjectField = objectField.objectField( "nestedObject", ObjectFieldStorage.NESTED )
+					.multiValued();
 			nestedObject = new SecondLevelObjectMapping( nestedObjectField );
 		}
 	}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/DocumentElementIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/DocumentElementIT.java
@@ -60,20 +60,20 @@ public class DocumentElementIT {
 	}
 
 	/**
-	 * Test that DocumentElement.add does not throw any exception when passing a non-null value.
+	 * Test that DocumentElement.addValue does not throw any exception when passing a non-null value.
 	 */
 	@Test
-	public void add_nonNull() {
+	public void addValue_nonNull() {
 		executeAdd( "1", document -> {
 			setNonNullValues( indexMapping, document );
 		} );
 	}
 
 	/**
-	 * Test that DocumentElement.add does not throw any exception when passing a null value.
+	 * Test that DocumentElement.addValue does not throw any exception when passing a null value.
 	 */
 	@Test
-	public void add_null() {
+	public void addValue_null() {
 		executeAdd( "1", document -> {
 			setNullValues( indexMapping, document );
 		} );
@@ -81,7 +81,7 @@ public class DocumentElementIT {
 
 	/**
 	 * Test that DocumentElement.addObject does not throw any exception,
-	 * add that DocumentElement.add does not throw an exception for returned objects.
+	 * add that DocumentElement.addValue does not throw an exception for returned objects.
 	 */
 	@Test
 	public void addObject() {
@@ -135,10 +135,10 @@ public class DocumentElementIT {
 	}
 
 	/**
-	 * Test that DocumentElement.add does not throw any exception when passing a reference to an excluded field.
+	 * Test that DocumentElement.addValue does not throw any exception when passing a reference to an excluded field.
 	 */
 	@Test
-	public void add_excludedFields() {
+	public void addValue_excludedFields() {
 		executeAdd( "1", document -> {
 			DocumentElement excludingObject = document.addObject( indexMapping.excludingObject.self );
 			setNonNullValues( indexMapping.excludingObject, excludingObject );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/MultiTenancyIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/MultiTenancyIT.java
@@ -615,7 +615,7 @@ public class MultiTenancyIT {
 			integer = root.field( "integer", f -> f.asInteger().projectable( Projectable.YES ) )
 					.toReference();
 			IndexSchemaObjectField nestedObjectField =
-					root.objectField( "nestedObject", ObjectFieldStorage.NESTED );
+					root.objectField( "nestedObject", ObjectFieldStorage.NESTED ).multiValued();
 			nestedObject = new ObjectMapping( nestedObjectField );
 		}
 	}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/ObjectFieldStorageIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/ObjectFieldStorageIT.java
@@ -338,9 +338,11 @@ public class ObjectFieldStorageIT {
 
 		IndexMapping(IndexSchemaElement root) {
 			string = root.field( "string", f -> f.asString() ).toReference();
-			IndexSchemaObjectField flattenedObjectField = root.objectField( "flattenedObject", ObjectFieldStorage.FLATTENED );
+			IndexSchemaObjectField flattenedObjectField = root.objectField( "flattenedObject", ObjectFieldStorage.FLATTENED )
+					.multiValued();
 			flattenedObject = new ObjectMapping( flattenedObjectField );
-			IndexSchemaObjectField nestedObjectField = root.objectField( "nestedObject", ObjectFieldStorage.NESTED );
+			IndexSchemaObjectField nestedObjectField = root.objectField( "nestedObject", ObjectFieldStorage.NESTED )
+					.multiValued();
 			nestedObject = new ObjectMapping( nestedObjectField );
 		}
 	}
@@ -354,13 +356,17 @@ public class ObjectFieldStorageIT {
 
 		ObjectMapping(IndexSchemaObjectField objectField) {
 			self = objectField.toReference();
-			string = objectField.field( "string", f -> f.asString() ).toReference();
+			string = objectField.field( "string", f -> f.asString() )
+					.multiValued()
+					.toReference();
 			string_analyzed = objectField.field(
 					"string_analyzed",
 					f -> f.asString().analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD_ENGLISH.name )
 			)
 					.toReference();
-			integer = objectField.field( "integer", f -> f.asInteger() ).toReference();
+			integer = objectField.field( "integer", f -> f.asInteger() )
+					.multiValued()
+					.toReference();
 			localDate = objectField.field( "localDate", f -> f.asLocalDate() ).toReference();
 		}
 	}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/SmokeIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/SmokeIT.java
@@ -367,9 +367,11 @@ public class SmokeIT {
 			integer = root.field( "integer", f -> f.asInteger() ).toReference();
 			localDate = root.field( "localDate", f -> f.asLocalDate() ).toReference();
 			geoPoint = root.field( "geoPoint", f -> f.asGeoPoint() ).toReference();
-			IndexSchemaObjectField flattenedObjectField = root.objectField( "flattenedObject", ObjectFieldStorage.FLATTENED );
+			IndexSchemaObjectField flattenedObjectField = root.objectField( "flattenedObject", ObjectFieldStorage.FLATTENED )
+					.multiValued();
 			flattenedObject = new ObjectMapping( flattenedObjectField );
-			IndexSchemaObjectField nestedObjectField = root.objectField( "nestedObject", ObjectFieldStorage.NESTED );
+			IndexSchemaObjectField nestedObjectField = root.objectField( "nestedObject", ObjectFieldStorage.NESTED )
+					.multiValued();
 			nestedObject = new ObjectMapping( nestedObjectField );
 		}
 	}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentElementBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentElementBaseIT.java
@@ -36,9 +36,9 @@ import org.junit.Rule;
 import org.junit.Test;
 
 /**
- * Test the behavior of implementations of {@link DocumentElement}.
+ * Test the basic behavior of implementations of {@link DocumentElement}.
  */
-public class DocumentElementIT {
+public class DocumentElementBaseIT {
 
 	private static final String INDEX_NAME = "IndexName";
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentElementIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentElementIT.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.integrationtest.backend.tck;
+package org.hibernate.search.integrationtest.backend.tck.document;
 
 import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentElementMultiValuedIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentElementMultiValuedIT.java
@@ -1,0 +1,343 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.tck.document;
+
+import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+
+import java.util.function.Consumer;
+
+import org.hibernate.search.engine.backend.document.DocumentElement;
+import org.hibernate.search.engine.backend.document.IndexFieldReference;
+import org.hibernate.search.engine.backend.document.IndexObjectFieldReference;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectField;
+import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
+import org.hibernate.search.engine.backend.index.spi.IndexWorkPlan;
+import org.hibernate.search.engine.mapper.mapping.building.spi.IndexBindingContext;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
+import org.hibernate.search.util.common.SearchException;
+import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.test.SubTest;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Test the behavior of implementations of {@link DocumentElement}
+ * when it comes to multi-valued fields.
+ */
+public class DocumentElementMultiValuedIT {
+
+	private static final String INDEX_NAME = "IndexName";
+
+	@Rule
+	public SearchSetupHelper setupHelper = new SearchSetupHelper();
+
+	private IndexMapping indexMapping;
+	private StubMappingIndexManager indexManager;
+
+	@Before
+	public void setup() {
+		setupHelper.withDefaultConfiguration()
+				.withIndex(
+						INDEX_NAME,
+						ctx -> this.indexMapping = new IndexMapping( ctx ),
+						indexManager -> this.indexManager = indexManager
+				)
+				.setup();
+	}
+
+	@Test
+	public void addValue_root() {
+		expectSuccess( "1", document -> {
+			document.addValue( indexMapping.singleValuedString, "1" );
+		} );
+		expectSingleValuedException( "2", "singleValuedString", document -> {
+			document.addValue( indexMapping.singleValuedString, "1" );
+			document.addValue( indexMapping.singleValuedString, "2" );
+		} );
+		expectSuccess( "3", document -> {
+			document.addValue( indexMapping.multiValuedString, "1" );
+		} );
+		expectSuccess( "4", document -> {
+			document.addValue( indexMapping.multiValuedString, "1" );
+			document.addValue( indexMapping.multiValuedString, "2" );
+			document.addValue( indexMapping.multiValuedString, "3" );
+		} );
+	}
+
+	@Test
+	public void addObject_flattened() {
+		expectSuccess( "1", document -> {
+			document.addObject( indexMapping.singleValuedFlattenedObject.self );
+		} );
+		expectSingleValuedException( "2", "singleValuedFlattenedObject", document -> {
+			document.addObject( indexMapping.singleValuedFlattenedObject.self );
+			document.addObject( indexMapping.singleValuedFlattenedObject.self );
+		} );
+		expectSuccess( "3", document -> {
+			document.addObject( indexMapping.multiValuedFlattenedObject.self );
+		} );
+		expectSuccess( "4", document -> {
+			document.addObject( indexMapping.multiValuedFlattenedObject.self );
+			document.addObject( indexMapping.multiValuedFlattenedObject.self );
+			document.addObject( indexMapping.multiValuedFlattenedObject.self );
+		} );
+	}
+
+	@Test
+	public void addObject_nested() {
+		expectSuccess( "1", document -> {
+			document.addObject( indexMapping.singleValuedNestedObject.self );
+		} );
+		expectSingleValuedException( "2", "singleValuedNestedObject", document -> {
+			document.addObject( indexMapping.singleValuedNestedObject.self );
+			document.addObject( indexMapping.singleValuedNestedObject.self );
+		} );
+		expectSuccess( "3", document -> {
+			document.addObject( indexMapping.multiValuedNestedObject.self );
+		} );
+		expectSuccess( "4", document -> {
+			document.addObject( indexMapping.multiValuedNestedObject.self );
+			document.addObject( indexMapping.multiValuedNestedObject.self );
+			document.addObject( indexMapping.multiValuedNestedObject.self );
+		} );
+	}
+
+	@Test
+	public void addNullObject_flattened() {
+		expectSuccess( "1", document -> {
+			document.addObject( indexMapping.singleValuedFlattenedObject.self );
+		} );
+		expectSingleValuedException( "2", "singleValuedFlattenedObject", document -> {
+			document.addNullObject( indexMapping.singleValuedFlattenedObject.self );
+			document.addNullObject( indexMapping.singleValuedFlattenedObject.self );
+		} );
+		expectSingleValuedException( "3", "singleValuedFlattenedObject", document -> {
+			document.addObject( indexMapping.singleValuedFlattenedObject.self );
+			document.addNullObject( indexMapping.singleValuedFlattenedObject.self );
+		} );
+		expectSingleValuedException( "4", "singleValuedFlattenedObject", document -> {
+			document.addNullObject( indexMapping.singleValuedFlattenedObject.self );
+			document.addObject( indexMapping.singleValuedFlattenedObject.self );
+		} );
+		expectSuccess( "5", document -> {
+			document.addObject( indexMapping.multiValuedFlattenedObject.self );
+		} );
+		expectSuccess( "6", document -> {
+			document.addNullObject( indexMapping.multiValuedFlattenedObject.self );
+			document.addNullObject( indexMapping.multiValuedFlattenedObject.self );
+			document.addNullObject( indexMapping.multiValuedFlattenedObject.self );
+		} );
+		expectSuccess( "7", document -> {
+			document.addNullObject( indexMapping.multiValuedFlattenedObject.self );
+			document.addObject( indexMapping.multiValuedFlattenedObject.self );
+			document.addNullObject( indexMapping.multiValuedFlattenedObject.self );
+		} );
+		expectSuccess( "8", document -> {
+			document.addObject( indexMapping.multiValuedFlattenedObject.self );
+			document.addNullObject( indexMapping.multiValuedFlattenedObject.self );
+			document.addNullObject( indexMapping.multiValuedFlattenedObject.self );
+		} );
+	}
+
+	@Test
+	public void addNullObject_nested() {
+		expectSuccess( "1", document -> {
+			document.addObject( indexMapping.singleValuedNestedObject.self );
+		} );
+		expectSingleValuedException( "2", "singleValuedNestedObject", document -> {
+			document.addNullObject( indexMapping.singleValuedNestedObject.self );
+			document.addNullObject( indexMapping.singleValuedNestedObject.self );
+		} );
+		expectSingleValuedException( "3", "singleValuedNestedObject", document -> {
+			document.addObject( indexMapping.singleValuedNestedObject.self );
+			document.addNullObject( indexMapping.singleValuedNestedObject.self );
+		} );
+		expectSingleValuedException( "4", "singleValuedNestedObject", document -> {
+			document.addNullObject( indexMapping.singleValuedNestedObject.self );
+			document.addObject( indexMapping.singleValuedNestedObject.self );
+		} );
+		expectSuccess( "5", document -> {
+			document.addObject( indexMapping.multiValuedNestedObject.self );
+		} );
+		expectSuccess( "6", document -> {
+			document.addNullObject( indexMapping.multiValuedNestedObject.self );
+			document.addNullObject( indexMapping.multiValuedNestedObject.self );
+			document.addNullObject( indexMapping.multiValuedNestedObject.self );
+		} );
+		expectSuccess( "7", document -> {
+			document.addNullObject( indexMapping.multiValuedNestedObject.self );
+			document.addObject( indexMapping.multiValuedNestedObject.self );
+			document.addNullObject( indexMapping.multiValuedNestedObject.self );
+		} );
+		expectSuccess( "8", document -> {
+			document.addObject( indexMapping.multiValuedNestedObject.self );
+			document.addNullObject( indexMapping.multiValuedNestedObject.self );
+			document.addNullObject( indexMapping.multiValuedNestedObject.self );
+		} );
+	}
+
+	@Test
+	public void addValue_inSingleValuedFlattenedObject() {
+		expectSuccess( "1", document -> {
+			DocumentElement level1 = document.addObject( indexMapping.singleValuedFlattenedObject.self );
+			level1.addValue( indexMapping.singleValuedFlattenedObject.singleValuedString, "1" );
+		} );
+		expectSingleValuedException( "2", "singleValuedFlattenedObject.singleValuedString", document -> {
+			DocumentElement level1 = document.addObject( indexMapping.singleValuedFlattenedObject.self );
+			level1.addValue( indexMapping.singleValuedFlattenedObject.singleValuedString, "1" );
+			level1.addValue( indexMapping.singleValuedFlattenedObject.singleValuedString, "2" );
+		} );
+		expectSuccess( "3", document -> {
+			DocumentElement level1 = document.addObject( indexMapping.singleValuedFlattenedObject.self );
+			level1.addValue( indexMapping.singleValuedFlattenedObject.multiValuedString, "1" );
+		} );
+		expectSuccess( "4", document -> {
+			DocumentElement level1 = document.addObject( indexMapping.singleValuedFlattenedObject.self );
+			level1.addValue( indexMapping.singleValuedFlattenedObject.multiValuedString, "1" );
+			level1.addValue( indexMapping.singleValuedFlattenedObject.multiValuedString, "2" );
+			level1.addValue( indexMapping.singleValuedFlattenedObject.multiValuedString, "3" );
+		} );
+	}
+
+	@Test
+	public void addValue_inMultiValuedFlattenedObject() {
+		expectSuccess( "1", document -> {
+			DocumentElement level1 = document.addObject( indexMapping.multiValuedFlattenedObject.self );
+			level1.addValue( indexMapping.multiValuedFlattenedObject.singleValuedString, "1" );
+		} );
+		expectSingleValuedException( "2", "multiValuedFlattenedObject.singleValuedString", document -> {
+			DocumentElement level1 = document.addObject( indexMapping.multiValuedFlattenedObject.self );
+			level1.addValue( indexMapping.multiValuedFlattenedObject.singleValuedString, "1" );
+			level1.addValue( indexMapping.multiValuedFlattenedObject.singleValuedString, "2" );
+		} );
+		expectSuccess( "3", document -> {
+			DocumentElement level1 = document.addObject( indexMapping.multiValuedFlattenedObject.self );
+			level1.addValue( indexMapping.multiValuedFlattenedObject.multiValuedString, "1" );
+		} );
+		expectSuccess( "4", document -> {
+			DocumentElement level1 = document.addObject( indexMapping.multiValuedFlattenedObject.self );
+			level1.addValue( indexMapping.multiValuedFlattenedObject.multiValuedString, "1" );
+			level1.addValue( indexMapping.multiValuedFlattenedObject.multiValuedString, "2" );
+			level1.addValue( indexMapping.multiValuedFlattenedObject.multiValuedString, "3" );
+		} );
+	}
+
+	@Test
+	public void addValue_inSingleValuedNestedObject() {
+		expectSuccess( "1", document -> {
+			DocumentElement level1 = document.addObject( indexMapping.singleValuedNestedObject.self );
+			level1.addValue( indexMapping.singleValuedNestedObject.singleValuedString, "1" );
+		} );
+		expectSingleValuedException( "2", "singleValuedNestedObject.singleValuedString", document -> {
+			DocumentElement level1 = document.addObject( indexMapping.singleValuedNestedObject.self );
+			level1.addValue( indexMapping.singleValuedNestedObject.singleValuedString, "1" );
+			level1.addValue( indexMapping.singleValuedNestedObject.singleValuedString, "2" );
+		} );
+		expectSuccess( "3", document -> {
+			DocumentElement level1 = document.addObject( indexMapping.singleValuedNestedObject.self );
+			level1.addValue( indexMapping.singleValuedNestedObject.multiValuedString, "1" );
+		} );
+		expectSuccess( "4", document -> {
+			DocumentElement level1 = document.addObject( indexMapping.singleValuedNestedObject.self );
+			level1.addValue( indexMapping.singleValuedNestedObject.multiValuedString, "1" );
+			level1.addValue( indexMapping.singleValuedNestedObject.multiValuedString, "2" );
+			level1.addValue( indexMapping.singleValuedNestedObject.multiValuedString, "3" );
+		} );
+	}
+
+	@Test
+	public void addValue_inMultiValuedNestedObject() {
+		expectSuccess( "1", document -> {
+			DocumentElement level1 = document.addObject( indexMapping.multiValuedNestedObject.self );
+			level1.addValue( indexMapping.multiValuedNestedObject.singleValuedString, "1" );
+		} );
+		expectSingleValuedException( "2", "multiValuedNestedObject.singleValuedString", document -> {
+			DocumentElement level1 = document.addObject( indexMapping.multiValuedNestedObject.self );
+			level1.addValue( indexMapping.multiValuedNestedObject.singleValuedString, "1" );
+			level1.addValue( indexMapping.multiValuedNestedObject.singleValuedString, "2" );
+		} );
+		expectSuccess( "3", document -> {
+			DocumentElement level1 = document.addObject( indexMapping.multiValuedNestedObject.self );
+			level1.addValue( indexMapping.multiValuedNestedObject.multiValuedString, "1" );
+		} );
+		expectSuccess( "4", document -> {
+			DocumentElement level1 = document.addObject( indexMapping.multiValuedNestedObject.self );
+			level1.addValue( indexMapping.multiValuedNestedObject.multiValuedString, "1" );
+			level1.addValue( indexMapping.multiValuedNestedObject.multiValuedString, "2" );
+			level1.addValue( indexMapping.multiValuedNestedObject.multiValuedString, "3" );
+		} );
+	}
+
+	private void expectSuccess(String id, Consumer<DocumentElement> documentContributor) {
+		executeAdd( id, documentContributor );
+	}
+
+	private void expectSingleValuedException(String id, String absoluteFieldPath, Consumer<DocumentElement> documentContributor) {
+		SubTest.expectException(
+				"Multiple values written to field '" + absoluteFieldPath + "'",
+				() -> executeAdd( id, documentContributor )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Multiple values were added to single-valued field '" + absoluteFieldPath + "'." )
+				.hasMessageContaining( "Declare the field as multi-valued in order to allow this." );
+	}
+
+	private void executeAdd(String id, Consumer<DocumentElement> documentContributor) {
+		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
+		workPlan.add( referenceProvider( id ), documentContributor::accept );
+		workPlan.execute().join();
+	}
+
+	private abstract static class AbstractObjectMapping {
+		final IndexFieldReference<String> singleValuedString;
+		final IndexFieldReference<String> multiValuedString;
+
+		AbstractObjectMapping(IndexSchemaElement schemaElement) {
+			singleValuedString = schemaElement.field( "singleValuedString", f -> f.asString() ).toReference();
+			multiValuedString = schemaElement.field( "multiValuedString", f -> f.asString() ).multiValued().toReference();
+		}
+	}
+
+	private static class IndexMapping extends AbstractObjectMapping {
+		final FirstLevelObjectMapping singleValuedFlattenedObject;
+		final FirstLevelObjectMapping multiValuedFlattenedObject;
+		final FirstLevelObjectMapping singleValuedNestedObject;
+		final FirstLevelObjectMapping multiValuedNestedObject;
+
+		IndexMapping(IndexBindingContext ctx) {
+			super( ctx.getSchemaElement() );
+			IndexSchemaElement root = ctx.getSchemaElement();
+
+			singleValuedFlattenedObject = new FirstLevelObjectMapping(
+					root.objectField( "singleValuedFlattenedObject", ObjectFieldStorage.FLATTENED )
+			);
+			multiValuedFlattenedObject = new FirstLevelObjectMapping(
+					root.objectField( "multiValuedFlattenedObject", ObjectFieldStorage.FLATTENED )
+							.multiValued()
+			);
+			singleValuedNestedObject = new FirstLevelObjectMapping(
+					root.objectField( "singleValuedNestedObject", ObjectFieldStorage.NESTED )
+			);
+			multiValuedNestedObject = new FirstLevelObjectMapping(
+					root.objectField( "multiValuedNestedObject", ObjectFieldStorage.NESTED )
+							.multiValued()
+			);
+		}
+	}
+
+	private static class FirstLevelObjectMapping extends AbstractObjectMapping {
+		final IndexObjectFieldReference self;
+		FirstLevelObjectMapping(IndexSchemaObjectField objectField) {
+			super( objectField );
+			self = objectField.toReference();
+		}
+	}
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentModelDslIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentModelDslIT.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.integrationtest.backend.tck;
+package org.hibernate.search.integrationtest.backend.tck.document;
 
 import java.util.List;
 import java.util.function.Consumer;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/ExistsSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/ExistsSearchPredicateIT.java
@@ -558,7 +558,8 @@ public class ExistsSearchPredicateIT {
 
 		ObjectMapping(IndexSchemaElement parent, String relativeFieldName, ObjectFieldStorage storage) {
 			this.relativeFieldName = relativeFieldName;
-			IndexSchemaObjectField objectField = parent.objectField( relativeFieldName, storage );
+			IndexSchemaObjectField objectField = parent.objectField( relativeFieldName, storage )
+					.multiValued();
 			self = objectField.toReference();
 			mapByTypeFields(
 					objectField, "byType_", ignored -> { },

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/NestedSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/NestedSearchPredicateIT.java
@@ -360,7 +360,8 @@ public class NestedSearchPredicateIT {
 		final ObjectMapping nestedObject;
 
 		IndexMapping(IndexSchemaElement root) {
-			IndexSchemaObjectField nestedObjectField = root.objectField( "nestedObject", ObjectFieldStorage.NESTED );
+			IndexSchemaObjectField nestedObjectField = root.objectField( "nestedObject", ObjectFieldStorage.NESTED )
+					.multiValued();
 			nestedObject = new ObjectMapping( nestedObjectField );
 		}
 	}
@@ -376,7 +377,8 @@ public class NestedSearchPredicateIT {
 			IndexSchemaObjectField nestedObjectField = objectField.objectField(
 					"nestedObject",
 					ObjectFieldStorage.NESTED
-			);
+			)
+					.multiValued();
 			nestedObject = new SecondLevelObjectMapping( nestedObjectField );
 		}
 	}
@@ -389,7 +391,7 @@ public class NestedSearchPredicateIT {
 		SecondLevelObjectMapping(IndexSchemaObjectField objectField) {
 			self = objectField.toReference();
 			field1 = objectField.field( "field1", f -> f.asString() ).toReference();
-			field2 = objectField.field( "field2", f -> f.asString() ).toReference();
+			field2 = objectField.field( "field2", f -> f.asString() ).multiValued().toReference();
 		}
 	}
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SimpleQueryStringSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SimpleQueryStringSearchPredicateIT.java
@@ -860,7 +860,7 @@ public class SimpleQueryStringSearchPredicateIT {
 			analyzedStringField3 = MainFieldModel.mapper(
 					c -> c.asString().analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD_ENGLISH.name )
 			)
-					.map( root, "analyzedString3" );
+					.mapMultiValued( root, "analyzedString3" );
 			analyzedStringFieldWithDslConverter = MainFieldModel.mapper(
 					c -> c.asString().analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD_ENGLISH.name )
 							.dslConverter( ValueWrapper.toIndexFieldConverter() )

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AbstractAutomaticIndexingMultiAssociationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AbstractAutomaticIndexingMultiAssociationIT.java
@@ -1007,6 +1007,11 @@ public abstract class AbstractAutomaticIndexingMultiAssociationIT<
 			> extends AssociationModelPrimitives<TIndexed, TContaining, TContained> {
 
 		@Override
+		default boolean isMultiValuedAssociation() {
+			return true;
+		}
+
+		@Override
 		default void setContainedIndexedEmbeddedSingle(TContaining containing, TContained contained) {
 			TContainedAssociation containedAssociation = getContainedIndexedEmbedded( containing );
 			clearContained( containedAssociation );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingBasicIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingBasicIT.java
@@ -49,8 +49,8 @@ public class AutomaticIndexingBasicIT {
 		backendMock.expectSchema( IndexedEntity.INDEX, b -> b
 				.field( "indexedField", String.class )
 				.field( "noReindexOnUpdateField", String.class )
-				.field( "indexedElementCollectionField", String.class )
-				.field( "noReindexOnUpdateElementCollectionField", String.class )
+				.field( "indexedElementCollectionField", String.class, b2 -> b2.multiValued( true ) )
+				.field( "noReindexOnUpdateElementCollectionField", String.class, b2 -> b2.multiValued( true ) )
 		);
 
 		sessionFactory = ormSetupHelper.withBackendMock( backendMock )

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingEmbeddableIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingEmbeddableIT.java
@@ -63,10 +63,12 @@ public class AutomaticIndexingEmbeddableIT {
 						)
 						.objectField( "containedEmbeddedList", b2 -> b2
 								.objectField( "containedList", b3 -> b3
+										.multiValued( true )
 										.field( "includedInEmbeddedList", String.class )
 								)
 						)
 						.objectField( "containedElementCollection", b2 -> b2
+								.multiValued( true )
 								.objectField( "containedSingle", b3 -> b3
 										.field( "includedInElementCollection", String.class )
 								)

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingSingleAssociationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingSingleAssociationIT.java
@@ -649,6 +649,11 @@ public class AutomaticIndexingSingleAssociationIT extends AbstractAutomaticIndex
 		}
 
 		@Override
+		public boolean isMultiValuedAssociation() {
+			return false;
+		}
+
+		@Override
 		public Class<IndexedEntity> getIndexedClass() {
 			return IndexedEntity.class;
 		}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/GenericPropertyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/GenericPropertyIT.java
@@ -53,7 +53,7 @@ public class GenericPropertyIT {
 						 * and Hibernate Search will fail to resolve the bridge for them
 						 */
 						.field( "content", String.class )
-						.field( "arrayContent", String.class )
+						.field( "arrayContent", String.class, b3 -> b3.multiValued( true ) )
 				)
 		);
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/smoke/AnnotationMappingSmokeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/smoke/AnnotationMappingSmokeIT.java
@@ -81,14 +81,16 @@ public class AnnotationMappingSmokeIT {
 				.field( "myLocalDateField", LocalDate.class )
 				.field( "numeric", Integer.class )
 				.objectField( "embeddedList", b2 -> b2
+						.multiValued( true )
 						.objectField( "otherPrefix_embedded", b3 -> b3
 								.objectField( "prefix_customBridgeOnClass", b4 -> b4
 										.field( "text", String.class )
 								)
 						)
 				)
-				.field( "embeddedMapKeys", String.class )
+				.field( "embeddedMapKeys", String.class, b2 -> b2.multiValued( true ) )
 				.objectField( "embeddedMap", b2 -> b2
+						.multiValued( true )
 						.objectField( "embedded", b3 -> b3
 								.field( "prefix_myLocalDateField", LocalDate.class )
 						)

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/smoke/ProgrammaticMappingSmokeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/smoke/ProgrammaticMappingSmokeIT.java
@@ -78,14 +78,16 @@ public class ProgrammaticMappingSmokeIT {
 				.field( "myLocalDateField", LocalDate.class )
 				.field( "numeric", Integer.class )
 				.objectField( "embeddedList", b2 -> b2
+						.multiValued( true )
 						.objectField( "otherPrefix_embedded", b3 -> b3
 								.objectField( "prefix_customBridgeOnClass", b4 -> b4
 										.field( "text", String.class )
 								)
 						)
 				)
-				.field( "embeddedMapKeys", String.class )
+				.field( "embeddedMapKeys", String.class, b2 -> b2.multiValued( true ) )
 				.objectField( "embeddedMap", b2 -> b2
+						.multiValued( true )
 						.objectField( "embedded", b3 -> b3
 								.field( "prefix_myLocalDateField", LocalDate.class )
 						)

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/AbstractFieldContainerExtractorIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/AbstractFieldContainerExtractorIT.java
@@ -66,7 +66,7 @@ public abstract class AbstractFieldContainerExtractorIT {
 	public void objectArray() {
 		doTest(
 				testModelProvider.objectArray(),
-				String.class,
+				String.class, true,
 				new String[] { STRING_VALUE_1, STRING_VALUE_2, STRING_VALUE_3 },
 				STRING_VALUE_1, STRING_VALUE_2, STRING_VALUE_3
 		);
@@ -76,7 +76,7 @@ public abstract class AbstractFieldContainerExtractorIT {
 	public void iterable() {
 		doTest(
 				testModelProvider.iterable(),
-				String.class,
+				String.class, true,
 				CollectionHelper.asList( STRING_VALUE_1, STRING_VALUE_2, STRING_VALUE_3 ),
 				STRING_VALUE_1, STRING_VALUE_2, STRING_VALUE_3
 		);
@@ -86,7 +86,7 @@ public abstract class AbstractFieldContainerExtractorIT {
 	public void collection() {
 		doTest(
 				testModelProvider.collection(),
-				String.class,
+				String.class, true,
 				CollectionHelper.asList( STRING_VALUE_1, STRING_VALUE_2, STRING_VALUE_3 ),
 				STRING_VALUE_1, STRING_VALUE_2, STRING_VALUE_3
 		);
@@ -96,7 +96,7 @@ public abstract class AbstractFieldContainerExtractorIT {
 	public void list() {
 		doTest(
 				testModelProvider.list(),
-				String.class,
+				String.class, true,
 				CollectionHelper.asList( STRING_VALUE_1, STRING_VALUE_2, STRING_VALUE_3 ),
 				STRING_VALUE_1, STRING_VALUE_2, STRING_VALUE_3
 		);
@@ -106,7 +106,7 @@ public abstract class AbstractFieldContainerExtractorIT {
 	public void set() {
 		doTest(
 				testModelProvider.set(),
-				String.class,
+				String.class, true,
 				CollectionHelper.asLinkedHashSet( STRING_VALUE_1, STRING_VALUE_2, STRING_VALUE_3 ),
 				STRING_VALUE_1, STRING_VALUE_2, STRING_VALUE_3
 		);
@@ -120,7 +120,7 @@ public abstract class AbstractFieldContainerExtractorIT {
 		Collections.addAll( set, STRING_VALUE_2, STRING_VALUE_1, STRING_VALUE_3 );
 		doTest(
 				testModelProvider.sortedSet(),
-				String.class,
+				String.class, true,
 				set,
 				STRING_VALUE_1, STRING_VALUE_2, STRING_VALUE_3
 		);
@@ -134,7 +134,7 @@ public abstract class AbstractFieldContainerExtractorIT {
 		map.put( STRING_VALUE_3, STRING_VALUE_6 );
 		doTest(
 				testModelProvider.mapValues(),
-				String.class,
+				String.class, true,
 				map,
 				STRING_VALUE_4, STRING_VALUE_5, STRING_VALUE_6
 		);
@@ -150,7 +150,7 @@ public abstract class AbstractFieldContainerExtractorIT {
 		map.put( STRING_VALUE_3, STRING_VALUE_6 );
 		doTest(
 				testModelProvider.sortedMapValues(),
-				String.class,
+				String.class, true,
 				map,
 				STRING_VALUE_4, STRING_VALUE_5, STRING_VALUE_6
 		);
@@ -163,7 +163,7 @@ public abstract class AbstractFieldContainerExtractorIT {
 		map.put( STRING_VALUE_4, CollectionHelper.asList( STRING_VALUE_5, STRING_VALUE_6 ) );
 		doTest(
 				testModelProvider.mapListValues(),
-				String.class,
+				String.class, true,
 				map,
 				STRING_VALUE_2, STRING_VALUE_3, STRING_VALUE_5, STRING_VALUE_6
 		);
@@ -173,7 +173,7 @@ public abstract class AbstractFieldContainerExtractorIT {
 	public void optional_nonEmpty() {
 		doTest(
 				testModelProvider.optional(),
-				String.class,
+				String.class, false,
 				Optional.of( STRING_VALUE_1 ),
 				STRING_VALUE_1
 		);
@@ -183,7 +183,7 @@ public abstract class AbstractFieldContainerExtractorIT {
 	public void optional_empty() {
 		doTestExpectMissing(
 				testModelProvider.optional(),
-				String.class,
+				String.class, false,
 				Optional.empty()
 		);
 	}
@@ -193,7 +193,7 @@ public abstract class AbstractFieldContainerExtractorIT {
 	public void optionalDouble_nonEmpty() {
 		doTest(
 				testModelProvider.optionalDouble(),
-				Double.class,
+				Double.class, false,
 				OptionalDouble.of( 42.42 ),
 				42.42
 		);
@@ -204,7 +204,7 @@ public abstract class AbstractFieldContainerExtractorIT {
 	public void optionalDouble_empty() {
 		doTestExpectMissing(
 				testModelProvider.optionalDouble(),
-				Double.class,
+				Double.class, false,
 				OptionalDouble.empty()
 		);
 	}
@@ -213,7 +213,7 @@ public abstract class AbstractFieldContainerExtractorIT {
 	public void optionalInt_nonEmpty() {
 		doTest(
 				testModelProvider.optionalInt(),
-				Integer.class,
+				Integer.class, false,
 				OptionalInt.of( 1 ),
 				1
 		);
@@ -223,7 +223,7 @@ public abstract class AbstractFieldContainerExtractorIT {
 	public void optionalInt_empty() {
 		doTestExpectMissing(
 				testModelProvider.optionalInt(),
-				Integer.class,
+				Integer.class, false,
 				OptionalInt.empty()
 		);
 	}
@@ -232,7 +232,7 @@ public abstract class AbstractFieldContainerExtractorIT {
 	public void optionalLong_nonEmpty() {
 		doTest(
 				testModelProvider.optionalLong(),
-				Long.class,
+				Long.class, false,
 				OptionalLong.of( 42L ),
 				42L
 		);
@@ -242,7 +242,7 @@ public abstract class AbstractFieldContainerExtractorIT {
 	public void optionalLong_empty() {
 		doTestExpectMissing(
 				testModelProvider.optionalLong(),
-				Long.class,
+				Long.class, false,
 				OptionalLong.empty()
 		);
 	}
@@ -254,7 +254,7 @@ public abstract class AbstractFieldContainerExtractorIT {
 	public void list_nonPassThroughBridge() {
 		doTest(
 				testModelProvider.list_implicitEnumBridge(),
-				String.class,
+				String.class, true,
 				CollectionHelper.asList( MyEnum.VALUE2, MyEnum.VALUE1 ),
 				MyEnum.VALUE2.name(), MyEnum.VALUE1.name()
 		);
@@ -268,7 +268,7 @@ public abstract class AbstractFieldContainerExtractorIT {
 	public void list_customBridge() {
 		doTest(
 				testModelProvider.list_explicitPrefixedStringBridge(),
-				String.class,
+				String.class, true,
 				CollectionHelper.asList( STRING_VALUE_1, STRING_VALUE_2, STRING_VALUE_3 ),
 				PrefixedStringBridge.PREFIX + STRING_VALUE_1,
 				PrefixedStringBridge.PREFIX + STRING_VALUE_2,
@@ -279,21 +279,26 @@ public abstract class AbstractFieldContainerExtractorIT {
 	@SafeVarargs
 	final <E, P, F> void doTest(Class<E> entityType,
 			BiFunction<Integer, P, E> newEntityFunction,
-			Class<F> indexedFieldType,
+			Class<F> indexedFieldType, boolean multiValued,
 			P propertyValue, F firstIndexedFieldValues, F... otherIndexedFieldValues) {
 		doTest(
 				new TestModel<>( entityType, newEntityFunction ),
 				indexedFieldType,
+				multiValued,
 				propertyValue, firstIndexedFieldValues, otherIndexedFieldValues
 		);
 	}
 
 	@SafeVarargs
-	final <E, P, F> void doTest(TestModel<E, P> testModel, Class<F> indexedFieldType,
+	final <E, P, F> void doTest(TestModel<E, P> testModel, Class<F> indexedFieldType, boolean multiValued,
 			P propertyValue, F firstIndexedFieldValues, F... otherIndexedFieldValues) {
 		// Schema
 		backendMock.expectSchema( INDEX_NAME, b -> b
-				.field( "myProperty", indexedFieldType )
+				.field( "myProperty", indexedFieldType, b2 -> {
+					if ( multiValued ) {
+						b2.multiValued( true );
+					}
+				} )
 		);
 		JavaBeanMapping mapping = setupHelper.withBackendMock( backendMock ).setup( testModel.getEntityClass() );
 		backendMock.verifyExpectationsMet();
@@ -319,11 +324,16 @@ public abstract class AbstractFieldContainerExtractorIT {
 		// TODO HSEARCH-3361 + HSEARCH-1895 also test projections going through the extractor
 	}
 
-	final <E, P, F> void doTestExpectMissing(TestModel<E, P> testModel, Class<F> indexedFieldType,
+	final <E, P, F> void doTestExpectMissing(TestModel<E, P> testModel,
+			Class<F> indexedFieldType, boolean multiValued,
 			P propertyValue) {
 		// Schema
 		backendMock.expectSchema( INDEX_NAME, b -> b
-				.field( "myProperty", indexedFieldType )
+				.field( "myProperty", indexedFieldType, b2 -> {
+					if ( multiValued ) {
+						b2.multiValued( true );
+					}
+				} )
 		);
 		JavaBeanMapping mapping = setupHelper.withBackendMock( backendMock ).setup( testModel.getEntityClass() );
 		backendMock.verifyExpectationsMet();

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/FieldContainerExtractorExplicitIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/FieldContainerExtractorExplicitIT.java
@@ -71,7 +71,7 @@ public class FieldContainerExtractorExplicitIT extends AbstractFieldContainerExt
 		map.put( STRING_VALUE_3, STRING_VALUE_6 );
 		doTest(
 				IndexedEntity.class, (id, p) -> new IndexedEntity( id, p ),
-				String.class,
+				String.class, true,
 				map,
 				STRING_VALUE_1, STRING_VALUE_2, STRING_VALUE_3
 		);
@@ -107,7 +107,7 @@ public class FieldContainerExtractorExplicitIT extends AbstractFieldContainerExt
 		map.put( CollectionHelper.asList( STRING_VALUE_4, STRING_VALUE_5 ), STRING_VALUE_6 );
 		doTest(
 				IndexedEntity.class, (id, p) -> new IndexedEntity( id, p ),
-				String.class,
+				String.class, true,
 				map,
 				STRING_VALUE_1, STRING_VALUE_2, STRING_VALUE_4, STRING_VALUE_5
 		);
@@ -137,7 +137,7 @@ public class FieldContainerExtractorExplicitIT extends AbstractFieldContainerExt
 		}
 		doTest(
 				IndexedEntity.class, (id, p) -> new IndexedEntity( id, p ),
-				String.class,
+				String.class, false,
 				CollectionHelper.asList( STRING_VALUE_1, STRING_VALUE_2, STRING_VALUE_3 ),
 				STRING_VALUE_1
 		);

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/MarkerBaseIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/MarkerBaseIT.java
@@ -1,0 +1,82 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.mapping.definition;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.invoke.MethodHandles;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.util.rule.JavaBeanMappingSetupHelper;
+import org.hibernate.search.mapper.pojo.bridge.declaration.MarkerMapping;
+import org.hibernate.search.mapper.pojo.bridge.declaration.MarkerRef;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.util.common.SearchException;
+import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.test.SubTest;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Test common use cases of markers and their mapping.
+ * <p>
+ * Does not test markers in depth for now;
+ * {@link org.hibernate.search.integrationtest.mapper.pojo.spatial.AnnotationMappingGeoPointBridgeIT}
+ * and {@link org.hibernate.search.integrationtest.mapper.pojo.spatial.ProgrammaticMappingGeoPointBridgeIT}
+ * should address that.
+ */
+@SuppressWarnings("unused")
+public class MarkerBaseIT {
+
+	private static final String INDEX_NAME = "IndexName";
+
+	@Rule
+	public BackendMock backendMock = new BackendMock( "stubBackend" );
+
+	@Rule
+	public JavaBeanMappingSetupHelper setupHelper = new JavaBeanMappingSetupHelper( MethodHandles.lookup() );
+
+	@Test
+	public void error_missingBuilderReference() {
+		@Indexed
+		class IndexedEntity {
+			Integer id;
+			@DocumentId
+			@MarkerAnnotationWithEmptyMarkerMapping
+			public Integer getId() {
+				return id;
+			}
+		}
+		SubTest.expectException(
+				() -> setupHelper.withBackendMock( backendMock ).setup( IndexedEntity.class )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.typeContext( IndexedEntity.class.getName() )
+						.pathContext( ".id" )
+						.annotationContextAnyParameters( MarkerAnnotationWithEmptyMarkerMapping.class )
+						.failure(
+								"Annotation type '" + MarkerAnnotationWithEmptyMarkerMapping.class.getName()
+										+ "' is annotated with '" + MarkerMapping.class.getName() + "',"
+										+ " but the marker builder reference is empty"
+						)
+						.build()
+				);
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target({ElementType.FIELD, ElementType.METHOD})
+	@MarkerMapping(builder = @MarkerRef)
+	private @interface MarkerAnnotationWithEmptyMarkerMapping {
+	}
+
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/PropertyBridgeBaseIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/PropertyBridgeBaseIT.java
@@ -21,31 +21,19 @@ import org.hibernate.search.integrationtest.mapper.pojo.testsupport.util.rule.Ja
 import org.hibernate.search.mapper.javabean.JavaBeanMapping;
 import org.hibernate.search.mapper.javabean.session.SearchSession;
 import org.hibernate.search.mapper.pojo.bridge.PropertyBridge;
-import org.hibernate.search.mapper.pojo.bridge.TypeBridge;
-import org.hibernate.search.mapper.pojo.bridge.ValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.binding.PropertyBridgeBindingContext;
-import org.hibernate.search.mapper.pojo.bridge.binding.TypeBridgeBindingContext;
-import org.hibernate.search.mapper.pojo.bridge.declaration.MarkerMapping;
-import org.hibernate.search.mapper.pojo.bridge.declaration.MarkerRef;
 import org.hibernate.search.mapper.pojo.bridge.declaration.PropertyBridgeMapping;
 import org.hibernate.search.mapper.pojo.bridge.declaration.PropertyBridgeRef;
-import org.hibernate.search.mapper.pojo.bridge.declaration.TypeBridgeMapping;
-import org.hibernate.search.mapper.pojo.bridge.declaration.TypeBridgeRef;
 import org.hibernate.search.mapper.pojo.bridge.mapping.BridgeBuilder;
 import org.hibernate.search.mapper.pojo.bridge.runtime.PropertyBridgeWriteContext;
-import org.hibernate.search.mapper.pojo.bridge.runtime.TypeBridgeWriteContext;
-import org.hibernate.search.mapper.pojo.bridge.runtime.ValueBridgeToIndexedValueContext;
 import org.hibernate.search.mapper.pojo.extractor.ContainerExtractorPath;
 import org.hibernate.search.mapper.pojo.extractor.builtin.BuiltinContainerExtractor;
 import org.hibernate.search.mapper.pojo.extractor.builtin.impl.CollectionElementExtractor;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.AssociationInverseSide;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
-import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
-import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ObjectPath;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.PropertyValue;
-import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ValueBridgeRef;
 import org.hibernate.search.mapper.pojo.model.PojoElementAccessor;
 import org.hibernate.search.mapper.pojo.model.path.PojoModelPath;
 import org.hibernate.search.util.common.AssertionFailure;
@@ -58,8 +46,13 @@ import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 import org.junit.Rule;
 import org.junit.Test;
 
+/**
+ * Test common use cases of (custom) property bridges and their annotation mapping.
+ * <p>
+ * Does not test reindexing in depth; this is tested in {@code AutomaticIndexing*} tests in the ORM mapper.
+ */
 @SuppressWarnings("unused")
-public class BridgeIT {
+public class PropertyBridgeBaseIT {
 
 	private static final String INDEX_NAME = "IndexName";
 
@@ -70,777 +63,6 @@ public class BridgeIT {
 	public JavaBeanMappingSetupHelper setupHelper = new JavaBeanMappingSetupHelper( MethodHandles.lookup() );
 
 	/**
-	 * Basic test checking that a "normal" custom type bridge will work as expected
-	 * when relying on accessors.
-	 * <p>
-	 * Note that reindexing is tested in depth in the ORM mapper integration tests.
-	 */
-	@Test
-	@TestForIssue(jiraKey = {"HSEARCH-2055", "HSEARCH-2641"})
-	public void typeBridge_accessors() {
-		@Indexed(index = INDEX_NAME)
-		class IndexedEntity {
-			Integer id;
-			String stringProperty;
-			@DocumentId
-			public Integer getId() {
-				return id;
-			}
-			public String getStringProperty() {
-				return stringProperty;
-			}
-		}
-
-		backendMock.expectSchema( INDEX_NAME, b ->
-				b.field( "someField", String.class, b2 -> {
-					b2.analyzerName( "myAnalyzer" ); // For HSEARCH-2641
-				} )
-		);
-
-		JavaBeanMapping mapping = setupHelper.withBackendMock( backendMock ).withConfiguration(
-				b -> b.programmaticMapping().type( IndexedEntity.class )
-						.bridge( (BridgeBuilder<TypeBridge>) buildContext -> BeanHolder.of( new TypeBridge() {
-							private PojoElementAccessor<String> pojoPropertyAccessor;
-							private IndexFieldReference<String> indexFieldReference;
-
-							@Override
-							public void bind(TypeBridgeBindingContext context) {
-								pojoPropertyAccessor = context.getBridgedElement()
-										.property( "stringProperty" )
-										.createAccessor( String.class );
-								indexFieldReference = context.getIndexSchemaElement().field(
-										"someField",
-										f -> f.asString().analyzer( "myAnalyzer" )
-								)
-										.toReference();
-							}
-
-							@Override
-							public void write(DocumentElement target, Object bridgedElement,
-									TypeBridgeWriteContext context) {
-								target.addValue( indexFieldReference, pojoPropertyAccessor.read( bridgedElement ) );
-							}
-						} ) )
-		)
-				.setup( IndexedEntity.class );
-		backendMock.verifyExpectationsMet();
-
-		IndexedEntity entity = new IndexedEntity();
-		entity.id = 1;
-		entity.stringProperty = "some string";
-
-		try ( SearchSession session = mapping.createSession() ) {
-			session.getMainWorkPlan().add( entity );
-
-			backendMock.expectWorks( INDEX_NAME )
-					.add( "1", b -> b.field( "someField", entity.stringProperty ) )
-					.preparedThenExecuted();
-		}
-		backendMock.verifyExpectationsMet();
-
-		try ( SearchSession session = mapping.createSession() ) {
-			entity.stringProperty = "some string 2";
-			session.getMainWorkPlan().update( entity, new String[] { "stringProperty" } );
-
-			backendMock.expectWorks( INDEX_NAME )
-					.update( "1", b -> b.field( "someField", entity.stringProperty ) )
-					.preparedThenExecuted();
-		}
-		backendMock.verifyExpectationsMet();
-	}
-
-	/**
-	 * Basic test checking that a "normal" custom type bridge will work as expected
-	 * when relying on explicit dependency declaration.
-	 * <p>
-	 * Note that reindexing is tested in depth in the ORM mapper integration tests.
-	 */
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3297")
-	public void typeBridge_explicitDependencies() {
-		@Indexed(index = INDEX_NAME)
-		class IndexedEntity {
-			Integer id;
-			String stringProperty;
-			@DocumentId
-			public Integer getId() {
-				return id;
-			}
-			public String getStringProperty() {
-				return stringProperty;
-			}
-		}
-
-		backendMock.expectSchema( INDEX_NAME, b ->
-				b.field( "someField", String.class, b2 -> {
-					b2.analyzerName( "myAnalyzer" ); // For HSEARCH-2641
-				} )
-		);
-
-		JavaBeanMapping mapping = setupHelper.withBackendMock( backendMock ).withConfiguration(
-				b -> b.programmaticMapping().type( IndexedEntity.class )
-						.bridge( (BridgeBuilder<TypeBridge>) buildContext -> BeanHolder.of( new TypeBridge() {
-							private IndexFieldReference<String> indexFieldReference;
-
-							@Override
-							public void bind(TypeBridgeBindingContext context) {
-								context.getDependencies().use( "stringProperty" );
-								indexFieldReference = context.getIndexSchemaElement().field(
-										"someField",
-										f -> f.asString().analyzer( "myAnalyzer" )
-								)
-										.toReference();
-							}
-
-							@Override
-							public void write(DocumentElement target, Object bridgedElement,
-									TypeBridgeWriteContext context) {
-								IndexedEntity castedBridgedElement = (IndexedEntity) bridgedElement;
-								target.addValue( indexFieldReference, castedBridgedElement.getStringProperty() );
-							}
-						} ) )
-		)
-				.setup( IndexedEntity.class );
-		backendMock.verifyExpectationsMet();
-
-		IndexedEntity entity = new IndexedEntity();
-		entity.id = 1;
-		entity.stringProperty = "some string";
-
-		try ( SearchSession session = mapping.createSession() ) {
-			session.getMainWorkPlan().add( entity );
-
-			backendMock.expectWorks( INDEX_NAME )
-					.add( "1", b -> b.field( "someField", entity.stringProperty ) )
-					.preparedThenExecuted();
-		}
-		backendMock.verifyExpectationsMet();
-
-		try ( SearchSession session = mapping.createSession() ) {
-			entity.stringProperty = "some string 2";
-			session.getMainWorkPlan().update( entity, new String[] { "stringProperty" } );
-
-			backendMock.expectWorks( INDEX_NAME )
-					.update( "1", b -> b.field( "someField", entity.stringProperty ) )
-					.preparedThenExecuted();
-		}
-		backendMock.verifyExpectationsMet();
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3297")
-	public void typeBridge_explicitDependencies_error_invalidProperty() {
-		@Indexed(index = INDEX_NAME)
-		class IndexedEntity {
-			Integer id;
-			String stringProperty;
-			@DocumentId
-			public Integer getId() {
-				return id;
-			}
-			public String getStringProperty() {
-				return stringProperty;
-			}
-		}
-
-		SubTest.expectException(
-				() -> setupHelper.withBackendMock( backendMock ).withConfiguration(
-						b -> b.programmaticMapping().type( IndexedEntity.class )
-								.bridge( (BridgeBuilder<TypeBridge>) buildContext -> BeanHolder.of( new TypeBridge() {
-									@Override
-									public void bind(TypeBridgeBindingContext context) {
-										context.getDependencies().use( "doesNotExist" );
-									}
-
-									@Override
-									public void write(DocumentElement target, Object bridgedElement,
-											TypeBridgeWriteContext context) {
-										throw new AssertionFailure( "Should not be called" );
-									}
-								} ) )
-				)
-						.setup( IndexedEntity.class )
-		)
-				.assertThrown()
-				.isInstanceOf( SearchException.class )
-				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.typeContext( IndexedEntity.class.getName() )
-						.failure(
-								"Unable to find property 'doesNotExist' on type '" + IndexedEntity.class.getName() + "'"
-						)
-						.build()
-				);
-	}
-
-	/**
-	 * Basic test checking that a "normal" custom type bridge will work as expected
-	 * when relying on explicit reindexing declaration.
-	 * <p>
-	 * Note that reindexing is tested in depth in the ORM mapper integration tests.
-	 */
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3297")
-	public void typeBridge_explicitReindexing() {
-		@Indexed(index = INDEX_NAME)
-		class IndexedEntity {
-			Integer id;
-			@DocumentId
-			public Integer getId() {
-				return id;
-			}
-		}
-		class ContainedEntity {
-			IndexedEntity parent;
-			String stringProperty;
-			public IndexedEntity getParent() {
-				return parent;
-			}
-			public String getStringProperty() {
-				return stringProperty;
-			}
-		}
-
-		backendMock.expectSchema( INDEX_NAME, b ->
-				b.field( "someField", String.class, b2 -> {
-					b2.analyzerName( "myAnalyzer" ); // For HSEARCH-2641
-				} )
-		);
-
-		JavaBeanMapping mapping = setupHelper.withBackendMock( backendMock ).withConfiguration(
-				b -> b.programmaticMapping().type( IndexedEntity.class )
-						.bridge( (BridgeBuilder<TypeBridge>) buildContext -> BeanHolder.of( new TypeBridge() {
-							private IndexFieldReference<String> indexFieldReference;
-
-							@Override
-							public void bind(TypeBridgeBindingContext context) {
-								context.getDependencies()
-										.fromOtherEntity( ContainedEntity.class, "parent" )
-										.use( "stringProperty" );
-								indexFieldReference = context.getIndexSchemaElement().field(
-										"someField",
-										f -> f.asString().analyzer( "myAnalyzer" )
-								)
-										.toReference();
-							}
-
-							@Override
-							public void write(DocumentElement target, Object bridgedElement,
-									TypeBridgeWriteContext context) {
-								IndexedEntity castedBridgedElement = (IndexedEntity) bridgedElement;
-								/*
-								 * In a real application this would run a query,
-								 * but we don't have the necessary infrastructure here
-								 * so we'll cut short and just index a constant.
-								 * We just need to know the bridge is executed anyway.
-								 */
-								target.addValue( indexFieldReference, "constant" );
-							}
-						} ) )
-		)
-				.setup( IndexedEntity.class, ContainedEntity.class );
-		backendMock.verifyExpectationsMet();
-
-		IndexedEntity entity = new IndexedEntity();
-		entity.id = 1;
-		ContainedEntity containedEntity = new ContainedEntity();
-		containedEntity.parent = entity;
-		containedEntity.stringProperty = "some string";
-
-		try ( SearchSession session = mapping.createSession() ) {
-			session.getMainWorkPlan().add( entity );
-			session.getMainWorkPlan().add( containedEntity );
-
-			backendMock.expectWorks( INDEX_NAME )
-					.add( "1", b -> b.field( "someField", "constant" ) )
-					.preparedThenExecuted();
-		}
-		backendMock.verifyExpectationsMet();
-
-		try ( SearchSession session = mapping.createSession() ) {
-			containedEntity.stringProperty = "some string";
-
-			session.getMainWorkPlan().update( containedEntity, new String[] { "stringProperty" } );
-
-			backendMock.expectWorks( INDEX_NAME )
-					.update( "1", b -> b.field( "someField", "constant" ) )
-					.preparedThenExecuted();
-		}
-		backendMock.verifyExpectationsMet();
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3297")
-	public void typeBridge_explicitReindexing_error_use_invalidProperty() {
-		@Indexed(index = INDEX_NAME)
-		class IndexedEntity {
-			Integer id;
-			@DocumentId
-			public Integer getId() {
-				return id;
-			}
-		}
-		class ContainedEntity {
-			IndexedEntity parent;
-			String stringProperty;
-			public IndexedEntity getParent() {
-				return parent;
-			}
-			public String getStringProperty() {
-				return stringProperty;
-			}
-		}
-
-		SubTest.expectException(
-				() -> setupHelper.withBackendMock( backendMock ).withConfiguration(
-						b -> b.programmaticMapping().type( IndexedEntity.class )
-								.bridge( (BridgeBuilder<TypeBridge>) buildContext -> BeanHolder.of( new TypeBridge() {
-									@Override
-									public void bind(TypeBridgeBindingContext context) {
-										context.getDependencies()
-												.fromOtherEntity(
-														ContainedEntity.class,
-														"parent"
-												)
-												.use( "doesNotExist" );
-									}
-
-									@Override
-									public void write(DocumentElement target, Object bridgedElement,
-											TypeBridgeWriteContext context) {
-										throw new AssertionFailure( "Should not be called" );
-									}
-								} ) )
-				)
-						.setup( IndexedEntity.class, ContainedEntity.class )
-		)
-				.assertThrown()
-				.isInstanceOf( SearchException.class )
-				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.typeContext( IndexedEntity.class.getName() )
-						.failure(
-								"Unable to find property 'doesNotExist' on type '" + ContainedEntity.class.getName() + "'"
-						)
-						.build()
-				);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3297")
-	public void typeBridge_explicitReindexing_error_fromOtherEntity_invalidProperty() {
-		@Indexed(index = INDEX_NAME)
-		class IndexedEntity {
-			Integer id;
-			@DocumentId
-			public Integer getId() {
-				return id;
-			}
-		}
-		class ContainedEntity {
-			IndexedEntity parent;
-			String stringProperty;
-			public IndexedEntity getParent() {
-				return parent;
-			}
-			public String getStringProperty() {
-				return stringProperty;
-			}
-		}
-
-		SubTest.expectException(
-				() -> setupHelper.withBackendMock( backendMock ).withConfiguration(
-						b -> b.programmaticMapping().type( IndexedEntity.class )
-								.bridge( (BridgeBuilder<TypeBridge>) buildContext -> BeanHolder.of( new TypeBridge() {
-									@Override
-									public void bind(TypeBridgeBindingContext context) {
-										context.getDependencies()
-												.fromOtherEntity(
-														ContainedEntity.class,
-														"doesNotExist"
-												);
-									}
-
-									@Override
-									public void write(DocumentElement target, Object bridgedElement,
-											TypeBridgeWriteContext context) {
-										throw new AssertionFailure( "Should not be called" );
-									}
-								} ) )
-				)
-						.setup( IndexedEntity.class, ContainedEntity.class )
-		)
-				.assertThrown()
-				.isInstanceOf( SearchException.class )
-				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.typeContext( IndexedEntity.class.getName() )
-						.failure(
-								"Unable to find property 'doesNotExist' on type '" + ContainedEntity.class.getName() + "'"
-						)
-						.build()
-				);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3297")
-	public void typeBridge_explicitReindexing_error_fromOtherEntity_bridgedElementNotEntityType() {
-		class NotEntity {
-			String stringProperty;
-			public String getStringProperty() {
-				return stringProperty;
-			}
-		}
-		@Indexed(index = INDEX_NAME)
-		class IndexedEntity {
-			Integer id;
-			NotEntity notEntity;
-			@DocumentId
-			public Integer getId() {
-				return id;
-			}
-			@IndexedEmbedded
-			public NotEntity getNotEntity() {
-				return notEntity;
-			}
-		}
-
-		SubTest.expectException(
-				() -> setupHelper.withBackendMock( backendMock ).withConfiguration(
-						b -> b.programmaticMapping().type( NotEntity.class )
-								.bridge( (BridgeBuilder<TypeBridge>) buildContext -> BeanHolder.of( new TypeBridge() {
-									@Override
-									public void bind(TypeBridgeBindingContext context) {
-										context.getDependencies()
-												.fromOtherEntity(
-														IndexedEntity.class,
-														"doesNotMatter"
-												);
-									}
-
-									@Override
-									public void write(DocumentElement target, Object bridgedElement,
-											TypeBridgeWriteContext context) {
-										throw new AssertionFailure( "Should not be called" );
-									}
-								} ) )
-				)
-						.withAnnotatedTypes( NotEntity.class )
-						.setup( IndexedEntity.class )
-		)
-				.assertThrown()
-				.isInstanceOf( SearchException.class )
-				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.typeContext( IndexedEntity.class.getName() )
-						.pathContext( ".notEntity<no value extractors>" )
-						.failure(
-								"'fromOtherEntity' can only be used when the bridged element has an entity type,"
-								+ " but the bridged element has type '" + NotEntity.class.getName() + "',"
-								+ " which is not an entity type."
-						)
-						.build()
-				);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3297")
-	public void typeBridge_explicitReindexing_error_fromOtherEntity_otherEntityTypeNotEntityType() {
-		@Indexed(index = INDEX_NAME)
-		class IndexedEntity {
-			Integer id;
-			@DocumentId
-			public Integer getId() {
-				return id;
-			}
-		}
-		class NotEntity {
-		}
-
-		SubTest.expectException(
-				() -> setupHelper.withBackendMock( backendMock ).withConfiguration(
-						b -> b.programmaticMapping().type( IndexedEntity.class )
-								.bridge( (BridgeBuilder<TypeBridge>) buildContext -> BeanHolder.of( new TypeBridge() {
-									@Override
-									public void bind(TypeBridgeBindingContext context) {
-										context.getDependencies()
-												.fromOtherEntity(
-														NotEntity.class,
-														"doesNotMatter"
-												);
-									}
-
-									@Override
-									public void write(DocumentElement target, Object bridgedElement,
-											TypeBridgeWriteContext context) {
-										throw new AssertionFailure( "Should not be called" );
-									}
-								} ) )
-				)
-						.withAnnotatedTypes( NotEntity.class )
-						.setup( IndexedEntity.class )
-		)
-				.assertThrown()
-				.isInstanceOf( SearchException.class )
-				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.typeContext( IndexedEntity.class.getName() )
-						.failure(
-								"'fromOtherEntity' expects an entity type; "
-								+ "type '" + NotEntity.class.getName() + "' is not an entity type."
-						)
-						.build()
-				);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3297")
-	public void typeBridge_explicitReindexing_error_fromOtherEntity_inverseAssociationPathTargetsWrongType() {
-		@Indexed(index = INDEX_NAME)
-		class IndexedEntity {
-			Integer id;
-			@DocumentId
-			public Integer getId() {
-				return id;
-			}
-		}
-		class DifferentEntity {
-		}
-		class ContainedEntity {
-			IndexedEntity parent;
-			String stringProperty;
-			DifferentEntity associationToDifferentEntity;
-			public IndexedEntity getParent() {
-				return parent;
-			}
-			public String getStringProperty() {
-				return stringProperty;
-			}
-			public DifferentEntity getAssociationToDifferentEntity() {
-				return associationToDifferentEntity;
-			}
-		}
-
-		SubTest.expectException(
-				() -> setupHelper.withBackendMock( backendMock ).withConfiguration(
-						b -> b.programmaticMapping().type( IndexedEntity.class )
-								.bridge( (BridgeBuilder<TypeBridge>) buildContext -> BeanHolder.of( new TypeBridge() {
-									@Override
-									public void bind(TypeBridgeBindingContext context) {
-										context.getDependencies()
-												.fromOtherEntity(
-														ContainedEntity.class,
-														"associationToDifferentEntity"
-												);
-									}
-
-									@Override
-									public void write(DocumentElement target, Object bridgedElement,
-											TypeBridgeWriteContext context) {
-										throw new AssertionFailure( "Should not be called" );
-									}
-								} ) )
-				)
-						.setup( IndexedEntity.class, ContainedEntity.class )
-		)
-				.assertThrown()
-				.isInstanceOf( SearchException.class )
-				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.typeContext( IndexedEntity.class.getName() )
-						.failure(
-								"The inverse association targets type '" + DifferentEntity.class.getName() + "',"
-								+ " but a supertype or subtype of '" + IndexedEntity.class.getName() + "' was expected."
-						)
-						.build()
-				);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3297")
-	public void typeBridge_missingDependencyDeclaration() {
-		@Indexed(index = INDEX_NAME)
-		class IndexedEntity {
-			Integer id;
-			String stringProperty;
-			@DocumentId
-			public Integer getId() {
-				return id;
-			}
-			public String getStringProperty() {
-				return stringProperty;
-			}
-		}
-
-		SubTest.expectException(
-				() -> setupHelper.withBackendMock( backendMock ).withConfiguration(
-						b -> b.programmaticMapping().type( IndexedEntity.class )
-								.bridge( (BridgeBuilder<TypeBridge>) buildContext -> BeanHolder.of( new TypeBridge() {
-									@Override
-									public void bind(TypeBridgeBindingContext context) {
-										// Do not declare any dependency
-									}
-
-									@Override
-									public void write(DocumentElement target, Object bridgedElement,
-											TypeBridgeWriteContext context) {
-										throw new AssertionFailure( "Should not be called" );
-									}
-								} ) )
-				)
-						.setup( IndexedEntity.class )
-		)
-				.assertThrown()
-				.isInstanceOf( SearchException.class )
-				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.typeContext( IndexedEntity.class.getName() )
-						.failure(
-								"The bridge did not declare any dependency to the entity model during binding."
-								+ " Declare dependencies using context.getDependencies().use(...) or,"
-								+ " if the bridge really does not depend on the entity model, context.getDependencies().useRootOnly()"
-						)
-						.build()
-				);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3297")
-	public void typeBridge_inconsistentDependencyDeclaration() {
-		@Indexed(index = INDEX_NAME)
-		class IndexedEntity {
-			Integer id;
-			String stringProperty;
-			@DocumentId
-			public Integer getId() {
-				return id;
-			}
-			public String getStringProperty() {
-				return stringProperty;
-			}
-		}
-
-		SubTest.expectException(
-				() -> setupHelper.withBackendMock( backendMock ).withConfiguration(
-						b -> b.programmaticMapping().type( IndexedEntity.class )
-								.bridge( (BridgeBuilder<TypeBridge>) buildContext -> BeanHolder.of( new TypeBridge() {
-									@Override
-									public void bind(TypeBridgeBindingContext context) {
-										// Declare no dependency, but also a dependency: this is inconsistent.
-										context.getDependencies()
-												.use( "stringProperty" )
-												.useRootOnly();
-									}
-
-									@Override
-									public void write(DocumentElement target, Object bridgedElement,
-											TypeBridgeWriteContext context) {
-										throw new AssertionFailure( "Should not be called" );
-									}
-								} ) )
-				)
-						.setup( IndexedEntity.class )
-		)
-				.assertThrown()
-				.isInstanceOf( SearchException.class )
-				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.typeContext( IndexedEntity.class.getName() )
-						.failure(
-								"The bridge called context.getDependencies().useRootOnly() during binding,"
-										+ " but also declared extra dependencies to the entity model."
-						)
-						.build()
-				);
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3297")
-	public void typeBridge_useRootOnly() {
-		@Indexed(index = INDEX_NAME)
-		class IndexedEntity {
-			Integer id;
-			CustomEnum enumProperty;
-			@DocumentId
-			public Integer getId() {
-				return id;
-			}
-			@IndexedEmbedded
-			public CustomEnum getEnumProperty() {
-				return enumProperty;
-			}
-		}
-
-		backendMock.expectSchema( INDEX_NAME, b -> b
-				.objectField( "enumProperty", b2 -> b2
-						.field( "someField", String.class )
-				)
-		);
-
-		JavaBeanMapping mapping = setupHelper.withBackendMock( backendMock ).withConfiguration(
-				b -> b.programmaticMapping().type( CustomEnum.class )
-						.bridge( (BridgeBuilder<TypeBridge>) buildContext -> BeanHolder.of( new TypeBridge() {
-							private IndexFieldReference<String> indexFieldReference;
-
-							@Override
-							public void bind(TypeBridgeBindingContext context) {
-								context.getDependencies().useRootOnly();
-								indexFieldReference = context.getIndexSchemaElement().field(
-										"someField",
-										f -> f.asString()
-								)
-										.toReference();
-							}
-
-							@Override
-							public void write(DocumentElement target, Object bridgedElement,
-									TypeBridgeWriteContext context) {
-								CustomEnum castedBridgedElement = (CustomEnum) bridgedElement;
-								// This is a strange way to use bridges,
-								// but then again a type bridges that only use the root *is* strange
-								target.addValue( indexFieldReference, castedBridgedElement.stringProperty );
-							}
-						} ) )
-		)
-				.setup( IndexedEntity.class );
-		backendMock.verifyExpectationsMet();
-
-		IndexedEntity entity = new IndexedEntity();
-		entity.id = 1;
-		entity.enumProperty = CustomEnum.VALUE1;
-
-		try ( SearchSession session = mapping.createSession() ) {
-
-			session.getMainWorkPlan().add( entity );
-
-			backendMock.expectWorks( INDEX_NAME )
-					.add( "1", b -> b
-							.objectField( "enumProperty", b2 -> b2
-									.field( "someField", entity.enumProperty.stringProperty )
-							)
-					)
-					.preparedThenExecuted();
-		}
-		backendMock.verifyExpectationsMet();
-
-		try ( SearchSession session = mapping.createSession() ) {
-			entity.enumProperty = CustomEnum.VALUE2;
-
-			session.getMainWorkPlan().update( entity, new String[] { "enumProperty" } );
-
-			backendMock.expectWorks( INDEX_NAME )
-					.update( "1", b -> b
-							.objectField( "enumProperty", b2 -> b2
-									.field( "someField", entity.enumProperty.stringProperty )
-							)
-					)
-					.preparedThenExecuted();
-		}
-		backendMock.verifyExpectationsMet();
-	}
-
-	private enum CustomEnum {
-		VALUE1("value1String"),
-		VALUE2("value2String");
-		final String stringProperty;
-		CustomEnum(String stringProperty) {
-			this.stringProperty = stringProperty;
-		}
-	}
-
-	/**
 	 * Basic test checking that a "normal" custom property bridge will work as expected
 	 * when relying on accessors.
 	 * <p>
@@ -848,7 +70,7 @@ public class BridgeIT {
 	 */
 	@Test
 	@TestForIssue(jiraKey = {"HSEARCH-2055", "HSEARCH-2641"})
-	public void propertyBridge_accessors() {
+	public void accessors() {
 		@Indexed(index = INDEX_NAME)
 		class IndexedEntity {
 			Integer id;
@@ -927,7 +149,7 @@ public class BridgeIT {
 	 */
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3297")
-	public void propertyBridge_explicitDependencies() {
+	public void explicitDependencies() {
 		class Contained {
 			String stringProperty;
 			public String getStringProperty() {
@@ -1007,7 +229,7 @@ public class BridgeIT {
 
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3297")
-	public void propertyBridge_explicitDependencies_error_invalidProperty() {
+	public void explicitDependencies_error_invalidProperty() {
 		class Contained {
 			String stringProperty;
 			public String getStringProperty() {
@@ -1061,7 +283,7 @@ public class BridgeIT {
 
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3297")
-	public void propertyBridge_explicitDependencies_error_invalidContainerExtractorPath() {
+	public void explicitDependencies_error_invalidContainerExtractorPath() {
 		class Contained {
 			String stringProperty;
 			public String getStringProperty() {
@@ -1126,7 +348,7 @@ public class BridgeIT {
 	 */
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3297")
-	public void propertyBridge_explicitReindexing() {
+	public void explicitReindexing() {
 		backendMock.expectSchema( INDEX_NAME, b ->
 				b.field( "someField", String.class, b2 -> {
 					b2.analyzerName( "myAnalyzer" ); // For HSEARCH-2641
@@ -1253,7 +475,7 @@ public class BridgeIT {
 
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3297")
-	public void propertyBridge_explicitReindexing_error_use_invalidProperty() {
+	public void explicitReindexing_error_use_invalidProperty() {
 		SubTest.expectException(
 				() -> setupHelper.withBackendMock( backendMock ).withConfiguration(
 						b -> b.programmaticMapping().type( PropertyBridgeExplicitIndexingClasses.IndexedEntity.class )
@@ -1297,7 +519,7 @@ public class BridgeIT {
 
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3297")
-	public void propertyBridge_explicitReindexing_error_fromOtherEntity_invalidProperty() {
+	public void explicitReindexing_error_fromOtherEntity_invalidProperty() {
 		SubTest.expectException(
 				() -> setupHelper.withBackendMock( backendMock ).withConfiguration(
 						b -> b.programmaticMapping().type( PropertyBridgeExplicitIndexingClasses.IndexedEntity.class )
@@ -1339,7 +561,7 @@ public class BridgeIT {
 
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3297")
-	public void propertyBridge_explicitReindexing_error_fromOtherEntity_invalidContainerExtractorPath() {
+	public void explicitReindexing_error_fromOtherEntity_invalidContainerExtractorPath() {
 		SubTest.expectException(
 				() -> setupHelper.withBackendMock( backendMock ).withConfiguration(
 						b -> b.programmaticMapping().type( PropertyBridgeExplicitIndexingClasses.IndexedEntity.class )
@@ -1384,7 +606,7 @@ public class BridgeIT {
 
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3297")
-	public void propertyBridge_explicitReindexing_error_fromOtherEntity_bridgedElementNotEntityType() {
+	public void explicitReindexing_error_fromOtherEntity_bridgedElementNotEntityType() {
 		SubTest.expectException(
 				() -> setupHelper.withBackendMock( backendMock ).withConfiguration(
 						b -> b.programmaticMapping().type( PropertyBridgeExplicitIndexingClasses.IndexedEntity.class )
@@ -1429,7 +651,7 @@ public class BridgeIT {
 
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3297")
-	public void propertyBridge_explicitReindexing_error_fromOtherEntity_otherEntityTypeNotEntityType() {
+	public void explicitReindexing_error_fromOtherEntity_otherEntityTypeNotEntityType() {
 		SubTest.expectException(
 				() -> setupHelper.withBackendMock( backendMock ).withConfiguration(
 						b -> b.programmaticMapping().type( PropertyBridgeExplicitIndexingClasses.IndexedEntity.class )
@@ -1474,7 +696,7 @@ public class BridgeIT {
 
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3297")
-	public void propertyBridge_explicitReindexing_error_fromOtherEntity_inverseAssociationPathTargetsWrongType() {
+	public void explicitReindexing_error_fromOtherEntity_inverseAssociationPathTargetsWrongType() {
 		SubTest.expectException(
 				() -> setupHelper.withBackendMock( backendMock ).withConfiguration(
 						b -> b.programmaticMapping().type( PropertyBridgeExplicitIndexingClasses.IndexedEntity.class )
@@ -1518,7 +740,7 @@ public class BridgeIT {
 
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3297")
-	public void propertyBridge_missingDependencyDeclaration() {
+	public void missingDependencyDeclaration() {
 		class Contained {
 			String stringProperty;
 			public String getStringProperty() {
@@ -1573,7 +795,7 @@ public class BridgeIT {
 
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3297")
-	public void propertyBridge_inconsistentDependencyDeclaration() {
+	public void inconsistentDependencyDeclaration() {
 		class Contained {
 			String stringProperty;
 			public String getStringProperty() {
@@ -1630,7 +852,7 @@ public class BridgeIT {
 
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3297")
-	public void propertyBridge_useRootOnly() {
+	public void useRootOnly() {
 		@Indexed(index = INDEX_NAME)
 		class IndexedEntity {
 			Integer id;
@@ -1703,123 +925,7 @@ public class BridgeIT {
 	}
 
 	@Test
-	public void typeBridgeMapping_error_missingBridgeReference() {
-		@Indexed
-		@BridgeAnnotationWithEmptyTypeBridgeRef
-		class IndexedEntity {
-			Integer id;
-			@DocumentId
-			public Integer getId() {
-				return id;
-			}
-		}
-		SubTest.expectException(
-				() -> setupHelper.withBackendMock( backendMock ).setup( IndexedEntity.class )
-		)
-				.assertThrown()
-				.isInstanceOf( SearchException.class )
-				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.typeContext( IndexedEntity.class.getName() )
-						.annotationContextAnyParameters( BridgeAnnotationWithEmptyTypeBridgeRef.class )
-						.failure(
-								"Annotation type '" + BridgeAnnotationWithEmptyTypeBridgeRef.class.getName()
-										+ "' is annotated with '" + TypeBridgeMapping.class.getName() + "',"
-										+ " but neither a bridge reference nor a bridge builder reference was provided."
-						)
-						.build()
-				);
-	}
-
-	@Retention(RetentionPolicy.RUNTIME)
-	@Target(ElementType.TYPE)
-	@TypeBridgeMapping(bridge = @TypeBridgeRef)
-	private @interface BridgeAnnotationWithEmptyTypeBridgeRef {
-	}
-
-	@Test
-	public void typeBridgeMapping_error_conflictingBridgeReferenceInBridgeMapping() {
-		@Indexed
-		@BridgeAnnotationWithConflictingReferencesInTypeBridgeMapping
-		class IndexedEntity {
-			Integer id;
-			@DocumentId
-			public Integer getId() {
-				return id;
-			}
-		}
-		SubTest.expectException(
-				() -> setupHelper.withBackendMock( backendMock ).setup( IndexedEntity.class )
-		)
-				.assertThrown()
-				.isInstanceOf( SearchException.class )
-				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.typeContext( IndexedEntity.class.getName() )
-						.annotationContextAnyParameters( BridgeAnnotationWithConflictingReferencesInTypeBridgeMapping.class )
-						.failure(
-								"Annotation type '" + BridgeAnnotationWithConflictingReferencesInTypeBridgeMapping.class.getName()
-										+ "' is annotated with '" + TypeBridgeMapping.class.getName() + "',"
-										+ " but both a bridge reference and a bridge builder reference were provided"
-						)
-						.build()
-				);
-	}
-
-	@Retention(RetentionPolicy.RUNTIME)
-	@Target(ElementType.TYPE)
-	@TypeBridgeMapping(bridge = @TypeBridgeRef(name = "foo", builderName = "bar"))
-	private @interface BridgeAnnotationWithConflictingReferencesInTypeBridgeMapping {
-	}
-
-	@Test
-	public void typeBridgeMapping_error_incompatibleRequestedType() {
-		@Indexed
-		@IncompatibleTypeRequestingTypeBridgeAnnotation
-		class IndexedEntity {
-			Integer id;
-			String stringProperty;
-			@DocumentId
-			public Integer getId() {
-				return id;
-			}
-			public String getStringProperty() {
-				return stringProperty;
-			}
-		}
-		SubTest.expectException(
-				() -> setupHelper.withBackendMock( backendMock ).setup( IndexedEntity.class )
-		)
-				.assertThrown()
-				.isInstanceOf( SearchException.class )
-				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.typeContext( IndexedEntity.class.getName() )
-						.failure(
-								"Requested incompatible type for '.stringProperty<no value extractors>'",
-								"'" + Integer.class.getName() + "'"
-						)
-						.build()
-				);
-	}
-
-	@Retention(RetentionPolicy.RUNTIME)
-	@Target(ElementType.TYPE)
-	@TypeBridgeMapping(bridge = @TypeBridgeRef(type = IncompatibleTypeRequestingTypeBridge.class))
-	private @interface IncompatibleTypeRequestingTypeBridgeAnnotation {
-	}
-
-	public static class IncompatibleTypeRequestingTypeBridge implements TypeBridge {
-		@Override
-		public void bind(TypeBridgeBindingContext context) {
-			context.getBridgedElement().property( "stringProperty" ).createAccessor( Integer.class );
-		}
-
-		@Override
-		public void write(DocumentElement target, Object bridgedElement, TypeBridgeWriteContext context) {
-			throw new UnsupportedOperationException( "This should not be called" );
-		}
-	}
-
-	@Test
-	public void propertyBridgeMapping_error_missingBridgeReference() {
+	public void mapping_error_missingBridgeReference() {
 		@Indexed
 		class IndexedEntity {
 			Integer id;
@@ -1854,7 +960,7 @@ public class BridgeIT {
 	}
 
 	@Test
-	public void propertyBridgeMapping_error_conflictingBridgeReferenceInBridgeMapping() {
+	public void mapping_error_conflictingBridgeReferenceInBridgeMapping() {
 		@Indexed
 		class IndexedEntity {
 			Integer id;
@@ -1889,42 +995,7 @@ public class BridgeIT {
 	}
 
 	@Test
-	public void markerMapping_error_missingBuilderReference() {
-		@Indexed
-		class IndexedEntity {
-			Integer id;
-			@DocumentId
-			@MarkerAnnotationWithEmptyMarkerMapping
-			public Integer getId() {
-				return id;
-			}
-		}
-		SubTest.expectException(
-				() -> setupHelper.withBackendMock( backendMock ).setup( IndexedEntity.class )
-		)
-				.assertThrown()
-				.isInstanceOf( SearchException.class )
-				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.typeContext( IndexedEntity.class.getName() )
-						.pathContext( ".id" )
-						.annotationContextAnyParameters( MarkerAnnotationWithEmptyMarkerMapping.class )
-						.failure(
-								"Annotation type '" + MarkerAnnotationWithEmptyMarkerMapping.class.getName()
-										+ "' is annotated with '" + MarkerMapping.class.getName() + "',"
-										+ " but the marker builder reference is empty"
-						)
-						.build()
-				);
-	}
-
-	@Retention(RetentionPolicy.RUNTIME)
-	@Target({ElementType.FIELD, ElementType.METHOD})
-	@MarkerMapping(builder = @MarkerRef)
-	private @interface MarkerAnnotationWithEmptyMarkerMapping {
-	}
-
-	@Test
-	public void propertyBridgeMapping_error_incompatibleRequestedType() {
+	public void mapping_error_incompatibleRequestedType() {
 		@Indexed
 		class IndexedEntity {
 			Integer id;
@@ -1972,85 +1043,4 @@ public class BridgeIT {
 		}
 	}
 
-	@Test
-	public void valueBridge_indexNullAs() {
-		@Indexed(index = INDEX_NAME)
-		class IndexedEntity {
-			Integer id;
-			Integer integer;
-			@DocumentId
-			public Integer getId() {
-				return id;
-			}
-			@GenericField(valueBridge = @ValueBridgeRef(type = ParsingValueBridge.class), indexNullAs = "7")
-			public Integer getInteger() { return integer; }
-		}
-
-		backendMock.expectSchema( INDEX_NAME, b -> b
-				.field( "integer", Integer.class, f -> f.indexNullAs( 7 ) )
-		);
-
-		JavaBeanMapping mapping = setupHelper.withBackendMock( backendMock ).setup( IndexedEntity.class );
-		backendMock.verifyExpectationsMet();
-
-		try ( SearchSession session = mapping.createSession() ) {
-			IndexedEntity entity = new IndexedEntity();
-			entity.id = 1;
-			session.getMainWorkPlan().add( entity );
-
-			backendMock.expectWorks( INDEX_NAME )
-					// Stub backend is not supposed to use 'indexNullAs' option
-					.add( "1", b -> b.field( "integer", null ) )
-					.preparedThenExecuted();
-		}
-		backendMock.verifyExpectationsMet();
-	}
-
-	@Test
-	public void valueBridge_indexNullAs_noParsing() {
-		@Indexed(index = INDEX_NAME)
-		class IndexedEntity {
-			Integer id;
-			Integer integer;
-			@DocumentId
-			public Integer getId() {
-				return id;
-			}
-			@GenericField(valueBridge = @ValueBridgeRef(type = NoParsingValueBridge.class), indexNullAs = "7")
-			public Integer getInteger() { return integer; }
-		}
-
-		SubTest.expectException( () -> setupHelper.withBackendMock( backendMock ).setup( IndexedEntity.class ) )
-				.assertThrown()
-				.isInstanceOf( SearchException.class )
-				.hasMessageContaining( "does not support parsing a value from a String" )
-				.hasMessageContaining( "integer" );
-	}
-
-	public static class NoParsingValueBridge implements ValueBridge<Integer, Integer> {
-
-		public NoParsingValueBridge() {
-		}
-
-		@Override
-		public Integer toIndexedValue(Integer value, ValueBridgeToIndexedValueContext context) {
-			return value;
-		}
-
-		@Override
-		public Integer cast(Object value) {
-			return (Integer) value;
-		}
-	}
-
-	public static class ParsingValueBridge extends NoParsingValueBridge {
-
-		public ParsingValueBridge() {
-		}
-
-		@Override
-		public Integer parse(String value) {
-			return Integer.parseInt( value );
-		}
-	}
 }

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/TypeBridgeBaseIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/TypeBridgeBaseIT.java
@@ -1,0 +1,944 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.mapping.definition;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.invoke.MethodHandles;
+
+import org.hibernate.search.engine.backend.document.DocumentElement;
+import org.hibernate.search.engine.backend.document.IndexFieldReference;
+import org.hibernate.search.engine.environment.bean.BeanHolder;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.util.rule.JavaBeanMappingSetupHelper;
+import org.hibernate.search.mapper.javabean.JavaBeanMapping;
+import org.hibernate.search.mapper.javabean.session.SearchSession;
+import org.hibernate.search.mapper.pojo.bridge.TypeBridge;
+import org.hibernate.search.mapper.pojo.bridge.binding.TypeBridgeBindingContext;
+import org.hibernate.search.mapper.pojo.bridge.declaration.TypeBridgeMapping;
+import org.hibernate.search.mapper.pojo.bridge.declaration.TypeBridgeRef;
+import org.hibernate.search.mapper.pojo.bridge.mapping.BridgeBuilder;
+import org.hibernate.search.mapper.pojo.bridge.runtime.TypeBridgeWriteContext;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
+import org.hibernate.search.mapper.pojo.model.PojoElementAccessor;
+import org.hibernate.search.util.common.AssertionFailure;
+import org.hibernate.search.util.common.SearchException;
+import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.test.SubTest;
+import org.hibernate.search.util.impl.test.annotation.TestForIssue;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Test common use cases of (custom) type bridges and their annotation mapping.
+ * <p>
+ * Does not test reindexing in depth; this is tested in {@code AutomaticIndexing*} tests in the ORM mapper.
+ */
+@SuppressWarnings("unused")
+public class TypeBridgeBaseIT {
+
+	private static final String INDEX_NAME = "IndexName";
+
+	@Rule
+	public BackendMock backendMock = new BackendMock( "stubBackend" );
+
+	@Rule
+	public JavaBeanMappingSetupHelper setupHelper = new JavaBeanMappingSetupHelper( MethodHandles.lookup() );
+
+	/**
+	 * Basic test checking that a "normal" custom type bridge will work as expected
+	 * when relying on accessors.
+	 * <p>
+	 * Note that reindexing is tested in depth in the ORM mapper integration tests.
+	 */
+	@Test
+	@TestForIssue(jiraKey = {"HSEARCH-2055", "HSEARCH-2641"})
+	public void accessors() {
+		@Indexed(index = INDEX_NAME)
+		class IndexedEntity {
+			Integer id;
+			String stringProperty;
+			@DocumentId
+			public Integer getId() {
+				return id;
+			}
+			public String getStringProperty() {
+				return stringProperty;
+			}
+		}
+
+		backendMock.expectSchema( INDEX_NAME, b ->
+				b.field( "someField", String.class, b2 -> {
+					b2.analyzerName( "myAnalyzer" ); // For HSEARCH-2641
+				} )
+		);
+
+		JavaBeanMapping mapping = setupHelper.withBackendMock( backendMock ).withConfiguration(
+				b -> b.programmaticMapping().type( IndexedEntity.class )
+						.bridge( (BridgeBuilder<TypeBridge>) buildContext -> BeanHolder.of( new TypeBridge() {
+							private PojoElementAccessor<String> pojoPropertyAccessor;
+							private IndexFieldReference<String> indexFieldReference;
+
+							@Override
+							public void bind(TypeBridgeBindingContext context) {
+								pojoPropertyAccessor = context.getBridgedElement()
+										.property( "stringProperty" )
+										.createAccessor( String.class );
+								indexFieldReference = context.getIndexSchemaElement().field(
+										"someField",
+										f -> f.asString().analyzer( "myAnalyzer" )
+								)
+										.toReference();
+							}
+
+							@Override
+							public void write(DocumentElement target, Object bridgedElement,
+									TypeBridgeWriteContext context) {
+								target.addValue( indexFieldReference, pojoPropertyAccessor.read( bridgedElement ) );
+							}
+						} ) )
+		)
+				.setup( IndexedEntity.class );
+		backendMock.verifyExpectationsMet();
+
+		IndexedEntity entity = new IndexedEntity();
+		entity.id = 1;
+		entity.stringProperty = "some string";
+
+		try ( SearchSession session = mapping.createSession() ) {
+			session.getMainWorkPlan().add( entity );
+
+			backendMock.expectWorks( INDEX_NAME )
+					.add( "1", b -> b.field( "someField", entity.stringProperty ) )
+					.preparedThenExecuted();
+		}
+		backendMock.verifyExpectationsMet();
+
+		try ( SearchSession session = mapping.createSession() ) {
+			entity.stringProperty = "some string 2";
+			session.getMainWorkPlan().update( entity, new String[] { "stringProperty" } );
+
+			backendMock.expectWorks( INDEX_NAME )
+					.update( "1", b -> b.field( "someField", entity.stringProperty ) )
+					.preparedThenExecuted();
+		}
+		backendMock.verifyExpectationsMet();
+	}
+
+	/**
+	 * Basic test checking that a "normal" custom type bridge will work as expected
+	 * when relying on explicit dependency declaration.
+	 * <p>
+	 * Note that reindexing is tested in depth in the ORM mapper integration tests.
+	 */
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-3297")
+	public void explicitDependencies() {
+		@Indexed(index = INDEX_NAME)
+		class IndexedEntity {
+			Integer id;
+			String stringProperty;
+			@DocumentId
+			public Integer getId() {
+				return id;
+			}
+			public String getStringProperty() {
+				return stringProperty;
+			}
+		}
+
+		backendMock.expectSchema( INDEX_NAME, b ->
+				b.field( "someField", String.class, b2 -> {
+					b2.analyzerName( "myAnalyzer" ); // For HSEARCH-2641
+				} )
+		);
+
+		JavaBeanMapping mapping = setupHelper.withBackendMock( backendMock ).withConfiguration(
+				b -> b.programmaticMapping().type( IndexedEntity.class )
+						.bridge( (BridgeBuilder<TypeBridge>) buildContext -> BeanHolder.of( new TypeBridge() {
+							private IndexFieldReference<String> indexFieldReference;
+
+							@Override
+							public void bind(TypeBridgeBindingContext context) {
+								context.getDependencies().use( "stringProperty" );
+								indexFieldReference = context.getIndexSchemaElement().field(
+										"someField",
+										f -> f.asString().analyzer( "myAnalyzer" )
+								)
+										.toReference();
+							}
+
+							@Override
+							public void write(DocumentElement target, Object bridgedElement,
+									TypeBridgeWriteContext context) {
+								IndexedEntity castedBridgedElement = (IndexedEntity) bridgedElement;
+								target.addValue( indexFieldReference, castedBridgedElement.getStringProperty() );
+							}
+						} ) )
+		)
+				.setup( IndexedEntity.class );
+		backendMock.verifyExpectationsMet();
+
+		IndexedEntity entity = new IndexedEntity();
+		entity.id = 1;
+		entity.stringProperty = "some string";
+
+		try ( SearchSession session = mapping.createSession() ) {
+			session.getMainWorkPlan().add( entity );
+
+			backendMock.expectWorks( INDEX_NAME )
+					.add( "1", b -> b.field( "someField", entity.stringProperty ) )
+					.preparedThenExecuted();
+		}
+		backendMock.verifyExpectationsMet();
+
+		try ( SearchSession session = mapping.createSession() ) {
+			entity.stringProperty = "some string 2";
+			session.getMainWorkPlan().update( entity, new String[] { "stringProperty" } );
+
+			backendMock.expectWorks( INDEX_NAME )
+					.update( "1", b -> b.field( "someField", entity.stringProperty ) )
+					.preparedThenExecuted();
+		}
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-3297")
+	public void explicitDependencies_error_invalidProperty() {
+		@Indexed(index = INDEX_NAME)
+		class IndexedEntity {
+			Integer id;
+			String stringProperty;
+			@DocumentId
+			public Integer getId() {
+				return id;
+			}
+			public String getStringProperty() {
+				return stringProperty;
+			}
+		}
+
+		SubTest.expectException(
+				() -> setupHelper.withBackendMock( backendMock ).withConfiguration(
+						b -> b.programmaticMapping().type( IndexedEntity.class )
+								.bridge( (BridgeBuilder<TypeBridge>) buildContext -> BeanHolder.of( new TypeBridge() {
+									@Override
+									public void bind(TypeBridgeBindingContext context) {
+										context.getDependencies().use( "doesNotExist" );
+									}
+
+									@Override
+									public void write(DocumentElement target, Object bridgedElement,
+											TypeBridgeWriteContext context) {
+										throw new AssertionFailure( "Should not be called" );
+									}
+								} ) )
+				)
+						.setup( IndexedEntity.class )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.typeContext( IndexedEntity.class.getName() )
+						.failure(
+								"Unable to find property 'doesNotExist' on type '" + IndexedEntity.class.getName() + "'"
+						)
+						.build()
+				);
+	}
+
+	/**
+	 * Basic test checking that a "normal" custom type bridge will work as expected
+	 * when relying on explicit reindexing declaration.
+	 * <p>
+	 * Note that reindexing is tested in depth in the ORM mapper integration tests.
+	 */
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-3297")
+	public void explicitReindexing() {
+		@Indexed(index = INDEX_NAME)
+		class IndexedEntity {
+			Integer id;
+			@DocumentId
+			public Integer getId() {
+				return id;
+			}
+		}
+		class ContainedEntity {
+			IndexedEntity parent;
+			String stringProperty;
+			public IndexedEntity getParent() {
+				return parent;
+			}
+			public String getStringProperty() {
+				return stringProperty;
+			}
+		}
+
+		backendMock.expectSchema( INDEX_NAME, b ->
+				b.field( "someField", String.class, b2 -> {
+					b2.analyzerName( "myAnalyzer" ); // For HSEARCH-2641
+				} )
+		);
+
+		JavaBeanMapping mapping = setupHelper.withBackendMock( backendMock ).withConfiguration(
+				b -> b.programmaticMapping().type( IndexedEntity.class )
+						.bridge( (BridgeBuilder<TypeBridge>) buildContext -> BeanHolder.of( new TypeBridge() {
+							private IndexFieldReference<String> indexFieldReference;
+
+							@Override
+							public void bind(TypeBridgeBindingContext context) {
+								context.getDependencies()
+										.fromOtherEntity( ContainedEntity.class, "parent" )
+										.use( "stringProperty" );
+								indexFieldReference = context.getIndexSchemaElement().field(
+										"someField",
+										f -> f.asString().analyzer( "myAnalyzer" )
+								)
+										.toReference();
+							}
+
+							@Override
+							public void write(DocumentElement target, Object bridgedElement,
+									TypeBridgeWriteContext context) {
+								IndexedEntity castedBridgedElement = (IndexedEntity) bridgedElement;
+								/*
+								 * In a real application this would run a query,
+								 * but we don't have the necessary infrastructure here
+								 * so we'll cut short and just index a constant.
+								 * We just need to know the bridge is executed anyway.
+								 */
+								target.addValue( indexFieldReference, "constant" );
+							}
+						} ) )
+		)
+				.setup( IndexedEntity.class, ContainedEntity.class );
+		backendMock.verifyExpectationsMet();
+
+		IndexedEntity entity = new IndexedEntity();
+		entity.id = 1;
+		ContainedEntity containedEntity = new ContainedEntity();
+		containedEntity.parent = entity;
+		containedEntity.stringProperty = "some string";
+
+		try ( SearchSession session = mapping.createSession() ) {
+			session.getMainWorkPlan().add( entity );
+			session.getMainWorkPlan().add( containedEntity );
+
+			backendMock.expectWorks( INDEX_NAME )
+					.add( "1", b -> b.field( "someField", "constant" ) )
+					.preparedThenExecuted();
+		}
+		backendMock.verifyExpectationsMet();
+
+		try ( SearchSession session = mapping.createSession() ) {
+			containedEntity.stringProperty = "some string";
+
+			session.getMainWorkPlan().update( containedEntity, new String[] { "stringProperty" } );
+
+			backendMock.expectWorks( INDEX_NAME )
+					.update( "1", b -> b.field( "someField", "constant" ) )
+					.preparedThenExecuted();
+		}
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-3297")
+	public void explicitReindexing_error_use_invalidProperty() {
+		@Indexed(index = INDEX_NAME)
+		class IndexedEntity {
+			Integer id;
+			@DocumentId
+			public Integer getId() {
+				return id;
+			}
+		}
+		class ContainedEntity {
+			IndexedEntity parent;
+			String stringProperty;
+			public IndexedEntity getParent() {
+				return parent;
+			}
+			public String getStringProperty() {
+				return stringProperty;
+			}
+		}
+
+		SubTest.expectException(
+				() -> setupHelper.withBackendMock( backendMock ).withConfiguration(
+						b -> b.programmaticMapping().type( IndexedEntity.class )
+								.bridge( (BridgeBuilder<TypeBridge>) buildContext -> BeanHolder.of( new TypeBridge() {
+									@Override
+									public void bind(TypeBridgeBindingContext context) {
+										context.getDependencies()
+												.fromOtherEntity(
+														ContainedEntity.class,
+														"parent"
+												)
+												.use( "doesNotExist" );
+									}
+
+									@Override
+									public void write(DocumentElement target, Object bridgedElement,
+											TypeBridgeWriteContext context) {
+										throw new AssertionFailure( "Should not be called" );
+									}
+								} ) )
+				)
+						.setup( IndexedEntity.class, ContainedEntity.class )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.typeContext( IndexedEntity.class.getName() )
+						.failure(
+								"Unable to find property 'doesNotExist' on type '" + ContainedEntity.class.getName() + "'"
+						)
+						.build()
+				);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-3297")
+	public void explicitReindexing_error_fromOtherEntity_invalidProperty() {
+		@Indexed(index = INDEX_NAME)
+		class IndexedEntity {
+			Integer id;
+			@DocumentId
+			public Integer getId() {
+				return id;
+			}
+		}
+		class ContainedEntity {
+			IndexedEntity parent;
+			String stringProperty;
+			public IndexedEntity getParent() {
+				return parent;
+			}
+			public String getStringProperty() {
+				return stringProperty;
+			}
+		}
+
+		SubTest.expectException(
+				() -> setupHelper.withBackendMock( backendMock ).withConfiguration(
+						b -> b.programmaticMapping().type( IndexedEntity.class )
+								.bridge( (BridgeBuilder<TypeBridge>) buildContext -> BeanHolder.of( new TypeBridge() {
+									@Override
+									public void bind(TypeBridgeBindingContext context) {
+										context.getDependencies()
+												.fromOtherEntity(
+														ContainedEntity.class,
+														"doesNotExist"
+												);
+									}
+
+									@Override
+									public void write(DocumentElement target, Object bridgedElement,
+											TypeBridgeWriteContext context) {
+										throw new AssertionFailure( "Should not be called" );
+									}
+								} ) )
+				)
+						.setup( IndexedEntity.class, ContainedEntity.class )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.typeContext( IndexedEntity.class.getName() )
+						.failure(
+								"Unable to find property 'doesNotExist' on type '" + ContainedEntity.class.getName() + "'"
+						)
+						.build()
+				);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-3297")
+	public void explicitReindexing_error_fromOtherEntity_bridgedElementNotEntityType() {
+		class NotEntity {
+			String stringProperty;
+			public String getStringProperty() {
+				return stringProperty;
+			}
+		}
+		@Indexed(index = INDEX_NAME)
+		class IndexedEntity {
+			Integer id;
+			NotEntity notEntity;
+			@DocumentId
+			public Integer getId() {
+				return id;
+			}
+			@IndexedEmbedded
+			public NotEntity getNotEntity() {
+				return notEntity;
+			}
+		}
+
+		SubTest.expectException(
+				() -> setupHelper.withBackendMock( backendMock ).withConfiguration(
+						b -> b.programmaticMapping().type( NotEntity.class )
+								.bridge( (BridgeBuilder<TypeBridge>) buildContext -> BeanHolder.of( new TypeBridge() {
+									@Override
+									public void bind(TypeBridgeBindingContext context) {
+										context.getDependencies()
+												.fromOtherEntity(
+														IndexedEntity.class,
+														"doesNotMatter"
+												);
+									}
+
+									@Override
+									public void write(DocumentElement target, Object bridgedElement,
+											TypeBridgeWriteContext context) {
+										throw new AssertionFailure( "Should not be called" );
+									}
+								} ) )
+				)
+						.withAnnotatedTypes( NotEntity.class )
+						.setup( IndexedEntity.class )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.typeContext( IndexedEntity.class.getName() )
+						.pathContext( ".notEntity<no value extractors>" )
+						.failure(
+								"'fromOtherEntity' can only be used when the bridged element has an entity type,"
+								+ " but the bridged element has type '" + NotEntity.class.getName() + "',"
+								+ " which is not an entity type."
+						)
+						.build()
+				);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-3297")
+	public void explicitReindexing_error_fromOtherEntity_otherEntityTypeNotEntityType() {
+		@Indexed(index = INDEX_NAME)
+		class IndexedEntity {
+			Integer id;
+			@DocumentId
+			public Integer getId() {
+				return id;
+			}
+		}
+		class NotEntity {
+		}
+
+		SubTest.expectException(
+				() -> setupHelper.withBackendMock( backendMock ).withConfiguration(
+						b -> b.programmaticMapping().type( IndexedEntity.class )
+								.bridge( (BridgeBuilder<TypeBridge>) buildContext -> BeanHolder.of( new TypeBridge() {
+									@Override
+									public void bind(TypeBridgeBindingContext context) {
+										context.getDependencies()
+												.fromOtherEntity(
+														NotEntity.class,
+														"doesNotMatter"
+												);
+									}
+
+									@Override
+									public void write(DocumentElement target, Object bridgedElement,
+											TypeBridgeWriteContext context) {
+										throw new AssertionFailure( "Should not be called" );
+									}
+								} ) )
+				)
+						.withAnnotatedTypes( NotEntity.class )
+						.setup( IndexedEntity.class )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.typeContext( IndexedEntity.class.getName() )
+						.failure(
+								"'fromOtherEntity' expects an entity type; "
+								+ "type '" + NotEntity.class.getName() + "' is not an entity type."
+						)
+						.build()
+				);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-3297")
+	public void explicitReindexing_error_fromOtherEntity_inverseAssociationPathTargetsWrongType() {
+		@Indexed(index = INDEX_NAME)
+		class IndexedEntity {
+			Integer id;
+			@DocumentId
+			public Integer getId() {
+				return id;
+			}
+		}
+		class DifferentEntity {
+		}
+		class ContainedEntity {
+			IndexedEntity parent;
+			String stringProperty;
+			DifferentEntity associationToDifferentEntity;
+			public IndexedEntity getParent() {
+				return parent;
+			}
+			public String getStringProperty() {
+				return stringProperty;
+			}
+			public DifferentEntity getAssociationToDifferentEntity() {
+				return associationToDifferentEntity;
+			}
+		}
+
+		SubTest.expectException(
+				() -> setupHelper.withBackendMock( backendMock ).withConfiguration(
+						b -> b.programmaticMapping().type( IndexedEntity.class )
+								.bridge( (BridgeBuilder<TypeBridge>) buildContext -> BeanHolder.of( new TypeBridge() {
+									@Override
+									public void bind(TypeBridgeBindingContext context) {
+										context.getDependencies()
+												.fromOtherEntity(
+														ContainedEntity.class,
+														"associationToDifferentEntity"
+												);
+									}
+
+									@Override
+									public void write(DocumentElement target, Object bridgedElement,
+											TypeBridgeWriteContext context) {
+										throw new AssertionFailure( "Should not be called" );
+									}
+								} ) )
+				)
+						.setup( IndexedEntity.class, ContainedEntity.class )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.typeContext( IndexedEntity.class.getName() )
+						.failure(
+								"The inverse association targets type '" + DifferentEntity.class.getName() + "',"
+								+ " but a supertype or subtype of '" + IndexedEntity.class.getName() + "' was expected."
+						)
+						.build()
+				);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-3297")
+	public void missingDependencyDeclaration() {
+		@Indexed(index = INDEX_NAME)
+		class IndexedEntity {
+			Integer id;
+			String stringProperty;
+			@DocumentId
+			public Integer getId() {
+				return id;
+			}
+			public String getStringProperty() {
+				return stringProperty;
+			}
+		}
+
+		SubTest.expectException(
+				() -> setupHelper.withBackendMock( backendMock ).withConfiguration(
+						b -> b.programmaticMapping().type( IndexedEntity.class )
+								.bridge( (BridgeBuilder<TypeBridge>) buildContext -> BeanHolder.of( new TypeBridge() {
+									@Override
+									public void bind(TypeBridgeBindingContext context) {
+										// Do not declare any dependency
+									}
+
+									@Override
+									public void write(DocumentElement target, Object bridgedElement,
+											TypeBridgeWriteContext context) {
+										throw new AssertionFailure( "Should not be called" );
+									}
+								} ) )
+				)
+						.setup( IndexedEntity.class )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.typeContext( IndexedEntity.class.getName() )
+						.failure(
+								"The bridge did not declare any dependency to the entity model during binding."
+								+ " Declare dependencies using context.getDependencies().use(...) or,"
+								+ " if the bridge really does not depend on the entity model, context.getDependencies().useRootOnly()"
+						)
+						.build()
+				);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-3297")
+	public void inconsistentDependencyDeclaration() {
+		@Indexed(index = INDEX_NAME)
+		class IndexedEntity {
+			Integer id;
+			String stringProperty;
+			@DocumentId
+			public Integer getId() {
+				return id;
+			}
+			public String getStringProperty() {
+				return stringProperty;
+			}
+		}
+
+		SubTest.expectException(
+				() -> setupHelper.withBackendMock( backendMock ).withConfiguration(
+						b -> b.programmaticMapping().type( IndexedEntity.class )
+								.bridge( (BridgeBuilder<TypeBridge>) buildContext -> BeanHolder.of( new TypeBridge() {
+									@Override
+									public void bind(TypeBridgeBindingContext context) {
+										// Declare no dependency, but also a dependency: this is inconsistent.
+										context.getDependencies()
+												.use( "stringProperty" )
+												.useRootOnly();
+									}
+
+									@Override
+									public void write(DocumentElement target, Object bridgedElement,
+											TypeBridgeWriteContext context) {
+										throw new AssertionFailure( "Should not be called" );
+									}
+								} ) )
+				)
+						.setup( IndexedEntity.class )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.typeContext( IndexedEntity.class.getName() )
+						.failure(
+								"The bridge called context.getDependencies().useRootOnly() during binding,"
+										+ " but also declared extra dependencies to the entity model."
+						)
+						.build()
+				);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-3297")
+	public void useRootOnly() {
+		@Indexed(index = INDEX_NAME)
+		class IndexedEntity {
+			Integer id;
+			CustomEnum enumProperty;
+			@DocumentId
+			public Integer getId() {
+				return id;
+			}
+			@IndexedEmbedded
+			public CustomEnum getEnumProperty() {
+				return enumProperty;
+			}
+		}
+
+		backendMock.expectSchema( INDEX_NAME, b -> b
+				.objectField( "enumProperty", b2 -> b2
+						.field( "someField", String.class )
+				)
+		);
+
+		JavaBeanMapping mapping = setupHelper.withBackendMock( backendMock ).withConfiguration(
+				b -> b.programmaticMapping().type( CustomEnum.class )
+						.bridge( (BridgeBuilder<TypeBridge>) buildContext -> BeanHolder.of( new TypeBridge() {
+							private IndexFieldReference<String> indexFieldReference;
+
+							@Override
+							public void bind(TypeBridgeBindingContext context) {
+								context.getDependencies().useRootOnly();
+								indexFieldReference = context.getIndexSchemaElement().field(
+										"someField",
+										f -> f.asString()
+								)
+										.toReference();
+							}
+
+							@Override
+							public void write(DocumentElement target, Object bridgedElement,
+									TypeBridgeWriteContext context) {
+								CustomEnum castedBridgedElement = (CustomEnum) bridgedElement;
+								// This is a strange way to use bridges,
+								// but then again a type bridges that only use the root *is* strange
+								target.addValue( indexFieldReference, castedBridgedElement.stringProperty );
+							}
+						} ) )
+		)
+				.setup( IndexedEntity.class );
+		backendMock.verifyExpectationsMet();
+
+		IndexedEntity entity = new IndexedEntity();
+		entity.id = 1;
+		entity.enumProperty = CustomEnum.VALUE1;
+
+		try ( SearchSession session = mapping.createSession() ) {
+
+			session.getMainWorkPlan().add( entity );
+
+			backendMock.expectWorks( INDEX_NAME )
+					.add( "1", b -> b
+							.objectField( "enumProperty", b2 -> b2
+									.field( "someField", entity.enumProperty.stringProperty )
+							)
+					)
+					.preparedThenExecuted();
+		}
+		backendMock.verifyExpectationsMet();
+
+		try ( SearchSession session = mapping.createSession() ) {
+			entity.enumProperty = CustomEnum.VALUE2;
+
+			session.getMainWorkPlan().update( entity, new String[] { "enumProperty" } );
+
+			backendMock.expectWorks( INDEX_NAME )
+					.update( "1", b -> b
+							.objectField( "enumProperty", b2 -> b2
+									.field( "someField", entity.enumProperty.stringProperty )
+							)
+					)
+					.preparedThenExecuted();
+		}
+		backendMock.verifyExpectationsMet();
+	}
+
+	private enum CustomEnum {
+		VALUE1("value1String"),
+		VALUE2("value2String");
+		final String stringProperty;
+		CustomEnum(String stringProperty) {
+			this.stringProperty = stringProperty;
+		}
+	}
+
+	@Test
+	public void mapping_error_missingBridgeReference() {
+		@Indexed
+		@BridgeAnnotationWithEmptyTypeBridgeRef
+		class IndexedEntity {
+			Integer id;
+			@DocumentId
+			public Integer getId() {
+				return id;
+			}
+		}
+		SubTest.expectException(
+				() -> setupHelper.withBackendMock( backendMock ).setup( IndexedEntity.class )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.typeContext( IndexedEntity.class.getName() )
+						.annotationContextAnyParameters( BridgeAnnotationWithEmptyTypeBridgeRef.class )
+						.failure(
+								"Annotation type '" + BridgeAnnotationWithEmptyTypeBridgeRef.class.getName()
+										+ "' is annotated with '" + TypeBridgeMapping.class.getName() + "',"
+										+ " but neither a bridge reference nor a bridge builder reference was provided."
+						)
+						.build()
+				);
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.TYPE)
+	@TypeBridgeMapping(bridge = @TypeBridgeRef)
+	private @interface BridgeAnnotationWithEmptyTypeBridgeRef {
+	}
+
+	@Test
+	public void mapping_error_conflictingBridgeReferenceInBridgeMapping() {
+		@Indexed
+		@BridgeAnnotationWithConflictingReferencesInTypeBridgeMapping
+		class IndexedEntity {
+			Integer id;
+			@DocumentId
+			public Integer getId() {
+				return id;
+			}
+		}
+		SubTest.expectException(
+				() -> setupHelper.withBackendMock( backendMock ).setup( IndexedEntity.class )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.typeContext( IndexedEntity.class.getName() )
+						.annotationContextAnyParameters( BridgeAnnotationWithConflictingReferencesInTypeBridgeMapping.class )
+						.failure(
+								"Annotation type '" + BridgeAnnotationWithConflictingReferencesInTypeBridgeMapping.class.getName()
+										+ "' is annotated with '" + TypeBridgeMapping.class.getName() + "',"
+										+ " but both a bridge reference and a bridge builder reference were provided"
+						)
+						.build()
+				);
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.TYPE)
+	@TypeBridgeMapping(bridge = @TypeBridgeRef(name = "foo", builderName = "bar"))
+	private @interface BridgeAnnotationWithConflictingReferencesInTypeBridgeMapping {
+	}
+
+	@Test
+	public void mapping_error_incompatibleRequestedType() {
+		@Indexed
+		@IncompatibleTypeRequestingTypeBridgeAnnotation
+		class IndexedEntity {
+			Integer id;
+			String stringProperty;
+			@DocumentId
+			public Integer getId() {
+				return id;
+			}
+			public String getStringProperty() {
+				return stringProperty;
+			}
+		}
+		SubTest.expectException(
+				() -> setupHelper.withBackendMock( backendMock ).setup( IndexedEntity.class )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.typeContext( IndexedEntity.class.getName() )
+						.failure(
+								"Requested incompatible type for '.stringProperty<no value extractors>'",
+								"'" + Integer.class.getName() + "'"
+						)
+						.build()
+				);
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.TYPE)
+	@TypeBridgeMapping(bridge = @TypeBridgeRef(type = IncompatibleTypeRequestingTypeBridge.class))
+	private @interface IncompatibleTypeRequestingTypeBridgeAnnotation {
+	}
+
+	public static class IncompatibleTypeRequestingTypeBridge implements TypeBridge {
+		@Override
+		public void bind(TypeBridgeBindingContext context) {
+			context.getBridgedElement().property( "stringProperty" ).createAccessor( Integer.class );
+		}
+
+		@Override
+		public void write(DocumentElement target, Object bridgedElement, TypeBridgeWriteContext context) {
+			throw new UnsupportedOperationException( "This should not be called" );
+		}
+	}
+
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/ValueBridgeBaseIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/ValueBridgeBaseIT.java
@@ -1,0 +1,126 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.mapping.definition;
+
+import java.lang.invoke.MethodHandles;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.util.rule.JavaBeanMappingSetupHelper;
+import org.hibernate.search.mapper.javabean.JavaBeanMapping;
+import org.hibernate.search.mapper.javabean.session.SearchSession;
+import org.hibernate.search.mapper.pojo.bridge.ValueBridge;
+import org.hibernate.search.mapper.pojo.bridge.runtime.ValueBridgeToIndexedValueContext;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ValueBridgeRef;
+import org.hibernate.search.util.common.SearchException;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.test.SubTest;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Test common use cases of (custom) value bridges.
+ * <p>
+ * Does not test reindexing in depth; this is tested in {@code AutomaticIndexing*} tests in the ORM mapper.
+ * <p>
+ * Does not test field annotations in depth; this is tested in {@link FieldBaseIT}.
+ */
+@SuppressWarnings("unused")
+public class ValueBridgeBaseIT {
+
+	private static final String INDEX_NAME = "IndexName";
+
+	@Rule
+	public BackendMock backendMock = new BackendMock( "stubBackend" );
+
+	@Rule
+	public JavaBeanMappingSetupHelper setupHelper = new JavaBeanMappingSetupHelper( MethodHandles.lookup() );
+
+	@Test
+	public void indexNullAs() {
+		@Indexed(index = INDEX_NAME)
+		class IndexedEntity {
+			Integer id;
+			Integer integer;
+			@DocumentId
+			public Integer getId() {
+				return id;
+			}
+			@GenericField(valueBridge = @ValueBridgeRef(type = ParsingValueBridge.class), indexNullAs = "7")
+			public Integer getInteger() { return integer; }
+		}
+
+		backendMock.expectSchema( INDEX_NAME, b -> b
+				.field( "integer", Integer.class, f -> f.indexNullAs( 7 ) )
+		);
+
+		JavaBeanMapping mapping = setupHelper.withBackendMock( backendMock ).setup( IndexedEntity.class );
+		backendMock.verifyExpectationsMet();
+
+		try ( SearchSession session = mapping.createSession() ) {
+			IndexedEntity entity = new IndexedEntity();
+			entity.id = 1;
+			session.getMainWorkPlan().add( entity );
+
+			backendMock.expectWorks( INDEX_NAME )
+					// Stub backend is not supposed to use 'indexNullAs' option
+					.add( "1", b -> b.field( "integer", null ) )
+					.preparedThenExecuted();
+		}
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void indexNullAs_noParsing() {
+		@Indexed(index = INDEX_NAME)
+		class IndexedEntity {
+			Integer id;
+			Integer integer;
+			@DocumentId
+			public Integer getId() {
+				return id;
+			}
+			@GenericField(valueBridge = @ValueBridgeRef(type = NoParsingValueBridge.class), indexNullAs = "7")
+			public Integer getInteger() { return integer; }
+		}
+
+		SubTest.expectException( () -> setupHelper.withBackendMock( backendMock ).setup( IndexedEntity.class ) )
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "does not support parsing a value from a String" )
+				.hasMessageContaining( "integer" );
+	}
+
+	public static class NoParsingValueBridge implements ValueBridge<Integer, Integer> {
+
+		public NoParsingValueBridge() {
+		}
+
+		@Override
+		public Integer toIndexedValue(Integer value, ValueBridgeToIndexedValueContext context) {
+			return value;
+		}
+
+		@Override
+		public Integer cast(Object value) {
+			return (Integer) value;
+		}
+	}
+
+	public static class ParsingValueBridge extends NoParsingValueBridge {
+
+		public ParsingValueBridge() {
+		}
+
+		@Override
+		public Integer parse(String value) {
+			return Integer.parseInt( value );
+		}
+	}
+}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/model/GenericPropertyIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/model/GenericPropertyIT.java
@@ -48,7 +48,7 @@ public class GenericPropertyIT {
 						 * and Hibernate Search will fail to resolve the bridge for them
 						 */
 						.field( "content", String.class )
-						.field( "arrayContent", String.class )
+						.field( "arrayContent", String.class, b3 -> b3.multiValued( true ) )
 				)
 		);
 

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/smoke/AnnotationMappingSmokeIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/smoke/AnnotationMappingSmokeIT.java
@@ -80,11 +80,13 @@ public class AnnotationMappingSmokeIT {
 				.field( "myLocalDateField", LocalDate.class )
 				.field( "numeric", Integer.class )
 				.objectField( "embeddedIterable", b2 -> b2
+						.multiValued( true )
 						.objectField( "embedded", b3 -> b3
 								.field( "prefix_myTextField", String.class )
 						)
 				)
 				.objectField( "embeddedList", b2 -> b2
+						.multiValued( true )
 						.objectField( "otherPrefix_embedded", b3 -> b3
 								.objectField( "prefix_customBridgeOnClass", b4 -> b4
 										.field( "text", String.class )
@@ -92,14 +94,16 @@ public class AnnotationMappingSmokeIT {
 						)
 				)
 				.objectField( "embeddedArrayList", b2 -> b2
+						.multiValued( true )
 						.objectField( "embedded", b3 -> b3
 								.objectField( "prefix_customBridgeOnProperty", b4 -> b4
 										.field( "text", String.class )
 								)
 						)
 				)
-				.field( "embeddedMapKeys", String.class )
+				.field( "embeddedMapKeys", String.class, b2 -> b2.multiValued( true ) )
 				.objectField( "embeddedMap", b2 -> b2
+						.multiValued( true )
 						.objectField( "embedded", b3 -> b3
 								.field( "prefix_myLocalDateField", LocalDate.class )
 						)

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/smoke/ProgrammaticMappingSmokeIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/smoke/ProgrammaticMappingSmokeIT.java
@@ -70,11 +70,13 @@ public class ProgrammaticMappingSmokeIT {
 				.field( "myLocalDateField", LocalDate.class )
 				.field( "numeric", Integer.class )
 				.objectField( "embeddedIterable", b2 -> b2
+						.multiValued( true )
 						.objectField( "embedded", b3 -> b3
 								.field( "prefix_myTextField", String.class )
 						)
 				)
 				.objectField( "embeddedList", b2 -> b2
+						.multiValued( true )
 						.objectField( "otherPrefix_embedded", b3 -> b3
 								.objectField( "prefix_customBridgeOnClass", b4 -> b4
 										.field( "text", String.class )
@@ -82,14 +84,16 @@ public class ProgrammaticMappingSmokeIT {
 						)
 				)
 				.objectField( "embeddedArrayList", b2 -> b2
+						.multiValued( true )
 						.objectField( "embedded", b3 -> b3
 								.objectField( "prefix_customBridgeOnProperty", b4 -> b4
 										.field( "text", String.class )
 								)
 						)
 				)
-				.field( "embeddedMapKeys", String.class )
+				.field( "embeddedMapKeys", String.class, b2 -> b2.multiValued( true ) )
 				.objectField( "embeddedMap", b2 -> b2
+						.multiValued( true )
 						.objectField( "embedded", b3 -> b3
 								.field( "prefix_myLocalDateField", LocalDate.class )
 						)

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/bridge/MultiKeywordStringBridge.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/bridge/MultiKeywordStringBridge.java
@@ -66,6 +66,7 @@ public class MultiKeywordStringBridge implements PropertyBridge {
 		valueFieldReference = context.getIndexSchemaElement().field(
 				fieldName, f -> f.asString()
 		)
+				.multiValued()
 				.toReference();
 	}
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/extractor/ContainerExtractor.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/extractor/ContainerExtractor.java
@@ -12,4 +12,8 @@ public interface ContainerExtractor<C, V> {
 
 	Stream<V> extract(C container);
 
+	default boolean isMultiValued() {
+		return true;
+	}
+
 }

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/extractor/builtin/impl/OptionalDoubleValueExtractor.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/extractor/builtin/impl/OptionalDoubleValueExtractor.java
@@ -21,4 +21,9 @@ public class OptionalDoubleValueExtractor implements ContainerExtractor<Optional
 			return Stream.empty();
 		}
 	}
+
+	@Override
+	public boolean isMultiValued() {
+		return false;
+	}
 }

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/extractor/builtin/impl/OptionalIntValueExtractor.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/extractor/builtin/impl/OptionalIntValueExtractor.java
@@ -21,4 +21,9 @@ public class OptionalIntValueExtractor implements ContainerExtractor<OptionalInt
 			return Stream.empty();
 		}
 	}
+
+	@Override
+	public boolean isMultiValued() {
+		return false;
+	}
 }

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/extractor/builtin/impl/OptionalLongValueExtractor.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/extractor/builtin/impl/OptionalLongValueExtractor.java
@@ -21,4 +21,9 @@ public class OptionalLongValueExtractor implements ContainerExtractor<OptionalLo
 			return Stream.empty();
 		}
 	}
+
+	@Override
+	public boolean isMultiValued() {
+		return false;
+	}
 }

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/extractor/builtin/impl/OptionalValueExtractor.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/extractor/builtin/impl/OptionalValueExtractor.java
@@ -16,4 +16,9 @@ public class OptionalValueExtractor<T> implements ContainerExtractor<Optional<T>
 	public Stream<T> extract(Optional<T> container) {
 		return container == null ? Stream.empty() : container.map( Stream::of ).orElseGet( Stream::empty );
 	}
+
+	@Override
+	public boolean isMultiValued() {
+		return false;
+	}
 }

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/extractor/impl/ChainingContainerExtractor.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/extractor/impl/ChainingContainerExtractor.java
@@ -27,6 +27,11 @@ class ChainingContainerExtractor<C, U, V> implements ContainerExtractor<C, V> {
 	}
 
 	@Override
+	public boolean isMultiValued() {
+		return parent.isMultiValued() || chained.isMultiValued();
+	}
+
+	@Override
 	public String toString() {
 		StringBuilder builder = new StringBuilder( "[" );
 		appendToString( builder, this, true );

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/impl/PojoIndexModelBinder.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/impl/PojoIndexModelBinder.java
@@ -66,7 +66,8 @@ public interface PojoIndexModelBinder {
 			BoundPojoModelPathPropertyNode<?, P> modelPath, BridgeBuilder<? extends PropertyBridge> bridgeBuilder);
 
 	<V> Optional<BoundValueBridge<V, ?>> addValueBridge(IndexBindingContext bindingContext,
-			BoundPojoModelPathValueNode<?, ?, V> modelPath, BridgeBuilder<? extends ValueBridge<?, ?>> bridgeBuilder,
+			BoundPojoModelPathValueNode<?, ?, V> modelPath, boolean multiValued,
+			BridgeBuilder<? extends ValueBridge<?, ?>> bridgeBuilder,
 			String relativeFieldName, FieldModelContributor contributor);
 
 }

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/processing/building/impl/PojoIndexingProcessorContainerElementNodeBuilder.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/processing/building/impl/PojoIndexingProcessorContainerElementNodeBuilder.java
@@ -42,7 +42,8 @@ class PojoIndexingProcessorContainerElementNodeBuilder<P extends C, C, V> extend
 
 		valueNodeProcessorCollectionBuilder = new PojoIndexingProcessorValueNodeBuilderDelegate<>(
 				modelPath,
-				mappingHelper, bindingContext
+				mappingHelper, bindingContext,
+				extractorHolder.get().isMultiValued()
 		);
 	}
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/processing/building/impl/PojoIndexingProcessorPropertyNodeBuilder.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/processing/building/impl/PojoIndexingProcessorPropertyNodeBuilder.java
@@ -68,7 +68,8 @@ class PojoIndexingProcessorPropertyNodeBuilder<T, P> extends AbstractPojoProcess
 
 		this.valueWithoutExtractorBuilderDelegate = new PojoIndexingProcessorValueNodeBuilderDelegate<>(
 				modelPath.valueWithoutExtractors(),
-				mappingHelper, bindingContext
+				mappingHelper, bindingContext,
+				false
 		);
 	}
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/processing/building/impl/PojoIndexingProcessorValueNodeBuilderDelegate.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/processing/building/impl/PojoIndexingProcessorValueNodeBuilderDelegate.java
@@ -51,11 +51,15 @@ class PojoIndexingProcessorValueNodeBuilderDelegate<P, V> extends AbstractPojoPr
 
 	private final Collection<PojoIndexingProcessorTypeNodeBuilder<V>> typeNodeBuilders = new ArrayList<>();
 
+	private final boolean multiValuedFromContainerExtractor;
+
 	PojoIndexingProcessorValueNodeBuilderDelegate(
 			BoundPojoModelPathValueNode<?, P, V> modelPath,
-			PojoMappingHelper mappingHelper, IndexBindingContext bindingContext) {
+			PojoMappingHelper mappingHelper, IndexBindingContext bindingContext,
+			boolean multiValuedFromContainerExtractor) {
 		super( mappingHelper, bindingContext );
 		this.modelPath = modelPath;
+		this.multiValuedFromContainerExtractor = multiValuedFromContainerExtractor;
 	}
 
 	@Override
@@ -67,7 +71,8 @@ class PojoIndexingProcessorValueNodeBuilderDelegate<P, V> extends AbstractPojoPr
 		}
 
 		mappingHelper.getIndexModelBinder().addValueBridge(
-				bindingContext, modelPath, builder, defaultedRelativeFieldName,
+				bindingContext, modelPath, multiValuedFromContainerExtractor,
+				builder, defaultedRelativeFieldName,
 				fieldModelContributor
 		)
 				.ifPresent( boundBridges::add );
@@ -84,7 +89,7 @@ class PojoIndexingProcessorValueNodeBuilderDelegate<P, V> extends AbstractPojoPr
 		BoundPojoModelPathTypeNode<?> holderTypePath = modelPath.getParent().getParent();
 
 		Optional<IndexedEmbeddedBindingContext> nestedBindingContextOptional = bindingContext.addIndexedEmbeddedIfIncluded(
-				holderTypePath.getTypeModel().getRawType(),
+				holderTypePath.getTypeModel().getRawType(), multiValuedFromContainerExtractor,
 				defaultedRelativePrefix, storage, maxDepth, includePaths
 		);
 		nestedBindingContextOptional.ifPresent( nestedBindingContext -> {

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/document/model/StubIndexSchemaNode.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/document/model/StubIndexSchemaNode.java
@@ -124,6 +124,11 @@ public final class StubIndexSchemaNode extends StubTreeNode<StubIndexSchemaNode>
 			return this;
 		}
 
+		public Builder multiValued(boolean multiValued) {
+			attribute( "multiValued", multiValued );
+			return this;
+		}
+
 		public Builder analyzerName(String analyzerName) {
 			attribute( "analyzerName", analyzerName );
 			return this;

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/document/model/impl/AbstractStubIndexSchemaObjectNodeBuilder.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/document/model/impl/AbstractStubIndexSchemaObjectNodeBuilder.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.util.impl.integrationtest.common.stub.backend.document.model.impl;
 
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
-import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldTerminalContext;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldContext;
 import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
 import org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaObjectFieldNodeBuilder;
 import org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaObjectNodeBuilder;
@@ -24,7 +24,7 @@ abstract class AbstractStubIndexSchemaObjectNodeBuilder implements IndexSchemaOb
 	}
 
 	@Override
-	public <F> IndexSchemaFieldTerminalContext<IndexFieldReference<F>> addField(String relativeFieldName,
+	public <F> IndexSchemaFieldContext<?, IndexFieldReference<F>> addField(String relativeFieldName,
 			IndexFieldType<F> indexFieldType) {
 		StubIndexSchemaNode.Builder childBuilder = StubIndexSchemaNode.field( builder, relativeFieldName );
 		getRootNodeBuilder().getBackendBehavior().onAddField(
@@ -38,7 +38,7 @@ abstract class AbstractStubIndexSchemaObjectNodeBuilder implements IndexSchemaOb
 	}
 
 	@Override
-	public <F> IndexSchemaFieldTerminalContext<IndexFieldReference<F>> createExcludedField(String relativeFieldName,
+	public <F> IndexSchemaFieldContext<?, IndexFieldReference<F>> createExcludedField(String relativeFieldName,
 			IndexFieldType<F> indexFieldType) {
 		StubIndexSchemaNode.Builder childBuilder = StubIndexSchemaNode.field( builder, relativeFieldName );
 		return new StubIndexSchemaFieldNodeBuilder<>( childBuilder, false );

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/document/model/impl/StubIndexSchemaFieldNodeBuilder.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/document/model/impl/StubIndexSchemaFieldNodeBuilder.java
@@ -7,11 +7,12 @@
 package org.hibernate.search.util.impl.integrationtest.common.stub.backend.document.model.impl;
 
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
-import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldTerminalContext;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldContext;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.document.impl.StubIndexFieldReference;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.document.model.StubIndexSchemaNode;
 
-class StubIndexSchemaFieldNodeBuilder<F> implements IndexSchemaFieldTerminalContext<IndexFieldReference<F>> {
+class StubIndexSchemaFieldNodeBuilder<F>
+		implements IndexSchemaFieldContext<StubIndexSchemaFieldNodeBuilder<F>, IndexFieldReference<F>> {
 
 	private final StubIndexSchemaNode.Builder builder;
 	private final boolean included;
@@ -21,6 +22,12 @@ class StubIndexSchemaFieldNodeBuilder<F> implements IndexSchemaFieldTerminalCont
 	StubIndexSchemaFieldNodeBuilder(StubIndexSchemaNode.Builder builder, boolean included) {
 		this.builder = builder;
 		this.included = included;
+	}
+
+	@Override
+	public StubIndexSchemaFieldNodeBuilder<F> multiValued() {
+		builder.multiValued( true );
+		return this;
 	}
 
 	@Override

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/document/model/impl/StubIndexSchemaObjectFieldNodeBuilder.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/document/model/impl/StubIndexSchemaObjectFieldNodeBuilder.java
@@ -34,6 +34,11 @@ class StubIndexSchemaObjectFieldNodeBuilder extends AbstractStubIndexSchemaObjec
 	}
 
 	@Override
+	public void multiValued() {
+		builder.multiValued( true );
+	}
+
+	@Override
 	public IndexObjectFieldReference toReference() {
 		if ( reference == null ) {
 			reference = new StubIndexObjectFieldReference(


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3324

Note this does not bring any feature in itself, it just makes sure the index schema is properly defined by users so that we will later be able to take advantage of the information "this field is multi-valued".