### PR TITLE
HSEARCH-3734 Configuration property hibernate.search.reflection.strategy is ignored

### DIFF
--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/SearchIntegrationBuilderImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/SearchIntegrationBuilderImpl.java
@@ -85,6 +85,11 @@ public class SearchIntegrationBuilderImpl implements SearchIntegrationBuilder {
 	}
 
 	@Override
+	public ConfigurationPropertySource getMaskedPropertySource() {
+		return propertySource;
+	}
+
+	@Override
 	public SearchIntegrationBuilder setClassResolver(ClassResolver classResolver) {
 		this.classResolver = classResolver;
 		return this;

--- a/engine/src/main/java/org/hibernate/search/engine/common/spi/SearchIntegrationBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/spi/SearchIntegrationBuilder.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.engine.common.spi;
 
+import org.hibernate.search.engine.cfg.spi.ConfigurationPropertySource;
 import org.hibernate.search.engine.environment.bean.spi.BeanProvider;
 import org.hibernate.search.engine.environment.classpath.spi.ClassResolver;
 import org.hibernate.search.engine.environment.classpath.spi.ResourceResolver;
@@ -16,6 +17,8 @@ import org.hibernate.search.engine.mapper.mapping.building.spi.MappingPartialBui
 
 
 public interface SearchIntegrationBuilder {
+
+	ConfigurationPropertySource getMaskedPropertySource();
 
 	SearchIntegrationBuilder setClassResolver(ClassResolver classResolver);
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/bootstrap/impl/HibernateOrmIntegrationBooterImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/bootstrap/impl/HibernateOrmIntegrationBooterImpl.java
@@ -66,7 +66,7 @@ public class HibernateOrmIntegrationBooterImpl implements HibernateOrmIntegratio
 	private final ServiceRegistryImplementor serviceRegistry;
 	private final ReflectionManager reflectionManager;
 	private final ConfigurationService ormConfigurationService;
-	private final ConfigurationPropertySource propertySource;
+	private final ConfigurationPropertySource rootPropertySource;
 	private final ConfigurationPropertyChecker propertyChecker;
 
 	private final Optional<EnvironmentSynchronizer> environmentSynchronizer;
@@ -93,7 +93,7 @@ public class HibernateOrmIntegrationBooterImpl implements HibernateOrmIntegratio
 		this.metadata = metadata;
 		this.serviceRegistry = (ServiceRegistryImplementor) bootstrapContext.getServiceRegistry();
 		this.reflectionManager = bootstrapContext.getReflectionManager();
-		this.propertySource = checkerWrappedPropertySource;
+		this.rootPropertySource = checkerWrappedPropertySource;
 		this.propertyChecker = propertyChecker;
 		this.ormConfigurationService = serviceRegistry.getService( ConfigurationService.class );
 
@@ -183,7 +183,7 @@ public class HibernateOrmIntegrationBooterImpl implements HibernateOrmIntegratio
 
 	private HibernateSearchContextProviderService bootNow(SessionFactoryImplementor sessionFactoryImplementor) {
 		Optional<HibernateOrmIntegrationPartialBuildState> partialBuildStateOptional =
-				INTEGRATION_PARTIAL_BUILD_STATE.get( propertySource );
+				INTEGRATION_PARTIAL_BUILD_STATE.get( rootPropertySource );
 
 		HibernateOrmIntegrationPartialBuildState partialBuildState;
 		if ( partialBuildStateOptional.isPresent() ) {
@@ -214,11 +214,12 @@ public class HibernateOrmIntegrationBooterImpl implements HibernateOrmIntegratio
 		BeanProvider beanProvider = null;
 		SearchIntegrationPartialBuildState searchIntegrationPartialBuildState = null;
 		try {
-			SearchIntegrationBuilder builder = SearchIntegration.builder( propertySource, propertyChecker );
+			SearchIntegrationBuilder builder = SearchIntegration.builder( rootPropertySource, propertyChecker );
 
 			HibernateOrmMappingKey mappingKey = new HibernateOrmMappingKey();
 			HibernateOrmMappingInitiator mappingInitiator = HibernateOrmMappingInitiator.create(
-					metadata, reflectionManager, ormConfigurationService, propertySource
+					metadata, reflectionManager, ormConfigurationService,
+					builder.getMaskedPropertySource()
 			);
 			builder.addMappingInitiator( mappingKey, mappingInitiator );
 
@@ -266,7 +267,7 @@ public class HibernateOrmIntegrationBooterImpl implements HibernateOrmIntegratio
 			HibernateOrmIntegrationPartialBuildState partialBuildState,
 			SessionFactoryImplementor sessionFactoryImplementor) {
 		SearchIntegrationFinalizer finalizer =
-				partialBuildState.integrationBuildState.finalizer( propertySource, propertyChecker );
+				partialBuildState.integrationBuildState.finalizer( rootPropertySource, propertyChecker );
 
 		HibernateOrmMapping mapping = finalizer.finalizeMapping(
 				partialBuildState.mappingKey,


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3734

Turns out we were passing a `propertySource` that was not masked ("hibernate.search." removed) to the introspector, which expected it to be masked. This PR solves the problem.

Not adding tests because I simply don't know how to check that method handles are not used.