### PR TITLE
HSEARCH-3834 + HSEARCH-3835 Adjust index fields in nested documents

### DIFF
--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/AbstractLuceneDocumentBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/AbstractLuceneDocumentBuilder.java
@@ -121,12 +121,12 @@ abstract class AbstractLuceneDocumentBuilder implements LuceneDocumentBuilder {
 		}
 	}
 
-	void contribute(String rootIndexName, MultiTenancyStrategy multiTenancyStrategy, String tenantId, String routingKey,
+	void contribute(MultiTenancyStrategy multiTenancyStrategy, String tenantId, String routingKey,
 			String rootId, List<Document> nestedDocuments) {
 		if ( flattenedObjectDocumentBuilders != null ) {
 			for ( LuceneFlattenedObjectDocumentBuilder flattenedObjectDocumentBuilder : flattenedObjectDocumentBuilders ) {
 				flattenedObjectDocumentBuilder.contribute(
-						rootIndexName, multiTenancyStrategy, tenantId, routingKey,
+						multiTenancyStrategy, tenantId, routingKey,
 						rootId, nestedDocuments
 				);
 			}
@@ -135,7 +135,7 @@ abstract class AbstractLuceneDocumentBuilder implements LuceneDocumentBuilder {
 		if ( nestedObjectDocumentBuilders != null ) {
 			for ( LuceneNestedObjectDocumentBuilder nestedObjectDocumentBuilder : nestedObjectDocumentBuilders ) {
 				nestedObjectDocumentBuilder.contribute(
-						rootIndexName, multiTenancyStrategy, tenantId, routingKey,
+						multiTenancyStrategy, tenantId, routingKey,
 						rootId, nestedDocuments
 				);
 			}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/AbstractLuceneNonFlattenedDocumentBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/AbstractLuceneNonFlattenedDocumentBuilder.java
@@ -53,7 +53,7 @@ abstract class AbstractLuceneNonFlattenedDocumentBuilder extends AbstractLuceneD
 	}
 
 	@Override
-	void contribute(String rootIndexName, MultiTenancyStrategy multiTenancyStrategy, String tenantId, String routingKey,
+	void contribute(MultiTenancyStrategy multiTenancyStrategy, String tenantId, String routingKey,
 			String rootId, List<Document> nestedDocuments) {
 		for ( Map.Entry<String, EncounteredFieldStatus> entry : fieldStatus.entrySet() ) {
 			EncounteredFieldStatus status = entry.getValue();
@@ -74,7 +74,7 @@ abstract class AbstractLuceneNonFlattenedDocumentBuilder extends AbstractLuceneD
 
 		multiTenancyStrategy.contributeToIndexedDocument( document, tenantId );
 
-		super.contribute( rootIndexName, multiTenancyStrategy, tenantId, routingKey, rootId, nestedDocuments );
+		super.contribute( multiTenancyStrategy, tenantId, routingKey, rootId, nestedDocuments );
 	}
 
 	private enum EncounteredFieldStatus {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneNestedObjectDocumentBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneNestedObjectDocumentBuilder.java
@@ -22,16 +22,15 @@ class LuceneNestedObjectDocumentBuilder extends AbstractLuceneNonFlattenedDocume
 	}
 
 	@Override
-	void contribute(String rootIndexName, MultiTenancyStrategy multiTenancyStrategy, String tenantId, String routingKey,
+	void contribute(MultiTenancyStrategy multiTenancyStrategy, String tenantId, String routingKey,
 			String rootId, List<Document> nestedDocuments) {
 		document.add( MetadataFields.searchableMetadataField( MetadataFields.typeFieldName(), MetadataFields.TYPE_CHILD_DOCUMENT ) );
 		document.add( MetadataFields.searchableMetadataField( MetadataFields.idFieldName(), rootId ) );
-		document.add( MetadataFields.searchableMetadataField( MetadataFields.rootIndexFieldName(), rootIndexName ) );
-		document.add( MetadataFields.retrievableMetadataField( MetadataFields.rootIdFieldName(), rootId ) );
+
 		document.add( MetadataFields.searchableMetadataField( MetadataFields.nestedDocumentPathFieldName(), schemaNode.getAbsolutePath() ) );
 
 		// all the ancestors of a subdocument must be added after it
-		super.contribute( rootIndexName, multiTenancyStrategy, tenantId, routingKey, rootId, nestedDocuments );
+		super.contribute( multiTenancyStrategy, tenantId, routingKey, rootId, nestedDocuments );
 		nestedDocuments.add( document );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneNestedObjectDocumentBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneNestedObjectDocumentBuilder.java
@@ -25,6 +25,7 @@ class LuceneNestedObjectDocumentBuilder extends AbstractLuceneNonFlattenedDocume
 	void contribute(String rootIndexName, MultiTenancyStrategy multiTenancyStrategy, String tenantId, String routingKey,
 			String rootId, List<Document> nestedDocuments) {
 		document.add( MetadataFields.searchableMetadataField( MetadataFields.typeFieldName(), MetadataFields.TYPE_CHILD_DOCUMENT ) );
+		document.add( MetadataFields.searchableMetadataField( MetadataFields.idFieldName(), rootId ) );
 		document.add( MetadataFields.searchableMetadataField( MetadataFields.rootIndexFieldName(), rootIndexName ) );
 		document.add( MetadataFields.retrievableMetadataField( MetadataFields.rootIdFieldName(), rootId ) );
 		document.add( MetadataFields.searchableMetadataField( MetadataFields.nestedDocumentPathFieldName(), schemaNode.getAbsolutePath() ) );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneRootDocumentBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneRootDocumentBuilder.java
@@ -40,18 +40,18 @@ public class LuceneRootDocumentBuilder extends AbstractLuceneNonFlattenedDocumen
 	public LuceneIndexEntry build(String tenantId, String id, String routingKey) {
 		return new LuceneIndexEntry(
 				indexName, id,
-				assembleDocuments( indexName, multiTenancyStrategy, tenantId, id, routingKey )
+				assembleDocuments( multiTenancyStrategy, tenantId, id, routingKey )
 		);
 	}
 
-	private List<Document> assembleDocuments(String indexName, MultiTenancyStrategy multiTenancyStrategy,
+	private List<Document> assembleDocuments(MultiTenancyStrategy multiTenancyStrategy,
 			String tenantId, String id, String routingKey) {
 		document.add( MetadataFields.searchableMetadataField( MetadataFields.typeFieldName(), MetadataFields.TYPE_MAIN_DOCUMENT ) );
 		document.add( MetadataFields.searchableRetrievableMetadataField( MetadataFields.idFieldName(), id ) );
 
 		// all the ancestors of a subdocument must be added after it
 		List<Document> documents = new ArrayList<>();
-		contribute( indexName, multiTenancyStrategy, tenantId, routingKey, id, documents );
+		contribute( multiTenancyStrategy, tenantId, routingKey, id, documents );
 
 		documents.add( document );
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/common/impl/MetadataFields.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/common/impl/MetadataFields.java
@@ -16,7 +16,6 @@ import org.apache.lucene.util.BytesRef;
 public class MetadataFields {
 
 	private static final FieldType METADATA_FIELD_TYPE_WITH_INDEX;
-	private static final FieldType METADATA_FIELD_TYPE_WITH_DOCVALUES;
 	private static final FieldType METADATA_FIELD_TYPE_WITH_INDEX_WITH_DOCVALUES;
 	static {
 		METADATA_FIELD_TYPE_WITH_INDEX = new FieldType();
@@ -24,13 +23,6 @@ public class MetadataFields {
 		METADATA_FIELD_TYPE_WITH_INDEX.setOmitNorms( true );
 		METADATA_FIELD_TYPE_WITH_INDEX.setIndexOptions( IndexOptions.DOCS );
 		METADATA_FIELD_TYPE_WITH_INDEX.freeze();
-
-		METADATA_FIELD_TYPE_WITH_DOCVALUES = new FieldType( METADATA_FIELD_TYPE_WITH_INDEX );
-		METADATA_FIELD_TYPE_WITH_DOCVALUES.setTokenized( false );
-		METADATA_FIELD_TYPE_WITH_DOCVALUES.setOmitNorms( true );
-		METADATA_FIELD_TYPE_WITH_DOCVALUES.setIndexOptions( IndexOptions.NONE );
-		METADATA_FIELD_TYPE_WITH_DOCVALUES.setDocValuesType( DocValuesType.BINARY );
-		METADATA_FIELD_TYPE_WITH_DOCVALUES.freeze();
 
 		METADATA_FIELD_TYPE_WITH_INDEX_WITH_DOCVALUES = new FieldType();
 		METADATA_FIELD_TYPE_WITH_INDEX_WITH_DOCVALUES.setTokenized( false );
@@ -57,10 +49,6 @@ public class MetadataFields {
 	public static final String TYPE_MAIN_DOCUMENT = "main";
 
 	public static final String TYPE_CHILD_DOCUMENT = "child";
-
-	private static final String ROOT_ID_FIELD_NAME = internalFieldName( "root_id" );
-
-	private static final String ROOT_INDEX_FIELD_NAME = internalFieldName( "root_index" );
 
 	private static final String NESTED_DOCUMENT_PATH = internalFieldName( "nested_document_path" );
 
@@ -91,10 +79,6 @@ public class MetadataFields {
 		return new Field( name, new BytesRef( value ), METADATA_FIELD_TYPE_WITH_INDEX_WITH_DOCVALUES );
 	}
 
-	public static IndexableField retrievableMetadataField(String name, String value) {
-		return new Field( name, new BytesRef( value ), METADATA_FIELD_TYPE_WITH_DOCVALUES );
-	}
-
 	public static String idFieldName() {
 		return ID_FIELD_NAME;
 	}
@@ -113,14 +97,6 @@ public class MetadataFields {
 
 	public static String fieldNamesFieldName() {
 		return FIELD_NAMES_FIELD_NAME;
-	}
-
-	public static String rootIdFieldName() {
-		return ROOT_ID_FIELD_NAME;
-	}
-
-	public static String rootIndexFieldName() {
-		return ROOT_INDEX_FIELD_NAME;
 	}
 
 	public static String nestedDocumentPathFieldName() {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneExplainWork.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneExplainWork.java
@@ -12,16 +12,15 @@ import java.lang.invoke.MethodHandles;
 import org.hibernate.search.backend.lucene.logging.impl.Log;
 import org.hibernate.search.backend.lucene.lowlevel.query.impl.MappedTypeNameQuery;
 import org.hibernate.search.backend.lucene.lowlevel.common.impl.MetadataFields;
+import org.hibernate.search.backend.lucene.lowlevel.query.impl.Queries;
 import org.hibernate.search.util.common.AssertionFailure;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
-import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
 
 class LuceneExplainWork implements LuceneReadWork<Explanation> {
@@ -79,7 +78,8 @@ class LuceneExplainWork implements LuceneReadWork<Explanation> {
 
 	private Query createExplainedDocumentQuery(LuceneReadWorkExecutionContext context) {
 		BooleanQuery.Builder builder = new BooleanQuery.Builder()
-				.add( new TermQuery( new Term( MetadataFields.idFieldName(), explainedDocumentId ) ), BooleanClause.Occur.FILTER )
+				.add( Queries.mainDocumentQuery(), BooleanClause.Occur.FILTER )
+				.add( Queries.term( MetadataFields.idFieldName(), explainedDocumentId ), BooleanClause.Occur.FILTER )
 				.add( new MappedTypeNameQuery( context.getIndexReaderMetadataResolver(), explainedDocumentIndexName ), BooleanClause.Occur.FILTER );
 		if ( explainedDocumentFilter != null ) {
 			builder.add( explainedDocumentFilter, BooleanClause.Occur.FILTER );

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/testsupport/util/LuceneIndexContentUtils.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/testsupport/util/LuceneIndexContentUtils.java
@@ -1,0 +1,73 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.lucene.testsupport.util;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
+
+import org.junit.rules.TemporaryFolder;
+
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+import org.assertj.core.api.iterable.ThrowingExtractor;
+
+public final class LuceneIndexContentUtils {
+
+	private LuceneIndexContentUtils() {
+	}
+
+	public static <T> T doOnIndexCopy(SearchSetupHelper setupHelper, TemporaryFolder temporaryFolder,
+			String indexName, ThrowingExtractor<DirectoryReader, T, IOException> action) throws IOException {
+		Path indexCopyPath = temporaryFolder.getRoot().toPath().resolve( indexName + "_copy" );
+
+		T result;
+		LuceneTckBackendAccessor accessor = (LuceneTckBackendAccessor) setupHelper.getBackendAccessor();
+		try {
+			// Copy the index to be able to open a directory despite the lock
+			accessor.copyIndexContent( indexCopyPath, indexName );
+
+			try ( Directory directory = FSDirectory.open( indexCopyPath );
+					DirectoryReader reader = DirectoryReader.open( directory ) ) {
+				result = action.apply( reader );
+			}
+		}
+		finally {
+			try {
+				deleteRecursively( indexCopyPath );
+			}
+			catch (RuntimeException | IOException e) {
+				System.out.println( "Could not delete '" + indexCopyPath + "': " + e );
+			}
+		}
+
+		return result;
+	}
+
+	public static void deleteRecursively(Path path) throws IOException {
+		Files.walkFileTree( path, new SimpleFileVisitor<Path>() {
+			@Override
+			public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+				Files.delete( file );
+				return FileVisitResult.CONTINUE;
+			}
+
+			@Override
+			public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+				Files.deleteIfExists( dir );
+				return FileVisitResult.CONTINUE;
+			}
+		} );
+	}
+
+}

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/work/LuceneIndexingNestedIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/work/LuceneIndexingNestedIT.java
@@ -1,0 +1,188 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.lucene.work;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.referenceProvider;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import org.hibernate.search.backend.lucene.cfg.LuceneBackendSettings;
+import org.hibernate.search.backend.lucene.multitenancy.MultiTenancyStrategyName;
+import org.hibernate.search.engine.backend.document.DocumentElement;
+import org.hibernate.search.engine.backend.document.IndexFieldReference;
+import org.hibernate.search.engine.backend.document.IndexObjectFieldReference;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectField;
+import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
+import org.hibernate.search.integrationtest.backend.lucene.testsupport.util.LuceneIndexContentUtils;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubBackendSessionContext;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingIndexManager;
+import org.hibernate.search.util.impl.test.annotation.TestForIssue;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Test indexing, and more importantly updates and deletions,
+ * when nested documents are involved.
+ */
+@TestForIssue(jiraKey = "HSEARCH-3834")
+public class LuceneIndexingNestedIT {
+
+	private static final String INDEX_NAME = "indexName";
+
+	@Rule
+	public SearchSetupHelper setupHelper = new SearchSetupHelper();
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	private IndexMapping indexMapping;
+	private StubMappingIndexManager indexManager;
+
+	private StubBackendSessionContext sessionContext;
+
+	@Test
+	public void add() throws IOException {
+		setup( MultiTenancyStrategyName.NONE );
+
+		assertThat( countWithField( "nestedObject.field1" ) ).isEqualTo( 1 );
+	}
+
+	@Test
+	public void update_byTerm() throws IOException {
+		// No multitenancy, which means the backend will use indexWriter.updateDocuments(Term, Iterable) for updates
+		setup( MultiTenancyStrategyName.NONE );
+
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan( sessionContext );
+		plan.update( referenceProvider( "1" ), document -> {
+			DocumentElement nested = document.addObject( indexMapping.nestedObject.self );
+			nested.addValue( indexMapping.nestedObject.field2, "value" );
+		} );
+		plan.execute().join();
+
+		assertThat( countWithField( "nestedObject.field2" ) ).isEqualTo( 1 );
+		// This used to fail before HSEARCH-3834, because the nested document was left in the index.
+		assertThat( countWithField( "nestedObject.field1" ) ).isEqualTo( 0 );
+	}
+
+	@Test
+	public void update_byQuery() throws IOException {
+		// Multitenancy enabled, which means the backend will use
+		// indexWriter.deleteDocuments(Query) then indexWriter.addDocument for updates
+		setup( MultiTenancyStrategyName.DISCRIMINATOR );
+
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan( sessionContext );
+		plan.update( referenceProvider( "1" ), document -> {
+			DocumentElement nested = document.addObject( indexMapping.nestedObject.self );
+			nested.addValue( indexMapping.nestedObject.field2, "value" );
+		} );
+		plan.execute().join();
+
+		assertThat( countWithField( "nestedObject.field2" ) ).isEqualTo( 1 );
+		// This used to fail before HSEARCH-3834, because the nested document was left in the index.
+		assertThat( countWithField( "nestedObject.field1" ) ).isEqualTo( 0 );
+	}
+
+	@Test
+	public void delete_byTerm() throws IOException {
+		// No multitenancy, which means the backend will use indexWriter.deleteDocuments(Term) for deletion
+		setup( MultiTenancyStrategyName.NONE );
+
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan( sessionContext );
+		plan.delete( referenceProvider( "1" ) );
+		plan.execute().join();
+
+		// This used to fail before HSEARCH-3834, because the nested document was left in the index.
+		assertThat( countWithField( "nestedObject.field1" ) ).isEqualTo( 0 );
+	}
+
+	@Test
+	public void delete_byQuery() throws IOException {
+		// Multitenancy enabled, which means the backend will use indexWriter.deleteDocuments(Query) for deletion
+		setup( MultiTenancyStrategyName.DISCRIMINATOR );
+
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan( sessionContext );
+		plan.delete( referenceProvider( "1" ) );
+		plan.execute().join();
+
+		// This used to fail before HSEARCH-3834, because the nested document was left in the index.
+		assertThat( countWithField( "nestedObject.field1" ) ).isEqualTo( 0 );
+	}
+
+	@Test
+	public void purge() throws IOException {
+		setup( MultiTenancyStrategyName.NONE );
+
+		indexManager.createWorkspace( sessionContext ).purge( Collections.emptySet() ).join();
+		indexManager.createWorkspace( sessionContext ).refresh().join();
+
+		assertThat( countWithField( "nestedObject.field1" ) ).isEqualTo( 0 );
+	}
+
+	private void setup(MultiTenancyStrategyName multiTenancyStrategyName) throws IOException {
+		setupHelper.start()
+				.withBackendProperty( LuceneBackendSettings.MULTI_TENANCY_STRATEGY, multiTenancyStrategyName )
+				.withIndex(
+						INDEX_NAME,
+						ctx -> this.indexMapping = new IndexMapping( ctx.getSchemaElement() ),
+						indexManager -> this.indexManager = indexManager
+				)
+				.setup();
+
+		assertThat( countWithField( "field1" ) ).isEqualTo( 0 );
+
+		if ( MultiTenancyStrategyName.NONE.equals( multiTenancyStrategyName ) ) {
+			sessionContext = new StubBackendSessionContext();
+		}
+		else {
+			sessionContext = new StubBackendSessionContext( "someTenantId" );
+		}
+
+		IndexIndexingPlan<? extends DocumentElement> plan = indexManager.createIndexingPlan( sessionContext );
+		plan.add( referenceProvider( "1" ), document -> {
+			DocumentElement nested = document.addObject( indexMapping.nestedObject.self );
+			nested.addValue( indexMapping.nestedObject.field1, "value" );
+		} );
+		plan.execute().join();
+	}
+
+	private int countWithField(String absoluteFieldPath) throws IOException {
+		return LuceneIndexContentUtils.doOnIndexCopy(
+				setupHelper, temporaryFolder, INDEX_NAME,
+				reader -> reader.getDocCount( absoluteFieldPath )
+		);
+	}
+
+	private static class IndexMapping {
+		final ObjectMapping nestedObject;
+
+		IndexMapping(IndexSchemaElement root) {
+			IndexSchemaObjectField nestedObjectField =
+					root.objectField( "nestedObject", ObjectFieldStorage.NESTED )
+							.multiValued();
+			nestedObject = new ObjectMapping( nestedObjectField );
+		}
+	}
+
+	private static class ObjectMapping {
+		final IndexObjectFieldReference self;
+		final IndexFieldReference<String> field1;
+		final IndexFieldReference<String> field2;
+
+		ObjectMapping(IndexSchemaObjectField objectField) {
+			self = objectField.toReference();
+			field1 = objectField.field( "field1", f -> f.asString() ).toReference();
+			field2 = objectField.field( "field2", f -> f.asString() ).toReference();
+		}
+	}
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexingFieldTypesIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexingFieldTypesIT.java
@@ -42,7 +42,7 @@ import org.junit.runners.Parameterized;
  * @param <F> The type of field values.
  */
 @RunWith(Parameterized.class)
-public class IndexingIT<F> {
+public class IndexingFieldTypesIT<F> {
 
 	private static final String INDEX_NAME = "IndexName";
 
@@ -62,7 +62,7 @@ public class IndexingIT<F> {
 	private IndexMapping indexMapping;
 	private StubMappingIndexManager indexManager;
 
-	public IndexingIT(FieldTypeDescriptor<F> typeDescriptor, Optional<IndexingExpectations<F>> expectations) {
+	public IndexingFieldTypesIT(FieldTypeDescriptor<F> typeDescriptor, Optional<IndexingExpectations<F>> expectations) {
 		Assume.assumeTrue(
 				"Type " + typeDescriptor + " does not define indexing expectations", expectations.isPresent()
 		);


### PR DESCRIPTION
* [HSEARCH-3834](https://hibernate.atlassian.net/browse/HSEARCH-3834): Nested documents are never deleted
* [HSEARCH-3835](https://hibernate.atlassian.net/browse/HSEARCH-3835): Remove the unused "__HSEARCH_root_index_name" and "__HSEARCH_root_id" fields from nested documents

Based on #2212 , which should be merged first.