### PR TITLE
HSEARCH-3714 + HSEARCH-3715 Restore temporary, SPI-only support for error handlers

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchBackendFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchBackendFactory.java
@@ -128,7 +128,8 @@ public class ElasticsearchBackendFactory implements BackendFactory {
 					typeFactoryProvider,
 					userFacingGson,
 					analysisDefinitionRegistry,
-					getMultiTenancyStrategy( name, propertySource )
+					getMultiTenancyStrategy( name, propertySource ),
+					buildContext.getErrorHandler()
 			);
 		}
 		catch (RuntimeException e) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchBackendImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchBackendImpl.java
@@ -29,7 +29,7 @@ import org.hibernate.search.engine.backend.spi.BackendImplementor;
 import org.hibernate.search.engine.backend.spi.BackendStartContext;
 import org.hibernate.search.engine.cfg.spi.ConfigurationPropertySource;
 import org.hibernate.search.engine.backend.spi.BackendBuildContext;
-import org.hibernate.search.engine.common.spi.LogErrorHandler;
+import org.hibernate.search.engine.common.spi.ErrorHandler;
 import org.hibernate.search.util.common.reporting.EventContext;
 import org.hibernate.search.engine.reporting.spi.EventContexts;
 import org.hibernate.search.util.common.impl.Closer;
@@ -67,15 +67,15 @@ class ElasticsearchBackendImpl implements BackendImplementor<ElasticsearchDocume
 			ElasticsearchIndexFieldTypeFactoryProvider typeFactoryProvider,
 			Gson userFacingGson,
 			ElasticsearchAnalysisDefinitionRegistry analysisDefinitionRegistry,
-			MultiTenancyStrategy multiTenancyStrategy) {
+			MultiTenancyStrategy multiTenancyStrategy,
+			ErrorHandler errorHandler) {
 		this.link = link;
 		this.name = name;
 
 		this.orchestratorProvider = new ElasticsearchWorkOrchestratorProvider(
 				"Elasticsearch parallel work orchestrator for backend " + name,
 				link,
-				// TODO the LogErrorHandler should be replaced with a user-configurable instance at some point. See HSEARCH-3110.
-				new LogErrorHandler()
+				errorHandler
 		);
 		this.analysisDefinitionRegistry = analysisDefinitionRegistry;
 		this.multiTenancyStrategy = multiTenancyStrategy;

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/impl/LuceneBackendFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/impl/LuceneBackendFactory.java
@@ -83,7 +83,8 @@ public class LuceneBackendFactory implements BackendFactory {
 				directoryProviderHolder,
 				new LuceneWorkFactoryImpl( multiTenancyStrategy ),
 				analysisDefinitionRegistry,
-				multiTenancyStrategy
+				multiTenancyStrategy,
+				buildContext.getErrorHandler()
 		);
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/impl/LuceneBackendImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/impl/LuceneBackendImpl.java
@@ -26,7 +26,7 @@ import org.hibernate.search.engine.backend.spi.BackendImplementor;
 import org.hibernate.search.engine.backend.spi.BackendStartContext;
 import org.hibernate.search.engine.cfg.spi.ConfigurationPropertySource;
 import org.hibernate.search.engine.backend.spi.BackendBuildContext;
-import org.hibernate.search.engine.common.spi.LogErrorHandler;
+import org.hibernate.search.engine.common.spi.ErrorHandler;
 import org.hibernate.search.engine.environment.bean.BeanHolder;
 import org.hibernate.search.util.common.reporting.EventContext;
 import org.hibernate.search.engine.reporting.spi.EventContexts;
@@ -53,7 +53,8 @@ public class LuceneBackendImpl implements BackendImplementor<LuceneRootDocumentB
 	LuceneBackendImpl(String name, BeanHolder<? extends DirectoryProvider> directoryProviderHolder,
 			LuceneWorkFactory workFactory,
 			LuceneAnalysisDefinitionRegistry analysisDefinitionRegistry,
-			MultiTenancyStrategy multiTenancyStrategy) {
+			MultiTenancyStrategy multiTenancyStrategy,
+			ErrorHandler errorHandler) {
 		this.name = name;
 		this.directoryProviderHolder = directoryProviderHolder;
 
@@ -69,8 +70,7 @@ public class LuceneBackendImpl implements BackendImplementor<LuceneRootDocumentB
 				eventContext, directoryProviderHolder.get(),
 				workFactory, multiTenancyStrategy,
 				analysisDefinitionRegistry,
-				// TODO the LogErrorHandler should be replaced with a user-configurable instance at some point. See HSEARCH-3110.
-				new LogErrorHandler(),
+				errorHandler,
 				readOrchestrator
 		);
 	}

--- a/documentation/src/main/asciidoc/mapper-orm-indexing-massindexer.asciidoc
+++ b/documentation/src/main/asciidoc/mapper-orm-indexing-massindexer.asciidoc
@@ -180,6 +180,19 @@ should not cause any problem.
 value to avoid loading too many entities accidentally. The value defined must be greater than 0.
 The parameter is not used by default. It is equivalent to keyword `LIMIT` in SQL.
 
+|`monitor(MassIndexingMonitor)`
+|A logging monitor.
+|
+The component responsible for monitoring progress of mass indexing.
++
+As a `MassIndexer` can take some time to finish its job,
+it is often necessary to monitor its progress.
+The default, built-in monitor logs progress periodically at the `INFO` level,
+but a custom monitor can be set by implementing the `MassIndexingMonitor` interface
+and passing an instance using the `monitor` method.
++
+Implementations of `MassIndexingMonitor` must be threadsafe.
+
 |===
 
 [[mapper-orm-indexing-massindexer-tuning]]

--- a/engine/src/main/java/org/hibernate/search/engine/backend/spi/BackendBuildContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/spi/BackendBuildContext.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.engine.backend.spi;
 
+import org.hibernate.search.engine.common.spi.ErrorHandler;
 import org.hibernate.search.engine.environment.bean.BeanResolver;
 import org.hibernate.search.engine.environment.classpath.spi.ClassResolver;
 import org.hibernate.search.engine.environment.classpath.spi.ResourceResolver;
@@ -20,5 +21,7 @@ public interface BackendBuildContext {
 	ResourceResolver getResourceResolver();
 
 	BeanResolver getBeanResolver();
+
+	ErrorHandler getErrorHandler();
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/cfg/spi/EngineSpiSettings.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/spi/EngineSpiSettings.java
@@ -9,6 +9,8 @@ package org.hibernate.search.engine.cfg.spi;
 import java.util.Collections;
 import java.util.List;
 
+import org.hibernate.search.engine.common.spi.ErrorHandler;
+import org.hibernate.search.engine.common.spi.LogErrorHandler;
 import org.hibernate.search.engine.environment.bean.BeanReference;
 import org.hibernate.search.engine.environment.bean.spi.BeanConfigurer;
 
@@ -33,6 +35,15 @@ public class EngineSpiSettings {
 	public static final String BEAN_CONFIGURERS = "bean_configurers";
 
 	/**
+	 * The {@link org.hibernate.search.engine.common.spi.ErrorHandler} instance to use at runtime.
+	 * <p>
+	 * Expects a reference to a bean of type {@link org.hibernate.search.engine.common.spi.ErrorHandler}.
+	 * <p>
+	 * Defaults to a logging handler.
+	 */
+	public static final String ERROR_HANDLER = "error_handler";
+
+	/**
 	 * Default values for the different settings if no values are given.
 	 */
 	public static final class Defaults {
@@ -41,5 +52,7 @@ public class EngineSpiSettings {
 		}
 
 		public static final List<BeanReference<? extends BeanConfigurer>> BEAN_CONFIGURERS = Collections.emptyList();
+
+		public static final BeanReference<? extends ErrorHandler> ERROR_HANDLER = BeanReference.of( LogErrorHandler.class );
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/DelegatingBuildContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/DelegatingBuildContext.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.engine.common.impl;
 
 import org.hibernate.search.engine.cfg.spi.ConfigurationPropertySource;
+import org.hibernate.search.engine.common.spi.ErrorHandler;
 import org.hibernate.search.engine.environment.bean.BeanResolver;
 import org.hibernate.search.engine.environment.classpath.spi.ClassResolver;
 import org.hibernate.search.engine.environment.classpath.spi.ResourceResolver;
@@ -33,5 +34,9 @@ class DelegatingBuildContext {
 
 	public ConfigurationPropertySource getConfigurationPropertySource() {
 		return delegate.getConfigurationPropertySource();
+	}
+
+	public ErrorHandler getErrorHandler() {
+		return delegate.getErrorHandler();
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/RootBuildContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/RootBuildContext.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.engine.common.impl;
 
 import org.hibernate.search.engine.cfg.spi.ConfigurationPropertySource;
+import org.hibernate.search.engine.common.spi.ErrorHandler;
 import org.hibernate.search.engine.environment.bean.BeanResolver;
 import org.hibernate.search.engine.environment.classpath.spi.ClassResolver;
 import org.hibernate.search.engine.environment.classpath.spi.ResourceResolver;
@@ -21,15 +22,23 @@ class RootBuildContext {
 	private final BeanResolver beanResolver;
 
 	private final FailureCollector failureCollector;
+	private final ErrorHandler errorHandler;
 
 	RootBuildContext(ConfigurationPropertySource propertySource,
 			ClassResolver classResolver, ResourceResolver resourceResolver,
-			BeanResolver beanResolver, FailureCollector failureCollector) {
+			BeanResolver beanResolver,
+			FailureCollector failureCollector,
+			ErrorHandler errorHandler) {
 		this.propertySource = propertySource;
 		this.classResolver = classResolver;
 		this.resourceResolver = resourceResolver;
 		this.beanResolver = beanResolver;
 		this.failureCollector = failureCollector;
+		this.errorHandler = errorHandler;
+	}
+
+	ConfigurationPropertySource getConfigurationPropertySource() {
+		return propertySource;
 	}
 
 	ClassResolver getClassResolver() {
@@ -48,7 +57,7 @@ class RootBuildContext {
 		return failureCollector;
 	}
 
-	ConfigurationPropertySource getConfigurationPropertySource() {
-		return propertySource;
+	ErrorHandler getErrorHandler() {
+		return errorHandler;
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/SearchIntegrationBuilderImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/SearchIntegrationBuilderImpl.java
@@ -22,6 +22,8 @@ import java.util.stream.Stream;
 
 import org.hibernate.search.engine.cfg.spi.ConfigurationPropertyChecker;
 import org.hibernate.search.engine.cfg.spi.ConfigurationPropertySource;
+import org.hibernate.search.engine.common.spi.ErrorHandler;
+import org.hibernate.search.engine.common.spi.LogErrorHandler;
 import org.hibernate.search.engine.common.spi.SearchIntegrationBuilder;
 import org.hibernate.search.engine.common.spi.SearchIntegrationPartialBuildState;
 import org.hibernate.search.engine.environment.bean.BeanResolver;
@@ -158,10 +160,11 @@ public class SearchIntegrationBuilderImpl implements SearchIntegrationBuilder {
 			}
 
 			BeanResolver beanResolver = new ConfiguredBeanResolver( serviceResolver, beanProvider, propertySource );
+			ErrorHandler errorHandler = new LogErrorHandler();
 			RootBuildContext rootBuildContext = new RootBuildContext(
 					propertySource,
 					classResolver, resourceResolver, beanResolver,
-					failureCollector
+					failureCollector, errorHandler
 			);
 
 			indexManagerBuildingStateHolder = new IndexManagerBuildingStateHolder( beanResolver, propertySource, rootBuildContext );

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/SearchIntegrationImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/SearchIntegrationImpl.java
@@ -13,7 +13,9 @@ import org.hibernate.search.engine.backend.Backend;
 import org.hibernate.search.engine.backend.index.IndexManager;
 import org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor;
 import org.hibernate.search.engine.backend.spi.BackendImplementor;
+import org.hibernate.search.engine.common.spi.ErrorHandler;
 import org.hibernate.search.engine.common.spi.SearchIntegration;
+import org.hibernate.search.engine.environment.bean.BeanHolder;
 import org.hibernate.search.engine.environment.bean.spi.BeanProvider;
 import org.hibernate.search.engine.logging.impl.Log;
 import org.hibernate.search.engine.mapper.mapping.spi.MappingImplementor;
@@ -26,16 +28,19 @@ public class SearchIntegrationImpl implements SearchIntegration {
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private final BeanProvider beanProvider;
+	private final BeanHolder<? extends ErrorHandler> errorHandlerHolder;
 
 	private final Map<MappingKey<?, ?>, MappingImplementor<?>> mappings;
 	private final Map<String, BackendImplementor<?>> backends;
 	private final Map<String, IndexManagerImplementor<?>> indexManagers;
 
 	SearchIntegrationImpl(BeanProvider beanProvider,
+			BeanHolder<? extends ErrorHandler> errorHandlerHolder,
 			Map<MappingKey<?, ?>, MappingImplementor<?>> mappings,
 			Map<String, BackendImplementor<?>> backends,
 			Map<String, IndexManagerImplementor<?>> indexManagers) {
 		this.beanProvider = beanProvider;
+		this.errorHandlerHolder = errorHandlerHolder;
 		this.mappings = mappings;
 		this.backends = backends;
 		this.indexManagers = indexManagers;
@@ -76,6 +81,7 @@ public class SearchIntegrationImpl implements SearchIntegration {
 			closer.pushAll( MappingImplementor::close, mappings.values() );
 			closer.pushAll( IndexManagerImplementor::close, indexManagers.values() );
 			closer.pushAll( BackendImplementor::close, backends.values() );
+			closer.pushAll( BeanHolder::close, errorHandlerHolder );
 			closer.pushAll( BeanProvider::close, beanProvider );
 		}
 	}

--- a/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/spi/MappingBuildContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/spi/MappingBuildContext.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.engine.mapper.mapping.spi;
 
 import org.hibernate.search.engine.cfg.spi.ConfigurationPropertySource;
+import org.hibernate.search.engine.common.spi.ErrorHandler;
 import org.hibernate.search.engine.environment.bean.BeanResolver;
 import org.hibernate.search.engine.environment.classpath.spi.ClassResolver;
 import org.hibernate.search.engine.environment.classpath.spi.ResourceResolver;
@@ -39,6 +40,8 @@ public interface MappingBuildContext {
 	 * @return A failure collector.
 	 */
 	ContextualFailureCollector getFailureCollector();
+
+	ErrorHandler getErrorHandler();
 
 	ConfigurationPropertySource getConfigurationPropertySource();
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingErrorHandlerIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingErrorHandlerIT.java
@@ -1,0 +1,275 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.orm.massindexing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
+
+import java.util.concurrent.CompletableFuture;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
+import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
+import org.hibernate.search.engine.cfg.spi.EngineSpiSettings;
+import org.hibernate.search.engine.common.spi.ErrorContext;
+import org.hibernate.search.engine.common.spi.ErrorHandler;
+import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.orm.automaticindexing.AutomaticIndexingStrategyName;
+import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
+import org.hibernate.search.mapper.orm.massindexing.MassIndexer;
+import org.hibernate.search.mapper.orm.session.SearchSession;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.integrationtest.orm.OrmSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.orm.OrmUtils;
+import org.hibernate.search.util.impl.test.ExceptionMatcherBuilder;
+import org.hibernate.search.util.impl.test.rule.ExpectedLog4jLog;
+import org.hibernate.search.util.impl.test.rule.StaticCounters;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.apache.log4j.Level;
+
+public class MassIndexingErrorHandlerIT {
+
+	public static final String TITLE_1 = "Oliver Twist";
+	public static final String AUTHOR_1 = "Charles Dickens";
+	public static final String TITLE_2 = "Ulysses";
+	public static final String AUTHOR_2 = "James Joyce";
+	public static final String TITLE_3 = "Frankenstein";
+	public static final String AUTHOR_3 = "Mary Shelley";
+
+	@Rule
+	public BackendMock backendMock = new BackendMock( "stubBackend" );
+
+	@Rule
+	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+
+	@Rule
+	public ExpectedLog4jLog log = ExpectedLog4jLog.create();
+
+	@Rule
+	public StaticCounters staticCounters = new StaticCounters();
+
+	@Test
+	public void defaultHandler() {
+		SessionFactory sessionFactory = setup( null );
+
+		OrmUtils.withinSession( sessionFactory, session -> {
+			SearchSession searchSession = Search.session( session );
+			MassIndexer indexer = searchSession.massIndexer();
+
+			CompletableFuture<?> indexingFuture = new CompletableFuture<>();
+			indexingFuture.completeExceptionally( new SimulatedFailure( "Indexing error" ) );
+
+			// add operations on indexes can follow any random order,
+			// since they are executed by different threads
+			backendMock.expectWorksAnyOrder(
+					Book.INDEX, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE
+			)
+					.add( "1", b -> b
+							.field( "title", TITLE_1 )
+							.field( "author", AUTHOR_1 )
+					)
+					.add( "3", b -> b
+							.field( "title", TITLE_3 )
+							.field( "author", AUTHOR_3 )
+					)
+					.processedThenExecuted();
+			backendMock.expectWorksAnyOrder(
+					Book.INDEX, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE
+			)
+					.add( "2", b -> b
+							.field( "title", TITLE_2 )
+							.field( "author", AUTHOR_2 )
+					)
+					.processedThenExecuted( indexingFuture );
+
+			// purgeAtStart, optimizeAfterPurge and purgeAtStart flags are active by default,
+			// so we expect 1 purge, 2 optimize and 1 flush calls in this order:
+			backendMock.expectIndexScopeWorks( Book.INDEX, session.getTenantIdentifier() )
+					.purge()
+					.optimize()
+					.optimize()
+					.flush();
+
+			log.expectEvent(
+					Level.ERROR,
+					ExceptionMatcherBuilder.isException( SimulatedFailure.class )
+							.withMessage( "Indexing error" )
+							.build(),
+					"Unable to index instance of type " + Book.class.getName()
+			)
+					.once();
+
+			try {
+				indexer.startAndWait();
+			}
+			catch (InterruptedException e) {
+				fail( "Unexpected InterruptedException: " + e.getMessage() );
+			}
+
+		} );
+
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void custom() {
+		assertThat( staticCounters.get( CountingErrorHandler.CREATE ) ).isEqualTo( 0 );
+		assertThat( staticCounters.get( CountingErrorHandler.HANDLE_CONTEXT ) ).isEqualTo( 0 );
+		assertThat( staticCounters.get( CountingErrorHandler.HANDLE_EXCEPTION ) ).isEqualTo( 0 );
+
+		SessionFactory sessionFactory = setup( CountingErrorHandler.class.getName() );
+
+		assertThat( staticCounters.get( CountingErrorHandler.CREATE ) ).isEqualTo( 1 );
+		assertThat( staticCounters.get( CountingErrorHandler.HANDLE_CONTEXT ) ).isEqualTo( 0 );
+		assertThat( staticCounters.get( CountingErrorHandler.HANDLE_EXCEPTION ) ).isEqualTo( 0 );
+
+		OrmUtils.withinSession( sessionFactory, session -> {
+			SearchSession searchSession = Search.session( session );
+			MassIndexer indexer = searchSession.massIndexer();
+
+			CompletableFuture<?> indexingFuture = new CompletableFuture<>();
+			indexingFuture.completeExceptionally( new SimulatedFailure( "Indexing error" ) );
+
+			// add operations on indexes can follow any random order,
+			// since they are executed by different threads
+			backendMock.expectWorksAnyOrder(
+					Book.INDEX, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE
+			)
+					.add( "1", b -> b
+							.field( "title", TITLE_1 )
+							.field( "author", AUTHOR_1 )
+					)
+					.add( "3", b -> b
+							.field( "title", TITLE_3 )
+							.field( "author", AUTHOR_3 )
+					)
+					.processedThenExecuted();
+			backendMock.expectWorksAnyOrder(
+					Book.INDEX, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE
+			)
+					.add( "2", b -> b
+							.field( "title", TITLE_2 )
+							.field( "author", AUTHOR_2 )
+					)
+					.processedThenExecuted( indexingFuture );
+
+			// purgeAtStart, optimizeAfterPurge and purgeAtStart flags are active by default,
+			// so we expect 1 purge, 2 optimize and 1 flush calls in this order:
+			backendMock.expectIndexScopeWorks( Book.INDEX, session.getTenantIdentifier() )
+					.purge()
+					.optimize()
+					.optimize()
+					.flush();
+
+			try {
+				indexer.startAndWait();
+			}
+			catch (InterruptedException e) {
+				fail( "Unexpected InterruptedException: " + e.getMessage() );
+			}
+
+		} );
+
+		backendMock.verifyExpectationsMet();
+
+		assertThat( staticCounters.get( CountingErrorHandler.CREATE ) ).isEqualTo( 1 );
+		assertThat( staticCounters.get( CountingErrorHandler.HANDLE_CONTEXT ) ).isEqualTo( 0 );
+		assertThat( staticCounters.get( CountingErrorHandler.HANDLE_EXCEPTION ) ).isEqualTo( 1 );
+	}
+
+	private SessionFactory setup(String errorHandler) {
+		backendMock.expectAnySchema( Book.INDEX );
+
+		SessionFactory sessionFactory = ormSetupHelper.start()
+				.withPropertyRadical( HibernateOrmMapperSettings.Radicals.AUTOMATIC_INDEXING_STRATEGY, AutomaticIndexingStrategyName.NONE )
+				.withPropertyRadical( EngineSpiSettings.ERROR_HANDLER, errorHandler )
+				.setup( Book.class );
+
+		backendMock.verifyExpectationsMet();
+
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			session.persist( new Book( 1, TITLE_1, AUTHOR_1 ) );
+			session.persist( new Book( 2, TITLE_2, AUTHOR_2 ) );
+			session.persist( new Book( 3, TITLE_3, AUTHOR_3 ) );
+		} );
+
+		return sessionFactory;
+	}
+
+	@Entity
+	@Table(name = "book")
+	@Indexed(index = Book.INDEX)
+	public static class Book {
+
+		public static final String INDEX = "Book";
+
+		@Id
+		private Integer id;
+
+		@GenericField
+		private String title;
+
+		@GenericField
+		private String author;
+
+		public Book() {
+		}
+
+		public Book(Integer id, String title, String author) {
+			this.id = id;
+			this.title = title;
+			this.author = author;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public String getTitle() {
+			return title;
+		}
+
+		public String getAuthor() {
+			return author;
+		}
+	}
+
+	public static class CountingErrorHandler implements ErrorHandler {
+
+		public static StaticCounters.Key CREATE = StaticCounters.createKey();
+		public static StaticCounters.Key HANDLE_CONTEXT = StaticCounters.createKey();
+		public static StaticCounters.Key HANDLE_EXCEPTION = StaticCounters.createKey();
+
+		public CountingErrorHandler() {
+			StaticCounters.get().increment( CREATE );
+		}
+
+		@Override
+		public void handle(ErrorContext context) {
+			StaticCounters.get().increment( HANDLE_CONTEXT );
+		}
+
+		@Override
+		public void handleException(String errorMsg, Throwable exception) {
+			StaticCounters.get().increment( HANDLE_EXCEPTION );
+		}
+	}
+
+	private static class SimulatedFailure extends RuntimeException {
+		SimulatedFailure(String message) {
+			super( message );
+		}
+	}
+}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingMonitorIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingMonitorIT.java
@@ -1,0 +1,211 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.orm.massindexing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
+
+import java.util.concurrent.CompletableFuture;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
+import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
+import org.hibernate.search.engine.cfg.spi.EngineSpiSettings;
+import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.orm.automaticindexing.AutomaticIndexingStrategyName;
+import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
+import org.hibernate.search.mapper.orm.massindexing.MassIndexer;
+import org.hibernate.search.mapper.orm.massindexing.monitor.MassIndexingMonitor;
+import org.hibernate.search.mapper.orm.session.SearchSession;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.integrationtest.orm.OrmSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.orm.OrmUtils;
+import org.hibernate.search.util.impl.test.rule.StaticCounters;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+public class MassIndexingMonitorIT {
+
+	public static final String TITLE_1 = "Oliver Twist";
+	public static final String AUTHOR_1 = "Charles Dickens";
+	public static final String TITLE_2 = "Ulysses";
+	public static final String AUTHOR_2 = "James Joyce";
+	public static final String TITLE_3 = "Frankenstein";
+	public static final String AUTHOR_3 = "Mary Shelley";
+
+	@Rule
+	public BackendMock backendMock = new BackendMock( "stubBackend" );
+
+	@Rule
+	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+
+	@Rule
+	public StaticCounters staticCounters = new StaticCounters();
+
+	@Test
+	public void simple() {
+		SessionFactory sessionFactory = setup( null );
+
+		OrmUtils.withinSession( sessionFactory, session -> {
+			SearchSession searchSession = Search.session( session );
+			MassIndexer indexer = searchSession.massIndexer();
+
+			CompletableFuture<?> indexingFuture = new CompletableFuture<>();
+			indexingFuture.completeExceptionally( new SimulatedFailure( "Indexing error" ) );
+
+			// add operations on indexes can follow any random order,
+			// since they are executed by different threads
+			backendMock.expectWorksAnyOrder(
+					Book.INDEX, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE
+			)
+					.add( "1", b -> b
+							.field( "title", TITLE_1 )
+							.field( "author", AUTHOR_1 )
+					)
+					.add( "3", b -> b
+							.field( "title", TITLE_3 )
+							.field( "author", AUTHOR_3 )
+					)
+					.processedThenExecuted();
+			backendMock.expectWorksAnyOrder(
+					Book.INDEX, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE
+			)
+					.add( "2", b -> b
+							.field( "title", TITLE_2 )
+							.field( "author", AUTHOR_2 )
+					)
+					.processedThenExecuted( indexingFuture );
+
+			// purgeAtStart, optimizeAfterPurge and purgeAtStart flags are active by default,
+			// so we expect 1 purge, 2 optimize and 1 flush calls in this order:
+			backendMock.expectIndexScopeWorks( Book.INDEX, session.getTenantIdentifier() )
+					.purge()
+					.optimize()
+					.optimize()
+					.flush();
+
+			try {
+				indexer.monitor( new StaticCountersMonitor() )
+						.startAndWait();
+			}
+			catch (InterruptedException e) {
+				fail( "Unexpected InterruptedException: " + e.getMessage() );
+			}
+		} );
+
+		backendMock.verifyExpectationsMet();
+
+		assertThat( staticCounters.get( StaticCountersMonitor.LOADED ) ).isEqualTo( 3 );
+		assertThat( staticCounters.get( StaticCountersMonitor.BUILT ) ).isEqualTo( 3 );
+		assertThat( staticCounters.get( StaticCountersMonitor.ADDED ) ).isEqualTo( 2 );
+		assertThat( staticCounters.get( StaticCountersMonitor.TOTAL ) ).isEqualTo( 3 );
+		assertThat( staticCounters.get( StaticCountersMonitor.INDEXING_COMPLETED ) ).isEqualTo( 1 );
+	}
+
+	private SessionFactory setup(String errorHandler) {
+		backendMock.expectAnySchema( Book.INDEX );
+
+		SessionFactory sessionFactory = ormSetupHelper.start()
+				.withPropertyRadical( HibernateOrmMapperSettings.Radicals.AUTOMATIC_INDEXING_STRATEGY, AutomaticIndexingStrategyName.NONE )
+				.withPropertyRadical( EngineSpiSettings.ERROR_HANDLER, errorHandler )
+				.setup( Book.class );
+
+		backendMock.verifyExpectationsMet();
+
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			session.persist( new Book( 1, TITLE_1, AUTHOR_1 ) );
+			session.persist( new Book( 2, TITLE_2, AUTHOR_2 ) );
+			session.persist( new Book( 3, TITLE_3, AUTHOR_3 ) );
+		} );
+
+		return sessionFactory;
+	}
+
+	@Entity
+	@Table(name = "book")
+	@Indexed(index = Book.INDEX)
+	public static class Book {
+
+		public static final String INDEX = "Book";
+
+		@Id
+		private Integer id;
+
+		@GenericField
+		private String title;
+
+		@GenericField
+		private String author;
+
+		public Book() {
+		}
+
+		public Book(Integer id, String title, String author) {
+			this.id = id;
+			this.title = title;
+			this.author = author;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public String getTitle() {
+			return title;
+		}
+
+		public String getAuthor() {
+			return author;
+		}
+	}
+
+	public static class StaticCountersMonitor implements MassIndexingMonitor {
+
+		public static StaticCounters.Key ADDED = StaticCounters.createKey();
+		public static StaticCounters.Key BUILT = StaticCounters.createKey();
+		public static StaticCounters.Key LOADED = StaticCounters.createKey();
+		public static StaticCounters.Key TOTAL = StaticCounters.createKey();
+		public static StaticCounters.Key INDEXING_COMPLETED = StaticCounters.createKey();
+
+		@Override
+		public void documentsAdded(long increment) {
+			StaticCounters.get().add( ADDED, (int) increment );
+		}
+
+		@Override
+		public void documentsBuilt(long increment) {
+			StaticCounters.get().add( BUILT, (int) increment );
+		}
+
+		@Override
+		public void entitiesLoaded(long increment) {
+			StaticCounters.get().add( LOADED, (int) increment );
+		}
+
+		@Override
+		public void addToTotalCount(long increment) {
+			StaticCounters.get().add( TOTAL, (int) increment );
+		}
+
+		@Override
+		public void indexingCompleted() {
+			StaticCounters.get().increment( INDEXING_COMPLETED );
+		}
+	}
+
+	private static class SimulatedFailure extends RuntimeException {
+		SimulatedFailure(String message) {
+			super( message );
+		}
+	}
+}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMapping.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMapping.java
@@ -19,6 +19,7 @@ import org.hibernate.search.engine.backend.session.spi.DetachedBackendSessionCon
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.cfg.spi.ConfigurationProperty;
 import org.hibernate.search.engine.cfg.spi.ConfigurationPropertySource;
+import org.hibernate.search.engine.common.spi.ErrorHandler;
 import org.hibernate.search.engine.mapper.mapping.spi.MappingImplementor;
 import org.hibernate.search.mapper.orm.automaticindexing.AutomaticIndexingSynchronizationStrategyName;
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
@@ -168,6 +169,11 @@ public class HibernateOrmMapping extends AbstractPojoMappingImplementor<Hibernat
 	@Override
 	public SessionFactoryImplementor getSessionFactory() {
 		return backendMappingContext.getSessionFactory();
+	}
+
+	@Override
+	public ErrorHandler getErrorHandler() {
+		return getDelegate().getErrorHandler();
 	}
 
 	@Override

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/MassIndexer.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/MassIndexer.java
@@ -9,6 +9,7 @@ package org.hibernate.search.mapper.orm.massindexing;
 import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.CacheMode;
+import org.hibernate.search.mapper.orm.massindexing.monitor.MassIndexingMonitor;
 
 /**
  * A MassIndexer is useful to rebuild the indexes from the
@@ -126,4 +127,14 @@ public interface MassIndexer {
 	 * @return {@code this} for method chaining
 	 */
 	MassIndexer transactionTimeout(int timeoutInSeconds);
+
+	/**
+	 * Set the {@link MassIndexingMonitor}.
+	 * <p>
+	 * The default monitor just logs the progress.
+	 *
+	 * @param monitor The monitor that will track mass indexing progress.
+	 * @return {@code this} for method chaining
+	 */
+	MassIndexer monitor(MassIndexingMonitor monitor);
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/BatchCoordinator.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/BatchCoordinator.java
@@ -60,8 +60,10 @@ public class BatchCoordinator extends ErrorHandledRunnable {
 			Set<Class<?>> rootEntities, PojoScopeWorkspace scopeWorkspace,
 			int typesToIndexInParallel, int documentBuilderThreads, CacheMode cacheMode,
 			int objectLoadingBatchSize, long objectsLimit, boolean optimizeAtEnd,
-			boolean purgeAtStart, boolean optimizeAfterPurge, MassIndexingMonitor monitor,
+			boolean purgeAtStart, boolean optimizeAfterPurge,
+			MassIndexingMonitor monitor,
 			int idFetchSize, Integer transactionTimeout) {
+		super( mappingContext.getErrorHandler() );
 		this.mappingContext = mappingContext;
 		this.sessionContext = sessionContext;
 		this.rootEntities = rootEntities;
@@ -136,7 +138,8 @@ public class BatchCoordinator extends ErrorHandledRunnable {
 				indexedType, idAttributeOfIndexedType,
 				documentBuilderThreads, cacheMode,
 				objectLoadingBatchSize, endAllSignal,
-				monitor, objectsLimit, idFetchSize, transactionTimeout
+				monitor, getErrorHandler(),
+				objectsLimit, idFetchSize, transactionTimeout
 		);
 	}
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/ErrorHandledRunnable.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/ErrorHandledRunnable.java
@@ -8,6 +8,7 @@ package org.hibernate.search.mapper.orm.massindexing.impl;
 
 import java.lang.invoke.MethodHandles;
 
+import org.hibernate.search.engine.common.spi.ErrorHandler;
 import org.hibernate.search.mapper.orm.logging.impl.Log;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
@@ -19,12 +20,14 @@ abstract class ErrorHandledRunnable implements Runnable {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	protected ErrorHandledRunnable() {
+	private final ErrorHandler errorHandler;
+
+	protected ErrorHandledRunnable(ErrorHandler errorHandler) {
+		this.errorHandler = errorHandler;
 	}
 
 	@Override
 	public final void run() {
-		// TODO HSEARCH-3110 extract error handler instance from work plan
 		try {
 			runWithErrorHandler();
 		}
@@ -39,14 +42,15 @@ abstract class ErrorHandledRunnable implements Runnable {
 			// being this an async thread we want to make sure everything is somehow reported
 			String errorMessage = log.massIndexerUnexpectedErrorMessage();
 
-			// TODO HSEARCH-3110 handle it with a exception handler
-			// errorHandler.handleException( errorMessage , re );
-			// temporary re-throwing a runtime exception
-			throw new RuntimeException( errorMessage, re );
+			errorHandler.handleException( errorMessage , re );
 		}
 	}
 
 	protected abstract void runWithErrorHandler() throws Exception;
+
+	protected ErrorHandler getErrorHandler() {
+		return errorHandler;
+	}
 
 	protected void cleanUpOnError() {
 		//no-op unless overridden

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/HibernateOrmMassIndexingMappingContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/HibernateOrmMassIndexingMappingContext.java
@@ -9,11 +9,14 @@ package org.hibernate.search.mapper.orm.massindexing.impl;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
+import org.hibernate.search.engine.common.spi.ErrorHandler;
 import org.hibernate.search.mapper.pojo.work.spi.PojoIndexer;
 
 public interface HibernateOrmMassIndexingMappingContext {
 
 	SessionFactoryImplementor getSessionFactory();
+
+	ErrorHandler getErrorHandler();
 
 	PojoIndexer createIndexer(SessionImplementor sessionImplementor,
 			DocumentCommitStrategy commitStrategy);

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/IdentifierConsumerDocumentProducer.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/IdentifierConsumerDocumentProducer.java
@@ -238,9 +238,8 @@ public class IdentifierConsumerDocumentProducer<E, I> implements Runnable {
 	private void handleException(Object entity, Throwable e) {
 		String errorMsg = log.massIndexerUnableToIndexInstance( entity.getClass().getName(), entity.toString() );
 
-		// TODO HSEARCH-3110 implements exception handler
-		// errorHandler.handleException( errorMsg, e );
-		// temporary re-throw the exception
+		errorHandler.handleException( errorMsg, e );
+		temporary re-throw the exception
 		throw new RuntimeException( errorMsg, e );
 	}
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/IdentifierConsumerDocumentProducer.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/IdentifierConsumerDocumentProducer.java
@@ -229,11 +229,7 @@ public class IdentifierConsumerDocumentProducer<E, I> implements Runnable {
 			throw new InterruptedException();
 		}
 
-		CompletableFuture<?> future = Futures.create( () -> indexer.add( entity )
-				.exceptionally( exception -> {
-					handleException( entity, exception );
-					return null;
-				} ) );
+		CompletableFuture<?> future = Futures.create( () -> indexer.add( entity ) );
 
 		monitor.documentsBuilt( 1 );
 		return future;

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/MassIndexerImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/MassIndexerImpl.java
@@ -176,7 +176,8 @@ public class MassIndexerImpl implements MassIndexer {
 				typesToIndexInParallel, documentBuilderThreads,
 				cacheMode, objectLoadingBatchSize, objectsLimit,
 				optimizeAtEnd, purgeAtStart, optimizeAfterPurge,
-				monitor, idFetchSize, idLoadingTransactionTimeout
+				monitor,
+				idFetchSize, idLoadingTransactionTimeout
 		);
 	}
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/MassIndexerImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/MassIndexerImpl.java
@@ -60,9 +60,6 @@ public class MassIndexerImpl implements MassIndexer {
 		this.sessionContext = sessionContext;
 		this.rootEntities = toRootEntities( targetedIndexedTypes );
 		this.scopeWorkspace = scopeWorkspace;
-
-		// TODO HSEARCH-3057 use a JMX monitor if JMX is enabled (see Search 5)
-		this.monitor = new SimpleIndexingProgressMonitor();
 	}
 
 	/*
@@ -156,6 +153,12 @@ public class MassIndexerImpl implements MassIndexer {
 	}
 
 	@Override
+	public MassIndexer monitor(MassIndexingMonitor monitor) {
+		this.monitor = monitor;
+		return this;
+	}
+
+	@Override
 	public CompletableFuture<?> start() {
 		return CompletableFuture.runAsync( createCoordinator() );
 	}
@@ -176,7 +179,7 @@ public class MassIndexerImpl implements MassIndexer {
 				typesToIndexInParallel, documentBuilderThreads,
 				cacheMode, objectLoadingBatchSize, objectsLimit,
 				optimizeAtEnd, purgeAtStart, optimizeAfterPurge,
-				monitor,
+				getOrCreateMonitor(),
 				idFetchSize, idLoadingTransactionTimeout
 		);
 	}
@@ -193,5 +196,14 @@ public class MassIndexerImpl implements MassIndexer {
 		// as special values which might be useful.
 		this.idFetchSize = idFetchSize;
 		return this;
+	}
+
+	private MassIndexingMonitor getOrCreateMonitor() {
+		if ( monitor != null ) {
+			return monitor;
+		}
+
+		// TODO HSEARCH-3057 use a JMX monitor if JMX is enabled (see Search 5)
+		return new SimpleIndexingProgressMonitor();
 	}
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/OptionallyWrapInJTATransaction.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/OptionallyWrapInJTATransaction.java
@@ -10,6 +10,7 @@ import java.lang.invoke.MethodHandles;
 import javax.transaction.SystemException;
 
 import org.hibernate.StatelessSession;
+import org.hibernate.search.engine.common.spi.ErrorHandler;
 import org.hibernate.search.mapper.orm.logging.impl.Log;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
@@ -28,13 +29,17 @@ public class OptionallyWrapInJTATransaction extends ErrorHandledRunnable {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private final StatelessSessionAwareRunnable statelessSessionAwareRunnable;
 	private final BatchTransactionalContext batchContext;
+	private final StatelessSessionAwareRunnable statelessSessionAwareRunnable;
 	private final Integer transactionTimeout;
 	private final boolean wrapInTransaction;
 	private final String tenantId;
 
-	public OptionallyWrapInJTATransaction(BatchTransactionalContext batchContext, StatelessSessionAwareRunnable statelessSessionAwareRunnable, Integer transactionTimeout, String tenantId) {
+	public OptionallyWrapInJTATransaction(BatchTransactionalContext batchContext,
+			ErrorHandler errorHandler,
+			StatelessSessionAwareRunnable statelessSessionAwareRunnable,
+			Integer transactionTimeout, String tenantId) {
+		super( errorHandler );
 		/*
 		 * Unfortunately we need to access SessionFactoryImplementor to detect:
 		 *  - whether or not we need to start the JTA transaction

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/monitor/MassIndexingMonitor.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/monitor/MassIndexingMonitor.java
@@ -7,16 +7,15 @@
 package org.hibernate.search.mapper.orm.massindexing.monitor;
 
 /**
- * As a MassIndexer can take some time to finish it's job,
- * a MassIndexerProgressMonitor can be defined in the configuration
- * property hibernate.search.worker.indexing.monitor
- * implementing this interface to track indexing performance.
+ * A component that monitors progress of mass indexing.
  * <p>
- * Implementations must:
- * <ul>
- * <li>	be threadsafe </li>
- * <li> have a no-arg constructor </li>
- * </ul>
+ * As a MassIndexer can take some time to finish its job,
+ * it is often necessary to monitor its progress.
+ * The default, built-in monitor logs progress periodically at the INFO level,
+ * but a custom monitor can be set by implementing this interface
+ * and passing an instance to {@link org.hibernate.search.mapper.orm.massindexing.MassIndexer#monitor(MassIndexingMonitor)}.
+ * <p>
+ * Implementations must be threadsafe.
  *
  * @author Sanne Grinovero
  * @author Hardy Ferentschik

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/impl/PojoMapper.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/impl/PojoMapper.java
@@ -16,6 +16,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 import org.hibernate.search.engine.backend.document.DocumentElement;
+import org.hibernate.search.engine.common.spi.ErrorHandler;
 import org.hibernate.search.engine.mapper.mapping.building.spi.IndexManagerBuildingState;
 import org.hibernate.search.engine.mapper.mapping.building.spi.IndexManagerBuildingStateProvider;
 import org.hibernate.search.engine.mapper.mapping.building.spi.Mapper;
@@ -63,6 +64,9 @@ public class PojoMapper<MPBS extends MappingPartialBuildState> implements Mapper
 	private final TypeMetadataContributorProvider<PojoTypeMetadataContributor> contributorProvider;
 	private final boolean implicitProvidedId;
 	private final boolean multiTenancyEnabled;
+
+	private final ErrorHandler errorHandler;
+
 	private final PojoMapperDelegate<MPBS> delegate;
 	private final PojoTypeAdditionalMetadataProvider typeAdditionalMetadataProvider;
 	private final ContainerExtractorBinder extractorBinder;
@@ -88,6 +92,9 @@ public class PojoMapper<MPBS extends MappingPartialBuildState> implements Mapper
 		this.contributorProvider = contributorProvider;
 		this.implicitProvidedId = implicitProvidedId;
 		this.multiTenancyEnabled = multiTenancyEnabled;
+
+		this.errorHandler = buildContext.getErrorHandler();
+
 		this.delegate = delegate;
 
 		typeAdditionalMetadataProvider = new PojoTypeAdditionalMetadataProvider(
@@ -264,6 +271,7 @@ public class PojoMapper<MPBS extends MappingPartialBuildState> implements Mapper
 			}
 
 			mappingDelegate = new PojoMappingDelegateImpl(
+					errorHandler,
 					indexedTypeManagerContainerBuilder.build(),
 					containedTypeManagerContainerBuilder.build()
 			);

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoMappingDelegateImpl.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoMappingDelegateImpl.java
@@ -8,6 +8,7 @@ package org.hibernate.search.mapper.pojo.mapping.impl;
 
 import java.util.Collection;
 
+import org.hibernate.search.engine.common.spi.ErrorHandler;
 import org.hibernate.search.mapper.pojo.mapping.context.spi.AbstractPojoBackendMappingContext;
 import org.hibernate.search.mapper.pojo.mapping.spi.PojoMappingDelegate;
 import org.hibernate.search.mapper.pojo.scope.impl.PojoScopeDelegateImpl;
@@ -21,11 +22,14 @@ import org.hibernate.search.util.common.impl.Closer;
 
 public class PojoMappingDelegateImpl implements PojoMappingDelegate {
 
+	private final ErrorHandler errorHandler;
 	private final PojoIndexedTypeManagerContainer indexedTypeManagers;
 	private final PojoContainedTypeManagerContainer containedTypeManagers;
 
-	public PojoMappingDelegateImpl(PojoIndexedTypeManagerContainer indexedTypeManagers,
+	public PojoMappingDelegateImpl(ErrorHandler errorHandler,
+			PojoIndexedTypeManagerContainer indexedTypeManagers,
 			PojoContainedTypeManagerContainer containedTypeManagers) {
+		this.errorHandler = errorHandler;
 		this.indexedTypeManagers = indexedTypeManagers;
 		this.containedTypeManagers = containedTypeManagers;
 	}
@@ -36,6 +40,11 @@ public class PojoMappingDelegateImpl implements PojoMappingDelegate {
 			closer.pushAll( PojoIndexedTypeManager::close, indexedTypeManagers.getAll() );
 			closer.pushAll( PojoContainedTypeManager::close, containedTypeManagers.getAll() );
 		}
+	}
+
+	@Override
+	public ErrorHandler getErrorHandler() {
+		return errorHandler;
 	}
 
 	@Override

--- a/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/spi/PojoMappingDelegate.java
+++ b/mapper/pojo/src/main/java/org/hibernate/search/mapper/pojo/mapping/spi/PojoMappingDelegate.java
@@ -8,6 +8,7 @@ package org.hibernate.search.mapper.pojo.mapping.spi;
 
 import java.util.Collection;
 
+import org.hibernate.search.engine.common.spi.ErrorHandler;
 import org.hibernate.search.mapper.pojo.mapping.context.spi.AbstractPojoBackendMappingContext;
 import org.hibernate.search.mapper.pojo.scope.spi.PojoScopeDelegate;
 import org.hibernate.search.mapper.pojo.scope.spi.PojoScopeTypeExtendedContextProvider;
@@ -18,6 +19,8 @@ public interface PojoMappingDelegate extends AutoCloseable {
 
 	@Override
 	void close();
+
+	ErrorHandler getErrorHandler();
 
 	<R, E, E2, C> PojoScopeDelegate<R, E2, C> createPojoScope(
 			AbstractPojoBackendMappingContext mappingContext,

--- a/util/internal/test/src/main/java/org/hibernate/search/util/impl/test/rule/ExpectedLog4jLog.java
+++ b/util/internal/test/src/main/java/org/hibernate/search/util/impl/test/rule/ExpectedLog4jLog.java
@@ -69,10 +69,10 @@ public class ExpectedLog4jLog implements TestRule {
 	 * <p>
 	 * Defaults to expecting the event once or more.
 	 */
-	public void expectEvent(Level level,
+	public LogExpectation expectEvent(Level level,
 			Matcher<? super Throwable> throwableMatcher,
 			String containedString, String... otherContainedStrings) {
-		expectEvent( CoreMatchers.allOf(
+		return expectEvent( CoreMatchers.allOf(
 				eventLevelMatcher( level ),
 				eventThrowableMatcher( throwableMatcher ),
 				eventMessageMatcher( containsAllStrings( containedString, otherContainedStrings ) )

--- a/util/internal/test/src/main/java/org/hibernate/search/util/impl/test/rule/StaticCounters.java
+++ b/util/internal/test/src/main/java/org/hibernate/search/util/impl/test/rule/StaticCounters.java
@@ -71,7 +71,11 @@ public final class StaticCounters implements TestRule {
 	}
 
 	public void increment(Key key) {
-		counters.merge( key, 1, (left, right) -> left + right );
+		add( key, 1 );
+	}
+
+	public void add(Key key, int count) {
+		counters.merge( key, count, (left, right) -> left + right );
 	}
 
 	public int get(Key key) {


### PR DESCRIPTION
* [HSEARCH-3714](https://hibernate.atlassian.net/browse/HSEARCH-3714): Restore temporary, SPI-only support for error handlers
* [HSEARCH-3715](https://hibernate.atlassian.net/browse/HSEARCH-3715): Restore support for custom mass indexing monitors

@fax4ever FYI. I'll merge right away as this is mostly straightforward changes or SPI changes and I need them for the release.