### PR TITLE
HSEARCH-3606 Revisit the names of "SearchWriter" and "SearchSessionWritePlan"

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/impl/ElasticsearchIndexManagerImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/impl/ElasticsearchIndexManagerImpl.java
@@ -25,7 +25,7 @@ import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy
 import org.hibernate.search.engine.backend.index.IndexManager;
 import org.hibernate.search.engine.backend.index.spi.IndexManagerStartContext;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
 import org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor;
 import org.hibernate.search.engine.backend.scope.spi.IndexScopeBuilder;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
@@ -162,8 +162,8 @@ class ElasticsearchIndexManagerImpl implements IndexManagerImplementor<Elasticse
 	}
 
 	@Override
-	public IndexWorkExecutor createWorkExecutor(DetachedBackendSessionContext sessionContext) {
-		return backendContext.createWorkExecutor(
+	public IndexWorkspace createWorkspace(DetachedBackendSessionContext sessionContext) {
+		return backendContext.createWorkspace(
 				parallelOrchestrator, elasticsearchIndexName, sessionContext
 		);
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/impl/ElasticsearchIndexManagerImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/impl/ElasticsearchIndexManagerImpl.java
@@ -29,7 +29,7 @@ import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
 import org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor;
 import org.hibernate.search.engine.backend.scope.spi.IndexScopeBuilder;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexDocumentWorkExecutor;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.cfg.spi.ConfigurationPropertySource;
 import org.hibernate.search.engine.cfg.spi.ConfigurationProperty;
 import org.hibernate.search.engine.backend.session.spi.DetachedBackendSessionContext;
@@ -141,10 +141,10 @@ class ElasticsearchIndexManagerImpl implements IndexManagerImplementor<Elasticse
 	}
 
 	@Override
-	public IndexWorkPlan<ElasticsearchDocumentObjectBuilder> createWorkPlan(BackendSessionContext sessionContext,
+	public IndexIndexingPlan<ElasticsearchDocumentObjectBuilder> createIndexingPlan(BackendSessionContext sessionContext,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
 		// The commit strategy is ignored, because Elasticsearch always commits changes to its transaction log.
-		return backendContext.createWorkPlan(
+		return backendContext.createIndexingPlan(
 				serialOrchestrator,
 				elasticsearchIndexName,
 				refreshStrategy,

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/impl/ElasticsearchIndexManagerImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/impl/ElasticsearchIndexManagerImpl.java
@@ -28,7 +28,7 @@ import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrateg
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
 import org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor;
 import org.hibernate.search.engine.backend.scope.spi.IndexScopeBuilder;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexDocumentWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.cfg.spi.ConfigurationPropertySource;
 import org.hibernate.search.engine.cfg.spi.ConfigurationProperty;
@@ -153,10 +153,10 @@ class ElasticsearchIndexManagerImpl implements IndexManagerImplementor<Elasticse
 	}
 
 	@Override
-	public IndexDocumentWorkExecutor<ElasticsearchDocumentObjectBuilder> createDocumentWorkExecutor(
+	public IndexIndexer<ElasticsearchDocumentObjectBuilder> createIndexer(
 			BackendSessionContext sessionContext, DocumentCommitStrategy commitStrategy) {
 		// The commit strategy is ignored, because Elasticsearch always commits changes to its transaction log.
-		return backendContext.createDocumentWorkExecutor(
+		return backendContext.createIndexer(
 				parallelOrchestrator, elasticsearchIndexName, sessionContext
 		);
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/impl/IndexManagerBackendContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/impl/IndexManagerBackendContext.java
@@ -27,12 +27,12 @@ import org.hibernate.search.backend.elasticsearch.orchestration.impl.Elasticsear
 import org.hibernate.search.backend.elasticsearch.orchestration.impl.ElasticsearchWorkOrchestratorProvider;
 import org.hibernate.search.backend.elasticsearch.work.execution.impl.ElasticsearchIndexDocumentWorkExecutor;
 import org.hibernate.search.backend.elasticsearch.work.execution.impl.ElasticsearchIndexWorkExecutor;
-import org.hibernate.search.backend.elasticsearch.work.execution.impl.ElasticsearchIndexWorkPlan;
+import org.hibernate.search.backend.elasticsearch.work.execution.impl.ElasticsearchIndexIndexingPlan;
 import org.hibernate.search.backend.elasticsearch.work.execution.impl.WorkExecutionBackendContext;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexDocumentWorkExecutor;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.mapping.spi.BackendMappingContext;
 import org.hibernate.search.engine.backend.session.spi.DetachedBackendSessionContext;
 import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
@@ -79,14 +79,14 @@ public class IndexManagerBackendContext implements SearchBackendContext, WorkExe
 	}
 
 	@Override
-	public IndexWorkPlan<ElasticsearchDocumentObjectBuilder> createWorkPlan(
+	public IndexIndexingPlan<ElasticsearchDocumentObjectBuilder> createIndexingPlan(
 			ElasticsearchWorkOrchestrator orchestrator,
 			URLEncodedString indexName,
 			DocumentRefreshStrategy refreshStrategy,
 			BackendSessionContext sessionContext) {
 		multiTenancyStrategy.checkTenantId( sessionContext.getTenantIdentifier(), eventContext );
 
-		return new ElasticsearchIndexWorkPlan(
+		return new ElasticsearchIndexIndexingPlan(
 				link.getWorkBuilderFactory(), multiTenancyStrategy, orchestrator,
 				indexName,
 				refreshStrategy,

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/impl/IndexManagerBackendContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/impl/IndexManagerBackendContext.java
@@ -26,12 +26,12 @@ import org.hibernate.search.backend.elasticsearch.multitenancy.impl.MultiTenancy
 import org.hibernate.search.backend.elasticsearch.orchestration.impl.ElasticsearchWorkOrchestrator;
 import org.hibernate.search.backend.elasticsearch.orchestration.impl.ElasticsearchWorkOrchestratorProvider;
 import org.hibernate.search.backend.elasticsearch.work.execution.impl.ElasticsearchIndexIndexer;
-import org.hibernate.search.backend.elasticsearch.work.execution.impl.ElasticsearchIndexWorkExecutor;
+import org.hibernate.search.backend.elasticsearch.work.execution.impl.ElasticsearchIndexWorkspace;
 import org.hibernate.search.backend.elasticsearch.work.execution.impl.ElasticsearchIndexIndexingPlan;
 import org.hibernate.search.backend.elasticsearch.work.execution.impl.WorkExecutionBackendContext;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.mapping.spi.BackendMappingContext;
 import org.hibernate.search.engine.backend.session.spi.DetachedBackendSessionContext;
@@ -106,11 +106,11 @@ public class IndexManagerBackendContext implements SearchBackendContext, WorkExe
 	}
 
 	@Override
-	public IndexWorkExecutor createWorkExecutor(ElasticsearchWorkOrchestrator orchestrator, URLEncodedString indexName,
+	public IndexWorkspace createWorkspace(ElasticsearchWorkOrchestrator orchestrator, URLEncodedString indexName,
 			DetachedBackendSessionContext sessionContext) {
 		multiTenancyStrategy.checkTenantId( sessionContext.getTenantIdentifier(), eventContext );
 
-		return new ElasticsearchIndexWorkExecutor(
+		return new ElasticsearchIndexWorkspace(
 				link.getWorkBuilderFactory(), multiTenancyStrategy, orchestrator, indexName,
 				sessionContext
 		);

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/impl/IndexManagerBackendContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/impl/IndexManagerBackendContext.java
@@ -25,11 +25,11 @@ import org.hibernate.search.backend.elasticsearch.index.admin.impl.IndexMetadata
 import org.hibernate.search.backend.elasticsearch.multitenancy.impl.MultiTenancyStrategy;
 import org.hibernate.search.backend.elasticsearch.orchestration.impl.ElasticsearchWorkOrchestrator;
 import org.hibernate.search.backend.elasticsearch.orchestration.impl.ElasticsearchWorkOrchestratorProvider;
-import org.hibernate.search.backend.elasticsearch.work.execution.impl.ElasticsearchIndexDocumentWorkExecutor;
+import org.hibernate.search.backend.elasticsearch.work.execution.impl.ElasticsearchIndexIndexer;
 import org.hibernate.search.backend.elasticsearch.work.execution.impl.ElasticsearchIndexWorkExecutor;
 import org.hibernate.search.backend.elasticsearch.work.execution.impl.ElasticsearchIndexIndexingPlan;
 import org.hibernate.search.backend.elasticsearch.work.execution.impl.WorkExecutionBackendContext;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexDocumentWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
@@ -95,13 +95,13 @@ public class IndexManagerBackendContext implements SearchBackendContext, WorkExe
 	}
 
 	@Override
-	public IndexDocumentWorkExecutor<ElasticsearchDocumentObjectBuilder> createDocumentWorkExecutor(
+	public IndexIndexer<ElasticsearchDocumentObjectBuilder> createIndexer(
 			ElasticsearchWorkOrchestrator orchestrator,
 			URLEncodedString indexName,
 			BackendSessionContext sessionContext) {
 		multiTenancyStrategy.checkTenantId( sessionContext.getTenantIdentifier(), eventContext );
 
-		return new ElasticsearchIndexDocumentWorkExecutor( link.getWorkBuilderFactory(), multiTenancyStrategy, orchestrator,
+		return new ElasticsearchIndexIndexer( link.getWorkBuilderFactory(), multiTenancyStrategy, orchestrator,
 				indexName, sessionContext );
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/execution/impl/ElasticsearchIndexIndexer.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/execution/impl/ElasticsearchIndexIndexer.java
@@ -16,12 +16,12 @@ import org.hibernate.search.backend.elasticsearch.work.impl.ElasticsearchWork;
 import org.hibernate.search.backend.elasticsearch.work.builder.factory.impl.ElasticsearchWorkBuilderFactory;
 import org.hibernate.search.engine.backend.work.execution.spi.DocumentContributor;
 import org.hibernate.search.engine.backend.work.execution.spi.DocumentReferenceProvider;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexDocumentWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
 
 import com.google.gson.JsonObject;
 
-public class ElasticsearchIndexDocumentWorkExecutor implements IndexDocumentWorkExecutor<ElasticsearchDocumentObjectBuilder> {
+public class ElasticsearchIndexIndexer implements IndexIndexer<ElasticsearchDocumentObjectBuilder> {
 
 	private final ElasticsearchWorkBuilderFactory factory;
 	private final MultiTenancyStrategy multiTenancyStrategy;
@@ -29,7 +29,7 @@ public class ElasticsearchIndexDocumentWorkExecutor implements IndexDocumentWork
 	private final URLEncodedString indexName;
 	private final String tenantId;
 
-	public ElasticsearchIndexDocumentWorkExecutor(ElasticsearchWorkBuilderFactory factory, MultiTenancyStrategy multiTenancyStrategy,
+	public ElasticsearchIndexIndexer(ElasticsearchWorkBuilderFactory factory, MultiTenancyStrategy multiTenancyStrategy,
 			ElasticsearchWorkOrchestrator orchestrator,
 			URLEncodedString indexName,
 			BackendSessionContext sessionContext) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/execution/impl/ElasticsearchIndexIndexingPlan.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/execution/impl/ElasticsearchIndexIndexingPlan.java
@@ -17,7 +17,7 @@ import org.hibernate.search.backend.elasticsearch.orchestration.impl.Elasticsear
 import org.hibernate.search.backend.elasticsearch.work.builder.factory.impl.ElasticsearchWorkBuilderFactory;
 import org.hibernate.search.backend.elasticsearch.work.impl.ElasticsearchWork;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.work.execution.spi.DocumentContributor;
 import org.hibernate.search.engine.backend.work.execution.spi.DocumentReferenceProvider;
 import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
@@ -26,7 +26,7 @@ import com.google.gson.JsonObject;
 
 
 
-public class ElasticsearchIndexWorkPlan implements IndexWorkPlan<ElasticsearchDocumentObjectBuilder> {
+public class ElasticsearchIndexIndexingPlan implements IndexIndexingPlan<ElasticsearchDocumentObjectBuilder> {
 
 	private final ElasticsearchWorkBuilderFactory builderFactory;
 	private final MultiTenancyStrategy multiTenancyStrategy;
@@ -37,7 +37,7 @@ public class ElasticsearchIndexWorkPlan implements IndexWorkPlan<ElasticsearchDo
 
 	private final List<ElasticsearchWork<?>> works = new ArrayList<>();
 
-	public ElasticsearchIndexWorkPlan(ElasticsearchWorkBuilderFactory builderFactory,
+	public ElasticsearchIndexIndexingPlan(ElasticsearchWorkBuilderFactory builderFactory,
 			MultiTenancyStrategy multiTenancyStrategy,
 			ElasticsearchWorkOrchestrator orchestrator,
 			URLEncodedString indexName,

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/execution/impl/ElasticsearchIndexWorkPlan.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/execution/impl/ElasticsearchIndexWorkPlan.java
@@ -78,7 +78,7 @@ public class ElasticsearchIndexWorkPlan implements IndexWorkPlan<ElasticsearchDo
 	}
 
 	@Override
-	public void prepare() {
+	public void process() {
 		/*
 		 * Nothing to do: we can't execute anything more
 		 * without sending a request to the cluster.

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/execution/impl/ElasticsearchIndexWorkspace.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/execution/impl/ElasticsearchIndexWorkspace.java
@@ -12,12 +12,12 @@ import org.hibernate.search.backend.elasticsearch.multitenancy.impl.MultiTenancy
 import org.hibernate.search.backend.elasticsearch.orchestration.impl.ElasticsearchWorkOrchestrator;
 import org.hibernate.search.backend.elasticsearch.util.spi.URLEncodedString;
 import org.hibernate.search.backend.elasticsearch.work.builder.factory.impl.ElasticsearchWorkBuilderFactory;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
 import org.hibernate.search.engine.backend.session.spi.DetachedBackendSessionContext;
 
 import com.google.gson.JsonObject;
 
-public class ElasticsearchIndexWorkExecutor implements IndexWorkExecutor {
+public class ElasticsearchIndexWorkspace implements IndexWorkspace {
 
 	private final ElasticsearchWorkBuilderFactory builderFactory;
 	private final MultiTenancyStrategy multiTenancyStrategy;
@@ -25,7 +25,7 @@ public class ElasticsearchIndexWorkExecutor implements IndexWorkExecutor {
 	private final URLEncodedString indexName;
 	private final DetachedBackendSessionContext sessionContext;
 
-	public ElasticsearchIndexWorkExecutor(ElasticsearchWorkBuilderFactory builderFactory,
+	public ElasticsearchIndexWorkspace(ElasticsearchWorkBuilderFactory builderFactory,
 			MultiTenancyStrategy multiTenancyStrategy, ElasticsearchWorkOrchestrator orchestrator,
 			URLEncodedString indexName,
 			DetachedBackendSessionContext sessionContext) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/execution/impl/WorkExecutionBackendContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/execution/impl/WorkExecutionBackendContext.java
@@ -11,7 +11,7 @@ import org.hibernate.search.backend.elasticsearch.orchestration.impl.Elasticsear
 import org.hibernate.search.backend.elasticsearch.util.spi.URLEncodedString;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.session.spi.DetachedBackendSessionContext;
 import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
@@ -40,7 +40,7 @@ public interface WorkExecutionBackendContext {
 			URLEncodedString indexName,
 			BackendSessionContext sessionContext);
 
-	IndexWorkExecutor createWorkExecutor(ElasticsearchWorkOrchestrator orchestrator, URLEncodedString indexName,
+	IndexWorkspace createWorkspace(ElasticsearchWorkOrchestrator orchestrator, URLEncodedString indexName,
 			DetachedBackendSessionContext sessionContext);
 
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/execution/impl/WorkExecutionBackendContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/execution/impl/WorkExecutionBackendContext.java
@@ -12,7 +12,7 @@ import org.hibernate.search.backend.elasticsearch.util.spi.URLEncodedString;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexDocumentWorkExecutor;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.session.spi.DetachedBackendSessionContext;
 import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
 
@@ -29,7 +29,7 @@ import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
  */
 public interface WorkExecutionBackendContext {
 
-	IndexWorkPlan<ElasticsearchDocumentObjectBuilder> createWorkPlan(
+	IndexIndexingPlan<ElasticsearchDocumentObjectBuilder> createIndexingPlan(
 			ElasticsearchWorkOrchestrator orchestrator,
 			URLEncodedString indexName,
 			DocumentRefreshStrategy refreshStrategy,

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/execution/impl/WorkExecutionBackendContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/execution/impl/WorkExecutionBackendContext.java
@@ -10,7 +10,7 @@ import org.hibernate.search.backend.elasticsearch.document.impl.ElasticsearchDoc
 import org.hibernate.search.backend.elasticsearch.orchestration.impl.ElasticsearchWorkOrchestrator;
 import org.hibernate.search.backend.elasticsearch.util.spi.URLEncodedString;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexDocumentWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.session.spi.DetachedBackendSessionContext;
@@ -35,7 +35,7 @@ public interface WorkExecutionBackendContext {
 			DocumentRefreshStrategy refreshStrategy,
 			BackendSessionContext sessionContext);
 
-	IndexDocumentWorkExecutor<ElasticsearchDocumentObjectBuilder> createDocumentWorkExecutor(
+	IndexIndexer<ElasticsearchDocumentObjectBuilder> createIndexer(
 			ElasticsearchWorkOrchestrator orchestrator,
 			URLEncodedString indexName,
 			BackendSessionContext sessionContext);

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/IndexManagerBackendContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/IndexManagerBackendContext.java
@@ -31,14 +31,14 @@ import org.hibernate.search.backend.lucene.search.query.impl.LuceneSearchQueryBu
 import org.hibernate.search.backend.lucene.search.query.impl.SearchBackendContext;
 import org.hibernate.search.backend.lucene.work.execution.impl.LuceneIndexDocumentWorkExecutor;
 import org.hibernate.search.backend.lucene.work.execution.impl.LuceneIndexWorkExecutor;
-import org.hibernate.search.backend.lucene.work.execution.impl.LuceneIndexWorkPlan;
+import org.hibernate.search.backend.lucene.work.execution.impl.LuceneIndexIndexingPlan;
 import org.hibernate.search.backend.lucene.work.execution.impl.WorkExecutionBackendContext;
 import org.hibernate.search.backend.lucene.work.execution.impl.WorkExecutionIndexManagerContext;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexDocumentWorkExecutor;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.backend.lucene.document.impl.LuceneRootDocumentBuilder;
 import org.hibernate.search.backend.lucene.multitenancy.impl.MultiTenancyStrategy;
 import org.hibernate.search.backend.lucene.work.impl.LuceneWorkFactory;
@@ -90,14 +90,14 @@ public class IndexManagerBackendContext implements WorkExecutionBackendContext, 
 	}
 
 	@Override
-	public IndexWorkPlan<LuceneRootDocumentBuilder> createWorkPlan(
+	public IndexIndexingPlan<LuceneRootDocumentBuilder> createIndexingPlan(
 			WorkExecutionIndexManagerContext indexManagerContext,
 			LuceneIndexEntryFactory indexEntryFactory,
 			BackendSessionContext sessionContext,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
 		multiTenancyStrategy.checkTenantId( sessionContext.getTenantIdentifier(), eventContext );
 
-		return new LuceneIndexWorkPlan(
+		return new LuceneIndexIndexingPlan(
 				workFactory,
 				indexManagerContext,
 				indexEntryFactory,

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/IndexManagerBackendContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/IndexManagerBackendContext.java
@@ -29,7 +29,7 @@ import org.hibernate.search.backend.lucene.search.impl.LuceneSearchContext;
 import org.hibernate.search.backend.lucene.search.projection.impl.LuceneSearchProjection;
 import org.hibernate.search.backend.lucene.search.query.impl.LuceneSearchQueryBuilder;
 import org.hibernate.search.backend.lucene.search.query.impl.SearchBackendContext;
-import org.hibernate.search.backend.lucene.work.execution.impl.LuceneIndexDocumentWorkExecutor;
+import org.hibernate.search.backend.lucene.work.execution.impl.LuceneIndexIndexer;
 import org.hibernate.search.backend.lucene.work.execution.impl.LuceneIndexWorkExecutor;
 import org.hibernate.search.backend.lucene.work.execution.impl.LuceneIndexIndexingPlan;
 import org.hibernate.search.backend.lucene.work.execution.impl.WorkExecutionBackendContext;
@@ -37,7 +37,7 @@ import org.hibernate.search.backend.lucene.work.execution.impl.WorkExecutionInde
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexDocumentWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.backend.lucene.document.impl.LuceneRootDocumentBuilder;
 import org.hibernate.search.backend.lucene.multitenancy.impl.MultiTenancyStrategy;
@@ -122,14 +122,14 @@ public class IndexManagerBackendContext implements WorkExecutionBackendContext, 
 	}
 
 	@Override
-	public IndexDocumentWorkExecutor<LuceneRootDocumentBuilder> createDocumentWorkExecutor(
+	public IndexIndexer<LuceneRootDocumentBuilder> createIndexer(
 			WorkExecutionIndexManagerContext indexManagerContext,
 			LuceneIndexEntryFactory indexEntryFactory,
 			BackendSessionContext sessionContext,
 			DocumentCommitStrategy commitStrategy) {
 		multiTenancyStrategy.checkTenantId( sessionContext.getTenantIdentifier(), eventContext );
 
-		return new LuceneIndexDocumentWorkExecutor(
+		return new LuceneIndexIndexer(
 				workFactory,
 				indexEntryFactory,
 				indexManagerContext,

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/IndexManagerBackendContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/IndexManagerBackendContext.java
@@ -30,13 +30,13 @@ import org.hibernate.search.backend.lucene.search.projection.impl.LuceneSearchPr
 import org.hibernate.search.backend.lucene.search.query.impl.LuceneSearchQueryBuilder;
 import org.hibernate.search.backend.lucene.search.query.impl.SearchBackendContext;
 import org.hibernate.search.backend.lucene.work.execution.impl.LuceneIndexIndexer;
-import org.hibernate.search.backend.lucene.work.execution.impl.LuceneIndexWorkExecutor;
+import org.hibernate.search.backend.lucene.work.execution.impl.LuceneIndexWorkspace;
 import org.hibernate.search.backend.lucene.work.execution.impl.LuceneIndexIndexingPlan;
 import org.hibernate.search.backend.lucene.work.execution.impl.WorkExecutionBackendContext;
 import org.hibernate.search.backend.lucene.work.execution.impl.WorkExecutionIndexManagerContext;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.backend.lucene.document.impl.LuceneRootDocumentBuilder;
@@ -139,11 +139,11 @@ public class IndexManagerBackendContext implements WorkExecutionBackendContext, 
 	}
 
 	@Override
-	public IndexWorkExecutor createWorkExecutor(WorkExecutionIndexManagerContext indexManagerContext,
+	public IndexWorkspace createWorkspace(WorkExecutionIndexManagerContext indexManagerContext,
 			DetachedBackendSessionContext sessionContext) {
 		multiTenancyStrategy.checkTenantId( sessionContext.getTenantIdentifier(), eventContext );
 
-		return new LuceneIndexWorkExecutor( workFactory, indexManagerContext, sessionContext );
+		return new LuceneIndexWorkspace( workFactory, indexManagerContext, sessionContext );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/LuceneIndexManagerImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/LuceneIndexManagerImpl.java
@@ -23,7 +23,7 @@ import org.hibernate.search.engine.backend.scope.spi.IndexScopeBuilder;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
 import org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexDocumentWorkExecutor;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.backend.lucene.document.impl.LuceneRootDocumentBuilder;
 import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexModel;
 import org.hibernate.search.backend.lucene.logging.impl.Log;
@@ -87,9 +87,9 @@ public class LuceneIndexManagerImpl
 	}
 
 	@Override
-	public IndexWorkPlan<LuceneRootDocumentBuilder> createWorkPlan(BackendSessionContext sessionContext,
+	public IndexIndexingPlan<LuceneRootDocumentBuilder> createIndexingPlan(BackendSessionContext sessionContext,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
-		return backendContext.createWorkPlan(
+		return backendContext.createIndexingPlan(
 				shardHolder, indexEntryFactory,
 				sessionContext, commitStrategy, refreshStrategy
 		);

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/LuceneIndexManagerImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/LuceneIndexManagerImpl.java
@@ -22,7 +22,7 @@ import org.hibernate.search.engine.backend.index.spi.IndexManagerStartContext;
 import org.hibernate.search.engine.backend.scope.spi.IndexScopeBuilder;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
 import org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexDocumentWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.backend.lucene.document.impl.LuceneRootDocumentBuilder;
 import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexModel;
@@ -96,9 +96,9 @@ public class LuceneIndexManagerImpl
 	}
 
 	@Override
-	public IndexDocumentWorkExecutor<LuceneRootDocumentBuilder> createDocumentWorkExecutor(
+	public IndexIndexer<LuceneRootDocumentBuilder> createIndexer(
 			BackendSessionContext sessionContext, DocumentCommitStrategy commitStrategy) {
-		return backendContext.createDocumentWorkExecutor(
+		return backendContext.createIndexer(
 				shardHolder, indexEntryFactory,
 				sessionContext, commitStrategy
 		);

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/LuceneIndexManagerImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/LuceneIndexManagerImpl.java
@@ -20,7 +20,7 @@ import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy
 import org.hibernate.search.engine.backend.index.IndexManager;
 import org.hibernate.search.engine.backend.index.spi.IndexManagerStartContext;
 import org.hibernate.search.engine.backend.scope.spi.IndexScopeBuilder;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
 import org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
@@ -105,8 +105,8 @@ public class LuceneIndexManagerImpl
 	}
 
 	@Override
-	public IndexWorkExecutor createWorkExecutor(DetachedBackendSessionContext sessionContext) {
-		return backendContext.createWorkExecutor( shardHolder, sessionContext );
+	public IndexWorkspace createWorkspace(DetachedBackendSessionContext sessionContext) {
+		return backendContext.createWorkspace( shardHolder, sessionContext );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/execution/impl/LuceneIndexIndexer.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/execution/impl/LuceneIndexIndexer.java
@@ -17,10 +17,10 @@ import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.engine.backend.work.execution.spi.DocumentContributor;
 import org.hibernate.search.engine.backend.work.execution.spi.DocumentReferenceProvider;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexDocumentWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
 
-public class LuceneIndexDocumentWorkExecutor implements IndexDocumentWorkExecutor<LuceneRootDocumentBuilder> {
+public class LuceneIndexIndexer implements IndexIndexer<LuceneRootDocumentBuilder> {
 
 	private final LuceneWorkFactory factory;
 	private final LuceneIndexEntryFactory indexEntryFactory;
@@ -28,7 +28,7 @@ public class LuceneIndexDocumentWorkExecutor implements IndexDocumentWorkExecuto
 	private final String tenantId;
 	private final DocumentCommitStrategy commitStrategy;
 
-	public LuceneIndexDocumentWorkExecutor(LuceneWorkFactory factory,
+	public LuceneIndexIndexer(LuceneWorkFactory factory,
 			LuceneIndexEntryFactory indexEntryFactory,
 			WorkExecutionIndexManagerContext indexManagerContext,
 			BackendSessionContext sessionContext,

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/execution/impl/LuceneIndexIndexingPlan.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/execution/impl/LuceneIndexIndexingPlan.java
@@ -15,7 +15,7 @@ import java.util.concurrent.CompletableFuture;
 import org.hibernate.search.backend.lucene.document.impl.LuceneIndexEntryFactory;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.work.execution.spi.DocumentContributor;
 import org.hibernate.search.engine.backend.work.execution.spi.DocumentReferenceProvider;
 import org.hibernate.search.backend.lucene.document.impl.LuceneIndexEntry;
@@ -25,7 +25,7 @@ import org.hibernate.search.backend.lucene.work.impl.LuceneWriteWork;
 import org.hibernate.search.backend.lucene.work.impl.LuceneWorkFactory;
 import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
 
-public class LuceneIndexWorkPlan implements IndexWorkPlan<LuceneRootDocumentBuilder> {
+public class LuceneIndexIndexingPlan implements IndexIndexingPlan<LuceneRootDocumentBuilder> {
 
 	private final LuceneWorkFactory factory;
 	private final LuceneIndexEntryFactory indexEntryFactory;
@@ -36,7 +36,7 @@ public class LuceneIndexWorkPlan implements IndexWorkPlan<LuceneRootDocumentBuil
 
 	private final Map<LuceneWriteWorkOrchestrator, List<LuceneWriteWork<?>>> worksByOrchestrator = new HashMap<>();
 
-	public LuceneIndexWorkPlan(LuceneWorkFactory factory,
+	public LuceneIndexIndexingPlan(LuceneWorkFactory factory,
 			WorkExecutionIndexManagerContext indexManagerContext,
 			LuceneIndexEntryFactory indexEntryFactory,
 			BackendSessionContext sessionContext,

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/execution/impl/LuceneIndexWorkPlan.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/execution/impl/LuceneIndexWorkPlan.java
@@ -80,7 +80,7 @@ public class LuceneIndexWorkPlan implements IndexWorkPlan<LuceneRootDocumentBuil
 	}
 
 	@Override
-	public void prepare() {
+	public void process() {
 		// Nothing to do: we only have to send the works to the orchestrator
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/execution/impl/LuceneIndexWorkspace.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/execution/impl/LuceneIndexWorkspace.java
@@ -14,16 +14,16 @@ import org.hibernate.search.backend.lucene.work.impl.LuceneWorkFactory;
 import org.hibernate.search.backend.lucene.work.impl.LuceneWriteWork;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
 import org.hibernate.search.engine.backend.session.spi.DetachedBackendSessionContext;
 
-public class LuceneIndexWorkExecutor implements IndexWorkExecutor {
+public class LuceneIndexWorkspace implements IndexWorkspace {
 
 	private final LuceneWorkFactory factory;
 	private final WorkExecutionIndexManagerContext indexManagerContext;
 	private final DetachedBackendSessionContext sessionContext;
 
-	public LuceneIndexWorkExecutor(LuceneWorkFactory factory,
+	public LuceneIndexWorkspace(LuceneWorkFactory factory,
 			WorkExecutionIndexManagerContext indexManagerContext,
 			DetachedBackendSessionContext sessionContext) {
 		this.factory = factory;

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/execution/impl/WorkExecutionBackendContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/execution/impl/WorkExecutionBackendContext.java
@@ -14,7 +14,7 @@ import org.hibernate.search.backend.lucene.lowlevel.writer.impl.IndexWriterDeleg
 import org.hibernate.search.backend.lucene.orchestration.impl.LuceneWriteWorkOrchestratorImplementor;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexDocumentWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.session.spi.DetachedBackendSessionContext;
@@ -41,7 +41,7 @@ public interface WorkExecutionBackendContext {
 	LuceneWriteWorkOrchestratorImplementor createOrchestrator(String indexName, Optional<String> shardId,
 			IndexWriterDelegator indexWriterDelegator);
 
-	IndexDocumentWorkExecutor<LuceneRootDocumentBuilder> createDocumentWorkExecutor(
+	IndexIndexer<LuceneRootDocumentBuilder> createIndexer(
 			WorkExecutionIndexManagerContext indexManagerContext,
 			LuceneIndexEntryFactory indexEntryFactory,
 			BackendSessionContext sessionContext,

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/execution/impl/WorkExecutionBackendContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/execution/impl/WorkExecutionBackendContext.java
@@ -16,7 +16,7 @@ import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexDocumentWorkExecutor;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.session.spi.DetachedBackendSessionContext;
 import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
 
@@ -32,7 +32,7 @@ import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
  * we would end up with methods with many parameters.
  */
 public interface WorkExecutionBackendContext {
-	IndexWorkPlan<LuceneRootDocumentBuilder> createWorkPlan(
+	IndexIndexingPlan<LuceneRootDocumentBuilder> createIndexingPlan(
 			WorkExecutionIndexManagerContext indexManagerContext,
 			LuceneIndexEntryFactory indexEntryFactory,
 			BackendSessionContext sessionContext,

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/execution/impl/WorkExecutionBackendContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/execution/impl/WorkExecutionBackendContext.java
@@ -15,7 +15,7 @@ import org.hibernate.search.backend.lucene.orchestration.impl.LuceneWriteWorkOrc
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.session.spi.DetachedBackendSessionContext;
 import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
@@ -47,6 +47,6 @@ public interface WorkExecutionBackendContext {
 			BackendSessionContext sessionContext,
 			DocumentCommitStrategy commitStrategy);
 
-	IndexWorkExecutor createWorkExecutor(WorkExecutionIndexManagerContext indexManagerContext,
+	IndexWorkspace createWorkspace(WorkExecutionIndexManagerContext indexManagerContext,
 			DetachedBackendSessionContext sessionContext);
 }

--- a/documentation/src/main/asciidoc/internals.asciidoc
+++ b/documentation/src/main/asciidoc/internals.asciidoc
@@ -146,14 +146,14 @@ so that the value is added to the field.
 
 The other part of indexing (or altering the index in any way) is to give an order to the index manager:
 "add this document", "delete this document", ...
-This is done through the `IndexWorkPlan` class.
-The mapper should create a work plan whenever it needs to execute a series of works.
+This is done through the `IndexIndexingPlan` class.
+The mapper should create an indexing plan whenever it needs to add, update or delete a document.
 
-`IndexWorkPlan` carries *some* context usually associated to a "session" in the JPA world,
+`IndexIndexingPlan` carries *some* context usually associated to a "session" in the JPA world,
 including the tenant identifier when using multi-tenancy, in particular.
-Thus the mapper should instantiate a new work plan whenever this context changes.
+Thus the mapper should instantiate a new indexing plan whenever this context changes.
 
-NOTE: For now index-scoped operations such as flush, optimize, etc. are unavailable from work plans.
+NOTE: For now index-scoped operations such as flush, optimize, etc. are unavailable from indexing plans.
 HSEARCH-3305 will introduce APIs and SPIs for these.
 
 === Searching

--- a/documentation/src/main/asciidoc/mapper-orm-indexing-automatic.asciidoc
+++ b/documentation/src/main/asciidoc/mapper-orm-indexing-automatic.asciidoc
@@ -55,7 +55,7 @@ entity changes performed up to the flush will be indexed correctly.
 If you come from Hibernate Search 5 or earlier,
 you may see this as a significant improvement:
 there is no need to call `flushToIndexes()` and update indexes in the middle of a transaction anymore,
-except for larger volumes of data (see <<mapper-orm-indexing-manual-writeplan-process-execute>>).
+except for larger volumes of data (see <<mapper-orm-indexing-manual-indexingplan-process-execute>>).
 ====
 Inside transactions, indexing happens after transactions are committed::
 When entity changes happen inside a transaction,
@@ -68,7 +68,7 @@ and perform flush/clear, regularly to save memory,
 be aware that Hibernate Search's internal buffer holding documents to index
 will grow on each flush, and will not be cleared until the transaction is committed or rolled back.
 If you encounter memory issues because of that,
-see <<mapper-orm-indexing-manual-writeplan-process-execute>> for a few solutions.
+see <<mapper-orm-indexing-manual-indexingplan-process-execute>> for a few solutions.
 Outside of transactions, indexing happens on session flush::
 When entity changes happen outside of any transaction (not recommended),
 indexes are updated immediately upon session `flush()`.

--- a/documentation/src/main/asciidoc/mapper-orm-indexing-manual.asciidoc
+++ b/documentation/src/main/asciidoc/mapper-orm-indexing-manual.asciidoc
@@ -24,8 +24,8 @@ As with everything in Hibernate Search,
 these APIs only affect the Hibernate Search indexes:
 they do not write anything to the database.
 
-[[mapper-orm-indexing-manual-writeplan-process-execute]]
-== Controlling entity reads and index writes with `SearchSessionWritePlan`
+[[mapper-orm-indexing-manual-indexingplan-process-execute]]
+== Controlling entity reads and index writes with `SearchIndexingPlan`
 // Search 5 anchors backward compatibility
 [[search-batchindex-flushtoindexes]]
 
@@ -91,7 +91,7 @@ include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/indexing/Hibe
 Note we're relying on automatic indexing to index the entity,
 but this would work just as well if automatic indexing was disabled,
 only requiring an extra call to index the entity.
-See <<mapper-orm-indexing-manual-writeplan-writes>>.
+See <<mapper-orm-indexing-manual-indexingplan-writes>>.
 <5> Commit the transaction at the end of each iteration of the outer loop.
 The entities will be flushed and indexed automatically.
 ====
@@ -113,7 +113,7 @@ after the call to `session.flush()`/`session.clear()`,
 without waiting for the database transaction to be committed:
 the internal document buffer will be cleared after each write to indexes.
 
-This is done by calling the `execute()` method on the write plan,
+This is done by calling the `execute()` method on the indexing plan,
 as shown in the example below.
 
 [IMPORTANT]
@@ -126,7 +126,7 @@ The index will thus be inconsistent with the database.
 To recover from that situation, you will have to either
 execute the exact same database changes that failed manually
 (to get the database back in sync with the index),
-or <<mapper-orm-indexing-manual-writeplan-writes,reindex the entities>> affected by the transaction manually
+or <<mapper-orm-indexing-manual-indexingplan-writes,reindex the entities>> affected by the transaction manually
 (to get the index back in sync with the database).
 
 Of course, if you can afford to take the indexes offline for a longer period of time,
@@ -141,13 +141,13 @@ and <<mapper-orm-indexing-massindexer,reindex everything>>.
 include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmManualIndexingIT.java[tags=persist-automatic-indexing-periodic-flush-execute-clear]
 ----
 <1> Get the `SearchSession`.
-<2> Get the search session's write plan.
+<2> Get the search session's indexing plan.
 <3> For every iteration of the loop, instantiate a new entity and persist it.
 Note we're relying on automatic indexing to index the entity,
 but this would work just as well if automatic indexing was disabled,
 only requiring an extra call to index the entity.
-See <<mapper-orm-indexing-manual-writeplan-writes>>.
-<4> After after a `flush()`/`clear()`, call `writePlan.execute()`.
+See <<mapper-orm-indexing-manual-indexingplan-writes>>.
+<4> After after a `flush()`/`clear()`, call `indexingPlan.execute()`.
 The entities will be processed and *the changes will be sent to the indexes immediately*.
 Hibernate Search will wait for index changes to be "completed"
 as required by the configured <<mapper-orm-indexing-automatic-synchronization,synchronization strategy>>.
@@ -156,7 +156,7 @@ The remaining entities that were not flushed/cleared will be flushed and indexed
 ====
 
 
-[[mapper-orm-indexing-manual-writeplan-writes]]
+[[mapper-orm-indexing-manual-indexingplan-writes]]
 == Explicitly indexing and deleting specific documents
 // Search 5 anchors backward compatibility
 [[_adding_instances_to_the_index]]
@@ -167,7 +167,7 @@ the indexes will start empty and stay that way
 until explicit indexing commands are sent to Hibernate Search.
 
 Indexing is done in the context of an ORM session
-using the `SearchSessionWritePlan` interface.
+using the `SearchIndexingPlan` interface.
 This interface represents the (mutable) set of changes
 that are planned in the context of a session,
 and will be applied to indexes upon transaction commit.
@@ -193,35 +193,35 @@ Respectively, process the changes and apply them to indexes.
 +
 These methods will be executed automatically on commit,
 so they are only useful when processing large number of items,
-as explained in <<mapper-orm-indexing-manual-writeplan-process-execute>>.
+as explained in <<mapper-orm-indexing-manual-indexingplan-process-execute>>.
 
 Below are examples of using `addOrUpdate` and `delete`.
 
-.Explicitly adding or updating an entity in the index using `SearchSessionWritePlan`
+.Explicitly adding or updating an entity in the index using `SearchIndexingPlan`
 ====
 [source, JAVA, indent=0]
 ----
-include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmManualIndexingIT.java[tags=write-plan-addOrUpdate]
+include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmManualIndexingIT.java[tags=indexing-plan-addOrUpdate]
 ----
 <1> Get the `SearchSession`.
-<2> Get the search session's write plan.
+<2> Get the search session's indexing plan.
 <3> Fetch from the database the `Book` we want to index.
-<4> Submit the `Book` to the write plan for an add-or-update operation.
+<4> Submit the `Book` to the indexing plan for an add-or-update operation.
 The operation won't be executed immediately,
 but will be delayed until the transaction is committed.
 <5> Commit the transaction, allowing Hibernate Search to actually write the document to the index.
 ====
 
-.Explicitly deleting an entity from the index using `SearchSessionWritePlan`
+.Explicitly deleting an entity from the index using `SearchIndexingPlan`
 ====
 [source, JAVA, indent=0]
 ----
-include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmManualIndexingIT.java[tags=write-plan-delete]
+include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmManualIndexingIT.java[tags=indexing-plan-delete]
 ----
 <1> Get the `SearchSession`.
-<2> Get the search session's write plan.
+<2> Get the search session's indexing plan.
 <3> Fetch from the database the `Book` we want to un-index.
-<4> Submit the `Book` to the write plan for a delete operation.
+<4> Submit the `Book` to the indexing plan for a delete operation.
 The operation won't be executed immediately,
 but will be delayed until the transaction is committed.
 <5> Commit the transaction, allowing Hibernate Search to actually delete the document from the index.
@@ -229,7 +229,7 @@ but will be delayed until the transaction is committed.
 
 [TIP]
 ====
-Multiple operations can be performed in a single write plan.
+Multiple operations can be performed in a single indexing plan.
 The same entity can even be changed multiple times,
 for example added and then removed:
 Hibernate Search will simplify the operation as expected.
@@ -238,7 +238,7 @@ This will work fine for any reasonable number of entities,
 but changing or simply loading large numbers of entities in a single session
 requires special care with Hibernate ORM,
 and then some extra care with Hibernate Search.
-See <<mapper-orm-indexing-manual-writeplan-process-execute>> for more information.
+See <<mapper-orm-indexing-manual-indexingplan-process-execute>> for more information.
 ====
 
 == Explicitly altering a whole index

--- a/documentation/src/main/asciidoc/mapper-orm-indexing-manual.asciidoc
+++ b/documentation/src/main/asciidoc/mapper-orm-indexing-manual.asciidoc
@@ -248,7 +248,7 @@ but rather about a large number of documents, possibly all of them.
 This includes, for example, purging the index to remove all of its content.
 
 The operations are performed *outside* of the context of an ORM session,
-using the `SearchWriter` interface.
+using the `SearchWorkspace` interface.
 This interface exposes various large-scale operations
 that can be applied to an index or a set of indexes.
 These operations are triggered as soon as they are requested,
@@ -257,10 +257,10 @@ without waiting for the transaction commit.
 This interface offers the following methods:
 
 `purge()`::
-Purge the indexes targeted by this writer, removing all documents.
+Purge the indexes targeted by this workspace, removing all documents.
 +
 When using multi-tenancy, only documents of one tenant will be removed:
-the tenant of the session from which this writer originated.
+the tenant of the session from which this workspace originated.
 `purgeAsync()`::
 Asynchronous version of `purge()` returning a `CompletableFuture`.
 `flush()`::
@@ -273,7 +273,7 @@ Only to be used by experts fully aware of the implications.
 `flushAsync()`::
 Asynchronous version of `flush()` returning a `CompletableFuture`.
 `optimize()`::
-Merge all segments of the indexes targeted by this writer into a single one.
+Merge all segments of the indexes targeted by this workspace into a single one.
 +
 Note this operation may affect performance positively as well as negatively.
 As a rule of thumb, if indexes are read-only for extended periods of time,
@@ -283,31 +283,31 @@ is likely to degrade read/write performance overall.
 `optimizeAsync()`::
 Asynchronous version of `optimize()` returning a `CompletableFuture`.
 
-Below is an example using a `SearchWriter` to purge several indexes.
+Below is an example using a `SearchWorkspace` to purge several indexes.
 
-.Purging indexes using a `SearchWriter`
+.Purging indexes using a `SearchWorkspace`
 ====
 [source, JAVA, indent=0]
 ----
-include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmManualIndexingIT.java[tags=writer-purge]
+include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmManualIndexingIT.java[tags=workspace-purge]
 ----
 <1> Get a `SearchSession`.
-<2> Get a writer targeting the indexes mapped to the `Book` and `Author` entity types.
+<2> Get a workspace targeting the indexes mapped to the `Book` and `Author` entity types.
 <3> Trigger a purge.
 This method is synchronous and will only return after the purge is complete,
 but an asynchronous method, `purgeAsync`, is also available.
 ====
 
-There are multiple ways to retrieve the `SearchWriter` to target one, several or all indexes:
+There are multiple ways to retrieve a `SearchWorkspace` to target one, several or all indexes:
 
-.Retrieving a `SearchWriter`
+.Retrieving a `SearchWorkspace`
 ====
 [source, JAVA, indent=0]
 ----
-include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmManualIndexingIT.java[tags=writer-retrieval]
+include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmManualIndexingIT.java[tags=workspace-retrieval]
 ----
 <1> Get a `SearchSession`.
-<2> Get a writer targeting all indexes.
-<3> Get a writer targeting the index mapped to the `Book` entity type.
-<4> Get a writer targeting the indexes mapped to the `Book` and `Author` entity types.
+<2> Get a workspace targeting all indexes.
+<3> Get a workspace targeting the index mapped to the `Book` entity type.
+<4> Get a workspace targeting the indexes mapped to the `Book` and `Author` entity types.
 ====

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmManualIndexingIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmManualIndexingIT.java
@@ -16,7 +16,7 @@ import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.automaticindexing.AutomaticIndexingStrategyName;
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.mapper.orm.session.SearchSessionWritePlan;
+import org.hibernate.search.mapper.orm.work.SearchIndexingPlan;
 import org.hibernate.search.mapper.orm.work.SearchWorkspace;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendConfiguration;
 import org.hibernate.search.util.impl.integrationtest.orm.OrmSetupHelper;
@@ -86,7 +86,7 @@ public class HibernateOrmManualIndexingIT {
 
 			// tag::persist-automatic-indexing-periodic-flush-execute-clear[]
 			SearchSession searchSession = Search.session( entityManager ); // <1>
-			SearchSessionWritePlan searchWritePlan = searchSession.writePlan(); // <2>
+			SearchIndexingPlan indexingPlan = searchSession.indexingPlan(); // <2>
 
 			entityManager.getTransaction().begin();
 			try {
@@ -97,7 +97,7 @@ public class HibernateOrmManualIndexingIT {
 					if ( ( i + 1 ) % BATCH_SIZE == 0 ) {
 						entityManager.flush();
 						entityManager.clear();
-						searchWritePlan.execute(); // <4>
+						indexingPlan.execute(); // <4>
 					}
 				}
 				entityManager.getTransaction().commit(); // <5>
@@ -151,15 +151,15 @@ public class HibernateOrmManualIndexingIT {
 		OrmUtils.withinEntityManager( entityManagerFactory, entityManager -> {
 			assertBookCount( entityManager, 0 );
 
-			// tag::write-plan-addOrUpdate[]
+			// tag::indexing-plan-addOrUpdate[]
 			SearchSession searchSession = Search.session( entityManager ); // <1>
-			SearchSessionWritePlan searchWritePlan = searchSession.writePlan(); // <2>
+			SearchIndexingPlan indexingPlan = searchSession.indexingPlan(); // <2>
 
 			entityManager.getTransaction().begin();
 			try {
 				Book book = entityManager.getReference( Book.class, 5 ); // <3>
 
-				searchWritePlan.addOrUpdate( book ); // <4>
+				indexingPlan.addOrUpdate( book ); // <4>
 
 				entityManager.getTransaction().commit(); // <5>
 			}
@@ -167,7 +167,7 @@ public class HibernateOrmManualIndexingIT {
 				entityManager.getTransaction().rollback();
 				throw e;
 			}
-			// end::write-plan-addOrUpdate[]
+			// end::indexing-plan-addOrUpdate[]
 
 			assertBookCount( entityManager, 1 );
 		} );
@@ -182,15 +182,15 @@ public class HibernateOrmManualIndexingIT {
 		OrmUtils.withinEntityManager( entityManagerFactory, entityManager -> {
 			assertBookCount( entityManager, numberOfBooks );
 
-			// tag::write-plan-delete[]
+			// tag::indexing-plan-delete[]
 			SearchSession searchSession = Search.session( entityManager ); // <1>
-			SearchSessionWritePlan searchWritePlan = searchSession.writePlan(); // <2>
+			SearchIndexingPlan indexingPlan = searchSession.indexingPlan(); // <2>
 
 			entityManager.getTransaction().begin();
 			try {
 				Book book = entityManager.getReference( Book.class, 5 ); // <3>
 
-				searchWritePlan.delete( book ); // <4>
+				indexingPlan.delete( book ); // <4>
 
 				entityManager.getTransaction().commit(); // <5>
 			}
@@ -198,7 +198,7 @@ public class HibernateOrmManualIndexingIT {
 				entityManager.getTransaction().rollback();
 				throw e;
 			}
-			// end::write-plan-delete[]
+			// end::indexing-plan-delete[]
 
 			assertBookCount( entityManager, numberOfBooks - 1 );
 		} );

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmManualIndexingIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/indexing/HibernateOrmManualIndexingIT.java
@@ -17,7 +17,7 @@ import org.hibernate.search.mapper.orm.automaticindexing.AutomaticIndexingStrate
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.orm.session.SearchSessionWritePlan;
-import org.hibernate.search.mapper.orm.writing.SearchWriter;
+import org.hibernate.search.mapper.orm.work.SearchWorkspace;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendConfiguration;
 import org.hibernate.search.util.impl.integrationtest.orm.OrmSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.orm.OrmUtils;
@@ -205,29 +205,29 @@ public class HibernateOrmManualIndexingIT {
 	}
 
 	@Test
-	public void writer() {
+	public void workspace() {
 		int numberOfBooks = 10;
 		EntityManagerFactory entityManagerFactory = setup( AutomaticIndexingStrategyName.SESSION );
 		initBooksAndAuthors( entityManagerFactory, numberOfBooks );
 
 		OrmUtils.withinEntityManager( entityManagerFactory, entityManager -> {
-			// tag::writer-retrieval[]
+			// tag::workspace-retrieval[]
 			SearchSession searchSession = Search.session( entityManager ); // <1>
-			SearchWriter writer1 = searchSession.writer(); // <2>
-			SearchWriter writer2 = searchSession.writer( Book.class ); // <3>
-			SearchWriter writer3 = searchSession.writer( Book.class, Author.class ); // <4>
-			// end::writer-retrieval[]
+			SearchWorkspace workspace1 = searchSession.workspace(); // <2>
+			SearchWorkspace workspace2 = searchSession.workspace( Book.class ); // <3>
+			SearchWorkspace workspace3 = searchSession.workspace( Book.class, Author.class ); // <4>
+			// end::workspace-retrieval[]
 		} );
 
 		OrmUtils.withinEntityManager( entityManagerFactory, entityManager -> {
 			assertBookCount( entityManager, numberOfBooks );
 			assertAuthorCount( entityManager, numberOfBooks );
 
-			// tag::writer-purge[]
+			// tag::workspace-purge[]
 			SearchSession searchSession = Search.session( entityManager ); // <1>
-			SearchWriter writer = searchSession.writer( Book.class, Author.class ); // <2>
-			writer.purge(); // <3>
-			// end::writer-purge[]
+			SearchWorkspace workspace = searchSession.workspace( Book.class, Author.class ); // <2>
+			workspace.purge(); // <3>
+			// end::workspace-purge[]
 
 			assertBookCount( entityManager, 0 );
 			assertAuthorCount( entityManager, 0 );
@@ -279,7 +279,7 @@ public class HibernateOrmManualIndexingIT {
 	private void assertBookCount(EntityManager entityManager, int expectedCount) {
 		SearchSession searchSession = Search.session( entityManager );
 		// Ensure every committed work is searchable: flush also executes a refresh on Elasticsearch
-		searchSession.writer().flush();
+		searchSession.workspace().flush();
 		assertThat(
 				searchSession.search( Book.class )
 						.predicate( f -> f.matchAll() )
@@ -291,7 +291,7 @@ public class HibernateOrmManualIndexingIT {
 	private void assertAuthorCount(EntityManager entityManager, int expectedCount) {
 		SearchSession searchSession = Search.session( entityManager );
 		// Ensure every committed work is searchable: flush also executes a refresh on Elasticsearch
-		searchSession.writer().flush();
+		searchSession.workspace().flush();
 		assertThat(
 				searchSession.search( Author.class )
 						.predicate( f -> f.matchAll() )

--- a/engine/src/main/java/org/hibernate/search/engine/backend/index/spi/IndexManagerImplementor.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/index/spi/IndexManagerImplementor.java
@@ -13,7 +13,7 @@ import org.hibernate.search.engine.backend.index.IndexManager;
 import org.hibernate.search.engine.backend.scope.spi.IndexScopeBuilder;
 import org.hibernate.search.engine.backend.spi.BackendStartContext;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.mapping.spi.BackendMappingContext;
 import org.hibernate.search.engine.backend.session.spi.DetachedBackendSessionContext;
@@ -48,7 +48,7 @@ public interface IndexManagerImplementor<D extends DocumentElement> extends Auto
 	IndexIndexer<D> createIndexer(BackendSessionContext sessionContext,
 			DocumentCommitStrategy commitStrategy);
 
-	IndexWorkExecutor createWorkExecutor(DetachedBackendSessionContext sessionContext);
+	IndexWorkspace createWorkspace(DetachedBackendSessionContext sessionContext);
 
 	IndexScopeBuilder createScopeBuilder(BackendMappingContext mappingContext);
 

--- a/engine/src/main/java/org/hibernate/search/engine/backend/index/spi/IndexManagerImplementor.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/index/spi/IndexManagerImplementor.java
@@ -14,7 +14,7 @@ import org.hibernate.search.engine.backend.scope.spi.IndexScopeBuilder;
 import org.hibernate.search.engine.backend.spi.BackendStartContext;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexDocumentWorkExecutor;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.mapping.spi.BackendMappingContext;
 import org.hibernate.search.engine.backend.session.spi.DetachedBackendSessionContext;
 import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
@@ -42,7 +42,7 @@ public interface IndexManagerImplementor<D extends DocumentElement> extends Auto
 	 */
 	IndexManager toAPI();
 
-	IndexWorkPlan<D> createWorkPlan(BackendSessionContext sessionContext,
+	IndexIndexingPlan<D> createIndexingPlan(BackendSessionContext sessionContext,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy);
 
 	IndexDocumentWorkExecutor<D> createDocumentWorkExecutor(BackendSessionContext sessionContext,

--- a/engine/src/main/java/org/hibernate/search/engine/backend/index/spi/IndexManagerImplementor.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/index/spi/IndexManagerImplementor.java
@@ -12,7 +12,7 @@ import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrateg
 import org.hibernate.search.engine.backend.index.IndexManager;
 import org.hibernate.search.engine.backend.scope.spi.IndexScopeBuilder;
 import org.hibernate.search.engine.backend.spi.BackendStartContext;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexDocumentWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.mapping.spi.BackendMappingContext;
@@ -45,7 +45,7 @@ public interface IndexManagerImplementor<D extends DocumentElement> extends Auto
 	IndexIndexingPlan<D> createIndexingPlan(BackendSessionContext sessionContext,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy);
 
-	IndexDocumentWorkExecutor<D> createDocumentWorkExecutor(BackendSessionContext sessionContext,
+	IndexIndexer<D> createIndexer(BackendSessionContext sessionContext,
 			DocumentCommitStrategy commitStrategy);
 
 	IndexWorkExecutor createWorkExecutor(DetachedBackendSessionContext sessionContext);

--- a/engine/src/main/java/org/hibernate/search/engine/backend/session/spi/DetachedBackendSessionContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/session/spi/DetachedBackendSessionContext.java
@@ -22,7 +22,7 @@ import org.hibernate.search.engine.backend.mapping.spi.BackendMappingContext;
  * everywhere {@link BackendSessionContext} can.
  * In particular, it cannot be used when creating document-related
  * {@link org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor#createIndexingPlan(BackendSessionContext, DocumentCommitStrategy, DocumentRefreshStrategy) indexing plans}
- * or {@link org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor#createDocumentWorkExecutor(BackendSessionContext, DocumentCommitStrategy) work executors}
+ * or {@link org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor#createIndexer(BackendSessionContext, DocumentCommitStrategy) indexers}
  * because these may need access to the session.
  */
 public final class DetachedBackendSessionContext {

--- a/engine/src/main/java/org/hibernate/search/engine/backend/session/spi/DetachedBackendSessionContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/session/spi/DetachedBackendSessionContext.java
@@ -21,7 +21,7 @@ import org.hibernate.search.engine.backend.mapping.spi.BackendMappingContext;
  * The main downside is that this context cannot be used
  * everywhere {@link BackendSessionContext} can.
  * In particular, it cannot be used when creating document-related
- * {@link org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor#createWorkPlan(BackendSessionContext, DocumentCommitStrategy, DocumentRefreshStrategy) work plans}
+ * {@link org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor#createIndexingPlan(BackendSessionContext, DocumentCommitStrategy, DocumentRefreshStrategy) indexing plans}
  * or {@link org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor#createDocumentWorkExecutor(BackendSessionContext, DocumentCommitStrategy) work executors}
  * because these may need access to the session.
  */

--- a/engine/src/main/java/org/hibernate/search/engine/backend/work/execution/spi/IndexIndexer.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/work/execution/spi/IndexIndexer.java
@@ -8,7 +8,12 @@ package org.hibernate.search.engine.backend.work.execution.spi;
 
 import java.util.concurrent.CompletableFuture;
 
-public interface IndexDocumentWorkExecutor<D> {
+/**
+ * An indexer scoped to a single index.
+ *
+ * @param <D> The expected document type.
+ */
+public interface IndexIndexer<D> {
 
 	CompletableFuture<?> add(DocumentReferenceProvider documentReferenceProvider, DocumentContributor<D> documentContributor);
 

--- a/engine/src/main/java/org/hibernate/search/engine/backend/work/execution/spi/IndexIndexingPlan.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/work/execution/spi/IndexIndexingPlan.java
@@ -9,18 +9,17 @@ package org.hibernate.search.engine.backend.work.execution.spi;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * A set of works to be executed on an index.
+ * A set of works to be executed on a single index.
  * <p>
  * Works are accumulated when methods such as {@link #add(DocumentReferenceProvider, DocumentContributor)}
  * or {@link #update(DocumentReferenceProvider, DocumentContributor)} are called,
  * and executed only when {@link #execute()} is called.
  * <p>
- * Relative ordering of works within a work plan will be preserved.
+ * Relative ordering of works within a plan will be preserved.
  * <p>
  * Implementations may not be thread-safe.
- *
  */
-public interface IndexWorkPlan<D> {
+public interface IndexIndexingPlan<D> {
 
 	/**
 	 * Add a document to the index, assuming that the document is absent from the index.

--- a/engine/src/main/java/org/hibernate/search/engine/backend/work/execution/spi/IndexWorkPlan.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/work/execution/spi/IndexWorkPlan.java
@@ -46,12 +46,12 @@ public interface IndexWorkPlan<D> {
 	void delete(DocumentReferenceProvider documentReferenceProvider);
 
 	/**
-	 * Prepare the work plan execution, i.e. execute as much as possible without writing to the index.
+	 * Process works before their execution, i.e. do as much as possible without writing to the index.
 	 * <p>
 	 * Calling this method is optional: the {@link #execute()} method
-	 * will perform the preparation if necessary.
+	 * will perform the processing if necessary.
 	 */
-	void prepare();
+	void process();
 
 	/**
 	 * Start executing all the works in this plan, and clear the plan so that it can be re-used.

--- a/engine/src/main/java/org/hibernate/search/engine/backend/work/execution/spi/IndexWorkspace.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/work/execution/spi/IndexWorkspace.java
@@ -8,7 +8,10 @@ package org.hibernate.search.engine.backend.work.execution.spi;
 
 import java.util.concurrent.CompletableFuture;
 
-public interface IndexWorkExecutor {
+/**
+ * The entry point for explicit index operations on a single index.
+ */
+public interface IndexWorkspace {
 
 	CompletableFuture<?> optimize();
 

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/MappedIndexManagerImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/MappedIndexManagerImpl.java
@@ -12,7 +12,7 @@ import org.hibernate.search.engine.backend.index.IndexManager;
 import org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
 import org.hibernate.search.engine.mapper.scope.spi.MappedIndexScopeBuilder;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.mapping.spi.BackendMappingContext;
@@ -46,8 +46,8 @@ class MappedIndexManagerImpl<D extends DocumentElement> implements MappedIndexMa
 	}
 
 	@Override
-	public IndexWorkExecutor createWorkExecutor(DetachedBackendSessionContext sessionContext) {
-		return implementor.createWorkExecutor( sessionContext );
+	public IndexWorkspace createWorkspace(DetachedBackendSessionContext sessionContext) {
+		return implementor.createWorkspace( sessionContext );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/MappedIndexManagerImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/MappedIndexManagerImpl.java
@@ -10,7 +10,7 @@ import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.index.IndexManager;
 import org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexDocumentWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
 import org.hibernate.search.engine.mapper.scope.spi.MappedIndexScopeBuilder;
@@ -40,9 +40,9 @@ class MappedIndexManagerImpl<D extends DocumentElement> implements MappedIndexMa
 	}
 
 	@Override
-	public IndexDocumentWorkExecutor<D> createDocumentWorkExecutor(BackendSessionContext sessionContext,
+	public IndexIndexer<D> createIndexer(BackendSessionContext sessionContext,
 			DocumentCommitStrategy commitStrategy) {
-		return implementor.createDocumentWorkExecutor( sessionContext, commitStrategy );
+		return implementor.createIndexer( sessionContext, commitStrategy );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/MappedIndexManagerImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/MappedIndexManagerImpl.java
@@ -14,7 +14,7 @@ import org.hibernate.search.engine.backend.work.execution.spi.IndexDocumentWorkE
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
 import org.hibernate.search.engine.mapper.scope.spi.MappedIndexScopeBuilder;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.mapping.spi.BackendMappingContext;
 import org.hibernate.search.engine.backend.session.spi.DetachedBackendSessionContext;
 import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
@@ -34,9 +34,9 @@ class MappedIndexManagerImpl<D extends DocumentElement> implements MappedIndexMa
 	}
 
 	@Override
-	public IndexWorkPlan<D> createWorkPlan(BackendSessionContext sessionContext,
+	public IndexIndexingPlan<D> createIndexingPlan(BackendSessionContext sessionContext,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
-		return implementor.createWorkPlan( sessionContext, commitStrategy, refreshStrategy );
+		return implementor.createIndexingPlan( sessionContext, commitStrategy, refreshStrategy );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/spi/MappedIndexManager.java
+++ b/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/spi/MappedIndexManager.java
@@ -9,7 +9,7 @@ package org.hibernate.search.engine.mapper.mapping.spi;
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.index.IndexManager;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexDocumentWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
@@ -30,7 +30,7 @@ public interface MappedIndexManager<D extends DocumentElement> {
 	IndexIndexingPlan<D> createIndexingPlan(BackendSessionContext sessionContext,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy);
 
-	IndexDocumentWorkExecutor<D> createDocumentWorkExecutor(BackendSessionContext sessionContext,
+	IndexIndexer<D> createIndexer(BackendSessionContext sessionContext,
 			DocumentCommitStrategy commitStrategy);
 
 	IndexWorkExecutor createWorkExecutor(DetachedBackendSessionContext sessionContext);

--- a/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/spi/MappedIndexManager.java
+++ b/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/spi/MappedIndexManager.java
@@ -12,7 +12,7 @@ import org.hibernate.search.engine.backend.index.IndexManager;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexDocumentWorkExecutor;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.mapping.spi.BackendMappingContext;
 import org.hibernate.search.engine.mapper.scope.spi.MappedIndexScopeBuilder;
 import org.hibernate.search.engine.backend.session.spi.DetachedBackendSessionContext;
@@ -27,7 +27,7 @@ public interface MappedIndexManager<D extends DocumentElement> {
 
 	IndexManager toAPI();
 
-	IndexWorkPlan<D> createWorkPlan(BackendSessionContext sessionContext,
+	IndexIndexingPlan<D> createIndexingPlan(BackendSessionContext sessionContext,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy);
 
 	IndexDocumentWorkExecutor<D> createDocumentWorkExecutor(BackendSessionContext sessionContext,

--- a/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/spi/MappedIndexManager.java
+++ b/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/spi/MappedIndexManager.java
@@ -11,7 +11,7 @@ import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy
 import org.hibernate.search.engine.backend.index.IndexManager;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.mapping.spi.BackendMappingContext;
 import org.hibernate.search.engine.mapper.scope.spi.MappedIndexScopeBuilder;
@@ -33,7 +33,7 @@ public interface MappedIndexManager<D extends DocumentElement> {
 	IndexIndexer<D> createIndexer(BackendSessionContext sessionContext,
 			DocumentCommitStrategy commitStrategy);
 
-	IndexWorkExecutor createWorkExecutor(DetachedBackendSessionContext sessionContext);
+	IndexWorkspace createWorkspace(DetachedBackendSessionContext sessionContext);
 
 	<R, E> MappedIndexScopeBuilder<R, E> createScopeBuilder(BackendMappingContext mappingContext);
 

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
@@ -27,7 +27,7 @@ import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.index.IndexManager;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.common.spi.SearchIntegration;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.predicate.SearchPredicate;
@@ -579,8 +579,8 @@ public class ElasticsearchExtensionIT {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( SECOND_ID ), document -> {
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( SECOND_ID ), document -> {
 			document.addValue( indexMapping.integer, "2" );
 			document.addValue( indexMapping.unsupportedType, "42" );
 
@@ -590,7 +590,7 @@ public class ElasticsearchExtensionIT {
 			document.addValue( indexMapping.sort4, "z" );
 			document.addValue( indexMapping.sort5, "a" );
 		} );
-		workPlan.add( referenceProvider( FIRST_ID ), document -> {
+		plan.add( referenceProvider( FIRST_ID ), document -> {
 			document.addValue( indexMapping.string, "'text 1'" );
 
 			document.addValue( indexMapping.sort1, "a" );
@@ -599,7 +599,7 @@ public class ElasticsearchExtensionIT {
 			document.addValue( indexMapping.sort4, "z" );
 			document.addValue( indexMapping.sort5, "a" );
 		} );
-		workPlan.add( referenceProvider( THIRD_ID ), document -> {
+		plan.add( referenceProvider( THIRD_ID ), document -> {
 			document.addValue( indexMapping.geoPoint, "{'lat': 40.12, 'lon': -71.34}" );
 
 			document.addValue( indexMapping.sort1, "z" );
@@ -608,7 +608,7 @@ public class ElasticsearchExtensionIT {
 			document.addValue( indexMapping.sort4, "z" );
 			document.addValue( indexMapping.sort5, "a" );
 		} );
-		workPlan.add( referenceProvider( FOURTH_ID ), document -> {
+		plan.add( referenceProvider( FOURTH_ID ), document -> {
 			document.addValue( indexMapping.dateWithColons, "'2018:01:12'" );
 
 			document.addValue( indexMapping.sort1, "z" );
@@ -617,7 +617,7 @@ public class ElasticsearchExtensionIT {
 			document.addValue( indexMapping.sort4, "a" );
 			document.addValue( indexMapping.sort5, "a" );
 		} );
-		workPlan.add( referenceProvider( FIFTH_ID ), document -> {
+		plan.add( referenceProvider( FIFTH_ID ), document -> {
 			// This document should not match any query
 			document.addValue( indexMapping.string, "'text 2'" );
 			document.addValue( indexMapping.integer, "1" );
@@ -627,9 +627,9 @@ public class ElasticsearchExtensionIT {
 
 			document.addValue( indexMapping.sort5, "z" );
 		} );
-		workPlan.add( referenceProvider( EMPTY_ID ), document -> { } );
+		plan.add( referenceProvider( EMPTY_ID ), document -> { } );
 
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		StubMappingScope scope = indexManager.createScope();

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/search/ElasticsearchMatchSearchPredicateIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/search/ElasticsearchMatchSearchPredicateIT.java
@@ -11,7 +11,7 @@ import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
@@ -64,9 +64,9 @@ public class ElasticsearchMatchSearchPredicateIT {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( "1" ), document -> document.addValue( indexMapping.normalizedStringField, TEST_TERM ) );
-		workPlan.execute().join();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( "1" ), document -> document.addValue( indexMapping.normalizedStringField, TEST_TERM ) );
+		plan.execute().join();
 	}
 
 	private static class IndexMapping {

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/work/ElasticsearchIndexingIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/work/ElasticsearchIndexingIT.java
@@ -14,7 +14,7 @@ import org.hibernate.search.backend.elasticsearch.util.spi.URLEncodedString;
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchClientSpy;
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchRequestAssertionMode;
 import org.hibernate.search.util.impl.integrationtest.elasticsearch.dialect.ElasticsearchTestDialect;
@@ -67,9 +67,9 @@ public class ElasticsearchIndexingIT {
 	@Test
 	public void addUpdateDelete_routing() {
 		String routingKey = "someRoutingKey";
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
 
-		workPlan.add( referenceProvider( "1", routingKey ), document -> {
+		plan.add( referenceProvider( "1", routingKey ), document -> {
 			document.addValue( indexMapping.string, "text1" );
 		} );
 		clientSpy.expectNext(
@@ -82,10 +82,10 @@ public class ElasticsearchIndexingIT {
 						.build(),
 				ElasticsearchRequestAssertionMode.EXTENSIBLE
 		);
-		workPlan.execute().join();
+		plan.execute().join();
 		clientSpy.verifyExpectationsMet();
 
-		workPlan.update( referenceProvider( "1", routingKey ), document -> {
+		plan.update( referenceProvider( "1", routingKey ), document -> {
 			document.addValue( indexMapping.string, "text2" );
 		} );
 		clientSpy.expectNext(
@@ -98,10 +98,10 @@ public class ElasticsearchIndexingIT {
 						.build(),
 				ElasticsearchRequestAssertionMode.EXTENSIBLE
 		);
-		workPlan.execute().join();
+		plan.execute().join();
 		clientSpy.verifyExpectationsMet();
 
-		workPlan.delete( referenceProvider( "1", routingKey ) );
+		plan.delete( referenceProvider( "1", routingKey ) );
 		clientSpy.expectNext(
 				ElasticsearchRequest.delete()
 						.pathComponent( URLEncodedString.fromString( INDEX_NAME ) )
@@ -111,7 +111,7 @@ public class ElasticsearchIndexingIT {
 						.build(),
 				ElasticsearchRequestAssertionMode.EXTENSIBLE
 		);
-		workPlan.execute().join();
+		plan.execute().join();
 		clientSpy.verifyExpectationsMet();
 	}
 

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneExtensionIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneExtensionIT.java
@@ -46,7 +46,7 @@ import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement
 import org.hibernate.search.engine.backend.types.Projectable;
 import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.engine.backend.index.IndexManager;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.common.spi.SearchIntegration;
 import org.hibernate.search.engine.search.projection.SearchProjection;
 import org.hibernate.search.engine.search.loading.context.spi.LoadingContext;
@@ -631,11 +631,11 @@ public class LuceneExtensionIT {
 
 	@Test
 	public void nativeField_invalidFieldPath() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
 
 		SubTest.expectException(
 				"native field contributing field with invalid field path",
-				() -> workPlan.add( referenceProvider( FIRST_ID ), document -> {
+				() -> plan.add( referenceProvider( FIRST_ID ), document -> {
 					document.addValue( indexMapping.nativeField_invalidFieldPath, 45 );
 				} ) )
 				.assertThrown()
@@ -680,8 +680,8 @@ public class LuceneExtensionIT {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( FIRST_ID ), document -> {
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( FIRST_ID ), document -> {
 			document.addValue( indexMapping.string, "text 1" );
 
 			document.addValue( indexMapping.nativeField, 37 );
@@ -691,7 +691,7 @@ public class LuceneExtensionIT {
 			document.addValue( indexMapping.sort2, "z" );
 			document.addValue( indexMapping.sort3, "z" );
 		} );
-		workPlan.add( referenceProvider( SECOND_ID ), document -> {
+		plan.add( referenceProvider( SECOND_ID ), document -> {
 			document.addValue( indexMapping.integer, 2 );
 
 			document.addValue( indexMapping.nativeField, 78 );
@@ -701,7 +701,7 @@ public class LuceneExtensionIT {
 			document.addValue( indexMapping.sort2, "a" );
 			document.addValue( indexMapping.sort3, "z" );
 		} );
-		workPlan.add( referenceProvider( THIRD_ID ), document -> {
+		plan.add( referenceProvider( THIRD_ID ), document -> {
 			document.addValue( indexMapping.geoPoint, GeoPoint.of( 40.12, -71.34 ) );
 
 			document.addValue( indexMapping.nativeField, 13 );
@@ -711,7 +711,7 @@ public class LuceneExtensionIT {
 			document.addValue( indexMapping.sort2, "z" );
 			document.addValue( indexMapping.sort3, "a" );
 		} );
-		workPlan.add( referenceProvider( FOURTH_ID ), document -> {
+		plan.add( referenceProvider( FOURTH_ID ), document -> {
 			document.addValue( indexMapping.nativeField, 89 );
 			document.addValue( indexMapping.nativeField_unsupportedProjection, 89 );
 
@@ -719,7 +719,7 @@ public class LuceneExtensionIT {
 			document.addValue( indexMapping.sort2, "z" );
 			document.addValue( indexMapping.sort3, "z" );
 		} );
-		workPlan.add( referenceProvider( FIFTH_ID ), document -> {
+		plan.add( referenceProvider( FIFTH_ID ), document -> {
 			// This document should not match any query
 			document.addValue( indexMapping.string, "text 2" );
 			document.addValue( indexMapping.integer, 1 );
@@ -730,7 +730,7 @@ public class LuceneExtensionIT {
 			document.addValue( indexMapping.sort3, "zz" );
 		} );
 
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		StubMappingScope scope = indexManager.createScope();

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/directory/AbstractDirectoryIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/directory/AbstractDirectoryIT.java
@@ -15,7 +15,7 @@ import org.hibernate.search.backend.lucene.cfg.LuceneBackendSettings;
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.common.spi.SearchIntegration;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;
@@ -47,17 +47,17 @@ public abstract class AbstractDirectoryIT {
 	protected StubMappingIndexManager indexManager;
 
 	protected final void checkIndexingAndQuerying() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( DOCUMENT_1 ), document -> {
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			document.addValue( indexMapping.string, "text 1" );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_2 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_2 ), document -> {
 			document.addValue( indexMapping.string, "text 2" );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_3 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_3 ), document -> {
 			document.addValue( indexMapping.string, "text 3" );
 		} );
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		StubMappingScope scope = indexManager.createScope();

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/mapping/LuceneFieldAttributesIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/mapping/LuceneFieldAttributesIT.java
@@ -17,7 +17,7 @@ import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.types.dsl.StringIndexFieldTypeOptionsStep;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.types.Norms;
 import org.hibernate.search.engine.backend.types.Projectable;
 import org.hibernate.search.engine.backend.types.TermVector;
@@ -123,8 +123,8 @@ public class LuceneFieldAttributesIT {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( "ID:1" ), document -> {
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( "ID:1" ), document -> {
 			document.addValue( indexMapping.string, "keyword" );
 			document.addValue( indexMapping.text, TEXT );
 			document.addValue( indexMapping.norms, TEXT );
@@ -133,7 +133,7 @@ public class LuceneFieldAttributesIT {
 			document.addValue( indexMapping.moreOptions, "Search 6 groundwork - Add the missing common field type options compared to Search 5" );
 		} );
 
-		workPlan.execute().join();
+		plan.execute().join();
 	}
 
 	private static class IndexMapping {

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/mapping/LuceneFieldTypesIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/mapping/LuceneFieldTypesIT.java
@@ -16,7 +16,7 @@ import org.hibernate.search.backend.lucene.LuceneExtension;
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.types.Projectable;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
@@ -90,16 +90,16 @@ public class LuceneFieldTypesIT {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
 
-		workPlan.add( referenceProvider( "ID:1" ), document -> {
+		plan.add( referenceProvider( "ID:1" ), document -> {
 			document.addValue( indexMapping.string, "keyword" );
 			document.addValue( indexMapping.text, TEXT_1 );
 			document.addValue( indexMapping.integer, 739 );
 			document.addValue( indexMapping.longNumber, 739L );
 			document.addValue( indexMapping.bool, true );
 		} );
-		workPlan.add( referenceProvider( "ID:2" ), document -> {
+		plan.add( referenceProvider( "ID:2" ), document -> {
 			document.addValue( indexMapping.string, "anotherKeyword" );
 			document.addValue( indexMapping.text, TEXT_2 );
 			document.addValue( indexMapping.integer, 123 );
@@ -107,7 +107,7 @@ public class LuceneFieldTypesIT {
 			document.addValue( indexMapping.bool, false );
 		} );
 
-		workPlan.execute().join();
+		plan.execute().join();
 	}
 
 	private static class IndexMapping {

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneFloatingPointInfinitySearchIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneFloatingPointInfinitySearchIT.java
@@ -20,7 +20,7 @@ import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement
 import org.hibernate.search.engine.backend.types.Aggregable;
 import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeFactory;
 import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeOptionsStep;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.search.aggregation.AggregationKey;
 import org.hibernate.search.engine.search.query.dsl.SearchQueryOptionsStep;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.StandardFieldMapper;
@@ -185,20 +185,20 @@ public class LuceneFloatingPointInfinitySearchIT<F> {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( "negative-infinity" ), document -> {
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( "negative-infinity" ), document -> {
 			document.addValue( indexMapping.floatFieldModel.reference, Float.NEGATIVE_INFINITY );
 			document.addValue( indexMapping.doubleFieldModel.reference, Double.NEGATIVE_INFINITY );
 		} );
-		workPlan.add( referenceProvider( "zero" ), document -> {
+		plan.add( referenceProvider( "zero" ), document -> {
 			document.addValue( indexMapping.floatFieldModel.reference, 0f );
 			document.addValue( indexMapping.doubleFieldModel.reference, 0d );
 		} );
-		workPlan.add( referenceProvider( "positive-infinity" ), document -> {
+		plan.add( referenceProvider( "positive-infinity" ), document -> {
 			document.addValue( indexMapping.floatFieldModel.reference, Float.POSITIVE_INFINITY );
 			document.addValue( indexMapping.doubleFieldModel.reference, Double.POSITIVE_INFINITY );
 		} );
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		SearchResultAssert.assertThat(

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneMatchSearchPredicateIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneMatchSearchPredicateIT.java
@@ -12,7 +12,7 @@ import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
@@ -67,9 +67,9 @@ public class LuceneMatchSearchPredicateIT {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( "1" ), document -> document.addValue( indexMapping.normalizedStringField, TEST_TERM ) );
-		workPlan.execute().join();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( "1" ), document -> document.addValue( indexMapping.normalizedStringField, TEST_TERM ) );
+		plan.execute().join();
 	}
 
 	private static class IndexMapping {

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneNormalizeWildcardExpressionsIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneNormalizeWildcardExpressionsIT.java
@@ -14,7 +14,7 @@ import java.util.function.Function;
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
@@ -103,20 +103,20 @@ public class LuceneNormalizeWildcardExpressionsIT {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( DOCUMENT_1 ), document -> {
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			document.addValue( indexMapping.analyzed, TEXT_MATCHING_PATTERN_1 );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_2 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_2 ), document -> {
 			document.addValue( indexMapping.analyzed, TEXT_MATCHING_PATTERN_2 );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_3 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_3 ), document -> {
 			document.addValue( indexMapping.analyzed, TEXT_MATCHING_PATTERN_3 );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_4 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_4 ), document -> {
 			document.addValue( indexMapping.analyzed, TEXT_MATCHING_PATTERN_2_AND_3 );
 		} );
-		workPlan.execute().join();
+		plan.execute().join();
 	}
 
 	private static class IndexMapping {

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneSearchMultiIndexIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneSearchMultiIndexIT.java
@@ -14,7 +14,7 @@ import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.engine.backend.types.Projectable;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.integrationtest.backend.tck.search.SearchMultiIndexIT;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.engine.backend.common.DocumentReference;
@@ -109,18 +109,18 @@ public class LuceneSearchMultiIndexIT {
 	private void initData() {
 		// Backend 1 / Index 1
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager_1_1.createWorkPlan();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager_1_1.createIndexingPlan();
 
-		workPlan.add( referenceProvider( DOCUMENT_1_1_1 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_1_1_1 ), document -> {
 			document.addValue( indexMapping_1_1.string, STRING_1 );
 			document.addValue( indexMapping_1_1.additionalField, ADDITIONAL_FIELD_1_1_1 );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_1_1_2 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_1_1_2 ), document -> {
 			document.addValue( indexMapping_1_1.string, STRING_2 );
 			document.addValue( indexMapping_1_1.additionalField, ADDITIONAL_FIELD_1_1_2 );
 		} );
 
-		workPlan.execute().join();
+		plan.execute().join();
 
 		StubMappingScope scope = indexManager_1_1.createScope();
 		SearchQuery<DocumentReference> query = scope.query()
@@ -130,13 +130,13 @@ public class LuceneSearchMultiIndexIT {
 
 		// Backend 1 / Index 2
 
-		workPlan = indexManager_1_2.createWorkPlan();
+		plan = indexManager_1_2.createIndexingPlan();
 
-		workPlan.add( referenceProvider( DOCUMENT_1_2_1 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_1_2_1 ), document -> {
 			document.addValue( indexMapping_1_2.string, STRING_1 );
 		} );
 
-		workPlan.execute().join();
+		plan.execute().join();
 
 		scope = indexManager_1_2.createScope();
 		query = scope.query()

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneSearchSortIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneSearchSortIT.java
@@ -15,7 +15,7 @@ import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.types.Sortable;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.search.sort.dsl.SortFinalStep;
 import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
 import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
@@ -80,19 +80,19 @@ public class LuceneSearchSortIT {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( FIRST_ID ), document -> {
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( FIRST_ID ), document -> {
 			document.addValue( indexMapping.geoPoint, GeoPoint.of( 45.7705687,4.835233 ) );
 		} );
-		workPlan.add( referenceProvider( SECOND_ID ), document -> {
+		plan.add( referenceProvider( SECOND_ID ), document -> {
 			document.addValue( indexMapping.geoPoint, GeoPoint.of( 45.7541719, 4.8386221 ) );
 		} );
-		workPlan.add( referenceProvider( THIRD_ID ), document -> {
+		plan.add( referenceProvider( THIRD_ID ), document -> {
 			document.addValue( indexMapping.geoPoint, GeoPoint.of( 45.7530374, 4.8510299 ) );
 		} );
-		workPlan.add( referenceProvider( EMPTY_ID ), document -> { } );
+		plan.add( referenceProvider( EMPTY_ID ), document -> { } );
 
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		StubMappingScope scope = indexManager.createScope();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/ObjectFieldStorageIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/ObjectFieldStorageIT.java
@@ -18,7 +18,7 @@ import org.hibernate.search.engine.backend.document.IndexObjectFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectField;
 import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
 import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
@@ -72,48 +72,48 @@ public class ObjectFieldStorageIT {
 
 	@Test
 	public void index_error_invalidFieldForDocumentElement_root() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
 
 		thrown.expect( SearchException.class );
 		thrown.expectMessage( "Invalid field reference for this document element" );
 		thrown.expectMessage( "this document element has path 'null', but the referenced field has a parent with path 'flattenedObject'." );
 
-		workPlan.add( referenceProvider( "willNotWork" ), document -> {
+		plan.add( referenceProvider( "willNotWork" ), document -> {
 			DocumentElement flattenedObject = document.addObject( indexMapping.flattenedObject.self );
 			flattenedObject.addValue( indexMapping.string, "willNotWork" );
 		} );
 
-		workPlan.execute().join();
+		plan.execute().join();
 	}
 
 	@Test
 	public void index_error_invalidFieldForDocumentElement_flattened() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
 
 		thrown.expect( SearchException.class );
 		thrown.expectMessage( "Invalid field reference for this document element" );
 		thrown.expectMessage( "this document element has path 'flattenedObject', but the referenced field has a parent with path 'null'." );
 
-		workPlan.add( referenceProvider( "willNotWork" ), document -> {
+		plan.add( referenceProvider( "willNotWork" ), document -> {
 			document.addValue( indexMapping.flattenedObject.string, "willNotWork" );
 		} );
 
-		workPlan.execute().join();
+		plan.execute().join();
 	}
 
 	@Test
 	public void index_error_invalidFieldForDocumentElement_nested() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
 
 		thrown.expect( SearchException.class );
 		thrown.expectMessage( "Invalid field reference for this document element" );
 		thrown.expectMessage( "this document element has path 'nestedObject', but the referenced field has a parent with path 'null'." );
 
-		workPlan.add( referenceProvider( "willNotWork" ), document -> {
+		plan.add( referenceProvider( "willNotWork" ), document -> {
 			document.addValue( indexMapping.nestedObject.string, "willNotWork" );
 		} );
 
-		workPlan.execute().join();
+		plan.execute().join();
 	}
 
 	@Test
@@ -220,8 +220,8 @@ public class ObjectFieldStorageIT {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( EXPECTED_NESTED_MATCH_ID ), document -> {
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( EXPECTED_NESTED_MATCH_ID ), document -> {
 			ObjectMapping objectMapping;
 			DocumentElement object;
 
@@ -251,7 +251,7 @@ public class ObjectFieldStorageIT {
 			object.addValue( objectMapping.localDate, NON_MATCHING_LOCAL_DATE );
 		} );
 
-		workPlan.add( referenceProvider( EXPECTED_NON_NESTED_MATCH_ID ), document -> {
+		plan.add( referenceProvider( EXPECTED_NON_NESTED_MATCH_ID ), document -> {
 			/*
 			 * Below, we use the same content for both the flattened object and the nested object.
 			 * This is to demonstrate the practical difference of object storage:
@@ -283,7 +283,7 @@ public class ObjectFieldStorageIT {
 			}
 		} );
 
-		workPlan.add( referenceProvider( "neverMatching" ), document -> {
+		plan.add( referenceProvider( "neverMatching" ), document -> {
 			/*
 			 * This should not match, be it on the nested or the flattened object.
 			 * For first-level nesting tests, it's because of the integer field.
@@ -310,9 +310,9 @@ public class ObjectFieldStorageIT {
 			}
 		} );
 
-		workPlan.add( referenceProvider( "empty" ), document -> { } );
+		plan.add( referenceProvider( "empty" ), document -> { } );
 
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		StubMappingScope scope = indexManager.createScope();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/SmokeIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/SmokeIT.java
@@ -14,7 +14,7 @@ import org.hibernate.search.engine.backend.document.IndexObjectFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectField;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
 import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
@@ -255,8 +255,8 @@ public class SmokeIT {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( "1" ), document -> {
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( "1" ), document -> {
 			document.addValue( indexMapping.string, "text 1" );
 			document.addValue( indexMapping.string_analyzed, "text 1" );
 			document.addValue( indexMapping.integer, 1 );
@@ -278,7 +278,7 @@ public class SmokeIT {
 			nestedObject.addValue( indexMapping.nestedObject.integer, 102 );
 		} );
 
-		workPlan.add( referenceProvider( "2" ), document -> {
+		plan.add( referenceProvider( "2" ), document -> {
 			document.addValue( indexMapping.string, "text 2" );
 			document.addValue( indexMapping.string_analyzed, "text 2" );
 			document.addValue( indexMapping.integer, 2 );
@@ -300,21 +300,21 @@ public class SmokeIT {
 			nestedObject.addValue( indexMapping.nestedObject.integer, 202 );
 		} );
 
-		workPlan.add( referenceProvider( "3" ), document -> {
+		plan.add( referenceProvider( "3" ), document -> {
 			document.addValue( indexMapping.string, "text 3" );
 			document.addValue( indexMapping.string_analyzed, "text 3" );
 			document.addValue( indexMapping.integer, 3 );
 		} );
 
-		workPlan.add( referenceProvider( "neverMatching" ), document -> {
+		plan.add( referenceProvider( "neverMatching" ), document -> {
 			document.addValue( indexMapping.string, "never matching" );
 			document.addValue( indexMapping.string_analyzed, "never matching" );
 			document.addValue( indexMapping.integer, 9484 );
 		} );
 
-		workPlan.add( referenceProvider( "empty" ), document -> { } );
+		plan.add( referenceProvider( "empty" ), document -> { } );
 
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		StubMappingScope scope = indexManager.createScope();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/analysis/AnalysisCustomIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/analysis/AnalysisCustomIT.java
@@ -21,7 +21,7 @@ import org.hibernate.search.engine.backend.types.dsl.StringIndexFieldTypeOptions
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBackendHelper;
 import org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert;
 import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;
@@ -276,19 +276,19 @@ public class AnalysisCustomIT {
 	}
 
 	private void initData(Consumer<AnalysisITDocumentBuilder> valueContributor) {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
 		List<String> documentIds = new ArrayList<>();
 		valueContributor.accept(
 				(String documentId, String ... fieldValues) -> {
 					documentIds.add( documentId );
-					workPlan.add( referenceProvider( documentId ), document -> {
+					plan.add( referenceProvider( documentId ), document -> {
 						for ( String fieldValue : fieldValues ) {
 							indexMapping.field.write( document, fieldValue );
 						}
 					} );
 				}
 		);
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		StubMappingScope scope = indexManager.createScope();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/decimalscale/DecimalScaleIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/decimalscale/DecimalScaleIT.java
@@ -15,7 +15,7 @@ import java.math.BigInteger;
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.types.Projectable;
 import org.hibernate.search.engine.mapper.mapping.building.spi.IndexFieldTypeDefaultsProvider;
 import org.hibernate.search.engine.mapper.mapping.building.spi.IndexedEntityBindingContext;
@@ -103,9 +103,9 @@ public class DecimalScaleIT {
 						indexManager -> this.indexManager = indexManager )
 				.setup();
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, new BigDecimal( "739.11111" ) ) );
-		workPlan.execute().join();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, new BigDecimal( "739.11111" ) ) );
+		plan.execute().join();
 
 		// decimal scale is 3, affecting the search precision
 		// so the provided value 739.11111 will be treated as if it were 739.111
@@ -121,9 +121,9 @@ public class DecimalScaleIT {
 						indexManager -> this.indexManager = indexManager )
 				.setup();
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, new BigDecimal( "739.11111" ) ) );
-		workPlan.execute().join();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, new BigDecimal( "739.11111" ) ) );
+		plan.execute().join();
 
 		// decimal scale is 0, affecting the search precision
 		// so the provided value 739.11111 will be treated as if it were 739
@@ -139,9 +139,9 @@ public class DecimalScaleIT {
 						indexManager -> this.indexManager = indexManager )
 				.setup();
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, new BigInteger( "739" ) ) );
-		workPlan.execute().join();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, new BigInteger( "739" ) ) );
+		plan.execute().join();
 
 		// decimal scale is 0, affecting the search precision
 		// so the provided value 739 will be treated as if it were 739
@@ -157,9 +157,9 @@ public class DecimalScaleIT {
 						indexManager -> this.indexManager = indexManager )
 				.setup();
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, new BigDecimal( "11111.11111" ) ) );
-		workPlan.execute().join();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, new BigDecimal( "11111.11111" ) ) );
+		plan.execute().join();
 
 		// decimal scale is -3, affecting the search precision
 		// so the provided value 11111.11111 will be treated as if it were 11000
@@ -175,9 +175,9 @@ public class DecimalScaleIT {
 						indexManager -> this.indexManager = indexManager )
 				.setup();
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, new BigInteger( "11111" ) ) );
-		workPlan.execute().join();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, new BigInteger( "11111" ) ) );
+		plan.execute().join();
 
 		// decimal scale is -3, affecting the search precision
 		// so the provided value 11111 will be treated as if it were 11000
@@ -217,9 +217,9 @@ public class DecimalScaleIT {
 		Assertions.assertThat( originalValue )
 				.isBetween( indexedValueLowerBound, indexedValueUpperBound );
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, originalValue ) );
-		workPlan.execute().join();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, originalValue ) );
+		plan.execute().join();
 
 		matchAbove( indexedValueLowerBound );
 		doNotMatchAbove( indexedValueUpperBound );
@@ -257,9 +257,9 @@ public class DecimalScaleIT {
 		Assertions.assertThat( originalValue )
 				.isBetween( indexedValueLowerBound, indexedValueUpperBound );
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, originalValue ) );
-		workPlan.execute().join();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, originalValue ) );
+		plan.execute().join();
 
 		matchAbove( indexedValueLowerBound );
 		doNotMatchAbove( indexedValueUpperBound );
@@ -297,9 +297,9 @@ public class DecimalScaleIT {
 		Assertions.assertThat( originalValue )
 				.isBetween( indexedValueLowerBound, indexedValueUpperBound );
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, originalValue ) );
-		workPlan.execute().join();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, originalValue ) );
+		plan.execute().join();
 
 		matchAbove( indexedValueLowerBound );
 		doNotMatchAbove( indexedValueUpperBound );
@@ -313,12 +313,12 @@ public class DecimalScaleIT {
 						indexManager -> this.indexManager = indexManager )
 				.setup();
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, new BigDecimal( "739.114999" ) ) );
-		workPlan.add( referenceProvider( "2" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, new BigDecimal( "739.115" ) ) );
-		workPlan.add( referenceProvider( "3" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, new BigDecimal( "739.11" ) ) );
-		workPlan.add( referenceProvider( "4" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, new BigDecimal( "739.12" ) ) );
-		workPlan.execute().join();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, new BigDecimal( "739.114999" ) ) );
+		plan.add( referenceProvider( "2" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, new BigDecimal( "739.115" ) ) );
+		plan.add( referenceProvider( "3" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, new BigDecimal( "739.11" ) ) );
+		plan.add( referenceProvider( "4" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, new BigDecimal( "739.12" ) ) );
+		plan.execute().join();
 
 		// RoundingMode.HALF_UP expected on both values:
 		match( new BigDecimal( "739.11" ), "1", "3" );
@@ -337,12 +337,12 @@ public class DecimalScaleIT {
 						indexManager -> this.indexManager = indexManager )
 				.setup();
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, new BigInteger( "7394999" ) ) );
-		workPlan.add( referenceProvider( "2" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, new BigInteger( "7395000" ) ) );
-		workPlan.add( referenceProvider( "3" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, new BigInteger( "7390000" ) ) );
-		workPlan.add( referenceProvider( "4" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, new BigInteger( "7400000" ) ) );
-		workPlan.execute().join();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, new BigInteger( "7394999" ) ) );
+		plan.add( referenceProvider( "2" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, new BigInteger( "7395000" ) ) );
+		plan.add( referenceProvider( "3" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, new BigInteger( "7390000" ) ) );
+		plan.add( referenceProvider( "4" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, new BigInteger( "7400000" ) ) );
+		plan.execute().join();
 
 		// RoundingMode.HALF_UP expected on both values:
 		match( new BigInteger( "7390000" ), "1", "3" );
@@ -365,9 +365,9 @@ public class DecimalScaleIT {
 		// If the exponent were 54, the test would fail for Elasticsearch, whereas it would work for Lucene backend.
 		BigDecimal largeDecimal = new BigDecimal( "2" ).pow( 53 );
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, largeDecimal ) );
-		workPlan.execute().join();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, largeDecimal ) );
+		plan.execute().join();
 
 		// the precision is supposed to be preserved
 		matchAbove( largeDecimal.subtract( BigDecimal.ONE ) );
@@ -386,9 +386,9 @@ public class DecimalScaleIT {
 		// If the exponent were 54, the test would fail for Elasticsearch, whereas it would work for Lucene backend.
 		BigInteger largeInteger = new BigInteger( "2" ).pow( 53 );
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, largeInteger ) );
-		workPlan.execute().join();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, largeInteger ) );
+		plan.execute().join();
 
 		// the precision is supposed to be preserved
 		matchAbove( largeInteger.subtract( BigInteger.ONE ) );
@@ -407,9 +407,9 @@ public class DecimalScaleIT {
 		BigDecimal tooLargeDecimal = BigDecimal.valueOf( Long.MAX_VALUE ).multiply( BigDecimal.TEN );
 
 		SubTest.expectException( () -> {
-			IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-			workPlan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, tooLargeDecimal ) );
-			workPlan.execute().join();
+			IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+			plan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, tooLargeDecimal ) );
+			plan.execute().join();
 		} )
 				.assertThrown()
 				.isInstanceOf( SearchException.class )
@@ -428,9 +428,9 @@ public class DecimalScaleIT {
 		// Provide a value that cannot be represented as a long
 		BigDecimal tooLargeDecimal = veryLargeDecimal.multiply( BigDecimal.TEN );
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, veryLargeDecimal ) );
-		workPlan.execute().join();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, veryLargeDecimal ) );
+		plan.execute().join();
 
 		SubTest.expectException( () -> {
 			indexManager.createScope()
@@ -454,9 +454,9 @@ public class DecimalScaleIT {
 		BigDecimal tooLargeDecimal = BigDecimal.valueOf( Long.MIN_VALUE ).multiply( BigDecimal.TEN );
 
 		SubTest.expectException( () -> {
-			IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-			workPlan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, tooLargeDecimal ) );
-			workPlan.execute().join();
+			IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+			plan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, tooLargeDecimal ) );
+			plan.execute().join();
 		} )
 				.assertThrown()
 				.isInstanceOf( SearchException.class )
@@ -475,9 +475,9 @@ public class DecimalScaleIT {
 		BigInteger tooLargeInteger = BigInteger.valueOf( Long.MAX_VALUE ).multiply( BigInteger.TEN );
 
 		SubTest.expectException( () -> {
-			IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-			workPlan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, tooLargeInteger ) );
-			workPlan.execute().join();
+			IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+			plan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, tooLargeInteger ) );
+			plan.execute().join();
 		} )
 				.assertThrown()
 				.isInstanceOf( SearchException.class )
@@ -496,9 +496,9 @@ public class DecimalScaleIT {
 		BigInteger tooLargeInteger = BigInteger.valueOf( Long.MIN_VALUE ).multiply( BigInteger.TEN );
 
 		SubTest.expectException( () -> {
-			IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-			workPlan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, tooLargeInteger ) );
-			workPlan.execute().join();
+			IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+			plan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, tooLargeInteger ) );
+			plan.execute().join();
 		} )
 				.assertThrown()
 				.isInstanceOf( SearchException.class )
@@ -517,9 +517,9 @@ public class DecimalScaleIT {
 		// Provide a value that cannot be represented as a long
 		BigInteger tooLargeInteger = veryLargeNegativeInteger.multiply( BigInteger.TEN );
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, veryLargeNegativeInteger ) );
-		workPlan.execute().join();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, veryLargeNegativeInteger ) );
+		plan.execute().join();
 
 		SubTest.expectException( () -> {
 			indexManager.createScope()
@@ -543,9 +543,9 @@ public class DecimalScaleIT {
 		BigDecimal tooLargeDecimal = BigDecimal.valueOf( Long.MAX_VALUE ).divide( BigDecimal.TEN );
 
 		SubTest.expectException( () -> {
-			IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-			workPlan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, tooLargeDecimal ) );
-			workPlan.execute().join();
+			IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+			plan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, tooLargeDecimal ) );
+			plan.execute().join();
 		} )
 				.assertThrown()
 				.isInstanceOf( SearchException.class )
@@ -564,9 +564,9 @@ public class DecimalScaleIT {
 		BigDecimal tooLargeDecimal = BigDecimal.valueOf( Long.MIN_VALUE ).divide( BigDecimal.TEN );
 
 		SubTest.expectException( () -> {
-			IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-			workPlan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, tooLargeDecimal ) );
-			workPlan.execute().join();
+			IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+			plan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, tooLargeDecimal ) );
+			plan.execute().join();
 		} )
 				.assertThrown()
 				.isInstanceOf( SearchException.class )
@@ -585,9 +585,9 @@ public class DecimalScaleIT {
 		BigDecimal tooLargeDecimal = BigDecimal.valueOf( Long.MIN_VALUE ).divide( BigDecimal.TEN );
 		BigDecimal veryLargeDecimal = tooLargeDecimal.divide( BigDecimal.TEN );
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, veryLargeDecimal ) );
-		workPlan.execute().join();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, veryLargeDecimal ) );
+		plan.execute().join();
 
 		SubTest.expectException( () -> {
 			indexManager.createScope()
@@ -611,9 +611,9 @@ public class DecimalScaleIT {
 		BigInteger tooLargeInteger = BigInteger.valueOf( Long.MAX_VALUE ).multiply( new BigInteger( "1000" ) );
 
 		SubTest.expectException( () -> {
-			IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-			workPlan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, tooLargeInteger ) );
-			workPlan.execute().join();
+			IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+			plan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, tooLargeInteger ) );
+			plan.execute().join();
 		} )
 				.assertThrown()
 				.isInstanceOf( SearchException.class )
@@ -632,9 +632,9 @@ public class DecimalScaleIT {
 		// Provide a value that if it were multiplied by 100, could not be represented as a long, because the scale of -2
 		BigInteger tooLargeInteger = veryLargeInteger.multiply( new BigInteger( "1000" ) );
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, veryLargeInteger ) );
-		workPlan.execute().join();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, veryLargeInteger ) );
+		plan.execute().join();
 
 		SubTest.expectException( () -> {
 			indexManager.createScope()
@@ -658,9 +658,9 @@ public class DecimalScaleIT {
 		BigInteger tooLargeInteger = BigInteger.valueOf( Long.MIN_VALUE ).multiply( new BigInteger( "1000" ) );
 
 		SubTest.expectException( () -> {
-			IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-			workPlan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, tooLargeInteger ) );
-			workPlan.execute().join();
+			IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+			plan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, tooLargeInteger ) );
+			plan.execute().join();
 		} )
 				.assertThrown()
 				.isInstanceOf( SearchException.class )
@@ -675,9 +675,9 @@ public class DecimalScaleIT {
 						indexManager -> this.indexManager = indexManager )
 				.setup();
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( "1" ), doc -> doc.addValue( defaultDecimalScaleIndexMapping.scaled, new BigDecimal( "739.11111" ) ) );
-		workPlan.execute().join();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( "1" ), doc -> doc.addValue( defaultDecimalScaleIndexMapping.scaled, new BigDecimal( "739.11111" ) ) );
+		plan.execute().join();
 
 		// default decimal scale is 2, affecting the search precision
 		// so the provided value 739.11111 will be treated as if it were 739.11
@@ -693,9 +693,9 @@ public class DecimalScaleIT {
 						indexManager -> this.indexManager = indexManager )
 				.setup();
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( "1" ), doc -> doc.addValue( defaultIntegerScaleIndexMapping.scaled, new BigInteger( "7391111" ) ) );
-		workPlan.execute().join();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( "1" ), doc -> doc.addValue( defaultIntegerScaleIndexMapping.scaled, new BigInteger( "7391111" ) ) );
+		plan.execute().join();
 
 		// default decimal scale is -2, affecting the search precision
 		// so the provided value 7391111 will be treated as if it were 7391100
@@ -711,9 +711,9 @@ public class DecimalScaleIT {
 						indexManager -> this.indexManager = indexManager )
 				.setup();
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( "1" ), doc -> doc.addValue( bothDecimalScaleIndexMapping.scaled, new BigDecimal( "739.11111" ) ) );
-		workPlan.execute().join();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( "1" ), doc -> doc.addValue( bothDecimalScaleIndexMapping.scaled, new BigDecimal( "739.11111" ) ) );
+		plan.execute().join();
 
 		// default decimal scale is 2
 		// decimal scale has been set to 3, overriding the default and affecting the search precision
@@ -730,9 +730,9 @@ public class DecimalScaleIT {
 						indexManager -> this.indexManager = indexManager )
 				.setup();
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( "1" ), doc -> doc.addValue( bothIntegerScaleIndexMapping.scaled, new BigInteger( "7391111" ) ) );
-		workPlan.execute().join();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( "1" ), doc -> doc.addValue( bothIntegerScaleIndexMapping.scaled, new BigInteger( "7391111" ) ) );
+		plan.execute().join();
 
 		// default decimal scale is -2,
 		// decimal scale has been set to -3, overriding the default and affecting the search precision
@@ -749,9 +749,9 @@ public class DecimalScaleIT {
 						indexManager -> this.indexManager = indexManager )
 				.setup();
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, new BigDecimal( "739.11111" ) ) );
-		workPlan.execute().join();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, new BigDecimal( "739.11111" ) ) );
+		plan.execute().join();
 
 		// even though decimal scale is 3, projected values wont be affected to
 		projection( new BigDecimal( "739.11111" ) );
@@ -765,9 +765,9 @@ public class DecimalScaleIT {
 						indexManager -> this.indexManager = indexManager )
 				.setup();
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, new BigInteger( "73911111" ) ) );
-		workPlan.execute().join();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, new BigInteger( "73911111" ) ) );
+		plan.execute().join();
 
 		// even though decimal scale is -7, projected values wont be affected to
 		projection( new BigInteger( "73911111" ) );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentElementBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentElementBaseIT.java
@@ -20,7 +20,7 @@ import org.hibernate.search.engine.backend.document.IndexObjectFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectField;
 import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.mapper.mapping.building.spi.IndexedEmbeddedBindingContext;
 import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
 import org.hibernate.search.engine.mapper.mapping.building.spi.IndexBindingContext;
@@ -230,9 +230,9 @@ public class DocumentElementBaseIT {
 	}
 
 	private void executeAdd(String id, Consumer<DocumentElement> documentContributor) {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( id ), documentContributor::accept );
-		workPlan.execute().join();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( id ), documentContributor::accept );
+		plan.execute().join();
 	}
 
 	/**

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentElementMultiValuedIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentElementMultiValuedIT.java
@@ -16,7 +16,7 @@ import org.hibernate.search.engine.backend.document.IndexObjectFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectField;
 import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.mapper.mapping.building.spi.IndexBindingContext;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
@@ -291,9 +291,9 @@ public class DocumentElementMultiValuedIT {
 	}
 
 	private void executeAdd(String id, Consumer<DocumentElement> documentContributor) {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( id ), documentContributor::accept );
-		workPlan.execute().join();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( id ), documentContributor::accept );
+		plan.execute().join();
 	}
 
 	private abstract static class AbstractObjectMapping {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/indexnull/IndexNullAsValueIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/indexnull/IndexNullAsValueIT.java
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.engine.spatial.GeoPoint;
@@ -113,8 +113,8 @@ public class IndexNullAsValueIT {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add(
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add(
 				referenceProvider( DOCUMENT_WITH_INDEX_NULL_AS_VALUES ),
 				document -> {
 					indexMapping.matchFieldModels.forEach( f -> f.indexNullAsValue.write( document ) );
@@ -123,7 +123,7 @@ public class IndexNullAsValueIT {
 					}
 				}
 		);
-		workPlan.add(
+		plan.add(
 				referenceProvider( DOCUMENT_WITH_DIFFERENT_VALUES ),
 				document -> {
 					indexMapping.matchFieldModels.forEach( f -> f.differentValue.write( document ) );
@@ -132,7 +132,7 @@ public class IndexNullAsValueIT {
 					}
 				}
 		);
-		workPlan.add(
+		plan.add(
 				referenceProvider( DOCUMENT_WITH_NULL_VALUES ),
 				document -> {
 					indexMapping.matchFieldModels.forEach( f -> f.nullValue.write( document ) );
@@ -141,7 +141,7 @@ public class IndexNullAsValueIT {
 					}
 				}
 		);
-		workPlan.execute().join();
+		plan.execute().join();
 	}
 
 	private static class IndexMapping {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/multitenancy/MultiTenancyBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/multitenancy/MultiTenancyBaseIT.java
@@ -18,7 +18,7 @@ import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement
 import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
 import org.hibernate.search.engine.backend.types.Projectable;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectField;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBackendHelper;
 import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
 import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
@@ -175,7 +175,7 @@ public class MultiTenancyBaseIT {
 
 	@Test
 	public void delete_only_deletes_elements_of_the_tenant() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan( tenant2SessionContext );
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan( tenant2SessionContext );
 
 		StubMappingScope scope = indexManager.createScope();
 		SearchQuery<DocumentReference> query = scope.query( tenant2SessionContext )
@@ -198,9 +198,9 @@ public class MultiTenancyBaseIT {
 				b.list( STRING_VALUE_2, INTEGER_VALUE_4 );
 		} );
 
-		workPlan.delete( referenceProvider( DOCUMENT_ID_1 ) );
+		plan.delete( referenceProvider( DOCUMENT_ID_1 ) );
 
-		workPlan.execute().join();
+		plan.execute().join();
 
 		assertThat( query )
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_ID_2 );
@@ -226,7 +226,7 @@ public class MultiTenancyBaseIT {
 
 	@Test
 	public void update_only_updates_elements_of_the_tenant() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan( tenant2SessionContext );
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan( tenant2SessionContext );
 
 		StubMappingScope scope = indexManager.createScope();
 		SearchQuery<DocumentReference> checkQuery = scope.query( tenant2SessionContext )
@@ -235,7 +235,7 @@ public class MultiTenancyBaseIT {
 		assertThat( checkQuery )
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_ID_1, DOCUMENT_ID_2 );
 
-		workPlan.update( referenceProvider( DOCUMENT_ID_2 ), document -> {
+		plan.update( referenceProvider( DOCUMENT_ID_2 ), document -> {
 			document.addValue( indexMapping.string, UPDATED_STRING );
 			document.addValue( indexMapping.integer, INTEGER_VALUE_4 );
 
@@ -244,7 +244,7 @@ public class MultiTenancyBaseIT {
 			nestedObject.addValue( indexMapping.nestedObject.integer, INTEGER_VALUE_4 );
 		} );
 
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// The tenant 2 has been updated properly.
 
@@ -347,9 +347,9 @@ public class MultiTenancyBaseIT {
 		thrown.expectMessage( "Backend" );
 		thrown.expectMessage( "has multi-tenancy enabled, but no tenant identifier is provided." );
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan( new StubBackendSessionContext() );
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan( new StubBackendSessionContext() );
 
-		workPlan.add( referenceProvider( DOCUMENT_ID_3 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_ID_3 ), document -> {
 			document.addValue( indexMapping.string, STRING_VALUE_3 );
 			document.addValue( indexMapping.integer, INTEGER_VALUE_5 );
 
@@ -358,7 +358,7 @@ public class MultiTenancyBaseIT {
 			nestedObject.addValue( indexMapping.nestedObject.integer, INTEGER_VALUE_5 );
 		} );
 
-		workPlan.execute().join();
+		plan.execute().join();
 	}
 
 	@Test
@@ -367,9 +367,9 @@ public class MultiTenancyBaseIT {
 		thrown.expectMessage( "Backend" );
 		thrown.expectMessage( "has multi-tenancy enabled, but no tenant identifier is provided." );
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan( new StubBackendSessionContext() );
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan( new StubBackendSessionContext() );
 
-		workPlan.update( referenceProvider( DOCUMENT_ID_2 ), document -> {
+		plan.update( referenceProvider( DOCUMENT_ID_2 ), document -> {
 			document.addValue( indexMapping.string, UPDATED_STRING );
 			document.addValue( indexMapping.integer, INTEGER_VALUE_4 );
 
@@ -378,7 +378,7 @@ public class MultiTenancyBaseIT {
 			nestedObject.addValue( indexMapping.nestedObject.integer, INTEGER_VALUE_4 );
 		} );
 
-		workPlan.execute().join();
+		plan.execute().join();
 	}
 
 	@Test
@@ -387,14 +387,14 @@ public class MultiTenancyBaseIT {
 		thrown.expectMessage( "Backend" );
 		thrown.expectMessage( "has multi-tenancy enabled, but no tenant identifier is provided." );
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan( new StubBackendSessionContext() );
-		workPlan.delete( referenceProvider( DOCUMENT_ID_1 ) );
-		workPlan.execute().join();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan( new StubBackendSessionContext() );
+		plan.delete( referenceProvider( DOCUMENT_ID_1 ) );
+		plan.execute().join();
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan( tenant1SessionContext );
-		workPlan.add( referenceProvider( DOCUMENT_ID_1 ), document -> {
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan( tenant1SessionContext );
+		plan.add( referenceProvider( DOCUMENT_ID_1 ), document -> {
 			document.addValue( indexMapping.string, STRING_VALUE_1 );
 			document.addValue( indexMapping.integer, INTEGER_VALUE_1 );
 
@@ -403,7 +403,7 @@ public class MultiTenancyBaseIT {
 			nestedObject.addValue( indexMapping.nestedObject.integer, INTEGER_VALUE_1 );
 		} );
 
-		workPlan.add( referenceProvider( DOCUMENT_ID_2 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_ID_2 ), document -> {
 			document.addValue( indexMapping.string, STRING_VALUE_2 );
 			document.addValue( indexMapping.integer, INTEGER_VALUE_2 );
 
@@ -412,10 +412,10 @@ public class MultiTenancyBaseIT {
 			nestedObject.addValue( indexMapping.nestedObject.integer, INTEGER_VALUE_2 );
 		} );
 
-		workPlan.execute().join();
+		plan.execute().join();
 
-		workPlan = indexManager.createWorkPlan( tenant2SessionContext );
-		workPlan.add( referenceProvider( DOCUMENT_ID_1 ), document -> {
+		plan = indexManager.createIndexingPlan( tenant2SessionContext );
+		plan.add( referenceProvider( DOCUMENT_ID_1 ), document -> {
 			document.addValue( indexMapping.string, STRING_VALUE_1 );
 			document.addValue( indexMapping.integer, INTEGER_VALUE_3 );
 
@@ -424,7 +424,7 @@ public class MultiTenancyBaseIT {
 			nestedObject.addValue( indexMapping.nestedObject.integer, INTEGER_VALUE_3 );
 		} );
 
-		workPlan.add( referenceProvider( DOCUMENT_ID_2 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_ID_2 ), document -> {
 			document.addValue( indexMapping.string, STRING_VALUE_2 );
 			document.addValue( indexMapping.integer, INTEGER_VALUE_4 );
 
@@ -433,7 +433,7 @@ public class MultiTenancyBaseIT {
 			nestedObject.addValue( indexMapping.nestedObject.integer, INTEGER_VALUE_4 );
 		} );
 
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		StubMappingScope scope = indexManager.createScope();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/multitenancy/MultiTenancyMismatchIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/multitenancy/MultiTenancyMismatchIT.java
@@ -12,7 +12,7 @@ import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.types.Projectable;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.stub.StubBackendSessionContext;
@@ -94,9 +94,9 @@ public class MultiTenancyMismatchIT {
 		thrown.expectMessage( "Tenant identifier" );
 		thrown.expectMessage( "is provided, but multi-tenancy is disabled for this backend" );
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan( tenant1SessionContext );
-		workPlan.update( referenceProvider( "1" ), document -> { } );
-		workPlan.execute().join();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan( tenant1SessionContext );
+		plan.update( referenceProvider( "1" ), document -> { } );
+		plan.execute().join();
 	}
 
 	@Test
@@ -113,9 +113,9 @@ public class MultiTenancyMismatchIT {
 		thrown.expectMessage( "Tenant identifier" );
 		thrown.expectMessage( "is provided, but multi-tenancy is disabled for this backend" );
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan( tenant1SessionContext );
-		workPlan.update( referenceProvider( "1" ), document -> { } );
-		workPlan.execute().join();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan( tenant1SessionContext );
+		plan.update( referenceProvider( "1" ), document -> { } );
+		plan.execute().join();
 	}
 
 	@Test
@@ -132,9 +132,9 @@ public class MultiTenancyMismatchIT {
 		thrown.expectMessage( "Tenant identifier" );
 		thrown.expectMessage( "is provided, but multi-tenancy is disabled for this backend" );
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan( tenant1SessionContext );
-		workPlan.delete( referenceProvider( "1" ) );
-		workPlan.execute().join();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan( tenant1SessionContext );
+		plan.delete( referenceProvider( "1" ) );
+		plan.execute().join();
 	}
 
 	private static class IndexMapping {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/SearchMultiIndexIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/SearchMultiIndexIT.java
@@ -14,7 +14,7 @@ import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.engine.backend.types.Projectable;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.engine.reporting.spi.EventContexts;
 import org.hibernate.search.engine.backend.common.DocumentReference;
@@ -297,22 +297,22 @@ public class SearchMultiIndexIT {
 	private void initData() {
 		// Backend 1 / Index 1
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager_1_1.createWorkPlan();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager_1_1.createIndexingPlan();
 
-		workPlan.add( referenceProvider( DOCUMENT_1_1_1 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_1_1_1 ), document -> {
 			document.addValue( indexMapping_1_1.string, STRING_1 );
 			document.addValue( indexMapping_1_1.additionalField, ADDITIONAL_FIELD_1_1_1 );
 			document.addValue( indexMapping_1_1.differentTypesField, DIFFERENT_TYPES_FIELD_1_1_1 );
 			document.addValue( indexMapping_1_1.sortField, SORT_FIELD_1_1_1 );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_1_1_2 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_1_1_2 ), document -> {
 			document.addValue( indexMapping_1_1.string, STRING_2 );
 			document.addValue( indexMapping_1_1.additionalField, ADDITIONAL_FIELD_1_1_2 );
 			document.addValue( indexMapping_1_1.differentTypesField, DIFFERENT_TYPES_FIELD_1_1_2 );
 			document.addValue( indexMapping_1_1.sortField, SORT_FIELD_1_1_2 );
 		} );
 
-		workPlan.execute().join();
+		plan.execute().join();
 
 		StubMappingScope scope = indexManager_1_1.createScope();
 		SearchQuery<DocumentReference> query = scope.query()
@@ -322,15 +322,15 @@ public class SearchMultiIndexIT {
 
 		// Backend 1 / Index 2
 
-		workPlan = indexManager_1_2.createWorkPlan();
+		plan = indexManager_1_2.createIndexingPlan();
 
-		workPlan.add( referenceProvider( DOCUMENT_1_2_1 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_1_2_1 ), document -> {
 			document.addValue( indexMapping_1_2.string, STRING_1 );
 			document.addValue( indexMapping_1_2.differentTypesField, DIFFERENT_TYPES_FIELD_1_2_1 );
 			document.addValue( indexMapping_1_2.sortField, SORT_FIELD_1_2_1 );
 		} );
 
-		workPlan.execute().join();
+		plan.execute().join();
 
 		scope = indexManager_1_2.createScope();
 		query = scope.query()
@@ -340,16 +340,16 @@ public class SearchMultiIndexIT {
 
 		// Backend 2 / Index 1
 
-		workPlan = indexManager_2_1.createWorkPlan();
+		plan = indexManager_2_1.createIndexingPlan();
 
-		workPlan.add( referenceProvider( DOCUMENT_2_1_1 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_2_1_1 ), document -> {
 			document.addValue( indexMapping_2_1.string, STRING_1 );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_2_1_2 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_2_1_2 ), document -> {
 			document.addValue( indexMapping_2_1.string, STRING_2 );
 		} );
 
-		workPlan.execute().join();
+		plan.execute().join();
 
 		scope = indexManager_2_1.createScope();
 		query = scope.query()

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/AggregationBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/AggregationBaseIT.java
@@ -16,7 +16,7 @@ import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.types.Aggregable;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.aggregation.AggregationKey;
 import org.hibernate.search.engine.search.aggregation.dsl.AggregationFinalStep;
@@ -96,19 +96,19 @@ public class AggregationBaseIT {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( DOCUMENT_1 ), document -> {
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			document.addValue( indexMapping.string, STRING_1 );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_2 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_2 ), document -> {
 			document.addValue( indexMapping.string, STRING_2 );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_3 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_3 ), document -> {
 			document.addValue( indexMapping.string, STRING_1 );
 		} );
-		workPlan.add( referenceProvider( EMPTY ), document -> { } );
+		plan.add( referenceProvider( EMPTY ), document -> { } );
 
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		StubMappingScope scope = indexManager.createScope();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/RangeAggregationSpecificsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/RangeAggregationSpecificsIT.java
@@ -25,7 +25,7 @@ import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement
 import org.hibernate.search.engine.backend.types.Aggregable;
 import org.hibernate.search.engine.backend.types.Searchable;
 import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeOptionsStep;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.aggregation.AggregationKey;
 import org.hibernate.search.engine.search.query.dsl.SearchQueryOptionsStep;
@@ -503,16 +503,16 @@ public class RangeAggregationSpecificsIT<F> {
 	private void initData() {
 		List<F> documentFieldValues = ascendingValues.subList( 0, 7 );
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
 		for ( int i = 0; i < documentFieldValues.size(); i++ ) {
 			F value = documentFieldValues.get( i );
-			workPlan.add( referenceProvider( "document_" + i ), document -> {
+			plan.add( referenceProvider( "document_" + i ), document -> {
 				document.addValue( indexMapping.fieldModel.reference, value );
 				document.addValue( indexMapping.fieldWithConverterModel.reference, value );
 			} );
 		}
-		workPlan.add( referenceProvider( "document_empty" ), document -> { } );
-		workPlan.execute().join();
+		plan.add( referenceProvider( "document_empty" ), document -> { } );
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		SearchResultAssert.assertThat(

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/SingleFieldAggregationBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/SingleFieldAggregationBaseIT.java
@@ -29,7 +29,7 @@ import org.hibernate.search.engine.backend.types.converter.FromDocumentFieldValu
 import org.hibernate.search.engine.backend.types.converter.runtime.FromDocumentFieldValueConvertContext;
 import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeFactory;
 import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeOptionsStep;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.search.aggregation.AggregationKey;
 import org.hibernate.search.engine.search.aggregation.SearchAggregation;
 import org.hibernate.search.engine.search.common.ValueConvert;
@@ -748,10 +748,10 @@ public class SingleFieldAggregationBaseIT<F> {
 		List<F> otherIndexDocumentFieldValues = expectations.getOtherIndexDocumentFieldValues();
 		List<List<F>> multiValuedIndexDocumentFieldValues = expectations.getMultiValuedIndexDocumentFieldValues();
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
 		for ( int i = 0; i < mainIndexDocumentFieldValues.size(); i++ ) {
 			F value = mainIndexDocumentFieldValues.get( i );
-			workPlan.add( referenceProvider( "document_" + i ), document -> {
+			plan.add( referenceProvider( "document_" + i ), document -> {
 				document.addValue( indexMapping.fieldModel.reference, value );
 				document.addValue( indexMapping.fieldWithConverterModel.reference, value );
 
@@ -764,46 +764,46 @@ public class SingleFieldAggregationBaseIT<F> {
 				nestedObject.addValue( indexMapping.nestedObject.fieldModel.reference, value );
 			} );
 		}
-		workPlan.add( referenceProvider( "document_empty" ), document -> { } );
-		workPlan.execute().join();
+		plan.add( referenceProvider( "document_empty" ), document -> { } );
+		plan.execute().join();
 
-		workPlan = compatibleIndexManager.createWorkPlan();
+		plan = compatibleIndexManager.createIndexingPlan();
 		for ( int i = 0; i < otherIndexDocumentFieldValues.size(); i++ ) {
 			F value = otherIndexDocumentFieldValues.get( i );
-			workPlan.add( referenceProvider( "compatibleindex_document_" + i ), document -> {
+			plan.add( referenceProvider( "compatibleindex_document_" + i ), document -> {
 				document.addValue( compatibleIndexMapping.fieldModel.reference, value );
 				document.addValue( compatibleIndexMapping.fieldWithConverterModel.reference, value );
 			} );
 		}
-		workPlan.execute().join();
+		plan.execute().join();
 
-		workPlan = rawFieldCompatibleIndexManager.createWorkPlan();
+		plan = rawFieldCompatibleIndexManager.createIndexingPlan();
 		for ( int i = 0; i < otherIndexDocumentFieldValues.size(); i++ ) {
 			F value = otherIndexDocumentFieldValues.get( i );
-			workPlan.add( referenceProvider( "rawcompatibleindex_document_" + i ), document -> {
+			plan.add( referenceProvider( "rawcompatibleindex_document_" + i ), document -> {
 				document.addValue( rawFieldCompatibleIndexMapping.fieldWithConverterModel.reference, value );
 			} );
 		}
-		workPlan.execute().join();
+		plan.execute().join();
 
-		workPlan = nullOnlyIndexManager.createWorkPlan();
-		workPlan.add( referenceProvider( "nullOnlyIndexManager_document_0" ), document -> {
+		plan = nullOnlyIndexManager.createIndexingPlan();
+		plan.add( referenceProvider( "nullOnlyIndexManager_document_0" ), document -> {
 			document.addValue( nullOnlyIndexMapping.fieldModel.reference, null );
 		} );
-		workPlan.execute().join();
+		plan.execute().join();
 
 		if ( TckConfiguration.get().getBackendFeatures().aggregationsOnMultiValuedFields( typeDescriptor.getJavaType() ) ) {
-			workPlan = multiValuedIndexManager.createWorkPlan();
+			plan = multiValuedIndexManager.createIndexingPlan();
 			for ( int i = 0; i < multiValuedIndexDocumentFieldValues.size(); i++ ) {
 				List<F> values = multiValuedIndexDocumentFieldValues.get( i );
-				workPlan.add( referenceProvider( "document_" + i ), document -> {
+				plan.add( referenceProvider( "document_" + i ), document -> {
 					for ( F value : values ) {
 						document.addValue( multiValuedIndexMapping.fieldModel.reference, value );
 					}
 				} );
 			}
-			workPlan.add( referenceProvider( "document_empty" ), document -> { } );
-			workPlan.execute().join();
+			plan.add( referenceProvider( "document_empty" ), document -> { } );
+			plan.execute().join();
 		}
 
 		// Check that all documents are searchable

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/TermsAggregationSpecificsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/TermsAggregationSpecificsIT.java
@@ -26,7 +26,7 @@ import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement
 import org.hibernate.search.engine.backend.types.Aggregable;
 import org.hibernate.search.engine.backend.types.Searchable;
 import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeOptionsStep;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.aggregation.AggregationKey;
 import org.hibernate.search.engine.search.query.dsl.SearchQueryOptionsStep;
@@ -606,21 +606,21 @@ public class TermsAggregationSpecificsIT<F> {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
 		int documentCount = 0;
 		for ( Map.Entry<F, List<String>> entry : documentIdPerTerm.entrySet() ) {
 			F value = entry.getKey();
 			for ( String documentId : entry.getValue() ) {
-				workPlan.add( referenceProvider( documentId ), document -> {
+				plan.add( referenceProvider( documentId ), document -> {
 					document.addValue( indexMapping.fieldModel.reference, value );
 					document.addValue( indexMapping.fieldWithConverterModel.reference, value );
 				} );
 				++documentCount;
 			}
 		}
-		workPlan.add( referenceProvider( "document_empty" ), document -> { } );
+		plan.add( referenceProvider( "document_empty" ), document -> { } );
 		++documentCount;
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		SearchResultAssert.assertThat(

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/bool/BooleanSortAndRangePredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/bool/BooleanSortAndRangePredicateIT.java
@@ -18,7 +18,7 @@ import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.types.Sortable;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.predicate.dsl.PredicateFinalStep;
 import org.hibernate.search.engine.search.sort.dsl.SortFinalStep;
@@ -174,24 +174,24 @@ public class BooleanSortAndRangePredicateIT {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( DOCUMENT_1 ), document -> {
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			document.addValue( indexMapping.bool, true );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_2 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_2 ), document -> {
 			document.addValue( indexMapping.bool, Boolean.FALSE );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_3 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_3 ), document -> {
 			document.addValue( indexMapping.bool, Boolean.TRUE );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_4 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_4 ), document -> {
 			document.addValue( indexMapping.bool, null );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_5 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_5 ), document -> {
 			document.addValue( indexMapping.bool, false );
 		} );
 
-		workPlan.execute().join();
+		plan.execute().join();
 		checkAllDocumentsAreSearchable();
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/BoolSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/BoolSearchPredicateIT.java
@@ -14,7 +14,7 @@ import java.util.function.Consumer;
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.search.predicate.dsl.MinimumShouldMatchConditionStep;
 import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
 import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
@@ -1029,22 +1029,22 @@ public class BoolSearchPredicateIT {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( DOCUMENT_1 ), document -> {
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			document.addValue( indexMapping.field1, FIELD1_VALUE1 );
 			document.addValue( indexMapping.field2, FIELD2_VALUE1 );
 			document.addValue( indexMapping.field3, FIELD3_VALUE1 );
 			document.addValue( indexMapping.field4, FIELD4_VALUE1AND2 );
 			document.addValue( indexMapping.field5, FIELD5_VALUE1AND2 );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_2 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_2 ), document -> {
 			document.addValue( indexMapping.field1, FIELD1_VALUE2 );
 			document.addValue( indexMapping.field2, FIELD2_VALUE2 );
 			document.addValue( indexMapping.field3, FIELD3_VALUE2 );
 			document.addValue( indexMapping.field4, FIELD4_VALUE1AND2 );
 			document.addValue( indexMapping.field5, FIELD5_VALUE1AND2 );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_3 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_3 ), document -> {
 			document.addValue( indexMapping.field1, FIELD1_VALUE3 );
 			document.addValue( indexMapping.field2, FIELD2_VALUE3 );
 			document.addValue( indexMapping.field3, FIELD3_VALUE3 );
@@ -1052,7 +1052,7 @@ public class BoolSearchPredicateIT {
 			document.addValue( indexMapping.field5, FIELD5_VALUE3 );
 		} );
 
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		StubMappingScope scope = indexManager.createScope();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/ExistsSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/ExistsSearchPredicateIT.java
@@ -20,7 +20,7 @@ import org.hibernate.search.engine.backend.document.IndexObjectFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectField;
 import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeFactory;
 import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeOptionsStep;
@@ -382,8 +382,8 @@ public class ExistsSearchPredicateIT {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( DOCUMENT_1 ), document -> {
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			indexMapping.supportedFieldModels.forEach( f -> f.document1Value.write( document ) );
 			indexMapping.supportedFieldWithDocValuesModels.forEach( f -> f.document1Value.write( document ) );
 			indexMapping.string1Field.document1Value.write( document );
@@ -405,7 +405,7 @@ public class ExistsSearchPredicateIT {
 			indexMapping.nestedObject.supportedFieldModels.forEach( f -> f.document2Value.write( nestedObject2 ) );
 			indexMapping.nestedObject.supportedFieldWithDocValuesModels.forEach( f -> f.document2Value.write( nestedObject2 ) );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_2 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_2 ), document -> {
 			indexMapping.supportedFieldModels.forEach( f -> f.document2Value.write( document ) );
 			indexMapping.supportedFieldWithDocValuesModels.forEach( f -> f.document2Value.write( document ) );
 			indexMapping.string2Field.document2Value.write( document );
@@ -422,7 +422,7 @@ public class ExistsSearchPredicateIT {
 			indexMapping.nestedObject.supportedFieldModels.forEach( f -> f.document2Value.write( nestedObject2 ) );
 			indexMapping.nestedObject.supportedFieldWithDocValuesModels.forEach( f -> f.document2Value.write( nestedObject2 ) );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_3 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_3 ), document -> {
 			indexMapping.string1Field.document3Value.write( document );
 
 			// Add two empty objects
@@ -433,20 +433,20 @@ public class ExistsSearchPredicateIT {
 			document.addObject( indexMapping.nestedObject.self );
 			document.addObject( indexMapping.nestedObject.self );
 		} );
-		workPlan.add( referenceProvider( EMPTY ), document -> { } );
-		workPlan.execute().join();
+		plan.add( referenceProvider( EMPTY ), document -> { } );
+		plan.execute().join();
 
-		workPlan = compatibleIndexManager.createWorkPlan();
-		workPlan.add( referenceProvider( COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
+		plan = compatibleIndexManager.createIndexingPlan();
+		plan.add( referenceProvider( COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
 			compatibleIndexMapping.supportedFieldModels.forEach( f -> f.document1Value.write( document ) );
 		} );
-		workPlan.execute().join();
+		plan.execute().join();
 
-		workPlan = rawFieldCompatibleIndexManager.createWorkPlan();
-		workPlan.add( referenceProvider( RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
+		plan = rawFieldCompatibleIndexManager.createIndexingPlan();
+		plan.add( referenceProvider( RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
 			rawFieldCompatibleIndexMapping.supportedFieldModels.forEach( f -> f.document1Value.write( document ) );
 		} );
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		SearchQuery<DocumentReference> query = indexManager.createScope().query()

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchAllSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchAllSearchPredicateIT.java
@@ -12,7 +12,7 @@ import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
 import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
@@ -113,18 +113,18 @@ public class MatchAllSearchPredicateIT {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( DOCUMENT_1 ), document -> {
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			document.addValue( indexMapping.string, STRING_1 );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_2 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_2 ), document -> {
 			document.addValue( indexMapping.string, STRING_2 );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_3 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_3 ), document -> {
 			document.addValue( indexMapping.string, STRING_3 );
 		} );
 
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		StubMappingScope scope = indexManager.createScope();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchIdSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchIdSearchPredicateIT.java
@@ -12,7 +12,7 @@ import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.
 import java.util.Arrays;
 
 import org.hibernate.search.engine.backend.document.DocumentElement;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
@@ -119,11 +119,11 @@ public class MatchIdSearchPredicateIT {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( DOCUMENT_1 ), document -> { } );
-		workPlan.add( referenceProvider( DOCUMENT_2 ), document -> { } );
-		workPlan.add( referenceProvider( DOCUMENT_3 ), document -> { } );
-		workPlan.execute().join();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( DOCUMENT_1 ), document -> { } );
+		plan.add( referenceProvider( DOCUMENT_2 ), document -> { } );
+		plan.add( referenceProvider( DOCUMENT_3 ), document -> { } );
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		StubMappingScope scope = indexManager.createScope();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchIdWithConverterSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchIdWithConverterSearchPredicateIT.java
@@ -14,7 +14,7 @@ import java.util.Arrays;
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.types.converter.spi.ToDocumentIdentifierValueConverter;
 import org.hibernate.search.engine.backend.types.converter.runtime.spi.ToDocumentIdentifierValueConvertContext;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
@@ -143,11 +143,11 @@ public class MatchIdWithConverterSearchPredicateIT {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( DOCUMENT_1 ), document -> { } );
-		workPlan.add( referenceProvider( DOCUMENT_2 ), document -> { } );
-		workPlan.add( referenceProvider( DOCUMENT_3 ), document -> { } );
-		workPlan.execute().join();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( DOCUMENT_1 ), document -> { } );
+		plan.add( referenceProvider( DOCUMENT_2 ), document -> { } );
+		plan.add( referenceProvider( DOCUMENT_3 ), document -> { } );
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		StubMappingScope scope = indexManager.createScope();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchSearchPredicateIT.java
@@ -19,7 +19,7 @@ import java.util.function.Function;
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.types.Searchable;
 import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeFactory;
 import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeOptionsStep;
@@ -1334,8 +1334,8 @@ public class MatchSearchPredicateIT {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( DOCUMENT_1 ), document -> {
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			indexMapping.supportedFieldModels.forEach( f -> f.document1Value.write( document ) );
 			indexMapping.supportedFieldWithDslConverterModels.forEach( f -> f.document1Value.write( document ) );
 			indexMapping.unsupportedFieldModels.forEach( f -> f.document1Value.write( document ) );
@@ -1351,7 +1351,7 @@ public class MatchSearchPredicateIT {
 			indexMapping.whitespaceLowercaseAnalyzedField.document1Value.write( document );
 			indexMapping.scaledBigDecimal.document1Value.write( document );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_2 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_2 ), document -> {
 			indexMapping.supportedFieldModels.forEach( f -> f.document2Value.write( document ) );
 			indexMapping.supportedFieldWithDslConverterModels.forEach( f -> f.document2Value.write( document ) );
 			indexMapping.unsupportedFieldModels.forEach( f -> f.document2Value.write( document ) );
@@ -1367,8 +1367,8 @@ public class MatchSearchPredicateIT {
 			indexMapping.whitespaceLowercaseAnalyzedField.document2Value.write( document );
 			indexMapping.scaledBigDecimal.document2Value.write( document );
 		} );
-		workPlan.add( referenceProvider( EMPTY ), document -> { } );
-		workPlan.add( referenceProvider( DOCUMENT_3 ), document -> {
+		plan.add( referenceProvider( EMPTY ), document -> { } );
+		plan.add( referenceProvider( DOCUMENT_3 ), document -> {
 			indexMapping.string1Field.document3Value.write( document );
 			indexMapping.string2Field.document3Value.write( document );
 			indexMapping.string3Field.document3Value.write( document );
@@ -1381,32 +1381,32 @@ public class MatchSearchPredicateIT {
 			indexMapping.whitespaceLowercaseAnalyzedField.document3Value.write( document );
 			indexMapping.scaledBigDecimal.document3Value.write( document );
 		} );
-		workPlan.execute().join();
+		plan.execute().join();
 
-		workPlan = compatibleIndexManager.createWorkPlan();
-		workPlan.add( referenceProvider( COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
+		plan = compatibleIndexManager.createIndexingPlan();
+		plan.add( referenceProvider( COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
 			compatibleIndexMapping.supportedFieldModels.forEach( f -> f.document1Value.write( document ) );
 			compatibleIndexMapping.supportedFieldWithDslConverterModels.forEach( f -> f.document1Value.write( document ) );
 		} );
-		workPlan.execute().join();
+		plan.execute().join();
 
-		workPlan = rawFieldCompatibleIndexManager.createWorkPlan();
-		workPlan.add( referenceProvider( RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
+		plan = rawFieldCompatibleIndexManager.createIndexingPlan();
+		plan.add( referenceProvider( RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
 			rawFieldCompatibleIndexMapping.supportedFieldModels.forEach( f -> f.document1Value.write( document ) );
 		} );
-		workPlan.execute().join();
+		plan.execute().join();
 
-		workPlan = incompatibleAnalyzerIndexManager.createWorkPlan();
-		workPlan.add( referenceProvider( INCOMPATIBLE_ANALYZER_INDEX_DOCUMENT_1 ), document -> {
+		plan = incompatibleAnalyzerIndexManager.createIndexingPlan();
+		plan.add( referenceProvider( INCOMPATIBLE_ANALYZER_INDEX_DOCUMENT_1 ), document -> {
 			incompatibleAnalyzerIndexMapping.analyzedStringField.document1Value.write( document );
 		} );
-		workPlan.execute().join();
+		plan.execute().join();
 
-		workPlan = incompatibleDecimalScaleIndexManager.createWorkPlan();
-		workPlan.add( referenceProvider( INCOMPATIBLE_DECIMAL_SCALE_INDEX_DOCUMENT_1 ), document -> {
+		plan = incompatibleDecimalScaleIndexManager.createIndexingPlan();
+		plan.add( referenceProvider( INCOMPATIBLE_DECIMAL_SCALE_INDEX_DOCUMENT_1 ), document -> {
 			incompatibleDecimalScaleIndexMapping.scaledBigDecimal.document1Value.write( document );
 		} );
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		SearchQuery<DocumentReference> query = indexManager.createScope().query()

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/NestedSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/NestedSearchPredicateIT.java
@@ -15,7 +15,7 @@ import org.hibernate.search.engine.backend.document.IndexObjectFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectField;
 import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
 import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
@@ -224,8 +224,8 @@ public class NestedSearchPredicateIT {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( DOCUMENT_1 ), document -> {
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			ObjectMapping level1;
 			SecondLevelObjectMapping level2;
 			DocumentElement object;
@@ -262,7 +262,7 @@ public class NestedSearchPredicateIT {
 			object.addNullObject( level2.self );
 		} );
 
-		workPlan.add( referenceProvider( DOCUMENT_2 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_2 ), document -> {
 			ObjectMapping level1 = indexMapping.nestedObject;
 			DocumentElement object = document.addObject( level1.self );
 			SecondLevelObjectMapping level2 = level1.nestedObject;
@@ -294,7 +294,7 @@ public class NestedSearchPredicateIT {
 			object = document.addObject( level1.self );
 		} );
 
-		workPlan.add( referenceProvider( "neverMatching" ), document -> {
+		plan.add( referenceProvider( "neverMatching" ), document -> {
 			ObjectMapping level1 = indexMapping.nestedObject;
 			SecondLevelObjectMapping level2 = level1.nestedObject;
 
@@ -335,9 +335,9 @@ public class NestedSearchPredicateIT {
 			secondLevelObject.addValue( level2.field2, NON_MATCHING_SECOND_LEVEL_CONDITION1_FIELD2 );
 		} );
 
-		workPlan.add( referenceProvider( "empty" ), document -> { } );
+		plan.add( referenceProvider( "empty" ), document -> { } );
 
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		StubMappingScope scope = indexManager.createScope();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/PhraseSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/PhraseSearchPredicateIT.java
@@ -19,7 +19,7 @@ import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeOptionsStep;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.types.Searchable;
 import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeFactory;
 import org.hibernate.search.engine.reporting.spi.EventContexts;
@@ -730,55 +730,55 @@ public class PhraseSearchPredicateIT {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( DOCUMENT_1 ), document -> {
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			document.addValue( indexMapping.analyzedStringField1.reference, PHRASE_1_TEXT_EXACT_MATCH );
 			document.addValue( indexMapping.analyzedStringFieldWithDslConverter.reference, PHRASE_1_TEXT_EXACT_MATCH );
 			document.addValue( indexMapping.whitespaceAnalyzedField.reference, PHRASE_1_TEXT_EXACT_MATCH.toLowerCase( Locale.ROOT ) );
 			document.addValue( indexMapping.whitespaceLowercaseAnalyzedField.reference, PHRASE_1_TEXT_EXACT_MATCH.toLowerCase( Locale.ROOT ) );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_2 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_2 ), document -> {
 			document.addValue( indexMapping.analyzedStringField1.reference, PHRASE_1_TEXT_SLOP_1_MATCH );
 			document.addValue( indexMapping.analyzedStringField2.reference, PHRASE_2_TEXT_EXACT_MATCH );
 			document.addValue( indexMapping.whitespaceAnalyzedField.reference, PHRASE_1_TEXT_EXACT_MATCH.toUpperCase( Locale.ROOT ) );
 			document.addValue( indexMapping.whitespaceLowercaseAnalyzedField.reference, PHRASE_1_TEXT_EXACT_MATCH.toUpperCase( Locale.ROOT ) );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_3 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_3 ), document -> {
 			document.addValue( indexMapping.analyzedStringField1.reference, PHRASE_1_TEXT_SLOP_2_MATCH );
 			document.addValue( indexMapping.analyzedStringField2.reference, PHRASE_3_TEXT_EXACT_MATCH );
 			document.addValue( indexMapping.analyzedStringField3.reference, PHRASE_1_TEXT_EXACT_MATCH );
 			document.addValue( indexMapping.whitespaceAnalyzedField.reference, PHRASE_1_TEXT_EXACT_MATCH );
 			document.addValue( indexMapping.whitespaceLowercaseAnalyzedField.reference, PHRASE_1_TEXT_EXACT_MATCH );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_4 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_4 ), document -> {
 			document.addValue( indexMapping.analyzedStringField1.reference, PHRASE_1_TEXT_SLOP_3_MATCH );
 			document.addValue( indexMapping.analyzedStringField3.reference, PHRASE_2_TEXT_EXACT_MATCH );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_5 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_5 ), document -> {
 			document.addValue( indexMapping.analyzedStringField1.reference, PHRASE_2_TEXT_EXACT_MATCH );
 			document.addValue( indexMapping.analyzedStringField2.reference, PHRASE_1_TEXT_EXACT_MATCH );
 		} );
-		workPlan.add( referenceProvider( EMPTY ), document -> {
+		plan.add( referenceProvider( EMPTY ), document -> {
 		} );
-		workPlan.execute().join();
+		plan.execute().join();
 
-		workPlan = compatibleIndexManager.createWorkPlan();
-		workPlan.add( referenceProvider( COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
+		plan = compatibleIndexManager.createIndexingPlan();
+		plan.add( referenceProvider( COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
 			document.addValue( compatibleIndexMapping.analyzedStringField1.reference, PHRASE_1_TEXT_EXACT_MATCH );
 		} );
-		workPlan.execute().join();
+		plan.execute().join();
 
-		workPlan = rawFieldCompatibleIndexManager.createWorkPlan();
-		workPlan.add( referenceProvider( RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
+		plan = rawFieldCompatibleIndexManager.createIndexingPlan();
+		plan.add( referenceProvider( RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
 			document.addValue( rawFieldCompatibleIndexMapping.analyzedStringField1.reference, PHRASE_1_TEXT_EXACT_MATCH );
 		} );
-		workPlan.execute().join();
+		plan.execute().join();
 
-		workPlan = incompatibleAnalyzerIndexManager.createWorkPlan();
-		workPlan.add( referenceProvider( INCOMPATIBLE_ANALYZER_INDEX_DOCUMENT_1 ), document -> {
+		plan = incompatibleAnalyzerIndexManager.createIndexingPlan();
+		plan.add( referenceProvider( INCOMPATIBLE_ANALYZER_INDEX_DOCUMENT_1 ), document -> {
 			document.addValue( incompatibleAnalyzerIndexMapping.analyzedStringField1.reference, PHRASE_1_TEXT_EXACT_MATCH );
 		} );
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		StubMappingScope scope = indexManager.createScope();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/RangeSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/RangeSearchPredicateIT.java
@@ -26,7 +26,7 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldM
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.RangePredicateExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldTypeDescriptor;
 import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.reporting.spi.EventContexts;
 import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
 import org.hibernate.search.engine.backend.common.DocumentReference;
@@ -983,8 +983,8 @@ public class RangeSearchPredicateIT {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( DOCUMENT_1 ), document -> {
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			indexMapping.supportedFieldModels.forEach( f -> f.document1Value.write( document ) );
 			indexMapping.supportedFieldWithDslConverterModels.forEach( f -> f.document1Value.write( document ) );
 			indexMapping.unsupportedFieldModels.forEach( f -> f.document1Value.write( document ) );
@@ -995,7 +995,7 @@ public class RangeSearchPredicateIT {
 			indexMapping.string2FieldWithDslConverter.document1Value.write( document );
 			indexMapping.scaledBigDecimal.document1Value.write( document );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_2 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_2 ), document -> {
 			indexMapping.supportedFieldModels.forEach( f -> f.document2Value.write( document ) );
 			indexMapping.supportedFieldWithDslConverterModels.forEach( f -> f.document2Value.write( document ) );
 			indexMapping.unsupportedFieldModels.forEach( f -> f.document2Value.write( document ) );
@@ -1006,7 +1006,7 @@ public class RangeSearchPredicateIT {
 			indexMapping.string2FieldWithDslConverter.document2Value.write( document );
 			indexMapping.scaledBigDecimal.document2Value.write( document );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_3 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_3 ), document -> {
 			indexMapping.supportedFieldModels.forEach( f -> f.document3Value.write( document ) );
 			indexMapping.supportedFieldWithDslConverterModels.forEach( f -> f.document3Value.write( document ) );
 			indexMapping.unsupportedFieldModels.forEach( f -> f.document3Value.write( document ) );
@@ -1017,27 +1017,27 @@ public class RangeSearchPredicateIT {
 			indexMapping.string2FieldWithDslConverter.document3Value.write( document );
 			indexMapping.scaledBigDecimal.document3Value.write( document );
 		} );
-		workPlan.add( referenceProvider( EMPTY_ID ), document -> { } );
-		workPlan.execute().join();
+		plan.add( referenceProvider( EMPTY_ID ), document -> { } );
+		plan.execute().join();
 
-		workPlan = compatibleIndexManager.createWorkPlan();
-		workPlan.add( referenceProvider( COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
+		plan = compatibleIndexManager.createIndexingPlan();
+		plan.add( referenceProvider( COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
 			indexMapping.supportedFieldModels.forEach( f -> f.document1Value.write( document ) );
 			indexMapping.supportedFieldWithDslConverterModels.forEach( f -> f.document1Value.write( document ) );
 		} );
-		workPlan.execute().join();
+		plan.execute().join();
 
-		workPlan = rawFieldCompatibleIndexManager.createWorkPlan();
-		workPlan.add( referenceProvider( RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
+		plan = rawFieldCompatibleIndexManager.createIndexingPlan();
+		plan.add( referenceProvider( RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
 			rawFieldCompatibleIndexMapping.supportedFieldModels.forEach( f -> f.document1Value.write( document ) );
 		} );
-		workPlan.execute().join();
+		plan.execute().join();
 
-		workPlan = incompatibleDecimalScaleIndexManager.createWorkPlan();
-		workPlan.add( referenceProvider( INCOMPATIBLE_DECIMAL_SCALE_INDEX_DOCUMENT_1 ), document -> {
+		plan = incompatibleDecimalScaleIndexManager.createIndexingPlan();
+		plan.add( referenceProvider( INCOMPATIBLE_DECIMAL_SCALE_INDEX_DOCUMENT_1 ), document -> {
 			incompatibleDecimalScaleIndexMapping.scaledBigDecimal.document1Value.write( document );
 		} );
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		SearchQuery<DocumentReference> query = indexManager.createScope().query()

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SearchPredicateIT.java
@@ -15,7 +15,7 @@ import java.util.function.Function;
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.predicate.SearchPredicate;
 import org.hibernate.search.engine.search.predicate.dsl.PredicateFinalStep;
@@ -340,16 +340,16 @@ public class SearchPredicateIT {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( DOCUMENT_1 ), document -> {
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			document.addValue( indexMapping.string, STRING_1 );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_2 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_2 ), document -> {
 			document.addValue( indexMapping.string, STRING_2 );
 		} );
-		workPlan.add( referenceProvider( EMPTY ), document -> { } );
+		plan.add( referenceProvider( EMPTY ), document -> { } );
 
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		StubMappingScope scope = indexManager.createScope();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SimpleQueryStringSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SimpleQueryStringSearchPredicateIT.java
@@ -18,7 +18,7 @@ import java.util.function.Function;
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.types.Searchable;
 import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeFactory;
 import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeOptionsStep;
@@ -828,8 +828,8 @@ public class SimpleQueryStringSearchPredicateIT {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( DOCUMENT_1 ), document -> {
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			document.addValue( indexMapping.analyzedStringField1.reference, TEXT_TERM_1_AND_TERM_2 );
 			document.addValue( indexMapping.analyzedStringFieldWithDslConverter.reference, TEXT_TERM_1_AND_TERM_2 );
 			document.addValue( indexMapping.analyzedStringField2.reference, TEXT_TERM_1_AND_TERM_3 );
@@ -838,48 +838,48 @@ public class SimpleQueryStringSearchPredicateIT {
 			document.addValue( indexMapping.whitespaceAnalyzedField.reference, TEXT_TERM_1_AND_TERM_2.toLowerCase( Locale.ROOT ) );
 			document.addValue( indexMapping.whitespaceLowercaseAnalyzedField.reference, TEXT_TERM_1_AND_TERM_2.toLowerCase( Locale.ROOT ) );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_2 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_2 ), document -> {
 			document.addValue( indexMapping.analyzedStringField1.reference, TEXT_TERM_1_AND_TERM_3 );
 			document.addValue( indexMapping.analyzedStringField4.reference, PREFIX_2 );
 			document.addValue( indexMapping.whitespaceAnalyzedField.reference, TEXT_TERM_1_AND_TERM_2.toUpperCase( Locale.ROOT ) );
 			document.addValue( indexMapping.whitespaceLowercaseAnalyzedField.reference, TEXT_TERM_1_AND_TERM_2.toUpperCase( Locale.ROOT ) );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_3 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_3 ), document -> {
 			document.addValue( indexMapping.analyzedStringField1.reference, TEXT_TERM_2_IN_PHRASE );
 			document.addValue( indexMapping.analyzedStringField4.reference, PREFIX_3 );
 			document.addValue( indexMapping.whitespaceAnalyzedField.reference, TEXT_TERM_1_AND_TERM_2 );
 			document.addValue( indexMapping.whitespaceLowercaseAnalyzedField.reference, TEXT_TERM_1_AND_TERM_2 );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_4 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_4 ), document -> {
 			document.addValue( indexMapping.analyzedStringField1.reference, TEXT_TERM_4_IN_PHRASE_SLOP_2 );
 			document.addValue( indexMapping.analyzedStringField2.reference, TEXT_TERM_2_IN_PHRASE );
 			document.addValue( indexMapping.analyzedStringField4.reference, PREFIX_4 );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_5 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_5 ), document -> {
 			document.addValue( indexMapping.analyzedStringField1.reference, TEXT_TERM_1_EDIT_DISTANCE_1 );
 			document.addValue( indexMapping.analyzedStringField3.reference, TEXT_TERM_2_IN_PHRASE );
 			document.addValue( indexMapping.analyzedStringField3.reference, TEXT_TERM_1_AND_TERM_3 );
 		} );
-		workPlan.add( referenceProvider( EMPTY ), document -> {
+		plan.add( referenceProvider( EMPTY ), document -> {
 		} );
-		workPlan.execute().join();
+		plan.execute().join();
 
-		workPlan = compatibleIndexManager.createWorkPlan();
-		workPlan.add( referenceProvider( COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
+		plan = compatibleIndexManager.createIndexingPlan();
+		plan.add( referenceProvider( COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
 			document.addValue( compatibleIndexMapping.analyzedStringField1.reference, TEXT_TERM_1_AND_TERM_2 );
 		} );
-		workPlan.execute().join();
+		plan.execute().join();
 
-		workPlan = rawFieldCompatibleIndexManager.createWorkPlan();
-		workPlan.add( referenceProvider( RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
+		plan = rawFieldCompatibleIndexManager.createIndexingPlan();
+		plan.add( referenceProvider( RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
 			document.addValue( rawFieldCompatibleIndexMapping.analyzedStringField1.reference, TEXT_TERM_1_AND_TERM_2 );
 		} );
-		workPlan.execute().join();
-		workPlan = incompatibleAnalyzerIndexManager.createWorkPlan();
-		workPlan.add( referenceProvider( INCOMPATIBLE_ANALYZER_INDEX_DOCUMENT_1 ), document -> {
+		plan.execute().join();
+		plan = incompatibleAnalyzerIndexManager.createIndexingPlan();
+		plan.add( referenceProvider( INCOMPATIBLE_ANALYZER_INDEX_DOCUMENT_1 ), document -> {
 			document.addValue( incompatibleAnalyzerIndexMapping.analyzedStringField1.reference, TEXT_TERM_1_AND_TERM_2 );
 		} );
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		StubMappingScope scope = indexManager.createScope();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/WildcardSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/WildcardSearchPredicateIT.java
@@ -18,7 +18,7 @@ import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeOptionsStep;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.types.Searchable;
 import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeFactory;
 import org.hibernate.search.engine.reporting.spi.EventContexts;
@@ -503,42 +503,42 @@ public class WildcardSearchPredicateIT {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( DOCUMENT_1 ), document -> {
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			document.addValue( indexMapping.analyzedStringField1.reference, TEXT_MATCHING_PATTERN_1 );
 			document.addValue( indexMapping.analyzedStringFieldWithDslConverter.reference, TEXT_MATCHING_PATTERN_1 );
 			document.addValue( indexMapping.normalizedField.reference, TERM_MATCHING_PATTERN_1 );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_2 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_2 ), document -> {
 			document.addValue( indexMapping.analyzedStringField1.reference, TEXT_MATCHING_PATTERN_2 );
 			document.addValue( indexMapping.normalizedField.reference, TERM_MATCHING_PATTERN_2 );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_3 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_3 ), document -> {
 			document.addValue( indexMapping.analyzedStringField1.reference, TEXT_MATCHING_PATTERN_3 );
 			document.addValue( indexMapping.normalizedField.reference, TERM_MATCHING_PATTERN_2_AND_3 );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_4 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_4 ), document -> {
 			document.addValue( indexMapping.analyzedStringField1.reference, TEXT_MATCHING_PATTERN_2_AND_3 );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_5 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_5 ), document -> {
 			document.addValue( indexMapping.analyzedStringField2.reference, TEXT_MATCHING_PATTERN_1 );
 			document.addValue( indexMapping.analyzedStringField3.reference, TEXT_MATCHING_PATTERN_3 );
 		} );
-		workPlan.add( referenceProvider( EMPTY ), document -> {
+		plan.add( referenceProvider( EMPTY ), document -> {
 		} );
-		workPlan.execute().join();
+		plan.execute().join();
 
-		workPlan = compatibleIndexManager.createWorkPlan();
-		workPlan.add( referenceProvider( COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
+		plan = compatibleIndexManager.createIndexingPlan();
+		plan.add( referenceProvider( COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
 			document.addValue( compatibleIndexMapping.analyzedStringField1.reference, TEXT_MATCHING_PATTERN_1 );
 		} );
-		workPlan.execute().join();
+		plan.execute().join();
 
-		workPlan = rawFieldCompatibleIndexManager.createWorkPlan();
-		workPlan.add( referenceProvider( RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
+		plan = rawFieldCompatibleIndexManager.createIndexingPlan();
+		plan.add( referenceProvider( RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
 			document.addValue( rawFieldCompatibleIndexMapping.analyzedStringField1.reference, TEXT_MATCHING_PATTERN_1 );
 		} );
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		StubMappingScope scope = indexManager.createScope();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/CompositeSearchProjectionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/CompositeSearchProjectionIT.java
@@ -21,7 +21,7 @@ import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement
 import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeFactory;
 import org.hibernate.search.engine.backend.types.Projectable;
 import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeOptionsStep;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.StandardFieldMapper;
@@ -326,24 +326,24 @@ public class CompositeSearchProjectionIT {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( DOCUMENT_1 ), document -> {
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			indexMapping.author.document1Value.write( document );
 			indexMapping.title.document1Value.write( document );
 			indexMapping.releaseDate.document1Value.write( document );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_2 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_2 ), document -> {
 			indexMapping.author.document2Value.write( document );
 			indexMapping.title.document2Value.write( document );
 			indexMapping.releaseDate.document2Value.write( document );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_3 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_3 ), document -> {
 			indexMapping.author.document3Value.write( document );
 			indexMapping.title.document3Value.write( document );
 			indexMapping.releaseDate.document3Value.write( document );
 		} );
 
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		StubMappingScope scope = indexManager.createScope();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/FieldSearchProjectionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/FieldSearchProjectionIT.java
@@ -26,7 +26,7 @@ import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectF
 import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
 import org.hibernate.search.engine.backend.types.Projectable;
 import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeOptionsStep;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.common.ValueConvert;
 import org.hibernate.search.engine.search.query.SearchQuery;
@@ -593,8 +593,8 @@ public class FieldSearchProjectionIT {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( DOCUMENT_1 ), document -> {
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			indexMapping.supportedFieldModels.forEach( f -> f.document1Value.write( document ) );
 			indexMapping.supportedFieldWithProjectionConverterModels.forEach( f -> f.document1Value.write( document ) );
 
@@ -608,7 +608,7 @@ public class FieldSearchProjectionIT {
 			DocumentElement nestedObject = document.addObject( indexMapping.nestedObject.self );
 			indexMapping.nestedObject.supportedFieldModels.forEach( f -> f.document1Value.write( nestedObject ) );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_2 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_2 ), document -> {
 			indexMapping.supportedFieldModels.forEach( f -> f.document2Value.write( document ) );
 			indexMapping.supportedFieldWithProjectionConverterModels.forEach( f -> f.document2Value.write( document ) );
 
@@ -622,7 +622,7 @@ public class FieldSearchProjectionIT {
 			DocumentElement nestedObject = document.addObject( indexMapping.nestedObject.self );
 			indexMapping.nestedObject.supportedFieldModels.forEach( f -> f.document2Value.write( nestedObject ) );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_3 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_3 ), document -> {
 			indexMapping.supportedFieldModels.forEach( f -> f.document3Value.write( document ) );
 			indexMapping.supportedFieldWithProjectionConverterModels.forEach( f -> f.document3Value.write( document ) );
 
@@ -636,21 +636,21 @@ public class FieldSearchProjectionIT {
 			DocumentElement nestedObject = document.addObject( indexMapping.nestedObject.self );
 			indexMapping.nestedObject.supportedFieldModels.forEach( f -> f.document3Value.write( nestedObject ) );
 		} );
-		workPlan.add( referenceProvider( EMPTY ), document -> { } );
-		workPlan.execute().join();
+		plan.add( referenceProvider( EMPTY ), document -> { } );
+		plan.execute().join();
 
-		workPlan = compatibleIndexManager.createWorkPlan();
-		workPlan.add( referenceProvider( COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
+		plan = compatibleIndexManager.createIndexingPlan();
+		plan.add( referenceProvider( COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
 			compatibleIndexMapping.supportedFieldModels.forEach( f -> f.document1Value.write( document ) );
 			compatibleIndexMapping.supportedFieldWithProjectionConverterModels.forEach( f -> f.document1Value.write( document ) );
 		} );
-		workPlan.execute().join();
+		plan.execute().join();
 
-		workPlan = rawFieldCompatibleIndexManager.createWorkPlan();
-		workPlan.add( referenceProvider( RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
+		plan = rawFieldCompatibleIndexManager.createIndexingPlan();
+		plan.add( referenceProvider( RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
 			rawFieldCompatibleIndexMapping.supportedFieldWithProjectionConverterModels.forEach( f -> f.document1Value.write( document ) );
 		} );
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		SearchQuery<DocumentReference> query = indexManager.createScope().query()

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/SearchProjectionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/SearchProjectionIT.java
@@ -23,7 +23,7 @@ import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage
 import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeFactory;
 import org.hibernate.search.engine.backend.types.Projectable;
 import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeOptionsStep;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.projection.SearchProjection;
 import org.hibernate.search.engine.search.projection.dsl.SearchProjectionFactory;
@@ -536,8 +536,8 @@ public class SearchProjectionIT extends EasyMockSupport {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( DOCUMENT_1 ), document -> {
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			indexMapping.string1Field.document1Value.write( document );
 			indexMapping.string2Field.document1Value.write( document );
 
@@ -552,7 +552,7 @@ public class SearchProjectionIT extends EasyMockSupport {
 			DocumentElement flattedDocument = nestedDocument.addObject( indexMapping.flattenedObject );
 			indexMapping.flattenedField.document1Value.write( flattedDocument );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_2 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_2 ), document -> {
 			indexMapping.string1Field.document2Value.write( document );
 			indexMapping.string2Field.document2Value.write( document );
 
@@ -567,7 +567,7 @@ public class SearchProjectionIT extends EasyMockSupport {
 			DocumentElement flattedDocument = nestedDocument.addObject( indexMapping.flattenedObject );
 			indexMapping.flattenedField.document2Value.write( flattedDocument );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_3 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_3 ), document -> {
 			indexMapping.string1Field.document3Value.write( document );
 			indexMapping.string2Field.document3Value.write( document );
 
@@ -582,9 +582,9 @@ public class SearchProjectionIT extends EasyMockSupport {
 			DocumentElement flattedDocument = nestedDocument.addObject( indexMapping.flattenedObject );
 			indexMapping.flattenedField.document3Value.write( flattedDocument );
 		} );
-		workPlan.add( referenceProvider( EMPTY ), document -> { } );
+		plan.add( referenceProvider( EMPTY ), document -> { } );
 
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		StubMappingScope scope = indexManager.createScope();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryBaseIT.java
@@ -135,7 +135,7 @@ public class SearchQueryBaseIT {
 		}
 
 		CompletableFuture.allOf( futures.toArray( new CompletableFuture<?>[0] ) ).join();
-		indexManager.createWorkExecutor().flush().join();
+		indexManager.createWorkspace().flush().join();
 
 		// Check that all documents are searchable
 		StubMappingScope scope = indexManager.createScope();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryBaseIT.java
@@ -18,7 +18,7 @@ import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexDocumentWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
 import org.hibernate.search.engine.backend.common.DocumentReference;
@@ -124,8 +124,8 @@ public class SearchQueryBaseIT {
 	}
 
 	private void initData(int documentCount) {
-		IndexDocumentWorkExecutor<? extends DocumentElement> executor =
-				indexManager.createDocumentWorkExecutor( DocumentCommitStrategy.NONE );
+		IndexIndexer<? extends DocumentElement> executor =
+				indexManager.createIndexer( DocumentCommitStrategy.NONE );
 		List<CompletableFuture<?>> futures = new ArrayList<>();
 		for ( int i = 0; i < documentCount; i++ ) {
 			int intValue = i;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryFetchIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryFetchIT.java
@@ -21,7 +21,7 @@ import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexDocumentWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.dsl.SearchQueryOptionsStep;
@@ -288,8 +288,8 @@ public class SearchQueryFetchIT {
 	}
 
 	private void initData() {
-		IndexDocumentWorkExecutor<? extends DocumentElement> executor =
-				indexManager.createDocumentWorkExecutor( DocumentCommitStrategy.NONE );
+		IndexIndexer<? extends DocumentElement> executor =
+				indexManager.createIndexer( DocumentCommitStrategy.NONE );
 		List<CompletableFuture<?>> futures = new ArrayList<>();
 		for ( int i = 0; i < DOCUMENT_COUNT; i++ ) {
 			int intValue = i;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryFetchIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryFetchIT.java
@@ -299,7 +299,7 @@ public class SearchQueryFetchIT {
 		}
 
 		CompletableFuture.allOf( futures.toArray( new CompletableFuture<?>[0] ) ).join();
-		indexManager.createWorkExecutor().flush().join();
+		indexManager.createWorkspace().flush().join();
 
 		// Check that all documents are searchable
 		StubMappingScope scope = indexManager.createScope();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryResultLoadingOrTransformingIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryResultLoadingOrTransformingIT.java
@@ -24,7 +24,7 @@ import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectField;
 import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
 import org.hibernate.search.engine.backend.types.Projectable;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.loading.context.spi.LoadingContext;
 import org.hibernate.search.engine.search.loading.spi.DefaultProjectionHitMapper;
@@ -547,8 +547,8 @@ public class SearchQueryResultLoadingOrTransformingIT extends EasyMockSupport {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( MAIN_ID ), document -> {
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( MAIN_ID ), document -> {
 			document.addValue( indexMapping.string, STRING_VALUE );
 			document.addValue( indexMapping.string_analyzed, STRING_ANALYZED_VALUE );
 			document.addValue( indexMapping.integer, INTEGER_VALUE );
@@ -566,9 +566,9 @@ public class SearchQueryResultLoadingOrTransformingIT extends EasyMockSupport {
 			nestedObject.addValue( indexMapping.nestedObject.integer, NESTED_OBJECT_INTEGER_VALUE );
 		} );
 
-		workPlan.add( referenceProvider( EMPTY_ID ), document -> { } );
+		plan.add( referenceProvider( EMPTY_ID ), document -> { } );
 
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		StubMappingScope scope = indexManager.createScope();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/CompositeSearchSortIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/CompositeSearchSortIT.java
@@ -20,7 +20,7 @@ import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage
 import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeFactory;
 import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeOptionsStep;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.sort.SearchSort;
 import org.hibernate.search.engine.search.sort.dsl.SearchSortFactory;
@@ -308,8 +308,8 @@ public class CompositeSearchSortIT {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( DOCUMENT_1 ), document -> {
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			indexMapping.identicalForFirstTwo.write( document, "aaa" );
 			indexMapping.identicalForLastTwo.write( document, "aaa" );
 
@@ -318,7 +318,7 @@ public class CompositeSearchSortIT {
 			DocumentElement nested = document.addObject( indexMapping.nestedObject );
 			indexMapping.nestedField.write( nested, "bbb" );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_2 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_2 ), document -> {
 			indexMapping.identicalForFirstTwo.write( document, "aaa" );
 			indexMapping.identicalForLastTwo.write( document, "bbb" );
 
@@ -327,7 +327,7 @@ public class CompositeSearchSortIT {
 			DocumentElement nested = document.addObject( indexMapping.nestedObject );
 			indexMapping.nestedField.write( nested, "aaa" );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_3 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_3 ), document -> {
 			indexMapping.identicalForFirstTwo.write( document, "bbb" );
 			indexMapping.identicalForLastTwo.write( document, "bbb" );
 
@@ -336,7 +336,7 @@ public class CompositeSearchSortIT {
 			DocumentElement nested = document.addObject( indexMapping.nestedObject );
 			indexMapping.nestedField.write( nested, "aaa" );
 		} );
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		SearchQuery<DocumentReference> query = indexManager.createScope().query()

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSearchSortIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSearchSortIT.java
@@ -25,7 +25,7 @@ import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage
 import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeFactory;
 import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeOptionsStep;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.search.sort.dsl.SortFinalStep;
 import org.hibernate.search.engine.search.common.ValueConvert;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldModelConsumer;
@@ -619,9 +619,9 @@ public class FieldSearchSortIT {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
 		// Important: do not index the documents in the expected order after sorts (1, 2, 3)
-		workPlan.add( referenceProvider( DOCUMENT_2 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_2 ), document -> {
 			indexMapping.supportedFieldModels.forEach( f -> f.document2Value.write( document ) );
 			indexMapping.supportedFieldWithDslConverterModels.forEach( f -> f.document2Value.write( document ) );
 			indexMapping.unsupportedFieldModels.forEach( f -> f.document2Value.write( document ) );
@@ -638,7 +638,7 @@ public class FieldSearchSortIT {
 
 			indexMapping.scaledBigDecimal.document2Value.write( document );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_1 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			indexMapping.supportedFieldModels.forEach( f -> f.document1Value.write( document ) );
 			indexMapping.supportedFieldWithDslConverterModels.forEach( f -> f.document1Value.write( document ) );
 			indexMapping.unsupportedFieldModels.forEach( f -> f.document1Value.write( document ) );
@@ -655,7 +655,7 @@ public class FieldSearchSortIT {
 
 			indexMapping.scaledBigDecimal.document1Value.write( document );
 		} );
-		workPlan.add( referenceProvider( DOCUMENT_3 ), document -> {
+		plan.add( referenceProvider( DOCUMENT_3 ), document -> {
 			indexMapping.supportedFieldModels.forEach( f -> f.document3Value.write( document ) );
 			indexMapping.supportedFieldWithDslConverterModels.forEach( f -> f.document3Value.write( document ) );
 			indexMapping.unsupportedFieldModels.forEach( f -> f.document3Value.write( document ) );
@@ -672,43 +672,43 @@ public class FieldSearchSortIT {
 
 			indexMapping.scaledBigDecimal.document3Value.write( document );
 		} );
-		workPlan.add( referenceProvider( EMPTY ), document -> { } );
-		workPlan.execute().join();
+		plan.add( referenceProvider( EMPTY ), document -> { } );
+		plan.execute().join();
 
-		workPlan = compatibleIndexManager.createWorkPlan();
-		workPlan.add( referenceProvider( COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
+		plan = compatibleIndexManager.createIndexingPlan();
+		plan.add( referenceProvider( COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
 			compatibleIndexMapping.supportedFieldModels.forEach( f -> f.document1Value.write( document ) );
 			compatibleIndexMapping.supportedFieldWithDslConverterModels.forEach( f -> f.document1Value.write( document ) );
 		} );
-		workPlan.execute().join();
+		plan.execute().join();
 
-		workPlan = rawFieldCompatibleIndexManager.createWorkPlan();
-		workPlan.add( referenceProvider( RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
+		plan = rawFieldCompatibleIndexManager.createIndexingPlan();
+		plan.add( referenceProvider( RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 ), document -> {
 			rawFieldCompatibleIndexMapping.supportedFieldModels.forEach( f -> f.document1Value.write( document ) );
 		} );
-		workPlan.execute().join();
+		plan.execute().join();
 
-		workPlan = incompatibleDecimalScaleIndexManager.createWorkPlan();
-		workPlan.add( referenceProvider( INCOMPATIBLE_DECIMAL_SCALE_INDEX_DOCUMENT_1 ), document -> {
+		plan = incompatibleDecimalScaleIndexManager.createIndexingPlan();
+		plan.add( referenceProvider( INCOMPATIBLE_DECIMAL_SCALE_INDEX_DOCUMENT_1 ), document -> {
 			incompatibleDecimalScaleIndexMapping.scaledBigDecimal.document1Value.write( document );
 		} );
-		workPlan.execute().join();
+		plan.execute().join();
 
-		workPlan = multipleEmptyIndexManager.createWorkPlan();
-		workPlan.add( referenceProvider( EMPTY_1 ), document -> { } );
-		workPlan.add( referenceProvider( DOCUMENT_2 ), document ->
+		plan = multipleEmptyIndexManager.createIndexingPlan();
+		plan.add( referenceProvider( EMPTY_1 ), document -> { } );
+		plan.add( referenceProvider( DOCUMENT_2 ), document ->
 			multipleEmptyIndexMapping.supportedFieldModels.forEach( f -> f.document2Value.write( document ) )
 		);
-		workPlan.add( referenceProvider( EMPTY_2 ), document -> { } );
-		workPlan.add( referenceProvider( DOCUMENT_3 ), document ->
+		plan.add( referenceProvider( EMPTY_2 ), document -> { } );
+		plan.add( referenceProvider( DOCUMENT_3 ), document ->
 			multipleEmptyIndexMapping.supportedFieldModels.forEach( f -> f.document3Value.write( document ) )
 		);
-		workPlan.add( referenceProvider( EMPTY_3 ), document -> { } );
-		workPlan.add( referenceProvider( DOCUMENT_1 ), document ->
+		plan.add( referenceProvider( EMPTY_3 ), document -> { } );
+		plan.add( referenceProvider( DOCUMENT_1 ), document ->
 			multipleEmptyIndexMapping.supportedFieldModels.forEach( f -> f.document1Value.write( document ) )
 		);
-		workPlan.add( referenceProvider( EMPTY_4 ), document -> { } );
-		workPlan.execute().join();
+		plan.add( referenceProvider( EMPTY_4 ), document -> { } );
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		SearchQuery<DocumentReference> query = indexManager.createScope().query()

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/SearchSortIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/SearchSortIT.java
@@ -20,7 +20,7 @@ import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectField;
 import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
 import org.hibernate.search.engine.backend.types.Sortable;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.predicate.SearchPredicate;
 import org.hibernate.search.engine.search.sort.dsl.SortFinalStep;
@@ -513,9 +513,9 @@ public class SearchSortIT {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
 		// Important: do not index the documents in the expected order after sorts
-		workPlan.add( referenceProvider( SECOND_ID ), document -> {
+		plan.add( referenceProvider( SECOND_ID ), document -> {
 			document.addValue( indexMapping.string, "george" );
 			document.addValue( indexMapping.geoPoint, GeoPoint.of( 45.7705687,4.835233 ) );
 
@@ -537,7 +537,7 @@ public class SearchSortIT {
 			nestedX2Object.addValue( indexMapping.nestedX2Object.string, "george" );
 			nestedX2Object.addValue( indexMapping.nestedX2Object.integer, 2 );
 		} );
-		workPlan.add( referenceProvider( FIRST_ID ), document -> {
+		plan.add( referenceProvider( FIRST_ID ), document -> {
 			document.addValue( indexMapping.string, "aaron" );
 			document.addValue( indexMapping.geoPoint, GeoPoint.of( 45.7541719, 4.8386221 ) );
 
@@ -559,7 +559,7 @@ public class SearchSortIT {
 			nestedX2Object.addValue( indexMapping.nestedX2Object.string, "aaron" );
 			nestedX2Object.addValue( indexMapping.nestedX2Object.integer, 1 );
 		} );
-		workPlan.add( referenceProvider( THIRD_ID ), document -> {
+		plan.add( referenceProvider( THIRD_ID ), document -> {
 			document.addValue( indexMapping.string, "zach" );
 			document.addValue( indexMapping.geoPoint, GeoPoint.of( 45.7530374, 4.8510299 ) );
 
@@ -581,9 +581,9 @@ public class SearchSortIT {
 			nestedX2Object.addValue( indexMapping.nestedX2Object.string, "zach" );
 			nestedX2Object.addValue( indexMapping.nestedX2Object.integer, 3 );
 		} );
-		workPlan.add( referenceProvider( EMPTY_ID ), document -> { } );
+		plan.add( referenceProvider( EMPTY_ID ), document -> { } );
 
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		StubMappingScope scope = indexManager.createScope();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/AbstractSpatialWithinSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/AbstractSpatialWithinSearchPredicateIT.java
@@ -15,7 +15,7 @@ import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement
 import org.hibernate.search.engine.backend.types.Searchable;
 import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.engine.backend.types.Projectable;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.engine.spatial.GeoPoint;
@@ -81,8 +81,8 @@ public abstract class AbstractSpatialWithinSearchPredicateIT {
 	}
 
 	protected void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( OURSON_QUI_BOIT_ID ), document -> {
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( OURSON_QUI_BOIT_ID ), document -> {
 			document.addValue( indexMapping.string, OURSON_QUI_BOIT_STRING );
 			document.addValue( indexMapping.geoPoint, OURSON_QUI_BOIT_GEO_POINT );
 			document.addValue( indexMapping.geoPoint_1, GeoPoint.of( OURSON_QUI_BOIT_GEO_POINT.getLatitude() - 1,
@@ -92,7 +92,7 @@ public abstract class AbstractSpatialWithinSearchPredicateIT {
 			document.addValue( indexMapping.geoPoint_with_longName, OURSON_QUI_BOIT_GEO_POINT );
 			document.addValue( indexMapping.projectableUnsortableGeoPoint, OURSON_QUI_BOIT_GEO_POINT );
 		} );
-		workPlan.add( referenceProvider( IMOUTO_ID ), document -> {
+		plan.add( referenceProvider( IMOUTO_ID ), document -> {
 			document.addValue( indexMapping.string, IMOUTO_STRING );
 			document.addValue( indexMapping.geoPoint, IMOUTO_GEO_POINT );
 			document.addValue( indexMapping.geoPoint_1, GeoPoint.of( IMOUTO_GEO_POINT.getLatitude() - 1,
@@ -102,7 +102,7 @@ public abstract class AbstractSpatialWithinSearchPredicateIT {
 			document.addValue( indexMapping.geoPoint_with_longName, IMOUTO_GEO_POINT );
 			document.addValue( indexMapping.projectableUnsortableGeoPoint, IMOUTO_GEO_POINT );
 		} );
-		workPlan.add( referenceProvider( CHEZ_MARGOTTE_ID ), document -> {
+		plan.add( referenceProvider( CHEZ_MARGOTTE_ID ), document -> {
 			document.addValue( indexMapping.string, CHEZ_MARGOTTE_STRING );
 			document.addValue( indexMapping.geoPoint, CHEZ_MARGOTTE_GEO_POINT );
 			document.addValue( indexMapping.geoPoint_1, GeoPoint.of( CHEZ_MARGOTTE_GEO_POINT.getLatitude() - 1,
@@ -112,9 +112,9 @@ public abstract class AbstractSpatialWithinSearchPredicateIT {
 			document.addValue( indexMapping.geoPoint_with_longName, CHEZ_MARGOTTE_GEO_POINT );
 			document.addValue( indexMapping.projectableUnsortableGeoPoint, CHEZ_MARGOTTE_GEO_POINT );
 		} );
-		workPlan.add( referenceProvider( EMPTY_ID ), document -> { } );
+		plan.add( referenceProvider( EMPTY_ID ), document -> { } );
 
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		StubMappingScope scope = indexManager.createScope();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/DistanceSearchSearchableSortableIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/DistanceSearchSearchableSortableIT.java
@@ -14,7 +14,7 @@ import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.types.Searchable;
 import org.hibernate.search.engine.backend.types.Sortable;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.engine.spatial.GeoPoint;
@@ -161,29 +161,29 @@ public class DistanceSearchSearchableSortableIT {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( OURSON_QUI_BOIT_ID ), document -> {
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( OURSON_QUI_BOIT_ID ), document -> {
 			document.addValue( indexMapping.searchableSortable, OURSON_QUI_BOIT_GEO_POINT );
 			document.addValue( indexMapping.searchableNotSortable, OURSON_QUI_BOIT_GEO_POINT );
 			document.addValue( indexMapping.searchableDefaultSortable, OURSON_QUI_BOIT_GEO_POINT );
 			document.addValue( indexMapping.notSearchableSortable, OURSON_QUI_BOIT_GEO_POINT );
 			document.addValue( indexMapping.defaultSearchableSortable, OURSON_QUI_BOIT_GEO_POINT );
 		} );
-		workPlan.add( referenceProvider( IMOUTO_ID ), document -> {
+		plan.add( referenceProvider( IMOUTO_ID ), document -> {
 			document.addValue( indexMapping.searchableSortable, IMOUTO_GEO_POINT );
 			document.addValue( indexMapping.searchableNotSortable, IMOUTO_GEO_POINT );
 			document.addValue( indexMapping.searchableDefaultSortable, IMOUTO_GEO_POINT );
 			document.addValue( indexMapping.notSearchableSortable, IMOUTO_GEO_POINT );
 			document.addValue( indexMapping.defaultSearchableSortable, IMOUTO_GEO_POINT );
 		} );
-		workPlan.add( referenceProvider( CHEZ_MARGOTTE_ID ), document -> {
+		plan.add( referenceProvider( CHEZ_MARGOTTE_ID ), document -> {
 			document.addValue( indexMapping.searchableSortable, CHEZ_MARGOTTE_GEO_POINT );
 			document.addValue( indexMapping.searchableNotSortable, CHEZ_MARGOTTE_GEO_POINT );
 			document.addValue( indexMapping.searchableDefaultSortable, CHEZ_MARGOTTE_GEO_POINT );
 			document.addValue( indexMapping.notSearchableSortable, CHEZ_MARGOTTE_GEO_POINT );
 			document.addValue( indexMapping.defaultSearchableSortable, CHEZ_MARGOTTE_GEO_POINT );
 		} );
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		StubMappingScope scope = indexManager.createScope();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/NestedDocumentDistanceProjectionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/NestedDocumentDistanceProjectionIT.java
@@ -20,7 +20,7 @@ import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectF
 import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
 import org.hibernate.search.engine.backend.types.Projectable;
 import org.hibernate.search.engine.backend.types.Sortable;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.engine.spatial.GeoPoint;
@@ -103,8 +103,8 @@ public class NestedDocumentDistanceProjectionIT {
 	}
 
 	private void initData() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( OURSON_QUI_BOIT_ID ), document -> {
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( OURSON_QUI_BOIT_ID ), document -> {
 			document.addValue( indexMapping.ordinalField, 1 );
 
 			DocumentElement nestedDocument = document.addObject( indexMapping.nestedDocument );
@@ -113,7 +113,7 @@ public class NestedDocumentDistanceProjectionIT {
 			DocumentElement flattenedDocument = document.addObject( indexMapping.flattenedDocument );
 			flattenedDocument.addValue( indexMapping.flattenedGeoPoint, OURSON_QUI_BOIT_GEO_POINT );
 		} );
-		workPlan.add( referenceProvider( IMOUTO_ID ), document -> {
+		plan.add( referenceProvider( IMOUTO_ID ), document -> {
 			document.addValue( indexMapping.ordinalField, 2 );
 
 			DocumentElement nestedDocument = document.addObject( indexMapping.nestedDocument );
@@ -122,7 +122,7 @@ public class NestedDocumentDistanceProjectionIT {
 			DocumentElement flattenedDocument = document.addObject( indexMapping.flattenedDocument );
 			flattenedDocument.addValue( indexMapping.flattenedGeoPoint, IMOUTO_GEO_POINT );
 		} );
-		workPlan.add( referenceProvider( CHEZ_MARGOTTE_ID ), document -> {
+		plan.add( referenceProvider( CHEZ_MARGOTTE_ID ), document -> {
 			document.addValue( indexMapping.ordinalField, 3 );
 
 			DocumentElement nestedDocument = document.addObject( indexMapping.nestedDocument );
@@ -131,7 +131,7 @@ public class NestedDocumentDistanceProjectionIT {
 			DocumentElement flattenedDocument = document.addObject( indexMapping.flattenedDocument );
 			flattenedDocument.addValue( indexMapping.flattenedGeoPoint, CHEZ_MARGOTTE_GEO_POINT );
 		} );
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		StubMappingScope scope = indexManager.createScope();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/SpatialWithinBoundingBoxSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/SpatialWithinBoundingBoxSearchPredicateIT.java
@@ -10,7 +10,7 @@ import static org.hibernate.search.util.impl.integrationtest.common.assertion.Se
 import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
 
 import org.hibernate.search.engine.backend.document.DocumentElement;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
 import org.hibernate.search.engine.reporting.spi.EventContexts;
 import org.hibernate.search.engine.backend.common.DocumentReference;
@@ -428,15 +428,15 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 	protected void initData() {
 		super.initData();
 
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
-		workPlan.add( referenceProvider( ADDITIONAL_POINT_1_ID ), document -> {
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
+		plan.add( referenceProvider( ADDITIONAL_POINT_1_ID ), document -> {
 			document.addValue( indexMapping.geoPoint, ADDITIONAL_POINT_1_GEO_POINT );
 		} );
-		workPlan.add( referenceProvider( ADDITIONAL_POINT_2_ID ), document -> {
+		plan.add( referenceProvider( ADDITIONAL_POINT_2_ID ), document -> {
 			document.addValue( indexMapping.geoPoint, ADDITIONAL_POINT_2_GEO_POINT );
 		} );
 
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// Check that all documents are searchable
 		StubMappingScope scope = indexManager.createScope();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/sharding/AbstractShardingIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/sharding/AbstractShardingIT.java
@@ -18,7 +18,7 @@ import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
 import org.hibernate.search.engine.mapper.mapping.building.spi.IndexedEntityBindingContext;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.util.impl.integrationtest.common.assertion.NormalizedDocRefHit;
@@ -66,8 +66,8 @@ public abstract class AbstractShardingIT {
 		}
 		CompletableFuture.allOf( tasks.toArray( new CompletableFuture<?>[0] ) ).join();
 
-		IndexWorkExecutor indexWorkExecutor = indexManager.createWorkExecutor();
-		indexWorkExecutor.flush().join();
+		IndexWorkspace workspace = indexManager.createWorkspace();
+		workspace.flush().join();
 	}
 
 	protected class IndexMapping {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/sharding/AbstractShardingIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/sharding/AbstractShardingIT.java
@@ -17,7 +17,7 @@ import java.util.stream.Stream;
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexDocumentWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
 import org.hibernate.search.engine.mapper.mapping.building.spi.IndexedEntityBindingContext;
 import org.hibernate.search.engine.backend.common.DocumentReference;
@@ -51,14 +51,14 @@ public abstract class AbstractShardingIT {
 	}
 
 	protected final void initData(Map<String, List<String>> docIdByRoutingKey) {
-		IndexDocumentWorkExecutor<? extends DocumentElement> documentWorkExecutor =
-				indexManager.createDocumentWorkExecutor( DocumentCommitStrategy.NONE );
+		IndexIndexer<? extends DocumentElement> indexer =
+				indexManager.createIndexer( DocumentCommitStrategy.NONE );
 		List<CompletableFuture<?>> tasks = new ArrayList<>();
 
 		for ( Map.Entry<String, List<String>> entry : docIdByRoutingKey.entrySet() ) {
 			String routingKey = entry.getKey();
 			for ( String documentId : entry.getValue() ) {
-				tasks.add( documentWorkExecutor.add(
+				tasks.add( indexer.add(
 						referenceProvider( documentId, routingKey ),
 						document -> document.addValue( indexMapping.indexedRoutingKey, routingKey )
 				) );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexIndexerIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexIndexerIT.java
@@ -14,7 +14,7 @@ import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexDocumentWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;
@@ -29,9 +29,9 @@ import org.junit.rules.ExpectedException;
 import org.assertj.core.api.Assertions;
 
 /**
- * Verify that the {@link IndexDocumentWorkExecutor}, provided by a backend, is working properly, storing correctly the indexes.
+ * Verify that the {@link IndexIndexer}, provided by a backend, is working properly, storing correctly the indexes.
  */
-public class IndexDocumentWorkExecutorIT {
+public class IndexIndexerIT {
 
 	private static final String INDEX_NAME = "lordOfTheRingsChapters";
 	private static final int NUMBER_OF_BOOKS = 200;
@@ -58,14 +58,14 @@ public class IndexDocumentWorkExecutorIT {
 
 	@Test
 	public void checkAllDocumentsAreSearchable() {
-		IndexDocumentWorkExecutor<? extends DocumentElement> documentWorkExecutor =
-				indexManager.createDocumentWorkExecutor( DocumentCommitStrategy.NONE );
+		IndexIndexer<? extends DocumentElement> indexer =
+				indexManager.createIndexer( DocumentCommitStrategy.NONE );
 		CompletableFuture<?>[] tasks = new CompletableFuture<?>[NUMBER_OF_BOOKS];
 		IndexWorkExecutor workExecutor = indexManager.createWorkExecutor();
 
 		for ( int i = 0; i < NUMBER_OF_BOOKS; i++ ) {
 			final String id = i + "";
-			tasks[i] = documentWorkExecutor.add( referenceProvider( id ), document -> {
+			tasks[i] = indexer.add( referenceProvider( id ), document -> {
 				document.addValue( indexMapping.title, "The Lord of the Rings cap. " + id );
 			} );
 		}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexIndexerIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexIndexerIT.java
@@ -15,7 +15,7 @@ import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
@@ -61,7 +61,7 @@ public class IndexIndexerIT {
 		IndexIndexer<? extends DocumentElement> indexer =
 				indexManager.createIndexer( DocumentCommitStrategy.NONE );
 		CompletableFuture<?>[] tasks = new CompletableFuture<?>[NUMBER_OF_BOOKS];
-		IndexWorkExecutor workExecutor = indexManager.createWorkExecutor();
+		IndexWorkspace workspace = indexManager.createWorkspace();
 
 		for ( int i = 0; i < NUMBER_OF_BOOKS; i++ ) {
 			final String id = i + "";
@@ -70,7 +70,7 @@ public class IndexIndexerIT {
 			} );
 		}
 		CompletableFuture.allOf( tasks ).join();
-		workExecutor.flush().join();
+		workspace.flush().join();
 
 		SearchQuery<DocumentReference> query = indexManager.createScope().query()
 				.predicate( f -> f.matchAll() )

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexIndexingPlanIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexIndexingPlanIT.java
@@ -12,7 +12,7 @@ import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
@@ -22,7 +22,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class IndexWorkPlanIT {
+public class IndexIndexingPlanIT {
 
 	private static final String INDEX_NAME = "indexName";
 
@@ -45,13 +45,13 @@ public class IndexWorkPlanIT {
 
 	@Test
 	public void discard() {
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
 
-		workPlan.add( referenceProvider( "1" ), document -> document.addValue( indexMapping.title, "Title of Book 1" ) );
-		workPlan.discard();
+		plan.add( referenceProvider( "1" ), document -> document.addValue( indexMapping.title, "Title of Book 1" ) );
+		plan.discard();
 
-		workPlan.add( referenceProvider( "2" ), document -> document.addValue( indexMapping.title, "Title of Book 2" ) );
-		workPlan.execute().join();
+		plan.add( referenceProvider( "2" ), document -> document.addValue( indexMapping.title, "Title of Book 2" ) );
+		plan.execute().join();
 
 		SearchQuery<DocumentReference> query = indexManager.createScope().query()
 				.predicate( f -> f.matchAll() )

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkExecutorIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkExecutorIT.java
@@ -14,7 +14,7 @@ import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexDocumentWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;
@@ -119,13 +119,13 @@ public class IndexWorkExecutorIT {
 	}
 
 	private void createBookIndexes(StubBackendSessionContext sessionContext) {
-		IndexDocumentWorkExecutor<? extends DocumentElement> documentWorkExecutor =
-				indexManager.createDocumentWorkExecutor( sessionContext, DocumentCommitStrategy.NONE );
+		IndexIndexer<? extends DocumentElement> indexer =
+				indexManager.createIndexer( sessionContext, DocumentCommitStrategy.NONE );
 		CompletableFuture<?>[] tasks = new CompletableFuture<?>[NUMBER_OF_BOOKS];
 
 		for ( int i = 0; i < NUMBER_OF_BOOKS; i++ ) {
 			final String id = i + "";
-			tasks[i] = documentWorkExecutor.add( referenceProvider( id ), document -> {
+			tasks[i] = indexer.add( referenceProvider( id ), document -> {
 				document.addValue( indexMapping.title, "The Lord of the Rings cap. " + id );
 			} );
 		}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceIT.java
@@ -15,7 +15,7 @@ import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBackendHelper;
@@ -31,10 +31,10 @@ import org.assertj.core.api.Assertions;
 
 /**
  * Verify that the work executor operations:
- * {@link IndexWorkExecutor#optimize()}, {@link IndexWorkExecutor#purge()}, {@link IndexWorkExecutor#flush()}
+ * {@link IndexWorkspace#optimize()}, {@link IndexWorkspace#purge()}, {@link IndexWorkspace#flush()}
  * work properly, in every backends.
  */
-public class IndexWorkExecutorIT {
+public class IndexWorkspaceIT {
 
 	private static final String TENANT_1 = "tenant1";
 	private static final String TENANT_2 = "tenant2";
@@ -69,18 +69,18 @@ public class IndexWorkExecutorIT {
 				.setup();
 
 		// Do not provide a tenant
-		IndexWorkExecutor workExecutor = indexManager.createWorkExecutor();
+		IndexWorkspace workspace = indexManager.createWorkspace();
 		createBookIndexes( noTenantSessionContext );
 
-		workExecutor.flush().join();
+		workspace.flush().join();
 		assertBookNumberIsEqualsTo( NUMBER_OF_BOOKS, noTenantSessionContext );
 
-		workExecutor.optimize().join();
+		workspace.optimize().join();
 		assertBookNumberIsEqualsTo( NUMBER_OF_BOOKS, noTenantSessionContext );
 
 		// purge without providing a tenant
-		workExecutor.purge().join();
-		workExecutor.flush().join();
+		workspace.purge().join();
+		workspace.flush().join();
 
 		assertBookNumberIsEqualsTo( 0, noTenantSessionContext );
 	}
@@ -97,21 +97,21 @@ public class IndexWorkExecutorIT {
 				.setup();
 
 		// Do provide a tenant ID
-		IndexWorkExecutor workExecutor = indexManager.createWorkExecutor( tenant1SessionContext );
+		IndexWorkspace workspace = indexManager.createWorkspace( tenant1SessionContext );
 
 		createBookIndexes( tenant1SessionContext );
 		createBookIndexes( tenant2SessionContext );
-		workExecutor.flush().join();
+		workspace.flush().join();
 
 		assertBookNumberIsEqualsTo( NUMBER_OF_BOOKS, tenant1SessionContext );
 		assertBookNumberIsEqualsTo( NUMBER_OF_BOOKS, tenant2SessionContext );
 
-		workExecutor.optimize().join();
+		workspace.optimize().join();
 		assertBookNumberIsEqualsTo( NUMBER_OF_BOOKS, tenant1SessionContext );
 		assertBookNumberIsEqualsTo( NUMBER_OF_BOOKS, tenant2SessionContext );
 
-		workExecutor.purge().join();
-		workExecutor.flush().join();
+		workspace.purge().join();
+		workspace.flush().join();
 
 		// check that only TENANT_1 is affected by the purge
 		assertBookNumberIsEqualsTo( 0, tenant1SessionContext );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexingIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexingIT.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.types.Projectable;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldTypeDescriptor;
@@ -88,16 +88,16 @@ public class IndexingIT<F> {
 		List<IdAndValue<F>> expectedDocuments = new ArrayList<>();
 
 		// Index all values, each in its own document
-		IndexWorkPlan<? extends DocumentElement> workPlan = indexManager.createWorkPlan();
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan();
 		for ( int i = 0; i < values.size(); i++ ) {
 			String documentId = "document_" + i;
 			F value = values.get( i );
-			workPlan.add( referenceProvider( documentId ), document -> {
+			plan.add( referenceProvider( documentId ), document -> {
 				document.addValue( indexMapping.fieldModel.reference, value );
 			} );
 			expectedDocuments.add( new IdAndValue<>( documentId, value ) );
 		}
-		workPlan.execute().join();
+		plan.execute().join();
 
 		// If we get here, indexing went well.
 		// However, it may have failed silently... Let's check the documents are there, with the right value.

--- a/integrationtest/mapper/orm-envers/src/test/java/org/hibernate/search/integrationtest/mapper/orm/envers/EnversIT.java
+++ b/integrationtest/mapper/orm-envers/src/test/java/org/hibernate/search/integrationtest/mapper/orm/envers/EnversIT.java
@@ -93,7 +93,7 @@ public class EnversIT {
 									.field( "text", "initial" )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 		checkEnversAuditedCorrectly( IndexedEntity.class,
@@ -114,7 +114,7 @@ public class EnversIT {
 									.field( "text", "initial" )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 		checkEnversAuditedCorrectly( IndexedEntity.class,
@@ -135,7 +135,7 @@ public class EnversIT {
 									.field( "text", "updated" )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 		checkEnversAuditedCorrectly( IndexedEntity.class,
@@ -151,7 +151,7 @@ public class EnversIT {
 
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.delete( "1" )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 		checkEnversAuditedCorrectly( IndexedEntity.class,

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AbstractAutomaticIndexingAssociationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AbstractAutomaticIndexingAssociationIT.java
@@ -189,7 +189,7 @@ public abstract class AbstractAutomaticIndexingAssociationIT<
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -206,7 +206,7 @@ public abstract class AbstractAutomaticIndexingAssociationIT<
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -252,7 +252,7 @@ public abstract class AbstractAutomaticIndexingAssociationIT<
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -307,7 +307,7 @@ public abstract class AbstractAutomaticIndexingAssociationIT<
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -328,7 +328,7 @@ public abstract class AbstractAutomaticIndexingAssociationIT<
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -349,7 +349,7 @@ public abstract class AbstractAutomaticIndexingAssociationIT<
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -413,7 +413,7 @@ public abstract class AbstractAutomaticIndexingAssociationIT<
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -436,7 +436,7 @@ public abstract class AbstractAutomaticIndexingAssociationIT<
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -484,7 +484,7 @@ public abstract class AbstractAutomaticIndexingAssociationIT<
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -542,7 +542,7 @@ public abstract class AbstractAutomaticIndexingAssociationIT<
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -562,7 +562,7 @@ public abstract class AbstractAutomaticIndexingAssociationIT<
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -599,7 +599,7 @@ public abstract class AbstractAutomaticIndexingAssociationIT<
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -620,7 +620,7 @@ public abstract class AbstractAutomaticIndexingAssociationIT<
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -641,7 +641,7 @@ public abstract class AbstractAutomaticIndexingAssociationIT<
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -679,7 +679,7 @@ public abstract class AbstractAutomaticIndexingAssociationIT<
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -697,7 +697,7 @@ public abstract class AbstractAutomaticIndexingAssociationIT<
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -715,7 +715,7 @@ public abstract class AbstractAutomaticIndexingAssociationIT<
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -747,7 +747,7 @@ public abstract class AbstractAutomaticIndexingAssociationIT<
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -798,7 +798,7 @@ public abstract class AbstractAutomaticIndexingAssociationIT<
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -861,7 +861,7 @@ public abstract class AbstractAutomaticIndexingAssociationIT<
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AbstractAutomaticIndexingBridgeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AbstractAutomaticIndexingBridgeIT.java
@@ -66,7 +66,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -83,7 +83,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -94,7 +94,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.delete( "1" )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -130,7 +130,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -155,7 +155,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -181,7 +181,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -216,7 +216,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -266,7 +266,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -284,7 +284,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -335,7 +335,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 									.field( "includedInSingleValuedPropertyBridge", null )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -357,7 +357,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 									.field( "includedInSingleValuedPropertyBridge", "initialValue" )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -380,7 +380,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 									.field( "includedInSingleValuedPropertyBridge", "updatedValue" )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -412,7 +412,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 									.field( "includedInSingleValuedPropertyBridge", null )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -460,7 +460,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 									.field( "includedInSingleValuedPropertyBridge", "initialValue" )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -475,7 +475,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 									.field( "includedInSingleValuedPropertyBridge", "updatedValue" )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -515,7 +515,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 									.field( "includedInMultiValuedPropertyBridge", null )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -543,7 +543,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 									.field( "includedInMultiValuedPropertyBridge", "value1" )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -571,7 +571,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 									.field( "includedInMultiValuedPropertyBridge", "value1 value2" )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -603,7 +603,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 									.field( "includedInMultiValuedPropertyBridge", "updatedValue" )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -621,7 +621,7 @@ public abstract class AbstractAutomaticIndexingBridgeIT {
 									.field( "includedInMultiValuedPropertyBridge", null )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AbstractAutomaticIndexingMultiAssociationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AbstractAutomaticIndexingMultiAssociationIT.java
@@ -51,7 +51,7 @@ public abstract class AbstractAutomaticIndexingMultiAssociationIT<
 
 			backendMock.expectWorks( primitives.getIndexName() )
 					.add( "1", b -> { } )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -73,7 +73,7 @@ public abstract class AbstractAutomaticIndexingMultiAssociationIT<
 									.field( "indexedField", VALUE_1 )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -98,7 +98,7 @@ public abstract class AbstractAutomaticIndexingMultiAssociationIT<
 									.field( "indexedField", VALUE_2 )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -117,7 +117,7 @@ public abstract class AbstractAutomaticIndexingMultiAssociationIT<
 									.field( "indexedField", VALUE_2 )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -150,7 +150,7 @@ public abstract class AbstractAutomaticIndexingMultiAssociationIT<
 									.field( "indexedField", VALUE_1 )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -178,7 +178,7 @@ public abstract class AbstractAutomaticIndexingMultiAssociationIT<
 									.field( "indexedField", VALUE_2 )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -198,7 +198,7 @@ public abstract class AbstractAutomaticIndexingMultiAssociationIT<
 
 			backendMock.expectWorks( primitives.getIndexName() )
 					.add( "1", b -> { } )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -273,7 +273,7 @@ public abstract class AbstractAutomaticIndexingMultiAssociationIT<
 
 			backendMock.expectWorks( primitives.getIndexName() )
 					.add( "1", b -> { } )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -295,7 +295,7 @@ public abstract class AbstractAutomaticIndexingMultiAssociationIT<
 			// TODO HSEARCH-3204: remove the statement below to not expect any work
 			backendMock.expectWorks( primitives.getIndexName() )
 					.update( "1", b -> { } )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -315,7 +315,7 @@ public abstract class AbstractAutomaticIndexingMultiAssociationIT<
 
 			backendMock.expectWorks( primitives.getIndexName() )
 					.add( "1", b -> { } )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -394,7 +394,7 @@ public abstract class AbstractAutomaticIndexingMultiAssociationIT<
 									.field( "indexedField", VALUE_1 )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -423,7 +423,7 @@ public abstract class AbstractAutomaticIndexingMultiAssociationIT<
 									.field( "indexedField", VALUE_2 )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -449,7 +449,7 @@ public abstract class AbstractAutomaticIndexingMultiAssociationIT<
 					.add( "1", b -> b
 							.objectField( "child", b2 -> { } )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -473,7 +473,7 @@ public abstract class AbstractAutomaticIndexingMultiAssociationIT<
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -500,7 +500,7 @@ public abstract class AbstractAutomaticIndexingMultiAssociationIT<
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -537,7 +537,7 @@ public abstract class AbstractAutomaticIndexingMultiAssociationIT<
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -577,7 +577,7 @@ public abstract class AbstractAutomaticIndexingMultiAssociationIT<
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -607,7 +607,7 @@ public abstract class AbstractAutomaticIndexingMultiAssociationIT<
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -634,7 +634,7 @@ public abstract class AbstractAutomaticIndexingMultiAssociationIT<
 					.add( "1", b -> b
 							.objectField( "child", b2 -> { } )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -715,7 +715,7 @@ public abstract class AbstractAutomaticIndexingMultiAssociationIT<
 					.add( "1", b -> b
 							.objectField( "child", b2 -> { } )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -739,7 +739,7 @@ public abstract class AbstractAutomaticIndexingMultiAssociationIT<
 					.update( "1", b -> b
 							.objectField( "child", b2 -> { } )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -767,7 +767,7 @@ public abstract class AbstractAutomaticIndexingMultiAssociationIT<
 					.add( "1", b -> b
 							.objectField( "child", b2 -> { } )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -853,7 +853,7 @@ public abstract class AbstractAutomaticIndexingMultiAssociationIT<
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -884,7 +884,7 @@ public abstract class AbstractAutomaticIndexingMultiAssociationIT<
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -926,7 +926,7 @@ public abstract class AbstractAutomaticIndexingMultiAssociationIT<
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -943,7 +943,7 @@ public abstract class AbstractAutomaticIndexingMultiAssociationIT<
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -984,7 +984,7 @@ public abstract class AbstractAutomaticIndexingMultiAssociationIT<
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingBasicIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingBasicIT.java
@@ -534,7 +534,7 @@ public class AutomaticIndexingBasicIT {
 			session.persist( entity1 );
 			session.persist( entity2 );
 
-			// flush triggers the prepare of the current PojoWorkPlan
+			// flush triggers the prepare of the current indexing plan
 			Consumer<StubDocumentNode.Builder> documentFieldConsumer = b -> b.field( "indexedField", "number1" ).field( "noReindexOnUpdateField", null );
 
 			backendMock.expectWorks( IndexedEntity.INDEX )
@@ -576,7 +576,7 @@ public class AutomaticIndexingBasicIT {
 			session.persist( entity5 );
 			session.persist( entity6 );
 
-			// flush triggers the prepare of the current PojoWorkPlan
+			// flush triggers the prepare of the current indexing plan
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.add( "5", expectedValue( "number5" ) )
 					.add( "6", expectedValue( "number6" ) )

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingBasicIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingBasicIT.java
@@ -84,7 +84,7 @@ public class AutomaticIndexingBasicIT {
 									entity1.getIndexedElementCollectionField().get( 0 )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -101,7 +101,7 @@ public class AutomaticIndexingBasicIT {
 									entity1.getIndexedElementCollectionField().get( 0 )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -112,7 +112,7 @@ public class AutomaticIndexingBasicIT {
 
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.delete( "1" )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -137,7 +137,7 @@ public class AutomaticIndexingBasicIT {
 									entity1.getIndexedElementCollectionField().get( 0 )
 							)
 					)
-					.prepared();
+					.processed();
 
 			session.flush();
 			backendMock.verifyExpectationsMet();
@@ -176,7 +176,7 @@ public class AutomaticIndexingBasicIT {
 									entity1.getIndexedElementCollectionField().get( 0 )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -195,7 +195,7 @@ public class AutomaticIndexingBasicIT {
 									entity1.getIndexedElementCollectionField().get( 1 )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -213,7 +213,7 @@ public class AutomaticIndexingBasicIT {
 									entity1.getIndexedElementCollectionField().get( 0 )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -244,7 +244,7 @@ public class AutomaticIndexingBasicIT {
 									entity1.getIndexedElementCollectionField().get( 0 )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -264,7 +264,7 @@ public class AutomaticIndexingBasicIT {
 									entity1.getIndexedElementCollectionField().get( 1 )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -288,7 +288,7 @@ public class AutomaticIndexingBasicIT {
 							.field( "indexedField", entity1.getIndexedField() )
 							.field( "noReindexOnUpdateField", null )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -328,7 +328,7 @@ public class AutomaticIndexingBasicIT {
 							.field( "indexedField", null )
 							.field( "noReindexOnUpdateField", null )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -373,7 +373,7 @@ public class AutomaticIndexingBasicIT {
 							.field( "indexedField", null )
 							.field( "noReindexOnUpdateField", null )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -389,7 +389,7 @@ public class AutomaticIndexingBasicIT {
 							.field( "indexedField", null )
 							.field( "noReindexOnUpdateField", null )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -413,7 +413,7 @@ public class AutomaticIndexingBasicIT {
 							.field( "indexedField", null )
 							.field( "noReindexOnUpdateField", entity1.getNoReindexOnUpdateField() )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -454,7 +454,7 @@ public class AutomaticIndexingBasicIT {
 							.field( "noReindexOnUpdateField", null )
 							.field( "noReindexOnUpdateElementCollectionField", "firstValue" )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -500,7 +500,7 @@ public class AutomaticIndexingBasicIT {
 							.field( "noReindexOnUpdateField", null )
 							.field( "noReindexOnUpdateElementCollectionField", "firstValue" )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -520,7 +520,7 @@ public class AutomaticIndexingBasicIT {
 									"newFirstValue", "newSecondValue"
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -540,7 +540,7 @@ public class AutomaticIndexingBasicIT {
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.add( "1", expectedValue( "number1" ) )
 					.add( "2", expectedValue( "number2" ) )
-					.prepared();
+					.processed();
 
 			session.flush();
 
@@ -557,7 +557,7 @@ public class AutomaticIndexingBasicIT {
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.add( "3", expectedValue( "number3" ) )
 					.add( "4", expectedValue( "number4" ) )
-					.prepared();
+					.processed();
 
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.add( "1", expectedValue( "number1" ) )
@@ -580,7 +580,7 @@ public class AutomaticIndexingBasicIT {
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.add( "5", expectedValue( "number5" ) )
 					.add( "6", expectedValue( "number6" ) )
-					.prepared();
+					.processed();
 
 			session.flush();
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingBasicIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingBasicIT.java
@@ -20,7 +20,7 @@ import javax.persistence.Id;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
 import org.hibernate.search.mapper.orm.Search;
-import org.hibernate.search.mapper.orm.session.SearchSessionWritePlan;
+import org.hibernate.search.mapper.orm.work.SearchIndexingPlan;
 import org.hibernate.search.mapper.pojo.automaticindexing.ReindexOnUpdate;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
@@ -595,12 +595,12 @@ public class AutomaticIndexingBasicIT {
 			session.persist( entity7 );
 			session.persist( entity8 );
 
-			SearchSessionWritePlan writePlan = Search.session( session ).writePlan();
-			writePlan.addOrUpdate( entity9 );
-			writePlan.addOrUpdate( entity10 );
+			SearchIndexingPlan indexingPlan = Search.session( session ).indexingPlan();
+			indexingPlan.addOrUpdate( entity9 );
+			indexingPlan.addOrUpdate( entity10 );
 
 			// the clear will revert the changes that haven't been flushed yet,
-			// including the ones that have been inserted directly in the write plan (bypassing the ORM session)
+			// including the ones that have been inserted directly in the indexing plan (bypassing the ORM session)
 			session.clear();
 
 			backendMock.expectWorks( IndexedEntity.INDEX )

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingBridgeExplicitReindexingFunctionalIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingBridgeExplicitReindexingFunctionalIT.java
@@ -95,7 +95,7 @@ public class AutomaticIndexingBridgeExplicitReindexingFunctionalIT {
 					.add( "1", b -> b
 							.objectField( "typeBridge", b2 -> { } )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -113,7 +113,7 @@ public class AutomaticIndexingBridgeExplicitReindexingFunctionalIT {
 									.field( "includedInTypeBridge", "value1" )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -136,7 +136,7 @@ public class AutomaticIndexingBridgeExplicitReindexingFunctionalIT {
 									.field( "includedInTypeBridge", "value1" )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -154,7 +154,7 @@ public class AutomaticIndexingBridgeExplicitReindexingFunctionalIT {
 										.field( "includedInTypeBridge", "value1", "value2" )
 								)
 						)
-						.preparedThenExecuted();
+						.processedThenExecuted();
 			} );
 			backendMock.verifyExpectationsMet();
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingEmbeddableIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingEmbeddableIT.java
@@ -116,7 +116,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -144,7 +144,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -173,7 +173,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -190,7 +190,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -228,7 +228,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -257,7 +257,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -275,7 +275,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -313,7 +313,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -334,7 +334,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -370,7 +370,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -398,7 +398,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -427,7 +427,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -444,7 +444,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -471,7 +471,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -499,7 +499,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -530,7 +530,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -553,7 +553,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -591,7 +591,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -612,7 +612,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -648,7 +648,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -677,7 +677,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -711,7 +711,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -735,7 +735,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -770,7 +770,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -799,7 +799,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -830,7 +830,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -850,7 +850,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -889,7 +889,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -911,7 +911,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -957,7 +957,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -986,7 +986,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -1005,7 +1005,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -1042,7 +1042,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -1062,7 +1062,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -1098,7 +1098,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -1126,7 +1126,7 @@ public class AutomaticIndexingEmbeddableIT {
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -1156,7 +1156,7 @@ public class AutomaticIndexingEmbeddableIT {
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -1174,7 +1174,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedEmbeddedList", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -1212,7 +1212,7 @@ public class AutomaticIndexingEmbeddableIT {
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -1242,7 +1242,7 @@ public class AutomaticIndexingEmbeddableIT {
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -1261,7 +1261,7 @@ public class AutomaticIndexingEmbeddableIT {
 									.objectField( "containedBidirectionalEmbedded", b3 -> { } )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -1299,7 +1299,7 @@ public class AutomaticIndexingEmbeddableIT {
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -1320,7 +1320,7 @@ public class AutomaticIndexingEmbeddableIT {
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingEmbeddedBridgeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingEmbeddedBridgeIT.java
@@ -113,7 +113,7 @@ public class AutomaticIndexingEmbeddedBridgeIT {
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -130,7 +130,7 @@ public class AutomaticIndexingEmbeddedBridgeIT {
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingGenericPolymorphicAssociationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingGenericPolymorphicAssociationIT.java
@@ -98,7 +98,7 @@ public class AutomaticIndexingGenericPolymorphicAssociationIT {
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -116,7 +116,7 @@ public class AutomaticIndexingGenericPolymorphicAssociationIT {
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingMappedSuperclassIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingMappedSuperclassIT.java
@@ -87,7 +87,7 @@ public class AutomaticIndexingMappedSuperclassIT {
 									.field( "includedInSingle", "initialValue" )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -102,7 +102,7 @@ public class AutomaticIndexingMappedSuperclassIT {
 									.field( "includedInSingle", "updatedValue" )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingNonEntityIdDocumentIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingNonEntityIdDocumentIdIT.java
@@ -74,7 +74,7 @@ public class AutomaticIndexingNonEntityIdDocumentIdIT {
 									entity1.getIndexedElementCollectionField().get( 0 )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -90,7 +90,7 @@ public class AutomaticIndexingNonEntityIdDocumentIdIT {
 									entity1.getIndexedElementCollectionField().get( 0 )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -101,7 +101,7 @@ public class AutomaticIndexingNonEntityIdDocumentIdIT {
 
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.delete( "42" )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -125,7 +125,7 @@ public class AutomaticIndexingNonEntityIdDocumentIdIT {
 									entity1.getIndexedElementCollectionField().get( 0 )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -143,7 +143,7 @@ public class AutomaticIndexingNonEntityIdDocumentIdIT {
 									entity1.getIndexedElementCollectionField().get( 1 )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -160,7 +160,7 @@ public class AutomaticIndexingNonEntityIdDocumentIdIT {
 									entity1.getIndexedElementCollectionField().get( 0 )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -191,7 +191,7 @@ public class AutomaticIndexingNonEntityIdDocumentIdIT {
 									entity1.getIndexedElementCollectionField().get( 0 )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -210,7 +210,7 @@ public class AutomaticIndexingNonEntityIdDocumentIdIT {
 									entity1.getIndexedElementCollectionField().get( 1 )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingOutOfTransactionIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingOutOfTransactionIT.java
@@ -54,7 +54,7 @@ public class AutomaticIndexingOutOfTransactionIT {
 
 			backendMock.expectWorks( IndexedEntity.INDEX_NAME )
 					.add( "1", b -> b.field( "text", "number1" ) )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 
 			// Flush without a transaction acts as a commit.
 			// So all the involved works here are supposed to be both prepared and executed,
@@ -82,7 +82,7 @@ public class AutomaticIndexingOutOfTransactionIT {
 			// only entity 2 is supposed to be flushed here
 			backendMock.expectWorks( IndexedEntity.INDEX_NAME )
 					.update( "2", b -> b.field( "text", "number2" ) )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 
 			session.flush();
 		} );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingOutOfTransactionIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingOutOfTransactionIT.java
@@ -14,7 +14,7 @@ import javax.persistence.Id;
 import org.hibernate.SessionFactory;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.search.mapper.orm.Search;
-import org.hibernate.search.mapper.orm.session.SearchSessionWritePlan;
+import org.hibernate.search.mapper.orm.work.SearchIndexingPlan;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
@@ -67,17 +67,17 @@ public class AutomaticIndexingOutOfTransactionIT {
 	@Test
 	public void clear() {
 		withinSession( sessionFactory, session -> {
-			SearchSessionWritePlan writePlan = Search.session( session ).writePlan();
+			SearchIndexingPlan indexingPlan = Search.session( session ).indexingPlan();
 
 			IndexedEntity entity1 = new IndexedEntity( 1, "number1" );
-			// working directly on the work plan to add works immediately (not at flush time!)
-			writePlan.addOrUpdate( entity1 );
+			// working directly on the indexing plan to add works immediately (not at flush time!)
+			indexingPlan.addOrUpdate( entity1 );
 
 			// clearing the update of entity 1
 			session.clear();
 
 			IndexedEntity entity2 = new IndexedEntity( 2, "number2" );
-			writePlan.addOrUpdate( entity2 );
+			indexingPlan.addOrUpdate( entity2 );
 
 			// only entity 2 is supposed to be flushed here
 			backendMock.expectWorks( IndexedEntity.INDEX_NAME )

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingOverReindexingIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingOverReindexingIT.java
@@ -135,7 +135,7 @@ public class AutomaticIndexingOverReindexingIT {
 					.add( "1", b -> b
 							.field( "property1FromBridge", "initialValue" )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 
 			backendMock.expectWorks( Level2Entity.INDEX )
 					.add( "2", b -> b
@@ -143,7 +143,7 @@ public class AutomaticIndexingOverReindexingIT {
 									.field( "property2", "initialValue" )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -158,7 +158,7 @@ public class AutomaticIndexingOverReindexingIT {
 									.field( "property2", "updatedValue" )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -172,7 +172,7 @@ public class AutomaticIndexingOverReindexingIT {
 					.update( "1", b -> b
 							.field( "property1FromBridge", "updatedValue" )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingPolymorphicInverseSideAssociationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingPolymorphicInverseSideAssociationIT.java
@@ -112,7 +112,7 @@ public class AutomaticIndexingPolymorphicInverseSideAssociationIT {
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -129,7 +129,7 @@ public class AutomaticIndexingPolymorphicInverseSideAssociationIT {
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -197,7 +197,7 @@ public class AutomaticIndexingPolymorphicInverseSideAssociationIT {
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -221,7 +221,7 @@ public class AutomaticIndexingPolymorphicInverseSideAssociationIT {
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingPolymorphicOriginalSideAssociationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingPolymorphicOriginalSideAssociationIT.java
@@ -131,7 +131,7 @@ public class AutomaticIndexingPolymorphicOriginalSideAssociationIT {
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -155,7 +155,7 @@ public class AutomaticIndexingPolymorphicOriginalSideAssociationIT {
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingSingleAssociationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingSingleAssociationIT.java
@@ -55,7 +55,7 @@ public class AutomaticIndexingSingleAssociationIT extends AbstractAutomaticIndex
 
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.add( "1", b -> { } )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -78,7 +78,7 @@ public class AutomaticIndexingSingleAssociationIT extends AbstractAutomaticIndex
 									.field( "indexedField", "initialValue" )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -102,7 +102,7 @@ public class AutomaticIndexingSingleAssociationIT extends AbstractAutomaticIndex
 									.field( "indexedField", "updatedValue" )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -115,7 +115,7 @@ public class AutomaticIndexingSingleAssociationIT extends AbstractAutomaticIndex
 
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.update( "1", b -> { } )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -136,7 +136,7 @@ public class AutomaticIndexingSingleAssociationIT extends AbstractAutomaticIndex
 
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.add( "1", b -> { } )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -203,7 +203,7 @@ public class AutomaticIndexingSingleAssociationIT extends AbstractAutomaticIndex
 
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.add( "1", b -> { } )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -278,7 +278,7 @@ public class AutomaticIndexingSingleAssociationIT extends AbstractAutomaticIndex
 					.add( "1", b -> b
 							.objectField( "child", b2 -> { } )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -303,7 +303,7 @@ public class AutomaticIndexingSingleAssociationIT extends AbstractAutomaticIndex
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -329,7 +329,7 @@ public class AutomaticIndexingSingleAssociationIT extends AbstractAutomaticIndex
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -361,7 +361,7 @@ public class AutomaticIndexingSingleAssociationIT extends AbstractAutomaticIndex
 					.update( "1", b -> b
 							.objectField( "child", b2 -> { } )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -390,7 +390,7 @@ public class AutomaticIndexingSingleAssociationIT extends AbstractAutomaticIndex
 					.add( "1", b -> b
 							.objectField( "child", b2 -> { } )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -466,7 +466,7 @@ public class AutomaticIndexingSingleAssociationIT extends AbstractAutomaticIndex
 					.add( "1", b -> b
 							.objectField( "child", b2 -> { } )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -546,7 +546,7 @@ public class AutomaticIndexingSingleAssociationIT extends AbstractAutomaticIndex
 					.add( "1", b -> b
 							.objectField( "child", b2 -> { } )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -573,7 +573,7 @@ public class AutomaticIndexingSingleAssociationIT extends AbstractAutomaticIndex
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -601,7 +601,7 @@ public class AutomaticIndexingSingleAssociationIT extends AbstractAutomaticIndex
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -634,7 +634,7 @@ public class AutomaticIndexingSingleAssociationIT extends AbstractAutomaticIndex
 					.update( "1", b -> b
 							.objectField( "child", b2 -> { } )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingSynchronizationStrategyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingSynchronizationStrategyIT.java
@@ -233,7 +233,7 @@ public class AutomaticIndexingSynchronizationStrategyIT {
 						.add( "1", b -> b
 								.field( "indexedField", entity1.getIndexedField() )
 						)
-						.preparedThenExecuted( workFuture );
+						.processedThenExecuted( workFuture );
 				justBeforeTransactionCommitFuture.complete( null );
 			} );
 			backendMock.verifyExpectationsMet();

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/SearchSessionFlushIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/SearchSessionFlushIT.java
@@ -18,7 +18,7 @@ import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
-import org.hibernate.search.mapper.pojo.work.spi.PojoWorkPlan;
+import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingPlan;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.orm.OrmSetupHelper;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
@@ -29,7 +29,7 @@ import org.junit.Test;
 
 /**
  * Tests the behaviour of different kinds of {@link Session#flush()}.
- * Each of ones has to trigger a {@link PojoWorkPlan#prepare()} exactly when the flush is expected.
+ * Each of ones has to trigger a {@link PojoIndexingPlan#prepare()} exactly when the flush is expected.
  */
 @TestForIssue( jiraKey = "HSEARCH-3360" )
 public class SearchSessionFlushIT {

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/SearchSessionFlushIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/SearchSessionFlushIT.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 
 /**
  * Tests the behaviour of different kinds of {@link Session#flush()}.
- * Each of ones has to trigger a {@link PojoIndexingPlan#prepare()} exactly when the flush is expected.
+ * Each of ones has to trigger a {@link PojoIndexingPlan#process()} exactly when the flush is expected.
  */
 @TestForIssue( jiraKey = "HSEARCH-3360" )
 public class SearchSessionFlushIT {

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/SearchSessionFlushIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/SearchSessionFlushIT.java
@@ -58,7 +58,7 @@ public class SearchSessionFlushIT {
 
 			backendMock.expectWorks( IndexedEntity.INDEX_NAME )
 					.add( "1", b -> b.field( "text", "number1" ) )
-					.prepared();
+					.processed();
 
 			session.flush();
 			backendMock.verifyExpectationsMet();
@@ -79,7 +79,7 @@ public class SearchSessionFlushIT {
 
 			backendMock.expectWorks( IndexedEntity.INDEX_NAME )
 					.add( "1", b -> b.field( "text", "number1" ) )
-					.prepared();
+					.processed();
 
 			// An auto flush is performed on query invocation
 			List<?> resultList = session.createQuery( "select i from IndexedEntity i" )

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/HibernateOrmIntegrationBooterIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/HibernateOrmIntegrationBooterIT.java
@@ -97,7 +97,7 @@ public class HibernateOrmIntegrationBooterIT {
 
 				backendMock.expectWorks( INDEX_NAME )
 						.add( "1", b -> { } )
-						.preparedThenExecuted();
+						.processedThenExecuted();
 			} );
 			// If the entity was indexed, it means Hibernate Search booted correctly
 			backendMock.verifyExpectationsMet();

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToHibernateOrmIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToHibernateOrmIT.java
@@ -74,7 +74,7 @@ public class ToHibernateOrmIT {
 					.add( "2", b -> b
 							.field( "text", entity2.getText() )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToJpaIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToJpaIT.java
@@ -78,7 +78,7 @@ public class ToJpaIT {
 					.add( "2", b -> b
 							.field( "text", entity2.getText() )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingBaseIT.java
@@ -90,7 +90,7 @@ public class MassIndexingBaseIT {
 							.field( "title", TITLE_3 )
 							.field( "author", AUTHOR_3 )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 
 			// purgeAtStart, optimizeAfterPurge and purgeAtStart flags are active by default,
 			// so we expect 1 purge, 2 optimize and 1 flush calls in this order:
@@ -134,7 +134,7 @@ public class MassIndexingBaseIT {
 						.field( "title", TITLE_3 )
 						.field( "author", AUTHOR_3 )
 				)
-				.preparedThenExecuted();
+				.processedThenExecuted();
 
 		// purgeAtStart, optimizeAfterPurge and purgeAtStart flags are active by default,
 		// so we expect 1 purge, 2 optimize and 1 flush calls in this order:

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingEmbeddedIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingEmbeddedIdIT.java
@@ -97,7 +97,7 @@ public class MassIndexingEmbeddedIdIT {
 							.field( "title", TITLE_3 )
 							.field( "author", AUTHOR_3 )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 
 			// purgeAtStart, optimizeAfterPurge and purgeAtStart flags are active by default,
 			// so we expect 1 purge, 2 optimize and 1 flush calls in this order:

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingNonEntityIdDocumentIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingNonEntityIdDocumentIdIT.java
@@ -89,7 +89,7 @@ public class MassIndexingNonEntityIdDocumentIdIT {
 							.field( "title", TITLE_3 )
 							.field( "author", AUTHOR_3 )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 
 			// purgeAtStart, optimizeAfterPurge and purgeAtStart flags are active by default,
 			// so we expect 1 purge, 2 optimize and 1 flush calls in this order:

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/AnnotationMappingAccessTypeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/AnnotationMappingAccessTypeIT.java
@@ -125,7 +125,7 @@ public class AnnotationMappingAccessTypeIT {
 									.field( "field", nonManaged.getField() )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 	}
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BindingUsingPropertyMarkerAccessIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BindingUsingPropertyMarkerAccessIT.java
@@ -97,7 +97,7 @@ public class BindingUsingPropertyMarkerAccessIT<TIndexed> {
 					.add( "1", b -> b
 							.field( "location", GeoPoint.of( 42.0, 42.0 ) )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BytecodeEnhancementIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BytecodeEnhancementIT.java
@@ -164,7 +164,7 @@ public class BytecodeEnhancementIT {
 							.field( "primitiveDouble", 42.0d )
 							.field( "transientText", "initialValue" )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 			} );
 
 			AtomicReference<IndexedEntity> entityFromTransaction = new AtomicReference<>();
@@ -212,7 +212,7 @@ public class BytecodeEnhancementIT {
 								.field( "primitiveDouble", 42.0d )
 								.field( "transientText", null )
 						)
-						.preparedThenExecuted();
+						.processedThenExecuted();
 		} );
 
 		assertPropertiesAreNotLoaded( entityFromTransaction.get(), "notIndexedText" );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/GenericPropertyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/GenericPropertyIT.java
@@ -88,7 +88,7 @@ public class GenericPropertyIT {
 									.field( "arrayContent", genericEntity.getArrayContent()[1] )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 	}
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/ProgrammaticMappingAccessTypeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/ProgrammaticMappingAccessTypeIT.java
@@ -127,7 +127,7 @@ public class ProgrammaticMappingAccessTypeIT {
 									.field( "field", nonManaged.getField() )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 	}
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/PropertyInheritanceIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/PropertyInheritanceIT.java
@@ -90,7 +90,7 @@ public class PropertyInheritanceIT {
 									.field( "childDeclaredProperty", entity2.getChildDeclaredProperty() )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 	}
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/ProxyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/ProxyIT.java
@@ -71,7 +71,7 @@ public class ProxyIT {
 					.add( "1", b -> b
 							.field( "text", entity1.text )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 
 		OrmUtils.withinTransaction( sessionFactory, session -> {
@@ -91,7 +91,7 @@ public class ProxyIT {
 					.update( "1", b -> b
 							.field( "text", proxy.getText() )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 	}
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/automaticindexing/ContainedInThroughNonContainingIndexedTypeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/automaticindexing/ContainedInThroughNonContainingIndexedTypeIT.java
@@ -83,13 +83,13 @@ public class ContainedInThroughNonContainingIndexedTypeIT {
 					.add( "1", b -> b
 							.field( "indexedInContaining", 0 )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 
 			backendMock.expectWorks( Contained.INDEX )
 					.add( "2", b -> b
 							.field( "indexedInContained", 0 )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -107,7 +107,7 @@ public class ContainedInThroughNonContainingIndexedTypeIT {
 					.update( "1", b -> b
 							.field( "indexedInContaining", 42 )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 
 			// No work is expected on the index for the Contained entity
 		} );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/automaticindexing/ContainedInTriggerUnnecessaryCollectionInitializationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/automaticindexing/ContainedInTriggerUnnecessaryCollectionInitializationIT.java
@@ -79,7 +79,7 @@ public class ContainedInTriggerUnnecessaryCollectionInitializationIT {
 							.field( "someField", "initialValue" )
 							.field( "someInteger", 42 )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 
 			backendMock.expectWorks( Post.INDEX )
 					.add( "2", b -> b
@@ -87,7 +87,7 @@ public class ContainedInTriggerUnnecessaryCollectionInitializationIT {
 									.field( "someInteger", 42 )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -111,7 +111,7 @@ public class ContainedInTriggerUnnecessaryCollectionInitializationIT {
 							.field( "someField", "updatedValue" )
 							.field( "someInteger", 42 )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 
 			// Do not expect any work on the Post index
 		} );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/automaticindexing/FlushClearEvictAllIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/automaticindexing/FlushClearEvictAllIT.java
@@ -70,7 +70,7 @@ public class FlushClearEvictAllIT {
 
 			backendMock.expectWorks( Post.NAME )
 					.add( post.getId().toString(), b -> b.field( "name", "This is a post" ) )
-					.prepared();
+					.processed();
 			entityManager.flush();
 			backendMock.verifyExpectationsMet();
 
@@ -94,7 +94,7 @@ public class FlushClearEvictAllIT {
 
 			backendMock.expectWorks( Comment.NAME )
 					.add( "2", b -> b.field( "name", "This is a comment" ) )
-					.prepared();
+					.processed();
 			entityManager.flush();
 			backendMock.verifyExpectationsMet();
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/automaticindexing/IndexingProcessorProxiedAssociatedEntityIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/automaticindexing/IndexingProcessorProxiedAssociatedEntityIT.java
@@ -80,7 +80,7 @@ public class IndexingProcessorProxiedAssociatedEntityIT {
 									.field( "text", "initialValue" )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -99,7 +99,7 @@ public class IndexingProcessorProxiedAssociatedEntityIT {
 									.field( "text", "initialValue" )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -123,7 +123,7 @@ public class IndexingProcessorProxiedAssociatedEntityIT {
 									.field( "text", "initialValue1" )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -147,7 +147,7 @@ public class IndexingProcessorProxiedAssociatedEntityIT {
 									.field( "text", "initialValue1" )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/automaticindexing/ReindexingResolverProxiedAssociatedEntityIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/automaticindexing/ReindexingResolverProxiedAssociatedEntityIT.java
@@ -87,7 +87,7 @@ public class ReindexingResolverProxiedAssociatedEntityIT {
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -107,7 +107,7 @@ public class ReindexingResolverProxiedAssociatedEntityIT {
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}
@@ -141,7 +141,7 @@ public class ReindexingResolverProxiedAssociatedEntityIT {
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 
@@ -166,7 +166,7 @@ public class ReindexingResolverProxiedAssociatedEntityIT {
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/massindexing/MassIndexingPrimitiveIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/massindexing/MassIndexingPrimitiveIdIT.java
@@ -68,7 +68,7 @@ public class MassIndexingPrimitiveIdIT {
 					.add( "1", b -> { } )
 					.add( "2", b -> { } )
 					.add( "3", b -> { } )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 
 			// purgeAtStart, optimizeAfterPurge and purgeAtStart flags are active by default,
 			// so we expect 1 purge, 2 optimize and 1 flush calls in this order:

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/SearchQueryBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/SearchQueryBaseIT.java
@@ -390,7 +390,7 @@ public class SearchQueryBaseIT {
 							.field( "title", TITLE_AVENUE_OF_MYSTERIES )
 							.field( "author", AUTHOR_AVENUE_OF_MYSTERIES )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 
 		backendMock.verifyExpectationsMet();

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/session/SearchIndexingPlanBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/session/SearchIndexingPlanBaseIT.java
@@ -179,7 +179,7 @@ public class SearchIndexingPlanBaseIT {
 			session.persist( entity1 );
 			session.persist( entity2 );
 
-			// flush triggers the prepare of the current PojoWorkPlan
+			// flush triggers the prepare of the current indexing plan
 			backend1Mock.expectWorks( IndexedEntity1.INDEX_NAME )
 					.add( "1", b -> b.field( "text", "number1" ) )
 					.add( "2", b -> b.field( "text", "number2" ) )

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/session/SearchIndexingPlanBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/session/SearchIndexingPlanBaseIT.java
@@ -71,7 +71,7 @@ public class SearchIndexingPlanBaseIT {
 					.update( "2", b -> b.field( "text", "number2" ) )
 					.delete( "3" )
 					.delete( "42" )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backend1Mock.verifyExpectationsMet();
 	}
@@ -147,7 +147,7 @@ public class SearchIndexingPlanBaseIT {
 					.delete( "7" )
 					// purge then addOrUpdate => update
 					.update( "8", b -> b.field( "text", "number8" ) )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backend1Mock.verifyExpectationsMet();
 	}
@@ -183,7 +183,7 @@ public class SearchIndexingPlanBaseIT {
 			backend1Mock.expectWorks( IndexedEntity1.INDEX_NAME )
 					.add( "1", b -> b.field( "text", "number1" ) )
 					.add( "2", b -> b.field( "text", "number2" ) )
-					.prepared();
+					.processed();
 
 			session.flush();
 
@@ -224,7 +224,7 @@ public class SearchIndexingPlanBaseIT {
 			backend1Mock.expectWorks( IndexedEntity1.INDEX_NAME )
 					.add( "1", b -> b.field( "text", "number1" ) )
 					.add( "2", b -> b.field( "text", "number2" ) )
-					.prepared();
+					.processed();
 
 			session.flush();
 			backend1Mock.verifyExpectationsMet();
@@ -259,7 +259,7 @@ public class SearchIndexingPlanBaseIT {
 			backend1Mock.expectWorks( IndexedEntity1.INDEX_NAME )
 					.add( "1", b -> b.field( "text", "number1" ) )
 					.add( "2", b -> b.field( "text", "number2" ) )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backend1Mock.verifyExpectationsMet();
 
@@ -280,7 +280,7 @@ public class SearchIndexingPlanBaseIT {
 					.delete( "2" )
 					// Automatic on persist
 					.add( "3", b -> b.field( "text", "number3" ) )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backend1Mock.verifyExpectationsMet();
 	}
@@ -306,10 +306,10 @@ public class SearchIndexingPlanBaseIT {
 			backend1Mock.expectWorks( IndexedEntity1.INDEX_NAME )
 					.update( "1", b -> b.field( "text", "number1" ) )
 					.delete( "3" )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 			backend2Mock.expectWorks( IndexedEntity2.INDEX_NAME )
 					.update( "2", b -> b.field( "text", "number2" ) )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backend1Mock.verifyExpectationsMet();
 		backend2Mock.verifyExpectationsMet();

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/session/SearchIndexingPlanNonEntityIdDocumentIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/session/SearchIndexingPlanNonEntityIdDocumentIdIT.java
@@ -15,7 +15,7 @@ import org.hibernate.SessionFactory;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.automaticindexing.AutomaticIndexingStrategyName;
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
-import org.hibernate.search.mapper.orm.session.SearchSessionWritePlan;
+import org.hibernate.search.mapper.orm.work.SearchIndexingPlan;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
@@ -27,9 +27,9 @@ import org.junit.Rule;
 import org.junit.Test;
 
 /**
- * Test usage of the session write plan with an entity type whose document ID is not the entity ID.
+ * Test usage of the session indexing plan with an entity type whose document ID is not the entity ID.
  */
-public class SearchSessionWritePlanNonEntityIdDocumentIdIT {
+public class SearchIndexingPlanNonEntityIdDocumentIdIT {
 
 	private static final String BACKEND_NAME = "stubBackend";
 
@@ -53,11 +53,11 @@ public class SearchSessionWritePlanNonEntityIdDocumentIdIT {
 			session.persist( entity2 );
 			session.persist( entity3 );
 
-			SearchSessionWritePlan writePlan = Search.session( session ).writePlan();
-			writePlan.addOrUpdate( entity1 );
-			writePlan.addOrUpdate( entity2 );
-			writePlan.delete( entity3 );
-			writePlan.purge( IndexedEntity.class, 47 ); // Does not exist in database, but may exist in the index
+			SearchIndexingPlan indexingPlan = Search.session( session ).indexingPlan();
+			indexingPlan.addOrUpdate( entity1 );
+			indexingPlan.addOrUpdate( entity2 );
+			indexingPlan.delete( entity3 );
+			indexingPlan.purge( IndexedEntity.class, 47 ); // Does not exist in database, but may exist in the index
 
 			backendMock.expectWorks( IndexedEntity.INDEX_NAME )
 					.update( "41", b -> b.field( "text", "number1" ) )

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/session/SearchIndexingPlanNonEntityIdDocumentIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/session/SearchIndexingPlanNonEntityIdDocumentIdIT.java
@@ -64,7 +64,7 @@ public class SearchIndexingPlanNonEntityIdDocumentIdIT {
 					.update( "42", b -> b.field( "text", "number2" ) )
 					.delete( "43" )
 					.delete( "47" )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 		backendMock.verifyExpectationsMet();
 	}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/session/SearchIndexingPlanPersistBatchIndexingIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/session/SearchIndexingPlanPersistBatchIndexingIT.java
@@ -63,7 +63,7 @@ public class SearchIndexingPlanPersistBatchIndexingIT {
 			for ( int i = 0; i < ENTITY_COUNT; i++ ) {
 				if ( i > 0 && i % BATCH_SIZE == 0 ) {
 					// For test only: register expectations regarding processing
-					expectAddWorks( firstIdOfThisBatch, i ).prepared();
+					expectAddWorks( firstIdOfThisBatch, i ).processed();
 					firstIdOfThisBatch = i;
 
 					session.flush();
@@ -80,7 +80,7 @@ public class SearchIndexingPlanPersistBatchIndexingIT {
 
 			// For test only: check on-commit processing/execution of works
 			// If the last batch was smaller, there is still some preparing that will occur on commit
-			expectAddWorks( firstIdOfThisBatch, ENTITY_COUNT ).prepared();
+			expectAddWorks( firstIdOfThisBatch, ENTITY_COUNT ).processed();
 			// Finally, the works will be executed on commit
 			expectAddWorks( 0, ENTITY_COUNT ).executed();
 		} );
@@ -105,7 +105,7 @@ public class SearchIndexingPlanPersistBatchIndexingIT {
 
 			for ( int i = 0; i < ENTITY_COUNT; i++ ) {
 				if ( i > 0 && i % BATCH_SIZE == 0 ) {
-					expectAddWorks( firstIdOfThisBatch, i ).prepared();
+					expectAddWorks( firstIdOfThisBatch, i ).processed();
 					session.flush();
 					backendMock.verifyExpectationsMet();
 
@@ -127,7 +127,7 @@ public class SearchIndexingPlanPersistBatchIndexingIT {
 
 			// For test only: check on-commit processing/execution of works
 			// If the last batch was smaller, there is still some indexing that will occur on commit
-			expectAddWorks( firstIdOfThisBatch, ENTITY_COUNT ).preparedThenExecuted();
+			expectAddWorks( firstIdOfThisBatch, ENTITY_COUNT ).processedThenExecuted();
 		} );
 		// This is for test only and wouldn't be present in real code
 		backendMock.verifyExpectationsMet();

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/session/SearchIndexingPlanPersistBatchIndexingIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/session/SearchIndexingPlanPersistBatchIndexingIT.java
@@ -13,7 +13,7 @@ import javax.persistence.Id;
 
 import org.hibernate.SessionFactory;
 import org.hibernate.search.mapper.orm.Search;
-import org.hibernate.search.mapper.orm.session.SearchSessionWritePlan;
+import org.hibernate.search.mapper.orm.work.SearchIndexingPlan;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
@@ -25,13 +25,13 @@ import org.junit.Test;
 
 /**
  * Test batch indexing relying not on the {@link org.hibernate.search.mapper.orm.massindexing.MassIndexer},
- * but on automatic indexing and on the {@link SearchSessionWritePlan},
+ * but on automatic indexing and on the {@link SearchIndexingPlan},
  * flushing and clearing the session periodically.
  * <p>
  * This is mostly useful when inserting lots of data into the database using JPA.
  */
 @TestForIssue(jiraKey = "HSEARCH-3049")
-public class SearchSessionWritePlanPersistBatchIndexingIT {
+public class SearchIndexingPlanPersistBatchIndexingIT {
 
 	private static final String BACKEND_NAME = "stubBackend";
 
@@ -55,7 +55,7 @@ public class SearchSessionWritePlanPersistBatchIndexingIT {
 		SessionFactory sessionFactory = setup();
 
 		withinTransaction( sessionFactory, session -> {
-			SearchSessionWritePlan writePlan = Search.session( session ).writePlan();
+			SearchIndexingPlan indexingPlan = Search.session( session ).indexingPlan();
 
 			// This is for test only and wouldn't be present in real code
 			int firstIdOfThisBatch = 0;
@@ -98,7 +98,7 @@ public class SearchSessionWritePlanPersistBatchIndexingIT {
 		SessionFactory sessionFactory = setup();
 
 		withinTransaction( sessionFactory, session -> {
-			SearchSessionWritePlan writePlan = Search.session( session ).writePlan();
+			SearchIndexingPlan indexingPlan = Search.session( session ).indexingPlan();
 
 			// This is for test only and wouldn't be present in real code
 			int firstIdOfThisBatch = 0;
@@ -113,7 +113,7 @@ public class SearchSessionWritePlanPersistBatchIndexingIT {
 					expectAddWorks( firstIdOfThisBatch, i ).executed();
 					firstIdOfThisBatch = i;
 
-					writePlan.execute();
+					indexingPlan.execute();
 
 					// For test only: check execution happens before the clear()
 					backendMock.verifyExpectationsMet();

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/smoke/AnnotationMappingSmokeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/smoke/AnnotationMappingSmokeIT.java
@@ -252,13 +252,13 @@ public class AnnotationMappingSmokeIT {
 									.field( "date", entity6.getLocalDate() )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 			backendMock.expectWorks( OtherIndexedEntity.INDEX )
 					.add( "4", b -> b
 							.field( "numeric", entity4.getNumeric() )
 							.field( "numericAsString", String.valueOf( entity4.getNumeric() ) )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 			backendMock.expectWorks( YetAnotherIndexedEntity.INDEX )
 					.add( "5", b -> b
 							.field( "myLocalDateField", entity5.getLocalDate() )
@@ -290,7 +290,7 @@ public class AnnotationMappingSmokeIT {
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 	}
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/smoke/ProgrammaticMappingSmokeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/smoke/ProgrammaticMappingSmokeIT.java
@@ -250,13 +250,13 @@ public class ProgrammaticMappingSmokeIT {
 									.field( "date", entity6.getLocalDate() )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 			backendMock.expectWorks( OtherIndexedEntity.INDEX )
 					.add( "4", b -> b
 							.field( "numeric", entity4.getNumeric() )
 							.field( "numericAsString", String.valueOf( entity4.getNumeric() ) )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 			backendMock.expectWorks( YetAnotherIndexedEntity.INDEX )
 					.add( "5", b -> b
 							.field( "myLocalDateField", entity5.getLocalDate() )
@@ -288,7 +288,7 @@ public class ProgrammaticMappingSmokeIT {
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		} );
 	}
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/workspace/AbstractSearchWorkspaceSimpleOperationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/workspace/AbstractSearchWorkspaceSimpleOperationIT.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.integrationtest.mapper.orm.writing;
+package org.hibernate.search.integrationtest.mapper.orm.workspace;
 
 import static org.hibernate.search.util.impl.test.FutureAssert.assertThat;
 
@@ -15,7 +15,7 @@ import javax.persistence.Id;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.search.mapper.orm.Search;
-import org.hibernate.search.mapper.orm.writing.SearchWriter;
+import org.hibernate.search.mapper.orm.work.SearchWorkspace;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.orm.OrmSetupHelper;
@@ -25,7 +25,7 @@ import org.hibernate.search.util.impl.test.SubTest;
 import org.junit.Rule;
 import org.junit.Test;
 
-public abstract class AbstractSearchWriterSimpleOperationIT {
+public abstract class AbstractSearchWorkspaceSimpleOperationIT {
 
 	private static final String BACKEND1_NAME = "stubBackend1";
 	private static final String BACKEND2_NAME = "stubBackend2";
@@ -44,17 +44,17 @@ public abstract class AbstractSearchWriterSimpleOperationIT {
 		SessionFactory sessionFactory = setup();
 
 		OrmUtils.withinSession( sessionFactory, session -> {
-			SearchWriter writer = Search.session( session ).writer( IndexedEntity1.class );
+			SearchWorkspace workspace = Search.session( session ).workspace( IndexedEntity1.class );
 
 			CompletableFuture<Object> futureFromBackend = new CompletableFuture<>();
 			expectWork( backend1Mock, IndexedEntity1.INDEX_NAME, futureFromBackend );
 
-			CompletableFuture<?> futureFromWriter = executeAsync( writer );
+			CompletableFuture<?> futureFromWorkspace = executeAsync( workspace );
 			backend1Mock.verifyExpectationsMet();
-			assertThat( futureFromWriter ).isPending();
+			assertThat( futureFromWorkspace ).isPending();
 
 			futureFromBackend.complete( new Object() );
-			assertThat( futureFromWriter ).isSuccessful();
+			assertThat( futureFromWorkspace ).isSuccessful();
 		} );
 	}
 
@@ -63,18 +63,18 @@ public abstract class AbstractSearchWriterSimpleOperationIT {
 		SessionFactory sessionFactory = setup();
 
 		OrmUtils.withinSession( sessionFactory, session -> {
-			SearchWriter writer = Search.session( session ).writer( IndexedEntity1.class );
+			SearchWorkspace workspace = Search.session( session ).workspace( IndexedEntity1.class );
 
 			CompletableFuture<Object> futureFromBackend = new CompletableFuture<>();
 			expectWork( backend1Mock, IndexedEntity1.INDEX_NAME, futureFromBackend );
 
-			CompletableFuture<?> futureFromWriter = executeAsync( writer );
+			CompletableFuture<?> futureFromWorkspace = executeAsync( workspace );
 			backend1Mock.verifyExpectationsMet();
-			assertThat( futureFromWriter ).isPending();
+			assertThat( futureFromWorkspace ).isPending();
 
 			RuntimeException exception = new RuntimeException();
 			futureFromBackend.completeExceptionally( exception );
-			assertThat( futureFromWriter ).isFailed( exception );
+			assertThat( futureFromWorkspace ).isFailed( exception );
 		} );
 	}
 
@@ -83,13 +83,13 @@ public abstract class AbstractSearchWriterSimpleOperationIT {
 		SessionFactory sessionFactory = setup();
 
 		OrmUtils.withinSession( sessionFactory, session -> {
-			SearchWriter writer = Search.session( session ).writer( IndexedEntity1.class );
+			SearchWorkspace workspace = Search.session( session ).workspace( IndexedEntity1.class );
 
 			CompletableFuture<Object> futureFromBackend = new CompletableFuture<>();
 			expectWork( backend1Mock, IndexedEntity1.INDEX_NAME, futureFromBackend );
 
 			futureFromBackend.complete( new Object() );
-			executeSync( writer );
+			executeSync( workspace );
 			backend1Mock.verifyExpectationsMet();
 		} );
 	}
@@ -99,7 +99,7 @@ public abstract class AbstractSearchWriterSimpleOperationIT {
 		SessionFactory sessionFactory = setup();
 
 		OrmUtils.withinSession( sessionFactory, session -> {
-			SearchWriter writer = Search.session( session ).writer( IndexedEntity1.class );
+			SearchWorkspace workspace = Search.session( session ).workspace( IndexedEntity1.class );
 
 			CompletableFuture<Object> futureFromBackend = new CompletableFuture<>();
 			expectWork( backend1Mock, IndexedEntity1.INDEX_NAME, futureFromBackend );
@@ -108,7 +108,7 @@ public abstract class AbstractSearchWriterSimpleOperationIT {
 			futureFromBackend.completeExceptionally( exception );
 
 			SubTest.expectException(
-					() -> executeSync( writer )
+					() -> executeSync( workspace )
 			)
 					.assertThrown()
 					.isSameAs( exception );
@@ -120,23 +120,23 @@ public abstract class AbstractSearchWriterSimpleOperationIT {
 		SessionFactory sessionFactory = setup();
 
 		OrmUtils.withinSession( sessionFactory, session -> {
-			SearchWriter writer = Search.session( session ).writer();
+			SearchWorkspace workspace = Search.session( session ).workspace();
 
 			CompletableFuture<Object> future1FromBackend = new CompletableFuture<>();
 			CompletableFuture<Object> future2FromBackend = new CompletableFuture<>();
 			expectWork( backend1Mock, IndexedEntity1.INDEX_NAME, future1FromBackend );
 			expectWork( backend2Mock, IndexedEntity2.INDEX_NAME, future2FromBackend );
 
-			CompletableFuture<?> futureFromWriter = executeAsync( writer );
+			CompletableFuture<?> futureFromWorkspace = executeAsync( workspace );
 			backend1Mock.verifyExpectationsMet();
 			backend2Mock.verifyExpectationsMet();
-			assertThat( futureFromWriter ).isPending();
+			assertThat( futureFromWorkspace ).isPending();
 
 			future1FromBackend.complete( new Object() );
-			assertThat( futureFromWriter ).isPending();
+			assertThat( futureFromWorkspace ).isPending();
 
 			future2FromBackend.complete( new Object() );
-			assertThat( futureFromWriter ).isSuccessful();
+			assertThat( futureFromWorkspace ).isSuccessful();
 		} );
 	}
 
@@ -144,32 +144,32 @@ public abstract class AbstractSearchWriterSimpleOperationIT {
 	public void outOfSession() {
 		SessionFactory sessionFactory = setup();
 
-		SearchWriter writer;
+		SearchWorkspace workspace;
 		try ( Session session = sessionFactory.openSession() ) {
-			writer = Search.session( session ).writer( IndexedEntity1.class );
+			workspace = Search.session( session ).workspace( IndexedEntity1.class );
 		}
 
 		CompletableFuture<Object> futureFromBackend = new CompletableFuture<>();
 		expectWork( backend1Mock, IndexedEntity1.INDEX_NAME, futureFromBackend );
 
-		CompletableFuture<?> futureFromWriter = executeAsync( writer );
+		CompletableFuture<?> futureFromWorkspace = executeAsync( workspace );
 		backend1Mock.verifyExpectationsMet();
-		assertThat( futureFromWriter ).isPending();
+		assertThat( futureFromWorkspace ).isPending();
 
 		futureFromBackend.complete( new Object() );
-		assertThat( futureFromWriter ).isSuccessful();
+		assertThat( futureFromWorkspace ).isSuccessful();
 	}
 
 	@Test
 	public void fromMappingWithoutSession() {
 		SessionFactory sessionFactory = setup();
 
-		SearchWriter writer = Search.mapping( sessionFactory ).scope( IndexedEntity1.class ).writer();
+		SearchWorkspace workspace = Search.mapping( sessionFactory ).scope( IndexedEntity1.class ).workspace();
 
 		CompletableFuture<Object> futureFromBackend = new CompletableFuture<>();
 		expectWork( backend1Mock, IndexedEntity1.INDEX_NAME, futureFromBackend );
 
-		CompletableFuture<?> futureFromWriter = executeAsync( writer );
+		CompletableFuture<?> futureFromWriter = executeAsync( workspace );
 		backend1Mock.verifyExpectationsMet();
 		assertThat( futureFromWriter ).isPending();
 
@@ -179,9 +179,9 @@ public abstract class AbstractSearchWriterSimpleOperationIT {
 
 	protected abstract void expectWork(BackendMock backendMock, String indexName, CompletableFuture<?> future);
 
-	protected abstract void executeSync(SearchWriter writer);
+	protected abstract void executeSync(SearchWorkspace workspace);
 
-	protected abstract CompletableFuture<?> executeAsync(SearchWriter writer);
+	protected abstract CompletableFuture<?> executeAsync(SearchWorkspace workspace);
 
 	private SessionFactory setup() {
 		backend1Mock.expectAnySchema( IndexedEntity1.INDEX_NAME );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/workspace/SearchWorkspaceFlushIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/workspace/SearchWorkspaceFlushIT.java
@@ -4,29 +4,29 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.integrationtest.mapper.orm.writing;
+package org.hibernate.search.integrationtest.mapper.orm.workspace;
 
 import java.util.concurrent.CompletableFuture;
 
-import org.hibernate.search.mapper.orm.writing.SearchWriter;
+import org.hibernate.search.mapper.orm.work.SearchWorkspace;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 @TestForIssue(jiraKey = "HSEARCH-3049")
-public class SearchWriterPurgeIT extends AbstractSearchWriterSimpleOperationIT {
+public class SearchWorkspaceFlushIT extends AbstractSearchWorkspaceSimpleOperationIT {
 	@Override
 	protected void expectWork(BackendMock backendMock, String indexName, CompletableFuture<?> future) {
 		backendMock.expectIndexScopeWorks( indexName )
-				.purge( future );
+				.flush( future );
 	}
 
 	@Override
-	protected void executeSync(SearchWriter writer) {
-		writer.purge();
+	protected void executeSync(SearchWorkspace workspace) {
+		workspace.flush();
 	}
 
 	@Override
-	protected CompletableFuture<?> executeAsync(SearchWriter writer) {
-		return writer.purgeAsync();
+	protected CompletableFuture<?> executeAsync(SearchWorkspace workspace) {
+		return workspace.flushAsync();
 	}
 }

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/workspace/SearchWorkspaceOptimizeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/workspace/SearchWorkspaceOptimizeIT.java
@@ -4,16 +4,16 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.integrationtest.mapper.orm.writing;
+package org.hibernate.search.integrationtest.mapper.orm.workspace;
 
 import java.util.concurrent.CompletableFuture;
 
-import org.hibernate.search.mapper.orm.writing.SearchWriter;
+import org.hibernate.search.mapper.orm.work.SearchWorkspace;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 @TestForIssue(jiraKey = "HSEARCH-3049")
-public class SearchWriterOptimizeIT extends AbstractSearchWriterSimpleOperationIT {
+public class SearchWorkspaceOptimizeIT extends AbstractSearchWorkspaceSimpleOperationIT {
 	@Override
 	protected void expectWork(BackendMock backendMock, String indexName, CompletableFuture<?> future) {
 		backendMock.expectIndexScopeWorks( indexName )
@@ -21,12 +21,12 @@ public class SearchWriterOptimizeIT extends AbstractSearchWriterSimpleOperationI
 	}
 
 	@Override
-	protected void executeSync(SearchWriter writer) {
-		writer.optimize();
+	protected void executeSync(SearchWorkspace workspace) {
+		workspace.optimize();
 	}
 
 	@Override
-	protected CompletableFuture<?> executeAsync(SearchWriter writer) {
-		return writer.optimizeAsync();
+	protected CompletableFuture<?> executeAsync(SearchWorkspace workspace) {
+		return workspace.optimizeAsync();
 	}
 }

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/workspace/SearchWorkspacePurgeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/workspace/SearchWorkspacePurgeIT.java
@@ -4,29 +4,29 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.integrationtest.mapper.orm.writing;
+package org.hibernate.search.integrationtest.mapper.orm.workspace;
 
 import java.util.concurrent.CompletableFuture;
 
-import org.hibernate.search.mapper.orm.writing.SearchWriter;
+import org.hibernate.search.mapper.orm.work.SearchWorkspace;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 @TestForIssue(jiraKey = "HSEARCH-3049")
-public class SearchWriterFlushIT extends AbstractSearchWriterSimpleOperationIT {
+public class SearchWorkspacePurgeIT extends AbstractSearchWorkspaceSimpleOperationIT {
 	@Override
 	protected void expectWork(BackendMock backendMock, String indexName, CompletableFuture<?> future) {
 		backendMock.expectIndexScopeWorks( indexName )
-				.flush( future );
+				.purge( future );
 	}
 
 	@Override
-	protected void executeSync(SearchWriter writer) {
-		writer.flush();
+	protected void executeSync(SearchWorkspace workspace) {
+		workspace.purge();
 	}
 
 	@Override
-	protected CompletableFuture<?> executeAsync(SearchWriter writer) {
-		return writer.flushAsync();
+	protected CompletableFuture<?> executeAsync(SearchWorkspace workspace) {
+		return workspace.purgeAsync();
 	}
 }

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/AbstractFieldContainerExtractorIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/AbstractFieldContainerExtractorIT.java
@@ -304,7 +304,7 @@ public abstract class AbstractFieldContainerExtractorIT {
 		try ( SearchSession session = mapping.createSession() ) {
 			E entity1 = testModel.newEntity( 1, propertyValue );
 
-			session.getMainWorkPlan().add( entity1 );
+			session.indexingPlan().add( entity1 );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.add( "1", b -> b
@@ -339,7 +339,7 @@ public abstract class AbstractFieldContainerExtractorIT {
 		try ( SearchSession session = mapping.createSession() ) {
 			E entity1 = testModel.newEntity( 1, propertyValue );
 
-			session.getMainWorkPlan().add( entity1 );
+			session.indexingPlan().add( entity1 );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.add( "1", b -> { } )

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/AbstractFieldContainerExtractorIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/AbstractFieldContainerExtractorIT.java
@@ -313,7 +313,7 @@ public abstract class AbstractFieldContainerExtractorIT {
 									firstIndexedFieldValues, (Object[]) otherIndexedFieldValues
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 		backendMock.verifyExpectationsMet();
 
@@ -343,7 +343,7 @@ public abstract class AbstractFieldContainerExtractorIT {
 
 			backendMock.expectWorks( INDEX_NAME )
 					.add( "1", b -> { } )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 		backendMock.verifyExpectationsMet();
 

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/DocumentIdDefaultBridgeIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/DocumentIdDefaultBridgeIT.java
@@ -110,7 +110,7 @@ public class DocumentIdDefaultBridgeIT<I> {
 						b -> { }
 				);
 			}
-			expectationSetter.preparedThenExecuted();
+			expectationSetter.processedThenExecuted();
 		}
 		backendMock.verifyExpectationsMet();
 	}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/DocumentIdDefaultBridgeIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/DocumentIdDefaultBridgeIT.java
@@ -98,7 +98,7 @@ public class DocumentIdDefaultBridgeIT<I> {
 		try ( SearchSession session = mapping.createSession() ) {
 			for ( I entityIdentifierValue : expectations.getEntityIdentifierValues() ) {
 				Object entity = expectations.instantiateTypeWithIdentifierBridge1( entityIdentifierValue );
-				session.getMainWorkPlan().add( entity );
+				session.indexingPlan().add( entity );
 			}
 
 			BackendMock.DocumentWorkCallListContext expectationSetter = backendMock.expectWorks(

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/FieldBaseIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/FieldBaseIT.java
@@ -304,7 +304,7 @@ public class FieldBaseIT {
 			backendMock.expectWorks( INDEX_NAME )
 					// Stub backend is not supposed to use 'indexNullAs' option
 					.add( "1", b -> b.field( "integer", null ) )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 		backendMock.verifyExpectationsMet();
 	}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/FieldBaseIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/FieldBaseIT.java
@@ -299,7 +299,7 @@ public class FieldBaseIT {
 		try ( SearchSession session = mapping.createSession() ) {
 			IndexedEntity entity = new IndexedEntity();
 			entity.id = 1;
-			session.getMainWorkPlan().add( entity );
+			session.indexingPlan().add( entity );
 
 			backendMock.expectWorks( INDEX_NAME )
 					// Stub backend is not supposed to use 'indexNullAs' option

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/FieldContainerExtractorBaseIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/FieldContainerExtractorBaseIT.java
@@ -79,7 +79,7 @@ public class FieldContainerExtractorBaseIT {
 			IndexedEntity entity = new IndexedEntity();
 			entity.id = 1;
 			entity.text = new MyContainer<>( "value1", "value2" );
-			session.getMainWorkPlan().add( entity );
+			session.indexingPlan().add( entity );
 
 			backendMock.expectWorks( INDEX_NAME )
 					// Stub backend is not supposed to use 'indexNullAs' option

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/FieldContainerExtractorBaseIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/FieldContainerExtractorBaseIT.java
@@ -84,7 +84,7 @@ public class FieldContainerExtractorBaseIT {
 			backendMock.expectWorks( INDEX_NAME )
 					// Stub backend is not supposed to use 'indexNullAs' option
 					.add( "1", b -> b.field( "text", "value1", "value2" ) )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 		backendMock.verifyExpectationsMet();
 	}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/FieldDefaultBridgeIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/FieldDefaultBridgeIT.java
@@ -115,7 +115,7 @@ public class FieldDefaultBridgeIT<V, F> {
 			int id = 0;
 			for ( V propertyValue : getPropertyValues() ) {
 				Object entity = expectations.instantiateTypeWithValueBridge1( id, propertyValue );
-				session.getMainWorkPlan().add( entity );
+				session.indexingPlan().add( entity );
 				++id;
 			}
 

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/FieldDefaultBridgeIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/FieldDefaultBridgeIT.java
@@ -134,7 +134,7 @@ public class FieldDefaultBridgeIT<V, F> {
 				} );
 				++id;
 			}
-			expectationSetter.preparedThenExecuted();
+			expectationSetter.processedThenExecuted();
 		}
 		backendMock.verifyExpectationsMet();
 	}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/FullTextFieldIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/FullTextFieldIT.java
@@ -407,7 +407,7 @@ public class FullTextFieldIT {
 					.add( "1", b -> b
 							.field( "myProperty", indexedFieldValue )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 		backendMock.verifyExpectationsMet();
 	}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/FullTextFieldIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/FullTextFieldIT.java
@@ -401,7 +401,7 @@ public class FullTextFieldIT {
 		try ( SearchSession session = mapping.createSession() ) {
 			E entity1 = newEntityFunction.apply( 1, propertyValue );
 
-			session.getMainWorkPlan().add( entity1 );
+			session.indexingPlan().add( entity1 );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.add( "1", b -> b

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/IndexedEmbeddedBaseIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/IndexedEmbeddedBaseIT.java
@@ -732,7 +732,7 @@ public class IndexedEmbeddedBaseIT {
 
 			backendMock.expectWorks( INDEX_NAME )
 					.add( "1", expectedDocumentContributor )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 		backendMock.verifyExpectationsMet();
 	}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/IndexedEmbeddedBaseIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/IndexedEmbeddedBaseIT.java
@@ -728,7 +728,7 @@ public class IndexedEmbeddedBaseIT {
 		try ( SearchSession session = mapping.createSession() ) {
 			E entity1 = newEntityFunction.apply( 1 );
 
-			session.getMainWorkPlan().add( entity1 );
+			session.indexingPlan().add( entity1 );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.add( "1", expectedDocumentContributor )

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/KeywordFieldIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/KeywordFieldIT.java
@@ -420,7 +420,7 @@ public class KeywordFieldIT {
 		try ( SearchSession session = mapping.createSession() ) {
 			E entity1 = newEntityFunction.apply( 1, propertyValue );
 
-			session.getMainWorkPlan().add( entity1 );
+			session.indexingPlan().add( entity1 );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.add( "1", b -> b

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/KeywordFieldIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/KeywordFieldIT.java
@@ -426,7 +426,7 @@ public class KeywordFieldIT {
 					.add( "1", b -> b
 							.field( "myProperty", indexedFieldValue )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 		backendMock.verifyExpectationsMet();
 	}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/PropertyBridgeBaseIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/PropertyBridgeBaseIT.java
@@ -125,7 +125,7 @@ public class PropertyBridgeBaseIT {
 
 		try ( SearchSession session = mapping.createSession() ) {
 			entity.stringProperty = "some string 2";
-			session.indexingPlan().update( entity, new String[] { "stringProperty" } );
+			session.indexingPlan().addOrUpdate( entity, new String[] { "stringProperty" } );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.update( "1", b -> b.field( "someField", entity.stringProperty ) )
@@ -206,7 +206,7 @@ public class PropertyBridgeBaseIT {
 
 		try ( SearchSession session = mapping.createSession() ) {
 			contained.stringProperty = "some string 2";
-			session.indexingPlan().update( entity, new String[] { "contained.stringProperty" } );
+			session.indexingPlan().addOrUpdate( entity, new String[] { "contained.stringProperty" } );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.update( "1", b -> b.field( "someField", contained.stringProperty ) )
@@ -384,7 +384,7 @@ public class PropertyBridgeBaseIT {
 
 		try ( SearchSession session = mapping.createSession() ) {
 			containedLevel2Entity.stringProperty = "some string";
-			session.indexingPlan().update( containedLevel2Entity, new String[] { "stringProperty" } );
+			session.indexingPlan().addOrUpdate( containedLevel2Entity, new String[] { "stringProperty" } );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.update( "1", b -> b.field( "someField", "constant" ) )
@@ -810,7 +810,7 @@ public class PropertyBridgeBaseIT {
 
 		try ( SearchSession session = mapping.createSession() ) {
 			entity.stringProperty.add( "value2" );
-			session.indexingPlan().update( entity, new String[] { "stringProperty" } );
+			session.indexingPlan().addOrUpdate( entity, new String[] { "stringProperty" } );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.update( "1", b -> b.field( "someField", "value1", "value2" ) )

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/PropertyBridgeBaseIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/PropertyBridgeBaseIT.java
@@ -115,7 +115,7 @@ public class PropertyBridgeBaseIT {
 		entity.stringProperty = "some string";
 
 		try ( SearchSession session = mapping.createSession() ) {
-			session.getMainWorkPlan().add( entity );
+			session.indexingPlan().add( entity );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.add( "1", b -> b.field( "someField", entity.stringProperty ) )
@@ -125,7 +125,7 @@ public class PropertyBridgeBaseIT {
 
 		try ( SearchSession session = mapping.createSession() ) {
 			entity.stringProperty = "some string 2";
-			session.getMainWorkPlan().update( entity, new String[] { "stringProperty" } );
+			session.indexingPlan().update( entity, new String[] { "stringProperty" } );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.update( "1", b -> b.field( "someField", entity.stringProperty ) )
@@ -196,7 +196,7 @@ public class PropertyBridgeBaseIT {
 		contained.stringProperty = "some string";
 
 		try ( SearchSession session = mapping.createSession() ) {
-			session.getMainWorkPlan().add( entity );
+			session.indexingPlan().add( entity );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.add( "1", b -> b.field( "someField", contained.stringProperty ) )
@@ -206,7 +206,7 @@ public class PropertyBridgeBaseIT {
 
 		try ( SearchSession session = mapping.createSession() ) {
 			contained.stringProperty = "some string 2";
-			session.getMainWorkPlan().update( entity, new String[] { "contained.stringProperty" } );
+			session.indexingPlan().update( entity, new String[] { "contained.stringProperty" } );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.update( "1", b -> b.field( "someField", contained.stringProperty ) )
@@ -373,8 +373,8 @@ public class PropertyBridgeBaseIT {
 		containedLevel2Entity.stringProperty = "some string";
 
 		try ( SearchSession session = mapping.createSession() ) {
-			session.getMainWorkPlan().add( entity );
-			session.getMainWorkPlan().add( containedLevel2Entity );
+			session.indexingPlan().add( entity );
+			session.indexingPlan().add( containedLevel2Entity );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.add( "1", b -> b.field( "someField", "constant" ) )
@@ -384,7 +384,7 @@ public class PropertyBridgeBaseIT {
 
 		try ( SearchSession session = mapping.createSession() ) {
 			containedLevel2Entity.stringProperty = "some string";
-			session.getMainWorkPlan().update( containedLevel2Entity, new String[] { "stringProperty" } );
+			session.indexingPlan().update( containedLevel2Entity, new String[] { "stringProperty" } );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.update( "1", b -> b.field( "someField", "constant" ) )
@@ -800,7 +800,7 @@ public class PropertyBridgeBaseIT {
 		entity.stringProperty.add( "value1" );
 
 		try ( SearchSession session = mapping.createSession() ) {
-			session.getMainWorkPlan().add( entity );
+			session.indexingPlan().add( entity );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.add( "1", b -> b.field( "someField", "value1" ) )
@@ -810,7 +810,7 @@ public class PropertyBridgeBaseIT {
 
 		try ( SearchSession session = mapping.createSession() ) {
 			entity.stringProperty.add( "value2" );
-			session.getMainWorkPlan().update( entity, new String[] { "stringProperty" } );
+			session.indexingPlan().update( entity, new String[] { "stringProperty" } );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.update( "1", b -> b.field( "someField", "value1", "value2" ) )

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/PropertyBridgeBaseIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/PropertyBridgeBaseIT.java
@@ -119,7 +119,7 @@ public class PropertyBridgeBaseIT {
 
 			backendMock.expectWorks( INDEX_NAME )
 					.add( "1", b -> b.field( "someField", entity.stringProperty ) )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 		backendMock.verifyExpectationsMet();
 
@@ -129,7 +129,7 @@ public class PropertyBridgeBaseIT {
 
 			backendMock.expectWorks( INDEX_NAME )
 					.update( "1", b -> b.field( "someField", entity.stringProperty ) )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 		backendMock.verifyExpectationsMet();
 	}
@@ -200,7 +200,7 @@ public class PropertyBridgeBaseIT {
 
 			backendMock.expectWorks( INDEX_NAME )
 					.add( "1", b -> b.field( "someField", contained.stringProperty ) )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 		backendMock.verifyExpectationsMet();
 
@@ -210,7 +210,7 @@ public class PropertyBridgeBaseIT {
 
 			backendMock.expectWorks( INDEX_NAME )
 					.update( "1", b -> b.field( "someField", contained.stringProperty ) )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 		backendMock.verifyExpectationsMet();
 	}
@@ -378,7 +378,7 @@ public class PropertyBridgeBaseIT {
 
 			backendMock.expectWorks( INDEX_NAME )
 					.add( "1", b -> b.field( "someField", "constant" ) )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 		backendMock.verifyExpectationsMet();
 
@@ -388,7 +388,7 @@ public class PropertyBridgeBaseIT {
 
 			backendMock.expectWorks( INDEX_NAME )
 					.update( "1", b -> b.field( "someField", "constant" ) )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 		backendMock.verifyExpectationsMet();
 	}
@@ -804,7 +804,7 @@ public class PropertyBridgeBaseIT {
 
 			backendMock.expectWorks( INDEX_NAME )
 					.add( "1", b -> b.field( "someField", "value1" ) )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 		backendMock.verifyExpectationsMet();
 
@@ -814,7 +814,7 @@ public class PropertyBridgeBaseIT {
 
 			backendMock.expectWorks( INDEX_NAME )
 					.update( "1", b -> b.field( "someField", "value1", "value2" ) )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 		backendMock.verifyExpectationsMet();
 	}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/TypeBridgeBaseIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/TypeBridgeBaseIT.java
@@ -119,7 +119,7 @@ public class TypeBridgeBaseIT {
 
 		try ( SearchSession session = mapping.createSession() ) {
 			entity.stringProperty = "some string 2";
-			session.indexingPlan().update( entity, new String[] { "stringProperty" } );
+			session.indexingPlan().addOrUpdate( entity, new String[] { "stringProperty" } );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.update( "1", b -> b.field( "someField", entity.stringProperty ) )
@@ -192,7 +192,7 @@ public class TypeBridgeBaseIT {
 
 		try ( SearchSession session = mapping.createSession() ) {
 			entity.stringProperty = "some string 2";
-			session.indexingPlan().update( entity, new String[] { "stringProperty" } );
+			session.indexingPlan().addOrUpdate( entity, new String[] { "stringProperty" } );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.update( "1", b -> b.field( "someField", entity.stringProperty ) )
@@ -318,7 +318,7 @@ public class TypeBridgeBaseIT {
 		try ( SearchSession session = mapping.createSession() ) {
 			containedEntity.stringProperty = "some string";
 
-			session.indexingPlan().update( containedEntity, new String[] { "stringProperty" } );
+			session.indexingPlan().addOrUpdate( containedEntity, new String[] { "stringProperty" } );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.update( "1", b -> b.field( "someField", "constant" ) )
@@ -713,7 +713,7 @@ public class TypeBridgeBaseIT {
 		try ( SearchSession session = mapping.createSession() ) {
 			entity.enumProperty = CustomEnum.VALUE2;
 
-			session.indexingPlan().update( entity, new String[] { "enumProperty" } );
+			session.indexingPlan().addOrUpdate( entity, new String[] { "enumProperty" } );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.update( "1", b -> b

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/TypeBridgeBaseIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/TypeBridgeBaseIT.java
@@ -109,7 +109,7 @@ public class TypeBridgeBaseIT {
 		entity.stringProperty = "some string";
 
 		try ( SearchSession session = mapping.createSession() ) {
-			session.getMainWorkPlan().add( entity );
+			session.indexingPlan().add( entity );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.add( "1", b -> b.field( "someField", entity.stringProperty ) )
@@ -119,7 +119,7 @@ public class TypeBridgeBaseIT {
 
 		try ( SearchSession session = mapping.createSession() ) {
 			entity.stringProperty = "some string 2";
-			session.getMainWorkPlan().update( entity, new String[] { "stringProperty" } );
+			session.indexingPlan().update( entity, new String[] { "stringProperty" } );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.update( "1", b -> b.field( "someField", entity.stringProperty ) )
@@ -182,7 +182,7 @@ public class TypeBridgeBaseIT {
 		entity.stringProperty = "some string";
 
 		try ( SearchSession session = mapping.createSession() ) {
-			session.getMainWorkPlan().add( entity );
+			session.indexingPlan().add( entity );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.add( "1", b -> b.field( "someField", entity.stringProperty ) )
@@ -192,7 +192,7 @@ public class TypeBridgeBaseIT {
 
 		try ( SearchSession session = mapping.createSession() ) {
 			entity.stringProperty = "some string 2";
-			session.getMainWorkPlan().update( entity, new String[] { "stringProperty" } );
+			session.indexingPlan().update( entity, new String[] { "stringProperty" } );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.update( "1", b -> b.field( "someField", entity.stringProperty ) )
@@ -306,8 +306,8 @@ public class TypeBridgeBaseIT {
 		containedEntity.stringProperty = "some string";
 
 		try ( SearchSession session = mapping.createSession() ) {
-			session.getMainWorkPlan().add( entity );
-			session.getMainWorkPlan().add( containedEntity );
+			session.indexingPlan().add( entity );
+			session.indexingPlan().add( containedEntity );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.add( "1", b -> b.field( "someField", "constant" ) )
@@ -318,7 +318,7 @@ public class TypeBridgeBaseIT {
 		try ( SearchSession session = mapping.createSession() ) {
 			containedEntity.stringProperty = "some string";
 
-			session.getMainWorkPlan().update( containedEntity, new String[] { "stringProperty" } );
+			session.indexingPlan().update( containedEntity, new String[] { "stringProperty" } );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.update( "1", b -> b.field( "someField", "constant" ) )
@@ -698,7 +698,7 @@ public class TypeBridgeBaseIT {
 
 		try ( SearchSession session = mapping.createSession() ) {
 
-			session.getMainWorkPlan().add( entity );
+			session.indexingPlan().add( entity );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.add( "1", b -> b
@@ -713,7 +713,7 @@ public class TypeBridgeBaseIT {
 		try ( SearchSession session = mapping.createSession() ) {
 			entity.enumProperty = CustomEnum.VALUE2;
 
-			session.getMainWorkPlan().update( entity, new String[] { "enumProperty" } );
+			session.indexingPlan().update( entity, new String[] { "enumProperty" } );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.update( "1", b -> b

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/TypeBridgeBaseIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/TypeBridgeBaseIT.java
@@ -113,7 +113,7 @@ public class TypeBridgeBaseIT {
 
 			backendMock.expectWorks( INDEX_NAME )
 					.add( "1", b -> b.field( "someField", entity.stringProperty ) )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 		backendMock.verifyExpectationsMet();
 
@@ -123,7 +123,7 @@ public class TypeBridgeBaseIT {
 
 			backendMock.expectWorks( INDEX_NAME )
 					.update( "1", b -> b.field( "someField", entity.stringProperty ) )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 		backendMock.verifyExpectationsMet();
 	}
@@ -186,7 +186,7 @@ public class TypeBridgeBaseIT {
 
 			backendMock.expectWorks( INDEX_NAME )
 					.add( "1", b -> b.field( "someField", entity.stringProperty ) )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 		backendMock.verifyExpectationsMet();
 
@@ -196,7 +196,7 @@ public class TypeBridgeBaseIT {
 
 			backendMock.expectWorks( INDEX_NAME )
 					.update( "1", b -> b.field( "someField", entity.stringProperty ) )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 		backendMock.verifyExpectationsMet();
 	}
@@ -311,7 +311,7 @@ public class TypeBridgeBaseIT {
 
 			backendMock.expectWorks( INDEX_NAME )
 					.add( "1", b -> b.field( "someField", "constant" ) )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 		backendMock.verifyExpectationsMet();
 
@@ -322,7 +322,7 @@ public class TypeBridgeBaseIT {
 
 			backendMock.expectWorks( INDEX_NAME )
 					.update( "1", b -> b.field( "someField", "constant" ) )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 		backendMock.verifyExpectationsMet();
 	}
@@ -706,7 +706,7 @@ public class TypeBridgeBaseIT {
 									.field( "someField", entity.enumProperty.stringProperty )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 		backendMock.verifyExpectationsMet();
 
@@ -721,7 +721,7 @@ public class TypeBridgeBaseIT {
 									.field( "someField", entity.enumProperty.stringProperty )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 		backendMock.verifyExpectationsMet();
 	}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/model/GenericPropertyIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/model/GenericPropertyIT.java
@@ -70,7 +70,7 @@ public class GenericPropertyIT {
 			entity1.setGenericProperty( genericEntity );
 			genericEntity.setParent( entity1 );
 
-			session.getMainWorkPlan().add( entity1 );
+			session.indexingPlan().add( entity1 );
 
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.add( "1", b -> b

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/model/GenericPropertyIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/model/GenericPropertyIT.java
@@ -80,7 +80,7 @@ public class GenericPropertyIT {
 									.field( "arrayContent", genericEntity.getArrayContent()[1] )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 	}
 

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/model/ImplementedInterfaceIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/model/ImplementedInterfaceIT.java
@@ -50,7 +50,7 @@ public class ImplementedInterfaceIT {
 
 			backendMock.expectWorks( IndexedPojo.class.getName() ).add( "1", b -> b
 					.field( "text", "Using some other text here" )
-			).preparedThenExecuted();
+			).processedThenExecuted();
 		}
 	}
 

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/model/ImplementedInterfaceIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/model/ImplementedInterfaceIT.java
@@ -46,7 +46,7 @@ public class ImplementedInterfaceIT {
 	public void index() {
 		try ( SearchSession session = mapping.createSession() ) {
 			IndexedPojo indexedPojo = new IndexedPojo( 1, "Using some other text here" );
-			session.getMainWorkPlan().add( indexedPojo );
+			session.indexingPlan().add( indexedPojo );
 
 			backendMock.expectWorks( IndexedPojo.class.getName() ).add( "1", b -> b
 					.field( "text", "Using some other text here" )

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/model/PropertyInheritanceIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/model/PropertyInheritanceIT.java
@@ -72,7 +72,7 @@ public class PropertyInheritanceIT {
 			entity1.setEmbedded( entity2 );
 			entity2.setEmbedding( entity1 );
 
-			session.getMainWorkPlan().add( entity1 );
+			session.indexingPlan().add( entity1 );
 
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.add( "1", b -> b

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/model/PropertyInheritanceIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/model/PropertyInheritanceIT.java
@@ -83,7 +83,7 @@ public class PropertyInheritanceIT {
 									.field( "childDeclaredProperty", entity2.getChildDeclaredProperty() )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 	}
 

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/nonregression/mapping/definition/IndexNullAsOnNumericContainerIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/nonregression/mapping/definition/IndexNullAsOnNumericContainerIT.java
@@ -63,7 +63,7 @@ public class IndexNullAsOnNumericContainerIT {
 							// Check that null values are forwarded as null to the backend (not as a String)
 							.field( "integerList", 1, null, 2 )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 	}
 

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/nonregression/mapping/definition/IndexNullAsOnNumericContainerIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/nonregression/mapping/definition/IndexNullAsOnNumericContainerIT.java
@@ -56,7 +56,7 @@ public class IndexNullAsOnNumericContainerIT {
 			entity1.getIntegerList().add( null );
 			entity1.getIntegerList().add( 2 );
 
-			session.getMainWorkPlan().add( entity1 );
+			session.indexingPlan().add( entity1 );
 
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.add( "1", b -> b

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/providedid/ProvidedIdIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/providedid/ProvidedIdIT.java
@@ -52,7 +52,7 @@ public class ProvidedIdIT {
 		try ( SearchSession session = mapping.createSession() ) {
 			IndexedEntity entity1 = new IndexedEntity();
 
-			session.getMainWorkPlan().add( "42", entity1 );
+			session.indexingPlan().add( "42", entity1 );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.add( "42", b -> { } )
@@ -96,7 +96,7 @@ public class ProvidedIdIT {
 			IndexedEntity entity1 = new IndexedEntity();
 
 			SubTest.expectException(
-					() -> session.getMainWorkPlan().add( entity1 )
+					() -> session.indexingPlan().add( entity1 )
 			)
 					.assertThrown()
 					.isInstanceOf( SearchException.class )

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/providedid/ProvidedIdIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/providedid/ProvidedIdIT.java
@@ -56,7 +56,7 @@ public class ProvidedIdIT {
 
 			backendMock.expectWorks( INDEX_NAME )
 					.add( "42", b -> { } )
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 		backendMock.verifyExpectationsMet();
 

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/routing/AnnotationMappingRoutingIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/routing/AnnotationMappingRoutingIT.java
@@ -67,7 +67,7 @@ public class AnnotationMappingRoutingIT {
 			entity1.setCategory( EntityCategory.CATEGORY_2 );
 			entity1.setValue( "val1" );
 
-			session.getMainWorkPlan().add( entity1 );
+			session.indexingPlan().add( entity1 );
 
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.add( b -> b
@@ -92,7 +92,7 @@ public class AnnotationMappingRoutingIT {
 			entity1.setCategory( EntityCategory.CATEGORY_2 );
 			entity1.setValue( "val1" );
 
-			session.getMainWorkPlan().add( entity1 );
+			session.indexingPlan().add( entity1 );
 
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.add( b -> b

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/routing/AnnotationMappingRoutingIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/routing/AnnotationMappingRoutingIT.java
@@ -78,7 +78,7 @@ public class AnnotationMappingRoutingIT {
 									.build()
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 	}
 
@@ -104,7 +104,7 @@ public class AnnotationMappingRoutingIT {
 									.build()
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 	}
 

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/routing/ProgrammaticMappingRoutingIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/routing/ProgrammaticMappingRoutingIT.java
@@ -72,7 +72,7 @@ public class ProgrammaticMappingRoutingIT {
 			entity1.setCategory( EntityCategory.CATEGORY_2 );
 			entity1.setValue( "val1" );
 
-			session.getMainWorkPlan().add( entity1 );
+			session.indexingPlan().add( entity1 );
 
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.add( b -> b
@@ -97,7 +97,7 @@ public class ProgrammaticMappingRoutingIT {
 			entity1.setCategory( EntityCategory.CATEGORY_2 );
 			entity1.setValue( "val1" );
 
-			session.getMainWorkPlan().add( entity1 );
+			session.indexingPlan().add( entity1 );
 
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.add( b -> b

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/routing/ProgrammaticMappingRoutingIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/routing/ProgrammaticMappingRoutingIT.java
@@ -83,7 +83,7 @@ public class ProgrammaticMappingRoutingIT {
 									.build()
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 	}
 
@@ -109,7 +109,7 @@ public class ProgrammaticMappingRoutingIT {
 									.build()
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 	}
 

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/smoke/AnnotationMappingSmokeIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/smoke/AnnotationMappingSmokeIT.java
@@ -291,13 +291,13 @@ public class AnnotationMappingSmokeIT {
 									.field( "date", entity6.getLocalDate() )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 			backendMock.expectWorks( OtherIndexedEntity.INDEX )
 					.add( "4", b -> b
 							.field( "numeric", entity4.getNumeric() )
 							.field( "numericAsString", String.valueOf( entity4.getNumeric() ) )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 			backendMock.expectWorks( YetAnotherIndexedEntity.INDEX )
 					.add( "5", b -> b
 							.field( "myLocalDateField", entity5.getLocalDate() )
@@ -358,7 +358,7 @@ public class AnnotationMappingSmokeIT {
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 	}
 

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/smoke/AnnotationMappingSmokeIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/smoke/AnnotationMappingSmokeIT.java
@@ -216,13 +216,13 @@ public class AnnotationMappingSmokeIT {
 			entity2.getEmbeddingAsMap().add( entity5 );
 			entity3.getEmbeddingAsMap().add( entity5 );
 
-			session.getMainWorkPlan().add( entity1 );
-			session.getMainWorkPlan().add( entity2 );
-			session.getMainWorkPlan().add( entity4 );
-			session.getMainWorkPlan().delete( entity1 );
-			session.getMainWorkPlan().add( entity3 );
-			session.getMainWorkPlan().add( entity5 );
-			session.getMainWorkPlan().add( entity6 );
+			session.indexingPlan().add( entity1 );
+			session.indexingPlan().add( entity2 );
+			session.indexingPlan().add( entity4 );
+			session.indexingPlan().delete( entity1 );
+			session.indexingPlan().add( entity3 );
+			session.indexingPlan().add( entity5 );
+			session.indexingPlan().add( entity6 );
 
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.add( "2", b -> b

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/smoke/ProgrammaticMappingSmokeIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/smoke/ProgrammaticMappingSmokeIT.java
@@ -341,13 +341,13 @@ public class ProgrammaticMappingSmokeIT {
 									.field( "date", entity6.getLocalDate() )
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 			backendMock.expectWorks( OtherIndexedEntity.INDEX )
 					.add( "4", b -> b
 							.field( "numeric", entity4.getNumeric() )
 							.field( "numericAsString", String.valueOf( entity4.getNumeric() ) )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 			backendMock.expectWorks( YetAnotherIndexedEntity.INDEX )
 					.add( "5", b -> b
 							.field( "myLocalDateField", entity5.getLocalDate() )
@@ -408,7 +408,7 @@ public class ProgrammaticMappingSmokeIT {
 									)
 							)
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 	}
 

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/smoke/ProgrammaticMappingSmokeIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/smoke/ProgrammaticMappingSmokeIT.java
@@ -266,13 +266,13 @@ public class ProgrammaticMappingSmokeIT {
 			entity2.getEmbeddingAsMap().add( entity5 );
 			entity3.getEmbeddingAsMap().add( entity5 );
 
-			session.getMainWorkPlan().add( entity1 );
-			session.getMainWorkPlan().add( entity2 );
-			session.getMainWorkPlan().add( entity4 );
-			session.getMainWorkPlan().delete( entity1 );
-			session.getMainWorkPlan().add( entity3 );
-			session.getMainWorkPlan().add( entity5 );
-			session.getMainWorkPlan().add( entity6 );
+			session.indexingPlan().add( entity1 );
+			session.indexingPlan().add( entity2 );
+			session.indexingPlan().add( entity4 );
+			session.indexingPlan().delete( entity1 );
+			session.indexingPlan().add( entity3 );
+			session.indexingPlan().add( entity5 );
+			session.indexingPlan().add( entity6 );
 
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.add( "2", b -> b

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/spatial/AnnotationMappingGeoPointBindingIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/spatial/AnnotationMappingGeoPointBindingIT.java
@@ -104,13 +104,13 @@ public class AnnotationMappingGeoPointBindingIT {
 									entity1.getWorkLatitude(), entity1.getWorkLongitude()
 							) )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 			backendMock.expectWorks( GeoPointOnCoordinatesPropertyEntity.INDEX )
 					.add( "2", b -> b
 							.field( "coord", entity2.getCoord() )
 							.field( "location", entity2.getCoord() )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 			backendMock.expectWorks( GeoPointOnCustomCoordinatesPropertyEntity.INDEX )
 					.add( "3", b -> b
 							.field( "coord", GeoPoint.of(
@@ -120,7 +120,7 @@ public class AnnotationMappingGeoPointBindingIT {
 									entity3.getCoord().getLat(), entity3.getCoord().getLon()
 							) )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 	}
 

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/spatial/AnnotationMappingGeoPointBindingIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/spatial/AnnotationMappingGeoPointBindingIT.java
@@ -91,9 +91,9 @@ public class AnnotationMappingGeoPointBindingIT {
 			entity3.setId( 3 );
 			entity3.setCoord( new CustomCoordinates( 3.1d, 3.2d ) );
 
-			session.getMainWorkPlan().add( entity1 );
-			session.getMainWorkPlan().add( entity2 );
-			session.getMainWorkPlan().add( entity3 );
+			session.indexingPlan().add( entity1 );
+			session.indexingPlan().add( entity2 );
+			session.indexingPlan().add( entity3 );
 
 			backendMock.expectWorks( GeoPointOnTypeEntity.INDEX )
 					.add( "1", b -> b

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/spatial/ProgrammaticMappingGeoPointBindingIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/spatial/ProgrammaticMappingGeoPointBindingIT.java
@@ -138,9 +138,9 @@ public class ProgrammaticMappingGeoPointBindingIT {
 			entity3.setId( 3 );
 			entity3.setCoord( new CustomCoordinates( 3.1d, 3.2d ) );
 
-			session.getMainWorkPlan().add( entity1 );
-			session.getMainWorkPlan().add( entity2 );
-			session.getMainWorkPlan().add( entity3 );
+			session.indexingPlan().add( entity1 );
+			session.indexingPlan().add( entity2 );
+			session.indexingPlan().add( entity3 );
 
 			backendMock.expectWorks( GeoPointOnTypeEntity.INDEX )
 					.add( "1", b -> b

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/spatial/ProgrammaticMappingGeoPointBindingIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/spatial/ProgrammaticMappingGeoPointBindingIT.java
@@ -151,13 +151,13 @@ public class ProgrammaticMappingGeoPointBindingIT {
 									entity1.getWorkLatitude(), entity1.getWorkLongitude()
 							) )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 			backendMock.expectWorks( GeoPointOnCoordinatesPropertyEntity.INDEX )
 					.add( "2", b -> b
 							.field( "coord", entity2.getCoord() )
 							.field( "location", entity2.getCoord() )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 			backendMock.expectWorks( GeoPointOnCustomCoordinatesPropertyEntity.INDEX )
 					.add( "3", b -> b
 							.field( "coord", GeoPoint.of(
@@ -167,7 +167,7 @@ public class ProgrammaticMappingGeoPointBindingIT {
 									entity3.getCoord().getLat(), entity3.getCoord().getLon()
 							) )
 					)
-					.preparedThenExecuted();
+					.processedThenExecuted();
 		}
 	}
 

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/mapping/SearchMapping.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/mapping/SearchMapping.java
@@ -37,7 +37,7 @@ public interface SearchMapping {
 	SearchScope scope(Collection<? extends Class<?>> types);
 
 	/**
-	 * @return A new session allowing to {@link SearchSession#getMainWorkPlan() index} or
+	 * @return A new session allowing to {@link SearchSession#indexingPlan() index} or
 	 * {@link SearchSession#search(Class) search for} entities.
 	 * @see #createSessionWithOptions()
 	 */

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/mapping/SearchMappingBuilder.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/mapping/SearchMappingBuilder.java
@@ -67,7 +67,7 @@ public final class SearchMappingBuilder {
 
 	/**
 	 * @param type The type to be considered as an entity type, i.e. a type that may be indexed
-	 * and whose instances be added/updated/deleted through the {@link SearchSession#getMainWorkPlan() work plan}.
+	 * and whose instances be added/updated/deleted through the {@link SearchSession#indexingPlan() indexing plan}.
 	 * @return {@code this}, for call chaining.
 	 */
 	public SearchMappingBuilder addEntityType(Class<?> type) {
@@ -77,7 +77,7 @@ public final class SearchMappingBuilder {
 
 	/**
 	 * @param types The types to be considered as entity types, i.e. types that may be indexed
-	 * and whose instances be added/updated/deleted through the {@link SearchSession#getMainWorkPlan() work plan}.
+	 * and whose instances be added/updated/deleted through the {@link SearchSession#indexingPlan() indexing plan}.
 	 * @return {@code this}, for call chaining.
 	 */
 	public SearchMappingBuilder addEntityTypes(Set<Class<?>> types) {

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/session/SearchSession.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/session/SearchSession.java
@@ -12,12 +12,12 @@ import java.util.Collections;
 import org.hibernate.search.engine.search.query.dsl.SearchQueryHitTypeStep;
 import org.hibernate.search.mapper.javabean.common.EntityReference;
 import org.hibernate.search.mapper.javabean.scope.SearchScope;
-import org.hibernate.search.mapper.javabean.work.SearchWorkPlan;
+import org.hibernate.search.mapper.javabean.work.SearchIndexingPlan;
 
 public interface SearchSession extends AutoCloseable {
 
 	/**
-	 * Execute any pending work in the {@link #getMainWorkPlan() main work plan}
+	 * Execute any pending work in the {@link #indexingPlan() indexing plan}
 	 * and release any resource held by this session.
 	 */
 	@Override
@@ -79,8 +79,8 @@ public interface SearchSession extends AutoCloseable {
 	SearchScope scope(Collection<? extends Class<?>> types);
 
 	/**
-	 * @return The main work plan for this session. It will be executed upon closing this session.
+	 * @return The indexing plan for this session. It will be executed upon closing this session.
 	 */
-	SearchWorkPlan getMainWorkPlan();
+	SearchIndexingPlan indexingPlan();
 
 }

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/session/SearchSessionBuilder.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/session/SearchSessionBuilder.java
@@ -19,13 +19,13 @@ public interface SearchSessionBuilder {
 	SearchSessionBuilder tenantId(String tenantId);
 
 	/**
-	 * @param commitStrategy The commit strategy for indexing works added to the {@link SearchSession#getMainWorkPlan() main work plan}.
+	 * @param commitStrategy The commit strategy for indexing works added to the {@link SearchSession#indexingPlan() indexing plan}.
 	 * @return {@code this} for method chaining.
 	 */
 	SearchSessionBuilder commitStrategy(DocumentCommitStrategy commitStrategy);
 
 	/**
-	 * @param refreshStrategy The refresh strategy for indexing works added to the {@link SearchSession#getMainWorkPlan() main work plan}.
+	 * @param refreshStrategy The refresh strategy for indexing works added to the {@link SearchSession#indexingPlan() indexing plan}.
 	 * @return {@code this} for method chaining.
 	 */
 	SearchSessionBuilder refreshStrategy(DocumentRefreshStrategy refreshStrategy);

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/session/impl/JavaBeanSearchSession.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/session/impl/JavaBeanSearchSession.java
@@ -73,7 +73,7 @@ public class JavaBeanSearchSession extends AbstractPojoSearchSession
 	@Override
 	public SearchWorkPlan getMainWorkPlan() {
 		if ( workPlan == null ) {
-			workPlan = new SearchWorkPlanImpl( getDelegate().createWorkPlan( commitStrategy, refreshStrategy ) );
+			workPlan = new SearchWorkPlanImpl( getDelegate().createIndexingPlan( commitStrategy, refreshStrategy ) );
 		}
 		return workPlan;
 	}

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/session/impl/JavaBeanSearchSession.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/session/impl/JavaBeanSearchSession.java
@@ -20,8 +20,8 @@ import org.hibernate.search.mapper.javabean.scope.impl.SearchScopeImpl;
 import org.hibernate.search.mapper.javabean.session.SearchSession;
 import org.hibernate.search.mapper.javabean.session.SearchSessionBuilder;
 import org.hibernate.search.mapper.javabean.session.context.impl.JavaBeanBackendSessionContext;
-import org.hibernate.search.mapper.javabean.work.SearchWorkPlan;
-import org.hibernate.search.mapper.javabean.work.impl.SearchWorkPlanImpl;
+import org.hibernate.search.mapper.javabean.work.SearchIndexingPlan;
+import org.hibernate.search.mapper.javabean.work.impl.SearchIndexingPlanImpl;
 import org.hibernate.search.mapper.javabean.common.impl.EntityReferenceImpl;
 import org.hibernate.search.mapper.pojo.mapping.spi.PojoMappingDelegate;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRuntimeIntrospector;
@@ -37,7 +37,7 @@ public class JavaBeanSearchSession extends AbstractPojoSearchSession
 
 	private final DocumentCommitStrategy commitStrategy;
 	private final DocumentRefreshStrategy refreshStrategy;
-	private SearchWorkPlanImpl workPlan;
+	private SearchIndexingPlanImpl indexingPlan;
 
 	private JavaBeanSearchSession(JavaBeanSearchSessionBuilder builder) {
 		super( builder, builder.buildSessionContext() );
@@ -49,8 +49,8 @@ public class JavaBeanSearchSession extends AbstractPojoSearchSession
 
 	@Override
 	public void close() {
-		if ( workPlan != null ) {
-			CompletableFuture<?> future = workPlan.execute();
+		if ( indexingPlan != null ) {
+			CompletableFuture<?> future = indexingPlan.execute();
 			future.join();
 		}
 	}
@@ -71,11 +71,11 @@ public class JavaBeanSearchSession extends AbstractPojoSearchSession
 	}
 
 	@Override
-	public SearchWorkPlan getMainWorkPlan() {
-		if ( workPlan == null ) {
-			workPlan = new SearchWorkPlanImpl( getDelegate().createIndexingPlan( commitStrategy, refreshStrategy ) );
+	public SearchIndexingPlan indexingPlan() {
+		if ( indexingPlan == null ) {
+			indexingPlan = new SearchIndexingPlanImpl( getDelegate().createIndexingPlan( commitStrategy, refreshStrategy ) );
 		}
-		return workPlan;
+		return indexingPlan;
 	}
 
 	@Override

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/SearchIndexingPlan.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/SearchIndexingPlan.java
@@ -7,16 +7,13 @@
 package org.hibernate.search.mapper.javabean.work;
 
 /**
- * A set of works to be executed on mapped indexes.
+ * An interface for indexing entities in the context of a session.
  * <p>
- * Works are accumulated when methods such as {@link #add(Object)} or {@link #update(Object, Object)} are called,
- * and executed only when the search manager is closed.
- * <p>
- * Relative ordering of works within a work plan will be preserved.
+ * This class is stateful: it queues operations internally to apply them when the session is closed.
  * <p>
  * This contract is not thread-safe.
  */
-public interface SearchWorkPlan {
+public interface SearchIndexingPlan {
 
 	/**
 	 * Add an entity to the index, assuming that the entity is absent from the index.

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/SearchIndexingPlan.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/SearchIndexingPlan.java
@@ -29,7 +29,7 @@ public interface SearchIndexingPlan {
 	 * <p>
 	 * <strong>Note:</strong> depending on the backend, this may lead to errors or duplicate entries in the index
 	 * if the entity was actually already present in the index before this call.
-	 * When in doubt, you should rather use {@link #update(Object, Object)} or {@link #update(Object)}.
+	 * When in doubt, you should rather use {@link #addOrUpdate(Object, Object)} or {@link #addOrUpdate(Object)}.
 	 *
 	 * @param providedId A value to extract the document ID from.
 	 * Generally the expected value is the entity ID, but a different value may be expected depending on the mapping.
@@ -41,11 +41,11 @@ public interface SearchIndexingPlan {
 	/**
 	 * Update an entity in the index, or add it if it's absent from the index.
 	 * <p>
-	 * Shorthand for {@code update(null, entity)}; see {@link #update(Object, Object)}.
+	 * Shorthand for {@code update(null, entity)}; see {@link #addOrUpdate(Object, Object)}.
 	 *
 	 * @param entity The entity to update in the index.
 	 */
-	void update(Object entity);
+	void addOrUpdate(Object entity);
 
 	/**
 	 * Update an entity in the index, or add it if it's absent from the index.
@@ -55,7 +55,7 @@ public interface SearchIndexingPlan {
 	 * If {@code null}, Hibernate Search will attempt to extract the ID from the entity.
 	 * @param entity The entity to update in the index.
 	 */
-	void update(Object providedId, Object entity);
+	void addOrUpdate(Object providedId, Object entity);
 
 	/**
 	 * Update an entity in the index, or add it if it's absent from the index,
@@ -64,13 +64,13 @@ public interface SearchIndexingPlan {
 	 * <p>
 	 * Assumes that the entity may already be present in the index.
 	 * <p>
-	 * Shorthand for {@code update(null, entity, dirtyPaths)}; see {@link #update(Object, Object)}.
+	 * Shorthand for {@code update(null, entity, dirtyPaths)}; see {@link #addOrUpdate(Object, Object)}.
 	 *
 	 * @param entity The entity to update in the index.
 	 * @param dirtyPaths The paths to consider dirty, formatted using the dot-notation
 	 * ("directEntityProperty.nestedPropery").
 	 */
-	void update(Object entity, String... dirtyPaths);
+	void addOrUpdate(Object entity, String... dirtyPaths);
 
 	/**
 	 * Update an entity in the index, or add it if it's absent from the index,
@@ -84,7 +84,7 @@ public interface SearchIndexingPlan {
 	 * @param dirtyPaths The paths to consider dirty, formatted using the dot-notation
 	 * ("directEntityProperty.nestedPropery").
 	 */
-	void update(Object providedId, Object entity, String... dirtyPaths);
+	void addOrUpdate(Object providedId, Object entity, String... dirtyPaths);
 
 	/**
 	 * Delete an entity from the index.

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexingPlanImpl.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexingPlanImpl.java
@@ -30,22 +30,22 @@ public class SearchIndexingPlanImpl implements SearchIndexingPlan {
 	}
 
 	@Override
-	public void update(Object entity) {
+	public void addOrUpdate(Object entity) {
 		delegate.addOrUpdate( entity );
 	}
 
 	@Override
-	public void update(Object providedId, Object entity) {
+	public void addOrUpdate(Object providedId, Object entity) {
 		delegate.addOrUpdate( providedId, entity );
 	}
 
 	@Override
-	public void update(Object entity, String... dirtyPaths) {
+	public void addOrUpdate(Object entity, String... dirtyPaths) {
 		delegate.addOrUpdate( entity, dirtyPaths );
 	}
 
 	@Override
-	public void update(Object providedId, Object entity, String... dirtyPaths) {
+	public void addOrUpdate(Object providedId, Object entity, String... dirtyPaths) {
 		delegate.addOrUpdate( providedId, entity, dirtyPaths );
 	}
 
@@ -57,10 +57,6 @@ public class SearchIndexingPlanImpl implements SearchIndexingPlan {
 	@Override
 	public void delete(Object providedId, Object entity) {
 		delegate.delete( providedId, entity );
-	}
-
-	public void prepare() {
-		delegate.process();
 	}
 
 	public CompletableFuture<?> execute() {

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexingPlanImpl.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexingPlanImpl.java
@@ -8,14 +8,14 @@ package org.hibernate.search.mapper.javabean.work.impl;
 
 import java.util.concurrent.CompletableFuture;
 
-import org.hibernate.search.mapper.javabean.work.SearchWorkPlan;
+import org.hibernate.search.mapper.javabean.work.SearchIndexingPlan;
 import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingPlan;
 
-public class SearchWorkPlanImpl implements SearchWorkPlan {
+public class SearchIndexingPlanImpl implements SearchIndexingPlan {
 
 	private final PojoIndexingPlan delegate;
 
-	public SearchWorkPlanImpl(PojoIndexingPlan delegate) {
+	public SearchIndexingPlanImpl(PojoIndexingPlan delegate) {
 		this.delegate = delegate;
 	}
 

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchWorkPlanImpl.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchWorkPlanImpl.java
@@ -9,13 +9,13 @@ package org.hibernate.search.mapper.javabean.work.impl;
 import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.search.mapper.javabean.work.SearchWorkPlan;
-import org.hibernate.search.mapper.pojo.work.spi.PojoWorkPlan;
+import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingPlan;
 
 public class SearchWorkPlanImpl implements SearchWorkPlan {
 
-	private final PojoWorkPlan delegate;
+	private final PojoIndexingPlan delegate;
 
-	public SearchWorkPlanImpl(PojoWorkPlan delegate) {
+	public SearchWorkPlanImpl(PojoIndexingPlan delegate) {
 		this.delegate = delegate;
 	}
 

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchWorkPlanImpl.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchWorkPlanImpl.java
@@ -31,22 +31,22 @@ public class SearchWorkPlanImpl implements SearchWorkPlan {
 
 	@Override
 	public void update(Object entity) {
-		delegate.update( entity );
+		delegate.addOrUpdate( entity );
 	}
 
 	@Override
 	public void update(Object providedId, Object entity) {
-		delegate.update( providedId, entity );
+		delegate.addOrUpdate( providedId, entity );
 	}
 
 	@Override
 	public void update(Object entity, String... dirtyPaths) {
-		delegate.update( entity, dirtyPaths );
+		delegate.addOrUpdate( entity, dirtyPaths );
 	}
 
 	@Override
 	public void update(Object providedId, Object entity, String... dirtyPaths) {
-		delegate.update( providedId, entity, dirtyPaths );
+		delegate.addOrUpdate( providedId, entity, dirtyPaths );
 	}
 
 	@Override
@@ -60,7 +60,7 @@ public class SearchWorkPlanImpl implements SearchWorkPlan {
 	}
 
 	public void prepare() {
-		delegate.prepare();
+		delegate.process();
 	}
 
 	public CompletableFuture<?> execute() {

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/automaticindexing/AutomaticIndexingStrategyName.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/automaticindexing/AutomaticIndexingStrategyName.java
@@ -22,7 +22,7 @@ public enum AutomaticIndexingStrategyName {
 	/**
 	 * No automatic indexing is performed:
 	 * indexing will only happen when explicitly requested through APIs
-	 * such as {@link SearchSession#writePlan()}.
+	 * such as {@link SearchSession#indexingPlan()}.
 	 */
 	NONE("none"),
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/event/impl/HibernateOrmListenerContextProvider.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/event/impl/HibernateOrmListenerContextProvider.java
@@ -8,7 +8,7 @@ package org.hibernate.search.mapper.orm.event.impl;
 
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.search.mapper.orm.session.AutomaticIndexingSynchronizationStrategy;
-import org.hibernate.search.mapper.pojo.work.spi.PojoWorkPlan;
+import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingPlan;
 
 public interface HibernateOrmListenerContextProvider {
 
@@ -16,6 +16,6 @@ public interface HibernateOrmListenerContextProvider {
 
 	AutomaticIndexingSynchronizationStrategy getSynchronizationStrategy();
 
-	PojoWorkPlan getCurrentWorkPlan(SessionImplementor session, boolean createIfDoesNotExist);
+	PojoIndexingPlan getCurrentIndexingPlan(SessionImplementor session, boolean createIfDoesNotExist);
 
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/event/impl/HibernateOrmListenerTypeContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/event/impl/HibernateOrmListenerTypeContext.java
@@ -8,6 +8,6 @@ package org.hibernate.search.mapper.orm.event.impl;
 
 public interface HibernateOrmListenerTypeContext {
 
-	Object toWorkPlanProvidedId(Object entityId);
+	Object toIndexingPlanProvidedId(Object entityId);
 
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmContainedTypeContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmContainedTypeContext.java
@@ -17,9 +17,9 @@ class HibernateOrmContainedTypeContext<E> extends AbstractHibernateOrmTypeContex
 	}
 
 	@Override
-	public Object toWorkPlanProvidedId(Object entityId) {
+	public Object toIndexingPlanProvidedId(Object entityId) {
 		// The concept of document ID is not relevant for contained types,
-		// so we always provide the entity ID to work plans
+		// so we always provide the entity ID to indexing plans
 		return entityId;
 	}
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmIndexedTypeContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmIndexedTypeContext.java
@@ -58,7 +58,7 @@ class HibernateOrmIndexedTypeContext<E> extends AbstractHibernateOrmTypeContext<
 	}
 
 	@Override
-	public Object toWorkPlanProvidedId(Object entityId) {
+	public Object toIndexingPlanProvidedId(Object entityId) {
 		if ( documentIdIsEntityId ) {
 			return entityId;
 		}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMapping.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMapping.java
@@ -40,7 +40,7 @@ import org.hibernate.search.mapper.orm.session.impl.HibernateOrmSearchSessionMap
 import org.hibernate.search.mapper.pojo.mapping.spi.AbstractPojoMappingImplementor;
 import org.hibernate.search.mapper.pojo.mapping.spi.PojoMappingDelegate;
 import org.hibernate.search.mapper.pojo.scope.spi.PojoScopeDelegate;
-import org.hibernate.search.mapper.pojo.work.spi.PojoSessionWorkExecutor;
+import org.hibernate.search.mapper.pojo.work.spi.PojoIndexer;
 import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingPlan;
 import org.hibernate.search.util.common.AssertionFailure;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
@@ -145,9 +145,9 @@ public class HibernateOrmMapping extends AbstractPojoMappingImplementor<Hibernat
 	}
 
 	@Override
-	public PojoSessionWorkExecutor createSessionWorkExecutor(SessionImplementor sessionImplementor,
+	public PojoIndexer createIndexer(SessionImplementor sessionImplementor,
 			DocumentCommitStrategy commitStrategy) {
-		return HibernateOrmSearchSession.get( this, sessionImplementor ).createSessionWorkExecutor( commitStrategy );
+		return HibernateOrmSearchSession.get( this, sessionImplementor ).createIndexer( commitStrategy );
 	}
 
 	@Override

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMapping.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMapping.java
@@ -41,7 +41,7 @@ import org.hibernate.search.mapper.pojo.mapping.spi.AbstractPojoMappingImplement
 import org.hibernate.search.mapper.pojo.mapping.spi.PojoMappingDelegate;
 import org.hibernate.search.mapper.pojo.scope.spi.PojoScopeDelegate;
 import org.hibernate.search.mapper.pojo.work.spi.PojoSessionWorkExecutor;
-import org.hibernate.search.mapper.pojo.work.spi.PojoWorkPlan;
+import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingPlan;
 import org.hibernate.search.util.common.AssertionFailure;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
@@ -181,8 +181,8 @@ public class HibernateOrmMapping extends AbstractPojoMappingImplementor<Hibernat
 	}
 
 	@Override
-	public PojoWorkPlan getCurrentWorkPlan(SessionImplementor session, boolean createIfDoesNotExist) {
-		return HibernateOrmSearchSession.get( this, session ).getCurrentWorkPlan( createIfDoesNotExist );
+	public PojoIndexingPlan getCurrentIndexingPlan(SessionImplementor session, boolean createIfDoesNotExist) {
+		return HibernateOrmSearchSession.get( this, session ).getCurrentIndexingPlan( createIfDoesNotExist );
 	}
 
 	@Override

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/HibernateOrmMassIndexingMappingContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/HibernateOrmMassIndexingMappingContext.java
@@ -9,13 +9,13 @@ package org.hibernate.search.mapper.orm.massindexing.impl;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
-import org.hibernate.search.mapper.pojo.work.spi.PojoSessionWorkExecutor;
+import org.hibernate.search.mapper.pojo.work.spi.PojoIndexer;
 
 public interface HibernateOrmMassIndexingMappingContext {
 
 	SessionFactoryImplementor getSessionFactory();
 
-	PojoSessionWorkExecutor createSessionWorkExecutor(SessionImplementor sessionImplementor,
+	PojoIndexer createIndexer(SessionImplementor sessionImplementor,
 			DocumentCommitStrategy commitStrategy);
 
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/MassIndexerImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/MassIndexerImpl.java
@@ -18,7 +18,7 @@ import org.hibernate.search.mapper.orm.massindexing.MassIndexer;
 import org.hibernate.search.mapper.orm.logging.impl.Log;
 import org.hibernate.search.mapper.orm.massindexing.monitor.MassIndexingMonitor;
 import org.hibernate.search.mapper.orm.massindexing.monitor.impl.SimpleIndexingProgressMonitor;
-import org.hibernate.search.mapper.pojo.work.spi.PojoScopeWorkExecutor;
+import org.hibernate.search.mapper.pojo.work.spi.PojoScopeWorkspace;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
 /**
@@ -37,7 +37,7 @@ public class MassIndexerImpl implements MassIndexer {
 	private final DetachedBackendSessionContext sessionContext;
 
 	private final Set<Class<?>> rootEntities;
-	private final PojoScopeWorkExecutor scopeWorkExecutor;
+	private final PojoScopeWorkspace scopeWorkspace;
 
 	// default settings defined here:
 	private int typesToIndexInParallel = 1;
@@ -55,11 +55,11 @@ public class MassIndexerImpl implements MassIndexer {
 	public MassIndexerImpl(HibernateOrmMassIndexingMappingContext mappingContext,
 			Set<? extends HibernateOrmMassIndexingIndexedTypeContext<?>> targetedIndexedTypes,
 			DetachedBackendSessionContext sessionContext,
-			PojoScopeWorkExecutor scopeWorkExecutor) {
+			PojoScopeWorkspace scopeWorkspace) {
 		this.mappingContext = mappingContext;
 		this.sessionContext = sessionContext;
 		this.rootEntities = toRootEntities( targetedIndexedTypes );
-		this.scopeWorkExecutor = scopeWorkExecutor;
+		this.scopeWorkspace = scopeWorkspace;
 
 		// TODO HSEARCH-3057 use a JMX monitor if JMX is enabled (see Search 5)
 		this.monitor = new SimpleIndexingProgressMonitor();
@@ -172,7 +172,7 @@ public class MassIndexerImpl implements MassIndexer {
 	protected BatchCoordinator createCoordinator() {
 		return new BatchCoordinator(
 				mappingContext, sessionContext,
-				rootEntities, scopeWorkExecutor,
+				rootEntities, scopeWorkspace,
 				typesToIndexInParallel, documentBuilderThreads,
 				cacheMode, objectLoadingBatchSize, objectsLimit,
 				optimizeAtEnd, purgeAtStart, optimizeAfterPurge,

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/scope/SearchScope.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/scope/SearchScope.java
@@ -17,7 +17,7 @@ import org.hibernate.search.engine.search.query.dsl.SearchQueryOptionsStep;
 import org.hibernate.search.engine.search.query.dsl.SearchQueryPredicateStep;
 import org.hibernate.search.engine.search.sort.dsl.SearchSortFactory;
 import org.hibernate.search.mapper.orm.massindexing.MassIndexer;
-import org.hibernate.search.mapper.orm.writing.SearchWriter;
+import org.hibernate.search.mapper.orm.work.SearchWorkspace;
 import org.hibernate.search.mapper.orm.search.query.dsl.HibernateOrmSearchQueryHitTypeStep;
 import org.hibernate.search.mapper.orm.common.EntityReference;
 
@@ -96,25 +96,25 @@ public interface SearchScope<E> {
 	SearchAggregationFactory aggregation();
 
 	/**
-	 * Create a {@link SearchWriter} for the indexes mapped to types in this scope, or to any of their sub-types.
+	 * Create a {@link SearchWorkspace} for the indexes mapped to types in this scope, or to any of their sub-types.
 	 * <p>
 	 * This method only works for single-tenant applications.
-	 * If multi-tenancy is enabled, use {@link #writer(String)} instead.
+	 * If multi-tenancy is enabled, use {@link #workspace(String)} instead.
 	 *
-	 * @return A {@link SearchWriter}.
+	 * @return A {@link SearchWorkspace}.
 	 */
-	SearchWriter writer();
+	SearchWorkspace workspace();
 
 	/**
-	 * Create a {@link SearchWriter} for the indexes mapped to types in this scope, or to any of their sub-types.
+	 * Create a {@link SearchWorkspace} for the indexes mapped to types in this scope, or to any of their sub-types.
 	 * <p>
 	 * This method only works for multi-tenant applications.
-	 * If multi-tenancy is disabled, use {@link #writer()} instead.
+	 * If multi-tenancy is disabled, use {@link #workspace()} instead.
 	 *
 	 * @param tenantId The identifier of the tenant whose index content should be targeted.
-	 * @return A {@link SearchWriter}.
+	 * @return A {@link SearchWorkspace}.
 	 */
-	SearchWriter writer(String tenantId);
+	SearchWorkspace workspace(String tenantId);
 
 	/**
 	 * Create a {@link MassIndexer} for the indexes mapped to types in this scope, or to any of their sub-types.

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/scope/impl/SearchScopeImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/scope/impl/SearchScopeImpl.java
@@ -17,8 +17,8 @@ import org.hibernate.search.mapper.orm.scope.SearchScope;
 import org.hibernate.search.mapper.orm.search.query.dsl.HibernateOrmSearchQueryHitTypeStep;
 import org.hibernate.search.mapper.orm.search.query.dsl.impl.HibernateOrmSearchQueryHitTypeStepImpl;
 import org.hibernate.search.mapper.orm.search.loading.context.impl.HibernateOrmLoadingContext;
-import org.hibernate.search.mapper.orm.writing.SearchWriter;
-import org.hibernate.search.mapper.orm.writing.impl.SearchWriterImpl;
+import org.hibernate.search.mapper.orm.work.SearchWorkspace;
+import org.hibernate.search.mapper.orm.work.impl.SearchWorkspaceImpl;
 import org.hibernate.search.mapper.pojo.scope.spi.PojoScopeDelegate;
 import org.hibernate.search.mapper.orm.common.EntityReference;
 
@@ -64,17 +64,17 @@ public class SearchScopeImpl<E> implements SearchScope<E> {
 	}
 
 	@Override
-	public SearchWriter writer() {
-		return writer( (String) null );
+	public SearchWorkspace workspace() {
+		return workspace( (String) null );
 	}
 
 	@Override
-	public SearchWriter writer(String tenantId) {
-		return writer( mappingContext.getDetachedBackendSessionContext( tenantId ) );
+	public SearchWorkspace workspace(String tenantId) {
+		return workspace( mappingContext.getDetachedBackendSessionContext( tenantId ) );
 	}
 
-	public SearchWriter writer(DetachedBackendSessionContext detachedSessionContext) {
-		return new SearchWriterImpl( delegate.executor( detachedSessionContext ) );
+	public SearchWorkspace workspace(DetachedBackendSessionContext detachedSessionContext) {
+		return new SearchWorkspaceImpl( delegate.executor( detachedSessionContext ) );
 	}
 
 	@Override

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/scope/impl/SearchScopeImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/scope/impl/SearchScopeImpl.java
@@ -74,7 +74,7 @@ public class SearchScopeImpl<E> implements SearchScope<E> {
 	}
 
 	public SearchWorkspace workspace(DetachedBackendSessionContext detachedSessionContext) {
-		return new SearchWorkspaceImpl( delegate.executor( detachedSessionContext ) );
+		return new SearchWorkspaceImpl( delegate.workspace( detachedSessionContext ) );
 	}
 
 	@Override
@@ -92,7 +92,7 @@ public class SearchScopeImpl<E> implements SearchScope<E> {
 				mappingContext,
 				delegate.getIncludedIndexedTypes(),
 				detachedSessionContext,
-				delegate.executor( detachedSessionContext )
+				delegate.workspace( detachedSessionContext )
 		);
 	}
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/SearchSession.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/SearchSession.java
@@ -14,7 +14,7 @@ import javax.persistence.EntityManager;
 
 import org.hibernate.Session;
 import org.hibernate.search.mapper.orm.scope.SearchScope;
-import org.hibernate.search.mapper.orm.writing.SearchWriter;
+import org.hibernate.search.mapper.orm.work.SearchWorkspace;
 import org.hibernate.search.mapper.orm.massindexing.MassIndexer;
 import org.hibernate.search.mapper.orm.search.query.dsl.HibernateOrmSearchQueryHitTypeStep;
 
@@ -59,31 +59,31 @@ public interface SearchSession {
 	<T> HibernateOrmSearchQueryHitTypeStep<T> search(SearchScope<T> scope);
 
 	/**
-	 * Create a {@link SearchWriter} for the indexes mapped to all indexed types.
+	 * Create a {@link SearchWorkspace} for the indexes mapped to all indexed types.
 	 *
-	 * @return A {@link SearchWriter}.
+	 * @return A {@link SearchWorkspace}.
 	 */
-	default SearchWriter writer() {
-		return writer( Collections.singleton( Object.class ) );
+	default SearchWorkspace workspace() {
+		return workspace( Collections.singleton( Object.class ) );
 	}
 
 	/**
-	 * Create a {@link SearchWriter} for the indexes mapped to the given type, or to any of its sub-types.
+	 * Create a {@link SearchWorkspace} for the indexes mapped to the given type, or to any of its sub-types.
 	 *
-	 * @param types One or more indexed types, or supertypes of all indexed types that will be targeted by the writer.
-	 * @return A {@link SearchWriter}.
+	 * @param types One or more indexed types, or supertypes of all indexed types that will be targeted by the workspace.
+	 * @return A {@link SearchWorkspace}.
 	 */
-	default SearchWriter writer(Class<?> ... types) {
-		return writer( Arrays.asList( types ) );
+	default SearchWorkspace workspace(Class<?> ... types) {
+		return workspace( Arrays.asList( types ) );
 	}
 
 	/**
-	 * Create a {@link SearchWriter} for the indexes mapped to the given types, or to any of their sub-types.
+	 * Create a {@link SearchWorkspace} for the indexes mapped to the given types, or to any of their sub-types.
 	 *
-	 * @param types A collection of indexed types, or supertypes of all indexed types that will be targeted by the writer.
-	 * @return A {@link SearchWriter}.
+	 * @param types A collection of indexed types, or supertypes of all indexed types that will be targeted by the workspace.
+	 * @return A {@link SearchWorkspace}.
 	 */
-	SearchWriter writer(Collection<? extends Class<?>> types);
+	SearchWorkspace workspace(Collection<? extends Class<?>> types);
 
 	/**
 	 * Creates a {@link MassIndexer} to rebuild the indexes of all indexed entity types.
@@ -101,7 +101,7 @@ public interface SearchSession {
 	 * <p>
 	 * {@link MassIndexer} instances cannot be reused.
 	 *
-	 * @param types An array of indexed types, or supertypes of all indexed types that will be targeted by the writer.
+	 * @param types An array of indexed types, or supertypes of all indexed types that will be targeted by the workspace.
 	 * @return The created mass indexer.
 	 */
 	default MassIndexer massIndexer(Class<?>... types) {
@@ -111,8 +111,8 @@ public interface SearchSession {
 	/**
 	 * Creates a {@link MassIndexer} to rebuild the indexes mapped to the given types, or to any of their sub-types.
 	 *
-	 * @param types A collection of indexed types, or supertypes of all indexed types that will be targeted by the writer.
-	 * @return A {@link SearchWriter}.
+	 * @param types A collection of indexed types, or supertypes of all indexed types that will be targeted by the workspace.
+	 * @return A {@link SearchWorkspace}.
 	 */
 	MassIndexer massIndexer(Collection<? extends Class<?>> types);
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/SearchSession.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/SearchSession.java
@@ -14,6 +14,7 @@ import javax.persistence.EntityManager;
 
 import org.hibernate.Session;
 import org.hibernate.search.mapper.orm.scope.SearchScope;
+import org.hibernate.search.mapper.orm.work.SearchIndexingPlan;
 import org.hibernate.search.mapper.orm.work.SearchWorkspace;
 import org.hibernate.search.mapper.orm.massindexing.MassIndexer;
 import org.hibernate.search.mapper.orm.search.query.dsl.HibernateOrmSearchQueryHitTypeStep;
@@ -156,10 +157,10 @@ public interface SearchSession {
 	}
 
 	/**
-	 * @return The write plan for this session, allowing to explicitly index or delete entities,
+	 * @return The indexing plan for this session, allowing to explicitly index entities or delete them from the index,
 	 * or to process entity changes or even write to the indexes before the transaction is committed.
 	 */
-	SearchSessionWritePlan writePlan();
+	SearchIndexingPlan indexingPlan();
 
 	/**
 	 * @return The underlying {@link EntityManager} used by this {@link SearchSession}.

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/HibernateOrmSearchSession.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/HibernateOrmSearchSession.java
@@ -52,7 +52,8 @@ import org.hibernate.search.util.common.logging.impl.LoggerFactory;
  * The actual implementation of {@link SearchSession}.
  */
 public class HibernateOrmSearchSession extends AbstractPojoSearchSession
-		implements SearchSession, HibernateOrmScopeSessionContext, ReferenceHitMapper<EntityReference> {
+		implements SearchSession, HibernateOrmScopeSessionContext, SearchSessionWritePlanContext,
+				ReferenceHitMapper<EntityReference> {
 
 	/**
 	 * @param sessionImplementor A Hibernate session
@@ -205,9 +206,11 @@ public class HibernateOrmSearchSession extends AbstractPojoSearchSession
 		return getDelegate().createSessionWorkExecutor( commitStrategy );
 	}
 
+	@Override
 	@SuppressWarnings("unchecked")
 	public PojoWorkPlan getCurrentWorkPlan(boolean createIfDoesNotExist) {
 		SessionImplementor sessionImplementor = sessionContext.getSession();
+		checkOrmSessionIsOpen( sessionImplementor );
 		Transaction transactionIdentifier = null;
 
 		TransientReference<Map<Transaction, PojoWorkPlan>> reference = (TransientReference<Map<Transaction, PojoWorkPlan>>) sessionImplementor.getProperties()
@@ -249,7 +252,8 @@ public class HibernateOrmSearchSession extends AbstractPojoSearchSession
 		return workPlan;
 	}
 
-	AutomaticIndexingSynchronizationStrategy getAutomaticIndexingSynchronizationStrategy() {
+	@Override
+	public AutomaticIndexingSynchronizationStrategy getAutomaticIndexingSynchronizationStrategy() {
 		return synchronizationStrategy;
 	}
 
@@ -312,11 +316,11 @@ public class HibernateOrmSearchSession extends AbstractPojoSearchSession
 				.isJta();
 	}
 
-	void checkOrmSessionIsOpen() {
+	private void checkOrmSessionIsOpen() {
 		checkOrmSessionIsOpen( sessionContext.getSession() );
 	}
 
-	static void checkOrmSessionIsOpen(SessionImplementor session) {
+	private static void checkOrmSessionIsOpen(SessionImplementor session) {
 		try {
 			session.checkOpen();
 		}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/HibernateOrmSearchSession.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/HibernateOrmSearchSession.java
@@ -39,7 +39,7 @@ import org.hibernate.search.mapper.orm.session.AutomaticIndexingSynchronizationS
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.orm.session.SearchSessionWritePlan;
 import org.hibernate.search.mapper.orm.session.context.impl.HibernateOrmSessionContextImpl;
-import org.hibernate.search.mapper.orm.writing.SearchWriter;
+import org.hibernate.search.mapper.orm.work.SearchWorkspace;
 import org.hibernate.search.mapper.pojo.mapping.spi.PojoMappingDelegate;
 import org.hibernate.search.mapper.pojo.session.spi.AbstractPojoSearchSession;
 import org.hibernate.search.mapper.pojo.work.spi.PojoSessionWorkExecutor;
@@ -133,8 +133,8 @@ public class HibernateOrmSearchSession extends AbstractPojoSearchSession
 	}
 
 	@Override
-	public SearchWriter writer(Collection<? extends Class<?>> types) {
-		return scope( types ).writer( DetachedBackendSessionContext.of( sessionContext ) );
+	public SearchWorkspace workspace(Collection<? extends Class<?>> types) {
+		return scope( types ).workspace( DetachedBackendSessionContext.of( sessionContext ) );
 	}
 
 	@Override

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/HibernateOrmSearchSession.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/HibernateOrmSearchSession.java
@@ -44,7 +44,7 @@ import org.hibernate.search.mapper.orm.work.impl.SearchIndexingPlanContext;
 import org.hibernate.search.mapper.orm.work.impl.SearchIndexingPlanImpl;
 import org.hibernate.search.mapper.pojo.mapping.spi.PojoMappingDelegate;
 import org.hibernate.search.mapper.pojo.session.spi.AbstractPojoSearchSession;
-import org.hibernate.search.mapper.pojo.work.spi.PojoSessionWorkExecutor;
+import org.hibernate.search.mapper.pojo.work.spi.PojoIndexer;
 import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingPlan;
 import org.hibernate.search.util.common.AssertionFailure;
 import org.hibernate.search.util.common.impl.TransientReference;
@@ -204,8 +204,8 @@ public class HibernateOrmSearchSession extends AbstractPojoSearchSession
 		return new EntityReferenceImpl( typeContext.getJavaClass(), id );
 	}
 
-	public PojoSessionWorkExecutor createSessionWorkExecutor(DocumentCommitStrategy commitStrategy) {
-		return getDelegate().createSessionWorkExecutor( commitStrategy );
+	public PojoIndexer createIndexer(DocumentCommitStrategy commitStrategy) {
+		return getDelegate().createIndexer( commitStrategy );
 	}
 
 	@Override

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/HibernateOrmSearchSession.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/HibernateOrmSearchSession.java
@@ -37,9 +37,11 @@ import org.hibernate.search.mapper.orm.scope.impl.SearchScopeImpl;
 import org.hibernate.search.mapper.orm.search.query.dsl.HibernateOrmSearchQueryHitTypeStep;
 import org.hibernate.search.mapper.orm.session.AutomaticIndexingSynchronizationStrategy;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.mapper.orm.session.SearchSessionWritePlan;
+import org.hibernate.search.mapper.orm.work.SearchIndexingPlan;
 import org.hibernate.search.mapper.orm.session.context.impl.HibernateOrmSessionContextImpl;
 import org.hibernate.search.mapper.orm.work.SearchWorkspace;
+import org.hibernate.search.mapper.orm.work.impl.SearchIndexingPlanContext;
+import org.hibernate.search.mapper.orm.work.impl.SearchIndexingPlanImpl;
 import org.hibernate.search.mapper.pojo.mapping.spi.PojoMappingDelegate;
 import org.hibernate.search.mapper.pojo.session.spi.AbstractPojoSearchSession;
 import org.hibernate.search.mapper.pojo.work.spi.PojoSessionWorkExecutor;
@@ -52,7 +54,7 @@ import org.hibernate.search.util.common.logging.impl.LoggerFactory;
  * The actual implementation of {@link SearchSession}.
  */
 public class HibernateOrmSearchSession extends AbstractPojoSearchSession
-		implements SearchSession, HibernateOrmScopeSessionContext, SearchSessionWritePlanContext,
+		implements SearchSession, HibernateOrmScopeSessionContext, SearchIndexingPlanContext,
 				ReferenceHitMapper<EntityReference> {
 
 	/**
@@ -100,7 +102,7 @@ public class HibernateOrmSearchSession extends AbstractPojoSearchSession
 	 */
 	private boolean enlistInTransaction = false;
 
-	private SearchSessionWritePlanImpl writePlan;
+	private SearchIndexingPlanImpl indexingPlan;
 
 	private HibernateOrmSearchSession(HibernateOrmSearchSessionBuilder builder) {
 		this( builder, builder.buildBackendSessionContext() );
@@ -160,11 +162,11 @@ public class HibernateOrmSearchSession extends AbstractPojoSearchSession
 	}
 
 	@Override
-	public SearchSessionWritePlan writePlan() {
-		if ( writePlan == null ) {
-			writePlan = new SearchSessionWritePlanImpl( this );
+	public SearchIndexingPlan indexingPlan() {
+		if ( indexingPlan == null ) {
+			indexingPlan = new SearchIndexingPlanImpl( this );
 		}
-		return writePlan;
+		return indexingPlan;
 	}
 
 	@Override

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/InTransactionWorkQueueSynchronization.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/InTransactionWorkQueueSynchronization.java
@@ -14,7 +14,7 @@ import javax.transaction.Synchronization;
 
 import org.hibernate.search.mapper.orm.logging.impl.Log;
 import org.hibernate.search.mapper.orm.session.AutomaticIndexingSynchronizationStrategy;
-import org.hibernate.search.mapper.pojo.work.spi.PojoWorkPlan;
+import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingPlan;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
 /**
@@ -26,16 +26,16 @@ public class InTransactionWorkQueueSynchronization implements Synchronization {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private final PojoWorkPlan workPlan;
-	private final Map<?, ?> workPlanPerTransaction;
+	private final PojoIndexingPlan indexingPlan;
+	private final Map<?, ?> indexingPlanPerTransaction;
 	private final Object transactionIdentifier;
 	private final AutomaticIndexingSynchronizationStrategy synchronizationStrategy;
 
-	public InTransactionWorkQueueSynchronization(PojoWorkPlan workPlan,
-			Map<?, ?> workPlanPerTransaction, Object transactionIdentifier,
+	public InTransactionWorkQueueSynchronization(PojoIndexingPlan indexingPlan,
+			Map<?, ?> indexingPlanPerTransaction, Object transactionIdentifier,
 			AutomaticIndexingSynchronizationStrategy synchronizationStrategy) {
-		this.workPlan = workPlan;
-		this.workPlanPerTransaction = workPlanPerTransaction;
+		this.indexingPlan = indexingPlan;
+		this.indexingPlanPerTransaction = indexingPlanPerTransaction;
 		this.transactionIdentifier = transactionIdentifier;
 		this.synchronizationStrategy = synchronizationStrategy;
 	}
@@ -47,12 +47,12 @@ public class InTransactionWorkQueueSynchronization implements Synchronization {
 			log.tracef(
 					"Processing Transaction's beforeCompletion() phase for %s. Performing work.", this
 			);
-			CompletableFuture<?> future = workPlan.execute();
+			CompletableFuture<?> future = indexingPlan.execute();
 			synchronizationStrategy.handleFuture( future );
 		}
 		finally {
 			//clean the Synchronization per Transaction
-			workPlanPerTransaction.remove( transactionIdentifier );
+			indexingPlanPerTransaction.remove( transactionIdentifier );
 		}
 	}
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/LazyInitSearchSession.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/LazyInitSearchSession.java
@@ -18,7 +18,7 @@ import org.hibernate.search.mapper.orm.scope.SearchScope;
 import org.hibernate.search.mapper.orm.search.query.dsl.HibernateOrmSearchQueryHitTypeStep;
 import org.hibernate.search.mapper.orm.session.AutomaticIndexingSynchronizationStrategy;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.mapper.orm.session.SearchSessionWritePlan;
+import org.hibernate.search.mapper.orm.work.SearchIndexingPlan;
 import org.hibernate.search.mapper.orm.work.SearchWorkspace;
 
 /**
@@ -75,8 +75,8 @@ public class LazyInitSearchSession implements SearchSession {
 	}
 
 	@Override
-	public SearchSessionWritePlan writePlan() {
-		return getDelegate().writePlan();
+	public SearchIndexingPlan indexingPlan() {
+		return getDelegate().indexingPlan();
 	}
 
 	@Override

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/LazyInitSearchSession.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/LazyInitSearchSession.java
@@ -19,7 +19,7 @@ import org.hibernate.search.mapper.orm.search.query.dsl.HibernateOrmSearchQueryH
 import org.hibernate.search.mapper.orm.session.AutomaticIndexingSynchronizationStrategy;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.orm.session.SearchSessionWritePlan;
-import org.hibernate.search.mapper.orm.writing.SearchWriter;
+import org.hibernate.search.mapper.orm.work.SearchWorkspace;
 
 /**
  * A lazily initializing {@link SearchSession}.
@@ -50,8 +50,8 @@ public class LazyInitSearchSession implements SearchSession {
 	}
 
 	@Override
-	public SearchWriter writer(Collection<? extends Class<?>> types) {
-		return getDelegate().writer( types );
+	public SearchWorkspace workspace(Collection<? extends Class<?>> types) {
+		return getDelegate().workspace( types );
 	}
 
 	@Override

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/PostTransactionWorkQueueSynchronization.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/PostTransactionWorkQueueSynchronization.java
@@ -43,7 +43,7 @@ public class PostTransactionWorkQueueSynchronization implements Synchronization 
 	@Override
 	public void beforeCompletion() {
 		log.tracef( "Processing Transaction's beforeCompletion() phase: %s", this );
-		indexingPlan.prepare();
+		indexingPlan.process();
 	}
 
 	@Override

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/SearchSessionWritePlanContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/SearchSessionWritePlanContext.java
@@ -1,0 +1,18 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.orm.session.impl;
+
+import org.hibernate.search.mapper.orm.session.AutomaticIndexingSynchronizationStrategy;
+import org.hibernate.search.mapper.pojo.work.spi.PojoWorkPlan;
+
+public interface SearchSessionWritePlanContext {
+
+	AutomaticIndexingSynchronizationStrategy getAutomaticIndexingSynchronizationStrategy();
+
+	PojoWorkPlan getCurrentWorkPlan(boolean createIfDoesNotExist);
+
+}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/SearchIndexingPlan.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/SearchIndexingPlan.java
@@ -4,10 +4,10 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.mapper.orm.session;
+package org.hibernate.search.mapper.orm.work;
 
 /**
- * An interface for writing to indexes in the context of an ORM Session.
+ * An interface for indexing entities in the context of an ORM Session.
  * <p>
  * This class is stateful: it queues operations internally to apply them at a later time.
  * <p>
@@ -28,7 +28,7 @@ package org.hibernate.search.mapper.orm.session;
  * {@link #process()} and {@link #execute()} are mostly useful when automatic indexing is disabled,
  * to control the indexing process explicitly.
  */
-public interface SearchSessionWritePlan {
+public interface SearchIndexingPlan {
 
 	/**
 	 * Add or update a document in the index if the entity type is mapped to an index
@@ -75,7 +75,7 @@ public interface SearchSessionWritePlan {
 	void purge(Class<?> entityClass, Object providedId);
 
 	/**
-	 * Extract all data from objects passed to the write plan so far,
+	 * Extract all data from objects passed to the indexing plan so far,
 	 * creates documents to be indexed and put them into an internal buffer,
 	 * without writing them to the indexes.
 	 * <p>

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/SearchWorkspace.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/SearchWorkspace.java
@@ -4,26 +4,29 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.mapper.orm.writing;
+package org.hibernate.search.mapper.orm.work;
 
 import java.util.concurrent.CompletableFuture;
 
 /**
- * The entry point for explicit index write operations.
+ * The entry point for explicit index operations.
+ * <p>
+ * A {@link SearchWorkspace} targets a pre-defined set of indexed types (and their indexes),
+ * filtered to only affect a single tenant, if relevant.
  * <p>
  * While {@link org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings#AUTOMATIC_INDEXING_STRATEGY automatic indexing}
  * generally takes care of indexing entities as they are persisted/deleted in the database,
  * there are cases where massive operations must be applied to the index,
  * such as completely purging the index.
- * This is where the {@link SearchWriter} comes in.
+ * This is where the {@link SearchWorkspace} comes in.
  */
-public interface SearchWriter {
+public interface SearchWorkspace {
 
 	/**
-	 * Purge the indexes targeted by this writer, removing all documents.
+	 * Purge the data targeted by this workspaces, removing all documents.
 	 * <p>
 	 * When using multi-tenancy, only documents of one tenant will be removed:
-	 * the tenant that was targeted by the session from where this writer originated.
+	 * the tenant that was targeted by the session from where this workspace originated.
 	 */
 	void purge();
 
@@ -60,7 +63,7 @@ public interface SearchWriter {
 	CompletableFuture<?> flushAsync();
 
 	/**
-	 * Merge all segments of the indexes targeted by this writer into a single one.
+	 * Merge all segments of the indexes targeted by this workspace into a single one.
 	 * <p>
 	 * Note this operation may affect performance positively as well as negatively.
 	 * As a rule of thumb, if indexes are read-only for extended periods of time,

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/impl/SearchIndexingPlanContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/impl/SearchIndexingPlanContext.java
@@ -4,12 +4,12 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.mapper.orm.session.impl;
+package org.hibernate.search.mapper.orm.work.impl;
 
 import org.hibernate.search.mapper.orm.session.AutomaticIndexingSynchronizationStrategy;
 import org.hibernate.search.mapper.pojo.work.spi.PojoWorkPlan;
 
-public interface SearchSessionWritePlanContext {
+public interface SearchIndexingPlanContext {
 
 	AutomaticIndexingSynchronizationStrategy getAutomaticIndexingSynchronizationStrategy();
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/impl/SearchIndexingPlanContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/impl/SearchIndexingPlanContext.java
@@ -7,12 +7,12 @@
 package org.hibernate.search.mapper.orm.work.impl;
 
 import org.hibernate.search.mapper.orm.session.AutomaticIndexingSynchronizationStrategy;
-import org.hibernate.search.mapper.pojo.work.spi.PojoWorkPlan;
+import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingPlan;
 
 public interface SearchIndexingPlanContext {
 
 	AutomaticIndexingSynchronizationStrategy getAutomaticIndexingSynchronizationStrategy();
 
-	PojoWorkPlan getCurrentWorkPlan(boolean createIfDoesNotExist);
+	PojoIndexingPlan getCurrentIndexingPlan(boolean createIfDoesNotExist);
 
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/impl/SearchIndexingPlanImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/impl/SearchIndexingPlanImpl.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.mapper.orm.work.impl;
 
 import org.hibernate.search.mapper.orm.work.SearchIndexingPlan;
-import org.hibernate.search.mapper.pojo.work.spi.PojoWorkPlan;
+import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingPlan;
 
 public final class SearchIndexingPlanImpl implements SearchIndexingPlan {
 
@@ -19,22 +19,22 @@ public final class SearchIndexingPlanImpl implements SearchIndexingPlan {
 
 	@Override
 	public void addOrUpdate(Object entity) {
-		context.getCurrentWorkPlan( true ).update( entity );
+		context.getCurrentIndexingPlan( true ).update( entity );
 	}
 
 	@Override
 	public void delete(Object entity) {
-		context.getCurrentWorkPlan( true ).delete( entity );
+		context.getCurrentIndexingPlan( true ).delete( entity );
 	}
 
 	@Override
 	public void purge(Class<?> entityClass, Object providedId) {
-		context.getCurrentWorkPlan( true ).purge( entityClass, providedId );
+		context.getCurrentIndexingPlan( true ).purge( entityClass, providedId );
 	}
 
 	@Override
 	public void process() {
-		PojoWorkPlan plan = context.getCurrentWorkPlan( false );
+		PojoIndexingPlan plan = context.getCurrentIndexingPlan( false );
 		if ( plan == null ) {
 			return;
 		}
@@ -43,7 +43,7 @@ public final class SearchIndexingPlanImpl implements SearchIndexingPlan {
 
 	@Override
 	public void execute() {
-		PojoWorkPlan plan = context.getCurrentWorkPlan( false );
+		PojoIndexingPlan plan = context.getCurrentIndexingPlan( false );
 		if ( plan == null ) {
 			return;
 		}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/impl/SearchIndexingPlanImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/impl/SearchIndexingPlanImpl.java
@@ -19,7 +19,7 @@ public final class SearchIndexingPlanImpl implements SearchIndexingPlan {
 
 	@Override
 	public void addOrUpdate(Object entity) {
-		context.getCurrentIndexingPlan( true ).update( entity );
+		context.getCurrentIndexingPlan( true ).addOrUpdate( entity );
 	}
 
 	@Override
@@ -38,7 +38,7 @@ public final class SearchIndexingPlanImpl implements SearchIndexingPlan {
 		if ( plan == null ) {
 			return;
 		}
-		plan.prepare();
+		plan.process();
 	}
 
 	@Override

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/impl/SearchIndexingPlanImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/impl/SearchIndexingPlanImpl.java
@@ -4,16 +4,16 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.mapper.orm.session.impl;
+package org.hibernate.search.mapper.orm.work.impl;
 
-import org.hibernate.search.mapper.orm.session.SearchSessionWritePlan;
+import org.hibernate.search.mapper.orm.work.SearchIndexingPlan;
 import org.hibernate.search.mapper.pojo.work.spi.PojoWorkPlan;
 
-final class SearchSessionWritePlanImpl implements SearchSessionWritePlan {
+public final class SearchIndexingPlanImpl implements SearchIndexingPlan {
 
-	private final SearchSessionWritePlanContext context;
+	private final SearchIndexingPlanContext context;
 
-	SearchSessionWritePlanImpl(SearchSessionWritePlanContext context) {
+	public SearchIndexingPlanImpl(SearchIndexingPlanContext context) {
 		this.context = context;
 	}
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/impl/SearchWorkspaceImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/impl/SearchWorkspaceImpl.java
@@ -9,14 +9,14 @@ package org.hibernate.search.mapper.orm.work.impl;
 import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.search.mapper.orm.work.SearchWorkspace;
-import org.hibernate.search.mapper.pojo.work.spi.PojoScopeWorkExecutor;
+import org.hibernate.search.mapper.pojo.work.spi.PojoScopeWorkspace;
 import org.hibernate.search.util.common.impl.Futures;
 
 public class SearchWorkspaceImpl implements SearchWorkspace {
-	private final PojoScopeWorkExecutor scopeWorkExecutor;
+	private final PojoScopeWorkspace delegate;
 
-	public SearchWorkspaceImpl(PojoScopeWorkExecutor scopeWorkExecutor) {
-		this.scopeWorkExecutor = scopeWorkExecutor;
+	public SearchWorkspaceImpl(PojoScopeWorkspace delegate) {
+		this.delegate = delegate;
 	}
 
 	@Override
@@ -26,7 +26,7 @@ public class SearchWorkspaceImpl implements SearchWorkspace {
 
 	@Override
 	public CompletableFuture<?> optimizeAsync() {
-		return scopeWorkExecutor.optimize();
+		return delegate.optimize();
 	}
 
 	@Override
@@ -36,7 +36,7 @@ public class SearchWorkspaceImpl implements SearchWorkspace {
 
 	@Override
 	public CompletableFuture<?> purgeAsync() {
-		return scopeWorkExecutor.purge();
+		return delegate.purge();
 	}
 
 	@Override
@@ -46,6 +46,6 @@ public class SearchWorkspaceImpl implements SearchWorkspace {
 
 	@Override
 	public CompletableFuture<?> flushAsync() {
-		return scopeWorkExecutor.flush();
+		return delegate.flush();
 	}
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/impl/SearchWorkspaceImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/impl/SearchWorkspaceImpl.java
@@ -4,18 +4,18 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.mapper.orm.writing.impl;
+package org.hibernate.search.mapper.orm.work.impl;
 
 import java.util.concurrent.CompletableFuture;
 
-import org.hibernate.search.mapper.orm.writing.SearchWriter;
+import org.hibernate.search.mapper.orm.work.SearchWorkspace;
 import org.hibernate.search.mapper.pojo.work.spi.PojoScopeWorkExecutor;
 import org.hibernate.search.util.common.impl.Futures;
 
-public class SearchWriterImpl implements SearchWriter {
+public class SearchWorkspaceImpl implements SearchWorkspace {
 	private final PojoScopeWorkExecutor scopeWorkExecutor;
 
-	public SearchWriterImpl(PojoScopeWorkExecutor scopeWorkExecutor) {
+	public SearchWorkspaceImpl(PojoScopeWorkExecutor scopeWorkExecutor) {
 		this.scopeWorkExecutor = scopeWorkExecutor;
 	}
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
@@ -409,7 +409,7 @@ public interface Log extends BasicLogger {
 					+ " Make sure you do not change entities within an entity getter or a custom bridge used for indexing,"
 					+ " and avoid any event that could trigger entity processing."
 					+ " Hibernate ORM flushes, in particular, must be avoided in entity getters and bridges.")
-	SearchException recursiveIndexingPlanPrepare();
+	SearchException recursiveIndexingPlanProcess();
 
 	@Message(id = ID_OFFSET_2 + 61, value = "Type '%1$s' cannot be indexed-embedded, because no index mapping (@GenericField, @FullTextField, ...) is defined for that type.")
 	SearchException invalidIndexedEmbedded(@FormatWith(PojoTypeModelFormatter.class) PojoTypeModel<?> typeModel);

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
@@ -409,7 +409,7 @@ public interface Log extends BasicLogger {
 					+ " Make sure you do not change entities within an entity getter or a custom bridge used for indexing,"
 					+ " and avoid any event that could trigger entity processing."
 					+ " Hibernate ORM flushes, in particular, must be avoided in entity getters and bridges.")
-	SearchException recursiveWorkPlanPrepare();
+	SearchException recursiveIndexingPlanPrepare();
 
 	@Message(id = ID_OFFSET_2 + 61, value = "Type '%1$s' cannot be indexed-embedded, because no index mapping (@GenericField, @FullTextField, ...) is defined for that type.")
 	SearchException invalidIndexedEmbedded(@FormatWith(PojoTypeModelFormatter.class) PojoTypeModel<?> typeModel);

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/impl/PojoIndexedTypeManagerBuilder.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/impl/PojoIndexedTypeManagerBuilder.java
@@ -118,7 +118,7 @@ class PojoIndexedTypeManagerBuilder<E, D extends DocumentElement> {
 
 		/*
 		 * TODO offer more flexibility to mapper implementations, allowing them to define their own dirtiness state?
-		 * Note this will require to allow them to define their own work plan APIs.
+		 * Note this will require to allow them to define their own indexing plan APIs.
 		 */
 		PojoPathFilterFactory<Set<String>> pathFilterFactory = typeAdditionalMetadata
 				.getEntityTypeMetadata().orElseThrow( () -> log.missingEntityTypeMetadata( typeModel ) )

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/impl/PojoMapper.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/impl/PojoMapper.java
@@ -232,7 +232,7 @@ public class PojoMapper<MPBS extends MappingPartialBuildState> implements Mapper
 			PojoRawTypeModel<T> entityType) {
 		/*
 		 * TODO offer more flexibility to mapper implementations, allowing them to define their own dirtiness state?
-		 * Note this will require to allow them to define their own work plan APIs.
+		 * Note this will require to allow them to define their own indexing plan APIs.
 		 */
 		PojoPathFilterFactory<Set<String>> pathFilterFactory = typeAdditionalMetadataProvider.get( entityType )
 				.getEntityTypeMetadata().orElseThrow( () -> log.missingEntityTypeMetadata( entityType ) )

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoContainedTypeManager.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoContainedTypeManager.java
@@ -16,7 +16,7 @@ import org.hibernate.search.mapper.pojo.model.spi.PojoRuntimeIntrospector;
 import org.hibernate.search.mapper.pojo.scope.impl.PojoScopeContainedTypeContext;
 import org.hibernate.search.mapper.pojo.session.context.spi.AbstractPojoBackendSessionContext;
 import org.hibernate.search.mapper.pojo.work.impl.CachingCastingEntitySupplier;
-import org.hibernate.search.mapper.pojo.work.impl.PojoContainedTypeWorkPlan;
+import org.hibernate.search.mapper.pojo.work.impl.PojoContainedTypeIndexingPlan;
 import org.hibernate.search.mapper.pojo.work.impl.PojoWorkContainedTypeContext;
 import org.hibernate.search.util.common.impl.ToStringTreeAppendable;
 import org.hibernate.search.util.common.impl.ToStringTreeBuilder;
@@ -76,8 +76,8 @@ public class PojoContainedTypeManager<E>
 	}
 
 	@Override
-	public PojoContainedTypeWorkPlan<E> createWorkPlan(AbstractPojoBackendSessionContext sessionContext) {
-		return new PojoContainedTypeWorkPlan<>(
+	public PojoContainedTypeIndexingPlan<E> createIndexingPlan(AbstractPojoBackendSessionContext sessionContext) {
+		return new PojoContainedTypeIndexingPlan<>(
 				this, sessionContext
 		);
 	}

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoIndexedTypeManager.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoIndexedTypeManager.java
@@ -31,7 +31,7 @@ import org.hibernate.search.mapper.pojo.work.impl.CachingCastingEntitySupplier;
 import org.hibernate.search.mapper.pojo.work.impl.PojoDocumentContributor;
 import org.hibernate.search.mapper.pojo.work.impl.PojoDocumentReferenceProvider;
 import org.hibernate.search.mapper.pojo.work.impl.PojoIndexedTypeIndexingPlan;
-import org.hibernate.search.mapper.pojo.work.impl.PojoTypeDocumentWorkExecutor;
+import org.hibernate.search.mapper.pojo.work.impl.PojoTypeIndexer;
 import org.hibernate.search.mapper.pojo.work.impl.PojoWorkIndexedTypeContext;
 import org.hibernate.search.util.common.impl.Closer;
 import org.hibernate.search.util.common.impl.ToStringTreeAppendable;
@@ -141,12 +141,12 @@ public class PojoIndexedTypeManager<I, E, D extends DocumentElement>
 	}
 
 	@Override
-	public PojoTypeDocumentWorkExecutor<I, E, D> createDocumentWorkExecutor(
+	public PojoTypeIndexer<I, E, D> createIndexer(
 			AbstractPojoBackendSessionContext sessionContext,
 			DocumentCommitStrategy commitStrategy) {
-		return new PojoTypeDocumentWorkExecutor<>(
+		return new PojoTypeIndexer<>(
 				this, sessionContext,
-				indexManager.createDocumentWorkExecutor( sessionContext, commitStrategy )
+				indexManager.createIndexer( sessionContext, commitStrategy )
 		);
 	}
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoIndexedTypeManager.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoIndexedTypeManager.java
@@ -13,7 +13,7 @@ import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.engine.backend.work.execution.spi.DocumentReferenceProvider;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
 import org.hibernate.search.engine.backend.mapping.spi.BackendMappingContext;
 import org.hibernate.search.engine.mapper.mapping.spi.MappedIndexManager;
 import org.hibernate.search.engine.mapper.scope.spi.MappedIndexScopeBuilder;
@@ -151,8 +151,8 @@ public class PojoIndexedTypeManager<I, E, D extends DocumentElement>
 	}
 
 	@Override
-	public IndexWorkExecutor createWorkExecutor(DetachedBackendSessionContext sessionContext) {
-		return indexManager.createWorkExecutor( sessionContext );
+	public IndexWorkspace createWorkspace(DetachedBackendSessionContext sessionContext) {
+		return indexManager.createWorkspace( sessionContext );
 	}
 
 	@Override

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoIndexedTypeManager.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoIndexedTypeManager.java
@@ -30,7 +30,7 @@ import org.hibernate.search.mapper.pojo.session.context.spi.AbstractPojoBackendS
 import org.hibernate.search.mapper.pojo.work.impl.CachingCastingEntitySupplier;
 import org.hibernate.search.mapper.pojo.work.impl.PojoDocumentContributor;
 import org.hibernate.search.mapper.pojo.work.impl.PojoDocumentReferenceProvider;
-import org.hibernate.search.mapper.pojo.work.impl.PojoIndexedTypeWorkPlan;
+import org.hibernate.search.mapper.pojo.work.impl.PojoIndexedTypeIndexingPlan;
 import org.hibernate.search.mapper.pojo.work.impl.PojoTypeDocumentWorkExecutor;
 import org.hibernate.search.mapper.pojo.work.impl.PojoWorkIndexedTypeContext;
 import org.hibernate.search.util.common.impl.Closer;
@@ -156,9 +156,9 @@ public class PojoIndexedTypeManager<I, E, D extends DocumentElement>
 	}
 
 	@Override
-	public PojoIndexedTypeWorkPlan<I, E, D> createWorkPlan(AbstractPojoBackendSessionContext sessionContext,
+	public PojoIndexedTypeIndexingPlan<I, E, D> createIndexingPlan(AbstractPojoBackendSessionContext sessionContext,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
-		return new PojoIndexedTypeWorkPlan<>(
+		return new PojoIndexedTypeIndexingPlan<>(
 				this, sessionContext,
 				indexManager.createWorkPlan( sessionContext, commitStrategy, refreshStrategy )
 		);

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoIndexedTypeManager.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoIndexedTypeManager.java
@@ -160,7 +160,7 @@ public class PojoIndexedTypeManager<I, E, D extends DocumentElement>
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
 		return new PojoIndexedTypeIndexingPlan<>(
 				this, sessionContext,
-				indexManager.createWorkPlan( sessionContext, commitStrategy, refreshStrategy )
+				indexManager.createIndexingPlan( sessionContext, commitStrategy, refreshStrategy )
 		);
 	}
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/additionalmetadata/impl/PojoTypeAdditionalMetadata.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/model/additionalmetadata/impl/PojoTypeAdditionalMetadata.java
@@ -27,7 +27,7 @@ public class PojoTypeAdditionalMetadata {
 	 * All other types are assumed to only be able to be embedded in other objects,
 	 * with their lifecycle completely tied to their embedding object.
 	 * As a result, entity types are the only types whose lifecycle events are expected to be sent
-	 * to POJO work plans.
+	 * to POJO indexing plans.
 	 *
 	 * @return {@code true} if this type is an entity type, {@code false} otherwise.
 	 */

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/scope/impl/PojoScopeDelegateImpl.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/scope/impl/PojoScopeDelegateImpl.java
@@ -28,8 +28,8 @@ import org.hibernate.search.mapper.pojo.scope.spi.PojoScopeTypeExtendedContextPr
 import org.hibernate.search.mapper.pojo.mapping.context.spi.AbstractPojoBackendMappingContext;
 import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
 import org.hibernate.search.engine.search.sort.dsl.SearchSortFactory;
-import org.hibernate.search.mapper.pojo.work.impl.PojoScopeWorkExecutorImpl;
-import org.hibernate.search.mapper.pojo.work.spi.PojoScopeWorkExecutor;
+import org.hibernate.search.mapper.pojo.work.impl.PojoScopeWorkspaceImpl;
+import org.hibernate.search.mapper.pojo.work.spi.PojoScopeWorkspace;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
 public final class PojoScopeDelegateImpl<R, E, E2, C> implements PojoScopeDelegate<R, E2, C> {
@@ -126,8 +126,8 @@ public final class PojoScopeDelegateImpl<R, E, E2, C> implements PojoScopeDelega
 	}
 
 	@Override
-	public PojoScopeWorkExecutor executor(DetachedBackendSessionContext sessionContext) {
-		return new PojoScopeWorkExecutorImpl(
+	public PojoScopeWorkspace workspace(DetachedBackendSessionContext sessionContext) {
+		return new PojoScopeWorkspaceImpl(
 				targetedTypeContexts, sessionContext
 		);
 	}

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/scope/spi/PojoScopeDelegate.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/scope/spi/PojoScopeDelegate.java
@@ -16,7 +16,7 @@ import org.hibernate.search.engine.search.projection.dsl.SearchProjectionFactory
 import org.hibernate.search.engine.search.query.dsl.SearchQueryHitTypeStep;
 import org.hibernate.search.engine.search.sort.dsl.SearchSortFactory;
 import org.hibernate.search.engine.search.loading.context.spi.LoadingContextBuilder;
-import org.hibernate.search.mapper.pojo.work.spi.PojoScopeWorkExecutor;
+import org.hibernate.search.mapper.pojo.work.spi.PojoScopeWorkspace;
 
 /**
  * @param <R> The type of entity references, i.e. the type of hits returned by
@@ -44,6 +44,6 @@ public interface PojoScopeDelegate<R, E, C> {
 
 	SearchAggregationFactory aggregation();
 
-	PojoScopeWorkExecutor executor(DetachedBackendSessionContext sessionContext);
+	PojoScopeWorkspace workspace(DetachedBackendSessionContext sessionContext);
 
 }

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/session/impl/PojoSearchSessionDelegateImpl.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/session/impl/PojoSearchSessionDelegateImpl.java
@@ -12,9 +12,9 @@ import org.hibernate.search.mapper.pojo.scope.impl.PojoScopeContainedTypeContext
 import org.hibernate.search.mapper.pojo.scope.impl.PojoScopeIndexedTypeContextProvider;
 import org.hibernate.search.mapper.pojo.session.context.spi.AbstractPojoBackendSessionContext;
 import org.hibernate.search.mapper.pojo.session.spi.PojoSearchSessionDelegate;
-import org.hibernate.search.mapper.pojo.work.impl.PojoSessionWorkExecutorImpl;
+import org.hibernate.search.mapper.pojo.work.impl.PojoIndexerImpl;
 import org.hibernate.search.mapper.pojo.work.impl.PojoIndexingPlanImpl;
-import org.hibernate.search.mapper.pojo.work.spi.PojoSessionWorkExecutor;
+import org.hibernate.search.mapper.pojo.work.spi.PojoIndexer;
 import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingPlan;
 
 public final class PojoSearchSessionDelegateImpl implements PojoSearchSessionDelegate {
@@ -45,8 +45,8 @@ public final class PojoSearchSessionDelegateImpl implements PojoSearchSessionDel
 	}
 
 	@Override
-	public PojoSessionWorkExecutor createSessionWorkExecutor(DocumentCommitStrategy commitStrategy) {
-		return new PojoSessionWorkExecutorImpl( indexedTypeContextProvider, backendSessionContext, commitStrategy );
+	public PojoIndexer createIndexer(DocumentCommitStrategy commitStrategy) {
+		return new PojoIndexerImpl( indexedTypeContextProvider, backendSessionContext, commitStrategy );
 	}
 
 }

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/session/impl/PojoSearchSessionDelegateImpl.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/session/impl/PojoSearchSessionDelegateImpl.java
@@ -13,9 +13,9 @@ import org.hibernate.search.mapper.pojo.scope.impl.PojoScopeIndexedTypeContextPr
 import org.hibernate.search.mapper.pojo.session.context.spi.AbstractPojoBackendSessionContext;
 import org.hibernate.search.mapper.pojo.session.spi.PojoSearchSessionDelegate;
 import org.hibernate.search.mapper.pojo.work.impl.PojoSessionWorkExecutorImpl;
-import org.hibernate.search.mapper.pojo.work.impl.PojoWorkPlanImpl;
+import org.hibernate.search.mapper.pojo.work.impl.PojoIndexingPlanImpl;
 import org.hibernate.search.mapper.pojo.work.spi.PojoSessionWorkExecutor;
-import org.hibernate.search.mapper.pojo.work.spi.PojoWorkPlan;
+import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingPlan;
 
 public final class PojoSearchSessionDelegateImpl implements PojoSearchSessionDelegate {
 
@@ -37,8 +37,8 @@ public final class PojoSearchSessionDelegateImpl implements PojoSearchSessionDel
 	}
 
 	@Override
-	public PojoWorkPlan createWorkPlan(DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
-		return new PojoWorkPlanImpl(
+	public PojoIndexingPlan createIndexingPlan(DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
+		return new PojoIndexingPlanImpl(
 				indexedTypeContextProvider, containedTypeContextProvider, backendSessionContext,
 				commitStrategy, refreshStrategy
 		);

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/session/spi/PojoSearchSessionDelegate.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/session/spi/PojoSearchSessionDelegate.java
@@ -10,13 +10,13 @@ import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.mapper.pojo.session.context.spi.AbstractPojoBackendSessionContext;
 import org.hibernate.search.mapper.pojo.work.spi.PojoSessionWorkExecutor;
-import org.hibernate.search.mapper.pojo.work.spi.PojoWorkPlan;
+import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingPlan;
 
 public interface PojoSearchSessionDelegate {
 
 	AbstractPojoBackendSessionContext getBackendSessionContext();
 
-	PojoWorkPlan createWorkPlan(DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy);
+	PojoIndexingPlan createIndexingPlan(DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy);
 
 	PojoSessionWorkExecutor createSessionWorkExecutor(DocumentCommitStrategy commitStrategy);
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/session/spi/PojoSearchSessionDelegate.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/session/spi/PojoSearchSessionDelegate.java
@@ -9,7 +9,7 @@ package org.hibernate.search.mapper.pojo.session.spi;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.mapper.pojo.session.context.spi.AbstractPojoBackendSessionContext;
-import org.hibernate.search.mapper.pojo.work.spi.PojoSessionWorkExecutor;
+import org.hibernate.search.mapper.pojo.work.spi.PojoIndexer;
 import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingPlan;
 
 public interface PojoSearchSessionDelegate {
@@ -18,6 +18,6 @@ public interface PojoSearchSessionDelegate {
 
 	PojoIndexingPlan createIndexingPlan(DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy);
 
-	PojoSessionWorkExecutor createSessionWorkExecutor(DocumentCommitStrategy commitStrategy);
+	PojoIndexer createIndexer(DocumentCommitStrategy commitStrategy);
 
 }

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/work/impl/AbstractPojoTypeIndexingPlan.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/work/impl/AbstractPojoTypeIndexingPlan.java
@@ -8,11 +8,11 @@ package org.hibernate.search.mapper.pojo.work.impl;
 
 import org.hibernate.search.mapper.pojo.session.context.spi.AbstractPojoBackendSessionContext;
 
-abstract class AbstractPojoTypeWorkPlan {
+abstract class AbstractPojoTypeIndexingPlan {
 
 	final AbstractPojoBackendSessionContext sessionContext;
 
-	AbstractPojoTypeWorkPlan(AbstractPojoBackendSessionContext sessionContext) {
+	AbstractPojoTypeIndexingPlan(AbstractPojoBackendSessionContext sessionContext) {
 		this.sessionContext = sessionContext;
 	}
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoContainedTypeIndexingPlan.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoContainedTypeIndexingPlan.java
@@ -21,16 +21,16 @@ import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 /**
  * @param <E> The contained entity type.
  */
-public class PojoContainedTypeWorkPlan<E> extends AbstractPojoTypeWorkPlan {
+public class PojoContainedTypeIndexingPlan<E> extends AbstractPojoTypeIndexingPlan {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private final PojoWorkContainedTypeContext<E> typeContext;
 
 	// Use a LinkedHashMap for deterministic iteration
-	private final Map<Object, ContainedEntityWorkPlan> workPlansPerId = new LinkedHashMap<>();
+	private final Map<Object, ContainedEntityIndexingPlan> indexingPlansPerId = new LinkedHashMap<>();
 
-	public PojoContainedTypeWorkPlan(PojoWorkContainedTypeContext<E> typeContext,
+	public PojoContainedTypeIndexingPlan(PojoWorkContainedTypeContext<E> typeContext,
 			AbstractPojoBackendSessionContext sessionContext) {
 		super( sessionContext );
 		this.typeContext = typeContext;
@@ -39,25 +39,25 @@ public class PojoContainedTypeWorkPlan<E> extends AbstractPojoTypeWorkPlan {
 	@Override
 	void add(Object providedId, Object entity) {
 		Supplier<E> entitySupplier = typeContext.toEntitySupplier( sessionContext, entity );
-		getWork( providedId ).add( entitySupplier );
+		getPlan( providedId ).add( entitySupplier );
 	}
 
 	@Override
 	void update(Object providedId, Object entity) {
 		Supplier<E> entitySupplier = typeContext.toEntitySupplier( sessionContext, entity );
-		getWork( providedId ).update( entitySupplier );
+		getPlan( providedId ).update( entitySupplier );
 	}
 
 	@Override
 	void update(Object providedId, Object entity, String... dirtyPaths) {
 		Supplier<E> entitySupplier = typeContext.toEntitySupplier( sessionContext, entity );
-		getWork( providedId ).update( entitySupplier, dirtyPaths );
+		getPlan( providedId ).update( entitySupplier, dirtyPaths );
 	}
 
 	@Override
 	void delete(Object providedId, Object entity) {
 		Supplier<E> entitySupplier = typeContext.toEntitySupplier( sessionContext, entity );
-		getWork( providedId ).delete( entitySupplier );
+		getPlan( providedId ).delete( entitySupplier );
 	}
 
 	@Override
@@ -66,21 +66,21 @@ public class PojoContainedTypeWorkPlan<E> extends AbstractPojoTypeWorkPlan {
 	}
 
 	void resolveDirty(PojoReindexingCollector containingEntityCollector) {
-		for ( ContainedEntityWorkPlan workPerDocument : workPlansPerId.values() ) {
-			workPerDocument.resolveDirty( containingEntityCollector );
+		for ( ContainedEntityIndexingPlan plan : indexingPlansPerId.values() ) {
+			plan.resolveDirty( containingEntityCollector );
 		}
 	}
 
-	private ContainedEntityWorkPlan getWork(Object identifier) {
-		ContainedEntityWorkPlan work = workPlansPerId.get( identifier );
-		if ( work == null ) {
-			work = new ContainedEntityWorkPlan();
-			workPlansPerId.put( identifier, work );
+	private ContainedEntityIndexingPlan getPlan(Object identifier) {
+		ContainedEntityIndexingPlan plan = indexingPlansPerId.get( identifier );
+		if ( plan == null ) {
+			plan = new ContainedEntityIndexingPlan();
+			indexingPlansPerId.put( identifier, plan );
 		}
-		return work;
+		return plan;
 	}
 
-	private class ContainedEntityWorkPlan {
+	private class ContainedEntityIndexingPlan {
 		private Supplier<E> entitySupplier;
 
 		private Boolean createdInThisPlan;

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexedTypeIndexingPlan.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexedTypeIndexingPlan.java
@@ -89,7 +89,7 @@ public class PojoIndexedTypeIndexingPlan<I, E, D extends DocumentElement> extend
 		}
 	}
 
-	void prepare() {
+	void process() {
 		sendCommandsToDelegate();
 		getDelegate().prepare();
 	}
@@ -107,7 +107,7 @@ public class PojoIndexedTypeIndexingPlan<I, E, D extends DocumentElement> extend
 		delegate.discard();
 	}
 
-	void clearNotPrepared() {
+	void discardNotProcessed() {
 		this.indexingPlansPerId.clear();
 	}
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexedTypeIndexingPlan.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexedTypeIndexingPlan.java
@@ -91,7 +91,7 @@ public class PojoIndexedTypeIndexingPlan<I, E, D extends DocumentElement> extend
 
 	void process() {
 		sendCommandsToDelegate();
-		getDelegate().prepare();
+		getDelegate().process();
 	}
 
 	CompletableFuture<?> execute() {

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexedTypeIndexingPlan.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexedTypeIndexingPlan.java
@@ -14,7 +14,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
 import org.hibernate.search.engine.backend.document.DocumentElement;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.work.execution.spi.DocumentReferenceProvider;
 import org.hibernate.search.mapper.pojo.automaticindexing.impl.PojoReindexingCollector;
 import org.hibernate.search.mapper.pojo.session.context.spi.AbstractPojoBackendSessionContext;
@@ -27,14 +27,14 @@ import org.hibernate.search.mapper.pojo.session.context.spi.AbstractPojoBackendS
 public class PojoIndexedTypeIndexingPlan<I, E, D extends DocumentElement> extends AbstractPojoTypeIndexingPlan {
 
 	private final PojoWorkIndexedTypeContext<I, E, D> typeContext;
-	private final IndexWorkPlan<D> delegate;
+	private final IndexIndexingPlan<D> delegate;
 
 	// Use a LinkedHashMap for deterministic iteration
 	private final Map<I, IndexedEntityIndexingPlan> indexingPlansPerId = new LinkedHashMap<>();
 
 	public PojoIndexedTypeIndexingPlan(PojoWorkIndexedTypeContext<I, E, D> typeContext,
 			AbstractPojoBackendSessionContext sessionContext,
-			IndexWorkPlan<D> delegate) {
+			IndexIndexingPlan<D> delegate) {
 		super( sessionContext );
 		this.typeContext = typeContext;
 		this.delegate = delegate;
@@ -120,7 +120,7 @@ public class PojoIndexedTypeIndexingPlan<I, E, D extends DocumentElement> extend
 		return plan;
 	}
 
-	private IndexWorkPlan<D> getDelegate() {
+	private IndexIndexingPlan<D> getDelegate() {
 		return delegate;
 	}
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoTypeIndexer.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoTypeIndexer.java
@@ -11,18 +11,18 @@ import java.util.function.Supplier;
 
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.work.execution.spi.DocumentReferenceProvider;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexDocumentWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.mapper.pojo.session.context.spi.AbstractPojoBackendSessionContext;
 
-public class PojoTypeDocumentWorkExecutor<I, E, D extends DocumentElement> {
+public class PojoTypeIndexer<I, E, D extends DocumentElement> {
 
 	private final AbstractPojoBackendSessionContext sessionContext;
 	private final PojoWorkIndexedTypeContext<I, E, D> typeContext;
-	private final IndexDocumentWorkExecutor<D> delegate;
+	private final IndexIndexer<D> delegate;
 
-	public PojoTypeDocumentWorkExecutor(PojoWorkIndexedTypeContext<I, E, D> typeContext,
+	public PojoTypeIndexer(PojoWorkIndexedTypeContext<I, E, D> typeContext,
 			AbstractPojoBackendSessionContext sessionContext,
-			IndexDocumentWorkExecutor<D> delegate) {
+			IndexIndexer<D> delegate) {
 		this.sessionContext = sessionContext;
 		this.typeContext = typeContext;
 		this.delegate = delegate;

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkContainedTypeContext.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkContainedTypeContext.java
@@ -25,6 +25,6 @@ public interface PojoWorkContainedTypeContext<E> {
 	void resolveEntitiesToReindex(PojoReindexingCollector collector, PojoRuntimeIntrospector runtimeIntrospector,
 			Supplier<E> entitySupplier, Set<String> dirtyPaths);
 
-	PojoContainedTypeWorkPlan<E> createWorkPlan(AbstractPojoBackendSessionContext sessionContext);
+	PojoContainedTypeIndexingPlan<E> createIndexingPlan(AbstractPojoBackendSessionContext sessionContext);
 
 }

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkIndexedTypeContext.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkIndexedTypeContext.java
@@ -13,7 +13,7 @@ import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.engine.backend.work.execution.spi.DocumentReferenceProvider;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
 import org.hibernate.search.engine.backend.session.spi.DetachedBackendSessionContext;
 import org.hibernate.search.mapper.pojo.bridge.mapping.impl.IdentifierMappingImplementor;
 import org.hibernate.search.mapper.pojo.automaticindexing.impl.PojoReindexingCollector;
@@ -51,6 +51,6 @@ public interface PojoWorkIndexedTypeContext<I, E, D extends DocumentElement> {
 			AbstractPojoBackendSessionContext sessionContext,
 			DocumentCommitStrategy commitStrategy);
 
-	IndexWorkExecutor createWorkExecutor(DetachedBackendSessionContext sessionContext);
+	IndexWorkspace createWorkspace(DetachedBackendSessionContext sessionContext);
 
 }

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkIndexedTypeContext.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkIndexedTypeContext.java
@@ -44,7 +44,7 @@ public interface PojoWorkIndexedTypeContext<I, E, D extends DocumentElement> {
 	void resolveEntitiesToReindex(PojoReindexingCollector collector, PojoRuntimeIntrospector runtimeIntrospector,
 			Supplier<E> entitySupplier, Set<String> dirtyPaths);
 
-	PojoIndexedTypeWorkPlan<I, E, D> createWorkPlan(AbstractPojoBackendSessionContext sessionContext,
+	PojoIndexedTypeIndexingPlan<I, E, D> createIndexingPlan(AbstractPojoBackendSessionContext sessionContext,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy);
 
 	PojoTypeDocumentWorkExecutor<I, E, D> createDocumentWorkExecutor(

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkIndexedTypeContext.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkIndexedTypeContext.java
@@ -47,7 +47,7 @@ public interface PojoWorkIndexedTypeContext<I, E, D extends DocumentElement> {
 	PojoIndexedTypeIndexingPlan<I, E, D> createIndexingPlan(AbstractPojoBackendSessionContext sessionContext,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy);
 
-	PojoTypeDocumentWorkExecutor<I, E, D> createDocumentWorkExecutor(
+	PojoTypeIndexer<I, E, D> createIndexer(
 			AbstractPojoBackendSessionContext sessionContext,
 			DocumentCommitStrategy commitStrategy);
 

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexer.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexer.java
@@ -8,7 +8,11 @@ package org.hibernate.search.mapper.pojo.work.spi;
 
 import java.util.concurrent.CompletableFuture;
 
-public interface PojoSessionWorkExecutor {
+/**
+ * An interface for indexing entities in the context of a session in a POJO mapper,
+ * immediately, asynchronously and without any sort of {@link PojoIndexingPlan planning}.
+ */
+public interface PojoIndexer {
 
 	/**
 	 * Add an entity to the index, assuming that the entity is absent from the index.

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexingPlan.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexingPlan.java
@@ -13,7 +13,7 @@ import java.util.concurrent.CompletableFuture;
  * <p>
  * This class is stateful: it queues operations internally to apply them at a later time.
  * <p>
- * When {@link #prepare()} is called,
+ * When {@link #process()} is called,
  * the entities will be processed and index documents will be built
  * and stored in an internal buffer.
  * <p>
@@ -21,7 +21,7 @@ import java.util.concurrent.CompletableFuture;
  * the operations will be actually sent to the index.
  * <p>
  * Note that {@link #execute()} will implicitly trigger processing of documents that weren't processed yet,
- * if any, so calling {@link #prepare()} is not necessary if you call {@link #execute()} just next.
+ * if any, so calling {@link #process()} is not necessary if you call {@link #execute()} just next.
  * <p>
  * Implementations may not be thread-safe.
  */
@@ -41,7 +41,7 @@ public interface PojoIndexingPlan {
 	 * <p>
 	 * <strong>Note:</strong> depending on the backend, this may lead to errors or duplicate entries in the index
 	 * if the entity was actually already present in the index before this call.
-	 * When in doubt, you should rather use {@link #update(Object, Object)} or {@link #update(Object)}.
+	 * When in doubt, you should rather use {@link #addOrUpdate(Object, Object)} or {@link #addOrUpdate(Object)}.
 	 *
 	 * @param providedId A value to extract the document ID from.
 	 * Generally the expected value is the entity ID, but a different value may be expected depending on the mapping.
@@ -53,11 +53,11 @@ public interface PojoIndexingPlan {
 	/**
 	 * Update an entity in the index, or add it if it's absent from the index.
 	 * <p>
-	 * Shorthand for {@code update(null, entity)}; see {@link #update(Object, Object)}.
+	 * Shorthand for {@code update(null, entity)}; see {@link #addOrUpdate(Object, Object)}.
 	 *
 	 * @param entity The entity to update in the index.
 	 */
-	void update(Object entity);
+	void addOrUpdate(Object entity);
 
 	/**
 	 * Update an entity in the index, or add it if it's absent from the index.
@@ -67,7 +67,7 @@ public interface PojoIndexingPlan {
 	 * If {@code null}, Hibernate Search will attempt to extract the ID from the entity.
 	 * @param entity The entity to update in the index.
 	 */
-	void update(Object providedId, Object entity);
+	void addOrUpdate(Object providedId, Object entity);
 
 	/**
 	 * Update an entity in the index, or add it if it's absent from the index,
@@ -76,13 +76,13 @@ public interface PojoIndexingPlan {
 	 * <p>
 	 * Assumes that the entity may already be present in the index.
 	 * <p>
-	 * Shorthand for {@code update(null, entity, dirtyPaths)}; see {@link #update(Object, Object)}.
+	 * Shorthand for {@code update(null, entity, dirtyPaths)}; see {@link #addOrUpdate(Object, Object)}.
 	 *
 	 * @param entity The entity to update in the index.
 	 * @param dirtyPaths The paths to consider dirty, formatted using the dot-notation
 	 * ("directEntityProperty.nestedPropery").
 	 */
-	void update(Object entity, String... dirtyPaths);
+	void addOrUpdate(Object entity, String... dirtyPaths);
 
 	/**
 	 * Update an entity in the index, or add it if it's absent from the index,
@@ -96,7 +96,7 @@ public interface PojoIndexingPlan {
 	 * @param dirtyPaths The paths to consider dirty, formatted using the dot-notation
 	 * ("directEntityProperty.nestedPropery").
 	 */
-	void update(Object providedId, Object entity, String... dirtyPaths);
+	void addOrUpdate(Object providedId, Object entity, String... dirtyPaths);
 
 	/**
 	 * Delete an entity from the index.
@@ -133,31 +133,35 @@ public interface PojoIndexingPlan {
 	void purge(Class<?> clazz, Object providedId);
 
 	/**
-	 * Prepare the execution of the indexing plan, i.e. execute as much as possible without writing to the index.
+	 * Extract all data from objects passed to the indexing plan so far,
+	 * create documents to be indexed and put them into an internal buffer,
+	 * without writing them to the indexes.
 	 * <p>
 	 * In particular, ensure that all data is extracted from the POJOs
 	 * and converted to the backend-specific format.
 	 * <p>
 	 * Calling this method is optional: the {@link #execute()} method
-	 * will perform the preparation if necessary.
+	 * will perform the processing if necessary.
 	 */
-	void prepare();
+	void process();
 
 	/**
-	 * Start executing all the works in this plan, and clear the plan so that it can be re-used.
+	 * Write all pending changes to the index now,
+	 * without waiting for a Hibernate ORM flush event or transaction commit,
+	 * and clear the plan so that it can be re-used.
 	 *
 	 * @return A {@link CompletableFuture} that will be completed when all the works are complete.
 	 */
 	CompletableFuture<?> execute();
 
 	/**
-	 * Discard all works that are prepared but not yet executed.
+	 * Discard all plans of indexing.
 	 */
 	void discard();
 
 	/**
-	 * Discard all works that are not prepared yet.
+	 * Discard all plans of indexing, except for parts that were already {@link #process() processed}.
 	 */
-	void clearNotPrepared();
+	void discardNotProcessed();
 
 }

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoScopeWorkspace.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoScopeWorkspace.java
@@ -8,7 +8,7 @@ package org.hibernate.search.mapper.pojo.work.spi;
 
 import java.util.concurrent.CompletableFuture;
 
-public interface PojoScopeWorkExecutor {
+public interface PojoScopeWorkspace {
 
 	CompletableFuture<?> optimize();
 

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendMock.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendMock.java
@@ -264,11 +264,11 @@ public class BackendMock implements TestRule {
 			return this;
 		}
 
-		public BackendMock preparedThenExecuted(CompletableFuture<?> future) {
+		public BackendMock processedThenExecuted(CompletableFuture<?> future) {
 			log.debugf( "Expecting %d works to be prepared, then executed", works.size() );
 			// First expect all works to be prepared, then expect all works to be executed
 			works.stream()
-					.map( work -> new DocumentWorkCall( indexName, DocumentWorkCall.WorkPhase.PREPARE, work ) )
+					.map( work -> new DocumentWorkCall( indexName, DocumentWorkCall.WorkPhase.PROCESS, work ) )
 					.forEach( expectationConsumer );
 			works.stream()
 					.map( work -> new DocumentWorkCall( indexName, DocumentWorkCall.WorkPhase.EXECUTE, work, future ) )
@@ -276,8 +276,8 @@ public class BackendMock implements TestRule {
 			return BackendMock.this;
 		}
 
-		public BackendMock preparedThenExecuted() {
-			return preparedThenExecuted( CompletableFuture.completedFuture( null ) );
+		public BackendMock processedThenExecuted() {
+			return processedThenExecuted( CompletableFuture.completedFuture( null ) );
 		}
 
 		public BackendMock executed(CompletableFuture<?> future) {
@@ -292,10 +292,10 @@ public class BackendMock implements TestRule {
 			return executed( CompletableFuture.completedFuture( null ) );
 		}
 
-		public BackendMock prepared() {
+		public BackendMock processed() {
 			log.debugf( "Expecting %d works to be prepared", works.size() );
 			works.stream()
-					.map( work -> new DocumentWorkCall( indexName, DocumentWorkCall.WorkPhase.PREPARE, work ) )
+					.map( work -> new DocumentWorkCall( indexName, DocumentWorkCall.WorkPhase.PROCESS, work ) )
 					.forEach( expectationConsumer );
 			return BackendMock.this;
 		}

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/DocumentWorkCall.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/DocumentWorkCall.java
@@ -18,17 +18,19 @@ class DocumentWorkCall extends Call<DocumentWorkCall> {
 
 	enum WorkPhase {
 		/**
-		 * The initial state for a work.
+		 * Processing of the work, in preparation for its execution.
 		 */
-		PREPARE,
+		PROCESS,
 
 		/**
-		 * Works that are prepared and never discarded, may be executed.
+		 * Actual execution of the work.
+		 * Happens after processing, unless the work was discarded.
 		 */
 		EXECUTE,
 
 		/**
-		 * Works that are prepared and not yet executed, may be discarded from executions.
+		 * Discarding of the work.
+		 * Happens after processing, if the mapper decides to cancel some changes.
 		 */
 		DISCARD
 	}

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/VerifyingStubBackendBehavior.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/VerifyingStubBackendBehavior.java
@@ -105,10 +105,10 @@ class VerifyingStubBackendBehavior extends StubBackendBehavior {
 	}
 
 	@Override
-	public void prepareDocumentWorks(String indexName, List<StubDocumentWork> works) {
+	public void processDocumentWorks(String indexName, List<StubDocumentWork> works) {
 		CallQueue<DocumentWorkCall> callQueue = getDocumentWorkCalls( indexName );
 		works.stream()
-				.map( work -> new DocumentWorkCall( indexName, DocumentWorkCall.WorkPhase.PREPARE, work ) )
+				.map( work -> new DocumentWorkCall( indexName, DocumentWorkCall.WorkPhase.PROCESS, work ) )
 				.forEach( call -> callQueue.verify(
 						call,
 						DocumentWorkCall::verify,
@@ -143,10 +143,10 @@ class VerifyingStubBackendBehavior extends StubBackendBehavior {
 	}
 
 	@Override
-	public CompletableFuture<?> prepareAndExecuteDocumentWork(String indexName, StubDocumentWork work) {
+	public CompletableFuture<?> processAndExecuteDocumentWork(String indexName, StubDocumentWork work) {
 		CallQueue<DocumentWorkCall> callQueue = getDocumentWorkCalls( indexName );
 		callQueue.verify(
-				new DocumentWorkCall( indexName, DocumentWorkCall.WorkPhase.PREPARE, work ),
+				new DocumentWorkCall( indexName, DocumentWorkCall.WorkPhase.PROCESS, work ),
 				DocumentWorkCall::verify,
 				noExpectationsBehavior( () -> CompletableFuture.completedFuture( null ) )
 		);

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/StubBackendBehavior.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/StubBackendBehavior.java
@@ -37,7 +37,7 @@ public abstract class StubBackendBehavior {
 		}
 
 		@Override
-		public void prepareDocumentWorks(String indexName, List<StubDocumentWork> works) {
+		public void processDocumentWorks(String indexName, List<StubDocumentWork> works) {
 			throw new IllegalStateException( "The stub backend behavior was not set when works were prepared for index '"
 					+ indexName + "': " + works );
 		}
@@ -55,7 +55,7 @@ public abstract class StubBackendBehavior {
 		}
 
 		@Override
-		public CompletableFuture<?> prepareAndExecuteDocumentWork(String indexName, StubDocumentWork work) {
+		public CompletableFuture<?> processAndExecuteDocumentWork(String indexName, StubDocumentWork work) {
 			throw new IllegalStateException( "The stub backend behavior was not set when work were prepared and executed for index '"
 					+ indexName + "': " + work );
 		}
@@ -102,13 +102,13 @@ public abstract class StubBackendBehavior {
 
 	public abstract void pushSchema(String indexName, StubIndexSchemaNode rootSchemaNode);
 
-	public abstract void prepareDocumentWorks(String indexName, List<StubDocumentWork> works);
+	public abstract void processDocumentWorks(String indexName, List<StubDocumentWork> works);
 
 	public abstract void discardDocumentWorks(String indexName, List<StubDocumentWork> works);
 
 	public abstract CompletableFuture<?> executeDocumentWorks(String indexName, List<StubDocumentWork> works);
 
-	public abstract CompletableFuture<?> prepareAndExecuteDocumentWork(String indexName, StubDocumentWork work);
+	public abstract CompletableFuture<?> processAndExecuteDocumentWork(String indexName, StubDocumentWork work);
 
 	public abstract <T> SearchResult<T> executeSearchWork(Set<String> indexNames, StubSearchWork work,
 			StubSearchProjectionContext projectionContext,

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubIndexIndexer.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubIndexIndexer.java
@@ -11,19 +11,19 @@ import java.util.concurrent.CompletableFuture;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.work.execution.spi.DocumentContributor;
 import org.hibernate.search.engine.backend.work.execution.spi.DocumentReferenceProvider;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexDocumentWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.document.StubDocumentNode;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.document.impl.StubDocumentElement;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.index.StubDocumentWork;
 
-public class StubIndexDocumentWorkExecutor implements IndexDocumentWorkExecutor<StubDocumentElement> {
+public class StubIndexIndexer implements IndexIndexer<StubDocumentElement> {
 	private final StubIndexManager indexManager;
 	private final BackendSessionContext sessionContext;
 	private final DocumentCommitStrategy commitStrategy;
 
-	public StubIndexDocumentWorkExecutor(StubIndexManager indexManager, BackendSessionContext sessionContext,
+	public StubIndexIndexer(StubIndexManager indexManager, BackendSessionContext sessionContext,
 			DocumentCommitStrategy commitStrategy) {
 		this.indexManager = indexManager;
 		this.sessionContext = sessionContext;

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubIndexIndexingPlan.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubIndexIndexingPlan.java
@@ -12,7 +12,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.work.execution.spi.DocumentContributor;
 import org.hibernate.search.engine.backend.work.execution.spi.DocumentReferenceProvider;
 import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
@@ -20,7 +20,7 @@ import org.hibernate.search.util.impl.integrationtest.common.stub.backend.docume
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.index.StubDocumentWork;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.document.impl.StubDocumentElement;
 
-class StubIndexWorkPlan implements IndexWorkPlan<StubDocumentElement> {
+class StubIndexIndexingPlan implements IndexIndexingPlan<StubDocumentElement> {
 	private final StubIndexManager indexManager;
 	private final BackendSessionContext sessionContext;
 	private final DocumentCommitStrategy commitStrategy;
@@ -30,7 +30,7 @@ class StubIndexWorkPlan implements IndexWorkPlan<StubDocumentElement> {
 
 	private int preparedIndex = 0;
 
-	StubIndexWorkPlan(StubIndexManager indexManager, BackendSessionContext sessionContext,
+	StubIndexIndexingPlan(StubIndexManager indexManager, BackendSessionContext sessionContext,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
 		this.sessionContext = sessionContext;
 		this.indexManager = indexManager;

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubIndexManager.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubIndexManager.java
@@ -13,7 +13,7 @@ import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy
 import org.hibernate.search.engine.backend.index.IndexManager;
 import org.hibernate.search.engine.backend.index.spi.IndexManagerStartContext;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
 import org.hibernate.search.engine.backend.scope.spi.IndexScopeBuilder;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
@@ -83,8 +83,8 @@ public class StubIndexManager implements IndexManagerImplementor<StubDocumentEle
 	}
 
 	@Override
-	public IndexWorkExecutor createWorkExecutor(DetachedBackendSessionContext sessionContext) {
-		return new StubIndexWorkExecutor( name, backend.getBehavior(), sessionContext );
+	public IndexWorkspace createWorkspace(DetachedBackendSessionContext sessionContext) {
+		return new StubIndexWorkspace( name, backend.getBehavior(), sessionContext );
 	}
 
 	@Override

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubIndexManager.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubIndexManager.java
@@ -16,7 +16,7 @@ import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrateg
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
 import org.hibernate.search.engine.backend.scope.spi.IndexScopeBuilder;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexDocumentWorkExecutor;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor;
 import org.hibernate.search.engine.backend.mapping.spi.BackendMappingContext;
 import org.hibernate.search.engine.backend.session.spi.DetachedBackendSessionContext;
@@ -71,9 +71,9 @@ public class StubIndexManager implements IndexManagerImplementor<StubDocumentEle
 	}
 
 	@Override
-	public IndexWorkPlan<StubDocumentElement> createWorkPlan(BackendSessionContext context,
+	public IndexIndexingPlan<StubDocumentElement> createIndexingPlan(BackendSessionContext context,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
-		return new StubIndexWorkPlan( this, context, commitStrategy, refreshStrategy );
+		return new StubIndexIndexingPlan( this, context, commitStrategy, refreshStrategy );
 	}
 
 	@Override

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubIndexManager.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubIndexManager.java
@@ -15,7 +15,7 @@ import org.hibernate.search.engine.backend.index.spi.IndexManagerStartContext;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
 import org.hibernate.search.engine.backend.scope.spi.IndexScopeBuilder;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexDocumentWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor;
 import org.hibernate.search.engine.backend.mapping.spi.BackendMappingContext;
@@ -77,9 +77,9 @@ public class StubIndexManager implements IndexManagerImplementor<StubDocumentEle
 	}
 
 	@Override
-	public IndexDocumentWorkExecutor<StubDocumentElement> createDocumentWorkExecutor(BackendSessionContext context,
+	public IndexIndexer<StubDocumentElement> createIndexer(BackendSessionContext context,
 			DocumentCommitStrategy commitStrategy) {
-		return new StubIndexDocumentWorkExecutor( this, context, commitStrategy );
+		return new StubIndexIndexer( this, context, commitStrategy );
 	}
 
 	@Override

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubIndexManager.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubIndexManager.java
@@ -111,8 +111,8 @@ public class StubIndexManager implements IndexManagerImplementor<StubDocumentEle
 		throw new SearchException( "Cannot unwrap " + this + " to " + clazz );
 	}
 
-	void prepare(List<StubDocumentWork> works) {
-		backend.getBehavior().prepareDocumentWorks( name, works );
+	void process(List<StubDocumentWork> works) {
+		backend.getBehavior().processDocumentWorks( name, works );
 	}
 
 	CompletableFuture<?> execute(List<StubDocumentWork> works) {
@@ -120,7 +120,7 @@ public class StubIndexManager implements IndexManagerImplementor<StubDocumentEle
 	}
 
 	CompletableFuture<?> prepareAndExecuteWork(StubDocumentWork work) {
-		return backend.getBehavior().prepareAndExecuteDocumentWork( name, work );
+		return backend.getBehavior().processAndExecuteDocumentWork( name, work );
 	}
 
 	public void discard(List<StubDocumentWork> works) {

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubIndexWorkPlan.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubIndexWorkPlan.java
@@ -76,14 +76,14 @@ class StubIndexWorkPlan implements IndexWorkPlan<StubDocumentElement> {
 	}
 
 	@Override
-	public void prepare() {
-		indexManager.prepare( works.subList( preparedIndex, works.size() ) );
+	public void process() {
+		indexManager.process( works.subList( preparedIndex, works.size() ) );
 		preparedIndex = works.size();
 	}
 
 	@Override
 	public CompletableFuture<?> execute() {
-		prepare();
+		process();
 		CompletableFuture<?> future = indexManager.execute( works );
 		works.clear();
 		preparedIndex = 0;

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubIndexWorkspace.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubIndexWorkspace.java
@@ -9,18 +9,18 @@ package org.hibernate.search.util.impl.integrationtest.common.stub.backend.index
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
 import org.hibernate.search.engine.backend.session.spi.DetachedBackendSessionContext;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.StubBackendBehavior;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.index.StubIndexScopeWork;
 
-class StubIndexWorkExecutor implements IndexWorkExecutor {
+class StubIndexWorkspace implements IndexWorkspace {
 
 	private final String indexName;
 	private final StubBackendBehavior behavior;
 	private final DetachedBackendSessionContext sessionContext;
 
-	StubIndexWorkExecutor(String indexName, StubBackendBehavior behavior,
+	StubIndexWorkspace(String indexName, StubBackendBehavior behavior,
 			DetachedBackendSessionContext sessionContext) {
 		this.indexName = indexName;
 		this.behavior = behavior;

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/StubMappingIndexManager.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/StubMappingIndexManager.java
@@ -8,7 +8,7 @@ package org.hibernate.search.util.impl.integrationtest.common.stub.mapper;
 
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexDocumentWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
@@ -52,14 +52,14 @@ public class StubMappingIndexManager {
 		return indexManager.createIndexingPlan( sessionContext, commitStrategy, refreshStrategy );
 	}
 
-	public IndexDocumentWorkExecutor<? extends DocumentElement> createDocumentWorkExecutor(
+	public IndexIndexer<? extends DocumentElement> createIndexer(
 			DocumentCommitStrategy commitStrategy) {
-		return createDocumentWorkExecutor( new StubBackendSessionContext(), commitStrategy );
+		return createIndexer( new StubBackendSessionContext(), commitStrategy );
 	}
 
-	public IndexDocumentWorkExecutor<? extends DocumentElement> createDocumentWorkExecutor(
+	public IndexIndexer<? extends DocumentElement> createIndexer(
 			StubBackendSessionContext sessionContext, DocumentCommitStrategy commitStrategy) {
-		return indexManager.createDocumentWorkExecutor( sessionContext, commitStrategy );
+		return indexManager.createIndexer( sessionContext, commitStrategy );
 	}
 
 	public IndexWorkExecutor createWorkExecutor() {

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/StubMappingIndexManager.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/StubMappingIndexManager.java
@@ -11,7 +11,7 @@ import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy
 import org.hibernate.search.engine.backend.work.execution.spi.IndexDocumentWorkExecutor;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkPlan;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.mapper.mapping.spi.MappedIndexManager;
 import org.hibernate.search.engine.mapper.scope.spi.MappedIndexScopeBuilder;
 import org.hibernate.search.engine.backend.session.spi.DetachedBackendSessionContext;
@@ -35,21 +35,21 @@ public class StubMappingIndexManager {
 		return clazz.cast( indexManager.toAPI() );
 	}
 
-	public IndexWorkPlan<? extends DocumentElement> createWorkPlan() {
-		return createWorkPlan( new StubBackendSessionContext() );
+	public IndexIndexingPlan<? extends DocumentElement> createIndexingPlan() {
+		return createIndexingPlan( new StubBackendSessionContext() );
 	}
 
-	public IndexWorkPlan<? extends DocumentElement> createWorkPlan(StubBackendSessionContext sessionContext) {
+	public IndexIndexingPlan<? extends DocumentElement> createIndexingPlan(StubBackendSessionContext sessionContext) {
 		/*
 		 * Use the same defaults as in the ORM mapper for the commit strategy,
 		 * but force refreshes because it's more convenient for tests.
 		 */
-		return indexManager.createWorkPlan( sessionContext, DocumentCommitStrategy.FORCE, DocumentRefreshStrategy.FORCE );
+		return indexManager.createIndexingPlan( sessionContext, DocumentCommitStrategy.FORCE, DocumentRefreshStrategy.FORCE );
 	}
 
-	public IndexWorkPlan<? extends DocumentElement> createWorkPlan(StubBackendSessionContext sessionContext,
+	public IndexIndexingPlan<? extends DocumentElement> createIndexingPlan(StubBackendSessionContext sessionContext,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
-		return indexManager.createWorkPlan( sessionContext, commitStrategy, refreshStrategy );
+		return indexManager.createIndexingPlan( sessionContext, commitStrategy, refreshStrategy );
 	}
 
 	public IndexDocumentWorkExecutor<? extends DocumentElement> createDocumentWorkExecutor(

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/StubMappingIndexManager.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/mapper/StubMappingIndexManager.java
@@ -10,7 +10,7 @@ import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkExecutor;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.mapper.mapping.spi.MappedIndexManager;
 import org.hibernate.search.engine.mapper.scope.spi.MappedIndexScopeBuilder;
@@ -62,16 +62,16 @@ public class StubMappingIndexManager {
 		return indexManager.createIndexer( sessionContext, commitStrategy );
 	}
 
-	public IndexWorkExecutor createWorkExecutor() {
-		return createWorkExecutor( new StubBackendSessionContext() );
+	public IndexWorkspace createWorkspace() {
+		return createWorkspace( new StubBackendSessionContext() );
 	}
 
-	public IndexWorkExecutor createWorkExecutor(StubBackendSessionContext sessionContext) {
-		return createWorkExecutor( DetachedBackendSessionContext.of( sessionContext ) );
+	public IndexWorkspace createWorkspace(StubBackendSessionContext sessionContext) {
+		return createWorkspace( DetachedBackendSessionContext.of( sessionContext ) );
 	}
 
-	public IndexWorkExecutor createWorkExecutor(DetachedBackendSessionContext sessionContext) {
-		return indexManager.createWorkExecutor( sessionContext );
+	public IndexWorkspace createWorkspace(DetachedBackendSessionContext sessionContext) {
+		return indexManager.createWorkspace( sessionContext );
 	}
 
 	/**


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3606

~Based on #2084 , which should be merged first.~ => Done

I renamed `SearchSessionWritePlan` to `SearchIndexingPlan`. It's both simpler, and more to the point: this is about indexing.
Also, it doesn't mention the session, which could prove useful in the future if we want to use it in APIs allowing users to implement their own mass indexer

I renamed `SearchWriter` to `SearchWorkspace`. The new name is still quite generic, but it makes more sense: a workspace is where work is done, it delimits what part of the indexes will affected.
Also, this name would be suitable for a future zero-downtime indexing solution: by creating a workspace with specific parameters, a user could trigger the creation of a temporary workspaces targeting temporary indexes, which could ultimately replace the main indexes.