### PR TITLE
Backport HSEARCH-3830 to branch 5.11 - Upgrade to Hibernate ORM 5.4.12.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
 
         <!-- Dependencies versions -->
 
-        <version.org.hibernate>5.4.10.Final</version.org.hibernate>
+        <version.org.hibernate>5.4.12.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>5.1.0.Final</version.org.hibernate.commons.annotations>
         <version.javax.persistence>2.2</version.javax.persistence>
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3830

Backport of #2203.

Will merge as soon as the CI build passes.