### PR TITLE
HSEARCH-3767 Elasticsearch date/time bridges throw NPE on projections

### DIFF
--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/bridge/builtin/impl/ElasticsearchCalendarBridge.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/bridge/builtin/impl/ElasticsearchCalendarBridge.java
@@ -77,11 +77,11 @@ public class ElasticsearchCalendarBridge
 	}
 
 	private String convertToString(Calendar value) {
-		return ElasticsearchDateHelper.calendarToString( ElasticsearchDateHelper.round( value, resolution ) );
+		return value == null ? null : ElasticsearchDateHelper.calendarToString( ElasticsearchDateHelper.round( value, resolution ) );
 	}
 
 	private Calendar convertFromString(String value) {
-		return ElasticsearchDateHelper.stringToCalendar( value );
+		return value == null ? null : ElasticsearchDateHelper.stringToCalendar( value );
 	}
 
 	@Override

--- a/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/bridge/builtin/impl/ElasticsearchDateBridge.java
+++ b/elasticsearch/src/main/java/org/hibernate/search/elasticsearch/bridge/builtin/impl/ElasticsearchDateBridge.java
@@ -77,11 +77,11 @@ public class ElasticsearchDateBridge
 	}
 
 	private String convertToString(Date value) {
-		return ElasticsearchDateHelper.dateToString( DateTools.round( value, resolution ) );
+		return value == null ? null : ElasticsearchDateHelper.dateToString( DateTools.round( value, resolution ) );
 	}
 
 	private Date convertFromString(String value) {
-		return ElasticsearchDateHelper.stringToDate( value );
+		return value == null ? null : ElasticsearchDateHelper.stringToDate( value );
 	}
 
 	@Override


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3767
