### PR TITLE
HSEARCH-3858 upgrade maven-checkstyle-plugin to 3.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
 
         <version.assembly.plugin>3.1.0</version.assembly.plugin>
         <version.buildhelper.plugin>3.0.0</version.buildhelper.plugin>
-        <version.checkstyle.plugin>3.1.0</version.checkstyle.plugin>
+        <version.checkstyle.plugin>3.1.1</version.checkstyle.plugin>
         <version.bundle.plugin>3.3.0</version.bundle.plugin>
         <version.clean.plugin>3.0.0</version.clean.plugin>
         <version.copy.plugin>0.0.5</version.copy.plugin>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3858

Checkstyle is looking to remove some deprecated methods and CI noticed that you are not on the latest maven-checkstyle-plugin which is still using some deprecated methods.

Issue: checkstyle/checkstyle/issues/7190
PR: checkstyle/checkstyle#7778