### PR TITLE
HSEARCH-3665 + HSEARCH-3706 Upgrade to Hibernate ORM 5.4.5.Final

### DIFF
--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingBridgeExplicitReindexingFunctionalIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingBridgeExplicitReindexingFunctionalIT.java
@@ -35,7 +35,6 @@ import org.hibernate.search.util.impl.integrationtest.orm.OrmUtils;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -84,7 +83,6 @@ public class AutomaticIndexingBridgeExplicitReindexingFunctionalIT {
 	}
 
 	@Test
-	@Ignore("TODO HSEARCH-3665")
 	public void test() {
 		// Init
 		OrmUtils.withinTransaction( sessionFactory, session -> {

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/event/impl/HibernateSearchEventListener.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/event/impl/HibernateSearchEventListener.java
@@ -149,16 +149,15 @@ public final class HibernateSearchEventListener implements PostDeleteEventListen
 
 	@Override
 	public void onAutoFlush(AutoFlushEvent event) throws HibernateException {
-//		TODO HSEARCH-3665 using #isFlushRequired to filter not significant autoflush event
-//		if ( !event.isFlushRequired() ) {
-//			/*
-//			 * Auto-flush was disabled or there wasn't any entity/collection to flush.
-//			 * Note this is not an optimization: we really need to avoid triggering entity processing in this case.
-//			 * There may be dirty entities, but ORM chose not to flush them,
-//			 * so we shouldn't flush the index changes either.
-//			 */
-//			return;
-//		}
+		if ( !event.isFlushRequired() ) {
+			/*
+			 * Auto-flush was disabled or there wasn't any entity/collection to flush.
+			 * Note this is not an optimization: we really need to avoid triggering entity processing in this case.
+			 * There may be dirty entities, but ORM chose not to flush them,
+			 * so we shouldn't flush the index changes either.
+			 */
+			return;
+		}
 		getCurrentIndexingPlan( state.getContextProvider(), event.getSession() ).process();
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
         <version.com.fasterxml.jackson.databind>2.9.9.3</version.com.fasterxml.jackson.databind>
 
         <!-- >>> ORM -->
-        <version.org.hibernate>5.4.4.Final</version.org.hibernate>
+        <version.org.hibernate>5.4.5.Final</version.org.hibernate>
         <javadoc.org.hibernate.url>http://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.majorVersion}.${parsed-version.org.hibernate.minorVersion}/javadocs/</javadoc.org.hibernate.url>
         <documentation.org.hibernate.url>http://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.majorVersion}.${parsed-version.org.hibernate.minorVersion}/userguide/html_single/Hibernate_User_Guide.html</documentation.org.hibernate.url>
         <version.org.hibernate.commons.annotations>5.1.0.Final</version.org.hibernate.commons.annotations>


### PR DESCRIPTION
* [HSEARCH-3706](https://hibernate.atlassian.net/browse/HSEARCH-3706): Upgrade to Hibernate ORM 5.4.5.Final
* [HSEARCH-3665](https://hibernate.atlassian.net/browse/HSEARCH-3665): Use the method AutoFlushEvent#isFlushRequired to filter auto flush events

