### PR TITLE
HSEARCH-3802 query.fetchTotalHitCounts always fails when setting a timeout with Elasticsearch

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/CountWork.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/CountWork.java
@@ -85,14 +85,7 @@ public class CountWork extends AbstractSimpleElasticsearchWork<Long> {
 				builder.multiValuedParam( "routing", routingKeys );
 			}
 
-			if ( timeoutValue != null && timeoutUnit != null ) {
-				builder.param( "timeout", getTimeoutString( timeoutValue, timeoutUnit ) );
-			}
-
 			if ( exceptionOnTimeout ) {
-				// the default is true
-				builder.param( "allow_partial_search_results", false );
-
 				// set timeoutValue and timeoutUnit only for hard timeout
 				builder.timeout( timeoutValue, timeoutUnit );
 			}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckTestRunner.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckTestRunner.java
@@ -21,6 +21,6 @@ import org.junit.runner.RunWith;
  * @author Gunnar Morling
  */
 @RunWith(ClasspathSuite.class)
-@ClasspathSuite.ClassnameFilters({ ".*\\.tck\\..*MultiTenancyBaseIT" })
+@ClasspathSuite.ClassnameFilters({ ".*\\.tck\\..*" })
 public class ElasticsearchTckTestRunner {
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryTimeoutIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryTimeoutIT.java
@@ -136,6 +136,15 @@ public class SearchQueryTimeoutIT {
 		assertThat( result.isTimedOut() ).isFalse();
 	}
 
+	@Test
+	public void timeout_fastCount_largeTimeout() {
+		SearchQuery<DocumentReference> query = startFastQuery()
+				.failAfter( 1, TimeUnit.DAYS )
+				.toQuery();
+
+		assertThat( query.fetchTotalHitCount() ).isEqualTo( 0 );
+	}
+
 	private SearchQueryOptionsStep<?, DocumentReference, ?, ?, ?> startSlowQuery() {
 		return indexManager.createScope().query()
 				.predicate( f -> f.bool( b -> {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3802
