### PR TITLE
HSEARCH-3691 Remove the ability to use @GeoPointBinding on properties of type GeoPoint

### DIFF
--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/spatial/AnnotationMappingGeoPointBindingIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/spatial/AnnotationMappingGeoPointBindingIT.java
@@ -18,6 +18,7 @@ import org.hibernate.search.mapper.pojo.bridge.builtin.annotation.Latitude;
 import org.hibernate.search.mapper.pojo.bridge.builtin.annotation.Longitude;
 import org.hibernate.search.mapper.javabean.session.SearchSession;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 
@@ -43,8 +44,8 @@ public class AnnotationMappingGeoPointBindingIT {
 				.field( "workLocation", GeoPoint.class, b2 -> b2.projectable( Projectable.DEFAULT ).sortable( Sortable.DEFAULT ) )
 		);
 		backendMock.expectSchema( GeoPointOnCoordinatesPropertyEntity.INDEX, b -> b
-				.field( "coord", GeoPoint.class, b2 -> b2.projectable( Projectable.DEFAULT ).sortable( Sortable.DEFAULT ) )
-				.field( "location", GeoPoint.class, b2 -> b2.projectable( Projectable.NO ).sortable( Sortable.DEFAULT ) )
+				.field( "coord", GeoPoint.class )
+				.field( "location", GeoPoint.class, b2 -> b2.projectable( Projectable.NO ) )
 		);
 		backendMock.expectSchema( GeoPointOnCustomCoordinatesPropertyEntity.INDEX, b -> b
 				.field( "coord", GeoPoint.class, b2 -> b2.projectable( Projectable.DEFAULT ).sortable( Sortable.DEFAULT ) )
@@ -206,8 +207,8 @@ public class AnnotationMappingGeoPointBindingIT {
 			this.id = id;
 		}
 
-		@GeoPointBinding
-		@GeoPointBinding(fieldName = "location", projectable = Projectable.NO)
+		@GenericField
+		@GenericField(name = "location", projectable = Projectable.NO)
 		public GeoPoint getCoord() {
 			return coord;
 		}

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/spatial/ProgrammaticMappingGeoPointBindingIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/spatial/ProgrammaticMappingGeoPointBindingIT.java
@@ -41,8 +41,8 @@ public class ProgrammaticMappingGeoPointBindingIT {
 				.field( "workLocation", GeoPoint.class, b2 -> b2.projectable( Projectable.DEFAULT ).sortable( Sortable.DEFAULT ) )
 		);
 		backendMock.expectSchema( GeoPointOnCoordinatesPropertyEntity.INDEX, b -> b
-				.field( "coord", GeoPoint.class, b2 -> b2.projectable( Projectable.DEFAULT ).sortable( Sortable.DEFAULT ) )
-				.field( "location", GeoPoint.class, b2 -> b2.projectable( Projectable.NO ).sortable( Sortable.DEFAULT ) )
+				.field( "coord", GeoPoint.class )
+				.field( "location", GeoPoint.class, b2 -> b2.projectable( Projectable.NO ) )
 		);
 		backendMock.expectSchema( GeoPointOnCustomCoordinatesPropertyEntity.INDEX, b -> b
 				.field( "coord", GeoPoint.class, b2 -> b2.projectable( Projectable.DEFAULT ).sortable( Sortable.DEFAULT ) )
@@ -86,11 +86,8 @@ public class ProgrammaticMappingGeoPointBindingIT {
 							.property( "id" )
 									.documentId()
 							.property( "coord" )
-									.binder( GeoPointBinder.create() )
-									.binder( GeoPointBinder.create()
-											.fieldName( "location" )
-											.projectable( Projectable.NO )
-									);
+									.genericField()
+									.genericField( "location" ).projectable( Projectable.NO );
 
 					mappingDefinition.type( GeoPointOnCustomCoordinatesPropertyEntity.class )
 							.indexed( GeoPointOnCustomCoordinatesPropertyEntity.INDEX )

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/spatial/impl/GeoPointBridge.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/spatial/impl/GeoPointBridge.java
@@ -153,33 +153,27 @@ public class GeoPointBridge implements TypeBridge, PropertyBridge {
 					.toReference();
 
 			Function<Object, GeoPoint> coordinatesExtractor;
-			if ( bridgedPojoModelElement.isAssignableTo( GeoPoint.class ) ) {
-				PojoElementAccessor<GeoPoint> sourceAccessor = bridgedPojoModelElement.createAccessor( GeoPoint.class );
-				coordinatesExtractor = sourceAccessor::read;
-			}
-			else {
-				PojoElementAccessor<Double> latitudeAccessor = bridgedPojoModelElement.properties()
-						.filter( model -> model.markers( LatitudeMarker.class )
-								.anyMatch( m -> Objects.equals( markerSet, m.getMarkerSet() ) ) )
-						.collect( singleMarkedProperty( "latitude", defaultedFieldName, markerSet ) )
-						.createAccessor( Double.class );
-				PojoElementAccessor<Double> longitudeAccessor = bridgedPojoModelElement.properties()
-						.filter( model -> model.markers( LongitudeMarker.class )
-								.anyMatch( m -> Objects.equals( markerSet, m.getMarkerSet() ) ) )
-						.collect( singleMarkedProperty( "longitude", defaultedFieldName, markerSet ) )
-						.createAccessor( Double.class );
+			PojoElementAccessor<Double> latitudeAccessor = bridgedPojoModelElement.properties()
+					.filter( model -> model.markers( LatitudeMarker.class )
+							.anyMatch( m -> Objects.equals( markerSet, m.getMarkerSet() ) ) )
+					.collect( singleMarkedProperty( "latitude", defaultedFieldName, markerSet ) )
+					.createAccessor( Double.class );
+			PojoElementAccessor<Double> longitudeAccessor = bridgedPojoModelElement.properties()
+					.filter( model -> model.markers( LongitudeMarker.class )
+							.anyMatch( m -> Objects.equals( markerSet, m.getMarkerSet() ) ) )
+					.collect( singleMarkedProperty( "longitude", defaultedFieldName, markerSet ) )
+					.createAccessor( Double.class );
 
-				coordinatesExtractor = bridgedElement -> {
-					Double latitude = latitudeAccessor.read( bridgedElement );
-					Double longitude = longitudeAccessor.read( bridgedElement );
+			coordinatesExtractor = bridgedElement -> {
+				Double latitude = latitudeAccessor.read( bridgedElement );
+				Double longitude = longitudeAccessor.read( bridgedElement );
 
-					if ( latitude == null || longitude == null ) {
-						return null;
-					}
+				if ( latitude == null || longitude == null ) {
+					return null;
+				}
 
-					return GeoPoint.of( latitude, longitude );
-				};
-			}
+				return GeoPoint.of( latitude, longitude );
+			};
 
 			return new GeoPointBridge(
 					coordinatesExtractor,


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3691

Documentation seems to be already updated.

IMHO we don't need to test that having a such binding does not work anymore. Usually I'm a big fan of having a test for everything, but not in this case (we have removed some code, not added it).
Anyway, we could add it anytime.