### PR TITLE
HSEARCH-3537 Maximum number of facets is limited to 100 by default, related Javadoc is wrong

### DIFF
--- a/documentation/src/main/asciidoc/query.asciidoc
+++ b/documentation/src/main/asciidoc/query.asciidoc
@@ -1921,7 +1921,8 @@ this particular field value occurs within the original query results. Parameters
 Parameter `orderedBy` allows to specify in which order the created facets will be returned. The
 default is `FacetSortOrder.COUNT_DESC`, but you can also sort on the field value. Parameter
 `includeZeroCount` determines whether facets with a count of 0 will be included in the result (by
-default they are not) and `maxFacetCount` allows to limit the maximum amount of facets returned.
+default they are not) and `maxFacetCount` allows to limit the maximum amount of facets returned
+(by default 100 facets are returned).
 
 [NOTE]
 ====

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ToElasticsearch.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/impl/ToElasticsearch.java
@@ -121,7 +121,7 @@ public class ToElasticsearch {
 			JsonObject termsJsonQuery = JsonBuilder.object().add( "terms",
 					JsonBuilder.object()
 							.addProperty( "field", aggregationFieldName )
-							.addProperty( "size", facetingRequest.getMaxNumberOfFacets() == -1 ? Integer.MAX_VALUE : facetingRequest.getMaxNumberOfFacets() )
+							.addProperty( "size", facetingRequest.getMaxNumberOfFacets() < 0 ? Integer.MAX_VALUE : facetingRequest.getMaxNumberOfFacets() )
 							.add( "order", fromFacetSortOrder( facetingRequest.getSort() ) )
 							.addProperty( "min_doc_count", facetingRequest.hasZeroCountsIncluded() ? 0 : 1 )
 					).build();

--- a/engine/src/main/java/org/hibernate/search/query/dsl/FacetParameterContext.java
+++ b/engine/src/main/java/org/hibernate/search/query/dsl/FacetParameterContext.java
@@ -8,6 +8,7 @@
 package org.hibernate.search.query.dsl;
 
 import org.hibernate.search.query.facet.FacetSortOrder;
+import org.hibernate.search.query.facet.FacetingRequest;
 
 /**
  * @author Hardy Ferentschik
@@ -31,7 +32,7 @@ public interface FacetParameterContext extends FacetTermination {
 	 * Limits the maximum numbers of facets to the specified number.
 	 *
 	 * @param maxFacetCount the maximum number of facets to include in the response. A negative value means that
-	 * all facets will be included
+	 * {@value FacetingRequest#DEFAULT_MAX_FACET_COUNT} facets will be included
 	 * @return a {@code FacetParameterContext} to continue building the facet request
 	 */
 	FacetParameterContext maxFacetCount(int maxFacetCount);

--- a/engine/src/main/java/org/hibernate/search/query/engine/impl/QueryHits.java
+++ b/engine/src/main/java/org/hibernate/search/query/engine/impl/QueryHits.java
@@ -73,7 +73,6 @@ public class QueryHits {
 	private static final Log log = LoggerFactory.make( MethodHandles.lookup() );
 
 	private static final int DEFAULT_TOP_DOC_RETRIEVAL_SIZE = 100;
-	private static final int DEFAULT_FACET_RETRIEVAL_SIZE = 100;
 
 
 	private final LazyQueryState searcher;
@@ -425,7 +424,8 @@ public class QueryHits {
 			termValues = findAllTermsForField( facetMetadata.getSourceField().getAbsoluteName(), searcher.getIndexReader() );
 		}
 
-		int maxFacetCount = facetRequest.getMaxNumberOfFacets() < 0 ? DEFAULT_FACET_RETRIEVAL_SIZE : facetRequest.getMaxNumberOfFacets();
+		int maxFacetCount = facetRequest.getMaxNumberOfFacets() < 0 ? FacetingRequest.DEFAULT_MAX_FACET_COUNT
+				: facetRequest.getMaxNumberOfFacets();
 		final FacetResult facetResult;
 		try {
 			// This might return null!

--- a/engine/src/main/java/org/hibernate/search/query/facet/FacetingRequest.java
+++ b/engine/src/main/java/org/hibernate/search/query/facet/FacetingRequest.java
@@ -12,6 +12,12 @@ package org.hibernate.search.query.facet;
  * @author Hardy Ferentschik
  */
 public interface FacetingRequest {
+
+	/**
+	 * The default maximum number of facets when {@link #getMaxNumberOfFacets()} is negative.
+	 */
+	int DEFAULT_MAX_FACET_COUNT = 100;
+
 	/**
 	 * @return the name of this faceting request. The faceting name can be an arbitrary string.
 	 */


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3537

To be backported to several other branches, see the ticket.

I already updated the migration guide from 5.2 to 5.3: http://hibernate.org/search/documentation/migrate/5.3/