### PR TITLE
HSEARCH-3562 Reporting errors about duplicate fields fails with an AssertionFailure when field is declared by a class bridge or class-level @Spatial

### DIFF
--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/AnnotationMetadataProvider.java
@@ -300,7 +300,7 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 
 		DocumentFieldMetadata.Builder fieldMetadataBuilder =
 				new DocumentFieldMetadata.Builder(
-						typeMetadataBuilder.getResultReference(),
+						typeMetadataBuilder,
 						propertyMetadataBuilder.getResultReference(), propertyMetadataBuilder,
 						fieldPath, Store.YES, index, termVector
 						)
@@ -383,7 +383,7 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 				reflectionManager.toClass( member.getType() ) );
 
 		DocumentFieldMetadata.Builder idMetadataBuilder = new DocumentFieldMetadata.Builder(
-						typeMetadataBuilder.getResultReference(),
+						typeMetadataBuilder,
 						propertyMetadataBuilder.getResultReference(), propertyMetadataBuilder,
 						fieldPath,
 						Store.YES,
@@ -491,7 +491,7 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 
 		DocumentFieldMetadata.Builder fieldMetadataBuilder =
 				new DocumentFieldMetadata.Builder(
-						typeMetadataBuilder.getResultReference(),
+						typeMetadataBuilder,
 						propertyMetadataBuilder.getResultReference(), propertyMetadataBuilder,
 						fieldPath,
 						Store.YES,
@@ -765,7 +765,7 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 
 		DocumentFieldMetadata.Builder fieldMetadataBuilder =
 				new DocumentFieldMetadata.Builder(
-						typeMetadataBuilder.getResultReference(),
+						typeMetadataBuilder,
 						// Class bridge, there's no related property
 						BackReference.<PropertyMetadata>empty(),
 						null,
@@ -823,7 +823,7 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 
 		DocumentFieldMetadata.Builder fieldMetadataBuilder =
 				new DocumentFieldMetadata.Builder(
-						typeMetadataBuilder.getResultReference(),
+						typeMetadataBuilder,
 						propertyMetadataBuilder.getResultReference(), propertyMetadataBuilder,
 						fieldPath, store, index, termVector
 				)
@@ -874,7 +874,7 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 
 		DocumentFieldMetadata.Builder fieldMetadataBuilder =
 				new DocumentFieldMetadata.Builder(
-						typeMetadataBuilder.getResultReference(),
+						typeMetadataBuilder,
 						BackReference.<PropertyMetadata>empty(), null, // Class-level spatial annotation, there's no related property
 						fieldPath, store, index, termVector
 				)
@@ -1362,7 +1362,7 @@ public class AnnotationMetadataProvider implements MetadataProvider {
 		}
 
 		DocumentFieldMetadata.Builder fieldMetadataBuilder = new DocumentFieldMetadata.Builder(
-						typeMetadataBuilder.getResultReference(),
+						typeMetadataBuilder,
 						propertyMetadataBuilder.getResultReference(), propertyMetadataBuilder,
 						fieldPath,
 						store,

--- a/engine/src/main/java/org/hibernate/search/engine/metadata/impl/TypeMetadata.java
+++ b/engine/src/main/java/org/hibernate/search/engine/metadata/impl/TypeMetadata.java
@@ -444,7 +444,7 @@ public class TypeMetadata {
 					PropertyMetadata sourceProperty = documentFieldMetadata.getSourceProperty();
 					String sourceTypeName = sourceProperty != null
 							? sourceProperty.getPropertyAccessor().getDeclaringClass().getName()
-							: documentFieldMetadata.getSourceType().getType().getName();
+							: documentFieldMetadata.getSourceTypeIdentifier().getName();
 					log.inconsistentFieldConfiguration( sourceTypeName, name );
 				}
 			}

--- a/engine/src/main/java/org/hibernate/search/engine/spi/DocumentBuilderIndexedEntity.java
+++ b/engine/src/main/java/org/hibernate/search/engine/spi/DocumentBuilderIndexedEntity.java
@@ -105,7 +105,7 @@ public class DocumentBuilderIndexedEntity extends AbstractDocumentBuilder {
 	static {
 		DocumentFieldMetadata fieldMetadata =
 				new DocumentFieldMetadata.Builder(
-						BackReference.<TypeMetadata>empty(),
+						null,
 						BackReference.<PropertyMetadata>empty(), null,
 						new DocumentFieldPath( "", "" ), // No field path
 						Store.NO,

--- a/engine/src/test/java/org/hibernate/search/test/bridge/DuplicateFieldTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/DuplicateFieldTest.java
@@ -6,16 +6,23 @@
  */
 package org.hibernate.search.test.bridge;
 
+import org.hibernate.search.annotations.ClassBridge;
 import org.hibernate.search.annotations.DocumentId;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Index;
 import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.bridge.LuceneOptions;
+import org.hibernate.search.bridge.MetadataProvidingFieldBridge;
+import org.hibernate.search.bridge.spi.FieldMetadataBuilder;
 import org.hibernate.search.test.util.impl.ExpectedLog4jLog;
+import org.hibernate.search.testsupport.TestForIssue;
 import org.hibernate.search.testsupport.junit.SearchIntegratorResource;
 import org.hibernate.search.testsupport.setup.SearchConfigurationForTest;
 
 import org.junit.Rule;
 import org.junit.Test;
+
+import org.apache.lucene.document.Document;
 
 public class DuplicateFieldTest {
 
@@ -41,6 +48,23 @@ public class DuplicateFieldTest {
 		integratorResource.create( cfg );
 	}
 
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-3562") // This used to fail because some metadata was accessed before it was created
+	public void shouldWarnButNotFailOnTwoFieldDefinitionsWithSameNameButDifferentIndexSettingFromClassBridges() {
+		SearchConfigurationForTest cfg = new SearchConfigurationForTest();
+		cfg.addClass( SampleWithTwoFieldDefinitionsWithSameNameButDifferentIndexSettingFromClassBridge.class );
+
+		logged.expectMessage(
+				"HSEARCH000120",
+				"There are multiple properties indexed against the same field name '"
+						+ SampleWithTwoFieldDefinitionsWithSameNameButDifferentIndexSettingFromClassBridge.class.getName() + ".theField'",
+				"with different indexing settings",
+				"The behaviour is undefined"
+		);
+
+		integratorResource.create( cfg );
+	}
+
 	@Indexed
 	static class SampleWithTwoFieldDefinitionsWithSameNameButDifferentIndexSetting {
 
@@ -52,5 +76,33 @@ public class DuplicateFieldTest {
 
 		@Field(name = "theField", index = Index.NO)
 		String otherProperty;
+	}
+
+	@Indexed
+	@ClassBridge(name = "theField", impl = MyBridge.class)
+	@ClassBridge(name = "theField", impl = MyBridge.class, index = Index.NO)
+	static class SampleWithTwoFieldDefinitionsWithSameNameButDifferentIndexSettingFromClassBridge {
+
+		@DocumentId
+		long id;
+
+		String someProperty;
+
+		String otherProperty;
+	}
+
+	public static class MyBridge implements MetadataProvidingFieldBridge {
+		public MyBridge() {
+		}
+
+		@Override
+		public void configureFieldMetadata(String name, FieldMetadataBuilder builder) {
+			// Nothing to do
+		}
+
+		@Override
+		public void set(String name, Object value, Document document, LuceneOptions luceneOptions) {
+			throw new UnsupportedOperationException( "This should not be called" );
+		}
 	}
 }

--- a/engine/src/test/java/org/hibernate/search/test/bridge/DuplicateFieldTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/DuplicateFieldTest.java
@@ -1,0 +1,56 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.test.bridge;
+
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Index;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.test.util.impl.ExpectedLog4jLog;
+import org.hibernate.search.testsupport.junit.SearchIntegratorResource;
+import org.hibernate.search.testsupport.setup.SearchConfigurationForTest;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+public class DuplicateFieldTest {
+
+	@Rule
+	public final SearchIntegratorResource integratorResource = new SearchIntegratorResource();
+
+	@Rule
+	public ExpectedLog4jLog logged = ExpectedLog4jLog.create();
+
+	@Test
+	public void shouldWarnOnTwoFieldDefinitionsWithSameNameButDifferentIndexSetting() {
+		SearchConfigurationForTest cfg = new SearchConfigurationForTest();
+		cfg.addClass( SampleWithTwoFieldDefinitionsWithSameNameButDifferentIndexSetting.class );
+
+		logged.expectMessage(
+				"HSEARCH000120",
+				"There are multiple properties indexed against the same field name '"
+						+ SampleWithTwoFieldDefinitionsWithSameNameButDifferentIndexSetting.class.getName() + ".theField'",
+				"with different indexing settings",
+				"The behaviour is undefined"
+		);
+
+		integratorResource.create( cfg );
+	}
+
+	@Indexed
+	static class SampleWithTwoFieldDefinitionsWithSameNameButDifferentIndexSetting {
+
+		@DocumentId
+		long id;
+
+		@Field(name = "theField")
+		String someProperty;
+
+		@Field(name = "theField", index = Index.NO)
+		String otherProperty;
+	}
+}

--- a/engine/src/test/java/org/hibernate/search/test/bridge/builtin/TikaBridgeTest.java
+++ b/engine/src/test/java/org/hibernate/search/test/bridge/builtin/TikaBridgeTest.java
@@ -61,7 +61,7 @@ public class TikaBridgeTest {
 		testDocument = new Document();
 		DocumentFieldMetadata fieldMetadata =
 				new DocumentFieldMetadata.Builder(
-						new BackReference<>(),
+						null,
 						new BackReference<>(), null,
 						new DocumentFieldPath( "", "" ), // No field path
 						Store.YES, Field.Index.ANALYZED, Field.TermVector.NO


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3562

To be backported to several other branches, see the ticket.