### PR TITLE
HSEARCH-3486 + HSEARCH-3743 + HSEARCH-3744 JDK14 support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -181,7 +181,7 @@ stage('Configure') {
 					new JdkBuildEnvironment(version: '8', tool: 'OpenJDK 8 Latest', status: BuildEnvironmentStatus.USED_IN_DEFAULT_BUILD),
 					new JdkBuildEnvironment(version: '11', tool: 'OpenJDK 11 Latest', status: BuildEnvironmentStatus.SUPPORTED),
 					new JdkBuildEnvironment(version: '13', tool: 'OpenJDK 13 Latest', status: BuildEnvironmentStatus.SUPPORTED),
-					new JdkBuildEnvironment(version: '14', tool: 'OpenJDK 14 Latest', status: BuildEnvironmentStatus.EXPERIMENTAL)
+					new JdkBuildEnvironment(version: '14', tool: 'OpenJDK 14 Latest', status: BuildEnvironmentStatus.SUPPORTED)
 			],
 			compiler: [
 					new CompilerBuildEnvironment(name: 'eclipse', mavenProfile: 'compiler-eclipse', status: BuildEnvironmentStatus.SUPPORTED),

--- a/integrationtest/backend/tck/pom.xml
+++ b/integrationtest/backend/tck/pom.xml
@@ -12,15 +12,6 @@
     <name>Hibernate Search Integration Tests - Backend TCK</name>
     <description>Hibernate Search backend TCK, including tests for every feature common to all the backends</description>
 
-    <properties>
-        <!--
-            Consider all sources as tests during Sonar analysis.
-            This is important because some analysis rules do not apply to test code.
-         -->
-        <sonar.sources>${rootProject.emptySubdirectory}</sonar.sources>
-        <sonar.tests>${project.build.sourceDirectory}</sonar.tests>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.hibernate.search</groupId>

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/BooleanFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/BooleanFieldTypeDescriptor.java
@@ -33,10 +33,7 @@ public class BooleanFieldTypeDescriptor extends FieldTypeDescriptor<Boolean> {
 	public Optional<IndexingExpectations<Boolean>> getIndexingExpectations() {
 		return Optional.of( new IndexingExpectations<>(
 				true,
-				false,
-				// This is ugly, but we test it on purpose
-				new Boolean( true ),
-				new Boolean( false )
+				false
 		) );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/ByteFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/ByteFieldTypeDescriptor.java
@@ -42,9 +42,7 @@ public class ByteFieldTypeDescriptor extends FieldTypeDescriptor<Byte> {
 	public Optional<IndexingExpectations<Byte>> getIndexingExpectations() {
 		return Optional.of( new IndexingExpectations<>(
 				Byte.MIN_VALUE, Byte.MAX_VALUE,
-				(byte) -42, (byte) -1, (byte) 0, (byte) 1, (byte) 3, (byte) 42,
-				// This is ugly, but we test it on purpose
-				new Byte( (byte) 44 )
+				(byte) -42, (byte) -1, (byte) 0, (byte) 1, (byte) 3, (byte) 42
 		) );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/DoubleFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/DoubleFieldTypeDescriptor.java
@@ -50,9 +50,7 @@ public class DoubleFieldTypeDescriptor extends FieldTypeDescriptor<Double> {
 				Math.nextDown( 0.0 ),
 				Math.nextUp( 0.0 ),
 				42.42,
-				1584514514.000000184,
-				// This is ugly, but we test it on purpose
-				new Double( 44.0 )
+				1584514514.000000184
 		) );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/FloatFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/FloatFieldTypeDescriptor.java
@@ -50,9 +50,7 @@ public class FloatFieldTypeDescriptor extends FieldTypeDescriptor<Float> {
 				Math.nextDown( 0.0f ),
 				Math.nextUp( 0.0f ),
 				42.42f,
-				1584514514.000000184f,
-				// This is ugly, but we test it on purpose
-				new Float( 44.0f )
+				1584514514.000000184f
 		) );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/IntegerFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/IntegerFieldTypeDescriptor.java
@@ -42,9 +42,7 @@ public class IntegerFieldTypeDescriptor extends FieldTypeDescriptor<Integer> {
 	public Optional<IndexingExpectations<Integer>> getIndexingExpectations() {
 		return Optional.of( new IndexingExpectations<>(
 				Integer.MIN_VALUE, Integer.MAX_VALUE,
-				-251_484_254, -42, -1, 0, 1, 3, 42, 151_484_254,
-				// This is ugly, but we test it on purpose
-				new Integer( 44 )
+				-251_484_254, -42, -1, 0, 1, 3, 42, 151_484_254
 		) );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/LongFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/LongFieldTypeDescriptor.java
@@ -43,9 +43,7 @@ public class LongFieldTypeDescriptor extends FieldTypeDescriptor<Long> {
 		return Optional.of( new IndexingExpectations<>(
 				Long.MIN_VALUE, Long.MAX_VALUE,
 				(long) Integer.MIN_VALUE, (long) Integer.MAX_VALUE,
-				-251_484_254L, -42L, -1L, 0L, 1L, 3L, 42L, 151_484_254L,
-				// This is ugly, but we test it on purpose
-				new Long( 44L )
+				-251_484_254L, -42L, -1L, 0L, 1L, 3L, 42L, 151_484_254L
 		) );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/ShortFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/ShortFieldTypeDescriptor.java
@@ -42,9 +42,7 @@ public class ShortFieldTypeDescriptor extends FieldTypeDescriptor<Short> {
 	public Optional<IndexingExpectations<Short>> getIndexingExpectations() {
 		return Optional.of( new IndexingExpectations<>(
 				Short.MIN_VALUE, Short.MAX_VALUE,
-				(short) -25435, (short) -42, (short) -1, (short) 0, (short) 1, (short) 3, (short) 42, (short) 18353,
-				// This is ugly, but we test it on purpose
-				new Short( (short) 47 )
+				(short) -25435, (short) -42, (short) -1, (short) 0, (short) 1, (short) 3, (short) 42, (short) 18353
 		) );
 	}
 

--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -15,6 +15,10 @@
     <properties>
         <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         <maven.javadoc.skip>true</maven.javadoc.skip>
+
+        <!-- Apply the test source/target settings to all code in integration test utils, even code in src/main -->
+        <maven.compiler.argument.source>${maven.compiler.argument.testSource}</maven.compiler.argument.source>
+        <maven.compiler.argument.target>${maven.compiler.argument.testTarget}</maven.compiler.argument.target>
     </properties>
 
     <modules>

--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -19,6 +19,13 @@
         <!-- Apply the test source/target settings to all code in integration test utils, even code in src/main -->
         <maven.compiler.argument.source>${maven.compiler.argument.testSource}</maven.compiler.argument.source>
         <maven.compiler.argument.target>${maven.compiler.argument.testTarget}</maven.compiler.argument.target>
+
+        <!--
+            Consider all sources as tests during Sonar analysis.
+            This is important because some analysis rules do not apply to test code.
+         -->
+        <sonar.sources>${rootProject.emptySubdirectory}</sonar.sources>
+        <sonar.tests>${project.build.sourceDirectory}</sonar.tests>
     </properties>
 
     <modules>

--- a/integrationtest/showcase/library/pom.xml
+++ b/integrationtest/showcase/library/pom.xml
@@ -126,6 +126,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
+                    <skip>${failsafe.spring.skip}</skip>
                     <!--
                         Since we do not pass the Hibernate ORM settings through system properties directly
                         (see the override of the failsafe.jvm.args.hibernate-orm near the top of this file),

--- a/integrationtest/showcase/library/pom.xml
+++ b/integrationtest/showcase/library/pom.xml
@@ -13,7 +13,7 @@
     <description>Hibernate Search showcase based on the ORM and Elasticsearch integrations, using libraries and books as business objects</description>
 
     <properties>
-        <version.org.springframework.boot>2.1.2.RELEASE</version.org.springframework.boot>
+        <version.org.springframework.boot>2.2.0.RELEASE</version.org.springframework.boot>
 
         <!--
             Remove Hibernate system properties from parent settings:

--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
         <version.site.plugin>3.6</version.site.plugin>
         <version.source.plugin>3.0.1</version.source.plugin>
         <!-- Surefire versions are a minefield of bugs: be careful with upgrades -->
-        <version.surefire.plugin>2.21.0</version.surefire.plugin>
+        <version.surefire.plugin>2.22.2</version.surefire.plugin>
         <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
         <version.org.wildfly.build-tools>1.2.9.Final</version.org.wildfly.build-tools>
         <version.jacoco.plugin>0.8.3</version.jacoco.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -2006,6 +2006,17 @@
         </profile>
 
         <profile>
+            <id>jdk14+</id>
+            <activation>
+                <jdk>[14,)</jdk>
+            </activation>
+            <properties>
+                <!-- ForbiddenAPIs doesn't provide bundled signatures for JDK14... yet. -->
+                <forbiddenapis.skip>true</forbiddenapis.skip>
+            </properties>
+        </profile>
+
+        <profile>
             <id>compiler-eclipse</id>
             <build>
                 <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
         <version.clean.plugin>3.0.0</version.clean.plugin>
         <version.copy.plugin>0.0.5</version.copy.plugin>
         <!-- Needing 3.6.2 at least because of MCOMPILER-294 -->
-        <version.compiler.plugin>3.7.0</version.compiler.plugin>
+        <version.compiler.plugin>3.8.1</version.compiler.plugin>
         <version.dependency.plugin>3.0.2</version.dependency.plugin>
         <!-- Check dependencies for security vulnerabilities -->
         <version.dependency-check.plugin>3.1.1</version.dependency-check.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -327,11 +327,17 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <!-- Set statically: we want our code to comply with this version -->
+        <java-version.baseline.major>1.8</java-version.baseline.major>
+        <!-- Updated dynamically depending on the current JDK using profiles (see further down) -->
+        <java-version.jdk.major>1.8</java-version.jdk.major>
+
+        <maven.compiler.target>${java-version.baseline.major}</maven.compiler.target>
+        <maven.compiler.source>${java-version.baseline.major}</maven.compiler.source>
         <!-- This is used to generate a link to the standard Java library javadoc -->
         <javadoc.javase.url>http://download.oracle.com/javase/8/docs/api/</javadoc.javase.url>
-        <maven.compiler.testTarget>${maven.compiler.target}</maven.compiler.testTarget>
+        <!-- Generate Java 13/14 bytecode for tests when building with JDK13/14 -->
+        <maven.compiler.testTarget>${java-version.jdk.major}</maven.compiler.testTarget>
         <maven.compiler.testSource>${maven.compiler.source}</maven.compiler.testSource>
         <!--
                 Options to override the compiler arguments directly on the compiler argument line to separate between what
@@ -1936,6 +1942,17 @@
             <modules>
                 <!-- Nothing at the moment -->
             </modules>
+        </profile>
+
+        <profile>
+            <id>jdk9+</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <properties>
+                <!-- 'java.specification.version' is only correct from Java 9 onwards -->
+                <java-version.jdk.major>${java.specification.version}</java-version.jdk.major>
+            </properties>
         </profile>
 
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -419,6 +419,9 @@
         <surefire.jvm.args>${surefire.jvm.args.memory} ${surefire.jvm.args.java-version} ${surefire.jvm.args.jacoco}</surefire.jvm.args>
         <failsafe.jvm.args>${surefire.jvm.args.memory} ${surefire.jvm.args.java-version} ${failsafe.jvm.args.jacoco} ${failsafe.jvm.args.hibernate-orm}</failsafe.jvm.args>
 
+        <!-- Disable integration tests selectively. To be set in specific profile, e.g. for a specific JDK version. -->
+        <failsafe.spring.skip>${skipITs}</failsafe.spring.skip>
+
         <!--
             Should be set by submodules.
             Used by integration tests modules that execute tests from another module.
@@ -2072,6 +2075,8 @@
             <properties>
                 <!-- ForbiddenAPIs doesn't provide bundled signatures for JDK14... yet. -->
                 <forbiddenapis.skip>true</forbiddenapis.skip>
+                <!-- Spring isn't ready for JDK14 yet: https://github.com/spring-projects/spring-framework/issues/23678 -->
+                <failsafe.spring.skip>true</failsafe.spring.skip>
             </properties>
         </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -279,6 +279,7 @@
         <version.source.plugin>3.0.1</version.source.plugin>
         <!-- Surefire versions are a minefield of bugs: be careful with upgrades -->
         <version.surefire.plugin>2.22.2</version.surefire.plugin>
+        <version.surefire.plugin.java-version.asm>7.2</version.surefire.plugin.java-version.asm>
         <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
         <version.org.wildfly.build-tools>1.2.9.Final</version.org.wildfly.build-tools>
         <version.jacoco.plugin>0.8.3</version.jacoco.plugin>
@@ -2003,6 +2004,47 @@
                 <!-- https://bugs.openjdk.java.net/browse/JDK-8212233?focusedCommentId=14245762 -->
                 <javadoc.additionalOptions.java-version>-html5 -source 8</javadoc.additionalOptions.java-version>
             </properties>
+        </profile>
+
+        <profile>
+            <id>jdk13+</id>
+            <activation>
+                <jdk>[13,)</jdk>
+            </activation>
+            <build>
+                <!--
+                     maven-surefire-plugin and maven-failsafe-plugin use an older version of ASM
+                     that cannot handle Java 13/14 bytecode.
+                     Let's upgrade that dependency and hope for the best;
+                     if it doesn't work, the build is very likely to fail and we'll know about it.
+                 -->
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-surefire-plugin</artifactId>
+                            <dependencies>
+                                <dependency>
+                                    <groupId>org.ow2.asm</groupId>
+                                    <artifactId>asm</artifactId>
+                                    <version>${version.surefire.plugin.java-version.asm}</version>
+                                </dependency>
+                            </dependencies>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-failsafe-plugin</artifactId>
+                            <dependencies>
+                                <dependency>
+                                    <groupId>org.ow2.asm</groupId>
+                                    <artifactId>asm</artifactId>
+                                    <version>${version.surefire.plugin.java-version.asm}</version>
+                                </dependency>
+                            </dependencies>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
         </profile>
 
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -1445,7 +1445,7 @@
                         <execution>
                             <id>verify-forbidden-apis</id>
                             <configuration>
-                                <targetVersion>10</targetVersion>
+                                <targetVersion>13</targetVersion>
                                 <!-- if the used Java version is too new, don't fail, just do nothing: -->
                                 <failOnUnsupportedJava>false</failOnUnsupportedJava>
                                 <excludes>
@@ -1489,16 +1489,22 @@
                                     <bundledSignature>jdk-unsafe-9</bundledSignature>
                                     <bundledSignature>jdk-unsafe-10</bundledSignature>
                                     <bundledSignature>jdk-unsafe-11</bundledSignature>
+                                    <bundledSignature>jdk-unsafe-12</bundledSignature>
+                                    <bundledSignature>jdk-unsafe-13</bundledSignature>
 
                                     <bundledSignature>jdk-deprecated-1.8</bundledSignature>
                                     <bundledSignature>jdk-deprecated-9</bundledSignature>
                                     <bundledSignature>jdk-deprecated-10</bundledSignature>
                                     <bundledSignature>jdk-deprecated-11</bundledSignature>
+                                    <bundledSignature>jdk-deprecated-12</bundledSignature>
+                                    <bundledSignature>jdk-deprecated-13</bundledSignature>
 
                                     <bundledSignature>jdk-internal-1.8</bundledSignature>
                                     <bundledSignature>jdk-internal-9</bundledSignature>
                                     <bundledSignature>jdk-internal-10</bundledSignature>
                                     <bundledSignature>jdk-internal-11</bundledSignature>
+                                    <bundledSignature>jdk-internal-12</bundledSignature>
+                                    <bundledSignature>jdk-internal-13</bundledSignature>
                                 </bundledSignatures>
                                 <failOnMissingClasses>false</failOnMissingClasses>
                                 <failOnUnresolvableSignatures>false</failOnUnresolvableSignatures>

--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,7 @@
         <version.deploy.plugin>2.8.2</version.deploy.plugin>
         <version.org.eclipse.m2e.lifecycle-mapping>1.0.0</version.org.eclipse.m2e.lifecycle-mapping>
         <version.enforcer.plugin>3.0.0-M1</version.enforcer.plugin>
-        <version.forbiddenapis.plugin>2.6</version.forbiddenapis.plugin>
+        <version.forbiddenapis.plugin>2.7</version.forbiddenapis.plugin>
         <version.help.plugin>2.2</version.help.plugin>
         <version.install.plugin>2.5.2</version.install.plugin>
         <version.japicmp.plugin>0.9.3</version.japicmp.plugin>

--- a/util/internal/integrationtest/pom.xml
+++ b/util/internal/integrationtest/pom.xml
@@ -17,6 +17,10 @@
         <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         <maven.javadoc.skip>true</maven.javadoc.skip>
 
+        <!-- Apply the test source/target settings to all code in integration test utils, even code in src/main -->
+        <maven.compiler.argument.source>${maven.compiler.argument.testSource}</maven.compiler.argument.source>
+        <maven.compiler.argument.target>${maven.compiler.argument.testTarget}</maven.compiler.argument.target>
+
         <!--
             Consider all sources as tests during Sonar analysis.
             This is important because some analysis rules do not apply to test code.
@@ -42,7 +46,7 @@
                     <executions>
                         <execution>
                             <id>verify-forbidden-apis</id>
-                            <!-- Do not use the main rules at all in integration tests, see below -->
+                            <!-- Do not use the main rules at all in integration test utils, see below -->
                             <phase>none</phase>
                         </execution>
                         <execution>

--- a/util/internal/test/pom.xml
+++ b/util/internal/test/pom.xml
@@ -16,6 +16,10 @@
         <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         <maven.javadoc.skip>true</maven.javadoc.skip>
 
+        <!-- Apply the test source/target settings to all code in test utils, even code in src/main -->
+        <maven.compiler.argument.source>${maven.compiler.argument.testSource}</maven.compiler.argument.source>
+        <maven.compiler.argument.target>${maven.compiler.argument.testTarget}</maven.compiler.argument.target>
+
         <!--
             Consider all sources as tests during Sonar analysis.
             This is important because some analysis rules do not apply to test code.


### PR DESCRIPTION
* [HSEARCH-3486](https://hibernate.atlassian.net/browse/HSEARCH-3486): Upgrade to forbiddenApis 2.7 and configure JDK12/13 signatures
* [HSEARCH-3743](https://hibernate.atlassian.net/browse/HSEARCH-3743): Generate Java 13/14 bytecode for tests when building with JDK13/14
* [HSEARCH-3744](https://hibernate.atlassian.net/browse/HSEARCH-3744): Upgrade integration tests to Spring 2.2.0

Full build: https://ci.hibernate.org/job/hibernate-search-personal-yoann/job/jdk14/20/

Just creating this for archive, so that we have a link to the changeset. Will merge immediately.