### PR TITLE
HSEARCH-3067 Remove the notion of explicit initialization of lazy collection/map/array in PojoRuntimeIntrospector

### DIFF
--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/spi/PojoRuntimeIntrospector.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/spi/PojoRuntimeIntrospector.java
@@ -24,28 +24,6 @@ public interface PojoRuntimeIntrospector {
 	 */
 	Object unproxy(Object value);
 
-	// TODO HSEARCH-3067 also add the following as necessary
-//	/**
-//	 * @param <T> the type of the elements in the collection
-//	 * @param value the collection to initialize
-//	 * @return the initialized Collection, to be used on lazily-loading collections
-//	 */
-//	<T> Collection<T> initializeCollection(Collection<T> value);
-//
-//	/**
-//	 * @param <K> key
-//	 * @param <V> value
-//	 * @param value the map to initialize
-//	 * @return the initialized Map, to be used on lazily-loading maps
-//	 */
-//	<K,V> Map<K,V> initializeMap(Map<K,V> value);
-//
-//	/**
-//	 * @param value the array to initialize
-//	 * @return the initialized array, to be used on lazily-loading arrays
-//	 */
-//	Object[] initializeArray(Object[] value);
-
 	static PojoRuntimeIntrospector noProxy() {
 		return NoProxyPojoRuntimeIntrospector.get();
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3067

It turns out that notion is obsolete.

There are remnants in the legacy code in
`org.hibernate.search.spi.InstanceInitializer#initializeCollection`
for example, but all implementations are no-op as of
8bc0e23.

Judging from that commit's message, this initialization was only useful
when dealing detached collections, and "we don't have to" do it anymore.
It was an SPI, but as far as I can tell it wasn't useful in any know
integration, so let's remove it for now and restore it if someone asks
for it (nicely).