### PR TITLE
HSEARCH-3659 Manage the version of Jackson to the latest available version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,8 @@
         <version.com.google.code.gson>2.8.5</version.com.google.code.gson>
         <version.uk.co.lucasweb.aws-v4-signer-java>1.3</version.uk.co.lucasweb.aws-v4-signer-java>
         <!-- Jackson: used by the Elasticsearch REST client and in tests (wiremock, ...) -->
-        <version.com.fasterxml.jackson>2.8.11</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.9.9</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson.databind>2.9.9.3</version.com.fasterxml.jackson.databind>
 
         <!-- >>> ORM -->
         <version.org.hibernate>5.4.4.Final</version.org.hibernate>
@@ -848,7 +849,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${version.com.fasterxml.jackson}</version>
+                <version>${version.com.fasterxml.jackson.databind}</version>
             </dependency>
 
             <!-- Test -->


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3659

Build testing all versions of Elasticsearch (shouldn't matter, but just in case): https://ci.hibernate.org/blue/organizations/jenkins/hibernate-search-personal-yoann/detail/HSEARCH-3659/2/pipeline