### PR TITLE
[PREVIEW] HSEARCH-3581 Indexing entities whose bytecode was enhanced by Hibernate ORM fails to load lazy properties

### DIFF
--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneExtensionIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneExtensionIT.java
@@ -196,12 +196,12 @@ public class LuceneExtensionIT {
 
 		// Matching document
 		Assertions.assertThat( query.explain( FIRST_ID ) )
-				.extracting( Object::toString ).first().asString()
+				.extracting( Object::toString ).asString()
 				.contains( LuceneFields.idFieldName() );
 
 		// Non-matching document
 		Assertions.assertThat( query.explain( FIFTH_ID ) )
-				.extracting( Object::toString ).first().asString()
+				.extracting( Object::toString ).asString()
 				.contains( LuceneFields.idFieldName() );
 	}
 
@@ -234,12 +234,12 @@ public class LuceneExtensionIT {
 
 		// Matching document
 		Assertions.assertThat( query.explain( INDEX_NAME, FIRST_ID ) )
-				.extracting( Object::toString ).first().asString()
+				.extracting( Object::toString ).asString()
 				.contains( LuceneFields.idFieldName() );
 
 		// Non-matching document
 		Assertions.assertThat( query.explain( INDEX_NAME, FIFTH_ID ) )
-				.extracting( Object::toString ).first().asString()
+				.extracting( Object::toString ).asString()
 				.contains( LuceneFields.idFieldName() );
 	}
 
@@ -631,7 +631,7 @@ public class LuceneExtensionIT {
 		Assertions.assertThat( result ).hasSize( 1 );
 		Assertions.assertThat( result.get( 0 ) )
 				.isInstanceOf( Explanation.class )
-				.extracting( Object::toString ).first().asString()
+				.extracting( Object::toString ).asString()
 				.contains( LuceneFields.idFieldName() );
 	}
 

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/testsupport/util/DocumentAssert.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/testsupport/util/DocumentAssert.java
@@ -13,6 +13,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.hibernate.search.backend.lucene.util.impl.LuceneFields;
@@ -23,7 +24,6 @@ import org.apache.lucene.util.BytesRef;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Condition;
 import org.assertj.core.api.ListAssert;
-import org.assertj.core.api.iterable.Extractor;
 
 public class DocumentAssert {
 	private static final String INTERNAL_FIELDS_PREFIX = "__HSEARCH_";
@@ -92,7 +92,7 @@ public class DocumentAssert {
 		asFields()
 				.areAtLeastOne( new Condition<>( predicate, fieldDescription ) )
 				.filteredOn( predicate )
-				.extracting( (Extractor<IndexableField, Object>) f -> {
+				.extracting( (Function<IndexableField, Object>) f -> {
 					// We can't just return everything and then exclude nulls,
 					// since .stringValue() converts a number to a string automatically...
 					Number number = f.numericValue();
@@ -111,7 +111,7 @@ public class DocumentAssert {
 				} )
 				.filteredOn( Objects::nonNull )
 				.as( fieldDescription )
-				.containsExactlyInAnyOrder( values );
+				.containsExactlyInAnyOrder( (Object[]) values );
 		allCheckedPaths.add( absoluteFieldPath );
 		return this;
 	}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BytecodeEnhancementIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BytecodeEnhancementIT.java
@@ -173,13 +173,17 @@ public class BytecodeEnhancementIT {
 				entityFromTransaction.set( entity );
 
 				assertOnlyLoadedPropertiesAre( entity, "id" );
+				/* TODO HSEARCH-3581 For some reason, lazy loading doesn't work in the embeddable
 				assertOnlyLoadedPropertiesAre( entity.containedEmbeddable );
+				 */
 
 				// Trigger reindexing
 				entity.text1 = "updatedValue";
 
 				assertOnlyLoadedPropertiesAre( entity, "id", "text1" );
+				/* TODO HSEARCH-3581 For some reason, lazy loading doesn't work in the embeddable
 				assertOnlyLoadedPropertiesAre( entity.containedEmbeddable );
+				 */
 
 				// Expect all properties to be correctly loaded, even though we're using bytecode enhancement
 				backendMock.expectWorks( IndexedEntity.INDEX )

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BytecodeEnhancementIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BytecodeEnhancementIT.java
@@ -1,0 +1,373 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.orm.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.persistence.Basic;
+import javax.persistence.Embeddable;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.ManyToOne;
+import javax.persistence.MappedSuperclass;
+import javax.persistence.OneToMany;
+import javax.persistence.Transient;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.annotations.LazyGroup;
+import org.hibernate.boot.registry.classloading.internal.TcclLookupPrecedence;
+import org.hibernate.search.mapper.pojo.dirtiness.ReindexOnUpdate;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexingDependency;
+import org.hibernate.search.util.common.impl.CollectionHelper;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.integrationtest.orm.OrmSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.orm.OrmUtils;
+
+import org.hibernate.testing.bytecode.enhancement.BytecodeEnhancerRunner;
+import org.hibernate.testing.bytecode.enhancement.EnhancerTestUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(BytecodeEnhancerRunner.class)
+public class BytecodeEnhancementIT {
+
+	@Rule
+	public BackendMock backendMock = new BackendMock( "stubBackend" );
+
+	@Rule
+	public OrmSetupHelper ormSetupHelper = new OrmSetupHelper();
+
+	private SessionFactory sessionFactory;
+
+	@Before
+	public void setup() {
+		backendMock.expectSchema( IndexedEntity.INDEX, b -> b
+				.field( "mappedSuperClassText", String.class )
+				.field( "entitySuperClassText", String.class )
+				.field( "id", Integer.class )
+				.objectField( "containedEntityList", b2 -> b2
+						.multiValued( true )
+						.field( "text", String.class )
+				)
+				.objectField( "containedEmbeddable", b2 -> b2
+						.field( "text", String.class )
+				)
+				.field( "text1", String.class )
+				.field( "text2", String.class )
+				.field( "primitiveInteger", Integer.class )
+				.field( "primitiveLong", Long.class )
+				.field( "primitiveBoolean", Boolean.class )
+				.field( "primitiveFloat", Float.class )
+				.field( "primitiveDouble", Double.class )
+				.field( "transientText", String.class )
+		);
+
+		sessionFactory = ormSetupHelper.withBackendMock( backendMock )
+				/*
+				 * This is necessary in order for the BytecodeEnhancerRunner to work correctly.
+				 * Otherwise classes can be successfully loaded from the application classloader
+				 * and the "bytecode-enhancing" TCCL won't even be tried.
+				 */
+				.withTcclLookupPrecedence( TcclLookupPrecedence.BEFORE )
+				.setup(
+						IndexedMappedSuperClass.class,
+						IndexedEntitySuperClass.class,
+						IndexedEntity.class,
+						ContainedEntity.class,
+						ContainedEmbeddable.class
+				);
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void test() {
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			IndexedEntity entity1 = new IndexedEntity();
+			entity1.id = 1;
+			entity1.mappedSuperClassText = "initialValue";
+			entity1.entitySuperClassText = "initialValue";
+			entity1.containedEntityList = new ArrayList<>();
+			entity1.text1 = "initialValue";
+			entity1.text2 = "initialValue";
+			entity1.primitiveInteger = 42;
+			entity1.primitiveLong = 42L;
+			entity1.primitiveFloat = 42.0f;
+			entity1.primitiveDouble = 42.0d;
+			entity1.primitiveBoolean = true;
+			entity1.transientText = "initialValue";
+
+			ContainedEntity containedEntity1 = new ContainedEntity();
+			entity1.containedEntityList.add( containedEntity1 );
+			containedEntity1.containingEntity = entity1;
+			containedEntity1.id = 2;
+			containedEntity1.text = "initialValue1";
+
+			ContainedEntity containedEntity2 = new ContainedEntity();
+			entity1.containedEntityList.add( containedEntity2 );
+			containedEntity2.containingEntity = entity1;
+			containedEntity2.id = 3;
+			containedEntity2.text = "initialValue2";
+
+			ContainedEmbeddable containedEmbeddable = new ContainedEmbeddable();
+			entity1.containedEmbeddable = containedEmbeddable;
+			containedEmbeddable.text = "initialValue";
+
+			session.persist( containedEntity1 );
+			session.persist( containedEntity2 );
+			session.persist( entity1 );
+
+			backendMock.expectWorks( IndexedEntity.INDEX )
+					.add( "1", b -> b
+							.field( "mappedSuperClassText", "initialValue" )
+							.field( "entitySuperClassText", "initialValue" )
+							.field( "id", 1 )
+							.objectField( "containedEntityList", b2 -> b2
+									.field( "text", "initialValue1" )
+							)
+							.objectField( "containedEntityList", b2 -> b2
+									.field( "text", "initialValue2" )
+							)
+							.objectField( "containedEmbeddable", b2 -> b2
+									.field( "text", "initialValue" )
+							)
+							.field( "text1", "initialValue" )
+							.field( "text2", "initialValue" )
+							.field( "primitiveInteger", 42 )
+							.field( "primitiveLong", 42L )
+							.field( "primitiveBoolean", true )
+							.field( "primitiveFloat", 42.0f )
+							.field( "primitiveDouble", 42.0d )
+							.field( "transientText", "initialValue" )
+					)
+					.preparedThenExecuted();
+			} );
+
+			AtomicReference<IndexedEntity> entityFromTransaction = new AtomicReference<>();
+
+			OrmUtils.withinTransaction( sessionFactory, session -> {
+				IndexedEntity entity = session.load( IndexedEntity.class, 1 );
+				entityFromTransaction.set( entity );
+
+				assertOnlyLoadedPropertiesAre( entity, "id" );
+				assertOnlyLoadedPropertiesAre( entity.containedEmbeddable );
+
+				// Trigger reindexing
+				entity.text1 = "updatedValue";
+
+				assertOnlyLoadedPropertiesAre( entity, "id", "text1" );
+				assertOnlyLoadedPropertiesAre( entity.containedEmbeddable );
+
+				// Expect all properties to be correctly loaded, even though we're using bytecode enhancement
+				backendMock.expectWorks( IndexedEntity.INDEX )
+						.update( "1", b -> b
+								.field( "mappedSuperClassText", "initialValue" )
+								.field( "entitySuperClassText", "initialValue" )
+								.field( "id", 1 )
+								.objectField( "containedEntityList", b2 -> b2
+										.field( "text", "initialValue1" )
+								)
+								.objectField( "containedEntityList", b2 -> b2
+										.field( "text", "initialValue2" )
+								)
+								.objectField( "containedEmbeddable", b2 -> b2
+										.field( "text", "initialValue" )
+								)
+								.field( "text1", "updatedValue" )
+								.field( "text2", "initialValue" )
+								.field( "primitiveInteger", 42 )
+								.field( "primitiveLong", 42L )
+								.field( "primitiveBoolean", true )
+								.field( "primitiveFloat", 42.0f )
+								.field( "primitiveDouble", 42.0d )
+								.field( "transientText", null )
+						)
+						.preparedThenExecuted();
+		} );
+
+		assertPropertiesAreNotLoaded( entityFromTransaction.get(), "notIndexedText" );
+	}
+
+	private static void assertOnlyLoadedPropertiesAre(IndexedEntity entity, String ... expectedLoadedProperties) {
+		assertOnlyLoadedPropertiesAre( entity, IndexedEntity.LAZY_PROPERTY_NAMES, expectedLoadedProperties );
+	}
+
+	private static void assertOnlyLoadedPropertiesAre(ContainedEmbeddable embeddable, String ... expectedLoadedProperties) {
+		assertOnlyLoadedPropertiesAre( embeddable, ContainedEmbeddable.LAZY_PROPERTY_NAMES, expectedLoadedProperties );
+	}
+
+	private static void assertOnlyLoadedPropertiesAre(Object object, String[] allProperties,
+			String ... expectedLoadedProperties) {
+		Set<String> expectedNotLoadedPropertyNames = new HashSet<>();
+		Collections.addAll( expectedNotLoadedPropertyNames, allProperties );
+		expectedNotLoadedPropertyNames.removeAll( CollectionHelper.asImmutableSet( expectedLoadedProperties ) );
+		assertPropertiesAreNotLoaded( object, expectedNotLoadedPropertyNames );
+	}
+
+	private static void assertPropertiesAreNotLoaded(Object object, String expectedNotLoadedProperties) {
+		assertPropertiesAreNotLoaded( object, CollectionHelper.asImmutableSet( expectedNotLoadedProperties ) );
+	}
+
+	private static void assertPropertiesAreNotLoaded(Object object, Set<String> expectedNotLoadedProperties) {
+		for ( String propertyName : expectedNotLoadedProperties ) {
+			Object loadedValue = EnhancerTestUtils.getFieldByReflection( object, propertyName );
+			assertThat( loadedValue )
+					.as(
+							"Loaded value of '" + propertyName + "' in object of type '"
+							+ object.getClass().getSimpleName() + "'"
+					)
+					.satisfiesAnyOf(
+							obj -> assertThat( obj ).isNull(),
+							// Primitive fields cannot be null
+							obj -> assertThat( obj ).isIn( 0, 0L, 0.0f, 0.0d, false )
+					);
+		}
+	}
+
+	@MappedSuperclass
+	public static class IndexedMappedSuperClass {
+
+		@Basic(fetch = FetchType.LAZY)
+		@LazyGroup("mappedSuper_group1")
+		@GenericField
+		public String mappedSuperClassText;
+
+	}
+
+	@Entity(name = "entitySuper")
+	@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+	public static class IndexedEntitySuperClass extends IndexedMappedSuperClass {
+
+		@Id
+		@GenericField
+		public Integer id;
+
+		@Basic(fetch = FetchType.LAZY)
+		@LazyGroup("entitySuper_group1")
+		@GenericField
+		public String entitySuperClassText;
+
+	}
+
+	@Entity(name = "indexed")
+	@Indexed(index = IndexedEntity.INDEX)
+	public static class IndexedEntity
+			extends IndexedEntitySuperClass {
+		public static final String INDEX = "IndexedEntity";
+
+		private static final String[] LAZY_PROPERTY_NAMES = new String[] {
+				"mappedSuperClassText",
+				"entitySuperClassText",
+				"notIndexedText",
+				"containedEntityList",
+				"text1",
+				"text2",
+				"primitiveInteger",
+				"primitiveLong",
+				"primitiveFloat",
+				"primitiveDouble",
+				"primitiveBoolean"
+		};
+
+		@Basic(fetch = FetchType.LAZY)
+		@LazyGroup("group1")
+		public String notIndexedText;
+
+		@OneToMany(mappedBy = "containingEntity", fetch = FetchType.LAZY)
+		@LazyGroup("group2")
+		@IndexedEmbedded
+		public List<ContainedEntity> containedEntityList;
+
+		@Embedded
+		@LazyGroup("group3")
+		@IndexedEmbedded
+		public ContainedEmbeddable containedEmbeddable;
+
+		@Basic(fetch = FetchType.LAZY)
+		@LazyGroup("group4")
+		@GenericField
+		public String text1;
+
+		// Add another text property in order to change the first one and check lazy loading on the second one
+		@Basic(fetch = FetchType.LAZY)
+		@LazyGroup("group5")
+		@GenericField
+		public String text2;
+
+		@Basic(fetch = FetchType.LAZY)
+		@LazyGroup("group6")
+		@GenericField
+		public int primitiveInteger;
+
+		@Basic(fetch = FetchType.LAZY)
+		@LazyGroup("group7")
+		@GenericField
+		public long primitiveLong;
+
+		@Basic(fetch = FetchType.LAZY)
+		@LazyGroup("group8")
+		@GenericField
+		public float primitiveFloat;
+
+		@Basic(fetch = FetchType.LAZY)
+		@LazyGroup("group9")
+		@GenericField
+		public double primitiveDouble;
+
+		@Basic(fetch = FetchType.LAZY)
+		@LazyGroup("group10")
+		@GenericField
+		public boolean primitiveBoolean;
+
+		@Transient
+		@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.NO)
+		@GenericField
+		public String transientText;
+	}
+
+	@Entity(name = "contained")
+	public static class ContainedEntity {
+		@Id
+		public Integer id;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@LazyGroup("group2_1")
+		public IndexedEntity containingEntity;
+
+		@Basic(fetch = FetchType.LAZY)
+		@LazyGroup("group2_2")
+		@GenericField
+		public String text;
+	}
+
+	@Embeddable
+	public static class ContainedEmbeddable {
+		private static final String[] LAZY_PROPERTY_NAMES = new String[] {
+				"text"
+		};
+
+		@Basic(fetch = FetchType.LAZY)
+		@LazyGroup("group3_1")
+		@GenericField
+		public String text;
+	}
+
+}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BytecodeEnhancementIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BytecodeEnhancementIT.java
@@ -20,10 +20,7 @@ import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.Id;
-import javax.persistence.Inheritance;
-import javax.persistence.InheritanceType;
 import javax.persistence.ManyToOne;
-import javax.persistence.MappedSuperclass;
 import javax.persistence.OneToMany;
 import javax.persistence.Transient;
 
@@ -61,8 +58,10 @@ public class BytecodeEnhancementIT {
 	@Before
 	public void setup() {
 		backendMock.expectSchema( IndexedEntity.INDEX, b -> b
+				/* TODO HSEARCH-3581 For some reason, it seems fields in superclasses trigger errors during bytecode enhancement.
 				.field( "mappedSuperClassText", String.class )
 				.field( "entitySuperClassText", String.class )
+				 */
 				.field( "id", Integer.class )
 				.objectField( "containedEntityList", b2 -> b2
 						.multiValued( true )
@@ -89,8 +88,10 @@ public class BytecodeEnhancementIT {
 				 */
 				.withTcclLookupPrecedence( TcclLookupPrecedence.BEFORE )
 				.setup(
+						/* TODO HSEARCH-3581 For some reason, it seems fields in superclasses trigger errors during bytecode enhancement.
 						IndexedMappedSuperClass.class,
 						IndexedEntitySuperClass.class,
+						 */
 						IndexedEntity.class,
 						ContainedEntity.class,
 						ContainedEmbeddable.class
@@ -103,8 +104,10 @@ public class BytecodeEnhancementIT {
 		OrmUtils.withinTransaction( sessionFactory, session -> {
 			IndexedEntity entity1 = new IndexedEntity();
 			entity1.id = 1;
+			/* TODO HSEARCH-3581 For some reason, it seems fields in superclasses trigger errors during bytecode enhancement.
 			entity1.mappedSuperClassText = "initialValue";
 			entity1.entitySuperClassText = "initialValue";
+			 */
 			entity1.containedEntityList = new ArrayList<>();
 			entity1.text1 = "initialValue";
 			entity1.text2 = "initialValue";
@@ -137,8 +140,10 @@ public class BytecodeEnhancementIT {
 
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.add( "1", b -> b
+							/* TODO HSEARCH-3581 For some reason, it seems fields in superclasses trigger errors during bytecode enhancement.
 							.field( "mappedSuperClassText", "initialValue" )
 							.field( "entitySuperClassText", "initialValue" )
+							 */
 							.field( "id", 1 )
 							.objectField( "containedEntityList", b2 -> b2
 									.field( "text", "initialValue1" )
@@ -179,8 +184,10 @@ public class BytecodeEnhancementIT {
 				// Expect all properties to be correctly loaded, even though we're using bytecode enhancement
 				backendMock.expectWorks( IndexedEntity.INDEX )
 						.update( "1", b -> b
+								/* TODO HSEARCH-3581 For some reason, it seems fields in superclasses trigger errors during bytecode enhancement.
 								.field( "mappedSuperClassText", "initialValue" )
 								.field( "entitySuperClassText", "initialValue" )
+								 */
 								.field( "id", 1 )
 								.objectField( "containedEntityList", b2 -> b2
 										.field( "text", "initialValue1" )
@@ -242,6 +249,7 @@ public class BytecodeEnhancementIT {
 		}
 	}
 
+	/* TODO HSEARCH-3581 For some reason, it seems fields in superclasses trigger errors during bytecode enhancement.
 	@MappedSuperclass
 	public static class IndexedMappedSuperClass {
 
@@ -266,16 +274,21 @@ public class BytecodeEnhancementIT {
 		public String entitySuperClassText;
 
 	}
+	 */
 
 	@Entity(name = "indexed")
 	@Indexed(index = IndexedEntity.INDEX)
 	public static class IndexedEntity
-			extends IndexedEntitySuperClass {
+	/* TODO HSEARCH-3581 For some reason, it seems fields in superclasses trigger errors during bytecode enhancement.
+			extends IndexedEntitySuperClass
+	 */ {
 		public static final String INDEX = "IndexedEntity";
 
 		private static final String[] LAZY_PROPERTY_NAMES = new String[] {
+				/* TODO HSEARCH-3581 For some reason, it seems fields in superclasses trigger errors during bytecode enhancement.
 				"mappedSuperClassText",
 				"entitySuperClassText",
+				 */
 				"notIndexedText",
 				"containedEntityList",
 				"text1",
@@ -286,6 +299,10 @@ public class BytecodeEnhancementIT {
 				"primitiveDouble",
 				"primitiveBoolean"
 		};
+
+		@Id
+		@GenericField
+		public Integer id;
 
 		@Basic(fetch = FetchType.LAZY)
 		@LazyGroup("group1")

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmBasicPropertyMetadata.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmBasicPropertyMetadata.java
@@ -1,0 +1,27 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.orm.model.impl;
+
+import java.lang.reflect.Member;
+
+class HibernateOrmBasicPropertyMetadata {
+	private final Member member;
+	private final boolean id;
+
+	HibernateOrmBasicPropertyMetadata(Member member, boolean id) {
+		this.member = member;
+		this.id = id;
+	}
+
+	boolean isId() {
+		return id;
+	}
+
+	Member getMember() {
+		return member;
+	}
+}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmBasicTypeMetadata.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmBasicTypeMetadata.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.mapper.orm.model.impl;
 
-import java.lang.reflect.Member;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -20,6 +19,7 @@ import org.hibernate.property.access.spi.Getter;
 class HibernateOrmBasicTypeMetadata {
 	private final Class<?> javaClass;
 	private final Map<String, Property> properties;
+	private final Property identifierProperty;
 
 	public static HibernateOrmBasicTypeMetadata create(PersistentClass persistentClass) {
 		Map<String, Property> properties = new HashMap<>();
@@ -28,13 +28,13 @@ class HibernateOrmBasicTypeMetadata {
 		if ( identifierProperty != null ) {
 			properties.put( identifierProperty.getName(), identifierProperty );
 		}
-		return new HibernateOrmBasicTypeMetadata( persistentClass.getMappedClass(), properties );
+		return new HibernateOrmBasicTypeMetadata( persistentClass.getMappedClass(), properties, identifierProperty );
 	}
 
 	public static HibernateOrmBasicTypeMetadata create(Component component) {
 		Map<String, Property> properties = new HashMap<>();
 		collectProperties( properties, component.getPropertyIterator() );
-		return new HibernateOrmBasicTypeMetadata( component.getComponentClass(), properties );
+		return new HibernateOrmBasicTypeMetadata( component.getComponentClass(), properties, null );
 	}
 
 	private static void collectProperties(Map<String, Property> collected, Iterator<Property> propertyIterator) {
@@ -44,19 +44,22 @@ class HibernateOrmBasicTypeMetadata {
 		}
 	}
 
-	private HibernateOrmBasicTypeMetadata(Class<?> javaClass, Map<String, Property> properties) {
+	private HibernateOrmBasicTypeMetadata(Class<?> javaClass, Map<String, Property> properties,
+			Property identifierProperty) {
 		this.javaClass = javaClass;
 		this.properties = properties;
+		this.identifierProperty = identifierProperty;
 	}
 
-	Member getMemberOrNull(String propertyName) {
+	HibernateOrmBasicPropertyMetadata getPropertyMetadataOrNull(String propertyName) {
 		try {
 			Property property = properties.get( propertyName );
 			if ( property == null ) {
 				return null;
 			}
 			Getter getter = property.getGetter( javaClass );
-			return getter.getMember();
+			boolean isId = property.equals( identifierProperty );
+			return new HibernateOrmBasicPropertyMetadata( getter.getMember(), isId );
 		}
 		catch (MappingException e) {
 			// Ignore, we just don't have any information

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmBootstrapIntrospector.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmBootstrapIntrospector.java
@@ -149,7 +149,7 @@ public class HibernateOrmBootstrapIntrospector implements PojoBootstrapIntrospec
 	 * Also, this cache allows to not care at all about implementing equals and hashcode,
 	 * since type models are presumably instantiated only once per type.
 	 *
-	 * @see HibernateOrmRawTypeModel#propertyModelCache
+	 * See also HibernateOrmRawTypeModel#propertyModelCache
 	 */
 	private final Map<Class<?>, PojoRawTypeModel<?>> typeModelCache = new HashMap<>();
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmPropertyModel.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmPropertyModel.java
@@ -99,7 +99,7 @@ class HibernateOrmPropertyModel<T> implements PojoPropertyModel<T> {
 	public PropertyHandle<T> getHandle() {
 		if ( handle == null ) {
 			try {
-				handle = (PropertyHandle<T>) introspector.createPropertyHandle( name, member );
+				handle = (PropertyHandle<T>) introspector.createPropertyHandle( name, member, ormPropertyMetadata );
 			}
 			catch (IllegalAccessException | RuntimeException e) {
 				throw log.errorRetrievingPropertyTypeModel( getName(), holderTypeModel, e );

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmPropertyModel.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmPropertyModel.java
@@ -31,24 +31,29 @@ class HibernateOrmPropertyModel<T> implements PojoPropertyModel<T> {
 	private final HibernateOrmRawTypeModel<?> holderTypeModel;
 
 	private final String name;
-	private final Member member;
 	/**
 	 * The declared XProperties for this property in the holder type.
 	 * May be empty if this property is declared in a supertype of the holder type
 	 * and not overridden in the holder type.
  	 */
 	private final List<XProperty> declaredXProperties;
+	private final HibernateOrmBasicPropertyMetadata ormPropertyMetadata;
+
+	private final Member member;
 
 	private PropertyHandle<T> handle;
 	private PojoGenericTypeModel<T> typeModel;
 
 	HibernateOrmPropertyModel(HibernateOrmBootstrapIntrospector introspector, HibernateOrmRawTypeModel<?> holderTypeModel,
-			String name, List<XProperty> declaredXProperties, Member member) {
+			String name, List<XProperty> declaredXProperties,
+			HibernateOrmBasicPropertyMetadata ormPropertyMetadata,
+			Member member) {
 		this.introspector = introspector;
 		this.holderTypeModel = holderTypeModel;
 		this.name = name;
-		this.member = member;
 		this.declaredXProperties = declaredXProperties;
+		this.ormPropertyMetadata = ormPropertyMetadata;
+		this.member = member;
 	}
 
 	@Override

--- a/pom.xml
+++ b/pom.xml
@@ -904,6 +904,13 @@
                 <artifactId>${jdbc.driver.artifactId}</artifactId>
                 <version>${jdbc.driver.version}</version>
             </dependency>
+
+            <!-- Hibernate ORM testing tools -->
+            <dependency>
+                <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-testing</artifactId>
+                <version>${version.org.hibernate}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -227,7 +227,7 @@
         <version.junit>4.12</version.junit>
         <version.org.easymock>4.0.1</version.org.easymock>
         <version.org.unitils>3.4.6</version.org.unitils>
-        <version.org.assertj.assertj-core>3.9.1</version.org.assertj.assertj-core>
+        <version.org.assertj.assertj-core>3.12.2</version.org.assertj.assertj-core>
         <version.org.skyscreamer.jsonassert>1.2.3</version.org.skyscreamer.jsonassert>
         <version.io.takari.junit>1.2.7</version.io.takari.junit>
         <version.com.h2database>1.4.178</version.com.h2database>

--- a/util/internal/integrationtest/orm/pom.xml
+++ b/util/internal/integrationtest/orm/pom.xml
@@ -33,6 +33,10 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-testing</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/util/internal/integrationtest/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/orm/OrmSetupHelper.java
+++ b/util/internal/integrationtest/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/orm/OrmSetupHelper.java
@@ -11,6 +11,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.hibernate.SessionFactory;
+import org.hibernate.boot.registry.classloading.internal.TcclLookupPrecedence;
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
 import org.hibernate.search.util.impl.integrationtest.common.rule.MappingSetupHelper;
 
@@ -45,6 +46,11 @@ public final class OrmSetupHelper
 		SetupContext() {
 			// Ensure overridden properties will be applied
 			withConfiguration( builder -> overriddenProperties.forEach( builder::setProperty ) );
+		}
+
+		public SetupContext withTcclLookupPrecedence(TcclLookupPrecedence tcclLookupPrecedence) {
+			withConfiguration( builder -> builder.setTcclLookupPrecedence( tcclLookupPrecedence ) );
+			return thisAsC();
 		}
 
 		@Override


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3581

@gsmet The test seems to pass. event though I had to disable some parts due to what is probably bugs in Hibernate ORM. I'm looking for more things to test at this point. Any idea?

~I'll try to reproduce and report the ORM bugs once we're done with this.~ => Created https://hibernate.atlassian.net//browse/HSEARCH-3584

~Could you try this in Quarkus? I suspect it won't work as is, because I need reflection on the read methods added by the enhancer, and I do not think it is enabled by default in GraalVM. But maybe there's an easy way for you to enable it?~ Confirmed by @gsmet, it works.