### PR TITLE
HSEARCH-3883 NullPointerException when building a SimpleQueryString predicate

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/scope/model/impl/ElasticsearchDifferentNestedObjectCompatibilityChecker.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/scope/model/impl/ElasticsearchDifferentNestedObjectCompatibilityChecker.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.backend.elasticsearch.scope.model.impl;
 
 import java.lang.invoke.MethodHandles;
+import java.util.Collections;
 import java.util.List;
 
 import org.hibernate.search.backend.elasticsearch.logging.impl.Log;
@@ -15,7 +16,7 @@ import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 public class ElasticsearchDifferentNestedObjectCompatibilityChecker {
 
 	public static ElasticsearchDifferentNestedObjectCompatibilityChecker empty(ElasticsearchScopeModel scopeModel) {
-		return new ElasticsearchDifferentNestedObjectCompatibilityChecker( scopeModel, null, null );
+		return new ElasticsearchDifferentNestedObjectCompatibilityChecker( scopeModel, null, Collections.emptyList() );
 	}
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
@@ -44,10 +45,6 @@ public class ElasticsearchDifferentNestedObjectCompatibilityChecker {
 
 	public List<String> getNestedPathHierarchy() {
 		return nestedPathHierarchy;
-	}
-
-	public boolean isEmpty() {
-		return nestedPathHierarchy == null || nestedPathHierarchy.isEmpty();
 	}
 
 	private static String getLastPath(List<String> hierarchy) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/scope/model/impl/ElasticsearchScopeModel.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/scope/model/impl/ElasticsearchScopeModel.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.backend.elasticsearch.scope.model.impl;
 
 import java.lang.invoke.MethodHandles;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -220,7 +221,7 @@ public class ElasticsearchScopeModel {
 				} )
 				.orElse( Optional.empty() );
 
-		return nestedDocumentPath.orElse( null );
+		return nestedDocumentPath.orElse( Collections.emptyList() );
 	}
 
 	public List<String> getNestedPathHierarchyForObject(String absoluteObjectPath) {
@@ -238,6 +239,6 @@ public class ElasticsearchScopeModel {
 				} )
 				.orElse( Optional.empty() );
 
-		return nestedDocumentPath.orElse( null );
+		return nestedDocumentPath.orElse( Collections.emptyList() );
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/AbstractElasticsearchSearchNestedPredicateBuilder.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/AbstractElasticsearchSearchNestedPredicateBuilder.java
@@ -26,7 +26,7 @@ public abstract class AbstractElasticsearchSearchNestedPredicateBuilder extends 
 	@Override
 	public final JsonObject build(ElasticsearchSearchPredicateContext context) {
 		JsonObject result = super.build( context );
-		if ( nestedPathHierarchy != null && !nestedPathHierarchy.isEmpty() ) {
+		if ( !nestedPathHierarchy.isEmpty() ) {
 			result = applyImplicitNested( result, nestedPathHierarchy, context );
 		}
 		return result;

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchSearchPredicateBuilderFactoryImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchSearchPredicateBuilderFactoryImpl.java
@@ -139,14 +139,15 @@ public class ElasticsearchSearchPredicateBuilderFactoryImpl implements Elasticse
 
 	@Override
 	public ExistsPredicateBuilder<ElasticsearchSearchPredicateBuilder> exists(String absoluteFieldPath) {
-		if ( !scopeModel.hasSchemaObjectNodeComponent( absoluteFieldPath ) ) {
+		List<String> nestedPathHierarchy;
+		if ( scopeModel.hasSchemaObjectNodeComponent( absoluteFieldPath ) ) {
+			nestedPathHierarchy = scopeModel.getNestedPathHierarchyForObject( absoluteFieldPath );
+		}
+		else {
+			nestedPathHierarchy = scopeModel.getNestedPathHierarchyForField( absoluteFieldPath );
 			// Make sure to fail for fields with different type or for unknown fields
 			// We may be able to relax this constraint, but that would require more extensive testing
 			scopeModel.getSchemaNodeComponent( absoluteFieldPath, PREDICATE_BUILDER_FACTORY_RETRIEVAL_STRATEGY );
-		}
-		List<String> nestedPathHierarchy = scopeModel.getNestedPathHierarchyForField( absoluteFieldPath );
-		if ( nestedPathHierarchy == null ) {
-			nestedPathHierarchy = scopeModel.getNestedPathHierarchyForObject( absoluteFieldPath );
 		}
 		return new ElasticsearchExistsPredicateBuilder( absoluteFieldPath, nestedPathHierarchy );
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/scope/model/impl/LuceneDifferentNestedObjectCompatibilityChecker.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/scope/model/impl/LuceneDifferentNestedObjectCompatibilityChecker.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.backend.lucene.scope.model.impl;
 
 import java.lang.invoke.MethodHandles;
+import java.util.Collections;
 import java.util.List;
 
 import org.hibernate.search.backend.lucene.logging.impl.Log;
@@ -15,7 +16,7 @@ import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 public class LuceneDifferentNestedObjectCompatibilityChecker {
 
 	public static LuceneDifferentNestedObjectCompatibilityChecker empty(LuceneScopeModel scopeModel) {
-		return new LuceneDifferentNestedObjectCompatibilityChecker( scopeModel, null, null );
+		return new LuceneDifferentNestedObjectCompatibilityChecker( scopeModel, null, Collections.emptyList() );
 	}
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
@@ -44,10 +45,6 @@ public class LuceneDifferentNestedObjectCompatibilityChecker {
 
 	public List<String> getNestedPathHierarchy() {
 		return nestedPathHierarchy;
-	}
-
-	public boolean isEmpty() {
-		return nestedPathHierarchy == null || nestedPathHierarchy.isEmpty();
 	}
 
 	private static String getLastPath(List<String> hierarchy) {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/scope/model/impl/LuceneScopeModel.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/scope/model/impl/LuceneScopeModel.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.backend.lucene.scope.model.impl;
 
 import java.lang.invoke.MethodHandles;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -250,7 +251,7 @@ public class LuceneScopeModel {
 				} )
 				.orElse( Optional.empty() );
 
-		return nestedDocumentPath.orElse( null );
+		return nestedDocumentPath.orElse( Collections.emptyList() );
 	}
 
 	public List<String> getNestedPathHierarchyForObject(String absoluteFieldPath) {
@@ -268,6 +269,6 @@ public class LuceneScopeModel {
 				} )
 				.orElse( Optional.empty() );
 
-		return nestedDocumentPath.orElse( null );
+		return nestedDocumentPath.orElse( Collections.emptyList() );
 	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3883

I didn't add a test because it turns out that the code triggering the NPE [was relying on unsupported behavior](https://discourse.hibernate.org/t/hibernate-search-6-0-0-beta6-simplequerydsl-breaking/3977/6?u=yrodiere), but I think this cleanup is a good think regardless. We can ask ourselves whether we want to officially support that use case later.
