### PR TITLE
HSEARCH-3042 Allow the definition of one "search" analyzer per field as part of the mapping

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/esnative/impl/PropertyMapping.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/esnative/impl/PropertyMapping.java
@@ -7,8 +7,6 @@
 package org.hibernate.search.backend.elasticsearch.document.model.esnative.impl;
 
 import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
 
 import com.google.gson.JsonElement;
 import com.google.gson.annotations.JsonAdapter;
@@ -55,11 +53,6 @@ public class PropertyMapping extends AbstractTypeMapping {
 	 */
 	@SerializedName("null_value")
 	private JsonElement nullValue;
-
-	/**
-	 * Must be null when we don't want to include it in JSON serialization.
-	 */
-	private Map<String, PropertyMapping> fields;
 
 	/*
 	 * Text datatype
@@ -141,25 +134,6 @@ public class PropertyMapping extends AbstractTypeMapping {
 
 	public void setNullValue(JsonElement nullValue) {
 		this.nullValue = nullValue;
-	}
-
-	public Map<String, PropertyMapping> getFields() {
-		return fields;
-	}
-
-	private Map<String, PropertyMapping> getInitializedFields() {
-		if ( fields == null ) {
-			fields = new TreeMap<>();
-		}
-		return fields;
-	}
-
-	public void addField(String name, PropertyMapping mapping) {
-		getInitializedFields().put( name, mapping );
-	}
-
-	public void removeField(String name) {
-		getInitializedFields().remove( name );
 	}
 
 	public String getAnalyzer() {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/esnative/impl/PropertyMapping.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/esnative/impl/PropertyMapping.java
@@ -62,6 +62,14 @@ public class PropertyMapping extends AbstractTypeMapping {
 	private String analyzer;
 
 	/*
+	 * Text datatype
+	 * https://www.elastic.co/guide/en/elasticsearch/reference/current/search-analyzer.html
+	 */
+
+	@SerializedName("search_analyzer")
+	private String searchAnalyzer;
+
+	/*
 	 * Keyword datatype
 	 * https://www.elastic.co/guide/en/elasticsearch/reference/current/keyword.html
 	 */
@@ -142,6 +150,14 @@ public class PropertyMapping extends AbstractTypeMapping {
 
 	public void setAnalyzer(String analyzer) {
 		this.analyzer = analyzer;
+	}
+
+	public String getSearchAnalyzer() {
+		return searchAnalyzer;
+	}
+
+	public void setSearchAnalyzer(String searchAnalyzer) {
+		this.searchAnalyzer = searchAnalyzer;
 	}
 
 	public String getNormalizer() {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/esnative/impl/PropertyMappingJsonAdapterFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/esnative/impl/PropertyMappingJsonAdapterFactory.java
@@ -6,16 +6,9 @@
  */
 package org.hibernate.search.backend.elasticsearch.document.model.esnative.impl;
 
-import java.util.Map;
-
 import com.google.gson.JsonPrimitive;
-import com.google.gson.reflect.TypeToken;
 
 public class PropertyMappingJsonAdapterFactory extends AbstractTypeMappingJsonAdapterFactory {
-
-	private static final TypeToken<Map<String, PropertyMapping>> FIELD_MAP_TYPE_TOKEN =
-			new TypeToken<Map<String, PropertyMapping>>() {
-			};
 
 	@Override
 	protected <T> void addFields(Builder<T> builder) {
@@ -26,7 +19,6 @@ public class PropertyMappingJsonAdapterFactory extends AbstractTypeMappingJsonAd
 		builder.add( "docValues", Boolean.class );
 		builder.add( "store", Boolean.class );
 		builder.add( "nullValue", JsonPrimitive.class );
-		builder.add( "fields", FIELD_MAP_TYPE_TOKEN );
 		builder.add( "analyzer", String.class );
 		builder.add( "normalizer", String.class );
 		builder.add( "format", new ElasticsearchFormatJsonAdapter() );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/esnative/impl/PropertyMappingJsonAdapterFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/esnative/impl/PropertyMappingJsonAdapterFactory.java
@@ -20,6 +20,7 @@ public class PropertyMappingJsonAdapterFactory extends AbstractTypeMappingJsonAd
 		builder.add( "store", Boolean.class );
 		builder.add( "nullValue", JsonPrimitive.class );
 		builder.add( "analyzer", String.class );
+		builder.add( "searchAnalyzer", String.class );
 		builder.add( "normalizer", String.class );
 		builder.add( "format", new ElasticsearchFormatJsonAdapter() );
 		builder.add( "scalingFactor", Double.class );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/admin/impl/ElasticsearchSchemaValidatorImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/admin/impl/ElasticsearchSchemaValidatorImpl.java
@@ -585,6 +585,7 @@ public class ElasticsearchSchemaValidatorImpl implements ElasticsearchSchemaVali
 
 	private void validateAnalyzerOptions(ValidationErrorCollector errorCollector, PropertyMapping expectedMapping, PropertyMapping actualMapping) {
 		validateEqualWithDefault( errorCollector, "analyzer", expectedMapping.getAnalyzer(), actualMapping.getAnalyzer(), "default" );
+		validateEqualWithoutDefault( errorCollector, "search_analyzer", expectedMapping.getSearchAnalyzer(), actualMapping.getSearchAnalyzer() );
 		validateEqualWithoutDefault( errorCollector, "normalizer", expectedMapping.getNormalizer(), actualMapping.getNormalizer() );
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/admin/impl/ElasticsearchSchemaValidatorImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/admin/impl/ElasticsearchSchemaValidatorImpl.java
@@ -559,11 +559,6 @@ public class ElasticsearchSchemaValidatorImpl implements ElasticsearchSchemaVali
 			validateEqualWithDefault( errorCollector, "term_vector", expectedMapping.getTermVector(), actualMapping.getTermVector(), "no" );
 
 			super.validate( errorCollector, expectedMapping, actualMapping );
-
-			// Validate fields with the same method as properties, since the content is about the same
-			validateAll( errorCollector, ValidationContextType.MAPPING_PROPERTY_FIELD, MESSAGES.propertyFieldMissing(),
-					getPropertyMappingValidator(),
-					expectedMapping.getFields(), actualMapping.getFields() );
 		}
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
@@ -591,4 +591,8 @@ public interface Log extends BasicLogger {
 	@Message(id = ID_OFFSET_3 + 86, value = "Multiple conflicting nested document paths to build a projection for field '%1$s'. '%2$s' vs. '%3$s'.")
 	SearchException conflictingNestedDocumentPathHierarchyForProjection(String absoluteFieldPath,
 			List<String> nestedDocumentPathHierarchy1, List<String> nestedDocumentPathHierarchy2, @Param EventContext context);
+
+	@Message(id = ID_OFFSET_3 + 87, value = "Cannot apply a search analyzer if an analyzer has not been defined on the same field." +
+			" Search analyzer: '%1$s'.")
+	SearchException searchAnalyzerWithoutAnalyzer(String searchAnalyzer, @Param EventContext context);
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchStringIndexFieldTypeOptionsStep.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchStringIndexFieldTypeOptionsStep.java
@@ -41,7 +41,6 @@ class ElasticsearchStringIndexFieldTypeOptionsStep
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private String analyzerName;
-	// TODO HSEARCH-3042 use this value
 	private String searchAnalyzerName;
 	private String normalizerName;
 	private Projectable projectable = Projectable.DEFAULT;
@@ -130,6 +129,7 @@ class ElasticsearchStringIndexFieldTypeOptionsStep
 		if ( analyzerName != null ) {
 			mapping.setType( DataTypes.TEXT );
 			mapping.setAnalyzer( analyzerName );
+			mapping.setSearchAnalyzer( searchAnalyzerName );
 			mapping.setTermVector( resolveTermVector() );
 
 			if ( normalizerName != null ) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchStringIndexFieldTypeOptionsStep.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchStringIndexFieldTypeOptionsStep.java
@@ -149,6 +149,10 @@ class ElasticsearchStringIndexFieldTypeOptionsStep
 			}
 		}
 		else {
+			if ( searchAnalyzerName != null ) {
+				throw log.searchAnalyzerWithoutAnalyzer( searchAnalyzerName, getBuildContext().getEventContext() );
+			}
+
 			mapping.setType( DataTypes.KEYWORD );
 			mapping.setNormalizer( normalizerName );
 			mapping.setDocValues( resolvedSortable || resolvedAggregable );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchStringIndexFieldTypeOptionsStep.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchStringIndexFieldTypeOptionsStep.java
@@ -41,6 +41,8 @@ class ElasticsearchStringIndexFieldTypeOptionsStep
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private String analyzerName;
+	// TODO HSEARCH-3042 use this value
+	private String searchAnalyzerName;
 	private String normalizerName;
 	private Projectable projectable = Projectable.DEFAULT;
 	private Searchable searchable = Searchable.DEFAULT;
@@ -57,6 +59,12 @@ class ElasticsearchStringIndexFieldTypeOptionsStep
 	@Override
 	public ElasticsearchStringIndexFieldTypeOptionsStep analyzer(String analyzerName) {
 		this.analyzerName = analyzerName;
+		return this;
+	}
+
+	@Override
+	public ElasticsearchStringIndexFieldTypeOptionsStep searchAnalyzer(String searchAnalyzerName) {
+		this.searchAnalyzerName = searchAnalyzerName;
 		return this;
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchTextFieldPredicateBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchTextFieldPredicateBuilderFactory.java
@@ -31,7 +31,8 @@ public class ElasticsearchTextFieldPredicateBuilderFactory
 			ElasticsearchFieldCodec<String> codec, PropertyMapping mapping) {
 		super( searchable, converter, rawConverter, codec );
 		this.type = mapping.getType();
-		this.analyzer = mapping.getAnalyzer();
+		this.analyzer = ( mapping.getSearchAnalyzer() != null ) ?
+				mapping.getSearchAnalyzer() : mapping.getAnalyzer();
 		this.normalizer = mapping.getNormalizer();
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
@@ -571,4 +571,8 @@ public interface Log extends BasicLogger {
 
 	@Message(id = ID_OFFSET_2 + 103, value = "This field does not support aggregations.")
 	SearchException unsupportedDSLAggregations(@Param EventContext context);
+
+	@Message(id = ID_OFFSET_2 + 104, value = "Cannot apply a search analyzer if an analyzer has not been defined on the same field." +
+			" Search analyzer: '%1$s'.")
+	SearchException searchAnalyzerWithoutAnalyzer(String searchAnalyzer, @Param EventContext context);
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneStringIndexFieldTypeOptionsStep.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneStringIndexFieldTypeOptionsStep.java
@@ -37,6 +37,8 @@ class LuceneStringIndexFieldTypeOptionsStep
 
 	private String analyzerName;
 	private Analyzer analyzer;
+
+	private String searchAnalyzerName;
 	private Analyzer searchAnalyzer;
 
 	private String normalizerName;
@@ -63,6 +65,7 @@ class LuceneStringIndexFieldTypeOptionsStep
 
 	@Override
 	public LuceneStringIndexFieldTypeOptionsStep searchAnalyzer(String searchAnalyzerName) {
+		this.searchAnalyzerName = searchAnalyzerName;
 		this.searchAnalyzer = getAnalysisDefinitionRegistry().getAnalyzerDefinition( searchAnalyzerName );
 		if ( searchAnalyzer == null ) {
 			throw log.unknownAnalyzer( searchAnalyzerName, getBuildContext().getEventContext() );
@@ -123,6 +126,9 @@ class LuceneStringIndexFieldTypeOptionsStep
 			if ( resolvedAggregable ) {
 				throw log.cannotUseAnalyzerOnAggregableField( analyzerName, getBuildContext().getEventContext() );
 			}
+		}
+		else if ( searchAnalyzer != null ) {
+			throw log.searchAnalyzerWithoutAnalyzer( searchAnalyzerName, getBuildContext().getEventContext() );
 		}
 
 		Analyzer analyzerOrNormalizer = analyzer != null ? analyzer : normalizer;

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneStringIndexFieldTypeOptionsStep.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneStringIndexFieldTypeOptionsStep.java
@@ -36,9 +36,9 @@ class LuceneStringIndexFieldTypeOptionsStep
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private String analyzerName;
-	// TODO HSEARCH-3042 use this value
-	private String searchAnalyzerName;
 	private Analyzer analyzer;
+	private Analyzer searchAnalyzer;
+
 	private String normalizerName;
 	private Analyzer normalizer;
 
@@ -63,7 +63,10 @@ class LuceneStringIndexFieldTypeOptionsStep
 
 	@Override
 	public LuceneStringIndexFieldTypeOptionsStep searchAnalyzer(String searchAnalyzerName) {
-		this.searchAnalyzerName = searchAnalyzerName;
+		this.searchAnalyzer = getAnalysisDefinitionRegistry().getAnalyzerDefinition( searchAnalyzerName );
+		if ( searchAnalyzer == null ) {
+			throw log.unknownAnalyzer( searchAnalyzerName, getBuildContext().getEventContext() );
+		}
 		return this;
 	}
 
@@ -142,7 +145,7 @@ class LuceneStringIndexFieldTypeOptionsStep
 				codec,
 				new LuceneTextFieldPredicateBuilderFactory<>(
 						resolvedSearchable, dslToIndexConverter, rawDslToIndexConverter, codec,
-						analyzerOrNormalizer, analyzer, normalizer
+						( searchAnalyzer != null ) ? searchAnalyzer : analyzerOrNormalizer
 				),
 				new LuceneTextFieldSortBuilderFactory<>(
 						resolvedSortable, dslToIndexConverter, rawDslToIndexConverter, codec

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneStringIndexFieldTypeOptionsStep.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/dsl/impl/LuceneStringIndexFieldTypeOptionsStep.java
@@ -36,6 +36,8 @@ class LuceneStringIndexFieldTypeOptionsStep
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private String analyzerName;
+	// TODO HSEARCH-3042 use this value
+	private String searchAnalyzerName;
 	private Analyzer analyzer;
 	private String normalizerName;
 	private Analyzer normalizer;
@@ -56,6 +58,12 @@ class LuceneStringIndexFieldTypeOptionsStep
 		if ( analyzer == null ) {
 			throw log.unknownAnalyzer( analyzerName, getBuildContext().getEventContext() );
 		}
+		return this;
+	}
+
+	@Override
+	public LuceneStringIndexFieldTypeOptionsStep searchAnalyzer(String searchAnalyzerName) {
+		this.searchAnalyzerName = searchAnalyzerName;
 		return this;
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneTextFieldPredicateBuilderFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/predicate/impl/LuceneTextFieldPredicateBuilderFactory.java
@@ -22,16 +22,12 @@ public final class LuceneTextFieldPredicateBuilderFactory<F>
 		extends AbstractLuceneStandardFieldPredicateBuilderFactory<F, LuceneTextFieldCodec<F>> {
 
 	private final Analyzer analyzerOrNormalizer;
-	private final Analyzer analyzer;
-	private final Analyzer normalizer;
 
-	public LuceneTextFieldPredicateBuilderFactory( boolean searchable,
+	public LuceneTextFieldPredicateBuilderFactory(boolean searchable,
 			ToDocumentFieldValueConverter<?, ? extends F> converter, ToDocumentFieldValueConverter<F, ? extends F> rawConverter,
-			LuceneTextFieldCodec<F> codec, Analyzer analyzerOrNormalizer, Analyzer analyzer, Analyzer normalizer) {
+			LuceneTextFieldCodec<F> codec, Analyzer analyzerOrNormalizer) {
 		super( searchable, converter, rawConverter, codec );
 		this.analyzerOrNormalizer = analyzerOrNormalizer;
-		this.analyzer = analyzer;
-		this.normalizer = normalizer;
 	}
 
 	@Override
@@ -80,6 +76,6 @@ public final class LuceneTextFieldPredicateBuilderFactory<F>
 		}
 
 		LuceneTextFieldPredicateBuilderFactory castedOther = (LuceneTextFieldPredicateBuilderFactory) other;
-		return Objects.equals( analyzer, castedOther.analyzer ) && Objects.equals( normalizer, castedOther.normalizer );
+		return Objects.equals( analyzerOrNormalizer, castedOther.analyzerOrNormalizer );
 	}
 }

--- a/documentation/src/main/asciidoc/mapper-orm-mapping.asciidoc
+++ b/documentation/src/main/asciidoc/mapper-orm-mapping.asciidoc
@@ -263,6 +263,8 @@ match fields ignoring diacritics,
 +
 Full-text fields must be assigned an <<mapper-orm-directfieldmapping-analyzer,analyzer>>, referenced by its name.
 See <<concepts-analysis>> for more details about analyzers and full-text analysis.
+Moreover, you can define <<mapper-orm-directfieldmapping-search-analyzer,a specific analyzer>>
+a search analyzer to analyze searched terms differently.
 +
 IMPORTANT: Full-text fields cannot be sorted on.
 If you need to sort on the value of a property,
@@ -368,6 +370,13 @@ in the section <<mapper-orm-containerextractor>>.
 [[mapper-orm-directfieldmapping-analyzer]] `analyzer`::
 The analyzer to apply to field values when indexing and querying.
 Only available on `@FullTextField`.
++
+See <<concepts-analysis>> for more details about analyzers and full-text analysis.
+
+[[mapper-orm-directfieldmapping-search-analyzer]] `searchAnalyzer`::
+An optional different analyzer, overriding the one defined with the `analyzer` attribute,
+to use only when analyzing searched terms.
+If not defined, the same `analyzer` will be used.
 +
 See <<concepts-analysis>> for more details about analyzers and full-text analysis.
 

--- a/engine/src/main/java/org/hibernate/search/engine/backend/types/dsl/StringIndexFieldTypeOptionsStep.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/types/dsl/StringIndexFieldTypeOptionsStep.java
@@ -29,6 +29,18 @@ public interface StringIndexFieldTypeOptionsStep<S extends StringIndexFieldTypeO
 	S analyzer(String analyzerName);
 
 	/**
+	 * Overrides {@link #analyzer} to use for query parameters at search time.
+	 * <p>
+	 * A search analyzer can only be set if an analyzer was set through {@link #analyzer(String)}.
+	 *
+	 * @param searchAnalyzerName The name of an analyzer to apply to values when querying the index only.
+	 * It overrides the {@link #analyzer(String)} when querying the index.
+	 * See the reference documentation for more information about analyzers and how to define them.
+	 * @return {@code this}, for method chaining.
+	 */
+	S searchAnalyzer(String searchAnalyzerName);
+
+	/**
 	 * Define the type as normalized.
 	 * <p>
 	 * Incompatible with {@link #analyzer(String)}.

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneDocumentModelDslIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneDocumentModelDslIT.java
@@ -9,6 +9,7 @@ package org.hibernate.search.integrationtest.backend.lucene;
 import java.util.function.Consumer;
 
 import org.hibernate.search.engine.mapper.mapping.building.spi.IndexBindingContext;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
@@ -58,6 +59,25 @@ public class LuceneDocumentModelDslIT {
 						.typeContext( TYPE_NAME )
 						.indexContext( INDEX_NAME )
 						.failure( "Unknown normalizer" )
+						.build() );
+	}
+
+	@Test
+	public void unknownSearchAnalyzer() {
+		SubTest.expectException(
+				"Referencing an unknown search analyzer",
+				() -> setup( ctx -> {
+					ctx.createTypeFactory().asString()
+							.analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD_ENGLISH.name )
+							.searchAnalyzer( "someNameThatIsClearlyNotAssignedToADefinition" );
+				} )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.typeContext( TYPE_NAME )
+						.indexContext( INDEX_NAME )
+						.failure( "Unknown analyzer" )
 						.build() );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentModelDslIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentModelDslIT.java
@@ -477,6 +477,32 @@ public class DocumentModelDslIT {
 	}
 
 	@Test
+	public void searchAnalyzerWithoutAnalyzer() {
+		SubTest.expectException(
+				"Setting a search analyzer, without setting an analyzer on the same field",
+				() -> setup( ctx -> {
+					IndexSchemaElement root = ctx.getSchemaElement();
+					root.field(
+							"myField",
+							f -> f.asString()
+									.searchAnalyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD_ENGLISH.name )
+					)
+							.toReference();
+				} )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.typeContext( TYPE_NAME )
+						.indexContext( INDEX_NAME )
+						.failure(
+								"Cannot apply a search analyzer if an analyzer has not been defined on the same field",
+								"'" + DefaultAnalysisDefinitions.ANALYZER_STANDARD_ENGLISH.name + "'"
+						)
+						.build() );
+	}
+
+	@Test
 	public void missingGetReferenceCall() {
 		for ( Function<IndexFieldTypeFactory, StandardIndexFieldTypeOptionsStep<?, ?>> typedContextFunction : MAIN_TYPES ) {
 			SubTest.expectException(

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchSearchPredicateIT.java
@@ -781,28 +781,46 @@ public class MatchSearchPredicateIT {
 
 		String whitespaceAnalyzedField = indexMapping.whitespaceAnalyzedField.relativeFieldName;
 		String whitespaceLowercaseAnalyzedField = indexMapping.whitespaceLowercaseAnalyzedField.relativeFieldName;
+		String whitespaceLowercaseSearchAnalyzedField = indexMapping.whitespaceLowercaseSearchAnalyzedField.relativeFieldName;
 
+		// Terms are never lower-cased, neither at write nor at query time.
 		SearchQuery<DocumentReference> query = scope.query()
 				.predicate( f -> f.match().field( whitespaceAnalyzedField ).matching( "NEW WORLD" ) )
 				.toQuery();
-
 		assertThat( query )
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_2 );
 
+		// Terms are always lower-cased, both at write and at query time.
 		query = scope.query()
 				.predicate( f -> f.match().field( whitespaceLowercaseAnalyzedField ).matching( "NEW WORLD" ) )
 				.toQuery();
-
 		assertThat( query )
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
 
+		// Terms are lower-cased only at query time. Because we are overriding the analyzer in the predicate.
 		query = scope.query()
 				.predicate( f -> f.match().field( whitespaceAnalyzedField ).matching( "NEW WORLD" )
 						.analyzer( OverrideAnalysisDefinitions.ANALYZER_WHITESPACE_LOWERCASE.name ) )
 				.toQuery();
-
 		assertThat( query )
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
+
+		// Same here. Terms are lower-cased only at query time. Because we've defined a search analyzer.
+		query = scope.query()
+				.predicate( f -> f.match().field( whitespaceLowercaseSearchAnalyzedField ).matching( "NEW WORLD" ) )
+				.toQuery();
+		assertThat( query )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
+
+		// As for the first query, terms are never lower-cased, neither at write nor at query time.
+		// Because even if we've defined a search analyzer, we are overriding it with an analyzer in the predicate,
+		// since the overriding takes precedence over the search analyzer.
+		query = scope.query()
+				.predicate( f -> f.match().field( whitespaceLowercaseSearchAnalyzedField ).matching( "NEW WORLD" )
+						.analyzer( OverrideAnalysisDefinitions.ANALYZER_WHITESPACE.name ) )
+				.toQuery();
+		assertThat( query )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_2 );
 	}
 
 	@Test
@@ -811,28 +829,46 @@ public class MatchSearchPredicateIT {
 
 		String whitespaceAnalyzedField = indexMapping.whitespaceAnalyzedField.relativeFieldName;
 		String whitespaceLowercaseAnalyzedField = indexMapping.whitespaceLowercaseAnalyzedField.relativeFieldName;
+		String whitespaceLowercaseSearchAnalyzedField = indexMapping.whitespaceLowercaseSearchAnalyzedField.relativeFieldName;
 
+		// Terms are never lower-cased, neither at write nor at query time.
 		SearchQuery<DocumentReference> query = scope.query()
 				.predicate( f -> f.match().field( whitespaceAnalyzedField ).matching( "WORD" ).fuzzy() )
 				.toQuery();
-
 		assertThat( query )
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_2, DOCUMENT_3 );
 
+		// Terms are always lower-cased, both at write and at query time.
 		query = scope.query()
 				.predicate( f -> f.match().field( whitespaceLowercaseAnalyzedField ).matching( "WORD" ).fuzzy() )
 				.toQuery();
-
 		assertThat( query )
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
 
+		// Terms are lower-cased only at query time. Because we are overriding the analyzer in the predicate.
 		query = scope.query()
 				.predicate( f -> f.match().field( whitespaceAnalyzedField ).matching( "WORD" ).fuzzy()
 						.analyzer( OverrideAnalysisDefinitions.ANALYZER_WHITESPACE_LOWERCASE.name ) )
 				.toQuery();
-
 		assertThat( query )
 				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
+
+		// Same here. Terms are lower-cased only at query time. Because we've defined a search analyzer.
+		query = scope.query()
+				.predicate( f -> f.match().field( whitespaceLowercaseSearchAnalyzedField ).matching( "WORD" ).fuzzy() )
+				.toQuery();
+		assertThat( query )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
+
+		// As for the first query, terms are never lower-cased, neither at write nor at query time.
+		// Because even if we've defined a search analyzer, we are overriding it with an analyzer in the predicate,
+		// since the overriding takes precedence over the search analyzer.
+		query = scope.query()
+				.predicate( f -> f.match().field( whitespaceLowercaseSearchAnalyzedField ).matching( "WORD" ).fuzzy()
+						.analyzer( OverrideAnalysisDefinitions.ANALYZER_WHITESPACE.name ) )
+				.toQuery();
+		assertThat( query )
+				.hasDocRefHitsAnyOrder( INDEX_NAME, DOCUMENT_2, DOCUMENT_3 );
 	}
 
 	@Test
@@ -1349,6 +1385,7 @@ public class MatchSearchPredicateIT {
 			indexMapping.normalizedStringField.document1Value.write( document );
 			indexMapping.whitespaceAnalyzedField.document1Value.write( document );
 			indexMapping.whitespaceLowercaseAnalyzedField.document1Value.write( document );
+			indexMapping.whitespaceLowercaseSearchAnalyzedField.document1Value.write( document );
 			indexMapping.scaledBigDecimal.document1Value.write( document );
 		} );
 		plan.add( referenceProvider( DOCUMENT_2 ), document -> {
@@ -1365,6 +1402,7 @@ public class MatchSearchPredicateIT {
 			indexMapping.normalizedStringField.document2Value.write( document );
 			indexMapping.whitespaceAnalyzedField.document2Value.write( document );
 			indexMapping.whitespaceLowercaseAnalyzedField.document2Value.write( document );
+			indexMapping.whitespaceLowercaseSearchAnalyzedField.document2Value.write( document );
 			indexMapping.scaledBigDecimal.document2Value.write( document );
 		} );
 		plan.add( referenceProvider( EMPTY ), document -> { } );
@@ -1379,6 +1417,7 @@ public class MatchSearchPredicateIT {
 			indexMapping.normalizedStringField.document3Value.write( document );
 			indexMapping.whitespaceAnalyzedField.document3Value.write( document );
 			indexMapping.whitespaceLowercaseAnalyzedField.document3Value.write( document );
+			indexMapping.whitespaceLowercaseSearchAnalyzedField.document3Value.write( document );
 			indexMapping.scaledBigDecimal.document3Value.write( document );
 		} );
 		plan.execute().join();
@@ -1469,6 +1508,7 @@ public class MatchSearchPredicateIT {
 
 		final MainFieldModel<String> whitespaceAnalyzedField;
 		final MainFieldModel<String> whitespaceLowercaseAnalyzedField;
+		final MainFieldModel<String> whitespaceLowercaseSearchAnalyzedField;
 
 		final MainFieldModel<BigDecimal> scaledBigDecimal;
 
@@ -1546,6 +1586,12 @@ public class MatchSearchPredicateIT {
 					"brave new world", "BRAVE NEW WORLD", "BRave NeW WoRlD"
 			)
 					.map( root, "whitespaceLowercaseAnalyzed" );
+			whitespaceLowercaseSearchAnalyzedField = MainFieldModel.mapper(
+					c -> c.asString().analyzer( OverrideAnalysisDefinitions.ANALYZER_WHITESPACE.name )
+							.searchAnalyzer( OverrideAnalysisDefinitions.ANALYZER_WHITESPACE_LOWERCASE.name ),
+					"brave new world", "BRAVE NEW WORLD", "BRave NeW WoRlD"
+			)
+					.map( root, "whitespaceLowercaseSearchAnalyzed" );
 			scaledBigDecimal = MainFieldModel.mapper(
 					c -> c.asBigDecimal().decimalScale( 3 ),
 					new BigDecimal( "739.739" ), BigDecimal.ONE, BigDecimal.TEN

--- a/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/FullTextFieldIT.java
+++ b/integrationtest/mapper/pojo/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/FullTextFieldIT.java
@@ -47,6 +47,7 @@ public class FullTextFieldIT {
 
 	private static final String INDEX_NAME = "IndexName";
 	private static final String ANALYZER_NAME = "myAnalyzer";
+	private static final String SEARCH_ANALYZER_NAME = "mySearchAnalyzer";
 
 	@Rule
 	public BackendMock backendMock = new BackendMock( "stubBackend" );
@@ -225,6 +226,31 @@ public class FullTextFieldIT {
 				.field( "moreOptions", String.class, f -> f.analyzerName( ANALYZER_NAME ).termVector( TermVector.WITH_POSITIONS_OFFSETS ) )
 				.field( "useDefault", String.class, f -> f.analyzerName( ANALYZER_NAME ) )
 				.field( "implicit", String.class, f -> f.analyzerName( ANALYZER_NAME ) )
+		);
+		setupHelper.start().setup( IndexedEntity.class );
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void searchAnalyzer() {
+		@Indexed(index = INDEX_NAME)
+		class IndexedEntity	{
+			Integer id;
+			String text;
+
+			@DocumentId
+			public Integer getId() {
+				return id;
+			}
+
+			@FullTextField(analyzer = ANALYZER_NAME, searchAnalyzer = SEARCH_ANALYZER_NAME)
+			public String getText() {
+				return text;
+			}
+		}
+
+		backendMock.expectSchema( INDEX_NAME, b -> b
+				.field( "text", String.class, f -> f.analyzerName( ANALYZER_NAME ).searchAnalyzerName( SEARCH_ANALYZER_NAME ) )
 		);
 		setupHelper.start().setup( IndexedEntity.class );
 		backendMock.verifyExpectationsMet();

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/FullTextField.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/FullTextField.java
@@ -56,6 +56,15 @@ public @interface FullTextField {
 	String analyzer();
 
 	/**
+	 * @return A reference to a different analyzer, overriding the {@link #analyzer()},
+	 * to use for query parameters at search time.
+	 * If not defined, the same {@link #analyzer()} will be used.
+	 * <p>
+	 * As above, see the documentation of your backend to know how to define analyzers.
+	 */
+	String searchAnalyzer() default "";
+
+	/**
 	 * @return Whether index-time scoring information should be stored or not.
 	 * @see Norms
 	 */

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/impl/AnnotationProcessorProvider.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/impl/AnnotationProcessorProvider.java
@@ -347,6 +347,10 @@ class AnnotationProcessorProvider {
 			PropertyMappingFullTextFieldOptionsStep fieldContext = mappingContext.fullTextField( fieldName )
 					.analyzer( annotation.analyzer() );
 
+			if ( !annotation.searchAnalyzer().isEmpty() ) {
+				fieldContext.searchAnalyzer( annotation.searchAnalyzer() );
+			}
+
 			Norms norms = annotation.norms();
 			if ( !Norms.DEFAULT.equals( norms ) ) {
 				fieldContext.norms( norms );

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/PropertyMappingFullTextFieldOptionsStep.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/PropertyMappingFullTextFieldOptionsStep.java
@@ -25,6 +25,13 @@ public interface PropertyMappingFullTextFieldOptionsStep
 	PropertyMappingFullTextFieldOptionsStep analyzer(String analyzerName);
 
 	/**
+	 * @param searchAnalyzerName A reference to the analyzer to use for query parameters at search time.
+	 * @return {@code this}, for method chaining.
+	 * @see FullTextField#searchAnalyzer()
+	 */
+	PropertyMappingFullTextFieldOptionsStep searchAnalyzer(String searchAnalyzerName);
+
+	/**
 	 * @param norms Whether index time scoring information should be stored or not.
 	 * @return {@code this}, for method chaining.
 	 * @see FullTextField#norms()

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/PropertyMappingFullTextFieldOptionsStepImpl.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/PropertyMappingFullTextFieldOptionsStepImpl.java
@@ -43,6 +43,12 @@ class PropertyMappingFullTextFieldOptionsStepImpl
 	}
 
 	@Override
+	public PropertyMappingFullTextFieldOptionsStep searchAnalyzer(String searchAnalyzerName) {
+		fieldModelContributor.add( (c, b) -> c.searchAnalyzer( searchAnalyzerName ) );
+		return thisAsS();
+	}
+
+	@Override
 	public PropertyMappingFullTextFieldOptionsStep norms(Norms norms) {
 		fieldModelContributor.add( (c, b) -> c.norms( norms ) );
 		return thisAsS();

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/document/model/StubIndexSchemaNode.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/document/model/StubIndexSchemaNode.java
@@ -138,6 +138,11 @@ public final class StubIndexSchemaNode extends StubTreeNode<StubIndexSchemaNode>
 			return this;
 		}
 
+		public Builder searchAnalyzerName(String searchAnalyzerName) {
+			attribute( "searchAnalyzerName", searchAnalyzerName );
+			return this;
+		}
+
 		public Builder normalizerName(String normalizerName) {
 			attribute( "normalizerName", normalizerName );
 			return this;

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/types/dsl/impl/StubStringIndexFieldTypeOptionsStep.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/types/dsl/impl/StubStringIndexFieldTypeOptionsStep.java
@@ -30,6 +30,12 @@ class StubStringIndexFieldTypeOptionsStep
 	}
 
 	@Override
+	public StubStringIndexFieldTypeOptionsStep searchAnalyzer(String searchAnalyzerName) {
+		modifiers.add( b -> b.searchAnalyzerName( searchAnalyzerName ) );
+		return this;
+	}
+
+	@Override
 	public StubStringIndexFieldTypeOptionsStep normalizer(String normalizerName) {
 		modifiers.add( b -> b.normalizerName( normalizerName ) );
 		return this;


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3042

~~Preview because:~~
~~1. Still need a test using a `ANALYZER_NGRAM` ( common case for having a search analyzer )~~ done!
~~2. Try what happens if we try to override a normalizer instead...~~ done!
~~3. Still missing multi-indexes compatibility check tests~~ done!
~~4. Documentation~~ done!