### PR TITLE
HSEARCH-3572 Add fetch methods to terminal steps of the query DSL

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/query/ElasticsearchSearchQueryContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/query/ElasticsearchSearchQueryContext.java
@@ -7,11 +7,13 @@
 package org.hibernate.search.backend.elasticsearch.search.dsl.query;
 
 import org.hibernate.search.backend.elasticsearch.search.dsl.sort.ElasticsearchSearchSortContainerContext;
+import org.hibernate.search.backend.elasticsearch.search.query.ElasticsearchSearchFetchable;
 import org.hibernate.search.backend.elasticsearch.search.query.ElasticsearchSearchQuery;
 import org.hibernate.search.engine.search.dsl.query.SearchQueryContext;
 
 public interface ElasticsearchSearchQueryContext<H>
-		extends SearchQueryContext<ElasticsearchSearchQueryContext<H>, H, ElasticsearchSearchSortContainerContext> {
+		extends SearchQueryContext<ElasticsearchSearchQueryContext<H>, H, ElasticsearchSearchSortContainerContext>,
+				ElasticsearchSearchFetchable<H> {
 
 	@Override
 	ElasticsearchSearchQuery<H> toQuery();

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/query/impl/ElasticsearchSearchQueryContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/query/impl/ElasticsearchSearchQueryContextImpl.java
@@ -13,16 +13,18 @@ import org.hibernate.search.backend.elasticsearch.search.dsl.query.Elasticsearch
 import org.hibernate.search.backend.elasticsearch.search.dsl.sort.ElasticsearchSearchSortContainerContext;
 import org.hibernate.search.backend.elasticsearch.search.impl.ElasticsearchSearchQueryElementCollector;
 import org.hibernate.search.backend.elasticsearch.search.query.ElasticsearchSearchQuery;
+import org.hibernate.search.backend.elasticsearch.search.query.ElasticsearchSearchResult;
 import org.hibernate.search.backend.elasticsearch.search.query.impl.ElasticsearchIndexSearchScope;
 import org.hibernate.search.backend.elasticsearch.search.query.impl.ElasticsearchSearchQueryBuilder;
 import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryContext;
-import org.hibernate.search.engine.search.dsl.query.spi.AbstractSearchQueryContext;
+import org.hibernate.search.engine.search.dsl.query.spi.AbstractExtendedSearchQueryContext;
 import org.hibernate.search.engine.search.dsl.sort.SearchSortContainerContext;
 
 class ElasticsearchSearchQueryContextImpl<H>
-		extends AbstractSearchQueryContext<
+		extends AbstractExtendedSearchQueryContext<
 				ElasticsearchSearchQueryContext<H>,
 				H,
+				ElasticsearchSearchResult<H>,
 				ElasticsearchSearchPredicateFactoryContext,
 				ElasticsearchSearchSortContainerContext,
 				ElasticsearchSearchQueryElementCollector

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/ElasticsearchSearchFetchable.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/ElasticsearchSearchFetchable.java
@@ -1,0 +1,13 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.search.query;
+
+import org.hibernate.search.engine.search.query.ExtendedSearchFetchable;
+
+public interface ElasticsearchSearchFetchable<H> extends ExtendedSearchFetchable<H, ElasticsearchSearchResult<H>> {
+
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/ElasticsearchSearchQuery.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/ElasticsearchSearchQuery.java
@@ -8,7 +8,8 @@ package org.hibernate.search.backend.elasticsearch.search.query;
 
 import org.hibernate.search.engine.search.query.ExtendedSearchQuery;
 
-public interface ElasticsearchSearchQuery<H> extends ExtendedSearchQuery<H, ElasticsearchSearchResult<H>> {
+public interface ElasticsearchSearchQuery<H>
+		extends ExtendedSearchQuery<H, ElasticsearchSearchResult<H>>, ElasticsearchSearchFetchable<H> {
 
 	/**
 	 * Explain score computation of this query for the document with the given id.

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/query/LuceneSearchQueryContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/query/LuceneSearchQueryContext.java
@@ -7,11 +7,13 @@
 package org.hibernate.search.backend.lucene.search.dsl.query;
 
 import org.hibernate.search.backend.lucene.search.dsl.sort.LuceneSearchSortContainerContext;
+import org.hibernate.search.backend.lucene.search.query.LuceneSearchFetchable;
 import org.hibernate.search.backend.lucene.search.query.LuceneSearchQuery;
 import org.hibernate.search.engine.search.dsl.query.SearchQueryContext;
 
 public interface LuceneSearchQueryContext<H>
-		extends SearchQueryContext<LuceneSearchQueryContext<H>, H, LuceneSearchSortContainerContext> {
+		extends SearchQueryContext<LuceneSearchQueryContext<H>, H, LuceneSearchSortContainerContext>,
+				LuceneSearchFetchable<H> {
 
 	@Override
 	LuceneSearchQuery<H> toQuery();

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/query/impl/LuceneSearchQueryContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/query/impl/LuceneSearchQueryContextImpl.java
@@ -13,19 +13,21 @@ import org.hibernate.search.backend.lucene.search.dsl.query.LuceneSearchQueryRes
 import org.hibernate.search.backend.lucene.search.dsl.sort.LuceneSearchSortContainerContext;
 import org.hibernate.search.backend.lucene.search.impl.LuceneSearchQueryElementCollector;
 import org.hibernate.search.backend.lucene.search.query.LuceneSearchQuery;
+import org.hibernate.search.backend.lucene.search.query.LuceneSearchResult;
 import org.hibernate.search.backend.lucene.search.query.impl.LuceneIndexSearchScope;
 import org.hibernate.search.backend.lucene.search.query.impl.LuceneSearchQueryBuilder;
 import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryContext;
-import org.hibernate.search.engine.search.dsl.query.spi.AbstractSearchQueryContext;
+import org.hibernate.search.engine.search.dsl.query.spi.AbstractExtendedSearchQueryContext;
 import org.hibernate.search.engine.search.dsl.sort.SearchSortContainerContext;
 
 class LuceneSearchQueryContextImpl<H>
-		extends AbstractSearchQueryContext<
-		LuceneSearchQueryContext<H>,
-		H,
-		LuceneSearchPredicateFactoryContext,
-		LuceneSearchSortContainerContext,
-		LuceneSearchQueryElementCollector
+		extends AbstractExtendedSearchQueryContext<
+				LuceneSearchQueryContext<H>,
+				H,
+				LuceneSearchResult<H>,
+				LuceneSearchPredicateFactoryContext,
+				LuceneSearchSortContainerContext,
+				LuceneSearchQueryElementCollector
 		>
 		implements LuceneSearchQueryResultContext<H>, LuceneSearchQueryContext<H> {
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/LuceneSearchFetchable.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/LuceneSearchFetchable.java
@@ -1,0 +1,13 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.search.query;
+
+import org.hibernate.search.engine.search.query.ExtendedSearchFetchable;
+
+public interface LuceneSearchFetchable<H> extends ExtendedSearchFetchable<H, LuceneSearchResult<H>> {
+
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/LuceneSearchQuery.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/LuceneSearchQuery.java
@@ -10,7 +10,8 @@ import org.hibernate.search.engine.search.query.ExtendedSearchQuery;
 
 import org.apache.lucene.search.Explanation;
 
-public interface LuceneSearchQuery<H> extends ExtendedSearchQuery<H, LuceneSearchResult<H>> {
+public interface LuceneSearchQuery<H>
+		extends ExtendedSearchQuery<H, LuceneSearchResult<H>>, LuceneSearchFetchable<H> {
 
 	/**
 	 * Explain score computation of this query for the document with the given id.

--- a/documentation/src/main/asciidoc/getting-started.asciidoc
+++ b/documentation/src/main/asciidoc/getting-started.asciidoc
@@ -293,12 +293,11 @@ include::{sourcedir}/org/hibernate/search/documentation/gettingstarted/withhsear
 but other options are available.
 <4> Define that only documents matching the given predicate should be returned.
 The predicate is created using a factory `f` passed as an argument to the lambda expression.
-<5> Build the query.
-<6> Execute the query and fetch the results.
-<7> Retrieve the total number of matching entities.
-<8> Retrieve matching entities.
-<9> In case you're not interested in the whole result, but only in the hits,
-you can also call `fetchHits()` on the query directly.
+<5> Build the query and fetch the results.
+<6> Retrieve the total number of matching entities.
+<7> Retrieve matching entities.
+<8> In case you're not interested in the whole result, but only in the hits,
+you can also call `fetchHits()` directly.
 ====
 
 If for some reason you don't want to use lambdas, you can use an alternative, object-based syntax,
@@ -317,23 +316,22 @@ include::{sourcedir}/org/hibernate/search/documentation/gettingstarted/withhsear
 but other options are available.
 <5> Define that only documents matching the given predicate should be returned.
 The predicate is created using the same search scope as the query.
-<6> Build the query.
-<7> Execute the query and fetch the results.
-<8> Retrieve the total number of matching entities.
-<9> Retrieve matching entities.
-<10> In case you're not interested in the whole result, but only in the hits,
-you can also call `fetchHits()` on the query directly.
+<6> Build the query and fetch the results.
+<7> Retrieve the total number of matching entities.
+<8> Retrieve matching entities.
+<9> In case you're not interested in the whole result, but only in the hits,
+you can also call `fetchHits()` directly.
 ====
 
-It is possible to get just the result size, using `fetchTotalHitCount()` method.
+It is possible to get just the total hit count, using `fetchTotalHitCount()` method.
 
-.Using Hibernate Search to count the indexes
+.Using Hibernate Search to count the matches
 ====
 [source, JAVA, indent=0, subs="+callouts"]
 ----
 include::{sourcedir}/org/hibernate/search/documentation/gettingstarted/withhsearch/withoutanalysis/GettingStartedWithoutAnalysisIT.java[tags=counting]
 ----
-<1> Fetch the result size.
+<1> Fetch the total hit count.
 ====
 
 [[getting-started-analysis]]

--- a/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withhsearch/withanalysis/GettingStartedWithAnalysisIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withhsearch/withanalysis/GettingStartedWithAnalysisIT.java
@@ -13,7 +13,6 @@ import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 
 import org.hibernate.search.mapper.orm.Search;
-import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.engine.search.query.SearchResult;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.util.impl.integrationtest.orm.OrmUtils;
@@ -79,15 +78,13 @@ public class GettingStartedWithAnalysisIT {
 			// Not shown: get the entity manager and open a transaction
 			SearchSession searchSession = Search.getSearchSession( entityManager );
 
-			SearchQuery<Book> query = searchSession.search( Book.class )
+			SearchResult<Book> result = searchSession.search( Book.class )
 					.asEntity()
 					.predicate( factory -> factory.match()
 							.onFields( "title", "authors.name" )
 							.matching( "refactor" )
 					)
-					.toQuery();
-
-			SearchResult<Book> result = query.fetch();
+					.fetch();
 			// Not shown: commit the transaction and close the entity manager
 			// end::searching[]
 
@@ -100,14 +97,13 @@ public class GettingStartedWithAnalysisIT {
 			SearchSession searchSession = Search.getSearchSession( entityManager );
 
 			for ( String term : new String[] { "Refactor", "refactors", "refactored", "refactoring" } ) {
-				SearchQuery<Book> query = searchSession.search( Book.class )
+				SearchResult<Book> result = searchSession.search( Book.class )
 						.asEntity()
 						.predicate( factory -> factory.match()
 								.onFields( "title", "authors.name" )
 								.matching( term )
 						)
-						.toQuery();
-				SearchResult<Book> result = query.fetch();
+						.fetch();
 				assertThat( result.getHits() ).as( "Result of searching for '" + term + "'" )
 						.extracting( "id" )
 						.containsExactlyInAnyOrder( bookIdHolder.get() );

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/directfieldmapping/HibernateOrmSimpleMappingIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/directfieldmapping/HibernateOrmSimpleMappingIT.java
@@ -16,7 +16,6 @@ import org.hibernate.search.documentation.testsupport.BackendSetupStrategy;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmAutomaticIndexingSynchronizationStrategyName;
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
-import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.mapper.orm.search.SearchScope;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.util.impl.integrationtest.orm.OrmSetupHelper;
@@ -74,7 +73,7 @@ public class HibernateOrmSimpleMappingIT {
 
 			SearchScope<Book> scope = searchSession.scope( Book.class );
 
-			SearchQuery<Book> query = scope.search()
+			List<Book> result = scope.search()
 					.asEntity()
 					.predicate( scope.predicate().matchAll().toPredicate() )
 					.sort(
@@ -83,9 +82,7 @@ public class HibernateOrmSimpleMappingIT {
 							.then().byField( "title_sort" )
 							.toSort()
 					)
-					.toQuery();
-
-			List<Book> result = query.fetchHits();
+					.fetchHits();
 			// end::sort-simple-objects[]
 
 			assertThat( result )
@@ -97,15 +94,13 @@ public class HibernateOrmSimpleMappingIT {
 			// tag::sort-simple-lambdas[]
 			SearchSession searchSession = Search.getSearchSession( entityManager );
 
-			SearchQuery<Book> query = searchSession.search( Book.class ) // <1>
+			List<Book> result = searchSession.search( Book.class ) // <1>
 					.asEntity()
 					.predicate( f -> f.matchAll() )
 					.sort( f -> f.byField( "pageCount" ).desc() // <2>
 							.then().byField( "title_sort" )
 					)
-					.toQuery();
-
-			List<Book> result = query.fetchHits(); // <3>
+					.fetchHits(); // <3>
 			// end::sort-simple-lambdas[]
 
 			assertThat( result )
@@ -122,12 +117,10 @@ public class HibernateOrmSimpleMappingIT {
 
 			SearchScope<Book> scope = searchSession.scope( Book.class );
 
-			SearchQuery<String> query = scope.search()
+			List<String> result = scope.search()
 					.asProjection( scope.projection().field( "title", String.class ).toProjection() )
 					.predicate( scope.predicate().matchAll().toPredicate() )
-					.toQuery();
-
-			List<String> result = query.fetchHits();
+					.fetchHits();
 			// end::projection-simple-objects[]
 
 			assertThat( result )
@@ -138,12 +131,10 @@ public class HibernateOrmSimpleMappingIT {
 			// tag::projection-simple-lambdas[]
 			SearchSession searchSession = Search.getSearchSession( entityManager );
 
-			SearchQuery<String> query = searchSession.search( Book.class ) // <1>
+			List<String> result = searchSession.search( Book.class ) // <1>
 					.asProjection( f -> f.field( "title", String.class ) ) // <2>
 					.predicate( f -> f.matchAll() )
-					.toQuery();
-
-			List<String> result = query.fetchHits(); // <3>
+					.fetchHits(); // <3>
 			// end::projection-simple-lambdas[]
 
 			assertThat( result )
@@ -157,16 +148,14 @@ public class HibernateOrmSimpleMappingIT {
 			// tag::projection-advanced[]
 			SearchSession searchSession = Search.getSearchSession( entityManager );
 
-			SearchQuery<MyEntityAndScoreBean<Book>> query = searchSession.search( Book.class )
+			List<MyEntityAndScoreBean<Book>> result = searchSession.search( Book.class )
 					.asProjection( f -> f.composite(
 							MyEntityAndScoreBean::new,
 							f.entity(),
 							f.score()
 					) )
 					.predicate( f -> f.matchAll() )
-					.toQuery();
-
-			List<MyEntityAndScoreBean<Book>> result = query.fetchHits();
+					.fetchHits();
 			// end::projection-advanced[]
 
 			assertThat( result )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/entityindexmapping/HibernateOrmIndexedIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/entityindexmapping/HibernateOrmIndexedIT.java
@@ -66,18 +66,16 @@ public class HibernateOrmIndexedIT {
 		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.getSearchSession( entityManager );
 
-			SearchQuery<Author> authorQuery = searchSession.search( Author.class )
+			List<Author> authorResult = searchSession.search( Author.class )
 					.asEntity()
 					.predicate( f -> f.matchAll() )
-					.toQuery();
-			List<Author> bookResult = authorQuery.fetchHits();
-			assertThat( bookResult ).hasSize( 1 );
+					.fetchHits();
+			assertThat( authorResult ).hasSize( 1 );
 
-			SearchQuery<User> userQuery = searchSession.search( User.class )
+			List<User> userResult = searchSession.search( User.class )
 					.asEntity()
 					.predicate( f -> f.matchAll() )
-					.toQuery();
-			List<User> userResult = userQuery.fetchHits();
+					.fetchHits();
 			assertThat( userResult ).hasSize( 1 );
 		} );
 	}

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmAutomaticIndexingIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmAutomaticIndexingIT.java
@@ -81,7 +81,6 @@ public class HibernateOrmAutomaticIndexingIT {
 
 			List<Book> result = searchSession.search( Book.class ).asEntity()
 					.predicate( f -> f.match().onField( "title" ).matching( "2nd edition" ) )
-					.toQuery()
 					.fetchHits(); // <5>
 			// end::automatic-indexing-synchronization-strategy-override[]
 

--- a/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/DslConverterIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/DslConverterIT.java
@@ -21,7 +21,6 @@ import org.hibernate.search.engine.search.predicate.DslConverter;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmAutomaticIndexingSynchronizationStrategyName;
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
-import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.bridge.ValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.runtime.ValueBridgeToIndexedValueContext;
@@ -72,14 +71,12 @@ public class DslConverterIT {
 			SearchSession searchSession = Search.getSearchSession( entityManager );
 
 			// tag::dsl-converter-enabled[]
-			SearchQuery<AuthenticationEvent> query = searchSession.search( AuthenticationEvent.class )
+			List<AuthenticationEvent> result = searchSession.search( AuthenticationEvent.class )
 					.asEntity()
 					.predicate( f -> f.match().onField( "outcome" )
 							.matching( AuthenticationOutcome.INVALID_PASSWORD ) )
-					.toQuery();
+					.fetchHits();
 			// end::dsl-converter-enabled[]
-
-			List<AuthenticationEvent> result = query.fetchHits();
 
 			assertThat( result )
 					.extracting( "id" )
@@ -93,14 +90,12 @@ public class DslConverterIT {
 			SearchSession searchSession = Search.getSearchSession( entityManager );
 
 			// tag::dsl-converter-disabled[]
-			SearchQuery<AuthenticationEvent> query = searchSession.search( AuthenticationEvent.class )
+			List<AuthenticationEvent> result = searchSession.search( AuthenticationEvent.class )
 					.asEntity()
 					.predicate( f -> f.match().onField( "outcome" )
 							.matching( "Invalid password", DslConverter.DISABLED ) )
-					.toQuery();
+					.fetchHits();
 			// end::dsl-converter-disabled[]
-
-			List<AuthenticationEvent> result = query.fetchHits();
 
 			assertThat( result )
 					.extracting( "id" )

--- a/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/ProjectionConverterIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/ProjectionConverterIT.java
@@ -24,7 +24,6 @@ import org.hibernate.search.engine.search.projection.ProjectionConverter;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmAutomaticIndexingSynchronizationStrategyName;
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
-import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
@@ -72,13 +71,11 @@ public class ProjectionConverterIT {
 			SearchSession searchSession = Search.getSearchSession( entityManager );
 
 			// tag::projection-converter-enabled[]
-			SearchQuery<OrderStatus> query = searchSession.search( Order.class )
+			List<OrderStatus> result = searchSession.search( Order.class )
 					.asProjection( f -> f.field( "status", OrderStatus.class ) )
 					.predicate( f -> f.matchAll() )
-					.toQuery();
+					.fetchHits();
 			// end::projection-converter-enabled[]
-
-			List<OrderStatus> result = query.fetchHits();
 
 			assertThat( result )
 					.containsExactlyInAnyOrder( OrderStatus.values() );
@@ -91,13 +88,11 @@ public class ProjectionConverterIT {
 			SearchSession searchSession = Search.getSearchSession( entityManager );
 
 			// tag::projection-converter-disabled[]
-			SearchQuery<String> query = searchSession.search( Order.class )
+			List<String> result = searchSession.search( Order.class )
 					.asProjection( f -> f.field( "status", String.class, ProjectionConverter.DISABLED ) )
 					.predicate( f -> f.matchAll() )
-					.toQuery();
+					.fetchHits();
 			// end::projection-converter-disabled[]
-
-			List<String> result = query.fetchHits();
 
 			assertThat( result )
 					.containsExactlyInAnyOrder(

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/SearchQueryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/SearchQueryContext.java
@@ -12,6 +12,7 @@ import java.util.function.Consumer;
 
 import org.hibernate.search.engine.search.SearchSort;
 import org.hibernate.search.engine.search.dsl.sort.SearchSortContainerContext;
+import org.hibernate.search.engine.search.query.SearchFetchable;
 import org.hibernate.search.engine.search.query.SearchQuery;
 
 /**
@@ -25,7 +26,8 @@ public interface SearchQueryContext<
 		S extends SearchQueryContext<? extends S, H, SC>,
 		H,
 		SC extends SearchSortContainerContext
-		> {
+		>
+		extends SearchFetchable<H> {
 
 	S routing(String routingKey);
 

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/spi/AbstractExtendedSearchQueryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/spi/AbstractExtendedSearchQueryContext.java
@@ -1,0 +1,50 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.dsl.query.spi;
+
+import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryContext;
+import org.hibernate.search.engine.search.dsl.query.SearchQueryContext;
+import org.hibernate.search.engine.search.dsl.sort.SearchSortContainerContext;
+import org.hibernate.search.engine.search.dsl.spi.IndexSearchScope;
+import org.hibernate.search.engine.search.query.ExtendedSearchQuery;
+import org.hibernate.search.engine.search.query.SearchResult;
+import org.hibernate.search.engine.search.query.spi.SearchQueryBuilder;
+
+public abstract class AbstractExtendedSearchQueryContext<
+		S extends SearchQueryContext<S, H, SC>,
+		H,
+		R extends SearchResult<H>,
+		PC extends SearchPredicateFactoryContext,
+		SC extends SearchSortContainerContext,
+		C
+		>
+		extends AbstractSearchQueryContext<S, H, PC, SC, C> {
+
+	public AbstractExtendedSearchQueryContext(IndexSearchScope<C> indexSearchScope,
+			SearchQueryBuilder<H, C> searchQueryBuilder) {
+		super( indexSearchScope, searchQueryBuilder );
+	}
+
+	@Override
+	public abstract ExtendedSearchQuery<H, R> toQuery();
+
+	@Override
+	public R fetch() {
+		return toQuery().fetch();
+	}
+
+	@Override
+	public R fetch(Integer limit) {
+		return toQuery().fetch( limit );
+	}
+
+	@Override
+	public R fetch(Integer limit, Integer offset) {
+		return toQuery().fetch( limit, offset );
+	}
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/spi/AbstractSearchQueryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/spi/AbstractSearchQueryContext.java
@@ -7,6 +7,8 @@
 package org.hibernate.search.engine.search.dsl.query.spi;
 
 import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -23,6 +25,7 @@ import org.hibernate.search.engine.search.dsl.sort.impl.SearchSortDslContextImpl
 import org.hibernate.search.engine.search.dsl.spi.IndexSearchScope;
 import org.hibernate.search.engine.search.predicate.spi.SearchPredicateBuilderFactory;
 import org.hibernate.search.engine.search.query.SearchQuery;
+import org.hibernate.search.engine.search.query.SearchResult;
 import org.hibernate.search.engine.search.query.spi.SearchQueryBuilder;
 import org.hibernate.search.engine.search.sort.spi.SearchSortBuilderFactory;
 
@@ -89,6 +92,46 @@ public abstract class AbstractSearchQueryContext<
 	@Override
 	public SearchQuery<H> toQuery() {
 		return searchQueryBuilder.build();
+	}
+
+	@Override
+	public SearchResult<H> fetch() {
+		return toQuery().fetch();
+	}
+
+	@Override
+	public SearchResult<H> fetch(Integer limit) {
+		return toQuery().fetch( limit );
+	}
+
+	@Override
+	public SearchResult<H> fetch(Integer limit, Integer offset) {
+		return toQuery().fetch( limit, offset );
+	}
+
+	@Override
+	public List<H> fetchHits() {
+		return toQuery().fetchHits();
+	}
+
+	@Override
+	public List<H> fetchHits(Integer limit) {
+		return toQuery().fetchHits( limit );
+	}
+
+	@Override
+	public List<H> fetchHits(Integer limit, Integer offset) {
+		return toQuery().fetchHits( limit, offset );
+	}
+
+	@Override
+	public Optional<H> fetchSingleHit() {
+		return toQuery().fetchSingleHit();
+	}
+
+	@Override
+	public long fetchTotalHitCount() {
+		return toQuery().fetchTotalHitCount();
 	}
 
 	private <B> void contribute(SearchPredicateBuilderFactory<? super C, B> factory, SearchPredicate predicate) {

--- a/engine/src/main/java/org/hibernate/search/engine/search/query/ExtendedSearchFetchable.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/query/ExtendedSearchFetchable.java
@@ -7,13 +7,21 @@
 package org.hibernate.search.engine.search.query;
 
 /**
- * A base interface for subtypes of {@link SearchQuery} allowing to
+ * A base interface for subtypes of {@link SearchFetchable} allowing to
  * easily override the result type for all relevant methods.
  *
  * @param <H> The type of query hits.
  * @param <R> The result type (extending {@link SearchResult}).
  */
-public interface ExtendedSearchQuery<H, R extends SearchResult<H>>
-		extends SearchQuery<H>, ExtendedSearchFetchable<H, R> {
+public interface ExtendedSearchFetchable<H, R extends SearchResult<H>> extends SearchFetchable<H> {
+
+	@Override
+	R fetch();
+
+	@Override
+	R fetch(Integer limit);
+
+	@Override
+	R fetch(Integer limit, Integer offset);
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/query/SearchFetchable.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/query/SearchFetchable.java
@@ -1,0 +1,106 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.query;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.hibernate.search.util.common.SearchException;
+
+/**
+ * A component allowing to fetch search results.
+ *
+ * @param <H> The type of query hits.
+ */
+public interface SearchFetchable<H> {
+
+	/**
+	 * Execute the query and return the {@link SearchResult}.
+	 *
+	 * @return The {@link SearchResult}.
+	 * @throws SearchException If something goes wrong while executing the query.
+	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
+	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
+	 */
+	SearchResult<H> fetch();
+
+	/**
+	 * Execute the query and return the {@link SearchResult}.
+	 *
+	 * @param limit The maximum number of hits to be included in the {@link SearchResult}. {@code null} means no limit.
+	 * @return The {@link SearchResult}.
+	 * @throws SearchException If something goes wrong while executing the query.
+	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
+	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
+	 */
+	SearchResult<H> fetch(Integer limit);
+
+	/**
+	 * Execute the query and return the {@link SearchResult}.
+	 *
+	 * @param limit The maximum number of hits to be included in the {@link SearchResult}. {@code null} means no limit.
+	 * @param offset The number of hits to skip before adding the hits to the {@link SearchResult}. {@code null} means no offset.
+	 * @return The {@link SearchResult}.
+	 * @throws SearchException If something goes wrong while executing the query.
+	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
+	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
+	 */
+	SearchResult<H> fetch(Integer limit, Integer offset);
+
+	/**
+	 * Execute the query and return the hits as a {@link List}.
+	 *
+	 * @return The query hits.
+	 * @throws SearchException If something goes wrong while executing the query.
+	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
+	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
+	 */
+	List<H> fetchHits();
+
+	/**
+	 * Execute the query and return the hits as a {@link List}.
+	 *
+	 * @param limit The maximum number of hits to be returned by this method. {@code null} means no limit.
+	 * @return The query hits.
+	 * @throws SearchException If something goes wrong while executing the query.
+	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
+	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
+	 */
+	List<H> fetchHits(Integer limit);
+
+	/**
+	 * Execute the query and return the hits as a {@link List}.
+	 *
+	 * @param limit The maximum number of hits to be returned by this method. {@code null} means no limit.
+	 * @param offset The number of hits to skip. {@code null} means no offset.
+	 * @return The query hits.
+	 * @throws SearchException If something goes wrong while executing the query.
+	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
+	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
+	 */
+	List<H> fetchHits(Integer limit, Integer offset);
+
+	/**
+	 * Execute the query and return the hits as a single, optional element.
+	 *
+	 * @return The single, optional query hit.
+	 * @throws SearchException If something goes wrong while executing the query,
+	 * or the number of hits is more than one.
+	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
+	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
+	 */
+	Optional<H> fetchSingleHit();
+
+	/**
+	 * Execute the query and return the total hit count.
+	 *
+	 * @return The total number of matching entities, ignoring pagination settings.
+	 * @throws SearchException If something goes wrong while executing the query.
+	 */
+	long fetchTotalHitCount();
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/query/SearchQuery.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/query/SearchQuery.java
@@ -6,9 +6,6 @@
  */
 package org.hibernate.search.engine.search.query;
 
-import java.util.List;
-import java.util.Optional;
-
 import org.hibernate.search.util.common.SearchException;
 
 /**
@@ -16,92 +13,7 @@ import org.hibernate.search.util.common.SearchException;
  *
  * @param <H> The type of query hits.
  */
-public interface SearchQuery<H> {
-
-	/**
-	 * Execute the query and return the {@link SearchResult}.
-	 *
-	 * @return The {@link SearchResult}.
-	 * @throws SearchException If something goes wrong while executing the query.
-	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
-	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
-	 */
-	SearchResult<H> fetch();
-
-	/**
-	 * Execute the query and return the {@link SearchResult}.
-	 *
-	 * @param limit The maximum number of hits to be included in the {@link SearchResult}. {@code null} means no limit.
-	 * @return The {@link SearchResult}.
-	 * @throws SearchException If something goes wrong while executing the query.
-	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
-	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
-	 */
-	SearchResult<H> fetch(Integer limit);
-
-	/**
-	 * Execute the query and return the {@link SearchResult}.
-	 *
-	 * @param limit The maximum number of hits to be included in the {@link SearchResult}. {@code null} means no limit.
-	 * @param offset The number of hits to skip before adding the hits to the {@link SearchResult}. {@code null} means no offset.
-	 * @return The {@link SearchResult}.
-	 * @throws SearchException If something goes wrong while executing the query.
-	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
-	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
-	 */
-	SearchResult<H> fetch(Integer limit, Integer offset);
-
-	/**
-	 * Execute the query and return the hits as a {@link List}.
-	 *
-	 * @return The query hits.
-	 * @throws SearchException If something goes wrong while executing the query.
-	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
-	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
-	 */
-	List<H> fetchHits();
-
-	/**
-	 * Execute the query and return the hits as a {@link List}.
-	 *
-	 * @param limit The maximum number of hits to be returned by this method. {@code null} means no limit.
-	 * @return The query hits.
-	 * @throws SearchException If something goes wrong while executing the query.
-	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
-	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
-	 */
-	List<H> fetchHits(Integer limit);
-
-	/**
-	 * Execute the query and return the hits as a {@link List}.
-	 *
-	 * @param limit The maximum number of hits to be returned by this method. {@code null} means no limit.
-	 * @param offset The number of hits to skip. {@code null} means no offset.
-	 * @return The query hits.
-	 * @throws SearchException If something goes wrong while executing the query.
-	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
-	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
-	 */
-	List<H> fetchHits(Integer limit, Integer offset);
-
-	/**
-	 * Execute the query and return the hits as a single, optional element.
-	 *
-	 * @return The single, optional query hit.
-	 * @throws SearchException If something goes wrong while executing the query,
-	 * or the number of hits is more than one.
-	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
-	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
-	 */
-	Optional<H> fetchSingleHit();
-
-	/**
-	 * Execute the query and return the total hit count.
-	 *
-	 * @return The total number of matching entities, ignoring pagination settings.
-	 * @throws SearchException If something goes wrong while executing the query.
-	 */
-	long fetchTotalHitCount();
+public interface SearchQuery<H> extends SearchFetchable<H> {
 
 	/**
 	 * @return A textual representation of the query.

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryFetchIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryFetchIT.java
@@ -23,6 +23,7 @@ import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement
 import org.hibernate.search.engine.backend.index.spi.IndexDocumentWorkExecutor;
 import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.engine.search.DocumentReference;
+import org.hibernate.search.engine.search.dsl.query.SearchQueryContext;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
@@ -63,8 +64,7 @@ public class SearchQueryFetchIT {
 
 	@Test
 	public void fetch_noArg() {
-		SearchQuery<DocumentReference> query = matchAllQuery();
-		assertThat( query.fetch() ).fromQuery( query )
+		assertThat( matchAllQuery().fetch() )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasDocRefHitsExactOrder( builder -> {
 					for ( int i = 0; i < DOCUMENT_COUNT; i++ ) {
@@ -72,8 +72,7 @@ public class SearchQueryFetchIT {
 					}
 				} );
 
-		query = matchFirstHalfQuery();
-		assertThat( query.fetch() ).fromQuery( query )
+		assertThat( matchFirstHalfQuery().fetch() )
 				.hasTotalHitCount( DOCUMENT_COUNT / 2 )
 				.hasDocRefHitsExactOrder( builder -> {
 					for ( int i = 0; i < DOCUMENT_COUNT / 2; i++ ) {
@@ -84,8 +83,7 @@ public class SearchQueryFetchIT {
 
 	@Test
 	public void fetch_limit() {
-		SearchQuery<DocumentReference> query = matchAllQuery();
-		assertThat( query.fetch( null ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetch( (Integer) null ) )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasDocRefHitsExactOrder( builder -> {
 					for ( int i = 0; i < DOCUMENT_COUNT; i++ ) {
@@ -93,21 +91,18 @@ public class SearchQueryFetchIT {
 					}
 				} );
 
-		query = matchAllQuery();
-		assertThat( query.fetch( 1 ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetch( 1 ) )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasDocRefHitsExactOrder( INDEX_NAME, docId( 0 ) );
 
-		query = matchAllQuery();
-		assertThat( query.fetch( 2 ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetch( 2 ) )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasDocRefHitsExactOrder( INDEX_NAME, docId( 0 ), docId( 1 ) );
 	}
 
 	@Test
 	public void fetch_limitAndOffset() {
-		SearchQuery<DocumentReference> query = matchAllQuery();
-		assertThat( query.fetch( null, 1 ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetch( null, 1 ) )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasDocRefHitsExactOrder( builder -> {
 					for ( int i = 1; i < DOCUMENT_COUNT; i++ ) {
@@ -115,18 +110,15 @@ public class SearchQueryFetchIT {
 					}
 				} );
 
-		query = matchAllQuery();
-		assertThat( query.fetch( 1, 1 ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetch( 1, 1 ) )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasDocRefHitsExactOrder( INDEX_NAME, docId( 1 ) );
 
-		query = matchAllQuery();
-		assertThat( query.fetch( 2, null ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetch( 2, null ) )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasDocRefHitsExactOrder( INDEX_NAME, docId( 0 ), docId( 1 ) );
 
-		query = matchAllQuery();
-		assertThat( query.fetch( null, null ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetch( null, null ) )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasDocRefHitsExactOrder( builder -> {
 					for ( int i = 0; i < DOCUMENT_COUNT; i++ ) {
@@ -135,24 +127,21 @@ public class SearchQueryFetchIT {
 				} );
 
 		// Fetch beyond the total hit count
-		query = matchAllQuery();
-		assertThat( query.fetch( null, DOCUMENT_COUNT + 1 ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetch( null, DOCUMENT_COUNT + 1 ) )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasNoHits();
 	}
 
 	@Test
 	public void fetchHits_noArg() {
-		SearchQuery<DocumentReference> query = matchAllQuery();
-		assertThat( query.fetchHits() ).fromQuery( query )
+		assertThat( matchAllQuery().fetchHits() )
 				.hasDocRefHitsExactOrder( builder -> {
 					for ( int i = 0; i < DOCUMENT_COUNT; i++ ) {
 						builder.doc( INDEX_NAME, docId( i ) );
 					}
 				} );
 
-		query = matchFirstHalfQuery();
-		assertThat( query.fetchHits() ).fromQuery( query )
+		assertThat( matchFirstHalfQuery().fetchHits() )
 				.hasDocRefHitsExactOrder( builder -> {
 					for ( int i = 0; i < DOCUMENT_COUNT / 2; i++ ) {
 						builder.doc( INDEX_NAME, docId( i ) );
@@ -162,43 +151,36 @@ public class SearchQueryFetchIT {
 
 	@Test
 	public void fetchHits_limit() {
-		SearchQuery<DocumentReference> query = matchAllQuery();
-		assertThat( query.fetchHits( null ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetchHits( (Integer) null ) )
 				.hasDocRefHitsExactOrder( builder -> {
 					for ( int i = 0; i < DOCUMENT_COUNT; i++ ) {
 						builder.doc( INDEX_NAME, docId( i ) );
 					}
 				} );
 
-		query = matchAllQuery();
-		assertThat( query.fetchHits( 1 ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetchHits( 1 ) )
 				.hasDocRefHitsExactOrder( INDEX_NAME, docId( 0 ) );
 
-		query = matchAllQuery();
-		assertThat( query.fetchHits( 2 ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetchHits( 2 ) )
 				.hasDocRefHitsExactOrder( INDEX_NAME, docId( 0 ), docId( 1 ) );
 	}
 
 	@Test
 	public void fetchHits_limitAndOffset() {
-		SearchQuery<DocumentReference> query = matchAllQuery();
-		assertThat( query.fetchHits( null, 1 ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetchHits( null, 1 ) )
 				.hasDocRefHitsExactOrder( builder -> {
 					for ( int i = 1; i < DOCUMENT_COUNT; i++ ) {
 						builder.doc( INDEX_NAME, docId( i ) );
 					}
 				} );
 
-		query = matchAllQuery();
-		assertThat( query.fetchHits( 1, 1 ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetchHits( 1, 1 ) )
 				.hasDocRefHitsExactOrder( INDEX_NAME, docId( 1 ) );
 
-		query = matchAllQuery();
-		assertThat( query.fetchHits( 2, null ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetchHits( 2, null ) )
 				.hasDocRefHitsExactOrder( INDEX_NAME, docId( 0 ), docId( 1 ) );
 
-		query = matchAllQuery();
-		assertThat( query.fetchHits( null, null ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetchHits( null, null ) )
 				.hasDocRefHitsExactOrder( builder -> {
 					for ( int i = 0; i < DOCUMENT_COUNT; i++ ) {
 						builder.doc( INDEX_NAME, docId( i ) );
@@ -206,36 +188,29 @@ public class SearchQueryFetchIT {
 				} );
 
 		// Fetch beyond the total hit count
-		query = matchAllQuery();
-		assertThat( query.fetchHits( null, DOCUMENT_COUNT + 1 ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetchHits( null, DOCUMENT_COUNT + 1 ) )
 				.isEmpty();
 	}
 
 	@Test
 	public void fetchTotalHitCount() {
-		SearchQuery<DocumentReference> query = matchAllQuery();
-		Assertions.assertThat( query.fetchTotalHitCount() ).isEqualTo( DOCUMENT_COUNT );
+		Assertions.assertThat( matchAllQuery().fetchTotalHitCount() ).isEqualTo( DOCUMENT_COUNT );
 
-		query = matchFirstHalfQuery();
-		Assertions.assertThat( query.fetchTotalHitCount() ).isEqualTo( DOCUMENT_COUNT / 2 );
+		Assertions.assertThat( matchFirstHalfQuery().fetchTotalHitCount() ).isEqualTo( DOCUMENT_COUNT / 2 );
 	}
 
 	@Test
 	public void fetchSingleHit() {
-		SearchQuery<DocumentReference> query = matchOneQuery( 4 );
-
-		Optional<DocumentReference> result = query.fetchSingleHit();
+		Optional<DocumentReference> result = matchOneQuery( 4 ).fetchSingleHit();
 		Assertions.assertThat( result ).isNotEmpty();
 		Assertions.assertThat( normalizeReference( result.get() ) )
 				.isEqualTo( normalizeReference( reference( INDEX_NAME, docId( 4 ) ) ) );
 
-		query = matchNoneQuery();
-		result = query.fetchSingleHit();
+		result = matchNoneQuery().fetchSingleHit();
 		Assertions.assertThat( result ).isEmpty();
 
 		SubTest.expectException( () -> {
-			SearchQuery<DocumentReference> matchAllQuery = matchAllQuery();
-			matchAllQuery.fetchSingleHit();
+			matchAllQuery().fetchSingleHit();
 		} )
 				.assertThrown()
 				.isInstanceOf( SearchException.class );
@@ -243,7 +218,7 @@ public class SearchQueryFetchIT {
 
 	@Test
 	public void fetch_limitAndOffset_reuseQuery() {
-		SearchQuery<DocumentReference> query = matchAllQuery();
+		SearchQuery<DocumentReference> query = matchAllQuery().toQuery();
 		assertThat( query.fetch( null, 1 ) ).fromQuery( query )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasDocRefHitsExactOrder( builder -> {
@@ -280,45 +255,39 @@ public class SearchQueryFetchIT {
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3389")
 	public void maxResults_zero() {
-		SearchQuery<DocumentReference> query = matchAllQuery();
-
-		assertThat( query.fetch( 0, 0 ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetch( 0, 0 ) )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasNoHits();
 	}
 
-	private SearchQuery<DocumentReference> matchAllQuery() {
+	private SearchQueryContext<?, DocumentReference, ?> matchAllQuery() {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		return scope.query()
 				.asReference()
 				.predicate( f -> f.matchAll() )
-				.sort( c -> c.byField( "integer" ).asc() )
-				.toQuery();
+				.sort( c -> c.byField( "integer" ).asc() );
 	}
 
-	private SearchQuery<DocumentReference> matchFirstHalfQuery() {
+	private SearchQueryContext<?, DocumentReference, ?> matchFirstHalfQuery() {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		return scope.query()
 				.asReference()
 				.predicate( f -> f.range().onField( "integer" ).below( DOCUMENT_COUNT / 2 ).excludeLimit() )
-				.sort( c -> c.byField( "integer" ).asc() )
-				.toQuery();
+				.sort( c -> c.byField( "integer" ).asc() );
 	}
 
-	private SearchQuery<DocumentReference> matchOneQuery(int id) {
+	private SearchQueryContext<?, DocumentReference, ?> matchOneQuery(int id) {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		return scope.query()
 				.asReference()
-				.predicate( f -> f.match().onField( "integer" ).matching( id ) )
-				.toQuery();
+				.predicate( f -> f.match().onField( "integer" ).matching( id ) );
 	}
 
-	private SearchQuery<DocumentReference> matchNoneQuery() {
+	private SearchQueryContext<?, DocumentReference, ?> matchNoneQuery() {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		return scope.query()
 				.asReference()
-				.predicate( f -> f.match().onField( "integer" ).matching( DOCUMENT_COUNT + 2 ) )
-				.toQuery();
+				.predicate( f -> f.match().onField( "integer" ).matching( DOCUMENT_COUNT + 2 ) );
 	}
 
 	private void initData() {

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchDocumentRepositoryImpl.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchDocumentRepositoryImpl.java
@@ -19,7 +19,6 @@ import org.hibernate.search.integrationtest.showcase.library.model.BookMedium;
 import org.hibernate.search.integrationtest.showcase.library.model.Document;
 import org.hibernate.search.integrationtest.showcase.library.model.LibraryServiceOption;
 import org.hibernate.search.mapper.orm.Search;
-import org.hibernate.search.engine.search.query.SearchQuery;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -33,13 +32,11 @@ public class IndexSearchDocumentRepositoryImpl implements IndexSearchDocumentRep
 
 	@Override
 	public List<Book> findAllIndexed() {
-		SearchQuery<Book> query = Search.getSearchSession( entityManager )
+		return Search.getSearchSession( entityManager )
 				.search( Book.class )
 				.asEntity()
 				.predicate( p -> p.matchAll() )
-				.toQuery();
-
-		return query.fetchHits();
+				.fetchHits();
 	}
 
 	@Override
@@ -48,18 +45,16 @@ public class IndexSearchDocumentRepositoryImpl implements IndexSearchDocumentRep
 			return Optional.empty();
 		}
 
-		SearchQuery<Book> query = Search.getSearchSession( entityManager ).search( Book.class )
-						.asEntity()
-						// onRawField option allows to bypass the bridge in the DSL
-						.predicate( f -> f.match().onField( "isbn" ).matching( isbnAsString, DslConverter.DISABLED ) )
-						.toQuery();
-
-		return query.fetchSingleHit();
+		return Search.getSearchSession( entityManager ).search( Book.class )
+				.asEntity()
+				// onRawField option allows to bypass the bridge in the DSL
+				.predicate( f -> f.match().onField( "isbn" ).matching( isbnAsString, DslConverter.DISABLED ) )
+				.fetchSingleHit();
 	}
 
 	@Override
 	public List<Book> searchByMedium(String terms, BookMedium medium, int limit, int offset) {
-		SearchQuery<Book> query = Search.getSearchSession( entityManager ).search( Book.class )
+		return Search.getSearchSession( entityManager ).search( Book.class )
 				.asEntity()
 				.predicate( f -> f.bool( b -> {
 					if ( terms != null && !terms.isEmpty() ) {
@@ -74,9 +69,7 @@ public class IndexSearchDocumentRepositoryImpl implements IndexSearchDocumentRep
 					);
 				} ) )
 				.sort( b -> b.byField( "title_sort" ) )
-				.toQuery();
-
-		return query.fetchHits( limit, offset );
+				.fetchHits( limit, offset );
 	}
 
 	@Override
@@ -84,7 +77,7 @@ public class IndexSearchDocumentRepositoryImpl implements IndexSearchDocumentRep
 			GeoPoint myLocation, Double maxDistanceInKilometers,
 			List<LibraryServiceOption> libraryServices,
 			int limit, int offset) {
-		SearchQuery<Document<?>> query = Search.getSearchSession( entityManager ).search( DOCUMENT_CLASS )
+		return Search.getSearchSession( entityManager ).search( DOCUMENT_CLASS )
 				.asEntity()
 				.predicate( f -> f.bool( b -> {
 					// Match query
@@ -139,14 +132,12 @@ public class IndexSearchDocumentRepositoryImpl implements IndexSearchDocumentRep
 					}
 					b.byScore();
 				} )
-				.toQuery();
-
-		return query.fetchHits( limit, offset );
+				.fetchHits( limit, offset );
 	}
 
 	@Override
 	public List<String> getAuthorsOfBooksHavingTerms(String terms, SortOrder order) {
-		SearchQuery<String> query = Search.getSearchSession( entityManager ).search( Document.class )
+		return Search.getSearchSession( entityManager ).search( Document.class )
 				.asProjection( f -> f.field( "author", String.class ) )
 				.predicate( f -> f.match()
 						.onField( "title" ).boostedTo( 2.0f )
@@ -154,8 +145,6 @@ public class IndexSearchDocumentRepositoryImpl implements IndexSearchDocumentRep
 						.matching( terms )
 				)
 				.sort( b -> b.byField( "author" ).order( order ) )
-				.toQuery();
-
-		return query.fetchHits();
+				.fetchHits();
 	}
 }

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchLibraryRepositoryImpl.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchLibraryRepositoryImpl.java
@@ -12,7 +12,6 @@ import javax.persistence.EntityManager;
 
 import org.hibernate.search.integrationtest.showcase.library.model.Library;
 import org.hibernate.search.mapper.orm.Search;
-import org.hibernate.search.engine.search.query.SearchQuery;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -26,7 +25,7 @@ public class IndexSearchLibraryRepositoryImpl implements IndexSearchLibraryRepos
 		if ( terms == null || terms.isEmpty() ) {
 			return Collections.emptyList();
 		}
-		SearchQuery<Library> query = Search.getSearchSession( entityManager )
+		return Search.getSearchSession( entityManager )
 				.search( Library.class )
 				.asEntity()
 				.predicate( f -> f.match().onField( "name" ).matching( terms ) )
@@ -34,8 +33,6 @@ public class IndexSearchLibraryRepositoryImpl implements IndexSearchLibraryRepos
 					c.byField( "collectionSize" ).desc();
 					c.byField( "name_sort" );
 				} )
-				.toQuery();
-
-		return query.fetchHits( limit, offset );
+				.fetchHits( limit, offset );
 	}
 }

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchPersonRepositoryImpl.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchPersonRepositoryImpl.java
@@ -12,7 +12,6 @@ import javax.persistence.EntityManager;
 
 import org.hibernate.search.integrationtest.showcase.library.model.Person;
 import org.hibernate.search.mapper.orm.Search;
-import org.hibernate.search.engine.search.query.SearchQuery;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -42,26 +41,22 @@ public class IndexSearchPersonRepositoryImpl implements IndexSearchPersonReposit
 			return Collections.emptyList();
 		}
 
-		SearchQuery<Person> query = Search.getSearchSession( entityManager ).search( Person.class )
+		return Search.getSearchSession( entityManager ).search( Person.class )
 				.asEntity()
 				.predicate( f -> f.match().onFields( "firstName", "lastName" ).matching( terms ) )
 				.sort( c -> {
 					c.byField( "lastName_sort" );
 					c.byField( "firstName_sort" );
 				} )
-				.toQuery();
-
-		return query.fetchHits( limit, offset );
+				.fetchHits( limit, offset );
 	}
 
 	private List<Person> listTopBorrowers(String borrowalsCountField, int limit, int offset) {
-		SearchQuery<Person> query = Search.getSearchSession( entityManager ).search( Person.class )
+		return Search.getSearchSession( entityManager ).search( Person.class )
 				.asEntity()
 				.predicate( f -> f.matchAll() )
 				.sort( c -> c.byField( borrowalsCountField ).desc() )
-				.toQuery();
-
-		return query.fetchHits( limit, offset );
+				.fetchHits( limit, offset );
 	}
 
 }


### PR DESCRIPTION
[HSEARCH-3572](https://hibernate.atlassian.net//browse/HSEARCH-3572): Add fetch methods to terminal steps of the query DSL

~Based on #1983 ([HSEARCH-3577](https://hibernate.atlassian.net//browse/HSEARCH-3577)), which should be merged first.~ => Done

To see how this improves APIs, have a look at `IndexSearchDocumentRepositoryImpl.java` or `org.hibernate.search.documentation.gettingstarted.withhsearch.withoutanalysis.GettingStartedWithoutAnalysisIT#test`