### PR TITLE
HSEARCH-2473 Get test naming practices straight

### DIFF
--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/automaticindexing/ContainedInThroughNonContainingIndexedTypeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/automaticindexing/ContainedInThroughNonContainingIndexedTypeIT.java
@@ -41,7 +41,7 @@ import org.junit.Test;
  * This should not matter given the current implementation, but better safe than sorry.
  */
 @TestForIssue(jiraKey = "HSEARCH-2496")
-public class ContainedInThroughNonContainingIndexedType {
+public class ContainedInThroughNonContainingIndexedTypeIT {
 
 	@Rule
 	public BackendMock backendMock = new BackendMock( "stubBackend" );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/automaticindexing/ContainedInTriggerUnnecessaryCollectionInitializationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/automaticindexing/ContainedInTriggerUnnecessaryCollectionInitializationIT.java
@@ -35,7 +35,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 @TestForIssue(jiraKey = "HSEARCH-1710")
-public class ContainedInTriggerUnnecessaryCollectionInitialization {
+public class ContainedInTriggerUnnecessaryCollectionInitializationIT {
 
 	@Rule
 	public BackendMock backendMock = new BackendMock( "stubBackend" );

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/nonregression/mapping/definition/IndexNullAsOnNumericContainerIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/nonregression/mapping/definition/IndexNullAsOnNumericContainerIT.java
@@ -28,7 +28,7 @@ import org.junit.Test;
  * would result in indexNullAs being interpreted as a string rather than the numeric type.
  */
 @TestForIssue(jiraKey = "HSEARCH-2663")
-public class IndexNullAsOnNumericContainer {
+public class IndexNullAsOnNumericContainerIT {
 
 	@Rule
 	public BackendMock backendMock = new BackendMock( "stubBackend" );

--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -15,7 +15,6 @@
     <properties>
         <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         <maven.javadoc.skip>true</maven.javadoc.skip>
-        <jqassistant.skip>true</jqassistant.skip>
     </properties>
 
     <modules>

--- a/jqassistant/rules.xml
+++ b/jqassistant/rules.xml
@@ -54,6 +54,7 @@
     </concept>
 
     <concept id="my-rules:Spi">
+        <requiresConcept refId="my-rules:Test" />
         <description>
             Contributes the :Spi label to SPI types
         </description>
@@ -61,7 +62,8 @@
             MATCH
                 (type:Type)
             WHERE
-                type.fqn =~ ".*\\.spi\\..*"
+                NOT type:Test
+                AND type.fqn =~ ".*\\.spi\\..*"
                 AND type.visibility = "public"
             SET
                 type:Spi, type:Public
@@ -71,6 +73,7 @@
     </concept>
 
     <concept id="my-rules:Impl">
+        <requiresConcept refId="my-rules:Test" />
         <description>
             Contributes the :Impl label to implementation types
         </description>
@@ -78,7 +81,8 @@
             MATCH
                 (type:Type)
             WHERE
-                type.fqn =~ ".*\\.impl\\..*"
+                NOT type:Test
+                AND type.fqn =~ ".*\\.impl\\..*"
                 // Apache HTTP Client uses an impl package, but puts public classes in there... Such as the client builder.
                 AND NOT type.fqn STARTS WITH "org.apache.http.impl."
                 OR type.visibility <> "public"

--- a/jqassistant/rules.xml
+++ b/jqassistant/rules.xml
@@ -168,6 +168,24 @@
         ]]></cypher>
     </concept>
 
+    <concept id="my-rules:IntegrationTestArtifacts">
+        <requiresConcept refId="my-rules:HibernateSearch" />
+        <description>
+            Contributes the :IntegrationTest label to :Maven:Artifact nodes representing integration testing artifacts.
+        </description>
+        <cypher><![CDATA[
+            MATCH
+                (artifact:Maven:Artifact:HibernateSearch)
+            WHERE
+                artifact.name =~ ".*-integrationtest-.*"
+                OR artifact.name = "hibernate-search-documentation"
+            SET
+                artifact:IntegrationTest
+            RETURN
+                artifact
+        ]]></cypher>
+    </concept>
+
     <concept id="my-rules:ArtifactMetadata">
         <requiresConcept refId="my-rules:HibernateSearch" />
         <description>
@@ -501,6 +519,43 @@
         ]]></cypher>
     </constraint>
 
+    <constraint id="my-rules:UnitTestsMustHaveProperSuffix">
+        <requiresConcept refId="my-rules:HibernateSearch" />
+        <requiresConcept refId="my-rules:IntegrationTestArtifacts" />
+        <description>
+            Unit test class names must be suffixed with "Test".
+        </description>
+        <cypher><![CDATA[
+            MATCH (artifact:Maven:Artifact:HibernateSearch)
+                    -[:CONTAINS]->(type:Type)-[:DECLARES]->(method:Method)
+                    -[:ANNOTATED_BY]->()-[:OF_TYPE]->(testAnnotation:Type)
+            WHERE
+                NOT artifact:IntegrationTest
+                AND testAnnotation.fqn = "org.junit.Test"
+                AND NOT type.name ENDS WITH "Test"
+            RETURN DISTINCT
+                artifact.name AS Artifact, type.fqn AS Test
+        ]]></cypher>
+    </constraint>
+
+    <constraint id="my-rules:IntegrationTestsMustHaveProperSuffix">
+        <requiresConcept refId="my-rules:HibernateSearch" />
+        <requiresConcept refId="my-rules:IntegrationTestArtifacts" />
+        <description>
+            Integration test class names must be suffixed with "IT".
+        </description>
+        <cypher><![CDATA[
+            MATCH (artifact:Maven:Artifact:HibernateSearch:IntegrationTest)
+                    -[:CONTAINS]->(type:Type)-[:DECLARES]->(method:Method)
+                    -[:ANNOTATED_BY]->()-[:OF_TYPE]->(testAnnotation:Type)
+            WHERE
+                testAnnotation.fqn = "org.junit.Test"
+                AND NOT type.name ENDS WITH "IT"
+            RETURN DISTINCT
+                artifact.name AS Artifact, type.fqn AS Test
+        ]]></cypher>
+    </constraint>
+
     <group id="default">
         <includeConstraint refId="my-rules:PublicTypesMayNotExtendInternalTypes" />
         <includeConstraint refId="my-rules:PublicMethodsMayNotExposeInternalTypes" />
@@ -513,6 +568,8 @@
         <includeConstraint refId="my-rules:AbstractTypesShouldUseAbstractPrefix" />
         <includeConstraint refId="my-rules:TypesExtendingTypeFromAnotherModuleMustHaveModuleSpecificKeywordInName" />
         <includeConstraint refId="my-rules:TypeNamesShouldBeUniqueInInterdependentModules" />
+        <includeConstraint refId="my-rules:UnitTestsMustHaveProperSuffix" />
+        <includeConstraint refId="my-rules:IntegrationTestsMustHaveProperSuffix" />
     </group>
 
     <group id="cycles">


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-2473

I tested the new JQAssistant rules locally by adding tests with the wrong suffix: it worked.