### PR TITLE
HSEARCH-3578 Make the call to asXXX() (asEntity, asReference) optional in the Search DSL

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/ElasticsearchExtension.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/ElasticsearchExtension.java
@@ -76,8 +76,8 @@ public final class ElasticsearchExtension<H, R, E>
 	private static final ElasticsearchExtension<Object, Object, Object> INSTANCE = new ElasticsearchExtension<>();
 
 	@SuppressWarnings("unchecked") // The instance works for any H, R and E
-	public static <Q, R, E> ElasticsearchExtension<Q, R, E> get() {
-		return (ElasticsearchExtension<Q, R, E>) INSTANCE;
+	public static <H, R, E> ElasticsearchExtension<H, R, E> get() {
+		return (ElasticsearchExtension<H, R, E>) INSTANCE;
 	}
 
 	private ElasticsearchExtension() {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/ElasticsearchExtension.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/ElasticsearchExtension.java
@@ -89,7 +89,7 @@ public final class ElasticsearchExtension<H, R, E>
 	 */
 	@Override
 	public Optional<ElasticsearchSearchQueryResultDefinitionContext<R, E>> extendOptional(
-			SearchQueryResultDefinitionContext<R, E, ?> original,
+			SearchQueryResultDefinitionContext<?, R, E, ?, ?> original,
 			IndexSearchScope<?> indexSearchScope,
 			SessionContextImplementor sessionContext,
 			LoadingContextBuilder<R, E> loadingContextBuilder) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/query/ElasticsearchSearchQueryContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/query/ElasticsearchSearchQueryContext.java
@@ -7,11 +7,13 @@
 package org.hibernate.search.backend.elasticsearch.search.dsl.query;
 
 import org.hibernate.search.backend.elasticsearch.search.dsl.sort.ElasticsearchSearchSortContainerContext;
+import org.hibernate.search.backend.elasticsearch.search.query.ElasticsearchSearchFetchable;
 import org.hibernate.search.backend.elasticsearch.search.query.ElasticsearchSearchQuery;
 import org.hibernate.search.engine.search.dsl.query.SearchQueryContext;
 
 public interface ElasticsearchSearchQueryContext<H>
-		extends SearchQueryContext<ElasticsearchSearchQueryContext<H>, H, ElasticsearchSearchSortContainerContext> {
+		extends SearchQueryContext<ElasticsearchSearchQueryContext<H>, H, ElasticsearchSearchSortContainerContext>,
+				ElasticsearchSearchFetchable<H> {
 
 	@Override
 	ElasticsearchSearchQuery<H> toQuery();

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/query/ElasticsearchSearchQueryResultDefinitionContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/query/ElasticsearchSearchQueryResultDefinitionContext.java
@@ -9,13 +9,21 @@ package org.hibernate.search.backend.elasticsearch.search.dsl.query;
 import java.util.List;
 import java.util.function.Function;
 
+import org.hibernate.search.backend.elasticsearch.search.dsl.predicate.ElasticsearchSearchPredicateFactoryContext;
 import org.hibernate.search.backend.elasticsearch.search.dsl.projection.ElasticsearchSearchProjectionFactoryContext;
 import org.hibernate.search.engine.search.SearchProjection;
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionTerminalContext;
 import org.hibernate.search.engine.search.dsl.query.SearchQueryResultDefinitionContext;
 
 public interface ElasticsearchSearchQueryResultDefinitionContext<R, E>
-		extends SearchQueryResultDefinitionContext<R, E, ElasticsearchSearchProjectionFactoryContext<R, E>> {
+		extends SearchQueryResultDefinitionContext<
+				ElasticsearchSearchQueryContext<E>,
+				R,
+				E,
+				ElasticsearchSearchProjectionFactoryContext<R, E>,
+				ElasticsearchSearchPredicateFactoryContext
+		>,
+		ElasticsearchSearchQueryResultContext<E> {
 
 	@Override
 	ElasticsearchSearchQueryResultContext<E> asEntity();

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/query/impl/ElasticsearchSearchQueryContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/query/impl/ElasticsearchSearchQueryContextImpl.java
@@ -13,16 +13,18 @@ import org.hibernate.search.backend.elasticsearch.search.dsl.query.Elasticsearch
 import org.hibernate.search.backend.elasticsearch.search.dsl.sort.ElasticsearchSearchSortContainerContext;
 import org.hibernate.search.backend.elasticsearch.search.impl.ElasticsearchSearchQueryElementCollector;
 import org.hibernate.search.backend.elasticsearch.search.query.ElasticsearchSearchQuery;
+import org.hibernate.search.backend.elasticsearch.search.query.ElasticsearchSearchResult;
 import org.hibernate.search.backend.elasticsearch.search.query.impl.ElasticsearchIndexSearchScope;
 import org.hibernate.search.backend.elasticsearch.search.query.impl.ElasticsearchSearchQueryBuilder;
 import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryContext;
-import org.hibernate.search.engine.search.dsl.query.spi.AbstractSearchQueryContext;
+import org.hibernate.search.engine.search.dsl.query.spi.AbstractExtendedSearchQueryContext;
 import org.hibernate.search.engine.search.dsl.sort.SearchSortContainerContext;
 
 class ElasticsearchSearchQueryContextImpl<H>
-		extends AbstractSearchQueryContext<
+		extends AbstractExtendedSearchQueryContext<
 				ElasticsearchSearchQueryContext<H>,
 				H,
+				ElasticsearchSearchResult<H>,
 				ElasticsearchSearchPredicateFactoryContext,
 				ElasticsearchSearchSortContainerContext,
 				ElasticsearchSearchQueryElementCollector

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/query/impl/ElasticsearchSearchQueryResultDefinitionContextImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/dsl/query/impl/ElasticsearchSearchQueryResultDefinitionContextImpl.java
@@ -10,23 +10,29 @@ import java.util.List;
 import java.util.function.Function;
 
 import org.hibernate.search.backend.elasticsearch.ElasticsearchExtension;
+import org.hibernate.search.backend.elasticsearch.search.dsl.predicate.ElasticsearchSearchPredicateFactoryContext;
 import org.hibernate.search.backend.elasticsearch.search.dsl.projection.ElasticsearchSearchProjectionFactoryContext;
+import org.hibernate.search.backend.elasticsearch.search.dsl.query.ElasticsearchSearchQueryContext;
 import org.hibernate.search.backend.elasticsearch.search.dsl.query.ElasticsearchSearchQueryResultContext;
 import org.hibernate.search.backend.elasticsearch.search.dsl.query.ElasticsearchSearchQueryResultDefinitionContext;
 import org.hibernate.search.backend.elasticsearch.search.impl.ElasticsearchSearchQueryElementCollector;
 import org.hibernate.search.backend.elasticsearch.search.query.impl.ElasticsearchIndexSearchScope;
 import org.hibernate.search.backend.elasticsearch.search.query.impl.ElasticsearchSearchQueryBuilder;
 import org.hibernate.search.engine.mapper.session.context.spi.SessionContextImplementor;
+import org.hibernate.search.engine.search.SearchPredicate;
 import org.hibernate.search.engine.search.SearchProjection;
+import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateTerminalContext;
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionTerminalContext;
 import org.hibernate.search.engine.search.dsl.query.spi.AbstractSearchQueryResultDefinitionContext;
 import org.hibernate.search.engine.search.loading.context.spi.LoadingContextBuilder;
 
 public class ElasticsearchSearchQueryResultDefinitionContextImpl<R, E>
 		extends AbstractSearchQueryResultDefinitionContext<
+				ElasticsearchSearchQueryContext<E>,
 				R,
 				E,
 				ElasticsearchSearchProjectionFactoryContext<R, E>,
+				ElasticsearchSearchPredicateFactoryContext,
 				ElasticsearchSearchQueryElementCollector
 		>
 		implements ElasticsearchSearchQueryResultDefinitionContext<R, E> {
@@ -78,6 +84,17 @@ public class ElasticsearchSearchQueryResultDefinitionContextImpl<R, E>
 		ElasticsearchSearchQueryBuilder<List<?>> builder = indexSearchScope.getSearchQueryBuilderFactory()
 				.asProjections( sessionContext, loadingContextBuilder, projections );
 		return createSearchQueryContext( builder );
+	}
+
+	@Override
+	public ElasticsearchSearchQueryContext<E> predicate(SearchPredicate predicate) {
+		return asEntity().predicate( predicate );
+	}
+
+	@Override
+	public ElasticsearchSearchQueryContext<E> predicate(
+			Function<? super ElasticsearchSearchPredicateFactoryContext, SearchPredicateTerminalContext> predicateContributor) {
+		return asEntity().predicate( predicateContributor );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/ElasticsearchSearchFetchable.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/ElasticsearchSearchFetchable.java
@@ -1,0 +1,13 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.search.query;
+
+import org.hibernate.search.engine.search.query.ExtendedSearchFetchable;
+
+public interface ElasticsearchSearchFetchable<H> extends ExtendedSearchFetchable<H, ElasticsearchSearchResult<H>> {
+
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/ElasticsearchSearchQuery.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/ElasticsearchSearchQuery.java
@@ -8,7 +8,8 @@ package org.hibernate.search.backend.elasticsearch.search.query;
 
 import org.hibernate.search.engine.search.query.ExtendedSearchQuery;
 
-public interface ElasticsearchSearchQuery<H> extends ExtendedSearchQuery<H, ElasticsearchSearchResult<H>> {
+public interface ElasticsearchSearchQuery<H>
+		extends ExtendedSearchQuery<H, ElasticsearchSearchResult<H>>, ElasticsearchSearchFetchable<H> {
 
 	/**
 	 * Explain score computation of this query for the document with the given id.

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/LuceneExtension.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/LuceneExtension.java
@@ -90,7 +90,7 @@ public final class LuceneExtension<H, R, E>
 	 */
 	@Override
 	public Optional<LuceneSearchQueryResultDefinitionContext<R, E>> extendOptional(
-			SearchQueryResultDefinitionContext<R, E, ?> original,
+			SearchQueryResultDefinitionContext<?, R, E, ?, ?> original,
 			IndexSearchScope<?> indexSearchScope,
 			SessionContextImplementor sessionContext,
 			LoadingContextBuilder<R, E> loadingContextBuilder) {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/query/LuceneSearchQueryContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/query/LuceneSearchQueryContext.java
@@ -7,11 +7,13 @@
 package org.hibernate.search.backend.lucene.search.dsl.query;
 
 import org.hibernate.search.backend.lucene.search.dsl.sort.LuceneSearchSortContainerContext;
+import org.hibernate.search.backend.lucene.search.query.LuceneSearchFetchable;
 import org.hibernate.search.backend.lucene.search.query.LuceneSearchQuery;
 import org.hibernate.search.engine.search.dsl.query.SearchQueryContext;
 
 public interface LuceneSearchQueryContext<H>
-		extends SearchQueryContext<LuceneSearchQueryContext<H>, H, LuceneSearchSortContainerContext> {
+		extends SearchQueryContext<LuceneSearchQueryContext<H>, H, LuceneSearchSortContainerContext>,
+				LuceneSearchFetchable<H> {
 
 	@Override
 	LuceneSearchQuery<H> toQuery();

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/query/LuceneSearchQueryResultDefinitionContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/query/LuceneSearchQueryResultDefinitionContext.java
@@ -9,13 +9,21 @@ package org.hibernate.search.backend.lucene.search.dsl.query;
 import java.util.List;
 import java.util.function.Function;
 
+import org.hibernate.search.backend.lucene.search.dsl.predicate.LuceneSearchPredicateFactoryContext;
 import org.hibernate.search.backend.lucene.search.dsl.projection.LuceneSearchProjectionFactoryContext;
 import org.hibernate.search.engine.search.SearchProjection;
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionTerminalContext;
 import org.hibernate.search.engine.search.dsl.query.SearchQueryResultDefinitionContext;
 
 public interface LuceneSearchQueryResultDefinitionContext<R, E>
-		extends SearchQueryResultDefinitionContext<R, E, LuceneSearchProjectionFactoryContext<R, E>> {
+		extends SearchQueryResultDefinitionContext<
+				LuceneSearchQueryContext<E>,
+				R,
+				E,
+				LuceneSearchProjectionFactoryContext<R, E>,
+				LuceneSearchPredicateFactoryContext
+		>,
+		LuceneSearchQueryResultContext<E> {
 
 	@Override
 	LuceneSearchQueryResultContext<E> asEntity();

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/query/impl/LuceneSearchQueryContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/query/impl/LuceneSearchQueryContextImpl.java
@@ -13,19 +13,21 @@ import org.hibernate.search.backend.lucene.search.dsl.query.LuceneSearchQueryRes
 import org.hibernate.search.backend.lucene.search.dsl.sort.LuceneSearchSortContainerContext;
 import org.hibernate.search.backend.lucene.search.impl.LuceneSearchQueryElementCollector;
 import org.hibernate.search.backend.lucene.search.query.LuceneSearchQuery;
+import org.hibernate.search.backend.lucene.search.query.LuceneSearchResult;
 import org.hibernate.search.backend.lucene.search.query.impl.LuceneIndexSearchScope;
 import org.hibernate.search.backend.lucene.search.query.impl.LuceneSearchQueryBuilder;
 import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryContext;
-import org.hibernate.search.engine.search.dsl.query.spi.AbstractSearchQueryContext;
+import org.hibernate.search.engine.search.dsl.query.spi.AbstractExtendedSearchQueryContext;
 import org.hibernate.search.engine.search.dsl.sort.SearchSortContainerContext;
 
 class LuceneSearchQueryContextImpl<H>
-		extends AbstractSearchQueryContext<
-		LuceneSearchQueryContext<H>,
-		H,
-		LuceneSearchPredicateFactoryContext,
-		LuceneSearchSortContainerContext,
-		LuceneSearchQueryElementCollector
+		extends AbstractExtendedSearchQueryContext<
+				LuceneSearchQueryContext<H>,
+				H,
+				LuceneSearchResult<H>,
+				LuceneSearchPredicateFactoryContext,
+				LuceneSearchSortContainerContext,
+				LuceneSearchQueryElementCollector
 		>
 		implements LuceneSearchQueryResultContext<H>, LuceneSearchQueryContext<H> {
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/query/impl/LuceneSearchQueryResultDefinitionContextImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/dsl/query/impl/LuceneSearchQueryResultDefinitionContextImpl.java
@@ -10,23 +10,29 @@ import java.util.List;
 import java.util.function.Function;
 
 import org.hibernate.search.backend.lucene.LuceneExtension;
+import org.hibernate.search.backend.lucene.search.dsl.predicate.LuceneSearchPredicateFactoryContext;
 import org.hibernate.search.backend.lucene.search.dsl.projection.LuceneSearchProjectionFactoryContext;
+import org.hibernate.search.backend.lucene.search.dsl.query.LuceneSearchQueryContext;
 import org.hibernate.search.backend.lucene.search.dsl.query.LuceneSearchQueryResultContext;
 import org.hibernate.search.backend.lucene.search.dsl.query.LuceneSearchQueryResultDefinitionContext;
 import org.hibernate.search.backend.lucene.search.impl.LuceneSearchQueryElementCollector;
 import org.hibernate.search.backend.lucene.search.query.impl.LuceneIndexSearchScope;
 import org.hibernate.search.backend.lucene.search.query.impl.LuceneSearchQueryBuilder;
 import org.hibernate.search.engine.mapper.session.context.spi.SessionContextImplementor;
+import org.hibernate.search.engine.search.SearchPredicate;
 import org.hibernate.search.engine.search.SearchProjection;
+import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateTerminalContext;
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionTerminalContext;
 import org.hibernate.search.engine.search.dsl.query.spi.AbstractSearchQueryResultDefinitionContext;
 import org.hibernate.search.engine.search.loading.context.spi.LoadingContextBuilder;
 
 public class LuceneSearchQueryResultDefinitionContextImpl<R, E>
 		extends AbstractSearchQueryResultDefinitionContext<
+				LuceneSearchQueryContext<E>,
 				R,
 				E,
 				LuceneSearchProjectionFactoryContext<R, E>,
+				LuceneSearchPredicateFactoryContext,
 				LuceneSearchQueryElementCollector
 		>
 		implements LuceneSearchQueryResultDefinitionContext<R, E> {
@@ -78,6 +84,17 @@ public class LuceneSearchQueryResultDefinitionContextImpl<R, E>
 		LuceneSearchQueryBuilder<List<?>> builder = indexSearchScope.getSearchQueryBuilderFactory()
 				.asProjections( sessionContext, loadingContextBuilder, projections );
 		return createSearchQueryContext( builder );
+	}
+
+	@Override
+	public LuceneSearchQueryContext<E> predicate(SearchPredicate predicate) {
+		return asEntity().predicate( predicate );
+	}
+
+	@Override
+	public LuceneSearchQueryContext<E> predicate(
+			Function<? super LuceneSearchPredicateFactoryContext, SearchPredicateTerminalContext> predicateContributor) {
+		return asEntity().predicate( predicateContributor );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/LuceneSearchFetchable.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/LuceneSearchFetchable.java
@@ -1,0 +1,13 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.search.query;
+
+import org.hibernate.search.engine.search.query.ExtendedSearchFetchable;
+
+public interface LuceneSearchFetchable<H> extends ExtendedSearchFetchable<H, LuceneSearchResult<H>> {
+
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/LuceneSearchQuery.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/LuceneSearchQuery.java
@@ -10,7 +10,8 @@ import org.hibernate.search.engine.search.query.ExtendedSearchQuery;
 
 import org.apache.lucene.search.Explanation;
 
-public interface LuceneSearchQuery<H> extends ExtendedSearchQuery<H, LuceneSearchResult<H>> {
+public interface LuceneSearchQuery<H>
+		extends ExtendedSearchQuery<H, LuceneSearchResult<H>>, LuceneSearchFetchable<H> {
 
 	/**
 	 * Explain score computation of this query for the document with the given id.

--- a/documentation/src/main/asciidoc/getting-started.asciidoc
+++ b/documentation/src/main/asciidoc/getting-started.asciidoc
@@ -289,14 +289,12 @@ include::{sourcedir}/org/hibernate/search/documentation/gettingstarted/withhsear
 ----
 <1> Get a Hibernate Search session, called `SearchSession`, from the `EntityManager`.
 <2> Initiate a search query on the index mapped to the `Book` entity.
-<3> Define the results expected from the query; here we expect managed Hibernate ORM entities,
-but other options are available.
-<4> Define that only documents matching the given predicate should be returned.
+<3> Define that only documents matching the given predicate should be returned.
 The predicate is created using a factory `f` passed as an argument to the lambda expression.
-<5> Build the query and fetch the results.
-<6> Retrieve the total number of matching entities.
-<7> Retrieve matching entities.
-<8> In case you're not interested in the whole result, but only in the hits,
+<4> Build the query and fetch the results.
+<5> Retrieve the total number of matching entities.
+<6> Retrieve matching entities.
+<7> In case you're not interested in the whole result, but only in the hits,
 you can also call `fetchHits()` directly.
 ====
 
@@ -312,14 +310,12 @@ include::{sourcedir}/org/hibernate/search/documentation/gettingstarted/withhsear
 <1> Get a Hibernate Search session, called `SearchSession`, from the `EntityManager`.
 <2> Create a "search scope", representing the indexed types that will be queried.
 <3> Initiate a search query targeting the search scope.
-<4> Define the results expected from the query; here we expect managed Hibernate ORM entities,
-but other options are available.
-<5> Define that only documents matching the given predicate should be returned.
+<4> Define that only documents matching the given predicate should be returned.
 The predicate is created using the same search scope as the query.
-<6> Build the query and fetch the results.
-<7> Retrieve the total number of matching entities.
-<8> Retrieve matching entities.
-<9> In case you're not interested in the whole result, but only in the hits,
+<5> Build the query and fetch the results.
+<6> Retrieve the total number of matching entities.
+<7> Retrieve matching entities.
+<8> In case you're not interested in the whole result, but only in the hits,
 you can also call `fetchHits()` directly.
 ====
 
@@ -333,6 +329,10 @@ include::{sourcedir}/org/hibernate/search/documentation/gettingstarted/withhsear
 ----
 <1> Fetch the total hit count.
 ====
+
+Note that, while the examples above retrieved hits as managed entities,
+it is just one of the possible hit types.
+See <<mapper-orm-query-concept, the section about Search Queries>> for more information.
 
 [[getting-started-analysis]]
 == Analysis

--- a/documentation/src/main/asciidoc/getting-started.asciidoc
+++ b/documentation/src/main/asciidoc/getting-started.asciidoc
@@ -293,12 +293,11 @@ include::{sourcedir}/org/hibernate/search/documentation/gettingstarted/withhsear
 but other options are available.
 <4> Define that only documents matching the given predicate should be returned.
 The predicate is created using a factory `f` passed as an argument to the lambda expression.
-<5> Build the query.
-<6> Execute the query and fetch the results.
-<7> Retrieve the total number of matching entities.
-<8> Retrieve matching entities.
-<9> In case you're not interested in the whole result, but only in the hits,
-you can also call `fetchHits()` on the query directly.
+<5> Build the query and fetch the results.
+<6> Retrieve the total number of matching entities.
+<7> Retrieve matching entities.
+<8> In case you're not interested in the whole result, but only in the hits,
+you can also call `fetchHits()` directly.
 ====
 
 If for some reason you don't want to use lambdas, you can use an alternative, object-based syntax,
@@ -317,23 +316,22 @@ include::{sourcedir}/org/hibernate/search/documentation/gettingstarted/withhsear
 but other options are available.
 <5> Define that only documents matching the given predicate should be returned.
 The predicate is created using the same search scope as the query.
-<6> Build the query.
-<7> Execute the query and fetch the results.
-<8> Retrieve the total number of matching entities.
-<9> Retrieve matching entities.
-<10> In case you're not interested in the whole result, but only in the hits,
-you can also call `fetchHits()` on the query directly.
+<6> Build the query and fetch the results.
+<7> Retrieve the total number of matching entities.
+<8> Retrieve matching entities.
+<9> In case you're not interested in the whole result, but only in the hits,
+you can also call `fetchHits()` directly.
 ====
 
-It is possible to get just the result size, using `fetchTotalHitCount()` method.
+It is possible to get just the total hit count, using `fetchTotalHitCount()` method.
 
-.Using Hibernate Search to count the indexes
+.Using Hibernate Search to count the matches
 ====
 [source, JAVA, indent=0, subs="+callouts"]
 ----
 include::{sourcedir}/org/hibernate/search/documentation/gettingstarted/withhsearch/withoutanalysis/GettingStartedWithoutAnalysisIT.java[tags=counting]
 ----
-<1> Fetch the result size.
+<1> Fetch the total hit count.
 ====
 
 [[getting-started-analysis]]

--- a/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withhsearch/withanalysis/GettingStartedWithAnalysisIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withhsearch/withanalysis/GettingStartedWithAnalysisIT.java
@@ -13,7 +13,6 @@ import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 
 import org.hibernate.search.mapper.orm.Search;
-import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.engine.search.query.SearchResult;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.util.impl.integrationtest.orm.OrmUtils;
@@ -79,15 +78,13 @@ public class GettingStartedWithAnalysisIT {
 			// Not shown: get the entity manager and open a transaction
 			SearchSession searchSession = Search.getSearchSession( entityManager );
 
-			SearchQuery<Book> query = searchSession.search( Book.class )
+			SearchResult<Book> result = searchSession.search( Book.class )
 					.asEntity()
 					.predicate( factory -> factory.match()
 							.onFields( "title", "authors.name" )
 							.matching( "refactor" )
 					)
-					.toQuery();
-
-			SearchResult<Book> result = query.fetch();
+					.fetch();
 			// Not shown: commit the transaction and close the entity manager
 			// end::searching[]
 
@@ -100,14 +97,13 @@ public class GettingStartedWithAnalysisIT {
 			SearchSession searchSession = Search.getSearchSession( entityManager );
 
 			for ( String term : new String[] { "Refactor", "refactors", "refactored", "refactoring" } ) {
-				SearchQuery<Book> query = searchSession.search( Book.class )
+				SearchResult<Book> result = searchSession.search( Book.class )
 						.asEntity()
 						.predicate( factory -> factory.match()
 								.onFields( "title", "authors.name" )
 								.matching( term )
 						)
-						.toQuery();
-				SearchResult<Book> result = query.fetch();
+						.fetch();
 				assertThat( result.getHits() ).as( "Result of searching for '" + term + "'" )
 						.extracting( "id" )
 						.containsExactlyInAnyOrder( bookIdHolder.get() );

--- a/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withhsearch/withanalysis/GettingStartedWithAnalysisIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withhsearch/withanalysis/GettingStartedWithAnalysisIT.java
@@ -79,7 +79,6 @@ public class GettingStartedWithAnalysisIT {
 			SearchSession searchSession = Search.getSearchSession( entityManager );
 
 			SearchResult<Book> result = searchSession.search( Book.class )
-					.asEntity()
 					.predicate( factory -> factory.match()
 							.onFields( "title", "authors.name" )
 							.matching( "refactor" )
@@ -98,7 +97,6 @@ public class GettingStartedWithAnalysisIT {
 
 			for ( String term : new String[] { "Refactor", "refactors", "refactored", "refactoring" } ) {
 				SearchResult<Book> result = searchSession.search( Book.class )
-						.asEntity()
 						.predicate( factory -> factory.match()
 								.onFields( "title", "authors.name" )
 								.matching( term )

--- a/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withhsearch/withoutanalysis/GettingStartedWithoutAnalysisIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withhsearch/withoutanalysis/GettingStartedWithoutAnalysisIT.java
@@ -105,29 +105,27 @@ public class GettingStartedWithoutAnalysisIT {
 			SearchScope<Book> scope = searchSession.scope( Book.class ); // <2>
 
 			SearchResult<Book> result = scope.search() // <3>
-					.asEntity() // <4>
-					.predicate( scope.predicate().match() // <5>
+					.predicate( scope.predicate().match() // <4>
 							.onFields( "title", "authors.name" )
 							.matching( "Refactoring: Improving the Design of Existing Code" )
 							.toPredicate()
 					)
-					.fetch(); // <6>
+					.fetch(); // <5>
 
-			long totalHitCount = result.getTotalHitCount(); // <7>
-			List<Book> hits = result.getHits(); // <8>
+			long totalHitCount = result.getTotalHitCount(); // <6>
+			List<Book> hits = result.getHits(); // <7>
 
 			List<Book> hits2 =
 					/* ... same DSL calls as above... */
 			// end::searching-objects[]
 					scope.search()
-					.asEntity()
 					.predicate( scope.predicate().match()
 							.onFields( "title", "authors.name" )
 							.matching( "Refactoring: Improving the Design of Existing Code" )
 							.toPredicate()
 					)
 			// tag::searching-objects[]
-					.fetchHits(); // <9>
+					.fetchHits(); // <8>
 			// Not shown: commit the transaction and close the entity manager
 			// end::searching-objects[]
 
@@ -144,27 +142,25 @@ public class GettingStartedWithoutAnalysisIT {
 			SearchSession searchSession = Search.getSearchSession( entityManager ); // <1>
 
 			SearchResult<Book> result = searchSession.search( Book.class ) // <2>
-					.asEntity() // <3>
-					.predicate( f -> f.match() // <4>
+					.predicate( f -> f.match() // <3>
 							.onFields( "title", "authors.name" )
 							.matching( "Refactoring: Improving the Design of Existing Code" )
 					)
-					.fetch(); // <5>
+					.fetch(); // <4>
 
-			long totalHitCount = result.getTotalHitCount(); // <6>
-			List<Book> hits = result.getHits(); // <7>
+			long totalHitCount = result.getTotalHitCount(); // <5>
+			List<Book> hits = result.getHits(); // <6>
 
 			List<Book> hits2 =
 					/* ... same DSL calls as above... */
 			// end::searching-lambdas[]
 					searchSession.search( Book.class )
-							.asEntity()
 							.predicate( f -> f.match()
 									.onFields( "title", "authors.name" )
 									.matching( "Refactoring: Improving the Design of Existing Code" )
 							)
 			// tag::searching-lambdas[]
-					.fetchHits(); // <8>
+					.fetchHits(); // <7>
 			// Not shown: commit the transaction and close the entity manager
 			// end::searching-lambdas[]
 
@@ -181,7 +177,6 @@ public class GettingStartedWithoutAnalysisIT {
 			SearchSession searchSession = Search.getSearchSession( entityManager );
 
 			long totalHitCount = searchSession.search( Book.class )
-					.asEntity()
 					.predicate( f -> f.match()
 							.onFields( "title", "authors.name" )
 							.matching( "Refactoring: Improving the Design of Existing Code" )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/directfieldmapping/HibernateOrmSimpleMappingIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/directfieldmapping/HibernateOrmSimpleMappingIT.java
@@ -16,7 +16,6 @@ import org.hibernate.search.documentation.testsupport.BackendSetupStrategy;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmAutomaticIndexingSynchronizationStrategyName;
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
-import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.mapper.orm.search.SearchScope;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.util.impl.integrationtest.orm.OrmSetupHelper;
@@ -74,7 +73,7 @@ public class HibernateOrmSimpleMappingIT {
 
 			SearchScope<Book> scope = searchSession.scope( Book.class );
 
-			SearchQuery<Book> query = scope.search()
+			List<Book> result = scope.search()
 					.asEntity()
 					.predicate( scope.predicate().matchAll().toPredicate() )
 					.sort(
@@ -83,9 +82,7 @@ public class HibernateOrmSimpleMappingIT {
 							.then().byField( "title_sort" )
 							.toSort()
 					)
-					.toQuery();
-
-			List<Book> result = query.fetchHits();
+					.fetchHits();
 			// end::sort-simple-objects[]
 
 			assertThat( result )
@@ -97,15 +94,13 @@ public class HibernateOrmSimpleMappingIT {
 			// tag::sort-simple-lambdas[]
 			SearchSession searchSession = Search.getSearchSession( entityManager );
 
-			SearchQuery<Book> query = searchSession.search( Book.class ) // <1>
+			List<Book> result = searchSession.search( Book.class ) // <1>
 					.asEntity()
 					.predicate( f -> f.matchAll() )
 					.sort( f -> f.byField( "pageCount" ).desc() // <2>
 							.then().byField( "title_sort" )
 					)
-					.toQuery();
-
-			List<Book> result = query.fetchHits(); // <3>
+					.fetchHits(); // <3>
 			// end::sort-simple-lambdas[]
 
 			assertThat( result )
@@ -122,12 +117,10 @@ public class HibernateOrmSimpleMappingIT {
 
 			SearchScope<Book> scope = searchSession.scope( Book.class );
 
-			SearchQuery<String> query = scope.search()
+			List<String> result = scope.search()
 					.asProjection( scope.projection().field( "title", String.class ).toProjection() )
 					.predicate( scope.predicate().matchAll().toPredicate() )
-					.toQuery();
-
-			List<String> result = query.fetchHits();
+					.fetchHits();
 			// end::projection-simple-objects[]
 
 			assertThat( result )
@@ -138,12 +131,10 @@ public class HibernateOrmSimpleMappingIT {
 			// tag::projection-simple-lambdas[]
 			SearchSession searchSession = Search.getSearchSession( entityManager );
 
-			SearchQuery<String> query = searchSession.search( Book.class ) // <1>
+			List<String> result = searchSession.search( Book.class ) // <1>
 					.asProjection( f -> f.field( "title", String.class ) ) // <2>
 					.predicate( f -> f.matchAll() )
-					.toQuery();
-
-			List<String> result = query.fetchHits(); // <3>
+					.fetchHits(); // <3>
 			// end::projection-simple-lambdas[]
 
 			assertThat( result )
@@ -157,16 +148,14 @@ public class HibernateOrmSimpleMappingIT {
 			// tag::projection-advanced[]
 			SearchSession searchSession = Search.getSearchSession( entityManager );
 
-			SearchQuery<MyEntityAndScoreBean<Book>> query = searchSession.search( Book.class )
+			List<MyEntityAndScoreBean<Book>> result = searchSession.search( Book.class )
 					.asProjection( f -> f.composite(
 							MyEntityAndScoreBean::new,
 							f.entity(),
 							f.score()
 					) )
 					.predicate( f -> f.matchAll() )
-					.toQuery();
-
-			List<MyEntityAndScoreBean<Book>> result = query.fetchHits();
+					.fetchHits();
 			// end::projection-advanced[]
 
 			assertThat( result )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/directfieldmapping/HibernateOrmSimpleMappingIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/directfieldmapping/HibernateOrmSimpleMappingIT.java
@@ -74,7 +74,6 @@ public class HibernateOrmSimpleMappingIT {
 			SearchScope<Book> scope = searchSession.scope( Book.class );
 
 			List<Book> result = scope.search()
-					.asEntity()
 					.predicate( scope.predicate().matchAll().toPredicate() )
 					.sort(
 							scope.sort()
@@ -95,7 +94,6 @@ public class HibernateOrmSimpleMappingIT {
 			SearchSession searchSession = Search.getSearchSession( entityManager );
 
 			List<Book> result = searchSession.search( Book.class ) // <1>
-					.asEntity()
 					.predicate( f -> f.matchAll() )
 					.sort( f -> f.byField( "pageCount" ).desc() // <2>
 							.then().byField( "title_sort" )

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/entityindexmapping/HibernateOrmIndexedIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/entityindexmapping/HibernateOrmIndexedIT.java
@@ -67,13 +67,11 @@ public class HibernateOrmIndexedIT {
 			SearchSession searchSession = Search.getSearchSession( entityManager );
 
 			List<Author> authorResult = searchSession.search( Author.class )
-					.asEntity()
 					.predicate( f -> f.matchAll() )
 					.fetchHits();
 			assertThat( authorResult ).hasSize( 1 );
 
 			List<User> userResult = searchSession.search( User.class )
-					.asEntity()
 					.predicate( f -> f.matchAll() )
 					.fetchHits();
 			assertThat( userResult ).hasSize( 1 );
@@ -91,7 +89,6 @@ public class HibernateOrmIndexedIT {
 					SearchQuery<Object> query = searchSession.search(
 									Arrays.asList( Author.class, User.class )
 							)
-							.asEntity()
 							.predicate( f -> f.matchAll() )
 							.toQuery();
 					// end::cross-backend-search[]

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/entityindexmapping/HibernateOrmIndexedIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/entityindexmapping/HibernateOrmIndexedIT.java
@@ -66,18 +66,16 @@ public class HibernateOrmIndexedIT {
 		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
 			SearchSession searchSession = Search.getSearchSession( entityManager );
 
-			SearchQuery<Author> authorQuery = searchSession.search( Author.class )
+			List<Author> authorResult = searchSession.search( Author.class )
 					.asEntity()
 					.predicate( f -> f.matchAll() )
-					.toQuery();
-			List<Author> bookResult = authorQuery.fetchHits();
-			assertThat( bookResult ).hasSize( 1 );
+					.fetchHits();
+			assertThat( authorResult ).hasSize( 1 );
 
-			SearchQuery<User> userQuery = searchSession.search( User.class )
+			List<User> userResult = searchSession.search( User.class )
 					.asEntity()
 					.predicate( f -> f.matchAll() )
-					.toQuery();
-			List<User> userResult = userQuery.fetchHits();
+					.fetchHits();
 			assertThat( userResult ).hasSize( 1 );
 		} );
 	}

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmAutomaticIndexingIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmAutomaticIndexingIT.java
@@ -81,7 +81,6 @@ public class HibernateOrmAutomaticIndexingIT {
 
 			List<Book> result = searchSession.search( Book.class ).asEntity()
 					.predicate( f -> f.match().onField( "title" ).matching( "2nd edition" ) )
-					.toQuery()
 					.fetchHits(); // <5>
 			// end::automatic-indexing-synchronization-strategy-override[]
 

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmAutomaticIndexingIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmAutomaticIndexingIT.java
@@ -79,7 +79,7 @@ public class HibernateOrmAutomaticIndexingIT {
 				entityManager.getTransaction().rollback();
 			}
 
-			List<Book> result = searchSession.search( Book.class ).asEntity()
+			List<Book> result = searchSession.search( Book.class )
 					.predicate( f -> f.match().onField( "title" ).matching( "2nd edition" ) )
 					.fetchHits(); // <5>
 			// end::automatic-indexing-synchronization-strategy-override[]

--- a/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/DslConverterIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/DslConverterIT.java
@@ -21,7 +21,6 @@ import org.hibernate.search.engine.search.predicate.DslConverter;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmAutomaticIndexingSynchronizationStrategyName;
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
-import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.bridge.ValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.runtime.ValueBridgeToIndexedValueContext;
@@ -72,14 +71,12 @@ public class DslConverterIT {
 			SearchSession searchSession = Search.getSearchSession( entityManager );
 
 			// tag::dsl-converter-enabled[]
-			SearchQuery<AuthenticationEvent> query = searchSession.search( AuthenticationEvent.class )
+			List<AuthenticationEvent> result = searchSession.search( AuthenticationEvent.class )
 					.asEntity()
 					.predicate( f -> f.match().onField( "outcome" )
 							.matching( AuthenticationOutcome.INVALID_PASSWORD ) )
-					.toQuery();
+					.fetchHits();
 			// end::dsl-converter-enabled[]
-
-			List<AuthenticationEvent> result = query.fetchHits();
 
 			assertThat( result )
 					.extracting( "id" )
@@ -93,14 +90,12 @@ public class DslConverterIT {
 			SearchSession searchSession = Search.getSearchSession( entityManager );
 
 			// tag::dsl-converter-disabled[]
-			SearchQuery<AuthenticationEvent> query = searchSession.search( AuthenticationEvent.class )
+			List<AuthenticationEvent> result = searchSession.search( AuthenticationEvent.class )
 					.asEntity()
 					.predicate( f -> f.match().onField( "outcome" )
 							.matching( "Invalid password", DslConverter.DISABLED ) )
-					.toQuery();
+					.fetchHits();
 			// end::dsl-converter-disabled[]
-
-			List<AuthenticationEvent> result = query.fetchHits();
 
 			assertThat( result )
 					.extracting( "id" )

--- a/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/DslConverterIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/DslConverterIT.java
@@ -72,7 +72,6 @@ public class DslConverterIT {
 
 			// tag::dsl-converter-enabled[]
 			List<AuthenticationEvent> result = searchSession.search( AuthenticationEvent.class )
-					.asEntity()
 					.predicate( f -> f.match().onField( "outcome" )
 							.matching( AuthenticationOutcome.INVALID_PASSWORD ) )
 					.fetchHits();
@@ -91,7 +90,6 @@ public class DslConverterIT {
 
 			// tag::dsl-converter-disabled[]
 			List<AuthenticationEvent> result = searchSession.search( AuthenticationEvent.class )
-					.asEntity()
 					.predicate( f -> f.match().onField( "outcome" )
 							.matching( "Invalid password", DslConverter.DISABLED ) )
 					.fetchHits();

--- a/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/ProjectionConverterIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/ProjectionConverterIT.java
@@ -24,7 +24,6 @@ import org.hibernate.search.engine.search.projection.ProjectionConverter;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmAutomaticIndexingSynchronizationStrategyName;
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
-import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
@@ -72,13 +71,11 @@ public class ProjectionConverterIT {
 			SearchSession searchSession = Search.getSearchSession( entityManager );
 
 			// tag::projection-converter-enabled[]
-			SearchQuery<OrderStatus> query = searchSession.search( Order.class )
+			List<OrderStatus> result = searchSession.search( Order.class )
 					.asProjection( f -> f.field( "status", OrderStatus.class ) )
 					.predicate( f -> f.matchAll() )
-					.toQuery();
+					.fetchHits();
 			// end::projection-converter-enabled[]
-
-			List<OrderStatus> result = query.fetchHits();
 
 			assertThat( result )
 					.containsExactlyInAnyOrder( OrderStatus.values() );
@@ -91,13 +88,11 @@ public class ProjectionConverterIT {
 			SearchSession searchSession = Search.getSearchSession( entityManager );
 
 			// tag::projection-converter-disabled[]
-			SearchQuery<String> query = searchSession.search( Order.class )
+			List<String> result = searchSession.search( Order.class )
 					.asProjection( f -> f.field( "status", String.class, ProjectionConverter.DISABLED ) )
 					.predicate( f -> f.matchAll() )
-					.toQuery();
+					.fetchHits();
 			// end::projection-converter-disabled[]
-
-			List<String> result = query.fetchHits();
 
 			assertThat( result )
 					.containsExactlyInAnyOrder(

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/MappedIndexSearchScopeImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/MappedIndexSearchScopeImpl.java
@@ -37,7 +37,7 @@ class MappedIndexSearchScopeImpl<C, R, E> implements MappedIndexSearchScope<R, E
 	}
 
 	@Override
-	public SearchQueryResultDefinitionContext<R, E, SearchProjectionFactoryContext<R, E>> search(
+	public SearchQueryResultDefinitionContext<?, R, E, SearchProjectionFactoryContext<R, E>, ?> search(
 			SessionContextImplementor sessionContext,
 			LoadingContextBuilder<R, E> loadingContextBuilder) {
 		return new DefaultSearchQueryResultDefinitionContext<>( delegate, sessionContext, loadingContextBuilder );

--- a/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/spi/MappedIndexSearchScope.java
+++ b/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/spi/MappedIndexSearchScope.java
@@ -29,7 +29,7 @@ public interface MappedIndexSearchScope<R, E> {
 	 * will be wrong.
 	 * In particular, we cannot accept a LoadingContextBuilder<R, T> with any T.
 	 */
-	SearchQueryResultDefinitionContext<R, E, SearchProjectionFactoryContext<R, E>> search(
+	SearchQueryResultDefinitionContext<?, R, E, SearchProjectionFactoryContext<R, E>, ?> search(
 			SessionContextImplementor sessionContext,
 			LoadingContextBuilder<R, E> loadingContextBuilder);
 

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/SearchQueryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/SearchQueryContext.java
@@ -12,6 +12,7 @@ import java.util.function.Consumer;
 
 import org.hibernate.search.engine.search.SearchSort;
 import org.hibernate.search.engine.search.dsl.sort.SearchSortContainerContext;
+import org.hibernate.search.engine.search.query.SearchFetchable;
 import org.hibernate.search.engine.search.query.SearchQuery;
 
 /**
@@ -25,7 +26,8 @@ public interface SearchQueryContext<
 		S extends SearchQueryContext<? extends S, H, SC>,
 		H,
 		SC extends SearchSortContainerContext
-		> {
+		>
+		extends SearchFetchable<H> {
 
 	S routing(String routingKey);
 

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/SearchQueryContextExtension.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/SearchQueryContextExtension.java
@@ -48,7 +48,7 @@ public interface SearchQueryContextExtension<T, R, E> {
 	 * @return An optional containing the extended search query context ({@link T}) in case
 	 * of success, or an empty optional otherwise.
 	 */
-	Optional<T> extendOptional(SearchQueryResultDefinitionContext<R, E, ?> original,
+	Optional<T> extendOptional(SearchQueryResultDefinitionContext<?, R, E, ?, ?> original,
 			IndexSearchScope<?> indexSearchScope,
 			SessionContextImplementor sessionContext,
 			LoadingContextBuilder<R, E> loadingContextBuilder);

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/SearchQueryResultContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/SearchQueryResultContext.java
@@ -17,12 +17,12 @@ import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateTerminalC
  *
  * @param <N> The type of the next context, returned after a predicate is defined.
  * @param <H> The type of hits for the created query.
- * @param <PC> The type of contexts used to create predicates in {@link #predicate(Function)}.
+ * @param <PDC> The type of contexts used to create predicates in {@link #predicate(Function)}.
  */
 public interface SearchQueryResultContext<
 		N extends SearchQueryContext<? extends N, H, ?>,
 		H,
-		PC extends SearchPredicateFactoryContext
+		PDC extends SearchPredicateFactoryContext
 		> {
 
 	/**
@@ -39,6 +39,6 @@ public interface SearchQueryResultContext<
 	 * Should generally be a lambda expression.
 	 * @return A context allowing to define the query further.
 	 */
-	N predicate(Function<? super PC, SearchPredicateTerminalContext> predicateContributor);
+	N predicate(Function<? super PDC, SearchPredicateTerminalContext> predicateContributor);
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/SearchQueryResultDefinitionContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/SearchQueryResultDefinitionContext.java
@@ -16,7 +16,7 @@ import org.hibernate.search.engine.search.dsl.projection.SearchProjectionTermina
 import org.hibernate.search.util.common.SearchException;
 
 /**
- * The context used when building a query, after the search result type has been defined.
+ * The context used when building a query, before the search result type has been defined.
  *
  * @param <R> The type of references, i.e. the type of hits returned by
  * {@link #asReference() reference queries},

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/SearchQueryResultDefinitionContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/SearchQueryResultDefinitionContext.java
@@ -10,7 +10,9 @@ import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import org.hibernate.search.engine.search.SearchPredicate;
 import org.hibernate.search.engine.search.SearchProjection;
+import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryContext;
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContext;
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionTerminalContext;
 import org.hibernate.search.util.common.SearchException;
@@ -18,15 +20,27 @@ import org.hibernate.search.util.common.SearchException;
 /**
  * The context used when building a query, before the search result type has been defined.
  *
+ * @param <N> The next context if no type of hits is explicitly selected,
+ * i.e. if {@link #predicate(SearchPredicate)} or {@link #predicate(Function)} is called directly
+ * without calling {@link #asEntity()}, or {@link #asReference()}, {@link #asProjection(SearchProjection)}
+ * or a similar method.
  * @param <R> The type of references, i.e. the type of hits returned by
  * {@link #asReference() reference queries},
  * or the type of objects returned for {@link SearchProjectionFactoryContext#reference() reference projections}.
  * @param <E> The type of entities, i.e. the type of hits returned by
  * {@link #asEntity() entity queries},
  * or the type of objects returned for {@link SearchProjectionFactoryContext#entity() entity projections}.
- * @param <PC> The type of contexts used to create projections in {@link #asProjection(Function)}.
+ * @param <PJC> The type of contexts used to create projections in {@link #asProjection(Function)}.
+ * @param <PDC> The type of contexts used to create predicates in {@link #predicate(Function)}.
  */
-public interface SearchQueryResultDefinitionContext<R, E, PC extends SearchProjectionFactoryContext<R, E>> {
+public interface SearchQueryResultDefinitionContext<
+				N extends SearchQueryContext<? extends N, E, ?>,
+				R,
+				E,
+				PJC extends SearchProjectionFactoryContext<R, E>,
+				PDC extends SearchPredicateFactoryContext
+		>
+		extends SearchQueryResultContext<N, E, PDC> {
 
 	/**
 	 * Define the query results as the entity was originally indexed, loaded from an external source (database, ...).
@@ -55,7 +69,7 @@ public interface SearchQueryResultDefinitionContext<R, E, PC extends SearchProje
 	 * @see SearchQueryResultContext
 	 */
 	<P> SearchQueryResultContext<?, P, ?> asProjection(
-			Function<? super PC, ? extends SearchProjectionTerminalContext<P>> projectionContributor);
+			Function<? super PJC, ? extends SearchProjectionTerminalContext<P>> projectionContributor);
 
 	/**
 	 * Define the query results as one projection for each matching document.

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/impl/DefaultSearchQueryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/impl/DefaultSearchQueryContext.java
@@ -17,7 +17,7 @@ import org.hibernate.search.engine.search.query.spi.SearchQueryBuilder;
 final class DefaultSearchQueryContext<H, C>
 		extends AbstractSearchQueryContext<
 						DefaultSearchQueryContext<H, C>,
-		H,
+						H,
 						SearchPredicateFactoryContext,
 						SearchSortContainerContext,
 						C

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/impl/DefaultSearchQueryResultDefinitionContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/impl/DefaultSearchQueryResultDefinitionContext.java
@@ -10,9 +10,13 @@ import java.util.List;
 import java.util.function.Function;
 
 import org.hibernate.search.engine.mapper.session.context.spi.SessionContextImplementor;
+import org.hibernate.search.engine.search.SearchPredicate;
 import org.hibernate.search.engine.search.SearchProjection;
+import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryContext;
+import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateTerminalContext;
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContext;
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionTerminalContext;
+import org.hibernate.search.engine.search.dsl.query.SearchQueryContext;
 import org.hibernate.search.engine.search.dsl.query.SearchQueryResultContext;
 import org.hibernate.search.engine.search.dsl.query.spi.AbstractSearchQueryResultDefinitionContext;
 import org.hibernate.search.engine.search.dsl.spi.IndexSearchScope;
@@ -20,7 +24,14 @@ import org.hibernate.search.engine.search.loading.context.spi.LoadingContextBuil
 import org.hibernate.search.engine.search.query.spi.SearchQueryBuilder;
 
 public final class DefaultSearchQueryResultDefinitionContext<R, E, C>
-		extends AbstractSearchQueryResultDefinitionContext<R, E, SearchProjectionFactoryContext<R, E>, C> {
+		extends AbstractSearchQueryResultDefinitionContext<
+				SearchQueryContext<?, E, ?>,
+				R,
+				E,
+				SearchProjectionFactoryContext<R, E>,
+				SearchPredicateFactoryContext,
+				C
+		> {
 
 	private final IndexSearchScope<C> indexSearchScope;
 	private final SessionContextImplementor sessionContext;
@@ -68,6 +79,17 @@ public final class DefaultSearchQueryResultDefinitionContext<R, E, C>
 		SearchQueryBuilder<List<?>, C> builder = indexSearchScope.getSearchQueryBuilderFactory()
 				.asProjections( sessionContext, loadingContextBuilder, projections );
 		return new DefaultSearchQueryContext<>( indexSearchScope, builder );
+	}
+
+	@Override
+	public SearchQueryContext<?, E, ?> predicate(
+			Function<? super SearchPredicateFactoryContext, SearchPredicateTerminalContext> predicateContributor) {
+		return asEntity().predicate( predicateContributor );
+	}
+
+	@Override
+	public SearchQueryContext<?, E, ?> predicate(SearchPredicate predicate) {
+		return asEntity().predicate( predicate );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/spi/AbstractDelegatingSearchQueryResultDefinitionContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/spi/AbstractDelegatingSearchQueryResultDefinitionContext.java
@@ -9,19 +9,29 @@ package org.hibernate.search.engine.search.dsl.query.spi;
 import java.util.List;
 import java.util.function.Function;
 
+import org.hibernate.search.engine.search.SearchPredicate;
 import org.hibernate.search.engine.search.SearchProjection;
+import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryContext;
+import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateTerminalContext;
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContext;
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionTerminalContext;
+import org.hibernate.search.engine.search.dsl.query.SearchQueryContext;
 import org.hibernate.search.engine.search.dsl.query.SearchQueryContextExtension;
 import org.hibernate.search.engine.search.dsl.query.SearchQueryResultContext;
 import org.hibernate.search.engine.search.dsl.query.SearchQueryResultDefinitionContext;
 
 public abstract class AbstractDelegatingSearchQueryResultDefinitionContext<R, E>
-		implements SearchQueryResultDefinitionContext<R, E, SearchProjectionFactoryContext<R, E>> {
+		implements SearchQueryResultDefinitionContext<
+				SearchQueryContext<?, E, ?>,
+				R,
+				E,
+				SearchProjectionFactoryContext<R, E>,
+				SearchPredicateFactoryContext
+		> {
 
-	private final SearchQueryResultDefinitionContext<R, E, ?> delegate;
+	private final SearchQueryResultDefinitionContext<?, R, E, ?, ?> delegate;
 
-	public AbstractDelegatingSearchQueryResultDefinitionContext(SearchQueryResultDefinitionContext<R, E, ?> delegate) {
+	public AbstractDelegatingSearchQueryResultDefinitionContext(SearchQueryResultDefinitionContext<?, R, E, ?, ?> delegate) {
 		this.delegate = delegate;
 	}
 
@@ -50,6 +60,17 @@ public abstract class AbstractDelegatingSearchQueryResultDefinitionContext<R, E>
 	public SearchQueryResultContext<?, List<?>, ?> asProjections(
 			SearchProjection<?>... projections) {
 		return delegate.asProjections( projections );
+	}
+
+	@Override
+	public SearchQueryContext<?, E, ?> predicate(
+			Function<? super SearchPredicateFactoryContext, SearchPredicateTerminalContext> predicateContributor) {
+		return delegate.predicate( predicateContributor );
+	}
+
+	@Override
+	public SearchQueryContext<?, E, ?> predicate(SearchPredicate predicate) {
+		return delegate.predicate( predicate );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/spi/AbstractExtendedSearchQueryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/spi/AbstractExtendedSearchQueryContext.java
@@ -1,0 +1,50 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.dsl.query.spi;
+
+import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryContext;
+import org.hibernate.search.engine.search.dsl.query.SearchQueryContext;
+import org.hibernate.search.engine.search.dsl.sort.SearchSortContainerContext;
+import org.hibernate.search.engine.search.dsl.spi.IndexSearchScope;
+import org.hibernate.search.engine.search.query.ExtendedSearchQuery;
+import org.hibernate.search.engine.search.query.SearchResult;
+import org.hibernate.search.engine.search.query.spi.SearchQueryBuilder;
+
+public abstract class AbstractExtendedSearchQueryContext<
+		S extends SearchQueryContext<S, H, SC>,
+		H,
+		R extends SearchResult<H>,
+		PC extends SearchPredicateFactoryContext,
+		SC extends SearchSortContainerContext,
+		C
+		>
+		extends AbstractSearchQueryContext<S, H, PC, SC, C> {
+
+	public AbstractExtendedSearchQueryContext(IndexSearchScope<C> indexSearchScope,
+			SearchQueryBuilder<H, C> searchQueryBuilder) {
+		super( indexSearchScope, searchQueryBuilder );
+	}
+
+	@Override
+	public abstract ExtendedSearchQuery<H, R> toQuery();
+
+	@Override
+	public R fetch() {
+		return toQuery().fetch();
+	}
+
+	@Override
+	public R fetch(Integer limit) {
+		return toQuery().fetch( limit );
+	}
+
+	@Override
+	public R fetch(Integer limit, Integer offset) {
+		return toQuery().fetch( limit, offset );
+	}
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/spi/AbstractExtendedSearchQueryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/spi/AbstractExtendedSearchQueryContext.java
@@ -15,14 +15,14 @@ import org.hibernate.search.engine.search.query.SearchResult;
 import org.hibernate.search.engine.search.query.spi.SearchQueryBuilder;
 
 public abstract class AbstractExtendedSearchQueryContext<
-		S extends SearchQueryContext<S, H, SC>,
-		H,
-		R extends SearchResult<H>,
-		PC extends SearchPredicateFactoryContext,
-		SC extends SearchSortContainerContext,
-		C
+				S extends SearchQueryContext<S, H, SC>,
+				H,
+				R extends SearchResult<H>,
+				PDC extends SearchPredicateFactoryContext,
+				SC extends SearchSortContainerContext,
+				C
 		>
-		extends AbstractSearchQueryContext<S, H, PC, SC, C> {
+		extends AbstractSearchQueryContext<S, H, PDC, SC, C> {
 
 	public AbstractExtendedSearchQueryContext(IndexSearchScope<C> indexSearchScope,
 			SearchQueryBuilder<H, C> searchQueryBuilder) {

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/spi/AbstractSearchQueryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/spi/AbstractSearchQueryContext.java
@@ -7,6 +7,8 @@
 package org.hibernate.search.engine.search.dsl.query.spi;
 
 import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -23,6 +25,7 @@ import org.hibernate.search.engine.search.dsl.sort.impl.SearchSortDslContextImpl
 import org.hibernate.search.engine.search.dsl.spi.IndexSearchScope;
 import org.hibernate.search.engine.search.predicate.spi.SearchPredicateBuilderFactory;
 import org.hibernate.search.engine.search.query.SearchQuery;
+import org.hibernate.search.engine.search.query.SearchResult;
 import org.hibernate.search.engine.search.query.spi.SearchQueryBuilder;
 import org.hibernate.search.engine.search.sort.spi.SearchSortBuilderFactory;
 
@@ -89,6 +92,46 @@ public abstract class AbstractSearchQueryContext<
 	@Override
 	public SearchQuery<H> toQuery() {
 		return searchQueryBuilder.build();
+	}
+
+	@Override
+	public SearchResult<H> fetch() {
+		return toQuery().fetch();
+	}
+
+	@Override
+	public SearchResult<H> fetch(Integer limit) {
+		return toQuery().fetch( limit );
+	}
+
+	@Override
+	public SearchResult<H> fetch(Integer limit, Integer offset) {
+		return toQuery().fetch( limit, offset );
+	}
+
+	@Override
+	public List<H> fetchHits() {
+		return toQuery().fetchHits();
+	}
+
+	@Override
+	public List<H> fetchHits(Integer limit) {
+		return toQuery().fetchHits( limit );
+	}
+
+	@Override
+	public List<H> fetchHits(Integer limit, Integer offset) {
+		return toQuery().fetchHits( limit, offset );
+	}
+
+	@Override
+	public Optional<H> fetchSingleHit() {
+		return toQuery().fetchSingleHit();
+	}
+
+	@Override
+	public long fetchTotalHitCount() {
+		return toQuery().fetchTotalHitCount();
 	}
 
 	private <B> void contribute(SearchPredicateBuilderFactory<? super C, B> factory, SearchPredicate predicate) {

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/spi/AbstractSearchQueryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/spi/AbstractSearchQueryContext.java
@@ -32,11 +32,11 @@ import org.hibernate.search.engine.search.sort.spi.SearchSortBuilderFactory;
 public abstract class AbstractSearchQueryContext<
 		S extends SearchQueryContext<S, H, SC>,
 		H,
-		PC extends SearchPredicateFactoryContext,
+		PDC extends SearchPredicateFactoryContext,
 		SC extends SearchSortContainerContext,
 		C
 		>
-		implements SearchQueryResultContext<S, H, PC>, SearchQueryContext<S, H, SC> {
+		implements SearchQueryResultContext<S, H, PDC>, SearchQueryContext<S, H, SC> {
 
 	private final IndexSearchScope<C> indexSearchScope;
 	private final SearchQueryBuilder<H, C> searchQueryBuilder;
@@ -55,7 +55,7 @@ public abstract class AbstractSearchQueryContext<
 	}
 
 	@Override
-	public S predicate(Function<? super PC, SearchPredicateTerminalContext> predicateContributor) {
+	public S predicate(Function<? super PDC, SearchPredicateTerminalContext> predicateContributor) {
 		SearchPredicateBuilderFactory<? super C, ?> factory = indexSearchScope.getSearchPredicateBuilderFactory();
 		SearchPredicateFactoryContext factoryContext = new DefaultSearchPredicateFactoryContext<>( factory );
 		SearchPredicate predicate = predicateContributor.apply( extendPredicateContext( factoryContext ) ).toPredicate();
@@ -158,7 +158,7 @@ public abstract class AbstractSearchQueryContext<
 
 	protected abstract S thisAsS();
 
-	protected abstract PC extendPredicateContext(SearchPredicateFactoryContext predicateFactoryContext);
+	protected abstract PDC extendPredicateContext(SearchPredicateFactoryContext predicateFactoryContext);
 
 	protected abstract SC extendSortContext(SearchSortContainerContext sortContainerContext);
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/spi/AbstractSearchQueryResultDefinitionContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/query/spi/AbstractSearchQueryResultDefinitionContext.java
@@ -8,15 +8,24 @@ package org.hibernate.search.engine.search.dsl.query.spi;
 
 import org.hibernate.search.engine.common.dsl.spi.DslExtensionState;
 import org.hibernate.search.engine.mapper.session.context.spi.SessionContextImplementor;
+import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryContext;
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContext;
 import org.hibernate.search.engine.search.dsl.projection.impl.DefaultSearchProjectionFactoryContext;
+import org.hibernate.search.engine.search.dsl.query.SearchQueryContext;
 import org.hibernate.search.engine.search.dsl.query.SearchQueryContextExtension;
 import org.hibernate.search.engine.search.dsl.query.SearchQueryResultDefinitionContext;
 import org.hibernate.search.engine.search.dsl.spi.IndexSearchScope;
 import org.hibernate.search.engine.search.loading.context.spi.LoadingContextBuilder;
 
-public abstract class AbstractSearchQueryResultDefinitionContext<R, E, PC extends SearchProjectionFactoryContext<R, E>, C>
-		implements SearchQueryResultDefinitionContext<R, E, PC> {
+public abstract class AbstractSearchQueryResultDefinitionContext<
+				N extends SearchQueryContext<? extends N, E, ?>,
+				R,
+				E,
+				PJC extends SearchProjectionFactoryContext<R, E>,
+				PDC extends SearchPredicateFactoryContext,
+				C
+		>
+		implements SearchQueryResultDefinitionContext<N, R, E, PJC, PDC> {
 
 	@Override
 	public <T> T extension(SearchQueryContextExtension<T, R, E> extension) {

--- a/engine/src/main/java/org/hibernate/search/engine/search/query/ExtendedSearchFetchable.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/query/ExtendedSearchFetchable.java
@@ -7,13 +7,21 @@
 package org.hibernate.search.engine.search.query;
 
 /**
- * A base interface for subtypes of {@link SearchQuery} allowing to
+ * A base interface for subtypes of {@link SearchFetchable} allowing to
  * easily override the result type for all relevant methods.
  *
  * @param <H> The type of query hits.
  * @param <R> The result type (extending {@link SearchResult}).
  */
-public interface ExtendedSearchQuery<H, R extends SearchResult<H>>
-		extends SearchQuery<H>, ExtendedSearchFetchable<H, R> {
+public interface ExtendedSearchFetchable<H, R extends SearchResult<H>> extends SearchFetchable<H> {
+
+	@Override
+	R fetch();
+
+	@Override
+	R fetch(Integer limit);
+
+	@Override
+	R fetch(Integer limit, Integer offset);
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/query/SearchFetchable.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/query/SearchFetchable.java
@@ -1,0 +1,106 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.query;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.hibernate.search.util.common.SearchException;
+
+/**
+ * A component allowing to fetch search results.
+ *
+ * @param <H> The type of query hits.
+ */
+public interface SearchFetchable<H> {
+
+	/**
+	 * Execute the query and return the {@link SearchResult}.
+	 *
+	 * @return The {@link SearchResult}.
+	 * @throws SearchException If something goes wrong while executing the query.
+	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
+	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
+	 */
+	SearchResult<H> fetch();
+
+	/**
+	 * Execute the query and return the {@link SearchResult}.
+	 *
+	 * @param limit The maximum number of hits to be included in the {@link SearchResult}. {@code null} means no limit.
+	 * @return The {@link SearchResult}.
+	 * @throws SearchException If something goes wrong while executing the query.
+	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
+	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
+	 */
+	SearchResult<H> fetch(Integer limit);
+
+	/**
+	 * Execute the query and return the {@link SearchResult}.
+	 *
+	 * @param limit The maximum number of hits to be included in the {@link SearchResult}. {@code null} means no limit.
+	 * @param offset The number of hits to skip before adding the hits to the {@link SearchResult}. {@code null} means no offset.
+	 * @return The {@link SearchResult}.
+	 * @throws SearchException If something goes wrong while executing the query.
+	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
+	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
+	 */
+	SearchResult<H> fetch(Integer limit, Integer offset);
+
+	/**
+	 * Execute the query and return the hits as a {@link List}.
+	 *
+	 * @return The query hits.
+	 * @throws SearchException If something goes wrong while executing the query.
+	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
+	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
+	 */
+	List<H> fetchHits();
+
+	/**
+	 * Execute the query and return the hits as a {@link List}.
+	 *
+	 * @param limit The maximum number of hits to be returned by this method. {@code null} means no limit.
+	 * @return The query hits.
+	 * @throws SearchException If something goes wrong while executing the query.
+	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
+	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
+	 */
+	List<H> fetchHits(Integer limit);
+
+	/**
+	 * Execute the query and return the hits as a {@link List}.
+	 *
+	 * @param limit The maximum number of hits to be returned by this method. {@code null} means no limit.
+	 * @param offset The number of hits to skip. {@code null} means no offset.
+	 * @return The query hits.
+	 * @throws SearchException If something goes wrong while executing the query.
+	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
+	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
+	 */
+	List<H> fetchHits(Integer limit, Integer offset);
+
+	/**
+	 * Execute the query and return the hits as a single, optional element.
+	 *
+	 * @return The single, optional query hit.
+	 * @throws SearchException If something goes wrong while executing the query,
+	 * or the number of hits is more than one.
+	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
+	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
+	 */
+	Optional<H> fetchSingleHit();
+
+	/**
+	 * Execute the query and return the total hit count.
+	 *
+	 * @return The total number of matching entities, ignoring pagination settings.
+	 * @throws SearchException If something goes wrong while executing the query.
+	 */
+	long fetchTotalHitCount();
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/query/SearchQuery.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/query/SearchQuery.java
@@ -6,9 +6,6 @@
  */
 package org.hibernate.search.engine.search.query;
 
-import java.util.List;
-import java.util.Optional;
-
 import org.hibernate.search.util.common.SearchException;
 
 /**
@@ -16,92 +13,7 @@ import org.hibernate.search.util.common.SearchException;
  *
  * @param <H> The type of query hits.
  */
-public interface SearchQuery<H> {
-
-	/**
-	 * Execute the query and return the {@link SearchResult}.
-	 *
-	 * @return The {@link SearchResult}.
-	 * @throws SearchException If something goes wrong while executing the query.
-	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
-	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
-	 */
-	SearchResult<H> fetch();
-
-	/**
-	 * Execute the query and return the {@link SearchResult}.
-	 *
-	 * @param limit The maximum number of hits to be included in the {@link SearchResult}. {@code null} means no limit.
-	 * @return The {@link SearchResult}.
-	 * @throws SearchException If something goes wrong while executing the query.
-	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
-	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
-	 */
-	SearchResult<H> fetch(Integer limit);
-
-	/**
-	 * Execute the query and return the {@link SearchResult}.
-	 *
-	 * @param limit The maximum number of hits to be included in the {@link SearchResult}. {@code null} means no limit.
-	 * @param offset The number of hits to skip before adding the hits to the {@link SearchResult}. {@code null} means no offset.
-	 * @return The {@link SearchResult}.
-	 * @throws SearchException If something goes wrong while executing the query.
-	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
-	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
-	 */
-	SearchResult<H> fetch(Integer limit, Integer offset);
-
-	/**
-	 * Execute the query and return the hits as a {@link List}.
-	 *
-	 * @return The query hits.
-	 * @throws SearchException If something goes wrong while executing the query.
-	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
-	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
-	 */
-	List<H> fetchHits();
-
-	/**
-	 * Execute the query and return the hits as a {@link List}.
-	 *
-	 * @param limit The maximum number of hits to be returned by this method. {@code null} means no limit.
-	 * @return The query hits.
-	 * @throws SearchException If something goes wrong while executing the query.
-	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
-	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
-	 */
-	List<H> fetchHits(Integer limit);
-
-	/**
-	 * Execute the query and return the hits as a {@link List}.
-	 *
-	 * @param limit The maximum number of hits to be returned by this method. {@code null} means no limit.
-	 * @param offset The number of hits to skip. {@code null} means no offset.
-	 * @return The query hits.
-	 * @throws SearchException If something goes wrong while executing the query.
-	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
-	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
-	 */
-	List<H> fetchHits(Integer limit, Integer offset);
-
-	/**
-	 * Execute the query and return the hits as a single, optional element.
-	 *
-	 * @return The single, optional query hit.
-	 * @throws SearchException If something goes wrong while executing the query,
-	 * or the number of hits is more than one.
-	 * @throws RuntimeException If something goes wrong while loading entities. The exact type depends on the mapper,
-	 * e.g. HibernateException/PersistenceException for the Hibernate ORM mapper.
-	 */
-	Optional<H> fetchSingleHit();
-
-	/**
-	 * Execute the query and return the total hit count.
-	 *
-	 * @return The total number of matching entities, ignoring pagination settings.
-	 * @throws SearchException If something goes wrong while executing the query.
-	 */
-	long fetchTotalHitCount();
+public interface SearchQuery<H> extends SearchFetchable<H> {
 
 	/**
 	 * @return A textual representation of the query.

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
@@ -142,6 +142,9 @@ public class ElasticsearchExtensionIT {
 				scope.query().extension( ElasticsearchExtension.get() ).asProjection( projection );
 		ElasticsearchSearchQueryResultContext<List<?>> asProjectionsContext =
 				scope.query().extension( ElasticsearchExtension.get() ).asProjections( projection, projection );
+		ElasticsearchSearchQueryContext<DocumentReference> defaultResultContext =
+				scope.query().extension( ElasticsearchExtension.get() )
+						.predicate( f -> f.fromJson( "{'match_all': {}}" ) );
 	}
 
 	@Test

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
@@ -152,7 +152,6 @@ public class ElasticsearchExtensionIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> genericQuery = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 
@@ -182,7 +181,6 @@ public class ElasticsearchExtensionIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		ElasticsearchSearchQuery<DocumentReference> query = scope.query().extension( ElasticsearchExtension.get() )
-				.asReference()
 				.predicate( f -> f.id().matching( FIRST_ID ) )
 				.toQuery();
 
@@ -202,7 +200,6 @@ public class ElasticsearchExtensionIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		ElasticsearchSearchQuery<DocumentReference> query = scope.query().extension( ElasticsearchExtension.get() )
-				.asReference()
 				.predicate( f -> f.id().matching( FIRST_ID ) )
 				.toQuery();
 
@@ -228,7 +225,6 @@ public class ElasticsearchExtensionIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope( otherIndexManager );
 
 		ElasticsearchSearchQuery<DocumentReference> query = scope.query().extension( ElasticsearchExtension.get() )
-				.asReference()
 				.predicate( f -> f.id().matching( FIRST_ID ) )
 				.toQuery();
 
@@ -248,7 +244,6 @@ public class ElasticsearchExtensionIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope( otherIndexManager );
 
 		ElasticsearchSearchQuery<DocumentReference> query = scope.query().extension( ElasticsearchExtension.get() )
-				.asReference()
 				.predicate( f -> f.id().matching( FIRST_ID ) )
 				.toQuery();
 
@@ -271,7 +266,6 @@ public class ElasticsearchExtensionIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope( otherIndexManager );
 
 		ElasticsearchSearchQuery<DocumentReference> query = scope.query().extension( ElasticsearchExtension.get() )
-				.asReference()
 				.predicate( f -> f.id().matching( FIRST_ID ) )
 				.toQuery();
 
@@ -293,7 +287,6 @@ public class ElasticsearchExtensionIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.extension( ElasticsearchExtension.get() )
 								.fromJson( "{'match': {'string': 'text 1'}}" )
@@ -355,7 +348,6 @@ public class ElasticsearchExtensionIT {
 				.toPredicate();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( booleanPredicate )
 				.toQuery();
 		assertThat( query )
@@ -368,7 +360,6 @@ public class ElasticsearchExtensionIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.sort( c -> c
 						.extension( ElasticsearchExtension.get() )
@@ -388,7 +379,6 @@ public class ElasticsearchExtensionIT {
 		);
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.sort( c -> c
 						.extension( ElasticsearchExtension.get() )
@@ -427,7 +417,6 @@ public class ElasticsearchExtensionIT {
 				.toSort();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.sort( c -> c.by( sort1Asc ).then().by( sort2Asc ).then().by( sort3Asc ).then().by( sort4Asc ) )
 				.toQuery();
@@ -449,7 +438,6 @@ public class ElasticsearchExtensionIT {
 				.toSort();
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.sort( c -> c.by( sort1Desc ).then().by( sort2Desc ).then().by( sort3Desc ).then().by( sort4Desc ) )
 				.toQuery();
@@ -649,7 +637,6 @@ public class ElasticsearchExtensionIT {
 		// Check that all documents are searchable
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder(

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/search/ElasticsearchMatchSearchPredicateIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/search/ElasticsearchMatchSearchPredicateIT.java
@@ -53,7 +53,6 @@ public class ElasticsearchMatchSearchPredicateIT {
 	@Test
 	public void match_skipAnalysis_normalizedStringField() {
 		SubTest.expectException( () -> indexManager.createSearchScope().query()
-				.asReference()
 				.predicate( f -> f.match().onField( "normalizedStringField" ).matching( TEST_TERM ).skipAnalysis() )
 				.toQuery()
 		)

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/search/query/ElasticsearchSearchQueryIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/search/query/ElasticsearchSearchQueryIT.java
@@ -89,7 +89,6 @@ public class ElasticsearchSearchQueryIT {
 		String routingKey = "someRoutingKey";
 
 		SearchQuery<?> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.routing( routingKey )
 				.toQuery();

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneExtensionIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneExtensionIT.java
@@ -152,6 +152,9 @@ public class LuceneExtensionIT {
 				scope.query().extension( LuceneExtension.get() ).asProjection( projection );
 		LuceneSearchQueryResultContext<List<?>> asProjectionsContext =
 				scope.query().extension( LuceneExtension.get() ).asProjections( projection, projection );
+		LuceneSearchQueryContext<DocumentReference> defaultResultContext =
+				scope.query().extension( LuceneExtension.get() )
+						.predicate( f -> f.fromLuceneQuery( new MatchAllDocsQuery() ) );
 	}
 
 	@Test

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneExtensionIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneExtensionIT.java
@@ -162,7 +162,6 @@ public class LuceneExtensionIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> genericQuery = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 
@@ -192,7 +191,6 @@ public class LuceneExtensionIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		LuceneSearchQuery<DocumentReference> query = scope.query().extension( LuceneExtension.get() )
-				.asReference()
 				.predicate( f -> f.id().matching( FIRST_ID ) )
 				.toQuery();
 
@@ -212,7 +210,6 @@ public class LuceneExtensionIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		LuceneSearchQuery<DocumentReference> query = scope.query().extension( LuceneExtension.get() )
-				.asReference()
 				.predicate( f -> f.id().matching( FIRST_ID ) )
 				.toQuery();
 
@@ -232,7 +229,6 @@ public class LuceneExtensionIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope( otherIndexManager );
 
 		LuceneSearchQuery<DocumentReference> query = scope.query().extension( LuceneExtension.get() )
-				.asReference()
 				.predicate( f -> f.id().matching( FIRST_ID ) )
 				.toQuery();
 
@@ -252,7 +248,6 @@ public class LuceneExtensionIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope( otherIndexManager );
 
 		LuceneSearchQuery<DocumentReference> query = scope.query().extension( LuceneExtension.get() )
-				.asReference()
 				.predicate( f -> f.id().matching( FIRST_ID ) )
 				.toQuery();
 
@@ -272,7 +267,6 @@ public class LuceneExtensionIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope( otherIndexManager );
 
 		LuceneSearchQuery<DocumentReference> query = scope.query().extension( LuceneExtension.get() )
-				.asReference()
 				.predicate( f -> f.id().matching( FIRST_ID ) )
 				.toQuery();
 
@@ -292,7 +286,6 @@ public class LuceneExtensionIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.extension( LuceneExtension.get() )
 								.fromLuceneQuery( new TermQuery( new Term( "string", "text 1" ) ) )
@@ -327,7 +320,6 @@ public class LuceneExtensionIT {
 				.toPredicate();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( booleanPredicate )
 				.toQuery();
 		assertThat( query )
@@ -340,7 +332,6 @@ public class LuceneExtensionIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.sort( c -> c
 						.extension( LuceneExtension.get() )
@@ -357,7 +348,6 @@ public class LuceneExtensionIT {
 		);
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.sort( c -> c
 						.extension().ifSupported(
@@ -400,7 +390,6 @@ public class LuceneExtensionIT {
 				.toSort();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.sort( c -> c.by( sort1 ).then().by( sort2 ).then().by( sort3 ) )
 				.toQuery();
@@ -417,7 +406,6 @@ public class LuceneExtensionIT {
 				.toSort();
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.sort( c -> c.by( sort ) )
 				.toQuery();
@@ -432,7 +420,6 @@ public class LuceneExtensionIT {
 		SubTest.expectException(
 				"match() predicate on unsupported native field",
 				() -> scope.query()
-						.asReference()
 						.predicate( f -> f.match().onField( "nativeField" ).matching( "37" ) )
 						.toQuery()
 				)
@@ -451,7 +438,6 @@ public class LuceneExtensionIT {
 		SubTest.expectException(
 				"sort on unsupported native field",
 				() -> scope.query()
-						.asReference()
 						.predicate( f -> f.matchAll() )
 						.sort( c -> c.byField( "nativeField" ) )
 						.toQuery()
@@ -469,7 +455,6 @@ public class LuceneExtensionIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.extension( LuceneExtension.get() )
 						.fromLuceneQuery( new TermQuery( new Term( "nativeField", "37" ) ) )
 				)
@@ -513,7 +498,6 @@ public class LuceneExtensionIT {
 
 		// let's check that it's possible to query the field beforehand
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.extension( LuceneExtension.get() )
 						.fromLuceneQuery( new TermQuery( new Term( "nativeField_unsupportedProjection", "37" ) ) )
 				)
@@ -540,7 +524,6 @@ public class LuceneExtensionIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.sort( c -> c.extension( LuceneExtension.get() ).fromLuceneSortField( new SortField( "nativeField", Type.LONG ) ) )
 				.toQuery();
@@ -758,7 +741,6 @@ public class LuceneExtensionIT {
 		// Check that all documents are searchable
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder(

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneBoolSearchPredicateIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneBoolSearchPredicateIT.java
@@ -47,7 +47,6 @@ public class LuceneBoolSearchPredicateIT {
 		SubTest.expectException(
 				"bool() predicate with a minimumShouldMatch constraint providing an out-of-bounds value",
 				() -> scope.query()
-						.asReference()
 						.predicate( f -> f.bool()
 								.minimumShouldMatchNumber( 3 )
 								.should( f.match().onField( "fieldName" ).matching( "blablabla" ) )

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneMatchSearchPredicateIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneMatchSearchPredicateIT.java
@@ -54,14 +54,12 @@ public class LuceneMatchSearchPredicateIT {
 	@Test
 	public void match_skipAnalysis_normalizedStringField() {
 		SearchQuery<DocumentReference> query = indexManager.createSearchScope().query()
-				.asReference()
 				.predicate( f -> f.match().onField( "normalizedStringField" ).matching( TEST_TERM ) )
 				.toQuery();
 
 		assertThat( query ).hasDocRefHitsAnyOrder( INDEX_NAME, "1" );
 
 		query = indexManager.createSearchScope().query()
-				.asReference()
 				.predicate( f -> f.match().onField( "normalizedStringField" ).matching( TEST_TERM ).skipAnalysis() )
 				.toQuery();
 

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneSearchMultiIndexIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneSearchMultiIndexIT.java
@@ -88,7 +88,6 @@ public class LuceneSearchMultiIndexIT {
 		StubMappingSearchScope scope = indexManager_1_1.createSearchScope( indexManager_1_2 );
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.sort( c -> c.byField( "additionalField" ).asc().onMissingValue().sortLast() )
 				.toQuery();
@@ -99,7 +98,6 @@ public class LuceneSearchMultiIndexIT {
 		} );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.sort( c -> c.byField( "additionalField" ).desc().onMissingValue().sortLast() )
 				.toQuery();
@@ -128,7 +126,6 @@ public class LuceneSearchMultiIndexIT {
 
 		StubMappingSearchScope scope = indexManager_1_1.createSearchScope();
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( INDEX_NAME_1_1, DOCUMENT_1_1_1, DOCUMENT_1_1_2 );
@@ -145,7 +142,6 @@ public class LuceneSearchMultiIndexIT {
 
 		scope = indexManager_1_2.createSearchScope();
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( INDEX_NAME_1_2, DOCUMENT_1_2_1 );

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneSearchSortIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneSearchSortIT.java
@@ -64,7 +64,6 @@ public class LuceneSearchSortIT {
 	private SearchQuery<DocumentReference> simpleQuery(Consumer<? super SearchSortContainerContext> sortContributor) {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		return scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.sort( sortContributor )
 				.toQuery();
@@ -96,7 +95,6 @@ public class LuceneSearchSortIT {
 		// Check that all documents are searchable
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID, EMPTY_ID );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/MultiTenancyIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/MultiTenancyIT.java
@@ -180,7 +180,6 @@ public class MultiTenancyIT {
 
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		SearchQuery<DocumentReference> query = scope.query( tenant2SessionContext )
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query )
@@ -220,7 +219,6 @@ public class MultiTenancyIT {
 		} );
 
 		query = scope.query( tenant1SessionContext )
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query )
@@ -233,7 +231,6 @@ public class MultiTenancyIT {
 
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		SearchQuery<DocumentReference> checkQuery = scope.query( tenant2SessionContext )
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( checkQuery )
@@ -368,7 +365,6 @@ public class MultiTenancyIT {
 
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		SearchQuery<DocumentReference> query = scope.query( tenant1SessionContext )
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query )
@@ -458,7 +454,6 @@ public class MultiTenancyIT {
 
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		SearchQuery<DocumentReference> query = scope.query( new StubSessionContext() )
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query )
@@ -562,7 +557,6 @@ public class MultiTenancyIT {
 		// Check that all documents are searchable
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		SearchQuery<DocumentReference> query = scope.query( tenant1SessionContext )
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query )
@@ -583,7 +577,6 @@ public class MultiTenancyIT {
 		} );
 
 		query = scope.query( tenant2SessionContext )
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query )

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/ObjectFieldStorageIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/ObjectFieldStorageIT.java
@@ -121,7 +121,6 @@ public class ObjectFieldStorageIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.must( f.match().onField( "flattenedObject.string" ).matching( MATCHING_STRING ) )
 						.must( f.match().onField( "flattenedObject.string_analyzed" ).matching( MATCHING_STRING_ANALYZED ) )
@@ -134,7 +133,6 @@ public class ObjectFieldStorageIT {
 				.hasTotalHitCount( 1 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.nested().onObjectField( "nestedObject" )
 						.nest( f.bool()
 								.must( f.match().onField( "nestedObject.string" ).matching( MATCHING_STRING ) )
@@ -154,7 +152,6 @@ public class ObjectFieldStorageIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.must( f.range().onField( "flattenedObject.string" )
 								.from( MATCHING_STRING ).to( MATCHING_STRING )
@@ -172,7 +169,6 @@ public class ObjectFieldStorageIT {
 				.hasTotalHitCount( 1 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.nested().onObjectField( "nestedObject" )
 						.nest( f.bool()
 								.must( f.range().onField( "nestedObject.string" )
@@ -321,7 +317,6 @@ public class ObjectFieldStorageIT {
 		// Check that all documents are searchable
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query )

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/SmokeIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/SmokeIT.java
@@ -61,7 +61,6 @@ public class SmokeIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( "string" ).matching( "text 1" ) )
 				.toQuery();
 		assertThat( query )
@@ -69,7 +68,6 @@ public class SmokeIT {
 				.hasTotalHitCount( 1 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( "string_analyzed" ).matching( "text" ) )
 				.toQuery();
 		assertThat( query )
@@ -77,7 +75,6 @@ public class SmokeIT {
 				.hasTotalHitCount( 3 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( "integer" ).matching( 1 ) )
 				.toQuery();
 		assertThat( query )
@@ -85,7 +82,6 @@ public class SmokeIT {
 				.hasTotalHitCount( 1 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( "localDate" ).matching( LocalDate.of( 2018, 1, 1 ) ) )
 				.toQuery();
 		assertThat( query )
@@ -93,7 +89,6 @@ public class SmokeIT {
 				.hasTotalHitCount( 1 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( "flattenedObject.string" ).matching( "text 1_1" ) )
 				.toQuery();
 		assertThat( query )
@@ -106,7 +101,6 @@ public class SmokeIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.range().onField( "string" ).from( "text 2" ).to( "text 42" ) )
 				.toQuery();
 		assertThat( query )
@@ -114,7 +108,6 @@ public class SmokeIT {
 				.hasTotalHitCount( 2 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.range().onField( "string_analyzed" ).from( "2" ).to( "42" ) )
 				.toQuery();
 		assertThat( query )
@@ -122,7 +115,6 @@ public class SmokeIT {
 				.hasTotalHitCount( 2 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.range().onField( "integer" ).from( 2 ).to( 42 ) )
 				.toQuery();
 		assertThat( query )
@@ -130,7 +122,6 @@ public class SmokeIT {
 				.hasTotalHitCount( 2 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.range().onField( "localDate" )
 						.from( LocalDate.of( 2018, 1, 2 ) )
 						.to( LocalDate.of( 2018, 2, 23 ) )
@@ -141,7 +132,6 @@ public class SmokeIT {
 				.hasTotalHitCount( 1 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.range().onField( "flattenedObject.integer" ).from( 201 ).to( 242 ) )
 				.toQuery();
 		assertThat( query )
@@ -154,7 +144,6 @@ public class SmokeIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.match().onField( "integer" ).matching( 1 ) )
 						.should( f.match().onField( "integer" ).matching( 2 ) )
@@ -165,7 +154,6 @@ public class SmokeIT {
 				.hasTotalHitCount( 2 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.must( f.match().onField( "string_analyzed" ).matching( "text" ) )
 						.filter( f.match().onField( "integer" ).matching( 1 ) )
@@ -176,7 +164,6 @@ public class SmokeIT {
 				.hasTotalHitCount( 1 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.must( f.match().onField( "string_analyzed" ).matching( "text" ) )
 						.mustNot( f.match().onField( "integer" ).matching( 2 ) )
@@ -193,7 +180,6 @@ public class SmokeIT {
 
 		// Without nested storage, we expect predicates to be able to match on different objects
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.must( f.match().onField( "flattenedObject.string" ).matching( "text 1_2" ) )
 						.must( f.match().onField( "flattenedObject.integer" ).matching( 101 ) )
@@ -205,7 +191,6 @@ public class SmokeIT {
 
 		// With nested storage, we expect direct queries to never match
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( "nestedObject.integer" ).matching( 101 ) )
 				.toQuery();
 		assertThat( query )
@@ -214,7 +199,6 @@ public class SmokeIT {
 
 		// ... and predicates within nested queries to be unable to match on different objects
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.nested().onObjectField( "nestedObject" )
 						.nest( f.bool()
 								.must( f.match().onField( "nestedObject.string" ).matching( "text 1_2" ) )
@@ -228,7 +212,6 @@ public class SmokeIT {
 
 		// ... but predicates should still be able to match on the same object
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.nested().onObjectField( "nestedObject" )
 						.nest( f.bool()
 								.must( f.match().onField( "nestedObject.string" ).matching( "text 1_1" ) )
@@ -247,7 +230,6 @@ public class SmokeIT {
 
 		SearchPredicate predicate = scope.predicate().match().onField( "string" ).matching( "text 1" ).toPredicate();
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( predicate )
 				.toQuery();
 		assertThat( query )
@@ -256,7 +238,6 @@ public class SmokeIT {
 
 		predicate = scope.predicate().range().onField( "integer" ).from( 1 ).to( 2 ).toPredicate();
 		query = scope.query()
-				.asReference()
 				.predicate( predicate )
 				.toQuery();
 		assertThat( query )
@@ -268,7 +249,6 @@ public class SmokeIT {
 				.should( f -> f.match().onField( "integer" ).matching( 2 ) )
 				.toPredicate();
 		query = scope.query()
-				.asReference()
 				.predicate( predicate )
 				.toQuery();
 		assertThat( query )
@@ -341,7 +321,6 @@ public class SmokeIT {
 		// Check that all documents are searchable
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query )

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/analysis/AnalysisCustomIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/analysis/AnalysisCustomIT.java
@@ -243,7 +243,6 @@ public class AnalysisCustomIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( indexMapping.field.relativeFieldName ).matching( valueToMatch ) )
 				.toQuery();
 
@@ -295,7 +294,6 @@ public class AnalysisCustomIT {
 		// Check that all documents are searchable
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query )

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/indexnull/IndexNullAsValueIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/indexnull/IndexNullAsValueIT.java
@@ -59,7 +59,6 @@ public class IndexNullAsValueIT {
 			Object valueToMatch = fieldModel.indexNullAsValue.indexedValue;
 
 			SearchQuery<DocumentReference> query = scope.query()
-					.asReference()
 					.predicate( f -> f.match().onField( absoluteFieldPath ).matching( valueToMatch ) )
 					.toQuery();
 
@@ -77,7 +76,6 @@ public class IndexNullAsValueIT {
 
 		setUp();
 		SearchQuery<DocumentReference> query = indexManager.createSearchScope().query()
-				.asReference()
 				.predicate( f -> f.spatial().within().onField( "geoPointField" ).circle( GeoPoint.of( 0.0, 0.0 ), 1 ) )
 				.toQuery();
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/SearchMultiIndexIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/SearchMultiIndexIT.java
@@ -116,7 +116,6 @@ public class SearchMultiIndexIT {
 		StubMappingSearchScope scope = indexManager_1_1.createSearchScope( indexManager_1_2 );
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( "string" ).matching( STRING_1 ) )
 				.toQuery();
 
@@ -131,7 +130,6 @@ public class SearchMultiIndexIT {
 		StubMappingSearchScope scope = indexManager_1_1.createSearchScope( indexManager_1_2 );
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.sort( c -> c.byField( "sortField" ).asc() )
 				.toQuery();
@@ -143,7 +141,6 @@ public class SearchMultiIndexIT {
 		} );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.sort( c -> c.byField( "sortField" ).desc() )
 				.toQuery();
@@ -177,7 +174,6 @@ public class SearchMultiIndexIT {
 
 		// Predicate
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( "additionalField" ).matching( ADDITIONAL_FIELD_1_1_1 ) )
 				.toQuery();
 
@@ -320,7 +316,6 @@ public class SearchMultiIndexIT {
 
 		StubMappingSearchScope scope = indexManager_1_1.createSearchScope();
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( INDEX_NAME_1_1, DOCUMENT_1_1_1, DOCUMENT_1_1_2 );
@@ -339,7 +334,6 @@ public class SearchMultiIndexIT {
 
 		scope = indexManager_1_2.createSearchScope();
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( INDEX_NAME_1_2, DOCUMENT_1_2_1 );
@@ -359,7 +353,6 @@ public class SearchMultiIndexIT {
 
 		scope = indexManager_2_1.createSearchScope();
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( INDEX_NAME_2_1, DOCUMENT_2_1_1, DOCUMENT_2_1_2 );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/bool/BooleanSortAndRangePredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/bool/BooleanSortAndRangePredicateIT.java
@@ -78,7 +78,6 @@ public class BooleanSortAndRangePredicateIT {
 	private SearchQuery<DocumentReference> sortQuery(Consumer<? super SearchSortContainerContext> sortContributor) {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		return scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.sort( sortContributor )
 				.toQuery();
@@ -87,7 +86,6 @@ public class BooleanSortAndRangePredicateIT {
 	private SearchQuery<DocumentReference> rangeQuery(Function<SearchPredicateFactoryContext, SearchPredicateTerminalContext> rangePredicate) {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		return scope.query()
-				.asReference()
 				.predicate( rangePredicate )
 				.toQuery();
 	}
@@ -133,7 +131,6 @@ public class BooleanSortAndRangePredicateIT {
 	public void rangeFromToSortByFieldQuery() {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.range().onField( FIELD_PATH ).from( Boolean.FALSE ).to( Boolean.TRUE ) )
 				.sort( c -> c.byField( FIELD_PATH ).onMissingValue().sortLast() )
 				.toQuery();
@@ -200,7 +197,6 @@ public class BooleanSortAndRangePredicateIT {
 	private void checkAllDocumentsAreSearchable() {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/BoolSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/BoolSearchPredicateIT.java
@@ -86,7 +86,6 @@ public class BoolSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.must( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) )
 				)
@@ -96,7 +95,6 @@ public class BoolSearchPredicateIT {
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.must( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) )
 						.must( f.match().onField( "field2" ).matching( FIELD2_VALUE2 ) )
@@ -106,7 +104,6 @@ public class BoolSearchPredicateIT {
 		assertThat( query ).hasNoHits();
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.must( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) )
 						.must( f.match().onField( "field2" ).matching( FIELD2_VALUE1 ) )
@@ -122,7 +119,6 @@ public class BoolSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.must( f2 -> f2.match().onField( "field1" ).matching( FIELD1_VALUE1 ) )
 				)
@@ -139,7 +135,6 @@ public class BoolSearchPredicateIT {
 		SearchPredicate predicate = scope.predicate().match().onField( "field1" ).matching( FIELD1_VALUE1 ).toPredicate();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate(	f -> f.bool().must( predicate ) )
 				.toQuery();
 
@@ -152,7 +147,6 @@ public class BoolSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) )
 				)
@@ -162,7 +156,6 @@ public class BoolSearchPredicateIT {
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) )
 						.should( f.match().onField( "field1" ).matching( FIELD1_VALUE2 ) )
@@ -178,7 +171,6 @@ public class BoolSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f2 -> f2.match().onField( "field1" ).matching( FIELD1_VALUE1 ) )
 						.should( f2 -> f2.match().onField( "field1" ).matching( FIELD1_VALUE2 ) )
@@ -197,7 +189,6 @@ public class BoolSearchPredicateIT {
 		SearchPredicate predicate2 = scope.predicate().match().onField( "field1" ).matching( FIELD1_VALUE3 ).toPredicate();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( predicate1 )
 						.should( predicate2 )
@@ -213,7 +204,6 @@ public class BoolSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.mustNot( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) )
 				)
@@ -223,7 +213,6 @@ public class BoolSearchPredicateIT {
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_2, DOCUMENT_3 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.mustNot( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) )
 						.mustNot( f.match().onField( "field1" ).matching( FIELD1_VALUE3 ) )
@@ -239,7 +228,6 @@ public class BoolSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.mustNot( f2 -> f2.match().onField( "field1" ).matching( FIELD1_VALUE1 ) )
 				)
@@ -256,7 +244,6 @@ public class BoolSearchPredicateIT {
 		SearchPredicate predicate = scope.predicate().match().onField( "field1" ).matching( FIELD1_VALUE2 ).toPredicate();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.mustNot( predicate )
 				)
@@ -271,7 +258,6 @@ public class BoolSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.filter( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) )
 				)
@@ -281,7 +267,6 @@ public class BoolSearchPredicateIT {
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.filter( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) )
 						.filter( f.match().onField( "field2" ).matching( FIELD2_VALUE2 ) )
@@ -291,7 +276,6 @@ public class BoolSearchPredicateIT {
 		assertThat( query ).hasNoHits();
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.filter( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) )
 						.filter( f.match().onField( "field2" ).matching( FIELD2_VALUE1 ) )
@@ -307,7 +291,6 @@ public class BoolSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.filter( f2 -> f2.match().onField( "field1" ).matching( FIELD1_VALUE1 ) )
 				)
@@ -324,7 +307,6 @@ public class BoolSearchPredicateIT {
 		SearchPredicate predicate = scope.predicate().match().onField( "field1" ).matching( FIELD1_VALUE1 ).toPredicate();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate(	f -> f.bool().filter( predicate ) )
 				.toQuery();
 
@@ -337,7 +319,6 @@ public class BoolSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) )
 						.should( f.match().onField( "field1" ).matching( FIELD1_VALUE3 ) )
@@ -354,7 +335,6 @@ public class BoolSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.must( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) )
 						.mustNot( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) )
@@ -364,7 +344,6 @@ public class BoolSearchPredicateIT {
 		assertThat( query ).hasNoHits();
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.must( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) )
 						.mustNot( f.match().onField( "field1" ).matching( FIELD1_VALUE2 ) )
@@ -380,7 +359,6 @@ public class BoolSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.must( f.bool()
 										.should( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) )
@@ -393,7 +371,6 @@ public class BoolSearchPredicateIT {
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_3 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.must( f.bool()
 								.should( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) )
@@ -412,7 +389,6 @@ public class BoolSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// 0.287682
 						.should( f.bool().must( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) ) )
@@ -427,7 +403,6 @@ public class BoolSearchPredicateIT {
 				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_3, DOCUMENT_1 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// withConstantScore 0.287682 => 1
 						.should( f.bool().withConstantScore().must( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) ) )
@@ -447,7 +422,6 @@ public class BoolSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.bool().withConstantScore().boostedTo( 7 ).must( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) ) )
 						.should( f.bool().withConstantScore().boostedTo( 39 ).must( f.match().onField( "field1" ).matching( FIELD1_VALUE3 ) ) )
@@ -459,7 +433,6 @@ public class BoolSearchPredicateIT {
 				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_3, DOCUMENT_1 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.bool().withConstantScore().boostedTo( 39 ).must( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) ) )
 						.should( f.bool().withConstantScore().boostedTo( 7 ).must( f.match().onField( "field1" ).matching( FIELD1_VALUE3 ) ) )
@@ -480,7 +453,6 @@ public class BoolSearchPredicateIT {
 
 		// Non-matching "should" clauses
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.must( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) )
 						.should( f.match().onField( "field2" ).matching( FIELD2_VALUE2 ) )
@@ -493,7 +465,6 @@ public class BoolSearchPredicateIT {
 
 		// One matching and one non-matching "should" clause
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.must( f.match().onField( "field1" ).matching( FIELD1_VALUE2 ) )
 						.should( f.match().onField( "field2" ).matching( FIELD2_VALUE1 ) )
@@ -514,7 +485,6 @@ public class BoolSearchPredicateIT {
 
 		// Non-matching "should" clauses
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.filter( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) )
 						.should( f.match().onField( "field2" ).matching( FIELD2_VALUE2 ) )
@@ -527,7 +497,6 @@ public class BoolSearchPredicateIT {
 
 		// One matching and one non-matching "should" clause
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.filter( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) )
 						.should( f.match().onField( "field2" ).matching( FIELD2_VALUE1 ) )
@@ -548,7 +517,6 @@ public class BoolSearchPredicateIT {
 
 		// Non-matching "should" clauses
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.mustNot( f.match().onField( "field1" ).matching( FIELD1_VALUE2 ) )
 						.mustNot( f.match().onField( "field1" ).matching( FIELD1_VALUE3 ) )
@@ -562,7 +530,6 @@ public class BoolSearchPredicateIT {
 
 		// One matching and one non-matching "should" clause
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.mustNot( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) )
 						.mustNot( f.match().onField( "field1" ).matching( FIELD1_VALUE3 ) )
@@ -581,7 +548,6 @@ public class BoolSearchPredicateIT {
 
 		// Expect default behavior (1 "should" clause has to match)
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.minimumShouldMatchNumber( 1 )
 						.should( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) )
@@ -594,7 +560,6 @@ public class BoolSearchPredicateIT {
 
 		// Expect to require 1 "should" clause to match even though there's a "must"
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.must( f.match().onField( "field4" ).matching( FIELD4_VALUE1AND2 ) )
 						.minimumShouldMatchNumber( 1 )
@@ -608,7 +573,6 @@ public class BoolSearchPredicateIT {
 
 		// Expect to require 2 "should" clauses to match
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.minimumShouldMatchNumber( 2 )
 						.should( f.match().onField( "field4" ).matching( FIELD4_VALUE1AND2 ) )
@@ -622,7 +586,6 @@ public class BoolSearchPredicateIT {
 
 		// Expect to require all "should" clauses to match
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.minimumShouldMatchNumber( 2 )
 						.should( f.match().onField( "field4" ).matching( FIELD4_VALUE1AND2 ) )
@@ -640,7 +603,6 @@ public class BoolSearchPredicateIT {
 
 		// Expect default behavior (1 "should" clause has to match)
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.minimumShouldMatchNumber( -1 )
 						.should( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) )
@@ -653,7 +615,6 @@ public class BoolSearchPredicateIT {
 
 		// Expect to require 1 "should" clause to match even though there's a "must"
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.must( f.match().onField( "field4" ).matching( FIELD4_VALUE1AND2 ) )
 						.minimumShouldMatchNumber( -1 )
@@ -667,7 +628,6 @@ public class BoolSearchPredicateIT {
 
 		// Expect to require 2 "should" clauses to match
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.minimumShouldMatchNumber( -1 )
 						.should( f.match().onField( "field4" ).matching( FIELD4_VALUE1AND2 ) )
@@ -686,7 +646,6 @@ public class BoolSearchPredicateIT {
 
 		// Expect default behavior (1 "should" clause has to match)
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.minimumShouldMatchPercent( 50 )
 						.should( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) )
@@ -699,7 +658,6 @@ public class BoolSearchPredicateIT {
 
 		// Expect to require 1 "should" clause to match even though there's a "must"
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.must( f.match().onField( "field4" ).matching( FIELD4_VALUE1AND2 ) )
 						.minimumShouldMatchPercent( 50 )
@@ -713,7 +671,6 @@ public class BoolSearchPredicateIT {
 
 		// Expect to require 2 "should" clauses to match
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.minimumShouldMatchPercent( 70 ) // The minimum should be rounded down to 2
 						.should( f.match().onField( "field4" ).matching( FIELD4_VALUE1AND2 ) )
@@ -727,7 +684,6 @@ public class BoolSearchPredicateIT {
 
 		// Expect to require all "should" clauses to match
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.minimumShouldMatchPercent( 100 )
 						.should( f.match().onField( "field4" ).matching( FIELD4_VALUE1AND2 ) )
@@ -745,7 +701,6 @@ public class BoolSearchPredicateIT {
 
 		// Expect default behavior (1 "should" clause has to match)
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.minimumShouldMatchPercent( -50 )
 						.should( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) )
@@ -758,7 +713,6 @@ public class BoolSearchPredicateIT {
 
 		// Expect to require 1 "should" clause to match even though there's a "must"
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.must( f.match().onField( "field4" ).matching( FIELD4_VALUE1AND2 ) )
 						.minimumShouldMatchPercent( -50 )
@@ -772,7 +726,6 @@ public class BoolSearchPredicateIT {
 
 		// Expect to require 2 "should" clauses to match
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.minimumShouldMatchPercent( -40 ) // The minimum should be rounded up to 2
 						.should( f.match().onField( "field4" ).matching( FIELD4_VALUE1AND2 ) )
@@ -795,7 +748,6 @@ public class BoolSearchPredicateIT {
 
 		// 0 "should" clause: expect the constraints to be ignored
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool( b -> {
 					b.minimumShouldMatch( minimumShouldMatchConstraints );
 					b.must( f.match().onField( "field4" ).matching( FIELD4_VALUE1AND2 ) );
@@ -807,7 +759,6 @@ public class BoolSearchPredicateIT {
 
 		// 1 "should" clause: expect to require all "should" clauses to match
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool( b -> {
 					b.minimumShouldMatch( minimumShouldMatchConstraints );
 					b.should( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) );
@@ -819,7 +770,6 @@ public class BoolSearchPredicateIT {
 
 		// 2 "should" clauses: expect to require all "should" clauses to match
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool( b -> {
 					b.minimumShouldMatch( minimumShouldMatchConstraints );
 					b.should( f.match().onField( "field4" ).matching( FIELD4_VALUE1AND2 ) );
@@ -832,7 +782,6 @@ public class BoolSearchPredicateIT {
 
 		// 3 "should" clauses: expect to require 2 "should" clauses to match
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool( b -> {
 					b.minimumShouldMatch( minimumShouldMatchConstraints );
 					b.should( f.match().onField( "field4" ).matching( FIELD4_VALUE1AND2 ) );
@@ -846,7 +795,6 @@ public class BoolSearchPredicateIT {
 
 		// 4 "should" clauses: expect to require 3 "should" clauses to match
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool( b -> {
 					b.minimumShouldMatch( minimumShouldMatchConstraints );
 					b.should( f.match().onField( "field4" ).matching( FIELD4_VALUE1AND2 ) );
@@ -861,7 +809,6 @@ public class BoolSearchPredicateIT {
 
 		// 5 "should" clauses: expect to require 3 "should" clauses to match
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool( b -> {
 					b.minimumShouldMatch( minimumShouldMatchConstraints );
 					b.should( f.match().onField( "field4" ).matching( FIELD4_VALUE1AND2 ) );
@@ -877,7 +824,6 @@ public class BoolSearchPredicateIT {
 
 		// 6 "should" clauses: expect to require 4 "should" clauses to match
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool( b -> {
 					b.minimumShouldMatch( minimumShouldMatchConstraints );
 					b.should( f.match().onField( "field4" ).matching( FIELD4_VALUE1AND2 ) );
@@ -905,7 +851,6 @@ public class BoolSearchPredicateIT {
 
 		// 1 "should" clause: expect to require 1 "should" clause to match
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool( b -> {
 					b.minimumShouldMatch( minimumShouldMatchConstraints );
 					b.should( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) );
@@ -917,7 +862,6 @@ public class BoolSearchPredicateIT {
 
 		// 2 "should" clauses: expect to require 1 "should" clause to match
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool( b -> {
 					b.minimumShouldMatch( minimumShouldMatchConstraints );
 					b.should( f.match().onField( "field1" ).matching( FIELD1_VALUE1 ) );
@@ -930,7 +874,6 @@ public class BoolSearchPredicateIT {
 
 		// 3 "should" clauses: expect to require 2 "should" clauses to match
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool( b -> {
 					b.minimumShouldMatch( minimumShouldMatchConstraints );
 					b.should( f.match().onField( "field4" ).matching( FIELD4_VALUE1AND2 ) );
@@ -995,7 +938,6 @@ public class BoolSearchPredicateIT {
 		// If the should is alone ( not having any sibling must ),
 		// the default minimum should match will be 1.
 		SearchQuery<DocumentReference> query = searchScope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.match().onField( "field1" ).matching( "no-match" ) )
 				)
@@ -1006,7 +948,6 @@ public class BoolSearchPredicateIT {
 		// If the should has a sibling must,
 		// the default minimum should match will be 0.
 		query = searchScope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.match().onField( "field1" ).matching( "no-match" ) )
 						.must( f.match().onField( "field5" ).matching( FIELD5_VALUE1AND2 ) ) // match 1 and 2
@@ -1018,7 +959,6 @@ public class BoolSearchPredicateIT {
 		// If there exists a must or a filter, but they are not a sibling of the should,
 		// the default minimum should match will be 1.
 		query = searchScope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.filter( f.bool()
 								.should( f.match().onField( "field1" ).matching( "no-match" ) )
@@ -1039,7 +979,6 @@ public class BoolSearchPredicateIT {
 		// If the should has a sibling must, even if the should is inside a filter,
 		// the default minimum should match will be 0.
 		SearchQuery<DocumentReference> query = searchScope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.filter( f.bool()
 								.should( f.match().onField( "field1" ).matching( "no-match" ) )
@@ -1059,7 +998,6 @@ public class BoolSearchPredicateIT {
 		// if the should has a sibling must-not inside a filter,
 		// the default minimum should match will be still 1.
 		SearchQuery<DocumentReference> query = searchScope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.filter( f.bool()
 								.should( f.match().onField( "field1" ).matching( "no-match" ) )
@@ -1079,7 +1017,6 @@ public class BoolSearchPredicateIT {
 		// If the should has a sibling filter, even if the should is inside a filter,
 		// the default minimum should match will be 0.
 		SearchQuery<DocumentReference> query = searchScope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.filter( f.bool()
 								.should( f.match().onField( "field1" ).matching( "no-match" ) )
@@ -1120,7 +1057,6 @@ public class BoolSearchPredicateIT {
 		// Check that all documents are searchable
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/ExistsSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/ExistsSearchPredicateIT.java
@@ -109,7 +109,6 @@ public class ExistsSearchPredicateIT {
 			String absoluteFieldPath = fieldModel.relativeFieldName;
 
 			SearchQuery<DocumentReference> query = scope.query()
-					.asReference()
 					.predicate( f -> f.exists().onField( absoluteFieldPath ) )
 					.toQuery();
 
@@ -130,7 +129,6 @@ public class ExistsSearchPredicateIT {
 			String absoluteFieldPath = fieldModel.relativeFieldName;
 
 			SearchQuery<DocumentReference> query = scope.query()
-					.asReference()
 					.predicate( f -> f.exists().onField( absoluteFieldPath ) )
 					.toQuery();
 
@@ -151,7 +149,6 @@ public class ExistsSearchPredicateIT {
 			String absoluteFieldPath = fieldModel.relativeFieldName;
 
 			SearchQuery<DocumentReference> query = scope.query()
-					.asReference()
 					.predicate( f -> f.bool().mustNot( f.exists().onField( absoluteFieldPath ) ) )
 					.toQuery();
 
@@ -165,7 +162,6 @@ public class ExistsSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.exists().onField( indexMapping.string1Field.relativeFieldName ) )
 						.should( f.exists().onField( indexMapping.string2Field.relativeFieldName ).boostedTo( 7 ) )
@@ -177,7 +173,6 @@ public class ExistsSearchPredicateIT {
 				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_2, DOCUMENT_1 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.exists().onField( indexMapping.string1Field.relativeFieldName ).boostedTo( 39 ) )
 						.should( f.exists().onField( indexMapping.string2Field.relativeFieldName ) )
@@ -197,7 +192,6 @@ public class ExistsSearchPredicateIT {
 			String absoluteFieldPath = indexMapping.flattenedObject.relativeFieldName + "." + fieldModel.relativeFieldName;
 
 			SearchQuery<DocumentReference> query = scope.query()
-					.asReference()
 					.predicate( f -> f.exists().onField( absoluteFieldPath ) )
 					.toQuery();
 
@@ -218,7 +212,6 @@ public class ExistsSearchPredicateIT {
 			String absoluteFieldPath = indexMapping.flattenedObject.relativeFieldName + "." + fieldModel.relativeFieldName;
 
 			SearchQuery<DocumentReference> query = scope.query()
-					.asReference()
 					.predicate( f -> f.exists().onField( absoluteFieldPath ) )
 					.toQuery();
 
@@ -238,7 +231,6 @@ public class ExistsSearchPredicateIT {
 			String absoluteFieldPath = indexMapping.nestedObject.relativeFieldName + "." + fieldModel.relativeFieldName;
 
 			SearchQuery<DocumentReference> query = scope.query()
-					.asReference()
 					.predicate( f -> f.exists().onField( absoluteFieldPath ) )
 					.toQuery();
 
@@ -254,7 +246,6 @@ public class ExistsSearchPredicateIT {
 			String absoluteFieldPath = indexMapping.nestedObject.relativeFieldName + "." + fieldModel.relativeFieldName;
 
 			SearchQuery<DocumentReference> query = scope.query()
-					.asReference()
 					.predicate( f -> f.nested().onObjectField( indexMapping.nestedObject.relativeFieldName )
 							.nest( f.exists().onField( absoluteFieldPath ) ) )
 					.toQuery();
@@ -276,7 +267,6 @@ public class ExistsSearchPredicateIT {
 			String absoluteFieldPath = indexMapping.nestedObject.relativeFieldName + "." + fieldModel.relativeFieldName;
 
 			SearchQuery<DocumentReference> query = scope.query()
-					.asReference()
 					.predicate( f -> f.nested().onObjectField( indexMapping.nestedObject.relativeFieldName )
 							.nest( f.exists().onField( absoluteFieldPath ) ) )
 					.toQuery();
@@ -298,7 +288,6 @@ public class ExistsSearchPredicateIT {
 			String absoluteFieldPath = indexMapping.nestedObject.relativeFieldName + "." + fieldModel.relativeFieldName;
 
 			SearchQuery<DocumentReference> query = scope.query()
-					.asReference()
 					.predicate( f -> f.nested().onObjectField( indexMapping.nestedObject.relativeFieldName )
 							.nest( f.bool().mustNot( f.exists().onField( absoluteFieldPath ) ) ) )
 					.toQuery();
@@ -332,7 +321,6 @@ public class ExistsSearchPredicateIT {
 				String absoluteFieldPath = model.relativeFieldName;
 
 				SearchQuery<DocumentReference> query = scope.query()
-						.asReference()
 						.predicate( f -> f.exists().onField( absoluteFieldPath ) )
 						.toQuery();
 
@@ -354,7 +342,6 @@ public class ExistsSearchPredicateIT {
 				String absoluteFieldPath = model.relativeFieldName;
 
 				SearchQuery<DocumentReference> query = scope.query()
-						.asReference()
 						.predicate( f -> f.exists().onField( absoluteFieldPath ) )
 						.toQuery();
 
@@ -463,17 +450,14 @@ public class ExistsSearchPredicateIT {
 
 		// Check that all documents are searchable
 		SearchQuery<DocumentReference> query = indexManager.createSearchScope().query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3, EMPTY );
 		query = compatibleIndexManager.createSearchScope().query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( COMPATIBLE_INDEX_NAME, COMPATIBLE_INDEX_DOCUMENT_1 );
 		query = rawFieldCompatibleIndexManager.createSearchScope().query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( RAW_FIELD_COMPATIBLE_INDEX_NAME, RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchAllSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchAllSearchPredicateIT.java
@@ -61,7 +61,6 @@ public class MatchAllSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 
@@ -74,7 +73,6 @@ public class MatchAllSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll().except( c2 -> c2.match().onField( "string" ).matching( STRING_1 ) ) )
 				.toQuery();
 
@@ -83,7 +81,6 @@ public class MatchAllSearchPredicateIT {
 
 		SearchPredicate searchPredicate = scope.predicate().match().onField( "string" ).matching( STRING_2 ).toPredicate();
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll().except( searchPredicate ) )
 				.toQuery();
 		assertThat( query )
@@ -95,7 +92,6 @@ public class MatchAllSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll()
 						.except( f.match().onField( "string" ).matching( STRING_1 ) )
 						.except( f.match().onField( "string" ).matching( STRING_2 ) )
@@ -109,7 +105,6 @@ public class MatchAllSearchPredicateIT {
 		SearchPredicate searchPredicate2 = scope.predicate().match().onField( "string" ).matching( STRING_2 ).toPredicate();
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll().except( searchPredicate1 ).except( searchPredicate2 ) )
 				.toQuery();
 
@@ -134,7 +129,6 @@ public class MatchAllSearchPredicateIT {
 		// Check that all documents are searchable
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchIdSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchIdSearchPredicateIT.java
@@ -53,7 +53,6 @@ public class MatchIdSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.id().matching( DOCUMENT_1 ) )
 				.toQuery();
 
@@ -66,7 +65,6 @@ public class MatchIdSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.id()
 						.matching( DOCUMENT_1 )
 						.matching( DOCUMENT_3 )
@@ -82,7 +80,6 @@ public class MatchIdSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.id()
 						.matching( DOCUMENT_2 )
 						.matchingAny( Arrays.asList( DOCUMENT_1 ) )
@@ -98,7 +95,6 @@ public class MatchIdSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.id()
 						.matchingAny( Arrays.asList( DOCUMENT_1 ) )
 				)
@@ -113,7 +109,6 @@ public class MatchIdSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.id()
 						.matchingAny( Arrays.asList( DOCUMENT_1, DOCUMENT_3 ) )
 				)
@@ -133,7 +128,6 @@ public class MatchIdSearchPredicateIT {
 		// Check that all documents are searchable
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchIdWithConverterSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchIdWithConverterSearchPredicateIT.java
@@ -77,7 +77,6 @@ public class MatchIdWithConverterSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.id().matching( 1 ) )
 				.toQuery();
 
@@ -90,7 +89,6 @@ public class MatchIdWithConverterSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.id()
 						.matching( 1 )
 						.matching( 3 )
@@ -106,7 +104,6 @@ public class MatchIdWithConverterSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.id()
 						.matching( 2 )
 						.matchingAny( Arrays.asList( 1 ) )
@@ -122,7 +119,6 @@ public class MatchIdWithConverterSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.id()
 						.matchingAny( Arrays.asList( 1 ) )
 				)
@@ -137,7 +133,6 @@ public class MatchIdWithConverterSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.id()
 						.matchingAny( Arrays.asList( 1, 3 ) )
 				)
@@ -157,7 +152,6 @@ public class MatchIdWithConverterSearchPredicateIT {
 		// Check that all documents are searchable
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchSearchPredicateIT.java
@@ -124,7 +124,6 @@ public class MatchSearchPredicateIT {
 			Object valueToMatch = fieldModel.predicateParameterValue;
 
 			SearchQuery<DocumentReference> query = scope.query()
-					.asReference()
 					.predicate( f -> f.match().onField( absoluteFieldPath ).matching( valueToMatch ) )
 					.toQuery();
 
@@ -142,7 +141,6 @@ public class MatchSearchPredicateIT {
 			Object valueToMatch = new ValueWrapper<>( fieldModel.predicateParameterValue );
 
 			SearchQuery<DocumentReference> query = scope.query()
-					.asReference()
 					.predicate( f -> f.match().onField( absoluteFieldPath ).matching( valueToMatch ) )
 					.toQuery();
 
@@ -159,7 +157,6 @@ public class MatchSearchPredicateIT {
 			String absoluteFieldPath = fieldModel.relativeFieldName;
 
 			SearchQuery<DocumentReference> query = scope.query()
-					.asReference()
 					.predicate( f -> f.match().onField( absoluteFieldPath ).matching( fieldModel.predicateParameterValue, DslConverter.DISABLED ) )
 					.toQuery();
 
@@ -175,7 +172,6 @@ public class MatchSearchPredicateIT {
 		MainFieldModel fieldModel = indexMapping.analyzedStringField;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( fieldModel.relativeFieldName ).matching( "" ) )
 				.toQuery();
 
@@ -190,7 +186,6 @@ public class MatchSearchPredicateIT {
 		MainFieldModel fieldModel = indexMapping.analyzedStringField;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				// Use a stopword, which should be removed by the analysis
 				.predicate( f -> f.match().onField( fieldModel.relativeFieldName ).matching( "a" ) )
 				.toQuery();
@@ -258,7 +253,6 @@ public class MatchSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.match().onField( indexMapping.string1Field.relativeFieldName )
 								.matching( indexMapping.string1Field.document1Value.indexedValue )
@@ -274,7 +268,6 @@ public class MatchSearchPredicateIT {
 				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_3, DOCUMENT_1 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.match().onField( indexMapping.string1Field.relativeFieldName ).boostedTo( 42 )
 								.matching( indexMapping.string1Field.document1Value.indexedValue )
@@ -295,7 +288,6 @@ public class MatchSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.match().onField( indexMapping.string1Field.relativeFieldName )
 								.matching( indexMapping.string1Field.document1Value.indexedValue )
@@ -312,7 +304,6 @@ public class MatchSearchPredicateIT {
 				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_3, DOCUMENT_1 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.match().onField( indexMapping.string1Field.relativeFieldName )
 								.matching( indexMapping.string1Field.document1Value.indexedValue )
@@ -334,7 +325,6 @@ public class MatchSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// 4 * 2 => boost x8
 						.should( f.match().onField( indexMapping.string1Field.relativeFieldName ).boostedTo( 4 )
@@ -354,7 +344,6 @@ public class MatchSearchPredicateIT {
 				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_3, DOCUMENT_1 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// 1 * 3 => boost x3
 						.should( f.match().onField( indexMapping.string1Field.relativeFieldName ).boostedTo( 3 )
@@ -378,7 +367,6 @@ public class MatchSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// 0.287682
 						.should( f.match().onField( indexMapping.string1Field.relativeFieldName )
@@ -397,7 +385,6 @@ public class MatchSearchPredicateIT {
 				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_3, DOCUMENT_1 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// withConstantScore 0.287682 => 1
 						.should( f.match().onField( indexMapping.string1Field.relativeFieldName )
@@ -421,7 +408,6 @@ public class MatchSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.match().onField( indexMapping.string1Field.relativeFieldName )
 								.matching( indexMapping.string1Field.document1Value.indexedValue )
@@ -439,7 +425,6 @@ public class MatchSearchPredicateIT {
 				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_3, DOCUMENT_1 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.match().onField( indexMapping.string1Field.relativeFieldName )
 								.matching( indexMapping.string1Field.document1Value.indexedValue )
@@ -462,7 +447,6 @@ public class MatchSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.match().onField( indexMapping.string1Field.relativeFieldName )
 								.orField( indexMapping.string2Field.relativeFieldName )
@@ -482,7 +466,6 @@ public class MatchSearchPredicateIT {
 				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_3, DOCUMENT_1 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.match().onField( indexMapping.string1Field.relativeFieldName )
 								.orField( indexMapping.string2Field.relativeFieldName )
@@ -509,7 +492,6 @@ public class MatchSearchPredicateIT {
 		String absoluteFieldPath = indexMapping.analyzedStringField.relativeFieldName;
 		Function<String, SearchQuery<DocumentReference>> createQuery =
 				text -> scope.query()
-						.asReference()
 						.predicate( f -> f.match()
 								.onField( absoluteFieldPath )
 								.matching( text )
@@ -534,7 +516,6 @@ public class MatchSearchPredicateIT {
 		String absoluteFieldPath = indexMapping.analyzedStringField.relativeFieldName;
 		BiFunction<String, Integer, SearchQuery<DocumentReference>> createQuery =
 				(text, maxEditDistance) -> scope.query()
-						.asReference()
 						.predicate( f -> f.match()
 								.onField( absoluteFieldPath )
 								.matching( text )
@@ -579,7 +560,6 @@ public class MatchSearchPredicateIT {
 		String absoluteFieldPath = indexMapping.analyzedStringField.relativeFieldName;
 		BiFunction<String, Integer, SearchQuery<DocumentReference>> createQuery =
 				(text, exactPrefixLength) -> scope.query()
-						.asReference()
 						.predicate( f -> f.match()
 								.onField( absoluteFieldPath )
 								.matching( text )
@@ -624,7 +604,6 @@ public class MatchSearchPredicateIT {
 		Function<String, SearchQuery<DocumentReference>> createQuery;
 
 		createQuery = param -> scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( absoluteFieldPath ).matching( param ).fuzzy() )
 				.toQuery();
 		assertThat( createQuery.apply( "Irving" ) )
@@ -637,7 +616,6 @@ public class MatchSearchPredicateIT {
 				.hasNoHits();
 
 		createQuery = param -> scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( absoluteFieldPath )
 						.matching( param ).fuzzy( 2, 1 ) )
 				.toQuery();
@@ -660,7 +638,6 @@ public class MatchSearchPredicateIT {
 		Function<String, SearchQuery<DocumentReference>> createQuery;
 
 		createQuery = param -> scope.query()
-				.asReference()
 				.predicate( f -> f.match().onFields( absoluteFieldPath1, absoluteFieldPath2 ).matching( param ).fuzzy() )
 				.toQuery();
 		assertThat( createQuery.apply( "word" ) ) // distance 1 from doc1:field2, 0 from doc2:field1
@@ -769,7 +746,6 @@ public class MatchSearchPredicateIT {
 		String whitespaceLowercaseAnalyzedField = indexMapping.whitespaceLowercaseAnalyzedField.relativeFieldName;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( whitespaceAnalyzedField ).matching( "NEW WORLD" ) )
 				.toQuery();
 
@@ -777,7 +753,6 @@ public class MatchSearchPredicateIT {
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_2 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( whitespaceLowercaseAnalyzedField ).matching( "NEW WORLD" ) )
 				.toQuery();
 
@@ -785,7 +760,6 @@ public class MatchSearchPredicateIT {
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( whitespaceAnalyzedField ).matching( "NEW WORLD" )
 						.analyzer( OverrideAnalysisDefinitions.ANALYZER_WHITESPACE_LOWERCASE.name ) )
 				.toQuery();
@@ -802,7 +776,6 @@ public class MatchSearchPredicateIT {
 		String whitespaceLowercaseAnalyzedField = indexMapping.whitespaceLowercaseAnalyzedField.relativeFieldName;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( whitespaceAnalyzedField ).matching( "WORD" ).fuzzy() )
 				.toQuery();
 
@@ -810,7 +783,6 @@ public class MatchSearchPredicateIT {
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_2, DOCUMENT_3 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( whitespaceLowercaseAnalyzedField ).matching( "WORD" ).fuzzy() )
 				.toQuery();
 
@@ -818,7 +790,6 @@ public class MatchSearchPredicateIT {
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( whitespaceAnalyzedField ).matching( "WORD" ).fuzzy()
 						.analyzer( OverrideAnalysisDefinitions.ANALYZER_WHITESPACE_LOWERCASE.name ) )
 				.toQuery();
@@ -833,7 +804,6 @@ public class MatchSearchPredicateIT {
 		String whitespaceAnalyzedField = indexMapping.whitespaceAnalyzedField.relativeFieldName;
 
 		SubTest.expectException( () -> scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( whitespaceAnalyzedField ).matching( "WORLD" )
 						// we have a normalizer with that name, but not an analyzer
 						.analyzer( DefaultAnalysisDefinitions.NORMALIZER_LOWERCASE.name ) )
@@ -850,7 +820,6 @@ public class MatchSearchPredicateIT {
 		String whitespaceAnalyzedField = indexMapping.whitespaceAnalyzedField.relativeFieldName;
 
 		SubTest.expectException( () -> scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( whitespaceAnalyzedField ).matching( "WORLD" )
 						// we don't have any analyzer with that name
 						.analyzer( "this_name_does_actually_not_exist" ) )
@@ -867,7 +836,6 @@ public class MatchSearchPredicateIT {
 		String absoluteFieldPath = indexMapping.whitespaceLowercaseAnalyzedField.relativeFieldName;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( absoluteFieldPath ).matching( "world another world" ) )
 				.toQuery();
 
@@ -877,7 +845,6 @@ public class MatchSearchPredicateIT {
 		// ignoring the analyzer means that the parameter of match predicate will not be tokenized
 		// so it will not match any token
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( absoluteFieldPath ).matching( "world another world" ).skipAnalysis() )
 				.toQuery();
 
@@ -886,7 +853,6 @@ public class MatchSearchPredicateIT {
 
 		// to have a match with the skipAnalysis option enabled, we have to pass the parameter as a token is
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( absoluteFieldPath ).matching( "world" ).skipAnalysis() )
 				.toQuery();
 
@@ -900,7 +866,6 @@ public class MatchSearchPredicateIT {
 		String absoluteFieldPath = indexMapping.whitespaceLowercaseAnalyzedField.relativeFieldName;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( absoluteFieldPath ).matching( "word another word" ).fuzzy() )
 				.toQuery();
 
@@ -910,7 +875,6 @@ public class MatchSearchPredicateIT {
 		// ignoring the analyzer means that the parameter of match predicate will not be tokenized
 		// so it will not match any token
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( absoluteFieldPath ).matching( "word another word" ).fuzzy().skipAnalysis() )
 				.toQuery();
 
@@ -919,7 +883,6 @@ public class MatchSearchPredicateIT {
 
 		// to have a match with the skipAnalysis option enabled, we have to pass the parameter as a token is
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( absoluteFieldPath ).matching( "word" ).fuzzy().skipAnalysis() )
 				.toQuery();
 
@@ -933,7 +896,6 @@ public class MatchSearchPredicateIT {
 		String absoluteFieldPath = indexMapping.normalizedStringField.relativeFieldName;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				// the matching parameter will be tokenized even if the field has a normalizer
 				.predicate( f -> f.match().onField( absoluteFieldPath ).matching( "Auster Coe" )
 					.analyzer( OverrideAnalysisDefinitions.ANALYZER_WHITESPACE_LOWERCASE.name ) )
@@ -950,14 +912,12 @@ public class MatchSearchPredicateIT {
 		String absoluteFieldPath = indexMapping.whitespaceLowercaseAnalyzedField.relativeFieldName;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( absoluteFieldPath ).matching( "worldofwordcraft" ) )
 				.toQuery();
 
 		assertThat( query ).hasNoHits();
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( absoluteFieldPath ).matching( "worldofwordcraft" )
 						.analyzer( OverrideAnalysisDefinitions.ANALYZER_NGRAM.name ) )
 				.toQuery();
@@ -973,7 +933,6 @@ public class MatchSearchPredicateIT {
 		// onField(...).orField(...)
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( indexMapping.string1Field.relativeFieldName )
 						.orField( indexMapping.string2Field.relativeFieldName )
 						.matching( indexMapping.string1Field.document1Value.indexedValue )
@@ -984,7 +943,6 @@ public class MatchSearchPredicateIT {
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( indexMapping.string1Field.relativeFieldName )
 						.orField( indexMapping.string2Field.relativeFieldName )
 						.matching( indexMapping.string2Field.document1Value.indexedValue )
@@ -997,7 +955,6 @@ public class MatchSearchPredicateIT {
 		// onField().orFields(...)
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( indexMapping.string1Field.relativeFieldName )
 						.orFields( indexMapping.string2Field.relativeFieldName, indexMapping.string3Field.relativeFieldName )
 						.matching( indexMapping.string1Field.document1Value.indexedValue )
@@ -1008,7 +965,6 @@ public class MatchSearchPredicateIT {
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( indexMapping.string1Field.relativeFieldName )
 						.orFields( indexMapping.string2Field.relativeFieldName, indexMapping.string3Field.relativeFieldName )
 						.matching( indexMapping.string2Field.document1Value.indexedValue )
@@ -1019,7 +975,6 @@ public class MatchSearchPredicateIT {
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( indexMapping.string1Field.relativeFieldName )
 						.orFields( indexMapping.string2Field.relativeFieldName, indexMapping.string3Field.relativeFieldName )
 						.matching( indexMapping.string3Field.document1Value.indexedValue )
@@ -1032,7 +987,6 @@ public class MatchSearchPredicateIT {
 		// onFields(...)
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onFields( indexMapping.string1Field.relativeFieldName, indexMapping.string3Field.relativeFieldName )
 						.matching( indexMapping.string1Field.document1Value.indexedValue )
 				)
@@ -1042,7 +996,6 @@ public class MatchSearchPredicateIT {
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onFields( indexMapping.string1Field.relativeFieldName, indexMapping.string2Field.relativeFieldName )
 						.matching( indexMapping.string2Field.document1Value.indexedValue )
 				)
@@ -1055,7 +1008,6 @@ public class MatchSearchPredicateIT {
 	@Test
 	public void multiFields_withDslConverter_dslConverterEnabled() {
 		SearchQuery<DocumentReference> query = indexManager.createSearchScope().query()
-				.asReference()
 				.predicate( f -> f.match()
 						.onField( indexMapping.string1FieldWithDslConverter.relativeFieldName )
 						.orField( indexMapping.string2FieldWithDslConverter.relativeFieldName )
@@ -1069,7 +1021,6 @@ public class MatchSearchPredicateIT {
 	@Test
 	public void multiFields_withDslConverter_dslConverterDisabled() {
 		SearchQuery<DocumentReference> query = indexManager.createSearchScope().query()
-				.asReference()
 				.predicate( f -> f.match()
 						.onField( indexMapping.string1FieldWithDslConverter.relativeFieldName )
 						.orField( indexMapping.string2FieldWithDslConverter.relativeFieldName )
@@ -1158,7 +1109,6 @@ public class MatchSearchPredicateIT {
 				Object valueToMatch = model.predicateParameterValue;
 
 				SearchQuery<DocumentReference> query = scope.query()
-						.asReference()
 						.predicate( f -> f.match().onField( absoluteFieldPath ).matching( valueToMatch ) )
 						.toQuery();
 
@@ -1201,7 +1151,6 @@ public class MatchSearchPredicateIT {
 				Object valueToMatch = model.predicateParameterValue;
 
 				SearchQuery<DocumentReference> query = scope.query()
-						.asReference()
 						.predicate( f -> f.match().onField( absoluteFieldPath ).matching( valueToMatch, DslConverter.DISABLED ) )
 						.toQuery();
 
@@ -1260,7 +1209,7 @@ public class MatchSearchPredicateIT {
 
 		SubTest.expectException(
 				() -> {
-					scope.query().asReference()
+					scope.query()
 							.predicate( f -> f.match().onField( absoluteFieldPath ).matching( "fox" ) )
 							.toQuery();
 				}
@@ -1279,7 +1228,7 @@ public class MatchSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope( incompatibleAnalyzerIndexManager );
 		String absoluteFieldPath = indexMapping.analyzedStringField.relativeFieldName;
 
-		SearchQuery<DocumentReference> query = scope.query().asReference()
+		SearchQuery<DocumentReference> query = scope.query()
 				.predicate( f -> f.match().onField( absoluteFieldPath ).matching( "fox" )
 						.analyzer( OverrideAnalysisDefinitions.ANALYZER_WHITESPACE_LOWERCASE.name ) )
 				.toQuery();
@@ -1295,7 +1244,7 @@ public class MatchSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope( incompatibleAnalyzerIndexManager );
 		String absoluteFieldPath = indexMapping.analyzedStringField.relativeFieldName;
 
-		SearchQuery<DocumentReference> query = scope.query().asReference()
+		SearchQuery<DocumentReference> query = scope.query()
 				.predicate( f -> f.match().onField( absoluteFieldPath ).matching( "fox" )
 						.skipAnalysis() )
 				.toQuery();
@@ -1374,22 +1323,18 @@ public class MatchSearchPredicateIT {
 
 		// Check that all documents are searchable
 		SearchQuery<DocumentReference> query = indexManager.createSearchScope().query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3, EMPTY );
 		query = compatibleIndexManager.createSearchScope().query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( COMPATIBLE_INDEX_NAME, COMPATIBLE_INDEX_DOCUMENT_1 );
 		query = rawFieldCompatibleIndexManager.createSearchScope().query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( RAW_FIELD_COMPATIBLE_INDEX_NAME, RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 );
 		query = incompatibleAnalyzerIndexManager.createSearchScope().query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( INCOMPATIBLE_ANALYZER_INDEX_NAME, INCOMPATIBLE_ANALYZER_INDEX_DOCUMENT_1 );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/NestedSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/NestedSearchPredicateIT.java
@@ -73,7 +73,6 @@ public class NestedSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.nested().onObjectField( "nestedObject" )
 						.nest( f.bool()
 								// This is referred to as "condition 1" in the data initialization method
@@ -115,7 +114,6 @@ public class NestedSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// This is referred to as "condition 1" in the data initialization method
 						.must( f.nested().onObjectField( "nestedObject.nestedObject" )
@@ -155,7 +153,6 @@ public class NestedSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.nested().onObjectField( "nestedObject" )
 						.nest( f.bool()
 								.must( f.match()
@@ -212,7 +209,6 @@ public class NestedSearchPredicateIT {
 				.toPredicate();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.nested().onObjectField( "nestedObject" )
 						.nest( f.bool()
 								// This is referred to as "condition 1" in the data initialization method
@@ -346,7 +342,6 @@ public class NestedSearchPredicateIT {
 		// Check that all documents are searchable
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query )

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/PhraseSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/PhraseSearchPredicateIT.java
@@ -128,7 +128,6 @@ public class PhraseSearchPredicateIT {
 		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.phrase().onField( absoluteFieldPath ).matching( PHRASE_1 ) )
 				.toQuery();
 
@@ -147,7 +146,6 @@ public class PhraseSearchPredicateIT {
 		String absoluteFieldPath = indexMapping.analyzedStringFieldWithDslConverter.relativeFieldName;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.phrase().onField( absoluteFieldPath ).matching( PHRASE_1 ) )
 				.toQuery();
 
@@ -162,7 +160,6 @@ public class PhraseSearchPredicateIT {
 		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.phrase().onField( absoluteFieldPath ).matching( PHRASE_1_UNIQUE_TERM ) )
 				.toQuery();
 
@@ -176,7 +173,6 @@ public class PhraseSearchPredicateIT {
 		MainFieldModel fieldModel = indexMapping.analyzedStringField1;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.phrase().onField( fieldModel.relativeFieldName ).matching( "" ) )
 				.toQuery();
 
@@ -190,7 +186,6 @@ public class PhraseSearchPredicateIT {
 		MainFieldModel fieldModel = indexMapping.analyzedStringField1;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				// Use stopwords, which should be removed by the analysis
 				.predicate( f -> f.phrase().onField( fieldModel.relativeFieldName ).matching( "the a" ) )
 				.toQuery();
@@ -207,7 +202,6 @@ public class PhraseSearchPredicateIT {
 		String whitespaceLowercaseAnalyzedField = indexMapping.whitespaceLowercaseAnalyzedField.relativeFieldName;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.phrase().onField( whitespaceAnalyzedField ).matching( "ONCE UPON" ) )
 				.toQuery();
 
@@ -215,7 +209,6 @@ public class PhraseSearchPredicateIT {
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_2 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.phrase().onField( whitespaceLowercaseAnalyzedField ).matching( "ONCE UPON" ) )
 				.toQuery();
 
@@ -223,7 +216,6 @@ public class PhraseSearchPredicateIT {
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.phrase().onField( whitespaceAnalyzedField ).matching( "ONCE UPON" )
 						.analyzer( OverrideAnalysisDefinitions.ANALYZER_WHITESPACE_LOWERCASE.name ) )
 				.toQuery();
@@ -238,7 +230,6 @@ public class PhraseSearchPredicateIT {
 		String whitespaceAnalyzedField = indexMapping.whitespaceAnalyzedField.relativeFieldName;
 
 		SubTest.expectException( () -> scope.query()
-				.asReference()
 				.predicate( f -> f.phrase().onField( whitespaceAnalyzedField ).matching( "ONCE UPON" )
 						// we don't have any analyzer with that name
 						.analyzer( "this_name_does_actually_not_exist" ) )
@@ -255,7 +246,6 @@ public class PhraseSearchPredicateIT {
 		String absoluteFieldPath = indexMapping.whitespaceLowercaseAnalyzedField.relativeFieldName;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.phrase().onField( absoluteFieldPath ).matching( "quick fox" ) )
 				.toQuery();
 
@@ -265,7 +255,6 @@ public class PhraseSearchPredicateIT {
 		// ignoring the analyzer means that the parameter of match predicate will not be tokenized
 		// so it will not match any token
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.phrase().onField( absoluteFieldPath ).matching( "quick fox" ).skipAnalysis() )
 				.toQuery();
 
@@ -274,7 +263,6 @@ public class PhraseSearchPredicateIT {
 
 		// to have a match with the skipAnalysis option enabled, we have to pass the parameter as a token is
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.phrase().onField( absoluteFieldPath ).matching( "fox" ).skipAnalysis() )
 				.toQuery();
 
@@ -325,7 +313,7 @@ public class PhraseSearchPredicateIT {
 	public void slop() {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
-		Function<Integer, SearchQuery<DocumentReference>> createQuery = slop -> scope.query().asReference()
+		Function<Integer, SearchQuery<DocumentReference>> createQuery = slop -> scope.query()
 				.predicate( f -> f.phrase().onField( absoluteFieldPath ).matching( PHRASE_1 ).withSlop( slop ) )
 				.toQuery();
 
@@ -369,7 +357,6 @@ public class PhraseSearchPredicateIT {
 		String absoluteFieldPath2 = indexMapping.analyzedStringField2.relativeFieldName;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.phrase()
 						.onField( absoluteFieldPath1 ).boostedTo( 42 )
 						.orField( absoluteFieldPath2 )
@@ -382,7 +369,6 @@ public class PhraseSearchPredicateIT {
 				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_5 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.phrase()
 						.onField( absoluteFieldPath1 )
 						.orField( absoluteFieldPath2 ).boostedTo( 42 )
@@ -402,7 +388,6 @@ public class PhraseSearchPredicateIT {
 		String absoluteFieldPath2 = indexMapping.analyzedStringField2.relativeFieldName;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.phrase().onField( absoluteFieldPath1 )
 								.matching( PHRASE_1 )
@@ -419,7 +404,6 @@ public class PhraseSearchPredicateIT {
 				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_5, DOCUMENT_1 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.phrase().onField( absoluteFieldPath1 )
 								.matching( PHRASE_1 )
@@ -443,7 +427,6 @@ public class PhraseSearchPredicateIT {
 		String absoluteFieldPath2 = indexMapping.analyzedStringField2.relativeFieldName;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.phrase().onField( absoluteFieldPath1 )
 								.matching( PHRASE_1 )
@@ -461,7 +444,6 @@ public class PhraseSearchPredicateIT {
 				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_5, DOCUMENT_1 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.phrase().onField( absoluteFieldPath1 )
 								.matching( PHRASE_1 )
@@ -489,7 +471,7 @@ public class PhraseSearchPredicateIT {
 
 		// onField(...)
 
-		createQuery = phrase -> scope.query().asReference()
+		createQuery = phrase -> scope.query()
 				.predicate( f -> f.phrase().onField( absoluteFieldPath1 )
 						.matching( phrase )
 				)
@@ -504,7 +486,7 @@ public class PhraseSearchPredicateIT {
 
 		// onField(...).orField(...)
 
-		createQuery = phrase -> scope.query().asReference()
+		createQuery = phrase -> scope.query()
 				.predicate( f -> f.phrase().onField( absoluteFieldPath1 )
 						.orField( absoluteFieldPath2 )
 						.matching( phrase )
@@ -521,7 +503,6 @@ public class PhraseSearchPredicateIT {
 		// onField().orFields(...)
 
 		createQuery = phrase -> scope.query()
-				.asReference()
 				.predicate( f -> f.phrase().onField( absoluteFieldPath1 )
 						.orFields( absoluteFieldPath2, absoluteFieldPath3 )
 						.matching( phrase )
@@ -538,7 +519,6 @@ public class PhraseSearchPredicateIT {
 		// onFields(...)
 
 		createQuery = phrase -> scope.query()
-				.asReference()
 				.predicate( f -> f.phrase()
 						.onFields( absoluteFieldPath1, absoluteFieldPath2 )
 						.matching( phrase )
@@ -633,7 +613,6 @@ public class PhraseSearchPredicateIT {
 		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.phrase().onField( absoluteFieldPath ).matching( PHRASE_1 ) )
 				.toQuery();
 
@@ -649,7 +628,6 @@ public class PhraseSearchPredicateIT {
 		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.phrase().onField( absoluteFieldPath ).matching( PHRASE_1 ) )
 				.toQuery();
 
@@ -666,7 +644,7 @@ public class PhraseSearchPredicateIT {
 
 		SubTest.expectException(
 				() -> {
-					scope.query().asReference()
+					scope.query()
 							.predicate( f -> f.phrase().onField( absoluteFieldPath ).matching( PHRASE_1_UNIQUE_TERM ) )
 							.toQuery();
 				}
@@ -686,7 +664,7 @@ public class PhraseSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope( incompatibleAnalyzerIndexManager );
 		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
 
-		SearchQuery<DocumentReference> query = scope.query().asReference()
+		SearchQuery<DocumentReference> query = scope.query()
 				.predicate( f -> f.phrase().onField( absoluteFieldPath ).matching( PHRASE_1_UNIQUE_TERM )
 						.analyzer( OverrideAnalysisDefinitions.ANALYZER_WHITESPACE_LOWERCASE.name ) )
 				.toQuery();
@@ -702,7 +680,7 @@ public class PhraseSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope( incompatibleAnalyzerIndexManager );
 		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
 
-		SearchQuery<DocumentReference> query = scope.query().asReference()
+		SearchQuery<DocumentReference> query = scope.query()
 				.predicate( f -> f.phrase().onField( absoluteFieldPath ).matching( PHRASE_1_UNIQUE_TERM )
 						.skipAnalysis() )
 				.toQuery();
@@ -767,23 +745,19 @@ public class PhraseSearchPredicateIT {
 		// Check that all documents are searchable
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query )
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3, DOCUMENT_4, DOCUMENT_5, EMPTY );
 		query = compatibleIndexManager.createSearchScope().query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( COMPATIBLE_INDEX_NAME, COMPATIBLE_INDEX_DOCUMENT_1 );
 		query = rawFieldCompatibleIndexManager.createSearchScope().query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( RAW_FIELD_COMPATIBLE_INDEX_NAME, RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 );
 		query = incompatibleAnalyzerIndexManager.createSearchScope().query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( INCOMPATIBLE_ANALYZER_INDEX_NAME, INCOMPATIBLE_ANALYZER_INDEX_DOCUMENT_1 );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/RangeSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/RangeSearchPredicateIT.java
@@ -106,7 +106,6 @@ public class RangeSearchPredicateIT {
 			Object lowerValueToMatch = fieldModel.predicateLowerBound;
 
 			SearchQuery<DocumentReference> query = scope.query()
-					.asReference()
 					.predicate( f -> f.range().onField( absoluteFieldPath ).above( lowerValueToMatch ) )
 					.toQuery();
 
@@ -124,7 +123,6 @@ public class RangeSearchPredicateIT {
 			Object lowerValueToMatch = new ValueWrapper<>( fieldModel.predicateLowerBound );
 
 			SearchQuery<DocumentReference> query = scope.query()
-					.asReference()
 					.predicate( f -> f.range().onField( absoluteFieldPath ).above( lowerValueToMatch ) )
 					.toQuery();
 
@@ -141,7 +139,6 @@ public class RangeSearchPredicateIT {
 			String absoluteFieldPath = fieldModel.relativeFieldName;
 
 			SearchQuery<DocumentReference> query = scope.query()
-					.asReference()
 					.predicate( f -> f.range().onField( absoluteFieldPath ).above( fieldModel.predicateLowerBound, DslConverter.DISABLED ) )
 					.toQuery();
 
@@ -161,7 +158,6 @@ public class RangeSearchPredicateIT {
 			// Default is inclusion
 
 			SearchQuery<DocumentReference> query = scope.query()
-					.asReference()
 					.predicate( f -> f.range().onField( absoluteFieldPath ).above( lowerValueToMatch ) )
 					.toQuery();
 
@@ -171,7 +167,6 @@ public class RangeSearchPredicateIT {
 			// explicit exclusion
 
 			query = scope.query()
-					.asReference()
 					.predicate( f -> f.range().onField( absoluteFieldPath ).above( lowerValueToMatch ).excludeLimit() )
 					.toQuery();
 
@@ -189,7 +184,6 @@ public class RangeSearchPredicateIT {
 			Object upperValueToMatch = fieldModel.predicateUpperBound;
 
 			SearchQuery<DocumentReference> query = scope.query()
-					.asReference()
 					.predicate( f -> f.range().onField( absoluteFieldPath ).below( upperValueToMatch ) )
 					.toQuery();
 
@@ -207,7 +201,6 @@ public class RangeSearchPredicateIT {
 			Object upperValueToMatch = new ValueWrapper<>( fieldModel.predicateUpperBound );
 
 			SearchQuery<DocumentReference> query = scope.query()
-					.asReference()
 					.predicate( f -> f.range().onField( absoluteFieldPath ).below( upperValueToMatch ) )
 					.toQuery();
 
@@ -224,7 +217,6 @@ public class RangeSearchPredicateIT {
 			String absoluteFieldPath = fieldModel.relativeFieldName;
 
 			SearchQuery<DocumentReference> query = scope.query()
-					.asReference()
 					.predicate( f -> f.range().onField( absoluteFieldPath ).below( fieldModel.predicateUpperBound, DslConverter.DISABLED ) )
 					.toQuery();
 
@@ -244,7 +236,6 @@ public class RangeSearchPredicateIT {
 			// Default is inclusion
 
 			SearchQuery<DocumentReference> query = scope.query()
-					.asReference()
 					.predicate( f -> f.range().onField( absoluteFieldPath ).below( upperValueToMatch ) )
 					.toQuery();
 
@@ -254,7 +245,6 @@ public class RangeSearchPredicateIT {
 			// explicit exclusion
 
 			query = scope.query()
-					.asReference()
 					.predicate( f -> f.range().onField( absoluteFieldPath ).below( upperValueToMatch ).excludeLimit() )
 					.toQuery();
 
@@ -273,7 +263,6 @@ public class RangeSearchPredicateIT {
 			Object upperValueToMatch = fieldModel.predicateUpperBound;
 
 			SearchQuery<DocumentReference> query = scope.query()
-					.asReference()
 					.predicate( f -> f.range().onField( absoluteFieldPath ).from( lowerValueToMatch ).to( upperValueToMatch ) )
 					.toQuery();
 
@@ -292,7 +281,6 @@ public class RangeSearchPredicateIT {
 			Object upperValueToMatch = new ValueWrapper<>( fieldModel.predicateUpperBound );
 
 			SearchQuery<DocumentReference> query = scope.query()
-					.asReference()
 					.predicate( f -> f.range().onField( absoluteFieldPath ).from( lowerValueToMatch ).to( upperValueToMatch ) )
 					.toQuery();
 
@@ -309,7 +297,6 @@ public class RangeSearchPredicateIT {
 			String absoluteFieldPath = fieldModel.relativeFieldName;
 
 			SearchQuery<DocumentReference> query = scope.query()
-					.asReference()
 					.predicate( f -> f.range().onField( absoluteFieldPath )
 							.from( fieldModel.predicateLowerBound, DslConverter.DISABLED )
 							.to( fieldModel.predicateUpperBound, DslConverter.DISABLED ) )
@@ -333,7 +320,6 @@ public class RangeSearchPredicateIT {
 			// Default is inclusion
 
 			SearchQuery<DocumentReference> query = scope.query()
-					.asReference()
 					.predicate( f -> f.range().onField( absoluteFieldPath ).from( value1ToMatch ).to( value2ToMatch ) )
 					.toQuery();
 
@@ -343,7 +329,6 @@ public class RangeSearchPredicateIT {
 			// explicit exclusion for the from clause
 
 			query = scope.query()
-					.asReference()
 					.predicate( f -> f.range().onField( absoluteFieldPath )
 							.from( value1ToMatch ).excludeLimit()
 							.to( value2ToMatch )
@@ -356,7 +341,6 @@ public class RangeSearchPredicateIT {
 			// explicit exclusion for the to clause
 
 			query = scope.query()
-					.asReference()
 					.predicate( f -> f.range().onField( absoluteFieldPath )
 							.from( value1ToMatch )
 							.to( value2ToMatch ).excludeLimit()
@@ -369,7 +353,6 @@ public class RangeSearchPredicateIT {
 			// explicit exclusion for both clauses
 
 			query = scope.query()
-					.asReference()
 					.predicate( f -> f.range().onField( absoluteFieldPath )
 							.from( value1ToMatch ).excludeLimit()
 							.to( value3ToMatch ).excludeLimit()
@@ -406,7 +389,6 @@ public class RangeSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.range().onField( indexMapping.string1Field.relativeFieldName )
 								.above( indexMapping.string1Field.document3Value.indexedValue )
@@ -422,7 +404,6 @@ public class RangeSearchPredicateIT {
 				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_3 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.range().onField( indexMapping.string1Field.relativeFieldName ).boostedTo( 42 )
 								.above( indexMapping.string1Field.document3Value.indexedValue )
@@ -443,7 +424,6 @@ public class RangeSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.range().onField( indexMapping.string1Field.relativeFieldName )
 								.above( indexMapping.string1Field.document3Value.indexedValue )
@@ -460,7 +440,6 @@ public class RangeSearchPredicateIT {
 				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_3 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.range().onField( indexMapping.string1Field.relativeFieldName )
 								.above( indexMapping.string1Field.document3Value.indexedValue )
@@ -482,7 +461,6 @@ public class RangeSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// 2 * 3 => boost x6
 						.should( f.range().onField( indexMapping.string1Field.relativeFieldName ).boostedTo( 3 )
@@ -502,7 +480,6 @@ public class RangeSearchPredicateIT {
 				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_3 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// 39 * 0.5 => boost x19.5
 						.should( f.range().onField( indexMapping.string1Field.relativeFieldName ).boostedTo( 0.5f )
@@ -527,7 +504,6 @@ public class RangeSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.range().onField( indexMapping.string1Field.relativeFieldName )
 								.orField( indexMapping.string2Field.relativeFieldName )
@@ -547,7 +523,6 @@ public class RangeSearchPredicateIT {
 				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_3 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.range().onField( indexMapping.string1Field.relativeFieldName )
 								.orField( indexMapping.string2Field.relativeFieldName )
@@ -574,7 +549,6 @@ public class RangeSearchPredicateIT {
 		// onField(...).orField(...)
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.range().onField( indexMapping.string1Field.relativeFieldName )
 						.orField( indexMapping.string2Field.relativeFieldName )
 						.below( indexMapping.string1Field.document1Value.indexedValue )
@@ -585,7 +559,6 @@ public class RangeSearchPredicateIT {
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.range().onField( indexMapping.string1Field.relativeFieldName )
 						.orField( indexMapping.string2Field.relativeFieldName )
 						.above( indexMapping.string2Field.document3Value.indexedValue )
@@ -598,7 +571,6 @@ public class RangeSearchPredicateIT {
 		// onField().orFields(...)
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.range().onField( indexMapping.string1Field.relativeFieldName )
 						.orFields( indexMapping.string2Field.relativeFieldName, indexMapping.string3Field.relativeFieldName )
 						.below( indexMapping.string1Field.document1Value.indexedValue )
@@ -609,7 +581,6 @@ public class RangeSearchPredicateIT {
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.range().onField( indexMapping.string1Field.relativeFieldName )
 						.orFields( indexMapping.string2Field.relativeFieldName, indexMapping.string3Field.relativeFieldName )
 						.from( "d" ).to( "e" )
@@ -620,7 +591,6 @@ public class RangeSearchPredicateIT {
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.range().onField( indexMapping.string1Field.relativeFieldName )
 						.orFields( indexMapping.string2Field.relativeFieldName, indexMapping.string3Field.relativeFieldName )
 						.above( indexMapping.string3Field.document3Value.indexedValue )
@@ -633,7 +603,6 @@ public class RangeSearchPredicateIT {
 		// onFields(...)
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.range().onFields( indexMapping.string1Field.relativeFieldName, indexMapping.string2Field.relativeFieldName )
 						.below( indexMapping.string1Field.document1Value.indexedValue )
 				)
@@ -643,7 +612,6 @@ public class RangeSearchPredicateIT {
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.range().onFields( indexMapping.string1Field.relativeFieldName, indexMapping.string2Field.relativeFieldName )
 						.above( indexMapping.string2Field.document3Value.indexedValue )
 				)
@@ -656,7 +624,6 @@ public class RangeSearchPredicateIT {
 	@Test
 	public void multiField_withDslConverter_dslConverterEnabled() {
 		SearchQuery<DocumentReference> query = indexManager.createSearchScope().query()
-				.asReference()
 				.predicate( f -> f.range().onField( indexMapping.string1FieldWithDslConverter.relativeFieldName )
 						.orField( indexMapping.string2FieldWithDslConverter.relativeFieldName )
 						.below( new ValueWrapper<>( indexMapping.string1FieldWithDslConverter.document1Value.indexedValue ) )
@@ -669,7 +636,6 @@ public class RangeSearchPredicateIT {
 	@Test
 	public void multiFields_withDslConverter_dslConverterDisabled() {
 		SearchQuery<DocumentReference> query = indexManager.createSearchScope().query()
-				.asReference()
 				.predicate( f -> f.range().onField( indexMapping.string1FieldWithDslConverter.relativeFieldName )
 						.orField( indexMapping.string2FieldWithDslConverter.relativeFieldName )
 						.below( indexMapping.string1FieldWithDslConverter.document1Value.indexedValue, DslConverter.DISABLED )
@@ -838,7 +804,6 @@ public class RangeSearchPredicateIT {
 			Object upperValueToMatch = fieldModel.predicateUpperBound;
 
 			SearchQuery<DocumentReference> query = scope.query()
-					.asReference()
 					.predicate( f -> f.range().onField( absoluteFieldPath ).below( upperValueToMatch ) )
 					.toQuery();
 
@@ -881,7 +846,6 @@ public class RangeSearchPredicateIT {
 			Object upperValueToMatch = fieldModel.predicateUpperBound;
 
 			SearchQuery<DocumentReference> query = scope.query()
-					.asReference()
 					.predicate( f -> f.range().onField( absoluteFieldPath ).below( upperValueToMatch, DslConverter.DISABLED ) )
 					.toQuery();
 
@@ -983,17 +947,14 @@ public class RangeSearchPredicateIT {
 
 		// Check that all documents are searchable
 		SearchQuery<DocumentReference> query = indexManager.createSearchScope().query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3, EMPTY_ID );
 		query = compatibleIndexManager.createSearchScope().query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( COMPATIBLE_INDEX_NAME, COMPATIBLE_INDEX_DOCUMENT_1 );
 		query = rawFieldCompatibleIndexManager.createSearchScope().query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( RAW_FIELD_COMPATIBLE_INDEX_NAME, RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SearchPredicateIT.java
@@ -71,7 +71,6 @@ public class SearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( "string" ).matching( STRING_1 ) )
 				.toQuery();
 
@@ -86,7 +85,6 @@ public class SearchPredicateIT {
 		SearchPredicate predicate = scope.predicate().match().onField( "string" ).matching( STRING_1 ).toPredicate();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( predicate )
 				.toQuery();
 
@@ -99,7 +97,6 @@ public class SearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( "string" ).matching( STRING_1 ) )
 				.toQuery();
 
@@ -127,7 +124,6 @@ public class SearchPredicateIT {
 		Assertions.assertThat( cache ).hasValue( null );
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( cachingPredicateProducer.apply( scope.predicate() ) )
 				.toQuery();
 
@@ -137,7 +133,6 @@ public class SearchPredicateIT {
 		Assertions.assertThat( cache ).doesNotHaveValue( null );
 
 		query = scope.query()
-				.asReference()
 				.predicate( cachingPredicateProducer.apply( scope.predicate() ) )
 				.toQuery();
 
@@ -165,7 +160,6 @@ public class SearchPredicateIT {
 		Assertions.assertThat( cache ).hasValue( null );
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool().must( cachingPredicateProducer.apply( f ) ) )
 				.toQuery();
 
@@ -175,7 +169,6 @@ public class SearchPredicateIT {
 		Assertions.assertThat( cache ).doesNotHaveValue( null );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( cachingPredicateProducer.apply( f ) )
 						.should( f.match().onField( "string" ).matching( STRING_2 ) )
@@ -193,7 +186,6 @@ public class SearchPredicateIT {
 
 		// Mandatory extension, supported
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.extension( new SupportedExtension() )
 						.extendedPredicate( "string", STRING_1 )
 				)
@@ -210,7 +202,6 @@ public class SearchPredicateIT {
 
 		// Conditional extensions with orElse - two, both supported
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.extension()
 						// FIXME find some way to forbid using the context passed to the consumers twice... ?
 						.ifSupported(
@@ -229,7 +220,6 @@ public class SearchPredicateIT {
 
 		// Conditional extensions with orElse - two, second supported
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.extension()
 						.ifSupported(
 								new UnSupportedExtension(),
@@ -249,7 +239,6 @@ public class SearchPredicateIT {
 
 		// Conditional extensions with orElse - two, both unsupported
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.extension()
 						.ifSupported(
 								new UnSupportedExtension(),
@@ -283,7 +272,6 @@ public class SearchPredicateIT {
 		// Check that all documents are searchable
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, EMPTY );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SimpleQueryStringSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SimpleQueryStringSearchPredicateIT.java
@@ -129,7 +129,7 @@ public class SimpleQueryStringSearchPredicateIT {
 	public void simpleQueryString() {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
-		Function<String, SearchQuery<DocumentReference>> createQuery = queryString -> scope.query().asReference()
+		Function<String, SearchQuery<DocumentReference>> createQuery = queryString -> scope.query()
 				.predicate( f -> f.simpleQueryString().onField( absoluteFieldPath ).matching( queryString ) )
 				.toQuery();
 
@@ -157,14 +157,14 @@ public class SimpleQueryStringSearchPredicateIT {
 		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
 		SearchQuery<DocumentReference> query;
 
-		query = scope.query().asReference()
+		query = scope.query()
 				.predicate( f -> f.simpleQueryString().onField( absoluteFieldPath )
 						.matching( TERM_1 + " " + TERM_2 ) )
 				.toQuery();
 		assertThat( query )
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
 
-		query = scope.query().asReference()
+		query = scope.query()
 				.predicate( f -> f.simpleQueryString().onField( absoluteFieldPath )
 						.matching( TERM_1 + " " + TERM_2 )
 						.withAndAsDefaultOperator() )
@@ -184,7 +184,6 @@ public class SimpleQueryStringSearchPredicateIT {
 		String absoluteFieldPath = indexMapping.analyzedStringFieldWithDslConverter.relativeFieldName;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.simpleQueryString().onField( absoluteFieldPath ).matching( TERM_1 ) )
 				.toQuery();
 
@@ -200,7 +199,6 @@ public class SimpleQueryStringSearchPredicateIT {
 		MainFieldModel fieldModel = indexMapping.analyzedStringField1;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.simpleQueryString().onField( fieldModel.relativeFieldName ).matching( "" ) )
 				.toQuery();
 
@@ -216,7 +214,6 @@ public class SimpleQueryStringSearchPredicateIT {
 		MainFieldModel fieldModel = indexMapping.analyzedStringField1;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.simpleQueryString().onField( fieldModel.relativeFieldName ).matching( "   " ) )
 				.toQuery();
 
@@ -230,7 +227,6 @@ public class SimpleQueryStringSearchPredicateIT {
 		MainFieldModel fieldModel = indexMapping.analyzedStringField1;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				// Use stopwords, which should be removed by the analysis
 				.predicate( f -> f.simpleQueryString().onField( fieldModel.relativeFieldName ).matching( "the a" ) )
 				.toQuery();
@@ -247,7 +243,6 @@ public class SimpleQueryStringSearchPredicateIT {
 		String whitespaceLowercaseAnalyzedField = indexMapping.whitespaceLowercaseAnalyzedField.relativeFieldName;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.simpleQueryString().onField( whitespaceAnalyzedField ).matching( "HERE | PANDA" ) )
 				.toQuery();
 
@@ -255,7 +250,6 @@ public class SimpleQueryStringSearchPredicateIT {
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_2 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.simpleQueryString().onField( whitespaceLowercaseAnalyzedField ).matching( "HERE | PANDA" ) )
 				.toQuery();
 
@@ -263,7 +257,6 @@ public class SimpleQueryStringSearchPredicateIT {
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.simpleQueryString().onField( whitespaceAnalyzedField ).matching( "HERE | PANDA" )
 						.analyzer( OverrideAnalysisDefinitions.ANALYZER_WHITESPACE_LOWERCASE.name ) )
 				.toQuery();
@@ -278,7 +271,6 @@ public class SimpleQueryStringSearchPredicateIT {
 		String whitespaceAnalyzedField = indexMapping.whitespaceAnalyzedField.relativeFieldName;
 
 		SubTest.expectException( () -> scope.query()
-				.asReference()
 				.predicate( f -> f.simpleQueryString().onField( whitespaceAnalyzedField ).matching( "HERE | PANDA" )
 						// we don't have any analyzer with that name
 						.analyzer( "this_name_does_actually_not_exist" ) )
@@ -295,7 +287,6 @@ public class SimpleQueryStringSearchPredicateIT {
 		String absoluteFieldPath = indexMapping.whitespaceLowercaseAnalyzedField.relativeFieldName;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.simpleQueryString().onField( absoluteFieldPath ).matching( "HERE | PANDA" ) )
 				.toQuery();
 
@@ -305,7 +296,6 @@ public class SimpleQueryStringSearchPredicateIT {
 		// ignoring the analyzer means that the parameter of match predicate will not be tokenized
 		// so it will not match any token
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.simpleQueryString().onField( absoluteFieldPath ).matching( "HERE | PANDA" ).skipAnalysis() )
 				.toQuery();
 
@@ -314,7 +304,6 @@ public class SimpleQueryStringSearchPredicateIT {
 
 		// to have a match with the skipAnalysis option enabled, we have to pass the parameter as a token is
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.simpleQueryString().onField( absoluteFieldPath ).matching( "here" ).skipAnalysis() )
 				.toQuery();
 
@@ -368,7 +357,7 @@ public class SimpleQueryStringSearchPredicateIT {
 	public void phrase() {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
-		Function<String, SearchQuery<DocumentReference>> createQuery = queryString -> scope.query().asReference()
+		Function<String, SearchQuery<DocumentReference>> createQuery = queryString -> scope.query()
 				.predicate( f -> f.simpleQueryString().onField( absoluteFieldPath ).matching( queryString ) )
 				.toQuery();
 
@@ -398,7 +387,7 @@ public class SimpleQueryStringSearchPredicateIT {
 		String absoluteFieldPath2 = indexMapping.analyzedStringField2.relativeFieldName;
 		SearchQuery<DocumentReference> query;
 
-		query = scope.query().asReference()
+		query = scope.query()
 				.predicate( f -> f.simpleQueryString()
 						.onField( absoluteFieldPath1 ).boostedTo( 5f )
 						.orField( absoluteFieldPath2 )
@@ -409,7 +398,7 @@ public class SimpleQueryStringSearchPredicateIT {
 		assertThat( query )
 				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_2, DOCUMENT_1 );
 
-		query = scope.query().asReference()
+		query = scope.query()
 				.predicate( f -> f.simpleQueryString()
 						.onField( absoluteFieldPath1 )
 						.orField( absoluteFieldPath2 ).boostedTo( 5f )
@@ -428,7 +417,6 @@ public class SimpleQueryStringSearchPredicateIT {
 		String absoluteFieldPath2 = indexMapping.analyzedStringField2.relativeFieldName;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.simpleQueryString().onField( absoluteFieldPath1 )
 								.matching( TERM_3 )
@@ -445,7 +433,6 @@ public class SimpleQueryStringSearchPredicateIT {
 				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.simpleQueryString().onField( absoluteFieldPath1 )
 								.matching( TERM_3 )
@@ -469,7 +456,6 @@ public class SimpleQueryStringSearchPredicateIT {
 		String absoluteFieldPath2 = indexMapping.analyzedStringField2.relativeFieldName;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.simpleQueryString().onField( absoluteFieldPath1 )
 								.matching( TERM_3 )
@@ -487,7 +473,6 @@ public class SimpleQueryStringSearchPredicateIT {
 				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.simpleQueryString().onField( absoluteFieldPath1 )
 								.matching( TERM_3 )
@@ -511,7 +496,7 @@ public class SimpleQueryStringSearchPredicateIT {
 	public void fuzzy() {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
-		Function<String, SearchQuery<DocumentReference>> createQuery = queryString -> scope.query().asReference()
+		Function<String, SearchQuery<DocumentReference>> createQuery = queryString -> scope.query()
 				.predicate( f -> f.simpleQueryString().onField( absoluteFieldPath ).matching( queryString ) )
 				.toQuery();
 
@@ -544,7 +529,7 @@ public class SimpleQueryStringSearchPredicateIT {
 
 		// onField(...)
 
-		createQuery = query -> scope.query().asReference()
+		createQuery = query -> scope.query()
 				.predicate( f -> f.simpleQueryString().onField( absoluteFieldPath1 )
 						.matching( query )
 				)
@@ -559,7 +544,7 @@ public class SimpleQueryStringSearchPredicateIT {
 
 		// onField(...).orField(...)
 
-		createQuery = query -> scope.query().asReference()
+		createQuery = query -> scope.query()
 				.predicate( f -> f.simpleQueryString().onField( absoluteFieldPath1 )
 						.orField( absoluteFieldPath2 )
 						.matching( query )
@@ -576,7 +561,6 @@ public class SimpleQueryStringSearchPredicateIT {
 		// onField().orFields(...)
 
 		createQuery = query -> scope.query()
-				.asReference()
 				.predicate( f -> f.simpleQueryString().onField( absoluteFieldPath1 )
 						.orFields( absoluteFieldPath2, absoluteFieldPath3 )
 						.matching( query )
@@ -593,7 +577,6 @@ public class SimpleQueryStringSearchPredicateIT {
 		// onFields(...)
 
 		createQuery = query -> scope.query()
-				.asReference()
 				.predicate( f -> f.simpleQueryString().onFields( absoluteFieldPath1, absoluteFieldPath2 )
 						.matching( query )
 				)
@@ -660,7 +643,6 @@ public class SimpleQueryStringSearchPredicateIT {
 		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.simpleQueryString().onField( absoluteFieldPath ).matching( TERM_1 ) )
 				.toQuery();
 
@@ -676,7 +658,6 @@ public class SimpleQueryStringSearchPredicateIT {
 		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.simpleQueryString().onField( absoluteFieldPath ).matching( TERM_1 ) )
 				.toQuery();
 
@@ -693,7 +674,7 @@ public class SimpleQueryStringSearchPredicateIT {
 
 		SubTest.expectException(
 				() -> {
-					scope.query().asReference()
+					scope.query()
 							.predicate( f -> f.simpleQueryString().onField( absoluteFieldPath ).matching( TERM_5 ) )
 							.toQuery();
 				}
@@ -713,7 +694,7 @@ public class SimpleQueryStringSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope( incompatibleAnalyzerIndexManager );
 		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
 
-		SearchQuery<DocumentReference> query = scope.query().asReference()
+		SearchQuery<DocumentReference> query = scope.query()
 				.predicate( f -> f.simpleQueryString().onField( absoluteFieldPath ).matching( TERM_5 )
 						.analyzer( OverrideAnalysisDefinitions.ANALYZER_WHITESPACE_LOWERCASE.name ) )
 				.toQuery();
@@ -729,7 +710,7 @@ public class SimpleQueryStringSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope( incompatibleAnalyzerIndexManager );
 		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
 
-		SearchQuery<DocumentReference> query = scope.query().asReference()
+		SearchQuery<DocumentReference> query = scope.query()
 				.predicate( f -> f.simpleQueryString().onField( absoluteFieldPath ).matching( TERM_5 )
 						.skipAnalysis() )
 				.toQuery();
@@ -793,23 +774,19 @@ public class SimpleQueryStringSearchPredicateIT {
 		// Check that all documents are searchable
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query )
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3, DOCUMENT_4, DOCUMENT_5, EMPTY );
 		query = compatibleIndexManager.createSearchScope().query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( COMPATIBLE_INDEX_NAME, COMPATIBLE_INDEX_DOCUMENT_1 );
 		query = rawFieldCompatibleIndexManager.createSearchScope().query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( RAW_FIELD_COMPATIBLE_INDEX_NAME, RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 );
 		query = incompatibleAnalyzerIndexManager.createSearchScope().query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( INCOMPATIBLE_ANALYZER_INDEX_NAME, INCOMPATIBLE_ANALYZER_INDEX_DOCUMENT_1 );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/WildcardSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/WildcardSearchPredicateIT.java
@@ -115,7 +115,7 @@ public class WildcardSearchPredicateIT {
 	public void wildcard() {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
-		Function<String, SearchQuery<DocumentReference>> createQuery = queryString -> scope.query().asReference()
+		Function<String, SearchQuery<DocumentReference>> createQuery = queryString -> scope.query()
 				.predicate( f -> f.wildcard().onField( absoluteFieldPath ).matching( queryString ) )
 				.toQuery();
 
@@ -140,7 +140,6 @@ public class WildcardSearchPredicateIT {
 		String absoluteFieldPath = indexMapping.analyzedStringFieldWithDslConverter.relativeFieldName;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.wildcard().onField( absoluteFieldPath ).matching( PATTERN_1 ) )
 				.toQuery();
 
@@ -154,7 +153,6 @@ public class WildcardSearchPredicateIT {
 		MainFieldModel fieldModel = indexMapping.analyzedStringField1;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.wildcard().onField( fieldModel.relativeFieldName ).matching( "" ) )
 				.toQuery();
 
@@ -205,7 +203,6 @@ public class WildcardSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.wildcard()
 						.onField( indexMapping.analyzedStringField1.relativeFieldName ).boostedTo( 42 )
 						.orField( indexMapping.analyzedStringField2.relativeFieldName )
@@ -218,7 +215,6 @@ public class WildcardSearchPredicateIT {
 				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_5 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.wildcard()
 						.onField( indexMapping.analyzedStringField1.relativeFieldName )
 						.orField( indexMapping.analyzedStringField2.relativeFieldName ).boostedTo( 42 )
@@ -236,7 +232,6 @@ public class WildcardSearchPredicateIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.wildcard().onField( indexMapping.analyzedStringField1.relativeFieldName )
 								.matching( PATTERN_1 )
@@ -253,7 +248,6 @@ public class WildcardSearchPredicateIT {
 				.hasDocRefHitsExactOrder( INDEX_NAME, DOCUMENT_5, DOCUMENT_1 );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						.should( f.wildcard().onField( indexMapping.analyzedStringField1.relativeFieldName )
 								.matching( PATTERN_1 )
@@ -280,7 +274,7 @@ public class WildcardSearchPredicateIT {
 
 		// onField(...)
 
-		createQuery = pattern -> scope.query().asReference()
+		createQuery = pattern -> scope.query()
 				.predicate( f -> f.wildcard().onField( absoluteFieldPath1 )
 						.matching( pattern )
 				)
@@ -295,7 +289,7 @@ public class WildcardSearchPredicateIT {
 
 		// onField(...).orField(...)
 
-		createQuery = pattern -> scope.query().asReference()
+		createQuery = pattern -> scope.query()
 				.predicate( f -> f.wildcard().onField( absoluteFieldPath1 )
 						.orField( absoluteFieldPath2 )
 						.matching( pattern )
@@ -312,7 +306,6 @@ public class WildcardSearchPredicateIT {
 		// onField().orFields(...)
 
 		createQuery = pattern -> scope.query()
-				.asReference()
 				.predicate( f -> f.wildcard().onField( absoluteFieldPath1 )
 						.orFields( absoluteFieldPath2, absoluteFieldPath3 )
 						.matching( pattern )
@@ -329,7 +322,6 @@ public class WildcardSearchPredicateIT {
 		// onFields(...)
 
 		createQuery = pattern -> scope.query()
-				.asReference()
 				.predicate( f -> f.wildcard().onFields( absoluteFieldPath1, absoluteFieldPath2 )
 						.matching( pattern )
 				)
@@ -397,7 +389,6 @@ public class WildcardSearchPredicateIT {
 		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.wildcard().onField( absoluteFieldPath ).matching( PATTERN_1 ) )
 				.toQuery();
 
@@ -414,7 +405,6 @@ public class WildcardSearchPredicateIT {
 		String absoluteFieldPath = indexMapping.analyzedStringField1.relativeFieldName;
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.wildcard().onField( absoluteFieldPath ).matching( PATTERN_1 ) )
 				.toQuery();
 
@@ -484,18 +474,15 @@ public class WildcardSearchPredicateIT {
 		// Check that all documents are searchable
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query )
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3, DOCUMENT_4, DOCUMENT_5, EMPTY );
 		query = compatibleIndexManager.createSearchScope().query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( COMPATIBLE_INDEX_NAME, COMPATIBLE_INDEX_DOCUMENT_1 );
 		query = rawFieldCompatibleIndexManager.createSearchScope().query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( RAW_FIELD_COMPATIBLE_INDEX_NAME, RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/CompositeSearchProjectionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/CompositeSearchProjectionIT.java
@@ -348,7 +348,6 @@ public class CompositeSearchProjectionIT {
 		// Check that all documents are searchable
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query )

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/FieldSearchProjectionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/FieldSearchProjectionIT.java
@@ -640,12 +640,10 @@ public class FieldSearchProjectionIT {
 
 		// Check that all documents are searchable
 		SearchQuery<DocumentReference> query = indexManager.createSearchScope().query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3, EMPTY );
 		query = compatibleIndexManager.createSearchScope().query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( COMPATIBLE_INDEX_NAME, COMPATIBLE_INDEX_DOCUMENT_1 );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/SearchProjectionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/SearchProjectionIT.java
@@ -415,7 +415,6 @@ public class SearchProjectionIT extends EasyMockSupport {
 		// Check that all documents are searchable
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query )

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryBaseIT.java
@@ -70,7 +70,6 @@ public class SearchQueryBaseIT {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( "string" ).matching( "platypus" ) )
 				.toQuery();
 
@@ -83,7 +82,7 @@ public class SearchQueryBaseIT {
 
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
-		SearchQuery<DocumentReference> query = scope.query().asReference()
+		SearchQuery<DocumentReference> query = scope.query()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 
@@ -139,7 +138,6 @@ public class SearchQueryBaseIT {
 		// Check that all documents are searchable
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		SearchResultAssert.assertThat( query ).hasTotalHitCount( documentCount );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryBaseIT.java
@@ -188,7 +188,7 @@ public class SearchQueryBaseIT {
 
 	private static class SupportedQueryDslExtension<R, E> implements SearchQueryContextExtension<MyExtendedDslContext<R>, R, E> {
 		@Override
-		public Optional<MyExtendedDslContext<R>> extendOptional(SearchQueryResultDefinitionContext<R, E, ?> original,
+		public Optional<MyExtendedDslContext<R>> extendOptional(SearchQueryResultDefinitionContext<?, R, E, ?, ?> original,
 				IndexSearchScope<?> indexSearchScope, SessionContextImplementor sessionContext,
 				LoadingContextBuilder<R, E> loadingContextBuilder) {
 			Assertions.assertThat( original ).isNotNull();
@@ -201,7 +201,7 @@ public class SearchQueryBaseIT {
 
 	private static class UnSupportedQueryDslExtension<R, E> implements SearchQueryContextExtension<MyExtendedDslContext<R>, R, E> {
 		@Override
-		public Optional<MyExtendedDslContext<R>> extendOptional(SearchQueryResultDefinitionContext<R, E, ?> original,
+		public Optional<MyExtendedDslContext<R>> extendOptional(SearchQueryResultDefinitionContext<?, R, E, ?, ?> original,
 				IndexSearchScope<?> indexSearchScope, SessionContextImplementor sessionContext,
 				LoadingContextBuilder<R, E> loadingContextBuilder) {
 			Assertions.assertThat( original ).isNotNull();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryFetchIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryFetchIT.java
@@ -263,7 +263,6 @@ public class SearchQueryFetchIT {
 	private SearchQueryContext<?, DocumentReference, ?> matchAllQuery() {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		return scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.sort( c -> c.byField( "integer" ).asc() );
 	}
@@ -271,7 +270,6 @@ public class SearchQueryFetchIT {
 	private SearchQueryContext<?, DocumentReference, ?> matchFirstHalfQuery() {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		return scope.query()
-				.asReference()
 				.predicate( f -> f.range().onField( "integer" ).below( DOCUMENT_COUNT / 2 ).excludeLimit() )
 				.sort( c -> c.byField( "integer" ).asc() );
 	}
@@ -279,14 +277,12 @@ public class SearchQueryFetchIT {
 	private SearchQueryContext<?, DocumentReference, ?> matchOneQuery(int id) {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		return scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( "integer" ).matching( id ) );
 	}
 
 	private SearchQueryContext<?, DocumentReference, ?> matchNoneQuery() {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		return scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( "integer" ).matching( DOCUMENT_COUNT + 2 ) );
 	}
 
@@ -306,7 +302,6 @@ public class SearchQueryFetchIT {
 		// Check that all documents are searchable
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasTotalHitCount( DOCUMENT_COUNT );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryFetchIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryFetchIT.java
@@ -23,6 +23,7 @@ import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement
 import org.hibernate.search.engine.backend.index.spi.IndexDocumentWorkExecutor;
 import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.engine.search.DocumentReference;
+import org.hibernate.search.engine.search.dsl.query.SearchQueryContext;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
@@ -63,8 +64,7 @@ public class SearchQueryFetchIT {
 
 	@Test
 	public void fetch_noArg() {
-		SearchQuery<DocumentReference> query = matchAllQuery();
-		assertThat( query.fetch() ).fromQuery( query )
+		assertThat( matchAllQuery().fetch() )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasDocRefHitsExactOrder( builder -> {
 					for ( int i = 0; i < DOCUMENT_COUNT; i++ ) {
@@ -72,8 +72,7 @@ public class SearchQueryFetchIT {
 					}
 				} );
 
-		query = matchFirstHalfQuery();
-		assertThat( query.fetch() ).fromQuery( query )
+		assertThat( matchFirstHalfQuery().fetch() )
 				.hasTotalHitCount( DOCUMENT_COUNT / 2 )
 				.hasDocRefHitsExactOrder( builder -> {
 					for ( int i = 0; i < DOCUMENT_COUNT / 2; i++ ) {
@@ -84,8 +83,7 @@ public class SearchQueryFetchIT {
 
 	@Test
 	public void fetch_limit() {
-		SearchQuery<DocumentReference> query = matchAllQuery();
-		assertThat( query.fetch( null ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetch( (Integer) null ) )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasDocRefHitsExactOrder( builder -> {
 					for ( int i = 0; i < DOCUMENT_COUNT; i++ ) {
@@ -93,21 +91,18 @@ public class SearchQueryFetchIT {
 					}
 				} );
 
-		query = matchAllQuery();
-		assertThat( query.fetch( 1 ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetch( 1 ) )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasDocRefHitsExactOrder( INDEX_NAME, docId( 0 ) );
 
-		query = matchAllQuery();
-		assertThat( query.fetch( 2 ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetch( 2 ) )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasDocRefHitsExactOrder( INDEX_NAME, docId( 0 ), docId( 1 ) );
 	}
 
 	@Test
 	public void fetch_limitAndOffset() {
-		SearchQuery<DocumentReference> query = matchAllQuery();
-		assertThat( query.fetch( null, 1 ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetch( null, 1 ) )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasDocRefHitsExactOrder( builder -> {
 					for ( int i = 1; i < DOCUMENT_COUNT; i++ ) {
@@ -115,18 +110,15 @@ public class SearchQueryFetchIT {
 					}
 				} );
 
-		query = matchAllQuery();
-		assertThat( query.fetch( 1, 1 ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetch( 1, 1 ) )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasDocRefHitsExactOrder( INDEX_NAME, docId( 1 ) );
 
-		query = matchAllQuery();
-		assertThat( query.fetch( 2, null ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetch( 2, null ) )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasDocRefHitsExactOrder( INDEX_NAME, docId( 0 ), docId( 1 ) );
 
-		query = matchAllQuery();
-		assertThat( query.fetch( null, null ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetch( null, null ) )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasDocRefHitsExactOrder( builder -> {
 					for ( int i = 0; i < DOCUMENT_COUNT; i++ ) {
@@ -135,24 +127,21 @@ public class SearchQueryFetchIT {
 				} );
 
 		// Fetch beyond the total hit count
-		query = matchAllQuery();
-		assertThat( query.fetch( null, DOCUMENT_COUNT + 1 ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetch( null, DOCUMENT_COUNT + 1 ) )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasNoHits();
 	}
 
 	@Test
 	public void fetchHits_noArg() {
-		SearchQuery<DocumentReference> query = matchAllQuery();
-		assertThat( query.fetchHits() ).fromQuery( query )
+		assertThat( matchAllQuery().fetchHits() )
 				.hasDocRefHitsExactOrder( builder -> {
 					for ( int i = 0; i < DOCUMENT_COUNT; i++ ) {
 						builder.doc( INDEX_NAME, docId( i ) );
 					}
 				} );
 
-		query = matchFirstHalfQuery();
-		assertThat( query.fetchHits() ).fromQuery( query )
+		assertThat( matchFirstHalfQuery().fetchHits() )
 				.hasDocRefHitsExactOrder( builder -> {
 					for ( int i = 0; i < DOCUMENT_COUNT / 2; i++ ) {
 						builder.doc( INDEX_NAME, docId( i ) );
@@ -162,43 +151,36 @@ public class SearchQueryFetchIT {
 
 	@Test
 	public void fetchHits_limit() {
-		SearchQuery<DocumentReference> query = matchAllQuery();
-		assertThat( query.fetchHits( null ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetchHits( (Integer) null ) )
 				.hasDocRefHitsExactOrder( builder -> {
 					for ( int i = 0; i < DOCUMENT_COUNT; i++ ) {
 						builder.doc( INDEX_NAME, docId( i ) );
 					}
 				} );
 
-		query = matchAllQuery();
-		assertThat( query.fetchHits( 1 ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetchHits( 1 ) )
 				.hasDocRefHitsExactOrder( INDEX_NAME, docId( 0 ) );
 
-		query = matchAllQuery();
-		assertThat( query.fetchHits( 2 ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetchHits( 2 ) )
 				.hasDocRefHitsExactOrder( INDEX_NAME, docId( 0 ), docId( 1 ) );
 	}
 
 	@Test
 	public void fetchHits_limitAndOffset() {
-		SearchQuery<DocumentReference> query = matchAllQuery();
-		assertThat( query.fetchHits( null, 1 ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetchHits( null, 1 ) )
 				.hasDocRefHitsExactOrder( builder -> {
 					for ( int i = 1; i < DOCUMENT_COUNT; i++ ) {
 						builder.doc( INDEX_NAME, docId( i ) );
 					}
 				} );
 
-		query = matchAllQuery();
-		assertThat( query.fetchHits( 1, 1 ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetchHits( 1, 1 ) )
 				.hasDocRefHitsExactOrder( INDEX_NAME, docId( 1 ) );
 
-		query = matchAllQuery();
-		assertThat( query.fetchHits( 2, null ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetchHits( 2, null ) )
 				.hasDocRefHitsExactOrder( INDEX_NAME, docId( 0 ), docId( 1 ) );
 
-		query = matchAllQuery();
-		assertThat( query.fetchHits( null, null ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetchHits( null, null ) )
 				.hasDocRefHitsExactOrder( builder -> {
 					for ( int i = 0; i < DOCUMENT_COUNT; i++ ) {
 						builder.doc( INDEX_NAME, docId( i ) );
@@ -206,36 +188,29 @@ public class SearchQueryFetchIT {
 				} );
 
 		// Fetch beyond the total hit count
-		query = matchAllQuery();
-		assertThat( query.fetchHits( null, DOCUMENT_COUNT + 1 ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetchHits( null, DOCUMENT_COUNT + 1 ) )
 				.isEmpty();
 	}
 
 	@Test
 	public void fetchTotalHitCount() {
-		SearchQuery<DocumentReference> query = matchAllQuery();
-		Assertions.assertThat( query.fetchTotalHitCount() ).isEqualTo( DOCUMENT_COUNT );
+		Assertions.assertThat( matchAllQuery().fetchTotalHitCount() ).isEqualTo( DOCUMENT_COUNT );
 
-		query = matchFirstHalfQuery();
-		Assertions.assertThat( query.fetchTotalHitCount() ).isEqualTo( DOCUMENT_COUNT / 2 );
+		Assertions.assertThat( matchFirstHalfQuery().fetchTotalHitCount() ).isEqualTo( DOCUMENT_COUNT / 2 );
 	}
 
 	@Test
 	public void fetchSingleHit() {
-		SearchQuery<DocumentReference> query = matchOneQuery( 4 );
-
-		Optional<DocumentReference> result = query.fetchSingleHit();
+		Optional<DocumentReference> result = matchOneQuery( 4 ).fetchSingleHit();
 		Assertions.assertThat( result ).isNotEmpty();
 		Assertions.assertThat( normalizeReference( result.get() ) )
 				.isEqualTo( normalizeReference( reference( INDEX_NAME, docId( 4 ) ) ) );
 
-		query = matchNoneQuery();
-		result = query.fetchSingleHit();
+		result = matchNoneQuery().fetchSingleHit();
 		Assertions.assertThat( result ).isEmpty();
 
 		SubTest.expectException( () -> {
-			SearchQuery<DocumentReference> matchAllQuery = matchAllQuery();
-			matchAllQuery.fetchSingleHit();
+			matchAllQuery().fetchSingleHit();
 		} )
 				.assertThrown()
 				.isInstanceOf( SearchException.class );
@@ -243,7 +218,7 @@ public class SearchQueryFetchIT {
 
 	@Test
 	public void fetch_limitAndOffset_reuseQuery() {
-		SearchQuery<DocumentReference> query = matchAllQuery();
+		SearchQuery<DocumentReference> query = matchAllQuery().toQuery();
 		assertThat( query.fetch( null, 1 ) ).fromQuery( query )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasDocRefHitsExactOrder( builder -> {
@@ -280,45 +255,39 @@ public class SearchQueryFetchIT {
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3389")
 	public void maxResults_zero() {
-		SearchQuery<DocumentReference> query = matchAllQuery();
-
-		assertThat( query.fetch( 0, 0 ) ).fromQuery( query )
+		assertThat( matchAllQuery().fetch( 0, 0 ) )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasNoHits();
 	}
 
-	private SearchQuery<DocumentReference> matchAllQuery() {
+	private SearchQueryContext<?, DocumentReference, ?> matchAllQuery() {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		return scope.query()
 				.asReference()
 				.predicate( f -> f.matchAll() )
-				.sort( c -> c.byField( "integer" ).asc() )
-				.toQuery();
+				.sort( c -> c.byField( "integer" ).asc() );
 	}
 
-	private SearchQuery<DocumentReference> matchFirstHalfQuery() {
+	private SearchQueryContext<?, DocumentReference, ?> matchFirstHalfQuery() {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		return scope.query()
 				.asReference()
 				.predicate( f -> f.range().onField( "integer" ).below( DOCUMENT_COUNT / 2 ).excludeLimit() )
-				.sort( c -> c.byField( "integer" ).asc() )
-				.toQuery();
+				.sort( c -> c.byField( "integer" ).asc() );
 	}
 
-	private SearchQuery<DocumentReference> matchOneQuery(int id) {
+	private SearchQueryContext<?, DocumentReference, ?> matchOneQuery(int id) {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		return scope.query()
 				.asReference()
-				.predicate( f -> f.match().onField( "integer" ).matching( id ) )
-				.toQuery();
+				.predicate( f -> f.match().onField( "integer" ).matching( id ) );
 	}
 
-	private SearchQuery<DocumentReference> matchNoneQuery() {
+	private SearchQueryContext<?, DocumentReference, ?> matchNoneQuery() {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		return scope.query()
 				.asReference()
-				.predicate( f -> f.match().onField( "integer" ).matching( DOCUMENT_COUNT + 2 ) )
-				.toQuery();
+				.predicate( f -> f.match().onField( "integer" ).matching( DOCUMENT_COUNT + 2 ) );
 	}
 
 	private void initData() {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryResultLoadingOrTransformingIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryResultLoadingOrTransformingIT.java
@@ -140,7 +140,6 @@ public class SearchQueryResultLoadingOrTransformingIT extends EasyMockSupport {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query )
@@ -426,21 +425,18 @@ public class SearchQueryResultLoadingOrTransformingIT extends EasyMockSupport {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 
 		assertEquals( 2L, query.fetchTotalHitCount() );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.match().onField( "string" ).matching( STRING_VALUE ) )
 				.toQuery();
 
 		assertEquals( 1L, query.fetchTotalHitCount() );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 
@@ -536,7 +532,6 @@ public class SearchQueryResultLoadingOrTransformingIT extends EasyMockSupport {
 		// Check that all documents are searchable
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query )

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSearchSortIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSearchSortIT.java
@@ -129,7 +129,6 @@ public class FieldSearchSortIT {
 
 	private SearchQuery<DocumentReference> simpleQuery(Consumer<? super SearchSortContainerContext> sortContributor, StubMappingSearchScope scope) {
 		return scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.sort( sortContributor )
 				.toQuery();
@@ -338,7 +337,6 @@ public class FieldSearchSortIT {
 		thrown.expectMessage( INDEX_NAME );
 
 		scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.sort( c -> c.byField( absoluteFieldPath ) )
 				.toQuery();
@@ -359,7 +357,6 @@ public class FieldSearchSortIT {
 		thrown.expectMessage( INDEX_NAME );
 
 		scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.sort( c -> c.byField( absoluteFieldPath ) )
 				.toQuery();
@@ -380,7 +377,6 @@ public class FieldSearchSortIT {
 		thrown.expectMessage( INDEX_NAME );
 
 		scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.sort( c -> c.byField( absoluteFieldPath ) )
 				.toQuery();
@@ -632,17 +628,14 @@ public class FieldSearchSortIT {
 
 		// Check that all documents are searchable
 		SearchQuery<DocumentReference> query = indexManager.createSearchScope().query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3, EMPTY );
 		query = compatibleIndexManager.createSearchScope().query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( COMPATIBLE_INDEX_NAME, COMPATIBLE_INDEX_DOCUMENT_1 );
 		query = rawFieldCompatibleIndexManager.createSearchScope().query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( RAW_FIELD_COMPATIBLE_INDEX_NAME, RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/SearchSortIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/SearchSortIT.java
@@ -89,7 +89,6 @@ public class SearchSortIT {
 	private SearchQuery<DocumentReference> simpleQuery(Consumer<? super SearchSortContainerContext> sortContributor) {
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		return scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.sort( sortContributor )
 				.toQuery();
@@ -130,7 +129,6 @@ public class SearchSortIT {
 				.match().onField( "string_analyzed_forScore" ).matching( "hooray" ).toPredicate();
 
 		query = scope.query()
-				.asReference()
 				.predicate( predicate )
 				.sort( c -> c.byScore() )
 				.toQuery();
@@ -138,7 +136,6 @@ public class SearchSortIT {
 				.hasDocRefHitsExactOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( predicate )
 				.sort( c -> c.byScore().desc() )
 				.toQuery();
@@ -146,7 +143,6 @@ public class SearchSortIT {
 				.hasDocRefHitsExactOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( predicate )
 				.sort( c -> c.byScore().asc() )
 				.toQuery();
@@ -164,7 +160,6 @@ public class SearchSortIT {
 				.toSort();
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.sort( sortAsc )
 				.toQuery();
@@ -172,7 +167,6 @@ public class SearchSortIT {
 				.hasDocRefHitsExactOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID, EMPTY_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.sort( c -> c.by( sortAsc ) )
 				.toQuery();
@@ -184,7 +178,6 @@ public class SearchSortIT {
 				.toSort();
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.sort( sortDesc )
 				.toQuery();
@@ -192,7 +185,6 @@ public class SearchSortIT {
 				.hasDocRefHitsExactOrder( INDEX_NAME, THIRD_ID, SECOND_ID, FIRST_ID, EMPTY_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.sort( c -> c.by( sortDesc ) )
 				.toQuery();
@@ -474,7 +466,6 @@ public class SearchSortIT {
 		// Check that all documents are searchable
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID, EMPTY_ID );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/AbstractSpatialWithinSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/AbstractSpatialWithinSearchPredicateIT.java
@@ -98,7 +98,6 @@ public abstract class AbstractSpatialWithinSearchPredicateIT {
 		// Check that all documents are searchable
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, IMOUTO_ID, CHEZ_MARGOTTE_ID, EMPTY_ID );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/SpatialWithinBoundingBoxSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/SpatialWithinBoundingBoxSearchPredicateIT.java
@@ -57,7 +57,6 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within().onField( "geoPoint" ).boundingBox( BOUNDING_BOX_2 ) )
 				.toQuery();
 
@@ -65,7 +64,6 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 				.hasDocRefHitsAnyOrder( INDEX_NAME, IMOUTO_ID, CHEZ_MARGOTTE_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within().onField( "geoPoint" ).boundingBox( BOUNDING_BOX_1 ) )
 				.toQuery();
 
@@ -73,7 +71,6 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 				.hasDocRefHitsAnyOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, IMOUTO_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within().onField( "geoPoint" )
 						.boundingBox( BOUNDING_BOX_2.getTopLeft().getLatitude(), BOUNDING_BOX_2.getTopLeft().getLongitude(),
 								BOUNDING_BOX_2.getBottomRight().getLatitude(), BOUNDING_BOX_2.getBottomRight().getLongitude() )
@@ -84,7 +81,6 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 				.hasDocRefHitsAnyOrder( INDEX_NAME, IMOUTO_ID, CHEZ_MARGOTTE_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within().onField( "geoPoint" )
 						.boundingBox( BOUNDING_BOX_1.getTopLeft().getLatitude(), BOUNDING_BOX_1.getTopLeft().getLongitude(),
 								BOUNDING_BOX_1.getBottomRight().getLatitude(), BOUNDING_BOX_1.getBottomRight().getLongitude() )
@@ -100,7 +96,6 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within().onField( "geoPoint" )
 						.boundingBox( GeoBoundingBox.of( GeoPoint.of( 25, 23 ), GeoPoint.of( 24, 26 ) ) )
 				)
@@ -131,7 +126,6 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// Base score: less than 2
 						.should( f.spatial().within().onField( "geoPoint" )
@@ -150,7 +144,6 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 				.hasDocRefHitsExactOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, CHEZ_MARGOTTE_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// Base score boosted 42x: more than 2
 						.should( f.spatial().within().onField( "geoPoint" ).boostedTo( 42 )
@@ -174,7 +167,6 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// Base score: less than 2
 						.should( f.spatial().within().onField( "geoPoint" )
@@ -193,7 +185,6 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 				.hasDocRefHitsExactOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, CHEZ_MARGOTTE_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// Base score boosted 39x: more than 2
 						.should( f.spatial().within().onField( "geoPoint" )
@@ -218,7 +209,6 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// Base score boosted 2*3=6x: less than 8
 						.should( f.spatial().within().onField( "geoPoint" ).boostedTo( 3 )
@@ -238,7 +228,6 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 				.hasDocRefHitsExactOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, CHEZ_MARGOTTE_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// Base score boosted 3*4=12x: more than 8
 						.should( f.spatial().within().onField( "geoPoint" ).boostedTo( 4 )
@@ -263,7 +252,6 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// Base score boosted 0.001x: less than 2
 						.should( f.spatial().within().onField( "geoPoint" )
@@ -284,7 +272,6 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 				.hasDocRefHitsExactOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, CHEZ_MARGOTTE_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// Base score boosted 39x: more than 2
 						.should( f.spatial().within().onField( "geoPoint" )
@@ -312,7 +299,6 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 		// onField(...).orField(...)
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within().onField( "geoPoint" ).orField( "geoPoint_1" ).boundingBox( BOUNDING_BOX_1 ) )
 				.toQuery();
 
@@ -320,7 +306,6 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 				.hasDocRefHitsAnyOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, IMOUTO_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within().onField( "geoPoint" ).orField( "geoPoint_1" ).boundingBox( BOUNDING_BOX_2_1 ) )
 				.toQuery();
 
@@ -330,7 +315,6 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 		// onField().orFields(...)
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within().onField( "geoPoint" ).orFields( "geoPoint_1" ).orFields( "geoPoint_2" )
 						.boundingBox( BOUNDING_BOX_2 )
 				)
@@ -340,7 +324,6 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 				.hasDocRefHitsAnyOrder( INDEX_NAME, IMOUTO_ID, CHEZ_MARGOTTE_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within().onField( "geoPoint" ).orFields( "geoPoint_1" ).orFields( "geoPoint_2" )
 						.boundingBox( BOUNDING_BOX_1_1 )
 				)
@@ -350,7 +333,6 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 				.hasDocRefHitsAnyOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, IMOUTO_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within().onField( "geoPoint" ).orFields( "geoPoint_1" ).orFields( "geoPoint_2" )
 						.boundingBox( BOUNDING_BOX_2_2 )
 				)
@@ -362,7 +344,6 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 		// onFields(...)
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within().onFields( "geoPoint", "geoPoint_2" ).boundingBox( BOUNDING_BOX_2 ) )
 				.toQuery();
 
@@ -370,7 +351,6 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 				.hasDocRefHitsAnyOrder( INDEX_NAME, CHEZ_MARGOTTE_ID, IMOUTO_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within().onFields( "geoPoint", "geoPoint_2" ).boundingBox( BOUNDING_BOX_1_2 ) )
 				.toQuery();
 
@@ -423,7 +403,6 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 		// Check that all documents are searchable
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, IMOUTO_ID, CHEZ_MARGOTTE_ID, EMPTY_ID, ADDITIONAL_POINT_1_ID,

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/SpatialWithinCircleSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/SpatialWithinCircleSearchPredicateIT.java
@@ -37,7 +37,6 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within()
 						.onField( "geoPoint" )
 						.circle( METRO_GARIBALDI, 1_500 )
@@ -48,7 +47,6 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 				.hasDocRefHitsAnyOrder( INDEX_NAME, CHEZ_MARGOTTE_ID, IMOUTO_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within()
 						.onField( "geoPoint" )
 						.circle( METRO_HOTEL_DE_VILLE, 500 )
@@ -59,7 +57,6 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 				.hasDocRefHitsAnyOrder( INDEX_NAME, OURSON_QUI_BOIT_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within()
 						.onField( "geoPoint" )
 						.circle( METRO_GARIBALDI.getLatitude(), METRO_GARIBALDI.getLongitude(), 1_500 )
@@ -70,7 +67,6 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 				.hasDocRefHitsAnyOrder( INDEX_NAME, CHEZ_MARGOTTE_ID, IMOUTO_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within()
 						.onField( "geoPoint" )
 						.circle( METRO_GARIBALDI.getLatitude(), METRO_GARIBALDI.getLongitude(), 1.5, DistanceUnit.KILOMETERS )
@@ -81,7 +77,6 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 				.hasDocRefHitsAnyOrder( INDEX_NAME, CHEZ_MARGOTTE_ID, IMOUTO_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within()
 						.onField( "geoPoint" )
 						.circle( METRO_GARIBALDI, 1.5, DistanceUnit.KILOMETERS )
@@ -115,7 +110,6 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// Base score: less than 2
 						.should( f.spatial().within()
@@ -135,7 +129,6 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 				.hasDocRefHitsExactOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, CHEZ_MARGOTTE_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// Base score boosted 42x: more than 2
 						.should( f.spatial().within()
@@ -160,7 +153,6 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// Base score boosted 0.123x: less than 2
 						.should( f.spatial().within()
@@ -181,7 +173,6 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 				.hasDocRefHitsExactOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, CHEZ_MARGOTTE_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// Base score boosted 39x: more than 2
 						.should( f.spatial().within()
@@ -207,7 +198,6 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// Base score boosted 0.123*4=0.492x: less than 2
 						.should( f.spatial().within()
@@ -228,7 +218,6 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 				.hasDocRefHitsExactOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, CHEZ_MARGOTTE_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// Base score boosted 39*7*4=273x: more than 2
 						.should( f.spatial().within()
@@ -254,7 +243,6 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// Base score boosted 0.123x: less than 2
 						.should( f.spatial().within()
@@ -275,7 +263,6 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 				.hasDocRefHitsExactOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, CHEZ_MARGOTTE_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// Base score boosted 39x: more than 2
 						.should( f.spatial().within()
@@ -303,7 +290,6 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 		// onField(...).orField(...)
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within()
 						.onField( "geoPoint" ).orField( "geoPoint_1" )
 						.circle( METRO_GARIBALDI, 400 )
@@ -314,7 +300,6 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 				.hasDocRefHitsAnyOrder( INDEX_NAME, CHEZ_MARGOTTE_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within()
 						.onField( "geoPoint" ).orField( "geoPoint_1" )
 						.circle( METRO_HOTEL_DE_VILLE_1, 500 )
@@ -327,7 +312,6 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 		// onField().orFields(...)
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within()
 						.onField( "geoPoint" ).orFields( "geoPoint_1" ).orFields( "geoPoint_2" )
 						.circle( METRO_HOTEL_DE_VILLE, 500 )
@@ -338,7 +322,6 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 				.hasDocRefHitsAnyOrder( INDEX_NAME, OURSON_QUI_BOIT_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within()
 						.onField( "geoPoint" ).orFields( "geoPoint_1" ).orFields( "geoPoint_2" )
 						.circle( METRO_GARIBALDI_1, 1_500 )
@@ -349,7 +332,6 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 				.hasDocRefHitsAnyOrder( INDEX_NAME, CHEZ_MARGOTTE_ID, IMOUTO_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within()
 						.onField( "geoPoint" ).orFields( "geoPoint_1" ).orFields( "geoPoint_2" )
 						.circle( METRO_GARIBALDI_2, 400 )
@@ -362,7 +344,6 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 		// onFields(...)
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within()
 						.onFields( "geoPoint", "geoPoint_2" )
 						.circle( METRO_GARIBALDI, 400 )
@@ -373,7 +354,6 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 				.hasDocRefHitsAnyOrder( INDEX_NAME, CHEZ_MARGOTTE_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within()
 						.onFields( "geoPoint", "geoPoint_2" )
 						.circle( METRO_HOTEL_DE_VILLE_2, 500 )

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/SpatialWithinPolygonSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/SpatialWithinPolygonSearchPredicateIT.java
@@ -59,7 +59,6 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within().onField( "geoPoint" ).polygon( POLYGON_2 ) )
 				.toQuery();
 
@@ -67,7 +66,6 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 				.hasDocRefHitsAnyOrder( INDEX_NAME, IMOUTO_ID, CHEZ_MARGOTTE_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within().onField( "geoPoint" ).polygon( POLYGON_1 ) )
 				.toQuery();
 
@@ -96,7 +94,6 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// Base score: less than 2
 						.should( f.spatial().within().onField( "geoPoint" ).polygon( CHEZ_MARGOTTE_POLYGON ) )
@@ -113,7 +110,6 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 				.hasDocRefHitsExactOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, CHEZ_MARGOTTE_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// Base score boosted 42x: more than 2
 						.should( f.spatial().within().onField( "geoPoint" ).boostedTo( 42 ).polygon( CHEZ_MARGOTTE_POLYGON ) )
@@ -135,7 +131,6 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// Base score: less than 2
 						.should( f.spatial().within().onField( "geoPoint" )
@@ -155,7 +150,6 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 				.hasDocRefHitsExactOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, CHEZ_MARGOTTE_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// Base score boosted 39x: more than 2
 						.should( f.spatial().within().onField( "geoPoint" )
@@ -180,7 +174,6 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// Base score boosted 0.1*7=0.7x: less than 8
 						.should( f.spatial().within().onField( "geoPoint" ).boostedTo( 7 )
@@ -200,7 +193,6 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 				.hasDocRefHitsExactOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, CHEZ_MARGOTTE_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// Base score boosted 39*10=390x: more than 8
 						.should( f.spatial().within().onField( "geoPoint" ).boostedTo( 10 )
@@ -225,7 +217,6 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 		StubMappingSearchScope scope = indexManager.createSearchScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// Base score boosted 0.1x: less than 2
 						.should( f.spatial().within().onField( "geoPoint" )
@@ -246,7 +237,6 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 				.hasDocRefHitsExactOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, CHEZ_MARGOTTE_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.bool()
 						// Base score boosted 39x: more than 2
 						.should( f.spatial().within().onField( "geoPoint" )
@@ -274,7 +264,6 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 		// onField(...).orField(...)
 
 		SearchQuery<DocumentReference> query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within().onField( "geoPoint" ).orField( "geoPoint_1" ).polygon( POLYGON_1 ) )
 				.toQuery();
 
@@ -282,7 +271,6 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 				.hasDocRefHitsAnyOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, IMOUTO_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within().onField( "geoPoint" ).orField( "geoPoint_1" ).polygon( POLYGON_2_1 ) )
 				.toQuery();
 
@@ -292,7 +280,6 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 		// onField().orFields(...)
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within().onField( "geoPoint" ).orFields( "geoPoint_1" ).orFields( "geoPoint_2" )
 						.polygon( POLYGON_2 )
 				)
@@ -302,7 +289,6 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 				.hasDocRefHitsAnyOrder( INDEX_NAME, IMOUTO_ID, CHEZ_MARGOTTE_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within().onField( "geoPoint" ).orFields( "geoPoint_1" ).orFields( "geoPoint_2" )
 						.polygon( POLYGON_1_1 )
 				)
@@ -312,7 +298,6 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 				.hasDocRefHitsAnyOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, IMOUTO_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within().onField( "geoPoint" ).orFields( "geoPoint_1" ).orFields( "geoPoint_2" )
 						.polygon( POLYGON_2_2 )
 				)
@@ -324,7 +309,6 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 		// onFields(...)
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within().onFields( "geoPoint", "geoPoint_2" ).polygon( POLYGON_2 ) )
 				.toQuery();
 
@@ -332,7 +316,6 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 				.hasDocRefHitsAnyOrder( INDEX_NAME, CHEZ_MARGOTTE_ID, IMOUTO_ID );
 
 		query = scope.query()
-				.asReference()
 				.predicate( f -> f.spatial().within().onFields( "geoPoint", "geoPoint_2" ).polygon( POLYGON_1_2 ) )
 				.toQuery();
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexDocumentWorkExecutorIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexDocumentWorkExecutorIT.java
@@ -71,7 +71,6 @@ public class IndexDocumentWorkExecutorIT {
 		workExecutor.flush().join();
 
 		SearchQuery<DocumentReference> query = indexManager.createSearchScope().query()
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkExecutorIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkExecutorIT.java
@@ -129,7 +129,6 @@ public class IndexWorkExecutorIT {
 
 	private void assertBookNumberIsEqualsTo(long bookNumber, StubSessionContext sessionContext) {
 		SearchQuery<DocumentReference> query = indexManager.createSearchScope().query( sessionContext )
-				.asReference()
 				.predicate( f -> f.matchAll() )
 				.toQuery();
 

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchDocumentRepositoryImpl.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchDocumentRepositoryImpl.java
@@ -34,7 +34,6 @@ public class IndexSearchDocumentRepositoryImpl implements IndexSearchDocumentRep
 	public List<Book> findAllIndexed() {
 		return Search.getSearchSession( entityManager )
 				.search( Book.class )
-				.asEntity()
 				.predicate( p -> p.matchAll() )
 				.fetchHits();
 	}
@@ -46,7 +45,6 @@ public class IndexSearchDocumentRepositoryImpl implements IndexSearchDocumentRep
 		}
 
 		return Search.getSearchSession( entityManager ).search( Book.class )
-				.asEntity()
 				// onRawField option allows to bypass the bridge in the DSL
 				.predicate( f -> f.match().onField( "isbn" ).matching( isbnAsString, DslConverter.DISABLED ) )
 				.fetchSingleHit();
@@ -55,7 +53,6 @@ public class IndexSearchDocumentRepositoryImpl implements IndexSearchDocumentRep
 	@Override
 	public List<Book> searchByMedium(String terms, BookMedium medium, int limit, int offset) {
 		return Search.getSearchSession( entityManager ).search( Book.class )
-				.asEntity()
 				.predicate( f -> f.bool( b -> {
 					if ( terms != null && !terms.isEmpty() ) {
 						b.must( f.match()
@@ -78,7 +75,6 @@ public class IndexSearchDocumentRepositoryImpl implements IndexSearchDocumentRep
 			List<LibraryServiceOption> libraryServices,
 			int limit, int offset) {
 		return Search.getSearchSession( entityManager ).search( DOCUMENT_CLASS )
-				.asEntity()
 				.predicate( f -> f.bool( b -> {
 					// Match query
 					if ( terms != null && !terms.isEmpty() ) {

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchDocumentRepositoryImpl.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchDocumentRepositoryImpl.java
@@ -19,7 +19,6 @@ import org.hibernate.search.integrationtest.showcase.library.model.BookMedium;
 import org.hibernate.search.integrationtest.showcase.library.model.Document;
 import org.hibernate.search.integrationtest.showcase.library.model.LibraryServiceOption;
 import org.hibernate.search.mapper.orm.Search;
-import org.hibernate.search.engine.search.query.SearchQuery;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -33,13 +32,11 @@ public class IndexSearchDocumentRepositoryImpl implements IndexSearchDocumentRep
 
 	@Override
 	public List<Book> findAllIndexed() {
-		SearchQuery<Book> query = Search.getSearchSession( entityManager )
+		return Search.getSearchSession( entityManager )
 				.search( Book.class )
 				.asEntity()
 				.predicate( p -> p.matchAll() )
-				.toQuery();
-
-		return query.fetchHits();
+				.fetchHits();
 	}
 
 	@Override
@@ -48,18 +45,16 @@ public class IndexSearchDocumentRepositoryImpl implements IndexSearchDocumentRep
 			return Optional.empty();
 		}
 
-		SearchQuery<Book> query = Search.getSearchSession( entityManager ).search( Book.class )
-						.asEntity()
-						// onRawField option allows to bypass the bridge in the DSL
-						.predicate( f -> f.match().onField( "isbn" ).matching( isbnAsString, DslConverter.DISABLED ) )
-						.toQuery();
-
-		return query.fetchSingleHit();
+		return Search.getSearchSession( entityManager ).search( Book.class )
+				.asEntity()
+				// onRawField option allows to bypass the bridge in the DSL
+				.predicate( f -> f.match().onField( "isbn" ).matching( isbnAsString, DslConverter.DISABLED ) )
+				.fetchSingleHit();
 	}
 
 	@Override
 	public List<Book> searchByMedium(String terms, BookMedium medium, int limit, int offset) {
-		SearchQuery<Book> query = Search.getSearchSession( entityManager ).search( Book.class )
+		return Search.getSearchSession( entityManager ).search( Book.class )
 				.asEntity()
 				.predicate( f -> f.bool( b -> {
 					if ( terms != null && !terms.isEmpty() ) {
@@ -74,9 +69,7 @@ public class IndexSearchDocumentRepositoryImpl implements IndexSearchDocumentRep
 					);
 				} ) )
 				.sort( b -> b.byField( "title_sort" ) )
-				.toQuery();
-
-		return query.fetchHits( limit, offset );
+				.fetchHits( limit, offset );
 	}
 
 	@Override
@@ -84,7 +77,7 @@ public class IndexSearchDocumentRepositoryImpl implements IndexSearchDocumentRep
 			GeoPoint myLocation, Double maxDistanceInKilometers,
 			List<LibraryServiceOption> libraryServices,
 			int limit, int offset) {
-		SearchQuery<Document<?>> query = Search.getSearchSession( entityManager ).search( DOCUMENT_CLASS )
+		return Search.getSearchSession( entityManager ).search( DOCUMENT_CLASS )
 				.asEntity()
 				.predicate( f -> f.bool( b -> {
 					// Match query
@@ -139,14 +132,12 @@ public class IndexSearchDocumentRepositoryImpl implements IndexSearchDocumentRep
 					}
 					b.byScore();
 				} )
-				.toQuery();
-
-		return query.fetchHits( limit, offset );
+				.fetchHits( limit, offset );
 	}
 
 	@Override
 	public List<String> getAuthorsOfBooksHavingTerms(String terms, SortOrder order) {
-		SearchQuery<String> query = Search.getSearchSession( entityManager ).search( Document.class )
+		return Search.getSearchSession( entityManager ).search( Document.class )
 				.asProjection( f -> f.field( "author", String.class ) )
 				.predicate( f -> f.match()
 						.onField( "title" ).boostedTo( 2.0f )
@@ -154,8 +145,6 @@ public class IndexSearchDocumentRepositoryImpl implements IndexSearchDocumentRep
 						.matching( terms )
 				)
 				.sort( b -> b.byField( "author" ).order( order ) )
-				.toQuery();
-
-		return query.fetchHits();
+				.fetchHits();
 	}
 }

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchLibraryRepositoryImpl.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchLibraryRepositoryImpl.java
@@ -27,7 +27,6 @@ public class IndexSearchLibraryRepositoryImpl implements IndexSearchLibraryRepos
 		}
 		return Search.getSearchSession( entityManager )
 				.search( Library.class )
-				.asEntity()
 				.predicate( f -> f.match().onField( "name" ).matching( terms ) )
 				.sort( c -> {
 					c.byField( "collectionSize" ).desc();

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchLibraryRepositoryImpl.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchLibraryRepositoryImpl.java
@@ -12,7 +12,6 @@ import javax.persistence.EntityManager;
 
 import org.hibernate.search.integrationtest.showcase.library.model.Library;
 import org.hibernate.search.mapper.orm.Search;
-import org.hibernate.search.engine.search.query.SearchQuery;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -26,7 +25,7 @@ public class IndexSearchLibraryRepositoryImpl implements IndexSearchLibraryRepos
 		if ( terms == null || terms.isEmpty() ) {
 			return Collections.emptyList();
 		}
-		SearchQuery<Library> query = Search.getSearchSession( entityManager )
+		return Search.getSearchSession( entityManager )
 				.search( Library.class )
 				.asEntity()
 				.predicate( f -> f.match().onField( "name" ).matching( terms ) )
@@ -34,8 +33,6 @@ public class IndexSearchLibraryRepositoryImpl implements IndexSearchLibraryRepos
 					c.byField( "collectionSize" ).desc();
 					c.byField( "name_sort" );
 				} )
-				.toQuery();
-
-		return query.fetchHits( limit, offset );
+				.fetchHits( limit, offset );
 	}
 }

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchPersonRepositoryImpl.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchPersonRepositoryImpl.java
@@ -12,7 +12,6 @@ import javax.persistence.EntityManager;
 
 import org.hibernate.search.integrationtest.showcase.library.model.Person;
 import org.hibernate.search.mapper.orm.Search;
-import org.hibernate.search.engine.search.query.SearchQuery;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -42,26 +41,22 @@ public class IndexSearchPersonRepositoryImpl implements IndexSearchPersonReposit
 			return Collections.emptyList();
 		}
 
-		SearchQuery<Person> query = Search.getSearchSession( entityManager ).search( Person.class )
+		return Search.getSearchSession( entityManager ).search( Person.class )
 				.asEntity()
 				.predicate( f -> f.match().onFields( "firstName", "lastName" ).matching( terms ) )
 				.sort( c -> {
 					c.byField( "lastName_sort" );
 					c.byField( "firstName_sort" );
 				} )
-				.toQuery();
-
-		return query.fetchHits( limit, offset );
+				.fetchHits( limit, offset );
 	}
 
 	private List<Person> listTopBorrowers(String borrowalsCountField, int limit, int offset) {
-		SearchQuery<Person> query = Search.getSearchSession( entityManager ).search( Person.class )
+		return Search.getSearchSession( entityManager ).search( Person.class )
 				.asEntity()
 				.predicate( f -> f.matchAll() )
 				.sort( c -> c.byField( borrowalsCountField ).desc() )
-				.toQuery();
-
-		return query.fetchHits( limit, offset );
+				.fetchHits( limit, offset );
 	}
 
 }

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchPersonRepositoryImpl.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchPersonRepositoryImpl.java
@@ -42,7 +42,6 @@ public class IndexSearchPersonRepositoryImpl implements IndexSearchPersonReposit
 		}
 
 		return Search.getSearchSession( entityManager ).search( Person.class )
-				.asEntity()
 				.predicate( f -> f.match().onFields( "firstName", "lastName" ).matching( terms ) )
 				.sort( c -> {
 					c.byField( "lastName_sort" );
@@ -53,7 +52,6 @@ public class IndexSearchPersonRepositoryImpl implements IndexSearchPersonReposit
 
 	private List<Person> listTopBorrowers(String borrowalsCountField, int limit, int offset) {
 		return Search.getSearchSession( entityManager ).search( Person.class )
-				.asEntity()
 				.predicate( f -> f.matchAll() )
 				.sort( c -> c.byField( borrowalsCountField ).desc() )
 				.fetchHits( limit, offset );

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/search/SearchScope.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/search/SearchScope.java
@@ -36,7 +36,7 @@ public interface SearchScope {
 	 * and ultimately {@link SearchQueryContext#toQuery() get the resulting query}.
 	 * @see SearchQueryResultDefinitionContext
 	 */
-	SearchQueryResultDefinitionContext<PojoReference, ?, ?> search();
+	SearchQueryResultDefinitionContext<?, PojoReference, ?, ?, ?> search();
 
 	/**
 	 * Initiate the building of a search predicate.

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/search/impl/SearchScopeImpl.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/search/impl/SearchScopeImpl.java
@@ -24,7 +24,7 @@ public class SearchScopeImpl implements SearchScope {
 	}
 
 	@Override
-	public SearchQueryResultDefinitionContext<PojoReference, ?, ?> search() {
+	public SearchQueryResultDefinitionContext<?, PojoReference, ?, ?, ?> search() {
 		return delegate.search( new JavaBeanLoadingContext.Builder( delegate ) );
 	}
 

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/session/SearchSession.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/session/SearchSession.java
@@ -34,7 +34,7 @@ public interface SearchSession extends AutoCloseable {
 	 * and ultimately {@link SearchQueryContext#toQuery() get the resulting query}.
 	 * @see SearchQueryResultDefinitionContext
 	 */
-	default SearchQueryResultDefinitionContext<PojoReference, ?, ?> search(Class<?> type) {
+	default SearchQueryResultDefinitionContext<?, PojoReference, ?, ?, ?> search(Class<?> type) {
 		return scope( type ).search();
 	}
 
@@ -48,7 +48,7 @@ public interface SearchSession extends AutoCloseable {
 	 * and ultimately {@link SearchQueryContext#toQuery() get the resulting query}.
 	 * @see SearchQueryResultDefinitionContext
 	 */
-	default SearchQueryResultDefinitionContext<PojoReference, ?, ?> search(Collection<? extends Class<?>> types) {
+	default SearchQueryResultDefinitionContext<?, PojoReference, ?, ?, ?> search(Collection<? extends Class<?>> types) {
 		return scope( types ).search();
 	}
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/dsl/query/HibernateOrmSearchQueryResultDefinitionContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/dsl/query/HibernateOrmSearchQueryResultDefinitionContext.java
@@ -7,16 +7,20 @@
 package org.hibernate.search.mapper.orm.search.dsl.query;
 
 import org.hibernate.query.Query;
+import org.hibernate.search.engine.search.dsl.predicate.SearchPredicateFactoryContext;
 import org.hibernate.search.engine.search.dsl.projection.SearchProjectionFactoryContext;
+import org.hibernate.search.engine.search.dsl.query.SearchQueryContext;
 import org.hibernate.search.engine.search.dsl.query.SearchQueryResultDefinitionContext;
 import org.hibernate.search.mapper.pojo.search.PojoReference;
 
 public interface HibernateOrmSearchQueryResultDefinitionContext<E>
 		extends SearchQueryResultDefinitionContext<
+				SearchQueryContext<?, E, ?>,
 				PojoReference,
 				E,
-				SearchProjectionFactoryContext<PojoReference, E>
-				> {
+				SearchProjectionFactoryContext<PojoReference, E>,
+				SearchPredicateFactoryContext
+		> {
 
 	/**
 	 * Set the JDBC fetch size for this query.

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/dsl/query/impl/HibernateOrmSearchQueryResultDefinitionContextImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/dsl/query/impl/HibernateOrmSearchQueryResultDefinitionContextImpl.java
@@ -18,7 +18,7 @@ public class HibernateOrmSearchQueryResultDefinitionContextImpl<E>
 	private final MutableEntityLoadingOptions loadingOptions;
 
 	public HibernateOrmSearchQueryResultDefinitionContextImpl(
-			SearchQueryResultDefinitionContext<PojoReference, E, ?> delegate,
+			SearchQueryResultDefinitionContext<?, PojoReference, E, ?, ?> delegate,
 			MutableEntityLoadingOptions loadingOptions) {
 		super( delegate );
 		this.loadingOptions = loadingOptions;

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoSearchScopeDelegateImpl.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoSearchScopeDelegateImpl.java
@@ -58,7 +58,7 @@ class PojoSearchScopeDelegateImpl<E, E2> implements PojoSearchScopeDelegate<E, E
 	}
 
 	@Override
-	public SearchQueryResultDefinitionContext<PojoReference, E2, SearchProjectionFactoryContext<PojoReference, E2>> search(
+	public SearchQueryResultDefinitionContext<?, PojoReference, E2, SearchProjectionFactoryContext<PojoReference, E2>, ?> search(
 			LoadingContextBuilder<PojoReference, E2> loadingContextBuilder) {
 		return getDelegate().search( sessionContext, loadingContextBuilder );
 	}

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/search/spi/PojoSearchScopeDelegate.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/search/spi/PojoSearchScopeDelegate.java
@@ -27,7 +27,7 @@ public interface PojoSearchScopeDelegate<E, E2> {
 
 	PojoReference toPojoReference(DocumentReference documentReference);
 
-	SearchQueryResultDefinitionContext<PojoReference, E2, SearchProjectionFactoryContext<PojoReference, E2>> search(
+	SearchQueryResultDefinitionContext<?, PojoReference, E2, SearchProjectionFactoryContext<PojoReference, E2>, ?> search(
 			LoadingContextBuilder<PojoReference, E2> loadingContextBuilder);
 
 	SearchPredicateFactoryContext predicate();

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/GenericStubMappingSearchScope.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/GenericStubMappingSearchScope.java
@@ -27,11 +27,11 @@ public class GenericStubMappingSearchScope<R, E> {
 		this.delegate = delegate;
 	}
 
-	public SearchQueryResultDefinitionContext<R, E, ?> query(LoadingContext<R, E> loadingContext) {
+	public SearchQueryResultDefinitionContext<?, R, E, ?, ?> query(LoadingContext<R, E> loadingContext) {
 		return query( new StubSessionContext(), loadingContext );
 	}
 
-	public SearchQueryResultDefinitionContext<R, E, ?> query(StubSessionContext sessionContext,
+	public SearchQueryResultDefinitionContext<?, R, E, ?, ?> query(StubSessionContext sessionContext,
 			LoadingContext<R, E> loadingContext) {
 		LoadingContextBuilder<R, E> loadingContextBuilder = () -> loadingContext;
 		return delegate.search( sessionContext, loadingContextBuilder );

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/StubMappingSearchScope.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/StubMappingSearchScope.java
@@ -23,11 +23,11 @@ public class StubMappingSearchScope extends GenericStubMappingSearchScope<Docume
 		super( delegate );
 	}
 
-	public SearchQueryResultDefinitionContext<DocumentReference, DocumentReference, ?> query() {
+	public SearchQueryResultDefinitionContext<?, DocumentReference, DocumentReference, ?, ?> query() {
 		return query( new StubLoadingContext() );
 	}
 
-	public SearchQueryResultDefinitionContext<DocumentReference, DocumentReference, ?> query(
+	public SearchQueryResultDefinitionContext<?, DocumentReference, DocumentReference, ?, ?> query(
 			StubSessionContext sessionContext) {
 		return query( sessionContext, new StubLoadingContext() );
 	}


### PR DESCRIPTION
[HSEARCH-3578](https://hibernate.atlassian.net//browse/HSEARCH-3578): Make the call to asXXX() (asEntity, asReference) optional in the Search DSL

Based on #1984 , which should be merged first.

I'm not very happy with how complex the generics are becoming in DSL interfaces, but that's the only way to make `asEntity()` optional, unfortunately: we need to make the first DSL interface as complex as the one it allows to "take a shortcut to".