### PR TITLE
HSEARCH-3748 Remove the bridge-based programmatic mapping APIs for TypeBridge, PropertyBridge and RoutingKeyBridge

### DIFF
--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/bridge/mapping/impl/BeanBinder.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/bridge/mapping/impl/BeanBinder.java
@@ -6,25 +6,14 @@
  */
 package org.hibernate.search.mapper.pojo.bridge.mapping.impl;
 
-import java.lang.annotation.Annotation;
-
 import org.hibernate.search.engine.environment.bean.BeanHolder;
 import org.hibernate.search.engine.environment.bean.BeanReference;
 import org.hibernate.search.engine.environment.bean.BeanResolver;
 import org.hibernate.search.mapper.pojo.bridge.IdentifierBridge;
-import org.hibernate.search.mapper.pojo.bridge.PropertyBridge;
-import org.hibernate.search.mapper.pojo.bridge.RoutingKeyBridge;
-import org.hibernate.search.mapper.pojo.bridge.TypeBridge;
 import org.hibernate.search.mapper.pojo.bridge.ValueBridge;
 import org.hibernate.search.mapper.pojo.bridge.binding.IdentifierBindingContext;
-import org.hibernate.search.mapper.pojo.bridge.binding.PropertyBindingContext;
-import org.hibernate.search.mapper.pojo.bridge.binding.RoutingKeyBindingContext;
-import org.hibernate.search.mapper.pojo.bridge.binding.TypeBindingContext;
 import org.hibernate.search.mapper.pojo.bridge.binding.ValueBindingContext;
 import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.IdentifierBinder;
-import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.PropertyBinder;
-import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.RoutingKeyBinder;
-import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.TypeBinder;
 import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.ValueBinder;
 import org.hibernate.search.util.common.AssertionFailure;
 import org.hibernate.search.util.common.impl.SuppressingCloser;
@@ -35,9 +24,7 @@ import org.hibernate.search.util.common.reflect.impl.ReflectionUtils;
  * A binder that simply retrieves the bridge as a bean from the bean provider.
  */
 public final class BeanBinder
-		implements TypeBinder<Annotation>, PropertyBinder<Annotation>,
-		RoutingKeyBinder<Annotation>,
-		IdentifierBinder, ValueBinder {
+		implements IdentifierBinder, ValueBinder {
 
 	private final BeanReference<?> beanReference;
 
@@ -51,58 +38,11 @@ public final class BeanBinder
 	}
 
 	@Override
-	public void initialize(Annotation annotation) {
-		throw new AssertionFailure( "This method should not be called on this object." );
-	}
-
-	@Override
-	public void bind(TypeBindingContext context) {
-		BeanHolder<? extends TypeBridge> bridgeHolder = doBuild( context.getBeanResolver(), TypeBridge.class );
-		try {
-			context.setBridge( bridgeHolder );
-		}
-		catch (RuntimeException e) {
-			new SuppressingCloser( e )
-					.push( holder -> holder.get().close(), bridgeHolder )
-					.push( bridgeHolder );
-			throw e;
-		}
-	}
-
-	@Override
-	public void bind(PropertyBindingContext context) {
-		BeanHolder<? extends PropertyBridge> bridgeHolder = doBuild( context.getBeanResolver(), PropertyBridge.class );
-		try {
-			context.setBridge( bridgeHolder );
-		}
-		catch (RuntimeException e) {
-			new SuppressingCloser( e )
-					.push( holder -> holder.get().close(), bridgeHolder )
-					.push( bridgeHolder );
-			throw e;
-		}
-	}
-
-	@Override
 	@SuppressWarnings({"unchecked"})
 	public void bind(IdentifierBindingContext<?> context) {
 		BeanHolder<? extends IdentifierBridge> bridgeHolder = doBuild( context.getBeanResolver(), IdentifierBridge.class );
 		try {
 			doBind( bridgeHolder, context );
-		}
-		catch (RuntimeException e) {
-			new SuppressingCloser( e )
-					.push( holder -> holder.get().close(), bridgeHolder )
-					.push( bridgeHolder );
-			throw e;
-		}
-	}
-
-	@Override
-	public void bind(RoutingKeyBindingContext context) {
-		BeanHolder<? extends RoutingKeyBridge> bridgeHolder = doBuild( context.getBeanResolver(), RoutingKeyBridge.class );
-		try {
-			context.setBridge( bridgeHolder );
 		}
 		catch (RuntimeException e) {
 			new SuppressingCloser( e )

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/PropertyMappingStep.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/PropertyMappingStep.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.search.mapper.pojo.mapping.definition.programmatic;
 
-import org.hibernate.search.engine.environment.bean.BeanReference;
-import org.hibernate.search.mapper.pojo.bridge.PropertyBridge;
 import org.hibernate.search.mapper.pojo.bridge.builtin.programmatic.GeoPointBinder;
 import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.MarkerBinder;
 import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.PropertyBinder;
@@ -45,22 +43,6 @@ public interface PropertyMappingStep {
 	 * @see DocumentId
 	 */
 	PropertyMappingDocumentIdOptionsStep documentId();
-
-	/**
-	 * @param bridgeClass The class of the bridge to use.
-	 * @return {@code this}, for method chaining.
-	 * @see PropertyBridge
-	 */
-	PropertyMappingStep bridge(Class<? extends PropertyBridge> bridgeClass);
-
-	/**
-	 * @param bridgeReference A {@link BeanReference} pointing to the bridge to use.
-	 * See the static "ofXXX()" methods of {@link BeanReference} for details about the various type of references
-	 * (by name, by type, ...).
-	 * @return {@code this}, for method chaining.
-	 * @see PropertyBridge
-	 */
-	PropertyMappingStep bridge(BeanReference<? extends PropertyBridge> bridgeReference);
 
 	/**
 	 * @param binder A {@link PropertyBinder} responsible for creating a bridge.

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/TypeMappingStep.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/TypeMappingStep.java
@@ -6,9 +6,6 @@
  */
 package org.hibernate.search.mapper.pojo.mapping.definition.programmatic;
 
-import org.hibernate.search.engine.environment.bean.BeanReference;
-import org.hibernate.search.mapper.pojo.bridge.RoutingKeyBridge;
-import org.hibernate.search.mapper.pojo.bridge.TypeBridge;
 import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.RoutingKeyBinder;
 import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.TypeBinder;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
@@ -47,43 +44,11 @@ public interface TypeMappingStep {
 	TypeMappingStep indexed(String backendName, String indexName);
 
 	/**
-	 * @param bridgeClass The class of the bridge to use.
-	 * @return {@code this}, for method chaining.
-	 * @see RoutingKeyBridge
-	 */
-	TypeMappingStep routingKeyBridge(Class<? extends RoutingKeyBridge> bridgeClass);
-
-	/**
-	 * @param bridgeReference A {@link BeanReference} pointing to the bridge to use.
-	 * See the static "ofXXX()" methods of {@link BeanReference} for details about the various type of references
-	 * (by name, by type, ...).
-	 * @return {@code this}, for method chaining.
-	 * @see RoutingKeyBridge
-	 */
-	TypeMappingStep routingKeyBridge(BeanReference<? extends RoutingKeyBridge> bridgeReference);
-
-	/**
 	 * @param binder A {@link RoutingKeyBinder} responsible for creating a bridge.
 	 * @return {@code this}, for method chaining.
 	 * @see RoutingKeyBinder
 	 */
 	TypeMappingStep routingKeyBinder(RoutingKeyBinder<?> binder);
-
-	/**
-	 * @param bridgeClass The class of the bridge to use.
-	 * @return {@code this}, for method chaining.
-	 * @see TypeBridge
-	 */
-	TypeMappingStep bridge(Class<? extends TypeBridge> bridgeClass);
-
-	/**
-	 * @param bridgeReference A {@link BeanReference} pointing to the bridge to use.
-	 * See the static "ofXXX()" methods of {@link BeanReference} for details about the various type of references
-	 * (by name, by type, ...).
-	 * @return {@code this}, for method chaining.
-	 * @see TypeBridge
-	 */
-	TypeMappingStep bridge(BeanReference<? extends TypeBridge> bridgeReference);
 
 	/**
 	 * @param binder A {@link TypeBinder} responsible for creating a bridge.

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/DelegatingPropertyMappingStep.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/DelegatingPropertyMappingStep.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.search.mapper.pojo.mapping.definition.programmatic.impl;
 
-import org.hibernate.search.engine.environment.bean.BeanReference;
-import org.hibernate.search.mapper.pojo.bridge.PropertyBridge;
 import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.MarkerBinder;
 import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.PropertyBinder;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.AssociationInverseSideOptionsStep;
@@ -39,16 +37,6 @@ class DelegatingPropertyMappingStep implements PropertyMappingStep {
 	@Override
 	public PropertyMappingStep property(String propertyName) {
 		return delegate.property( propertyName );
-	}
-
-	@Override
-	public PropertyMappingStep bridge(Class<? extends PropertyBridge> bridgeClass) {
-		return delegate.bridge( bridgeClass );
-	}
-
-	@Override
-	public PropertyMappingStep bridge(BeanReference<? extends PropertyBridge> bridgeReference) {
-		return delegate.bridge( bridgeReference );
 	}
 
 	@Override

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/InitialPropertyMappingStep.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/InitialPropertyMappingStep.java
@@ -6,9 +6,6 @@
  */
 package org.hibernate.search.mapper.pojo.mapping.definition.programmatic.impl;
 
-import org.hibernate.search.engine.environment.bean.BeanReference;
-import org.hibernate.search.mapper.pojo.bridge.PropertyBridge;
-import org.hibernate.search.mapper.pojo.bridge.mapping.impl.BeanBinder;
 import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.MarkerBinder;
 import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.PropertyBinder;
 import org.hibernate.search.mapper.pojo.mapping.building.spi.ErrorCollectingPojoPropertyMetadataContributor;
@@ -66,16 +63,6 @@ class InitialPropertyMappingStep
 	@Override
 	public PropertyMappingStep property(String propertyName) {
 		return parent.property( propertyName );
-	}
-
-	@Override
-	public PropertyMappingStep bridge(Class<? extends PropertyBridge> bridgeClass) {
-		return bridge( BeanReference.of( bridgeClass ) );
-	}
-
-	@Override
-	public PropertyMappingStep bridge(BeanReference<? extends PropertyBridge> bridgeReference) {
-		return binder( new BeanBinder( bridgeReference ) );
 	}
 
 	@Override

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/TypeMappingStepImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/TypeMappingStepImpl.java
@@ -6,12 +6,8 @@
  */
 package org.hibernate.search.mapper.pojo.mapping.definition.programmatic.impl;
 
-import org.hibernate.search.engine.environment.bean.BeanReference;
 import org.hibernate.search.engine.mapper.mapping.building.spi.MappingConfigurationCollector;
 import org.hibernate.search.engine.mapper.mapping.building.spi.MappingBuildContext;
-import org.hibernate.search.mapper.pojo.bridge.RoutingKeyBridge;
-import org.hibernate.search.mapper.pojo.bridge.TypeBridge;
-import org.hibernate.search.mapper.pojo.bridge.mapping.impl.BeanBinder;
 import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.RoutingKeyBinder;
 import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.TypeBinder;
 import org.hibernate.search.mapper.pojo.mapping.building.spi.ErrorCollectingPojoTypeMetadataContributor;
@@ -68,29 +64,9 @@ public class TypeMappingStepImpl
 	}
 
 	@Override
-	public TypeMappingStep routingKeyBridge(Class<? extends RoutingKeyBridge> bridgeClass) {
-		return routingKeyBridge( BeanReference.of( bridgeClass ) );
-	}
-
-	@Override
-	public TypeMappingStep routingKeyBridge(BeanReference<? extends RoutingKeyBridge> bridgeReference) {
-		return routingKeyBinder( new BeanBinder( bridgeReference ) );
-	}
-
-	@Override
 	public TypeMappingStep routingKeyBinder(RoutingKeyBinder<?> binder) {
 		children.add( new RoutingKeyBridgeMappingContributor( binder ) );
 		return this;
-	}
-
-	@Override
-	public TypeMappingStep bridge(Class<? extends TypeBridge> bridgeClass) {
-		return bridge( BeanReference.of( bridgeClass ) );
-	}
-
-	@Override
-	public TypeMappingStep bridge(BeanReference<? extends TypeBridge> bridgeReference) {
-		return binder( new BeanBinder( bridgeReference ) );
 	}
 
 	@Override


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3748
