### PR TITLE
HSEARCH-3761 Use GSON rather than strings to pass JSON objects around in Elasticsearch APIs

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/impl/IndexManagerBackendContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/impl/IndexManagerBackendContext.java
@@ -69,8 +69,7 @@ public class IndexManagerBackendContext implements SearchBackendContext, WorkExe
 		this.documentReferenceExtractorHelper =
 				new DocumentReferenceExtractorHelper( indexNameConverter, multiTenancyStrategy );
 		this.searchProjectionBackendContext = new SearchProjectionBackendContext(
-				documentReferenceExtractorHelper,
-				userFacingGson
+				documentReferenceExtractorHelper
 		);
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/dsl/ElasticsearchSearchAggregationFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/dsl/ElasticsearchSearchAggregationFactory.java
@@ -16,25 +16,25 @@ public interface ElasticsearchSearchAggregationFactory extends SearchAggregation
 	/**
 	 * Create an aggregation from JSON.
 	 * <p>
-	 * The created aggregation will return the result as a JSON-formatted string.
+	 * The created aggregation will return the result as a {@link JsonObject}.
 	 *
 	 * @param jsonObject A {@link JsonObject} representing an Elasticsearch aggregation.
 	 * The JSON object must be a syntactically correct Elasticsearch aggregation.
 	 * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html">the Elasticsearch documentation</a>.
 	 * @return The final step of the aggregation DSL.
 	 */
-	AggregationFinalStep<String> fromJson(JsonObject jsonObject);
+	AggregationFinalStep<JsonObject> fromJson(JsonObject jsonObject);
 
 	/**
 	 * Create an aggregation from JSON.
 	 * <p>
-	 * The created aggregation will return the result as a JSON-formatted string.
+	 * The created aggregation will return the result as a {@link JsonObject}.
 	 *
 	 * @param jsonString A JSON-formatted string representing an Elasticsearch aggregation.
 	 * The JSON object must be a syntactically correct Elasticsearch aggregation.
 	 * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html">the Elasticsearch documentation</a>.
 	 * @return The final step of the aggregation DSL.
 	 */
-	AggregationFinalStep<String> fromJson(String jsonString);
+	AggregationFinalStep<JsonObject> fromJson(String jsonString);
 
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/dsl/ElasticsearchSearchAggregationFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/dsl/ElasticsearchSearchAggregationFactory.java
@@ -9,6 +9,8 @@ package org.hibernate.search.backend.elasticsearch.search.aggregation.dsl;
 import org.hibernate.search.engine.search.aggregation.dsl.AggregationFinalStep;
 import org.hibernate.search.engine.search.aggregation.dsl.SearchAggregationFactory;
 
+import com.google.gson.JsonObject;
+
 public interface ElasticsearchSearchAggregationFactory extends SearchAggregationFactory {
 
 	/**
@@ -16,7 +18,19 @@ public interface ElasticsearchSearchAggregationFactory extends SearchAggregation
 	 * <p>
 	 * The created aggregation will return the result as a JSON-formatted string.
 	 *
-	 * @param jsonString A string representing an Elasticsearch aggregation as a JSON object.
+	 * @param jsonObject A {@link JsonObject} representing an Elasticsearch aggregation.
+	 * The JSON object must be a syntactically correct Elasticsearch aggregation.
+	 * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html">the Elasticsearch documentation</a>.
+	 * @return The final step of the aggregation DSL.
+	 */
+	AggregationFinalStep<String> fromJson(JsonObject jsonObject);
+
+	/**
+	 * Create an aggregation from JSON.
+	 * <p>
+	 * The created aggregation will return the result as a JSON-formatted string.
+	 *
+	 * @param jsonString A JSON-formatted string representing an Elasticsearch aggregation.
 	 * The JSON object must be a syntactically correct Elasticsearch aggregation.
 	 * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html">the Elasticsearch documentation</a>.
 	 * @return The final step of the aggregation DSL.

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/dsl/impl/ElasticsearchJsonAggregationFinalStep.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/dsl/impl/ElasticsearchJsonAggregationFinalStep.java
@@ -10,16 +10,18 @@ import org.hibernate.search.engine.search.aggregation.SearchAggregation;
 import org.hibernate.search.engine.search.aggregation.dsl.AggregationFinalStep;
 import org.hibernate.search.engine.search.aggregation.spi.SearchAggregationBuilder;
 
-final class ElasticsearchJsonStringAggregationFinalStep
-		implements AggregationFinalStep<String> {
-	private final SearchAggregationBuilder<String> builder;
+import com.google.gson.JsonObject;
 
-	ElasticsearchJsonStringAggregationFinalStep(SearchAggregationBuilder<String> builder) {
+final class ElasticsearchJsonAggregationFinalStep
+		implements AggregationFinalStep<JsonObject> {
+	private final SearchAggregationBuilder<JsonObject> builder;
+
+	ElasticsearchJsonAggregationFinalStep(SearchAggregationBuilder<JsonObject> builder) {
 		this.builder = builder;
 	}
 
 	@Override
-	public SearchAggregation<String> toAggregation() {
+	public SearchAggregation<JsonObject> toAggregation() {
 		return builder.build();
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/dsl/impl/ElasticsearchSearchAggregationFactoryImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/dsl/impl/ElasticsearchSearchAggregationFactoryImpl.java
@@ -28,15 +28,15 @@ public class ElasticsearchSearchAggregationFactoryImpl
 	}
 
 	@Override
-	public AggregationFinalStep<String> fromJson(JsonObject jsonObject) {
-		return new ElasticsearchJsonStringAggregationFinalStep(
+	public AggregationFinalStep<JsonObject> fromJson(JsonObject jsonObject) {
+		return new ElasticsearchJsonAggregationFinalStep(
 				dslContext.getBuilderFactory().fromJson( jsonObject )
 		);
 	}
 
 	@Override
-	public AggregationFinalStep<String> fromJson(String jsonString) {
-		return new ElasticsearchJsonStringAggregationFinalStep(
+	public AggregationFinalStep<JsonObject> fromJson(String jsonString) {
+		return new ElasticsearchJsonAggregationFinalStep(
 				dslContext.getBuilderFactory().fromJson( jsonString )
 		);
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/dsl/impl/ElasticsearchSearchAggregationFactoryImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/dsl/impl/ElasticsearchSearchAggregationFactoryImpl.java
@@ -13,6 +13,8 @@ import org.hibernate.search.engine.search.aggregation.dsl.SearchAggregationFacto
 import org.hibernate.search.engine.search.aggregation.dsl.spi.DelegatingSearchAggregationFactory;
 import org.hibernate.search.engine.search.aggregation.dsl.spi.SearchAggregationDslContext;
 
+import com.google.gson.JsonObject;
+
 public class ElasticsearchSearchAggregationFactoryImpl
 		extends DelegatingSearchAggregationFactory
 		implements ElasticsearchSearchAggregationFactory {
@@ -23,6 +25,13 @@ public class ElasticsearchSearchAggregationFactoryImpl
 			SearchAggregationDslContext<ElasticsearchSearchAggregationBuilderFactory> dslContext) {
 		super( delegate );
 		this.dslContext = dslContext;
+	}
+
+	@Override
+	public AggregationFinalStep<String> fromJson(JsonObject jsonObject) {
+		return new ElasticsearchJsonStringAggregationFinalStep(
+				dslContext.getBuilderFactory().fromJson( jsonObject )
+		);
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/impl/ElasticsearchSearchAggregationBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/impl/ElasticsearchSearchAggregationBuilderFactory.java
@@ -26,6 +26,8 @@ import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 import org.hibernate.search.util.common.reporting.EventContext;
 
+import com.google.gson.JsonObject;
+
 public class ElasticsearchSearchAggregationBuilderFactory
 		implements SearchAggregationBuilderFactory<ElasticsearchSearchAggregationCollector> {
 
@@ -82,8 +84,12 @@ public class ElasticsearchSearchAggregationBuilderFactory
 		);
 	}
 
+	public SearchAggregationBuilder<String> fromJson(JsonObject jsonObject) {
+		return new ElasticsearchUserProvidedJsonAggregation.Builder( searchContext, jsonObject );
+	}
+
 	public SearchAggregationBuilder<String> fromJson(String jsonString) {
-		return new ElasticsearchUserProvidedJsonAggregation.Builder( searchContext, jsonString );
+		return fromJson( searchContext.getUserFacingGson().fromJson( jsonString, JsonObject.class ) );
 	}
 
 	private void checkConverterCompatibility(

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/impl/ElasticsearchSearchAggregationBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/impl/ElasticsearchSearchAggregationBuilderFactory.java
@@ -84,11 +84,11 @@ public class ElasticsearchSearchAggregationBuilderFactory
 		);
 	}
 
-	public SearchAggregationBuilder<String> fromJson(JsonObject jsonObject) {
+	public SearchAggregationBuilder<JsonObject> fromJson(JsonObject jsonObject) {
 		return new ElasticsearchUserProvidedJsonAggregation.Builder( searchContext, jsonObject );
 	}
 
-	public SearchAggregationBuilder<String> fromJson(String jsonString) {
+	public SearchAggregationBuilder<JsonObject> fromJson(String jsonString) {
 		return fromJson( searchContext.getUserFacingGson().fromJson( jsonString, JsonObject.class ) );
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/impl/ElasticsearchUserProvidedJsonAggregation.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/impl/ElasticsearchUserProvidedJsonAggregation.java
@@ -8,7 +8,6 @@ package org.hibernate.search.backend.elasticsearch.search.aggregation.impl;
 
 import org.hibernate.search.backend.elasticsearch.search.impl.ElasticsearchSearchContext;
 
-import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 
 
@@ -37,9 +36,9 @@ class ElasticsearchUserProvidedJsonAggregation extends AbstractElasticsearchAggr
 
 		private final JsonObject json;
 
-		Builder(ElasticsearchSearchContext searchContext, String jsonString) {
+		Builder(ElasticsearchSearchContext searchContext, JsonObject json) {
 			super( searchContext );
-			this.json = searchContext.getUserFacingGson().fromJson( jsonString, JsonObject.class );
+			this.json = json;
 		}
 
 		@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/impl/ElasticsearchUserProvidedJsonAggregation.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/impl/ElasticsearchUserProvidedJsonAggregation.java
@@ -11,14 +11,12 @@ import org.hibernate.search.backend.elasticsearch.search.impl.ElasticsearchSearc
 import com.google.gson.JsonObject;
 
 
-class ElasticsearchUserProvidedJsonAggregation extends AbstractElasticsearchAggregation<String> {
+class ElasticsearchUserProvidedJsonAggregation extends AbstractElasticsearchAggregation<JsonObject> {
 
-	private final Gson gson;
 	private final JsonObject requestJson;
 
 	private ElasticsearchUserProvidedJsonAggregation(Builder builder) {
 		super( builder );
-		this.gson = builder.searchContext.getUserFacingGson();
 		this.requestJson = builder.json;
 	}
 
@@ -28,11 +26,11 @@ class ElasticsearchUserProvidedJsonAggregation extends AbstractElasticsearchAggr
 	}
 
 	@Override
-	public String extract(JsonObject aggregationResult, AggregationExtractContext context) {
-		return gson.toJson( aggregationResult );
+	public JsonObject extract(JsonObject aggregationResult, AggregationExtractContext context) {
+		return aggregationResult;
 	}
 
-	static class Builder extends AbstractBuilder<String> {
+	static class Builder extends AbstractBuilder<JsonObject> {
 
 		private final JsonObject json;
 
@@ -42,7 +40,7 @@ class ElasticsearchUserProvidedJsonAggregation extends AbstractElasticsearchAggr
 		}
 
 		@Override
-		public ElasticsearchSearchAggregation<String> build() {
+		public ElasticsearchSearchAggregation<JsonObject> build() {
 			return new ElasticsearchUserProvidedJsonAggregation( this );
 		}
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/dsl/ElasticsearchSearchPredicateFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/dsl/ElasticsearchSearchPredicateFactory.java
@@ -9,6 +9,8 @@ package org.hibernate.search.backend.elasticsearch.search.predicate.dsl;
 import org.hibernate.search.engine.search.predicate.dsl.PredicateFinalStep;
 import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
 
+import com.google.gson.JsonObject;
+
 /**
  * A factory for search predicates with some Elasticsearch-specific methods.
  */
@@ -17,11 +19,21 @@ public interface ElasticsearchSearchPredicateFactory extends SearchPredicateFact
 	/**
 	 * Create a predicate from JSON.
 	 *
-	 * @param jsonString A string representing an Elasticsearch query as a JSON object.
+	 * @param jsonString A JSON-formatted string representing an Elasticsearch query.
 	 * The JSON object must be a syntactically correct Elasticsearch query.
 	 * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html">the Elasticsearch documentation</a>.
 	 * @return The final step of the predicate DSL.
 	 */
 	PredicateFinalStep fromJson(String jsonString);
+
+	/**
+	 * Create a predicate from JSON.
+	 *
+	 * @param jsonObject A {@link JsonObject} representing an Elasticsearch query.
+	 * The JSON object must be a syntactically correct Elasticsearch query.
+	 * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html">the Elasticsearch documentation</a>.
+	 * @return The final step of the predicate DSL.
+	 */
+	PredicateFinalStep fromJson(JsonObject jsonObject);
 
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/dsl/impl/ElasticsearchJsonPredicateFinalStep.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/dsl/impl/ElasticsearchJsonPredicateFinalStep.java
@@ -11,12 +11,19 @@ import org.hibernate.search.backend.elasticsearch.search.predicate.impl.Elastics
 import org.hibernate.search.engine.search.predicate.dsl.PredicateFinalStep;
 import org.hibernate.search.engine.search.predicate.dsl.spi.AbstractPredicateFinalStep;
 
-final class ElasticsearchJsonStringPredicateFinalStep
+import com.google.gson.JsonObject;
+
+final class ElasticsearchJsonPredicateFinalStep
 		extends AbstractPredicateFinalStep<ElasticsearchSearchPredicateBuilder>
 		implements PredicateFinalStep {
 	private final ElasticsearchSearchPredicateBuilder builder;
 
-	ElasticsearchJsonStringPredicateFinalStep(ElasticsearchSearchPredicateBuilderFactory factory, String jsonString) {
+	ElasticsearchJsonPredicateFinalStep(ElasticsearchSearchPredicateBuilderFactory factory, JsonObject jsonObject) {
+		super( factory );
+		this.builder = factory.fromJson( jsonObject );
+	}
+
+	ElasticsearchJsonPredicateFinalStep(ElasticsearchSearchPredicateBuilderFactory factory, String jsonString) {
 		super( factory );
 		this.builder = factory.fromJson( jsonString );
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/dsl/impl/ElasticsearchSearchPredicateFactoryImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/dsl/impl/ElasticsearchSearchPredicateFactoryImpl.java
@@ -12,6 +12,8 @@ import org.hibernate.search.engine.search.predicate.dsl.PredicateFinalStep;
 import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
 import org.hibernate.search.engine.search.predicate.dsl.spi.DelegatingSearchPredicateFactory;
 
+import com.google.gson.JsonObject;
+
 
 public class ElasticsearchSearchPredicateFactoryImpl
 		extends DelegatingSearchPredicateFactory
@@ -27,6 +29,11 @@ public class ElasticsearchSearchPredicateFactoryImpl
 
 	@Override
 	public PredicateFinalStep fromJson(String jsonString) {
-		return new ElasticsearchJsonStringPredicateFinalStep( factory, jsonString );
+		return new ElasticsearchJsonPredicateFinalStep( factory, jsonString );
+	}
+
+	@Override
+	public PredicateFinalStep fromJson(JsonObject jsonObject) {
+		return new ElasticsearchJsonPredicateFinalStep( factory, jsonObject );
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchSearchPredicateBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchSearchPredicateBuilderFactory.java
@@ -8,9 +8,13 @@ package org.hibernate.search.backend.elasticsearch.search.predicate.impl;
 
 import org.hibernate.search.engine.search.predicate.spi.SearchPredicateBuilderFactory;
 
+import com.google.gson.JsonObject;
+
 public interface ElasticsearchSearchPredicateBuilderFactory
 		extends
 		SearchPredicateBuilderFactory<ElasticsearchSearchPredicateCollector, ElasticsearchSearchPredicateBuilder> {
+
+	ElasticsearchSearchPredicateBuilder fromJson(JsonObject jsonObject);
 
 	ElasticsearchSearchPredicateBuilder fromJson(String jsonString);
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchSearchPredicateBuilderFactoryImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchSearchPredicateBuilderFactoryImpl.java
@@ -166,10 +166,13 @@ public class ElasticsearchSearchPredicateBuilderFactoryImpl implements Elasticse
 	}
 
 	@Override
+	public ElasticsearchSearchPredicateBuilder fromJson(JsonObject jsonObject) {
+		return new ElasticsearchUserProvidedJsonPredicateBuilder( jsonObject );
+	}
+
+	@Override
 	public ElasticsearchSearchPredicateBuilder fromJson(String jsonString) {
-		return new ElasticsearchUserProvidedJsonPredicateBuilder(
-				searchContext.getUserFacingGson().fromJson( jsonString, JsonObject.class )
-		);
+		return fromJson( searchContext.getUserFacingGson().fromJson( jsonString, JsonObject.class ) );
 	}
 
 	private static class PredicateBuilderFactoryRetrievalStrategy

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/dsl/ElasticsearchSearchProjectionFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/dsl/ElasticsearchSearchProjectionFactory.java
@@ -9,6 +9,8 @@ package org.hibernate.search.backend.elasticsearch.search.projection.dsl;
 import org.hibernate.search.engine.search.projection.dsl.SearchProjectionFactory;
 import org.hibernate.search.engine.search.projection.dsl.ProjectionFinalStep;
 
+import com.google.gson.JsonObject;
+
 /**
  * A factory for search projections with some Elasticsearch-specific methods.
  *
@@ -19,20 +21,20 @@ import org.hibernate.search.engine.search.projection.dsl.ProjectionFinalStep;
 public interface ElasticsearchSearchProjectionFactory<R, E> extends SearchProjectionFactory<R, E> {
 
 	/**
-	 * Project to a string representing the JSON document as stored in Elasticsearch.
+	 * Project to a {@link JsonObject} representing the document as stored in Elasticsearch.
 	 *
 	 * @return The final step of the projection DSL.
 	 */
-	ProjectionFinalStep<String> source();
+	ProjectionFinalStep<JsonObject> source();
 
 	/**
-	 * Project to a string representing a JSON object describing the score computation for the hit.
+	 * Project to a {@link JsonObject} describing the score computation for the hit.
 	 * <p>
 	 * This feature is relatively expensive, do not use unless you return a limited
-	 * amount of objects (using pagination).
+	 * amount of hits (using pagination).
 	 *
 	 * @return The final step of the projection DSL.
 	 */
-	ProjectionFinalStep<String> explanation();
+	ProjectionFinalStep<JsonObject> explanation();
 
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/dsl/impl/ElasticsearchExplanationProjectionFinalStep.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/dsl/impl/ElasticsearchExplanationProjectionFinalStep.java
@@ -11,15 +11,17 @@ import org.hibernate.search.engine.search.projection.SearchProjection;
 import org.hibernate.search.engine.search.projection.dsl.ProjectionFinalStep;
 import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilder;
 
-public class ElasticsearchExplanationProjectionFinalStep implements ProjectionFinalStep<String> {
-	private final SearchProjectionBuilder<String> builder;
+import com.google.gson.JsonObject;
+
+public class ElasticsearchExplanationProjectionFinalStep implements ProjectionFinalStep<JsonObject> {
+	private final SearchProjectionBuilder<JsonObject> builder;
 
 	ElasticsearchExplanationProjectionFinalStep(ElasticsearchSearchProjectionBuilderFactory factory) {
 		this.builder = factory.explanation();
 	}
 
 	@Override
-	public SearchProjection<String> toProjection() {
+	public SearchProjection<JsonObject> toProjection() {
 		return builder.build();
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/dsl/impl/ElasticsearchSearchProjectionFactoryImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/dsl/impl/ElasticsearchSearchProjectionFactoryImpl.java
@@ -12,6 +12,8 @@ import org.hibernate.search.engine.search.projection.dsl.SearchProjectionFactory
 import org.hibernate.search.engine.search.projection.dsl.ProjectionFinalStep;
 import org.hibernate.search.engine.search.projection.dsl.spi.DelegatingSearchProjectionFactory;
 
+import com.google.gson.JsonObject;
+
 public class ElasticsearchSearchProjectionFactoryImpl<R, E>
 		extends DelegatingSearchProjectionFactory<R, E>
 		implements ElasticsearchSearchProjectionFactory<R, E> {
@@ -25,12 +27,12 @@ public class ElasticsearchSearchProjectionFactoryImpl<R, E>
 	}
 
 	@Override
-	public ProjectionFinalStep<String> source() {
+	public ProjectionFinalStep<JsonObject> source() {
 		return new ElasticsearchSourceProjectionFinalStep( factory );
 	}
 
 	@Override
-	public ProjectionFinalStep<String> explanation() {
+	public ProjectionFinalStep<JsonObject> explanation() {
 		return new ElasticsearchExplanationProjectionFinalStep( factory );
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/dsl/impl/ElasticsearchSourceProjectionFinalStep.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/dsl/impl/ElasticsearchSourceProjectionFinalStep.java
@@ -11,15 +11,17 @@ import org.hibernate.search.engine.search.projection.SearchProjection;
 import org.hibernate.search.engine.search.projection.dsl.ProjectionFinalStep;
 import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilder;
 
-public class ElasticsearchSourceProjectionFinalStep implements ProjectionFinalStep<String> {
-	private final SearchProjectionBuilder<String> builder;
+import com.google.gson.JsonObject;
+
+public class ElasticsearchSourceProjectionFinalStep implements ProjectionFinalStep<JsonObject> {
+	private final SearchProjectionBuilder<JsonObject> builder;
 
 	ElasticsearchSourceProjectionFinalStep(ElasticsearchSearchProjectionBuilderFactory factory) {
 		this.builder = factory.source();
 	}
 
 	@Override
-	public SearchProjection<String> toProjection() {
+	public SearchProjection<JsonObject> toProjection() {
 		return builder.build();
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchExplanationProjection.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchExplanationProjection.java
@@ -13,20 +13,17 @@ import org.hibernate.search.backend.elasticsearch.gson.impl.JsonObjectAccessor;
 import org.hibernate.search.engine.search.loading.spi.LoadingResult;
 import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 
-import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 
-class ElasticsearchExplanationProjection implements ElasticsearchSearchProjection<String, String> {
+class ElasticsearchExplanationProjection implements ElasticsearchSearchProjection<JsonObject, JsonObject> {
 
 	private static final JsonAccessor<Boolean> REQUEST_EXPLAIN_ACCESSOR = JsonAccessor.root().property( "explain" ).asBoolean();
 	private static final JsonObjectAccessor HIT_EXPLANATION_ACCESSOR = JsonAccessor.root().property( "_explanation" ).asObject();
 
 	private final Set<String> indexNames;
-	private final Gson gson;
 
-	ElasticsearchExplanationProjection(Set<String> indexNames, Gson gson) {
+	ElasticsearchExplanationProjection(Set<String> indexNames) {
 		this.indexNames = indexNames;
-		this.gson = gson;
 	}
 
 	@Override
@@ -35,14 +32,14 @@ class ElasticsearchExplanationProjection implements ElasticsearchSearchProjectio
 	}
 
 	@Override
-	public String extract(ProjectionHitMapper<?, ?> projectionHitMapper, JsonObject responseBody, JsonObject hit,
+	public JsonObject extract(ProjectionHitMapper<?, ?> projectionHitMapper, JsonObject responseBody, JsonObject hit,
 			SearchProjectionExtractContext context) {
 		// We expect the optional to always be non-empty.
-		return gson.toJson( HIT_EXPLANATION_ACCESSOR.get( hit ).get() );
+		return HIT_EXPLANATION_ACCESSOR.get( hit ).get();
 	}
 
 	@Override
-	public String transform(LoadingResult<?> loadingResult, String extractedData,
+	public JsonObject transform(LoadingResult<?> loadingResult, JsonObject extractedData,
 			SearchProjectionTransformContext context) {
 		return extractedData;
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchExplanationProjectionBuilder.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchExplanationProjectionBuilder.java
@@ -11,19 +11,19 @@ import java.util.Set;
 import org.hibernate.search.engine.search.projection.SearchProjection;
 import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilder;
 
-import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 
 
-class ElasticsearchExplanationProjectionBuilder implements SearchProjectionBuilder<String> {
+class ElasticsearchExplanationProjectionBuilder implements SearchProjectionBuilder<JsonObject> {
 
 	private final ElasticsearchExplanationProjection projection;
 
-	ElasticsearchExplanationProjectionBuilder(Set<String> indexNames, Gson gson) {
-		this.projection = new ElasticsearchExplanationProjection( indexNames, gson );
+	ElasticsearchExplanationProjectionBuilder(Set<String> indexNames) {
+		this.projection = new ElasticsearchExplanationProjection( indexNames );
 	}
 
 	@Override
-	public SearchProjection<String> build() {
+	public SearchProjection<JsonObject> build() {
 		return projection;
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchSearchProjectionBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchSearchProjectionBuilderFactory.java
@@ -35,6 +35,8 @@ import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.common.function.TriFunction;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
+import com.google.gson.JsonObject;
+
 public class ElasticsearchSearchProjectionBuilderFactory implements SearchProjectionBuilderFactory {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
@@ -139,11 +141,11 @@ public class ElasticsearchSearchProjectionBuilderFactory implements SearchProjec
 		);
 	}
 
-	public SearchProjectionBuilder<String> source() {
+	public SearchProjectionBuilder<JsonObject> source() {
 		return searchProjectionBackendContext.createSourceProjectionBuilder( scopeModel.getHibernateSearchIndexNames() );
 	}
 
-	public SearchProjectionBuilder<String> explanation() {
+	public SearchProjectionBuilder<JsonObject> explanation() {
 		return searchProjectionBackendContext.createExplanationProjectionBuilder( scopeModel.getHibernateSearchIndexNames() );
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchSourceProjection.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchSourceProjection.java
@@ -15,23 +15,20 @@ import org.hibernate.search.backend.elasticsearch.gson.impl.JsonObjectAccessor;
 import org.hibernate.search.engine.search.loading.spi.LoadingResult;
 import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 
-import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 
-class ElasticsearchSourceProjection implements ElasticsearchSearchProjection<String, String> {
+class ElasticsearchSourceProjection implements ElasticsearchSearchProjection<JsonObject, JsonObject> {
 
 	private static final JsonArrayAccessor REQUEST_SOURCE_ACCESSOR = JsonAccessor.root().property( "_source" ).asArray();
 	private static final JsonObjectAccessor HIT_SOURCE_ACCESSOR = JsonAccessor.root().property( "_source" ).asObject();
 	private static final JsonPrimitive WILDCARD_ALL = new JsonPrimitive( "*" );
 
 	private final Set<String> indexNames;
-	private final Gson gson;
 
-	ElasticsearchSourceProjection(Set<String> indexNames, Gson gson) {
+	ElasticsearchSourceProjection(Set<String> indexNames) {
 		this.indexNames = indexNames;
-		this.gson = gson;
 	}
 
 	@Override
@@ -43,11 +40,11 @@ class ElasticsearchSourceProjection implements ElasticsearchSearchProjection<Str
 	}
 
 	@Override
-	public String extract(ProjectionHitMapper<?, ?> projectionHitMapper, JsonObject responseBody, JsonObject hit,
+	public JsonObject extract(ProjectionHitMapper<?, ?> projectionHitMapper, JsonObject responseBody, JsonObject hit,
 			SearchProjectionExtractContext context) {
 		Optional<JsonObject> sourceElement = HIT_SOURCE_ACCESSOR.get( hit );
 		if ( sourceElement.isPresent() ) {
-			return gson.toJson( sourceElement.get() );
+			return sourceElement.get();
 		}
 		else {
 			return null;
@@ -55,7 +52,7 @@ class ElasticsearchSourceProjection implements ElasticsearchSearchProjection<Str
 	}
 
 	@Override
-	public String transform(LoadingResult<?> loadingResult, String extractedData,
+	public JsonObject transform(LoadingResult<?> loadingResult, JsonObject extractedData,
 			SearchProjectionTransformContext context) {
 		return extractedData;
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchSourceProjectionBuilder.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchSourceProjectionBuilder.java
@@ -11,19 +11,19 @@ import java.util.Set;
 import org.hibernate.search.engine.search.projection.SearchProjection;
 import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilder;
 
-import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 
 
-class ElasticsearchSourceProjectionBuilder implements SearchProjectionBuilder<String> {
+class ElasticsearchSourceProjectionBuilder implements SearchProjectionBuilder<JsonObject> {
 
 	private final ElasticsearchSourceProjection projection;
 
-	ElasticsearchSourceProjectionBuilder(Set<String> indexNames, Gson gson) {
-		this.projection = new ElasticsearchSourceProjection( indexNames, gson );
+	ElasticsearchSourceProjectionBuilder(Set<String> indexNames) {
+		this.projection = new ElasticsearchSourceProjection( indexNames );
 	}
 
 	@Override
-	public SearchProjection<String> build() {
+	public SearchProjection<JsonObject> build() {
 		return projection;
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/SearchProjectionBackendContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/SearchProjectionBackendContext.java
@@ -8,20 +8,12 @@ package org.hibernate.search.backend.elasticsearch.search.projection.impl;
 
 import java.util.Set;
 
-import org.hibernate.search.engine.search.projection.spi.SearchProjectionBuilder;
-
-import com.google.gson.Gson;
-
 public class SearchProjectionBackendContext {
 
 	private final DocumentReferenceExtractorHelper documentReferenceExtractorHelper;
-	private final Gson userFacingGson;
 
-	@SuppressWarnings("rawtypes")
-	public SearchProjectionBackendContext(DocumentReferenceExtractorHelper documentReferenceExtractorHelper,
-			Gson userFacingGson) {
+	public SearchProjectionBackendContext(DocumentReferenceExtractorHelper documentReferenceExtractorHelper) {
 		this.documentReferenceExtractorHelper = documentReferenceExtractorHelper;
-		this.userFacingGson = userFacingGson;
 	}
 
 	ElasticsearchDocumentReferenceProjectionBuilder createDocumentReferenceProjectionBuilder(Set<String> indexNames) {
@@ -41,10 +33,10 @@ public class SearchProjectionBackendContext {
 	}
 
 	ElasticsearchSourceProjectionBuilder createSourceProjectionBuilder(Set<String> indexNames) {
-		return new ElasticsearchSourceProjectionBuilder( indexNames, userFacingGson );
+		return new ElasticsearchSourceProjectionBuilder( indexNames );
 	}
 
-	public SearchProjectionBuilder<String> createExplanationProjectionBuilder(Set<String> indexNames) {
-		return new ElasticsearchExplanationProjectionBuilder( indexNames, userFacingGson );
+	ElasticsearchExplanationProjectionBuilder createExplanationProjectionBuilder(Set<String> indexNames) {
+		return new ElasticsearchExplanationProjectionBuilder( indexNames );
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/ElasticsearchSearchQuery.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/ElasticsearchSearchQuery.java
@@ -8,6 +8,8 @@ package org.hibernate.search.backend.elasticsearch.search.query;
 
 import org.hibernate.search.engine.search.query.ExtendedSearchQuery;
 
+import com.google.gson.JsonObject;
+
 public interface ElasticsearchSearchQuery<H>
 		extends ExtendedSearchQuery<H, ElasticsearchSearchResult<H>>, ElasticsearchSearchFetchable<H> {
 
@@ -17,11 +19,11 @@ public interface ElasticsearchSearchQuery<H>
 	 * This is a shorthand for {@link #explain(String, String)} when the query only targets one index.
 	 *
 	 * @param id The id of the document to test.
-	 * @return A string representing a JSON object describing the score computation for the hit.
+	 * @return A {@link JsonObject} describing the score computation for the hit.
 	 * @throws org.hibernate.search.util.common.SearchException If the query targets multiple indexes,
 	 * or if the explain request fails.
 	 */
-	String explain(String id);
+	JsonObject explain(String id);
 
 	/**
 	 * Explain score computation of this query for the document with the given id in the given index.
@@ -30,10 +32,10 @@ public interface ElasticsearchSearchQuery<H>
 	 *
 	 * @param indexName The name of the index containing the document to test.
 	 * @param id The id of the document to test.
-	 * @return A string representing a JSON object describing the score computation for the hit.
+	 * @return A {@link JsonObject} describing the score computation for the hit.
 	 * @throws org.hibernate.search.util.common.SearchException If the given index name does not refer to an index targeted by this query,
 	 * or if the explain request fails.
 	 */
-	String explain(String indexName, String id);
+	JsonObject explain(String indexName, String id);
 
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchQueryImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchQueryImpl.java
@@ -125,7 +125,7 @@ public class ElasticsearchSearchQueryImpl<H> extends AbstractSearchQuery<H, Elas
 	}
 
 	@Override
-	public String explain(String id) {
+	public JsonObject explain(String id) {
 		Contracts.assertNotNull( id, "id" );
 
 		Set<URLEncodedString> targetedIndexNames = searchContext.getIndexNames();
@@ -137,7 +137,7 @@ public class ElasticsearchSearchQueryImpl<H> extends AbstractSearchQuery<H, Elas
 	}
 
 	@Override
-	public String explain(String indexName, String id) {
+	public JsonObject explain(String indexName, String id) {
 		Contracts.assertNotNull( indexName, "indexName" );
 		Contracts.assertNotNull( id, "id" );
 
@@ -170,7 +170,7 @@ public class ElasticsearchSearchQueryImpl<H> extends AbstractSearchQuery<H, Elas
 		}
 	}
 
-	private String doExplain(URLEncodedString encodedIndexName, String id) {
+	private JsonObject doExplain(URLEncodedString encodedIndexName, String id) {
 		URLEncodedString elasticsearchId = URLEncodedString.fromString(
 				searchContext.toElasticsearchId( sessionContext.getTenantIdentifier(), id )
 		);
@@ -180,6 +180,6 @@ public class ElasticsearchSearchQueryImpl<H> extends AbstractSearchQuery<H, Elas
 				.build();
 
 		ExplainResult explainResult = Futures.unwrappedExceptionJoin( queryOrchestrator.submit( work ) );
-		return searchContext.getUserFacingGson().toJson( explainResult.getJsonObject() );
+		return explainResult.getJsonObject();
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/sort/dsl/ElasticsearchSearchSortFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/sort/dsl/ElasticsearchSearchSortFactory.java
@@ -9,6 +9,8 @@ package org.hibernate.search.backend.elasticsearch.search.sort.dsl;
 import org.hibernate.search.engine.search.sort.dsl.SortThenStep;
 import org.hibernate.search.engine.search.sort.dsl.SearchSortFactory;
 
+import com.google.gson.JsonObject;
+
 /**
  * A factory for search sorts with some Elasticsearch-specific methods.
  */
@@ -17,12 +19,23 @@ public interface ElasticsearchSearchSortFactory extends SearchSortFactory {
 	/**
 	 * Order elements according to a JSON sort definition.
 	 *
-	 * @param jsonString A string representing an Elasticsearch sort as a JSON object.
-	 * The JSON object must be represent a syntactically correct Elasticsearch sort.
+	 * @param jsonString A JSON-formatted string representing an Elasticsearch sort.
+	 * The JSON object must be a syntactically correct Elasticsearch sort.
 	 * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#request-body-search-sort">the Elasticsearch documentation</a>.
 	 * @return A {@link SortThenStep} allowing the retrieval of the sort
 	 * or the chaining of other sorts.
 	 */
 	SortThenStep fromJson(String jsonString);
+
+	/**
+	 * Order elements according to a JSON sort definition.
+	 *
+	 * @param jsonObject A {@link JsonObject} representing an Elasticsearch sort.
+	 * The JSON object must be a syntactically correct Elasticsearch sort.
+	 * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#request-body-search-sort">the Elasticsearch documentation</a>.
+	 * @return A {@link SortThenStep} allowing the retrieval of the sort
+	 * or the chaining of other sorts.
+	 */
+	SortThenStep fromJson(JsonObject jsonObject);
 
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/sort/dsl/impl/ElasticsearchSearchSortFactoryImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/sort/dsl/impl/ElasticsearchSearchSortFactoryImpl.java
@@ -15,6 +15,8 @@ import org.hibernate.search.engine.search.sort.dsl.spi.DelegatingSearchSortFacto
 import org.hibernate.search.engine.search.sort.dsl.spi.StaticSortThenStep;
 import org.hibernate.search.engine.search.sort.dsl.spi.SearchSortDslContext;
 
+import com.google.gson.JsonObject;
+
 
 public class ElasticsearchSearchSortFactoryImpl
 		extends DelegatingSearchSortFactory
@@ -26,6 +28,11 @@ public class ElasticsearchSearchSortFactoryImpl
 			SearchSortDslContext<ElasticsearchSearchSortBuilderFactory, ElasticsearchSearchSortBuilder> dslContext) {
 		super( delegate );
 		this.dslContext = dslContext;
+	}
+
+	@Override
+	public SortThenStep fromJson(JsonObject jsonObject) {
+		return staticThenStep( dslContext.getBuilderFactory().fromJson( jsonObject ) );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/sort/impl/ElasticsearchSearchSortBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/sort/impl/ElasticsearchSearchSortBuilderFactory.java
@@ -8,8 +8,12 @@ package org.hibernate.search.backend.elasticsearch.search.sort.impl;
 
 import org.hibernate.search.engine.search.sort.spi.SearchSortBuilderFactory;
 
+import com.google.gson.JsonObject;
+
 public interface ElasticsearchSearchSortBuilderFactory
 		extends SearchSortBuilderFactory<ElasticsearchSearchSortCollector, ElasticsearchSearchSortBuilder> {
+
+	ElasticsearchSearchSortBuilder fromJson(JsonObject jsonObject);
 
 	ElasticsearchSearchSortBuilder fromJson(String jsonString);
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/sort/impl/ElasticsearchSearchSortBuilderFactoryImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/sort/impl/ElasticsearchSearchSortBuilderFactoryImpl.java
@@ -92,10 +92,13 @@ public class ElasticsearchSearchSortBuilderFactoryImpl implements ElasticsearchS
 	}
 
 	@Override
+	public ElasticsearchSearchSortBuilder fromJson(JsonObject jsonObject) {
+		return new ElasticsearchUserProvidedJsonSortBuilder( jsonObject );
+	}
+
+	@Override
 	public ElasticsearchSearchSortBuilder fromJson(String jsonString) {
-		return new ElasticsearchUserProvidedJsonSortBuilder(
-				searchContext.getUserFacingGson().fromJson( jsonString, JsonObject.class )
-		);
+		return fromJson( searchContext.getUserFacingGson().fromJson( jsonString, JsonObject.class ) );
 	}
 
 	private static class SortBuilderFactoryRetrievalStrategy

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchJsonElementFieldCodec.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/codec/impl/ElasticsearchJsonElementFieldCodec.java
@@ -10,28 +10,28 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 
-public class ElasticsearchJsonStringFieldCodec implements ElasticsearchFieldCodec<String> {
+public class ElasticsearchJsonElementFieldCodec implements ElasticsearchFieldCodec<JsonElement> {
 
 	private final Gson gson;
 
-	public ElasticsearchJsonStringFieldCodec(Gson gson) {
+	public ElasticsearchJsonElementFieldCodec(Gson gson) {
 		this.gson = gson;
 	}
 
 	@Override
-	public JsonElement encode(String value) {
+	public JsonElement encode(JsonElement value) {
 		if ( value == null ) {
 			return JsonNull.INSTANCE;
 		}
-		return gson.fromJson( value, JsonElement.class );
+		return value;
 	}
 
 	@Override
-	public String decode(JsonElement element) {
+	public JsonElement decode(JsonElement element) {
 		if ( element == null || element.isJsonNull() ) {
 			return null;
 		}
-		return gson.toJson( element );
+		return element;
 	}
 
 	@Override
@@ -43,7 +43,7 @@ public class ElasticsearchJsonStringFieldCodec implements ElasticsearchFieldCode
 			return false;
 		}
 
-		ElasticsearchJsonStringFieldCodec castedOther = (ElasticsearchJsonStringFieldCodec) other;
+		ElasticsearchJsonElementFieldCodec castedOther = (ElasticsearchJsonElementFieldCodec) other;
 		return gson.equals( castedOther.gson );
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/ElasticsearchIndexFieldTypeFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/ElasticsearchIndexFieldTypeFactory.java
@@ -29,12 +29,8 @@ public interface ElasticsearchIndexFieldTypeFactory extends IndexFieldTypeFactor
 	 *     using {@link ElasticsearchSearchPredicateFactory#fromJson(String)}
 	 *     or {@link ElasticsearchSearchSortFactory#fromJson(String)}</li>
 	 * </ul>
-	 *
-	 * @param mappingJsonString A string representing an Elasticsearch field mapping as a JSON object.
-	 * The JSON object must be a syntactically correct Elasticsearch field mapping.
-	 * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html">the Elasticsearch documentation</a>.
 	 * @return A DSL step where the index field type can be defined in more details.
 	 */
-	ElasticsearchNativeIndexFieldTypeOptionsStep<?> asNative(String mappingJsonString);
+	ElasticsearchNativeIndexFieldTypeMappingStep asNative();
 
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/ElasticsearchNativeIndexFieldTypeMappingStep.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/ElasticsearchNativeIndexFieldTypeMappingStep.java
@@ -1,0 +1,29 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.types.dsl;
+
+import com.google.gson.JsonObject;
+
+public interface ElasticsearchNativeIndexFieldTypeMappingStep {
+
+	/**
+	 * @param jsonObject A {@link JsonObject} representing an Elasticsearch field mapping.
+	 * The JSON object must be a syntactically correct Elasticsearch field mapping.
+	 * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html">the Elasticsearch documentation</a>.
+	 * @return A DSL step where the index field type can be defined in more details.
+	 */
+	ElasticsearchNativeIndexFieldTypeOptionsStep<?> mapping(JsonObject jsonObject);
+
+	/**
+	 * @param jsonString A JSON-formatted string representing an Elasticsearch field mapping.
+	 * The JSON object must be a syntactically correct Elasticsearch field mapping.
+	 * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html">the Elasticsearch documentation</a>.
+	 * @return A DSL step where the index field type can be defined in more details.
+	 */
+	ElasticsearchNativeIndexFieldTypeOptionsStep<?> mapping(String jsonString);
+
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/ElasticsearchNativeIndexFieldTypeOptionsStep.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/ElasticsearchNativeIndexFieldTypeOptionsStep.java
@@ -8,7 +8,9 @@ package org.hibernate.search.backend.elasticsearch.types.dsl;
 
 import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeOptionsStep;
 
+import com.google.gson.JsonElement;
+
 public interface ElasticsearchNativeIndexFieldTypeOptionsStep<S extends ElasticsearchNativeIndexFieldTypeOptionsStep<?>>
-		extends IndexFieldTypeOptionsStep<S, String> {
+		extends IndexFieldTypeOptionsStep<S, JsonElement> {
 
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchIndexFieldTypeFactoryImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchIndexFieldTypeFactoryImpl.java
@@ -22,7 +22,7 @@ import java.time.ZonedDateTime;
 
 import org.hibernate.search.backend.elasticsearch.logging.impl.Log;
 import org.hibernate.search.backend.elasticsearch.types.dsl.ElasticsearchIndexFieldTypeFactory;
-import org.hibernate.search.backend.elasticsearch.types.dsl.ElasticsearchNativeIndexFieldTypeOptionsStep;
+import org.hibernate.search.backend.elasticsearch.types.dsl.ElasticsearchNativeIndexFieldTypeMappingStep;
 import org.hibernate.search.backend.elasticsearch.types.format.impl.ElasticsearchDefaultFieldFormatProvider;
 import org.hibernate.search.engine.backend.types.dsl.ScaledNumberIndexFieldTypeOptionsStep;
 import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeOptionsStep;
@@ -232,8 +232,8 @@ public class ElasticsearchIndexFieldTypeFactoryImpl
 	}
 
 	@Override
-	public ElasticsearchNativeIndexFieldTypeOptionsStep<?> asNative(String mappingJsonString) {
-		return new ElasticsearchNativeIndexFieldTypeOptionsStepImpl( this, mappingJsonString );
+	public ElasticsearchNativeIndexFieldTypeMappingStep asNative() {
+		return new ElasticsearchNativeIndexFieldTypeMappingStepImpl( this );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchNativeIndexFieldTypeMappingStepImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchNativeIndexFieldTypeMappingStepImpl.java
@@ -1,0 +1,39 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.types.dsl.impl;
+
+import org.hibernate.search.backend.elasticsearch.document.model.esnative.impl.PropertyMapping;
+import org.hibernate.search.backend.elasticsearch.types.dsl.ElasticsearchNativeIndexFieldTypeMappingStep;
+import org.hibernate.search.backend.elasticsearch.types.dsl.ElasticsearchNativeIndexFieldTypeOptionsStep;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+
+class ElasticsearchNativeIndexFieldTypeMappingStepImpl
+		implements ElasticsearchNativeIndexFieldTypeMappingStep {
+
+	private final ElasticsearchIndexFieldTypeBuildContext buildContext;
+
+	ElasticsearchNativeIndexFieldTypeMappingStepImpl(ElasticsearchIndexFieldTypeBuildContext buildContext) {
+		this.buildContext = buildContext;
+	}
+
+	@Override
+	public ElasticsearchNativeIndexFieldTypeOptionsStep<?> mapping(JsonObject jsonObject) {
+		Gson gson = buildContext.getUserFacingGson();
+		PropertyMapping mapping = gson.fromJson( jsonObject, PropertyMapping.class );
+		return new ElasticsearchNativeIndexFieldTypeOptionsStepImpl( buildContext, mapping );
+	}
+
+	@Override
+	public ElasticsearchNativeIndexFieldTypeOptionsStep<?> mapping(String jsonString) {
+		Gson gson = buildContext.getUserFacingGson();
+		return mapping( gson.fromJson( jsonString, JsonObject.class ) );
+	}
+
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchNativeIndexFieldTypeOptionsStepImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchNativeIndexFieldTypeOptionsStepImpl.java
@@ -19,18 +19,19 @@ import org.hibernate.search.engine.backend.types.converter.spi.DslConverter;
 import org.hibernate.search.engine.backend.types.IndexFieldType;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 
 
 class ElasticsearchNativeIndexFieldTypeOptionsStepImpl
 		extends AbstractElasticsearchIndexFieldTypeOptionsStep<ElasticsearchNativeIndexFieldTypeOptionsStepImpl, String>
 		implements ElasticsearchNativeIndexFieldTypeOptionsStep<ElasticsearchNativeIndexFieldTypeOptionsStepImpl> {
 
-	private final String mappingJsonString;
+	private final PropertyMapping mapping;
 
 	ElasticsearchNativeIndexFieldTypeOptionsStepImpl(ElasticsearchIndexFieldTypeBuildContext buildContext,
-			String mappingJsonString) {
+			PropertyMapping mapping) {
 		super( buildContext, String.class );
-		this.mappingJsonString = mappingJsonString;
+		this.mapping = mapping;
 	}
 
 	@Override
@@ -41,7 +42,6 @@ class ElasticsearchNativeIndexFieldTypeOptionsStepImpl
 	@Override
 	public IndexFieldType<String> toIndexFieldType() {
 		Gson gson = getBuildContext().getUserFacingGson();
-		PropertyMapping mapping = gson.fromJson( mappingJsonString, PropertyMapping.class );
 
 		DslConverter<?, ? extends String> dslConverter = createDslConverter();
 		DslConverter<String, ? extends String> rawDslConverter = createRawDslConverter();

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchNativeIndexFieldTypeOptionsStepImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/dsl/impl/ElasticsearchNativeIndexFieldTypeOptionsStepImpl.java
@@ -8,7 +8,7 @@ package org.hibernate.search.backend.elasticsearch.types.dsl.impl;
 
 import org.hibernate.search.backend.elasticsearch.document.model.esnative.impl.PropertyMapping;
 import org.hibernate.search.backend.elasticsearch.types.aggregation.impl.ElasticsearchStandardFieldAggregationBuilderFactory;
-import org.hibernate.search.backend.elasticsearch.types.codec.impl.ElasticsearchJsonStringFieldCodec;
+import org.hibernate.search.backend.elasticsearch.types.codec.impl.ElasticsearchJsonElementFieldCodec;
 import org.hibernate.search.backend.elasticsearch.types.dsl.ElasticsearchNativeIndexFieldTypeOptionsStep;
 import org.hibernate.search.backend.elasticsearch.types.impl.ElasticsearchIndexFieldType;
 import org.hibernate.search.backend.elasticsearch.types.predicate.impl.ElasticsearchStandardFieldPredicateBuilderFactory;
@@ -19,18 +19,18 @@ import org.hibernate.search.engine.backend.types.converter.spi.DslConverter;
 import org.hibernate.search.engine.backend.types.IndexFieldType;
 
 import com.google.gson.Gson;
-import com.google.gson.JsonObject;
+import com.google.gson.JsonElement;
 
 
 class ElasticsearchNativeIndexFieldTypeOptionsStepImpl
-		extends AbstractElasticsearchIndexFieldTypeOptionsStep<ElasticsearchNativeIndexFieldTypeOptionsStepImpl, String>
+		extends AbstractElasticsearchIndexFieldTypeOptionsStep<ElasticsearchNativeIndexFieldTypeOptionsStepImpl, JsonElement>
 		implements ElasticsearchNativeIndexFieldTypeOptionsStep<ElasticsearchNativeIndexFieldTypeOptionsStepImpl> {
 
 	private final PropertyMapping mapping;
 
 	ElasticsearchNativeIndexFieldTypeOptionsStepImpl(ElasticsearchIndexFieldTypeBuildContext buildContext,
 			PropertyMapping mapping) {
-		super( buildContext, String.class );
+		super( buildContext, JsonElement.class );
 		this.mapping = mapping;
 	}
 
@@ -40,14 +40,14 @@ class ElasticsearchNativeIndexFieldTypeOptionsStepImpl
 	}
 
 	@Override
-	public IndexFieldType<String> toIndexFieldType() {
+	public IndexFieldType<JsonElement> toIndexFieldType() {
 		Gson gson = getBuildContext().getUserFacingGson();
 
-		DslConverter<?, ? extends String> dslConverter = createDslConverter();
-		DslConverter<String, ? extends String> rawDslConverter = createRawDslConverter();
-		ProjectionConverter<? super String, ?> projectionConverter = createProjectionConverter();
-		ProjectionConverter<? super String, String> rawProjectionConverter = createRawProjectionConverter();
-		ElasticsearchJsonStringFieldCodec codec = new ElasticsearchJsonStringFieldCodec( gson );
+		DslConverter<?, ? extends JsonElement> dslConverter = createDslConverter();
+		DslConverter<JsonElement, ? extends JsonElement> rawDslConverter = createRawDslConverter();
+		ProjectionConverter<? super JsonElement, ?> projectionConverter = createProjectionConverter();
+		ProjectionConverter<? super JsonElement, JsonElement> rawProjectionConverter = createRawProjectionConverter();
+		ElasticsearchJsonElementFieldCodec codec = new ElasticsearchJsonElementFieldCodec( gson );
 
 		return new ElasticsearchIndexFieldType<>(
 				codec,

--- a/documentation/src/main/asciidoc/backend-elasticsearch.asciidoc
+++ b/documentation/src/main/asciidoc/backend-elasticsearch.asciidoc
@@ -457,15 +457,15 @@ would work as well.
 <3> Apply the Elasticsearch extension to the type factory.
 <4> Call `asNative` to start defining a native type.
 <5> Pass the Elasticsearch mapping as JSON.
-<6> Values of native fields are represented as strings in Hibernate Search,
-but those strings are expected to be JSON.
+<6> Values of native fields are represented as a `JsonElement` in Hibernate Search.
+`JsonElement` is a type from the link:{gsonUrl}[Gson] library.
 Do not forget to format them correctly before you pass them to the backend.
-Here we're using link:{gsonUrl}[Gson]
-to convert the string to a JSON string,
-escaping characters as appropriate,
-but any JSON library will do.
-<7> Same goes for projections: JSON is passed to the bridge,
-and it should be parsed appropriately.
+Here we are creating a `JsonPrimitive` (a subtype of `JsonElement`) from a `String`
+because we just need a JSON string,
+but it's completely possible to handle more complex objects,
+or even to convert directly from POJOs to JSON using Gson.
+<7> For nicer projections, you can also implement this method to convert
+from `JsonElement` to the mapped type (here, `String`).
 
 [source, JAVA, indent=0, subs="+callouts"]
 ----

--- a/documentation/src/main/asciidoc/search-dsl.asciidoc
+++ b/documentation/src/main/asciidoc/search-dsl.asciidoc
@@ -1854,7 +1854,7 @@ include::todo-placeholder.asciidoc[]
 ----
 include::{sourcedir}/org/hibernate/search/documentation/search/aggregation/AggregationDslIT.java[tags=elasticsearch-fromJson-jsonObject]
 ----
-<1> The aggregation result is a JSON-formatted string.
+<1> The aggregation result is a `JsonObject`.
 ====
 
 .Defining a native Elasticsearch JSON aggregation as a JSON-formatted string
@@ -1863,7 +1863,7 @@ include::{sourcedir}/org/hibernate/search/documentation/search/aggregation/Aggre
 ----
 include::{sourcedir}/org/hibernate/search/documentation/search/aggregation/AggregationDslIT.java[tags=elasticsearch-fromJson-string]
 ----
-<1> The aggregation result is a JSON-formatted string.
+<1> The aggregation result is a `JsonObject`.
 ====
 
 [[search-dsl-type-compatibility]]

--- a/documentation/src/main/asciidoc/search-dsl.asciidoc
+++ b/documentation/src/main/asciidoc/search-dsl.asciidoc
@@ -1120,11 +1120,19 @@ include::{sourcedir}/org/hibernate/search/documentation/search/predicate/Predica
 [[search-dsl-predicate-extensions-elasticsearch-from-json]]
 ==== Elasticsearch: `fromJson`
 
-.Matching a native Elasticsearch JSON query
+.Matching a native Elasticsearch JSON query provided as a `JsonObject`
 ====
 [source, JAVA, indent=0, subs="+callouts"]
 ----
-include::{sourcedir}/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java[tags=elasticsearch-fromJson]
+include::{sourcedir}/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java[tags=elasticsearch-fromJson-jsonObject]
+----
+====
+
+.Matching a native Elasticsearch JSON query provided as a JSON-formatted string
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java[tags=elasticsearch-fromJson-string]
 ----
 ====
 

--- a/documentation/src/main/asciidoc/search-dsl.asciidoc
+++ b/documentation/src/main/asciidoc/search-dsl.asciidoc
@@ -1299,7 +1299,7 @@ include::todo-placeholder.asciidoc[]
 [[search-dsl-sort-extensions-lucene-from-lucene-sort]]
 ==== Lucene: `fromLuceneSort`
 
-.Matching a native `org.apache.lucene.search.Sort`
+.Sorting by a native `org.apache.lucene.search.Sort`
 ====
 [source, JAVA, indent=0, subs="+callouts"]
 ----
@@ -1312,7 +1312,7 @@ include::{sourcedir}/org/hibernate/search/documentation/search/sort/SortDslIT.ja
 // Search 5 anchors backward compatibility
 [[_using_native_sorts_within_the_sort_dsl]]
 
-.Matching a native `org.apache.lucene.search.SortField`
+.Sorting by a native `org.apache.lucene.search.SortField`
 ====
 [source, JAVA, indent=0, subs="+callouts"]
 ----
@@ -1323,7 +1323,7 @@ include::{sourcedir}/org/hibernate/search/documentation/search/sort/SortDslIT.ja
 [[search-dsl-sort-extensions-elasticsearch-from-json]]
 ==== Elasticsearch: `fromJson`
 
-.Matching a native Elasticsearch JSON sort
+.Sorting by a native Elasticsearch JSON sort
 ====
 [source, JAVA, indent=0, subs="+callouts"]
 ----

--- a/documentation/src/main/asciidoc/search-dsl.asciidoc
+++ b/documentation/src/main/asciidoc/search-dsl.asciidoc
@@ -1566,7 +1566,7 @@ include::{sourcedir}/org/hibernate/search/documentation/search/projection/Projec
 [[search-dsl-projection-extensions-elasticsearch-source]]
 ==== Elasticsearch: `source`
 
-.Returning the matched document source as a JSON-formatted String
+.Returning the matched document source as a `JsonObject`
 ====
 [source, JAVA, indent=0, subs="+callouts"]
 ----
@@ -1583,7 +1583,7 @@ Explanations are rather costly performance-wise:
 only use them for <<search-dsl-query-debugging-scores,debugging>> purposes.
 ====
 
-.Returning the score explanation as a JSON-formatted String
+.Returning the score explanation as a `JsonObject`
 ====
 [source, JAVA, indent=0, subs="+callouts"]
 ----

--- a/documentation/src/main/asciidoc/search-dsl.asciidoc
+++ b/documentation/src/main/asciidoc/search-dsl.asciidoc
@@ -1848,11 +1848,20 @@ include::todo-placeholder.asciidoc[]
 [[search-dsl-aggregation-extensions-elasticsearch-from-json]]
 ==== Elasticsearch: `fromJson`
 
-.Matching a native Elasticsearch JSON aggregation
+.Defining a native Elasticsearch JSON aggregation as a `JsonObject`
 ====
 [source, JAVA, indent=0, subs="+callouts"]
 ----
-include::{sourcedir}/org/hibernate/search/documentation/search/aggregation/AggregationDslIT.java[tags=elasticsearch-fromJson]
+include::{sourcedir}/org/hibernate/search/documentation/search/aggregation/AggregationDslIT.java[tags=elasticsearch-fromJson-jsonObject]
+----
+<1> The aggregation result is a JSON-formatted string.
+====
+
+.Defining a native Elasticsearch JSON aggregation as a JSON-formatted string
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/search/aggregation/AggregationDslIT.java[tags=elasticsearch-fromJson-string]
 ----
 <1> The aggregation result is a JSON-formatted string.
 ====

--- a/documentation/src/main/asciidoc/search-dsl.asciidoc
+++ b/documentation/src/main/asciidoc/search-dsl.asciidoc
@@ -1331,11 +1331,19 @@ include::{sourcedir}/org/hibernate/search/documentation/search/sort/SortDslIT.ja
 [[search-dsl-sort-extensions-elasticsearch-from-json]]
 ==== Elasticsearch: `fromJson`
 
-.Sorting by a native Elasticsearch JSON sort
+.Sorting by a native Elasticsearch JSON sort provided as a `JsonObject`
 ====
 [source, JAVA, indent=0, subs="+callouts"]
 ----
-include::{sourcedir}/org/hibernate/search/documentation/search/sort/SortDslIT.java[tags=elasticsearch-fromJson]
+include::{sourcedir}/org/hibernate/search/documentation/search/sort/SortDslIT.java[tags=elasticsearch-fromJson-jsonObject]
+----
+====
+
+.Sorting by a native Elasticsearch JSON sort provided as a JSON-formatted string
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/search/sort/SortDslIT.java[tags=elasticsearch-fromJson-string]
 ----
 ====
 

--- a/documentation/src/test/java/org/hibernate/search/documentation/backend/elasticsearch/type/asnative/IpAddressValueBinder.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/backend/elasticsearch/type/asnative/IpAddressValueBinder.java
@@ -13,7 +13,8 @@ import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.ValueBinder;
 import org.hibernate.search.mapper.pojo.bridge.runtime.ValueBridgeFromIndexedValueContext;
 import org.hibernate.search.mapper.pojo.bridge.runtime.ValueBridgeToIndexedValueContext;
 
-import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
 
 //tag::include[]
 public class IpAddressValueBinder implements ValueBinder { // <1>
@@ -29,17 +30,15 @@ public class IpAddressValueBinder implements ValueBinder { // <1>
 		);
 	}
 
-	private static class IpAddressValueBridge implements ValueBridge<String, String> {
-		private static final Gson GSON = new Gson();
-
+	private static class IpAddressValueBridge implements ValueBridge<String, JsonElement> {
 		@Override
-		public String toIndexedValue(String value, ValueBridgeToIndexedValueContext context) {
-			return value == null ? null : GSON.toJson( value ); // <6>
+		public JsonElement toIndexedValue(String value, ValueBridgeToIndexedValueContext context) {
+			return value == null ? null : new JsonPrimitive( value ); // <6>
 		}
 
 		@Override
-		public String fromIndexedValue(String value, ValueBridgeFromIndexedValueContext context) {
-			return value == null ? null : GSON.fromJson( value, String.class ); // <7>
+		public String fromIndexedValue(JsonElement value, ValueBridgeFromIndexedValueContext context) {
+			return value == null ? null : value.getAsString(); // <7>
 		}
 	}
 }

--- a/documentation/src/test/java/org/hibernate/search/documentation/backend/elasticsearch/type/asnative/IpAddressValueBinder.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/backend/elasticsearch/type/asnative/IpAddressValueBinder.java
@@ -24,9 +24,8 @@ public class IpAddressValueBinder implements ValueBinder { // <1>
 				new IpAddressValueBridge(),
 				context.getTypeFactory() // <2>
 						.extension( ElasticsearchExtension.get() ) // <3>
-						.asNative( // <4>
-								"{\"type\": \"ip\"}" // <5>
-						)
+						.asNative() // <4>
+								.mapping( "{\"type\": \"ip\"}" ) // <5>
 		);
 	}
 

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/aggregation/AggregationDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/aggregation/AggregationDslIT.java
@@ -392,13 +392,13 @@ public class AggregationDslIT {
 					)
 					// tag::elasticsearch-fromJson-jsonObject[]
 					/* ... */;
-			AggregationKey<String> countsByPriceHistogramKey = AggregationKey.of( "countsByPriceHistogram" );
+			AggregationKey<JsonObject> countsByPriceHistogramKey = AggregationKey.of( "countsByPriceHistogram" );
 			SearchResult<Book> result = searchSession.search( Book.class )
 					.extension( ElasticsearchExtension.get() )
 					.predicate( f -> f.matchAll() )
 					.aggregation( countsByPriceHistogramKey, f -> f.fromJson( jsonObject ) )
 					.fetch( 20 );
-			String countsByPriceHistogram = result.getAggregation( countsByPriceHistogramKey ); // <1>
+			JsonObject countsByPriceHistogram = result.getAggregation( countsByPriceHistogramKey ); // <1>
 			// end::elasticsearch-fromJson-jsonObject[]
 			assertJsonEquals(
 					"{"
@@ -417,13 +417,13 @@ public class AggregationDslIT {
 									+ "}"
 							+ "]"
 					+ "}",
-					countsByPriceHistogram
+					countsByPriceHistogram.toString()
 			);
 		} );
 
 		withinSearchSession( searchSession -> {
 			// tag::elasticsearch-fromJson-string[]
-			AggregationKey<String> countsByPriceHistogramKey = AggregationKey.of( "countsByPriceHistogram" );
+			AggregationKey<JsonObject> countsByPriceHistogramKey = AggregationKey.of( "countsByPriceHistogram" );
 			SearchResult<Book> result = searchSession.search( Book.class )
 					.extension( ElasticsearchExtension.get() )
 					.predicate( f -> f.matchAll() )
@@ -434,7 +434,7 @@ public class AggregationDslIT {
 									+ "}"
 							+ "}" ) )
 					.fetch( 20 );
-			String countsByPriceHistogram = result.getAggregation( countsByPriceHistogramKey ); // <1>
+			JsonObject countsByPriceHistogram = result.getAggregation( countsByPriceHistogramKey ); // <1>
 			// end::elasticsearch-fromJson-string[]
 			assertJsonEquals(
 					"{"
@@ -453,7 +453,7 @@ public class AggregationDslIT {
 									+ "}"
 							+ "]"
 					+ "}",
-					countsByPriceHistogram
+					countsByPriceHistogram.toString()
 			);
 		} );
 	}

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/predicate/PredicateDslIT.java
@@ -41,6 +41,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.RegexpQuery;
 
@@ -729,7 +731,31 @@ public class PredicateDslIT {
 		Assume.assumeTrue( backendConfiguration instanceof ElasticsearchBackendConfiguration );
 
 		withinSearchSession( searchSession -> {
-			// tag::elasticsearch-fromJson[]
+			// tag::elasticsearch-fromJson-jsonObject[]
+			JsonObject jsonObject =
+					// end::elasticsearch-fromJson-jsonObject[]
+					new Gson().fromJson(
+							"{"
+									+ "\"regexp\": {"
+											+ "\"description\": \"neighbor|neighbour\""
+									+ "}"
+							+ "}",
+							JsonObject.class
+					)
+					// tag::elasticsearch-fromJson-jsonObject[]
+					/* ... */;
+			List<Book> hits = searchSession.search( Book.class )
+					.extension( ElasticsearchExtension.get() )
+					.predicate( f -> f.fromJson( jsonObject ) )
+					.fetchHits( 20 );
+			// end::elasticsearch-fromJson-jsonObject[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactlyInAnyOrder( BOOK4_ID );
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::elasticsearch-fromJson-string[]
 			List<Book> hits = searchSession.search( Book.class )
 					.extension( ElasticsearchExtension.get() )
 					.predicate( f -> f.fromJson( "{"
@@ -738,7 +764,7 @@ public class PredicateDslIT {
 									+ "}"
 							+ "}" ) )
 					.fetchHits( 20 );
-			// end::elasticsearch-fromJson[]
+			// end::elasticsearch-fromJson-string[]
 			assertThat( hits )
 					.extracting( Book::getId )
 					.containsExactlyInAnyOrder( BOOK4_ID );

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/projection/ProjectionDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/projection/ProjectionDslIT.java
@@ -44,6 +44,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import com.google.gson.JsonObject;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.search.Explanation;
 
@@ -387,7 +388,7 @@ public class ProjectionDslIT {
 
 		withinSearchSession( searchSession -> {
 			// tag::elasticsearch-source[]
-			List<String> hits = searchSession.search( Book.class )
+			List<JsonObject> hits = searchSession.search( Book.class )
 					.extension( ElasticsearchExtension.get() )
 					.asProjection( f -> f.source() )
 					.predicate( f -> f.matchAll() )
@@ -398,7 +399,7 @@ public class ProjectionDslIT {
 
 		withinSearchSession( searchSession -> {
 			// tag::elasticsearch-explanation[]
-			List<String> hits = searchSession.search( Book.class )
+			List<JsonObject> hits = searchSession.search( Book.class )
 					.extension( ElasticsearchExtension.get() )
 					.asProjection( f -> f.explanation() )
 					.predicate( f -> f.matchAll() )

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/query/QueryDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/query/QueryDslIT.java
@@ -44,6 +44,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import com.google.gson.JsonObject;
 import org.apache.lucene.search.Explanation;
 
 @RunWith(Parameterized.class)
@@ -296,14 +297,14 @@ public class QueryDslIT {
 							.matching( "robot" ) )
 					.toQuery(); // <2>
 
-			String explanation1 = query.explain( "1" ); // <3>
-			String explanation2 = query.explain( "Book", "1" ); // <4>
+			JsonObject explanation1 = query.explain( "1" ); // <3>
+			JsonObject explanation2 = query.explain( "Book", "1" ); // <4>
 
 			ElasticsearchSearchQuery<Book> elasticsearchQuery = query.extension( ElasticsearchExtension.get() ); // <5>
 			// end::explain-elasticsearch[]
 
-			assertThat( explanation1 ).contains( "title" );
-			assertThat( explanation2 ).contains( "title" );
+			assertThat( explanation1 ).asString().contains( "title" );
+			assertThat( explanation2 ).asString().contains( "title" );
 			assertThat( elasticsearchQuery ).isNotNull();
 		} );
 	}

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/sort/SortDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/sort/SortDslIT.java
@@ -36,6 +36,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 
@@ -317,7 +319,30 @@ public class SortDslIT {
 		Assume.assumeTrue( backendConfiguration instanceof ElasticsearchBackendConfiguration );
 
 		withinSearchSession( searchSession -> {
-			// tag::elasticsearch-fromJson[]
+			// tag::elasticsearch-fromJson-jsonObject[]
+			JsonObject jsonObject =
+					// end::elasticsearch-fromJson-jsonObject[]
+					new Gson().fromJson(
+							"{"
+									+ "\"title_sort\": \"asc\""
+							+ "}",
+							JsonObject.class
+					)
+					// tag::elasticsearch-fromJson-jsonObject[]
+					/* ... */;
+			List<Book> hits = searchSession.search( Book.class )
+					.extension( ElasticsearchExtension.get() )
+					.predicate( f -> f.matchAll() )
+					.sort( f -> f.fromJson( jsonObject ) )
+					.fetchHits( 20 );
+			// end::elasticsearch-fromJson-jsonObject[]
+			assertThat( hits )
+					.extracting( Book::getId )
+					.containsExactly( BOOK1_ID, BOOK4_ID, BOOK2_ID, BOOK3_ID );
+		} );
+
+		withinSearchSession( searchSession -> {
+			// tag::elasticsearch-fromJson-string[]
 			List<Book> hits = searchSession.search( Book.class )
 					.extension( ElasticsearchExtension.get() )
 					.predicate( f -> f.matchAll() )
@@ -325,7 +350,7 @@ public class SortDslIT {
 									+ "\"title_sort\": \"asc\""
 							+ "}" ) )
 					.fetchHits( 20 );
-			// end::elasticsearch-fromJson[]
+			// end::elasticsearch-fromJson-string[]
 			assertThat( hits )
 					.extracting( Book::getId )
 					.containsExactly( BOOK1_ID, BOOK4_ID, BOOK2_ID, BOOK3_ID );

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
@@ -860,7 +860,7 @@ public class ElasticsearchExtensionIT {
 	public void aggregation_nativeField_fromJson_jsonObject() {
 		StubMappingScope scope = indexManager.createScope();
 
-		AggregationKey<String> documentCountPerValue = AggregationKey.of( "documentCountPerValue" );
+		AggregationKey<JsonObject> documentCountPerValue = AggregationKey.of( "documentCountPerValue" );
 
 		SearchQuery<DocumentReference> query = scope.query()
 				.extension( ElasticsearchExtension.get() )
@@ -874,12 +874,12 @@ public class ElasticsearchExtensionIT {
 						JsonObject.class
 				) ) )
 				.toQuery();
-		String aggregationResult = query.fetchAll().getAggregation( documentCountPerValue );
+		JsonObject aggregationResult = query.fetchAll().getAggregation( documentCountPerValue );
 		assertJsonEquals(
 				"{"
 						+ "'value': 3,"
 						+ "}",
-				aggregationResult
+				aggregationResult.toString()
 		);
 	}
 
@@ -888,7 +888,7 @@ public class ElasticsearchExtensionIT {
 	public void aggregation_nativeField_fromJson_string() {
 		StubMappingScope scope = indexManager.createScope();
 
-		AggregationKey<String> documentCountPerValue = AggregationKey.of( "documentCountPerValue" );
+		AggregationKey<JsonObject> documentCountPerValue = AggregationKey.of( "documentCountPerValue" );
 
 		SearchQuery<DocumentReference> query = scope.query()
 				.extension( ElasticsearchExtension.get() )
@@ -901,12 +901,12 @@ public class ElasticsearchExtensionIT {
 								+ "}"
 				) )
 				.toQuery();
-		String aggregationResult = query.fetchAll().getAggregation( documentCountPerValue );
+		JsonObject aggregationResult = query.fetchAll().getAggregation( documentCountPerValue );
 		assertJsonEquals(
 				"{"
 						+ "'value': 3,"
 						+ "}",
-				aggregationResult
+				aggregationResult.toString()
 		);
 	}
 

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
@@ -512,7 +512,123 @@ public class ElasticsearchExtensionIT {
 	}
 
 	@Test
-	public void sort_nativeField_fromJson() {
+	public void sort_nativeField_jsonObject() {
+		StubMappingScope scope = indexManager.createScope();
+
+		SearchQuery<DocumentReference> query = scope.query()
+				.predicate( f -> f.matchAll() )
+				.sort( f -> f
+						.extension( ElasticsearchExtension.get() ).fromJson( gson.fromJson(
+								"{'nativeField_sort1': 'asc'}", JsonObject.class
+						) )
+						.then().extension( ElasticsearchExtension.get() ).fromJson( gson.fromJson(
+								"{'nativeField_sort2': 'asc'}", JsonObject.class
+						) )
+						.then().extension( ElasticsearchExtension.get() ).fromJson( gson.fromJson(
+								"{'nativeField_sort3': 'asc'}", JsonObject.class
+						) )
+						.then().extension( ElasticsearchExtension.get() ).fromJson( gson.fromJson(
+								"{'nativeField_sort4': {'order': 'asc', 'missing': '_last'}}", JsonObject.class
+						) )
+						.then().extension( ElasticsearchExtension.get() ).fromJson( gson.fromJson(
+								"{'nativeField_sort5': {'order': 'asc', 'missing': '_first'}}", JsonObject.class
+						) )
+				)
+				.toQuery();
+		assertThat( query ).hasDocRefHitsExactOrder(
+				INDEX_NAME,
+				FIRST_ID, SECOND_ID, THIRD_ID, FOURTH_ID, EMPTY_ID, FIFTH_ID
+		);
+
+		query = scope.query()
+				.predicate( f -> f.matchAll() )
+				.sort( f -> f
+						.extension( ElasticsearchExtension.get() ).fromJson( gson.fromJson(
+								"{'nativeField_sort1': 'desc'}", JsonObject.class
+						) )
+						.then().extension( ElasticsearchExtension.get() ).fromJson( gson.fromJson(
+								"{'nativeField_sort2': 'desc'}", JsonObject.class
+						) )
+						.then().extension( ElasticsearchExtension.get() ).fromJson( gson.fromJson(
+								"{'nativeField_sort3': 'desc'}", JsonObject.class
+						) )
+						.then().extension( ElasticsearchExtension.get() ).fromJson( gson.fromJson(
+								"{'nativeField_sort4': {'order': 'desc', 'missing': '_last'}}", JsonObject.class
+						) )
+						.then().extension( ElasticsearchExtension.get() ).fromJson( gson.fromJson(
+								"{'nativeField_sort5': {'order': 'asc', 'missing': '_first'}}", JsonObject.class
+						) )
+				)
+				.toQuery();
+		assertThat( query ).hasDocRefHitsExactOrder(
+				INDEX_NAME,
+				FOURTH_ID, THIRD_ID, SECOND_ID, FIRST_ID, EMPTY_ID, FIFTH_ID
+		);
+	}
+
+	@Test
+	public void sort_nativeField_fromJson_jsonObject_separateSort() {
+		StubMappingScope scope = indexManager.createScope();
+
+		SearchSort sort1Asc = scope.sort().extension( ElasticsearchExtension.get() ).fromJson( gson.fromJson(
+						"{'nativeField_sort1': 'asc'}", JsonObject.class
+				) )
+				.toSort();
+		SearchSort sort2Asc = scope.sort().extension( ElasticsearchExtension.get() ).fromJson( gson.fromJson(
+						"{'nativeField_sort2': 'asc'}", JsonObject.class
+				) )
+				.toSort();
+		SearchSort sort3Asc = scope.sort().extension( ElasticsearchExtension.get() ).fromJson( gson.fromJson(
+						"{'nativeField_sort3': 'asc'}", JsonObject.class
+				) )
+				.toSort();
+		SearchSort sort4Asc = scope.sort()
+				.extension( ElasticsearchExtension.get() ).fromJson( gson.fromJson(
+						"{'nativeField_sort4': {'order': 'asc', 'missing': '_last'}}", JsonObject.class
+				) )
+				.then().extension( ElasticsearchExtension.get() ).fromJson( gson.fromJson(
+						"{'nativeField_sort5': {'order': 'asc', 'missing': '_first'}}", JsonObject.class
+				) )
+				.toSort();
+
+		SearchQuery<DocumentReference> query = scope.query()
+				.predicate( f -> f.matchAll() )
+				.sort( f -> f.composite().add( sort1Asc ).add( sort2Asc ).add( sort3Asc ).add( sort4Asc ) )
+				.toQuery();
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID, FOURTH_ID, EMPTY_ID, FIFTH_ID );
+
+		SearchSort sort1Desc = scope.sort().extension( ElasticsearchExtension.get() ).fromJson( gson.fromJson(
+						"{'nativeField_sort1': 'desc'}", JsonObject.class
+				) )
+				.toSort();
+		SearchSort sort2Desc = scope.sort().extension( ElasticsearchExtension.get() ).fromJson( gson.fromJson(
+						"{'nativeField_sort2': 'desc'}", JsonObject.class
+				) )
+				.toSort();
+		SearchSort sort3Desc = scope.sort().extension( ElasticsearchExtension.get() ).fromJson( gson.fromJson(
+						"{'nativeField_sort3': 'desc'}", JsonObject.class
+				) )
+				.toSort();
+		SearchSort sort4Desc = scope.sort()
+				.extension( ElasticsearchExtension.get() ).fromJson( gson.fromJson(
+						"{'nativeField_sort4': {'order': 'desc', 'missing': '_last'}}", JsonObject.class
+				) )
+				.then().extension( ElasticsearchExtension.get() ).fromJson( gson.fromJson(
+						"{'nativeField_sort5': {'order': 'asc', 'missing': '_first'}}", JsonObject.class
+				) )
+				.toSort();
+
+		query = scope.query()
+				.predicate( f -> f.matchAll() )
+				.sort( f -> f.composite().add( sort1Desc ).add( sort2Desc ).add( sort3Desc ).add( sort4Desc ) )
+				.toQuery();
+		assertThat( query )
+				.hasDocRefHitsExactOrder( INDEX_NAME, FOURTH_ID, THIRD_ID, SECOND_ID, FIRST_ID, EMPTY_ID, FIFTH_ID );
+	}
+
+	@Test
+	public void sort_nativeField_fromJson_string() {
 		StubMappingScope scope = indexManager.createScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
@@ -557,7 +673,7 @@ public class ElasticsearchExtensionIT {
 	}
 
 	@Test
-	public void sort_nativeField_fromJson_separateSort() {
+	public void sort_nativeField_fromJson_string_separateSort() {
 		StubMappingScope scope = indexManager.createScope();
 
 		SearchSort sort1Asc = scope.sort().extension( ElasticsearchExtension.get() )

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
@@ -202,11 +202,13 @@ public class ElasticsearchExtensionIT {
 
 		// Matching document
 		Assertions.assertThat( query.explain( FIRST_ID ) )
+				.asString()
 				.contains( "\"description\":" )
 				.contains( "\"details\":" );
 
 		// Non-matching document
 		Assertions.assertThat( query.explain( FIFTH_ID ) )
+				.asString()
 				.contains( "\"description\":" )
 				.contains( "\"details\":" );
 	}
@@ -246,11 +248,13 @@ public class ElasticsearchExtensionIT {
 
 		// Matching document
 		Assertions.assertThat( query.explain( INDEX_NAME, FIRST_ID ) )
+				.asString()
 				.contains( "\"description\":" )
 				.contains( "\"details\":" );
 
 		// Non-matching document
 		Assertions.assertThat( query.explain( INDEX_NAME, FIFTH_ID ) )
+				.asString()
 				.contains( "\"description\":" )
 				.contains( "\"details\":" );
 	}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
@@ -857,7 +857,35 @@ public class ElasticsearchExtensionIT {
 	}
 
 	@Test
-	public void aggregation_nativeField_fromJson() throws JSONException {
+	public void aggregation_nativeField_fromJson_jsonObject() {
+		StubMappingScope scope = indexManager.createScope();
+
+		AggregationKey<String> documentCountPerValue = AggregationKey.of( "documentCountPerValue" );
+
+		SearchQuery<DocumentReference> query = scope.query()
+				.extension( ElasticsearchExtension.get() )
+				.predicate( f -> f.matchAll() )
+				.aggregation( documentCountPerValue, f -> f.fromJson( gson.fromJson(
+						"{"
+								+ "'value_count' : {"
+										+ "'field' : 'nativeField_aggregation'"
+								+ " }"
+								+ "}",
+						JsonObject.class
+				) ) )
+				.toQuery();
+		String aggregationResult = query.fetchAll().getAggregation( documentCountPerValue );
+		assertJsonEquals(
+				"{"
+						+ "'value': 3,"
+						+ "}",
+				aggregationResult
+		);
+	}
+
+
+	@Test
+	public void aggregation_nativeField_fromJson_string() {
 		StubMappingScope scope = indexManager.createScope();
 
 		AggregationKey<String> documentCountPerValue = AggregationKey.of( "documentCountPerValue" );

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
@@ -54,6 +54,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import com.google.gson.JsonObject;
 import org.apache.http.nio.client.HttpAsyncClient;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.HamcrestCondition;
@@ -569,14 +570,14 @@ public class ElasticsearchExtensionIT {
 	public void projection_document() throws JSONException {
 		StubMappingScope scope = indexManager.createScope();
 
-		SearchQuery<String> query = scope.query()
+		SearchQuery<JsonObject> query = scope.query()
 				.asProjection(
 						f -> f.extension( ElasticsearchExtension.get() ).source()
 				)
 				.predicate( f -> f.id().matching( FIFTH_ID ) )
 				.toQuery();
 
-		List<String> result = query.fetchAll().getHits();
+		List<JsonObject> result = query.fetchAll().getHits();
 		Assertions.assertThat( result ).hasSize( 1 );
 		assertJsonEquals(
 				"{"
@@ -587,7 +588,7 @@ public class ElasticsearchExtensionIT {
 						+ "'nativeField_unsupportedType': 'foobar',"
 						+ "'nativeField_sort5': 'z'"
 						+ "}",
-				result.get( 0 )
+				result.get( 0 ).toString()
 		);
 	}
 
@@ -609,8 +610,8 @@ public class ElasticsearchExtensionIT {
 				.predicate( f -> f.id().matching( FIFTH_ID ) )
 				.toQuery();
 
-		List<String> result = query.fetchAll().getHits().stream()
-				.map( list -> (String) list.get( 0 ) )
+		List<JsonObject> result = query.fetchAll().getHits().stream()
+				.map( list -> (JsonObject) list.get( 0 ) )
 				.collect( Collectors.toList() );
 		Assertions.assertThat( result ).hasSize( 1 );
 		assertJsonEquals(
@@ -622,7 +623,7 @@ public class ElasticsearchExtensionIT {
 						+ "'nativeField_unsupportedType': 'foobar',"
 						+ "'nativeField_sort5': 'z'"
 						+ "}",
-				result.get( 0 )
+				result.get( 0 ).toString()
 		);
 	}
 
@@ -630,12 +631,12 @@ public class ElasticsearchExtensionIT {
 	public void projection_explanation() {
 		StubMappingScope scope = indexManager.createScope();
 
-		SearchQuery<String> query = scope.query()
+		SearchQuery<JsonObject> query = scope.query()
 				.asProjection( f -> f.extension( ElasticsearchExtension.get() ).explanation() )
 				.predicate( f -> f.id().matching( FIRST_ID ) )
 				.toQuery();
 
-		List<String> result = query.fetchAll().getHits();
+		List<JsonObject> result = query.fetchAll().getHits();
 		Assertions.assertThat( result ).hasSize( 1 );
 		Assertions.assertThat( result.get( 0 ) )
 				.asString()

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
@@ -1061,13 +1061,13 @@ public class ElasticsearchExtensionIT {
 			nativeField_integer = root.field(
 					"nativeField_integer",
 					f -> f.extension( ElasticsearchExtension.get() )
-							.asNative( "{'type': 'integer'}" )
+							.asNative().mapping( "{'type': 'integer'}" )
 			)
 					.toReference();
 			nativeField_integer_converted = root.field(
 					"nativeField_integer_converted",
 					f -> f.extension( ElasticsearchExtension.get() )
-							.asNative( "{'type': 'integer'}" )
+							.asNative().mapping( "{'type': 'integer'}" )
 							.dslConverter( ValueWrapper.class, ValueWrapper.toIndexFieldConverter() )
 							.projectionConverter( ValueWrapper.class, ValueWrapper.fromIndexFieldConverter() )
 			)
@@ -1075,63 +1075,63 @@ public class ElasticsearchExtensionIT {
 			nativeField_string = root.field(
 					"nativeField_string",
 					f -> f.extension( ElasticsearchExtension.get() )
-							.asNative( "{'type': 'keyword'}" )
+							.asNative().mapping( "{'type': 'keyword'}" )
 			)
 					.toReference();
 			nativeField_geoPoint = root.field(
 					"nativeField_geoPoint",
 					f -> f.extension( ElasticsearchExtension.get() )
-							.asNative( "{'type': 'geo_point'}" )
+							.asNative().mapping( "{'type': 'geo_point'}" )
 			)
 					.toReference();
 			nativeField_dateWithColons = root.field(
 					"nativeField_dateWithColons",
 					f -> f.extension( ElasticsearchExtension.get() )
-							.asNative( "{'type': 'date', 'format': 'yyyy:MM:dd'}" )
+							.asNative().mapping( "{'type': 'date', 'format': 'yyyy:MM:dd'}" )
 			)
 					.toReference();
 			nativeField_unsupportedType = root.field(
 					"nativeField_unsupportedType",
 					f -> f.extension( ElasticsearchExtension.get() )
-							.asNative( "{'type': 'half_float', 'ignore_malformed': true}" )
+							.asNative().mapping( "{'type': 'half_float', 'ignore_malformed': true}" )
 			)
 					.toReference();
 
 			nativeField_sort1 = root.field(
 					"nativeField_sort1",
 					f -> f.extension( ElasticsearchExtension.get() )
-							.asNative( "{'type': 'keyword', 'doc_values': true}" )
+							.asNative().mapping( "{'type': 'keyword', 'doc_values': true}" )
 			)
 					.toReference();
 			nativeField_sort2 = root.field(
 					"nativeField_sort2",
 					f -> f.extension( ElasticsearchExtension.get() )
-							.asNative( "{'type': 'keyword', 'doc_values': true}" )
+							.asNative().mapping( "{'type': 'keyword', 'doc_values': true}" )
 			)
 					.toReference();
 			nativeField_sort3 = root.field(
 					"nativeField_sort3",
 					f -> f.extension( ElasticsearchExtension.get() )
-							.asNative( "{'type': 'keyword', 'doc_values': true}" )
+							.asNative().mapping( "{'type': 'keyword', 'doc_values': true}" )
 			)
 					.toReference();
 			nativeField_sort4 = root.field(
 					"nativeField_sort4",
 					f -> f.extension( ElasticsearchExtension.get() )
-							.asNative( "{'type': 'keyword', 'doc_values': true}" )
+							.asNative().mapping( "{'type': 'keyword', 'doc_values': true}" )
 			)
 					.toReference();
 			nativeField_sort5 = root.field(
 					"nativeField_sort5",
 					f -> f.extension( ElasticsearchExtension.get() )
-							.asNative( "{'type': 'keyword', 'doc_values': true}" )
+							.asNative().mapping( "{'type': 'keyword', 'doc_values': true}" )
 			)
 					.toReference();
 
 			nativeField_aggregation = root.field(
 					"nativeField_aggregation",
 					f -> f.extension( ElasticsearchExtension.get() )
-							.asNative( "{'type': 'keyword', 'doc_values': true}" )
+							.asNative().mapping( "{'type': 'keyword', 'doc_values': true}" )
 			)
 					.toReference();
 		}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/mapping/ElasticsearchFieldAttributesIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/mapping/ElasticsearchFieldAttributesIT.java
@@ -83,7 +83,7 @@ public class ElasticsearchFieldAttributesIT {
 			root.field(
 					"native",
 					f -> f.extension( ElasticsearchExtension.get() )
-							.asNative( "{\"type\": \"half_float\",\"ignore_malformed\": true}" )
+							.asNative().mapping( "{\"type\": \"half_float\",\"ignore_malformed\": true}" )
 			)
 					.toReference();
 		}, properties );

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/mapping/ElasticsearchFieldTypesIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/mapping/ElasticsearchFieldTypesIT.java
@@ -130,7 +130,7 @@ public class ElasticsearchFieldTypesIT {
 			root.field(
 					"unsupportedType",
 					f -> f.extension( ElasticsearchExtension.get() )
-							.asNative( "{\"type\": \"half_float\"}" )
+							.asNative().mapping( "{\"type\": \"half_float\"}" )
 			)
 					.toReference();
 		}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3761
