### PR TITLE
HSEARCH-3738 Upgrade to Byteman 4.0.8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -169,7 +169,7 @@ stage('Configure') {
 					new JdkBuildEnvironment(version: '13', tool: 'OpenJDK 13 Latest', status: BuildEnvironmentStatus.SUPPORTED,
 							// Elasticsearch won't run on JDK13+
 							elasticsearchTool: 'OpenJDK 11 Latest'),
-					new JdkBuildEnvironment(version: '14', tool: 'OpenJDK 14 Latest', status: BuildEnvironmentStatus.EXPERIMENTAL,
+					new JdkBuildEnvironment(version: '14', tool: 'OpenJDK 14 Latest', status: BuildEnvironmentStatus.SUPPORTED,
 							// Elasticsearch won't run on JDK13+
 							elasticsearchTool: 'OpenJDK 11 Latest')
 			],

--- a/pom.xml
+++ b/pom.xml
@@ -2072,6 +2072,17 @@
         </profile>
 
         <profile>
+            <id>jdk14+</id>
+            <activation>
+                <jdk>[14,)</jdk>
+            </activation>
+            <properties>
+                <!-- JMS tests fail with JDK14 for some reason -->
+                <failsafe.wildfly.skip>true</failsafe.wildfly.skip>
+            </properties>
+        </profile>
+
+        <profile>
             <id>compiler-eclipse</id>
             <build>
                 <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
         <version.com.github.tomakehurst.wiremock>2.5.1</version.com.github.tomakehurst.wiremock>
         <!-- Fixes dependency convergence within Wiremock, see below -->
         <version.com.fasterxml.jackson>2.8.6</version.com.fasterxml.jackson>
-        <version.org.jboss.byteman>4.0.7</version.org.jboss.byteman>
+        <version.org.jboss.byteman>4.0.8</version.org.jboss.byteman>
         <version.io.takari.junit>1.2.7</version.io.takari.junit>
         <version.com.h2database>1.4.178</version.com.h2database>
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3738

Targeting branch 5.11 only, since we don't use Byteman in 6.0 (master) for now.

Build on JDK14: https://ci.hibernate.org/job/hibernate-search/job/PR-2129/9/