### PR TITLE
HSEARCH-3612 Normalize the terms to match in wildcard/prefix predicates

### DIFF
--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneTextFieldPredicateBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneTextFieldPredicateBuilderFactory.java
@@ -61,7 +61,7 @@ public final class LuceneTextFieldPredicateBuilderFactory<F>
 	public WildcardPredicateBuilder<LuceneSearchPredicateBuilder> createWildcardPredicateBuilder(
 			String absoluteFieldPath) {
 		checkSearchable( absoluteFieldPath );
-		return new LuceneTextWildcardPredicateBuilder( absoluteFieldPath );
+		return new LuceneTextWildcardPredicateBuilder( absoluteFieldPath, analyzerOrNormalizer );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneTextWildcardPredicateBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneTextWildcardPredicateBuilder.java
@@ -9,21 +9,27 @@ package org.hibernate.search.backend.lucene.types.predicate.impl;
 import org.hibernate.search.backend.lucene.search.predicate.impl.AbstractLuceneSearchPredicateBuilder;
 import org.hibernate.search.backend.lucene.search.predicate.impl.LuceneSearchPredicateBuilder;
 import org.hibernate.search.backend.lucene.search.predicate.impl.LuceneSearchPredicateContext;
+import org.hibernate.search.backend.lucene.types.predicate.parse.impl.LuceneWildcardExpressionHelper;
 import org.hibernate.search.engine.search.predicate.spi.WildcardPredicateBuilder;
 
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.WildcardQuery;
+import org.apache.lucene.util.BytesRef;
 
 class LuceneTextWildcardPredicateBuilder extends AbstractLuceneSearchPredicateBuilder
 		implements WildcardPredicateBuilder<LuceneSearchPredicateBuilder> {
 
 	protected final String absoluteFieldPath;
 
+	private final Analyzer analyzer;
+
 	private String pattern;
 
-	LuceneTextWildcardPredicateBuilder(String absoluteFieldPath) {
+	LuceneTextWildcardPredicateBuilder(String absoluteFieldPath, Analyzer analyzer) {
 		this.absoluteFieldPath = absoluteFieldPath;
+		this.analyzer = analyzer;
 	}
 
 	@Override
@@ -33,6 +39,7 @@ class LuceneTextWildcardPredicateBuilder extends AbstractLuceneSearchPredicateBu
 
 	@Override
 	protected Query doBuild(LuceneSearchPredicateContext context) {
-		return new WildcardQuery( new Term( absoluteFieldPath, pattern ) );
+		BytesRef analyzedWildcard = LuceneWildcardExpressionHelper.analyzeWildcard( analyzer, absoluteFieldPath, pattern );
+		return new WildcardQuery( new Term( absoluteFieldPath, analyzedWildcard ) );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/parse/impl/LuceneWildcardExpressionHelper.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/parse/impl/LuceneWildcardExpressionHelper.java
@@ -1,0 +1,53 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.types.predicate.parse.impl;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
+
+/**
+ * Copied and adapted from {@code org.apache.lucene.queryparser.classic.QueryParserBase#analyzeWildcard}
+ * of <a href="https://github.com/apache/lucene-solr">Apache Lucene and Solr</a>.
+ * <p>
+ * Allows to normalize a wildcard expression term.
+ */
+public class LuceneWildcardExpressionHelper {
+
+	private static final Pattern WILDCARD_PATTERN = Pattern.compile( "(\\\\.)|([?*]+)" );
+
+	private LuceneWildcardExpressionHelper() {
+	}
+
+	public static BytesRef analyzeWildcard(Analyzer analyzer, String field, String termStr) {
+		// best effort to not pass the wildcard characters and escaped characters through #normalize
+		Matcher wildcardMatcher = WILDCARD_PATTERN.matcher( termStr );
+		BytesRefBuilder sb = new BytesRefBuilder();
+		int last = 0;
+
+		while ( wildcardMatcher.find() ) {
+			if ( wildcardMatcher.start() > 0 ) {
+				String chunk = termStr.substring( last, wildcardMatcher.start() );
+				BytesRef normalized = analyzer.normalize( field, chunk );
+				sb.append( normalized );
+			}
+			//append the matched group - without normalizing
+			sb.append( new BytesRef( wildcardMatcher.group() ) );
+
+			last = wildcardMatcher.end();
+		}
+		if ( last < termStr.length() ) {
+			String chunk = termStr.substring( last );
+			BytesRef normalized = analyzer.normalize( field, chunk );
+			sb.append( normalized );
+		}
+		return sb.toBytesRef();
+	}
+}

--- a/documentation/src/main/asciidoc/search-dsl.asciidoc
+++ b/documentation/src/main/asciidoc/search-dsl.asciidoc
@@ -510,30 +510,27 @@ include::{sourcedir}/org/hibernate/search/documentation/searchdsl/predicate/Pred
 ----
 ====
 
-// TODO HSEARCH-3612 When the ticket is fixed, rephrase this warning to state that only ES 6.7 and below is affected by the normalization problem.
-
 [IMPORTANT]
 ====
-Patterns used in wildcard predicates are not analyzed or normalized,
-and they are expected to match a *single* indexed token, not a sequence of tokens.
+If a normalizer has been defined on the field, the patterns used in wildcard predicates
+will be normalized.
 
-For example, a pattern such as `Cat*` will not match anything
-when targeting a field that applies a lowercase filter when indexing.
-`cat*` may match, since it's already lowercased.
+If an analyzer has been defined on the field:
 
-Similarly, a pattern such as `john gr*` will not match anything
+* when using the Elasticsearch backend, the patterns won't be analyzed nor normalized,
+and will be expected to match a *single* indexed token, not a sequence of tokens.
+* when using the Lucene backend the patterns will be normalized, but not tokenized:
+the pattern will still be expected to match a *single* indexed token, not a sequence of tokens.
+
+For example, a pattern such as `Cat*` could match `cat`
+when targeting a field having a normalizer that applies a lowercase filter when indexing.
+
+A pattern such as `john gr*` will not match anything
 when targeting a field that tokenizes on spaces.
 `gr*` may match, since it doesn't include any space.
 
-These limitations generally make the wildcard predicate unadvisable for high-level,
-user-exposed features,
-though it can still be useful in very specific cases.
-
 When the goal is to match user-provided query strings,
 the <<search-dsl-predicate-simple-query-string,simple query string predicate>> should be preferred.
-At the very least it fixes the second issue by automatically splitting the query string around spaces,
-even though it may also suffer from the case-sensitivity issue in some cases
-(see https://hibernate.atlassian.net/browse/HSEARCH-3612[HSEARCH-3612]).
 ====
 
 [[search-dsl-predicate-boolean]]

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneNormalizeWildcardExpressionsIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneNormalizeWildcardExpressionsIT.java
@@ -1,0 +1,130 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.lucene.search;
+
+import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+
+import java.util.function.Function;
+
+import org.hibernate.search.engine.backend.document.DocumentElement;
+import org.hibernate.search.engine.backend.document.IndexFieldReference;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.search.DocumentReference;
+import org.hibernate.search.engine.search.query.SearchQuery;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.test.annotation.TestForIssue;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Extends {@link org.hibernate.search.integrationtest.backend.tck.search.predicate.WildcardSearchPredicateIT},
+ * verifying the normalization of the terms to match in wildcard/prefix predicates,
+ * when an analyzer (not just a normalizer) has been defined on the target field.
+ * <p>
+ * This case seems to be not already supported for the current version of Elasticsearch server.
+ */
+@TestForIssue(jiraKey = "HSEARCH-3612")
+public class LuceneNormalizeWildcardExpressionsIT {
+
+	private static final String INDEX_NAME = "IndexName";
+
+	private static final String DOCUMENT_1 = "document1";
+	private static final String DOCUMENT_2 = "document2";
+	private static final String DOCUMENT_3 = "document3";
+	private static final String DOCUMENT_4 = "document4";
+
+	// notice the arbitrary cases of the terms:
+	private static final String PATTERN_1 = "loCAL*n";
+	private static final String PATTERN_2 = "iNtER*On";
+	private static final String PATTERN_3 = "lA*d";
+	private static final String PATTERN_1_AND_2 = PATTERN_1 + " " + PATTERN_2;
+
+	private static final String TEXT_MATCHING_PATTERN_1 = "Localization in English is a must-have.";
+	private static final String TEXT_MATCHING_PATTERN_2 = "Internationalization allows to adapt the application to multiple locales.";
+	private static final String TEXT_MATCHING_PATTERN_3 = "A had to call the landlord.";
+	private static final String TEXT_MATCHING_PATTERN_2_AND_3 = "I had some interaction with that lad.";
+
+	@Rule
+	public SearchSetupHelper setupHelper = new SearchSetupHelper();
+
+	private IndexMapping indexMapping;
+	private StubMappingIndexManager indexManager;
+
+	@Before
+	public void setup() {
+		setupHelper.start()
+				.withIndex(
+						INDEX_NAME,
+						ctx -> this.indexMapping = new IndexMapping( ctx.getSchemaElement() ),
+						indexManager -> this.indexManager = indexManager
+				)
+				.setup();
+
+		initData();
+	}
+
+	@Test
+	public void wildcard_normalizeMatchingExpression() {
+		StubMappingScope scope = indexManager.createScope();
+		Function<String, SearchQuery<DocumentReference>> createQuery = queryString -> scope.query()
+				.predicate( f -> f.wildcard().onField( "analyzed" ).matching( queryString ) )
+				.toQuery();
+
+		assertThat( createQuery.apply( PATTERN_1 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
+
+		assertThat( createQuery.apply( PATTERN_2 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_2, DOCUMENT_4 );
+
+		assertThat( createQuery.apply( PATTERN_3 ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_3, DOCUMENT_4 );
+	}
+
+	@Test
+	public void wildcard_tokenizeMatchingExpression() {
+		StubMappingScope scope = indexManager.createScope();
+		SearchQuery<DocumentReference> query = scope.query()
+				.predicate( f -> f.wildcard().onField( "analyzed" ).matching( PATTERN_1_AND_2 ) )
+				.toQuery();
+
+		// The matching expression is supposed to be normalized only, never tokenized.
+		assertThat( query ).hasNoHits();
+	}
+
+	private void initData() {
+		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
+		workPlan.add( referenceProvider( DOCUMENT_1 ), document -> {
+			document.addValue( indexMapping.analyzed, TEXT_MATCHING_PATTERN_1 );
+		} );
+		workPlan.add( referenceProvider( DOCUMENT_2 ), document -> {
+			document.addValue( indexMapping.analyzed, TEXT_MATCHING_PATTERN_2 );
+		} );
+		workPlan.add( referenceProvider( DOCUMENT_3 ), document -> {
+			document.addValue( indexMapping.analyzed, TEXT_MATCHING_PATTERN_3 );
+		} );
+		workPlan.add( referenceProvider( DOCUMENT_4 ), document -> {
+			document.addValue( indexMapping.analyzed, TEXT_MATCHING_PATTERN_2_AND_3 );
+		} );
+		workPlan.execute().join();
+	}
+
+	private static class IndexMapping {
+		final IndexFieldReference<String> analyzed;
+
+		IndexMapping(IndexSchemaElement root) {
+			analyzed = root.field( "analyzed", c -> c.asString().analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD_ENGLISH.name ) )
+					.toReference();
+		}
+	}
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SimpleQueryStringSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SimpleQueryStringSearchPredicateIT.java
@@ -73,12 +73,28 @@ public class SimpleQueryStringSearchPredicateIT {
 	private static final String TEXT_TERM_4_IN_PHRASE_SLOP_2 = "An elephant ran past John.";
 	private static final String TEXT_TERM_1_EDIT_DISTANCE_1 = "I came to the world in a dumpster.";
 
-	private static final String PREFIX_SEPARATOR = " ";
 	// Taken from William Blake's Only Sonnet
-	private static final String PREFIX_1 = "Smile on our loves, and while thou drawest the";
-	private static final String PREFIX_2 = PREFIX_1 + PREFIX_SEPARATOR + "Blue curtains of the sky, scatter thy silver dew";
-	private static final String PREFIX_3 = PREFIX_2 + PREFIX_SEPARATOR + "On every flower that shuts its sweet eyes";
-	private static final String PREFIX_4 = PREFIX_3 + PREFIX_SEPARATOR + "In timely sleep.";
+	private static final String ROW_1 = "Smile on our loves, and while thou drawest the";
+	private static final String ROW_2 = "Blue curtains of the sky, scatter thy silver dew";
+	private static final String ROW_3 = "On every flower that shuts its sweet eyes";
+	private static final String ROW_4 = "In timely sleep.";
+
+	private static final String PREFIX_SEPARATOR = " ";
+
+	private static final String PREFIX_1 = ROW_1;
+	private static final String PREFIX_2 = PREFIX_1 + PREFIX_SEPARATOR + ROW_2;
+	private static final String PREFIX_3 = PREFIX_2 + PREFIX_SEPARATOR + ROW_3;
+	private static final String PREFIX_4 = PREFIX_3 + PREFIX_SEPARATOR + ROW_4;
+
+	private static final String ROW_1_DIFFERENT_CASE = "SmILE on oUr LOves, and while thou dRAWest thE";
+	private static final String ROW_2_DIFFERENT_CASE = "bLUE cURTaiNs of tHE skY, scATTer thY SILver dEw";
+	private static final String ROW_3_DIFFERENT_CASE = "ON eVErY flowEr thAt sHUts ITs sWEeT EyEs";
+	private static final String ROW_4_DIFFERENT_CASE = "in tiMeLy sLEEp.";
+
+	private static final String PREFIX_1_DIFFERENT_CASE = ROW_1_DIFFERENT_CASE;
+	private static final String PREFIX_2_DIFFERENT_CASE = PREFIX_1_DIFFERENT_CASE + PREFIX_SEPARATOR + ROW_2_DIFFERENT_CASE;
+	private static final String PREFIX_3_DIFFERENT_CASE = PREFIX_2_DIFFERENT_CASE + PREFIX_SEPARATOR + ROW_3_DIFFERENT_CASE;
+	private static final String PREFIX_4_DIFFERENT_CASE = PREFIX_3_DIFFERENT_CASE + PREFIX_SEPARATOR + ROW_4_DIFFERENT_CASE;
 
 	private static final String COMPATIBLE_INDEX_DOCUMENT_1 = "compatible_1";
 	private static final String RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 = "raw_field_compatible_1";
@@ -564,7 +580,24 @@ public class SimpleQueryStringSearchPredicateIT {
 	@Test
 	@TestForIssue( jiraKey = "HSEARCH-3612" )
 	public void prefix_normalizePrefixTerm() {
-		// TODO HSEARCH-3612
+		StubMappingScope scope = indexManager.createScope();
+		String absoluteFieldPath = indexMapping.analyzedStringField4.relativeFieldName;
+
+		Function<String, SearchQuery<DocumentReference>> createQuery = queryString -> scope.query()
+				.predicate( f -> f.simpleQueryString().onField( absoluteFieldPath ).matching( queryString ) )
+				.toQuery();
+
+		assertThat( createQuery.apply( "\"" + PREFIX_1_DIFFERENT_CASE + "\"*" ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3, DOCUMENT_4 );
+
+		assertThat( createQuery.apply( "\"" + PREFIX_2_DIFFERENT_CASE + "\"*" ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_2, DOCUMENT_3, DOCUMENT_4 );
+
+		assertThat( createQuery.apply( "\"" + PREFIX_3_DIFFERENT_CASE + "\"*" ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_3, DOCUMENT_4 );
+
+		assertThat( createQuery.apply( "\"" + PREFIX_4_DIFFERENT_CASE + "\"*" ) )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_4 );
 	}
 
 	@Test


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3612

Tested locally for all Elasticsearch supported profiles: the behavior seems consistent among all of them.