### PR TITLE
HSEARCH-3727 Elasticsearch orchestrators do not wait for single-work worksets to finish with ElasticsearchParallelWorkProcessor

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/orchestration/impl/ElasticsearchParallelWorkProcessor.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/orchestration/impl/ElasticsearchParallelWorkProcessor.java
@@ -49,7 +49,8 @@ class ElasticsearchParallelWorkProcessor implements ElasticsearchWorkProcessor {
 	public <T> CompletableFuture<T> submit(ElasticsearchWork<T> work) {
 		aggregator.initSequence();
 		CompletableFuture<T> workFuture = work.aggregate( aggregator );
-		aggregator.buildSequence();
+		CompletableFuture<Void> future = aggregator.buildSequence();
+		sequenceFutures.add( future );
 		return workFuture;
 	}
 

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/orchestration/impl/ElasticsearchParallelWorkProcessorTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/orchestration/impl/ElasticsearchParallelWorkProcessorTest.java
@@ -54,7 +54,7 @@ public class ElasticsearchParallelWorkProcessorTest extends EasyMockSupport {
 		CompletableFuture<Void> sequenceFuture = new CompletableFuture<>();
 
 		replayAll();
-		ElasticsearchParallelWorkProcessor strategy =
+		ElasticsearchParallelWorkProcessor processor =
 				new ElasticsearchParallelWorkProcessor( sequenceBuilderMock, bulkerMock );
 		verifyAll();
 
@@ -70,14 +70,14 @@ public class ElasticsearchParallelWorkProcessorTest extends EasyMockSupport {
 		expect( bulkerMock.addWorksToSequence() ).andReturn( true );
 		expect( sequenceBuilderMock.build() ).andReturn( sequenceFuture );
 		replayAll();
-		CompletableFuture<Void> returnedSequenceFuture = strategy.submit( workset1 );
+		CompletableFuture<Void> returnedSequenceFuture = processor.submit( workset1 );
 		verifyAll();
 		assertThat( returnedSequenceFuture ).isSameAs( sequenceFuture );
 
 		resetAll();
 		bulkerMock.finalizeBulkWork();
 		replayAll();
-		CompletableFuture<Void> futureAll = strategy.endBatch();
+		CompletableFuture<Void> futureAll = processor.endBatch();
 		verifyAll();
 		assertThat( futureAll ).isPending();
 		sequenceFuture.complete( null );
@@ -96,7 +96,7 @@ public class ElasticsearchParallelWorkProcessorTest extends EasyMockSupport {
 		CompletableFuture<Void> sequence2Future = new CompletableFuture<>();
 
 		replayAll();
-		ElasticsearchParallelWorkProcessor strategy =
+		ElasticsearchParallelWorkProcessor processor =
 				new ElasticsearchParallelWorkProcessor( sequenceBuilderMock, bulkerMock );
 		verifyAll();
 
@@ -109,7 +109,7 @@ public class ElasticsearchParallelWorkProcessorTest extends EasyMockSupport {
 		expect( bulkerMock.addWorksToSequence() ).andReturn( false );
 		expect( sequenceBuilderMock.build() ).andReturn( sequence1Future );
 		replayAll();
-		CompletableFuture<Void> returnedSequence1Future = strategy.submit( workset1 );
+		CompletableFuture<Void> returnedSequence1Future = processor.submit( workset1 );
 		verifyAll();
 		assertThat( returnedSequence1Future ).isSameAs( sequence1Future );
 
@@ -121,14 +121,14 @@ public class ElasticsearchParallelWorkProcessorTest extends EasyMockSupport {
 		expect( bulkerMock.addWorksToSequence() ).andReturn( true );
 		expect( sequenceBuilderMock.build() ).andReturn( sequence2Future );
 		replayAll();
-		CompletableFuture<Void> returnedSequence2Future = strategy.submit( workset2 );
+		CompletableFuture<Void> returnedSequence2Future = processor.submit( workset2 );
 		verifyAll();
 		assertThat( returnedSequence2Future ).isSameAs( sequence2Future );
 
 		resetAll();
 		bulkerMock.finalizeBulkWork();
 		replayAll();
-		CompletableFuture<Void> futureAll = strategy.endBatch();
+		CompletableFuture<Void> futureAll = processor.endBatch();
 		verifyAll();
 		assertThat( futureAll ).isPending();
 		sequence2Future.complete( null );
@@ -149,7 +149,7 @@ public class ElasticsearchParallelWorkProcessorTest extends EasyMockSupport {
 		CompletableFuture<Void> sequence2Future = new CompletableFuture<>();
 
 		replayAll();
-		ElasticsearchParallelWorkProcessor strategy =
+		ElasticsearchParallelWorkProcessor processor =
 				new ElasticsearchParallelWorkProcessor( sequenceBuilderMock, bulkerMock );
 		verifyAll();
 
@@ -161,7 +161,7 @@ public class ElasticsearchParallelWorkProcessorTest extends EasyMockSupport {
 		expect( bulkerMock.addWorksToSequence() ).andReturn( true );
 		expect( sequenceBuilderMock.build() ).andReturn( sequence1Future );
 		replayAll();
-		CompletableFuture<Void> returnedSequence1Future = strategy.submit( workset1 );
+		CompletableFuture<Void> returnedSequence1Future = processor.submit( workset1 );
 		verifyAll();
 		assertThat( returnedSequence1Future ).isSameAs( sequence1Future );
 
@@ -173,14 +173,14 @@ public class ElasticsearchParallelWorkProcessorTest extends EasyMockSupport {
 		expect( bulkerMock.addWorksToSequence() ).andReturn( true );
 		expect( sequenceBuilderMock.build() ).andReturn( sequence2Future );
 		replayAll();
-		CompletableFuture<Void> returnedSequence2Future = strategy.submit( workset2 );
+		CompletableFuture<Void> returnedSequence2Future = processor.submit( workset2 );
 		verifyAll();
 		assertThat( returnedSequence2Future ).isSameAs( sequence2Future );
 
 		resetAll();
 		bulkerMock.finalizeBulkWork();
 		replayAll();
-		CompletableFuture<Void> futureAll = strategy.endBatch();
+		CompletableFuture<Void> futureAll = processor.endBatch();
 		verifyAll();
 		assertThat( futureAll ).isPending();
 
@@ -207,7 +207,7 @@ public class ElasticsearchParallelWorkProcessorTest extends EasyMockSupport {
 		CompletableFuture<Void> sequence1Future = new CompletableFuture<>();
 
 		replayAll();
-		ElasticsearchParallelWorkProcessor strategy =
+		ElasticsearchParallelWorkProcessor processor =
 				new ElasticsearchParallelWorkProcessor( sequenceBuilderMock, bulkerMock );
 		verifyAll();
 
@@ -227,14 +227,14 @@ public class ElasticsearchParallelWorkProcessorTest extends EasyMockSupport {
 		expect( bulkerMock.addWorksToSequence() ).andReturn( true );
 		expect( sequenceBuilderMock.build() ).andReturn( sequence1Future );
 		replayAll();
-		CompletableFuture<Void> returnedSequence1Future = strategy.submit( workset1 );
+		CompletableFuture<Void> returnedSequence1Future = processor.submit( workset1 );
 		verifyAll();
 		assertThat( returnedSequence1Future ).isSameAs( sequence1Future );
 
 		resetAll();
 		bulkerMock.finalizeBulkWork();
 		replayAll();
-		CompletableFuture<Void> futureAll = strategy.endBatch();
+		CompletableFuture<Void> futureAll = processor.endBatch();
 		verifyAll();
 		assertThat( futureAll ).isPending();
 
@@ -257,7 +257,7 @@ public class ElasticsearchParallelWorkProcessorTest extends EasyMockSupport {
 		CompletableFuture<Void> sequence2Future = new CompletableFuture<>();
 
 		replayAll();
-		ElasticsearchParallelWorkProcessor strategy =
+		ElasticsearchParallelWorkProcessor processor =
 				new ElasticsearchParallelWorkProcessor( sequenceBuilderMock, bulkerMock );
 		verifyAll();
 
@@ -269,7 +269,7 @@ public class ElasticsearchParallelWorkProcessorTest extends EasyMockSupport {
 		expect( bulkerMock.addWorksToSequence() ).andReturn( true );
 		expect( sequenceBuilderMock.build() ).andReturn( sequence1Future );
 		replayAll();
-		CompletableFuture<Void> returnedSequence1Future = strategy.submit( workset1 );
+		CompletableFuture<Void> returnedSequence1Future = processor.submit( workset1 );
 		verifyAll();
 		assertThat( returnedSequence1Future ).isSameAs( sequence1Future );
 
@@ -286,14 +286,14 @@ public class ElasticsearchParallelWorkProcessorTest extends EasyMockSupport {
 		expect( bulkerMock.addWorksToSequence() ).andReturn( false );
 		expect( sequenceBuilderMock.build() ).andReturn( sequence2Future );
 		replayAll();
-		CompletableFuture<Void> returnedSequence2Future = strategy.submit( workset2 );
+		CompletableFuture<Void> returnedSequence2Future = processor.submit( workset2 );
 		verifyAll();
 		assertThat( returnedSequence2Future ).isSameAs( sequence2Future );
 
 		resetAll();
 		bulkerMock.finalizeBulkWork();
 		replayAll();
-		CompletableFuture<Void> futureAll = strategy.endBatch();
+		CompletableFuture<Void> futureAll = processor.endBatch();
 		verifyAll();
 		assertThat( futureAll ).isPending();
 

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/orchestration/impl/ElasticsearchParallelWorkProcessorTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/orchestration/impl/ElasticsearchParallelWorkProcessorTest.java
@@ -8,7 +8,6 @@ package org.hibernate.search.backend.elasticsearch.orchestration.impl;
 
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.getCurrentArguments;
 import static org.hibernate.search.util.impl.test.FutureAssert.assertThat;
 
@@ -47,8 +46,8 @@ public class ElasticsearchParallelWorkProcessorTest extends EasyMockSupport {
 
 	@Test
 	public void simple() {
-		ElasticsearchWork<?> work1 = work( 1 );
-		BulkableElasticsearchWork<?> work2 = bulkableWork( 2 );
+		ElasticsearchWork<Object> work1 = work( 1 );
+		BulkableElasticsearchWork<Object> work2 = bulkableWork( 2 );
 		List<ElasticsearchWork<?>> workset1 = Arrays.asList( work1, work2 );
 
 		CompletableFuture<Void> sequenceFuture = new CompletableFuture<>();
@@ -60,12 +59,10 @@ public class ElasticsearchParallelWorkProcessorTest extends EasyMockSupport {
 
 		resetAll();
 		sequenceBuilderMock.init( anyObject() );
-		work1.aggregate( anyObject() );
-		expectLastCall().andAnswer( nonBulkableAggregateAnswer( work1 ) );
+		expect( work1.aggregate( anyObject() ) ).andAnswer( nonBulkableAggregateAnswer( work1 ) );
 		expect( bulkerMock.addWorksToSequence() ).andReturn( false );
 		expect( sequenceBuilderMock.addNonBulkExecution( work1 ) ).andReturn( unusedReturnValue() );
-		work2.aggregate( anyObject() );
-		expectLastCall().andAnswer( bulkableAggregateAnswer( work2 ) );
+		expect( work2.aggregate( anyObject() ) ).andAnswer( bulkableAggregateAnswer( work2 ) );
 		expect( bulkerMock.add( work2 ) ).andReturn( unusedReturnValue() );
 		expect( bulkerMock.addWorksToSequence() ).andReturn( true );
 		expect( sequenceBuilderMock.build() ).andReturn( sequenceFuture );
@@ -86,10 +83,10 @@ public class ElasticsearchParallelWorkProcessorTest extends EasyMockSupport {
 
 	@Test
 	public void parallelSequenceBetweenWorkset() {
-		ElasticsearchWork<?> work1 = work( 1 );
+		ElasticsearchWork<Object> work1 = work( 1 );
 		List<ElasticsearchWork<?>> workset1 = Arrays.asList( work1 );
 
-		BulkableElasticsearchWork<?> work2 = bulkableWork( 2 );
+		BulkableElasticsearchWork<Object> work2 = bulkableWork( 2 );
 		List<ElasticsearchWork<?>> workset2 = Arrays.asList( work2 );
 
 		CompletableFuture<Void> sequence1Future = new CompletableFuture<>();
@@ -102,8 +99,7 @@ public class ElasticsearchParallelWorkProcessorTest extends EasyMockSupport {
 
 		resetAll();
 		sequenceBuilderMock.init( anyObject() );
-		work1.aggregate( anyObject() );
-		expectLastCall().andAnswer( nonBulkableAggregateAnswer( work1 ) );
+		expect( work1.aggregate( anyObject() ) ).andAnswer( nonBulkableAggregateAnswer( work1 ) );
 		expect( bulkerMock.addWorksToSequence() ).andReturn( false );
 		expect( sequenceBuilderMock.addNonBulkExecution( work1 ) ).andReturn( unusedReturnValue() );
 		expect( bulkerMock.addWorksToSequence() ).andReturn( false );
@@ -115,8 +111,7 @@ public class ElasticsearchParallelWorkProcessorTest extends EasyMockSupport {
 
 		resetAll();
 		sequenceBuilderMock.init( anyObject() );
-		work2.aggregate( anyObject() );
-		expectLastCall().andAnswer( bulkableAggregateAnswer( work2 ) );
+		expect( work2.aggregate( anyObject() ) ).andAnswer( bulkableAggregateAnswer( work2 ) );
 		expect( bulkerMock.add( work2 ) ).andReturn( unusedReturnValue() );
 		expect( bulkerMock.addWorksToSequence() ).andReturn( true );
 		expect( sequenceBuilderMock.build() ).andReturn( sequence2Future );
@@ -139,10 +134,10 @@ public class ElasticsearchParallelWorkProcessorTest extends EasyMockSupport {
 
 	@Test
 	public void reuseBulkAcrossSequences() {
-		BulkableElasticsearchWork<?> work1 = bulkableWork( 1 );
+		BulkableElasticsearchWork<Object> work1 = bulkableWork( 1 );
 		List<ElasticsearchWork<?>> workset1 = Arrays.asList( work1 );
 
-		BulkableElasticsearchWork<?> work2 = bulkableWork( 2 );
+		BulkableElasticsearchWork<Object> work2 = bulkableWork( 2 );
 		List<ElasticsearchWork<?>> workset2 = Arrays.asList( work2 );
 
 		CompletableFuture<Void> sequence1Future = new CompletableFuture<>();
@@ -155,8 +150,7 @@ public class ElasticsearchParallelWorkProcessorTest extends EasyMockSupport {
 
 		resetAll();
 		sequenceBuilderMock.init( anyObject() );
-		work1.aggregate( anyObject() );
-		expectLastCall().andAnswer( bulkableAggregateAnswer( work1 ) );
+		expect( work1.aggregate( anyObject() ) ).andAnswer( bulkableAggregateAnswer( work1 ) );
 		expect( bulkerMock.add( work1 ) ).andReturn( unusedReturnValue() );
 		expect( bulkerMock.addWorksToSequence() ).andReturn( true );
 		expect( sequenceBuilderMock.build() ).andReturn( sequence1Future );
@@ -167,8 +161,7 @@ public class ElasticsearchParallelWorkProcessorTest extends EasyMockSupport {
 
 		resetAll();
 		sequenceBuilderMock.init( anyObject() );
-		work2.aggregate( anyObject() );
-		expectLastCall().andAnswer( bulkableAggregateAnswer( work2 ) );
+		expect( work2.aggregate( anyObject() ) ).andAnswer( bulkableAggregateAnswer( work2 ) );
 		expect( bulkerMock.add( work2 ) ).andReturn( unusedReturnValue() );
 		expect( bulkerMock.addWorksToSequence() ).andReturn( true );
 		expect( sequenceBuilderMock.build() ).andReturn( sequence2Future );
@@ -199,9 +192,9 @@ public class ElasticsearchParallelWorkProcessorTest extends EasyMockSupport {
 
 	@Test
 	public void newBulkIfNonBulkable_sameWorkset() {
-		BulkableElasticsearchWork<?> work1 = bulkableWork( 1 );
-		ElasticsearchWork<?> work2 = work( 2 );
-		BulkableElasticsearchWork<?> work3 = bulkableWork( 3 );
+		BulkableElasticsearchWork<Object> work1 = bulkableWork( 1 );
+		ElasticsearchWork<Object> work2 = work( 2 );
+		BulkableElasticsearchWork<Object> work3 = bulkableWork( 3 );
 		List<ElasticsearchWork<?>> workset1 = Arrays.asList( work1, work2, work3 );
 
 		CompletableFuture<Void> sequence1Future = new CompletableFuture<>();
@@ -213,15 +206,12 @@ public class ElasticsearchParallelWorkProcessorTest extends EasyMockSupport {
 
 		resetAll();
 		sequenceBuilderMock.init( anyObject() );
-		work1.aggregate( anyObject() );
-		expectLastCall().andAnswer( bulkableAggregateAnswer( work1 ) );
+		expect( work1.aggregate( anyObject() ) ).andAnswer( bulkableAggregateAnswer( work1 ) );
 		expect( bulkerMock.add( work1 ) ).andReturn( unusedReturnValue() );
-		work2.aggregate( anyObject() );
-		expectLastCall().andAnswer( nonBulkableAggregateAnswer( work2 ) );
+		expect( work2.aggregate( anyObject() ) ).andAnswer( nonBulkableAggregateAnswer( work2 ) );
 		expect( bulkerMock.addWorksToSequence() ).andReturn( true );
 		expect( sequenceBuilderMock.addNonBulkExecution( work2 ) ).andReturn( unusedReturnValue() );
-		work3.aggregate( anyObject() );
-		expectLastCall().andAnswer( bulkableAggregateAnswer( work3 ) );
+		expect( work3.aggregate( anyObject() ) ).andAnswer( bulkableAggregateAnswer( work3 ) );
 		bulkerMock.finalizeBulkWork();
 		expect( bulkerMock.add( work3 ) ).andReturn( unusedReturnValue() );
 		expect( bulkerMock.addWorksToSequence() ).andReturn( true );
@@ -247,10 +237,10 @@ public class ElasticsearchParallelWorkProcessorTest extends EasyMockSupport {
 
 	@Test
 	public void newBulkIfNonBulkable_differentWorksets() {
-		BulkableElasticsearchWork<?> work1 = bulkableWork( 1 );
+		BulkableElasticsearchWork<Object> work1 = bulkableWork( 1 );
 		List<ElasticsearchWork<?>> workset1 = Arrays.asList( work1 );
-		ElasticsearchWork<?> work2 = work( 2 );
-		BulkableElasticsearchWork<?> work3 = bulkableWork( 3 );
+		ElasticsearchWork<Object> work2 = work( 2 );
+		BulkableElasticsearchWork<Object> work3 = bulkableWork( 3 );
 		List<ElasticsearchWork<?>> workset2 = Arrays.asList( work2, work3 );
 
 		CompletableFuture<Void> sequence1Future = new CompletableFuture<>();
@@ -263,8 +253,7 @@ public class ElasticsearchParallelWorkProcessorTest extends EasyMockSupport {
 
 		resetAll();
 		sequenceBuilderMock.init( anyObject() );
-		work1.aggregate( anyObject() );
-		expectLastCall().andAnswer( bulkableAggregateAnswer( work1 ) );
+		expect( work1.aggregate( anyObject() ) ).andAnswer( bulkableAggregateAnswer( work1 ) );
 		expect( bulkerMock.add( work1 ) ).andReturn( unusedReturnValue() );
 		expect( bulkerMock.addWorksToSequence() ).andReturn( true );
 		expect( sequenceBuilderMock.build() ).andReturn( sequence1Future );
@@ -275,12 +264,10 @@ public class ElasticsearchParallelWorkProcessorTest extends EasyMockSupport {
 
 		resetAll();
 		sequenceBuilderMock.init( anyObject() );
-		work2.aggregate( anyObject() );
-		expectLastCall().andAnswer( nonBulkableAggregateAnswer( work2 ) );
+		expect( work2.aggregate( anyObject() ) ).andAnswer( nonBulkableAggregateAnswer( work2 ) );
 		expect( bulkerMock.addWorksToSequence() ).andReturn( true );
 		expect( sequenceBuilderMock.addNonBulkExecution( work2 ) ).andReturn( unusedReturnValue() );
-		work3.aggregate( anyObject() );
-		expectLastCall().andAnswer( bulkableAggregateAnswer( work3 ) );
+		expect( work3.aggregate( anyObject() ) ).andAnswer( bulkableAggregateAnswer( work3 ) );
 		bulkerMock.finalizeBulkWork();
 		expect( bulkerMock.add( work3 ) ).andReturn( unusedReturnValue() );
 		expect( bulkerMock.addWorksToSequence() ).andReturn( false );
@@ -318,19 +305,17 @@ public class ElasticsearchParallelWorkProcessorTest extends EasyMockSupport {
 		return createStrictMock( "bulkableWork" + index, BulkableElasticsearchWork.class );
 	}
 
-	private IAnswer<Void> nonBulkableAggregateAnswer(ElasticsearchWork<?> mock) {
+	private <T> IAnswer<CompletableFuture<T>> nonBulkableAggregateAnswer(ElasticsearchWork<T> mock) {
 		return () -> {
 			ElasticsearchWorkAggregator aggregator = (ElasticsearchWorkAggregator) getCurrentArguments()[0];
-			aggregator.addNonBulkable( mock );
-			return null;
+			return aggregator.addNonBulkable( mock );
 		};
 	}
 
-	private IAnswer<Void> bulkableAggregateAnswer(BulkableElasticsearchWork<?> mock) {
+	private <T> IAnswer<CompletableFuture<T>> bulkableAggregateAnswer(BulkableElasticsearchWork<T> mock) {
 		return () -> {
 			ElasticsearchWorkAggregator aggregator = (ElasticsearchWorkAggregator) getCurrentArguments()[0];
-			aggregator.addBulkable( mock );
-			return null;
+			return aggregator.addBulkable( mock );
 		};
 	}
 }

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/orchestration/impl/ElasticsearchSerialWorkProcessorTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/orchestration/impl/ElasticsearchSerialWorkProcessorTest.java
@@ -8,7 +8,6 @@ package org.hibernate.search.backend.elasticsearch.orchestration.impl;
 
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.getCurrentArguments;
 import static org.hibernate.search.util.impl.test.FutureAssert.assertThat;
 
@@ -47,8 +46,8 @@ public class ElasticsearchSerialWorkProcessorTest extends EasyMockSupport {
 
 	@Test
 	public void simple() {
-		ElasticsearchWork<?> work1 = work( 1 );
-		BulkableElasticsearchWork<?> work2 = bulkableWork( 2 );
+		ElasticsearchWork<Object> work1 = work( 1 );
+		BulkableElasticsearchWork<Object> work2 = bulkableWork( 2 );
 		List<ElasticsearchWork<?>> workset1 = Arrays.asList( work1, work2 );
 
 		CompletableFuture<Void> sequenceFuture = new CompletableFuture<>();
@@ -60,12 +59,10 @@ public class ElasticsearchSerialWorkProcessorTest extends EasyMockSupport {
 
 		resetAll();
 		sequenceBuilderMock.init( anyObject() );
-		work1.aggregate( anyObject() );
-		expectLastCall().andAnswer( nonBulkableAggregateAnswer( work1 ) );
+		expect( work1.aggregate( anyObject() ) ).andAnswer( nonBulkableAggregateAnswer( work1 ) );
 		expect( bulkerMock.addWorksToSequence() ).andReturn( false );
 		expect( sequenceBuilderMock.addNonBulkExecution( work1 ) ).andReturn( unusedReturnValue() );
-		work2.aggregate( anyObject() );
-		expectLastCall().andAnswer( bulkableAggregateAnswer( work2 ) );
+		expect( work2.aggregate( anyObject() ) ).andAnswer( bulkableAggregateAnswer( work2 ) );
 		expect( bulkerMock.add( work2 ) ).andReturn( unusedReturnValue() );
 		expect( bulkerMock.addWorksToSequence() ).andReturn( true );
 		expect( sequenceBuilderMock.build() ).andReturn( sequenceFuture );
@@ -84,10 +81,10 @@ public class ElasticsearchSerialWorkProcessorTest extends EasyMockSupport {
 
 	@Test
 	public void newSequenceBetweenWorkset() {
-		ElasticsearchWork<?> work1 = work( 1 );
+		ElasticsearchWork<Object> work1 = work( 1 );
 		List<ElasticsearchWork<?>> workset1 = Arrays.asList( work1 );
 
-		BulkableElasticsearchWork<?> work2 = bulkableWork( 2 );
+		BulkableElasticsearchWork<Object> work2 = bulkableWork( 2 );
 		List<ElasticsearchWork<?>> workset2 = Arrays.asList( work2 );
 
 		CompletableFuture<Void> sequence1Future = new CompletableFuture<>();
@@ -100,8 +97,7 @@ public class ElasticsearchSerialWorkProcessorTest extends EasyMockSupport {
 
 		resetAll();
 		sequenceBuilderMock.init( anyObject() );
-		work1.aggregate( anyObject() );
-		expectLastCall().andAnswer( nonBulkableAggregateAnswer( work1 ) );
+		expect( work1.aggregate( anyObject() ) ).andAnswer( nonBulkableAggregateAnswer( work1 ) );
 		expect( bulkerMock.addWorksToSequence() ).andReturn( false );
 		expect( sequenceBuilderMock.addNonBulkExecution( work1 ) ).andReturn( unusedReturnValue() );
 		expect( bulkerMock.addWorksToSequence() ).andReturn( false );
@@ -113,8 +109,7 @@ public class ElasticsearchSerialWorkProcessorTest extends EasyMockSupport {
 
 		resetAll();
 		sequenceBuilderMock.init( sequence1Future );
-		work2.aggregate( anyObject() );
-		expectLastCall().andAnswer( bulkableAggregateAnswer( work2 ) );
+		expect( work2.aggregate( anyObject() ) ).andAnswer( bulkableAggregateAnswer( work2 ) );
 		expect( bulkerMock.add( work2 ) ).andReturn( unusedReturnValue() );
 		expect( bulkerMock.addWorksToSequence() ).andReturn( true );
 		expect( sequenceBuilderMock.build() ).andReturn( sequence2Future );
@@ -133,10 +128,10 @@ public class ElasticsearchSerialWorkProcessorTest extends EasyMockSupport {
 
 	@Test
 	public void reuseBulkAcrossSequences() {
-		BulkableElasticsearchWork<?> work1 = bulkableWork( 1 );
+		BulkableElasticsearchWork<Object> work1 = bulkableWork( 1 );
 		List<ElasticsearchWork<?>> workset1 = Arrays.asList( work1 );
 
-		BulkableElasticsearchWork<?> work2 = bulkableWork( 2 );
+		BulkableElasticsearchWork<Object> work2 = bulkableWork( 2 );
 		List<ElasticsearchWork<?>> workset2 = Arrays.asList( work2 );
 
 		CompletableFuture<Void> sequence1Future = new CompletableFuture<>();
@@ -149,8 +144,7 @@ public class ElasticsearchSerialWorkProcessorTest extends EasyMockSupport {
 
 		resetAll();
 		sequenceBuilderMock.init( anyObject() );
-		work1.aggregate( anyObject() );
-		expectLastCall().andAnswer( bulkableAggregateAnswer( work1 ) );
+		expect( work1.aggregate( anyObject() ) ).andAnswer( bulkableAggregateAnswer( work1 ) );
 		expect( bulkerMock.add( work1 ) ).andReturn( unusedReturnValue() );
 		expect( bulkerMock.addWorksToSequence() ).andReturn( true );
 		expect( sequenceBuilderMock.build() ).andReturn( sequence1Future );
@@ -161,8 +155,7 @@ public class ElasticsearchSerialWorkProcessorTest extends EasyMockSupport {
 
 		resetAll();
 		sequenceBuilderMock.init( sequence1Future );
-		work2.aggregate( anyObject() );
-		expectLastCall().andAnswer( bulkableAggregateAnswer( work2 ) );
+		expect( work2.aggregate( anyObject() ) ).andAnswer( bulkableAggregateAnswer( work2 ) );
 		expect( bulkerMock.add( work2 ) ).andReturn( unusedReturnValue() );
 		expect( bulkerMock.addWorksToSequence() ).andReturn( true );
 		expect( sequenceBuilderMock.build() ).andReturn( sequence2Future );
@@ -181,9 +174,9 @@ public class ElasticsearchSerialWorkProcessorTest extends EasyMockSupport {
 
 	@Test
 	public void newBulkIfNonBulkable_sameWorkset() {
-		BulkableElasticsearchWork<?> work1 = bulkableWork( 1 );
-		ElasticsearchWork<?> work2 = work( 2 );
-		BulkableElasticsearchWork<?> work3 = bulkableWork( 3 );
+		BulkableElasticsearchWork<Object> work1 = bulkableWork( 1 );
+		ElasticsearchWork<Object> work2 = work( 2 );
+		BulkableElasticsearchWork<Object> work3 = bulkableWork( 3 );
 		List<ElasticsearchWork<?>> workset1 = Arrays.asList( work1, work2, work3 );
 
 		CompletableFuture<Void> sequence1Future = new CompletableFuture<>();
@@ -195,15 +188,12 @@ public class ElasticsearchSerialWorkProcessorTest extends EasyMockSupport {
 
 		resetAll();
 		sequenceBuilderMock.init( anyObject() );
-		work1.aggregate( anyObject() );
-		expectLastCall().andAnswer( bulkableAggregateAnswer( work1 ) );
+		expect( work1.aggregate( anyObject() ) ).andAnswer( bulkableAggregateAnswer( work1 ) );
 		expect( bulkerMock.add( work1 ) ).andReturn( unusedReturnValue() );
-		work2.aggregate( anyObject() );
-		expectLastCall().andAnswer( nonBulkableAggregateAnswer( work2 ) );
+		expect( work2.aggregate( anyObject() ) ).andAnswer( nonBulkableAggregateAnswer( work2 ) );
 		expect( bulkerMock.addWorksToSequence() ).andReturn( true );
 		expect( sequenceBuilderMock.addNonBulkExecution( work2 ) ).andReturn( unusedReturnValue() );
-		work3.aggregate( anyObject() );
-		expectLastCall().andAnswer( bulkableAggregateAnswer( work3 ) );
+		expect( work3.aggregate( anyObject() ) ).andAnswer( bulkableAggregateAnswer( work3 ) );
 		bulkerMock.finalizeBulkWork();
 		expect( bulkerMock.add( work3 ) ).andReturn( unusedReturnValue() );
 		expect( bulkerMock.addWorksToSequence() ).andReturn( true );
@@ -223,10 +213,10 @@ public class ElasticsearchSerialWorkProcessorTest extends EasyMockSupport {
 
 	@Test
 	public void newBulkIfNonBulkable_differentWorksets() {
-		BulkableElasticsearchWork<?> work1 = bulkableWork( 1 );
+		BulkableElasticsearchWork<Object> work1 = bulkableWork( 1 );
 		List<ElasticsearchWork<?>> workset1 = Arrays.asList( work1 );
-		ElasticsearchWork<?> work2 = work( 2 );
-		BulkableElasticsearchWork<?> work3 = bulkableWork( 3 );
+		ElasticsearchWork<Object> work2 = work( 2 );
+		BulkableElasticsearchWork<Object> work3 = bulkableWork( 3 );
 		List<ElasticsearchWork<?>> workset2 = Arrays.asList( work2, work3 );
 
 		CompletableFuture<Void> sequence1Future = new CompletableFuture<>();
@@ -239,8 +229,7 @@ public class ElasticsearchSerialWorkProcessorTest extends EasyMockSupport {
 
 		resetAll();
 		sequenceBuilderMock.init( anyObject() );
-		work1.aggregate( anyObject() );
-		expectLastCall().andAnswer( bulkableAggregateAnswer( work1 ) );
+		expect( work1.aggregate( anyObject() ) ).andAnswer( bulkableAggregateAnswer( work1 ) );
 		expect( bulkerMock.add( work1 ) ).andReturn( unusedReturnValue() );
 		expect( bulkerMock.addWorksToSequence() ).andReturn( true );
 		expect( sequenceBuilderMock.build() ).andReturn( sequence1Future );
@@ -251,12 +240,10 @@ public class ElasticsearchSerialWorkProcessorTest extends EasyMockSupport {
 
 		resetAll();
 		sequenceBuilderMock.init( anyObject() );
-		work2.aggregate( anyObject() );
-		expectLastCall().andAnswer( nonBulkableAggregateAnswer( work2 ) );
+		expect( work2.aggregate( anyObject() ) ).andAnswer( nonBulkableAggregateAnswer( work2 ) );
 		expect( bulkerMock.addWorksToSequence() ).andReturn( true );
 		expect( sequenceBuilderMock.addNonBulkExecution( work2 ) ).andReturn( unusedReturnValue() );
-		work3.aggregate( anyObject() );
-		expectLastCall().andAnswer( bulkableAggregateAnswer( work3 ) );
+		expect( work3.aggregate( anyObject() ) ).andAnswer( bulkableAggregateAnswer( work3 ) );
 		bulkerMock.finalizeBulkWork();
 		expect( bulkerMock.add( work3 ) ).andReturn( unusedReturnValue() );
 		expect( bulkerMock.addWorksToSequence() ).andReturn( false );
@@ -274,27 +261,25 @@ public class ElasticsearchSerialWorkProcessorTest extends EasyMockSupport {
 		assertThat( futureAll ).isSameAs( sequence2Future );
 	}
 
-	private ElasticsearchWork<?> work(int index) {
+	private <T> ElasticsearchWork<T> work(int index) {
 		return createStrictMock( "work" + index, ElasticsearchWork.class );
 	}
 
-	private BulkableElasticsearchWork<?> bulkableWork(int index) {
+	private <T> BulkableElasticsearchWork<T> bulkableWork(int index) {
 		return createStrictMock( "bulkableWork" + index, BulkableElasticsearchWork.class );
 	}
 
-	private IAnswer<Void> nonBulkableAggregateAnswer(ElasticsearchWork<?> mock) {
+	private <T> IAnswer<CompletableFuture<T>> nonBulkableAggregateAnswer(ElasticsearchWork<T> mock) {
 		return () -> {
 			ElasticsearchWorkAggregator aggregator = (ElasticsearchWorkAggregator) getCurrentArguments()[0];
-			aggregator.addNonBulkable( mock );
-			return null;
+			return aggregator.addNonBulkable( mock );
 		};
 	}
 
-	private IAnswer<Void> bulkableAggregateAnswer(BulkableElasticsearchWork<?> mock) {
+	private <T> IAnswer<CompletableFuture<T>> bulkableAggregateAnswer(BulkableElasticsearchWork<T> mock) {
 		return () -> {
 			ElasticsearchWorkAggregator aggregator = (ElasticsearchWorkAggregator) getCurrentArguments()[0];
-			aggregator.addBulkable( mock );
-			return null;
+			return aggregator.addBulkable( mock );
 		};
 	}
 }

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/orchestration/impl/ElasticsearchSerialWorkProcessorTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/orchestration/impl/ElasticsearchSerialWorkProcessorTest.java
@@ -54,7 +54,7 @@ public class ElasticsearchSerialWorkProcessorTest extends EasyMockSupport {
 		CompletableFuture<Void> sequenceFuture = new CompletableFuture<>();
 
 		replayAll();
-		ElasticsearchSerialWorkProcessor strategy =
+		ElasticsearchSerialWorkProcessor processor =
 				new ElasticsearchSerialWorkProcessor( sequenceBuilderMock, bulkerMock );
 		verifyAll();
 
@@ -70,14 +70,14 @@ public class ElasticsearchSerialWorkProcessorTest extends EasyMockSupport {
 		expect( bulkerMock.addWorksToSequence() ).andReturn( true );
 		expect( sequenceBuilderMock.build() ).andReturn( sequenceFuture );
 		replayAll();
-		CompletableFuture<Void> returnedSequenceFuture = strategy.submit( workset1 );
+		CompletableFuture<Void> returnedSequenceFuture = processor.submit( workset1 );
 		verifyAll();
 		assertThat( returnedSequenceFuture ).isSameAs( sequenceFuture );
 
 		resetAll();
 		bulkerMock.finalizeBulkWork();
 		replayAll();
-		CompletableFuture<Void> futureAll = strategy.endBatch();
+		CompletableFuture<Void> futureAll = processor.endBatch();
 		verifyAll();
 		assertThat( futureAll ).isSameAs( sequenceFuture );
 	}
@@ -94,7 +94,7 @@ public class ElasticsearchSerialWorkProcessorTest extends EasyMockSupport {
 		CompletableFuture<Void> sequence2Future = new CompletableFuture<>();
 
 		replayAll();
-		ElasticsearchSerialWorkProcessor strategy =
+		ElasticsearchSerialWorkProcessor processor =
 				new ElasticsearchSerialWorkProcessor( sequenceBuilderMock, bulkerMock );
 		verifyAll();
 
@@ -107,7 +107,7 @@ public class ElasticsearchSerialWorkProcessorTest extends EasyMockSupport {
 		expect( bulkerMock.addWorksToSequence() ).andReturn( false );
 		expect( sequenceBuilderMock.build() ).andReturn( sequence1Future );
 		replayAll();
-		CompletableFuture<Void> returnedSequence1Future = strategy.submit( workset1 );
+		CompletableFuture<Void> returnedSequence1Future = processor.submit( workset1 );
 		verifyAll();
 		assertThat( returnedSequence1Future ).isSameAs( sequence1Future );
 
@@ -119,14 +119,14 @@ public class ElasticsearchSerialWorkProcessorTest extends EasyMockSupport {
 		expect( bulkerMock.addWorksToSequence() ).andReturn( true );
 		expect( sequenceBuilderMock.build() ).andReturn( sequence2Future );
 		replayAll();
-		CompletableFuture<Void> returnedSequence2Future = strategy.submit( workset2 );
+		CompletableFuture<Void> returnedSequence2Future = processor.submit( workset2 );
 		verifyAll();
 		assertThat( returnedSequence2Future ).isSameAs( sequence2Future );
 
 		resetAll();
 		bulkerMock.finalizeBulkWork();
 		replayAll();
-		CompletableFuture<Void> futureAll = strategy.endBatch();
+		CompletableFuture<Void> futureAll = processor.endBatch();
 		verifyAll();
 		assertThat( futureAll ).isSameAs( sequence2Future );
 	}
@@ -143,7 +143,7 @@ public class ElasticsearchSerialWorkProcessorTest extends EasyMockSupport {
 		CompletableFuture<Void> sequence2Future = new CompletableFuture<>();
 
 		replayAll();
-		ElasticsearchSerialWorkProcessor strategy =
+		ElasticsearchSerialWorkProcessor processor =
 				new ElasticsearchSerialWorkProcessor( sequenceBuilderMock, bulkerMock );
 		verifyAll();
 
@@ -155,7 +155,7 @@ public class ElasticsearchSerialWorkProcessorTest extends EasyMockSupport {
 		expect( bulkerMock.addWorksToSequence() ).andReturn( true );
 		expect( sequenceBuilderMock.build() ).andReturn( sequence1Future );
 		replayAll();
-		CompletableFuture<Void> returnedSequence1Future = strategy.submit( workset1 );
+		CompletableFuture<Void> returnedSequence1Future = processor.submit( workset1 );
 		verifyAll();
 		assertThat( returnedSequence1Future ).isSameAs( sequence1Future );
 
@@ -167,14 +167,14 @@ public class ElasticsearchSerialWorkProcessorTest extends EasyMockSupport {
 		expect( bulkerMock.addWorksToSequence() ).andReturn( true );
 		expect( sequenceBuilderMock.build() ).andReturn( sequence2Future );
 		replayAll();
-		CompletableFuture<Void> returnedSequence2Future = strategy.submit( workset2 );
+		CompletableFuture<Void> returnedSequence2Future = processor.submit( workset2 );
 		verifyAll();
 		assertThat( returnedSequence2Future ).isSameAs( sequence2Future );
 
 		resetAll();
 		bulkerMock.finalizeBulkWork();
 		replayAll();
-		CompletableFuture<Void> futureAll = strategy.endBatch();
+		CompletableFuture<Void> futureAll = processor.endBatch();
 		verifyAll();
 		assertThat( futureAll ).isSameAs( sequence2Future );
 	}
@@ -189,7 +189,7 @@ public class ElasticsearchSerialWorkProcessorTest extends EasyMockSupport {
 		CompletableFuture<Void> sequence1Future = new CompletableFuture<>();
 
 		replayAll();
-		ElasticsearchSerialWorkProcessor strategy =
+		ElasticsearchSerialWorkProcessor processor =
 				new ElasticsearchSerialWorkProcessor( sequenceBuilderMock, bulkerMock );
 		verifyAll();
 
@@ -209,14 +209,14 @@ public class ElasticsearchSerialWorkProcessorTest extends EasyMockSupport {
 		expect( bulkerMock.addWorksToSequence() ).andReturn( true );
 		expect( sequenceBuilderMock.build() ).andReturn( sequence1Future );
 		replayAll();
-		CompletableFuture<Void> returnedSequence1Future = strategy.submit( workset1 );
+		CompletableFuture<Void> returnedSequence1Future = processor.submit( workset1 );
 		verifyAll();
 		assertThat( returnedSequence1Future ).isSameAs( sequence1Future );
 
 		resetAll();
 		bulkerMock.finalizeBulkWork();
 		replayAll();
-		CompletableFuture<Void> futureAll = strategy.endBatch();
+		CompletableFuture<Void> futureAll = processor.endBatch();
 		verifyAll();
 		assertThat( futureAll ).isSameAs( sequence1Future );
 	}
@@ -233,7 +233,7 @@ public class ElasticsearchSerialWorkProcessorTest extends EasyMockSupport {
 		CompletableFuture<Void> sequence2Future = new CompletableFuture<>();
 
 		replayAll();
-		ElasticsearchSerialWorkProcessor strategy =
+		ElasticsearchSerialWorkProcessor processor =
 				new ElasticsearchSerialWorkProcessor( sequenceBuilderMock, bulkerMock );
 		verifyAll();
 
@@ -245,7 +245,7 @@ public class ElasticsearchSerialWorkProcessorTest extends EasyMockSupport {
 		expect( bulkerMock.addWorksToSequence() ).andReturn( true );
 		expect( sequenceBuilderMock.build() ).andReturn( sequence1Future );
 		replayAll();
-		CompletableFuture<Void> returnedSequence1Future = strategy.submit( workset1 );
+		CompletableFuture<Void> returnedSequence1Future = processor.submit( workset1 );
 		verifyAll();
 		assertThat( returnedSequence1Future ).isSameAs( sequence1Future );
 
@@ -262,14 +262,14 @@ public class ElasticsearchSerialWorkProcessorTest extends EasyMockSupport {
 		expect( bulkerMock.addWorksToSequence() ).andReturn( false );
 		expect( sequenceBuilderMock.build() ).andReturn( sequence2Future );
 		replayAll();
-		CompletableFuture<Void> returnedSequence2Future = strategy.submit( workset2 );
+		CompletableFuture<Void> returnedSequence2Future = processor.submit( workset2 );
 		verifyAll();
 		assertThat( returnedSequence2Future ).isSameAs( sequence2Future );
 
 		resetAll();
 		bulkerMock.finalizeBulkWork();
 		replayAll();
-		CompletableFuture<Void> futureAll = strategy.endBatch();
+		CompletableFuture<Void> futureAll = processor.endBatch();
 		verifyAll();
 		assertThat( futureAll ).isSameAs( sequence2Future );
 	}

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/orchestration/impl/ElasticsearchSerialWorkProcessorTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/orchestration/impl/ElasticsearchSerialWorkProcessorTest.java
@@ -45,7 +45,41 @@ public class ElasticsearchSerialWorkProcessorTest extends EasyMockSupport {
 	}
 
 	@Test
-	public void simple() {
+	public void simple_singleWorkInWorkSet() {
+		ElasticsearchWork<Object> work = work( 1 );
+
+		CompletableFuture<Void> sequenceFuture = new CompletableFuture<>();
+
+		replayAll();
+		ElasticsearchSerialWorkProcessor processor =
+				new ElasticsearchSerialWorkProcessor( sequenceBuilderMock, bulkerMock );
+		verifyAll();
+
+		CompletableFuture<Object> workFuture = new CompletableFuture<>();
+		resetAll();
+		sequenceBuilderMock.init( anyObject() );
+		expect( work.aggregate( anyObject() ) ).andAnswer( nonBulkableAggregateAnswer( work ) );
+		expect( bulkerMock.addWorksToSequence() ).andReturn( false );
+		expect( sequenceBuilderMock.addNonBulkExecution( work ) ).andReturn( workFuture );
+		expect( bulkerMock.addWorksToSequence() ).andReturn( false );
+		expect( sequenceBuilderMock.build() ).andReturn( sequenceFuture );
+		replayAll();
+		CompletableFuture<Object> returnedWork2Future = processor.submit( work );
+		verifyAll();
+		assertThat( returnedWork2Future ).isSameAs( workFuture );
+
+		resetAll();
+		bulkerMock.finalizeBulkWork();
+		replayAll();
+		CompletableFuture<Void> futureAll = processor.endBatch();
+		verifyAll();
+		assertThat( futureAll ).isPending();
+		sequenceFuture.complete( null );
+		assertThat( futureAll ).isSuccessful( (Void) null );
+	}
+
+	@Test
+	public void simple_multipleWorksInWorkSet() {
 		ElasticsearchWork<Object> work1 = work( 1 );
 		BulkableElasticsearchWork<Object> work2 = bulkableWork( 2 );
 		List<ElasticsearchWork<?>> workset1 = Arrays.asList( work1, work2 );


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3727

Mainly useful for HSEARCH-3110 (restore support for ErrorHandler).