### PR TITLE
HSEARCH-3728 All background operations should propagate exceptions from the mapper to the user thread

### DIFF
--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/UnusedPropertiesIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/UnusedPropertiesIT.java
@@ -31,16 +31,16 @@ public class UnusedPropertiesIT {
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
 
 	@Rule
-	public ExpectedLog4jLog log = ExpectedLog4jLog.create();
+	public ExpectedLog4jLog logged = ExpectedLog4jLog.create();
 
 	@Test
 	public void checkDisabled_unusedProperty() {
 		String unusedPropertyKey = "hibernate.search.indexes.myIndex.foo";
-		log.expectMessage(
+		logged.expectMessage(
 				"Some properties in the Hibernate Search configuration were not used"
 		)
 				.never();
-		log.expectMessage( "Configuration property tracking is disabled" )
+		logged.expectMessage( "Configuration property tracking is disabled" )
 				.once();
 		setup( builder -> {
 			builder.setProperty( EngineSettings.CONFIGURATION_PROPERTY_CHECKING_STRATEGY, "ignore" );
@@ -51,15 +51,15 @@ public class UnusedPropertiesIT {
 	@Test
 	public void checkEnabledByDefault_unusedProperty() {
 		String unusedPropertyKey = "hibernate.search.indexes.myIndex.foo";
-		log.expectMessage(
+		logged.expectMessage(
 				"Some properties in the Hibernate Search configuration were not used",
 				"[" + unusedPropertyKey + "]"
 		)
 				.once();
-		log.expectMessage( "Configuration property tracking is disabled" )
+		logged.expectMessage( "Configuration property tracking is disabled" )
 				.never();
 		// Also check that used properties are not reported as unused
-		log.expectMessage( "not used", EngineSettings.DEFAULT_BACKEND )
+		logged.expectMessage( "not used", EngineSettings.DEFAULT_BACKEND )
 				.never();
 
 		setup( builder -> {
@@ -74,9 +74,9 @@ public class UnusedPropertiesIT {
 		 * This is a corner case worth testing, since the property may legitimately be accessed before
 		 * we start tracking property usage.
  		 */
-		log.expectMessage( "Some properties in the Hibernate Search configuration were not used" )
+		logged.expectMessage( "Some properties in the Hibernate Search configuration were not used" )
 				.never();
-		log.expectMessage( "Configuration property tracking is disabled" )
+		logged.expectMessage( "Configuration property tracking is disabled" )
 				.never();
 		setup( builder -> {
 			builder.setProperty( EngineSettings.CONFIGURATION_PROPERTY_CHECKING_STRATEGY, "warn" );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingFailureIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingFailureIT.java
@@ -59,7 +59,7 @@ public class MassIndexingFailureIT {
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
 
 	@Rule
-	public ExpectedLog4jLog log = ExpectedLog4jLog.create();
+	public ExpectedLog4jLog logged = ExpectedLog4jLog.create();
 
 	@Rule
 	public StaticCounters staticCounters = new StaticCounters();
@@ -71,7 +71,7 @@ public class MassIndexingFailureIT {
 	public void indexing_defaultHandler() {
 		SessionFactory sessionFactory = setup( null );
 
-		log.expectEvent(
+		logged.expectEvent(
 				Level.ERROR,
 				ExceptionMatcherBuilder.isException( SimulatedFailure.class )
 						.withMessage( "Indexing failure" )
@@ -127,7 +127,7 @@ public class MassIndexingFailureIT {
 	public void getId_defaultHandler() {
 		SessionFactory sessionFactory = setup( null );
 
-		log.expectEvent(
+		logged.expectEvent(
 				Level.ERROR,
 				ExceptionMatcherBuilder.isException( SearchException.class )
 						.withMessage( "Exception while invoking" )
@@ -170,7 +170,7 @@ public class MassIndexingFailureIT {
 	public void getTitle_defaultHandler() {
 		SessionFactory sessionFactory = setup( null );
 
-		log.expectEvent(
+		logged.expectEvent(
 				Level.ERROR,
 				ExceptionMatcherBuilder.isException( SearchException.class )
 						.withMessage( "Exception while invoking" )
@@ -212,7 +212,7 @@ public class MassIndexingFailureIT {
 	public void purge_defaultHandler() {
 		SessionFactory sessionFactory = setup( null );
 
-		log.expectEvent(
+		logged.expectEvent(
 				Level.ERROR,
 				ExceptionMatcherBuilder.isException( SimulatedFailure.class )
 						.withMessage( "Index-scope operation failure" )
@@ -255,7 +255,7 @@ public class MassIndexingFailureIT {
 	public void optimizeBefore_defaultHandler() {
 		SessionFactory sessionFactory = setup( null );
 
-		log.expectEvent(
+		logged.expectEvent(
 				Level.ERROR,
 				ExceptionMatcherBuilder.isException( SimulatedFailure.class )
 						.withMessage( "Index-scope operation failure" )
@@ -300,7 +300,7 @@ public class MassIndexingFailureIT {
 	public void optimizeAfter_defaultHandler() {
 		SessionFactory sessionFactory = setup( null );
 
-		log.expectEvent(
+		logged.expectEvent(
 				Level.ERROR,
 				ExceptionMatcherBuilder.isException( SimulatedFailure.class )
 						.withMessage( "Index-scope operation failure" )
@@ -349,7 +349,7 @@ public class MassIndexingFailureIT {
 	public void flush_defaultHandler() {
 		SessionFactory sessionFactory = setup( null );
 
-		log.expectEvent(
+		logged.expectEvent(
 				Level.ERROR,
 				ExceptionMatcherBuilder.isException( SimulatedFailure.class )
 						.withMessage( "Index-scope operation failure" )

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingFailureIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingFailureIT.java
@@ -43,6 +43,8 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.apache.log4j.Level;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.InstanceOfAssertFactory;
 import org.awaitility.Awaitility;
 
 public class MassIndexingFailureIT {
@@ -87,7 +89,14 @@ public class MassIndexingFailureIT {
 		doMassIndexingWithFailure(
 				sessionFactory,
 				ThreadExpectation.CREATED_AND_TERMINATED,
-				null, // TODO HSEARCH-3728 expect an exception when at least one entity failed to index
+				throwable -> assertThat( throwable ).isInstanceOf( SearchException.class )
+						.hasMessageContainingAll(
+								"1 entities could not be indexed",
+								"See the logs for details.",
+								"First failure on entity 'Book#2': ",
+								"Indexing failure"
+						)
+						.hasCauseInstanceOf( SimulatedFailure.class ),
 				expectIndexScopeWork( StubIndexScopeWork.Type.PURGE, ExecutionExpectation.SUCCEED ),
 				expectIndexScopeWork( StubIndexScopeWork.Type.OPTIMIZE, ExecutionExpectation.SUCCEED ),
 				expectIndexingWorks( ExecutionExpectation.FAIL ),
@@ -113,7 +122,13 @@ public class MassIndexingFailureIT {
 		doMassIndexingWithFailure(
 				sessionFactory,
 				ThreadExpectation.CREATED_AND_TERMINATED,
-				null, // TODO HSEARCH-3728 expect an exception when at least one entity failed to index
+				throwable -> assertThat( throwable ).isInstanceOf( SearchException.class )
+						.hasMessageContainingAll(
+								"1 entities could not be indexed",
+								"See the logs for details.",
+								"First failure on entity 'Book#2': ",
+								"Indexing failure"
+						),
 				expectIndexScopeWork( StubIndexScopeWork.Type.PURGE, ExecutionExpectation.SUCCEED ),
 				expectIndexScopeWork( StubIndexScopeWork.Type.OPTIMIZE, ExecutionExpectation.SUCCEED ),
 				expectIndexingWorks( ExecutionExpectation.FAIL ),
@@ -433,7 +448,15 @@ public class MassIndexingFailureIT {
 		doMassIndexingWithFailure(
 				sessionFactory,
 				ThreadExpectation.CREATED_AND_TERMINATED,
-				null, // TODO HSEARCH-3728 expect an exception when at least one entity failed to index
+				throwable -> assertThat( throwable ).isInstanceOf( SearchException.class )
+						.hasMessageContainingAll(
+								"1 entities could not be indexed",
+								"See the logs for details.",
+								"First failure on entity 'Book#2': ",
+								"Exception while invoking"
+						)
+						.extracting( Throwable::getCause ).asInstanceOf( new InstanceOfAssertFactory<>( SearchException.class, Assertions::assertThat ) )
+						.hasMessageContaining( "Exception while invoking" ),
 				ExecutionExpectation.FAIL, ExecutionExpectation.SKIP,
 				expectIndexScopeWork( StubIndexScopeWork.Type.PURGE, ExecutionExpectation.SUCCEED ),
 				expectIndexScopeWork( StubIndexScopeWork.Type.OPTIMIZE, ExecutionExpectation.SUCCEED ),
@@ -447,7 +470,15 @@ public class MassIndexingFailureIT {
 		doMassIndexingWithFailure(
 				sessionFactory,
 				ThreadExpectation.CREATED_AND_TERMINATED,
-				null, // TODO HSEARCH-3728 expect an exception when at least one entity failed to index
+				throwable -> assertThat( throwable ).isInstanceOf( SearchException.class )
+						.hasMessageContainingAll(
+								"1 entities could not be indexed",
+								"See the logs for details.",
+								"First failure on entity 'Book#2': ",
+								"Exception while invoking"
+						)
+						.extracting( Throwable::getCause ).asInstanceOf( new InstanceOfAssertFactory<>( SearchException.class, Assertions::assertThat ) )
+						.hasMessageContaining( "Exception while invoking" ),
 				ExecutionExpectation.SUCCEED, ExecutionExpectation.FAIL,
 				expectIndexScopeWork( StubIndexScopeWork.Type.PURGE, ExecutionExpectation.SUCCEED ),
 				expectIndexScopeWork( StubIndexScopeWork.Type.OPTIMIZE, ExecutionExpectation.SUCCEED ),

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingFailureIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingFailureIT.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Fail.fail;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
@@ -34,6 +35,7 @@ import org.hibernate.search.util.impl.integrationtest.common.stub.backend.index.
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.test.ExceptionMatcherBuilder;
+import org.hibernate.search.util.impl.test.SubTest;
 import org.hibernate.search.util.impl.test.rule.ExpectedLog4jLog;
 import org.hibernate.search.util.impl.test.rule.StaticCounters;
 
@@ -85,6 +87,7 @@ public class MassIndexingFailureIT {
 		doMassIndexingWithFailure(
 				sessionFactory,
 				ThreadExpectation.CREATED_AND_TERMINATED,
+				null, // TODO HSEARCH-3728 expect an exception when at least one entity failed to index
 				expectIndexScopeWork( StubIndexScopeWork.Type.PURGE, ExecutionExpectation.SUCCEED ),
 				expectIndexScopeWork( StubIndexScopeWork.Type.OPTIMIZE, ExecutionExpectation.SUCCEED ),
 				expectIndexingWorks( ExecutionExpectation.FAIL ),
@@ -110,6 +113,7 @@ public class MassIndexingFailureIT {
 		doMassIndexingWithFailure(
 				sessionFactory,
 				ThreadExpectation.CREATED_AND_TERMINATED,
+				null, // TODO HSEARCH-3728 expect an exception when at least one entity failed to index
 				expectIndexScopeWork( StubIndexScopeWork.Type.PURGE, ExecutionExpectation.SUCCEED ),
 				expectIndexScopeWork( StubIndexScopeWork.Type.OPTIMIZE, ExecutionExpectation.SUCCEED ),
 				expectIndexingWorks( ExecutionExpectation.FAIL ),
@@ -215,7 +219,7 @@ public class MassIndexingFailureIT {
 		logged.expectEvent(
 				Level.ERROR,
 				ExceptionMatcherBuilder.isException( SimulatedFailure.class )
-						.withMessage( "Index-scope operation failure" )
+						.withMessage( "PURGE failure" )
 						.build(),
 				"MassIndexer operation"
 		)
@@ -224,6 +228,8 @@ public class MassIndexingFailureIT {
 		doMassIndexingWithFailure(
 				sessionFactory,
 				ThreadExpectation.NOT_CREATED,
+				throwable -> assertThat( throwable ).isInstanceOf( SimulatedFailure.class )
+						.hasMessageContaining( "PURGE failure" ),
 				expectIndexScopeWork( StubIndexScopeWork.Type.PURGE, ExecutionExpectation.FAIL )
 		);
 	}
@@ -243,6 +249,8 @@ public class MassIndexingFailureIT {
 		doMassIndexingWithFailure(
 				sessionFactory,
 				ThreadExpectation.NOT_CREATED,
+				throwable -> assertThat( throwable ).isInstanceOf( SimulatedFailure.class )
+						.hasMessageContaining( "PURGE failure" ),
 				expectIndexScopeWork( StubIndexScopeWork.Type.PURGE, ExecutionExpectation.FAIL )
 		);
 
@@ -258,7 +266,7 @@ public class MassIndexingFailureIT {
 		logged.expectEvent(
 				Level.ERROR,
 				ExceptionMatcherBuilder.isException( SimulatedFailure.class )
-						.withMessage( "Index-scope operation failure" )
+						.withMessage( "OPTIMIZE failure" )
 						.build(),
 				"MassIndexer operation"
 		)
@@ -267,6 +275,8 @@ public class MassIndexingFailureIT {
 		doMassIndexingWithFailure(
 				sessionFactory,
 				ThreadExpectation.NOT_CREATED,
+				throwable -> assertThat( throwable ).isInstanceOf( SimulatedFailure.class )
+						.hasMessageContaining( "OPTIMIZE failure" ),
 				expectIndexScopeWork( StubIndexScopeWork.Type.PURGE, ExecutionExpectation.SUCCEED ),
 				expectIndexScopeWork( StubIndexScopeWork.Type.OPTIMIZE, ExecutionExpectation.FAIL )
 		);
@@ -287,6 +297,8 @@ public class MassIndexingFailureIT {
 		doMassIndexingWithFailure(
 				sessionFactory,
 				ThreadExpectation.NOT_CREATED,
+				throwable -> assertThat( throwable ).isInstanceOf( SimulatedFailure.class )
+						.hasMessageContaining( "OPTIMIZE failure" ),
 				expectIndexScopeWork( StubIndexScopeWork.Type.PURGE, ExecutionExpectation.SUCCEED ),
 				expectIndexScopeWork( StubIndexScopeWork.Type.OPTIMIZE, ExecutionExpectation.FAIL )
 		);
@@ -303,7 +315,7 @@ public class MassIndexingFailureIT {
 		logged.expectEvent(
 				Level.ERROR,
 				ExceptionMatcherBuilder.isException( SimulatedFailure.class )
-						.withMessage( "Index-scope operation failure" )
+						.withMessage( "OPTIMIZE failure" )
 						.build(),
 				"MassIndexer operation"
 		)
@@ -312,6 +324,8 @@ public class MassIndexingFailureIT {
 		doMassIndexingWithFailure(
 				sessionFactory,
 				ThreadExpectation.CREATED_AND_TERMINATED,
+				throwable -> assertThat( throwable ).isInstanceOf( SimulatedFailure.class )
+						.hasMessageContaining( "OPTIMIZE failure" ),
 				expectIndexScopeWork( StubIndexScopeWork.Type.PURGE, ExecutionExpectation.SUCCEED ),
 				expectIndexScopeWork( StubIndexScopeWork.Type.OPTIMIZE, ExecutionExpectation.SUCCEED ),
 				expectIndexingWorks( ExecutionExpectation.SUCCEED ),
@@ -334,6 +348,8 @@ public class MassIndexingFailureIT {
 		doMassIndexingWithFailure(
 				sessionFactory,
 				ThreadExpectation.CREATED_AND_TERMINATED,
+				throwable -> assertThat( throwable ).isInstanceOf( SimulatedFailure.class )
+						.hasMessageContaining( "OPTIMIZE failure" ),
 				expectIndexScopeWork( StubIndexScopeWork.Type.PURGE, ExecutionExpectation.SUCCEED ),
 				expectIndexScopeWork( StubIndexScopeWork.Type.OPTIMIZE, ExecutionExpectation.SUCCEED ),
 				expectIndexingWorks( ExecutionExpectation.SUCCEED ),
@@ -352,7 +368,7 @@ public class MassIndexingFailureIT {
 		logged.expectEvent(
 				Level.ERROR,
 				ExceptionMatcherBuilder.isException( SimulatedFailure.class )
-						.withMessage( "Index-scope operation failure" )
+						.withMessage( "FLUSH failure" )
 						.build(),
 				"MassIndexer operation"
 		)
@@ -361,6 +377,8 @@ public class MassIndexingFailureIT {
 		doMassIndexingWithFailure(
 				sessionFactory,
 				ThreadExpectation.CREATED_AND_TERMINATED,
+				throwable -> assertThat( throwable ).isInstanceOf( SimulatedFailure.class )
+						.hasMessageContaining( "FLUSH failure" ),
 				expectIndexScopeWork( StubIndexScopeWork.Type.PURGE, ExecutionExpectation.SUCCEED ),
 				expectIndexScopeWork( StubIndexScopeWork.Type.OPTIMIZE, ExecutionExpectation.SUCCEED ),
 				expectIndexingWorks( ExecutionExpectation.SUCCEED ),
@@ -384,6 +402,8 @@ public class MassIndexingFailureIT {
 		doMassIndexingWithFailure(
 				sessionFactory,
 				ThreadExpectation.CREATED_AND_TERMINATED,
+				throwable -> assertThat( throwable ).isInstanceOf( SimulatedFailure.class )
+						.hasMessageContaining( "FLUSH failure" ),
 				expectIndexScopeWork( StubIndexScopeWork.Type.PURGE, ExecutionExpectation.SUCCEED ),
 				expectIndexScopeWork( StubIndexScopeWork.Type.OPTIMIZE, ExecutionExpectation.SUCCEED ),
 				expectIndexingWorks( ExecutionExpectation.SUCCEED ),
@@ -396,11 +416,14 @@ public class MassIndexingFailureIT {
 		assertThat( staticCounters.get( StubFailureHandler.HANDLE_GENERIC_CONTEXT ) ).isEqualTo( 1 );
 	}
 
-	private void doMassIndexingWithFailure(SessionFactory sessionFactory, ThreadExpectation threadExpectation,
+	private void doMassIndexingWithFailure(SessionFactory sessionFactory,
+			ThreadExpectation threadExpectation,
+			Consumer<Throwable> thrownExpectation,
 			Runnable ... expectationSetters) {
 		doMassIndexingWithFailure(
 				sessionFactory,
 				threadExpectation,
+				thrownExpectation,
 				ExecutionExpectation.SUCCEED, ExecutionExpectation.SUCCEED,
 				expectationSetters
 		);
@@ -410,6 +433,7 @@ public class MassIndexingFailureIT {
 		doMassIndexingWithFailure(
 				sessionFactory,
 				ThreadExpectation.CREATED_AND_TERMINATED,
+				null, // TODO HSEARCH-3728 expect an exception when at least one entity failed to index
 				ExecutionExpectation.FAIL, ExecutionExpectation.SKIP,
 				expectIndexScopeWork( StubIndexScopeWork.Type.PURGE, ExecutionExpectation.SUCCEED ),
 				expectIndexScopeWork( StubIndexScopeWork.Type.OPTIMIZE, ExecutionExpectation.SUCCEED ),
@@ -423,6 +447,7 @@ public class MassIndexingFailureIT {
 		doMassIndexingWithFailure(
 				sessionFactory,
 				ThreadExpectation.CREATED_AND_TERMINATED,
+				null, // TODO HSEARCH-3728 expect an exception when at least one entity failed to index
 				ExecutionExpectation.SUCCEED, ExecutionExpectation.FAIL,
 				expectIndexScopeWork( StubIndexScopeWork.Type.PURGE, ExecutionExpectation.SUCCEED ),
 				expectIndexScopeWork( StubIndexScopeWork.Type.OPTIMIZE, ExecutionExpectation.SUCCEED ),
@@ -432,7 +457,9 @@ public class MassIndexingFailureIT {
 		);
 	}
 
-	private void doMassIndexingWithFailure(SessionFactory sessionFactory, ThreadExpectation threadExpectation,
+	private void doMassIndexingWithFailure(SessionFactory sessionFactory,
+			ThreadExpectation threadExpectation,
+			Consumer<Throwable> thrownExpectation,
 			ExecutionExpectation book2GetIdExpectation, ExecutionExpectation book2GetTitleExpectation,
 			Runnable ... expectationSetters) {
 		Book.failOnBook2GetId.set( ExecutionExpectation.FAIL.equals( book2GetIdExpectation ) );
@@ -447,11 +474,22 @@ public class MassIndexingFailureIT {
 					expectationSetter.run();
 				}
 
-				try {
-					indexer.startAndWait();
+				// TODO HSEARCH-3728 simplify this when even indexing exceptions are propagated
+				Runnable runnable = () -> {
+					try {
+						indexer.startAndWait();
+					}
+					catch (InterruptedException e) {
+						fail( "Unexpected InterruptedException: " + e.getMessage() );
+					}
+				};
+				if ( thrownExpectation == null ) {
+					runnable.run();
 				}
-				catch (InterruptedException e) {
-					fail( "Unexpected InterruptedException: " + e.getMessage() );
+				else {
+					SubTest.expectException( runnable )
+							.assertThrown()
+							.satisfies( thrownExpectation );
 				}
 			} );
 			backendMock.verifyExpectationsMet();
@@ -496,7 +534,7 @@ public class MassIndexingFailureIT {
 					break;
 				case FAIL:
 					CompletableFuture<?> failingFuture = new CompletableFuture<>();
-					failingFuture.completeExceptionally( new SimulatedFailure( "Index-scope operation failure" ) );
+					failingFuture.completeExceptionally( new SimulatedFailure( type.name() + " failure" ) );
 					backendMock.expectIndexScopeWorks( Book.NAME )
 							.indexScopeWork( type, failingFuture );
 					break;

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingMonitorIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingMonitorIT.java
@@ -26,6 +26,7 @@ import org.hibernate.search.mapper.orm.massindexing.monitor.MassIndexingMonitor;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
@@ -97,6 +98,9 @@ public class MassIndexingMonitorIT {
 			try {
 				indexer.monitor( new StaticCountersMonitor() )
 						.startAndWait();
+			}
+			catch (SearchException ignored) {
+				// Expected, but not relevant to this test
 			}
 			catch (InterruptedException e) {
 				fail( "Unexpected InterruptedException: " + e.getMessage() );

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/logging/impl/Log.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/logging/impl/Log.java
@@ -206,4 +206,10 @@ public interface Log extends BasicLogger {
 
 	@Message(id = ID_OFFSET_2 + 25, value = "Exception while handling transactions: %1$s")
 	SearchException massIndexingTransactionHandlingException(String causeMessage, @Cause Throwable cause);
+
+	@Message(id = ID_OFFSET_2 + 26, value = "%1$s entities could not be indexed. See the logs for details."
+			+ " First failure on entity '%2$s': %3$s")
+	SearchException massIndexingEntityFailures(long finalFailureCount,
+			EntityReference firstFailureEntity, String firstFailureMessage,
+			@Cause Throwable firstFailure);
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/logging/impl/Log.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/logging/impl/Log.java
@@ -80,7 +80,7 @@ public interface Log extends BasicLogger {
 	void cannotGuessTransactionStatus(@Cause Exception e);
 
 	@LogMessage(level = ERROR)
-	@Message(id = ID_OFFSET_1 + 62, value = "Batch indexing was interrupted")
+	@Message(id = ID_OFFSET_1 + 62, value = "Mass indexing was interrupted")
 	void interruptedBatchIndexing();
 
 	@LogMessage(level = ERROR)
@@ -155,8 +155,8 @@ public interface Log extends BasicLogger {
 	@Message(id = ID_OFFSET_2 + 12, value = "Exception while retrieving property type model for '%1$s' on '%2$s'.")
 	SearchException errorRetrievingPropertyTypeModel(String propertyModelName, @FormatWith(PojoTypeModelFormatter.class) PojoRawTypeModel<?> parentTypeModel, @Cause Exception cause);
 
-	@Message(id = ID_OFFSET_2 + 13, value = "Interrupted on batch Indexing; index will be left in unknown state!")
-	SearchException interruptedBatchIndexingException(@Cause Exception cause);
+	@Message(id = ID_OFFSET_2 + 13, value = "Mass indexing was interrupted; index will be left in unknown state!")
+	SearchException massIndexingThreadInterrupted(@Cause InterruptedException e);
 
 	@Message(id = ID_OFFSET_2 + 15,
 			value = "Invalid reflection strategy name: '%1$s'. Valid names are: %2$s.")
@@ -203,4 +203,7 @@ public interface Log extends BasicLogger {
 
 	@Message(id = ID_OFFSET_2 + 24, value = "Automatic indexing failed after transaction completion: %1$s" )
 	SearchException synchronizationAfterTransactionFailure(String causeMessage, @Cause Throwable cause);
+
+	@Message(id = ID_OFFSET_2 + 25, value = "Exception while handling transactions: %1$s")
+	SearchException massIndexingTransactionHandlingException(String causeMessage, @Cause Throwable cause);
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/BatchCoordinator.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/BatchCoordinator.java
@@ -137,8 +137,6 @@ public class BatchCoordinator extends FailureHandledRunnable {
 		// Wait for the executor to finish
 		Futures.unwrappedExceptionGet(
 				CompletableFuture.allOf( indexingFutures.toArray( new CompletableFuture[0] ) )
-						// Exceptions are handled by each runnable
-						.exceptionally( ignored -> null )
 		);
 	}
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/BatchCoordinator.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/BatchCoordinator.java
@@ -84,14 +84,9 @@ public class BatchCoordinator extends FailureHandledRunnable {
 			throw new AssertionFailure( "BatchCoordinator instance not expected to be reused" );
 		}
 
-		try {
-			beforeBatch(); // purgeAll and pre-optimize activities
-			doBatchWork();
-			afterBatch();
-		}
-		finally {
-			getNotifier().notifyIndexingComplete();
-		}
+		beforeBatch(); // purgeAll and pre-optimize activities
+		doBatchWork();
+		afterBatch();
 	}
 
 	@Override
@@ -108,8 +103,18 @@ public class BatchCoordinator extends FailureHandledRunnable {
 	}
 
 	@Override
+	protected void notifySuccess() {
+		getNotifier().notifyIndexingCompletedSuccessfully();
+	}
+
+	@Override
 	protected void notifyInterrupted(InterruptedException exception) {
-		log.interruptedBatchIndexing();
+		getNotifier().notifyIndexingCompletedWithInterruption();
+	}
+
+	@Override
+	protected void notifyFailure(RuntimeException exception) {
+		getNotifier().notifyIndexingCompletedWithFailure( exception );
 	}
 
 	private void cancelPendingTasks() {

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/BatchIndexingWorkspace.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/BatchIndexingWorkspace.java
@@ -101,8 +101,6 @@ public class BatchIndexingWorkspace<E, I> extends FailureHandledRunnable {
 		// Wait for indexing to finish.
 		Futures.unwrappedExceptionGet(
 				CompletableFuture.allOf( indexingFutures.toArray( new CompletableFuture[0] ) )
-						// Exceptions are handled by each runnable
-						.exceptionally( ignored -> null )
 		);
 		log.debugf( "Indexing for %s is done", indexedType.getName() );
 	}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/FailureHandledRunnable.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/FailureHandledRunnable.java
@@ -55,6 +55,9 @@ abstract class FailureHandledRunnable implements Runnable {
 			}
 
 			notifyFailure( e );
+
+			// Also propagate the exception
+			throw e;
 		}
 		finally {
 			if ( interrupted ) {

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/FailureHandledRunnable.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/FailureHandledRunnable.java
@@ -28,8 +28,10 @@ abstract class FailureHandledRunnable implements Runnable {
 	@Override
 	public final void run() {
 		boolean interrupted = false;
+		boolean successful = false;
 		try {
 			runWithFailureHandler();
+			successful = true;
 		}
 		catch (InterruptedException e) {
 			interrupted = true;
@@ -40,6 +42,7 @@ abstract class FailureHandledRunnable implements Runnable {
 				e.addSuppressed( e2 );
 			}
 
+			// This may throw an exception, and we're fine with not catching it.
 			notifyInterrupted( e );
 		}
 		catch (RuntimeException e) {
@@ -54,6 +57,7 @@ abstract class FailureHandledRunnable implements Runnable {
 				e.addSuppressed( e2 );
 			}
 
+			// This may throw an exception, and we're fine with not catching it.
 			notifyFailure( e );
 
 			// Also propagate the exception
@@ -65,6 +69,11 @@ abstract class FailureHandledRunnable implements Runnable {
 				Thread.currentThread().interrupt();
 			}
 		}
+
+		if ( successful ) {
+			// This may throw an exception, and we're fine with not catching it.
+			notifySuccess();
+		}
 	}
 
 	protected abstract void runWithFailureHandler() throws InterruptedException;
@@ -75,6 +84,10 @@ abstract class FailureHandledRunnable implements Runnable {
 
 	protected final MassIndexingNotifier getNotifier() {
 		return notifier;
+	}
+
+	protected void notifySuccess() {
+		// Do nothing by default
 	}
 
 	protected void notifyInterrupted(InterruptedException exception) {

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/FailureHandledRunnable.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/FailureHandledRunnable.java
@@ -8,8 +8,6 @@ package org.hibernate.search.mapper.orm.massindexing.impl;
 
 import java.lang.invoke.MethodHandles;
 
-import org.hibernate.search.engine.reporting.FailureContext;
-import org.hibernate.search.engine.reporting.FailureHandler;
 import org.hibernate.search.mapper.orm.logging.impl.Log;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
@@ -21,10 +19,10 @@ abstract class FailureHandledRunnable implements Runnable {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private final FailureHandler failureHandler;
+	private final MassIndexingNotifier notifier;
 
-	protected FailureHandledRunnable(FailureHandler failureHandler) {
-		this.failureHandler = failureHandler;
+	protected FailureHandledRunnable(MassIndexingNotifier notifier) {
+		this.notifier = notifier;
 	}
 
 	@Override
@@ -72,22 +70,22 @@ abstract class FailureHandledRunnable implements Runnable {
 
 	protected abstract void cleanUpOnFailure() throws InterruptedException;
 
-	protected final FailureHandler getFailureHandler() {
-		return failureHandler;
+	protected final MassIndexingNotifier getNotifier() {
+		return notifier;
 	}
 
 	protected void notifyInterrupted(InterruptedException exception) {
-		FailureContext.Builder contextBuilder = FailureContext.builder();
-		contextBuilder.throwable( log.massIndexingThreadInterrupted( exception ) );
-		contextBuilder.failingOperation( log.massIndexerOperation() );
-		failureHandler.handle( contextBuilder.build() );
+		notifier.notifyRunnableFailure(
+				log.massIndexingThreadInterrupted( exception ),
+				log.massIndexerOperation()
+		);
 	}
 
 	protected void notifyFailure(RuntimeException exception) {
-		FailureContext.Builder contextBuilder = FailureContext.builder();
-		contextBuilder.throwable( exception );
-		contextBuilder.failingOperation( log.massIndexerOperation() );
-		failureHandler.handle( contextBuilder.build() );
+		notifier.notifyRunnableFailure(
+				exception,
+				log.massIndexerOperation()
+		);
 	}
 
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/IdentifierConsumerDocumentProducer.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/IdentifierConsumerDocumentProducer.java
@@ -9,7 +9,6 @@ package org.hibernate.search.mapper.orm.massindexing.impl;
 import java.lang.invoke.MethodHandles;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
 import javax.persistence.LockModeType;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
@@ -59,7 +58,6 @@ public class IdentifierConsumerDocumentProducer<E, I> implements Runnable {
 	private final MassIndexingMonitor monitor;
 	private final FailureHandler failureHandler;
 	private final SingularAttribute<? super E, I> idAttributeOfIndexedType;
-	private final CountDownLatch producerEndSignal;
 	private final Integer transactionTimeout;
 	private final String tenantId;
 
@@ -72,7 +70,7 @@ public class IdentifierConsumerDocumentProducer<E, I> implements Runnable {
 			ProducerConsumerQueue<List<I>> fromIdentifierListToEntities,
 			MassIndexingMonitor monitor, FailureHandler failureHandler,
 			HibernateOrmMassIndexingMappingContext mappingContext,
-			CountDownLatch producerEndSignal, CacheMode cacheMode,
+			CacheMode cacheMode,
 			Class<E> indexedType, String entityName, SingularAttribute<? super E, I> idAttributeOfIndexedType,
 			Integer transactionTimeout,
 			String tenantId) {
@@ -84,7 +82,6 @@ public class IdentifierConsumerDocumentProducer<E, I> implements Runnable {
 		this.monitor = monitor;
 		this.failureHandler = failureHandler;
 		this.idAttributeOfIndexedType = idAttributeOfIndexedType;
-		this.producerEndSignal = producerEndSignal;
 		this.transactionTimeout = transactionTimeout;
 		this.tenantId = tenantId;
 		this.transactionManager = mappingContext.getSessionFactory()
@@ -115,7 +112,6 @@ public class IdentifierConsumerDocumentProducer<E, I> implements Runnable {
 			failureHandler.handle( failureContextBuilder.build() );
 		}
 		finally {
-			producerEndSignal.countDown();
 			session.close();
 		}
 		log.trace( "finished" );

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/IdentifierConsumerDocumentProducer.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/IdentifierConsumerDocumentProducer.java
@@ -95,14 +95,13 @@ public class IdentifierConsumerDocumentProducer<E, I> implements Runnable {
 	@Override
 	public void run() {
 		log.trace( "started" );
-		SessionImplementor session = (SessionImplementor) mappingContext.getSessionFactory()
+		try ( SessionImplementor session = (SessionImplementor) mappingContext.getSessionFactory()
 				.withOptions()
 				.tenantIdentifier( tenantId )
-				.openSession();
-		session.setHibernateFlushMode( FlushMode.MANUAL );
-		session.setCacheMode( cacheMode );
-		session.setDefaultReadOnly( true );
-		try {
+				.openSession() ) {
+			session.setHibernateFlushMode( FlushMode.MANUAL );
+			session.setCacheMode( cacheMode );
+			session.setDefaultReadOnly( true );
 			loadAllFromQueue( session );
 		}
 		catch (Exception exception) {
@@ -110,9 +109,6 @@ public class IdentifierConsumerDocumentProducer<E, I> implements Runnable {
 			failureContextBuilder.throwable( exception );
 			failureContextBuilder.failingOperation( log.massIndexingLoadingAndExtractingEntityData( entityName ) );
 			failureHandler.handle( failureContextBuilder.build() );
-		}
-		finally {
-			session.close();
 		}
 		log.trace( "finished" );
 	}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/IdentifierProducer.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/IdentifierProducer.java
@@ -98,7 +98,7 @@ public class IdentifierProducer<E, I> implements StatelessSessionAwareRunnable {
 		try {
 			inTransactionWrapper( upperSession );
 		}
-		catch (Exception exception) {
+		catch (RuntimeException exception) {
 			FailureContext.Builder contextBuilder = FailureContext.builder();
 			contextBuilder.throwable( exception );
 			contextBuilder.failingOperation( log.massIndexerFetchingIds( entityName ) );

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/MassIndexerImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/MassIndexerImpl.java
@@ -186,13 +186,17 @@ public class MassIndexerImpl implements MassIndexer {
 	}
 
 	protected BatchCoordinator createCoordinator() {
+		MassIndexingNotifier notifier = new MassIndexingNotifier(
+				mappingContext.getFailureHandler(),
+				getOrCreateMonitor()
+		);
 		return new BatchCoordinator(
 				mappingContext, sessionContext,
+				notifier,
 				rootEntities, scopeWorkspace,
 				typesToIndexInParallel, documentBuilderThreads,
 				cacheMode, objectLoadingBatchSize, objectsLimit,
 				optimizeAtEnd, purgeAtStart, optimizeAfterPurge,
-				getOrCreateMonitor(),
 				idFetchSize, idLoadingTransactionTimeout
 		);
 	}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/MassIndexingNotifier.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/MassIndexingNotifier.java
@@ -1,0 +1,92 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.orm.massindexing.impl;
+
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.atomic.LongAdder;
+
+import org.hibernate.Session;
+import org.hibernate.search.engine.reporting.EntityIndexingFailureContext;
+import org.hibernate.search.engine.reporting.FailureContext;
+import org.hibernate.search.engine.reporting.FailureHandler;
+import org.hibernate.search.mapper.orm.common.EntityReference;
+import org.hibernate.search.mapper.orm.common.impl.EntityReferenceImpl;
+import org.hibernate.search.mapper.orm.logging.impl.Log;
+import org.hibernate.search.mapper.orm.massindexing.monitor.MassIndexingMonitor;
+import org.hibernate.search.util.common.logging.impl.LoggerFactory;
+
+class MassIndexingNotifier {
+
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+
+	private final FailureHandler failureHandler;
+	private final MassIndexingMonitor monitor;
+
+	private final LongAdder failureCount = new LongAdder();
+
+	MassIndexingNotifier(FailureHandler failureHandler,
+			MassIndexingMonitor monitor) {
+		this.failureHandler = failureHandler;
+		this.monitor = monitor;
+	}
+
+	void notifyAddedTotalCount(long totalCount) {
+		monitor.addToTotalCount( totalCount );
+	}
+
+	void notifyRunnableFailure(Exception exception, String operation) {
+		FailureContext.Builder contextBuilder = FailureContext.builder();
+		contextBuilder.throwable( exception );
+		contextBuilder.failingOperation( operation );
+		failureHandler.handle( contextBuilder.build() );
+	}
+
+	void notifyEntitiesLoaded(int size) {
+		monitor.entitiesLoaded( size );
+	}
+
+	void notifyDocumentBuilt() {
+		monitor.documentsBuilt( 1 );
+	}
+
+	void notifyDocumentsAdded(int size) {
+		monitor.documentsAdded( size );
+	}
+
+	<T> void notifyEntityIndexingFailure(Class<T> entityType, String entityName,
+			Session session, T entity, Throwable throwable) {
+		failureCount.increment();
+		EntityIndexingFailureContext.Builder contextBuilder = EntityIndexingFailureContext.builder();
+		contextBuilder.throwable( throwable );
+		// Add minimal information here, but information we're sure we can get
+		contextBuilder.failingOperation( log.massIndexerIndexingInstance( entityName ) );
+		// Add more information here, but information that may not be available if the session completely broke down
+		// (we're being extra careful here because we don't want to throw an exception while handling and exception)
+		EntityReference entityReference = extractReferenceOrSuppress( entityType, entityName, session, entity, throwable );
+		if ( entityReference != null ) {
+			contextBuilder.entityReference( entityReference );
+		}
+		failureHandler.handle( contextBuilder.build() );
+	}
+
+	void notifyIndexingComplete() {
+		monitor.indexingCompleted();
+	}
+
+	private <T> EntityReference extractReferenceOrSuppress(Class<T> entityType, String entityName,
+			Session session, Object entity, Throwable throwable) {
+		try {
+			return new EntityReferenceImpl( entityType, entityName, session.getIdentifier( entity ) );
+		}
+		catch (RuntimeException e) {
+			// We failed to extract a reference.
+			// Let's just give up and suppress the exception.
+			throwable.addSuppressed( e );
+			return null;
+		}
+	}
+}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/OptionallyWrapInJTATransaction.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/OptionallyWrapInJTATransaction.java
@@ -14,7 +14,6 @@ import javax.transaction.RollbackException;
 import javax.transaction.SystemException;
 
 import org.hibernate.StatelessSession;
-import org.hibernate.search.engine.reporting.FailureHandler;
 import org.hibernate.search.mapper.orm.logging.impl.Log;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
@@ -40,10 +39,10 @@ public class OptionallyWrapInJTATransaction extends FailureHandledRunnable {
 	private final String tenantId;
 
 	public OptionallyWrapInJTATransaction(BatchTransactionalContext batchContext,
-			FailureHandler failureHandler,
+			MassIndexingNotifier notifier,
 			StatelessSessionAwareRunnable statelessSessionAwareRunnable,
 			Integer transactionTimeout, String tenantId) {
-		super( failureHandler );
+		super( notifier );
 		/*
 		 * Unfortunately we need to access SessionFactoryImplementor to detect:
 		 *  - whether or not we need to start the JTA transaction

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/StatelessSessionAwareRunnable.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/StatelessSessionAwareRunnable.java
@@ -13,6 +13,6 @@ import org.hibernate.StatelessSession;
  */
 public interface StatelessSessionAwareRunnable {
 
-	void run(StatelessSession session) throws Exception;
+	void run(StatelessSession session);
 
 }


### PR DESCRIPTION
[HSEARCH-3728](https://hibernate.atlassian.net/browse/HSEARCH-3728): All background operations should propagate exceptions from the mapper to the user thread

~Based on #2125 , which should be merged first.~ => Done

All operations are already tested and already behave this way, except the mass indexer. So this is only about the mass indexer.