### PR TITLE
HSEARCH-3851 + HSEARCH-3852 Bugfixes for indexing failure reporting

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/impl/ElasticsearchIndexManagerImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/impl/ElasticsearchIndexManagerImpl.java
@@ -183,15 +183,16 @@ class ElasticsearchIndexManagerImpl implements IndexManagerImplementor,
 	}
 
 	@Override
-	public IndexIndexingPlan createIndexingPlan(BackendSessionContext sessionContext,
-			EntityReferenceFactory<?> entityReferenceFactory,
+	public <R> IndexIndexingPlan<R> createIndexingPlan(BackendSessionContext sessionContext,
+			EntityReferenceFactory<R> entityReferenceFactory,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
 		// The commit strategy is ignored, because Elasticsearch always commits changes to its transaction log.
 		return backendContext.createIndexingPlan(
 				serialOrchestrator,
 				this,
-				refreshStrategy,
-				sessionContext
+				sessionContext,
+				entityReferenceFactory,
+				refreshStrategy
 		);
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/impl/ElasticsearchIndexManagerImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/impl/ElasticsearchIndexManagerImpl.java
@@ -25,6 +25,7 @@ import org.hibernate.search.backend.elasticsearch.logging.impl.Log;
 import org.hibernate.search.backend.elasticsearch.orchestration.impl.ElasticsearchWorkOrchestratorImplementor;
 import org.hibernate.search.backend.elasticsearch.util.spi.URLEncodedString;
 import org.hibernate.search.backend.elasticsearch.work.execution.impl.WorkExecutionIndexManagerContext;
+import org.hibernate.search.engine.backend.common.spi.EntityReferenceFactory;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.index.IndexManager;
 import org.hibernate.search.engine.backend.index.spi.IndexManagerStartContext;
@@ -183,6 +184,7 @@ class ElasticsearchIndexManagerImpl implements IndexManagerImplementor,
 
 	@Override
 	public IndexIndexingPlan createIndexingPlan(BackendSessionContext sessionContext,
+			EntityReferenceFactory<?> entityReferenceFactory,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
 		// The commit strategy is ignored, because Elasticsearch always commits changes to its transaction log.
 		return backendContext.createIndexingPlan(

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/impl/IndexManagerBackendContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/impl/IndexManagerBackendContext.java
@@ -28,6 +28,7 @@ import org.hibernate.search.backend.elasticsearch.work.execution.impl.Elasticsea
 import org.hibernate.search.backend.elasticsearch.work.execution.impl.ElasticsearchIndexWorkspace;
 import org.hibernate.search.backend.elasticsearch.work.execution.impl.WorkExecutionBackendContext;
 import org.hibernate.search.backend.elasticsearch.work.execution.impl.WorkExecutionIndexManagerContext;
+import org.hibernate.search.engine.backend.common.spi.EntityReferenceFactory;
 import org.hibernate.search.engine.backend.mapping.spi.BackendMappingContext;
 import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
 import org.hibernate.search.engine.backend.session.spi.DetachedBackendSessionContext;
@@ -78,18 +79,19 @@ public class IndexManagerBackendContext implements SearchBackendContext, WorkExe
 	}
 
 	@Override
-	public IndexIndexingPlan createIndexingPlan(
+	public <R> IndexIndexingPlan<R> createIndexingPlan(
 			ElasticsearchWorkOrchestrator orchestrator,
 			WorkExecutionIndexManagerContext indexManagerContext,
-			DocumentRefreshStrategy refreshStrategy,
-			BackendSessionContext sessionContext) {
+			BackendSessionContext sessionContext, EntityReferenceFactory<R> entityReferenceFactory,
+			DocumentRefreshStrategy refreshStrategy) {
 		multiTenancyStrategy.checkTenantId( sessionContext.getTenantIdentifier(), eventContext );
 
-		return new ElasticsearchIndexIndexingPlan(
+		return new ElasticsearchIndexIndexingPlan<>(
 				link.getWorkBuilderFactory(), orchestrator,
 				indexManagerContext,
-				refreshStrategy,
-				sessionContext
+				sessionContext,
+				entityReferenceFactory,
+				refreshStrategy
 		);
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/builder/factory/impl/Elasticsearch67WorkBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/builder/factory/impl/Elasticsearch67WorkBuilderFactory.java
@@ -45,18 +45,19 @@ public class Elasticsearch67WorkBuilderFactory extends Elasticsearch7WorkBuilder
 		super( gsonProvider );
 	}
 
+
 	@Override
-	public IndexWorkBuilder index(String mappedTypeName, URLEncodedString elasticsearchIndexName,
-			URLEncodedString id, String routingKey, JsonObject document) {
-		return IndexWork.Builder.forElasticsearch67AndBelow( mappedTypeName, elasticsearchIndexName,
-				Paths.DOC, id, routingKey, document );
+	public IndexWorkBuilder index(String entityTypeName, Object entityIdentifier,
+			URLEncodedString elasticsearchIndexName, URLEncodedString id, String routingKey, JsonObject document) {
+		return IndexWork.Builder.forElasticsearch67AndBelow( entityTypeName, entityIdentifier,
+				elasticsearchIndexName, Paths.DOC, id, routingKey, document );
 	}
 
 	@Override
-	public DeleteWorkBuilder delete(String mappedTypeName, URLEncodedString elasticsearchIndexName,
-			URLEncodedString id, String routingKey) {
-		return DeleteWork.Builder.forElasticsearch67AndBelow( mappedTypeName, elasticsearchIndexName,
-				Paths.DOC, id, routingKey );
+	public DeleteWorkBuilder delete(String entityTypeName, Object entityIdentifier,
+			URLEncodedString elasticsearchIndexName, URLEncodedString id, String routingKey) {
+		return DeleteWork.Builder.forElasticsearch67AndBelow( entityTypeName, entityIdentifier,
+				elasticsearchIndexName, Paths.DOC, id, routingKey );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/builder/factory/impl/Elasticsearch7WorkBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/builder/factory/impl/Elasticsearch7WorkBuilderFactory.java
@@ -75,17 +75,17 @@ public class Elasticsearch7WorkBuilderFactory implements ElasticsearchWorkBuilde
 	}
 
 	@Override
-	public IndexWorkBuilder index(String mappedTypeName, URLEncodedString elasticsearchIndexName,
-			URLEncodedString id, String routingKey, JsonObject document) {
-		return IndexWork.Builder.forElasticsearch7AndAbove( mappedTypeName, elasticsearchIndexName,
-				id, routingKey, document );
+	public IndexWorkBuilder index(String entityTypeName, Object entityIdentifier,
+			URLEncodedString elasticsearchIndexName, URLEncodedString id, String routingKey, JsonObject document) {
+		return IndexWork.Builder.forElasticsearch7AndAbove( entityTypeName, entityIdentifier,
+				elasticsearchIndexName, id, routingKey, document );
 	}
 
 	@Override
-	public DeleteWorkBuilder delete(String mappedTypeName, URLEncodedString elasticsearchIndexName,
-			URLEncodedString id, String routingKey) {
-		return DeleteWork.Builder.forElasticsearch7AndAbove( mappedTypeName, elasticsearchIndexName,
-				id, routingKey );
+	public DeleteWorkBuilder delete(String entityTypeName, Object entityIdentifier,
+			URLEncodedString elasticsearchIndexName, URLEncodedString id, String routingKey) {
+		return DeleteWork.Builder.forElasticsearch7AndAbove( entityTypeName, entityIdentifier,
+				elasticsearchIndexName, id, routingKey );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/builder/factory/impl/ElasticsearchWorkBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/builder/factory/impl/ElasticsearchWorkBuilderFactory.java
@@ -44,11 +44,11 @@ import com.google.gson.JsonObject;
 
 public interface ElasticsearchWorkBuilderFactory {
 
-	IndexWorkBuilder index(String mappedTypeName, URLEncodedString elasticsearchIndexName,
-			URLEncodedString id, String routingKey, JsonObject document);
+	IndexWorkBuilder index(String entityTypeName, Object entityIdentifier,
+			URLEncodedString elasticsearchIndexName, URLEncodedString id, String routingKey, JsonObject document);
 
-	DeleteWorkBuilder delete(String mappedTypeName, URLEncodedString elasticsearchIndexName,
-			URLEncodedString id, String routingKey);
+	DeleteWorkBuilder delete(String entityTypeName, Object entityIdentifier,
+			URLEncodedString elasticsearchIndexName, URLEncodedString id, String routingKey);
 
 	DeleteByQueryWorkBuilder deleteByQuery(URLEncodedString indexName, JsonObject payload);
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/execution/impl/ElasticsearchIndexIndexer.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/execution/impl/ElasticsearchIndexIndexer.java
@@ -46,7 +46,7 @@ public class ElasticsearchIndexIndexer implements IndexIndexer {
 		JsonObject document = indexManagerContext.createDocument( tenantId, id, documentContributor );
 
 		ElasticsearchWork<Void> work = factory.index(
-				indexManagerContext.getMappedTypeName(),
+				indexManagerContext.getMappedTypeName(), referenceProvider.getEntityIdentifier(),
 				indexManagerContext.getElasticsearchIndexWriteName(),
 				URLEncodedString.fromString( elasticsearchId ), routingKey, document
 		)

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/execution/impl/WorkExecutionBackendContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/execution/impl/WorkExecutionBackendContext.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.backend.elasticsearch.work.execution.impl;
 
 import org.hibernate.search.backend.elasticsearch.orchestration.impl.ElasticsearchWorkOrchestrator;
+import org.hibernate.search.engine.backend.common.spi.EntityReferenceFactory;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
@@ -27,11 +28,11 @@ import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
  */
 public interface WorkExecutionBackendContext {
 
-	IndexIndexingPlan createIndexingPlan(
+	<R> IndexIndexingPlan<R> createIndexingPlan(
 			ElasticsearchWorkOrchestrator orchestrator,
 			WorkExecutionIndexManagerContext indexManagerContext,
-			DocumentRefreshStrategy refreshStrategy,
-			BackendSessionContext sessionContext);
+			BackendSessionContext sessionContext, EntityReferenceFactory<R> entityReferenceFactory,
+			DocumentRefreshStrategy refreshStrategy);
 
 	IndexIndexer createIndexer(
 			ElasticsearchWorkOrchestrator orchestrator,

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/AbstractSingleDocumentElasticsearchWork.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/AbstractSingleDocumentElasticsearchWork.java
@@ -20,17 +20,32 @@ import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 import com.google.gson.JsonObject;
 
 
-public abstract class AbstractSimpleBulkableElasticsearchWork<R>
+public abstract class AbstractSingleDocumentElasticsearchWork<R>
 		extends AbstractSimpleElasticsearchWork<R>
-		implements BulkableElasticsearchWork<R> {
+		implements BulkableElasticsearchWork<R>, SingleDocumentElasticsearchWork<R> {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private final JsonObject bulkableActionMetadata;
 
-	protected AbstractSimpleBulkableElasticsearchWork(AbstractBuilder<?> builder) {
+	private final String entityTypeName;
+	private final Object entityIdentifier;
+
+	protected AbstractSingleDocumentElasticsearchWork(AbstractBuilder<?> builder) {
 		super( builder );
 		this.bulkableActionMetadata = builder.buildBulkableActionMetadata();
+		this.entityTypeName = builder.entityTypeName;
+		this.entityIdentifier = builder.entityIdentifier;
+	}
+
+	@Override
+	public String getEntityTypeName() {
+		return entityTypeName;
+	}
+
+	@Override
+	public Object getEntityIdentifier() {
+		return entityIdentifier;
 	}
 
 	@Override
@@ -107,8 +122,14 @@ public abstract class AbstractSimpleBulkableElasticsearchWork<R>
 	protected abstract static class AbstractBuilder<B>
 			extends AbstractSimpleElasticsearchWork.AbstractBuilder<B> {
 
-		public AbstractBuilder(URLEncodedString dirtiedIndexName, ElasticsearchRequestSuccessAssessor resultAssessor) {
+		private final String entityTypeName;
+		private final Object entityIdentifier;
+
+		public AbstractBuilder(URLEncodedString dirtiedIndexName, ElasticsearchRequestSuccessAssessor resultAssessor,
+				String entityTypeName, Object entityIdentifier) {
 			super( dirtiedIndexName, resultAssessor );
+			this.entityTypeName = entityTypeName;
+			this.entityIdentifier = entityIdentifier;
 		}
 
 		protected abstract JsonObject buildBulkableActionMetadata();

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/DeleteWork.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/DeleteWork.java
@@ -9,27 +9,19 @@ package org.hibernate.search.backend.elasticsearch.work.impl;
 import org.hibernate.search.backend.elasticsearch.client.impl.Paths;
 import org.hibernate.search.backend.elasticsearch.client.spi.ElasticsearchRequest;
 import org.hibernate.search.backend.elasticsearch.client.spi.ElasticsearchResponse;
-import org.hibernate.search.backend.elasticsearch.search.impl.ElasticsearchDocumentReference;
 import org.hibernate.search.backend.elasticsearch.util.spi.URLEncodedString;
 import org.hibernate.search.backend.elasticsearch.work.builder.impl.DeleteWorkBuilder;
-import org.hibernate.search.engine.backend.common.DocumentReference;
 
 import com.google.gson.JsonObject;
 
 
-public class DeleteWork extends AbstractSimpleBulkableElasticsearchWork<Void>
-		implements SingleDocumentElasticsearchWork<Void> {
+public class DeleteWork extends AbstractSingleDocumentElasticsearchWork<Void> {
 
 	private static final ElasticsearchRequestSuccessAssessor SUCCESS_ASSESSOR =
 			DefaultElasticsearchRequestSuccessAssessor.builder().ignoreErrorStatuses( 404 ).build();
 
-	private final String mappedTypeName;
-	private final URLEncodedString id;
-
 	private DeleteWork(Builder builder) {
 		super( builder );
-		this.mappedTypeName = builder.mappedTypeName;
-		this.id = builder.id;
 	}
 
 	@Override
@@ -42,34 +34,30 @@ public class DeleteWork extends AbstractSimpleBulkableElasticsearchWork<Void>
 		return null;
 	}
 
-	@Override
-	public DocumentReference getDocumentReference() {
-		return new ElasticsearchDocumentReference( mappedTypeName, id.original );
-	}
-
 	public static class Builder
-			extends AbstractSimpleBulkableElasticsearchWork.AbstractBuilder<Builder>
+			extends AbstractSingleDocumentElasticsearchWork.AbstractBuilder<Builder>
 			implements DeleteWorkBuilder {
-		private final String mappedTypeName;
 		private final URLEncodedString indexName;
 		private final URLEncodedString typeName;
 		private final URLEncodedString id;
 		private final String routingKey;
 
-		public static Builder forElasticsearch67AndBelow(String mappedTypeName,
+		public static Builder forElasticsearch67AndBelow(String entityTypeName, Object entityIdentifier,
 				URLEncodedString elasticsearchIndexName, URLEncodedString typeName, URLEncodedString id, String routingKey) {
-			return new Builder( mappedTypeName, elasticsearchIndexName, typeName, id, routingKey );
+			return new Builder( entityTypeName, entityIdentifier,
+					elasticsearchIndexName, typeName, id, routingKey );
 		}
 
-		public static Builder forElasticsearch7AndAbove(String mappedTypeName,
+		public static Builder forElasticsearch7AndAbove(String entityTypeName, Object entityIdentifier,
 				URLEncodedString elasticsearchIndexName, URLEncodedString id, String routingKey) {
-			return new Builder( mappedTypeName, elasticsearchIndexName, null, id, routingKey );
+			return new Builder( entityTypeName, entityIdentifier,
+					elasticsearchIndexName, null, id, routingKey );
 		}
 
-		private Builder(String mappedTypeName, URLEncodedString elasticsearchIndexName,
+		private Builder(String entityTypeName, Object entityIdentifier,
+				URLEncodedString elasticsearchIndexName,
 				URLEncodedString typeName, URLEncodedString id, String routingKey) {
-			super( elasticsearchIndexName, SUCCESS_ASSESSOR );
-			this.mappedTypeName = mappedTypeName;
+			super( elasticsearchIndexName, SUCCESS_ASSESSOR, entityTypeName, entityIdentifier );
 			this.indexName = elasticsearchIndexName;
 			this.typeName = typeName;
 			this.id = id;

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/IndexWork.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/IndexWork.java
@@ -9,24 +9,17 @@ package org.hibernate.search.backend.elasticsearch.work.impl;
 import org.hibernate.search.backend.elasticsearch.client.impl.Paths;
 import org.hibernate.search.backend.elasticsearch.client.spi.ElasticsearchRequest;
 import org.hibernate.search.backend.elasticsearch.client.spi.ElasticsearchResponse;
-import org.hibernate.search.backend.elasticsearch.search.impl.ElasticsearchDocumentReference;
 import org.hibernate.search.backend.elasticsearch.util.spi.URLEncodedString;
 import org.hibernate.search.backend.elasticsearch.work.builder.impl.IndexWorkBuilder;
-import org.hibernate.search.engine.backend.common.DocumentReference;
 
 import com.google.gson.JsonObject;
 
 
-public class IndexWork extends AbstractSimpleBulkableElasticsearchWork<Void>
+public class IndexWork extends AbstractSingleDocumentElasticsearchWork<Void>
 		implements SingleDocumentElasticsearchWork<Void> {
-
-	private final String mappedTypeName;
-	private final URLEncodedString id;
 
 	private IndexWork(Builder builder) {
 		super( builder );
-		this.mappedTypeName = builder.mappedTypeName;
-		this.id = builder.id;
 	}
 
 	@Override
@@ -39,37 +32,33 @@ public class IndexWork extends AbstractSimpleBulkableElasticsearchWork<Void>
 		return null;
 	}
 
-	@Override
-	public DocumentReference getDocumentReference() {
-		return new ElasticsearchDocumentReference( mappedTypeName, id.original );
-	}
-
 	public static class Builder
-			extends AbstractSimpleBulkableElasticsearchWork.AbstractBuilder<Builder>
+			extends AbstractSingleDocumentElasticsearchWork.AbstractBuilder<Builder>
 			implements IndexWorkBuilder {
-		private final String mappedTypeName;
 		private final URLEncodedString indexName;
 		private final URLEncodedString typeName;
 		private final URLEncodedString id;
 		private final String routingKey;
 		private final JsonObject document;
 
-		public static Builder forElasticsearch67AndBelow(String mappedTypeName,
+		public static Builder forElasticsearch67AndBelow(String entityTypeName, Object entityIdentifier,
 				URLEncodedString elasticsearchIndexName, URLEncodedString typeName, URLEncodedString id, String routingKey,
 				JsonObject document) {
-			return new Builder( mappedTypeName, elasticsearchIndexName, typeName, id, routingKey, document );
+			return new Builder( entityTypeName, entityIdentifier,
+					elasticsearchIndexName, typeName, id, routingKey, document );
 		}
 
-		public static Builder forElasticsearch7AndAbove(String mappedTypeName,
+		public static Builder forElasticsearch7AndAbove(String entityTypeName, Object entityIdentifier,
 				URLEncodedString elasticsearchIndexName, URLEncodedString id, String routingKey,
 				JsonObject document) {
-			return new Builder( mappedTypeName, elasticsearchIndexName, null, id, routingKey, document );
+			return new Builder( entityTypeName, entityIdentifier,
+					elasticsearchIndexName, null, id, routingKey, document );
 		}
 
-		private Builder(String mappedTypeName, URLEncodedString elasticsearchIndexName,
+		private Builder(String entityTypeName, Object entityIdentifier, URLEncodedString elasticsearchIndexName,
 					URLEncodedString typeName, URLEncodedString id, String routingKey, JsonObject document) {
-			super( elasticsearchIndexName, DefaultElasticsearchRequestSuccessAssessor.INSTANCE );
-			this.mappedTypeName = mappedTypeName;
+			super( elasticsearchIndexName, DefaultElasticsearchRequestSuccessAssessor.INSTANCE,
+					entityTypeName, entityIdentifier );
 			this.indexName = elasticsearchIndexName;
 			this.typeName = typeName;
 			this.id = id;

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/SingleDocumentElasticsearchWork.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/work/impl/SingleDocumentElasticsearchWork.java
@@ -6,11 +6,10 @@
  */
 package org.hibernate.search.backend.elasticsearch.work.impl;
 
-import org.hibernate.search.engine.backend.common.DocumentReference;
-
-
 public interface SingleDocumentElasticsearchWork<T> extends ElasticsearchWork<T> {
 
-	DocumentReference getDocumentReference();
+	String getEntityTypeName();
+
+	Object getEntityIdentifier();
 
 }

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/work/execution/impl/ElasticsearchIndexingPlanWorkSetTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/work/execution/impl/ElasticsearchIndexingPlanWorkSetTest.java
@@ -11,12 +11,12 @@ import static org.easymock.EasyMock.expect;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.search.backend.elasticsearch.orchestration.impl.ElasticsearchWorkProcessor;
-import org.hibernate.search.backend.elasticsearch.search.impl.ElasticsearchDocumentReference;
 import org.hibernate.search.backend.elasticsearch.work.impl.SingleDocumentElasticsearchWork;
-import org.hibernate.search.engine.backend.common.DocumentReference;
+import org.hibernate.search.engine.backend.common.spi.EntityReferenceFactory;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlanExecutionReport;
 import org.hibernate.search.util.impl.test.FutureAssert;
 
@@ -31,11 +31,14 @@ import org.easymock.EasyMockSupport;
  */
 public class ElasticsearchIndexingPlanWorkSetTest extends EasyMockSupport {
 
-	private static final String INDEX_NAME = "SomeIndexName";
+	private static final String TYPE_NAME = "SomeTypeName";
 
 	private ElasticsearchWorkProcessor processorMock = createStrictMock( ElasticsearchWorkProcessor.class );
 
 	private List<SingleDocumentElasticsearchWork<Void>> workMocks = new ArrayList<>();
+
+	private EntityReferenceFactory<StubEntityReference> entityReferenceFactoryMock =
+			createStrictMock( EntityReferenceFactory.class );
 
 	@Test
 	public void success() {
@@ -43,10 +46,11 @@ public class ElasticsearchIndexingPlanWorkSetTest extends EasyMockSupport {
 		CompletableFuture<Void> work1Future = new CompletableFuture<>();
 		CompletableFuture<Void> work2Future = new CompletableFuture<>();
 		CompletableFuture<Void> workSequenceFuture = new CompletableFuture<>();
-		CompletableFuture<IndexIndexingPlanExecutionReport> workSetFuture = new CompletableFuture<>();
+		CompletableFuture<IndexIndexingPlanExecutionReport<StubEntityReference>> workSetFuture =
+				new CompletableFuture<>();
 
-		ElasticsearchIndexingPlanWorkSet workSet = new ElasticsearchIndexingPlanWorkSet(
-				createWorkMocks( 3 ), workSetFuture
+		ElasticsearchIndexingPlanWorkSet<StubEntityReference> workSet = new ElasticsearchIndexingPlanWorkSet<>(
+				createWorkMocks( 3 ), entityReferenceFactoryMock, workSetFuture
 		);
 
 		FutureAssert.assertThat( workSetFuture ).isPending();
@@ -79,17 +83,18 @@ public class ElasticsearchIndexingPlanWorkSetTest extends EasyMockSupport {
 			assertThat( report ).isNotNull();
 			SoftAssertions.assertSoftly( softly -> {
 				softly.assertThat( report.getThrowable() ).isEmpty();
-				softly.assertThat( report.getFailingDocuments() ).isEmpty();
+				softly.assertThat( report.getFailingEntityReferences() ).isEmpty();
 			} );
 		} );
 	}
 
 	@Test
 	public void markAsFailed() {
-		CompletableFuture<IndexIndexingPlanExecutionReport> workSetFuture = new CompletableFuture<>();
+		CompletableFuture<IndexIndexingPlanExecutionReport<StubEntityReference>> workSetFuture =
+				new CompletableFuture<>();
 
-		ElasticsearchIndexingPlanWorkSet workSet = new ElasticsearchIndexingPlanWorkSet(
-				createWorkMocks( 3 ), workSetFuture
+		ElasticsearchIndexingPlanWorkSet<StubEntityReference> workSet = new ElasticsearchIndexingPlanWorkSet<>(
+				createWorkMocks( 3 ), entityReferenceFactoryMock, workSetFuture
 		);
 
 		FutureAssert.assertThat( workSetFuture ).isPending();
@@ -110,10 +115,11 @@ public class ElasticsearchIndexingPlanWorkSetTest extends EasyMockSupport {
 		CompletableFuture<Void> work1Future = new CompletableFuture<>();
 		CompletableFuture<Void> work2Future = new CompletableFuture<>();
 		CompletableFuture<Void> workSequenceFuture = new CompletableFuture<>();
-		CompletableFuture<IndexIndexingPlanExecutionReport> workSetFuture = new CompletableFuture<>();
+		CompletableFuture<IndexIndexingPlanExecutionReport<StubEntityReference>> workSetFuture =
+				new CompletableFuture<>();
 
-		ElasticsearchIndexingPlanWorkSet workSet = new ElasticsearchIndexingPlanWorkSet(
-				createWorkMocks( 3 ), workSetFuture
+		ElasticsearchIndexingPlanWorkSet<StubEntityReference> workSet = new ElasticsearchIndexingPlanWorkSet<>(
+				createWorkMocks( 3 ), entityReferenceFactoryMock, workSetFuture
 		);
 
 		FutureAssert.assertThat( workSetFuture ).isPending();
@@ -132,7 +138,7 @@ public class ElasticsearchIndexingPlanWorkSetTest extends EasyMockSupport {
 
 		RuntimeException workException = new RuntimeException( "Some message" );
 		resetAll();
-		expectWorkGetInfo( 0, 1, 2 );
+		expectWorkGetInfo( 1 );
 		replayAll();
 		work0Future.complete( null );
 		FutureAssert.assertThat( workSetFuture ).isPending();
@@ -148,10 +154,10 @@ public class ElasticsearchIndexingPlanWorkSetTest extends EasyMockSupport {
 			assertThat( report ).isNotNull();
 			SoftAssertions.assertSoftly( softly -> {
 				softly.assertThat( report.getThrowable() ).containsSame( workException );
-				softly.assertThat( report.getFailingDocuments() )
+				softly.assertThat( report.getFailingEntityReferences() )
 						.containsExactly(
 								// Only documents whose indexing failed
-								docReference( 1 )
+								entityReference( 1 )
 						);
 			} );
 		} );
@@ -165,10 +171,11 @@ public class ElasticsearchIndexingPlanWorkSetTest extends EasyMockSupport {
 		CompletableFuture<Void> work3Future = new CompletableFuture<>();
 		CompletableFuture<Void> work4Future = new CompletableFuture<>();
 		CompletableFuture<Void> workSequenceFuture = new CompletableFuture<>();
-		CompletableFuture<IndexIndexingPlanExecutionReport> workSetFuture = new CompletableFuture<>();
+		CompletableFuture<IndexIndexingPlanExecutionReport<StubEntityReference>> workSetFuture =
+				new CompletableFuture<>();
 
-		ElasticsearchIndexingPlanWorkSet workSet = new ElasticsearchIndexingPlanWorkSet(
-				createWorkMocks( 5 ), workSetFuture
+		ElasticsearchIndexingPlanWorkSet<StubEntityReference> workSet = new ElasticsearchIndexingPlanWorkSet<>(
+				createWorkMocks( 5 ), entityReferenceFactoryMock, workSetFuture
 		);
 
 		FutureAssert.assertThat( workSetFuture ).isPending();
@@ -190,7 +197,7 @@ public class ElasticsearchIndexingPlanWorkSetTest extends EasyMockSupport {
 		RuntimeException work1Exception = new RuntimeException( "Some message" );
 		RuntimeException work3Exception = new RuntimeException( "Some message" );
 		resetAll();
-		expectWorkGetInfo( 0, 1, 2, 3, 4 );
+		expectWorkGetInfo( 1, 3 );
 		replayAll();
 		work0Future.complete( null );
 		FutureAssert.assertThat( workSetFuture ).isPending();
@@ -211,10 +218,10 @@ public class ElasticsearchIndexingPlanWorkSetTest extends EasyMockSupport {
 			SoftAssertions.assertSoftly( softly -> {
 				softly.assertThat( report.getThrowable() ).containsSame( work1Exception );
 				softly.assertThat( work1Exception ).hasSuppressedException( work3Exception );
-				softly.assertThat( report.getFailingDocuments() )
+				softly.assertThat( report.getFailingEntityReferences() )
 						.containsExactly(
 								// Only documents whose indexing failed
-								docReference( 1 ), docReference( 3 )
+								entityReference( 1 ), entityReference( 3 )
 						);
 			} );
 		} );
@@ -226,10 +233,11 @@ public class ElasticsearchIndexingPlanWorkSetTest extends EasyMockSupport {
 		CompletableFuture<Void> work1Future = new CompletableFuture<>();
 		CompletableFuture<Void> work2Future = new CompletableFuture<>();
 		CompletableFuture<Void> workSequenceFuture = new CompletableFuture<>();
-		CompletableFuture<IndexIndexingPlanExecutionReport> workSetFuture = new CompletableFuture<>();
+		CompletableFuture<IndexIndexingPlanExecutionReport<StubEntityReference>> workSetFuture =
+				new CompletableFuture<>();
 
-		ElasticsearchIndexingPlanWorkSet workSet = new ElasticsearchIndexingPlanWorkSet(
-				createWorkMocks( 3 ), workSetFuture
+		ElasticsearchIndexingPlanWorkSet<StubEntityReference> workSet = new ElasticsearchIndexingPlanWorkSet<>(
+				createWorkMocks( 3 ), entityReferenceFactoryMock, workSetFuture
 		);
 
 		FutureAssert.assertThat( workSetFuture ).isPending();
@@ -248,7 +256,6 @@ public class ElasticsearchIndexingPlanWorkSetTest extends EasyMockSupport {
 
 		RuntimeException sequenceException = new RuntimeException( "Some other message" );
 		resetAll();
-		expectWorkGetInfo( 0, 1, 2 );
 		replayAll();
 		work0Future.complete( null );
 		FutureAssert.assertThat( workSetFuture ).isPending();
@@ -264,7 +271,7 @@ public class ElasticsearchIndexingPlanWorkSetTest extends EasyMockSupport {
 			assertThat( report ).isNotNull();
 			SoftAssertions.assertSoftly( softly -> {
 				softly.assertThat( report.getThrowable() ).containsSame( sequenceException );
-				softly.assertThat( report.getFailingDocuments() )
+				softly.assertThat( report.getFailingEntityReferences() )
 						// No indexing failed. Happens for example when forcing refresh fails.
 						.isEmpty();
 			} );
@@ -277,10 +284,11 @@ public class ElasticsearchIndexingPlanWorkSetTest extends EasyMockSupport {
 		CompletableFuture<Void> work1Future = new CompletableFuture<>();
 		CompletableFuture<Void> work2Future = new CompletableFuture<>();
 		CompletableFuture<Void> workSequenceFuture = new CompletableFuture<>();
-		CompletableFuture<IndexIndexingPlanExecutionReport> workSetFuture = new CompletableFuture<>();
+		CompletableFuture<IndexIndexingPlanExecutionReport<StubEntityReference>> workSetFuture =
+				new CompletableFuture<>();
 
-		ElasticsearchIndexingPlanWorkSet workSet = new ElasticsearchIndexingPlanWorkSet(
-				createWorkMocks( 3 ), workSetFuture
+		ElasticsearchIndexingPlanWorkSet<StubEntityReference> workSet = new ElasticsearchIndexingPlanWorkSet<>(
+				createWorkMocks( 3 ), entityReferenceFactoryMock, workSetFuture
 		);
 
 		FutureAssert.assertThat( workSetFuture ).isPending();
@@ -300,7 +308,7 @@ public class ElasticsearchIndexingPlanWorkSetTest extends EasyMockSupport {
 		RuntimeException workException = new RuntimeException( "Some message" );
 		RuntimeException sequenceException = new RuntimeException( "Some other message" );
 		resetAll();
-		expectWorkGetInfo( 0, 1, 2 );
+		expectWorkGetInfo( 1 );
 		replayAll();
 		work0Future.complete( null );
 		FutureAssert.assertThat( workSetFuture ).isPending();
@@ -317,10 +325,10 @@ public class ElasticsearchIndexingPlanWorkSetTest extends EasyMockSupport {
 			SoftAssertions.assertSoftly( softly -> {
 				softly.assertThat( report.getThrowable() ).containsSame( workException );
 				softly.assertThat( workException ).hasSuppressedException( sequenceException );
-				softly.assertThat( report.getFailingDocuments() )
+				softly.assertThat( report.getFailingEntityReferences() )
 						.containsExactly(
 								// Only documents whose indexing failed
-								docReference( 1 )
+								entityReference( 1 )
 						);
 			} );
 		} );
@@ -330,7 +338,10 @@ public class ElasticsearchIndexingPlanWorkSetTest extends EasyMockSupport {
 		for ( int id : ids ) {
 			SingleDocumentElasticsearchWork<?> workMock = workMocks.get( id );
 			EasyMock.expect( workMock.getInfo() ).andStubReturn( workInfo( id ) );
-			EasyMock.expect( workMock.getDocumentReference() ).andStubReturn( docReference( id ) );
+			EasyMock.expect( workMock.getEntityTypeName() ).andStubReturn( TYPE_NAME );
+			EasyMock.expect( workMock.getEntityIdentifier() ).andStubReturn( id );
+			EasyMock.expect( entityReferenceFactoryMock.createEntityReference( TYPE_NAME, id ) )
+					.andReturn( entityReference( id ) );
 		}
 	}
 
@@ -349,12 +360,47 @@ public class ElasticsearchIndexingPlanWorkSetTest extends EasyMockSupport {
 		return workMock;
 	}
 
-	private DocumentReference docReference(int id) {
-		return new ElasticsearchDocumentReference( INDEX_NAME, String.valueOf( id ) );
+	private StubEntityReference entityReference(int id) {
+		return new StubEntityReference( TYPE_NAME, id );
 	}
 
 	private String workInfo(int index) {
 		return "work_" + index;
 	}
 
+	private static class StubEntityReference {
+		private final String typeName;
+		private final Object identifier;
+
+		private StubEntityReference(String typeName, Object identifier) {
+			this.typeName = typeName;
+			this.identifier = identifier;
+		}
+
+		@Override
+		public String toString() {
+			return "StubEntityReference{" +
+					"typeName='" + typeName + '\'' +
+					", identifier=" + identifier +
+					'}';
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			StubEntityReference that = (StubEntityReference) o;
+			return Objects.equals( typeName, that.typeName ) &&
+					Objects.equals( identifier, that.identifier );
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( typeName, identifier );
+		}
+	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/IndexManagerBackendContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/IndexManagerBackendContext.java
@@ -35,6 +35,7 @@ import org.hibernate.search.backend.lucene.work.execution.impl.LuceneIndexWorksp
 import org.hibernate.search.backend.lucene.work.execution.impl.WorkExecutionBackendContext;
 import org.hibernate.search.backend.lucene.work.execution.impl.WorkExecutionIndexManagerContext;
 import org.hibernate.search.backend.lucene.work.impl.LuceneWorkFactory;
+import org.hibernate.search.engine.backend.common.spi.EntityReferenceFactory;
 import org.hibernate.search.engine.backend.mapping.spi.BackendMappingContext;
 import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
 import org.hibernate.search.engine.backend.session.spi.DetachedBackendSessionContext;
@@ -99,18 +100,20 @@ public class IndexManagerBackendContext implements WorkExecutionBackendContext, 
 	}
 
 	@Override
-	public IndexIndexingPlan createIndexingPlan(
+	public <R> IndexIndexingPlan<R> createIndexingPlan(
 			WorkExecutionIndexManagerContext indexManagerContext,
 			LuceneIndexEntryFactory indexEntryFactory,
 			BackendSessionContext sessionContext,
+			EntityReferenceFactory<R> entityReferenceFactory,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
 		multiTenancyStrategy.checkTenantId( sessionContext.getTenantIdentifier(), eventContext );
 
-		return new LuceneIndexIndexingPlan(
+		return new LuceneIndexIndexingPlan<>(
 				workFactory,
 				indexManagerContext,
 				indexEntryFactory,
 				sessionContext,
+				entityReferenceFactory,
 				commitStrategy, refreshStrategy
 		);
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/LuceneIndexManagerImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/LuceneIndexManagerImpl.java
@@ -92,12 +92,13 @@ public class LuceneIndexManagerImpl
 	}
 
 	@Override
-	public IndexIndexingPlan createIndexingPlan(BackendSessionContext sessionContext,
-			EntityReferenceFactory<?> entityReferenceFactory,
+	public <R> IndexIndexingPlan<R> createIndexingPlan(BackendSessionContext sessionContext,
+			EntityReferenceFactory<R> entityReferenceFactory,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
 		return backendContext.createIndexingPlan(
 				shardHolder, indexEntryFactory,
-				sessionContext, commitStrategy, refreshStrategy
+				sessionContext, entityReferenceFactory,
+				commitStrategy, refreshStrategy
 		);
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/LuceneIndexManagerImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/LuceneIndexManagerImpl.java
@@ -16,6 +16,7 @@ import org.hibernate.search.backend.lucene.document.impl.LuceneIndexEntryFactory
 import org.hibernate.search.backend.lucene.index.LuceneIndexManager;
 import org.hibernate.search.backend.lucene.lowlevel.reader.impl.DirectoryReaderCollector;
 import org.hibernate.search.backend.lucene.scope.model.impl.LuceneScopeIndexManagerContext;
+import org.hibernate.search.engine.backend.common.spi.EntityReferenceFactory;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.index.IndexManager;
 import org.hibernate.search.engine.backend.index.spi.IndexManagerStartContext;
@@ -92,6 +93,7 @@ public class LuceneIndexManagerImpl
 
 	@Override
 	public IndexIndexingPlan createIndexingPlan(BackendSessionContext sessionContext,
+			EntityReferenceFactory<?> entityReferenceFactory,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
 		return backendContext.createIndexingPlan(
 				shardHolder, indexEntryFactory,

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/ShardHolder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/ShardHolder.java
@@ -126,6 +126,11 @@ class ShardHolder implements ReadIndexManagerContext, WorkExecutionIndexManagerC
 	}
 
 	@Override
+	public String getMappedTypeName() {
+		return model.getMappedTypeName();
+	}
+
+	@Override
 	public LuceneWriteWorkOrchestrator getWriteOrchestrator(String documentId, String routingKey) {
 		return toShard( documentId, routingKey ).getWriteOrchestrator();
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
@@ -234,13 +234,13 @@ public interface Log extends BasicLogger {
 	SearchException unableToInitializeIndexDirectory(String causeMessage,
 			@Param EventContext context, @Cause Exception cause);
 
-	@Message(id = ID_OFFSET_2 + 16, value = "Unable to index entry '%2$s' with tenant identifier '%1$s'.")
-	SearchException unableToIndexEntry(String tenantId, String id,
+	@Message(id = ID_OFFSET_2 + 16, value = "Unable to index entity of type '%2$s' with identifier '%3$s' and tenant identifier '%1$s'.")
+	SearchException unableToIndexEntry(String tenantId, String entityTypeName, Object entityIdentifier,
 			@Param EventContext context, @Cause Exception e);
 
 	@Message(id = ID_OFFSET_2 + 17,
-			value = "Unable to delete entry '%2$s' with tenant identifier '%1$s'.")
-	SearchException unableToDeleteEntryFromIndex(String tenantId, String id,
+			value = "Unable to delete entity of type '%2$s' with identifier '%3$s' and tenant identifier '%1$s'.")
+	SearchException unableToDeleteEntryFromIndex(String tenantId, String entityTypeName, Object entityIdentifier,
 			@Param EventContext context, @Cause Exception e);
 
 	@Message(id = ID_OFFSET_2 + 18,

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/execution/impl/LuceneIndexIndexer.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/execution/impl/LuceneIndexIndexer.java
@@ -50,7 +50,10 @@ public class LuceneIndexIndexer implements IndexIndexer {
 		LuceneWriteWorkOrchestrator orchestrator = indexManagerContext.getWriteOrchestrator( id, routingKey );
 
 		return orchestrator.submit(
-				factory.add( tenantId, id, indexEntry ),
+				factory.add(
+						tenantId, indexManagerContext.getMappedTypeName(), referenceProvider.getEntityIdentifier(),
+						indexEntry
+				),
 				commitStrategy,
 				DocumentRefreshStrategy.NONE
 		);

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/execution/impl/LuceneIndexIndexingPlan.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/execution/impl/LuceneIndexIndexingPlan.java
@@ -12,25 +12,27 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import org.hibernate.search.backend.lucene.document.impl.LuceneIndexEntry;
 import org.hibernate.search.backend.lucene.document.impl.LuceneIndexEntryFactory;
+import org.hibernate.search.backend.lucene.orchestration.impl.LuceneWriteWorkOrchestrator;
 import org.hibernate.search.backend.lucene.work.impl.LuceneSingleDocumentWriteWork;
+import org.hibernate.search.backend.lucene.work.impl.LuceneWorkFactory;
+import org.hibernate.search.engine.backend.common.spi.EntityReferenceFactory;
+import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
-import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.work.execution.spi.DocumentContributor;
 import org.hibernate.search.engine.backend.work.execution.spi.DocumentReferenceProvider;
-import org.hibernate.search.backend.lucene.document.impl.LuceneIndexEntry;
-import org.hibernate.search.backend.lucene.orchestration.impl.LuceneWriteWorkOrchestrator;
-import org.hibernate.search.backend.lucene.work.impl.LuceneWorkFactory;
-import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlanExecutionReport;
 
-public class LuceneIndexIndexingPlan implements IndexIndexingPlan {
+public class LuceneIndexIndexingPlan<R> implements IndexIndexingPlan<R> {
 
 	private final LuceneWorkFactory factory;
 	private final LuceneIndexEntryFactory indexEntryFactory;
 	private final WorkExecutionIndexManagerContext indexManagerContext;
 	private final String tenantId;
+	private final EntityReferenceFactory<R> entityReferenceFactory;
 	private final DocumentCommitStrategy commitStrategy;
 	private final DocumentRefreshStrategy refreshStrategy;
 
@@ -40,11 +42,13 @@ public class LuceneIndexIndexingPlan implements IndexIndexingPlan {
 			WorkExecutionIndexManagerContext indexManagerContext,
 			LuceneIndexEntryFactory indexEntryFactory,
 			BackendSessionContext sessionContext,
+			EntityReferenceFactory<R> entityReferenceFactory,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
 		this.factory = factory;
 		this.indexEntryFactory = indexEntryFactory;
 		this.indexManagerContext = indexManagerContext;
 		this.tenantId = sessionContext.getTenantIdentifier();
+		this.entityReferenceFactory = entityReferenceFactory;
 		this.commitStrategy = commitStrategy;
 		this.refreshStrategy = refreshStrategy;
 	}
@@ -57,7 +61,10 @@ public class LuceneIndexIndexingPlan implements IndexIndexingPlan {
 
 		LuceneIndexEntry indexEntry = indexEntryFactory.create( tenantId, id, routingKey, documentContributor );
 
-		collect( id, routingKey, factory.add( tenantId, id, indexEntry ) );
+		collect( id, routingKey, factory.add(
+				tenantId, indexManagerContext.getMappedTypeName(), referenceProvider.getEntityIdentifier(),
+				indexEntry
+		) );
 	}
 
 	@Override
@@ -68,7 +75,10 @@ public class LuceneIndexIndexingPlan implements IndexIndexingPlan {
 
 		LuceneIndexEntry indexEntry = indexEntryFactory.create( tenantId, id, routingKey, documentContributor );
 
-		collect( id, routingKey, factory.update( tenantId, id, indexEntry ) );
+		collect( id, routingKey, factory.update(
+				tenantId, indexManagerContext.getMappedTypeName(), referenceProvider.getEntityIdentifier(),
+				id, indexEntry
+		) );
 	}
 
 	@Override
@@ -76,7 +86,10 @@ public class LuceneIndexIndexingPlan implements IndexIndexingPlan {
 		String id = referenceProvider.getIdentifier();
 		String routingKey = referenceProvider.getRoutingKey();
 
-		collect( id, routingKey, factory.delete( tenantId, id ) );
+		collect( id, routingKey, factory.delete(
+				tenantId, indexManagerContext.getMappedTypeName(), referenceProvider.getEntityIdentifier(),
+				id
+		) );
 	}
 
 	@Override
@@ -85,15 +98,17 @@ public class LuceneIndexIndexingPlan implements IndexIndexingPlan {
 	}
 
 	@Override
-	public CompletableFuture<IndexIndexingPlanExecutionReport> executeAndReport() {
+	public CompletableFuture<IndexIndexingPlanExecutionReport<R>> executeAndReport() {
 		try {
-			List<CompletableFuture<IndexIndexingPlanExecutionReport>> shardReportFutures = new ArrayList<>();
+			List<CompletableFuture<IndexIndexingPlanExecutionReport<R>>> shardReportFutures = new ArrayList<>();
 			for ( Map.Entry<LuceneWriteWorkOrchestrator, List<LuceneSingleDocumentWriteWork<?>>> entry : worksByOrchestrator.entrySet() ) {
 				LuceneWriteWorkOrchestrator orchestrator = entry.getKey();
 				List<LuceneSingleDocumentWriteWork<?>> works = entry.getValue();
-				CompletableFuture<IndexIndexingPlanExecutionReport> shardReportFuture = new CompletableFuture<>();
-				orchestrator.submit( new LuceneIndexingPlanWriteWorkSet(
-						indexManagerContext.getIndexName(), works, shardReportFuture, commitStrategy, refreshStrategy
+				CompletableFuture<IndexIndexingPlanExecutionReport<R>> shardReportFuture = new CompletableFuture<>();
+				orchestrator.submit( new LuceneIndexingPlanWriteWorkSet<>(
+						works,
+						entityReferenceFactory,
+						shardReportFuture, commitStrategy, refreshStrategy
 				) );
 				shardReportFutures.add( shardReportFuture );
 			}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/execution/impl/WorkExecutionBackendContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/execution/impl/WorkExecutionBackendContext.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.backend.lucene.work.execution.impl;
 
 import org.hibernate.search.backend.lucene.document.impl.LuceneIndexEntryFactory;
+import org.hibernate.search.engine.backend.common.spi.EntityReferenceFactory;
 import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
 import org.hibernate.search.engine.backend.session.spi.DetachedBackendSessionContext;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
@@ -27,10 +28,11 @@ import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
  * we would end up with methods with many parameters.
  */
 public interface WorkExecutionBackendContext {
-	IndexIndexingPlan createIndexingPlan(
+	<R> IndexIndexingPlan<R> createIndexingPlan(
 			WorkExecutionIndexManagerContext indexManagerContext,
 			LuceneIndexEntryFactory indexEntryFactory,
 			BackendSessionContext sessionContext,
+			EntityReferenceFactory<R> entityReferenceFactory,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy);
 
 	IndexIndexer createIndexer(

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/execution/impl/WorkExecutionIndexManagerContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/execution/impl/WorkExecutionIndexManagerContext.java
@@ -26,6 +26,8 @@ public interface WorkExecutionIndexManagerContext {
 
 	String getIndexName();
 
+	String getMappedTypeName();
+
 	LuceneWriteWorkOrchestrator getWriteOrchestrator(String documentId, String routingKey);
 
 	Collection<LuceneWriteWorkOrchestrator> getWriteOrchestrators(Set<String> routingKeys);

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/AbstractLuceneSingleDocumentWriteWork.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/AbstractLuceneSingleDocumentWriteWork.java
@@ -1,0 +1,46 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.work.impl;
+
+public abstract class AbstractLuceneSingleDocumentWriteWork<T> extends AbstractLuceneWriteWork<T>
+		implements LuceneSingleDocumentWriteWork<T> {
+
+	protected final String tenantId;
+	protected final String entityTypeName;
+	protected final Object entityIdentifier;
+
+	AbstractLuceneSingleDocumentWriteWork(String workType, String tenantId,
+			String entityTypeName, Object entityIdentifier) {
+		super( workType );
+		this.tenantId = tenantId;
+		this.entityTypeName = entityTypeName;
+		this.entityIdentifier = entityIdentifier;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder( getClass().getSimpleName() )
+				.append( "[" )
+				.append( "type=" ).append( workType )
+				.append( ", tenantId=" ).append( tenantId )
+				.append( ", entityTypeName=" ).append( entityTypeName )
+				.append( ", entityIdentifier=" ).append( entityIdentifier )
+				.append( "]" );
+		return sb.toString();
+	}
+
+	@Override
+	public String getEntityTypeName() {
+		return entityTypeName;
+	}
+
+	@Override
+	public Object getEntityIdentifier() {
+		return entityIdentifier;
+	}
+
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneAddEntryWork.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneAddEntryWork.java
@@ -15,21 +15,15 @@ import org.hibernate.search.backend.lucene.lowlevel.writer.impl.IndexWriterDeleg
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
 
-public class LuceneAddEntryWork extends AbstractLuceneWriteWork<Long>
-		implements LuceneSingleDocumentWriteWork<Long> {
+public class LuceneAddEntryWork extends AbstractLuceneSingleDocumentWriteWork<Long> {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private final String tenantId;
-
-	private final String id;
-
 	private final LuceneIndexEntry indexEntry;
 
-	LuceneAddEntryWork(String tenantId, String id, LuceneIndexEntry indexEntry) {
-		super( "addEntry" );
-		this.tenantId = tenantId;
-		this.id = id;
+	LuceneAddEntryWork(String tenantId, String entityTypeName, Object entityIdentifier,
+			LuceneIndexEntry indexEntry) {
+		super( "addEntry", tenantId, entityTypeName, entityIdentifier );
 		this.indexEntry = indexEntry;
 	}
 
@@ -40,23 +34,10 @@ public class LuceneAddEntryWork extends AbstractLuceneWriteWork<Long>
 			return indexWriterDelegator.addDocuments( indexEntry );
 		}
 		catch (IOException e) {
-			throw log.unableToIndexEntry( tenantId, id, context.getEventContext(), e );
+			throw log.unableToIndexEntry(
+					tenantId, entityTypeName, entityIdentifier, context.getEventContext(), e
+			);
 		}
-	}
-
-	@Override
-	public String toString() {
-		StringBuilder sb = new StringBuilder( getClass().getSimpleName() )
-				.append( "[" )
-				.append( "type=" ).append( workType )
-				.append( ", entry=" ).append( indexEntry )
-				.append( "]" );
-		return sb.toString();
-	}
-
-	@Override
-	public String getDocumentId() {
-		return id;
 	}
 
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneDeleteEntryWork.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneDeleteEntryWork.java
@@ -20,40 +20,25 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 
 
-public class LuceneDeleteEntryWork extends AbstractLuceneWriteWork<Long>
-		implements LuceneSingleDocumentWriteWork<Long> {
+public class LuceneDeleteEntryWork extends AbstractLuceneSingleDocumentWriteWork<Long> {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private final String tenantId;
-
-	private final String id;
-
+	private final String documentIdentifier;
 	private final Query filter;
 
-	LuceneDeleteEntryWork(String tenantId, String id, Query filter) {
-		super( "deleteEntry" );
-		this.tenantId = tenantId;
-		this.id = id;
+	LuceneDeleteEntryWork(String tenantId, String entityTypeName, Object entityIdentifier,
+			String documentIdentifier, Query filter) {
+		super( "deleteEntry", tenantId, entityTypeName, entityIdentifier );
+		this.documentIdentifier = documentIdentifier;
 		this.filter = filter;
-	}
-
-	@Override
-	public String toString() {
-		StringBuilder sb = new StringBuilder( getClass().getSimpleName() )
-				.append( "[" )
-				.append( "type=" ).append( workType )
-				.append( ", tenantId=" ).append( tenantId )
-				.append( ", id=" ).append( id )
-				.append( "]" );
-		return sb.toString();
 	}
 
 	@Override
 	public Long execute(LuceneWriteWorkExecutionContext context) {
 		try {
 			IndexWriterDelegator indexWriterDelegator = context.getIndexWriterDelegator();
-			Term idTerm = new Term( MetadataFields.idFieldName(), id );
+			Term idTerm = new Term( MetadataFields.idFieldName(), documentIdentifier );
 			if ( filter == null ) {
 				// Pass the term directly instead of a query: presumably more efficient.
 				return indexWriterDelegator.deleteDocuments( idTerm );
@@ -63,12 +48,10 @@ public class LuceneDeleteEntryWork extends AbstractLuceneWriteWork<Long>
 			}
 		}
 		catch (IOException e) {
-			throw log.unableToDeleteEntryFromIndex( tenantId, id, context.getEventContext(), e );
+			throw log.unableToDeleteEntryFromIndex(
+					tenantId, entityTypeName, entityIdentifier, context.getEventContext(), e
+			);
 		}
 	}
 
-	@Override
-	public String getDocumentId() {
-		return id;
-	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneSingleDocumentWriteWork.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneSingleDocumentWriteWork.java
@@ -9,6 +9,8 @@ package org.hibernate.search.backend.lucene.work.impl;
 
 public interface LuceneSingleDocumentWriteWork<T> extends LuceneWriteWork<T> {
 
-	String getDocumentId();
+	String getEntityTypeName();
+
+	Object getEntityIdentifier();
 
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneUpdateEntryWork.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneUpdateEntryWork.java
@@ -21,43 +21,28 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 
 
-public class LuceneUpdateEntryWork extends AbstractLuceneWriteWork<Long>
-		implements LuceneSingleDocumentWriteWork<Long> {
+public class LuceneUpdateEntryWork extends AbstractLuceneSingleDocumentWriteWork<Long> {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private final String tenantId;
-
-	private final String id;
-
+	private final String documentIdentifier;
 	private final Query filter;
 
 	private final LuceneIndexEntry indexEntry;
 
-	LuceneUpdateEntryWork(String tenantId, String id, Query filter, LuceneIndexEntry indexEntry) {
-		super( "updateEntry" );
-		this.tenantId = tenantId;
-		this.id = id;
+	LuceneUpdateEntryWork(String tenantId, String entityTypeName, Object entityIdentifier,
+			String documentIdentifier, Query filter, LuceneIndexEntry indexEntry) {
+		super( "updateEntry", tenantId, entityTypeName, entityIdentifier );
+		this.documentIdentifier = documentIdentifier;
 		this.filter = filter;
 		this.indexEntry = indexEntry;
-	}
-
-	@Override
-	public String toString() {
-		StringBuilder sb = new StringBuilder( getClass().getSimpleName() )
-				.append( "[" )
-				.append( "type=" ).append( workType )
-				.append( ", tenantId=" ).append( tenantId )
-				.append( ", entry=" ).append( indexEntry )
-				.append( "]" );
-		return sb.toString();
 	}
 
 	@Override
 	public Long execute(LuceneWriteWorkExecutionContext context) {
 		try {
 			IndexWriterDelegator indexWriterDelegator = context.getIndexWriterDelegator();
-			Term idTerm = new Term( MetadataFields.idFieldName(), id );
+			Term idTerm = new Term( MetadataFields.idFieldName(), documentIdentifier );
 			if ( filter == null ) {
 				// Atomic update: presumably more efficient.
 				return indexWriterDelegator.updateDocuments( idTerm, indexEntry );
@@ -68,12 +53,8 @@ public class LuceneUpdateEntryWork extends AbstractLuceneWriteWork<Long>
 			}
 		}
 		catch (IOException e) {
-			throw log.unableToIndexEntry( tenantId, id, context.getEventContext(), e );
+			throw log.unableToIndexEntry( tenantId, entityTypeName, entityIdentifier, context.getEventContext(), e );
 		}
 	}
 
-	@Override
-	public String getDocumentId() {
-		return id;
-	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneWorkFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneWorkFactory.java
@@ -16,11 +16,13 @@ import org.apache.lucene.search.Query;
 
 public interface LuceneWorkFactory {
 
-	LuceneSingleDocumentWriteWork<?> add(String tenantId, String id, LuceneIndexEntry indexEntry);
+	LuceneSingleDocumentWriteWork<?> add(String tenantId, String entityTypeName, Object entityIdentifier,
+			LuceneIndexEntry indexEntry);
 
-	LuceneSingleDocumentWriteWork<?> update(String tenantId, String id, LuceneIndexEntry indexEntry);
+	LuceneSingleDocumentWriteWork<?> update(String tenantId, String entityTypeName, Object entityIdentifier,
+			String documentIdentifier, LuceneIndexEntry indexEntry);
 
-	LuceneSingleDocumentWriteWork<?> delete(String tenantId, String id);
+	LuceneSingleDocumentWriteWork<?> delete(String tenantId, String entityTypeName, Object entityIdentifier, String id);
 
 	LuceneWriteWork<?> deleteAll(String tenantId, Set<String> routingKeys);
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneWorkFactoryImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/work/impl/LuceneWorkFactoryImpl.java
@@ -28,22 +28,24 @@ public class LuceneWorkFactoryImpl implements LuceneWorkFactory {
 	}
 
 	@Override
-	public LuceneSingleDocumentWriteWork<?> add(String tenantId, String id,
+	public LuceneSingleDocumentWriteWork<?> add(String tenantId, String entityTypeName, Object entityIdentifier,
 			LuceneIndexEntry indexEntry) {
-		return new LuceneAddEntryWork( tenantId, id, indexEntry );
+		return new LuceneAddEntryWork( tenantId, entityTypeName, entityIdentifier, indexEntry );
 	}
 
 	@Override
-	public LuceneSingleDocumentWriteWork<?> update(String tenantId, String id,
-			LuceneIndexEntry indexEntry) {
+	public LuceneSingleDocumentWriteWork<?> update(String tenantId, String entityTypeName, Object entityIdentifier,
+			String documentIdentifier, LuceneIndexEntry indexEntry) {
 		Query filter = multiTenancyStrategy.getFilterOrNull( tenantId );
-		return new LuceneUpdateEntryWork( tenantId, id, filter, indexEntry );
+		return new LuceneUpdateEntryWork( tenantId, entityTypeName, entityIdentifier,
+				documentIdentifier, filter, indexEntry );
 	}
 
 	@Override
-	public LuceneSingleDocumentWriteWork<?> delete(String tenantId, String id) {
+	public LuceneSingleDocumentWriteWork<?> delete(String tenantId, String entityTypeName, Object entityIdentifier,
+			String documentIdentifier) {
 		Query filter = multiTenancyStrategy.getFilterOrNull( tenantId );
-		return new LuceneDeleteEntryWork( tenantId, id, filter );
+		return new LuceneDeleteEntryWork( tenantId, entityTypeName, entityIdentifier, documentIdentifier, filter );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/backend/common/spi/EntityReferenceFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/common/spi/EntityReferenceFactory.java
@@ -1,0 +1,13 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.backend.common.spi;
+
+public interface EntityReferenceFactory<R> {
+
+	R createEntityReference(String typeName, Object identifier);
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/backend/index/spi/IndexManagerImplementor.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/index/spi/IndexManagerImplementor.java
@@ -59,8 +59,8 @@ public interface IndexManagerImplementor {
 	 */
 	IndexManager toAPI();
 
-	IndexIndexingPlan createIndexingPlan(BackendSessionContext sessionContext,
-			EntityReferenceFactory<?> entityReferenceFactory,
+	<R> IndexIndexingPlan<R> createIndexingPlan(BackendSessionContext sessionContext,
+			EntityReferenceFactory<R> entityReferenceFactory,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy);
 
 	IndexIndexer createIndexer(BackendSessionContext sessionContext,

--- a/engine/src/main/java/org/hibernate/search/engine/backend/index/spi/IndexManagerImplementor.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/index/spi/IndexManagerImplementor.java
@@ -8,6 +8,7 @@ package org.hibernate.search.engine.backend.index.spi;
 
 import java.util.concurrent.CompletableFuture;
 
+import org.hibernate.search.engine.backend.common.spi.EntityReferenceFactory;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.engine.backend.index.IndexManager;
@@ -59,6 +60,7 @@ public interface IndexManagerImplementor {
 	IndexManager toAPI();
 
 	IndexIndexingPlan createIndexingPlan(BackendSessionContext sessionContext,
+			EntityReferenceFactory<?> entityReferenceFactory,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy);
 
 	IndexIndexer createIndexer(BackendSessionContext sessionContext,

--- a/engine/src/main/java/org/hibernate/search/engine/backend/session/spi/DetachedBackendSessionContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/session/spi/DetachedBackendSessionContext.java
@@ -21,7 +21,7 @@ import org.hibernate.search.engine.backend.mapping.spi.BackendMappingContext;
  * The main downside is that this context cannot be used
  * everywhere {@link BackendSessionContext} can.
  * In particular, it cannot be used when creating document-related
- * {@link org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor#createIndexingPlan(BackendSessionContext, DocumentCommitStrategy, DocumentRefreshStrategy) indexing plans}
+ * {@link org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor#createIndexingPlan(BackendSessionContext, org.hibernate.search.engine.backend.common.spi.EntityReferenceFactory, DocumentCommitStrategy, DocumentRefreshStrategy) indexing plans}
  * or {@link org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor#createIndexer(BackendSessionContext, DocumentCommitStrategy) indexers}
  * because these may need access to the session.
  */

--- a/engine/src/main/java/org/hibernate/search/engine/backend/work/execution/spi/DocumentReferenceProvider.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/work/execution/spi/DocumentReferenceProvider.java
@@ -8,8 +8,19 @@ package org.hibernate.search.engine.backend.work.execution.spi;
 
 public interface DocumentReferenceProvider {
 
+	/**
+	 * @return The document identifier.
+	 */
 	String getIdentifier();
 
+	/**
+	 * @return The routing key.
+	 */
 	String getRoutingKey();
+
+	/**
+	 * @return The entity identifier. Used when reporting failures.
+	 */
+	Object getEntityIdentifier();
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/backend/work/execution/spi/IndexIndexingPlan.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/work/execution/spi/IndexIndexingPlan.java
@@ -20,8 +20,10 @@ import org.hibernate.search.util.common.impl.Throwables;
  * Relative ordering of works within a plan will be preserved.
  * <p>
  * Implementations may not be thread-safe.
+ *
+ * @param <R> The type of entity references in the {@link #executeAndReport() execution report}.
  */
-public interface IndexIndexingPlan {
+public interface IndexIndexingPlan<R> {
 
 	/**
 	 * Add a document to the index, assuming that the document is absent from the index.
@@ -76,7 +78,7 @@ public interface IndexIndexingPlan {
 	 * The future will be completed normally even if a work failed,
 	 * but the report will contain an exception.
 	 */
-	CompletableFuture<IndexIndexingPlanExecutionReport> executeAndReport();
+	CompletableFuture<IndexIndexingPlanExecutionReport<R>> executeAndReport();
 
 	/**
 	 * Discard all works that are present in this plan.

--- a/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/impl/MappedIndexManagerImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/impl/MappedIndexManagerImpl.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.engine.mapper.mapping.impl;
 
+import org.hibernate.search.engine.backend.common.spi.EntityReferenceFactory;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.index.IndexManager;
 import org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor;
@@ -35,12 +36,17 @@ public class MappedIndexManagerImpl implements MappedIndexManager {
 
 	@Override
 	public IndexIndexingPlan createIndexingPlan(BackendSessionContext sessionContext,
+			EntityReferenceFactory<?> entityReferenceFactory,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
-		return implementor.createIndexingPlan( sessionContext, commitStrategy, refreshStrategy );
+		return implementor.createIndexingPlan(
+				sessionContext, entityReferenceFactory,
+				commitStrategy, refreshStrategy
+		);
 	}
 
 	@Override
 	public IndexIndexer createIndexer(BackendSessionContext sessionContext,
+			EntityReferenceFactory<?> entityReferenceFactory,
 			DocumentCommitStrategy commitStrategy) {
 		return implementor.createIndexer( sessionContext, commitStrategy );
 	}

--- a/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/impl/MappedIndexManagerImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/impl/MappedIndexManagerImpl.java
@@ -35,8 +35,8 @@ public class MappedIndexManagerImpl implements MappedIndexManager {
 	}
 
 	@Override
-	public IndexIndexingPlan createIndexingPlan(BackendSessionContext sessionContext,
-			EntityReferenceFactory<?> entityReferenceFactory,
+	public <R> IndexIndexingPlan<R> createIndexingPlan(BackendSessionContext sessionContext,
+			EntityReferenceFactory<R> entityReferenceFactory,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
 		return implementor.createIndexingPlan(
 				sessionContext, entityReferenceFactory,

--- a/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/spi/MappedIndexManager.java
+++ b/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/spi/MappedIndexManager.java
@@ -27,8 +27,8 @@ public interface MappedIndexManager {
 
 	IndexManager toAPI();
 
-	IndexIndexingPlan createIndexingPlan(BackendSessionContext sessionContext,
-			EntityReferenceFactory<?> entityReferenceFactory,
+	<R> IndexIndexingPlan<R> createIndexingPlan(BackendSessionContext sessionContext,
+			EntityReferenceFactory<R> entityReferenceFactory,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy);
 
 	IndexIndexer createIndexer(BackendSessionContext sessionContext,

--- a/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/spi/MappedIndexManager.java
+++ b/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/spi/MappedIndexManager.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.engine.mapper.mapping.spi;
 
+import org.hibernate.search.engine.backend.common.spi.EntityReferenceFactory;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.index.IndexManager;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
@@ -27,9 +28,11 @@ public interface MappedIndexManager {
 	IndexManager toAPI();
 
 	IndexIndexingPlan createIndexingPlan(BackendSessionContext sessionContext,
+			EntityReferenceFactory<?> entityReferenceFactory,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy);
 
 	IndexIndexer createIndexer(BackendSessionContext sessionContext,
+			EntityReferenceFactory<?> entityReferenceFactory,
 			DocumentCommitStrategy commitStrategy);
 
 	IndexWorkspace createWorkspace(DetachedBackendSessionContext sessionContext);

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
@@ -1014,7 +1014,7 @@ public class ElasticsearchExtensionIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( SECOND_ID ), document -> {
 			document.addValue( indexMapping.string, "text 2" );
 

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/mapping/ElasticsearchTypeNameMappingBaseIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/mapping/ElasticsearchTypeNameMappingBaseIT.java
@@ -249,7 +249,7 @@ public class ElasticsearchTypeNameMappingBaseIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = index1Manager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = index1Manager.createIndexingPlan();
 		plan.add( referenceProvider( ID_1 ), document -> { } );
 		plan.add( referenceProvider( ID_2 ), document -> { } );
 		plan.execute().join();

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/search/ElasticsearchMatchSearchPredicateIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/search/ElasticsearchMatchSearchPredicateIT.java
@@ -63,7 +63,7 @@ public class ElasticsearchMatchSearchPredicateIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), document -> document.addValue( indexMapping.normalizedStringField, TEST_TERM ) );
 		plan.execute().join();
 	}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/work/ElasticsearchIndexingIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/work/ElasticsearchIndexingIT.java
@@ -92,7 +92,7 @@ public class ElasticsearchIndexingIT {
 	@Test
 	public void addUpdateDelete_routing() {
 		String routingKey = "someRoutingKey";
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 
 		plan.add( referenceProvider( "1", routingKey ), document -> {
 			document.addValue( indexMapping.string, "text1" );

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneExtensionIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneExtensionIT.java
@@ -657,7 +657,7 @@ public class LuceneExtensionIT {
 
 	@Test
 	public void nativeField_invalidFieldPath() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 
 		SubTest.expectException(
 				"native field contributing field with invalid field path",
@@ -726,7 +726,7 @@ public class LuceneExtensionIT {
 	}
 
 	private static void indexDataSet(IndexMapping indexMapping, StubMappingIndexManager indexManager) {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( FIRST_ID ), document -> {
 			document.addValue( indexMapping.string, "text 1" );
 

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/directory/AbstractDirectoryIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/directory/AbstractDirectoryIT.java
@@ -45,7 +45,7 @@ public abstract class AbstractDirectoryIT {
 	protected StubMappingIndexManager indexManager;
 
 	protected final void checkIndexingAndQuerying() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			document.addValue( indexMapping.string, "text 1" );
 		} );

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/reader/LuceneIndexReaderRefreshIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/reader/LuceneIndexReaderRefreshIT.java
@@ -80,7 +80,7 @@ public class LuceneIndexReaderRefreshIT {
 
 		assertThat( query ).hasNoHits();
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan(
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan(
 				new StubBackendSessionContext(),
 				commitStrategy, // This is irrelevant
 				DocumentRefreshStrategy.NONE // The refresh should be executed regardless of this parameter
@@ -102,7 +102,7 @@ public class LuceneIndexReaderRefreshIT {
 
 		assertThat( query ).hasNoHits();
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan(
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan(
 				new StubBackendSessionContext(),
 				commitStrategy, // This is irrelevant
 				DocumentRefreshStrategy.NONE // The refresh should be executed regardless of this parameter
@@ -124,7 +124,7 @@ public class LuceneIndexReaderRefreshIT {
 
 		assertThat( query ).hasNoHits();
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan(
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan(
 				new StubBackendSessionContext(),
 				commitStrategy, // This is irrelevant
 				DocumentRefreshStrategy.NONE // This means no refresh will take place until after the refresh interval
@@ -149,7 +149,7 @@ public class LuceneIndexReaderRefreshIT {
 
 		assertThat( query ).hasNoHits();
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan(
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan(
 				new StubBackendSessionContext(),
 				commitStrategy, // This is irrelevant
 				DocumentRefreshStrategy.FORCE // This will force a refresh before the end of the refresh interval
@@ -171,7 +171,7 @@ public class LuceneIndexReaderRefreshIT {
 
 		assertThat( query ).hasNoHits();
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan(
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan(
 				new StubBackendSessionContext(),
 				DocumentCommitStrategy.FORCE, // With the debug IO strategy, commit is necessary for changes to be visible
 				DocumentRefreshStrategy.NONE // The refresh should be executed regardless of this parameter

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/writer/LuceneIndexWriterCommitIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/writer/LuceneIndexWriterCommitIT.java
@@ -80,7 +80,7 @@ public class LuceneIndexWriterCommitIT {
 		assertThat( countDocsOnDisk() ).isEqualTo( 0 );
 
 		// Add the document to the index
-		IndexIndexingPlan plan = indexManager.createIndexingPlan(
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan(
 				new StubBackendSessionContext(),
 				DocumentCommitStrategy.NONE, // The commit will happen at some point, but the indexing plan will be considered completed before that
 				DocumentRefreshStrategy.NONE // This is irrelevant
@@ -108,7 +108,7 @@ public class LuceneIndexWriterCommitIT {
 		assertThat( countDocsOnDisk() ).isEqualTo( 0 );
 
 		// Add the document to the index
-		IndexIndexingPlan plan = indexManager.createIndexingPlan(
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan(
 				new StubBackendSessionContext(),
 				DocumentCommitStrategy.FORCE, // The commit will happen before the indexing plan is considered completed
 				DocumentRefreshStrategy.NONE // This is irrelevant
@@ -131,7 +131,7 @@ public class LuceneIndexWriterCommitIT {
 		assertThat( countDocsOnDisk() ).isEqualTo( 0 );
 
 		// Add the document to the index
-		IndexIndexingPlan plan = indexManager.createIndexingPlan(
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan(
 				new StubBackendSessionContext(),
 				DocumentCommitStrategy.NONE, // The commit should not be necessary for changes to be visible
 				DocumentRefreshStrategy.NONE // The refresh should be done regardless of this parameter

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/mapping/LuceneFieldAttributesIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/mapping/LuceneFieldAttributesIT.java
@@ -121,7 +121,7 @@ public class LuceneFieldAttributesIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( "ID:1" ), document -> {
 			document.addValue( indexMapping.string, "keyword" );
 			document.addValue( indexMapping.text, TEXT );

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/mapping/LuceneFieldTypesIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/mapping/LuceneFieldTypesIT.java
@@ -87,7 +87,7 @@ public class LuceneFieldTypesIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 
 		plan.add( referenceProvider( "ID:1" ), document -> {
 			document.addValue( indexMapping.string, "keyword" );

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneFloatingPointInfinitySearchIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneFloatingPointInfinitySearchIT.java
@@ -184,7 +184,7 @@ public class LuceneFloatingPointInfinitySearchIT<F> {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( "negative-infinity" ), document -> {
 			document.addValue( indexMapping.floatFieldModel.reference, Float.NEGATIVE_INFINITY );
 			document.addValue( indexMapping.doubleFieldModel.reference, Double.NEGATIVE_INFINITY );

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneMatchSearchPredicateIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneMatchSearchPredicateIT.java
@@ -66,7 +66,7 @@ public class LuceneMatchSearchPredicateIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), document -> document.addValue( indexMapping.normalizedStringField, TEST_TERM ) );
 		plan.execute().join();
 	}

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneNormalizeWildcardExpressionsIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneNormalizeWildcardExpressionsIT.java
@@ -102,7 +102,7 @@ public class LuceneNormalizeWildcardExpressionsIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			document.addValue( indexMapping.analyzed, TEXT_MATCHING_PATTERN_1 );
 		} );

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneSearchMultiIndexIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneSearchMultiIndexIT.java
@@ -124,7 +124,7 @@ public class LuceneSearchMultiIndexIT {
 	private void initData() {
 		// Backend 1 / Index 1
 
-		IndexIndexingPlan plan = indexManager_1_1.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager_1_1.createIndexingPlan();
 
 		plan.add( referenceProvider( DOCUMENT_1_1_1 ), document -> {
 			document.addValue( indexMapping_1_1.string, STRING_1 );

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/work/LuceneIndexingNestedIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/work/LuceneIndexingNestedIT.java
@@ -63,7 +63,7 @@ public class LuceneIndexingNestedIT {
 		// No multitenancy, which means the backend will use indexWriter.updateDocuments(Term, Iterable) for updates
 		setup( MultiTenancyStrategyName.NONE );
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan( sessionContext );
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan( sessionContext );
 		plan.update( referenceProvider( "1" ), document -> {
 			DocumentElement nested = document.addObject( indexMapping.nestedObject.self );
 			nested.addValue( indexMapping.nestedObject.field2, "value" );
@@ -81,7 +81,7 @@ public class LuceneIndexingNestedIT {
 		// indexWriter.deleteDocuments(Query) then indexWriter.addDocument for updates
 		setup( MultiTenancyStrategyName.DISCRIMINATOR );
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan( sessionContext );
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan( sessionContext );
 		plan.update( referenceProvider( "1" ), document -> {
 			DocumentElement nested = document.addObject( indexMapping.nestedObject.self );
 			nested.addValue( indexMapping.nestedObject.field2, "value" );
@@ -98,7 +98,7 @@ public class LuceneIndexingNestedIT {
 		// No multitenancy, which means the backend will use indexWriter.deleteDocuments(Term) for deletion
 		setup( MultiTenancyStrategyName.NONE );
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan( sessionContext );
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan( sessionContext );
 		plan.delete( referenceProvider( "1" ) );
 		plan.execute().join();
 
@@ -111,7 +111,7 @@ public class LuceneIndexingNestedIT {
 		// Multitenancy enabled, which means the backend will use indexWriter.deleteDocuments(Query) for deletion
 		setup( MultiTenancyStrategyName.DISCRIMINATOR );
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan( sessionContext );
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan( sessionContext );
 		plan.delete( referenceProvider( "1" ) );
 		plan.execute().join();
 
@@ -148,7 +148,7 @@ public class LuceneIndexingNestedIT {
 			sessionContext = new StubBackendSessionContext( "someTenantId" );
 		}
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan( sessionContext );
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan( sessionContext );
 		plan.add( referenceProvider( "1" ), document -> {
 			DocumentElement nested = document.addObject( indexMapping.nestedObject.self );
 			nested.addValue( indexMapping.nestedObject.field1, "value" );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/ObjectFieldStorageIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/ObjectFieldStorageIT.java
@@ -72,7 +72,7 @@ public class ObjectFieldStorageIT {
 
 	@Test
 	public void index_error_invalidFieldForDocumentElement_root() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 
 		thrown.expect( SearchException.class );
 		thrown.expectMessage( "Invalid field reference for this document element" );
@@ -88,7 +88,7 @@ public class ObjectFieldStorageIT {
 
 	@Test
 	public void index_error_invalidFieldForDocumentElement_flattened() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 
 		thrown.expect( SearchException.class );
 		thrown.expectMessage( "Invalid field reference for this document element" );
@@ -103,7 +103,7 @@ public class ObjectFieldStorageIT {
 
 	@Test
 	public void index_error_invalidFieldForDocumentElement_nested() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 
 		thrown.expect( SearchException.class );
 		thrown.expectMessage( "Invalid field reference for this document element" );
@@ -219,7 +219,7 @@ public class ObjectFieldStorageIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( EXPECTED_NESTED_MATCH_ID ), document -> {
 			ObjectMapping objectMapping;
 			DocumentElement object;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/SmokeIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/SmokeIT.java
@@ -255,7 +255,7 @@ public class SmokeIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), document -> {
 			document.addValue( indexMapping.string, "text 1" );
 			document.addValue( indexMapping.string_analyzed, "text 1" );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/analysis/AnalysisCustomIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/analysis/AnalysisCustomIT.java
@@ -276,7 +276,7 @@ public class AnalysisCustomIT {
 	}
 
 	private void initData(Consumer<AnalysisITDocumentBuilder> valueContributor) {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		List<String> documentIds = new ArrayList<>();
 		valueContributor.accept(
 				(String documentId, String ... fieldValues) -> {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/decimalscale/DecimalScaleIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/decimalscale/DecimalScaleIT.java
@@ -102,7 +102,7 @@ public class DecimalScaleIT {
 						indexManager -> this.indexManager = indexManager )
 				.setup();
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, new BigDecimal( "739.11111" ) ) );
 		plan.execute().join();
 
@@ -120,7 +120,7 @@ public class DecimalScaleIT {
 						indexManager -> this.indexManager = indexManager )
 				.setup();
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, new BigDecimal( "739.11111" ) ) );
 		plan.execute().join();
 
@@ -138,7 +138,7 @@ public class DecimalScaleIT {
 						indexManager -> this.indexManager = indexManager )
 				.setup();
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, new BigInteger( "739" ) ) );
 		plan.execute().join();
 
@@ -156,7 +156,7 @@ public class DecimalScaleIT {
 						indexManager -> this.indexManager = indexManager )
 				.setup();
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, new BigDecimal( "11111.11111" ) ) );
 		plan.execute().join();
 
@@ -174,7 +174,7 @@ public class DecimalScaleIT {
 						indexManager -> this.indexManager = indexManager )
 				.setup();
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, new BigInteger( "11111" ) ) );
 		plan.execute().join();
 
@@ -216,7 +216,7 @@ public class DecimalScaleIT {
 		Assertions.assertThat( originalValue )
 				.isBetween( indexedValueLowerBound, indexedValueUpperBound );
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, originalValue ) );
 		plan.execute().join();
 
@@ -256,7 +256,7 @@ public class DecimalScaleIT {
 		Assertions.assertThat( originalValue )
 				.isBetween( indexedValueLowerBound, indexedValueUpperBound );
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, originalValue ) );
 		plan.execute().join();
 
@@ -296,7 +296,7 @@ public class DecimalScaleIT {
 		Assertions.assertThat( originalValue )
 				.isBetween( indexedValueLowerBound, indexedValueUpperBound );
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, originalValue ) );
 		plan.execute().join();
 
@@ -312,7 +312,7 @@ public class DecimalScaleIT {
 						indexManager -> this.indexManager = indexManager )
 				.setup();
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, new BigDecimal( "739.114999" ) ) );
 		plan.add( referenceProvider( "2" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, new BigDecimal( "739.115" ) ) );
 		plan.add( referenceProvider( "3" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, new BigDecimal( "739.11" ) ) );
@@ -336,7 +336,7 @@ public class DecimalScaleIT {
 						indexManager -> this.indexManager = indexManager )
 				.setup();
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, new BigInteger( "7394999" ) ) );
 		plan.add( referenceProvider( "2" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, new BigInteger( "7395000" ) ) );
 		plan.add( referenceProvider( "3" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, new BigInteger( "7390000" ) ) );
@@ -364,7 +364,7 @@ public class DecimalScaleIT {
 		// If the exponent were 54, the test would fail for Elasticsearch, whereas it would work for Lucene backend.
 		BigDecimal largeDecimal = new BigDecimal( "2" ).pow( 53 );
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, largeDecimal ) );
 		plan.execute().join();
 
@@ -385,7 +385,7 @@ public class DecimalScaleIT {
 		// If the exponent were 54, the test would fail for Elasticsearch, whereas it would work for Lucene backend.
 		BigInteger largeInteger = new BigInteger( "2" ).pow( 53 );
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, largeInteger ) );
 		plan.execute().join();
 
@@ -406,7 +406,7 @@ public class DecimalScaleIT {
 		BigDecimal tooLargeDecimal = BigDecimal.valueOf( Long.MAX_VALUE ).multiply( BigDecimal.TEN );
 
 		SubTest.expectException( () -> {
-			IndexIndexingPlan plan = indexManager.createIndexingPlan();
+			IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 			plan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, tooLargeDecimal ) );
 			plan.execute().join();
 		} )
@@ -427,7 +427,7 @@ public class DecimalScaleIT {
 		// Provide a value that cannot be represented as a long
 		BigDecimal tooLargeDecimal = veryLargeDecimal.multiply( BigDecimal.TEN );
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, veryLargeDecimal ) );
 		plan.execute().join();
 
@@ -453,7 +453,7 @@ public class DecimalScaleIT {
 		BigDecimal tooLargeDecimal = BigDecimal.valueOf( Long.MIN_VALUE ).multiply( BigDecimal.TEN );
 
 		SubTest.expectException( () -> {
-			IndexIndexingPlan plan = indexManager.createIndexingPlan();
+			IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 			plan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, tooLargeDecimal ) );
 			plan.execute().join();
 		} )
@@ -474,7 +474,7 @@ public class DecimalScaleIT {
 		BigInteger tooLargeInteger = BigInteger.valueOf( Long.MAX_VALUE ).multiply( BigInteger.TEN );
 
 		SubTest.expectException( () -> {
-			IndexIndexingPlan plan = indexManager.createIndexingPlan();
+			IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 			plan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, tooLargeInteger ) );
 			plan.execute().join();
 		} )
@@ -495,7 +495,7 @@ public class DecimalScaleIT {
 		BigInteger tooLargeInteger = BigInteger.valueOf( Long.MIN_VALUE ).multiply( BigInteger.TEN );
 
 		SubTest.expectException( () -> {
-			IndexIndexingPlan plan = indexManager.createIndexingPlan();
+			IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 			plan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, tooLargeInteger ) );
 			plan.execute().join();
 		} )
@@ -516,7 +516,7 @@ public class DecimalScaleIT {
 		// Provide a value that cannot be represented as a long
 		BigInteger tooLargeInteger = veryLargeNegativeInteger.multiply( BigInteger.TEN );
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, veryLargeNegativeInteger ) );
 		plan.execute().join();
 
@@ -542,7 +542,7 @@ public class DecimalScaleIT {
 		BigDecimal tooLargeDecimal = BigDecimal.valueOf( Long.MAX_VALUE ).divide( BigDecimal.TEN );
 
 		SubTest.expectException( () -> {
-			IndexIndexingPlan plan = indexManager.createIndexingPlan();
+			IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 			plan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, tooLargeDecimal ) );
 			plan.execute().join();
 		} )
@@ -563,7 +563,7 @@ public class DecimalScaleIT {
 		BigDecimal tooLargeDecimal = BigDecimal.valueOf( Long.MIN_VALUE ).divide( BigDecimal.TEN );
 
 		SubTest.expectException( () -> {
-			IndexIndexingPlan plan = indexManager.createIndexingPlan();
+			IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 			plan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, tooLargeDecimal ) );
 			plan.execute().join();
 		} )
@@ -584,7 +584,7 @@ public class DecimalScaleIT {
 		BigDecimal tooLargeDecimal = BigDecimal.valueOf( Long.MIN_VALUE ).divide( BigDecimal.TEN );
 		BigDecimal veryLargeDecimal = tooLargeDecimal.divide( BigDecimal.TEN );
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, veryLargeDecimal ) );
 		plan.execute().join();
 
@@ -610,7 +610,7 @@ public class DecimalScaleIT {
 		BigInteger tooLargeInteger = BigInteger.valueOf( Long.MAX_VALUE ).multiply( new BigInteger( "1000" ) );
 
 		SubTest.expectException( () -> {
-			IndexIndexingPlan plan = indexManager.createIndexingPlan();
+			IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 			plan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, tooLargeInteger ) );
 			plan.execute().join();
 		} )
@@ -631,7 +631,7 @@ public class DecimalScaleIT {
 		// Provide a value that if it were multiplied by 100, could not be represented as a long, because the scale of -2
 		BigInteger tooLargeInteger = veryLargeInteger.multiply( new BigInteger( "1000" ) );
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, veryLargeInteger ) );
 		plan.execute().join();
 
@@ -657,7 +657,7 @@ public class DecimalScaleIT {
 		BigInteger tooLargeInteger = BigInteger.valueOf( Long.MIN_VALUE ).multiply( new BigInteger( "1000" ) );
 
 		SubTest.expectException( () -> {
-			IndexIndexingPlan plan = indexManager.createIndexingPlan();
+			IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 			plan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, tooLargeInteger ) );
 			plan.execute().join();
 		} )
@@ -674,7 +674,7 @@ public class DecimalScaleIT {
 						indexManager -> this.indexManager = indexManager )
 				.setup();
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), doc -> doc.addValue( defaultDecimalScaleIndexMapping.scaled, new BigDecimal( "739.11111" ) ) );
 		plan.execute().join();
 
@@ -692,7 +692,7 @@ public class DecimalScaleIT {
 						indexManager -> this.indexManager = indexManager )
 				.setup();
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), doc -> doc.addValue( defaultIntegerScaleIndexMapping.scaled, new BigInteger( "7391111" ) ) );
 		plan.execute().join();
 
@@ -710,7 +710,7 @@ public class DecimalScaleIT {
 						indexManager -> this.indexManager = indexManager )
 				.setup();
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), doc -> doc.addValue( bothDecimalScaleIndexMapping.scaled, new BigDecimal( "739.11111" ) ) );
 		plan.execute().join();
 
@@ -729,7 +729,7 @@ public class DecimalScaleIT {
 						indexManager -> this.indexManager = indexManager )
 				.setup();
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), doc -> doc.addValue( bothIntegerScaleIndexMapping.scaled, new BigInteger( "7391111" ) ) );
 		plan.execute().join();
 
@@ -748,7 +748,7 @@ public class DecimalScaleIT {
 						indexManager -> this.indexManager = indexManager )
 				.setup();
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), doc -> doc.addValue( decimalScaleIndexMapping.scaled, new BigDecimal( "739.11111" ) ) );
 		plan.execute().join();
 
@@ -764,7 +764,7 @@ public class DecimalScaleIT {
 						indexManager -> this.indexManager = indexManager )
 				.setup();
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), doc -> doc.addValue( integerScaleIndexMapping.scaled, new BigInteger( "73911111" ) ) );
 		plan.execute().join();
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentElementBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentElementBaseIT.java
@@ -231,7 +231,7 @@ public class DocumentElementBaseIT {
 	}
 
 	private void executeAdd(String id, Consumer<DocumentElement> documentContributor) {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( id ), documentContributor::accept );
 		plan.execute().join();
 	}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentElementMultiValuedIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/document/DocumentElementMultiValuedIT.java
@@ -291,7 +291,7 @@ public class DocumentElementMultiValuedIT {
 	}
 
 	private void executeAdd(String id, Consumer<DocumentElement> documentContributor) {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( id ), documentContributor::accept );
 		plan.execute().join();
 	}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/indexnull/IndexNullAsValueIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/indexnull/IndexNullAsValueIT.java
@@ -113,7 +113,7 @@ public class IndexNullAsValueIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add(
 				referenceProvider( DOCUMENT_WITH_INDEX_NULL_AS_VALUES ),
 				document -> {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/multitenancy/MultiTenancyBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/multitenancy/MultiTenancyBaseIT.java
@@ -175,7 +175,7 @@ public class MultiTenancyBaseIT {
 
 	@Test
 	public void delete_only_deletes_elements_of_the_tenant() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan( tenant2SessionContext );
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan( tenant2SessionContext );
 
 		StubMappingScope scope = indexManager.createScope();
 		SearchQuery<DocumentReference> query = scope.query( tenant2SessionContext )
@@ -226,7 +226,7 @@ public class MultiTenancyBaseIT {
 
 	@Test
 	public void update_only_updates_elements_of_the_tenant() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan( tenant2SessionContext );
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan( tenant2SessionContext );
 
 		StubMappingScope scope = indexManager.createScope();
 		SearchQuery<DocumentReference> checkQuery = scope.query( tenant2SessionContext )
@@ -347,7 +347,7 @@ public class MultiTenancyBaseIT {
 		thrown.expectMessage( "Backend" );
 		thrown.expectMessage( "has multi-tenancy enabled, but no tenant identifier is provided." );
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan( new StubBackendSessionContext() );
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan( new StubBackendSessionContext() );
 
 		plan.add( referenceProvider( DOCUMENT_ID_3 ), document -> {
 			document.addValue( indexMapping.string, STRING_VALUE_3 );
@@ -367,7 +367,7 @@ public class MultiTenancyBaseIT {
 		thrown.expectMessage( "Backend" );
 		thrown.expectMessage( "has multi-tenancy enabled, but no tenant identifier is provided." );
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan( new StubBackendSessionContext() );
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan( new StubBackendSessionContext() );
 
 		plan.update( referenceProvider( DOCUMENT_ID_2 ), document -> {
 			document.addValue( indexMapping.string, UPDATED_STRING );
@@ -387,13 +387,13 @@ public class MultiTenancyBaseIT {
 		thrown.expectMessage( "Backend" );
 		thrown.expectMessage( "has multi-tenancy enabled, but no tenant identifier is provided." );
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan( new StubBackendSessionContext() );
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan( new StubBackendSessionContext() );
 		plan.delete( referenceProvider( DOCUMENT_ID_1 ) );
 		plan.execute().join();
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan( tenant1SessionContext );
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan( tenant1SessionContext );
 		plan.add( referenceProvider( DOCUMENT_ID_1 ), document -> {
 			document.addValue( indexMapping.string, STRING_VALUE_1 );
 			document.addValue( indexMapping.integer, INTEGER_VALUE_1 );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/multitenancy/MultiTenancyMismatchIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/multitenancy/MultiTenancyMismatchIT.java
@@ -93,7 +93,7 @@ public class MultiTenancyMismatchIT {
 		thrown.expectMessage( "Tenant identifier" );
 		thrown.expectMessage( "is provided, but multi-tenancy is disabled for this backend" );
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan( tenant1SessionContext );
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan( tenant1SessionContext );
 		plan.update( referenceProvider( "1" ), document -> { } );
 		plan.execute().join();
 	}
@@ -112,7 +112,7 @@ public class MultiTenancyMismatchIT {
 		thrown.expectMessage( "Tenant identifier" );
 		thrown.expectMessage( "is provided, but multi-tenancy is disabled for this backend" );
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan( tenant1SessionContext );
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan( tenant1SessionContext );
 		plan.update( referenceProvider( "1" ), document -> { } );
 		plan.execute().join();
 	}
@@ -131,7 +131,7 @@ public class MultiTenancyMismatchIT {
 		thrown.expectMessage( "Tenant identifier" );
 		thrown.expectMessage( "is provided, but multi-tenancy is disabled for this backend" );
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan( tenant1SessionContext );
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan( tenant1SessionContext );
 		plan.delete( referenceProvider( "1" ) );
 		plan.execute().join();
 	}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/SearchMultiIndexIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/SearchMultiIndexIT.java
@@ -296,7 +296,7 @@ public class SearchMultiIndexIT {
 	private void initData() {
 		// Backend 1 / Index 1
 
-		IndexIndexingPlan plan = indexManager_1_1.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager_1_1.createIndexingPlan();
 
 		plan.add( referenceProvider( DOCUMENT_1_1_1 ), document -> {
 			document.addValue( indexMapping_1_1.string, STRING_1 );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/AggregationBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/AggregationBaseIT.java
@@ -95,7 +95,7 @@ public class AggregationBaseIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			document.addValue( indexMapping.string, STRING_1 );
 		} );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/RangeAggregationSpecificsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/RangeAggregationSpecificsIT.java
@@ -502,7 +502,7 @@ public class RangeAggregationSpecificsIT<F> {
 	private void initData() {
 		List<F> documentFieldValues = ascendingValues.subList( 0, 7 );
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		for ( int i = 0; i < documentFieldValues.size(); i++ ) {
 			F value = documentFieldValues.get( i );
 			plan.add( referenceProvider( "document_" + i ), document -> {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/SingleFieldAggregationBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/SingleFieldAggregationBaseIT.java
@@ -748,7 +748,7 @@ public class SingleFieldAggregationBaseIT<F> {
 		List<F> otherIndexDocumentFieldValues = expectations.getOtherIndexDocumentFieldValues();
 		List<List<F>> multiValuedIndexDocumentFieldValues = expectations.getMultiValuedIndexDocumentFieldValues();
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		for ( int i = 0; i < mainIndexDocumentFieldValues.size(); i++ ) {
 			F value = mainIndexDocumentFieldValues.get( i );
 			plan.add( referenceProvider( "document_" + i ), document -> {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/TermsAggregationSpecificsIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/TermsAggregationSpecificsIT.java
@@ -605,7 +605,7 @@ public class TermsAggregationSpecificsIT<F> {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		int documentCount = 0;
 		for ( Map.Entry<F, List<String>> entry : documentIdPerTerm.entrySet() ) {
 			F value = entry.getKey();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/bool/BooleanSortAndRangePredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/bool/BooleanSortAndRangePredicateIT.java
@@ -174,7 +174,7 @@ public class BooleanSortAndRangePredicateIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			document.addValue( indexMapping.bool, true );
 		} );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/BoolSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/BoolSearchPredicateIT.java
@@ -1028,7 +1028,7 @@ public class BoolSearchPredicateIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			document.addValue( indexMapping.field1, FIELD1_VALUE1 );
 			document.addValue( indexMapping.field2, FIELD2_VALUE1 );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/ExistsSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/ExistsSearchPredicateIT.java
@@ -382,7 +382,7 @@ public class ExistsSearchPredicateIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			indexMapping.supportedFieldModels.forEach( f -> f.document1Value.write( document ) );
 			indexMapping.supportedFieldWithDocValuesModels.forEach( f -> f.document1Value.write( document ) );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchAllSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchAllSearchPredicateIT.java
@@ -112,7 +112,7 @@ public class MatchAllSearchPredicateIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			document.addValue( indexMapping.string, STRING_1 );
 		} );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchIdSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchIdSearchPredicateIT.java
@@ -186,7 +186,7 @@ public class MatchIdSearchPredicateIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( DOCUMENT_1 ), document -> { } );
 		plan.add( referenceProvider( DOCUMENT_2 ), document -> { } );
 		plan.add( referenceProvider( DOCUMENT_3 ), document -> { } );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchIdWithConverterSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchIdWithConverterSearchPredicateIT.java
@@ -142,7 +142,7 @@ public class MatchIdWithConverterSearchPredicateIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( DOCUMENT_1 ), document -> { } );
 		plan.add( referenceProvider( DOCUMENT_2 ), document -> { } );
 		plan.add( referenceProvider( DOCUMENT_3 ), document -> { } );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchSearchPredicateIT.java
@@ -1405,7 +1405,7 @@ public class MatchSearchPredicateIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			indexMapping.supportedFieldModels.forEach( f -> f.document1Value.write( document ) );
 			indexMapping.supportedFieldWithDslConverterModels.forEach( f -> f.document1Value.write( document ) );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/NestedSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/NestedSearchPredicateIT.java
@@ -224,7 +224,7 @@ public class NestedSearchPredicateIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			ObjectMapping level1;
 			SecondLevelObjectMapping level2;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/ObjectExistsSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/ObjectExistsSearchPredicateIT.java
@@ -361,7 +361,7 @@ public class ObjectExistsSearchPredicateIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( DOCUMENT_0 ), document -> { } );
 
 		plan.add( referenceProvider( DOCUMENT_1 ), document -> {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/PhraseSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/PhraseSearchPredicateIT.java
@@ -789,7 +789,7 @@ public class PhraseSearchPredicateIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			document.addValue( indexMapping.analyzedStringField1.reference, PHRASE_1_TEXT_EXACT_MATCH );
 			document.addValue( indexMapping.analyzedStringFieldWithDslConverter.reference, PHRASE_1_TEXT_EXACT_MATCH );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/RangeSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/RangeSearchPredicateIT.java
@@ -1022,7 +1022,7 @@ public class RangeSearchPredicateIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			indexMapping.supportedFieldModels.forEach( f -> f.document1Value.write( document ) );
 			indexMapping.supportedFieldWithDslConverterModels.forEach( f -> f.document1Value.write( document ) );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SearchPredicateIT.java
@@ -353,7 +353,7 @@ public class SearchPredicateIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			document.addValue( indexMapping.string, STRING_1 );
 		} );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SimpleQueryStringSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SimpleQueryStringSearchPredicateIT.java
@@ -896,7 +896,7 @@ public class SimpleQueryStringSearchPredicateIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			document.addValue( indexMapping.nonAnalyzedField.reference, TEXT_TERM_1_AND_TERM_2 );
 			document.addValue( indexMapping.analyzedStringField1.reference, TEXT_TERM_1_AND_TERM_2 );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/WildcardSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/WildcardSearchPredicateIT.java
@@ -530,7 +530,7 @@ public class WildcardSearchPredicateIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			document.addValue( indexMapping.analyzedStringField1.reference, TEXT_MATCHING_PATTERN_1 );
 			document.addValue( indexMapping.analyzedStringFieldWithDslConverter.reference, TEXT_MATCHING_PATTERN_1 );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/CompositeSearchProjectionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/CompositeSearchProjectionIT.java
@@ -326,7 +326,7 @@ public class CompositeSearchProjectionIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			indexMapping.author.document1Value.write( document );
 			indexMapping.title.document1Value.write( document );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/FieldSearchProjectionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/FieldSearchProjectionIT.java
@@ -593,7 +593,7 @@ public class FieldSearchProjectionIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			indexMapping.supportedFieldModels.forEach( f -> f.document1Value.write( document ) );
 			indexMapping.supportedFieldWithProjectionConverterModels.forEach( f -> f.document1Value.write( document ) );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/SearchProjectionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/projection/SearchProjectionIT.java
@@ -536,7 +536,7 @@ public class SearchProjectionIT extends EasyMockSupport {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			indexMapping.string1Field.document1Value.write( document );
 			indexMapping.string2Field.document1Value.write( document );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryResultLoadingOrTransformingIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryResultLoadingOrTransformingIT.java
@@ -619,7 +619,7 @@ public class SearchQueryResultLoadingOrTransformingIT extends EasyMockSupport {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( MAIN_ID ), document -> {
 			document.addValue( indexMapping.string, STRING_VALUE );
 			document.addValue( indexMapping.string_analyzed, STRING_ANALYZED_VALUE );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryTimeoutIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryTimeoutIT.java
@@ -159,7 +159,7 @@ public class SearchQueryTimeoutIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		// Use a batch approach for a real application
 		// Here the huge bulk is used to provoke a timeout
 		for ( int i = 0; i < ROUNDS; i++ ) {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/CompositeSearchSortIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/CompositeSearchSortIT.java
@@ -308,7 +308,7 @@ public class CompositeSearchSortIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( DOCUMENT_1 ), document -> {
 			indexMapping.identicalForFirstTwo.write( document, "aaa" );
 			indexMapping.identicalForLastTwo.write( document, "aaa" );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSearchSortIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSearchSortIT.java
@@ -696,7 +696,7 @@ public class FieldSearchSortIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		// Important: do not index the documents in the expected order after sorts (1, 2, 3)
 		plan.add( referenceProvider( DOCUMENT_2 ), document -> {
 			indexMapping.supportedFieldModels.forEach( f -> f.document2Value.write( document ) );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/SearchSortIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/SearchSortIT.java
@@ -590,7 +590,7 @@ public class SearchSortIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		// Important: do not index the documents in the expected order after sorts
 		plan.add( referenceProvider( SECOND_ID ), document -> {
 			GeoPoint geoPoint = GeoPoint.of( 45.7705687, 4.835233 );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/AbstractSpatialWithinSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/AbstractSpatialWithinSearchPredicateIT.java
@@ -80,7 +80,7 @@ public abstract class AbstractSpatialWithinSearchPredicateIT {
 	}
 
 	protected void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( OURSON_QUI_BOIT_ID ), document -> {
 			document.addValue( indexMapping.string, OURSON_QUI_BOIT_STRING );
 			document.addValue( indexMapping.geoPoint, OURSON_QUI_BOIT_GEO_POINT );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/DistanceSearchSearchableSortableIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/DistanceSearchSearchableSortableIT.java
@@ -160,7 +160,7 @@ public class DistanceSearchSearchableSortableIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( OURSON_QUI_BOIT_ID ), document -> {
 			document.addValue( indexMapping.searchableSortable, OURSON_QUI_BOIT_GEO_POINT );
 			document.addValue( indexMapping.searchableNotSortable, OURSON_QUI_BOIT_GEO_POINT );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/MultivaluedSpatialIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/MultivaluedSpatialIT.java
@@ -69,7 +69,7 @@ public class MultivaluedSpatialIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), f -> {
 			f.addValue( indexMapping.geoPoint, NORTH_WEST );
 			f.addValue( indexMapping.geoPoint, SOUTH_EAST );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/NestedDocumentDistanceProjectionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/NestedDocumentDistanceProjectionIT.java
@@ -103,7 +103,7 @@ public class NestedDocumentDistanceProjectionIT {
 	}
 
 	private void initData() {
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( OURSON_QUI_BOIT_ID ), document -> {
 			document.addValue( indexMapping.ordinalField, 1 );
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/SpatialWithinBoundingBoxSearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/spatial/SpatialWithinBoundingBoxSearchPredicateIT.java
@@ -427,7 +427,7 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 	protected void initData() {
 		super.initData();
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( ADDITIONAL_POINT_1_ID ), document -> {
 			document.addValue( indexMapping.geoPoint, ADDITIONAL_POINT_1_GEO_POINT );
 		} );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexIndexingPlanIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexIndexingPlanIT.java
@@ -45,7 +45,7 @@ public class IndexIndexingPlanIT {
 	public void success() {
 		setup();
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), document -> document.addValue( indexMapping.title, "Title of Book 1" ) );
 		plan.add( referenceProvider( "2" ), document -> document.addValue( indexMapping.title, "Title of Book 2" ) );
 
@@ -66,7 +66,7 @@ public class IndexIndexingPlanIT {
 	public void discard() {
 		setup();
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 
 		plan.add( referenceProvider( "1" ), document -> document.addValue( indexMapping.title, "Title of Book 1" ) );
 		plan.discard();
@@ -89,7 +89,7 @@ public class IndexIndexingPlanIT {
 	public void failure() {
 		setup();
 
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		plan.add( referenceProvider( "1" ), document -> document.addValue( indexMapping.title, "Title of Book 1" ) );
 		plan.add( referenceProvider( "2" ), document -> document.addValue( indexMapping.title, "Title of Book 2" ) );
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexingFieldTypesIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexingFieldTypesIT.java
@@ -87,7 +87,7 @@ public class IndexingFieldTypesIT<F> {
 		List<IdAndValue<F>> expectedDocuments = new ArrayList<>();
 
 		// Index all values, each in its own document
-		IndexIndexingPlan plan = indexManager.createIndexingPlan();
+		IndexIndexingPlan<?> plan = indexManager.createIndexingPlan();
 		for ( int i = 0; i < values.size(); i++ ) {
 			String documentId = "document_" + i;
 			F value = values.get( i );

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/AbstractOnTheFlyIndexingBenchmarks.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/AbstractOnTheFlyIndexingBenchmarks.java
@@ -120,7 +120,7 @@ public abstract class AbstractOnTheFlyIndexingBenchmarks extends AbstractBackend
 		StubBackendSessionContext sessionContext = new StubBackendSessionContext();
 		PerThreadIndexPartition partition = getIndexPartition();
 		MappedIndex index = partition.getIndex();
-		IndexIndexingPlan indexingPlan = index.getIndexManager()
+		IndexIndexingPlan<?> indexingPlan = index.getIndexManager()
 				.createIndexingPlan( sessionContext, getCommitStrategyParam(), refreshStrategy );
 
 		for ( Long documentIdInThread : idsToAdd ) {

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexingPlanImpl.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexingPlanImpl.java
@@ -17,10 +17,10 @@ import org.hibernate.search.util.common.impl.Throwables;
 public class SearchIndexingPlanImpl implements SearchIndexingPlan {
 
 	private final PojoRuntimeIntrospector introspector;
-	private final PojoIndexingPlan delegate;
+	private final PojoIndexingPlan<?> delegate;
 
 	public SearchIndexingPlanImpl(PojoRuntimeIntrospector introspector,
-			PojoIndexingPlan delegate) {
+			PojoIndexingPlan<?> delegate) {
 		this.introspector = introspector;
 		this.delegate = delegate;
 	}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/event/impl/HibernateOrmListenerContextProvider.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/event/impl/HibernateOrmListenerContextProvider.java
@@ -8,13 +8,14 @@ package org.hibernate.search.mapper.orm.event.impl;
 
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.search.mapper.orm.automaticindexing.session.impl.ConfiguredAutomaticIndexingSynchronizationStrategy;
+import org.hibernate.search.mapper.orm.common.EntityReference;
 import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingPlan;
 
 public interface HibernateOrmListenerContextProvider {
 
 	HibernateOrmListenerTypeContextProvider getTypeContextProvider();
 
-	PojoIndexingPlan getCurrentIndexingPlan(SessionImplementor session, boolean createIfDoesNotExist);
+	PojoIndexingPlan<EntityReference> getCurrentIndexingPlan(SessionImplementor session, boolean createIfDoesNotExist);
 
 	ConfiguredAutomaticIndexingSynchronizationStrategy getCurrentAutomaticIndexingSynchronizationStrategy(
 			SessionImplementor session);

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/event/impl/HibernateSearchEventListener.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/event/impl/HibernateSearchEventListener.java
@@ -33,6 +33,7 @@ import org.hibernate.event.spi.PostInsertEventListener;
 import org.hibernate.event.spi.PostUpdateEvent;
 import org.hibernate.event.spi.PostUpdateEventListener;
 import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.search.mapper.orm.common.EntityReference;
 import org.hibernate.search.mapper.orm.logging.impl.Log;
 import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingPlan;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
@@ -99,7 +100,7 @@ public final class HibernateSearchEventListener implements PostDeleteEventListen
 		final Object entity = event.getEntity();
 		HibernateOrmListenerTypeContext typeContext = getTypeContext( contextProvider, event.getPersister() );
 		if ( typeContext != null ) {
-			PojoIndexingPlan plan = getCurrentIndexingPlan( contextProvider, event.getSession() );
+			PojoIndexingPlan<?> plan = getCurrentIndexingPlan( contextProvider, event.getSession() );
 			Object providedId = typeContext.toIndexingPlanProvidedId( event.getId() );
 			if ( dirtyCheckingEnabled ) {
 				plan.addOrUpdate( typeContext.getTypeIdentifier(), providedId, entity, getDirtyPropertyNames( event ) );
@@ -134,7 +135,7 @@ public final class HibernateSearchEventListener implements PostDeleteEventListen
 		HibernateOrmListenerContextProvider contextProvider = state.getContextProvider();
 		EventSource session = event.getSession();
 
-		PojoIndexingPlan plan = getCurrentIndexingPlanIfExisting( contextProvider, session );
+		PojoIndexingPlan<EntityReference> plan = getCurrentIndexingPlanIfExisting( contextProvider, session );
 		if ( plan == null ) {
 			// Nothing to flush
 			return;
@@ -168,7 +169,7 @@ public final class HibernateSearchEventListener implements PostDeleteEventListen
 	@Override
 	public void onClear(ClearEvent event) {
 		EventSource session = event.getSession();
-		PojoIndexingPlan plan = getCurrentIndexingPlanIfExisting( state.getContextProvider(), session );
+		PojoIndexingPlan<?> plan = getCurrentIndexingPlanIfExisting( state.getContextProvider(), session );
 
 		// skip the clearNotPrepared operation in case there has been no one to clear
 		if ( plan != null ) {
@@ -184,12 +185,12 @@ public final class HibernateSearchEventListener implements PostDeleteEventListen
 		return contextProvider;
 	}
 
-	private PojoIndexingPlan getCurrentIndexingPlan(HibernateOrmListenerContextProvider contextProvider,
+	private PojoIndexingPlan<EntityReference> getCurrentIndexingPlan(HibernateOrmListenerContextProvider contextProvider,
 			SessionImplementor sessionImplementor) {
 		return contextProvider.getCurrentIndexingPlan( sessionImplementor, true );
 	}
 
-	private PojoIndexingPlan getCurrentIndexingPlanIfExisting(HibernateOrmListenerContextProvider contextProvider,
+	private PojoIndexingPlan<EntityReference> getCurrentIndexingPlanIfExisting(HibernateOrmListenerContextProvider contextProvider,
 			SessionImplementor sessionImplementor) {
 		return contextProvider.getCurrentIndexingPlan( sessionImplementor, false );
 	}
@@ -213,7 +214,7 @@ public final class HibernateSearchEventListener implements PostDeleteEventListen
 		HibernateOrmListenerTypeContext typeContext = contextProvider.getTypeContextProvider()
 				.getByHibernateOrmEntityName( event.getAffectedOwnerEntityName() );
 		if ( typeContext != null ) {
-			PojoIndexingPlan plan = getCurrentIndexingPlan( contextProvider, event.getSession() );
+			PojoIndexingPlan<?> plan = getCurrentIndexingPlan( contextProvider, event.getSession() );
 			Object providedId = typeContext.toIndexingPlanProvidedId( event.getAffectedOwnerIdOrNull() );
 
 			if ( dirtyCheckingEnabled ) {

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMapping.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMapping.java
@@ -209,7 +209,8 @@ public class HibernateOrmMapping extends AbstractPojoMappingImplementor<Hibernat
 	}
 
 	@Override
-	public PojoIndexingPlan getCurrentIndexingPlan(SessionImplementor session, boolean createIfDoesNotExist) {
+	public PojoIndexingPlan<EntityReference> getCurrentIndexingPlan(SessionImplementor session,
+			boolean createIfDoesNotExist) {
 		return HibernateOrmSearchSession.get( this, session ).getCurrentIndexingPlan( createIfDoesNotExist );
 	}
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/HibernateOrmSearchSession.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/HibernateOrmSearchSession.java
@@ -188,9 +188,7 @@ public class HibernateOrmSearchSession extends AbstractPojoSearchSession<EntityR
 	public void setAutomaticIndexingSynchronizationStrategy(
 			AutomaticIndexingSynchronizationStrategy synchronizationStrategy) {
 		ConfiguredAutomaticIndexingSynchronizationStrategy.Builder builder =
-				new ConfiguredAutomaticIndexingSynchronizationStrategy.Builder(
-						mappingContext.getFailureHandler(), this
-				);
+				new ConfiguredAutomaticIndexingSynchronizationStrategy.Builder( mappingContext.getFailureHandler() );
 		synchronizationStrategy.apply( builder );
 		this.configuredAutomaticIndexingSynchronizationStrategy = builder.build();
 	}
@@ -248,13 +246,14 @@ public class HibernateOrmSearchSession extends AbstractPojoSearchSession<EntityR
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public PojoIndexingPlan getCurrentIndexingPlan(boolean createIfDoesNotExist) {
+	public PojoIndexingPlan<EntityReference> getCurrentIndexingPlan(boolean createIfDoesNotExist) {
 		checkOrmSessionIsOpen();
 		Transaction transactionIdentifier = null;
 
-		TransientReference<Map<Transaction, PojoIndexingPlan>> reference = (TransientReference<Map<Transaction, PojoIndexingPlan>>) sessionImplementor.getProperties()
+		TransientReference<Map<Transaction, PojoIndexingPlan<EntityReference>>> reference =
+				(TransientReference<Map<Transaction, PojoIndexingPlan<EntityReference>>>) sessionImplementor.getProperties()
 				.get( INDEXING_PLAN_PER_TRANSACTION_MAP_KEY );
-		Map<Transaction, PojoIndexingPlan> planPerTransaction = reference == null ? null : reference.get();
+		Map<Transaction, PojoIndexingPlan<EntityReference>> planPerTransaction = reference == null ? null : reference.get();
 		if ( planPerTransaction == null ) {
 			planPerTransaction = new HashMap<>();
 			reference = new TransientReference<>( planPerTransaction );
@@ -266,7 +265,7 @@ public class HibernateOrmSearchSession extends AbstractPojoSearchSession<EntityR
 		}
 		// For out of transaction case we will use null as transaction identifier
 
-		PojoIndexingPlan plan = planPerTransaction.get( transactionIdentifier );
+		PojoIndexingPlan<EntityReference> plan = planPerTransaction.get( transactionIdentifier );
 		if ( plan != null ) {
 			return plan;
 		}
@@ -298,8 +297,9 @@ public class HibernateOrmSearchSession extends AbstractPojoSearchSession<EntityR
 		return configuredAutomaticIndexingSynchronizationStrategy;
 	}
 
-	private Synchronization createTransactionWorkQueueSynchronization(PojoIndexingPlan indexingPlan,
-			Map<Transaction, PojoIndexingPlan> indexingPlanPerTransaction, Transaction transactionIdentifier,
+	private Synchronization createTransactionWorkQueueSynchronization(PojoIndexingPlan<EntityReference> indexingPlan,
+			Map<Transaction, PojoIndexingPlan<EntityReference>> indexingPlanPerTransaction,
+			Transaction transactionIdentifier,
 			ConfiguredAutomaticIndexingSynchronizationStrategy synchronizationStrategy) {
 		if ( enlistInTransaction ) {
 			return new InTransactionWorkQueueSynchronization(

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/InTransactionWorkQueueSynchronization.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/InTransactionWorkQueueSynchronization.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import javax.transaction.Synchronization;
 
 import org.hibernate.search.mapper.orm.automaticindexing.session.impl.ConfiguredAutomaticIndexingSynchronizationStrategy;
+import org.hibernate.search.mapper.orm.common.EntityReference;
 import org.hibernate.search.mapper.orm.logging.impl.Log;
 import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingPlan;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
@@ -25,12 +26,12 @@ class InTransactionWorkQueueSynchronization implements Synchronization {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private final PojoIndexingPlan indexingPlan;
+	private final PojoIndexingPlan<EntityReference> indexingPlan;
 	private final Map<?, ?> indexingPlanPerTransaction;
 	private final Object transactionIdentifier;
 	private final ConfiguredAutomaticIndexingSynchronizationStrategy synchronizationStrategy;
 
-	InTransactionWorkQueueSynchronization(PojoIndexingPlan indexingPlan,
+	InTransactionWorkQueueSynchronization(PojoIndexingPlan<EntityReference> indexingPlan,
 			Map<?, ?> indexingPlanPerTransaction, Object transactionIdentifier,
 			ConfiguredAutomaticIndexingSynchronizationStrategy synchronizationStrategy) {
 		this.indexingPlan = indexingPlan;

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/PostTransactionWorkQueueSynchronization.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/PostTransactionWorkQueueSynchronization.java
@@ -12,6 +12,7 @@ import javax.transaction.Status;
 import javax.transaction.Synchronization;
 
 import org.hibernate.search.mapper.orm.automaticindexing.session.impl.ConfiguredAutomaticIndexingSynchronizationStrategy;
+import org.hibernate.search.mapper.orm.common.EntityReference;
 import org.hibernate.search.mapper.orm.logging.impl.Log;
 import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingPlan;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
@@ -25,12 +26,12 @@ class PostTransactionWorkQueueSynchronization implements Synchronization {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private final PojoIndexingPlan indexingPlan;
+	private final PojoIndexingPlan<EntityReference> indexingPlan;
 	private final Map<?, ?> indexingPlanPerTransaction;
 	private final Object transactionIdentifier;
 	private final ConfiguredAutomaticIndexingSynchronizationStrategy synchronizationStrategy;
 
-	PostTransactionWorkQueueSynchronization(PojoIndexingPlan indexingPlan,
+	PostTransactionWorkQueueSynchronization(PojoIndexingPlan<EntityReference> indexingPlan,
 			Map<?, ?> indexingPlanPerTransaction, Object transactionIdentifier,
 			ConfiguredAutomaticIndexingSynchronizationStrategy synchronizationStrategy) {
 		this.indexingPlan = indexingPlan;

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/impl/SearchIndexingPlanExecutionReportImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/impl/SearchIndexingPlanExecutionReportImpl.java
@@ -6,25 +6,27 @@
  */
 package org.hibernate.search.mapper.orm.work.impl;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
 
-import org.hibernate.search.engine.backend.common.DocumentReference;
-import org.hibernate.search.engine.backend.common.spi.DocumentReferenceConverter;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlanExecutionReport;
 import org.hibernate.search.mapper.orm.common.EntityReference;
 import org.hibernate.search.mapper.orm.work.SearchIndexingPlanExecutionReport;
 import org.hibernate.search.util.common.AssertionFailure;
-import org.hibernate.search.util.common.impl.Throwables;
 
 public class SearchIndexingPlanExecutionReportImpl implements SearchIndexingPlanExecutionReport {
 
-	public static Function<IndexIndexingPlanExecutionReport, SearchIndexingPlanExecutionReport> factory(
-			DocumentReferenceConverter<EntityReference> referenceConverter) {
-		return report -> convert( referenceConverter, report );
+	public static SearchIndexingPlanExecutionReport from(IndexIndexingPlanExecutionReport<EntityReference> indexReport) {
+		Throwable throwable = indexReport.getThrowable().orElse( null );
+		List<EntityReference> failingEntities = indexReport.getFailingEntityReferences();
+		if ( throwable == null && !failingEntities.isEmpty() ) {
+			throwable = new AssertionFailure(
+					"Unknown throwable: missing throwable when reporting the failure."
+							+ " There is probably a bug in Hibernate Search, please report it."
+			);
+		}
+		return new SearchIndexingPlanExecutionReportImpl( throwable, failingEntities );
 	}
 
 	private Throwable throwable;
@@ -46,37 +48,4 @@ public class SearchIndexingPlanExecutionReportImpl implements SearchIndexingPlan
 		return failingEntities;
 	}
 
-	private static SearchIndexingPlanExecutionReport convert(DocumentReferenceConverter<EntityReference> referenceConverter,
-			IndexIndexingPlanExecutionReport indexReport) {
-		Throwable throwable = indexReport.getThrowable().orElse( null );
-		if ( throwable == null && !indexReport.getFailingDocuments().isEmpty() ) {
-			throwable = new AssertionFailure(
-					"Unknown throwable: missing throwable when reporting the failure."
-							+ " There is probably a bug in Hibernate Search, please report it."
-			);
-		}
-		List<EntityReference> failingEntities = null;
-		for ( DocumentReference failingDocument : indexReport.getFailingDocuments() ) {
-			if ( failingEntities == null ) {
-				failingEntities = new ArrayList<>();
-			}
-			// If we get here, throwable is non-null.
-			EntityReference reference = convertOrFail( referenceConverter, failingDocument, throwable );
-			failingEntities.add( reference );
-		}
-		return new SearchIndexingPlanExecutionReportImpl( throwable, failingEntities );
-	}
-
-	private static EntityReference convertOrFail(DocumentReferenceConverter<EntityReference> referenceConverter,
-			DocumentReference documentReference, Throwable throwable) {
-		try {
-			return referenceConverter.fromDocumentReference( documentReference );
-		}
-		catch (RuntimeException e) {
-			// We failed to convert a reference.
-			// Let's just give up and propagate the original exception, without the report.
-			throwable.addSuppressed( e );
-			throw Throwables.toRuntimeException( throwable );
-		}
-	}
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/impl/SearchIndexingPlanImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/impl/SearchIndexingPlanImpl.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.mapper.orm.work.impl;
 
+import org.hibernate.search.mapper.orm.common.EntityReference;
 import org.hibernate.search.mapper.orm.work.SearchIndexingPlan;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeIdentifier;
 import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingPlan;
@@ -47,7 +48,7 @@ public final class SearchIndexingPlanImpl implements SearchIndexingPlan {
 
 	@Override
 	public void process() {
-		PojoIndexingPlan plan = sessionContext.getCurrentIndexingPlan( false );
+		PojoIndexingPlan<?> plan = sessionContext.getCurrentIndexingPlan( false );
 		if ( plan == null ) {
 			return;
 		}
@@ -56,7 +57,7 @@ public final class SearchIndexingPlanImpl implements SearchIndexingPlan {
 
 	@Override
 	public void execute() {
-		PojoIndexingPlan plan = sessionContext.getCurrentIndexingPlan( false );
+		PojoIndexingPlan<EntityReference> plan = sessionContext.getCurrentIndexingPlan( false );
 		if ( plan == null ) {
 			return;
 		}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/impl/SearchIndexingPlanSessionContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/impl/SearchIndexingPlanSessionContext.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.mapper.orm.work.impl;
 
 import org.hibernate.search.mapper.orm.automaticindexing.session.impl.ConfiguredAutomaticIndexingSynchronizationStrategy;
+import org.hibernate.search.mapper.orm.common.EntityReference;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRuntimeIntrospector;
 import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingPlan;
 
@@ -16,6 +17,6 @@ public interface SearchIndexingPlanSessionContext {
 
 	PojoRuntimeIntrospector getRuntimeIntrospector();
 
-	PojoIndexingPlan getCurrentIndexingPlan(boolean createIfDoesNotExist);
+	PojoIndexingPlan<EntityReference> getCurrentIndexingPlan(boolean createIfDoesNotExist);
 
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoContainedTypeManager.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoContainedTypeManager.java
@@ -63,13 +63,13 @@ public class PojoContainedTypeManager<E>
 	}
 
 	@Override
-	public Supplier<E> toEntitySupplier(PojoWorkSessionContext sessionContext, Object entity) {
+	public Supplier<E> toEntitySupplier(PojoWorkSessionContext<?> sessionContext, Object entity) {
 		PojoRuntimeIntrospector introspector = sessionContext.getRuntimeIntrospector();
 		return new CachingCastingEntitySupplier<>( caster, introspector, entity );
 	}
 
 	@Override
-	public void resolveEntitiesToReindex(PojoReindexingCollector collector, PojoWorkSessionContext sessionContext,
+	public void resolveEntitiesToReindex(PojoReindexingCollector collector, PojoWorkSessionContext<?> sessionContext,
 			Supplier<E> entitySupplier, Set<String> dirtyPaths) {
 		PojoRuntimeIntrospector introspector = sessionContext.getRuntimeIntrospector();
 		reindexingResolver.resolveEntitiesToReindex(
@@ -78,7 +78,7 @@ public class PojoContainedTypeManager<E>
 	}
 
 	@Override
-	public PojoContainedTypeIndexingPlan<E> createIndexingPlan(PojoWorkSessionContext sessionContext) {
+	public PojoContainedTypeIndexingPlan<E> createIndexingPlan(PojoWorkSessionContext<?> sessionContext) {
 		return new PojoContainedTypeIndexingPlan<>(
 				this, sessionContext
 		);

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoIndexedTypeManager.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoIndexedTypeManager.java
@@ -104,13 +104,13 @@ public class PojoIndexedTypeManager<I, E>
 	}
 
 	@Override
-	public Supplier<E> toEntitySupplier(PojoWorkSessionContext sessionContext, Object entity) {
+	public Supplier<E> toEntitySupplier(PojoWorkSessionContext<?> sessionContext, Object entity) {
 		PojoRuntimeIntrospector introspector = sessionContext.getRuntimeIntrospector();
 		return new CachingCastingEntitySupplier<>( caster, introspector, entity );
 	}
 
 	@Override
-	public DocumentReferenceProvider toDocumentReferenceProvider(PojoWorkSessionContext sessionContext,
+	public DocumentReferenceProvider toDocumentReferenceProvider(PojoWorkSessionContext<?> sessionContext,
 			I identifier, Supplier<E> entitySupplier) {
 		String documentIdentifier = identifierMapping.toDocumentIdentifier(
 				identifier, sessionContext.getMappingContext()
@@ -120,20 +120,24 @@ public class PojoIndexedTypeManager<I, E>
 				entitySupplier,
 				sessionContext
 		);
-		return new PojoDocumentReferenceProvider( documentIdentifier, routingKey );
+		return new PojoDocumentReferenceProvider(
+				documentIdentifier, routingKey, identifier
+		);
 	}
 
 	@Override
-	public DocumentReferenceProvider toDocumentReferenceProvider(PojoWorkSessionContext sessionContext, I identifier,
-			String providedRoutingKey) {
+	public DocumentReferenceProvider toDocumentReferenceProvider(PojoWorkSessionContext<?> sessionContext,
+			I identifier, String providedRoutingKey) {
 		String documentIdentifier = identifierMapping.toDocumentIdentifier(
 				identifier, sessionContext.getMappingContext()
 		);
-		return new PojoDocumentReferenceProvider( documentIdentifier, providedRoutingKey );
+		return new PojoDocumentReferenceProvider(
+				documentIdentifier, providedRoutingKey, identifier
+		);
 	}
 
 	@Override
-	public PojoDocumentContributor<E> toDocumentContributor(Supplier<E> entitySupplier, PojoWorkSessionContext sessionContext) {
+	public PojoDocumentContributor<E> toDocumentContributor(Supplier<E> entitySupplier, PojoWorkSessionContext<?> sessionContext) {
 		return new PojoDocumentContributor<>( processor, sessionContext, entitySupplier );
 	}
 
@@ -151,11 +155,14 @@ public class PojoIndexedTypeManager<I, E>
 	}
 
 	@Override
-	public PojoTypeIndexer<I, E> createIndexer(PojoWorkSessionContext sessionContext,
+	public PojoTypeIndexer<I, E> createIndexer(PojoWorkSessionContext<?> sessionContext,
 			DocumentCommitStrategy commitStrategy) {
 		return new PojoTypeIndexer<>(
 				this, sessionContext,
-				indexManager.createIndexer( sessionContext, commitStrategy )
+				indexManager.createIndexer(
+						sessionContext, sessionContext.getEntityReferenceFactory(),
+						commitStrategy
+				)
 		);
 	}
 
@@ -165,11 +172,14 @@ public class PojoIndexedTypeManager<I, E>
 	}
 
 	@Override
-	public PojoIndexedTypeIndexingPlan<I, E> createIndexingPlan(PojoWorkSessionContext sessionContext,
+	public PojoIndexedTypeIndexingPlan<I, E> createIndexingPlan(PojoWorkSessionContext<?> sessionContext,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
 		return new PojoIndexedTypeIndexingPlan<>(
 				this, sessionContext,
-				indexManager.createIndexingPlan( sessionContext, commitStrategy, refreshStrategy )
+				indexManager.createIndexingPlan(
+						sessionContext, sessionContext.getEntityReferenceFactory(),
+						commitStrategy, refreshStrategy
+				)
 		);
 	}
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoIndexedTypeManager.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoIndexedTypeManager.java
@@ -172,7 +172,7 @@ public class PojoIndexedTypeManager<I, E>
 	}
 
 	@Override
-	public PojoIndexedTypeIndexingPlan<I, E> createIndexingPlan(PojoWorkSessionContext<?> sessionContext,
+	public <R> PojoIndexedTypeIndexingPlan<I, E, R> createIndexingPlan(PojoWorkSessionContext<R> sessionContext,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
 		return new PojoIndexedTypeIndexingPlan<>(
 				this, sessionContext,

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoMappingDelegateImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoMappingDelegateImpl.java
@@ -76,7 +76,7 @@ public class PojoMappingDelegateImpl implements PojoMappingDelegate {
 	}
 
 	@Override
-	public PojoIndexingPlan createIndexingPlan(PojoWorkSessionContext context, DocumentCommitStrategy commitStrategy,
+	public PojoIndexingPlan createIndexingPlan(PojoWorkSessionContext<?> context, DocumentCommitStrategy commitStrategy,
 			DocumentRefreshStrategy refreshStrategy) {
 		return new PojoIndexingPlanImpl(
 				indexedTypeManagers, containedTypeManagers,
@@ -85,7 +85,7 @@ public class PojoMappingDelegateImpl implements PojoMappingDelegate {
 	}
 
 	@Override
-	public PojoIndexer createIndexer(PojoWorkSessionContext context, DocumentCommitStrategy commitStrategy) {
+	public PojoIndexer createIndexer(PojoWorkSessionContext<?> context, DocumentCommitStrategy commitStrategy) {
 		return new PojoIndexerImpl(
 				indexedTypeManagers,
 				context, commitStrategy

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoMappingDelegateImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoMappingDelegateImpl.java
@@ -76,9 +76,10 @@ public class PojoMappingDelegateImpl implements PojoMappingDelegate {
 	}
 
 	@Override
-	public PojoIndexingPlan createIndexingPlan(PojoWorkSessionContext<?> context, DocumentCommitStrategy commitStrategy,
+	public <R> PojoIndexingPlan<R> createIndexingPlan(PojoWorkSessionContext<R> context,
+			DocumentCommitStrategy commitStrategy,
 			DocumentRefreshStrategy refreshStrategy) {
-		return new PojoIndexingPlanImpl(
+		return new PojoIndexingPlanImpl<>(
 				indexedTypeManagers, containedTypeManagers,
 				context, commitStrategy, refreshStrategy
 		);

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/spi/AbstractPojoMappingImplementor.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/spi/AbstractPojoMappingImplementor.java
@@ -65,8 +65,8 @@ public abstract class AbstractPojoMappingImplementor<M>
 	}
 
 	@Override
-	public PojoIndexingPlan createIndexingPlan(PojoWorkSessionContext<?> context, DocumentCommitStrategy commitStrategy,
-			DocumentRefreshStrategy refreshStrategy) {
+	public <R> PojoIndexingPlan<R> createIndexingPlan(PojoWorkSessionContext<R> context,
+			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
 		return delegate.createIndexingPlan( context, commitStrategy, refreshStrategy );
 	}
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/spi/AbstractPojoMappingImplementor.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/spi/AbstractPojoMappingImplementor.java
@@ -65,13 +65,13 @@ public abstract class AbstractPojoMappingImplementor<M>
 	}
 
 	@Override
-	public PojoIndexingPlan createIndexingPlan(PojoWorkSessionContext context, DocumentCommitStrategy commitStrategy,
+	public PojoIndexingPlan createIndexingPlan(PojoWorkSessionContext<?> context, DocumentCommitStrategy commitStrategy,
 			DocumentRefreshStrategy refreshStrategy) {
 		return delegate.createIndexingPlan( context, commitStrategy, refreshStrategy );
 	}
 
 	@Override
-	public PojoIndexer createIndexer(PojoWorkSessionContext context, DocumentCommitStrategy commitStrategy) {
+	public PojoIndexer createIndexer(PojoWorkSessionContext<?> context, DocumentCommitStrategy commitStrategy) {
 		return delegate.createIndexer( context, commitStrategy );
 	}
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/spi/PojoMappingDelegate.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/spi/PojoMappingDelegate.java
@@ -34,7 +34,7 @@ public interface PojoMappingDelegate extends AutoCloseable {
 			Collection<? extends PojoRawTypeIdentifier<? extends E>> targetedTypes,
 			PojoScopeTypeExtendedContextProvider<E, C> indexedTypeExtendedContextProvider);
 
-	PojoIndexingPlan createIndexingPlan(PojoWorkSessionContext<?> context,
+	<R> PojoIndexingPlan<R> createIndexingPlan(PojoWorkSessionContext<R> context,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy);
 
 	PojoIndexer createIndexer(PojoWorkSessionContext<?> context, DocumentCommitStrategy commitStrategy);

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/spi/PojoMappingDelegate.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/spi/PojoMappingDelegate.java
@@ -34,9 +34,9 @@ public interface PojoMappingDelegate extends AutoCloseable {
 			Collection<? extends PojoRawTypeIdentifier<? extends E>> targetedTypes,
 			PojoScopeTypeExtendedContextProvider<E, C> indexedTypeExtendedContextProvider);
 
-	PojoIndexingPlan createIndexingPlan(PojoWorkSessionContext context,
+	PojoIndexingPlan createIndexingPlan(PojoWorkSessionContext<?> context,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy);
 
-	PojoIndexer createIndexer(PojoWorkSessionContext context, DocumentCommitStrategy commitStrategy);
+	PojoIndexer createIndexer(PojoWorkSessionContext<?> context, DocumentCommitStrategy commitStrategy);
 
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/session/spi/AbstractPojoSearchSession.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/session/spi/AbstractPojoSearchSession.java
@@ -19,7 +19,7 @@ import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingPlan;
 import org.hibernate.search.mapper.pojo.work.spi.PojoWorkSessionContext;
 
 
-public abstract class AbstractPojoSearchSession implements PojoWorkSessionContext {
+public abstract class AbstractPojoSearchSession<R> implements PojoWorkSessionContext<R> {
 
 	private final PojoSearchSessionMappingContext mappingContext;
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/session/spi/AbstractPojoSearchSession.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/session/spi/AbstractPojoSearchSession.java
@@ -60,7 +60,7 @@ public abstract class AbstractPojoSearchSession<R> implements PojoWorkSessionCon
 		return sessionBasedBridgeOperationContext;
 	}
 
-	protected PojoIndexingPlan createIndexingPlan(DocumentCommitStrategy commitStrategy,
+	protected PojoIndexingPlan<R> createIndexingPlan(DocumentCommitStrategy commitStrategy,
 			DocumentRefreshStrategy refreshStrategy) {
 		return mappingContext.createIndexingPlan( this, commitStrategy, refreshStrategy );
 	}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/session/spi/PojoSearchSessionMappingContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/session/spi/PojoSearchSessionMappingContext.java
@@ -18,9 +18,9 @@ import org.hibernate.search.mapper.pojo.work.spi.PojoWorkSessionContext;
  */
 public interface PojoSearchSessionMappingContext extends PojoWorkMappingContext {
 
-	PojoIndexingPlan createIndexingPlan(PojoWorkSessionContext context,
+	PojoIndexingPlan createIndexingPlan(PojoWorkSessionContext<?> context,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy);
 
-	PojoIndexer createIndexer(PojoWorkSessionContext context, DocumentCommitStrategy commitStrategy);
+	PojoIndexer createIndexer(PojoWorkSessionContext<?> context, DocumentCommitStrategy commitStrategy);
 
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/session/spi/PojoSearchSessionMappingContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/session/spi/PojoSearchSessionMappingContext.java
@@ -18,7 +18,7 @@ import org.hibernate.search.mapper.pojo.work.spi.PojoWorkSessionContext;
  */
 public interface PojoSearchSessionMappingContext extends PojoWorkMappingContext {
 
-	PojoIndexingPlan createIndexingPlan(PojoWorkSessionContext<?> context,
+	<R> PojoIndexingPlan<R> createIndexingPlan(PojoWorkSessionContext<R> context,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy);
 
 	PojoIndexer createIndexer(PojoWorkSessionContext<?> context, DocumentCommitStrategy commitStrategy);

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/AbstractPojoTypeIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/AbstractPojoTypeIndexingPlan.java
@@ -10,9 +10,9 @@ import org.hibernate.search.mapper.pojo.work.spi.PojoWorkSessionContext;
 
 abstract class AbstractPojoTypeIndexingPlan {
 
-	final PojoWorkSessionContext sessionContext;
+	final PojoWorkSessionContext<?> sessionContext;
 
-	AbstractPojoTypeIndexingPlan(PojoWorkSessionContext sessionContext) {
+	AbstractPojoTypeIndexingPlan(PojoWorkSessionContext<?> sessionContext) {
 		this.sessionContext = sessionContext;
 	}
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoContainedTypeIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoContainedTypeIndexingPlan.java
@@ -31,7 +31,7 @@ public class PojoContainedTypeIndexingPlan<E> extends AbstractPojoTypeIndexingPl
 	private final Map<Object, ContainedEntityIndexingPlan> indexingPlansPerId = new LinkedHashMap<>();
 
 	public PojoContainedTypeIndexingPlan(PojoWorkContainedTypeContext<E> typeContext,
-			PojoWorkSessionContext sessionContext) {
+			PojoWorkSessionContext<?> sessionContext) {
 		super( sessionContext );
 		this.typeContext = typeContext;
 	}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoDocumentContributor.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoDocumentContributor.java
@@ -20,11 +20,11 @@ public final class PojoDocumentContributor<E> implements DocumentContributor {
 
 	private final PojoIndexingProcessor<E> processor;
 
-	private final PojoWorkSessionContext sessionContext;
+	private final PojoWorkSessionContext<?> sessionContext;
 
 	private final Supplier<E> entitySupplier;
 
-	public PojoDocumentContributor(PojoIndexingProcessor<E> processor, PojoWorkSessionContext sessionContext,
+	public PojoDocumentContributor(PojoIndexingProcessor<E> processor, PojoWorkSessionContext<?> sessionContext,
 			Supplier<E> entitySupplier) {
 		this.processor = processor;
 		this.sessionContext = sessionContext;

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoDocumentReferenceProvider.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoDocumentReferenceProvider.java
@@ -13,10 +13,14 @@ public final class PojoDocumentReferenceProvider implements DocumentReferencePro
 	private final String documentIdentifier;
 	private final String routingKey;
 
+	private final Object entityIdentifier;
+
 	public PojoDocumentReferenceProvider(String documentIdentifier,
-			String routingKey) {
+			String routingKey,
+			Object entityIdentifier) {
 		this.documentIdentifier = documentIdentifier;
 		this.routingKey = routingKey;
+		this.entityIdentifier = entityIdentifier;
 	}
 
 	@Override
@@ -29,4 +33,8 @@ public final class PojoDocumentReferenceProvider implements DocumentReferencePro
 		return routingKey;
 	}
 
+	@Override
+	public Object getEntityIdentifier() {
+		return entityIdentifier;
+	}
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexedTypeIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexedTypeIndexingPlan.java
@@ -32,7 +32,7 @@ public class PojoIndexedTypeIndexingPlan<I, E> extends AbstractPojoTypeIndexingP
 	private final Map<I, IndexedEntityIndexingPlan> indexingPlansPerId = new LinkedHashMap<>();
 
 	public PojoIndexedTypeIndexingPlan(PojoWorkIndexedTypeContext<I, E> typeContext,
-			PojoWorkSessionContext sessionContext,
+			PojoWorkSessionContext<?> sessionContext,
 			IndexIndexingPlan delegate) {
 		super( sessionContext );
 		this.typeContext = typeContext;

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexedTypeIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexedTypeIndexingPlan.java
@@ -22,18 +22,19 @@ import org.hibernate.search.mapper.pojo.work.spi.PojoWorkSessionContext;
 /**
  * @param <I> The identifier type for the mapped entity type.
  * @param <E> The entity type mapped to the index.
+ * @param <R> The type of entity references returned in the {@link #executeAndReport() failure report}.
  */
-public class PojoIndexedTypeIndexingPlan<I, E> extends AbstractPojoTypeIndexingPlan {
+public class PojoIndexedTypeIndexingPlan<I, E, R> extends AbstractPojoTypeIndexingPlan {
 
 	private final PojoWorkIndexedTypeContext<I, E> typeContext;
-	private final IndexIndexingPlan delegate;
+	private final IndexIndexingPlan<R> delegate;
 
 	// Use a LinkedHashMap for deterministic iteration
 	private final Map<I, IndexedEntityIndexingPlan> indexingPlansPerId = new LinkedHashMap<>();
 
 	public PojoIndexedTypeIndexingPlan(PojoWorkIndexedTypeContext<I, E> typeContext,
 			PojoWorkSessionContext<?> sessionContext,
-			IndexIndexingPlan delegate) {
+			IndexIndexingPlan<R> delegate) {
 		super( sessionContext );
 		this.typeContext = typeContext;
 		this.delegate = delegate;
@@ -93,7 +94,7 @@ public class PojoIndexedTypeIndexingPlan<I, E> extends AbstractPojoTypeIndexingP
 		getDelegate().process();
 	}
 
-	CompletableFuture<IndexIndexingPlanExecutionReport> executeAndReport() {
+	CompletableFuture<IndexIndexingPlanExecutionReport<R>> executeAndReport() {
 		sendCommandsToDelegate();
 		/*
 		 * No need to call prepare() here:
@@ -119,7 +120,7 @@ public class PojoIndexedTypeIndexingPlan<I, E> extends AbstractPojoTypeIndexingP
 		return plan;
 	}
 
-	private IndexIndexingPlan getDelegate() {
+	private IndexIndexingPlan<?> getDelegate() {
 		return delegate;
 	}
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexerImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexerImpl.java
@@ -24,13 +24,13 @@ public class PojoIndexerImpl implements PojoIndexer {
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private final PojoWorkIndexedTypeContextProvider indexedTypeContextProvider;
-	private final PojoWorkSessionContext sessionContext;
+	private final PojoWorkSessionContext<?> sessionContext;
 	private final DocumentCommitStrategy commitStrategy;
 
 	private final Map<PojoRawTypeIdentifier<?>, PojoTypeIndexer<?, ?>> typeExecutors = new HashMap<>();
 
 	public PojoIndexerImpl(PojoWorkIndexedTypeContextProvider indexedTypeContextProvider,
-			PojoWorkSessionContext sessionContext,
+			PojoWorkSessionContext<?> sessionContext,
 			DocumentCommitStrategy commitStrategy) {
 		this.indexedTypeContextProvider = indexedTypeContextProvider;
 		this.sessionContext = sessionContext;

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanImpl.java
@@ -31,7 +31,7 @@ public class PojoIndexingPlanImpl implements PojoIndexingPlan {
 
 	private final PojoWorkIndexedTypeContextProvider indexedTypeContextProvider;
 	private final PojoWorkContainedTypeContextProvider containedTypeContextProvider;
-	private final PojoWorkSessionContext sessionContext;
+	private final PojoWorkSessionContext<?> sessionContext;
 	private final PojoRuntimeIntrospector introspector;
 	private final DocumentCommitStrategy commitStrategy;
 	private final DocumentRefreshStrategy refreshStrategy;
@@ -44,7 +44,7 @@ public class PojoIndexingPlanImpl implements PojoIndexingPlan {
 
 	public PojoIndexingPlanImpl(PojoWorkIndexedTypeContextProvider indexedTypeContextProvider,
 			PojoWorkContainedTypeContextProvider containedTypeContextProvider,
-			PojoWorkSessionContext sessionContext,
+			PojoWorkSessionContext<?> sessionContext,
 			DocumentCommitStrategy commitStrategy,
 			DocumentRefreshStrategy refreshStrategy) {
 		this.indexedTypeContextProvider = indexedTypeContextProvider;

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanImpl.java
@@ -25,26 +25,26 @@ import org.hibernate.search.mapper.pojo.work.spi.PojoWorkSessionContext;
 import org.hibernate.search.util.common.AssertionFailure;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
-public class PojoIndexingPlanImpl implements PojoIndexingPlan {
+public class PojoIndexingPlanImpl<R> implements PojoIndexingPlan<R> {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private final PojoWorkIndexedTypeContextProvider indexedTypeContextProvider;
 	private final PojoWorkContainedTypeContextProvider containedTypeContextProvider;
-	private final PojoWorkSessionContext<?> sessionContext;
+	private final PojoWorkSessionContext<R> sessionContext;
 	private final PojoRuntimeIntrospector introspector;
 	private final DocumentCommitStrategy commitStrategy;
 	private final DocumentRefreshStrategy refreshStrategy;
 
 	// Use a LinkedHashMap for deterministic iteration
-	private final Map<PojoRawTypeIdentifier<?>, PojoIndexedTypeIndexingPlan<?, ?>> indexedTypeDelegates = new LinkedHashMap<>();
+	private final Map<PojoRawTypeIdentifier<?>, PojoIndexedTypeIndexingPlan<?, ?, R>> indexedTypeDelegates = new LinkedHashMap<>();
 	private final Map<PojoRawTypeIdentifier<?>, PojoContainedTypeIndexingPlan<?>> containedTypeDelegates = new LinkedHashMap<>();
 
 	private boolean isProcessing = false;
 
 	public PojoIndexingPlanImpl(PojoWorkIndexedTypeContextProvider indexedTypeContextProvider,
 			PojoWorkContainedTypeContextProvider containedTypeContextProvider,
-			PojoWorkSessionContext<?> sessionContext,
+			PojoWorkSessionContext<R> sessionContext,
 			DocumentCommitStrategy commitStrategy,
 			DocumentRefreshStrategy refreshStrategy) {
 		this.indexedTypeContextProvider = indexedTypeContextProvider;
@@ -96,10 +96,10 @@ public class PojoIndexingPlanImpl implements PojoIndexingPlan {
 			for ( PojoContainedTypeIndexingPlan<?> delegate : containedTypeDelegates.values() ) {
 				delegate.resolveDirty( this::updateBecauseOfContained );
 			}
-			for ( PojoIndexedTypeIndexingPlan<?, ?> delegate : indexedTypeDelegates.values() ) {
+			for ( PojoIndexedTypeIndexingPlan<?, ?, ?> delegate : indexedTypeDelegates.values() ) {
 				delegate.resolveDirty( this::updateBecauseOfContained );
 			}
-			for ( PojoIndexedTypeIndexingPlan<?, ?> delegate : indexedTypeDelegates.values() ) {
+			for ( PojoIndexedTypeIndexingPlan<?, ?, ?> delegate : indexedTypeDelegates.values() ) {
 				delegate.process();
 			}
 		}
@@ -109,11 +109,11 @@ public class PojoIndexingPlanImpl implements PojoIndexingPlan {
 	}
 
 	@Override
-	public CompletableFuture<IndexIndexingPlanExecutionReport> executeAndReport() {
+	public CompletableFuture<IndexIndexingPlanExecutionReport<R>> executeAndReport() {
 		try {
 			process();
-			List<CompletableFuture<IndexIndexingPlanExecutionReport>> futures = new ArrayList<>();
-			for ( PojoIndexedTypeIndexingPlan<?, ?> delegate : indexedTypeDelegates.values() ) {
+			List<CompletableFuture<IndexIndexingPlanExecutionReport<R>>> futures = new ArrayList<>();
+			for ( PojoIndexedTypeIndexingPlan<?, ?, R> delegate : indexedTypeDelegates.values() ) {
 				futures.add( delegate.executeAndReport() );
 			}
 			return IndexIndexingPlanExecutionReport.allOf( futures );
@@ -126,7 +126,7 @@ public class PojoIndexingPlanImpl implements PojoIndexingPlan {
 	@Override
 	public void discard() {
 		try {
-			for ( PojoIndexedTypeIndexingPlan<?, ?> delegate : indexedTypeDelegates.values() ) {
+			for ( PojoIndexedTypeIndexingPlan<?, ?, ?> delegate : indexedTypeDelegates.values() ) {
 				delegate.discard();
 			}
 		}
@@ -137,7 +137,7 @@ public class PojoIndexingPlanImpl implements PojoIndexingPlan {
 
 	@Override
 	public void discardNotProcessed() {
-		for ( PojoIndexedTypeIndexingPlan<?, ?> delegate : indexedTypeDelegates.values() ) {
+		for ( PojoIndexedTypeIndexingPlan<?, ?, ?> delegate : indexedTypeDelegates.values() ) {
 			delegate.discardNotProcessed();
 		}
 	}
@@ -161,7 +161,7 @@ public class PojoIndexingPlanImpl implements PojoIndexingPlan {
 		Optional<? extends PojoWorkIndexedTypeContext<?, ?>> indexedTypeContextOptional =
 				indexedTypeContextProvider.getByExactType( typeIdentifier );
 		if ( indexedTypeContextOptional.isPresent() ) {
-			PojoIndexedTypeIndexingPlan<?, ?> delegate = indexedTypeContextOptional.get()
+			PojoIndexedTypeIndexingPlan<?, ?, R> delegate = indexedTypeContextOptional.get()
 					.createIndexingPlan( sessionContext, commitStrategy, refreshStrategy );
 			indexedTypeDelegates.put( typeIdentifier, delegate );
 			return delegate;
@@ -179,8 +179,8 @@ public class PojoIndexingPlanImpl implements PojoIndexingPlan {
 		throw log.notIndexedTypeNorAsDelegate( typeIdentifier );
 	}
 
-	private PojoIndexedTypeIndexingPlan<?, ?> getOrCreateIndexedDelegateForContainedUpdate(PojoRawTypeIdentifier<?> typeIdentifier) {
-		PojoIndexedTypeIndexingPlan<?, ?> delegate = indexedTypeDelegates.get( typeIdentifier );
+	private PojoIndexedTypeIndexingPlan<?, ?, ?> getOrCreateIndexedDelegateForContainedUpdate(PojoRawTypeIdentifier<?> typeIdentifier) {
+		PojoIndexedTypeIndexingPlan<?, ?, R> delegate = indexedTypeDelegates.get( typeIdentifier );
 		if ( delegate != null ) {
 			return delegate;
 		}
@@ -211,7 +211,7 @@ public class PojoIndexingPlanImpl implements PojoIndexingPlan {
 							+ " There is a bug in Hibernate Search, please report it."
 			);
 		}
-		PojoIndexedTypeIndexingPlan<?, ?> delegate = getOrCreateIndexedDelegateForContainedUpdate( typeIdentifier );
+		PojoIndexedTypeIndexingPlan<?, ?, ?> delegate = getOrCreateIndexedDelegateForContainedUpdate( typeIdentifier );
 		delegate.updateBecauseOfContained( containingEntity );
 	}
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoTypeIndexer.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoTypeIndexer.java
@@ -15,12 +15,12 @@ import org.hibernate.search.mapper.pojo.work.spi.PojoWorkSessionContext;
 
 public class PojoTypeIndexer<I, E> {
 
-	private final PojoWorkSessionContext sessionContext;
+	private final PojoWorkSessionContext<?> sessionContext;
 	private final PojoWorkIndexedTypeContext<I, E> typeContext;
 	private final IndexIndexer delegate;
 
 	public PojoTypeIndexer(PojoWorkIndexedTypeContext<I, E> typeContext,
-			PojoWorkSessionContext sessionContext,
+			PojoWorkSessionContext<?> sessionContext,
 			IndexIndexer delegate) {
 		this.sessionContext = sessionContext;
 		this.typeContext = typeContext;
@@ -30,7 +30,10 @@ public class PojoTypeIndexer<I, E> {
 	CompletableFuture<?> add(Object providedId, Object entity) {
 		Supplier<E> entitySupplier = typeContext.toEntitySupplier( sessionContext, entity );
 		I identifier = typeContext.getIdentifierMapping().getIdentifier( providedId, entitySupplier );
-		DocumentReferenceProvider referenceProvider = typeContext.toDocumentReferenceProvider( sessionContext, identifier, entitySupplier );
+		DocumentReferenceProvider referenceProvider = typeContext.toDocumentReferenceProvider(
+				sessionContext,
+				identifier, entitySupplier
+		);
 		return delegate.add( referenceProvider, typeContext.toDocumentContributor( entitySupplier, sessionContext ) );
 	}
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkContainedTypeContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkContainedTypeContext.java
@@ -20,11 +20,11 @@ public interface PojoWorkContainedTypeContext<E> {
 
 	PojoRawTypeIdentifier<E> getTypeIdentifier();
 
-	Supplier<E> toEntitySupplier(PojoWorkSessionContext sessionContext, Object entity);
+	Supplier<E> toEntitySupplier(PojoWorkSessionContext<?> sessionContext, Object entity);
 
-	void resolveEntitiesToReindex(PojoReindexingCollector collector, PojoWorkSessionContext sessionContext,
+	void resolveEntitiesToReindex(PojoReindexingCollector collector, PojoWorkSessionContext<?> sessionContext,
 			Supplier<E> entitySupplier, Set<String> dirtyPaths);
 
-	PojoContainedTypeIndexingPlan<E> createIndexingPlan(PojoWorkSessionContext sessionContext);
+	PojoContainedTypeIndexingPlan<E> createIndexingPlan(PojoWorkSessionContext<?> sessionContext);
 
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkIndexedTypeContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkIndexedTypeContext.java
@@ -46,7 +46,7 @@ public interface PojoWorkIndexedTypeContext<I, E> {
 	void resolveEntitiesToReindex(PojoReindexingCollector collector, PojoRuntimeIntrospector runtimeIntrospector,
 			Supplier<E> entitySupplier, Set<String> dirtyPaths);
 
-	PojoIndexedTypeIndexingPlan<I, E> createIndexingPlan(PojoWorkSessionContext<?> sessionContext,
+	<R> PojoIndexedTypeIndexingPlan<I, E, R> createIndexingPlan(PojoWorkSessionContext<R> sessionContext,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy);
 
 	PojoTypeIndexer<I, E> createIndexer(PojoWorkSessionContext<?> sessionContext,

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkIndexedTypeContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkIndexedTypeContext.java
@@ -30,26 +30,26 @@ public interface PojoWorkIndexedTypeContext<I, E> {
 
 	IdentifierMappingImplementor<I, E> getIdentifierMapping();
 
-	Supplier<E> toEntitySupplier(PojoWorkSessionContext sessionContext, Object entity);
+	Supplier<E> toEntitySupplier(PojoWorkSessionContext<?> sessionContext, Object entity);
 
-	DocumentReferenceProvider toDocumentReferenceProvider(PojoWorkSessionContext sessionContext,
+	DocumentReferenceProvider toDocumentReferenceProvider(PojoWorkSessionContext<?> sessionContext,
 			I identifier, Supplier<E> entitySupplier);
 
-	DocumentReferenceProvider toDocumentReferenceProvider(PojoWorkSessionContext sessionContext,
+	DocumentReferenceProvider toDocumentReferenceProvider(PojoWorkSessionContext<?> sessionContext,
 			I identifier, String providedRoutingKey);
 
 	PojoDocumentContributor<E> toDocumentContributor(Supplier<E> entitySupplier,
-			PojoWorkSessionContext sessionContext);
+			PojoWorkSessionContext<?> sessionContext);
 
 	boolean requiresSelfReindexing(Set<String> dirtyPaths);
 
 	void resolveEntitiesToReindex(PojoReindexingCollector collector, PojoRuntimeIntrospector runtimeIntrospector,
 			Supplier<E> entitySupplier, Set<String> dirtyPaths);
 
-	PojoIndexedTypeIndexingPlan<I, E> createIndexingPlan(PojoWorkSessionContext sessionContext,
+	PojoIndexedTypeIndexingPlan<I, E> createIndexingPlan(PojoWorkSessionContext<?> sessionContext,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy);
 
-	PojoTypeIndexer<I, E> createIndexer(PojoWorkSessionContext sessionContext,
+	PojoTypeIndexer<I, E> createIndexer(PojoWorkSessionContext<?> sessionContext,
 			DocumentCommitStrategy commitStrategy);
 
 	IndexWorkspace createWorkspace(DetachedBackendSessionContext sessionContext);

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexingPlan.java
@@ -28,7 +28,7 @@ import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeIdentifier;
  * <p>
  * Implementations may not be thread-safe.
  */
-public interface PojoIndexingPlan {
+public interface PojoIndexingPlan<R> {
 
 	/**
 	 * Add an entity to the index, assuming that the entity is absent from the index.
@@ -117,7 +117,7 @@ public interface PojoIndexingPlan {
 	 *
 	 * @return A {@link CompletableFuture} that will be completed with an execution report when all the works are complete.
 	 */
-	CompletableFuture<IndexIndexingPlanExecutionReport> executeAndReport();
+	CompletableFuture<IndexIndexingPlanExecutionReport<R>> executeAndReport();
 
 	/**
 	 * Discard all plans of indexing.

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoWorkSessionContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoWorkSessionContext.java
@@ -6,17 +6,22 @@
  */
 package org.hibernate.search.mapper.pojo.work.spi;
 
+import org.hibernate.search.engine.backend.common.spi.EntityReferenceFactory;
 import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
 import org.hibernate.search.mapper.pojo.bridge.runtime.spi.BridgeSessionContext;
 import org.hibernate.search.mapper.pojo.processing.spi.PojoIndexingProcessorSessionContext;
 
 /**
  * Session-scoped information and operations for use in POJO work execution.
+ *
+ * @param <R> The type of entity references.
  */
-public interface PojoWorkSessionContext
+public interface PojoWorkSessionContext<R>
 		extends BackendSessionContext, BridgeSessionContext, PojoIndexingProcessorSessionContext {
 
 	@Override
 	PojoWorkMappingContext getMappingContext();
+
+	EntityReferenceFactory<R> getEntityReferenceFactory();
 
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/StubDocumentWork.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/StubDocumentWork.java
@@ -24,6 +24,7 @@ public final class StubDocumentWork {
 	private final String tenantIdentifier;
 	private final String identifier;
 	private final String routingKey;
+	private final Object entityIdentifier;
 	private final DocumentCommitStrategy commitStrategy;
 	private final DocumentRefreshStrategy refreshStrategy;
 	private final StubDocumentNode document;
@@ -33,6 +34,7 @@ public final class StubDocumentWork {
 		this.tenantIdentifier = builder.tenantIdentifier;
 		this.identifier = builder.identifier;
 		this.routingKey = builder.routingKey;
+		this.entityIdentifier = builder.entityIdentifier;
 		this.commitStrategy = builder.commitStrategy;
 		this.refreshStrategy = builder.refreshStrategy;
 		this.document = builder.document;
@@ -48,6 +50,10 @@ public final class StubDocumentWork {
 
 	public String getIdentifier() {
 		return identifier;
+	}
+
+	public Object getEntityIdentifier() {
+		return entityIdentifier;
 	}
 
 	public String getRoutingKey() {
@@ -85,6 +91,7 @@ public final class StubDocumentWork {
 		private String tenantIdentifier;
 		private String identifier;
 		private String routingKey;
+		private Object entityIdentifier;
 		private DocumentCommitStrategy commitStrategy;
 		private DocumentRefreshStrategy refreshStrategy;
 		private StubDocumentNode document;
@@ -105,6 +112,11 @@ public final class StubDocumentWork {
 
 		public Builder routingKey(String routingKey) {
 			this.routingKey = routingKey;
+			return this;
+		}
+
+		public Builder entityIdentifier(Object entityIdentifier) {
+			this.entityIdentifier = entityIdentifier;
 			return this;
 		}
 

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubBackend.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubBackend.java
@@ -65,6 +65,6 @@ public class StubBackend implements BackendImplementor, Backend {
 	public IndexManagerBuilder createIndexManagerBuilder(String indexName,
 			String mappedTypeName, boolean isMultiTenancyEnabled, BackendBuildContext context,
 			ConfigurationPropertySource propertySource) {
-		return new StubIndexManagerBuilder( this, indexName, mappedTypeName );
+		return new StubIndexManagerBuilder( this, indexName, mappedTypeName, mappedTypeName );
 	}
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubIndexManager.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubIndexManager.java
@@ -8,6 +8,7 @@ package org.hibernate.search.util.impl.integrationtest.common.stub.backend.index
 
 import java.util.concurrent.CompletableFuture;
 
+import org.hibernate.search.engine.backend.common.spi.EntityReferenceFactory;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.index.IndexManager;
 import org.hibernate.search.engine.backend.index.spi.IndexManagerStartContext;
@@ -75,6 +76,7 @@ public class StubIndexManager implements IndexManagerImplementor, IndexManager {
 
 	@Override
 	public IndexIndexingPlan createIndexingPlan(BackendSessionContext context,
+			EntityReferenceFactory<?> entityReferenceFactory,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
 		return new StubIndexIndexingPlan( name, backend.getBehavior(), context, commitStrategy, refreshStrategy );
 	}

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubIndexManager.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubIndexManager.java
@@ -32,14 +32,17 @@ public class StubIndexManager implements IndexManagerImplementor, IndexManager {
 
 	private final StubBackend backend;
 	private final String name;
+	private final String mappedTypeName;
 	private final StubIndexSchemaNode rootSchemaNode;
 
 	private boolean running = true;
 
-	StubIndexManager(StubBackend backend, String name, StubIndexSchemaNode rootSchemaNode) {
+	StubIndexManager(StubBackend backend, String name, String mappedTypeName,
+			StubIndexSchemaNode rootSchemaNode) {
 		StaticCounters.get().increment( INSTANCE_COUNTER_KEY );
 		this.backend = backend;
 		this.name = name;
+		this.mappedTypeName = mappedTypeName;
 		this.rootSchemaNode = rootSchemaNode;
 		backend.getBehavior().pushSchema( name, rootSchemaNode );
 	}
@@ -75,10 +78,13 @@ public class StubIndexManager implements IndexManagerImplementor, IndexManager {
 	}
 
 	@Override
-	public IndexIndexingPlan createIndexingPlan(BackendSessionContext context,
-			EntityReferenceFactory<?> entityReferenceFactory,
+	public <R> IndexIndexingPlan<R> createIndexingPlan(BackendSessionContext context,
+			EntityReferenceFactory<R> entityReferenceFactory,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
-		return new StubIndexIndexingPlan( name, backend.getBehavior(), context, commitStrategy, refreshStrategy );
+		return new StubIndexIndexingPlan<>(
+				name, mappedTypeName, backend.getBehavior(),
+				context, entityReferenceFactory, commitStrategy, refreshStrategy
+		);
 	}
 
 	@Override

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubIndexManagerBuilder.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubIndexManagerBuilder.java
@@ -21,14 +21,17 @@ public class StubIndexManagerBuilder implements IndexManagerBuilder {
 
 	private final StubBackend backend;
 	private final String name;
+	private final String mappedTypeName;
 	private final StubIndexSchemaRootNodeBuilder schemaRootNodeBuilder;
 
 	private boolean closed = false;
 
-	public StubIndexManagerBuilder(StubBackend backend, String name, String mappedTypeName) {
+	public StubIndexManagerBuilder(StubBackend backend, String name, String mappedTypeName1,
+			String mappedTypeName) {
 		StaticCounters.get().increment( INSTANCE_COUNTER_KEY );
 		this.backend = backend;
 		this.name = name;
+		this.mappedTypeName = mappedTypeName;
 		this.schemaRootNodeBuilder = new StubIndexSchemaRootNodeBuilder( backend.getBehavior(), name, mappedTypeName );
 	}
 
@@ -57,6 +60,6 @@ public class StubIndexManagerBuilder implements IndexManagerBuilder {
 		}
 		StaticCounters.get().increment( BUILD_COUNTER_KEY );
 		closed = true;
-		return new StubIndexManager( backend, name, schemaRootNodeBuilder.build() );
+		return new StubIndexManager( backend, name, mappedTypeName, schemaRootNodeBuilder.build() );
 	}
 }

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubDocumentReferenceProvider.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubDocumentReferenceProvider.java
@@ -27,4 +27,9 @@ class StubDocumentReferenceProvider implements DocumentReferenceProvider {
 	public String getRoutingKey() {
 		return routingKey;
 	}
+
+	@Override
+	public Object getEntityIdentifier() {
+		return identifier;
+	}
 }

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubEntityReference.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubEntityReference.java
@@ -1,0 +1,53 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.impl.integrationtest.mapper.stub;
+
+import java.util.Objects;
+
+import org.hibernate.search.engine.backend.common.spi.EntityReferenceFactory;
+
+public class StubEntityReference {
+
+	public static EntityReferenceFactory<StubEntityReference> FACTORY = StubEntityReference::new;
+
+	private final String typeName;
+
+	private final Object id;
+
+	public StubEntityReference(String typeName, Object id) {
+		this.typeName = typeName;
+		this.id = id;
+	}
+
+	public String getTypeName() {
+		return typeName;
+	}
+
+	public Object getId() {
+		return id;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ( obj == null || obj.getClass() != getClass() ) {
+			return false;
+		}
+		StubEntityReference other = (StubEntityReference) obj;
+		return typeName.equals( other.typeName ) && Objects.equals( id, other.id );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( typeName, id );
+	}
+
+	@Override
+	public String toString() {
+		return typeName + "#" + id;
+	}
+
+}

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMappingIndexManager.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMappingIndexManager.java
@@ -47,22 +47,23 @@ public class StubMappingIndexManager {
 		 * Use the same defaults as in the ORM mapper for the commit strategy,
 		 * but force refreshes because it's more convenient for tests.
 		 */
-		return indexManager.createIndexingPlan( sessionContext, DocumentCommitStrategy.FORCE, DocumentRefreshStrategy.FORCE );
+		return indexManager.createIndexingPlan( sessionContext, StubEntityReference.FACTORY,
+				DocumentCommitStrategy.FORCE, DocumentRefreshStrategy.FORCE );
 	}
 
 	public IndexIndexingPlan createIndexingPlan(StubBackendSessionContext sessionContext,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
-		return indexManager.createIndexingPlan( sessionContext, commitStrategy, refreshStrategy );
+		return indexManager.createIndexingPlan( sessionContext, StubEntityReference.FACTORY,
+				commitStrategy, refreshStrategy );
 	}
 
-	public IndexIndexer createIndexer(
-			DocumentCommitStrategy commitStrategy) {
+	public IndexIndexer createIndexer(DocumentCommitStrategy commitStrategy) {
 		return createIndexer( new StubBackendSessionContext(), commitStrategy );
 	}
 
 	public IndexIndexer createIndexer(
 			StubBackendSessionContext sessionContext, DocumentCommitStrategy commitStrategy) {
-		return indexManager.createIndexer( sessionContext, commitStrategy );
+		return indexManager.createIndexer( sessionContext, StubEntityReference.FACTORY, commitStrategy );
 	}
 
 	public IndexWorkspace createWorkspace() {

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMappingIndexManager.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMappingIndexManager.java
@@ -38,11 +38,11 @@ public class StubMappingIndexManager {
 		return clazz.cast( indexManager.toAPI() );
 	}
 
-	public IndexIndexingPlan createIndexingPlan() {
+	public IndexIndexingPlan<StubEntityReference> createIndexingPlan() {
 		return createIndexingPlan( new StubBackendSessionContext() );
 	}
 
-	public IndexIndexingPlan createIndexingPlan(StubBackendSessionContext sessionContext) {
+	public IndexIndexingPlan<StubEntityReference> createIndexingPlan(StubBackendSessionContext sessionContext) {
 		/*
 		 * Use the same defaults as in the ORM mapper for the commit strategy,
 		 * but force refreshes because it's more convenient for tests.
@@ -51,7 +51,7 @@ public class StubMappingIndexManager {
 				DocumentCommitStrategy.FORCE, DocumentRefreshStrategy.FORCE );
 	}
 
-	public IndexIndexingPlan createIndexingPlan(StubBackendSessionContext sessionContext,
+	public IndexIndexingPlan<StubEntityReference> createIndexingPlan(StubBackendSessionContext sessionContext,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
 		return indexManager.createIndexingPlan( sessionContext, StubEntityReference.FACTORY,
 				commitStrategy, refreshStrategy );


### PR DESCRIPTION
* [HSEARCH-3851](https://hibernate.atlassian.net/browse/HSEARCH-3851): Entities whose indexing failed are not reported when even just one document ID cannot be converted
* [HSEARCH-3852](https://hibernate.atlassian.net/browse/HSEARCH-3852): Failure to index reports the wrong document ID with Elasticsearch discriminator multi-tenancy

Waiting for CI, then I'll merge.