### PR TITLE
Backport HSEARCH-3697 to branch 5.11 - Test Hibernate Search on JDK13 regularly on the CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -166,7 +166,6 @@ stage('Configure') {
 					// See http://www.oracle.com/technetwork/java/javase/eol-135779.html
 					new JdkBuildEnvironment(version: '8', tool: 'OpenJDK 8 Latest', status: BuildEnvironmentStatus.USED_IN_DEFAULT_BUILD),
 					new JdkBuildEnvironment(version: '11', tool: 'OpenJDK 11 Latest', status: BuildEnvironmentStatus.SUPPORTED),
-					new JdkBuildEnvironment(version: '12', tool: 'OpenJDK 12 Latest', status: BuildEnvironmentStatus.SUPPORTED),
 					new JdkBuildEnvironment(version: '13', tool: 'OpenJDK 13 Latest', status: BuildEnvironmentStatus.SUPPORTED,
 							// Elasticsearch won't run on JDK13+
 							elasticsearchTool: 'OpenJDK 11 Latest'),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -167,7 +167,7 @@ stage('Configure') {
 					new JdkBuildEnvironment(version: '8', tool: 'OpenJDK 8 Latest', status: BuildEnvironmentStatus.USED_IN_DEFAULT_BUILD),
 					new JdkBuildEnvironment(version: '11', tool: 'OpenJDK 11 Latest', status: BuildEnvironmentStatus.SUPPORTED),
 					new JdkBuildEnvironment(version: '12', tool: 'OpenJDK 12 Latest', status: BuildEnvironmentStatus.SUPPORTED),
-					new JdkBuildEnvironment(version: '13', tool: 'OpenJDK 13 Latest', status: BuildEnvironmentStatus.EXPERIMENTAL,
+					new JdkBuildEnvironment(version: '13', tool: 'OpenJDK 13 Latest', status: BuildEnvironmentStatus.SUPPORTED,
 							// Elasticsearch won't run on JDK13+
 							elasticsearchTool: 'OpenJDK 11 Latest'),
 					new JdkBuildEnvironment(version: '14', tool: 'OpenJDK 14 Latest', status: BuildEnvironmentStatus.EXPERIMENTAL,


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3697
