### PR TITLE
HSEARCH-3618 Distance projection may lead to missing hits in the Lucene and Elasticsearch backends

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchGeoPointIndexFieldTypeContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchGeoPointIndexFieldTypeContext.java
@@ -30,6 +30,9 @@ class ElasticsearchGeoPointIndexFieldTypeContext
 				createIndexToProjectionConverter();
 		ElasticsearchGeoPointFieldCodec codec = ElasticsearchGeoPointFieldCodec.INSTANCE;
 
+		// We need doc values for the projection script when not sorting on the same field
+		mapping.setDocValues( resolvedSortable || resolvedProjectable );
+
 		return new ElasticsearchIndexFieldType<>(
 				codec,
 				new ElasticsearchGeoPointFieldPredicateBuilderFactory( resolvedSearchable ),

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/extraction/impl/LuceneCollectorsBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/extraction/impl/LuceneCollectorsBuilder.java
@@ -55,6 +55,7 @@ public class LuceneCollectorsBuilder {
 	}
 
 	public DistanceCollector addDistanceCollector(String absoluteFieldPath, GeoPoint center) {
+		this.requireTopDocs = true; // We can't collect distances if we don't know from which documents it should be collected
 		DistanceCollector distanceCollector = new DistanceCollector( absoluteFieldPath, center, maxDocs );
 		luceneCollectors.add( distanceCollector );
 		distanceCollectors.put( new DistanceCollectorKey( absoluteFieldPath, center ), distanceCollector );

--- a/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/projection/ProjectionDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/projection/ProjectionDslIT.java
@@ -252,11 +252,6 @@ public class ProjectionDslIT {
 
 	@Test
 	public void distance() {
-		Assume.assumeTrue(
-				"TODO HSEARCH-3618 Distance projection may lead to missing hits",
-				false
-		);
-
 		withinSearchSession( searchSession -> {
 			// tag::distance[]
 			GeoPoint center = GeoPoint.of( 47.506060, 2.473916 );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/AbstractSpatialWithinSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/AbstractSpatialWithinSearchPredicateIT.java
@@ -90,6 +90,7 @@ public abstract class AbstractSpatialWithinSearchPredicateIT {
 			document.addValue( indexMapping.geoPoint_2, GeoPoint.of( OURSON_QUI_BOIT_GEO_POINT.getLatitude() - 2,
 					OURSON_QUI_BOIT_GEO_POINT.getLongitude() - 2 ) );
 			document.addValue( indexMapping.geoPoint_with_longName, OURSON_QUI_BOIT_GEO_POINT );
+			document.addValue( indexMapping.projectableUnsortableGeoPoint, OURSON_QUI_BOIT_GEO_POINT );
 		} );
 		workPlan.add( referenceProvider( IMOUTO_ID ), document -> {
 			document.addValue( indexMapping.string, IMOUTO_STRING );
@@ -99,6 +100,7 @@ public abstract class AbstractSpatialWithinSearchPredicateIT {
 			document.addValue( indexMapping.geoPoint_2, GeoPoint.of( IMOUTO_GEO_POINT.getLatitude() - 2,
 					IMOUTO_GEO_POINT.getLongitude() - 2 ) );
 			document.addValue( indexMapping.geoPoint_with_longName, IMOUTO_GEO_POINT );
+			document.addValue( indexMapping.projectableUnsortableGeoPoint, IMOUTO_GEO_POINT );
 		} );
 		workPlan.add( referenceProvider( CHEZ_MARGOTTE_ID ), document -> {
 			document.addValue( indexMapping.string, CHEZ_MARGOTTE_STRING );
@@ -108,6 +110,7 @@ public abstract class AbstractSpatialWithinSearchPredicateIT {
 			document.addValue( indexMapping.geoPoint_2, GeoPoint.of( CHEZ_MARGOTTE_GEO_POINT.getLatitude() - 2,
 					CHEZ_MARGOTTE_GEO_POINT.getLongitude() - 2 ) );
 			document.addValue( indexMapping.geoPoint_with_longName, CHEZ_MARGOTTE_GEO_POINT );
+			document.addValue( indexMapping.projectableUnsortableGeoPoint, CHEZ_MARGOTTE_GEO_POINT );
 		} );
 		workPlan.add( referenceProvider( EMPTY_ID ), document -> { } );
 
@@ -128,6 +131,7 @@ public abstract class AbstractSpatialWithinSearchPredicateIT {
 		final IndexFieldReference<GeoPoint> geoPoint_with_longName;
 		final IndexFieldReference<GeoPoint> nonProjectableGeoPoint;
 		final IndexFieldReference<GeoPoint> unsortableGeoPoint;
+		final IndexFieldReference<GeoPoint> projectableUnsortableGeoPoint;
 		final IndexFieldReference<String> string;
 
 		IndexMapping(IndexSchemaElement root) {
@@ -156,6 +160,11 @@ public abstract class AbstractSpatialWithinSearchPredicateIT {
 			unsortableGeoPoint = root.field(
 					"unsortableGeoPoint",
 					f -> f.asGeoPoint().sortable( Sortable.NO )
+			)
+					.toReference();
+			projectableUnsortableGeoPoint = root.field(
+					"projectableUnsortableGeoPoint",
+					f -> f.asGeoPoint().projectable( Projectable.YES ).sortable( Sortable.NO )
 			)
 					.toReference();
 			string = root.field(

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/DistanceSearchProjectionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/DistanceSearchProjectionIT.java
@@ -30,7 +30,27 @@ public class DistanceSearchProjectionIT extends AbstractSpatialWithinSearchPredi
 
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3618")
-	public void distanceProjection() {
+	public void distanceProjection_unsortable() {
+		StubMappingScope scope = indexManager.createScope();
+
+		SearchQuery<Double> query = scope.query()
+				// Do NOT add any additional projection here: this serves as a non-regression test for HSEARCH-3618
+				.asProjection( f ->
+						f.distance( "projectableUnsortableGeoPoint", GeoPoint.of( 45.749828, 4.854172 ) )
+				)
+				.predicate( f -> f.matchAll() )
+				.sort( f -> f.byField( "string" ).onMissingValue().sortLast().asc() )
+				.toQuery();
+		SearchResult<Double> results = query.fetch();
+
+		checkResult( results.getHits().get( 0 ), 430d, Offset.offset( 10d ) );
+		checkResult( results.getHits().get( 1 ), 1300d, Offset.offset( 10d ) );
+		checkResult( results.getHits().get( 2 ), 2730d, Offset.offset( 10d ) );
+		checkResult( results.getHits().get( 3 ), null, null );
+	}
+
+	@Test
+	public void distanceProjection_sortable() {
 		StubMappingScope scope = indexManager.createScope();
 
 		SearchQuery<Double> query = scope.query()


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3618

Turns out there were two very different problems, but leading to the same symptoms.

A full build is running right now to check other versions of Elasticsearch: https://ci.hibernate.org/blue/organizations/jenkins/hibernate-search-yoann/detail/HSEARCH-3618/6/