### PR TITLE
HSEARCH-3653 Run Elasticsearch in JDK11 by default in the Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -654,12 +654,14 @@ class CompilerBuildEnvironment extends BuildEnvironment {
 class DatabaseBuildEnvironment extends BuildEnvironment {
 	String dbName
 	String mavenProfile
+	@Override
 	String getTag() { "database-$dbName" }
 }
 
 class EsLocalBuildEnvironment extends BuildEnvironment {
 	String versionRange
 	String mavenProfile
+	@Override
 	String getTag() { "elasticsearch-local-$versionRange" }
 }
 
@@ -668,6 +670,7 @@ class EsAwsBuildEnvironment extends BuildEnvironment {
 	String mavenProfile
 	String endpointUrl = null
 	String awsRegion = null
+	@Override
 	String getTag() { "elasticsearch-aws-$version" }
 	String getNameEmbeddableVersion() {
 		version.replaceAll('\\.', '')


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3653

I ran a full build here: https://ci.hibernate.org/blue/organizations/jenkins/hibernate-search-personal-yoann/detail/HSEARCH-3653/6/pipeline/25
(the AWS failures are unrelated, see https://hibernate.atlassian.net/browse/HSEARCH-3716)