### PR TITLE
HSEARCH-3658 Upgrade to AWS Elasticsearch Service 6.7 in the Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -209,7 +209,8 @@ stage('Configure') {
 					new EsAwsBuildEnvironment(version: '6.3', mavenProfile: 'elasticsearch-6.0', status: BuildEnvironmentStatus.SUPPORTED),
 					// ES 6.4 has a bug that prevents our integration tests from passing. See https://github.com/hibernate/hibernate-search/pull/1981/
 					new EsAwsBuildEnvironment(version: '6.4', mavenProfile: 'elasticsearch-6.0', status: BuildEnvironmentStatus.EXPERIMENTAL),
-					new EsAwsBuildEnvironment(version: '6.5', mavenProfile: 'elasticsearch-6.0', status: BuildEnvironmentStatus.SUPPORTED)
+					new EsAwsBuildEnvironment(version: '6.5', mavenProfile: 'elasticsearch-6.0', status: BuildEnvironmentStatus.SUPPORTED),
+					new EsAwsBuildEnvironment(version: '6.7', mavenProfile: 'elasticsearch-6.7', status: BuildEnvironmentStatus.SUPPORTED)
 			]
 	])
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3658

Will run the full IT suite and merge if it passes.