### PR TITLE
HSEARCH-3656 Update mapper ORM documentation chapter: writeplan API process is no longer necessary

### DIFF
--- a/documentation/src/main/asciidoc/mapper-orm-indexing-automatic.asciidoc
+++ b/documentation/src/main/asciidoc/mapper-orm-indexing-automatic.asciidoc
@@ -7,6 +7,9 @@ By default, every time an entity is changed through a Hibernate ORM Session,
 if that entity is <<mapper-orm-entityindexmapping,mapped to an index>>,
 Hibernate Search updates the relevant index.
 
+To be precise, index updates happen on transaction commit or,
+if working outside of a transaction, on session flush.
+
 [[mapper-orm-indexing-automatic-configuration]]
 == Configuration
 
@@ -15,7 +18,7 @@ or if you update it regularly through <<mapper-orm-indexing-explicit,explicit in
 You can enable or disable automatic indexing by setting the configuration property
 `hibernate.search.automatic_indexing.strategy`:
 
-* when set to `session`, each change to an indexed entity
+* when set to `session` (the default), each change to an indexed entity
 (persist, update, delete) through a Hibernate ORM Session/EntityManager
 will automatically lead to a similar modification to the index.
 * when set to `none`, changes to entities are ignored,
@@ -35,22 +38,41 @@ are not detected by Hibernate Search.
 This is because queries are executed on the database side,
  without Hibernate having any knowledge of which entities are actually created, deleted or updated.
 One workaround is to <<mapper-orm-indexing-explicit,explicitly reindex>> after you run such queries.
-Indexing happens after transactions are committed::
-Indexes are not updated immediately, but only after transactions are successfully committed.
+Entity data is retrieved from entities upon session flushes::
+When a Hibernate ORM session is flushed,
+Hibernate Search will extract data from the entities
+to build documents to index,
+and will put these documents in an internal buffer for later indexing (see the next paragraphs).
++
+This means in particular that you can safely `clear()` the session after a `flush()`:
+entity changes performed up to the flush will be indexed correctly.
+[NOTE]
+====
+If you come from Hibernate Search 5 or earlier,
+you may see this as a significant improvement:
+there is no need to call `flushToIndexes()` and update indexes in the middle of a transaction anymore,
+except for larger volumes of data (see <<mapper-orm-indexing-explicit-writeplan-process-execute>>).
+====
+Inside transactions, indexing happens after transactions are committed::
+When entity changes happen inside a transaction,
+indexes are not updated immediately, but only after the transaction is successfully committed.
 That way, if a transaction is rolled back, the indexes will be left in a state consistent with the database,
 discarding all the index changes that were planned during the transaction.
 +
-This means in particular that Hibernate Search will retrieve the state of entities after the transaction is committed.
-As a result, clearing the session during the transaction may cause trouble:
-some entities may end up being referenced by Hibernate Search for indexing,
-without being attached to the session.
-When Hibernate Search will try to index them, they will not be being able to load some of their lazy properties,
-leading to a `LazyInitializationException`.
-See <<mapper-orm-indexing-explicit-writeplan-process-execute>> for a few solutions.
+However, if you perform a batch process inside a transaction,
+and perform flush/clear, regularly to save memory,
+be aware that Hibernate Search's internal buffer holding documents to index
+will grow on each flush, and will not be cleared until the transaction is committed or rolled back.
+If you encounter memory issues because of that,
+see <<mapper-orm-indexing-explicit-writeplan-process-execute>> for a few solutions.
+Outside of transactions, indexing happens on session flush::
+When entity changes happen outside of any transaction (not recommended),
+indexes are updated immediately upon session `flush()`.
+Without that flush, indexes will not be updated automatically.
 Index changes may not be visible immediately::
-By default, the transaction commit will return after index changes are committed to the indexes.
+By default, indexing will resume the application thread after index changes are committed to the indexes.
 This means index changes are safely stored to disk,
-but this does not mean a search query ran immediately after the transaction commit will take the changes into account:
+but this does not mean a search query ran immediately after indexing will take the changes into account:
 when using the Elasticsearch backend in particular, changes may take some time to be visible from search queries.
 +
 See <<mapper-orm-indexing-automatic-synchronization>> for details.
@@ -89,19 +111,19 @@ include::todo-placeholder.asciidoc[]
 
 Hibernate Search offers multiple strategies to control synchronization with the indexes
 during automatic indexing,
-i.e. to control the minimum progress of indexing before the transaction commit returns.
+i.e. to control the minimum progress of indexing before the application thread is resumed.
 
 You can define a default strategy for all sessions by setting the configuration property
 `hibernate.search.automatic_indexing.synchronization_strategy`:
 
-* when set to `queued`, the transaction commit will return as soon as
+* when set to `queued`, the application thread will be resumed as soon as
 the index changes are queued in the backend.
 +
 This strategy offers no guarantee as to whether indexing will be performed successfully,
 or even whether indexing will be performed at all:
 the local JVM may crash before the works are executed, in which case the indexing requests will be forgotten,
 or indexing may simply fail.
-* by default or when set to `committed`, the transaction commit will return as soon as
+* by default or when set to `committed`, the application thread will be resumed as soon as
 the index changes are committed to disk.
 +
 This generally means that at the very least
@@ -112,13 +134,13 @@ and confirmed to Hibernate Search it did so
 +
 This strategy offers no guarantee as to whether indexed documents are searchable:
 the backend may delay indexing in order to improve performance,
-meaning a search query executed immediately after Hibernate ORM returns from the transaction
+meaning a search query executed immediately after the application thread is resumed
 may return outdated information.
 +
 This is true in particular with the Elasticsearch backend,
 which is link:{elasticsearchDocUrl}/getting-started-concepts.html#_near_realtime_nrt[near-real-time]
 by default.
-* when set to `searchable`, the transaction commit will return as soon as
+* when set to `searchable`, the application thread will be resumed as soon as
 the index changes are committed to disk
 *and* the relevant documents are searchable.
 The backend will be told to make the documents searchable as soon as possible.

--- a/documentation/src/main/asciidoc/mapper-orm-indexing-explicit.asciidoc
+++ b/documentation/src/main/asciidoc/mapper-orm-indexing-explicit.asciidoc
@@ -53,30 +53,32 @@ while keeping the memory footprint reasonably low.
 Below is an example of this pattern to persist a large number of entities
 when not using Hibernate Search.
 
-.A batch process without Hibernate Search
+.A batch process with JPA
 ====
 [source, JAVA, indent=0]
 ----
-include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmExplicitIndexingIT.java[tags=persist-no-automatic-indexing]
+include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmExplicitIndexingIT.java[tags=persist-automatic-indexing-periodic-flush-clear]
 ----
 <1> Execute a loop for a large number of elements, inside a transaction.
 <2> For every iteration of the loop, instantiate a new entity and persist it.
-<3> Every `BATCH_SIZE` iterations of the loop, `flush` the ORM session to send the changes to the database-side buffer.
+<3> Every `BATCH_SIZE` iterations of the loop, `flush` the entity manager to send the changes to the database-side buffer.
 <4> After a `flush`, `clear` the ORM session to release some memory.
 ====
 
-With Hibernate Search, that pattern is problematic,
-because clearing the session means entities that were registered for later indexing
-will be detached from the session,
-and as a result they will not be able to load lazy properties upon transaction commit,
-when Hibernate Search tries to process changes.
-This may lead to a `LazyInitializationException`.
+With Hibernate Search 6 (on contrary to Hibernate Search 5 and earlier),
+this pattern will work as expected:
+documents will be built on flushes,
+and sent to the index upon transaction commit.
 
-To address that problem, the `SearchSessionWritePlan` interface provides explicit control over execution of index writes.
+However, each `flush` call will potentially add data to an internal document buffer,
+which for large volumes of data may lead to an `OutOfMemoryException`,
+depending on the JVM heap size and on the complexity and number of documents.
 
-The first solution is to just write to indexes
-after the call to `session.flush()` and before the call to `session.clear()`,
-without waiting for the database transaction to be committed.
+If you run into memory issues,
+the first solution is to just write to indexes
+after the call to `session.flush()`/`session.clear()`,
+without waiting for the database transaction to be committed:
+the internal document buffer will be cleared after each write to indexes.
 
 This is done by calling the `execute()` method on the write plan,
 as shown in the example below.
@@ -88,7 +90,7 @@ part of the data will already be in the index, with no way to roll back the chan
 while the database changes will have been rolled back.
 The index will thus be inconsistent with the database.
 
-To fix that situation, you will have to either cancel your database changes manually,
+To recover from that situation, you will have to either cancel your database changes manually,
 or wipe the indexes clean and <<mapper-orm-indexing-explicit-massindexer,reindex>>.
 ====
 
@@ -96,7 +98,7 @@ or wipe the indexes clean and <<mapper-orm-indexing-explicit-massindexer,reindex
 ====
 [source, JAVA, indent=0]
 ----
-include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmExplicitIndexingIT.java[tags=persist-automatic-indexing-periodic-execute]
+include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmExplicitIndexingIT.java[tags=persist-automatic-indexing-periodic-flush-execute-clear]
 ----
 <1> Get the `SearchSession`.
 <2> Get the search session's write plan.
@@ -105,7 +107,7 @@ Note we're relying on automatic indexing to index the entity,
 but this would work just as well if automatic indexing was disabled,
 only requiring an extra call to index the entity.
 See <<mapper-orm-indexing-explicit-writeplan-writes>>.
-<4> After after a `flush()`, call `writePlan.execute()`.
+<4> After after a `flush()`/`clear()`, call `writePlan.execute()`.
 The entities will be processed and *the changes will be sent to the indexes immediately*.
 Hibernate Search will wait for index changes to be "completed"
 as required by the configured <<mapper-orm-indexing-automatic-synchronization,synchronization strategy>>.
@@ -115,9 +117,8 @@ The remaining entities that were not flushed/cleared will be flushed and indexed
 
 If leaving the index in an inconsistent state when the transaction fails is not an option,
 a second solution is to break down the batch process
-into multiple transactions, each handling a smaller number of elements,
-and to *not* apply a periodic `flush`/`clear`,
-so that entities are still attached to the session upon commit.
+into multiple transactions, each handling a smaller number of elements:
+the internal document buffer will be cleared after each transaction.
 
 See below for an example.
 
@@ -150,57 +151,12 @@ See <<mapper-orm-indexing-explicit-writeplan-writes>>.
 The entities will be flushed and indexed automatically.
 ====
 
-Finally, if the other solutions are unacceptable because
-the index needs to stay in its original state when the batch process fails,
-or because the process cannot be broken down in small enough transactions,
-there is a third solution: just tell Hibernate Search to process the entities
-after the call to `session.flush()` and before the call to `session.clear()`,
-without waiting for the database transaction to be committed.
-Hibernate Search will read the entities,
-build the corresponding documents and store them in an internal buffer,
-which will be written to indexes upon commit.
-
-This is done by calling the `process()` method on the write plan,
-as shown in the example below.
-
-[IMPORTANT]
-====
-This pattern will require less memory than without the periodic `flush`/`process`/`clear`,
-but it will still maintain an internal buffer that will grow as more entities are processed,
-and may lead to an `OutOfMemoryException` depending on the JVM heap size and the complexity and number of documents.
-Only use this in production after careful testing with an appropriate JVM heap size.
-
-However, if enough memory is available,
-this is the safest pattern, leaving both the database and indexes unaffected
-if an error happens during the batch process.
-====
-
-.A batch process with Hibernate Search using `process()`
-====
-[source, JAVA, indent=0]
-----
-include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmExplicitIndexingIT.java[tags=persist-automatic-indexing-periodic-process]
-----
-<1> Get the `SearchSession`.
-<2> Get the search session's write plan.
-<3> For every iteration of the loop, instantiate a new entity and persist it.
-Note we're relying on automatic indexing to index the entity,
-but this would work just as well if automatic indexing was disabled,
-only requiring an extra call to index the entity.
-See <<mapper-orm-indexing-explicit-writeplan-writes>>.
-<4> After after a `flush()`, call `writePlan.process()`.
-The entities will be processed but *the changes will not be sent to the indexes*,
-and will instead be stored in an internal buffer.
-<5> After the loop, commit the transaction.
-The changes stored in the internal buffer, as well as the remaining entities that were not flushed/cleared,
-will be indexed automatically.
-====
-
 [NOTE]
 ====
-The multi-transaction solution and the periodic `process()` solution can be combined,
+The multi-transaction solution
+and the original `flush()`/`clear()` loop pattern can be combined,
 breaking down the process in multiple medium-sized transactions,
-and periodically calling `flush`/`process`/`clear` inside each transaction.
+and periodically calling `flush`/`clear` inside each transaction.
 
 This combined solution is the most flexible,
 hence the most suitable if you want to fine-tune your batch process.

--- a/documentation/src/main/asciidoc/mapper-orm-indexing-explicit.asciidoc
+++ b/documentation/src/main/asciidoc/mapper-orm-indexing-explicit.asciidoc
@@ -137,8 +137,15 @@ part of the data will already be in the index, with no way to roll back the chan
 while the database changes will have been rolled back.
 The index will thus be inconsistent with the database.
 
-To recover from that situation, you will have to either cancel your database changes manually,
-or wipe the indexes clean and <<mapper-orm-indexing-explicit-massindexer,reindex>>.
+To recover from that situation, you will have to either
+execute the exact same database changes that failed manually
+(to get the database back in sync with the index),
+or <<mapper-orm-indexing-explicit-writeplan-writes,reindex the entities>> affected by the transaction manually
+(to get the index back in sync with the database).
+
+Of course, if you can afford to take the indexes offline for a longer period of time,
+a simpler solution would be to wipe the indexes clean
+and <<mapper-orm-indexing-explicit-massindexer,reindex everything>>.
 ====
 
 .A batch process with Hibernate Search using `execute()`

--- a/documentation/src/main/asciidoc/mapper-orm-indexing-explicit.asciidoc
+++ b/documentation/src/main/asciidoc/mapper-orm-indexing-explicit.asciidoc
@@ -75,48 +75,7 @@ which for large volumes of data may lead to an `OutOfMemoryException`,
 depending on the JVM heap size and on the complexity and number of documents.
 
 If you run into memory issues,
-the first solution is to just write to indexes
-after the call to `session.flush()`/`session.clear()`,
-without waiting for the database transaction to be committed:
-the internal document buffer will be cleared after each write to indexes.
-
-This is done by calling the `execute()` method on the write plan,
-as shown in the example below.
-
-[IMPORTANT]
-====
-With this pattern, if an exception is thrown,
-part of the data will already be in the index, with no way to roll back the changes,
-while the database changes will have been rolled back.
-The index will thus be inconsistent with the database.
-
-To recover from that situation, you will have to either cancel your database changes manually,
-or wipe the indexes clean and <<mapper-orm-indexing-explicit-massindexer,reindex>>.
-====
-
-.A batch process with Hibernate Search using `execute()`
-====
-[source, JAVA, indent=0]
-----
-include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmExplicitIndexingIT.java[tags=persist-automatic-indexing-periodic-flush-execute-clear]
-----
-<1> Get the `SearchSession`.
-<2> Get the search session's write plan.
-<3> For every iteration of the loop, instantiate a new entity and persist it.
-Note we're relying on automatic indexing to index the entity,
-but this would work just as well if automatic indexing was disabled,
-only requiring an extra call to index the entity.
-See <<mapper-orm-indexing-explicit-writeplan-writes>>.
-<4> After after a `flush()`/`clear()`, call `writePlan.execute()`.
-The entities will be processed and *the changes will be sent to the indexes immediately*.
-Hibernate Search will wait for index changes to be "completed"
-as required by the configured <<mapper-orm-indexing-automatic-synchronization,synchronization strategy>>.
-<5> After the loop, commit the transaction.
-The remaining entities that were not flushed/cleared will be flushed and indexed automatically.
-====
-
-If leaving the index in an inconsistent state when the transaction fails is not an option,
-a second solution is to break down the batch process
+the first solution is to break down the batch process
 into multiple transactions, each handling a smaller number of elements:
 the internal document buffer will be cleared after each transaction.
 
@@ -161,6 +120,48 @@ and periodically calling `flush`/`clear` inside each transaction.
 This combined solution is the most flexible,
 hence the most suitable if you want to fine-tune your batch process.
 ====
+
+If breaking down the batch process into multiple transactions is not an option,
+a second solution is to just write to indexes
+after the call to `session.flush()`/`session.clear()`,
+without waiting for the database transaction to be committed:
+the internal document buffer will be cleared after each write to indexes.
+
+This is done by calling the `execute()` method on the write plan,
+as shown in the example below.
+
+[IMPORTANT]
+====
+With this pattern, if an exception is thrown,
+part of the data will already be in the index, with no way to roll back the changes,
+while the database changes will have been rolled back.
+The index will thus be inconsistent with the database.
+
+To recover from that situation, you will have to either cancel your database changes manually,
+or wipe the indexes clean and <<mapper-orm-indexing-explicit-massindexer,reindex>>.
+====
+
+.A batch process with Hibernate Search using `execute()`
+====
+[source, JAVA, indent=0]
+----
+include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmExplicitIndexingIT.java[tags=persist-automatic-indexing-periodic-flush-execute-clear]
+----
+<1> Get the `SearchSession`.
+<2> Get the search session's write plan.
+<3> For every iteration of the loop, instantiate a new entity and persist it.
+Note we're relying on automatic indexing to index the entity,
+but this would work just as well if automatic indexing was disabled,
+only requiring an extra call to index the entity.
+See <<mapper-orm-indexing-explicit-writeplan-writes>>.
+<4> After after a `flush()`/`clear()`, call `writePlan.execute()`.
+The entities will be processed and *the changes will be sent to the indexes immediately*.
+Hibernate Search will wait for index changes to be "completed"
+as required by the configured <<mapper-orm-indexing-automatic-synchronization,synchronization strategy>>.
+<5> After the loop, commit the transaction.
+The remaining entities that were not flushed/cleared will be flushed and indexed automatically.
+====
+
 
 [[mapper-orm-indexing-explicit-writeplan-writes]]
 == Explicitly indexing and deleting specific documents

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmExplicitIndexingIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmExplicitIndexingIT.java
@@ -69,6 +69,7 @@ public class HibernateOrmExplicitIndexingIT {
 			}
 			catch (RuntimeException e) {
 				entityManager.getTransaction().rollback();
+				throw e;
 			}
 			// end::persist-automatic-indexing-periodic-flush-clear[]
 
@@ -103,6 +104,7 @@ public class HibernateOrmExplicitIndexingIT {
 			}
 			catch (RuntimeException e) {
 				entityManager.getTransaction().rollback();
+				throw e;
 			}
 			// end::persist-automatic-indexing-periodic-flush-execute-clear[]
 
@@ -132,6 +134,7 @@ public class HibernateOrmExplicitIndexingIT {
 			}
 			catch (RuntimeException e) {
 				entityManager.getTransaction().rollback();
+				throw e;
 			}
 			// end::persist-automatic-indexing-multiple-transactions[]
 
@@ -162,6 +165,7 @@ public class HibernateOrmExplicitIndexingIT {
 			}
 			catch (RuntimeException e) {
 				entityManager.getTransaction().rollback();
+				throw e;
 			}
 			// end::write-plan-addOrUpdate[]
 
@@ -192,6 +196,7 @@ public class HibernateOrmExplicitIndexingIT {
 			}
 			catch (RuntimeException e) {
 				entityManager.getTransaction().rollback();
+				throw e;
 			}
 			// end::write-plan-delete[]
 
@@ -251,6 +256,7 @@ public class HibernateOrmExplicitIndexingIT {
 			}
 			catch (RuntimeException e) {
 				entityManager.getTransaction().rollback();
+				throw e;
 			}
 		} );
 	}

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmExplicitIndexingIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmExplicitIndexingIT.java
@@ -47,13 +47,13 @@ public class HibernateOrmExplicitIndexingIT {
 	}
 
 	@Test
-	public void persist_noAutomaticIndexing() {
-		EntityManagerFactory entityManagerFactory = setup( HibernateOrmAutomaticIndexingStrategyName.NONE );
+	public void persist_automaticIndexing_periodicFlushClear() {
+		EntityManagerFactory entityManagerFactory = setup( HibernateOrmAutomaticIndexingStrategyName.SESSION );
 
 		OrmUtils.withinEntityManager( entityManagerFactory, entityManager -> {
 			assertBookCount( entityManager, 0 );
 
-			// tag::persist-no-automatic-indexing[]
+			// tag::persist-automatic-indexing-periodic-flush-clear[]
 			entityManager.getTransaction().begin();
 			try {
 				for ( int i = 0 ; i < NUMBER_OF_BOOKS ; ++i ) { // <1>
@@ -70,54 +70,20 @@ public class HibernateOrmExplicitIndexingIT {
 			catch (RuntimeException e) {
 				entityManager.getTransaction().rollback();
 			}
-			// end::persist-no-automatic-indexing[]
-
-			assertBookCount( entityManager, 0 );
-		} );
-	}
-
-	@Test
-	public void persist_automaticIndexing_periodicProcess() {
-		EntityManagerFactory entityManagerFactory = setup( HibernateOrmAutomaticIndexingStrategyName.SESSION );
-
-		OrmUtils.withinEntityManager( entityManagerFactory, entityManager -> {
-			assertBookCount( entityManager, 0 );
-
-			// tag::persist-automatic-indexing-periodic-process[]
-			SearchSession searchSession = Search.session( entityManager ); // <1>
-			SearchSessionWritePlan searchWritePlan = searchSession.writePlan(); // <2>
-
-			entityManager.getTransaction().begin();
-			try {
-				for ( int i = 0 ; i < NUMBER_OF_BOOKS ; ++i ) {
-					Book book = newBook( i );
-					entityManager.persist( book ); // <3>
-
-					if ( ( i + 1 ) % BATCH_SIZE == 0 ) {
-						entityManager.flush();
-						searchWritePlan.process(); // <4>
-						entityManager.clear();
-					}
-				}
-				entityManager.getTransaction().commit(); // <5>
-			}
-			catch (RuntimeException e) {
-				entityManager.getTransaction().rollback();
-			}
-			// end::persist-automatic-indexing-periodic-process[]
+			// end::persist-automatic-indexing-periodic-flush-clear[]
 
 			assertBookCount( entityManager, NUMBER_OF_BOOKS );
 		} );
 	}
 
 	@Test
-	public void persist_automaticIndexing_periodicExecute() {
+	public void persist_automaticIndexing_periodicFlushExecuteClear() {
 		EntityManagerFactory entityManagerFactory = setup( HibernateOrmAutomaticIndexingStrategyName.SESSION );
 
 		OrmUtils.withinEntityManager( entityManagerFactory, entityManager -> {
 			assertBookCount( entityManager, 0 );
 
-			// tag::persist-automatic-indexing-periodic-execute[]
+			// tag::persist-automatic-indexing-periodic-flush-execute-clear[]
 			SearchSession searchSession = Search.session( entityManager ); // <1>
 			SearchSessionWritePlan searchWritePlan = searchSession.writePlan(); // <2>
 
@@ -129,8 +95,8 @@ public class HibernateOrmExplicitIndexingIT {
 
 					if ( ( i + 1 ) % BATCH_SIZE == 0 ) {
 						entityManager.flush();
-						searchWritePlan.execute(); // <4>
 						entityManager.clear();
+						searchWritePlan.execute(); // <4>
 					}
 				}
 				entityManager.getTransaction().commit(); // <5>
@@ -138,7 +104,7 @@ public class HibernateOrmExplicitIndexingIT {
 			catch (RuntimeException e) {
 				entityManager.getTransaction().rollback();
 			}
-			// end::persist-automatic-indexing-periodic-execute[]
+			// end::persist-automatic-indexing-periodic-flush-execute-clear[]
 
 			assertBookCount( entityManager, NUMBER_OF_BOOKS );
 		} );


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3656

@fax4ever Could you review this today, please? I'd like to put it in today's release.