### PR TITLE
HSEARCH-3597 Document all available predicates/sorts/projections and query DSL basics

### DIFF
--- a/documentation/src/main/asciidoc/search-dsl.asciidoc
+++ b/documentation/src/main/asciidoc/search-dsl.asciidoc
@@ -90,9 +90,36 @@ include::todo-placeholder.asciidoc[]
 [[search-dsl-predicate-concepts]]
 === Generality
 
-include::todo-placeholder.asciidoc[]
+The main component of a search query is the _predicate_,
+i.e. the condition that every document must satisfy in order to be included in search results.
 
-// TODO introduction, common concepts, entry point, ...
+The predicate is configured when building the search query:
+
+.Defining the predicate of a search query
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/directfieldmapping/HibernateOrmSimpleMappingIT.java[tags=predicate-simple-lambdas]
+----
+<1> Start building the query.
+<2> Mention that the results of the query are expected to have a `title` field matching the value `robot`.
+If the field does not exist or cannot be searched on, an exception will be thrown.
+<3> The results match the given predicate.
+====
+
+Or alternatively, if you don't want to use lambdas:
+
+.Defining the predicate of a search query - object-based syntax
+====
+[source, JAVA, indent=0]
+----
+include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/directfieldmapping/HibernateOrmSimpleMappingIT.java[tags=predicate-simple-objects]
+----
+====
+
+The predicate DSL offers more predicate types, and multiple options for each type of predicate.
+To learn more about the `match` predicate, and all the other types of predicate,
+refer to the following sections.
 
 [[search-dsl-predicate-common]]
 === Options common to multiple predicate types

--- a/documentation/src/main/asciidoc/search-dsl.asciidoc
+++ b/documentation/src/main/asciidoc/search-dsl.asciidoc
@@ -85,6 +85,8 @@ include::todo-placeholder.asciidoc[]
 
 include::todo-placeholder.asciidoc[]
 
+// TODO add more than just examples in the sub-sections
+
 [[search-dsl-predicate-concepts]]
 === Generality
 
@@ -92,14 +94,538 @@ include::todo-placeholder.asciidoc[]
 
 // TODO introduction, common concepts, entry point, ...
 
-////
-TODO Include a detailed description of all available predicates.
-////
-
-[[search-dsl-predicate-boolean]]
-=== Boolean junction
+[[search-dsl-predicate-common]]
+=== Options common to multiple predicate types
+// Search 5 anchors backward compatibility
+[[_query_options]]
 
 include::todo-placeholder.asciidoc[]
+
+// TODO boostedTo, withConstantScore, ...
+
+[[search-dsl-predicate-match-all]]
+=== `matchAll`: match all documents
+
+.Matching all documents
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=matchAll]
+----
+====
+
+.Matching all documents except those matching a given predicate
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=matchAll-except]
+----
+====
+
+[[search-dsl-predicate-id]]
+=== `id`: match a document identifier
+
+.Matching a document with a given identifier
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=id]
+----
+====
+
+.Matching all documents with an identifier among a given collection
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=id-matchingAny]
+----
+====
+
+[[search-dsl-predicate-match]]
+=== `match`: match a value
+// Search 5 anchors backward compatibility
+[[_keyword_queries]]
+
+.Matching a value
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=match]
+----
+====
+
+.Matching multiple terms
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=match-multipleTerms]
+----
+<1> For full-text fields, the value passed to `matching` may be a string containing multiple terms.
+The string will be analyzed and each term identified.
+<2> All returned hits will match *at least one* term of the given string.
+Hits matching multiple terms will have a higher score.
+====
+
+// TODO HSEARCH-917 add an option to match all terms instead of any term, then document it here
+
+.Matching a value in any of multiple fields
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=match-orField]
+----
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=match-fields]
+----
+====
+
+.Matching a text value approximately
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=match-fuzzy]
+----
+====
+
+// TODO fuzzy parameters: edit distance, prefix length, ...
+
+.Matching a value, analyzing it with a different analyzer
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=match-analyzer]
+----
+====
+
+.Matching a value without analyzing it
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=match-skipAnalysis]
+----
+====
+
+// TODO per-field boosts?
+
+[[search-dsl-predicate-range]]
+=== `range`: match a range of values
+// Search 5 anchors backward compatibility
+[[_range_queries]]
+
+.Matching a range of values
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=range-between]
+----
+====
+
+.Matching values above a given value
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=range-above]
+----
+====
+
+.Matching values below a given value
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=range-below]
+----
+====
+
+.Matching a range of values, excluding the limit(s)
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=range-excludeLimit]
+----
+====
+
+// TODO multiple fields?
+
+// TODO per-field boosts?
+
+[[search-dsl-predicate-phrase]]
+=== `phrase`: match a sequence of words
+// Search 5 anchors backward compatibility
+[[_phrase_queries]]
+
+.Matching a sequence of words
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=phrase]
+----
+====
+
+.Matching a sequence of words approximately
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=phrase-withSlop]
+----
+====
+
+// TODO analyzer?
+
+// TODO skipAnalysis?
+
+// TODO multiple fields?
+
+// TODO per-field boosts?
+
+[[search-dsl-predicate-exists]]
+=== `exists`: match fields with non-null values
+
+[NOTE]
+====
+This predicate currently only works with non-object fields.
+
+See https://hibernate.atlassian.net/browse/HSEARCH-2389[HSEARCH-2389].
+====
+
+.Matching fields with non-null values
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=exists]
+----
+====
+
+[TIP]
+====
+There isn't any built-in predicate to match fields with exclusively null values,
+but you can easily create one yourself
+using an `exists` predicate in a `mustNot` clause in a <<search-dsl-predicate-boolean,boolean predicate>>.
+====
+
+[[search-dsl-predicate-wildcard]]
+=== `wildcard`: match a simple pattern
+// Search 5 anchors backward compatibility
+[[_wildcard_queries]]
+
+.Matching a simple pattern
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=wildcard]
+----
+====
+
+// TODO HSEARCH-3612 When the ticket is fixed, rephrase this warning to state that only ES 6.7 and below is affected by the normalization problem.
+
+[IMPORTANT]
+====
+Patterns used in wildcard predicates are not analyzed or normalized,
+and they are expected to match a *single* indexed token, not a sequence of tokens.
+
+For example, a pattern such as `Cat*` will not match anything
+when targeting a field that applies a lowercase filter when indexing.
+`cat*` may match, since it's already lowercased.
+
+Similarly, a pattern such as `john gr*` will not match anything
+when targeting a field that tokenizes on spaces.
+`gr*` may match, since it doesn't include any space.
+
+These limitations generally make the wildcard predicate unadvisable for high-level,
+user-exposed features,
+though it can still be useful in very specific cases.
+
+When the goal is to match user-provided query strings,
+the <<search-dsl-predicate-simple-query-string,simple query string predicate>> should be preferred.
+At the very least it fixes the second issue by automatically splitting the query string around spaces,
+even though it may also suffer from the case-sensitivity issue in some cases
+(see https://hibernate.atlassian.net/browse/HSEARCH-3612[HSEARCH-3612]).
+====
+
+[[search-dsl-predicate-boolean]]
+=== `bool`: combine predicates (or/and/...)
+// Search 5 anchors backward compatibility
+[[_combining_queries]]
+
+.Matching a document that matches any of multiple given predicates (~`OR` operator)
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=bool-or]
+----
+<1> The hits *should* have a `title` field matching the text `robot`,
+*or* they should match any other clause in the same boolean predicate.
+<2> The hits *should* have a `description` field matching the text `investigation`,
+*or* they should match any other clause in the same boolean predicate.
+<3> All returned hits will match *at least one* of the clauses above:
+they will have a `title` field matching the text `robot`
+*or* they will have a `description` field matching the text `investigation`.
+====
+
+.Matching a document that matches all of multiple given predicates (~`AND` operator)
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=bool-and]
+----
+<1> The hits *must* have a `title` field matching the text `robot`,
+independently from other clauses in the same boolean predicate.
+<2> The hits *must* have a `description` field matching the text `crime`,
+independently from other clauses in the same boolean predicate.
+<3> All returned hits will match *all* of the clauses above:
+they will have a `title` field matching the text `robot`
+*and* they will have a `description` field matching the text `crime`.
+====
+
+.Matching a document that does *not* match a given predicate
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=bool-mustNot]
+----
+<1> The hits *must* have a `title` field matching the text `robot`,
+independently from other clauses in the same boolean predicate.
+<2> The hits *must not* have a `description` field matching the text `investigation`,
+independently from other clauses in the same boolean predicate.
+<3> All returned hits will match *all* of the clauses above:
+they will have a `title` field matching the text `robot`
+*and* they will not have a `description` field matching the text `investigation`.
+
+[NOTE]
+======
+While it is possible to execute a boolean predicate with only "negative" clauses (`mustNot`),
+performance may be disappointing because the full power of indexes cannot be leveraged in that case.
+======
+====
+
+.Matching a document that matches a given predicate without affecting the score
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=bool-filter]
+----
+<1> Create a top-level boolean predicate, with two `should` clauses.
+<2> In the first `should` clause, create a nested boolean predicate.
+<3> Use a `filter` clause to require documents to have the `science-fiction` genre,
+without taking this predicate into account when scoring.
+<4> Use a `must` clause to require documents with the `science-fiction` genre
+to have a `title` field matching `crime`,
+and take this predicate into account when scoring.
+<5> In the second `should` clause, create a nested boolean predicate.
+<6> Use a `filter` clause to require documents to have the `crime fiction` genre,
+without taking this predicate into account when scoring.
+<7> Use a `must` clause to require documents with the `crime fiction` genre
+to have a `description` field matching `robot`,
+and take this predicate into account when scoring.
+<8> The score of hits will ignore the `filter` clauses,
+leading to fairer sorts if there are much more "crime fiction" documents than "science-fiction" documents.
+====
+
+.Using optional `should` clauses to boost the score of some documents
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=bool-mustAndShould]
+----
+<1> The hits *must* have a `title` field matching the text `robot`,
+independently from other clauses in the same boolean predicate.
+<2> The hits *should* have a `description` field matching the text `crime`,
+but they may not, because matching the `must` clause above is enough.
+However, matching this `should` clause will improve the score of the document.
+<3> The hits *should* have a `description` field matching the text `investigation`,
+but they may not, because matching the `must` clause above is enough.
+However, matching this `should` clause will improve the score of the document.
+<4> All returned hits will match the `must` clause, and optionally the `should` clauses:
+they will have a `title` field matching the text `robot`,
+and the ones whose description matches either `crime` or `investigation` will have a better score.
+====
+
+.Fine-tuning `should` clauses matching requirements with `minimumShouldMatch`
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=bool-minimumShouldMatchNumber]
+----
+<1> At least two "should" clauses must match for this boolean predicate to match.
+<2> The hits *should* have a `description` field matching the text `robot`.
+<3> The hits *should* have a `description` field matching the text `investigate`.
+<4> The hits *should* have a `description` field matching the text `crime`.
+<5> All returned hits will match at least two of the `should` clauses:
+their description will match either `robot` and `investigate`,
+`robot` and `crime`, `investigate` and `crime`, or all three of these terms.
+====
+
+.Easily adding clauses dynamically with the lambda syntax
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=bool-dynamicParameters]
+----
+<1> Get a custom object holding the search parameters provided by the user through a web form, for example.
+<2> Call `.bool(Consumer)`.
+The consumer, implemented by a lambda expression, will receive a builder as an argument
+and will add clauses to that builder as necessary.
+<3> By default, a boolean predicate will match nothing if there is no clause.
+To match every document when there is no clause, add a `must` clause that matches everything.
+<4> Inside the lambda, the code is free to check conditions before adding clauses.
+In this case, we only add clauses if the relevant parameter was filled in by the user.
+<5> The hits will match the clauses added by the lambda expression.
+====
+
+[[search-dsl-predicate-simple-query-string]]
+=== `simpleQueryString`: match a user-provided query
+// Search 5 anchors backward compatibility
+[[_simple_query_string_queries]]
+
+.Matching a simple query string: AND/OR operators
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=simpleQueryString-boolean]
+----
+====
+
+.Matching a simple query string: NOT operator
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=simpleQueryString-not]
+----
+====
+
+.Matching a simple query string: AND as default operator
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=simpleQueryString-withAndAsDefaultOperator]
+----
+====
+
+.Matching a simple query string: prefix
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=simpleQueryString-prefix]
+----
+====
+
+.Matching a simple query string: fuzzy
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=simpleQueryString-fuzzy]
+----
+====
+
+.Matching a simple query string: phrase
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=simpleQueryString-phrase]
+----
+====
+
+.Matching a simple query string: phrase with slop
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=simpleQueryString-phrase-withSlop]
+----
+====
+
+// TODO multiple fields?
+
+// TODO per-field boosts?
+
+[[search-dsl-predicate-nested]]
+=== `nested`: match nested documents
+
+.Matching a simple pattern
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=nested]
+----
+<1> Create a nested predicate on the `authors` object field.
+<2> The author must have a first name matching `isaac`.
+<3> The author must have a last name matching `asimov`.
+<4> All returned hits will be books for which at least one author
+has a first name matching `isaac` and a last name matching `asimov`.
+Books that happen to have multiple authors,
+one of which has a first name matching `isaac`
+and *another* of which has a last name matching `asimov`,
+will *not* match.
+====
+
+[[search-dsl-predicate-spatial-within]]
+=== `within`: match points within a circle, box, polygon
+// Search 5 anchors backward compatibility
+[[spatial-queries]]
+
+.Matching points within a circle
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=within-circle]
+----
+====
+
+// TODO alternative syntaxes?
+
+.Matching points within a box
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=within-box]
+----
+====
+
+// TODO alternative syntaxes?
+
+.Matching points within a polygon
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=within-box]
+----
+====
+
+// TODO alternative syntaxes?
+
+[[search-dsl-predicate-more-like-this]]
+=== More like this
+[[search-query-querydsl-mlt]]
+
+include::todo-placeholder.asciidoc[]
+
+[[search-dsl-predicate-extensions]]
+=== Backend-specific extensions
+
+include::todo-placeholder.asciidoc[]
+
+// TODO introduction to extensions or links to that introduction
+
+[[search-dsl-predicate-extensions-lucene-from-lucene-query]]
+==== Lucene: `fromLuceneQuery`
+
+.Matching a native `org.apache.lucene.search.Query`
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=lucene-fromLuceneQuery]
+----
+====
+
+[[search-dsl-predicate-extensions-elasticsearch-from-json]]
+==== Elasticsearch: `fromJson`
+
+.Matching a native Elasticsearch JSON query
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=elasticsearch-fromJson]
+----
+====
 
 [[search-dsl-sort]]
 == Sort DSL

--- a/documentation/src/main/asciidoc/search-dsl.asciidoc
+++ b/documentation/src/main/asciidoc/search-dsl.asciidoc
@@ -586,7 +586,7 @@ include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/Pred
 ====
 [source, JAVA, indent=0, subs="+callouts"]
 ----
-include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=within-box]
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=within-polygon]
 ----
 ====
 
@@ -839,6 +839,8 @@ include::{sourcedir}/org/hibernate/search/documentation/searchdsl/sort/SortDslIT
 
 include::todo-placeholder.asciidoc[]
 
+// TODO add more than just examples in the sub-sections
+
 [[search-dsl-projection-concepts]]
 === Generality
 
@@ -903,10 +905,195 @@ The projection DSL offers more projection types, and multiple options for each t
 To learn more about the field projection, and all the other types of projection,
 refer to the following sections.
 
-////
-TODO The ORM mapper query section has a link pointing here and expects the section to
-include a detailed description of all available projections.
-////
+[[search-dsl-projection-common]]
+=== Options common to multiple projection types
+
+include::todo-placeholder.asciidoc[]
+
+// TODO common options, if there are any?
+
+[[search-dsl-projection-documentReference]]
+=== `documentReference`: return references to matched documents
+
+.Returning references to matched documents
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/projection/ProjectionDslIT.java[tags=documentReference]
+----
+====
+
+[[search-dsl-projection-reference]]
+=== `reference`: return references to matched entities
+
+.Returning references to matched entities
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/projection/ProjectionDslIT.java[tags=reference]
+----
+====
+
+[[search-dsl-projection-entity]]
+=== `entity`: return matched entities loaded from the database
+
+.Returning matched entities loaded from the database
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/projection/ProjectionDslIT.java[tags=entity]
+----
+====
+
+[[search-dsl-projection-field]]
+=== `field`: return field values from matched documents
+
+.Returning field values from matched documents
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/projection/ProjectionDslIT.java[tags=field]
+----
+====
+
+.Returning field values from matched documents, without specifying the field type
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/projection/ProjectionDslIT.java[tags=field-noType]
+----
+====
+
+.Returning field values from matched documents, without converting the field value
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/projection/ProjectionDslIT.java[tags=field-noProjectionConverter]
+----
+====
+
+[[search-dsl-projection-score]]
+=== `score`: return the score of matched documents
+
+.Returning the score of matched documents
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/projection/ProjectionDslIT.java[tags=score]
+----
+====
+
+[[search-dsl-projection-distance]]
+=== `distance`: return the distance to a point
+
+.Returning the distance to a point
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/projection/ProjectionDslIT.java[tags=distance]
+----
+====
+
+.Returning the distance to a point with a given distance unit
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/projection/ProjectionDslIT.java[tags=distance-unit]
+----
+====
+
+[[search-dsl-projection-composite]]
+=== `composite`: combine projections
+
+.Returning custom objects created from multiple projected values
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/projection/ProjectionDslIT.java[tags=composite-customObject]
+----
+<1> Call `.composite(...)`.
+<2> Use the constructor of a custom object, `MyPair`, as the combining function.
+The combining function can be a `Function`, a `BiFunction`,
+or a `org.hibernate.search.util.common.function.TriFunction`.
+It will combine values returned by other projections and create an object returned by the composite projection.
+Depending on the type of function,
+either one, two, or three additional arguments are expected.
+<3> Define the first projection to combine as a projection on the `title` field,
+meaning the constructor of `MyPair` will be called for each matched document
+with the value of the `title` field as its first argument.
+<4> Define the second projection to combine as a projection on the `genre` field,
+meaning the constructor of `MyPair` will be called for each matched document
+with the value of the `genre` field as its second argument.
+<5> The hits will be the result of calling the combining function for each matched document,
+in this case `MyPair` instances.
+====
+
+.Returning a `List` of projected values
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/projection/ProjectionDslIT.java[tags=composite-list]
+----
+<1> Call `.composite(...)`.
+<2> Define the first projection to combine as a projection on the `title` field,
+meaning the hits will be `List` instances with the value of the `title` field of the matched document at index `0`.
+<3> Define the second projection to combine as a projection on the `genre` field,
+meaning the hits will be `List` instances with the value of the `genre` field of the matched document at index `1`.
+<4> The hits will be `List` instances holding the result of the given projections, in order for each matched document.
+====
+
+[[search-dsl-projection-extensions]]
+=== Backend-specific extensions
+
+include::todo-placeholder.asciidoc[]
+
+// TODO introduction to extensions or links to that introduction
+
+[[search-dsl-projection-extensions-lucene-document]]
+==== Lucene: `document`
+
+.Returning the matched document as a native `org.apache.lucene.document.Document`
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/projection/ProjectionDslIT.java[tags=lucene-document]
+----
+====
+
+// TODO explain limitations: not the original documents, fields reconstructed from what we find, not all fields presents, ...
+
+[[search-dsl-projection-extensions-lucene-explanation]]
+==== Lucene: `explanation`
+
+.Returning the score explanation as a native `org.apache.lucene.search.Explanation`
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/projection/ProjectionDslIT.java[tags=lucene-explanation]
+----
+====
+
+[[search-dsl-projection-extensions-elasticsearch-source]]
+==== Elasticsearch: `source`
+
+.Returning the matched document source as a JSON-formatted String
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/projection/ProjectionDslIT.java[tags=elasticsearch-source]
+----
+====
+
+[[search-dsl-projection-extensions-elasticsearch-explanation]]
+==== Elasticsearch: `explanation`
+
+.Returning the score explanation as a JSON-formatted String
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/projection/ProjectionDslIT.java[tags=elasticsearch-explanation]
+----
+====
 
 [[search-dsl-type-compatibility]]
 == Field types and compatibility

--- a/documentation/src/main/asciidoc/search-dsl.asciidoc
+++ b/documentation/src/main/asciidoc/search-dsl.asciidoc
@@ -634,6 +634,8 @@ include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/Pred
 
 include::todo-placeholder.asciidoc[]
 
+// TODO add more than just examples in the sub-sections
+
 [[search-dsl-sort-concepts]]
 === Generality
 
@@ -674,10 +676,161 @@ The sort DSL offers more sort types, and multiple options for each type of sort.
 To learn more about the field sort, and all the other types of sort,
 refer to the following sections.
 
-////
-TODO The ORM mapper query section has a link pointing here and expects the section to
-include a detailed description of all available sorts.
-////
+[[search-dsl-sort-common]]
+=== Options common to multiple sort types
+
+include::todo-placeholder.asciidoc[]
+
+// TODO asc(), desc(), order(SortOrder), ...
+
+[[search-dsl-sort-score]]
+=== `byScore`: sort by matching score (relevance)
+
+.Sorting by relevance
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/sort/SortDslIT.java[tags=byScore]
+----
+====
+
+[[search-dsl-sort-index-order]]
+=== `byIndexOrder`: sort according to the order of documents on storage
+
+.Sorting according to the order of documents on storage
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/sort/SortDslIT.java[tags=byIndexOrder]
+----
+====
+
+[[search-dsl-sort-field]]
+=== `byField`: sort by field values
+
+.Sorting by field values
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/sort/SortDslIT.java[tags=byField]
+----
+====
+
+// Search 5 anchors backward compatibility
+[[_handling_missing_values]]
+
+.Sorting by field values, with missing values in first position
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/sort/SortDslIT.java[tags=byField_onMissingValue_sortFirst]
+----
+====
+
+.Sorting by field values, with missing values in last position
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/sort/SortDslIT.java[tags=byField_onMissingValue_sortLast]
+----
+====
+
+.Sorting by field values, with missing values replaced by a given value
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/sort/SortDslIT.java[tags=byField_onMissingValue_use]
+----
+====
+
+[[search-dsl-sort-distance]]
+=== `byDistance`: sort by distance to a point
+
+.Sorting by distance to a point
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/sort/SortDslIT.java[tags=byDistance]
+----
+====
+
+// TODO alternative syntaxes?
+
+[[search-dsl-sort-composite]]
+=== `byComposite`: combine sorts
+
+.Sorting by multiple composed sorts using `byComposite()`
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/sort/SortDslIT.java[tags=byComposite]
+----
+====
+
+.Sorting by multiple composed sorts using `then()`
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/sort/SortDslIT.java[tags=then]
+----
+====
+
+.Easily composing sorts dynamically with the lambda syntax
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/sort/SortDslIT.java[tags=byComposite_dynamicParameters]
+----
+<1> Get a custom object holding the search parameters provided by the user through a web form, for example.
+<2> Call `.byComposite(Consumer)`.
+The consumer, implemented by a lambda expression, will receive a builder as an argument
+and will add sorts to that builder as necessary.
+<3> Inside the lambda, the code is free to do whatever is necessary before adding sorts.
+In this case, we iterate over user-selected sorts and add sorts accordingly.
+<4> The hits will be sorted according to sorts added by the lambda expression.
+====
+
+[[search-dsl-sort-extensions]]
+=== Backend-specific extensions
+
+include::todo-placeholder.asciidoc[]
+
+// TODO introduction to extensions or links to that introduction
+
+[[search-dsl-sort-extensions-lucene-from-lucene-sort]]
+==== Lucene: `fromLuceneSort`
+
+.Matching a native `org.apache.lucene.search.Sort`
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/sort/SortDslIT.java[tags=lucene-fromLuceneSort]
+----
+====
+
+[[search-dsl-sort-extensions-lucene-from-lucene-sort-field]]
+==== Lucene: `fromLuceneSortField`
+// Search 5 anchors backward compatibility
+[[_using_native_sorts_within_the_sort_dsl]]
+
+.Matching a native `org.apache.lucene.search.SortField`
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/sort/SortDslIT.java[tags=lucene-fromLuceneSortField]
+----
+====
+
+[[search-dsl-sort-extensions-elasticsearch-from-json]]
+==== Elasticsearch: `fromJson`
+
+.Matching a native Elasticsearch JSON sort
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/sort/SortDslIT.java[tags=elasticsearch-fromJson]
+----
+====
 
 [[search-dsl-projection]]
 == Projection DSL

--- a/documentation/src/main/asciidoc/search-dsl.asciidoc
+++ b/documentation/src/main/asciidoc/search-dsl.asciidoc
@@ -15,8 +15,6 @@ effectively offering a new type of query for Hibernate ORM entities.
 // Search 5 anchors backward compatibility
 [[search-query]]
 
-include::todo-placeholder.asciidoc[]
-
 [[search-dsl-query-generality]]
 === Generality
 // Search 5 anchors backward compatibility
@@ -118,8 +116,6 @@ include::todo-placeholder.asciidoc[]
 == Predicate DSL
 // Search 5 anchors backward compatibility
 [[query-predicate]]
-
-include::todo-placeholder.asciidoc[]
 
 // TODO add more than just examples in the sub-sections
 
@@ -695,8 +691,6 @@ include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/Pred
 // Search 5 anchors backward compatibility
 [[query-sorting]]
 
-include::todo-placeholder.asciidoc[]
-
 // TODO add more than just examples in the sub-sections
 
 [[search-dsl-sort-concepts]]
@@ -899,8 +893,6 @@ include::{sourcedir}/org/hibernate/search/documentation/searchdsl/sort/SortDslIT
 == Projection DSL
 // Search 5 anchors backward compatibility
 [[projections]]
-
-include::todo-placeholder.asciidoc[]
 
 // TODO add more than just examples in the sub-sections
 

--- a/documentation/src/main/asciidoc/search-dsl.asciidoc
+++ b/documentation/src/main/asciidoc/search-dsl.asciidoc
@@ -40,7 +40,7 @@ See <<search-dsl-predicate>> for more information about predicates.
 <6> Retrieve matching entities.
 ====
 
-By default, the hits of a search query will be managed Hibernate ORM entities,
+By default, the hits of a search query will be entities managed by Hibernate ORM,
 bound to the entity manager used to create the search session.
 This provides all the benefits of Hibernate ORM,
 in particular the ability to navigate the entity graph to retrieve associated entities if necessary.
@@ -49,7 +49,8 @@ The query DSL offers many features, detailed in the following sections.
 Some commonly used features include:
 
 * <<search-dsl-predicate,predicates>>,
-to define which documents must be included in the search results.
+the main component of a search query,
+i.e. the condition that every document must satisfy in order to be included in search results.
 * <<search-dsl-query-fetching-results,fetching the results differently>>:
 getting the hits directly as a list,
 using pagination, scrolling, etc.
@@ -139,7 +140,7 @@ include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/Pred
 <1> Start building the query.
 <2> Mention that the results of the query are expected to have a `title` field matching the value `robot`.
 If the field does not exist or cannot be searched on, an exception will be thrown.
-<3> The results match the given predicate.
+<3> Fetch the results, which will match the given predicate.
 ====
 
 Or alternatively, if you don't want to use lambdas:
@@ -714,7 +715,7 @@ include::{sourcedir}/org/hibernate/search/documentation/searchdsl/sort/SortDslIT
 <2> Mention that the results of the query are expected to be sorted on field "pageCount" in descending order,
 then (for those with the same page count) on field "title_sort" in ascending order.
 If the field does not exist or cannot be sorted on, an exception will be thrown.
-<3> The results are sorted according to instructions.
+<3> Fetch the results, which will be sorted according to instructions.
 ====
 
 Or alternatively, if you don't want to use lambdas:
@@ -922,7 +923,7 @@ include::{sourcedir}/org/hibernate/search/documentation/searchdsl/projection/Pro
 <1> Start building the query as usual.
 <2> Mention that the expected result of the query is a projection on field "title", of type String.
 If that type is not appropriate or if the field does not exist, an exception will be thrown.
-<3> The query is type-safe and will return results of the expected type.
+<3> Fetch the results, which will have the expected type.
 ====
 
 Or alternatively, if you don't want to use lambdas:

--- a/documentation/src/main/asciidoc/search-dsl.asciidoc
+++ b/documentation/src/main/asciidoc/search-dsl.asciidoc
@@ -274,7 +274,7 @@ As a result, any call to the DSL will be expected to pass an `AuthenticationOutc
 ====
 [source, JAVA, indent=0]
 ----
-include::{sourcedir}/org/hibernate/search/documentation/searchdsl/DslConverterIT.java[tags=dsl-converter-enabled]
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/converter/DslConverterIT.java[tags=dsl-converter-enabled]
 ----
 ====
 
@@ -296,7 +296,7 @@ and pass `DslConverter.DISABLED`:
 ====
 [source, JAVA, indent=0]
 ----
-include::{sourcedir}/org/hibernate/search/documentation/searchdsl/DslConverterIT.java[tags=dsl-converter-disabled]
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/converter/DslConverterIT.java[tags=dsl-converter-disabled]
 ----
 ====
 
@@ -345,7 +345,7 @@ As a result, any projection on the `status` field will return an `OrderStatus` i
 ====
 [source, JAVA, indent=0]
 ----
-include::{sourcedir}/org/hibernate/search/documentation/searchdsl/ProjectionConverterIT.java[tags=projection-converter-enabled]
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/converter/ProjectionConverterIT.java[tags=projection-converter-enabled]
 ----
 ====
 
@@ -361,7 +361,7 @@ and pass `ProjectionConverter.DISABLED`:
 ====
 [source, JAVA, indent=0, subs="+callouts"]
 ----
-include::{sourcedir}/org/hibernate/search/documentation/searchdsl/ProjectionConverterIT.java[tags=projection-converter-disabled]
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/converter/ProjectionConverterIT.java[tags=projection-converter-disabled]
 ----
 ====
 

--- a/documentation/src/main/asciidoc/search-dsl.asciidoc
+++ b/documentation/src/main/asciidoc/search-dsl.asciidoc
@@ -3,28 +3,63 @@
 // Search 5 anchors backward compatibility
 [[search-query-querydsl]]
 
-include::todo-placeholder.asciidoc[]
+Beyond simply indexing, Hibernate Search also exposes high-level APIs to search these indexes
+without having to resort to native APIs.
+
+One key feature of these search APIs is the ability to use indexes to perform the search,
+but to return entities loaded *from the database*,
+effectively offering a new type of query for Hibernate ORM entities.
 
 [[search-dsl-query]]
 == Query DSL
 // Search 5 anchors backward compatibility
 [[search-query]]
 
+include::todo-placeholder.asciidoc[]
+
 [[search-dsl-query-generality]]
 === Generality
 // Search 5 anchors backward compatibility
 [[_building_a_hibernate_search_query]]
 
-include::todo-placeholder.asciidoc[]
+Preparing and executing a query requires just a few lines:
 
-////
-TODO explain the general concepts around querying the index.
-It's not as obvious as it seems, in particular in the Hibernate Search / ORM integration:
-we're querying the index, but getting the results from the database...
-See the Search 5 docs, it's probably explained in detail there.
-Also briefly explain the main features (predicate, sort, projection, ...)
-and point to the various other sections (predicate DSL, sort DSL, projection DSL, ...) where relevant.
-////
+.Executing a search query
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/query/QueryDslIT.java[tags=entryPoint]
+----
+<1> Get a Hibernate Search session, called `SearchSession`, from the `EntityManager`.
+<2> Initiate a search query on the index mapped to the `Book` entity.
+<3> Define that only documents matching the given predicate should be returned.
+The predicate is created using a factory `f` passed as an argument to the lambda expression.
+See <<search-dsl-predicate>> for more information about predicates.
+<4> Build the query and fetch the results.
+<5> Retrieve the total number of matching entities.
+<6> Retrieve matching entities.
+====
+
+By default, the hits of a search query will be managed Hibernate ORM entities,
+bound to the entity manager used to create the search session.
+This provides all the benefits of Hibernate ORM,
+in particular the ability to navigate the entity graph to retrieve associated entities if necessary.
+
+The query DSL offers many features, detailed in the following sections.
+Some commonly used features include:
+
+* <<search-dsl-predicate,predicates>>,
+to define which documents must be included in the search results.
+* <<search-dsl-query-fetching-results,fetching the results differently>>:
+getting the hits directly as a list,
+using pagination, scrolling, etc.
+* <<search-dsl-sort,sorts>>,
+to order the hits in various ways:
+by score, by the value of a field, by distance to a point, etc.
+* <<search-dsl-projection,projections>>,
+to retrieve hits that are not just managed entities:
+data can be extracted from the index (field values),
+or even from both the index and the database.
 
 [[search-dsl-query-fetching-results]]
 === Fetching results

--- a/documentation/src/main/asciidoc/search-dsl.asciidoc
+++ b/documentation/src/main/asciidoc/search-dsl.asciidoc
@@ -909,26 +909,13 @@ so that it is correctly stored in the index.
 
 While field projections are certainly the most common,
 they are not the only type of projection.
-Other projections allow to compose custom beans containing extracted data,
-get references to the extracted documents or the corresponding entities,
-or get information about the search query itself (score, ...).
+Other projections allow to
+<<search-dsl-projection-composite,compose custom beans containing extracted data>>,
+get references to the <<search-dsl-projection-documentReference,extracted documents>>
+or the <<search-dsl-projection-reference,corresponding entities>>,
+or get information related to the search query itself
+(<<search-dsl-projection-score,score>>, ...).
 
-The following example shows how to retrieve the managed entity corresponding to each matched document
-along with the score of that document, and wraps this information into a custom bean:
-
-.Using advanced projection types
-====
-[source, JAVA, indent=0]
-----
-include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/directfieldmapping/HibernateOrmSimpleMappingIT.java[tags=projection-advanced-bean]
-----
-[source, JAVA, indent=0]
-----
-include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/directfieldmapping/HibernateOrmSimpleMappingIT.java[tags=projection-advanced]
-----
-====
-
-The projection DSL offers more projection types, and multiple options for each type of projection.
 To learn more about the field projection, and all the other types of projection,
 refer to the following sections.
 

--- a/documentation/src/main/asciidoc/search-dsl.asciidoc
+++ b/documentation/src/main/asciidoc/search-dsl.asciidoc
@@ -99,7 +99,7 @@ The predicate is configured when building the search query:
 ====
 [source, JAVA, indent=0, subs="+callouts"]
 ----
-include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/directfieldmapping/HibernateOrmSimpleMappingIT.java[tags=predicate-simple-lambdas]
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=entryPoint-lambdas]
 ----
 <1> Start building the query.
 <2> Mention that the results of the query are expected to have a `title` field matching the value `robot`.
@@ -113,7 +113,7 @@ Or alternatively, if you don't want to use lambdas:
 ====
 [source, JAVA, indent=0]
 ----
-include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/directfieldmapping/HibernateOrmSimpleMappingIT.java[tags=predicate-simple-objects]
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java[tags=entryPoint-objects]
 ----
 ====
 
@@ -673,7 +673,7 @@ Other sorts, including the sort by field value, can be configured when building 
 ====
 [source, JAVA, indent=0, subs="+callouts"]
 ----
-include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/directfieldmapping/HibernateOrmSimpleMappingIT.java[tags=sort-simple-lambdas]
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/sort/SortDslIT.java[tags=entryPoint-lambdas]
 ----
 <1> Start building the query as usual.
 <2> Mention that the results of the query are expected to be sorted on field "pageCount" in descending order,
@@ -688,7 +688,7 @@ Or alternatively, if you don't want to use lambdas:
 ====
 [source, JAVA, indent=0]
 ----
-include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/directfieldmapping/HibernateOrmSimpleMappingIT.java[tags=sort-simple-objects]
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/sort/SortDslIT.java[tags=entryPoint-objects]
 ----
 ====
 
@@ -882,7 +882,7 @@ Projections can be configured when building the search query:
 ====
 [source, JAVA, indent=0, subs="+callouts"]
 ----
-include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/directfieldmapping/HibernateOrmSimpleMappingIT.java[tags=projection-simple-lambdas]
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/projection/ProjectionDslIT.java[tags=entryPoint-lambdas]
 ----
 <1> Start building the query as usual.
 <2> Mention that the expected result of the query is a projection on field "title", of type String.
@@ -896,7 +896,7 @@ Or alternatively, if you don't want to use lambdas:
 ====
 [source, JAVA, indent=0]
 ----
-include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/directfieldmapping/HibernateOrmSimpleMappingIT.java[tags=projection-simple-objects]
+include::{sourcedir}/org/hibernate/search/documentation/searchdsl/projection/ProjectionDslIT.java[tags=entryPoint-objects]
 ----
 ====
 

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/directfieldmapping/HibernateOrmSimpleMappingIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/directfieldmapping/HibernateOrmSimpleMappingIT.java
@@ -176,29 +176,6 @@ public class HibernateOrmSimpleMappingIT {
 		} );
 	}
 
-	@Test
-	public void projection_advanced() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
-			// tag::projection-advanced[]
-			SearchSession searchSession = Search.getSearchSession( entityManager );
-
-			List<MyEntityAndScoreBean<Book>> result = searchSession.search( Book.class )
-					.asProjection( f -> f.composite(
-							MyEntityAndScoreBean::new,
-							f.entity(),
-							f.score()
-					) )
-					.predicate( f -> f.matchAll() )
-					.fetchHits();
-			// end::projection-advanced[]
-
-			assertThat( result )
-					.extracting( "entity" )
-					.extracting( "title", String.class )
-					.containsExactlyInAnyOrder( BOOK1_TITLE, BOOK2_TITLE, BOOK3_TITLE );
-		} );
-	}
-
 	private void initData() {
 		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
 			Book book1 = new Book();
@@ -216,17 +193,5 @@ public class HibernateOrmSimpleMappingIT {
 			entityManager.persist( book3 );
 		} );
 	}
-
-	// Note: ideally we should use "static" here, but it looks better without it in the documentation.
-	// tag::projection-advanced-bean[]
-	public class MyEntityAndScoreBean<T> {
-		public final T entity;
-		public final float score;
-		public MyEntityAndScoreBean(T entity, float score) {
-			this.entity = entity;
-			this.score = score;
-		}
-	}
-	// end::projection-advanced-bean[]
 
 }

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/directfieldmapping/HibernateOrmSimpleMappingIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/directfieldmapping/HibernateOrmSimpleMappingIT.java
@@ -16,7 +16,6 @@ import org.hibernate.search.documentation.testsupport.BackendSetupStrategy;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmAutomaticIndexingSynchronizationStrategyName;
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
-import org.hibernate.search.mapper.orm.scope.SearchScope;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.util.impl.integrationtest.orm.OrmSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.orm.OrmUtils;
@@ -27,6 +26,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+/**
+ * Test that the simple mapping defined in Book works as expected.
+ */
 @RunWith(Parameterized.class)
 public class HibernateOrmSimpleMappingIT {
 	private static final String BOOK1_TITLE = "I, Robot";
@@ -66,67 +68,8 @@ public class HibernateOrmSimpleMappingIT {
 	}
 
 	@Test
-	public void predicate_simple() {
+	public void sort() {
 		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
-			// tag::predicate-simple-objects[]
-			SearchSession searchSession = Search.getSearchSession( entityManager );
-
-			SearchScope<Book> scope = searchSession.scope( Book.class );
-
-			List<Book> result = scope.search()
-					.predicate( scope.predicate().match().onField( "title" )
-							.matching( "robot" )
-							.toPredicate() )
-					.fetchHits();
-			// end::predicate-simple-objects[]
-
-			assertThat( result )
-					.extracting( "title" )
-					.containsExactlyInAnyOrder( BOOK1_TITLE, BOOK3_TITLE );
-		} );
-
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
-			// tag::predicate-simple-lambdas[]
-			SearchSession searchSession = Search.getSearchSession( entityManager );
-
-			List<Book> result = searchSession.search( Book.class ) // <1>
-					.predicate( f -> f.match().onField( "title" ) // <2>
-							.matching( "robot" ) )
-					.fetchHits(); // <3>
-			// end::predicate-simple-lambdas[]
-
-			assertThat( result )
-					.extracting( "title" )
-					.containsExactlyInAnyOrder( BOOK1_TITLE, BOOK3_TITLE );
-		} );
-	}
-
-	@Test
-	public void sort_simple() {
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
-			// tag::sort-simple-objects[]
-			SearchSession searchSession = Search.getSearchSession( entityManager );
-
-			SearchScope<Book> scope = searchSession.scope( Book.class );
-
-			List<Book> result = scope.search()
-					.predicate( scope.predicate().matchAll().toPredicate() )
-					.sort(
-							scope.sort()
-							.byField( "pageCount" ).desc()
-							.then().byField( "title_sort" )
-							.toSort()
-					)
-					.fetchHits();
-			// end::sort-simple-objects[]
-
-			assertThat( result )
-					.extracting( "title" )
-					.containsExactly( BOOK3_TITLE, BOOK1_TITLE, BOOK2_TITLE );
-		} );
-
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
-			// tag::sort-simple-lambdas[]
 			SearchSession searchSession = Search.getSearchSession( entityManager );
 
 			List<Book> result = searchSession.search( Book.class ) // <1>
@@ -135,7 +78,6 @@ public class HibernateOrmSimpleMappingIT {
 							.then().byField( "title_sort" )
 					)
 					.fetchHits(); // <3>
-			// end::sort-simple-lambdas[]
 
 			assertThat( result )
 					.extracting( "title" )
@@ -146,30 +88,12 @@ public class HibernateOrmSimpleMappingIT {
 	@Test
 	public void projection_simple() {
 		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
-			// tag::projection-simple-objects[]
-			SearchSession searchSession = Search.getSearchSession( entityManager );
-
-			SearchScope<Book> scope = searchSession.scope( Book.class );
-
-			List<String> result = scope.search()
-					.asProjection( scope.projection().field( "title", String.class ).toProjection() )
-					.predicate( scope.predicate().matchAll().toPredicate() )
-					.fetchHits();
-			// end::projection-simple-objects[]
-
-			assertThat( result )
-					.containsExactlyInAnyOrder( BOOK1_TITLE, BOOK2_TITLE, BOOK3_TITLE );
-		} );
-
-		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
-			// tag::projection-simple-lambdas[]
 			SearchSession searchSession = Search.getSearchSession( entityManager );
 
 			List<String> result = searchSession.search( Book.class ) // <1>
 					.asProjection( f -> f.field( "title", String.class ) ) // <2>
 					.predicate( f -> f.matchAll() )
 					.fetchHits(); // <3>
-			// end::projection-simple-lambdas[]
 
 			assertThat( result )
 					.containsExactlyInAnyOrder( BOOK1_TITLE, BOOK2_TITLE, BOOK3_TITLE );

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/directfieldmapping/HibernateOrmSimpleMappingIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/directfieldmapping/HibernateOrmSimpleMappingIT.java
@@ -66,6 +66,42 @@ public class HibernateOrmSimpleMappingIT {
 	}
 
 	@Test
+	public void predicate_simple() {
+		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+			// tag::predicate-simple-objects[]
+			SearchSession searchSession = Search.getSearchSession( entityManager );
+
+			SearchScope<Book> scope = searchSession.scope( Book.class );
+
+			List<Book> result = scope.search()
+					.predicate( scope.predicate().match().onField( "title" )
+							.matching( "robot" )
+							.toPredicate() )
+					.fetchHits();
+			// end::predicate-simple-objects[]
+
+			assertThat( result )
+					.extracting( "title" )
+					.containsExactlyInAnyOrder( BOOK1_TITLE, BOOK3_TITLE );
+		} );
+
+		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+			// tag::predicate-simple-lambdas[]
+			SearchSession searchSession = Search.getSearchSession( entityManager );
+
+			List<Book> result = searchSession.search( Book.class ) // <1>
+					.predicate( f -> f.match().onField( "title" ) // <2>
+							.matching( "robot" ) )
+					.fetchHits(); // <3>
+			// end::predicate-simple-lambdas[]
+
+			assertThat( result )
+					.extracting( "title" )
+					.containsExactlyInAnyOrder( BOOK1_TITLE, BOOK3_TITLE );
+		} );
+	}
+
+	@Test
 	public void sort_simple() {
 		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
 			// tag::sort-simple-objects[]

--- a/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/converter/DslConverterIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/converter/DslConverterIT.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.documentation.searchdsl;
+package org.hibernate.search.documentation.searchdsl.converter;
 
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/converter/ProjectionConverterIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/converter/ProjectionConverterIT.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.documentation.searchdsl;
+package org.hibernate.search.documentation.searchdsl.converter;
 
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/predicate/Author.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/predicate/Author.java
@@ -1,0 +1,82 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.documentation.searchdsl.predicate;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.ManyToMany;
+
+import org.hibernate.search.mapper.pojo.bridge.builtin.spatial.annotation.GeoPointBridge;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+@Entity
+@Indexed
+public class Author {
+
+	@Id
+	private Integer id;
+
+	@FullTextField(analyzer = "name")
+	private String firstName;
+
+	@FullTextField(analyzer = "name")
+	private String lastName;
+
+	@Embedded
+	@GeoPointBridge
+	private EmbeddableGeoPoint placeOfBirth;
+
+	@ManyToMany(mappedBy = "authors")
+	private List<Book> books = new ArrayList<>();
+
+	public Author() {
+	}
+
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getFirstName() {
+		return firstName;
+	}
+
+	public void setFirstName(String firstName) {
+		this.firstName = firstName;
+	}
+
+	public String getLastName() {
+		return lastName;
+	}
+
+	public void setLastName(String lastName) {
+		this.lastName = lastName;
+	}
+
+	public EmbeddableGeoPoint getPlaceOfBirth() {
+		return placeOfBirth;
+	}
+
+	public void setPlaceOfBirth(EmbeddableGeoPoint placeOfBirth) {
+		this.placeOfBirth = placeOfBirth;
+	}
+
+	public List<Book> getBooks() {
+		return books;
+	}
+
+	public void setBooks(List<Book> books) {
+		this.books = books;
+	}
+}

--- a/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/predicate/Book.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/predicate/Book.java
@@ -1,0 +1,107 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.documentation.searchdsl.predicate;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.ManyToMany;
+
+import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
+
+@Entity
+@Indexed
+public class Book {
+
+	@Id
+	private Integer id;
+
+	@FullTextField(analyzer = "english")
+	@FullTextField(name = "title_autocomplete", analyzer = "autocomplete_indexing")
+	private String title;
+
+	@FullTextField(analyzer = "english")
+	private String description;
+
+	@GenericField
+	private Integer pageCount;
+
+	@KeywordField
+	private Genre genre;
+
+	@FullTextField(analyzer = "english")
+	private String comment;
+
+	@ManyToMany
+	@IndexedEmbedded(storage = ObjectFieldStorage.NESTED)
+	private List<Author> authors = new ArrayList<>();
+
+	public Book() {
+	}
+
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public Integer getPageCount() {
+		return pageCount;
+	}
+
+	public void setPageCount(Integer pageCount) {
+		this.pageCount = pageCount;
+	}
+
+	public Genre getGenre() {
+		return genre;
+	}
+
+	public void setGenre(Genre genre) {
+		this.genre = genre;
+	}
+
+	public String getComment() {
+		return comment;
+	}
+
+	public void setComment(String comment) {
+		this.comment = comment;
+	}
+
+	public List<Author> getAuthors() {
+		return authors;
+	}
+
+	public void setAuthors(List<Author> authors) {
+		this.authors = authors;
+	}
+}

--- a/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/predicate/EmbeddableGeoPoint.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/predicate/EmbeddableGeoPoint.java
@@ -1,0 +1,46 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.documentation.searchdsl.predicate;
+
+import javax.persistence.Basic;
+import javax.persistence.Embeddable;
+
+import org.hibernate.search.engine.spatial.GeoPoint;
+
+@Embeddable
+public class EmbeddableGeoPoint implements GeoPoint {
+
+	public static EmbeddableGeoPoint of(double latitude, double longitude) {
+		return new EmbeddableGeoPoint( latitude, longitude );
+	}
+
+	@Basic
+	private Double latitude;
+	@Basic
+	private Double longitude;
+
+	protected EmbeddableGeoPoint() {
+		// For Hibernate ORM
+	}
+
+	private EmbeddableGeoPoint(double latitude, double longitude) {
+		this.latitude = latitude;
+		this.longitude = longitude;
+	}
+
+	@Override
+	@Basic
+	public double getLatitude() {
+		return latitude;
+	}
+
+	@Override
+	@Basic
+	public double getLongitude() {
+		return longitude;
+	}
+}

--- a/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/predicate/Genre.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/predicate/Genre.java
@@ -1,0 +1,14 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.documentation.searchdsl.predicate;
+
+public enum Genre {
+
+	SCIENCE_FICTION,
+	CRIME_FICTION
+
+}

--- a/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java
@@ -1,0 +1,782 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.documentation.searchdsl.predicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import javax.persistence.EntityManagerFactory;
+
+import org.hibernate.search.backend.elasticsearch.ElasticsearchExtension;
+import org.hibernate.search.backend.lucene.LuceneExtension;
+import org.hibernate.search.documentation.testsupport.BackendSetupStrategy;
+import org.hibernate.search.engine.spatial.DistanceUnit;
+import org.hibernate.search.engine.spatial.GeoBoundingBox;
+import org.hibernate.search.engine.spatial.GeoPoint;
+import org.hibernate.search.engine.spatial.GeoPolygon;
+import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.orm.cfg.HibernateOrmAutomaticIndexingSynchronizationStrategyName;
+import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
+import org.hibernate.search.mapper.orm.session.SearchSession;
+import org.hibernate.search.util.impl.integrationtest.orm.OrmSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.orm.OrmUtils;
+
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.RegexpQuery;
+
+@RunWith(Parameterized.class)
+public class PredicateDslIT {
+
+	private static final int ASIMOV_ID = 1;
+	private static final int MARTINEZ_ID = 2;
+
+	private static final int BOOK1_ID = 1;
+	private static final int BOOK2_ID = 2;
+	private static final int BOOK3_ID = 3;
+	private static final int BOOK4_ID = 4;
+
+	@Parameterized.Parameters(name = "{0}")
+	public static Object[] backendSetups() {
+		return BackendSetupStrategy.simple().toArray();
+	}
+
+	@Rule
+	public OrmSetupHelper setupHelper = new OrmSetupHelper();
+
+	private final BackendSetupStrategy backendSetupStrategy;
+
+	private EntityManagerFactory entityManagerFactory;
+
+	public PredicateDslIT(BackendSetupStrategy backendSetupStrategy) {
+		this.backendSetupStrategy = backendSetupStrategy;
+	}
+
+	@Before
+	public void setup() {
+		entityManagerFactory = backendSetupStrategy.withSingleBackend( setupHelper )
+				.withProperty(
+						HibernateOrmMapperSettings.AUTOMATIC_INDEXING_SYNCHRONIZATION_STRATEGY,
+						HibernateOrmAutomaticIndexingSynchronizationStrategyName.SEARCHABLE
+				)
+				.setup( Book.class, Author.class, EmbeddableGeoPoint.class );
+		initData();
+	}
+
+	@Test
+	public void matchAll() {
+		withinSearchSession( searchSession -> {
+			// tag::matchAll[]
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate( f -> f.matchAll() )
+					.fetchHits();
+			// end::matchAll[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK1_ID, BOOK2_ID, BOOK3_ID, BOOK4_ID );
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::matchAll-except[]
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate( f -> f.matchAll()
+							.except( f.match().onField( "title" )
+									.matching( "robot" ) )
+					)
+					.fetchHits();
+			// end::matchAll-except[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK2_ID, BOOK4_ID );
+		} );
+	}
+
+	@Test
+	public void id() {
+		// DO NOT USE THE BOOKX_ID CONSTANTS INSIDE TAGS BELOW:
+		// we don't want the constants to appear in the documentation.
+
+		withinSearchSession( searchSession -> {
+			// tag::id[]
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate( f -> f.id().matching( 1 ) )
+					.fetchHits();
+			// end::id[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK1_ID );
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::id-matchingAny[]
+			List<Integer> ids = new ArrayList<>();
+			ids.add( 1 );
+			ids.add( 2 );
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate( f -> f.id().matchingAny( ids ) )
+					.fetchHits();
+			// end::id-matchingAny[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK1_ID, BOOK2_ID );
+		} );
+	}
+
+	@Test
+	public void bool() {
+		withinSearchSession( searchSession -> {
+			// tag::bool-or[]
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate( f -> f.bool()
+							.should( f.match().onField( "title" )
+									.matching( "robot" ) ) // <1>
+							.should( f.match().onField( "description" )
+									.matching( "investigation" ) ) // <2>
+					)
+					.fetchHits(); // <3>
+			// end::bool-or[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK1_ID, BOOK2_ID, BOOK3_ID );
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::bool-and[]
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate( f -> f.bool()
+							.must( f.match().onField( "title" )
+									.matching( "robot" ) ) // <1>
+							.must( f.match().onField( "description" )
+									.matching( "crime" ) ) // <2>
+					)
+					.fetchHits(); // <3>
+			// end::bool-and[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK3_ID );
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::bool-mustNot[]
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate( f -> f.bool()
+							.must( f.match().onField( "title" )
+									.matching( "robot" ) ) // <1>
+							.mustNot( f.match().onField( "description" )
+									.matching( "investigation" ) ) // <2>
+					)
+					.fetchHits(); // <3>
+			// end::bool-mustNot[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK1_ID, BOOK3_ID );
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::bool-filter[]
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate( f -> f.bool() // <1>
+							.should( f.bool() // <2>
+									.filter( f.match().onField( "genre" )
+											.matching( Genre.SCIENCE_FICTION ) ) // <3>
+									.must( f.match().onFields( "description" )
+											.matching( "crime" ) ) // <4>
+							)
+							.should( f.bool() // <5>
+									.filter( f.match().onField( "genre" )
+											.matching( Genre.CRIME_FICTION ) ) // <6>
+									.must( f.match().onFields( "description" )
+											.matching( "robot" ) ) // <7>
+							)
+					)
+					.fetchHits(); // <8>
+			// end::bool-filter[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK3_ID, BOOK4_ID );
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::bool-mustAndShould[]
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate( f -> f.bool()
+							.must( f.match().onField( "title" )
+									.matching( "robot" ) ) // <1>
+							.should( f.match().onField( "description" )
+									.matching( "crime" ) ) // <2>
+							.should( f.match().onField( "description" )
+									.matching( "investigation" ) ) // <3>
+					)
+					.fetchHits(); // <4>
+			// end::bool-mustAndShould[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK1_ID, BOOK3_ID );
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::bool-minimumShouldMatchNumber[]
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate( f -> f.bool()
+							.minimumShouldMatchNumber( 2 ) // <1>
+							.should( f.match().onField( "description" )
+									.matching( "robot" ) ) // <2>
+							.should( f.match().onField( "description" )
+									.matching( "investigation" ) ) // <3>
+							.should( f.match().onField( "description" )
+									.matching( "disappearance" ) ) // <4>
+					)
+					.fetchHits(); // <5>
+			// end::bool-minimumShouldMatchNumber[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK2_ID, BOOK4_ID );
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::bool-dynamicParameters[]
+			MySearchParameters searchParameters = getSearchParameters(); // <1>
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate( f -> f.bool( b -> { // <2>
+						b.must( f.matchAll() ); // <3>
+						if ( searchParameters.getGenreFilter() != null ) { // <4>
+							b.must( f.match().onField( "genre" )
+									.matching( searchParameters.getGenreFilter() ) );
+						}
+						if ( searchParameters.getFullTextFilter() != null ) {
+							b.must( f.match().onFields( "title", "description" )
+									.matching( searchParameters.getFullTextFilter() ) );
+						}
+						if ( searchParameters.getPageCountMaxFilter() != null ) {
+							b.must( f.range().onField( "pageCount" )
+									.below( searchParameters.getPageCountMaxFilter() ) );
+						}
+					} ) )
+					.fetchHits(); // <5>
+			// end::bool-dynamicParameters[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK1_ID, BOOK2_ID );
+		} );
+	}
+
+	@Test
+	public void match() {
+		withinSearchSession( searchSession -> {
+			// tag::match[]
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate( f -> f.match().onField( "title" )
+							.matching( "robot" ) )
+					.fetchHits();
+			// end::match[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK1_ID, BOOK3_ID );
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::match-multipleTerms[]
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate( f -> f.match().onField( "title" )
+							.matching( "robot dawn" ) ) // <1>
+					.fetchHits(); // <2>
+			// end::match-multipleTerms[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK1_ID, BOOK3_ID );
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::match-orField[]
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate(
+							f -> f.match()
+									.onField( "title" ).orField( "description" )
+									.matching( "robot" )
+					)
+					.fetchHits();
+			// end::match-orField[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK1_ID, BOOK2_ID, BOOK3_ID, BOOK4_ID );
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::match-fields[]
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate(
+							f -> f.match()
+									.onFields( "title", "description" )
+									.matching( "robot" )
+					)
+					.fetchHits();
+			// end::match-fields[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK1_ID, BOOK2_ID, BOOK3_ID, BOOK4_ID );
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::match-fuzzy[]
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate(
+							f -> f.match()
+									.onField( "title" )
+									.matching( "robto" )
+									.fuzzy()
+					)
+					.fetchHits();
+			// end::match-fuzzy[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK1_ID, BOOK3_ID );
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::match-analyzer[]
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate(
+							f -> f.match()
+									.onField( "title_autocomplete" )
+									.matching( "robo" )
+									.analyzer( "autocomplete_query" )
+					)
+					.fetchHits();
+			// end::match-analyzer[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK1_ID, BOOK3_ID );
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::match-skipAnalysis[]
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate(
+							f -> f.match()
+									.onField( "title" )
+									.matching( "robot" )
+									.skipAnalysis()
+					)
+					.fetchHits();
+			// end::match-skipAnalysis[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK1_ID, BOOK3_ID );
+		} );
+	}
+
+	@Test
+	public void range() {
+		withinSearchSession( searchSession -> {
+			// tag::range-between[]
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate( f -> f.range().onField( "pageCount" )
+							.from( 210 ).to( 250 ) )
+					.fetchHits();
+			// end::range-between[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK1_ID, BOOK4_ID );
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::range-above[]
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate( f -> f.range().onField( "pageCount" )
+							.above( 400 ) )
+					.fetchHits();
+			// end::range-above[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK3_ID );
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::range-below[]
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate( f -> f.range().onField( "pageCount" )
+							.below( 400 ) )
+					.fetchHits();
+			// end::range-below[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK1_ID, BOOK2_ID, BOOK4_ID );
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::range-excludeLimit[]
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate( f -> f.range().onField( "pageCount" )
+							.from( 200 ).excludeLimit()
+							.to( 250 ).excludeLimit() )
+					.fetchHits();
+			// end::range-excludeLimit[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK2_ID, BOOK4_ID );
+		} );
+	}
+
+	@Test
+	public void phrase() {
+		withinSearchSession( searchSession -> {
+			// tag::phrase[]
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate( f -> f.phrase().onField( "title" )
+							.matching( "robots of dawn" ) )
+					.fetchHits();
+			// end::phrase[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK3_ID );
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::phrase-withSlop[]
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate( f -> f.phrase().onField( "title" )
+							.matching( "dawn robot" )
+							.withSlop( 3 ) )
+					.fetchHits();
+			// end::phrase-withSlop[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK3_ID );
+		} );
+	}
+
+	@Test
+	public void simpleQueryString() {
+		withinSearchSession( searchSession -> {
+			// tag::simpleQueryString-boolean[]
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate( f -> f.simpleQueryString().onField( "description" )
+							.matching( "robots + (crime | investigation | disappearance)" ) )
+					.fetchHits();
+			// end::simpleQueryString-boolean[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK2_ID, BOOK4_ID );
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::simpleQueryString-not[]
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate( f -> f.simpleQueryString().onField( "description" )
+							.matching( "robots + -investigation" ) )
+					.fetchHits();
+			// end::simpleQueryString-not[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK1_ID, BOOK4_ID );
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::simpleQueryString-withAndAsDefaultOperator[]
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate( f -> f.simpleQueryString().onField( "description" )
+							.matching( "robots investigation" )
+							.withAndAsDefaultOperator() )
+					.fetchHits();
+			// end::simpleQueryString-withAndAsDefaultOperator[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK2_ID );
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::simpleQueryString-prefix[]
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate( f -> f.simpleQueryString().onField( "description" )
+							.matching( "rob*" ) )
+					.fetchHits();
+			// end::simpleQueryString-prefix[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK1_ID, BOOK2_ID, BOOK3_ID, BOOK4_ID );
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::simpleQueryString-fuzzy[]
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate( f -> f.simpleQueryString().onField( "description" )
+							.matching( "robto~2" ) )
+					.fetchHits();
+			// end::simpleQueryString-fuzzy[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK1_ID, BOOK2_ID, BOOK4_ID );
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::simpleQueryString-phrase[]
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate( f -> f.simpleQueryString().onField( "title" )
+							.matching( "\"robots of dawn\"" ) )
+					.fetchHits();
+			// end::simpleQueryString-phrase[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK3_ID );
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::simpleQueryString-phrase-withSlop[]
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate( f -> f.simpleQueryString().onField( "title" )
+							.matching( "\"dawn robot\"~3" ) )
+					.fetchHits();
+			// end::simpleQueryString-phrase-withSlop[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK3_ID );
+		} );
+	}
+
+	@Test
+	public void exists() {
+		withinSearchSession( searchSession -> {
+			// tag::exists[]
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate( f -> f.exists().onField( "comment" ) )
+					.fetchHits();
+			// end::exists[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK2_ID );
+		} );
+	}
+
+	@Test
+	public void wildcard() {
+		withinSearchSession( searchSession -> {
+			// tag::wildcard[]
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate( f -> f.wildcard().onField( "description" )
+							.matching( "rob*t" ) )
+					.fetchHits();
+			// end::wildcard[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK1_ID, BOOK2_ID, BOOK4_ID );
+		} );
+	}
+
+	@Test
+	public void nested() {
+		withinSearchSession( searchSession -> {
+			// tag::nested[]
+			List<Book> hits = searchSession.search( Book.class )
+					.predicate( f -> f.nested().onObjectField( "authors" ) // <1>
+							.nest( f.bool()
+									.must( f.match().onField( "authors.firstName" )
+											.matching( "isaac" ) ) // <2>
+									.must( f.match().onField( "authors.lastName" )
+											.matching( "asimov" ) ) // <3>
+							) )
+					.fetchHits(); // <4>
+			// end::nested[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK1_ID, BOOK2_ID, BOOK3_ID );
+		} );
+	}
+
+	@Test
+	public void within() {
+		withinSearchSession( searchSession -> {
+			// tag::within-circle[]
+			GeoPoint center = GeoPoint.of( 53.970000, 32.150000 );
+			List<Author> hits = searchSession.search( Author.class )
+					.predicate( f -> f.spatial().within().onField( "placeOfBirth" )
+							.circle( center, 50, DistanceUnit.KILOMETERS ) )
+					.fetchHits();
+			// end::within-circle[]
+			assertThat( hits )
+					.extracting( Author::getId )
+					.containsExactlyInAnyOrder( ASIMOV_ID );
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::within-box[]
+			GeoBoundingBox box = GeoBoundingBox.of(
+					53.99, 32.13,
+					53.95, 32.17
+			);
+			List<Author> hits = searchSession.search( Author.class )
+					.predicate( f -> f.spatial().within().onField( "placeOfBirth" )
+							.boundingBox( box ) )
+					.fetchHits();
+			// end::within-box[]
+			assertThat( hits )
+					.extracting( Author::getId )
+					.containsExactlyInAnyOrder( ASIMOV_ID );
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::within-polygon[]
+			GeoPolygon polygon = GeoPolygon.of(
+					GeoPoint.of( 53.976177, 32.138627 ),
+					GeoPoint.of( 53.986177, 32.148627 ),
+					GeoPoint.of( 53.979177, 32.168627 ),
+					GeoPoint.of( 53.876177, 32.159627 ),
+					GeoPoint.of( 53.956177, 32.155627 ),
+					GeoPoint.of( 53.976177, 32.138627 )
+			);
+			List<Author> hits = searchSession.search( Author.class )
+					.predicate( f -> f.spatial().within().onField( "placeOfBirth" )
+							.polygon( polygon ) )
+					.fetchHits();
+			// end::within-polygon[]
+			assertThat( hits )
+					.extracting( Author::getId )
+					.containsExactlyInAnyOrder( ASIMOV_ID );
+		} );
+	}
+
+	@Test
+	public void lucene() {
+		Assume.assumeTrue( BackendSetupStrategy.LUCENE.equals( backendSetupStrategy ) );
+
+		withinSearchSession( searchSession -> {
+			// tag::lucene-fromLuceneQuery[]
+			List<Book> hits = searchSession.search( Book.class )
+					.extension( LuceneExtension.get() )
+					.predicate( f -> f.fromLuceneQuery(
+							new RegexpQuery( new Term( "description", "neighbor|neighbour" ) )
+					) )
+					.fetchHits();
+			// end::lucene-fromLuceneQuery[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK4_ID );
+		} );
+	}
+
+	@Test
+	public void elasticsearch() {
+		Assume.assumeTrue( BackendSetupStrategy.ELASTICSEARCH.equals( backendSetupStrategy ) );
+
+		withinSearchSession( searchSession -> {
+			// tag::elasticsearch-fromJson[]
+			List<Book> hits = searchSession.search( Book.class )
+					.extension( ElasticsearchExtension.get() )
+					.predicate( f -> f.fromJson( "{"
+									+ "\"regexp\": {"
+											+ "\"description\": \"neighbor|neighbour\""
+									+ "}"
+							+ "}" ) )
+					.fetchHits();
+			// end::elasticsearch-fromJson[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK4_ID );
+		} );
+	}
+
+	private MySearchParameters getSearchParameters() {
+		return new MySearchParameters() {
+			@Override
+			public Genre getGenreFilter() {
+				return Genre.SCIENCE_FICTION;
+			}
+
+			@Override
+			public String getFullTextFilter() {
+				return "robot";
+			}
+
+			@Override
+			public Integer getPageCountMaxFilter() {
+				return 400;
+			}
+		};
+	}
+
+	private void withinSearchSession(Consumer<SearchSession> action) {
+		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+			SearchSession searchSession = Search.getSearchSession( entityManager );
+			action.accept( searchSession );
+		} );
+	}
+
+	private void initData() {
+		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+			Author isaacAsimov = new Author();
+			isaacAsimov.setId( ASIMOV_ID );
+			isaacAsimov.setFirstName( "Isaac" );
+			isaacAsimov.setLastName( "Asimov" );
+			isaacAsimov.setPlaceOfBirth( EmbeddableGeoPoint.of( 53.976177, 32.158627 ) );
+
+			Author aLeeMartinez = new Author();
+			aLeeMartinez.setId( MARTINEZ_ID );
+			aLeeMartinez.setFirstName( "A. Lee" );
+			aLeeMartinez.setLastName( "Martinez" );
+			aLeeMartinez.setPlaceOfBirth( EmbeddableGeoPoint.of( 31.814315, -106.475524 ) );
+
+			Book book1 = new Book();
+			book1.setId( BOOK1_ID );
+			book1.setTitle( "I, Robot" );
+			book1.setDescription( "A robot becomes self-aware." );
+			book1.setPageCount( 250 );
+			book1.setGenre( Genre.SCIENCE_FICTION );
+			book1.getAuthors().add( isaacAsimov );
+			isaacAsimov.getBooks().add( book1 );
+
+			Book book2 = new Book();
+			book2.setId( BOOK2_ID );
+			book2.setTitle( "The Caves of Steel" );
+			book2.setDescription( "A robot helps investigate a murder on an extrasolar colony." );
+			book2.setPageCount( 206 );
+			book2.setGenre( Genre.SCIENCE_FICTION );
+			book2.setComment( "Really liked this one!" );
+			book2.getAuthors().add( isaacAsimov );
+			isaacAsimov.getBooks().add( book2 );
+
+			Book book3 = new Book();
+			book3.setId( BOOK3_ID );
+			book3.setTitle( "The Robots of Dawn" );
+			book3.setDescription( "A crime story about the first \"roboticide\"." );
+			book3.setPageCount( 435 );
+			book3.setGenre( Genre.SCIENCE_FICTION );
+			book3.getAuthors().add( isaacAsimov );
+			isaacAsimov.getBooks().add( book3 );
+
+			Book book4 = new Book();
+			book4.setId( BOOK4_ID );
+			book4.setTitle( "The Automatic Detective" );
+			book4.setDescription( "A robot cab driver turns PI after the disappearance of a neighboring family." );
+			book4.setPageCount( 222 );
+			book4.setGenre( Genre.CRIME_FICTION );
+			book4.getAuthors().add( aLeeMartinez );
+			aLeeMartinez.getBooks().add( book3 );
+
+			entityManager.persist( isaacAsimov );
+			entityManager.persist( aLeeMartinez );
+
+			entityManager.persist( book1 );
+			entityManager.persist( book2 );
+			entityManager.persist( book3 );
+			entityManager.persist( book4 );
+		} );
+	}
+
+	private interface MySearchParameters {
+		Genre getGenreFilter();
+		String getFullTextFilter();
+		Integer getPageCountMaxFilter();
+	}
+}

--- a/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/projection/Author.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/projection/Author.java
@@ -1,0 +1,83 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.documentation.searchdsl.projection;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.ManyToMany;
+
+import org.hibernate.search.engine.backend.types.Projectable;
+import org.hibernate.search.mapper.pojo.bridge.builtin.spatial.annotation.GeoPointBridge;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+@Entity
+@Indexed
+public class Author {
+
+	@Id
+	private Integer id;
+
+	@FullTextField(analyzer = "name", projectable = Projectable.YES)
+	private String firstName;
+
+	@FullTextField(analyzer = "name", projectable = Projectable.YES)
+	private String lastName;
+
+	@Embedded
+	@GeoPointBridge(projectable = Projectable.YES)
+	private EmbeddableGeoPoint placeOfBirth;
+
+	@ManyToMany(mappedBy = "authors")
+	private List<Book> books = new ArrayList<>();
+
+	public Author() {
+	}
+
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getFirstName() {
+		return firstName;
+	}
+
+	public void setFirstName(String firstName) {
+		this.firstName = firstName;
+	}
+
+	public String getLastName() {
+		return lastName;
+	}
+
+	public void setLastName(String lastName) {
+		this.lastName = lastName;
+	}
+
+	public EmbeddableGeoPoint getPlaceOfBirth() {
+		return placeOfBirth;
+	}
+
+	public void setPlaceOfBirth(EmbeddableGeoPoint placeOfBirth) {
+		this.placeOfBirth = placeOfBirth;
+	}
+
+	public List<Book> getBooks() {
+		return books;
+	}
+
+	public void setBooks(List<Book> books) {
+		this.books = books;
+	}
+}

--- a/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/projection/Book.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/projection/Book.java
@@ -1,0 +1,73 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.documentation.searchdsl.projection;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.ManyToMany;
+
+import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
+import org.hibernate.search.engine.backend.types.Projectable;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
+
+@Entity
+@Indexed
+public class Book {
+
+	@Id
+	private Integer id;
+
+	@FullTextField(analyzer = "english", projectable = Projectable.YES)
+	private String title;
+
+	@KeywordField(projectable = Projectable.YES)
+	private Genre genre;
+
+	@ManyToMany
+	@IndexedEmbedded(storage = ObjectFieldStorage.NESTED)
+	private List<Author> authors = new ArrayList<>();
+
+	public Book() {
+	}
+
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public Genre getGenre() {
+		return genre;
+	}
+
+	public void setGenre(Genre genre) {
+		this.genre = genre;
+	}
+
+	public List<Author> getAuthors() {
+		return authors;
+	}
+
+	public void setAuthors(List<Author> authors) {
+		this.authors = authors;
+	}
+}

--- a/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/projection/EmbeddableGeoPoint.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/projection/EmbeddableGeoPoint.java
@@ -1,0 +1,46 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.documentation.searchdsl.projection;
+
+import javax.persistence.Basic;
+import javax.persistence.Embeddable;
+
+import org.hibernate.search.engine.spatial.GeoPoint;
+
+@Embeddable
+public class EmbeddableGeoPoint implements GeoPoint {
+
+	public static EmbeddableGeoPoint of(double latitude, double longitude) {
+		return new EmbeddableGeoPoint( latitude, longitude );
+	}
+
+	@Basic
+	private Double latitude;
+	@Basic
+	private Double longitude;
+
+	protected EmbeddableGeoPoint() {
+		// For Hibernate ORM
+	}
+
+	private EmbeddableGeoPoint(double latitude, double longitude) {
+		this.latitude = latitude;
+		this.longitude = longitude;
+	}
+
+	@Override
+	@Basic
+	public double getLatitude() {
+		return latitude;
+	}
+
+	@Override
+	@Basic
+	public double getLongitude() {
+		return longitude;
+	}
+}

--- a/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/projection/Genre.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/projection/Genre.java
@@ -1,0 +1,14 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.documentation.searchdsl.projection;
+
+public enum Genre {
+
+	SCIENCE_FICTION,
+	CRIME_FICTION
+
+}

--- a/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/projection/ProjectionDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/projection/ProjectionDslIT.java
@@ -1,0 +1,453 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.documentation.searchdsl.projection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+import javax.persistence.EntityManagerFactory;
+
+import org.hibernate.Session;
+import org.hibernate.search.backend.elasticsearch.ElasticsearchExtension;
+import org.hibernate.search.backend.lucene.LuceneExtension;
+import org.hibernate.search.documentation.testsupport.BackendSetupStrategy;
+import org.hibernate.search.engine.search.DocumentReference;
+import org.hibernate.search.engine.search.projection.ProjectionConverter;
+import org.hibernate.search.engine.search.query.SearchResult;
+import org.hibernate.search.engine.spatial.DistanceUnit;
+import org.hibernate.search.engine.spatial.GeoPoint;
+import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.orm.cfg.HibernateOrmAutomaticIndexingSynchronizationStrategyName;
+import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
+import org.hibernate.search.mapper.orm.session.SearchSession;
+import org.hibernate.search.mapper.pojo.mapping.impl.PojoReferenceImpl;
+import org.hibernate.search.mapper.pojo.search.PojoReference;
+import org.hibernate.search.util.impl.integrationtest.common.assertion.SearchHitsAssert;
+import org.hibernate.search.util.impl.integrationtest.orm.OrmSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.orm.OrmUtils;
+
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.search.Explanation;
+
+@RunWith(Parameterized.class)
+public class ProjectionDslIT {
+
+	private static final int ASIMOV_ID = 1;
+	private static final int MARTINEZ_ID = 2;
+
+	private static final String BOOK_INDEX_NAME = Book.class.getName();
+	private static final int BOOK1_ID = 1;
+	private static final int BOOK2_ID = 2;
+	private static final int BOOK3_ID = 3;
+	private static final int BOOK4_ID = 4;
+
+	@Parameterized.Parameters(name = "{0}")
+	public static Object[] backendSetups() {
+		return BackendSetupStrategy.simple().toArray();
+	}
+
+	@Rule
+	public OrmSetupHelper setupHelper = new OrmSetupHelper();
+
+	private final BackendSetupStrategy backendSetupStrategy;
+
+	private EntityManagerFactory entityManagerFactory;
+
+	public ProjectionDslIT(BackendSetupStrategy backendSetupStrategy) {
+		this.backendSetupStrategy = backendSetupStrategy;
+	}
+
+	@Before
+	public void setup() {
+		entityManagerFactory = backendSetupStrategy.withSingleBackend( setupHelper )
+				.withProperty(
+						HibernateOrmMapperSettings.AUTOMATIC_INDEXING_SYNCHRONIZATION_STRATEGY,
+						HibernateOrmAutomaticIndexingSynchronizationStrategyName.SEARCHABLE
+				)
+				.setup( Book.class, Author.class, EmbeddableGeoPoint.class );
+		initData();
+	}
+
+	@Test
+	public void documentReference() {
+		withinSearchSession( searchSession -> {
+			// tag::documentReference[]
+			List<DocumentReference> hits = searchSession.search( Book.class )
+					.asProjection( f -> f.documentReference() )
+					.predicate( f -> f.matchAll() )
+					.fetchHits();
+			// end::documentReference[]
+			SearchHitsAssert.assertThat( hits ).hasDocRefHitsAnyOrder(
+					BOOK_INDEX_NAME,
+					String.valueOf( BOOK1_ID ),
+					String.valueOf( BOOK2_ID ),
+					String.valueOf( BOOK3_ID ),
+					String.valueOf( BOOK4_ID )
+			);
+		} );
+	}
+
+	@Test
+	public void reference() {
+		withinSearchSession( searchSession -> {
+			// tag::reference[]
+			List<PojoReference> hits = searchSession.search( Book.class )
+					.asProjection( f -> f.reference() )
+					.predicate( f -> f.matchAll() )
+					.fetchHits();
+			// end::reference[]
+			assertThat( hits ).containsExactlyInAnyOrder(
+					new PojoReferenceImpl( Book.class, BOOK1_ID ),
+					new PojoReferenceImpl( Book.class, BOOK2_ID ),
+					new PojoReferenceImpl( Book.class, BOOK3_ID ),
+					new PojoReferenceImpl( Book.class, BOOK4_ID )
+			);
+		} );
+	}
+
+	@Test
+	public void entity() {
+		withinSearchSession( searchSession -> {
+			// tag::entity[]
+			List<Book> hits = searchSession.search( Book.class )
+					.asProjection( f -> f.entity() )
+					.predicate( f -> f.matchAll() )
+					.fetchHits();
+			// end::entity[]
+			Session session = searchSession.toOrmSession();
+			assertThat( hits ).containsExactlyInAnyOrder(
+					session.getReference( Book.class, BOOK1_ID ),
+					session.getReference( Book.class, BOOK2_ID ),
+					session.getReference( Book.class, BOOK3_ID ),
+					session.getReference( Book.class, BOOK4_ID )
+			);
+		} );
+	}
+
+	@Test
+	public void field() {
+		withinSearchSession( searchSession -> {
+			// tag::field[]
+			List<Genre> hits = searchSession.search( Book.class )
+					.asProjection( f -> f.field( "genre", Genre.class ) )
+					.predicate( f -> f.matchAll() )
+					.fetchHits();
+			// end::field[]
+			Session session = searchSession.toOrmSession();
+			assertThat( hits ).containsExactlyInAnyOrder(
+					session.getReference( Book.class, BOOK1_ID ).getGenre(),
+					session.getReference( Book.class, BOOK2_ID ).getGenre(),
+					session.getReference( Book.class, BOOK3_ID ).getGenre(),
+					session.getReference( Book.class, BOOK4_ID ).getGenre()
+			);
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::field-noType[]
+			List<Object> hits = searchSession.search( Book.class )
+					.asProjection( f -> f.field( "genre" ) )
+					.predicate( f -> f.matchAll() )
+					.fetchHits();
+			// end::field-noType[]
+			Session session = searchSession.toOrmSession();
+			assertThat( hits ).containsExactlyInAnyOrder(
+					session.getReference( Book.class, BOOK1_ID ).getGenre(),
+					session.getReference( Book.class, BOOK2_ID ).getGenre(),
+					session.getReference( Book.class, BOOK3_ID ).getGenre(),
+					session.getReference( Book.class, BOOK4_ID ).getGenre()
+			);
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::field-noProjectionConverter[]
+			List<String> hits = searchSession.search( Book.class )
+					.asProjection( f -> f.field(
+							"genre", String.class, ProjectionConverter.DISABLED
+					) )
+					.predicate( f -> f.matchAll() )
+					.fetchHits();
+			// end::field-noProjectionConverter[]
+			Session session = searchSession.toOrmSession();
+			assertThat( hits ).containsExactlyInAnyOrder(
+					session.getReference( Book.class, BOOK1_ID ).getGenre().name(),
+					session.getReference( Book.class, BOOK2_ID ).getGenre().name(),
+					session.getReference( Book.class, BOOK3_ID ).getGenre().name(),
+					session.getReference( Book.class, BOOK4_ID ).getGenre().name()
+			);
+		} );
+	}
+
+	@Test
+	public void score() {
+		withinSearchSession( searchSession -> {
+			// tag::score[]
+			List<Float> hits = searchSession.search( Book.class )
+					.asProjection( f -> f.score() )
+					.predicate( f -> f.match().onField( "title" )
+							.matching( "robot dawn" ) )
+					.fetchHits();
+			// end::score[]
+			assertThat( hits )
+					.hasSize( 2 )
+					.allSatisfy(
+							score -> assertThat( score ).isGreaterThan( 0.0f )
+					);
+		} );
+	}
+
+	@Test
+	public void distance() {
+		Assume.assumeTrue(
+				"TODO HSEARCH-3618 Distance projection may lead to missing hits",
+				false
+		);
+
+		withinSearchSession( searchSession -> {
+			// tag::distance[]
+			GeoPoint center = GeoPoint.of( 47.506060, 2.473916 );
+			SearchResult<Double> result = searchSession.search( Author.class )
+					.asProjection( f -> f.distance( "placeOfBirth", center ) )
+					.predicate( f -> f.matchAll() )
+					.fetch(); // <3>
+			// end::distance[]
+			assertThat( result.getHits() )
+					.hasSize( 2 )
+					.allSatisfy(
+							distance -> assertThat( distance ).isBetween( 1_000_000.0, 10_000_000.0 )
+					);
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::distance-unit[]
+			GeoPoint center = GeoPoint.of( 47.506060, 2.473916 );
+			SearchResult<Double> result = searchSession.search( Author.class )
+					.asProjection( f -> f.distance( "placeOfBirth", center )
+							.unit( DistanceUnit.KILOMETERS ) )
+					.predicate( f -> f.matchAll() )
+					.fetch(); // <3>
+			// end::distance-unit[]
+			assertThat( result.getHits() )
+					.hasSize( 2 )
+					.allSatisfy(
+							distance -> assertThat( distance ).isBetween( 1_000.0, 10_000.0 )
+					);
+		} );
+	}
+
+	@Test
+	public void composite() {
+		withinSearchSession( searchSession -> {
+			// tag::composite-customObject[]
+			List<MyPair<String, Genre>> hits = searchSession.search( Book.class )
+					.asProjection( f -> f.composite( // <1>
+							MyPair::new, // <2>
+							f.field( "title", String.class ), // <3>
+							f.field( "genre", Genre.class ) // <4>
+					) )
+					.predicate( f -> f.matchAll() )
+					.fetchHits(); // <5>
+			// end::composite-customObject[]
+			Session session = searchSession.toOrmSession();
+			assertThat( hits ).containsExactlyInAnyOrder(
+					new MyPair<>(
+							session.getReference( Book.class, BOOK1_ID ).getTitle(),
+							session.getReference( Book.class, BOOK1_ID ).getGenre()
+					),
+					new MyPair<>(
+							session.getReference( Book.class, BOOK2_ID ).getTitle(),
+							session.getReference( Book.class, BOOK2_ID ).getGenre()
+					),
+					new MyPair<>(
+							session.getReference( Book.class, BOOK3_ID ).getTitle(),
+							session.getReference( Book.class, BOOK3_ID ).getGenre()
+					),
+					new MyPair<>(
+							session.getReference( Book.class, BOOK4_ID ).getTitle(),
+							session.getReference( Book.class, BOOK4_ID ).getGenre()
+					)
+			);
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::composite-list[]
+			List<List<?>> hits = searchSession.search( Book.class )
+					.asProjection( f -> f.composite( // <1>
+							f.field( "title", String.class ), // <2>
+							f.field( "genre", Genre.class ) // <3>
+					) )
+					.predicate( f -> f.matchAll() )
+					.fetchHits(); // <4>
+			// end::composite-list[]
+			Session session = searchSession.toOrmSession();
+			assertThat( hits ).containsExactlyInAnyOrder(
+					Arrays.asList(
+							session.getReference( Book.class, BOOK1_ID ).getTitle(),
+							session.getReference( Book.class, BOOK1_ID ).getGenre()
+					),
+					Arrays.asList(
+							session.getReference( Book.class, BOOK2_ID ).getTitle(),
+							session.getReference( Book.class, BOOK2_ID ).getGenre()
+					),
+					Arrays.asList(
+							session.getReference( Book.class, BOOK3_ID ).getTitle(),
+							session.getReference( Book.class, BOOK3_ID ).getGenre()
+					),
+					Arrays.asList(
+							session.getReference( Book.class, BOOK4_ID ).getTitle(),
+							session.getReference( Book.class, BOOK4_ID ).getGenre()
+					)
+			);
+		} );
+	}
+
+	@Test
+	public void lucene() {
+		Assume.assumeTrue( BackendSetupStrategy.LUCENE.equals( backendSetupStrategy ) );
+
+		withinSearchSession( searchSession -> {
+			// tag::lucene-document[]
+			List<Document> hits = searchSession.search( Book.class )
+					.extension( LuceneExtension.get() )
+					.asProjection( f -> f.document() )
+					.predicate( f -> f.matchAll() )
+					.fetchHits();
+			// end::lucene-document[]
+			assertThat( hits ).hasSize( 4 );
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::lucene-explanation[]
+			List<Explanation> hits = searchSession.search( Book.class )
+					.extension( LuceneExtension.get() )
+					.asProjection( f -> f.explanation() )
+					.predicate( f -> f.matchAll() )
+					.fetchHits();
+			// end::lucene-explanation[]
+			assertThat( hits ).hasSize( 4 );
+		} );
+	}
+
+	@Test
+	public void elasticsearch() {
+		Assume.assumeTrue( BackendSetupStrategy.ELASTICSEARCH.equals( backendSetupStrategy ) );
+
+		withinSearchSession( searchSession -> {
+			// tag::elasticsearch-source[]
+			List<String> hits = searchSession.search( Book.class )
+					.extension( ElasticsearchExtension.get() )
+					.asProjection( f -> f.source() )
+					.predicate( f -> f.matchAll() )
+					.fetchHits();
+			// end::elasticsearch-source[]
+			assertThat( hits ).hasSize( 4 );
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::elasticsearch-explanation[]
+			List<String> hits = searchSession.search( Book.class )
+					.extension( ElasticsearchExtension.get() )
+					.asProjection( f -> f.explanation() )
+					.predicate( f -> f.matchAll() )
+					.fetchHits();
+			// end::elasticsearch-explanation[]
+			assertThat( hits ).hasSize( 4 );
+		} );
+	}
+
+	private void withinSearchSession(Consumer<SearchSession> action) {
+		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+			SearchSession searchSession = Search.getSearchSession( entityManager );
+			action.accept( searchSession );
+		} );
+	}
+
+	private void initData() {
+		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+			Author isaacAsimov = new Author();
+			isaacAsimov.setId( ASIMOV_ID );
+			isaacAsimov.setFirstName( "Isaac" );
+			isaacAsimov.setLastName( "Asimov" );
+			isaacAsimov.setPlaceOfBirth( EmbeddableGeoPoint.of( 53.976177, 32.158627 ) );
+
+			Author aLeeMartinez = new Author();
+			aLeeMartinez.setId( MARTINEZ_ID );
+			aLeeMartinez.setFirstName( "A. Lee" );
+			aLeeMartinez.setLastName( "Martinez" );
+			aLeeMartinez.setPlaceOfBirth( EmbeddableGeoPoint.of( 31.814315, -106.475524 ) );
+
+			Book book1 = new Book();
+			book1.setId( BOOK1_ID );
+			book1.setTitle( "I, Robot" );
+			book1.setGenre( Genre.SCIENCE_FICTION );
+			book1.getAuthors().add( isaacAsimov );
+			isaacAsimov.getBooks().add( book1 );
+
+			Book book2 = new Book();
+			book2.setId( BOOK2_ID );
+			book2.setTitle( "The Caves of Steel" );
+			book2.setGenre( Genre.SCIENCE_FICTION );
+			book2.getAuthors().add( isaacAsimov );
+			isaacAsimov.getBooks().add( book2 );
+
+			Book book3 = new Book();
+			book3.setId( BOOK3_ID );
+			book3.setTitle( "The Robots of Dawn" );
+			book3.setGenre( Genre.SCIENCE_FICTION );
+			book3.getAuthors().add( isaacAsimov );
+			isaacAsimov.getBooks().add( book3 );
+
+			Book book4 = new Book();
+			book4.setId( BOOK4_ID );
+			book4.setTitle( "The Automatic Detective" );
+			book4.setGenre( Genre.CRIME_FICTION );
+			book4.getAuthors().add( aLeeMartinez );
+			aLeeMartinez.getBooks().add( book3 );
+
+			entityManager.persist( isaacAsimov );
+			entityManager.persist( aLeeMartinez );
+
+			entityManager.persist( book1 );
+			entityManager.persist( book2 );
+			entityManager.persist( book3 );
+			entityManager.persist( book4 );
+		} );
+	}
+
+	private static class MyPair<T1, T2> {
+		private final T1 first;
+		private final T2 second;
+
+		MyPair(T1 first, T2 second) {
+			this.first = first;
+			this.second = second;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if ( obj == null || !MyPair.class.equals( obj.getClass() ) ) {
+				return false;
+			}
+			MyPair<?, ?> other = (MyPair<?, ?>) obj;
+			return Objects.equals( first, other.first ) && Objects.equals( second, other.second );
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( first, second );
+		}
+	}
+}

--- a/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/query/Book.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/query/Book.java
@@ -1,0 +1,45 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.documentation.searchdsl.query;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.search.engine.backend.types.Projectable;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+@Entity
+@Indexed
+public class Book {
+
+	@Id
+	private Integer id;
+
+	@FullTextField(analyzer = "english", projectable = Projectable.YES)
+	private String title;
+
+	public Book() {
+	}
+
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+}

--- a/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/query/QueryDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/query/QueryDslIT.java
@@ -1,0 +1,114 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.documentation.searchdsl.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import javax.persistence.EntityManagerFactory;
+
+import org.hibernate.search.documentation.testsupport.BackendSetupStrategy;
+import org.hibernate.search.engine.search.query.SearchResult;
+import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.orm.cfg.HibernateOrmAutomaticIndexingSynchronizationStrategyName;
+import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
+import org.hibernate.search.mapper.orm.session.SearchSession;
+import org.hibernate.search.util.impl.integrationtest.orm.OrmSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.orm.OrmUtils;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class QueryDslIT {
+
+	private static final int BOOK1_ID = 1;
+	private static final int BOOK2_ID = 2;
+	private static final int BOOK3_ID = 3;
+	private static final int BOOK4_ID = 4;
+
+	@Parameterized.Parameters(name = "{0}")
+	public static Object[] backendSetups() {
+		return BackendSetupStrategy.simple().toArray();
+	}
+
+	@Rule
+	public OrmSetupHelper setupHelper = new OrmSetupHelper();
+
+	private final BackendSetupStrategy backendSetupStrategy;
+
+	private EntityManagerFactory entityManagerFactory;
+
+	public QueryDslIT(BackendSetupStrategy backendSetupStrategy) {
+		this.backendSetupStrategy = backendSetupStrategy;
+	}
+
+	@Before
+	public void setup() {
+		entityManagerFactory = backendSetupStrategy.withSingleBackend( setupHelper )
+				.withProperty(
+						HibernateOrmMapperSettings.AUTOMATIC_INDEXING_SYNCHRONIZATION_STRATEGY,
+						HibernateOrmAutomaticIndexingSynchronizationStrategyName.SEARCHABLE
+				)
+				.setup( Book.class );
+		initData();
+	}
+
+	@Test
+	public void entryPoint() {
+		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+			// tag::entryPoint[]
+			// Not shown: get the entity manager and open a transaction
+			SearchSession searchSession = Search.getSearchSession( entityManager ); // <1>
+
+			SearchResult<Book> result = searchSession.search( Book.class ) // <2>
+					.predicate( f -> f.match() // <3>
+							.onField( "title" )
+							.matching( "robot" ) )
+					.fetch(); // <4>
+
+			long totalHitCount = result.getTotalHitCount(); // <5>
+			List<Book> hits = result.getHits(); // <6>
+			// Not shown: commit the transaction and close the entity manager
+			// end::entryPoint[]
+
+			assertThat( totalHitCount ).isEqualTo( 2 );
+			assertThat( hits ).extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK1_ID, BOOK3_ID );
+		} );
+	}
+
+	private void initData() {
+		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+			Book book1 = new Book();
+			book1.setId( BOOK1_ID );
+			book1.setTitle( "I, Robot" );
+
+			Book book2 = new Book();
+			book2.setId( BOOK2_ID );
+			book2.setTitle( "The Caves of Steel" );
+
+			Book book3 = new Book();
+			book3.setId( BOOK3_ID );
+			book3.setTitle( "The Robots of Dawn" );
+
+			Book book4 = new Book();
+			book4.setId( BOOK4_ID );
+			book4.setTitle( "The Automatic Detective" );
+
+			entityManager.persist( book1 );
+			entityManager.persist( book2 );
+			entityManager.persist( book3 );
+			entityManager.persist( book4 );
+		} );
+	}
+
+
+}

--- a/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/sort/Author.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/sort/Author.java
@@ -1,0 +1,86 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.documentation.searchdsl.sort;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.ManyToMany;
+
+import org.hibernate.search.engine.backend.types.Sortable;
+import org.hibernate.search.mapper.pojo.bridge.builtin.spatial.annotation.GeoPointBridge;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
+
+@Entity
+@Indexed
+public class Author {
+
+	@Id
+	private Integer id;
+
+	@FullTextField(analyzer = "name")
+	@KeywordField(name = "firstName_sort", normalizer = "name", sortable = Sortable.YES)
+	private String firstName;
+
+	@FullTextField(analyzer = "name")
+	@KeywordField(name = "lastName_sort", normalizer = "name", sortable = Sortable.YES)
+	private String lastName;
+
+	@Embedded
+	@GeoPointBridge(sortable = Sortable.YES)
+	private EmbeddableGeoPoint placeOfBirth;
+
+	@ManyToMany(mappedBy = "authors")
+	private List<Book> books = new ArrayList<>();
+
+	public Author() {
+	}
+
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getFirstName() {
+		return firstName;
+	}
+
+	public void setFirstName(String firstName) {
+		this.firstName = firstName;
+	}
+
+	public String getLastName() {
+		return lastName;
+	}
+
+	public void setLastName(String lastName) {
+		this.lastName = lastName;
+	}
+
+	public EmbeddableGeoPoint getPlaceOfBirth() {
+		return placeOfBirth;
+	}
+
+	public void setPlaceOfBirth(EmbeddableGeoPoint placeOfBirth) {
+		this.placeOfBirth = placeOfBirth;
+	}
+
+	public List<Book> getBooks() {
+		return books;
+	}
+
+	public void setBooks(List<Book> books) {
+		this.books = books;
+	}
+}

--- a/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/sort/Book.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/sort/Book.java
@@ -1,0 +1,87 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.documentation.searchdsl.sort;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.ManyToMany;
+
+import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
+import org.hibernate.search.engine.backend.types.Sortable;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
+
+@Entity
+@Indexed
+public class Book {
+
+	@Id
+	private Integer id;
+
+	@FullTextField(analyzer = "english")
+	@KeywordField(name = "title_sort", normalizer = "english", sortable = Sortable.YES)
+	private String title;
+
+	@GenericField(sortable = Sortable.YES)
+	private Integer pageCount;
+
+	@KeywordField
+	@KeywordField(name = "genre_sort", normalizer = "english", sortable = Sortable.YES)
+	private Genre genre;
+
+	@ManyToMany
+	@IndexedEmbedded(storage = ObjectFieldStorage.NESTED)
+	private List<Author> authors = new ArrayList<>();
+
+	public Book() {
+	}
+
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public Integer getPageCount() {
+		return pageCount;
+	}
+
+	public void setPageCount(Integer pageCount) {
+		this.pageCount = pageCount;
+	}
+
+	public Genre getGenre() {
+		return genre;
+	}
+
+	public void setGenre(Genre genre) {
+		this.genre = genre;
+	}
+
+	public List<Author> getAuthors() {
+		return authors;
+	}
+
+	public void setAuthors(List<Author> authors) {
+		this.authors = authors;
+	}
+}

--- a/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/sort/EmbeddableGeoPoint.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/sort/EmbeddableGeoPoint.java
@@ -1,0 +1,46 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.documentation.searchdsl.sort;
+
+import javax.persistence.Basic;
+import javax.persistence.Embeddable;
+
+import org.hibernate.search.engine.spatial.GeoPoint;
+
+@Embeddable
+public class EmbeddableGeoPoint implements GeoPoint {
+
+	public static EmbeddableGeoPoint of(double latitude, double longitude) {
+		return new EmbeddableGeoPoint( latitude, longitude );
+	}
+
+	@Basic
+	private Double latitude;
+	@Basic
+	private Double longitude;
+
+	protected EmbeddableGeoPoint() {
+		// For Hibernate ORM
+	}
+
+	private EmbeddableGeoPoint(double latitude, double longitude) {
+		this.latitude = latitude;
+		this.longitude = longitude;
+	}
+
+	@Override
+	@Basic
+	public double getLatitude() {
+		return latitude;
+	}
+
+	@Override
+	@Basic
+	public double getLongitude() {
+		return longitude;
+	}
+}

--- a/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/sort/Genre.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/sort/Genre.java
@@ -1,0 +1,14 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.documentation.searchdsl.sort;
+
+public enum Genre {
+
+	SCIENCE_FICTION,
+	CRIME_FICTION
+
+}

--- a/documentation/src/test/java/org/hibernate/search/documentation/testsupport/BackendSetupStrategy.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/testsupport/BackendSetupStrategy.java
@@ -25,36 +25,40 @@ public interface BackendSetupStrategy {
 
 	static List<BackendSetupStrategy> simple() {
 		return Arrays.asList(
-				new BackendSetupStrategy() {
-					@Override
-					public String toString() {
-						return "lucene";
-					}
-					@Override
-					public OrmSetupHelper.SetupContext withBackend(OrmSetupHelper.SetupContext setupContext, String backendName) {
-						return setupContext.withBackend( "backend-lucene", backendName )
-								.withBackendProperty(
-										backendName,
-										LuceneBackendSettings.ANALYSIS_CONFIGURER,
-										new LuceneSimpleMappingAnalysisConfigurer()
-								);
-					}
-				},
-				new BackendSetupStrategy() {
-					@Override
-					public String toString() {
-						return "elasticsearch";
-					}
-					@Override
-					public OrmSetupHelper.SetupContext withBackend(OrmSetupHelper.SetupContext setupContext, String backendName) {
-						return setupContext.withBackend( "backend-elasticsearch", backendName )
-								.withBackendProperty(
-										backendName,
-										ElasticsearchBackendSettings.ANALYSIS_CONFIGURER,
-										new ElasticsearchSimpleMappingAnalysisConfigurer()
-								);
-					}
-				}
+				LUCENE,
+				ELASTICSEARCH
 		);
 	}
+
+	BackendSetupStrategy LUCENE = new BackendSetupStrategy() {
+		@Override
+		public String toString() {
+			return "lucene";
+		}
+		@Override
+		public OrmSetupHelper.SetupContext withBackend(OrmSetupHelper.SetupContext setupContext, String backendName) {
+			return setupContext.withBackend( "backend-lucene", backendName )
+					.withBackendProperty(
+							backendName,
+							LuceneBackendSettings.ANALYSIS_CONFIGURER,
+							new LuceneSimpleMappingAnalysisConfigurer()
+					);
+		}
+	};
+
+	BackendSetupStrategy ELASTICSEARCH = new BackendSetupStrategy() {
+		@Override
+		public String toString() {
+			return "elasticsearch";
+		}
+		@Override
+		public OrmSetupHelper.SetupContext withBackend(OrmSetupHelper.SetupContext setupContext, String backendName) {
+			return setupContext.withBackend( "backend-elasticsearch", backendName )
+					.withBackendProperty(
+							backendName,
+							ElasticsearchBackendSettings.ANALYSIS_CONFIGURER,
+							new ElasticsearchSimpleMappingAnalysisConfigurer()
+					);
+		}
+	};
 }

--- a/documentation/src/test/java/org/hibernate/search/documentation/testsupport/ElasticsearchSimpleMappingAnalysisConfigurer.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/testsupport/ElasticsearchSimpleMappingAnalysisConfigurer.java
@@ -42,5 +42,8 @@ class ElasticsearchSimpleMappingAnalysisConfigurer implements ElasticsearchAnaly
 
 		context.normalizer( "english" ).custom()
 				.withTokenFilters( "asciifolding", "lowercase" );
+
+		context.normalizer( "name" ).custom()
+				.withTokenFilters( "asciifolding", "lowercase" );
 	}
 }

--- a/documentation/src/test/java/org/hibernate/search/documentation/testsupport/ElasticsearchSimpleMappingAnalysisConfigurer.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/testsupport/ElasticsearchSimpleMappingAnalysisConfigurer.java
@@ -12,8 +12,34 @@ import org.hibernate.search.backend.elasticsearch.analysis.model.dsl.Elasticsear
 class ElasticsearchSimpleMappingAnalysisConfigurer implements ElasticsearchAnalysisConfigurer {
 	@Override
 	public void configure(ElasticsearchAnalysisDefinitionContainerContext context) {
-		context.analyzer( "english" ).type( "standard" );
-		context.analyzer( "name" ).type( "standard" );
+		context.analyzer( "english" ).custom()
+				.withTokenizer( "standard" )
+				.withTokenFilters( "asciifolding", "lowercase", "snowball_english" );
+
+		context.tokenFilter( "snowball_english" )
+				.type( "snowball" )
+				.param( "language", "English" );
+
+		context.analyzer( "name" ).custom()
+				.withTokenizer( "standard" )
+				.withTokenFilters( "asciifolding", "lowercase" );
+
+		context.analyzer( "autocomplete_indexing" ).custom()
+				.withTokenizer( "standard" )
+				.withTokenFilters( "asciifolding", "lowercase", "snowball_english", "autocomplete_edge_ngram" );
+
+		context.tokenFilter( "autocomplete_edge_ngram" )
+				.type( "edge_ngram" )
+				.param( "min_gram", 3 )
+				.param( "max_gram", 7 );
+
+		// Same as "autocomplete-indexing", but without the edge-ngram filter
+		context.analyzer( "autocomplete_query" ).custom()
+				.withTokenizer( "standard" )
+				.withTokenFilters( "asciifolding", "lowercase", "snowball_english" );
+
+		// Normalizers
+
 		context.normalizer( "english" ).custom()
 				.withTokenFilters( "asciifolding", "lowercase" );
 	}

--- a/documentation/src/test/java/org/hibernate/search/documentation/testsupport/LuceneSimpleMappingAnalysisConfigurer.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/testsupport/LuceneSimpleMappingAnalysisConfigurer.java
@@ -11,13 +11,45 @@ import org.hibernate.search.backend.lucene.analysis.model.dsl.LuceneAnalysisDefi
 
 import org.apache.lucene.analysis.core.LowerCaseFilterFactory;
 import org.apache.lucene.analysis.miscellaneous.ASCIIFoldingFilterFactory;
-import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.analysis.ngram.EdgeNGramFilterFactory;
+import org.apache.lucene.analysis.snowball.SnowballPorterFilterFactory;
+import org.apache.lucene.analysis.standard.StandardTokenizerFactory;
 
 class LuceneSimpleMappingAnalysisConfigurer implements LuceneAnalysisConfigurer {
 	@Override
 	public void configure(LuceneAnalysisDefinitionContainerContext context) {
-		context.analyzer( "english" ).instance( new StandardAnalyzer() );
-		context.analyzer( "name" ).instance( new StandardAnalyzer() );
+		context.analyzer( "english" ).custom()
+				.tokenizer( StandardTokenizerFactory.class )
+				.tokenFilter( ASCIIFoldingFilterFactory.class )
+				.tokenFilter( LowerCaseFilterFactory.class )
+				.tokenFilter( SnowballPorterFilterFactory.class )
+						.param( "language", "English" );
+
+		context.analyzer( "name" ).custom()
+				.tokenizer( StandardTokenizerFactory.class )
+				.tokenFilter( ASCIIFoldingFilterFactory.class )
+				.tokenFilter( LowerCaseFilterFactory.class );
+
+		context.analyzer( "autocomplete_indexing" ).custom()
+				.tokenizer( StandardTokenizerFactory.class )
+				.tokenFilter( ASCIIFoldingFilterFactory.class )
+				.tokenFilter( LowerCaseFilterFactory.class )
+				.tokenFilter( SnowballPorterFilterFactory.class )
+						.param( "language", "English" )
+				.tokenFilter( EdgeNGramFilterFactory.class )
+						.param( "minGramSize", "3" )
+						.param( "maxGramSize", "7" );
+
+		// Same as "autocomplete-indexing", but without the edge-ngram filter
+		context.analyzer( "autocomplete_query" ).custom()
+				.tokenizer( StandardTokenizerFactory.class )
+				.tokenFilter( ASCIIFoldingFilterFactory.class )
+				.tokenFilter( LowerCaseFilterFactory.class )
+				.tokenFilter( SnowballPorterFilterFactory.class )
+						.param( "language", "English" );
+
+		// Normalizers
+
 		context.normalizer( "english" ).custom()
 				.tokenFilter( ASCIIFoldingFilterFactory.class )
 				.tokenFilter( LowerCaseFilterFactory.class );

--- a/documentation/src/test/java/org/hibernate/search/documentation/testsupport/LuceneSimpleMappingAnalysisConfigurer.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/testsupport/LuceneSimpleMappingAnalysisConfigurer.java
@@ -53,5 +53,9 @@ class LuceneSimpleMappingAnalysisConfigurer implements LuceneAnalysisConfigurer 
 		context.normalizer( "english" ).custom()
 				.tokenFilter( ASCIIFoldingFilterFactory.class )
 				.tokenFilter( LowerCaseFilterFactory.class );
+
+		context.normalizer( "name" ).custom()
+				.tokenFilter( ASCIIFoldingFilterFactory.class )
+				.tokenFilter( LowerCaseFilterFactory.class );
 	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3597

Based on #2012, which should be merged first.

The easiest way to review this PR is probably to build the documentation and then read the "Searching" section:

```
mvn clean install -DskipTests -pl documentation -am
xdg-open ./documentation/target/asciidoctor/en-US/html_single/index.html
```