### PR TITLE
HSEARCH-3867 + HSEARCH-3870 Upgrade to Lucene 8.5.0 / ES 7.6.1

### DIFF
--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/query/impl/FuzzyQueryBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/query/impl/FuzzyQueryBuilder.java
@@ -6,8 +6,11 @@
  */
 package org.hibernate.search.backend.lucene.lowlevel.query.impl;
 
+import static org.apache.lucene.search.BoostAttribute.DEFAULT_BOOST;
+
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BoostQuery;
 import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.QueryBuilder;
@@ -23,7 +26,12 @@ public final class FuzzyQueryBuilder extends QueryBuilder {
 	}
 
 	@Override
-	protected Query newTermQuery(Term term) {
-		return new FuzzyQuery( term, maxEditDistance, prefixLength );
+	protected Query newTermQuery(Term term, float boost) {
+		Query q = new FuzzyQuery( term, maxEditDistance, prefixLength );
+		if ( boost == DEFAULT_BOOST ) {
+			return q;
+		}
+		return new BoostQuery( q, boost );
 	}
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
         <!-- When updating the following versions you will likely need to update the
              matching test profile as well, e.g. elasticsearch-6.0 for the 6.0+ series -->
         <!-- The main version of Elasticsearch targeted by Hibernate Search, tested in the default profile -->
-        <version.org.elasticsearch.main>7.6.0</version.org.elasticsearch.main>
+        <version.org.elasticsearch.main>7.6.1</version.org.elasticsearch.main>
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently from the version of the remote cluster -->
         <version.org.elasticsearch.client>${version.org.elasticsearch.main}</version.org.elasticsearch.client>
         <documentation.org.elasticsearch.url>https://www.elastic.co/guide/en/elasticsearch/reference/${parsed-version.org.elasticsearch.main.majorVersion}.${parsed-version.org.elasticsearch.main.minorVersion}</documentation.org.elasticsearch.url>

--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@
         <!-- Nothing beyond common dependencies -->
 
         <!-- >>> Lucene -->
-        <version.org.apache.lucene>8.4.1</version.org.apache.lucene>
+        <version.org.apache.lucene>8.5.0</version.org.apache.lucene>
         <javadoc.org.apache.lucene.tag>${parsed-version.org.apache.lucene.majorVersion}_${parsed-version.org.apache.lucene.minorVersion}_${parsed-version.org.apache.lucene.incrementalVersion}</javadoc.org.apache.lucene.tag>
         <javadoc.org.apache.lucene.core.url>https://lucene.apache.org/core/${javadoc.org.apache.lucene.tag}/core/</javadoc.org.apache.lucene.core.url>
         <javadoc.org.apache.lucene.analyzers-common.url>https://lucene.apache.org/core/${javadoc.org.apache.lucene.tag}/analyzers-common/</javadoc.org.apache.lucene.analyzers-common.url>


### PR DESCRIPTION
* [HSEARCH-3867](https://hibernate.atlassian.net/browse/HSEARCH-3867): Upgrade to Lucene 8.5.0
* [HSEARCH-3870](https://hibernate.atlassian.net/browse/HSEARCH-3870): Upgrade to Elasticsearch 7.6.1

