### PR TITLE
Backport HSEARCH-3595 to branch 5.11 - Upgrade to Hibernate ORM 5.4.3.Final

### DIFF
--- a/orm/src/main/java/org/hibernate/search/query/hibernate/impl/FullTextQueryImpl.java
+++ b/orm/src/main/java/org/hibernate/search/query/hibernate/impl/FullTextQueryImpl.java
@@ -518,7 +518,13 @@ public class FullTextQueryImpl extends AbstractProducedQuery implements FullText
 
 	@Override
 	public LockOptions getLockOptions() {
-		throw new UnsupportedOperationException( "Lock options are not implemented in Hibernate Search queries" );
+		/*
+		 * Ideally we'd throw an UnsupportedOperationException,
+		 * but we can't because getLockOptions is called
+		 * when AbstractProducedQuery converts exceptions.
+		 * So let's just return null, which at least seems acceptable for AbstractProducedQuery.
+		 */
+		return null;
 	}
 
 	@Override

--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
 
         <!-- Dependencies versions -->
 
-        <version.org.hibernate>5.4.2.Final</version.org.hibernate>
+        <version.org.hibernate>5.4.3.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>5.1.0.Final</version.org.hibernate.commons.annotations>
         <version.javax.persistence>2.2</version.javax.persistence>
 


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3595

Backport of #2002 , which should be merged first.