### PR TITLE
HSEARCH-3751 dropAndCreateSchema() as an alternative to purge() in the MassIndexer

### DIFF
--- a/documentation/src/main/asciidoc/mapper-orm-indexing-massindexer.asciidoc
+++ b/documentation/src/main/asciidoc/mapper-orm-indexing-massindexer.asciidoc
@@ -141,6 +141,26 @@ will attempt to preload everything in memory.
 accept special values, for example MySQL might benefit from using `Integer#MIN_VALUE`, otherwise it
 will attempt to preload everything in memory.
 
+|[[mapper-orm-indexing-massindexer-parameters-drop-and-create-schema]]`dropAndCreateSchemaOnStart(boolean)`
+|`false`
+|Drops the indexes and their schema (if they exist) and re-creates them before indexing.
+
+Indexes will be unavailable for a short time during the dropping and re-creation,
+so this should only be used when failures of concurrent operations on the indexes (automatic indexing, ...)
+are acceptable.
+
+This should be used when the existing schema is known to be obsolete,
+for example when <<mapper-orm-mapping-changes,the Hibernate Search mapping changed>>
+and some fields now have a different type, a different analyzer, new capabilities (projectable, ...), etc.
+
+This may also be used when the schema is up-to-date,
+since it can be faster than a purge (`purgeAllOnStart`) on large indexes,
+especially with the Elasticsearch backend.
+
+As an alternative to this parameter,
+you can also use a schema manager to manage schemas manually at the time of your choosing:
+<<mapper-orm-schema-management-manager>>.
+
 |`purgeAllOnStart(boolean)`
 |`true`
 |Removes all entities from the indexes before indexing.

--- a/documentation/src/main/asciidoc/mapper-orm-indexing-massindexer.asciidoc
+++ b/documentation/src/main/asciidoc/mapper-orm-indexing-massindexer.asciidoc
@@ -143,8 +143,8 @@ will attempt to preload everything in memory.
 
 |`purgeAllOnStart(boolean)`
 |`true`
-|Whether the existing index should be purged at the beginning of the job. This operation
-takes place before indexing.
+|Removes all entities from the indexes before indexing.
+
 Only set this to `false` if you know the index is already empty;
 otherwise, you will end up with duplicates in the index.
 
@@ -184,23 +184,24 @@ The parameter is not used by default. It is equivalent to keyword `LIMIT` in SQL
 |A logging monitor.
 |
 The component responsible for monitoring progress of mass indexing.
-+
+
 As a `MassIndexer` can take some time to finish its job,
 it is often necessary to monitor its progress.
 The default, built-in monitor logs progress periodically at the `INFO` level,
 but a custom monitor can be set by implementing the `MassIndexingMonitor` interface
 and passing an instance using the `monitor` method.
-+
-Implementations of `MassIndexingMonitor` must be threadsafe.
+
+Implementations of `MassIndexingMonitor` must be thread-safe.
 
 |`failureHandler(MassIndexingFailureHandler)`
 |A failure handler.
 |
 The component responsible for handling failures occurring during mass indexing.
-+
+
 A `MassIndexer` performs multiple operations in parallel,
 some of which can fail without stopping the whole mass indexing process.
 As a result, it may be necessary to trace individual failures.
+
 The default, built-in failure handler just forwards the failures
 to the global <<configuration-background-failure-handling,background failure handler>>,
 which by default will log them at the `ERROR` level,
@@ -209,8 +210,8 @@ and passing an instance using the `failureHandler` method.
 This can be used to simply log failures in a context specific to the mass indexer,
 e.g. a web interface in a maintenance console from which mass indexing was requested,
 or for more advanced use cases, such as cancelling mass indexing on the first failure.
-+
-Implementations of `MassIndexingFailureHandler` must be threadsafe.
+
+Implementations of `MassIndexingFailureHandler` must be thread-safe.
 
 |===
 

--- a/documentation/src/main/asciidoc/mapper-orm-schema.asciidoc
+++ b/documentation/src/main/asciidoc/mapper-orm-schema.asciidoc
@@ -128,6 +128,9 @@ because <<mapper-orm-schema-management-concepts-lucene-schema,local Lucene index
 
 Below is an example using a `SearchSchemaManager` to drop and create indexes,
 then using a <<mapper-orm-indexing-massindexer,mass indexer>> to re-populate the indexes.
+The
+<<mapper-orm-indexing-massindexer-parameters-drop-and-create-schema,`dropAndCreateSchemaOnStart` setting of the mass indexer>>
+would be an alternative solution to achieve the same results.
 
 .Reinitializing indexes using a `SearchSchemaManager`
 ====

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/AbstractMassIndexingFailureIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/AbstractMassIndexingFailureIT.java
@@ -28,9 +28,11 @@ import org.hibernate.search.mapper.orm.massindexing.MassIndexingFailureHandler;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.util.common.SearchException;
+import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.common.rule.ThreadSpy;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.index.StubIndexScaleWork;
+import org.hibernate.search.util.impl.integrationtest.common.stub.backend.index.StubSchemaManagementWork;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.test.SubTest;
@@ -180,13 +182,36 @@ public abstract class AbstractMassIndexingFailureIT {
 	}
 
 	@Test
+	public void dropAndCreateSchema_exception() {
+		SessionFactory sessionFactory = setup();
+
+		String exceptionMessage = "DROP_AND_CREATE failure";
+		String failingOperationAsString = "MassIndexer operation";
+
+		expectMassIndexerOperationFailureHandling( SearchException.class, exceptionMessage, failingOperationAsString );
+
+		doMassIndexingWithFailure(
+				Search.mapping( sessionFactory ).scope( Object.class ).massIndexer().dropAndCreateSchemaOnStart( true ),
+				ThreadExpectation.NOT_CREATED,
+				throwable -> assertThat( throwable ).isInstanceOf( SearchException.class )
+						.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+								.typeContext( Book.class.getName() )
+								.failure( exceptionMessage )
+								.build() ),
+				expectSchemaManagementWorkException( StubSchemaManagementWork.Type.DROP_AND_CREATE )
+		);
+
+		assertMassIndexerOperationFailureHandling( SearchException.class, exceptionMessage, failingOperationAsString );
+	}
+
+	@Test
 	public void purge() {
 		SessionFactory sessionFactory = setup();
 
 		String exceptionMessage = "PURGE failure";
 		String failingOperationAsString = "MassIndexer operation";
 
-		expectMassIndexerOperationFailureHandling( exceptionMessage, failingOperationAsString );
+		expectMassIndexerOperationFailureHandling( SimulatedFailure.class, exceptionMessage, failingOperationAsString );
 
 		doMassIndexingWithFailure(
 				Search.mapping( sessionFactory ).scope( Object.class ).massIndexer(),
@@ -196,7 +221,7 @@ public abstract class AbstractMassIndexingFailureIT {
 				expectIndexScaleWork( StubIndexScaleWork.Type.PURGE, ExecutionExpectation.FAIL )
 		);
 
-		assertMassIndexerOperationFailureHandling( exceptionMessage, failingOperationAsString );
+		assertMassIndexerOperationFailureHandling( SimulatedFailure.class, exceptionMessage, failingOperationAsString );
 	}
 
 	@Test
@@ -206,7 +231,7 @@ public abstract class AbstractMassIndexingFailureIT {
 		String exceptionMessage = "MERGE_SEGMENTS failure";
 		String failingOperationAsString = "MassIndexer operation";
 
-		expectMassIndexerOperationFailureHandling( exceptionMessage, failingOperationAsString );
+		expectMassIndexerOperationFailureHandling( SimulatedFailure.class, exceptionMessage, failingOperationAsString );
 
 		doMassIndexingWithFailure(
 				Search.mapping( sessionFactory ).scope( Object.class ).massIndexer(),
@@ -217,7 +242,7 @@ public abstract class AbstractMassIndexingFailureIT {
 				expectIndexScaleWork( StubIndexScaleWork.Type.MERGE_SEGMENTS, ExecutionExpectation.FAIL )
 		);
 
-		assertMassIndexerOperationFailureHandling( exceptionMessage, failingOperationAsString );
+		assertMassIndexerOperationFailureHandling( SimulatedFailure.class, exceptionMessage, failingOperationAsString );
 	}
 
 	@Test
@@ -227,7 +252,7 @@ public abstract class AbstractMassIndexingFailureIT {
 		String exceptionMessage = "MERGE_SEGMENTS failure";
 		String failingOperationAsString = "MassIndexer operation";
 
-		expectMassIndexerOperationFailureHandling( exceptionMessage, failingOperationAsString );
+		expectMassIndexerOperationFailureHandling( SimulatedFailure.class, exceptionMessage, failingOperationAsString );
 
 		doMassIndexingWithFailure(
 				Search.mapping( sessionFactory ).scope( Object.class ).massIndexer()
@@ -241,7 +266,7 @@ public abstract class AbstractMassIndexingFailureIT {
 				expectIndexScaleWork( StubIndexScaleWork.Type.MERGE_SEGMENTS, ExecutionExpectation.FAIL )
 		);
 
-		assertMassIndexerOperationFailureHandling( exceptionMessage, failingOperationAsString );
+		assertMassIndexerOperationFailureHandling( SimulatedFailure.class, exceptionMessage, failingOperationAsString );
 	}
 
 	@Test
@@ -251,7 +276,7 @@ public abstract class AbstractMassIndexingFailureIT {
 		String exceptionMessage = "FLUSH failure";
 		String failingOperationAsString = "MassIndexer operation";
 
-		expectMassIndexerOperationFailureHandling( exceptionMessage, failingOperationAsString );
+		expectMassIndexerOperationFailureHandling( SimulatedFailure.class, exceptionMessage, failingOperationAsString );
 
 		doMassIndexingWithFailure(
 				Search.mapping( sessionFactory ).scope( Object.class ).massIndexer(),
@@ -264,7 +289,7 @@ public abstract class AbstractMassIndexingFailureIT {
 				expectIndexScaleWork( StubIndexScaleWork.Type.FLUSH, ExecutionExpectation.FAIL )
 		);
 
-		assertMassIndexerOperationFailureHandling( exceptionMessage, failingOperationAsString );
+		assertMassIndexerOperationFailureHandling( SimulatedFailure.class, exceptionMessage, failingOperationAsString );
 	}
 
 	@Test
@@ -274,7 +299,7 @@ public abstract class AbstractMassIndexingFailureIT {
 		String exceptionMessage = "REFRESH failure";
 		String failingOperationAsString = "MassIndexer operation";
 
-		expectMassIndexerOperationFailureHandling( exceptionMessage, failingOperationAsString );
+		expectMassIndexerOperationFailureHandling( SimulatedFailure.class, exceptionMessage, failingOperationAsString );
 
 		doMassIndexingWithFailure(
 				Search.mapping( sessionFactory ).scope( Object.class ).massIndexer(),
@@ -288,7 +313,7 @@ public abstract class AbstractMassIndexingFailureIT {
 				expectIndexScaleWork( StubIndexScaleWork.Type.REFRESH, ExecutionExpectation.FAIL )
 		);
 
-		assertMassIndexerOperationFailureHandling( exceptionMessage, failingOperationAsString );
+		assertMassIndexerOperationFailureHandling( SimulatedFailure.class, exceptionMessage, failingOperationAsString );
 	}
 
 	@Test
@@ -409,10 +434,12 @@ public abstract class AbstractMassIndexingFailureIT {
 			String exceptionMessage, String failingOperationAsString);
 
 	protected abstract void expectMassIndexerOperationFailureHandling(
-			String exceptionMessage, String failingOperationAsString);
+			Class<? extends Throwable> exceptionType, String exceptionMessage,
+			String failingOperationAsString);
 
 	protected abstract void assertMassIndexerOperationFailureHandling(
-			String exceptionMessage, String failingOperationAsString);
+			Class<? extends Throwable> exceptionType, String exceptionMessage,
+			String failingOperationAsString);
 
 	protected abstract void expectEntityIndexingAndMassIndexerOperationFailureHandling(
 			String entityName, String entityReferenceAsString,
@@ -503,6 +530,15 @@ public abstract class AbstractMassIndexingFailureIT {
 				}
 			}
 		}
+	}
+
+	private Runnable expectSchemaManagementWorkException(StubSchemaManagementWork.Type type) {
+		return () -> {
+			CompletableFuture<?> failingFuture = new CompletableFuture<>();
+			failingFuture.completeExceptionally( new SimulatedFailure( type.name() + " failure" ) );
+			backendMock.expectSchemaManagementWorks( Book.NAME )
+					.work( type, failingFuture );
+		};
 	}
 
 	private Runnable expectIndexScaleWork(StubIndexScaleWork.Type type, ExecutionExpectation executionExpectation) {

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingFailureCustomBackgroundFailureHandlerIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingFailureCustomBackgroundFailureHandlerIT.java
@@ -76,12 +76,16 @@ public class MassIndexingFailureCustomBackgroundFailureHandlerIT extends Abstrac
 	}
 
 	@Override
-	protected void expectMassIndexerOperationFailureHandling(String exceptionMessage, String failingOperationAsString) {
+	protected void expectMassIndexerOperationFailureHandling(
+			Class<? extends Throwable> exceptionType, String exceptionMessage,
+			String failingOperationAsString) {
 		// We'll check in the assert*() method, see below.
 	}
 
 	@Override
-	protected void assertMassIndexerOperationFailureHandling(String exceptionMessage, String failingOperationAsString) {
+	protected void assertMassIndexerOperationFailureHandling(
+			Class<? extends Throwable> exceptionType, String exceptionMessage,
+			String failingOperationAsString) {
 		assertThat( staticCounters.get( StubFailureHandler.CREATE ) ).isEqualTo( 1 );
 		assertThat( staticCounters.get( StubFailureHandler.HANDLE_INDEX_CONTEXT ) ).isEqualTo( 0 );
 		assertThat( staticCounters.get( StubFailureHandler.HANDLE_GENERIC_CONTEXT ) ).isEqualTo( 1 );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingFailureCustomMassIndexingFailureHandlerIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingFailureCustomMassIndexingFailureHandlerIT.java
@@ -100,20 +100,24 @@ public class MassIndexingFailureCustomMassIndexingFailureHandlerIT extends Abstr
 	}
 
 	@Override
-	protected void expectMassIndexerOperationFailureHandling(String exceptionMessage, String failingOperationAsString) {
+	protected void expectMassIndexerOperationFailureHandling(
+			Class<? extends Throwable> exceptionType, String exceptionMessage,
+			String failingOperationAsString) {
 		reset( failureHandler );
 		failureHandler.handle( capture( genericFailureContextCapture ) );
 		replay( failureHandler );
 	}
 
 	@Override
-	protected void assertMassIndexerOperationFailureHandling(String exceptionMessage, String failingOperationAsString) {
+	protected void assertMassIndexerOperationFailureHandling(
+			Class<? extends Throwable> exceptionType, String exceptionMessage,
+			String failingOperationAsString) {
 		verify( failureHandler );
 
 		MassIndexingFailureContext context = genericFailureContextCapture.getValue();
 		Assert.assertThat(
 				context.getThrowable(),
-				ExceptionMatcherBuilder.isException( SimulatedFailure.class )
+				ExceptionMatcherBuilder.isException( exceptionType )
 						.withMessage( exceptionMessage )
 						.build()
 		);

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingFailureDefaultBackgroundFailureHandlerIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingFailureDefaultBackgroundFailureHandlerIT.java
@@ -75,10 +75,12 @@ public class MassIndexingFailureDefaultBackgroundFailureHandlerIT extends Abstra
 	}
 
 	@Override
-	protected void expectMassIndexerOperationFailureHandling(String exceptionMessage, String failingOperationAsString) {
+	protected void expectMassIndexerOperationFailureHandling(
+			Class<? extends Throwable> exceptionType, String exceptionMessage,
+			String failingOperationAsString) {
 		logged.expectEvent(
 				Level.ERROR,
-				ExceptionMatcherBuilder.isException( SimulatedFailure.class )
+				ExceptionMatcherBuilder.isException( exceptionType )
 						.withMessage( exceptionMessage )
 						.build(),
 				failingOperationAsString
@@ -87,7 +89,9 @@ public class MassIndexingFailureDefaultBackgroundFailureHandlerIT extends Abstra
 	}
 
 	@Override
-	protected void assertMassIndexerOperationFailureHandling(String exceptionMessage, String failingOperationAsString) {
+	protected void assertMassIndexerOperationFailureHandling(
+			Class<? extends Throwable> exceptionType, String exceptionMessage,
+			String failingOperationAsString) {
 		// If we get there, everything works fine.
 	}
 

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/service/AdminService.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/service/AdminService.java
@@ -29,4 +29,8 @@ public class AdminService {
 	public void dropAndCreateSchema() {
 		Search.session( entityManager ).schemaManager().dropAndCreate();
 	}
+
+	public void dropSchema() {
+		Search.session( entityManager ).schemaManager().dropIfExisting();
+	}
 }

--- a/integrationtest/showcase/library/src/test/java/org/hibernate/search/integrationtest/showcase/library/LibraryShowcaseBaseIT.java
+++ b/integrationtest/showcase/library/src/test/java/org/hibernate/search/integrationtest/showcase/library/LibraryShowcaseBaseIT.java
@@ -62,12 +62,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
-@TestPropertySource(properties = { "automatic_indexing.strategy=session" })
 @ActiveProfiles(resolver = TestActiveProfilesResolver.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class LibraryShowcaseBaseIT {

--- a/integrationtest/showcase/library/src/test/java/org/hibernate/search/integrationtest/showcase/library/LibraryShowcaseMassIndexingIT.java
+++ b/integrationtest/showcase/library/src/test/java/org/hibernate/search/integrationtest/showcase/library/LibraryShowcaseMassIndexingIT.java
@@ -29,7 +29,9 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
-@TestPropertySource(properties = { "automatic_indexing.strategy=none" })
+@TestPropertySource(properties = {
+		"spring.jpa.properties.hibernate.search.automatic_indexing.strategy=none"
+})
 @ActiveProfiles(resolver = TestActiveProfilesResolver.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class LibraryShowcaseMassIndexingIT {

--- a/integrationtest/showcase/library/src/test/java/org/hibernate/search/integrationtest/showcase/library/LibraryShowcaseOutOfSyncIndexIT.java
+++ b/integrationtest/showcase/library/src/test/java/org/hibernate/search/integrationtest/showcase/library/LibraryShowcaseOutOfSyncIndexIT.java
@@ -20,7 +20,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 /**
@@ -28,7 +27,6 @@ import org.springframework.test.context.junit4.SpringRunner;
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest
-@TestPropertySource(properties = { "automatic_indexing.strategy=session" })
 @ActiveProfiles(resolver = TestActiveProfilesResolver.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class LibraryShowcaseOutOfSyncIndexIT {

--- a/integrationtest/showcase/library/src/test/java/org/hibernate/search/integrationtest/showcase/library/LibraryShowcaseTransactionIT.java
+++ b/integrationtest/showcase/library/src/test/java/org/hibernate/search/integrationtest/showcase/library/LibraryShowcaseTransactionIT.java
@@ -23,12 +23,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
-@TestPropertySource(properties = { "automatic_indexing.strategy=session" })
 @ActiveProfiles(resolver = TestActiveProfilesResolver.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class LibraryShowcaseTransactionIT {

--- a/integrationtest/showcase/library/src/test/resources/application-test.yaml
+++ b/integrationtest/showcase/library/src/test/resources/application-test.yaml
@@ -5,7 +5,6 @@ spring.jpa:
     hibernate.search:
       schema_management.strategy: drop-and-create-and-drop
       automatic_indexing:
-        strategy: ${automatic_indexing.strategy}
         # This really is only for tests:
         # it makes documents searchable directly upon returning from a transaction,
         # but it also hurts performance.

--- a/integrationtest/showcase/library/src/test/resources/application-test.yaml
+++ b/integrationtest/showcase/library/src/test/resources/application-test.yaml
@@ -3,6 +3,7 @@ spring.jpa:
     ddl-auto: create-drop
   properties:
     hibernate.search:
+      # Overridden in some tests
       schema_management.strategy: drop-and-create-and-drop
       automatic_indexing:
         # This really is only for tests:

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/MassIndexer.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/MassIndexer.java
@@ -76,6 +76,25 @@ public interface MassIndexer {
 	MassIndexer mergeSegmentsAfterPurge(boolean enable);
 
 	/**
+	 * Drops the indexes and their schema (if they exist) and re-creates them before indexing.
+	 * <p>
+	 * Indexes will be unavailable for a short time during the dropping and re-creation,
+	 * so this should only be used when failures of concurrent operations on the indexes (automatic indexing, ...)
+	 * are acceptable.
+	 * <p>
+	 * This should be used when the existing schema is known to be obsolete, for example when the Hibernate Search mapping
+	 * changed and some fields now have a different type, a different analyzer, new capabilities (projectable, ...), etc.
+	 * <p>
+	 * This may also be used when the schema is up-to-date,
+	 * since it can be faster than a {@link #purgeAllOnStart(boolean) purge} on large indexes.
+	 * <p>
+	 * Defaults to {@code false}.
+	 * @param dropAndCreateSchema if {@code true} the indexes and their schema will be dropped then re-created before starting the indexing
+	 * @return {@code this} for method chaining
+	 */
+	MassIndexer dropAndCreateSchemaOnStart(boolean dropAndCreateSchema);
+
+	/**
 	 * Removes all entities from the indexes before indexing.
 	 * <p>
 	 * Set this to false only if you know there are no

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/MassIndexer.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/MassIndexer.java
@@ -9,6 +9,7 @@ package org.hibernate.search.mapper.orm.massindexing;
 import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.CacheMode;
+import org.hibernate.search.util.common.annotaion.Incubating;
 
 /**
  * A MassIndexer is useful to rebuild the indexes from the
@@ -22,7 +23,8 @@ public interface MassIndexer {
 
 	/**
 	 * Sets the number of entity types to be indexed in parallel.
-	 * Defaults to 1.
+	 * <p>
+	 * Defaults to {@code 1}.
 	 *
 	 * @param threadsToIndexObjects  number of entity types to be indexed in parallel
 	 * @return {@code this} for method chaining
@@ -30,7 +32,7 @@ public interface MassIndexer {
 	MassIndexer typesToIndexInParallel(int threadsToIndexObjects);
 
 	/**
-	 * Set the number of threads to be used to load
+	 * Sets the number of threads to be used to load
 	 * the root entities.
 	 * @param numberOfThreads the number of threads
 	 * @return {@code this} for method chaining
@@ -46,6 +48,7 @@ public interface MassIndexer {
 
 	/**
 	 * Sets the cache interaction mode for the data loading tasks.
+	 * <p>
 	 * Defaults to {@code CacheMode.IGNORE}.
 	 * @param cacheMode the cache interaction mode
 	 * @return {@code this} for method chaining
@@ -53,14 +56,17 @@ public interface MassIndexer {
 	MassIndexer cacheMode(CacheMode cacheMode);
 
 	/**
-	 * Merge each index into a single segment after indexing. Defaults to {@code false}.
+	 * Merges each index into a single segment after indexing.
+	 * <p>
+	 * Defaults to {@code false}.
 	 * @param enable {@code true} to enable this operation, {@code false} to disable it.
 	 * @return {@code this} for method chaining
 	 */
 	MassIndexer mergeSegmentsOnFinish(boolean enable);
 
 	/**
-	 * Merge each index into a single segment after the initial index purge, just before indexing.
+	 * Merges each index into a single segment after the initial index purge, just before indexing.
+	 * <p>
 	 * Defaults to {@code true}.
 	 * <p>
 	 * This setting has no effect if {@code purgeAllOnStart} is set to false.
@@ -70,36 +76,40 @@ public interface MassIndexer {
 	MassIndexer mergeSegmentsAfterPurge(boolean enable);
 
 	/**
-	 * If all entities should be removed from the index before starting
-	 * using purgeAll. Set it to false only if you know there are no
-	 * entities in the index: otherwise search results may be duplicated.
-	 * Defaults to true.
-	 * @param purgeAll if {@code true} all entities will be removed from the index before starting the indexing
+	 * Removes all entities from the indexes before indexing.
+	 * <p>
+	 * Set this to false only if you know there are no
+	 * entities in the indexes: otherwise search results may be duplicated.
+	 * <p>
+	 * Defaults to {@code true}.
+	 * @param purgeAll if {@code true} all entities will be removed from the indexes before starting the indexing
 	 * @return {@code this} for method chaining
 	 */
 	MassIndexer purgeAllOnStart(boolean purgeAll);
 
 	/**
-	 * EXPERIMENTAL method: will probably change
-	 *
-	 * Will stop indexing after having indexed a set amount of objects.
-	 * As a results the index will not be consistent
+	 * Stops indexing after having indexed a set amount of objects.
+	 * <p>
+	 * As a results the indexes will not be consistent
 	 * with the database: use only for testing on an (undefined) subset of database data.
 	 * @param maximum the maximum number of objects to index
 	 * @return {@code this} for method chaining
 	 */
+	@Incubating
 	MassIndexer limitIndexedObjectsTo(long maximum);
 
 	/**
 	 * Starts the indexing process in background (asynchronous).
-	 * Can be called only once.
+	 * <p>
+	 * May only be called once.
 	 * @return a Future to control the indexing task.
 	 */
 	CompletableFuture<?> start();
 
 	/**
 	 * Starts the indexing process, and then block until it's finished.
-	 * Can be called only once.
+	 * <p>
+	 * May only be called once.
 	 * @throws InterruptedException if the current thread is interrupted
 	 * while waiting.
 	 */
@@ -107,7 +117,9 @@ public interface MassIndexer {
 
 	/**
 	 * Specifies the fetch size to be used when loading primary keys
-	 * if objects to be indexed. Some databases accept special values,
+	 * if objects to be indexed.
+	 * <p>
+	 * Some databases accept special values,
 	 * for example MySQL might benefit from using {@link Integer#MIN_VALUE}
 	 * otherwise it will attempt to preload everything in memory.
 	 * @param idFetchSize the fetch size to be used when loading primary keys
@@ -116,7 +128,9 @@ public interface MassIndexer {
 	MassIndexer idFetchSize(int idFetchSize);
 
 	/**
-	 * Timeout of transactions for loading ids and entities to be re-indexed. Specify a timeout which is long enough to
+	 * Timeout of transactions for loading ids and entities to be re-indexed.
+	 * <p>
+	 * Specify a timeout which is long enough to
 	 * load and index all entities of the type with the most instances, taking into account the configured batch size
 	 * and number of threads to load objects.
 	 * <p>
@@ -129,7 +143,7 @@ public interface MassIndexer {
 	MassIndexer transactionTimeout(int timeoutInSeconds);
 
 	/**
-	 * Set the {@link MassIndexingMonitor}.
+	 * Sets the {@link MassIndexingMonitor}.
 	 * <p>
 	 * The default monitor just logs the progress.
 	 *
@@ -139,7 +153,7 @@ public interface MassIndexer {
 	MassIndexer monitor(MassIndexingMonitor monitor);
 
 	/**
-	 * Set the {@link MassIndexingFailureHandler}.
+	 * Sets the {@link MassIndexingFailureHandler}.
 	 * <p>
 	 * The default handler just forwards failures to the
 	 * {@link org.hibernate.search.engine.cfg.EngineSettings#BACKGROUND_FAILURE_HANDLER background failure handler}.

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/MassIndexerImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/MassIndexerImpl.java
@@ -149,6 +149,11 @@ public class MassIndexerImpl implements MassIndexer {
 	}
 
 	@Override
+	public MassIndexer dropAndCreateSchemaOnStart(boolean enable) {
+		throw new UnsupportedOperationException( "Not implemented yet" );
+	}
+
+	@Override
 	public MassIndexer purgeAllOnStart(boolean enable) {
 		this.purgeAtStart = enable;
 		return this;

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/MassIndexerImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/MassIndexerImpl.java
@@ -21,6 +21,7 @@ import org.hibernate.search.mapper.orm.massindexing.MassIndexer;
 import org.hibernate.search.mapper.orm.logging.impl.Log;
 import org.hibernate.search.mapper.orm.massindexing.MassIndexingFailureHandler;
 import org.hibernate.search.mapper.orm.massindexing.MassIndexingMonitor;
+import org.hibernate.search.mapper.pojo.schema.management.spi.PojoScopeSchemaManager;
 import org.hibernate.search.mapper.pojo.work.spi.PojoScopeWorkspace;
 import org.hibernate.search.util.common.impl.Futures;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
@@ -43,6 +44,7 @@ public class MassIndexerImpl implements MassIndexer {
 	private final DetachedBackendSessionContext sessionContext;
 
 	private final Set<HibernateOrmMassIndexingIndexedTypeContext<?>> rootEntityTypes;
+	private final PojoScopeSchemaManager scopeSchemaManager;
 	private final PojoScopeWorkspace scopeWorkspace;
 
 	// default settings defined here:
@@ -52,6 +54,7 @@ public class MassIndexerImpl implements MassIndexer {
 	private long objectsLimit = 0; //means no limit at all
 	private CacheMode cacheMode = CacheMode.IGNORE;
 	private boolean mergeSegmentsOnFinish = false;
+	private boolean dropAndCreateSchemaOnStart = false;
 	private boolean purgeAtStart = true;
 	private boolean mergeSegmentsAfterPurge = true;
 	private int idFetchSize = 100; //reasonable default as we only load IDs
@@ -63,10 +66,12 @@ public class MassIndexerImpl implements MassIndexer {
 	public MassIndexerImpl(HibernateOrmMassIndexingMappingContext mappingContext,
 			Set<? extends HibernateOrmMassIndexingIndexedTypeContext<?>> targetedIndexedTypes,
 			DetachedBackendSessionContext sessionContext,
+			PojoScopeSchemaManager scopeSchemaManager,
 			PojoScopeWorkspace scopeWorkspace) {
 		this.mappingContext = mappingContext;
 		this.sessionContext = sessionContext;
 		this.rootEntityTypes = toRootEntityTypes( targetedIndexedTypes );
+		this.scopeSchemaManager = scopeSchemaManager;
 		this.scopeWorkspace = scopeWorkspace;
 	}
 
@@ -150,7 +155,8 @@ public class MassIndexerImpl implements MassIndexer {
 
 	@Override
 	public MassIndexer dropAndCreateSchemaOnStart(boolean enable) {
-		throw new UnsupportedOperationException( "Not implemented yet" );
+		this.dropAndCreateSchemaOnStart = enable;
+		return this;
 	}
 
 	@Override
@@ -202,10 +208,10 @@ public class MassIndexerImpl implements MassIndexer {
 		return new BatchCoordinator(
 				mappingContext, sessionContext,
 				notifier,
-				rootEntityTypes, scopeWorkspace,
+				rootEntityTypes, scopeSchemaManager, scopeWorkspace,
 				typesToIndexInParallel, documentBuilderThreads,
 				cacheMode, objectLoadingBatchSize, objectsLimit,
-				mergeSegmentsOnFinish, purgeAtStart, mergeSegmentsAfterPurge,
+				mergeSegmentsOnFinish, dropAndCreateSchemaOnStart, purgeAtStart, mergeSegmentsAfterPurge,
 				idFetchSize, idLoadingTransactionTimeout
 		);
 	}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/scope/impl/SearchScopeImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/scope/impl/SearchScopeImpl.java
@@ -100,6 +100,7 @@ public class SearchScopeImpl<E> implements SearchScope<E> {
 				mappingContext,
 				delegate.getIncludedIndexedTypes(),
 				detachedSessionContext,
+				delegate.schemaManager(),
 				delegate.workspace( detachedSessionContext )
 		);
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3751

Based on #2230 , which should be merged first.