### PR TITLE
HSEARCH-3801 Hibernate Search blocks loading of non hibernate batch jobs

### DIFF
--- a/jsr352/jberet/src/main/java/org/hibernate/search/jsr352/jberet/impl/HibernateSearchJobXmlResolver.java
+++ b/jsr352/jberet/src/main/java/org/hibernate/search/jsr352/jberet/impl/HibernateSearchJobXmlResolver.java
@@ -15,7 +15,6 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.jsr352.massindexing.MassIndexingJob;
 
 import org.jberet.spi.JobXmlResolver;
@@ -47,7 +46,7 @@ public final class HibernateSearchJobXmlResolver extends AbstractJobXmlResolver 
 			return classLoader.getResourceAsStream( path );
 		}
 		else {
-			throw new SearchException( "Not a Hibernate Search JSR-352 job: " + jobXml );
+			return null;
 		}
 	}
 }


### PR DESCRIPTION
In reference of `org.jberet.spi.JobXmlResolver` it's defined that a resolver that is not responsible should return `null` instead of throwing a runtime exception. The exception prevent that further available resolver will be consider.
```
    /**
     * Locates the job XML and creates a stream to the contents.
     *
     * @param jobXml      the name of the job XML with a {@code .xml} suffix
     * @param classLoader the class loader for the application
     *
     * @return a stream of the job XML or {@code null} if the job XML content was not found
     *
     * @throws java.io.IOException if an error occurs creating the stream
     */
```