### PR TITLE
HSEARCH-3621 Clarify the error message when the Elasticsearch cluster cannot be reached upon startup

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/impl/ElasticsearchClientUtils.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/impl/ElasticsearchClientUtils.java
@@ -63,7 +63,7 @@ public class ElasticsearchClientUtils {
 						.orElseThrow( () -> new AssertionFailure( "Missing version number in JSON response" ) );
 			}
 			catch (RuntimeException e) {
-				throw log.elasticsearchRequestFailed( request, response, e );
+				throw log.elasticsearchRequestFailed( request, response, e.getMessage(), e );
 			}
 		}
 		catch (RuntimeException e) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/impl/ElasticsearchClientUtils.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/impl/ElasticsearchClientUtils.java
@@ -67,7 +67,7 @@ public class ElasticsearchClientUtils {
 			}
 		}
 		catch (RuntimeException e) {
-			throw log.failedToDetectElasticsearchVersion( e );
+			throw log.failedToDetectElasticsearchVersion( e.getMessage(), e );
 		}
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchBackendFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchBackendFactory.java
@@ -36,9 +36,7 @@ import org.hibernate.search.engine.cfg.spi.OptionalConfigurationProperty;
 import org.hibernate.search.engine.environment.bean.BeanHolder;
 import org.hibernate.search.engine.environment.bean.BeanResolver;
 import org.hibernate.search.engine.environment.bean.BeanReference;
-import org.hibernate.search.engine.reporting.spi.EventContexts;
 import org.hibernate.search.util.common.AssertionFailure;
-import org.hibernate.search.util.common.reporting.EventContext;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 import org.hibernate.search.util.common.impl.SuppressingCloser;
 
@@ -81,8 +79,6 @@ public class ElasticsearchBackendFactory implements BackendFactory {
 
 	@Override
 	public BackendImplementor<?> create(String name, BackendBuildContext buildContext, ConfigurationPropertySource propertySource) {
-		EventContext backendContext = EventContexts.fromBackendName( name );
-
 		boolean logPrettyPrinting = LOG_JSON_PRETTY_PRINTING.get( propertySource );
 		/*
 		 * The Elasticsearch client only converts JsonObjects to String and
@@ -124,7 +120,7 @@ public class ElasticsearchBackendFactory implements BackendFactory {
 					dialect.createIndexTypeFieldFactoryProvider( userFacingGson );
 
 			ElasticsearchAnalysisDefinitionRegistry analysisDefinitionRegistry =
-					getAnalysisDefinitionRegistry( backendContext, buildContext, propertySource );
+					getAnalysisDefinitionRegistry( buildContext, propertySource );
 
 			return new ElasticsearchBackendImpl(
 					link,
@@ -159,7 +155,7 @@ public class ElasticsearchBackendFactory implements BackendFactory {
 		}
 	}
 
-	private ElasticsearchAnalysisDefinitionRegistry getAnalysisDefinitionRegistry(EventContext backendContext,
+	private ElasticsearchAnalysisDefinitionRegistry getAnalysisDefinitionRegistry(
 			BackendBuildContext buildContext, ConfigurationPropertySource propertySource) {
 		try {
 			// Apply the user-provided analysis configurer if necessary
@@ -177,7 +173,7 @@ public class ElasticsearchBackendFactory implements BackendFactory {
 					.orElseGet( ElasticsearchAnalysisDefinitionRegistry::new );
 		}
 		catch (Exception e) {
-			throw log.unableToApplyAnalysisConfiguration( e.getMessage(), backendContext, e );
+			throw log.unableToApplyAnalysisConfiguration( e.getMessage(), e );
 		}
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/ElasticsearchResponseFormatter.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/ElasticsearchResponseFormatter.java
@@ -24,7 +24,7 @@ public class ElasticsearchResponseFormatter {
 
 	public static String formatResponse(ElasticsearchResponse response) {
 		if ( response == null ) {
-			return null;
+			return "(no response)";
 		}
 
 		JsonLogHelper helper = JsonLogHelper.get();

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
@@ -68,20 +68,22 @@ public interface Log extends BasicLogger {
 	int ID_OFFSET_2 = MessageConstants.BACKEND_ES_ID_RANGE_MIN;
 
 	@Message(id = ID_OFFSET_2 + 7,
-			value = "Elasticsearch request failed.\nRequest: %1$s\nResponse: %2$s"
+			value = "Elasticsearch request failed: %3$s\nRequest: %1$s\nResponse: %2$s"
 	)
 	SearchException elasticsearchRequestFailed(
 			@FormatWith( ElasticsearchRequestFormatter.class ) ElasticsearchRequest request,
 			@FormatWith( ElasticsearchResponseFormatter.class ) ElasticsearchResponse response,
+			String causeMessage,
 			@Cause Exception cause);
 
 	@Message(id = ID_OFFSET_2 + 8,
 			// Note: no need to add a '\n' before "Response", since the formatter will always add one
-			value = "Elasticsearch bulked request failed.\nRequest metadata: %1$sResponse: %2$s"
+			value = "Elasticsearch bulked request failed: %3$s\nRequest metadata: %1$sResponse: %2$s"
 	)
 	SearchException elasticsearchBulkedRequestFailed(
 			@FormatWith( ElasticsearchJsonObjectFormatter.class ) JsonObject requestMetadata,
 			@FormatWith( ElasticsearchJsonObjectFormatter.class ) JsonObject response,
+			String causeMessage,
 			@Cause Exception cause);
 
 	@Message(id = ID_OFFSET_2 + 10,

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
@@ -170,7 +170,7 @@ public interface Log extends BasicLogger {
 
 	@Message(id = ID_OFFSET_2 + 75,
 			value = "Error while applying analysis configuration: %1$s")
-	SearchException unableToApplyAnalysisConfiguration(String errorMessage, @Param EventContext context, @Cause Exception e);
+	SearchException unableToApplyAnalysisConfiguration(String errorMessage, @Cause Exception e);
 
 	@Message(id = ID_OFFSET_2 + 76,
 			value = "Invalid analyzer definition for name '%1$s'. Analyzer definitions must at least define the tokenizer.")

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
@@ -189,8 +189,8 @@ public interface Log extends BasicLogger {
 	SearchException invalidElasticsearchTokenFilterDefinition(String name);
 
 	@Message(id = ID_OFFSET_2 + 80,
-			value = "Failed to detect the Elasticsearch version running on the cluster." )
-	SearchException failedToDetectElasticsearchVersion(@Cause Exception e);
+			value = "Failed to detect the Elasticsearch version running on the cluster: %s" )
+	SearchException failedToDetectElasticsearchVersion(String causeMessage, @Cause Exception e);
 
 	@Message(id = ID_OFFSET_2 + 81,
 			value = "An unsupported Elasticsearch version runs on the Elasticsearch cluster: '%s'."

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/AbstractSimpleBulkableElasticsearchWork.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/AbstractSimpleBulkableElasticsearchWork.java
@@ -96,18 +96,21 @@ public abstract class AbstractSimpleBulkableElasticsearchWork<R>
 			}
 		}
 		catch (RuntimeException e) {
-			throw log.elasticsearchBulkedRequestFailed( getBulkableActionMetadata(), bulkResponseItem, e );
+			throw log.elasticsearchBulkedRequestFailed(
+					getBulkableActionMetadata(), bulkResponseItem,
+					e.getMessage(),
+					e
+			);
 		}
 
 		return afterSuccess( executionContext )
-				.exceptionally( Futures.handler(
-						throwable -> {
-							throw log.elasticsearchBulkedRequestFailed(
-									getBulkableActionMetadata(),
-									bulkResponseItem, Throwables.expectException( throwable )
-							);
-						}
-				) )
+				.exceptionally( Futures.handler( throwable -> {
+					throw log.elasticsearchBulkedRequestFailed(
+							getBulkableActionMetadata(), bulkResponseItem,
+							throwable.getMessage(),
+							Throwables.expectException( throwable )
+					);
+				} ) )
 				.thenApply( ignored -> result );
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/BulkWork.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/BulkWork.java
@@ -75,10 +75,13 @@ public class BulkWork implements ElasticsearchWork<BulkResult> {
 	public CompletableFuture<BulkResult> execute(ElasticsearchWorkExecutionContext context) {
 		return Futures.create( () -> context.getClient().submit( request ) )
 				.thenApply( this::generateResult )
-				.exceptionally( Futures.handler(
-						throwable -> {
-							throw log.elasticsearchRequestFailed( request, null, Throwables.expectException( throwable ) ); }
-				) );
+				.exceptionally( Futures.handler( throwable -> {
+					throw log.elasticsearchRequestFailed(
+							request, null,
+							throwable.getMessage(),
+							Throwables.expectException( throwable )
+					);
+				} ) );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
@@ -135,7 +135,7 @@ public interface Log extends BasicLogger {
 
 	@Message(id = ID_OFFSET_1 + 329,
 			value = "Error while applying analysis configuration: %1$s")
-	SearchException unableToApplyAnalysisConfiguration(String errorMessage, @Param EventContext context, @Cause Exception e);
+	SearchException unableToApplyAnalysisConfiguration(String errorMessage, @Cause Exception e);
 
 	@Message(id = ID_OFFSET_1 + 330,
 			value = "Multiple analyzer definitions with the same name: '%1$s'. The analyzer names must be unique." )
@@ -184,21 +184,19 @@ public interface Log extends BasicLogger {
 
 	@Message(id = ID_OFFSET_2 + 1,
 			value = "Root directory '%1$s' exists but is not a writable directory.")
-	SearchException localDirectoryBackendRootDirectoryNotWritableDirectory(Path rootDirectory,
-			@Param EventContext context);
+	SearchException localDirectoryBackendRootDirectoryNotWritableDirectory(Path rootDirectory);
 
 	@Message(id = ID_OFFSET_2 + 2,
 			value = "Unable to create root directory '%1$s'.")
-	SearchException unableToCreateRootDirectoryForLocalDirectoryBackend(Path rootDirectory,
-			@Param EventContext context, @Cause Exception e);
+	SearchException unableToCreateRootDirectoryForLocalDirectoryBackend(Path rootDirectory, @Cause Exception e);
 
 	@Message(id = ID_OFFSET_2 + 3,
 			value = "Undefined Lucene directory provider for property '%1$s'.")
-	SearchException undefinedLuceneDirectoryProvider(String propertyKey, @Param EventContext context);
+	SearchException undefinedLuceneDirectoryProvider(String propertyKey);
 
 	@Message(id = ID_OFFSET_2 + 4,
 			value = "Unrecognized Lucene directory provider '%1$s'.")
-	SearchException unrecognizedLuceneDirectoryProvider(String directoryProvider, @Param EventContext context);
+	SearchException unrecognizedLuceneDirectoryProvider(String directoryProvider);
 
 	@Message(id = ID_OFFSET_2 + 5,
 			value = "The Lucene extension can only be applied to objects"

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/SearchIntegrationBuilderImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/SearchIntegrationBuilderImpl.java
@@ -255,8 +255,8 @@ public class SearchIntegrationBuilderImpl implements SearchIntegrationBuilder {
 			TypeMetadataContributorProviderImpl contributorProvider = new TypeMetadataContributorProviderImpl();
 			mapper = mappingInitiator.createMapper( buildContext, contributorProvider );
 
-			Set<MappableTypeModel> potentiallyMappedToIndexTypes = new LinkedHashSet<>(
-					contributionByType.keySet() );
+			// We need to create a separate Set because calls to mapper.addIndexed() might add more contributions
+			Set<MappableTypeModel> potentiallyMappedToIndexTypes = new LinkedHashSet<>( contributionByType.keySet() );
 			for ( MappableTypeModel typeModel : potentiallyMappedToIndexTypes ) {
 				TypeMappingContribution<C> contribution = contributionByType.get( typeModel );
 				String indexName = contribution.getIndexName();

--- a/engine/src/main/java/org/hibernate/search/engine/reporting/impl/RootFailureCollector.java
+++ b/engine/src/main/java/org/hibernate/search/engine/reporting/impl/RootFailureCollector.java
@@ -159,7 +159,11 @@ public class RootFailureCollector implements FailureCollector {
 		final void appendChildrenFailuresTo(ToStringTreeBuilder builder) {
 			if ( children != null ) {
 				for ( ContextualFailureCollectorImpl child : children.values() ) {
-					child.appendFailuresTo( builder );
+					// Some contexts may have been mentioned without any failure being ever reported.
+					// Only display contexts that had at least one failure reported.
+					if ( child.hasFailure() ) {
+						child.appendFailuresTo( builder );
+					}
 				}
 			}
 		}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/analysis/ElasticsearchAnalysisConfigurerIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/analysis/ElasticsearchAnalysisConfigurerIT.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 
 public class ElasticsearchAnalysisConfigurerIT {
 
-	private static final String MAPPED_TYPE_NAME = "TypeName";
 	private static final String BACKEND_NAME = "BackendName";
 	private static final String INDEX_NAME = "IndexName";
 
@@ -39,8 +38,6 @@ public class ElasticsearchAnalysisConfigurerIT {
 				.assertThrown()
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.typeContext( MAPPED_TYPE_NAME )
-						.indexContext( INDEX_NAME )
 						.backendContext( BACKEND_NAME )
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
@@ -61,8 +58,6 @@ public class ElasticsearchAnalysisConfigurerIT {
 				.assertThrown()
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.typeContext( MAPPED_TYPE_NAME )
-						.indexContext( INDEX_NAME )
 						.backendContext( BACKEND_NAME )
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
@@ -94,8 +89,6 @@ public class ElasticsearchAnalysisConfigurerIT {
 				.assertThrown()
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.typeContext( MAPPED_TYPE_NAME )
-						.indexContext( INDEX_NAME )
 						.backendContext( BACKEND_NAME )
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
@@ -123,8 +116,6 @@ public class ElasticsearchAnalysisConfigurerIT {
 				.assertThrown()
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.typeContext( MAPPED_TYPE_NAME )
-						.indexContext( INDEX_NAME )
 						.backendContext( BACKEND_NAME )
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
@@ -152,8 +143,6 @@ public class ElasticsearchAnalysisConfigurerIT {
 				.assertThrown()
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.typeContext( MAPPED_TYPE_NAME )
-						.indexContext( INDEX_NAME )
 						.backendContext( BACKEND_NAME )
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
@@ -180,8 +169,6 @@ public class ElasticsearchAnalysisConfigurerIT {
 				.assertThrown()
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.typeContext( MAPPED_TYPE_NAME )
-						.indexContext( INDEX_NAME )
 						.backendContext( BACKEND_NAME )
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
@@ -207,8 +194,6 @@ public class ElasticsearchAnalysisConfigurerIT {
 				.assertThrown()
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.typeContext( MAPPED_TYPE_NAME )
-						.indexContext( INDEX_NAME )
 						.backendContext( BACKEND_NAME )
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
@@ -235,8 +220,6 @@ public class ElasticsearchAnalysisConfigurerIT {
 				.assertThrown()
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.typeContext( MAPPED_TYPE_NAME )
-						.indexContext( INDEX_NAME )
 						.backendContext( BACKEND_NAME )
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
@@ -262,8 +245,6 @@ public class ElasticsearchAnalysisConfigurerIT {
 				.assertThrown()
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.typeContext( MAPPED_TYPE_NAME )
-						.indexContext( INDEX_NAME )
 						.backendContext( BACKEND_NAME )
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
@@ -290,8 +271,6 @@ public class ElasticsearchAnalysisConfigurerIT {
 				.assertThrown()
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.typeContext( MAPPED_TYPE_NAME )
-						.indexContext( INDEX_NAME )
 						.backendContext( BACKEND_NAME )
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
@@ -317,8 +296,6 @@ public class ElasticsearchAnalysisConfigurerIT {
 				.assertThrown()
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.typeContext( MAPPED_TYPE_NAME )
-						.indexContext( INDEX_NAME )
 						.backendContext( BACKEND_NAME )
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
@@ -353,9 +330,7 @@ public class ElasticsearchAnalysisConfigurerIT {
 				)
 				.withIndex(
 						INDEX_NAME,
-						c -> c.mappedType( MAPPED_TYPE_NAME ),
-						mappingContributor,
-						indexManager -> { }
+						mappingContributor
 				)
 				.setup();
 	}

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/analysis/LuceneAnalysisConfigurerIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/analysis/LuceneAnalysisConfigurerIT.java
@@ -25,7 +25,6 @@ import org.apache.lucene.analysis.standard.StandardAnalyzer;
 
 public class LuceneAnalysisConfigurerIT {
 
-	private static final String MAPPED_TYPE_NAME = "TypeName";
 	private static final String BACKEND_NAME = "BackendName";
 	private static final String INDEX_NAME = "IndexName";
 
@@ -42,8 +41,6 @@ public class LuceneAnalysisConfigurerIT {
 				.assertThrown()
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.typeContext( MAPPED_TYPE_NAME )
-						.indexContext( INDEX_NAME )
 						.backendContext( BACKEND_NAME )
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
@@ -64,8 +61,6 @@ public class LuceneAnalysisConfigurerIT {
 				.assertThrown()
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.typeContext( MAPPED_TYPE_NAME )
-						.indexContext( INDEX_NAME )
 						.backendContext( BACKEND_NAME )
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
@@ -97,8 +92,6 @@ public class LuceneAnalysisConfigurerIT {
 				.assertThrown()
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.typeContext( MAPPED_TYPE_NAME )
-						.indexContext( INDEX_NAME )
 						.backendContext( BACKEND_NAME )
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
@@ -126,8 +119,6 @@ public class LuceneAnalysisConfigurerIT {
 				.assertThrown()
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.typeContext( MAPPED_TYPE_NAME )
-						.indexContext( INDEX_NAME )
 						.backendContext( BACKEND_NAME )
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
@@ -155,8 +146,6 @@ public class LuceneAnalysisConfigurerIT {
 				.assertThrown()
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.typeContext( MAPPED_TYPE_NAME )
-						.indexContext( INDEX_NAME )
 						.backendContext( BACKEND_NAME )
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
@@ -192,9 +181,7 @@ public class LuceneAnalysisConfigurerIT {
 				)
 				.withIndex(
 						INDEX_NAME,
-						c -> c.mappedType( MAPPED_TYPE_NAME ),
-						mappingContributor,
-						indexManager -> { }
+						mappingContributor
 				)
 				.setup();
 	}

--- a/util/common/src/main/java/org/hibernate/search/util/common/reporting/EventContext.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/reporting/EventContext.java
@@ -8,6 +8,7 @@ package org.hibernate.search.util.common.reporting;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.StringJoiner;
 
 import org.hibernate.search.util.common.reporting.impl.CommonEventContextMessages;
@@ -48,6 +49,23 @@ public final class EventContext {
 	@Override
 	public String toString() {
 		return getClass() + "[" + render() + "]";
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ( obj == null || !getClass().equals( obj.getClass() ) ) {
+			return false;
+		}
+
+		EventContext other = (EventContext) obj;
+
+		return Objects.equals( parent, other.parent )
+				&& element.equals( other.element );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( parent, element );
 	}
 
 	public List<EventContextElement> getElements() {


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3621

~Based on #2038, which should be merged first.~ => Done

In short, this:

```
org.hibernate.search.util.common.SearchException: HSEARCH000520: Hibernate Search bootstrap failed. Failures:

    ORM mapping: 
        type 'com.acme.model.Type1': 
            index 'IndexName1': 
                failures: 
                  - HSEARCH400080: Failed to detect the Elasticsearch version running on the cluster.
        type 'com.acme.model.Type2': 
            index 'IndexName2': 
                failures: 
                  - HSEARCH400080: Failed to detect the Elasticsearch version running on the cluster.
	at org.hibernate.search.engine.reporting.impl.RootFailureCollector.checkNoFailure(RootFailureCollector.java:56)
	at org.hibernate.search.engine.common.impl.SearchIntegrationBuilderImpl.prepareBuild(SearchIntegrationBuilderImpl.java:170)
```

is now reported like this:

```
org.hibernate.search.util.common.SearchException: HSEARCH000520: Hibernate Search bootstrap failed. Failures:

    backend 'BackendName': 
        failures: 
          - HSEARCH400080: Failed to detect the Elasticsearch version running on the cluster: HSEARCH400007: Elasticsearch request failed: java.net.ConnectException: Connection refused
Request: GET  with parameters {}
Response: (no response)
	at org.hibernate.search.engine.reporting.impl.RootFailureCollector.checkNoFailure(RootFailureCollector.java:56)
	at org.hibernate.search.engine.common.impl.SearchIntegrationBuilderImpl.prepareBuild(SearchIntegrationBuilderImpl.java:172)
```