### PR TITLE
HSEARCH-3616 + HSEARCH-3617 DSL fixes

### DIFF
--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/MatchIdPredicateContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/predicate/MatchIdPredicateContext.java
@@ -30,7 +30,7 @@ public interface MatchIdPredicateContext {
 	 * @param values the collection of identifiers to match.
 	 * @return {@code this} for method chaining.
 	 */
-	default MatchIdPredicateTerminalContext matchingAny(Collection<Object> values) {
+	default MatchIdPredicateTerminalContext matchingAny(Collection<?> values) {
 		MatchIdPredicateTerminalContext context = null;
 		for ( Object value : values ) {
 			context = matching( value );

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/sort/SearchSortFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/sort/SearchSortFactoryContext.java
@@ -8,7 +8,6 @@ package org.hibernate.search.engine.search.dsl.sort;
 
 import java.util.function.Consumer;
 
-import org.hibernate.search.engine.search.SearchSort;
 import org.hibernate.search.engine.spatial.GeoPoint;
 import org.hibernate.search.util.common.SearchException;
 
@@ -78,15 +77,6 @@ public interface SearchSortFactoryContext {
 	default DistanceSortContext byDistance(String absoluteFieldPath, double latitude, double longitude) {
 		return byDistance( absoluteFieldPath, GeoPoint.of( latitude, longitude ) );
 	}
-
-	/**
-	 * Order by the given sort.
-	 *
-	 * @param sort A previously-built {@link SearchSort} object.
-	 * @return A context allowing to {@link NonEmptySortContext#then() chain other sorts}
-	 * or {@link SearchSortTerminalContext#toSort() get the resulting sort}.
-	 */
-	NonEmptySortContext by(SearchSort sort);
 
 	/**
 	 * Order by a sort composed of several elements.

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/sort/impl/DefaultSearchSortFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/sort/impl/DefaultSearchSortFactoryContext.java
@@ -9,7 +9,6 @@ package org.hibernate.search.engine.search.dsl.sort.impl;
 import java.util.function.Consumer;
 
 import org.hibernate.search.engine.common.dsl.spi.DslExtensionState;
-import org.hibernate.search.engine.search.SearchSort;
 import org.hibernate.search.engine.search.dsl.sort.CompositeSortContext;
 import org.hibernate.search.engine.search.dsl.sort.DistanceSortContext;
 import org.hibernate.search.engine.search.dsl.sort.FieldSortContext;
@@ -29,11 +28,6 @@ public class DefaultSearchSortFactoryContext<B> implements SearchSortFactoryCont
 
 	public DefaultSearchSortFactoryContext(SearchSortDslContext<?, B> dslContext) {
 		this.dslContext = dslContext;
-	}
-
-	@Override
-	public NonEmptySortContext by(SearchSort sort) {
-		return staticNonEmptyContext( dslContext.getFactory().toImplementation( sort ) );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/search/dsl/sort/spi/DelegatingSearchSortFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/dsl/sort/spi/DelegatingSearchSortFactoryContext.java
@@ -8,7 +8,6 @@ package org.hibernate.search.engine.search.dsl.sort.spi;
 
 import java.util.function.Consumer;
 
-import org.hibernate.search.engine.search.SearchSort;
 import org.hibernate.search.engine.search.dsl.sort.CompositeSortContext;
 import org.hibernate.search.engine.search.dsl.sort.DistanceSortContext;
 import org.hibernate.search.engine.search.dsl.sort.FieldSortContext;
@@ -55,11 +54,6 @@ public class DelegatingSearchSortFactoryContext implements SearchSortFactoryCont
 	@Override
 	public DistanceSortContext byDistance(String absoluteFieldPath, double latitude, double longitude) {
 		return delegate.byDistance( absoluteFieldPath, latitude, longitude );
-	}
-
-	@Override
-	public NonEmptySortContext by(SearchSort sort) {
-		return delegate.by( sort );
 	}
 
 	@Override

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
@@ -418,7 +418,7 @@ public class ElasticsearchExtensionIT {
 
 		SearchQuery<DocumentReference> query = scope.query()
 				.predicate( f -> f.matchAll() )
-				.sort( f -> f.by( sort1Asc ).then().by( sort2Asc ).then().by( sort3Asc ).then().by( sort4Asc ) )
+				.sort( f -> f.byComposite().add( sort1Asc ).add( sort2Asc ).add( sort3Asc ).add( sort4Asc ) )
 				.toQuery();
 		assertThat( query )
 				.hasDocRefHitsExactOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID, FOURTH_ID, EMPTY_ID, FIFTH_ID );
@@ -439,7 +439,7 @@ public class ElasticsearchExtensionIT {
 
 		query = scope.query()
 				.predicate( f -> f.matchAll() )
-				.sort( f -> f.by( sort1Desc ).then().by( sort2Desc ).then().by( sort3Desc ).then().by( sort4Desc ) )
+				.sort( f -> f.byComposite().add( sort1Desc ).add( sort2Desc ).add( sort3Desc ).add( sort4Desc ) )
 				.toQuery();
 		assertThat( query )
 				.hasDocRefHitsExactOrder( INDEX_NAME, FOURTH_ID, THIRD_ID, SECOND_ID, FIRST_ID, EMPTY_ID, FIFTH_ID );

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneExtensionIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneExtensionIT.java
@@ -392,7 +392,7 @@ public class LuceneExtensionIT {
 
 		SearchQuery<DocumentReference> query = scope.query()
 				.predicate( f -> f.matchAll() )
-				.sort( f -> f.by( sort1 ).then().by( sort2 ).then().by( sort3 ) )
+				.sort( f -> f.byComposite().add( sort1 ).add( sort2 ).add( sort3 ) )
 				.toQuery();
 		assertThat( query )
 				.hasDocRefHitsExactOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID, FOURTH_ID, FIFTH_ID );
@@ -408,7 +408,7 @@ public class LuceneExtensionIT {
 
 		query = scope.query()
 				.predicate( f -> f.matchAll() )
-				.sort( f -> f.by( sort ) )
+				.sort( sort )
 				.toQuery();
 		assertThat( query )
 				.hasDocRefHitsExactOrder( INDEX_NAME, THIRD_ID, SECOND_ID, FIRST_ID, FOURTH_ID, FIFTH_ID );


### PR DESCRIPTION
Just some fixes for problems I noticed while working on the documentation.

* [HSEARCH-3616](https://hibernate.atlassian.net//browse/HSEARCH-3616): Accept Collection<?> instead of Collection<Object>  in the ID predicate
* [HSEARCH-3617](https://hibernate.atlassian.net//browse/HSEARCH-3617): Search 6 groundwork - Remove the by(SearchSort) method from the sort DSL
