### PR TITLE
HSEARCH-3819 JsonSyntaxException when validating or migrating an Elasticsearch schema with a geo_point field with null_value

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/esnative/impl/PropertyMappingJsonAdapterFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/esnative/impl/PropertyMappingJsonAdapterFactory.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.backend.elasticsearch.document.model.esnative.impl;
 
-import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonElement;
 
 public class PropertyMappingJsonAdapterFactory extends AbstractTypeMappingJsonAdapterFactory {
 
@@ -18,7 +18,7 @@ public class PropertyMappingJsonAdapterFactory extends AbstractTypeMappingJsonAd
 		builder.add( "norms", Boolean.class );
 		builder.add( "docValues", Boolean.class );
 		builder.add( "store", Boolean.class );
-		builder.add( "nullValue", JsonPrimitive.class );
+		builder.add( "nullValue", JsonElement.class );
 		builder.add( "analyzer", String.class );
 		builder.add( "searchAnalyzer", String.class );
 		builder.add( "normalizer", String.class );


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3819

I encountered the problem while working on something else.

I checked this solves the problem on my other branch, but I don't think it's worth an automated test. A lot of tests will fail in case of regression anyway, at least once my other branch is merged.