### PR TITLE
HSEARCH-3755 Configuration property checking displays the wrong name for the property controlling its behavior

### DIFF
--- a/documentation/src/main/asciidoc/configuration.asciidoc
+++ b/documentation/src/main/asciidoc/configuration.asciidoc
@@ -119,8 +119,10 @@ or a reference by type as a `java.lang.Class`
 |Whitespace separated string containing bean references (see above)
 |===============
 
+[[configuration-property-checking]]
+== Configuration property checking
+// Backward compatibility with an older version of the documentation
 [[configuration-property-tracking]]
-== Configuration property tracking
 
 Hibernate Search will track the parts of the provided configuration that are actually used
 and will log a warning if any configuration property starting with "hibernate.search." is never used,

--- a/engine/src/main/java/org/hibernate/search/engine/cfg/spi/ConfigurationPropertyChecker.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/spi/ConfigurationPropertyChecker.java
@@ -39,6 +39,8 @@ public class ConfigurationPropertyChecker {
 		return new ConfigurationPropertyChecker();
 	}
 
+	private String configurationPropertyCheckingStrategyPropertyName;
+
 	private final Set<String> availablePropertyKeys = ConcurrentHashMap.newKeySet();
 	private final Set<String> consumedPropertyKeys = ConcurrentHashMap.newKeySet();
 
@@ -54,6 +56,8 @@ public class ConfigurationPropertyChecker {
 				);
 		ConfigurationPropertyCheckingStrategyName checkingStrategy =
 				CONFIGURATION_PROPERTY_CHECKING_STRATEGY.get( trackingSource );
+		this.configurationPropertyCheckingStrategyPropertyName =
+				CONFIGURATION_PROPERTY_CHECKING_STRATEGY.resolveOrRaw( source );
 		switch ( checkingStrategy ) {
 			case WARN:
 				this.warn = true;
@@ -74,7 +78,7 @@ public class ConfigurationPropertyChecker {
 		}
 	}
 
-	public void afterBoot(ConfigurationPropertyChecker firstPhaseChecker, ConfigurationPropertySource propertySource) {
+	public void afterBoot(ConfigurationPropertyChecker firstPhaseChecker) {
 		if ( !warn ) {
 			return;
 		}
@@ -96,7 +100,7 @@ public class ConfigurationPropertyChecker {
 		if ( !unconsumedPropertyKeys.isEmpty() ) {
 			log.configurationPropertyTrackingUnusedProperties(
 					unconsumedPropertyKeys,
-					CONFIGURATION_PROPERTY_CHECKING_STRATEGY.resolveOrRaw( propertySource ),
+					configurationPropertyCheckingStrategyPropertyName,
 					ConfigurationPropertyCheckingStrategyName.IGNORE.getExternalRepresentation()
 			);
 		}

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/SearchIntegrationPartialBuildStateImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/SearchIntegrationPartialBuildStateImpl.java
@@ -168,7 +168,7 @@ class SearchIntegrationPartialBuildStateImpl implements SearchIntegrationPartial
 				);
 			}
 
-			propertyChecker.afterBoot( partialConfigurationPropertyChecker, propertySource );
+			propertyChecker.afterBoot( partialConfigurationPropertyChecker );
 
 			return new SearchIntegrationImpl(
 					beanProvider,

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/UnusedPropertiesIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/UnusedPropertiesIT.java
@@ -53,7 +53,9 @@ public class UnusedPropertiesIT {
 		String unusedPropertyKey = "hibernate.search.indexes.myIndex.foo";
 		logged.expectMessage(
 				"Some properties in the Hibernate Search configuration were not used",
-				"[" + unusedPropertyKey + "]"
+				"[" + unusedPropertyKey + "]",
+				"To disable this warning, set the property '"
+						+ EngineSettings.CONFIGURATION_PROPERTY_CHECKING_STRATEGY + "' to 'ignore'"
 		)
 				.once();
 		logged.expectMessage( "Configuration property tracking is disabled" )


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3755
