### PR TITLE
HSEARCH-3610 Rename Search.getSearchSession(Session) to Search.session(Session)

### DIFF
--- a/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withhsearch/withanalysis/GettingStartedWithAnalysisIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withhsearch/withanalysis/GettingStartedWithAnalysisIT.java
@@ -76,7 +76,7 @@ public class GettingStartedWithAnalysisIT {
 		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
 			// tag::searching[]
 			// Not shown: get the entity manager and open a transaction
-			SearchSession searchSession = Search.getSearchSession( entityManager );
+			SearchSession searchSession = Search.session( entityManager );
 
 			SearchResult<Book> result = searchSession.search( Book.class )
 					.predicate( factory -> factory.match()
@@ -93,7 +93,7 @@ public class GettingStartedWithAnalysisIT {
 
 		// Also test the other terms mentioned in the getting started guide
 		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
-			SearchSession searchSession = Search.getSearchSession( entityManager );
+			SearchSession searchSession = Search.session( entityManager );
 
 			for ( String term : new String[] { "Refactor", "refactors", "refactored", "refactoring" } ) {
 				SearchResult<Book> result = searchSession.search( Book.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withhsearch/withoutanalysis/GettingStartedWithoutAnalysisIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withhsearch/withoutanalysis/GettingStartedWithoutAnalysisIT.java
@@ -84,7 +84,7 @@ public class GettingStartedWithoutAnalysisIT {
 		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
 			try {
 			// tag::manual-index[]
-				SearchSession searchSession = Search.getSearchSession( entityManager ); // <1>
+				SearchSession searchSession = Search.session( entityManager ); // <1>
 
 				MassIndexer indexer = searchSession.massIndexer( Book.class ) // <2>
 						.threadsToLoadObjects( 7 ); // <3>
@@ -100,7 +100,7 @@ public class GettingStartedWithoutAnalysisIT {
 		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
 			// tag::searching-objects[]
 			// Not shown: get the entity manager and open a transaction
-			SearchSession searchSession = Search.getSearchSession( entityManager ); // <1>
+			SearchSession searchSession = Search.session( entityManager ); // <1>
 
 			SearchScope<Book> scope = searchSession.scope( Book.class ); // <2>
 
@@ -139,7 +139,7 @@ public class GettingStartedWithoutAnalysisIT {
 		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
 			// tag::searching-lambdas[]
 			// Not shown: get the entity manager and open a transaction
-			SearchSession searchSession = Search.getSearchSession( entityManager ); // <1>
+			SearchSession searchSession = Search.session( entityManager ); // <1>
 
 			SearchResult<Book> result = searchSession.search( Book.class ) // <2>
 					.predicate( f -> f.match() // <3>
@@ -174,7 +174,7 @@ public class GettingStartedWithoutAnalysisIT {
 		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
 			// tag::counting[]
 			// Not shown: get the entity manager and open a transaction
-			SearchSession searchSession = Search.getSearchSession( entityManager );
+			SearchSession searchSession = Search.session( entityManager );
 
 			long totalHitCount = searchSession.search( Book.class )
 					.predicate( f -> f.match()

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/directfieldmapping/HibernateOrmSimpleMappingIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/directfieldmapping/HibernateOrmSimpleMappingIT.java
@@ -70,7 +70,7 @@ public class HibernateOrmSimpleMappingIT {
 	@Test
 	public void sort() {
 		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
-			SearchSession searchSession = Search.getSearchSession( entityManager );
+			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class ) // <1>
 					.predicate( f -> f.matchAll() )
@@ -88,7 +88,7 @@ public class HibernateOrmSimpleMappingIT {
 	@Test
 	public void projection_simple() {
 		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
-			SearchSession searchSession = Search.getSearchSession( entityManager );
+			SearchSession searchSession = Search.session( entityManager );
 
 			List<String> result = searchSession.search( Book.class ) // <1>
 					.asProjection( f -> f.field( "title", String.class ) ) // <2>

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/entityindexmapping/HibernateOrmIndexedIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/entityindexmapping/HibernateOrmIndexedIT.java
@@ -63,7 +63,7 @@ public class HibernateOrmIndexedIT {
 	@Test
 	public void search_separateQueries() {
 		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
-			SearchSession searchSession = Search.getSearchSession( entityManager );
+			SearchSession searchSession = Search.session( entityManager );
 
 			List<Author> authorResult = searchSession.search( Author.class )
 					.predicate( f -> f.matchAll() )
@@ -81,7 +81,7 @@ public class HibernateOrmIndexedIT {
 	public void search_singleQuery() {
 		SubTest.expectException(
 				() -> OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
-					SearchSession searchSession = Search.getSearchSession( entityManager );
+					SearchSession searchSession = Search.session( entityManager );
 
 					// tag::cross-backend-search[]
 					// This will fail because Author and User are indexed in different backends

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmAutomaticIndexingIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmAutomaticIndexingIT.java
@@ -61,7 +61,7 @@ public class HibernateOrmAutomaticIndexingIT {
 
 		OrmUtils.withinEntityManager( entityManagerFactory, entityManager -> {
 			// tag::automatic-indexing-synchronization-strategy-override[]
-			SearchSession searchSession = Search.getSearchSession( entityManager ); // <1>
+			SearchSession searchSession = Search.session( entityManager ); // <1>
 			searchSession.setAutomaticIndexingSynchronizationStrategy(
 					AutomaticIndexingSynchronizationStrategy.searchable()
 			); // <2>

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmExplicitIndexingIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmExplicitIndexingIT.java
@@ -85,7 +85,7 @@ public class HibernateOrmExplicitIndexingIT {
 			assertBookCount( entityManager, 0 );
 
 			// tag::persist-automatic-indexing-periodic-process[]
-			SearchSession searchSession = Search.getSearchSession( entityManager ); // <1>
+			SearchSession searchSession = Search.session( entityManager ); // <1>
 			SearchSessionWritePlan searchWritePlan = searchSession.writePlan(); // <2>
 
 			entityManager.getTransaction().begin();
@@ -119,7 +119,7 @@ public class HibernateOrmExplicitIndexingIT {
 			assertBookCount( entityManager, 0 );
 
 			// tag::persist-automatic-indexing-periodic-execute[]
-			SearchSession searchSession = Search.getSearchSession( entityManager ); // <1>
+			SearchSession searchSession = Search.session( entityManager ); // <1>
 			SearchSessionWritePlan searchWritePlan = searchSession.writePlan(); // <2>
 
 			entityManager.getTransaction().begin();
@@ -184,7 +184,7 @@ public class HibernateOrmExplicitIndexingIT {
 			assertBookCount( entityManager, 0 );
 
 			// tag::write-plan-addOrUpdate[]
-			SearchSession searchSession = Search.getSearchSession( entityManager ); // <1>
+			SearchSession searchSession = Search.session( entityManager ); // <1>
 			SearchSessionWritePlan searchWritePlan = searchSession.writePlan(); // <2>
 
 			entityManager.getTransaction().begin();
@@ -214,7 +214,7 @@ public class HibernateOrmExplicitIndexingIT {
 			assertBookCount( entityManager, numberOfBooks );
 
 			// tag::write-plan-delete[]
-			SearchSession searchSession = Search.getSearchSession( entityManager ); // <1>
+			SearchSession searchSession = Search.session( entityManager ); // <1>
 			SearchSessionWritePlan searchWritePlan = searchSession.writePlan(); // <2>
 
 			entityManager.getTransaction().begin();
@@ -242,7 +242,7 @@ public class HibernateOrmExplicitIndexingIT {
 
 		OrmUtils.withinEntityManager( entityManagerFactory, entityManager -> {
 			// tag::writer-retrieval[]
-			SearchSession searchSession = Search.getSearchSession( entityManager ); // <1>
+			SearchSession searchSession = Search.session( entityManager ); // <1>
 			SearchWriter writer1 = searchSession.writer(); // <2>
 			SearchWriter writer2 = searchSession.writer( Book.class ); // <3>
 			SearchWriter writer3 = searchSession.writer( Book.class, Author.class ); // <4>
@@ -254,7 +254,7 @@ public class HibernateOrmExplicitIndexingIT {
 			assertAuthorCount( entityManager, numberOfBooks );
 
 			// tag::writer-purge[]
-			SearchSession searchSession = Search.getSearchSession( entityManager ); // <1>
+			SearchSession searchSession = Search.session( entityManager ); // <1>
 			SearchWriter writer = searchSession.writer( Book.class, Author.class ); // <2>
 			writer.purge(); // <3>
 			// end::writer-purge[]
@@ -306,7 +306,7 @@ public class HibernateOrmExplicitIndexingIT {
 	}
 
 	private void assertBookCount(EntityManager entityManager, int expectedCount) {
-		SearchSession searchSession = Search.getSearchSession( entityManager );
+		SearchSession searchSession = Search.session( entityManager );
 		// Ensure every committed work is searchable: flush also executes a refresh on Elasticsearch
 		searchSession.writer().flush();
 		assertThat(
@@ -318,7 +318,7 @@ public class HibernateOrmExplicitIndexingIT {
 	}
 
 	private void assertAuthorCount(EntityManager entityManager, int expectedCount) {
-		SearchSession searchSession = Search.getSearchSession( entityManager );
+		SearchSession searchSession = Search.session( entityManager );
 		// Ensure every committed work is searchable: flush also executes a refresh on Elasticsearch
 		searchSession.writer().flush();
 		assertThat(

--- a/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/converter/DslConverterIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/converter/DslConverterIT.java
@@ -68,7 +68,7 @@ public class DslConverterIT {
 	@Test
 	public void dslConverterEnabled() {
 		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
-			SearchSession searchSession = Search.getSearchSession( entityManager );
+			SearchSession searchSession = Search.session( entityManager );
 
 			// tag::dsl-converter-enabled[]
 			List<AuthenticationEvent> result = searchSession.search( AuthenticationEvent.class )
@@ -86,7 +86,7 @@ public class DslConverterIT {
 	@Test
 	public void dslConverterDisabled() {
 		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
-			SearchSession searchSession = Search.getSearchSession( entityManager );
+			SearchSession searchSession = Search.session( entityManager );
 
 			// tag::dsl-converter-disabled[]
 			List<AuthenticationEvent> result = searchSession.search( AuthenticationEvent.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/converter/ProjectionConverterIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/converter/ProjectionConverterIT.java
@@ -68,7 +68,7 @@ public class ProjectionConverterIT {
 	@Test
 	public void projectionConverterEnabled() {
 		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
-			SearchSession searchSession = Search.getSearchSession( entityManager );
+			SearchSession searchSession = Search.session( entityManager );
 
 			// tag::projection-converter-enabled[]
 			List<OrderStatus> result = searchSession.search( Order.class )
@@ -85,7 +85,7 @@ public class ProjectionConverterIT {
 	@Test
 	public void projectionConverterDisabled() {
 		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
-			SearchSession searchSession = Search.getSearchSession( entityManager );
+			SearchSession searchSession = Search.session( entityManager );
 
 			// tag::projection-converter-disabled[]
 			List<String> result = searchSession.search( Order.class )

--- a/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/predicate/PredicateDslIT.java
@@ -81,7 +81,7 @@ public class PredicateDslIT {
 	public void entryPoint() {
 		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
 			// tag::entryPoint-lambdas[]
-			SearchSession searchSession = Search.getSearchSession( entityManager );
+			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class ) // <1>
 					.predicate( f -> f.match().onField( "title" ) // <2>
@@ -95,7 +95,7 @@ public class PredicateDslIT {
 
 		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
 			// tag::entryPoint-objects[]
-			SearchSession searchSession = Search.getSearchSession( entityManager );
+			SearchSession searchSession = Search.session( entityManager );
 
 			SearchScope<Book> scope = searchSession.scope( Book.class );
 
@@ -734,7 +734,7 @@ public class PredicateDslIT {
 
 	private void withinSearchSession(Consumer<SearchSession> action) {
 		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
-			SearchSession searchSession = Search.getSearchSession( entityManager );
+			SearchSession searchSession = Search.session( entityManager );
 			action.accept( searchSession );
 		} );
 	}

--- a/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/projection/ProjectionDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/projection/ProjectionDslIT.java
@@ -87,7 +87,7 @@ public class ProjectionDslIT {
 	public void entryPoint() {
 		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
 			// tag::entryPoint-lambdas[]
-			SearchSession searchSession = Search.getSearchSession( entityManager );
+			SearchSession searchSession = Search.session( entityManager );
 
 			List<String> result = searchSession.search( Book.class ) // <1>
 					.asProjection( f -> f.field( "title", String.class ) ) // <2>
@@ -104,7 +104,7 @@ public class ProjectionDslIT {
 
 		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
 			// tag::entryPoint-objects[]
-			SearchSession searchSession = Search.getSearchSession( entityManager );
+			SearchSession searchSession = Search.session( entityManager );
 
 			SearchScope<Book> scope = searchSession.scope( Book.class );
 
@@ -406,7 +406,7 @@ public class ProjectionDslIT {
 
 	private void withinSearchSession(Consumer<SearchSession> action) {
 		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
-			SearchSession searchSession = Search.getSearchSession( entityManager );
+			SearchSession searchSession = Search.session( entityManager );
 			action.accept( searchSession );
 		} );
 	}

--- a/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/query/QueryDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/query/QueryDslIT.java
@@ -66,7 +66,7 @@ public class QueryDslIT {
 		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
 			// tag::entryPoint[]
 			// Not shown: get the entity manager and open a transaction
-			SearchSession searchSession = Search.getSearchSession( entityManager ); // <1>
+			SearchSession searchSession = Search.session( entityManager ); // <1>
 
 			SearchResult<Book> result = searchSession.search( Book.class ) // <2>
 					.predicate( f -> f.match() // <3>

--- a/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/sort/SortDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/searchdsl/sort/SortDslIT.java
@@ -78,7 +78,7 @@ public class SortDslIT {
 	public void entryPoint() {
 		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
 			// tag::entryPoint-lambdas[]
-			SearchSession searchSession = Search.getSearchSession( entityManager );
+			SearchSession searchSession = Search.session( entityManager );
 
 			List<Book> result = searchSession.search( Book.class ) // <1>
 					.predicate( f -> f.matchAll() )
@@ -93,7 +93,7 @@ public class SortDslIT {
 
 		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
 			// tag::entryPoint-objects[]
-			SearchSession searchSession = Search.getSearchSession( entityManager );
+			SearchSession searchSession = Search.session( entityManager );
 
 			SearchScope<Book> scope = searchSession.scope( Book.class );
 
@@ -343,7 +343,7 @@ public class SortDslIT {
 
 	private void withinSearchSession(Consumer<SearchSession> action) {
 		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
-			SearchSession searchSession = Search.getSearchSession( entityManager );
+			SearchSession searchSession = Search.session( entityManager );
 			action.accept( searchSession );
 		} );
 	}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingSynchronizationStrategyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingSynchronizationStrategyIT.java
@@ -221,7 +221,7 @@ public class AutomaticIndexingSynchronizationStrategyIT {
 		CompletableFuture<?> transactionFuture = CompletableFuture.runAsync( () -> {
 			OrmUtils.withinTransaction( sessionFactory, session -> {
 				if ( customStrategy != null ) {
-					Search.getSearchSession( session ).setAutomaticIndexingSynchronizationStrategy( customStrategy );
+					Search.session( session ).setAutomaticIndexingSynchronizationStrategy( customStrategy );
 				}
 				IndexedEntity entity1 = new IndexedEntity();
 				entity1.setId( 1 );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToHibernateOrmIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToHibernateOrmIT.java
@@ -81,7 +81,7 @@ public class ToHibernateOrmIT {
 	@Test
 	public void toHibernateOrmSession() {
 		OrmUtils.withinSession( sessionFactory, session -> {
-			SearchSession searchSession = Search.getSearchSession( session );
+			SearchSession searchSession = Search.session( session );
 			assertThat( searchSession.toOrmSession() ).isSameAs( session );
 		} );
 	}
@@ -100,7 +100,7 @@ public class ToHibernateOrmIT {
 
 		Session closedSession = session;
 		SubTest.expectException( () -> {
-			Search.getSearchSession( closedSession );
+			Search.session( closedSession );
 		} )
 				.assertThrown()
 				.isInstanceOf( SearchException.class )
@@ -110,7 +110,7 @@ public class ToHibernateOrmIT {
 	@Test
 	public void toHibernateOrmQuery() {
 		OrmUtils.withinSession( sessionFactory, session -> {
-			SearchSession searchSession = Search.getSearchSession( session );
+			SearchSession searchSession = Search.session( session );
 			Query<IndexedEntity> query = Search.toOrmQuery( createSimpleQuery( searchSession ) );
 			assertThat( query ).isNotNull();
 		} );
@@ -119,7 +119,7 @@ public class ToHibernateOrmIT {
 	@Test
 	public void list() {
 		OrmUtils.withinSession( sessionFactory, session -> {
-			SearchSession searchSession = Search.getSearchSession( session );
+			SearchSession searchSession = Search.session( session );
 			Query<IndexedEntity> query = Search.toOrmQuery( createSimpleQuery( searchSession ) );
 
 			backendMock.expectSearchObjects(
@@ -144,7 +144,7 @@ public class ToHibernateOrmIT {
 	@Test
 	public void uniqueResult() {
 		OrmUtils.withinSession( sessionFactory, session -> {
-			SearchSession searchSession = Search.getSearchSession( session );
+			SearchSession searchSession = Search.session( session );
 			Query<IndexedEntity> query = Search.toOrmQuery( createSimpleQuery( searchSession ) );
 
 			backendMock.expectSearchObjects(
@@ -204,7 +204,7 @@ public class ToHibernateOrmIT {
 	@Test
 	public void pagination() {
 		OrmUtils.withinSession( sessionFactory, session -> {
-			SearchSession searchSession = Search.getSearchSession( session );
+			SearchSession searchSession = Search.session( session );
 			Query<IndexedEntity> query = Search.toOrmQuery( createSimpleQuery( searchSession ) );
 
 			assertThat( query.getFirstResult() ).isEqualTo( 0 );
@@ -232,7 +232,7 @@ public class ToHibernateOrmIT {
 	@TestForIssue( jiraKey = "HSEARCH-1857" )
 	public void reuseSearchSessionAfterOrmSessionIsClosed_noMatching() {
 		Session session = sessionFactory.openSession();
-		SearchSession searchSession = Search.getSearchSession( session );
+		SearchSession searchSession = Search.session( session );
 		// a SearchSession instance is created lazily,
 		// so we need to use it to have an instance of it
 		createSimpleQuery( searchSession );
@@ -250,7 +250,7 @@ public class ToHibernateOrmIT {
 	public void lazyCrateSearchSessionAfterOrmSessionIsClosed() {
 		Session session = sessionFactory.openSession();
 		// Search session is not created, since we don't use it
-		SearchSession searchSession = Search.getSearchSession( session );
+		SearchSession searchSession = Search.session( session );
 		session.close();
 
 		SubTest.expectException( () -> {
@@ -265,7 +265,7 @@ public class ToHibernateOrmIT {
 	@TestForIssue( jiraKey = "HSEARCH-1857" )
 	public void reuseSearchQueryAfterOrmSessionIsClosed_noMatching() {
 		Session session = sessionFactory.openSession();
-		SearchSession searchSession = Search.getSearchSession( session );
+		SearchSession searchSession = Search.session( session );
 		SearchQuery<IndexedEntity> query = createSimpleQuery( searchSession );
 		session.close();
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToJpaIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToJpaIT.java
@@ -85,7 +85,7 @@ public class ToJpaIT {
 	@Test
 	public void toJpaEntityManager() {
 		OrmUtils.withinEntityManager( sessionFactory, entityManager -> {
-			SearchSession searchSession = Search.getSearchSession( entityManager );
+			SearchSession searchSession = Search.session( entityManager );
 			assertThat( searchSession.toEntityManager() ).isSameAs( entityManager );
 		} );
 	}
@@ -104,7 +104,7 @@ public class ToJpaIT {
 
 		EntityManager closedEntityManager = entityManager;
 		SubTest.expectException( () -> {
-			Search.getSearchSession( closedEntityManager );
+			Search.session( closedEntityManager );
 		} )
 				.assertThrown()
 				.isInstanceOf( SearchException.class )
@@ -114,7 +114,7 @@ public class ToJpaIT {
 	@Test
 	public void toJpaQuery() {
 		OrmUtils.withinEntityManager( sessionFactory, entityManager -> {
-			SearchSession searchSession = Search.getSearchSession( entityManager );
+			SearchSession searchSession = Search.session( entityManager );
 			TypedQuery<IndexedEntity> query = Search.toJpaQuery( createSimpleQuery( searchSession ) );
 			assertThat( query ).isNotNull();
 		} );
@@ -123,7 +123,7 @@ public class ToJpaIT {
 	@Test
 	public void getResultList() {
 		OrmUtils.withinEntityManager( sessionFactory, entityManager -> {
-			SearchSession searchSession = Search.getSearchSession( entityManager );
+			SearchSession searchSession = Search.session( entityManager );
 			TypedQuery<IndexedEntity> query = Search.toJpaQuery( createSimpleQuery( searchSession ) );
 
 			backendMock.expectSearchObjects(
@@ -148,7 +148,7 @@ public class ToJpaIT {
 	@Test
 	public void getSingleResult() {
 		OrmUtils.withinEntityManager( sessionFactory, entityManager -> {
-			SearchSession searchSession = Search.getSearchSession( entityManager );
+			SearchSession searchSession = Search.session( entityManager );
 			TypedQuery<IndexedEntity> query = Search.toJpaQuery( createSimpleQuery( searchSession ) );
 
 			backendMock.expectSearchObjects(
@@ -211,7 +211,7 @@ public class ToJpaIT {
 	@Test
 	public void pagination() {
 		OrmUtils.withinEntityManager( sessionFactory, entityManager -> {
-			SearchSession searchSession = Search.getSearchSession( entityManager );
+			SearchSession searchSession = Search.session( entityManager );
 			TypedQuery<IndexedEntity> query = Search.toJpaQuery( createSimpleQuery( searchSession ) );
 
 			assertThat( query.getFirstResult() ).isEqualTo( 0 );
@@ -239,7 +239,7 @@ public class ToJpaIT {
 	@TestForIssue( jiraKey = "HSEARCH-1857" )
 	public void reuseSearchSessionAfterEntityManagerIsClosed_noMatching() {
 		EntityManager entityManager = sessionFactory.createEntityManager();
-		SearchSession searchSession = Search.getSearchSession( entityManager );
+		SearchSession searchSession = Search.session( entityManager );
 		// a SearchSession instance is created lazily,
 		// so we need to use it to have an instance of it
 		createSimpleQuery( searchSession );
@@ -257,7 +257,7 @@ public class ToJpaIT {
 	public void lazyCrateSearchSessionAfterEntityManagerIsClosed() {
 		EntityManager entityManager = sessionFactory.createEntityManager();
 		// Search session is not created, since we don't use it
-		SearchSession searchSession = Search.getSearchSession( entityManager );
+		SearchSession searchSession = Search.session( entityManager );
 		entityManager.close();
 
 		SubTest.expectException( () -> {

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingBaseIT.java
@@ -69,7 +69,7 @@ public class MassIndexingBaseIT {
 	@Test
 	public void defaultMassIndexerStartAndWait() throws Exception {
 		OrmUtils.withinSession( sessionFactory, session -> {
-			SearchSession searchSession = Search.getSearchSession( session );
+			SearchSession searchSession = Search.session( session );
 			MassIndexer indexer = searchSession.massIndexer();
 
 			// add operations on indexes can follow any random order,
@@ -114,7 +114,7 @@ public class MassIndexingBaseIT {
 	@Test
 	public void reuseSearchSessionAfterOrmSessionIsClosed_createMassIndexer() {
 		Session session = sessionFactory.openSession();
-		SearchSession searchSession = Search.getSearchSession( session );
+		SearchSession searchSession = Search.session( session );
 		// a SearchSession instance is created lazily,
 		// so we need to use it to have an instance of it
 		searchSession.massIndexer();
@@ -132,7 +132,7 @@ public class MassIndexingBaseIT {
 	public void lazyCrateSearchSessionAfterOrmSessionIsClosed_createMassIndexer() {
 		Session session = sessionFactory.openSession();
 		// Search session is not created, since we don't use it
-		SearchSession searchSession = Search.getSearchSession( session );
+		SearchSession searchSession = Search.session( session );
 		session.close();
 
 		SubTest.expectException( () -> {

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingEmbeddedIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingEmbeddedIdIT.java
@@ -77,7 +77,7 @@ public class MassIndexingEmbeddedIdIT {
 	@Test
 	public void defaultMassIndexerStartAndWait() {
 		OrmUtils.withinSession( sessionFactory, session -> {
-			SearchSession searchSession = Search.getSearchSession( session );
+			SearchSession searchSession = Search.session( session );
 			MassIndexer indexer = searchSession.massIndexer();
 
 			// add operations on indexes can follow any random order,

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingNonEntityIdDocumentIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingNonEntityIdDocumentIdIT.java
@@ -69,7 +69,7 @@ public class MassIndexingNonEntityIdDocumentIdIT {
 	@TestForIssue(jiraKey = "HSEARCH-3203")
 	public void defaultMassIndexerStartAndWait() {
 		OrmUtils.withinSession( sessionFactory, session -> {
-			SearchSession searchSession = Search.getSearchSession( session );
+			SearchSession searchSession = Search.session( session );
 			MassIndexer indexer = searchSession.massIndexer();
 
 			// add operations on indexes can follow any random order,

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/massindexing/MassIndexingPrimitiveIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/massindexing/MassIndexingPrimitiveIdIT.java
@@ -57,7 +57,7 @@ public class MassIndexingPrimitiveIdIT {
 	@Test
 	public void entityWithPrimitiveId() {
 		OrmUtils.withinSession( sessionFactory, session -> {
-			SearchSession searchSession = Search.getSearchSession( session );
+			SearchSession searchSession = Search.session( session );
 			MassIndexer indexer = searchSession.massIndexer();
 
 			// add operations on indexes can follow any random order,

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/SearchQueryBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/SearchQueryBaseIT.java
@@ -75,7 +75,7 @@ public class SearchQueryBaseIT {
 	@Test
 	public void asEntity() {
 		OrmUtils.withinSession( sessionFactory, session -> {
-			SearchSession searchSession = Search.getSearchSession( session );
+			SearchSession searchSession = Search.session( session );
 
 			SearchQuery<Book> query = searchSession.search( Book.class )
 					.asEntity()
@@ -104,7 +104,7 @@ public class SearchQueryBaseIT {
 	@Test
 	public void asProjection_searchProjectionObject_single() {
 		OrmUtils.withinSession( sessionFactory, session -> {
-			SearchSession searchSession = Search.getSearchSession( session );
+			SearchSession searchSession = Search.session( session );
 
 			SearchScope<Book> scope = searchSession.scope( Book.class );
 
@@ -137,7 +137,7 @@ public class SearchQueryBaseIT {
 	@Test
 	public void asProjection_searchProjectionObject_multiple() {
 		OrmUtils.withinSession( sessionFactory, session -> {
-			SearchSession searchSession = Search.getSearchSession( session );
+			SearchSession searchSession = Search.session( session );
 
 			SearchScope<Book> scope = searchSession.scope( Book.class );
 
@@ -203,7 +203,7 @@ public class SearchQueryBaseIT {
 	@Test
 	public void asProjection_lambda() {
 		OrmUtils.withinSession( sessionFactory, session -> {
-			SearchSession searchSession = Search.getSearchSession( session );
+			SearchSession searchSession = Search.session( session );
 
 			SearchQuery<Book_Author_Score> query = searchSession.search( Book.class )
 					.asProjection( f ->
@@ -251,7 +251,7 @@ public class SearchQueryBaseIT {
 	@Test
 	public void asProjection_compositeAndLoading() {
 		OrmUtils.withinSession( sessionFactory, session -> {
-			SearchSession searchSession = Search.getSearchSession( session );
+			SearchSession searchSession = Search.session( session );
 
 			SearchQuery<Book_Author_Score> query = searchSession.search( Book.class )
 					.asProjection( f ->

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/SearchQueryEntityLoadingIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/SearchQueryEntityLoadingIT.java
@@ -64,7 +64,7 @@ public class SearchQueryEntityLoadingIT {
 	@Test
 	public void entityIdDocumentId() {
 		OrmUtils.withinSession( sessionFactory, session -> {
-			SearchSession searchSession = Search.getSearchSession( session );
+			SearchSession searchSession = Search.session( session );
 
 			SearchQuery<EntityIdDocumentIdIndexedEntity> query = searchSession.search( EntityIdDocumentIdIndexedEntity.class )
 					.predicate( f -> f.matchAll() )
@@ -93,7 +93,7 @@ public class SearchQueryEntityLoadingIT {
 	@TestForIssue(jiraKey = "HSEARCH-3203")
 	public void nonEntityIdDocumentId() {
 		OrmUtils.withinSession( sessionFactory, session -> {
-			SearchSession searchSession = Search.getSearchSession( session );
+			SearchSession searchSession = Search.session( session );
 
 			SearchQuery<NonEntityIdDocumentIdIndexedEntity> query = searchSession.search( NonEntityIdDocumentIdIndexedEntity.class )
 					.predicate( f -> f.matchAll() )
@@ -122,7 +122,7 @@ public class SearchQueryEntityLoadingIT {
 	@TestForIssue(jiraKey = "HSEARCH-3203")
 	public void mixed() {
 		OrmUtils.withinSession( sessionFactory, session -> {
-			SearchSession searchSession = Search.getSearchSession( session );
+			SearchSession searchSession = Search.session( session );
 
 			SearchQuery<Object> query = searchSession.search( Arrays.asList(
 							EntityIdDocumentIdIndexedEntity.class,

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/session/SearchSessionWritePlanBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/session/SearchSessionWritePlanBaseIT.java
@@ -60,7 +60,7 @@ public class SearchSessionWritePlanBaseIT {
 			session.persist( entity2 );
 			session.persist( entity3 );
 
-			SearchSessionWritePlan writePlan = Search.getSearchSession( session ).writePlan();
+			SearchSessionWritePlan writePlan = Search.session( session ).writePlan();
 			writePlan.addOrUpdate( entity1 );
 			writePlan.addOrUpdate( entity2 );
 			writePlan.delete( entity3 );
@@ -99,7 +99,7 @@ public class SearchSessionWritePlanBaseIT {
 			session.persist( entity7 );
 			session.persist( entity8 );
 
-			SearchSessionWritePlan writePlan = Search.getSearchSession( session ).writePlan();
+			SearchSessionWritePlan writePlan = Search.session( session ).writePlan();
 
 			writePlan.addOrUpdate( entity1 );
 			writePlan.addOrUpdate( entity1 );
@@ -157,7 +157,7 @@ public class SearchSessionWritePlanBaseIT {
 		SessionFactory sessionFactory = setup( HibernateOrmAutomaticIndexingStrategyName.NONE );
 
 		withinTransaction( sessionFactory, session -> {
-			SearchSessionWritePlan writePlan = Search.getSearchSession( session ).writePlan();
+			SearchSessionWritePlan writePlan = Search.session( session ).writePlan();
 			SubTest.expectException(
 					() -> writePlan.purge( ContainedEntity.class, 42 )
 			)
@@ -180,7 +180,7 @@ public class SearchSessionWritePlanBaseIT {
 			session.persist( entity2 );
 			session.flush();
 
-			SearchSessionWritePlan writePlan = Search.getSearchSession( session ).writePlan();
+			SearchSessionWritePlan writePlan = Search.session( session ).writePlan();
 
 			backend1Mock.expectWorks( IndexedEntity1.INDEX_NAME )
 					.add( "1", b -> b.field( "text", "number1" ) )
@@ -224,7 +224,7 @@ public class SearchSessionWritePlanBaseIT {
 			session.persist( entity2 );
 			session.flush();
 
-			SearchSessionWritePlan writePlan = Search.getSearchSession( session ).writePlan();
+			SearchSessionWritePlan writePlan = Search.session( session ).writePlan();
 
 			backend1Mock.expectWorks( IndexedEntity1.INDEX_NAME )
 					.add( "1", b -> b.field( "text", "number1" ) )
@@ -265,7 +265,7 @@ public class SearchSessionWritePlanBaseIT {
 
 			session.persist( entity3 );
 
-			SearchSessionWritePlan writePlan = Search.getSearchSession( session ).writePlan();
+			SearchSessionWritePlan writePlan = Search.session( session ).writePlan();
 			writePlan.addOrUpdate( entity1 );
 			writePlan.delete( entity2 );
 
@@ -293,7 +293,7 @@ public class SearchSessionWritePlanBaseIT {
 			session.persist( entity2 );
 			session.persist( entity3 );
 
-			SearchSessionWritePlan writePlan = Search.getSearchSession( session ).writePlan();
+			SearchSessionWritePlan writePlan = Search.session( session ).writePlan();
 			writePlan.addOrUpdate( entity1 );
 			writePlan.addOrUpdate( entity2 );
 			writePlan.delete( entity3 );
@@ -319,7 +319,7 @@ public class SearchSessionWritePlanBaseIT {
 		try ( Session session = sessionFactory.openSession() ) {
 			entity = new IndexedEntity1( 1, "number1" );
 			session.persist( entity );
-			writePlan = Search.getSearchSession( session ).writePlan();
+			writePlan = Search.session( session ).writePlan();
 		}
 
 		SubTest.expectException(

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/session/SearchSessionWritePlanNonEntityIdDocumentIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/session/SearchSessionWritePlanNonEntityIdDocumentIdIT.java
@@ -53,7 +53,7 @@ public class SearchSessionWritePlanNonEntityIdDocumentIdIT {
 			session.persist( entity2 );
 			session.persist( entity3 );
 
-			SearchSessionWritePlan writePlan = Search.getSearchSession( session ).writePlan();
+			SearchSessionWritePlan writePlan = Search.session( session ).writePlan();
 			writePlan.addOrUpdate( entity1 );
 			writePlan.addOrUpdate( entity2 );
 			writePlan.delete( entity3 );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/session/SearchSessionWritePlanPersistBatchIndexingIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/session/SearchSessionWritePlanPersistBatchIndexingIT.java
@@ -55,7 +55,7 @@ public class SearchSessionWritePlanPersistBatchIndexingIT {
 		SessionFactory sessionFactory = setup();
 
 		withinTransaction( sessionFactory, session -> {
-			SearchSessionWritePlan writePlan = Search.getSearchSession( session ).writePlan();
+			SearchSessionWritePlan writePlan = Search.session( session ).writePlan();
 
 			// This is for test only and wouldn't be present in real code
 			int firstIdOfThisBatch = 0;
@@ -100,7 +100,7 @@ public class SearchSessionWritePlanPersistBatchIndexingIT {
 		SessionFactory sessionFactory = setup();
 
 		withinTransaction( sessionFactory, session -> {
-			SearchSessionWritePlan writePlan = Search.getSearchSession( session ).writePlan();
+			SearchSessionWritePlan writePlan = Search.session( session ).writePlan();
 
 			// This is for test only and wouldn't be present in real code
 			int firstIdOfThisBatch = 0;

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/smoke/AnnotationMappingSmokeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/smoke/AnnotationMappingSmokeIT.java
@@ -297,7 +297,7 @@ public class AnnotationMappingSmokeIT {
 	@Test
 	public void search() {
 		OrmUtils.withinSession( sessionFactory, session -> {
-			SearchSession searchSession = Search.getSearchSession( session );
+			SearchSession searchSession = Search.session( session );
 			SearchQuery<ParentIndexedEntity> query = searchSession.search(
 							Arrays.asList( IndexedEntity.class, YetAnotherIndexedEntity.class )
 					)

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/smoke/ProgrammaticMappingSmokeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/smoke/ProgrammaticMappingSmokeIT.java
@@ -295,7 +295,7 @@ public class ProgrammaticMappingSmokeIT {
 	@Test
 	public void search() {
 		OrmUtils.withinSession( sessionFactory, session -> {
-			SearchSession searchSession = Search.getSearchSession( session );
+			SearchSession searchSession = Search.session( session );
 			SearchQuery<ParentIndexedEntity> query = searchSession.search(
 							Arrays.asList( IndexedEntity.class, YetAnotherIndexedEntity.class )
 					)

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/writing/AbstractSearchWriterSimpleOperationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/writing/AbstractSearchWriterSimpleOperationIT.java
@@ -44,7 +44,7 @@ public abstract class AbstractSearchWriterSimpleOperationIT {
 		SessionFactory sessionFactory = setup();
 
 		OrmUtils.withinSession( sessionFactory, session -> {
-			SearchWriter writer = Search.getSearchSession( session ).writer( IndexedEntity1.class );
+			SearchWriter writer = Search.session( session ).writer( IndexedEntity1.class );
 
 			CompletableFuture<Object> futureFromBackend = new CompletableFuture<>();
 			expectWork( backend1Mock, IndexedEntity1.INDEX_NAME, futureFromBackend );
@@ -63,7 +63,7 @@ public abstract class AbstractSearchWriterSimpleOperationIT {
 		SessionFactory sessionFactory = setup();
 
 		OrmUtils.withinSession( sessionFactory, session -> {
-			SearchWriter writer = Search.getSearchSession( session ).writer( IndexedEntity1.class );
+			SearchWriter writer = Search.session( session ).writer( IndexedEntity1.class );
 
 			CompletableFuture<Object> futureFromBackend = new CompletableFuture<>();
 			expectWork( backend1Mock, IndexedEntity1.INDEX_NAME, futureFromBackend );
@@ -83,7 +83,7 @@ public abstract class AbstractSearchWriterSimpleOperationIT {
 		SessionFactory sessionFactory = setup();
 
 		OrmUtils.withinSession( sessionFactory, session -> {
-			SearchWriter writer = Search.getSearchSession( session ).writer( IndexedEntity1.class );
+			SearchWriter writer = Search.session( session ).writer( IndexedEntity1.class );
 
 			CompletableFuture<Object> futureFromBackend = new CompletableFuture<>();
 			expectWork( backend1Mock, IndexedEntity1.INDEX_NAME, futureFromBackend );
@@ -99,7 +99,7 @@ public abstract class AbstractSearchWriterSimpleOperationIT {
 		SessionFactory sessionFactory = setup();
 
 		OrmUtils.withinSession( sessionFactory, session -> {
-			SearchWriter writer = Search.getSearchSession( session ).writer( IndexedEntity1.class );
+			SearchWriter writer = Search.session( session ).writer( IndexedEntity1.class );
 
 			CompletableFuture<Object> futureFromBackend = new CompletableFuture<>();
 			expectWork( backend1Mock, IndexedEntity1.INDEX_NAME, futureFromBackend );
@@ -120,7 +120,7 @@ public abstract class AbstractSearchWriterSimpleOperationIT {
 		SessionFactory sessionFactory = setup();
 
 		OrmUtils.withinSession( sessionFactory, session -> {
-			SearchWriter writer = Search.getSearchSession( session ).writer();
+			SearchWriter writer = Search.session( session ).writer();
 
 			CompletableFuture<Object> future1FromBackend = new CompletableFuture<>();
 			CompletableFuture<Object> future2FromBackend = new CompletableFuture<>();
@@ -146,7 +146,7 @@ public abstract class AbstractSearchWriterSimpleOperationIT {
 
 		SearchWriter writer;
 		try ( Session session = sessionFactory.openSession() ) {
-			writer = Search.getSearchSession( session ).writer( IndexedEntity1.class );
+			writer = Search.session( session ).writer( IndexedEntity1.class );
 		}
 
 		CompletableFuture<Object> futureFromBackend = new CompletableFuture<>();

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchDocumentRepositoryImpl.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchDocumentRepositoryImpl.java
@@ -32,7 +32,7 @@ public class IndexSearchDocumentRepositoryImpl implements IndexSearchDocumentRep
 
 	@Override
 	public List<Book> findAllIndexed() {
-		return Search.getSearchSession( entityManager )
+		return Search.session( entityManager )
 				.search( Book.class )
 				.predicate( p -> p.matchAll() )
 				.fetchHits();
@@ -44,7 +44,7 @@ public class IndexSearchDocumentRepositoryImpl implements IndexSearchDocumentRep
 			return Optional.empty();
 		}
 
-		return Search.getSearchSession( entityManager ).search( Book.class )
+		return Search.session( entityManager ).search( Book.class )
 				// onRawField option allows to bypass the bridge in the DSL
 				.predicate( f -> f.match().onField( "isbn" ).matching( isbnAsString, DslConverter.DISABLED ) )
 				.fetchSingleHit();
@@ -52,7 +52,7 @@ public class IndexSearchDocumentRepositoryImpl implements IndexSearchDocumentRep
 
 	@Override
 	public List<Book> searchByMedium(String terms, BookMedium medium, int limit, int offset) {
-		return Search.getSearchSession( entityManager ).search( Book.class )
+		return Search.session( entityManager ).search( Book.class )
 				.predicate( f -> f.bool( b -> {
 					if ( terms != null && !terms.isEmpty() ) {
 						b.must( f.match()
@@ -74,7 +74,7 @@ public class IndexSearchDocumentRepositoryImpl implements IndexSearchDocumentRep
 			GeoPoint myLocation, Double maxDistanceInKilometers,
 			List<LibraryServiceOption> libraryServices,
 			int limit, int offset) {
-		return Search.getSearchSession( entityManager ).search( DOCUMENT_CLASS )
+		return Search.session( entityManager ).search( DOCUMENT_CLASS )
 				.predicate( f -> f.bool( b -> {
 					// Match query
 					if ( terms != null && !terms.isEmpty() ) {
@@ -133,7 +133,7 @@ public class IndexSearchDocumentRepositoryImpl implements IndexSearchDocumentRep
 
 	@Override
 	public List<String> getAuthorsOfBooksHavingTerms(String terms, SortOrder order) {
-		return Search.getSearchSession( entityManager ).search( Document.class )
+		return Search.session( entityManager ).search( Document.class )
 				.asProjection( f -> f.field( "author", String.class ) )
 				.predicate( f -> f.match()
 						.onField( "title" ).boostedTo( 2.0f )

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchLibraryRepositoryImpl.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchLibraryRepositoryImpl.java
@@ -25,7 +25,7 @@ public class IndexSearchLibraryRepositoryImpl implements IndexSearchLibraryRepos
 		if ( terms == null || terms.isEmpty() ) {
 			return Collections.emptyList();
 		}
-		return Search.getSearchSession( entityManager )
+		return Search.session( entityManager )
 				.search( Library.class )
 				.predicate( f -> f.match().onField( "name" ).matching( terms ) )
 				.sort( f -> f.byField( "collectionSize" ).desc()

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchPersonRepositoryImpl.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchPersonRepositoryImpl.java
@@ -41,7 +41,7 @@ public class IndexSearchPersonRepositoryImpl implements IndexSearchPersonReposit
 			return Collections.emptyList();
 		}
 
-		return Search.getSearchSession( entityManager ).search( Person.class )
+		return Search.session( entityManager ).search( Person.class )
 				.predicate( f -> f.match().onFields( "firstName", "lastName" ).matching( terms ) )
 				.sort( f -> f.byField( "lastName_sort" )
 						.then().byField( "firstName_sort" )
@@ -50,7 +50,7 @@ public class IndexSearchPersonRepositoryImpl implements IndexSearchPersonReposit
 	}
 
 	private List<Person> listTopBorrowers(String borrowalsCountField, int limit, int offset) {
-		return Search.getSearchSession( entityManager ).search( Person.class )
+		return Search.session( entityManager ).search( Person.class )
 				.predicate( f -> f.matchAll() )
 				.sort( f -> f.byField( borrowalsCountField ).desc() )
 				.fetchHits( limit, offset );

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/service/AdminService.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/service/AdminService.java
@@ -23,6 +23,6 @@ public class AdminService {
 	private EntityManager entityManager;
 
 	public MassIndexer createMassIndexer() {
-		return Search.getSearchSession( entityManager ).massIndexer();
+		return Search.session( entityManager ).massIndexer();
 	}
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/Search.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/Search.java
@@ -39,8 +39,8 @@ public final class Search {
 	 * @return The corresponding {@link SearchSession}.
 	 * @throws org.hibernate.search.util.common.SearchException if the session NOT {@link Session#isOpen()}.
 	 */
-	public static SearchSession getSearchSession(Session session) {
-		SessionImplementor sessionImpl = null;
+	public static SearchSession session(Session session) {
+		SessionImplementor sessionImpl;
 		try {
 			sessionImpl = session.unwrap( SessionImplementor.class );
 		}
@@ -62,8 +62,8 @@ public final class Search {
 	 * @return The corresponding {@link SearchSession}.
 	 * @throws org.hibernate.search.util.common.SearchException if the entity manager NOT {@link EntityManager#isOpen()}.
 	 */
-	public static SearchSession getSearchSession(EntityManager entityManager) {
-		SessionImplementor sessionImpl = null;
+	public static SearchSession session(EntityManager entityManager) {
+		SessionImplementor sessionImpl;
 		try {
 			sessionImpl = entityManager.unwrap( SessionImplementor.class );
 		}
@@ -72,6 +72,30 @@ public final class Search {
 		}
 
 		return createSearchSession( sessionImpl );
+	}
+
+	/**
+	 * Retrieve the {@link SearchSession} from a Hibernate ORM {@link Session}.
+	 * @param session A Hibernate ORM session.
+	 * @return The corresponding {@link SearchSession}.
+	 * @throws org.hibernate.search.util.common.SearchException if the session NOT {@link Session#isOpen()}.
+	 * @deprecated Use {@link #session(Session)} instead.
+	 */
+	@Deprecated
+	public static SearchSession getSearchSession(Session session) {
+		return session( session );
+	}
+
+	/**
+	 * Retrieve the {@link SearchSession} from a Hibernate ORM {@link Session}.
+	 * @param entityManager A JPA entity manager.
+	 * @return The corresponding {@link SearchSession}.
+	 * @throws org.hibernate.search.util.common.SearchException if the entity manager NOT {@link EntityManager#isOpen()}.
+	 * @deprecated Use {@link #session(EntityManager)} instead.
+	 */
+	@Deprecated
+	public static SearchSession getSearchSession(EntityManager entityManager) {
+		return session( entityManager );
 	}
 
 	/**

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/LazyInitSearchSession.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/LazyInitSearchSession.java
@@ -20,7 +20,7 @@ import org.hibernate.search.mapper.orm.session.SearchSessionWritePlan;
 /**
  * A lazily initializing {@link SearchSession}.
  * <p>
- * This implementation allows to call {@link org.hibernate.search.mapper.orm.Search#getSearchSession(Session)}
+ * This implementation allows to call {@link org.hibernate.search.mapper.orm.Search#session(Session)}
  * before Hibernate Search is fully initialized, which can be useful in CDI/Spring environments.
  */
 public class LazyInitSearchSession implements SearchSession {


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3610

This:

```
SearchResult<Book> result = Search.getSearchSession(em).search(Book.class)
        .predicate(f -> f.matchAll())
        .fetch(20, 0);
```

now looks a bit shorter, like this:

```
SearchResult<Book> result = Search.session(em).search(Book.class)
        .predicate(f -> f.matchAll())
        .fetch(20, 0);
```
