### PR TITLE
HSEARCH-3827 Restore simple backend performance tests

### DIFF
--- a/engine/src/main/java/org/hibernate/search/engine/cfg/impl/SystemConfigurationPropertySource.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/impl/SystemConfigurationPropertySource.java
@@ -1,0 +1,57 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.cfg.impl;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.hibernate.search.engine.cfg.spi.AllAwareConfigurationPropertySource;
+
+public class SystemConfigurationPropertySource implements AllAwareConfigurationPropertySource {
+
+	private static final SystemConfigurationPropertySource INSTANCE = new SystemConfigurationPropertySource();
+
+	public static AllAwareConfigurationPropertySource get() {
+		return INSTANCE;
+	}
+
+	private SystemConfigurationPropertySource() {
+	}
+
+	@Override
+	public Optional<?> get(String key) {
+		Object value = System.getProperty( key );
+		return Optional.ofNullable( value );
+	}
+
+	@Override
+	public Optional<String> resolve(String key) {
+		return Optional.of( key );
+	}
+
+	@Override
+	public Set<String> resolveAll(String prefix) {
+		Set<String> prefixedPropertyKeys = new HashSet<>();
+		for ( Map.Entry<Object, Object> entry : System.getProperties().entrySet() ) {
+			Object key = entry.getKey();
+			if ( key instanceof String ) {
+				String stringKey = (String) key;
+				if ( stringKey.startsWith( prefix ) ) {
+					prefixedPropertyKeys.add( stringKey );
+				}
+			}
+		}
+		return prefixedPropertyKeys;
+	}
+
+	@Override
+	public String toString() {
+		return getClass().getSimpleName();
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/engine/cfg/spi/ConfigurationPropertySource.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/spi/ConfigurationPropertySource.java
@@ -15,6 +15,7 @@ import org.hibernate.search.engine.cfg.impl.MapConfigurationPropertySource;
 import org.hibernate.search.engine.cfg.impl.MaskedConfigurationPropertySource;
 import org.hibernate.search.engine.cfg.impl.OverriddenConfigurationPropertySource;
 import org.hibernate.search.engine.cfg.impl.PrefixedConfigurationPropertySource;
+import org.hibernate.search.engine.cfg.impl.SystemConfigurationPropertySource;
 
 /**
  * A source of property values for Hibernate Search.
@@ -95,6 +96,13 @@ public interface ConfigurationPropertySource {
 	 */
 	static AllAwareConfigurationPropertySource fromMap(Map<String, ?> map) {
 		return new MapConfigurationPropertySource( map );
+	}
+
+	/**
+	 * @return A source containing the system properties ({@link System#getProperty(String)}).
+	 */
+	static AllAwareConfigurationPropertySource system() {
+		return SystemConfigurationPropertySource.get();
 	}
 
 	/**

--- a/engine/src/test/java/org/hibernate/search/engine/cfg/AbstractAllAwareConfigurationPropertySourceTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/cfg/AbstractAllAwareConfigurationPropertySourceTest.java
@@ -1,0 +1,65 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.cfg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import org.hibernate.search.engine.cfg.spi.AllAwareConfigurationPropertySource;
+import org.hibernate.search.engine.cfg.spi.ConfigurationPropertySource;
+
+import org.junit.Test;
+
+@SuppressWarnings("unchecked")
+public abstract class AbstractAllAwareConfigurationPropertySourceTest {
+
+	@Test
+	public void get_missing() {
+		ConfigurationPropertySource propertySource = createPropertySource( "ignored", "foo" );
+		assertThat( propertySource.get( "someKey" ) ).isEmpty();
+	}
+
+	@Test
+	public void get_string() {
+		ConfigurationPropertySource propertySource = createPropertySource( "someKey", "foo" );
+		assertThat( (Optional<Object>) propertySource.get( "someKey" ) ).contains( "foo" );
+	}
+
+	@Test
+	public void resolve_missing() {
+		ConfigurationPropertySource propertySource = createPropertySource( "ignored", "foo" );
+		assertThat( propertySource.resolve( "someKey" ) ).contains( "someKey" );
+	}
+
+	@Test
+	public void resolve_present() {
+		ConfigurationPropertySource propertySource = createPropertySource( "someKey", "foo" );
+		assertThat( propertySource.resolve( "someKey" ) ).contains( "someKey" );
+	}
+
+	@Test
+	public void resolveAll_missing() {
+		AllAwareConfigurationPropertySource propertySource = createPropertySource( "ignored", "foo" );
+		assertThat( propertySource.resolveAll( "someKey" ) ).isEmpty();
+	}
+
+	@Test
+	public void resolveAll_present() {
+		AllAwareConfigurationPropertySource propertySource = createPropertySource(
+				"someKey.someSubKey1", "foo",
+				"someKey.someSubKey2", "foo"
+		);
+		assertThat( propertySource.resolveAll( "someKey." ) )
+				.containsExactlyInAnyOrder( "someKey.someSubKey1", "someKey.someSubKey2" );
+	}
+
+	protected abstract AllAwareConfigurationPropertySource createPropertySource(String key, String value);
+
+	protected abstract AllAwareConfigurationPropertySource createPropertySource(String key, String value,
+			String key2, String value2);
+}

--- a/engine/src/test/java/org/hibernate/search/engine/cfg/MapConfigurationPropertySourceTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/cfg/MapConfigurationPropertySourceTest.java
@@ -1,0 +1,54 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.cfg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.hibernate.search.engine.cfg.spi.AllAwareConfigurationPropertySource;
+import org.hibernate.search.engine.cfg.spi.ConfigurationPropertySource;
+
+import org.junit.Test;
+
+@SuppressWarnings("unchecked")
+public class MapConfigurationPropertySourceTest extends AbstractAllAwareConfigurationPropertySourceTest {
+
+	@Test
+	public void to_string() {
+		ConfigurationPropertySource propertySource = createPropertySource( "someKey", "foo" );
+		assertThat( propertySource ).asString()
+				.contains( "Map" )
+				.contains( "someKey=foo" );
+	}
+
+	@Test
+	public void get_integer() {
+		ConfigurationPropertySource propertySource = ConfigurationPropertySource.fromMap(
+				Collections.singletonMap( "someKey", 42 )
+		);
+		assertThat( (Optional<Object>) propertySource.get( "someKey" ) ).contains( 42 );
+	}
+
+	@Override
+	protected AllAwareConfigurationPropertySource createPropertySource(String key, String value) {
+		Map<String, Object> map = Collections.singletonMap( key, value );
+		return ConfigurationPropertySource.fromMap( map );
+	}
+
+	@Override
+	protected AllAwareConfigurationPropertySource createPropertySource(String key, String value,
+			String key2, String value2) {
+		Map<String, Object> map = new LinkedHashMap<>();
+		map.put( key, value );
+		map.put( key2, value2 );
+		return ConfigurationPropertySource.fromMap( map );
+	}
+}

--- a/engine/src/test/java/org/hibernate/search/engine/cfg/SystemConfigurationPropertySourceTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/cfg/SystemConfigurationPropertySourceTest.java
@@ -1,0 +1,54 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.cfg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.search.engine.cfg.spi.AllAwareConfigurationPropertySource;
+import org.hibernate.search.engine.cfg.spi.ConfigurationPropertySource;
+
+import org.junit.After;
+import org.junit.Test;
+
+public class SystemConfigurationPropertySourceTest extends AbstractAllAwareConfigurationPropertySourceTest {
+	private final List<String> toClear = new ArrayList<>();
+
+	@Test
+	public void to_string() {
+		ConfigurationPropertySource propertySource = createPropertySource( "someKey", "foo" );
+		assertThat( propertySource ).asString().contains( "System" );
+	}
+
+	@After
+	public void clearSystemProperties() {
+		for ( String key : toClear ) {
+			System.clearProperty( key );
+		}
+	}
+
+	@Override
+	protected AllAwareConfigurationPropertySource createPropertySource(String key, String value) {
+		clearSystemProperties();
+		toClear.add( key );
+		System.setProperty( key, value );
+		return ConfigurationPropertySource.system();
+	}
+
+	@Override
+	protected AllAwareConfigurationPropertySource createPropertySource(String key, String value,
+			String key2, String value2) {
+		clearSystemProperties();
+		toClear.add( key );
+		toClear.add( key2 );
+		System.setProperty( key, value );
+		System.setProperty( key2, value2 );
+		return ConfigurationPropertySource.system();
+	}
+}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.integrationtest.backend.elasticsearch;
 
 import static org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.ElasticsearchIndexMetadataTestUtils.defaultPrimaryName;
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 import static org.hibernate.search.util.impl.test.JsonHelper.assertJsonEquals;
 
 import java.util.List;
@@ -43,9 +43,9 @@ import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.ValueWrapper;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubLoadingOptionsStep;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubLoadingOptionsStep;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.util.impl.test.ExceptionMatcherBuilder;
 import org.hibernate.search.util.impl.test.SubTest;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/mapping/ElasticsearchTypeNameMappingBaseIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/mapping/ElasticsearchTypeNameMappingBaseIT.java
@@ -10,7 +10,7 @@ import static org.hibernate.search.util.impl.integrationtest.backend.elasticsear
 import static org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.ElasticsearchIndexMetadataTestUtils.defaultWriteAlias;
 import static org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.ElasticsearchIndexMetadataTestUtils.mappingWithDiscriminatorProperty;
 import static org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.ElasticsearchIndexMetadataTestUtils.mappingWithoutAnyProperty;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
 import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
@@ -25,7 +25,7 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.Se
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.rule.TestElasticsearchClient;
 import org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
 import org.hibernate.search.util.impl.test.SubTest;
 
 import org.junit.Rule;

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/search/ElasticsearchMatchSearchPredicateIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/search/ElasticsearchMatchSearchPredicateIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.backend.elasticsearch.search;
 
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
@@ -15,7 +15,7 @@ import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
 import org.hibernate.search.util.impl.test.SubTest;
 
 import org.junit.Before;

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/search/query/ElasticsearchSearchQueryIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/search/query/ElasticsearchSearchQueryIT.java
@@ -23,8 +23,8 @@ import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.co
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchClientSpy;
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchRequestAssertionMode;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 
 import org.junit.Before;
 import org.junit.Rule;

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/search/query/ElasticsearchSearchQueryRequestTransformerIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/search/query/ElasticsearchSearchQueryRequestTransformerIT.java
@@ -25,8 +25,8 @@ import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchClientSpy;
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchRequestAssertionMode;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 
 import org.junit.Before;
 import org.junit.Rule;

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/work/ElasticsearchIndexingIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/work/ElasticsearchIndexingIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.integrationtest.backend.elasticsearch.work;
 
 import static org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.ElasticsearchIndexMetadataTestUtils.defaultWriteAlias;
 import static org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.ElasticsearchIndexMetadataTestUtils.encodeName;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
 import org.hibernate.search.backend.elasticsearch.cfg.spi.ElasticsearchBackendSpiSettings;
@@ -24,7 +24,7 @@ import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.ut
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchRequestAssertionMode;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.ElasticsearchTestDialect;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
 
 import org.junit.Before;
 import org.junit.Rule;

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/work/ElasticsearchZeroDowntimeReindexingIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/work/ElasticsearchZeroDowntimeReindexingIT.java
@@ -12,7 +12,7 @@ import static org.hibernate.search.util.impl.integrationtest.backend.elasticsear
 import static org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.ElasticsearchIndexMetadataTestUtils.readAliasDefinition;
 import static org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.ElasticsearchIndexMetadataTestUtils.writeAliasDefinition;
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import org.hibernate.search.backend.elasticsearch.util.spi.URLEncodedString;
 import org.hibernate.search.engine.backend.common.DocumentReference;
@@ -25,7 +25,7 @@ import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.rule.TestElasticsearchClient;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Before;

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneExtensionIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneExtensionIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.integrationtest.backend.lucene;
 
 import static org.hibernate.search.integrationtest.backend.lucene.testsupport.util.DocumentAssert.containsDocument;
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.util.List;
 import java.util.Optional;
@@ -52,9 +52,9 @@ import org.hibernate.search.engine.search.common.ValueConvert;
 import org.hibernate.search.engine.search.projection.SearchProjection;
 import org.hibernate.search.engine.search.loading.context.spi.LoadingContext;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.ValueWrapper;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubLoadingOptionsStep;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubLoadingOptionsStep;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.backend.lucene.LuceneExtension;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.engine.reporting.spi.EventContexts;

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/directory/AbstractDirectoryIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/directory/AbstractDirectoryIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.lucene.lowlevel.directory;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.util.function.Function;
 
@@ -20,8 +20,8 @@ import org.hibernate.search.engine.common.spi.SearchIntegration;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/reader/LuceneIndexReaderRefreshIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/reader/LuceneIndexReaderRefreshIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.lucene.lowlevel.reader;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import org.hibernate.search.backend.lucene.cfg.LuceneIndexSettings;
 import org.hibernate.search.engine.backend.common.DocumentReference;
@@ -19,8 +19,8 @@ import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrateg
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.common.stub.StubBackendSessionContext;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubBackendSessionContext;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
 
 import org.junit.Rule;
 import org.junit.Test;

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/writer/LuceneIndexWriterCommitIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/writer/LuceneIndexWriterCommitIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.integrationtest.backend.lucene.lowlevel.writer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
@@ -26,8 +26,8 @@ import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.common.spi.SearchIntegration;
 import org.hibernate.search.integrationtest.backend.lucene.testsupport.util.LuceneTckBackendAccessor;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.common.stub.StubBackendSessionContext;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubBackendSessionContext;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
 
 import org.junit.Rule;
 import org.junit.Test;

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/mapping/LuceneFieldAttributesIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/mapping/LuceneFieldAttributesIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.backend.lucene.mapping;
 
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.util.List;
 
@@ -23,7 +23,7 @@ import org.hibernate.search.engine.backend.types.Projectable;
 import org.hibernate.search.engine.backend.types.TermVector;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
 
 import org.junit.Before;
 import org.junit.Rule;

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/mapping/LuceneFieldTypesIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/mapping/LuceneFieldTypesIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.integrationtest.backend.lucene.mapping;
 
 
 import static org.hibernate.search.integrationtest.backend.lucene.testsupport.util.DocumentAssert.containsDocument;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.util.List;
 
@@ -21,7 +21,7 @@ import org.hibernate.search.engine.backend.types.Projectable;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Before;

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneBoolSearchPredicateIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneBoolSearchPredicateIT.java
@@ -10,8 +10,8 @@ import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.util.impl.test.SubTest;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneFloatingPointInfinitySearchIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneFloatingPointInfinitySearchIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.integrationtest.backend.lucene.search;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.util.Map;
 import java.util.function.Function;
@@ -28,7 +28,7 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.Se
 import org.hibernate.search.util.common.data.Range;
 import org.hibernate.search.util.common.data.RangeBoundInclusion;
 import org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Before;

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneMatchSearchPredicateIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneMatchSearchPredicateIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.lucene.search;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
@@ -17,7 +17,7 @@ import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
 
 import org.junit.Before;
 import org.junit.Rule;

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneNormalizeWildcardExpressionsIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneNormalizeWildcardExpressionsIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.lucene.search;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.util.function.Function;
 
@@ -19,8 +19,8 @@ import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Before;

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneSearchMultiIndexIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneSearchMultiIndexIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.lucene.search;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
@@ -19,8 +19,8 @@ import org.hibernate.search.integrationtest.backend.tck.search.SearchMultiIndexI
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 
 import org.junit.Before;
 import org.junit.Rule;

--- a/integrationtest/backend/tck/pom.xml
+++ b/integrationtest/backend/tck/pom.xml
@@ -21,6 +21,10 @@
             <groupId>org.hibernate.search</groupId>
             <artifactId>hibernate-search-util-internal-integrationtest-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-util-internal-integrationtest-mapper-stub</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/ObjectFieldStorageIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/ObjectFieldStorageIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.time.LocalDate;
 import java.util.Arrays;
@@ -19,8 +19,8 @@ import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectField;
 import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.engine.backend.common.DocumentReference;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/SmokeIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/SmokeIT.java
@@ -15,8 +15,8 @@ import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement
 import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectField;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.engine.backend.common.DocumentReference;
@@ -28,7 +28,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 
 public class SmokeIT {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/analysis/AnalysisCustomIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/analysis/AnalysisCustomIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.analysis;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -20,9 +20,9 @@ import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeFinalStep;
 import org.hibernate.search.engine.backend.types.dsl.StringIndexFieldTypeOptionsStep;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBackendHelper;
 import org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/decimalscale/DecimalScaleIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/decimalscale/DecimalScaleIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.decimalscale;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -23,7 +23,7 @@ import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
 import org.hibernate.search.util.impl.test.SubTest;
 
 import org.junit.Rule;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentElementBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentElementBaseIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.backend.tck.document;
 
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -23,13 +23,13 @@ import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.mapper.mapping.building.spi.IndexedEmbeddedDefinition;
 import org.hibernate.search.engine.mapper.mapping.building.spi.IndexedEmbeddedBindingContext;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
 import org.hibernate.search.engine.mapper.mapping.building.spi.IndexBindingContext;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.engine.spatial.GeoPoint;
 import org.hibernate.search.util.common.SearchException;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubTypeModel;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubTypeModel;
 import org.hibernate.search.util.impl.test.SubTest;
 
 import org.junit.Before;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentElementMultiValuedIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentElementMultiValuedIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.backend.tck.document;
 
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.util.function.Consumer;
 
@@ -20,7 +20,7 @@ import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.mapper.mapping.building.spi.IndexBindingContext;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
 import org.hibernate.search.util.impl.test.SubTest;
 
 import org.junit.Before;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/indexnull/IndexNullAsValueIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/indexnull/IndexNullAsValueIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.indexnull;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -26,8 +26,8 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.util.Standar
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConfiguration;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.util.impl.test.SubTest;
 
 import org.junit.Assume;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/multitenancy/MultiTenancyBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/multitenancy/MultiTenancyBaseIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.multitenancy;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.util.List;
 
@@ -20,13 +20,13 @@ import org.hibernate.search.engine.backend.types.Projectable;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectField;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBackendHelper;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.util.common.SearchException;
-import org.hibernate.search.util.impl.integrationtest.common.stub.StubBackendSessionContext;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubBackendSessionContext;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Before;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/multitenancy/MultiTenancyMismatchIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/multitenancy/MultiTenancyMismatchIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.backend.tck.multitenancy;
 
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
@@ -15,9 +15,9 @@ import org.hibernate.search.engine.backend.types.Projectable;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
-import org.hibernate.search.util.impl.integrationtest.common.stub.StubBackendSessionContext;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubBackendSessionContext;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 
 import org.junit.Rule;
 import org.junit.Test;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/SearchMultiIndexIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/SearchMultiIndexIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.search;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
@@ -21,8 +21,8 @@ import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.util.impl.test.SubTest;
 
 import org.junit.Before;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/AggregationBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/AggregationBaseIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.search.aggregation;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.util.Map;
 import java.util.Optional;
@@ -27,8 +27,8 @@ import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.util.impl.test.SubTest;
 
 import org.junit.Before;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/RangeAggregationSpecificsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/RangeAggregationSpecificsIT.java
@@ -9,7 +9,7 @@ package org.hibernate.search.integrationtest.backend.tck.search.aggregation;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.hibernate.search.util.impl.integrationtest.common.NormalizationUtils.normalize;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 import static org.junit.Assume.assumeTrue;
 
 import java.util.ArrayList;
@@ -40,7 +40,7 @@ import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.common.data.Range;
 import org.hibernate.search.util.common.data.RangeBoundInclusion;
 import org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
 import org.hibernate.search.util.impl.test.SubTest;
 import org.hibernate.search.util.impl.test.annotation.PortedFromSearch5;
 import org.hibernate.search.util.impl.test.singleinstance.BeforeAll;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/SingleFieldAggregationBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/SingleFieldAggregationBaseIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.search.aggregation;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 import static org.junit.Assume.assumeTrue;
 
 import java.util.ArrayList;
@@ -48,8 +48,8 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.util.ValueWr
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.util.impl.test.SubTest;
 import org.hibernate.search.util.impl.test.annotation.PortedFromSearch5;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/SingleFieldAggregationUnsupportedTypesIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/SingleFieldAggregationUnsupportedTypesIT.java
@@ -22,7 +22,7 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.util.Standar
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
 import org.hibernate.search.util.impl.test.SubTest;
 import org.hibernate.search.util.impl.test.annotation.PortedFromSearch5;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/TermsAggregationSpecificsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/TermsAggregationSpecificsIT.java
@@ -9,7 +9,7 @@ package org.hibernate.search.integrationtest.backend.tck.search.aggregation;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.hibernate.search.util.impl.integrationtest.common.NormalizationUtils.normalize;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 import static org.junit.Assume.assumeTrue;
 
 import java.util.ArrayList;
@@ -38,7 +38,7 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConf
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.ValueWrapper;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
 import org.hibernate.search.util.impl.test.SubTest;
 import org.hibernate.search.util.impl.test.annotation.PortedFromSearch5;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/bool/BooleanSortAndRangePredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/bool/BooleanSortAndRangePredicateIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.search.bool;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -28,8 +28,8 @@ import org.hibernate.search.engine.search.sort.dsl.SearchSortFactory;
 import org.hibernate.search.integrationtest.backend.tck.search.predicate.RangeSearchPredicateIT;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.integrationtest.backend.tck.search.sort.FieldSearchSortIT;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 
 import org.junit.Before;
 import org.junit.Rule;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/BoolSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/BoolSearchPredicateIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.search.predicate;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.util.function.Consumer;
 
@@ -16,8 +16,8 @@ import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.search.predicate.dsl.MinimumShouldMatchConditionStep;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.predicate.SearchPredicate;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/ExistsSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/ExistsSearchPredicateIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.search.predicate;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,8 +36,8 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.util.ValueWr
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.util.impl.test.SubTest;
 
 import org.junit.Before;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchAllSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchAllSearchPredicateIT.java
@@ -7,14 +7,14 @@
 package org.hibernate.search.integrationtest.backend.tck.search.predicate;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.predicate.SearchPredicate;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchIdSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchIdSearchPredicateIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.search.predicate;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.util.Arrays;
 
@@ -22,8 +22,8 @@ import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.util.impl.test.SubTest;
 
 import org.junit.Before;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchIdWithConverterSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchIdWithConverterSearchPredicateIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.search.predicate;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.util.Arrays;
 
@@ -18,8 +18,8 @@ import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchSearchPredicateIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.search.predicate;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -39,8 +39,8 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.Se
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.util.impl.test.SubTest;
 import org.hibernate.search.util.impl.test.annotation.PortedFromSearch5;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/NestedSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/NestedSearchPredicateIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.search.predicate;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
@@ -16,8 +16,8 @@ import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectField;
 import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.predicate.SearchPredicate;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/ObjectExistsSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/ObjectExistsSearchPredicateIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.search.predicate;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchHitsAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 import static org.junit.Assume.assumeFalse;
 
 import java.util.List;
@@ -26,8 +26,8 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConf
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.util.impl.test.SubTest;
 
 import org.junit.Before;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/PhraseSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/PhraseSearchPredicateIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.search.predicate;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,8 +35,8 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.util.ValueWr
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.util.impl.test.SubTest;
 import org.hibernate.search.util.impl.test.annotation.PortedFromSearch5;
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/RangeSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/RangeSearchPredicateIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.search.predicate;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -37,8 +37,8 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.Se
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.common.data.RangeBoundInclusion;
 import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.util.impl.test.SubTest;
 
 import org.junit.Before;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SearchPredicateIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.search.predicate;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.util.Optional;
 import java.util.function.Function;
@@ -25,8 +25,8 @@ import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactoryEx
 import org.hibernate.search.engine.search.predicate.spi.SearchPredicateBuilderFactory;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.util.impl.test.SubTest;
 
 import org.junit.Before;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SimpleQueryStringSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SimpleQueryStringSearchPredicateIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.search.predicate;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,8 +36,8 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.util.ValueWr
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.util.impl.test.SubTest;
 import org.hibernate.search.util.impl.test.annotation.PortedFromSearch5;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/WildcardSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/WildcardSearchPredicateIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.search.predicate;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,8 +32,8 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.util.ValueWr
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.util.impl.test.SubTest;
 import org.hibernate.search.util.impl.test.annotation.PortedFromSearch5;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/CompositeSearchProjectionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/CompositeSearchProjectionIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.search.projection;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.time.LocalDate;
 import java.util.Arrays;
@@ -26,8 +26,8 @@ import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.StandardFieldMapper;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/FieldSearchProjectionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/FieldSearchProjectionIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.search.projection;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -37,8 +37,8 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.util.Standar
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.ValueWrapper;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.util.impl.test.SubTest;
 
 import org.junit.Assume;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/SearchProjectionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/SearchProjectionIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.integrationtest.backend.tck.search.projection;
 
 import static org.hibernate.search.util.impl.integrationtest.common.NormalizationUtils.reference;
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.util.List;
 import java.util.Optional;
@@ -43,10 +43,10 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.stub.StubTra
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.StandardFieldMapper;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.GenericStubMappingScope;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.stub.MapperEasyMockUtils;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.GenericStubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.util.impl.test.SubTest;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
@@ -205,7 +205,7 @@ public class SearchProjectionIT extends EasyMockSupport {
 		verifyAll();
 
 		resetAll();
-		StubMapperUtils.expectHitMapping(
+		MapperEasyMockUtils.expectHitMapping(
 				loadingContextMock, documentReferenceConverterMock, objectLoaderMock,
 				/*
 				 * Expect each reference to be transformed because of the reference projection,

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryBaseIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.search.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
@@ -36,9 +36,9 @@ import org.hibernate.search.engine.search.query.SearchResult;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubLoadingContext;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubLoadingContext;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.util.impl.test.SubTest;
 
 import org.junit.Before;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryFetchIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryFetchIT.java
@@ -9,7 +9,7 @@ package org.hibernate.search.integrationtest.backend.tck.search.query;
 import static org.hibernate.search.util.impl.integrationtest.common.NormalizationUtils.normalize;
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
 import static org.hibernate.search.util.impl.integrationtest.common.stub.backend.StubBackendUtils.reference;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,8 +28,8 @@ import org.hibernate.search.engine.search.query.dsl.SearchQueryOptionsStep;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.util.impl.test.SubTest;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryResultLoadingOrTransformingIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryResultLoadingOrTransformingIT.java
@@ -10,7 +10,7 @@ import static org.easymock.EasyMock.expect;
 import static org.hibernate.search.util.impl.integrationtest.common.EasyMockUtils.projectionMatcher;
 import static org.hibernate.search.util.impl.integrationtest.common.NormalizationUtils.reference;
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 import static org.junit.Assert.assertEquals;
 
 import java.time.LocalDate;
@@ -40,10 +40,10 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.stub.StubTra
 import org.hibernate.search.integrationtest.backend.tck.testsupport.stub.StubTransformedReference;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.GenericStubMappingScope;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.stub.MapperEasyMockUtils;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.GenericStubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Before;
@@ -125,7 +125,7 @@ public class SearchQueryResultLoadingOrTransformingIT extends EasyMockSupport {
 		 * which must happen every time we execute the query,
 		 * so that the mapper can run state checks (session is still open, ...).
 		 */
-		StubMapperUtils.expectHitMapping(
+		MapperEasyMockUtils.expectHitMapping(
 				loadingContextMock, documentReferenceConverterMock, objectLoaderMock,
 				c -> c
 						.load( mainReference, mainTransformedReference, mainLoadedObject )
@@ -191,7 +191,7 @@ public class SearchQueryResultLoadingOrTransformingIT extends EasyMockSupport {
 		 * which must happen every time we execute the query,
 		 * so that the mapper can run state checks (session is still open, ...).
 		 */
-		StubMapperUtils.expectHitMapping(
+		MapperEasyMockUtils.expectHitMapping(
 				loadingContextMock, documentReferenceConverterMock, objectLoaderMock,
 				c -> c
 						.entityReference( mainReference, mainTransformedReference )
@@ -235,7 +235,7 @@ public class SearchQueryResultLoadingOrTransformingIT extends EasyMockSupport {
 		 * which must happen every time we execute the query,
 		 * so that the mapper can run state checks (session is still open, ...).
 		 */
-		StubMapperUtils.expectHitMapping(
+		MapperEasyMockUtils.expectHitMapping(
 				loadingContextMock, documentReferenceConverterMock, objectLoaderMock,
 				c -> c
 						.load( mainReference, mainTransformedReference, mainLoadedObject )
@@ -286,7 +286,7 @@ public class SearchQueryResultLoadingOrTransformingIT extends EasyMockSupport {
 		 * which must happen every time we execute the query,
 		 * so that the mapper can run state checks (session is still open, ...).
 		 */
-		StubMapperUtils.expectHitMapping(
+		MapperEasyMockUtils.expectHitMapping(
 				loadingContextMock, documentReferenceConverterMock, objectLoaderMock,
 				/*
 				 * Expect each reference to be transformed because of the entity reference projection,
@@ -397,7 +397,7 @@ public class SearchQueryResultLoadingOrTransformingIT extends EasyMockSupport {
 		 * which must happen every time we execute the query,
 		 * so that the mapper can run state checks (session is still open, ...).
 		 */
-		StubMapperUtils.expectHitMapping(
+		MapperEasyMockUtils.expectHitMapping(
 				loadingContextMock, documentReferenceConverterMock, objectLoaderMock,
 				/*
 				 * Expect each reference to be transformed because of the entity reference projection,
@@ -605,7 +605,7 @@ public class SearchQueryResultLoadingOrTransformingIT extends EasyMockSupport {
 		verifyAll();
 
 		resetAll();
-		StubMapperUtils.expectHitMapping(
+		MapperEasyMockUtils.expectHitMapping(
 				loadingContextMock, documentReferenceConverterMock, objectLoaderMock,
 				c -> c
 						// Return "null" when loading, meaning the entity failed to load

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryTimeoutIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryTimeoutIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.search.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -30,7 +30,7 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConf
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchTimeoutException;
 import org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
 import org.hibernate.search.util.impl.test.SubTest;
 
 import org.junit.Assume;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/CompositeSearchSortIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/CompositeSearchSortIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.search.sort;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.util.function.Function;
 
@@ -28,8 +28,8 @@ import org.hibernate.search.engine.search.sort.dsl.SortFinalStep;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.StandardFieldMapper;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Before;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSearchSortIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSearchSortIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.search.sort;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -32,8 +32,8 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldM
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.FieldSortExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldTypeDescriptor;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConfiguration;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.engine.reporting.spi.EventContexts;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/SearchSortIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/SearchSortIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.search.sort;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.util.List;
 import java.util.Optional;
@@ -35,8 +35,8 @@ import org.hibernate.search.engine.spatial.GeoPoint;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.util.impl.test.SubTest;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/AbstractSpatialWithinSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/AbstractSpatialWithinSearchPredicateIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.search.spatial;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
@@ -20,8 +20,8 @@ import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.engine.spatial.GeoPoint;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 
 import org.junit.Before;
 import org.junit.Rule;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/DistanceSearchProjectionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/DistanceSearchProjectionIT.java
@@ -15,7 +15,7 @@ import org.hibernate.search.engine.search.query.SearchResult;
 import org.hibernate.search.engine.spatial.DistanceUnit;
 import org.hibernate.search.engine.spatial.GeoPoint;
 import org.hibernate.search.util.common.SearchException;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.util.impl.test.SubTest;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/DistanceSearchSearchableSortableIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/DistanceSearchSearchableSortableIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.search.spatial;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
@@ -20,8 +20,8 @@ import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.engine.spatial.GeoPoint;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.util.impl.test.SubTest;
 
 import org.junit.Before;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/NestedDocumentDistanceProjectionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/NestedDocumentDistanceProjectionIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.search.spatial;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 import static org.junit.Assert.assertEquals;
 
 import java.util.List;
@@ -25,8 +25,8 @@ import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.engine.spatial.GeoPoint;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 
 import org.junit.Before;
 import org.junit.Rule;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/SpatialWithinBoundingBoxSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/SpatialWithinBoundingBoxSearchPredicateIT.java
@@ -7,11 +7,11 @@
 package org.hibernate.search.integrationtest.backend.tck.search.spatial;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.engine.reporting.spi.EventContexts;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/SpatialWithinCircleSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/SpatialWithinCircleSearchPredicateIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.integrationtest.backend.tck.search.spatial;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
 
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.engine.reporting.spi.EventContexts;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/SpatialWithinPolygonSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/SpatialWithinPolygonSearchPredicateIT.java
@@ -11,7 +11,7 @@ import static org.hibernate.search.util.impl.integrationtest.common.assertion.Se
 import java.util.ArrayList;
 import java.util.List;
 
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 import org.hibernate.search.engine.reporting.spi.EventContexts;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/sharding/AbstractShardingIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/sharding/AbstractShardingIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.backend.tck.sharding;
 
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +22,7 @@ import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
 import org.hibernate.search.engine.mapper.mapping.building.spi.IndexedEntityBindingContext;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.util.impl.integrationtest.common.assertion.NormalizedDocRefHit;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
 import org.hibernate.search.util.impl.test.annotation.PortedFromSearch5;
 
 /**

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/stub/MapperEasyMockUtils.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/stub/MapperEasyMockUtils.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.util.impl.integrationtest.common.stub.mapper;
+package org.hibernate.search.integrationtest.backend.tck.testsupport.stub;
 
 import static org.easymock.EasyMock.expect;
 import static org.hibernate.search.util.impl.integrationtest.common.EasyMockUtils.referenceMatcher;
@@ -16,27 +16,18 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import org.hibernate.search.engine.backend.work.execution.spi.DocumentReferenceProvider;
 import org.hibernate.search.engine.backend.common.DocumentReference;
+import org.hibernate.search.engine.backend.common.spi.DocumentReferenceConverter;
 import org.hibernate.search.engine.search.loading.context.spi.LoadingContext;
 import org.hibernate.search.engine.search.loading.spi.DefaultProjectionHitMapper;
 import org.hibernate.search.engine.search.loading.spi.EntityLoader;
-import org.hibernate.search.engine.backend.common.spi.DocumentReferenceConverter;
 import org.hibernate.search.util.impl.integrationtest.common.EasyMockUtils;
 
 import org.easymock.EasyMock;
 
-public final class StubMapperUtils {
+public final class MapperEasyMockUtils {
 
-	private StubMapperUtils() {
-	}
-
-	public static DocumentReferenceProvider referenceProvider(String identifier) {
-		return referenceProvider( identifier, null );
-	}
-
-	public static DocumentReferenceProvider referenceProvider(String identifier, String routingKey) {
-		return new StubDocumentReferenceProvider( identifier, routingKey );
+	private MapperEasyMockUtils() {
 	}
 
 	/**

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/stub/MapperEasyMockUtils.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/stub/MapperEasyMockUtils.java
@@ -38,7 +38,7 @@ public final class MapperEasyMockUtils {
 	 * @param <R> The reference type.
 	 * @param <E> The entity type.
 	 */
-	@SuppressWarnings({"unchecked", "rawtypes"})
+	@SuppressWarnings({"unchecked"})
 	public static <R, E> void expectHitMapping(
 			LoadingContext<R, E> loadingContextMock,
 			DocumentReferenceConverter<R> referenceTransformerMock,
@@ -67,12 +67,9 @@ public final class MapperEasyMockUtils {
 		expect( objectLoaderMock.loadBlocking(
 				EasyMockUtils.collectionAnyOrderMatcher( new ArrayList<>( context.loadingMap.keySet() ) )
 		) )
-				.andAnswer(
-						// We need to cast to a raw type to conform to List<? extends E>
-						() -> (List) ( (List<R>) EasyMock.getCurrentArguments()[0] ).stream()
+				.andAnswer( () -> ( (List<R>) EasyMock.getCurrentArguments()[0] ).stream()
 						.map( context.loadingMap::get )
-						.collect( Collectors.toList() )
-				);
+						.collect( Collectors.toList() ) );
 	}
 
 	public static class HitMappingDefinitionContext<R, E> {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/rule/SearchSetupHelper.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/rule/SearchSetupHelper.java
@@ -27,13 +27,13 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBack
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBackendSetupStrategy;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConfiguration;
 import org.hibernate.search.util.impl.integrationtest.common.TestConfigurationProvider;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
 import org.hibernate.search.engine.cfg.spi.ConfigurationPropertySource;
 import org.hibernate.search.engine.common.spi.SearchIntegration;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapping;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingInitiator;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapping;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingInitiator;
 import org.hibernate.search.util.common.impl.Closer;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingKey;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingKey;
 
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/AbstractIndexWorkspaceSimpleOperationIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/AbstractIndexWorkspaceSimpleOperationIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.backend.tck.work;
 
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -21,7 +21,7 @@ import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.logging.impl.Log;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
 import org.hibernate.search.util.impl.test.FutureAssert;
 
 import org.junit.Assume;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexIndexerIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexIndexerIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.backend.tck.work;
 
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -23,7 +23,7 @@ import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.logging.impl.Log;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
 import org.hibernate.search.util.impl.test.FutureAssert;
 import org.hibernate.search.util.impl.test.rule.ExpectedLog4jLog;
 import org.hibernate.search.util.impl.test.rule.StaticCounters;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexIndexingPlanIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexIndexingPlanIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.backend.tck.work;
 
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -22,7 +22,7 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.Se
 import org.hibernate.search.util.common.logging.impl.Log;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 import org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
 import org.hibernate.search.util.impl.test.FutureAssert;
 
 import org.junit.Rule;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceFlushIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceFlushIT.java
@@ -10,7 +10,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConfiguration;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
 
 public class IndexWorkspaceFlushIT extends AbstractIndexWorkspaceSimpleOperationIT {
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.backend.tck.work;
 
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -20,8 +20,8 @@ import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBackendHelper;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.common.stub.StubBackendSessionContext;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubBackendSessionContext;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
 
 import org.junit.Rule;
 import org.junit.Test;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceMergeSegmentsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspaceMergeSegmentsIT.java
@@ -10,7 +10,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConfiguration;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
 
 public class IndexWorkspaceMergeSegmentsIT extends AbstractIndexWorkspaceSimpleOperationIT {
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspacePurgeIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexWorkspacePurgeIT.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
 
 public class IndexWorkspacePurgeIT extends AbstractIndexWorkspaceSimpleOperationIT {
 	@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexingIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexingIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.work;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
-import static org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,8 +24,8 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldT
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.expectations.IndexingExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.StandardFieldMapper;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingIndexManager;
-import org.hibernate.search.util.impl.integrationtest.common.stub.mapper.StubMappingScope;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 
 import org.junit.Assume;
 import org.junit.Before;

--- a/integrationtest/performance/backend/README.md
+++ b/integrationtest/performance/backend/README.md
@@ -1,0 +1,90 @@
+# Backend Performance tests
+
+This module is designed to verify throughput of the document creation and indexing.
+
+This module is decoupled from any mapper to allow running performance diagnostics
+and find regressions in isolation from the various mappers.
+
+## Build
+
+To build the performance tests:
+
+```
+mvn clean install -pl integrationtest/performance/backend/elasticsearch -am -DskipTests
+# OR
+mvn clean install -pl integrationtest/performance/backend/lucene -am -DskipTests
+```
+
+## Run it from command line with standard jars
+
+To run the benchmarks:
+
+## Run it from command line
+
+There is an alternative way to run it which might be handy when needing to copy the
+performance test to a dedicated server and for some reason you're not liking rsync:
+
+```
+java -jar integrationtest/performance/backend/elasticsearch/target/benchmarks.jar
+# OR
+java -jar integrationtest/performance/backend/lucene/target/benchmarks.jar
+```
+
+You may set parameters:
+
+```
+java -jar integrationtest/performance/backend/elasticsearch/benchmarks.jar \
+    -jvmArgsPrepend -Dhosts=es1.mycompany.com \
+    -jvmArgsPrepend -Dprotocol=https \
+    -i 10 -p batchSize=50
+```
+
+* `jvmArgsPrepend`: add additional JVM properties to the forked process which runs the benchmark.
+Note that this can be used to override backend properties, such as the Elasticsearch hosts in this example.
+* `e`: excludes running all benchmarks matching this name.
+* `w`: sets the number of warm-up iterations.
+* `i`: sets the number of measurement iterations.
+* `p`: set testing parameters (`@Param` in the code).
+
+## Run it from your IDE
+
+Within your IDE, run the test `SmokeIT` located in the project you're interested in.
+
+## Run flight recorder: long runs on a specific test
+
+```
+java -jar integrationtest/performance/backend/elasticsearch/benchmarks.jar \
+    -jvmArgsPrepend -XX:+FlightRecorder \
+    -i 30000
+```
+
+We're setting it a very high number of iterations here to have time to play with
+Flight Recorder before it shuts down.
+
+You can also dump the result to a .jfr file and study it later (useful to run it on a remote server):
+
+```
+java -jar integrationtest/performance/backend/elasticsearch/benchmarks.jar \
+    -jvmArgsPrepend -XX:+FlightRecorder \
+    -jvmArgsPrepend -XX:StartFlightRecording=filename=output/profile.jfr,settings=profile
+```
+
+## Produce GC logs suited for tools
+
+```
+java -jar target/benchmarks.jar \
+    -jvmArgsPrepend "-Xloggc:lognameHere.log -XX:+PrintGCDetails -XX:+PrintTenuringDistribution -XX:+PrintGCApplicationStoppedTime -XX:+PrintGCCause" \
+    -i 30000
+```
+
+# Notes
+
+For best results disable features such as power management, dynamic CPU scaling,
+and run it on a dedicated box which has no other significant services running.
+
+In particular the "run it from your IDE" approach is just meant for development of new tests.
+
+## TODO
+
+- add more tests, especially those focusing on backend performance
+- add search tests

--- a/integrationtest/performance/backend/base/pom.xml
+++ b/integrationtest/performance/backend/base/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate Search, full-text search for your domain model
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-integrationtest-performance</artifactId>
+        <version>6.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>hibernate-search-integrationtest-performance-backend-base</artifactId>
+
+    <name>Hibernate Search Integration Tests - Performance - Backend base</name>
+    <description>Base for backend performance tests</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-engine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-util-internal-integrationtest-mapper-stub</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/AbstractBackendBenchmarks.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/AbstractBackendBenchmarks.java
@@ -11,11 +11,16 @@ import org.hibernate.search.integrationtest.performance.backend.base.testsupport
 import org.hibernate.search.integrationtest.performance.backend.base.testsupport.index.PerThreadIndexPartition;
 
 import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.infra.ThreadParams;
 
 @State(Scope.Thread)
+// Use a longer iteration time than the default of 10s:
+// backends have background operations that execute every second,
+// which could introduce significant errors in 10-second iterations.
+@Measurement(time = 30)
 public abstract class AbstractBackendBenchmarks {
 
 	private IndexInitializer indexInitializer;

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/AbstractBackendBenchmarks.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/AbstractBackendBenchmarks.java
@@ -1,0 +1,39 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.performance.backend.base;
+
+import org.hibernate.search.integrationtest.performance.backend.base.testsupport.index.AbstractBackendHolder;
+import org.hibernate.search.integrationtest.performance.backend.base.testsupport.index.IndexInitializer;
+import org.hibernate.search.integrationtest.performance.backend.base.testsupport.index.PerThreadIndexPartition;
+
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.ThreadParams;
+
+@State(Scope.Thread)
+public abstract class AbstractBackendBenchmarks {
+
+	private IndexInitializer indexInitializer;
+	private PerThreadIndexPartition indexPartition;
+
+	protected void doSetupTrial(AbstractBackendHolder backendHolder, IndexInitializer indexInitializer,
+			ThreadParams threadParams) {
+		this.indexInitializer = indexInitializer;
+		this.indexPartition = new PerThreadIndexPartition( backendHolder, indexInitializer, threadParams );
+	}
+
+	@CompilerControl(CompilerControl.Mode.INLINE)
+	protected final IndexInitializer getIndexInitializer() {
+		return indexInitializer;
+	}
+
+	@CompilerControl(CompilerControl.Mode.INLINE)
+	protected final PerThreadIndexPartition getIndexPartition() {
+		return indexPartition;
+	}
+}

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/AbstractMassIndexingBenchmarks.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/AbstractMassIndexingBenchmarks.java
@@ -1,0 +1,85 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.performance.backend.base;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.hibernate.search.engine.backend.document.DocumentElement;
+import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
+import org.hibernate.search.integrationtest.performance.backend.base.testsupport.dataset.Dataset;
+import org.hibernate.search.integrationtest.performance.backend.base.testsupport.dataset.DatasetHolder;
+import org.hibernate.search.integrationtest.performance.backend.base.testsupport.index.AbstractBackendHolder;
+import org.hibernate.search.integrationtest.performance.backend.base.testsupport.index.MappedIndex;
+import org.hibernate.search.util.common.impl.Futures;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubBackendSessionContext;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+
+/**
+ * Abstract class for JMH benchmarks related to mass indexing,
+ * i.e. document adds with few commits.
+ * <p>
+ * This benchmark generates and executes batches of documents to add to the index from a single thread,
+ * guaranteeing not to conflict with any other thread in the same trial.
+ */
+@Fork(1)
+@State(Scope.Thread)
+public abstract class AbstractMassIndexingBenchmarks extends AbstractBackendBenchmarks {
+
+	@Param({ "NONE" })
+	private DocumentCommitStrategy commitStrategy;
+
+	/**
+	 * Equivalent to the MassIndexer's "batchSizeToLoadObjects".
+	 */
+	@Param({ "10" })
+	private int batchSize;
+
+	private MappedIndex index;
+	private IndexIndexer<? extends DocumentElement> indexer;
+	private Dataset dataset;
+
+	private long currentDocumentIdInThread = 0L;
+
+	@Setup(Level.Iteration)
+	public void prepareIteration(DatasetHolder datasetHolder) {
+		index = getIndexPartition().getIndex();
+		StubBackendSessionContext sessionContext = new StubBackendSessionContext();
+		indexer = index.getIndexManager()
+				.createIndexer( sessionContext, commitStrategy );
+		dataset = datasetHolder.getDataset();
+	}
+
+	@Benchmark
+	@Threads(3 * AbstractBackendHolder.INDEX_COUNT)
+	public void writeBatch(WriteCounters counters) throws InterruptedException {
+		CompletableFuture<?>[] futures = new CompletableFuture<?>[batchSize];
+
+		for ( int i = 0; i < batchSize; ++i ) {
+			long documentId = getIndexPartition().toDocumentId( currentDocumentIdInThread++ );
+			futures[i] = indexer.add(
+					StubMapperUtils.referenceProvider( String.valueOf( documentId ) ),
+					document -> dataset.populate( index, document, documentId, 0L )
+			);
+		}
+
+		// Do not return until works are *actually* executed
+		Futures.unwrappedExceptionGet( CompletableFuture.allOf( futures ) );
+
+		counters.write += batchSize;
+	}
+
+}

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/AbstractMassIndexingBenchmarks.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/AbstractMassIndexingBenchmarks.java
@@ -45,7 +45,7 @@ public abstract class AbstractMassIndexingBenchmarks extends AbstractBackendBenc
 	/**
 	 * Equivalent to the MassIndexer's "batchSizeToLoadObjects".
 	 */
-	@Param({ "10" })
+	@Param({ "200" })
 	private int batchSize;
 
 	private MappedIndex index;
@@ -64,7 +64,7 @@ public abstract class AbstractMassIndexingBenchmarks extends AbstractBackendBenc
 	}
 
 	@Benchmark
-	@Threads(3 * AbstractBackendHolder.INDEX_COUNT)
+	@Threads(10 * AbstractBackendHolder.INDEX_COUNT)
 	public void writeBatch(WriteCounters counters) throws InterruptedException {
 		CompletableFuture<?>[] futures = new CompletableFuture<?>[batchSize];
 

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/AbstractOnTheFlyIndexingBenchmarks.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/AbstractOnTheFlyIndexingBenchmarks.java
@@ -62,7 +62,7 @@ public abstract class AbstractOnTheFlyIndexingBenchmarks extends AbstractBackend
 	 * The number of works of each type (add/update/delete)
 	 * to put in each workset.
 	 */
-	@Param({ "3" })
+	@Param({ "20" })
 	private int worksPerTypePerWorkset;
 
 	/*
@@ -116,7 +116,7 @@ public abstract class AbstractOnTheFlyIndexingBenchmarks extends AbstractBackend
 	}
 
 	@Benchmark
-	@Threads(3 * AbstractBackendHolder.INDEX_COUNT)
+	@Threads(10 * AbstractBackendHolder.INDEX_COUNT)
 	public void workset(WriteCounters counters) {
 		StubBackendSessionContext sessionContext = new StubBackendSessionContext();
 		PerThreadIndexPartition partition = getIndexPartition();
@@ -159,7 +159,7 @@ public abstract class AbstractOnTheFlyIndexingBenchmarks extends AbstractBackend
 	}
 
 	@Benchmark
-	@GroupThreads(2 * AbstractBackendHolder.INDEX_COUNT)
+	@GroupThreads(10 * AbstractBackendHolder.INDEX_COUNT)
 	@Group("concurrentReadWrite")
 	public void concurrentWorkset(WriteCounters counters) {
 		workset( counters );

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/QueryParams.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/QueryParams.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.performance.backend.base;
+
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Thread)
+public class QueryParams {
+
+	@Param({ "100" })
+	private int maxResults;
+
+	public int getQueryMaxResults() {
+		return maxResults;
+	}
+
+}

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/WriteCounters.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/WriteCounters.java
@@ -1,0 +1,20 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.performance.backend.base;
+
+import org.openjdk.jmh.annotations.AuxCounters;
+import org.openjdk.jmh.annotations.AuxCounters.Type;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Thread)
+@AuxCounters(Type.OPERATIONS)
+public class WriteCounters {
+
+	public int write;
+
+}

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/profiler/JfrProfiler.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/profiler/JfrProfiler.java
@@ -1,0 +1,119 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.performance.backend.base.profiler;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.profile.ExternalProfiler;
+import org.openjdk.jmh.profile.ProfilerException;
+import org.openjdk.jmh.results.BenchmarkResult;
+import org.openjdk.jmh.results.Result;
+
+public class JfrProfiler implements ExternalProfiler {
+
+	private final Path outputDir;
+	private final String jfrOptions;
+
+	private Path dump;
+
+	public JfrProfiler(String initLine) throws ProfilerException {
+		Map<String, String> options = new LinkedHashMap<>();
+		String[] split = initLine.split( ";" );
+		for ( String keyValue : split ) {
+			String[] keyValueSplit = keyValue.split( "=" );
+			String key = keyValueSplit[0];
+			String value = keyValueSplit[1];
+			options.put( key, value );
+		}
+
+		this.outputDir = Paths.get( Optional.ofNullable( options.remove( "outputDir" ) ).orElse( "." ) );
+		this.jfrOptions = Optional.ofNullable( options.remove( "jfrOptions" ) ).orElse( "settings=profile,maxsize=30M" );
+
+		if ( !options.isEmpty() ) {
+			throw new ProfilerException( "Unknown options: " + options );
+		}
+	}
+
+	@Override
+	public String getDescription() {
+		return "Java Flight Recorder";
+	}
+
+	@Override
+	public Collection<String> addJVMInvokeOptions(BenchmarkParams params) {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public Collection<String> addJVMOptions(BenchmarkParams params) {
+		dump = generateDumpPath( params );
+		List<String> options = new ArrayList<>();
+		options.add( "dumponexit=true" );
+		options.add( jfrOptions );
+		options.add( "filename=" + dump );
+		String optionsString = String.join( ",", options );
+		return Arrays.asList(
+				"-XX:+FlightRecorder",
+				"-XX:StartFlightRecording=" + optionsString
+		);
+	}
+
+	@Override
+	public void beforeTrial(BenchmarkParams benchmarkParams) {
+		// Nothing to do
+	}
+
+	@Override
+	public Collection<? extends Result<?>> afterTrial(BenchmarkResult br, long pid, File stdOut, File stdErr) {
+		//CHECKSTYLE:OFF
+		System.out.println( "Java Flight Recording dumped to " + dump );
+		//CHECKSTYLE:ON
+		return Collections.emptyList();
+	}
+
+	@Override
+	public boolean allowPrintOut() {
+		return true;
+	}
+
+	@Override
+	public boolean allowPrintErr() {
+		return true;
+	}
+
+	private Path generateDumpPath(BenchmarkParams params) {
+		StringBuilder paramString = new StringBuilder();
+		for ( String key : params.getParamsKeys() ) {
+			if ( paramString.length() > 0 ) {
+				paramString.append( "-" );
+			}
+			paramString.append( key ).append( "-" ).append( params.getParam( key ) );
+		}
+		// Use sub-directories to avoid hitting the filename limit
+		Path dumpDir = outputDir.resolve( params.getBenchmark() );
+		try {
+			Files.createDirectories( dumpDir );
+		}
+		catch (IOException e) {
+			throw new IllegalStateException( "Could not create directory " + dumpDir, e );
+		}
+		return dumpDir.resolve( paramString.toString() + ".jfr" );
+	}
+}

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/analysis/Analyzers.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/analysis/Analyzers.java
@@ -1,0 +1,25 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.performance.backend.base.testsupport.analysis;
+
+public final class Analyzers {
+
+	private Analyzers() {
+	}
+
+	/**
+	 * tokenizer: standard
+	 * token filters: lowercase, snowball-porter(english), asciifolding
+	 */
+	public static final String ANALYZER_ENGLISH = "english";
+
+	/**
+	 * token filters: lowercase, asciifolding
+	 */
+	public static final String NORMALIZER_ENGLISH = "english";
+
+}

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/dataset/ConstantDataset.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/dataset/ConstantDataset.java
@@ -1,0 +1,27 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.performance.backend.base.testsupport.dataset;
+
+import org.hibernate.search.engine.backend.document.DocumentElement;
+import org.hibernate.search.integrationtest.performance.backend.base.testsupport.index.MappedIndex;
+
+import org.openjdk.jmh.annotations.CompilerControl;
+
+@CompilerControl(CompilerControl.Mode.INLINE)
+final class ConstantDataset implements Dataset {
+
+	@Override
+	public void populate(MappedIndex index, DocumentElement documentElement, long documentId, long randomizer) {
+		index.populate(
+				documentElement,
+				"Some short text " + randomizer,
+				"Some very long text should be stored here. No, I mean long as in a book. " + randomizer,
+				documentId + randomizer
+		);
+	}
+
+}

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/dataset/Dataset.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/dataset/Dataset.java
@@ -1,0 +1,16 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.performance.backend.base.testsupport.dataset;
+
+import org.hibernate.search.engine.backend.document.DocumentElement;
+import org.hibernate.search.integrationtest.performance.backend.base.testsupport.index.MappedIndex;
+
+public interface Dataset {
+
+	void populate(MappedIndex index, DocumentElement documentElement, long documentId, long randomizer);
+
+}

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/dataset/DatasetHolder.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/dataset/DatasetHolder.java
@@ -1,0 +1,36 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.performance.backend.base.testsupport.dataset;
+
+import java.io.IOException;
+
+import org.hibernate.search.integrationtest.performance.backend.base.testsupport.filesystem.TemporaryFileHolder;
+
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class DatasetHolder {
+
+	@Param({ Datasets.HIBERNATE_DEV_ML_2016_01 })
+	private String dataset;
+
+	private Dataset datasetInstance;
+
+	@Setup(Level.Trial)
+	public void setup(TemporaryFileHolder temporaryFileHolder) throws IOException {
+		datasetInstance = Datasets.createDataset( dataset, temporaryFileHolder.getCacheDirectory() );
+	}
+
+	public Dataset getDataset() {
+		return datasetInstance;
+	}
+
+}

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/dataset/Datasets.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/dataset/Datasets.java
@@ -1,0 +1,74 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.performance.backend.base.testsupport.dataset;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+
+public final class Datasets {
+
+	public static final String CONSTANT_TEXT = "constant-text";
+
+	public static final String HIBERNATE_DEV_ML_2016_01 = "hibernate-dev-ml-2016-01";
+
+	private static final String DATASET_CACHE_DIRECTORY = "dataset";
+
+	private static final URI HIBERNATE_DEV_MAILING_LIST_URI =
+			URI.create( "http://lists.jboss.org/pipermail/hibernate-dev/2016-January.txt" );
+
+	private Datasets() {
+	}
+
+	public static Dataset createDataset(String name, Path cacheDirectory)
+			throws IOException {
+		switch ( name ) {
+			case CONSTANT_TEXT:
+				return new ConstantDataset();
+			case HIBERNATE_DEV_ML_2016_01:
+				Path path = fetch( name, HIBERNATE_DEV_MAILING_LIST_URI, cacheDirectory );
+				return new SampleDataset( parseMailingListDigest( path ) );
+			default:
+				throw new IllegalArgumentException( "Unknown dataset: " + name );
+		}
+	}
+
+	private static Path fetch(String name, URI uri, Path cacheDirectory) throws IOException {
+		Path datasetCacheDirectory = cacheDirectory.resolve( DATASET_CACHE_DIRECTORY );
+		if ( !Files.exists( datasetCacheDirectory ) ) {
+			Files.createDirectory( datasetCacheDirectory );
+		}
+
+		Path outputPath = datasetCacheDirectory.resolve( name );
+		if ( Files.exists( outputPath ) ) {
+			return outputPath;
+		}
+
+		try ( InputStream input = uri.toURL().openStream();
+				ReadableByteChannel inputChannel = Channels.newChannel( input );
+				FileChannel outputChannel = FileChannel.open(
+						outputPath, StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW ) ) {
+			outputChannel.transferFrom( inputChannel, 0, Long.MAX_VALUE );
+		}
+		return outputPath;
+	}
+
+	private static List<SampleDataset.DataSample> parseMailingListDigest(Path path) throws IOException {
+		try ( BufferedReader reader = Files.newBufferedReader( path ) ) {
+			return new MailingListDigestParser( reader ).parse();
+		}
+	}
+
+}

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/dataset/MailingListDigestParser.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/dataset/MailingListDigestParser.java
@@ -1,0 +1,121 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.performance.backend.base.testsupport.dataset;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+final class MailingListDigestParser {
+
+	private final BufferedReader reader;
+
+	private final List<SampleDataset.DataSample> result = new ArrayList<>();
+
+	private int currentSampleId = 0;
+
+	private String currentSampleSubject = null;
+
+	private final StringBuilder currentSampleText = new StringBuilder();
+
+	private final List<String> peekBuffer = new ArrayList<>();
+
+	private State state = State.INITIAL;
+
+	public MailingListDigestParser(BufferedReader reader) {
+		this.reader = reader;
+	}
+
+	public List<SampleDataset.DataSample> parse() throws IOException {
+		String line = reader.readLine();
+		while ( line != null ) {
+			peekBuffer.add( line );
+			state = state.parseLine( this, line );
+			line = reader.readLine();
+		}
+		flushPeekBuffer();
+		pushCurrentSample();
+		return result;
+	}
+
+	private void flushPeekBuffer() {
+		for ( String line : peekBuffer ) {
+			currentSampleText.append( line ).append( "\n" );
+		}
+		peekBuffer.clear();
+	}
+
+	public void setCurrentSampleSubject(String currentSampleSubject) {
+		this.currentSampleSubject = currentSampleSubject;
+	}
+
+	private void pushCurrentSample() {
+		result.add( new SampleDataset.DataSample(
+				currentSampleSubject, currentSampleText.toString(), currentSampleId
+		) );
+		++this.currentSampleId;
+		this.currentSampleSubject = null;
+		this.currentSampleText.setLength( 0 );
+	}
+
+	private abstract static class State {
+
+		private static final State INITIAL = new State( Pattern.compile( "^From " ) ) {
+			@Override
+			protected State nextState(MailingListDigestParser parser, Matcher matcher) {
+				return AFTER_FROM_1;
+			}
+		};
+
+		private static final State AFTER_FROM_1 = new State( Pattern.compile( "^From: " ) ) {
+			@Override
+			protected State nextState(MailingListDigestParser parser, Matcher matcher) {
+				return AFTER_FROM_2;
+			}
+		};
+
+		private static final State AFTER_FROM_2 = new State( Pattern.compile( "^Date: " ) ) {
+			@Override
+			protected State nextState(MailingListDigestParser parser, Matcher matcher) {
+				return AFTER_DATE;
+			}
+		};
+
+		private static final State AFTER_DATE = new State( Pattern.compile( "^Subject: (.*)" ) ) {
+			@Override
+			protected State nextState(MailingListDigestParser parser, Matcher matcher) {
+				parser.pushCurrentSample();
+				parser.flushPeekBuffer();
+				parser.setCurrentSampleSubject( matcher.group( 1 ) );
+				return INITIAL;
+			}
+		};
+
+		private final Pattern pattern;
+
+		private State(Pattern pattern) {
+			this.pattern = pattern;
+		}
+
+		public State parseLine(MailingListDigestParser parser, String line) {
+			Matcher matcher = pattern.matcher( line );
+			if ( matcher.find() ) {
+				return nextState( parser, matcher );
+			}
+			else {
+				parser.flushPeekBuffer();
+				return State.INITIAL;
+			}
+		}
+
+		protected abstract State nextState(MailingListDigestParser parser, Matcher matcher);
+	}
+
+}

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/dataset/SampleDataset.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/dataset/SampleDataset.java
@@ -1,0 +1,64 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.performance.backend.base.testsupport.dataset;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.hibernate.search.engine.backend.document.DocumentElement;
+import org.hibernate.search.integrationtest.performance.backend.base.testsupport.index.MappedIndex;
+
+import org.openjdk.jmh.annotations.CompilerControl;
+
+@CompilerControl(CompilerControl.Mode.INLINE)
+final class SampleDataset implements Dataset {
+
+	private final List<DataSample> samples;
+
+	private final int size;
+
+	SampleDataset(Collection<DataSample> samples) {
+		this.samples = new ArrayList<>( samples );
+		this.size = this.samples.size();
+	}
+
+	@Override
+	public void populate(MappedIndex index, DocumentElement documentElement, long documentId, long randomizer) {
+		// Use the the randomizer, which is only based on the document ID, so select the sample.
+		// That way, documents updates should actually change indexed data most of the time.
+		int sampleIndex = (int) ( ( documentId + randomizer ) % size );
+		DataSample sample = samples.get( sampleIndex );
+		index.populate(
+				documentElement,
+				sample.shortText,
+				sample.longText,
+				sample.numeric
+		);
+	}
+
+	public static class DataSample {
+
+		private final String shortText;
+		private final String longText;
+		private final int numeric;
+
+		public DataSample(String shortText, String longText, int numeric) {
+			this.shortText = shortText;
+			this.longText = longText;
+			this.numeric = numeric;
+		}
+
+		@Override
+		public String toString() {
+			return new StringBuilder()
+					.append( getClass().getSimpleName() )
+					.append( "<" ).append( shortText ).append( ">" )
+					.toString();
+		}
+	}
+}

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/filesystem/TemporaryFileHolder.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/filesystem/TemporaryFileHolder.java
@@ -1,0 +1,110 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.performance.backend.base.testsupport.filesystem;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.hibernate.search.util.common.impl.Closer;
+
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+@State(Scope.Benchmark)
+public class TemporaryFileHolder {
+
+	/**
+	 * Set this system property to an alternative path if you want
+	 * cache files (downloads) to be stored in a specific place
+	 * (other than "/tmp/" + TEST_DIR_PREFIX + "cache-path").
+	 */
+	private static final String CACHE_PATH_PROPERTY_KEY = "cache-path";
+
+	/**
+	 * Set this system property to an alternative path if you want
+	 * index files to be stored in a specific place
+	 * (other than "/tmp/" + TEST_DIR_PREFIX + "indexes-path").
+	 */
+	private static final String INDEXES_PATH_PROPERTY_KEY = "indexes-path";
+
+	/**
+	 * Prefix used to identify the generated directories for
+	 * running tests which need writing to a filesystem.
+	 */
+	private static final String TEST_DIR_PREFIX = "hsearch-perf-";
+
+	private final Set<Path> toCleanUp = new LinkedHashSet<>();
+
+	@TearDown(Level.Trial)
+	public void cleanUp() throws IOException {
+		deleteAll( toCleanUp );
+	}
+
+	public Path getCacheDirectory() throws IOException {
+		return getTemporaryDirectory( CACHE_PATH_PROPERTY_KEY, false );
+	}
+
+	public Path getIndexesDirectory() throws IOException {
+		return getTemporaryDirectory( INDEXES_PATH_PROPERTY_KEY, true );
+	}
+
+	private Path getTemporaryDirectory(String key, boolean cleanup) throws IOException {
+		String userSelectedPath = System.getProperty( key );
+		Path path;
+		if ( userSelectedPath != null ) {
+			path = Paths.get( userSelectedPath );
+		}
+		else {
+			path = Paths.get( System.getProperty( "java.io.tmpdir" ) )
+					.resolve( TEST_DIR_PREFIX + key );
+		}
+
+		if ( cleanup ) {
+			if ( Files.exists( path ) ) {
+				deleteRecursively( path );
+			}
+			toCleanUp.add( path );
+		}
+
+		if ( !Files.exists( path ) ) {
+			Files.createDirectory( path );
+		}
+
+		return path;
+	}
+
+	private void deleteAll(Set<Path> paths) throws IOException {
+		try ( Closer<IOException> closer = new Closer<>() ) {
+			closer.pushAll( this::deleteRecursively, paths );
+		}
+	}
+
+	private void deleteRecursively(Path path) throws IOException {
+		Files.walkFileTree( path, new SimpleFileVisitor<Path>() {
+			@Override
+			public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+				Files.delete( file );
+				return FileVisitResult.CONTINUE;
+			}
+
+			@Override
+			public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+				Files.delete( dir );
+				return FileVisitResult.CONTINUE;
+			}
+		} );
+	}
+}

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/index/AbstractBackendHolder.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/index/AbstractBackendHolder.java
@@ -1,0 +1,116 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.performance.backend.base.testsupport.index;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.hibernate.search.engine.cfg.EngineSettings;
+import org.hibernate.search.engine.cfg.spi.ConfigurationPropertyChecker;
+import org.hibernate.search.engine.cfg.spi.ConfigurationPropertySource;
+import org.hibernate.search.engine.common.spi.SearchIntegration;
+import org.hibernate.search.engine.common.spi.SearchIntegrationBuilder;
+import org.hibernate.search.engine.common.spi.SearchIntegrationFinalizer;
+import org.hibernate.search.engine.common.spi.SearchIntegrationPartialBuildState;
+import org.hibernate.search.integrationtest.performance.backend.base.testsupport.filesystem.TemporaryFileHolder;
+import org.hibernate.search.util.common.impl.SuppressingCloser;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapping;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingInitiator;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingKey;
+
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+@State(Scope.Thread)
+public abstract class AbstractBackendHolder {
+
+	public static final int INDEX_COUNT = 3;
+
+	private static final String BACKEND_NAME = "testedBackend";
+
+	private SearchIntegration integration;
+	private List<MappedIndex> indexes;
+
+	@Setup(Level.Trial)
+	public void startHibernateSearch(TemporaryFileHolder temporaryFileHolder) throws IOException {
+		Map<String, Object> baseProperties = new LinkedHashMap<>();
+		baseProperties.put( EngineSettings.DEFAULT_BACKEND, BACKEND_NAME );
+
+		ConfigurationPropertySource propertySource = ConfigurationPropertySource.fromMap( baseProperties )
+				.withOverride(
+						getDefaultBackendProperties( temporaryFileHolder )
+								// Allow overrides at the backend level using system properties
+								.withOverride( ConfigurationPropertySource.system() )
+								.withPrefix( EngineSettings.BACKENDS + "." + BACKEND_NAME )
+				);
+
+		ConfigurationPropertyChecker unusedPropertyChecker = ConfigurationPropertyChecker.create();
+
+		SearchIntegrationBuilder integrationBuilder =
+				SearchIntegration.builder( propertySource, unusedPropertyChecker );
+
+		StubMappingInitiator initiator = new StubMappingInitiator( false );
+		StubMappingKey mappingKey = new StubMappingKey();
+		integrationBuilder.addMappingInitiator( mappingKey, initiator );
+
+		indexes = new ArrayList<>();
+		for ( int i = 0; i < INDEX_COUNT; ++i ) {
+			MappedIndex index = new MappedIndex();
+			indexes.add( index );
+			initiator.add(
+					"type_" + i, BACKEND_NAME, "index_" + i,
+					index::bind
+			);
+		}
+
+		SearchIntegrationPartialBuildState integrationPartialBuildState = integrationBuilder.prepareBuild();
+		try {
+			SearchIntegrationFinalizer finalizer =
+					integrationPartialBuildState.finalizer( propertySource, unusedPropertyChecker );
+			StubMapping mapping = finalizer.finalizeMapping(
+					mappingKey, (context, partialMapping) -> partialMapping.finalizeMapping()
+			);
+			for ( int i = 0; i < INDEX_COUNT; ++i ) {
+				MappedIndex index = indexes.get( i );
+				String typeId = "type_" + i;
+				index.setIndexManager( mapping.getIndexMappingByTypeIdentifier( typeId ) );
+			}
+			integration = finalizer.finalizeIntegration();
+		}
+		catch (RuntimeException e) {
+			new SuppressingCloser( e )
+					.push( SearchIntegrationPartialBuildState::closeOnFailure, integrationPartialBuildState );
+			throw e;
+		}
+	}
+
+	@Setup(Level.Iteration)
+	public void initializeIndexes(IndexInitializer indexInitializer) {
+		indexInitializer.intializeIndexes( indexes );
+	}
+
+	@TearDown(Level.Trial)
+	public void stopHibernateSearch() {
+		if ( integration != null ) {
+			integration.close();
+		}
+	}
+
+	public List<MappedIndex> getIndexes() {
+		return indexes;
+	}
+
+	protected abstract ConfigurationPropertySource getDefaultBackendProperties(TemporaryFileHolder temporaryFileHolder)
+			throws IOException;
+
+}

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/index/IndexInitializer.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/index/IndexInitializer.java
@@ -1,0 +1,110 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.performance.backend.base.testsupport.index;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinTask;
+import java.util.stream.LongStream;
+
+import org.hibernate.search.engine.backend.document.DocumentElement;
+import org.hibernate.search.engine.backend.session.spi.DetachedBackendSessionContext;
+import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
+import org.hibernate.search.integrationtest.performance.backend.base.testsupport.dataset.Dataset;
+import org.hibernate.search.integrationtest.performance.backend.base.testsupport.dataset.DatasetHolder;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubBackendSessionContext;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils;
+
+import org.jboss.logging.Logger;
+
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class IndexInitializer {
+
+	private static final Logger log = Logger.getLogger( "initialization" );
+
+	@Param({ "10000" })
+	private long initialIndexSize;
+
+	private Dataset dataset;
+
+	@Setup(Level.Trial)
+	public void setup(DatasetHolder datasetHolder) {
+		dataset = datasetHolder.getDataset();
+	}
+
+	public long getInitialIndexSize() {
+		return initialIndexSize;
+	}
+
+	public void intializeIndexes(List<MappedIndex> indexes) {
+		ForkJoinPool forkJoinPool = ForkJoinPool.commonPool();
+		List<ForkJoinTask<?>> tasks = new ArrayList<>();
+		for ( MappedIndex index : indexes ) {
+			ForkJoinTask<?> task = forkJoinPool.submit(
+					() -> initializeIndex( index, LongStream.range( 0, initialIndexSize ) )
+			);
+			tasks.add( task );
+		}
+		for ( ForkJoinTask<?> task : tasks ) {
+			task.join();
+		}
+	}
+
+	public void addToIndex(MappedIndex index, LongStream idStream) {
+		StubBackendSessionContext sessionContext = new StubBackendSessionContext();
+
+		log( index, "Adding documents to index..." );
+
+		IndexWorkspace workspace = index.getIndexManager()
+				.createWorkspace( DetachedBackendSessionContext.of( sessionContext ) );
+
+		IndexIndexer<? extends DocumentElement> indexer = index.getIndexManager()
+				.createIndexer( new StubBackendSessionContext(), DocumentCommitStrategy.NONE );
+		List<CompletableFuture<?>> futures = new ArrayList<>();
+		idStream.forEach( id -> {
+			CompletableFuture<?> future = indexer.add(
+					StubMapperUtils.referenceProvider( String.valueOf( id ) ),
+					document -> dataset.populate( index, document, id, 0L )
+			);
+			futures.add( future );
+		} );
+		CompletableFuture.allOf( futures.toArray( new CompletableFuture[0] ) ).join();
+		workspace.flush().join();
+
+		log( index, " ... added " + futures.size() + " documents to the index." );
+	}
+
+	private void initializeIndex(MappedIndex index, LongStream idStream) {
+		log( index, "Starting index initialization..." );
+		StubBackendSessionContext sessionContext = new StubBackendSessionContext();
+
+		log( index, "Purging..." );
+		IndexWorkspace workspace = index.getIndexManager()
+				.createWorkspace( DetachedBackendSessionContext.of( sessionContext ) );
+		workspace.purge().join();
+		log( index, "Finished purge." );
+
+		addToIndex( index, idStream );
+
+		log( index, "Finished index initialization." );
+	}
+
+	private static void log(MappedIndex index, String message) {
+		log.infof( "[%s] %s",index.getIndexManager().getName(), message );
+	}
+
+}

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/index/MappedIndex.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/index/MappedIndex.java
@@ -1,0 +1,58 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.performance.backend.base.testsupport.index;
+
+import org.hibernate.search.engine.backend.document.DocumentElement;
+import org.hibernate.search.engine.backend.document.IndexFieldReference;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.types.Sortable;
+import org.hibernate.search.engine.mapper.mapping.building.spi.IndexedEntityBindingContext;
+import org.hibernate.search.integrationtest.performance.backend.base.testsupport.analysis.Analyzers;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+
+import org.openjdk.jmh.annotations.CompilerControl;
+
+@CompilerControl(CompilerControl.Mode.INLINE)
+public class MappedIndex {
+
+	public static final String SHORT_TEXT_FIELD_NAME = "shortText";
+	public static final String LONG_TEXT_FIELD_NAME = "longText";
+	public static final String NUMERIC_FIELD_NAME = "numeric";
+
+	private IndexFieldReference<String> shortTextField;
+	private IndexFieldReference<String> longTextField;
+	private IndexFieldReference<Long> numericField;
+
+	private StubMappingIndexManager indexManager;
+
+	public void bind(IndexedEntityBindingContext context) {
+		IndexSchemaElement root = context.getSchemaElement();
+		shortTextField = root.field(
+				SHORT_TEXT_FIELD_NAME,
+				f -> f.asString().normalizer( Analyzers.NORMALIZER_ENGLISH ).sortable( Sortable.YES )
+		)
+				.toReference();
+		longTextField = root.field( LONG_TEXT_FIELD_NAME, f -> f.asString().analyzer( Analyzers.ANALYZER_ENGLISH ) )
+				.toReference();
+		numericField = root.field( NUMERIC_FIELD_NAME, f -> f.asLong() ).toReference();
+	}
+
+	public void setIndexManager(StubMappingIndexManager indexManager) {
+		this.indexManager = indexManager;
+	}
+
+	public StubMappingIndexManager getIndexManager() {
+		return indexManager;
+	}
+
+	public void populate(DocumentElement documentElement, String shortText, String longText, long numeric) {
+		documentElement.addValue( shortTextField, shortText );
+		documentElement.addValue( longTextField, longText );
+		documentElement.addValue( numericField, numeric );
+	}
+
+}

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/index/PerThreadIndexPartition.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/index/PerThreadIndexPartition.java
@@ -1,0 +1,49 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.performance.backend.base.testsupport.index;
+
+import java.util.List;
+
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.infra.ThreadParams;
+
+/**
+ * Partitions indexes so that each thread targets a single set of documents.
+ */
+@CompilerControl(CompilerControl.Mode.INLINE)
+public class PerThreadIndexPartition {
+
+	private final MappedIndex indexTargetedByThread;
+
+	private final long documentIdOffset;
+	private final long documentIdGap;
+
+	public PerThreadIndexPartition(AbstractBackendHolder indexHolder, IndexInitializer indexInitializer,
+			ThreadParams threadParams) {
+		int threadIndex = threadParams.getThreadIndex();
+		List<MappedIndex> indexes = indexHolder.getIndexes();
+		indexTargetedByThread = indexes.get( threadIndex % indexes.size() );
+
+		documentIdOffset =
+				// Avoid conflict between initial documents and new documents:
+				indexInitializer.getInitialIndexSize()
+				// Avoid conflict between threads: use a different starting point based on the thread index...
+				+ threadIndex;
+		// ... and then a gap based on the thread count
+		documentIdGap = threadParams.getThreadCount();
+	}
+
+	public MappedIndex getIndex() {
+		return indexTargetedByThread;
+	}
+
+	public long toDocumentId(long idInThread) {
+		// Avoid conflict between threads by using a different starting point based on the thread index
+		return documentIdOffset + idInThread * documentIdGap;
+	}
+
+}

--- a/integrationtest/performance/backend/base/src/main/org.openjdk.jmh.profile.Profiler
+++ b/integrationtest/performance/backend/base/src/main/org.openjdk.jmh.profile.Profiler
@@ -1,0 +1,1 @@
+org.hibernate.search.integrationtest.performance.backend.base.profiler.JfrProfiler

--- a/integrationtest/performance/backend/elasticsearch/pom.xml
+++ b/integrationtest/performance/backend/elasticsearch/pom.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate Search, full-text search for your domain model
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-integrationtest-performance</artifactId>
+        <version>6.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>hibernate-search-integrationtest-performance-backend-elasticsearch</artifactId>
+
+    <name>Hibernate Search Integration Tests - Performance - Backend - Elasticsearch</name>
+    <description>Performance tests for the Elasticsearch backend</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-backend-elasticsearch</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-backend-elasticsearch-aws</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-integrationtest-performance-backend-base</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-util-internal-integrationtest-backend-elasticsearch</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>it</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.github.alexcojocaru</groupId>
+                <artifactId>elasticsearch-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.bsc.maven</groupId>
+                <artifactId>maven-processor-plugin</artifactId>
+                <executions>
+                    <!-- Run JMH annotation processor on src/main/java sources -->
+                    <execution>
+                        <id>processjmh</id>
+                        <goals>
+                            <goal>process</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <processors>
+                                <processor>org.openjdk.jmh.generators.BenchmarkProcessor</processor>
+                            </processors>
+                            <!-- Also process the source from the base project -->
+                            <appendSourceArtifacts>true</appendSourceArtifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.openjdk.jmh</groupId>
+                        <artifactId>jmh-generator-annprocess</artifactId>
+                        <version>${version.org.openjdk.jmh}</version>
+                        <scope>compile</scope>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>benchmarks</finalName>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                                </transformer>
+                                <!-- Needed for service entries implementing BeanConfigurer in particular -->
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <!--
+                                        Shading signed JARs will fail without this.
+                                        http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
+                                    -->
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/integrationtest/performance/backend/elasticsearch/src/main/java/org/hibernate/search/integrationtest/performance/backend/elasticsearch/testsupport/ElasticsearchBackendHolder.java
+++ b/integrationtest/performance/backend/elasticsearch/src/main/java/org/hibernate/search/integrationtest/performance/backend/elasticsearch/testsupport/ElasticsearchBackendHolder.java
@@ -18,11 +18,25 @@ import org.hibernate.search.engine.cfg.spi.ConfigurationPropertySource;
 import org.hibernate.search.integrationtest.performance.backend.base.testsupport.filesystem.TemporaryFileHolder;
 import org.hibernate.search.integrationtest.performance.backend.base.testsupport.index.AbstractBackendHolder;
 
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 
 @State(Scope.Benchmark)
 public class ElasticsearchBackendHolder extends AbstractBackendHolder {
+
+	/**
+	 * A list of configuration properties to apply to the backend and indexes.
+	 * <p>
+	 * Format: {@code <key>=<value>&<key2>=<value2>} (etc.).
+	 * Multiple configurations can be tested by providing multiple values for this parameter,
+	 * e.g. {@code foo=1&bar=2,foo=2&bar=1} for two configurations setting {@code foo} and {@code bar} to different values.
+	 * <p>
+	 * Note that configuration properties are applied both at the backend level and at the index level,
+	 * so using the "index_defaults." prefix is optional when setting index-level properties.
+	 */
+	@Param({ "", "max_connections_per_route=1" })
+	private String configuration;
 
 	@Override
 	protected ConfigurationPropertySource getDefaultBackendProperties(TemporaryFileHolder temporaryFileHolder) {
@@ -43,5 +57,10 @@ public class ElasticsearchBackendHolder extends AbstractBackendHolder {
 		);
 
 		return ConfigurationPropertySource.fromMap( map );
+	}
+
+	@Override
+	protected String getConfigurationParameter() {
+		return configuration;
 	}
 }

--- a/integrationtest/performance/backend/elasticsearch/src/main/java/org/hibernate/search/integrationtest/performance/backend/elasticsearch/testsupport/ElasticsearchBackendHolder.java
+++ b/integrationtest/performance/backend/elasticsearch/src/main/java/org/hibernate/search/integrationtest/performance/backend/elasticsearch/testsupport/ElasticsearchBackendHolder.java
@@ -1,0 +1,47 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.performance.backend.elasticsearch.testsupport;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
+import org.hibernate.search.backend.elasticsearch.index.IndexLifecycleStrategyName;
+import org.hibernate.search.backend.elasticsearch.index.IndexStatus;
+import org.hibernate.search.engine.cfg.BackendSettings;
+import org.hibernate.search.engine.cfg.spi.ConfigurationPropertySource;
+import org.hibernate.search.integrationtest.performance.backend.base.testsupport.filesystem.TemporaryFileHolder;
+import org.hibernate.search.integrationtest.performance.backend.base.testsupport.index.AbstractBackendHolder;
+
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class ElasticsearchBackendHolder extends AbstractBackendHolder {
+
+	@Override
+	protected ConfigurationPropertySource getDefaultBackendProperties(TemporaryFileHolder temporaryFileHolder) {
+		Map<String, Object> map = new LinkedHashMap<>();
+
+		map.put( BackendSettings.TYPE, ElasticsearchBackendSettings.TYPE_NAME );
+		// Custom connection info is provided by setting system properties,
+		// e.g. "hosts" or "aws.signing.enabled".
+		map.put( ElasticsearchBackendSettings.ANALYSIS_CONFIGURER, ElasticsearchPerformanceAnalysisConfigurer.class );
+
+		map.put(
+				BackendSettings.INDEX_DEFAULTS + "." + ElasticsearchIndexSettings.LIFECYCLE_STRATEGY,
+				IndexLifecycleStrategyName.DROP_AND_CREATE_AND_DROP
+		);
+		map.put(
+				BackendSettings.INDEX_DEFAULTS + "." + ElasticsearchIndexSettings.LIFECYCLE_MINIMAL_REQUIRED_STATUS,
+				IndexStatus.YELLOW
+		);
+
+		return ConfigurationPropertySource.fromMap( map );
+	}
+}

--- a/integrationtest/performance/backend/elasticsearch/src/main/java/org/hibernate/search/integrationtest/performance/backend/elasticsearch/testsupport/ElasticsearchMassIndexingBenchmarks.java
+++ b/integrationtest/performance/backend/elasticsearch/src/main/java/org/hibernate/search/integrationtest/performance/backend/elasticsearch/testsupport/ElasticsearchMassIndexingBenchmarks.java
@@ -1,0 +1,27 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.performance.backend.elasticsearch.testsupport;
+
+import org.hibernate.search.integrationtest.performance.backend.base.AbstractMassIndexingBenchmarks;
+import org.hibernate.search.integrationtest.performance.backend.base.testsupport.index.IndexInitializer;
+
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.ThreadParams;
+
+@State(Scope.Thread)
+public class ElasticsearchMassIndexingBenchmarks extends AbstractMassIndexingBenchmarks {
+
+	@Setup(Level.Trial)
+	public void setupTrial(ElasticsearchBackendHolder backendHolder, IndexInitializer indexInitializer,
+			ThreadParams threadParams) {
+		doSetupTrial( backendHolder, indexInitializer, threadParams );
+	}
+
+}

--- a/integrationtest/performance/backend/elasticsearch/src/main/java/org/hibernate/search/integrationtest/performance/backend/elasticsearch/testsupport/ElasticsearchOnTheFlyIndexingBenchmarks.java
+++ b/integrationtest/performance/backend/elasticsearch/src/main/java/org/hibernate/search/integrationtest/performance/backend/elasticsearch/testsupport/ElasticsearchOnTheFlyIndexingBenchmarks.java
@@ -1,0 +1,36 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.performance.backend.elasticsearch.testsupport;
+
+import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
+import org.hibernate.search.integrationtest.performance.backend.base.AbstractOnTheFlyIndexingBenchmarks;
+import org.hibernate.search.integrationtest.performance.backend.base.testsupport.index.IndexInitializer;
+
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.ThreadParams;
+
+@State(Scope.Thread)
+public class ElasticsearchOnTheFlyIndexingBenchmarks extends AbstractOnTheFlyIndexingBenchmarks {
+
+	@Param({ "FORCE" }) // No need to test "NONE": this parameter is ignored by the Elasticsearch backend anyway.
+	private DocumentCommitStrategy commitStrategy;
+
+	@Setup(Level.Trial)
+	public void setupTrial(ElasticsearchBackendHolder backendHolder, IndexInitializer indexInitializer,
+			ThreadParams threadParams) {
+		doSetupTrial( backendHolder, indexInitializer, threadParams );
+	}
+
+	@Override
+	protected DocumentCommitStrategy getCommitStrategyParam() {
+		return commitStrategy;
+	}
+}

--- a/integrationtest/performance/backend/elasticsearch/src/main/java/org/hibernate/search/integrationtest/performance/backend/elasticsearch/testsupport/ElasticsearchPerformanceAnalysisConfigurer.java
+++ b/integrationtest/performance/backend/elasticsearch/src/main/java/org/hibernate/search/integrationtest/performance/backend/elasticsearch/testsupport/ElasticsearchPerformanceAnalysisConfigurer.java
@@ -1,0 +1,29 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.performance.backend.elasticsearch.testsupport;
+
+import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurationContext;
+import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurer;
+import org.hibernate.search.integrationtest.performance.backend.base.testsupport.analysis.Analyzers;
+
+public class ElasticsearchPerformanceAnalysisConfigurer implements ElasticsearchAnalysisConfigurer {
+
+	@Override
+	public void configure(ElasticsearchAnalysisConfigurationContext context) {
+		context.analyzer( Analyzers.ANALYZER_ENGLISH ).custom()
+				.tokenizer( "standard" )
+				.tokenFilters( "lowercase", "snowball_english", "asciifolding" );
+
+		context.tokenFilter( "snowball_english" )
+				.type( "snowball" )
+				.param( "language", "English" );
+
+		context.normalizer( Analyzers.NORMALIZER_ENGLISH ).custom()
+				.tokenFilters( "lowercase", "asciifolding" );
+	}
+
+}

--- a/integrationtest/performance/backend/elasticsearch/src/main/resources/log4j.properties
+++ b/integrationtest/performance/backend/elasticsearch/src/main/resources/log4j.properties
@@ -1,0 +1,10 @@
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p %c{1}:%L %m%n
+
+log4j.rootLogger=info, stdout
+log4j.logger.org.jboss=info
+log4j.logger.org.hibernate=info
+log4j.logger.org.hibernate.search=info
+log4j.logger.org.elasticsearch.client=info

--- a/integrationtest/performance/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/performance/backend/elasticsearch/SmokeIT.java
+++ b/integrationtest/performance/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/performance/backend/elasticsearch/SmokeIT.java
@@ -47,6 +47,11 @@ public class SmokeIT {
 				.warmupIterations( 0 )
 				.measurementIterations( 1 )
 				.measurementTime( TimeValue.seconds( 1 ) )
+				.param(
+						"configuration",
+						"",
+						"max_connections_per_route=30"
+				)
 				.param( "initialIndexSize", "100" )
 				.param( "batchSize", "10" )
 				.param( "maxResults", "10" )

--- a/integrationtest/performance/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/performance/backend/elasticsearch/SmokeIT.java
+++ b/integrationtest/performance/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/performance/backend/elasticsearch/SmokeIT.java
@@ -1,0 +1,60 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.performance.backend.elasticsearch;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.ElasticsearchTestHostConnectionConfiguration;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+/**
+ * Test that JMH benchmarks work correctly on a very short run.
+ * <p>
+ * This may not work correctly when run from the IDE.
+ * <p>
+ * See README to know how to run the benchmark from the command line to obtain more reliable results.
+ */
+public class SmokeIT {
+
+	@Before
+	public void setupConnectionInfo() {
+		Map<String, String> connectionInfo = new LinkedHashMap<>();
+		ElasticsearchTestHostConnectionConfiguration.get().addToBackendProperties( connectionInfo );
+		connectionInfo.forEach( (key, value) -> {
+			if ( value != null ) {
+				System.setProperty( key, value );
+			}
+		} );
+	}
+
+	@Test
+	public void test() throws RunnerException {
+		Options opts = new OptionsBuilder()
+				.include( ".*" )
+				.warmupIterations( 0 )
+				.measurementIterations( 1 )
+				.measurementTime( TimeValue.seconds( 1 ) )
+				.param( "initialIndexSize", "100" )
+				.param( "batchSize", "10" )
+				.param( "maxResults", "10" )
+				.shouldFailOnError( true )
+				.forks( 0 ) // To simplify debugging; Remember this implies JVM parameters via @Fork won't be applied.
+				.build();
+
+		new Runner( opts ).run();
+	}
+
+}

--- a/integrationtest/performance/backend/lucene/pom.xml
+++ b/integrationtest/performance/backend/lucene/pom.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate Search, full-text search for your domain model
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-integrationtest-performance</artifactId>
+        <version>6.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>hibernate-search-integrationtest-performance-backend-lucene</artifactId>
+
+    <name>Hibernate Search Integration Tests - Performance - Backend - Lucene</name>
+    <description>Performance tests for the Lucene backend</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-backend-lucene</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-integrationtest-performance-backend-base</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-util-internal-integrationtest-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>it</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.bsc.maven</groupId>
+                <artifactId>maven-processor-plugin</artifactId>
+                <executions>
+                    <!-- Run JMH annotation processor on src/main/java sources -->
+                    <execution>
+                        <id>processjmh</id>
+                        <goals>
+                            <goal>process</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <processors>
+                                <processor>org.openjdk.jmh.generators.BenchmarkProcessor</processor>
+                            </processors>
+                            <!-- Also process the source from the base project -->
+                            <appendSourceArtifacts>true</appendSourceArtifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.openjdk.jmh</groupId>
+                        <artifactId>jmh-generator-annprocess</artifactId>
+                        <version>${version.org.openjdk.jmh}</version>
+                        <scope>compile</scope>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>benchmarks</finalName>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                                </transformer>
+                                <!-- Needed for service entries implementing BeanConfigurer in particular -->
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <!--
+                                        Shading signed JARs will fail without this.
+                                        http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
+                                    -->
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/integrationtest/performance/backend/lucene/src/main/java/org/hibernate/search/integrationtest/performance/backend/lucene/testsupport/LuceneBackendHolder.java
+++ b/integrationtest/performance/backend/lucene/src/main/java/org/hibernate/search/integrationtest/performance/backend/lucene/testsupport/LuceneBackendHolder.java
@@ -16,11 +16,25 @@ import org.hibernate.search.engine.cfg.spi.ConfigurationPropertySource;
 import org.hibernate.search.integrationtest.performance.backend.base.testsupport.filesystem.TemporaryFileHolder;
 import org.hibernate.search.integrationtest.performance.backend.base.testsupport.index.AbstractBackendHolder;
 
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 
 @State(Scope.Benchmark)
 public class LuceneBackendHolder extends AbstractBackendHolder {
+
+	/**
+	 * A list of configuration properties to apply to the backend and indexes.
+	 * <p>
+	 * Format: {@code <key>=<value>&<key2>=<value2>} (etc.).
+	 * Multiple configurations can be tested by providing multiple values for this parameter,
+	 * e.g. {@code foo=1&bar=2,foo=2&bar=1} for two configurations setting {@code foo} and {@code bar} to different values.
+	 * <p>
+	 * Note that configuration properties are applied both at the backend level and at the index level,
+	 * so using the "index_defaults." prefix is optional when setting index-level properties.
+	 */
+	@Param({ "", "io.commit_interval=1000", "io.commit_interval=1000&io.refresh_interval=1000", "io.strategy=debug" })
+	private String configuration;
 
 	@Override
 	protected ConfigurationPropertySource getDefaultBackendProperties(TemporaryFileHolder temporaryFileHolder)
@@ -32,5 +46,10 @@ public class LuceneBackendHolder extends AbstractBackendHolder {
 		map.put( LuceneBackendSettings.ANALYSIS_CONFIGURER, LucenePerformanceAnalysisConfigurer.class );
 
 		return ConfigurationPropertySource.fromMap( map );
+	}
+
+	@Override
+	protected String getConfigurationParameter() {
+		return configuration;
 	}
 }

--- a/integrationtest/performance/backend/lucene/src/main/java/org/hibernate/search/integrationtest/performance/backend/lucene/testsupport/LuceneBackendHolder.java
+++ b/integrationtest/performance/backend/lucene/src/main/java/org/hibernate/search/integrationtest/performance/backend/lucene/testsupport/LuceneBackendHolder.java
@@ -1,0 +1,36 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.performance.backend.lucene.testsupport;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.hibernate.search.backend.lucene.cfg.LuceneBackendSettings;
+import org.hibernate.search.engine.cfg.BackendSettings;
+import org.hibernate.search.engine.cfg.spi.ConfigurationPropertySource;
+import org.hibernate.search.integrationtest.performance.backend.base.testsupport.filesystem.TemporaryFileHolder;
+import org.hibernate.search.integrationtest.performance.backend.base.testsupport.index.AbstractBackendHolder;
+
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class LuceneBackendHolder extends AbstractBackendHolder {
+
+	@Override
+	protected ConfigurationPropertySource getDefaultBackendProperties(TemporaryFileHolder temporaryFileHolder)
+			throws IOException {
+		Map<String, Object> map = new LinkedHashMap<>();
+
+		map.put( BackendSettings.TYPE, LuceneBackendSettings.TYPE_NAME );
+		map.put( LuceneBackendSettings.DIRECTORY_ROOT, temporaryFileHolder.getIndexesDirectory().toAbsolutePath() );
+		map.put( LuceneBackendSettings.ANALYSIS_CONFIGURER, LucenePerformanceAnalysisConfigurer.class );
+
+		return ConfigurationPropertySource.fromMap( map );
+	}
+}

--- a/integrationtest/performance/backend/lucene/src/main/java/org/hibernate/search/integrationtest/performance/backend/lucene/testsupport/LuceneMassIndexingBenchmarks.java
+++ b/integrationtest/performance/backend/lucene/src/main/java/org/hibernate/search/integrationtest/performance/backend/lucene/testsupport/LuceneMassIndexingBenchmarks.java
@@ -1,0 +1,27 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.performance.backend.lucene.testsupport;
+
+import org.hibernate.search.integrationtest.performance.backend.base.AbstractMassIndexingBenchmarks;
+import org.hibernate.search.integrationtest.performance.backend.base.testsupport.index.IndexInitializer;
+
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.ThreadParams;
+
+@State(Scope.Thread)
+public class LuceneMassIndexingBenchmarks extends AbstractMassIndexingBenchmarks {
+
+	@Setup(Level.Trial)
+	public void setupTrial(LuceneBackendHolder backendHolder, IndexInitializer indexInitializer,
+			ThreadParams threadParams) {
+		doSetupTrial( backendHolder, indexInitializer, threadParams );
+	}
+
+}

--- a/integrationtest/performance/backend/lucene/src/main/java/org/hibernate/search/integrationtest/performance/backend/lucene/testsupport/LuceneOnTheFlyIndexingBenchmarks.java
+++ b/integrationtest/performance/backend/lucene/src/main/java/org/hibernate/search/integrationtest/performance/backend/lucene/testsupport/LuceneOnTheFlyIndexingBenchmarks.java
@@ -1,0 +1,36 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.performance.backend.lucene.testsupport;
+
+import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
+import org.hibernate.search.integrationtest.performance.backend.base.AbstractOnTheFlyIndexingBenchmarks;
+import org.hibernate.search.integrationtest.performance.backend.base.testsupport.index.IndexInitializer;
+
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.ThreadParams;
+
+@State(Scope.Thread)
+public class LuceneOnTheFlyIndexingBenchmarks extends AbstractOnTheFlyIndexingBenchmarks {
+
+	@Param({ "NONE", "FORCE" })
+	private DocumentCommitStrategy commitStrategy;
+
+	@Setup(Level.Trial)
+	public void setupTrial(LuceneBackendHolder backendHolder, IndexInitializer indexInitializer,
+			ThreadParams threadParams) {
+		doSetupTrial( backendHolder, indexInitializer, threadParams );
+	}
+
+	@Override
+	protected DocumentCommitStrategy getCommitStrategyParam() {
+		return commitStrategy;
+	}
+}

--- a/integrationtest/performance/backend/lucene/src/main/java/org/hibernate/search/integrationtest/performance/backend/lucene/testsupport/LucenePerformanceAnalysisConfigurer.java
+++ b/integrationtest/performance/backend/lucene/src/main/java/org/hibernate/search/integrationtest/performance/backend/lucene/testsupport/LucenePerformanceAnalysisConfigurer.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.performance.backend.lucene.testsupport;
+
+import org.hibernate.search.backend.lucene.analysis.LuceneAnalysisConfigurationContext;
+import org.hibernate.search.backend.lucene.analysis.LuceneAnalysisConfigurer;
+import org.hibernate.search.integrationtest.performance.backend.base.testsupport.analysis.Analyzers;
+
+import org.apache.lucene.analysis.core.LowerCaseFilterFactory;
+import org.apache.lucene.analysis.miscellaneous.ASCIIFoldingFilterFactory;
+import org.apache.lucene.analysis.snowball.SnowballPorterFilterFactory;
+import org.apache.lucene.analysis.standard.StandardTokenizerFactory;
+
+public class LucenePerformanceAnalysisConfigurer implements LuceneAnalysisConfigurer {
+
+	@Override
+	public void configure(LuceneAnalysisConfigurationContext context) {
+		context.analyzer( Analyzers.ANALYZER_ENGLISH ).custom()
+				.tokenizer( StandardTokenizerFactory.class )
+				.tokenFilter( LowerCaseFilterFactory.class )
+				.tokenFilter( SnowballPorterFilterFactory.class )
+						.param( "language", "English" )
+				.tokenFilter( ASCIIFoldingFilterFactory.class );
+
+		context.normalizer( Analyzers.NORMALIZER_ENGLISH ).custom()
+				.tokenFilter( LowerCaseFilterFactory.class )
+				.tokenFilter( ASCIIFoldingFilterFactory.class );
+	}
+
+}

--- a/integrationtest/performance/backend/lucene/src/main/resources/log4j.properties
+++ b/integrationtest/performance/backend/lucene/src/main/resources/log4j.properties
@@ -1,0 +1,9 @@
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p %c{1}:%L %m%n
+
+log4j.rootLogger=info, stdout
+log4j.logger.org.jboss=info
+log4j.logger.org.hibernate=info
+log4j.logger.org.hibernate.search=info

--- a/integrationtest/performance/backend/lucene/src/test/java/org/hibernate/search/integrationtest/performance/backend/lucene/SmokeIT.java
+++ b/integrationtest/performance/backend/lucene/src/test/java/org/hibernate/search/integrationtest/performance/backend/lucene/SmokeIT.java
@@ -1,0 +1,43 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.performance.backend.lucene;
+
+import org.junit.Test;
+
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+/**
+ * Test that JMH benchmarks work correctly on a very short run.
+ * <p>
+ * This may not work correctly when run from the IDE.
+ * <p>
+ * See README to know how to run the benchmark from the command line to obtain more reliable results.
+ */
+public class SmokeIT {
+
+	@Test
+	public void test() throws RunnerException {
+		Options opts = new OptionsBuilder()
+				.include( ".*" )
+				.warmupIterations( 0 )
+				.measurementIterations( 1 )
+				.measurementTime( TimeValue.seconds( 1 ) )
+				.param( "initialIndexSize", "100" )
+				.param( "batchSize", "10" )
+				.param( "maxResults", "10" )
+				.shouldFailOnError( true )
+				.forks( 0 ) // To simplify debugging; Remember this implies JVM parameters via @Fork won't be applied.
+				.build();
+
+		new Runner( opts ).run();
+	}
+
+}

--- a/integrationtest/performance/backend/lucene/src/test/java/org/hibernate/search/integrationtest/performance/backend/lucene/SmokeIT.java
+++ b/integrationtest/performance/backend/lucene/src/test/java/org/hibernate/search/integrationtest/performance/backend/lucene/SmokeIT.java
@@ -30,6 +30,11 @@ public class SmokeIT {
 				.warmupIterations( 0 )
 				.measurementIterations( 1 )
 				.measurementTime( TimeValue.seconds( 1 ) )
+				.param(
+						"configuration",
+						"",
+						"io.commit_interval=100&io.refresh_interval=100"
+				)
 				.param( "initialIndexSize", "100" )
 				.param( "batchSize", "10" )
 				.param( "maxResults", "10" )

--- a/integrationtest/performance/pom.xml
+++ b/integrationtest/performance/pom.xml
@@ -15,6 +15,7 @@
     <modules>
         <module>backend/base</module>
         <module>backend/elasticsearch</module>
+        <module>backend/lucene</module>
     </modules>
 
     <dependencyManagement>

--- a/integrationtest/performance/pom.xml
+++ b/integrationtest/performance/pom.xml
@@ -1,0 +1,29 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-integrationtest</artifactId>
+        <version>6.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>hibernate-search-integrationtest-performance</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Hibernate Search Integration Tests - Performance - Parent POM</name>
+    <description>Parent POM of Hibernate Search performance tests</description>
+
+    <modules>
+        <module>backend/base</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-integrationtest-performance-backend-base</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>
+

--- a/integrationtest/performance/pom.xml
+++ b/integrationtest/performance/pom.xml
@@ -14,6 +14,7 @@
 
     <modules>
         <module>backend/base</module>
+        <module>backend/elasticsearch</module>
     </modules>
 
     <dependencyManagement>

--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -21,6 +21,7 @@
         <module>mapper/orm</module>
         <module>mapper/orm-cdi</module>
         <module>mapper/orm-envers</module>
+        <module>performance</module>
         <module>showcase/library</module>
     </modules>
 

--- a/jenkins/performance-elasticsearch.groovy
+++ b/jenkins/performance-elasticsearch.groovy
@@ -107,6 +107,8 @@ lock(label: esAwsBuildEnv.lockedResourcesLabel) {
 							-jvmArgsAppend -Daws.signing.access_key=$AWS_ACCESS_KEY_ID \
 							-jvmArgsAppend -Daws.signing.secret_key=$AWS_SECRET_ACCESS_KEY \
 							-jvmArgsAppend -Daws.signing.region=$esAwsBuildEnv.awsRegion \
+							-e OnTheFlyIndexingBenchmarks.concurrentReadWrite \
+							-e OnTheFlyIndexingBenchmarks.query \
 							-wi 1 -i 10 \
 							-prof org.hibernate.search.integrationtest.performance.backend.base.profiler.JfrProfiler:outputDir=output \
 							-rff output/benchmark-results-elasticsearch.csv \

--- a/jenkins/performance-elasticsearch.groovy
+++ b/jenkins/performance-elasticsearch.groovy
@@ -14,7 +14,7 @@ import groovy.transform.Field
 import org.hibernate.jenkins.pipeline.helpers.job.JobHelper
 
 @Field final String MAVEN_TOOL = 'Apache Maven 3.6'
-@Field final String JDK_TOOL = 'OpenJDK 8 Latest'
+@Field final String JDK_TOOL = 'OpenJDK 11 Latest'
 
 // Performance node pattern, to be used for stages involving performance tests.
 @Field final String PERFORMANCE_NODE_PATTERN = 'Performance'
@@ -108,6 +108,7 @@ lock(label: esAwsBuildEnv.lockedResourcesLabel) {
 							-jvmArgsAppend -Daws.signing.secret_key=$AWS_SECRET_ACCESS_KEY \
 							-jvmArgsAppend -Daws.signing.region=$esAwsBuildEnv.awsRegion \
 							-wi 1 -i 10 \
+							-prof org.hibernate.search.integrationtest.performance.backend.base.profiler.JfrProfiler:outputDir=output \
 							-rff output/benchmark-results-elasticsearch.csv \
 					"""
 				}

--- a/jenkins/performance-elasticsearch.groovy
+++ b/jenkins/performance-elasticsearch.groovy
@@ -1,26 +1,149 @@
-node ('Performance') {
-	stage ('Checkout') {
-		checkout scm
-	}
-	
-	stage ('Build') {
-		sh "mvn clean install" +
-				" -U -am -pl :hibernate-search-performance-engine-elasticsearch" +
-				" -DskipTests"
-	}
-	
-	stage ('Performance test') {
-		sh 'mkdir output'
-		withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-elasticsearch',
-				usernameVariable: 'AWS_ACCESS_KEY_ID', passwordVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-			sh "java " +
-					" -Dhost=${env.ES_ENDPOINT} -Daws.access-key=${AWS_ACCESS_KEY_ID}" +
-					" -Daws.secret-key=${AWS_SECRET_ACCESS_KEY} -Daws.signing.region=${env.AWS_REGION}" +
-					" -jar legacy/integrationtest/performance/engine-elasticsearch/target/benchmarks.jar " +
-					" -wi 1 -i 10" +
-					" -rff output/elasticsearch-benchmark-results.csv" +
-					" -p indexSize=1000 -p maxResults=100 -p changesetsPerFlush=50 -p streamedAddsPerFlush=5000"
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+import groovy.transform.Field
+
+/*
+ * See https://github.com/hibernate/hibernate-jenkins-pipeline-helpers
+ */
+@Library('hibernate-jenkins-pipeline-helpers@1.2')
+import org.hibernate.jenkins.pipeline.helpers.job.JobHelper
+
+@Field final String MAVEN_TOOL = 'Apache Maven 3.6'
+@Field final String JDK_TOOL = 'OpenJDK 8 Latest'
+
+// Performance node pattern, to be used for stages involving performance tests.
+@Field final String PERFORMANCE_NODE_PATTERN = 'Performance'
+// Quick-use node pattern, to be used for very light, quick, and environment-independent stages,
+// such as sending a notification. May include the master node in particular.
+@Field final String QUICK_USE_NODE_PATTERN = 'Master||Slave||Performance'
+
+@Field JobHelper helper
+
+@Field EsAwsBuildEnvironment esAwsBuildEnv = new EsAwsBuildEnvironment(version: "7.1")
+
+this.helper = new JobHelper(this)
+
+helper.runWithNotification {
+
+stage('Configure') {
+	helper.configure {
+		configurationNodePattern QUICK_USE_NODE_PATTERN
+		file 'job-configuration.yaml'
+		jdk {
+			defaultTool JDK_TOOL
 		}
-		archiveArtifacts artifacts: 'output/*'
+		maven {
+			defaultTool MAVEN_TOOL
+			producedArtifactPattern "org/hibernate/search/*"
+		}
+	}
+
+	properties([
+			pipelineTriggers(
+					[
+							issueCommentTrigger('.*test Elasticsearch performance please.*')
+					]
+			),
+			helper.generateNotificationProperty()
+	])
+
+	esAwsBuildEnv.endpointUrl = env.getProperty(esAwsBuildEnv.endpointVariableName)
+	if (!esAwsBuildEnv.endpointUrl) {
+		throw new IllegalStateException(
+				"Cannot run performance test because environment variable '$esAwsBuildEnv.endpointVariableName' is not defined."
+		)
+	}
+	esAwsBuildEnv.awsRegion = env.ES_AWS_REGION
+	if (!esAwsBuildEnv.awsRegion) {
+		throw new IllegalStateException(
+				"Cannot run performance test because environment variable 'ES_AWS_REGION' is not defined."
+		)
+	}
+}
+
+lock(label: esAwsBuildEnv.lockedResourcesLabel) {
+	node ('Performance') {
+		stage ('Checkout') {
+			checkout scm
+		}
+
+		stage ('Build') {
+			helper.withMavenWorkspace {
+				sh """ \
+						mvn clean install \
+						-U -am -pl :hibernate-search-integrationtest-performance-backend-elasticsearch \
+						-DskipTests \
+				"""
+				dir ('integrationtest/performance/backend/elasticsearch/target') {
+					stash name:'jar', includes:'benchmarks.jar'
+				}
+			}
+		}
+
+		stage ('Performance test') {
+			def awsCredentialsId = helper.configuration.file?.aws?.credentials
+			if (!awsCredentialsId) {
+				throw new IllegalStateException("Missing AWS credentials")
+			}
+			withCredentials([[$class: 'AmazonWebServicesCredentialsBinding',
+							  credentialsId   : awsCredentialsId,
+							  usernameVariable: 'AWS_ACCESS_KEY_ID',
+							  passwordVariable: 'AWS_SECRET_ACCESS_KEY'
+			]]) {
+				helper.withMavenWorkspace { // Mainly to set the default JDK
+					unstash name:'jar'
+					sh 'mkdir output'
+					sh """ \
+							java \
+							-jar benchmarks.jar \
+							-jvmArgsAppend -Dhosts=$esAwsBuildEnv.endpointHostAndPort \
+							-jvmArgsAppend -Dprotocol=$esAwsBuildEnv.endpointProtocol \
+							-jvmArgsAppend -Daws.signing.enabled=true \
+							-jvmArgsAppend -Daws.signing.access_key=$AWS_ACCESS_KEY_ID \
+							-jvmArgsAppend -Daws.signing.secret_key=$AWS_SECRET_ACCESS_KEY \
+							-jvmArgsAppend -Daws.signing.region=$esAwsBuildEnv.awsRegion \
+							-wi 1 -i 10 \
+							-rff output/benchmark-results-elasticsearch.csv \
+					"""
+				}
+			}
+			archiveArtifacts artifacts: 'output/**'
+		}
+	}
+}
+
+} // End of helper.runWithNotification
+
+class EsAwsBuildEnvironment {
+	String version
+	String endpointUrl = null
+	String endpointHostAndPort = null
+	String endpointProtocol = null
+	String awsRegion = null
+	String getNameEmbeddableVersion() {
+		version.replaceAll('\\.', '')
+	}
+	String getEndpointVariableName() {
+		"ES_AWS_${nameEmbeddableVersion}_ENDPOINT"
+	}
+	String getLockedResourcesLabel() {
+		"es-aws-${nameEmbeddableVersion}"
+	}
+	String setEndpointUrl(String url) {
+		this.endpointUrl = url
+		if ( endpointUrl ) {
+			def matcher = endpointUrl =~ /^(?:(https?):\/\/)?(.*)$/
+			endpointProtocol = matcher[0][1]
+			endpointHostAndPort = matcher[0][2]
+		}
+		else {
+			endpointProtocol = null
+			endpointHostAndPort = null
+		}
 	}
 }

--- a/jenkins/performance-lucene.groovy
+++ b/jenkins/performance-lucene.groovy
@@ -14,7 +14,7 @@ import groovy.transform.Field
 import org.hibernate.jenkins.pipeline.helpers.job.JobHelper
 
 @Field final String MAVEN_TOOL = 'Apache Maven 3.6'
-@Field final String JDK_TOOL = 'OpenJDK 8 Latest'
+@Field final String JDK_TOOL = 'OpenJDK 11 Latest'
 
 // Performance node pattern, to be used for stages involving performance tests.
 @Field final String PERFORMANCE_NODE_PATTERN = 'Performance'
@@ -77,6 +77,7 @@ node (PERFORMANCE_NODE_PATTERN) {
 					java \
 					-jar benchmarks.jar \
 					-wi 1 -i 10 \
+					-prof org.hibernate.search.integrationtest.performance.backend.base.profiler.JfrProfiler:outputDir=output \
 					-rff output/benchmark-results-lucene.csv \
 			"""
 		}

--- a/jenkins/performance-lucene.groovy
+++ b/jenkins/performance-lucene.groovy
@@ -1,22 +1,87 @@
-node ('Performance') {
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+import groovy.transform.Field
+
+/*
+ * See https://github.com/hibernate/hibernate-jenkins-pipeline-helpers
+ */
+@Library('hibernate-jenkins-pipeline-helpers@1.2')
+import org.hibernate.jenkins.pipeline.helpers.job.JobHelper
+
+@Field final String MAVEN_TOOL = 'Apache Maven 3.6'
+@Field final String JDK_TOOL = 'OpenJDK 8 Latest'
+
+// Performance node pattern, to be used for stages involving performance tests.
+@Field final String PERFORMANCE_NODE_PATTERN = 'Performance'
+// Quick-use node pattern, to be used for very light, quick, and environment-independent stages,
+// such as sending a notification. May include the master node in particular.
+@Field final String QUICK_USE_NODE_PATTERN = 'Master||Slave||Performance'
+
+@Field JobHelper helper
+
+this.helper = new JobHelper(this)
+
+helper.runWithNotification {
+
+stage('Configure') {
+	helper.configure {
+		configurationNodePattern QUICK_USE_NODE_PATTERN
+		file 'job-configuration.yaml'
+		jdk {
+			defaultTool JDK_TOOL
+		}
+		maven {
+			defaultTool MAVEN_TOOL
+			producedArtifactPattern "org/hibernate/search/*"
+		}
+	}
+
+	properties([
+			pipelineTriggers(
+					[
+							issueCommentTrigger('.*test Lucene performance please.*')
+					]
+			),
+			helper.generateNotificationProperty()
+	])
+}
+
+node (PERFORMANCE_NODE_PATTERN) {
 	stage ('Checkout') {
 		checkout scm
 	}
-	
+
 	stage ('Build') {
-		sh "mvn clean install" +
-				" -U -am -pl :hibernate-search-performance-engine-lucene" +
-				" -DskipTests"
+		helper.withMavenWorkspace {
+			sh """ \
+					mvn clean install \
+					-U -am -pl :hibernate-search-integrationtest-performance-backend-lucene \
+					-DskipTests \
+			"""
+			dir ('integrationtest/performance/backend/lucene/target') {
+				stash name:'jar', includes:'benchmarks.jar'
+			}
+		}
 	}
-	
+
 	stage ('Performance test') {
-		unstash 'benchmarks-lucene'
-		sh 'mkdir output'
-		sh "java " +
-				" -jar legacy/integrationtest/performance/engine-lucene/target/benchmarks.jar" +
-				" -wi 1 -i 10" +
-				" -rff output/lucene-benchmark-results.csv" +
-				" -p directorytype=fs -p indexsize=100 -p maxResults=10"
-		archiveArtifacts artifacts: 'output/*'
+		helper.withMavenWorkspace { // Mainly to set the default JDK
+			unstash name:'jar'
+			sh 'mkdir output'
+			sh """ \
+					java \
+					-jar benchmarks.jar \
+					-wi 1 -i 10 \
+					-rff output/benchmark-results-lucene.csv \
+			"""
+		}
+		archiveArtifacts artifacts: 'output/**'
 	}
 }
+
+} // End of helper.runWithNotification

--- a/jenkins/performance-lucene.groovy
+++ b/jenkins/performance-lucene.groovy
@@ -76,6 +76,8 @@ node (PERFORMANCE_NODE_PATTERN) {
 			sh """ \
 					java \
 					-jar benchmarks.jar \
+					-e OnTheFlyIndexingBenchmarks.concurrentReadWrite \
+					-e OnTheFlyIndexingBenchmarks.query \
 					-wi 1 -i 10 \
 					-prof org.hibernate.search.integrationtest.performance.backend.base.profiler.JfrProfiler:outputDir=output \
 					-rff output/benchmark-results-lucene.csv \

--- a/parents/integrationtest/pom.xml
+++ b/parents/integrationtest/pom.xml
@@ -55,6 +55,11 @@
             </dependency>
             <dependency>
                 <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-util-internal-integrationtest-mapper-stub</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
                 <artifactId>hibernate-search-util-internal-integrationtest-mapper-orm</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
     </modules>
 
     <properties>
-        <!-- Dependencies versions -->
+        <!-- Main dependencies -->
 
         <!-- >>> Common -->
         <version.org.jboss.logging.jboss-logging>3.4.0.Final</version.org.jboss.logging.jboss-logging>
@@ -229,6 +229,7 @@
 
         <!-- Test dependencies -->
 
+        <!-- >>> Common -->
         <version.org.slf4j>1.7.25</version.org.slf4j>
         <version.log4j>1.2.16</version.log4j>
         <version.junit>4.12</version.junit>
@@ -244,6 +245,9 @@
         <version.com.github.tomakehurst.wiremock>2.25.1</version.com.github.tomakehurst.wiremock>
         <version.org.apache.commons.lang3>3.8.1</version.org.apache.commons.lang3>
         <version.org.jboss.weld>3.1.3.Final</version.org.jboss.weld>
+
+        <!-- >>> Performance tests -->
+        <version.org.openjdk.jmh>1.23</version.org.openjdk.jmh>
 
         <!-- Maven plugins versions -->
 
@@ -982,6 +986,13 @@
                 <groupId>org.jboss.weld.se</groupId>
                 <artifactId>weld-se-shaded</artifactId>
                 <version>${version.org.jboss.weld}</version>
+            </dependency>
+
+            <!-- Performance tests -->
+            <dependency>
+                <groupId>org.openjdk.jmh</groupId>
+                <artifactId>jmh-core</artifactId>
+                <version>${version.org.openjdk.jmh}</version>
             </dependency>
 
             <!-- Hibernate ORM testing tools -->
@@ -2003,6 +2014,12 @@
                     <groupId>org.jboss.logging</groupId>
                     <artifactId>jboss-logging-processor</artifactId>
                     <version>${version.org.jboss.logging.jboss-logging-tools}</version>
+                    <scope>compile</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.openjdk.jmh</groupId>
+                    <artifactId>jmh-generator-annprocess</artifactId>
+                    <version>${version.org.openjdk.jmh}</version>
                     <scope>compile</scope>
                 </dependency>
             </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -576,6 +576,11 @@
             </dependency>
             <dependency>
                 <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-mapper-stub</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
                 <artifactId>hibernate-search-integrationtest-backend-elasticsearch</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/ElasticsearchTestHostConnectionConfiguration.java
+++ b/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/ElasticsearchTestHostConnectionConfiguration.java
@@ -52,7 +52,7 @@ public class ElasticsearchTestHostConnectionConfiguration {
 		return awsSigningEnabled;
 	}
 
-	public void addToBackendProperties(Map<String, Object> properties) {
+	public void addToBackendProperties(Map<String, ? super String> properties) {
 		properties.put( "hosts", hosts );
 		properties.put( "protocol", protocol );
 		properties.put( "username", username );

--- a/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/ElasticsearchTestHostConnectionConfiguration.java
+++ b/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/ElasticsearchTestHostConnectionConfiguration.java
@@ -23,7 +23,8 @@ public class ElasticsearchTestHostConnectionConfiguration {
 		return instance;
 	}
 
-	private final String url;
+	private final String hosts;
+	private final String protocol;
 	private final String username;
 	private final String password;
 	private final boolean awsSigningEnabled;
@@ -32,7 +33,8 @@ public class ElasticsearchTestHostConnectionConfiguration {
 	private final String awsSigningRegion;
 
 	private ElasticsearchTestHostConnectionConfiguration() {
-		this.url = System.getProperty( "test.elasticsearch.connection.hosts" );
+		this.hosts = System.getProperty( "test.elasticsearch.connection.hosts" );
+		this.protocol = System.getProperty( "test.elasticsearch.connection.protocol" );
 		this.username = System.getProperty( "test.elasticsearch.connection.username" );
 		this.password = System.getProperty( "test.elasticsearch.connection.password" );
 		this.awsSigningEnabled = Boolean.getBoolean( "test.elasticsearch.connection.aws.signing.enabled" );
@@ -41,8 +43,8 @@ public class ElasticsearchTestHostConnectionConfiguration {
 		this.awsSigningRegion = System.getProperty( "test.elasticsearch.connection.aws.signing.region" );
 
 		log.infof(
-				"Integration tests will connect to '%s' (AWS signing enabled: '%s')",
-				url, awsSigningEnabled
+				"Integration tests will connect to '%s' using protocol '%s' (AWS signing enabled: '%s')",
+				hosts, protocol, awsSigningEnabled
 		);
 	}
 
@@ -51,7 +53,8 @@ public class ElasticsearchTestHostConnectionConfiguration {
 	}
 
 	public void addToBackendProperties(Map<String, Object> properties) {
-		properties.put( "hosts", url );
+		properties.put( "hosts", hosts );
+		properties.put( "protocol", protocol );
 		properties.put( "username", username );
 		properties.put( "password", password );
 		properties.put( "aws.signing.enabled", String.valueOf( awsSigningEnabled ) );

--- a/util/internal/integrationtest/common/src/main/resources/log4j.properties
+++ b/util/internal/integrationtest/common/src/main/resources/log4j.properties
@@ -4,18 +4,6 @@ log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} (%t) %5p %c{1}:%L - %m%n
 
-### direct messages to file hibernate.log ###
-log4j.appender.file=org.apache.log4j.FileAppender
-log4j.appender.file.File=hibernate.log
-log4j.appender.file.layout=org.apache.log4j.PatternLayout
-log4j.appender.file.layout.ConversionPattern=%d{ABSOLUTE} (%t) %5p %c{1}:%L - %m%n
-
-### direct messages to socket - chainsaw ###
-log4j.appender.socket=org.apache.log4j.net.SocketAppender
-log4j.appender.socket.remoteHost=localhost
-log4j.appender.socket.port=4560
-log4j.appender.socket.locationInfo=true
-
 ### set log levels - for more verbose logging change 'info' to 'debug' ###
 
 log4j.rootLogger=info, stdout

--- a/util/internal/integrationtest/mapper/stub/pom.xml
+++ b/util/internal/integrationtest/mapper/stub/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate Search, full-text search for your domain model
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.search</groupId>
+        <artifactId>hibernate-search-util-internal-integrationtest-parent</artifactId>
+        <version>6.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>hibernate-search-util-internal-integrationtest-mapper-stub</artifactId>
+
+    <name>Hibernate Search Utils - Internal - Integration Tests - Stub Mapper</name>
+    <description>Hibernate Search Stub Mapper for testing purposes</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-engine</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/GenericStubMappingScope.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/GenericStubMappingScope.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.util.impl.integrationtest.common.stub.mapper;
+package org.hibernate.search.util.impl.integrationtest.mapper.stub;
 
 import org.hibernate.search.engine.mapper.scope.spi.MappedIndexScope;
 import org.hibernate.search.engine.search.aggregation.dsl.SearchAggregationFactory;
@@ -14,7 +14,6 @@ import org.hibernate.search.engine.search.query.dsl.SearchQuerySelectStep;
 import org.hibernate.search.engine.search.sort.dsl.SearchSortFactory;
 import org.hibernate.search.engine.search.loading.context.spi.LoadingContext;
 import org.hibernate.search.engine.search.loading.context.spi.LoadingContextBuilder;
-import org.hibernate.search.util.impl.integrationtest.common.stub.StubBackendSessionContext;
 
 /**
  * A wrapper around {@link MappedIndexScope} providing some syntactic sugar,

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubBackendMappingContext.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubBackendMappingContext.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.util.impl.integrationtest.common.stub;
+package org.hibernate.search.util.impl.integrationtest.mapper.stub;
 
 import org.hibernate.search.engine.backend.mapping.spi.BackendMappingContext;
 

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubBackendSessionContext.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubBackendSessionContext.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.util.impl.integrationtest.common.stub;
+package org.hibernate.search.util.impl.integrationtest.mapper.stub;
 
 import org.hibernate.search.engine.backend.mapping.spi.BackendMappingContext;
 import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubDocumentReferenceProvider.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubDocumentReferenceProvider.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.util.impl.integrationtest.common.stub.mapper;
+package org.hibernate.search.util.impl.integrationtest.mapper.stub;
 
 import org.hibernate.search.engine.backend.work.execution.spi.DocumentReferenceProvider;
 

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubLoadingContext.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubLoadingContext.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.util.impl.integrationtest.common.stub.mapper;
+package org.hibernate.search.util.impl.integrationtest.mapper.stub;
 
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.loading.context.spi.LoadingContext;

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubLoadingOptionsStep.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubLoadingOptionsStep.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.util.impl.integrationtest.common.stub.mapper;
+package org.hibernate.search.util.impl.integrationtest.mapper.stub;
 
 public class StubLoadingOptionsStep {
 

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMapper.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMapper.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.util.impl.integrationtest.common.stub.mapper;
+package org.hibernate.search.util.impl.integrationtest.mapper.stub;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMapper.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMapper.java
@@ -118,10 +118,11 @@ class StubMapper implements Mapper<StubMappingPartialBuildState>, IndexedEntityB
 		for ( Map.Entry<StubTypeModel, MappedIndexManagerBuilder<?>> entry : indexManagerBuilders.entrySet() ) {
 			StubTypeModel typeModel = entry.getKey();
 			try {
+				String indexName = entry.getValue().getIndexName();
 				MappedIndexManager<?> indexManager = entry.getValue().build();
 				indexMappingsByTypeIdentifier.put(
 						typeModel.asString(),
-						new StubMappingIndexManager( indexManager )
+						new StubMappingIndexManager( indexName, indexManager )
 				);
 			}
 			catch (RuntimeException e) {

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMapperUtils.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMapperUtils.java
@@ -1,0 +1,24 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.impl.integrationtest.mapper.stub;
+
+import org.hibernate.search.engine.backend.work.execution.spi.DocumentReferenceProvider;
+
+public final class StubMapperUtils {
+
+	private StubMapperUtils() {
+	}
+
+	public static DocumentReferenceProvider referenceProvider(String identifier) {
+		return referenceProvider( identifier, null );
+	}
+
+	public static DocumentReferenceProvider referenceProvider(String identifier, String routingKey) {
+		return new StubDocumentReferenceProvider( identifier, routingKey );
+	}
+
+}

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMapping.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMapping.java
@@ -4,28 +4,31 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.util.impl.integrationtest.common.stub.mapper;
+package org.hibernate.search.util.impl.integrationtest.mapper.stub;
 
 import java.util.Map;
 
 import org.hibernate.search.engine.mapper.mapping.spi.MappingImplementor;
-import org.hibernate.search.engine.mapper.mapping.building.spi.MappingPartialBuildState;
 
-public class StubMappingPartialBuildState implements MappingPartialBuildState {
+public class StubMapping implements MappingImplementor<StubMapping> {
 
 	private final Map<String, StubMappingIndexManager> indexMappingsByTypeIdentifier;
 
-	StubMappingPartialBuildState(Map<String, StubMappingIndexManager> indexMappingsByTypeIdentifier) {
+	StubMapping(Map<String, StubMappingIndexManager> indexMappingsByTypeIdentifier) {
 		this.indexMappingsByTypeIdentifier = indexMappingsByTypeIdentifier;
 	}
 
 	@Override
-	public void closeOnFailure() {
+	public StubMapping toConcreteType() {
+		return this;
+	}
+
+	public StubMappingIndexManager getIndexMappingByTypeIdentifier(String typeId) {
+		return indexMappingsByTypeIdentifier.get( typeId );
+	}
+
+	@Override
+	public void close() {
 		// Nothing to do
 	}
-
-	public MappingImplementor<StubMapping> finalizeMapping() {
-		return new StubMapping( indexMappingsByTypeIdentifier );
-	}
-
 }

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMappingIndexManager.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMappingIndexManager.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.util.impl.integrationtest.common.stub.mapper;
+package org.hibernate.search.util.impl.integrationtest.mapper.stub;
 
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
@@ -16,8 +16,6 @@ import org.hibernate.search.engine.mapper.mapping.spi.MappedIndexManager;
 import org.hibernate.search.engine.mapper.scope.spi.MappedIndexScopeBuilder;
 import org.hibernate.search.engine.backend.session.spi.DetachedBackendSessionContext;
 import org.hibernate.search.engine.backend.common.DocumentReference;
-import org.hibernate.search.util.impl.integrationtest.common.stub.StubBackendMappingContext;
-import org.hibernate.search.util.impl.integrationtest.common.stub.StubBackendSessionContext;
 
 /**
  * A wrapper around {@link MappedIndexManager} providing some syntactic sugar,

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMappingIndexManager.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMappingIndexManager.java
@@ -23,10 +23,16 @@ import org.hibernate.search.engine.backend.common.DocumentReference;
  */
 public class StubMappingIndexManager {
 
+	private final String indexName;
 	private final MappedIndexManager<?> indexManager;
 
-	StubMappingIndexManager(MappedIndexManager<?> indexManager) {
+	StubMappingIndexManager(String indexName, MappedIndexManager<?> indexManager) {
+		this.indexName = indexName;
 		this.indexManager = indexManager;
+	}
+
+	public String getName() {
+		return indexName;
 	}
 
 	public <T> T unwrapForTests(Class<T> clazz) {

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMappingInitiator.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMappingInitiator.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.util.impl.integrationtest.common.stub.mapper;
+package org.hibernate.search.util.impl.integrationtest.mapper.stub;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMappingKey.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMappingKey.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.util.impl.integrationtest.common.stub.mapper;
+package org.hibernate.search.util.impl.integrationtest.mapper.stub;
 
 import org.hibernate.search.engine.mapper.mapping.building.spi.MappingKey;
 

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMappingPartialBuildState.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMappingPartialBuildState.java
@@ -4,31 +4,28 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.util.impl.integrationtest.common.stub.mapper;
+package org.hibernate.search.util.impl.integrationtest.mapper.stub;
 
 import java.util.Map;
 
 import org.hibernate.search.engine.mapper.mapping.spi.MappingImplementor;
+import org.hibernate.search.engine.mapper.mapping.building.spi.MappingPartialBuildState;
 
-public class StubMapping implements MappingImplementor<StubMapping> {
+public class StubMappingPartialBuildState implements MappingPartialBuildState {
 
 	private final Map<String, StubMappingIndexManager> indexMappingsByTypeIdentifier;
 
-	StubMapping(Map<String, StubMappingIndexManager> indexMappingsByTypeIdentifier) {
+	StubMappingPartialBuildState(Map<String, StubMappingIndexManager> indexMappingsByTypeIdentifier) {
 		this.indexMappingsByTypeIdentifier = indexMappingsByTypeIdentifier;
 	}
 
 	@Override
-	public StubMapping toConcreteType() {
-		return this;
-	}
-
-	public StubMappingIndexManager getIndexMappingByTypeIdentifier(String typeId) {
-		return indexMappingsByTypeIdentifier.get( typeId );
-	}
-
-	@Override
-	public void close() {
+	public void closeOnFailure() {
 		// Nothing to do
 	}
+
+	public MappingImplementor<StubMapping> finalizeMapping() {
+		return new StubMapping( indexMappingsByTypeIdentifier );
+	}
+
 }

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMappingScope.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMappingScope.java
@@ -4,12 +4,11 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.util.impl.integrationtest.common.stub.mapper;
+package org.hibernate.search.util.impl.integrationtest.mapper.stub;
 
 import org.hibernate.search.engine.mapper.scope.spi.MappedIndexScope;
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.search.query.dsl.SearchQuerySelectStep;
-import org.hibernate.search.util.impl.integrationtest.common.stub.StubBackendSessionContext;
 
 /**
  * A wrapper around {@link MappedIndexScope} providing some syntactic sugar,

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubTypeMetadataContributor.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubTypeMetadataContributor.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.util.impl.integrationtest.common.stub.mapper;
+package org.hibernate.search.util.impl.integrationtest.mapper.stub;
 
 import java.util.function.Consumer;
 

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubTypeModel.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubTypeModel.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.util.impl.integrationtest.common.stub.mapper;
+package org.hibernate.search.util.impl.integrationtest.mapper.stub;
 
 import java.util.Objects;
 import java.util.stream.Stream;

--- a/util/internal/integrationtest/pom.xml
+++ b/util/internal/integrationtest/pom.xml
@@ -32,6 +32,7 @@
         <module>common</module>
         <module>backend/elasticsearch</module>
         <module>mapper/orm</module>
+        <module>mapper/stub</module>
         <module>sharedresources</module>
     </modules>
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3827

~Based on #2200, which should be merged first.~ => Done

I'm getting the following numbers of writes per second for Lucene.
Note that absolute numbers don't mean anything, since they heavily depend on hardware, the number of threads, etc. What's important is that we actually see an improvement when we set a commit interval.

Mass indexing (without a DB, generated content):

``` 
configuration                                       Score           Score Error (99.9%)
(default)                                           85,802.99       3,425.56
io.commit_interval=1000                             236,790.43      6,360.17
io.commit_interval=1000&io.refresh_interval=1000    238,705.66      10,294.92
io.strategy=debug                                   89,021.94       3,367.94
```

Automatic indexing (without a DB, generated content):

```
configuration                                     commitStrategy  Score        Score Error (99.9%)
(default)                                         FORCE           7,569.90     157.26
                                                  NONE            99,333.15    2,313.56
io.commit_interval=1000                           FORCE           9,155.50     223.43
                                                  NONE            664815.0894  40274.47602
io.commit_interval=1000&io.refresh_interval=1000  FORCE           9359.757108  215.647766
                                                  NONE            643673.987   25927.36115
io.strategy=debug                                 FORCE           7753.374738  227.715543
                                                  NONE            103691.1606  4578.391557
```

