### PR TITLE
HSEARCH-3726 Exceptions are not propagated from the Elasticsearch backend to the mapper when using IndexingPlan or automatic indexing

### DIFF
--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/orchestration/impl/ElasticsearchParallelWorkProcessorTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/orchestration/impl/ElasticsearchParallelWorkProcessorTest.java
@@ -116,6 +116,45 @@ public class ElasticsearchParallelWorkProcessorTest extends EasyMockSupport {
 	}
 
 	@Test
+	public void simple_sequenceFailure() {
+		ElasticsearchWork<Object> work = work( 1 );
+
+		CompletableFuture<Void> sequenceFuture = new CompletableFuture<>();
+
+		replayAll();
+		ElasticsearchParallelWorkProcessor processor =
+				new ElasticsearchParallelWorkProcessor( sequenceBuilderMock, bulkerMock );
+		verifyAll();
+
+		CompletableFuture<Object> workFuture = new CompletableFuture<>();
+		resetAll();
+		sequenceBuilderMock.init( anyObject() );
+		expect( work.aggregate( anyObject() ) ).andAnswer( nonBulkableAggregateAnswer( work ) );
+		expect( bulkerMock.addWorksToSequence() ).andReturn( false );
+		expect( sequenceBuilderMock.addNonBulkExecution( work ) ).andReturn( workFuture );
+		expect( bulkerMock.addWorksToSequence() ).andReturn( false );
+		expect( sequenceBuilderMock.build() ).andReturn( sequenceFuture );
+		replayAll();
+		CompletableFuture<Object> returnedWork2Future = processor.submit( work );
+		verifyAll();
+		assertThat( returnedWork2Future ).isSameAs( workFuture );
+
+		resetAll();
+		bulkerMock.finalizeBulkWork();
+		replayAll();
+		CompletableFuture<Void> futureAll = processor.endBatch();
+		verifyAll();
+		assertThat( futureAll ).isPending();
+
+		resetAll();
+		replayAll();
+		sequenceFuture.completeExceptionally( new RuntimeException() );
+		verifyAll();
+		// Failures in a sequence should be ignored
+		assertThat( futureAll ).isSuccessful( (Void) null );
+	}
+
+	@Test
 	public void parallelSequenceBetweenWorkset() {
 		ElasticsearchWork<Object> work1 = work( 1 );
 		List<ElasticsearchWork<?>> workset1 = Arrays.asList( work1 );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexIndexingPlanIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexIndexingPlanIT.java
@@ -118,8 +118,7 @@ public class IndexIndexingPlanIT {
 
 		// The operation should fail.
 		// Just check the failure is reported through the completable future.
-		// TODO HSEARCH-3736 Exceptions are not propagated to the future when using the Elasticsearch backend
-		//FutureAssert.assertThat( future ).isFailed();
+		FutureAssert.assertThat( future ).isFailed();
 
 		try {
 			setupHelper.cleanUp();
@@ -151,8 +150,7 @@ public class IndexIndexingPlanIT {
 
 		// The operation should fail.
 		// Just check the failure is reported through the completable future.
-		// TODO HSEARCH-3736 Exceptions are not propagated to the future when using the Elasticsearch backend
-		//FutureAssert.assertThat( future ).isFailed();
+		FutureAssert.assertThat( future ).isFailed();
 
 		// The custom failure handler should have received a failure.
 		// The ES backend may report multiple failures because it executes all works in bulk.


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3726

~Based on #2121 , which should be merged first.~ => Done