### PR TITLE
HSEARCH-3893 + HSEARCH-3894 Bugfixes for aggregations on fields in nested documents

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/impl/AbstractElasticsearchBucketAggregation.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/impl/AbstractElasticsearchBucketAggregation.java
@@ -6,9 +6,13 @@
  */
 package org.hibernate.search.backend.elasticsearch.search.aggregation.impl;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Map;
 
+import org.hibernate.search.backend.elasticsearch.gson.impl.JsonAccessor;
+import org.hibernate.search.backend.elasticsearch.logging.impl.Log;
 import org.hibernate.search.backend.elasticsearch.search.impl.ElasticsearchSearchContext;
+import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -20,6 +24,19 @@ import com.google.gson.JsonObject;
 public abstract class AbstractElasticsearchBucketAggregation<K, V>
 		extends AbstractElasticsearchNestableAggregation<Map<K, V>> {
 
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+
+	private static final JsonAccessor<JsonObject> REQUEST_REVERSE_NESTED_ACCESSOR =
+			JsonAccessor.root().property( "reverse_nested" ).asObject();
+
+	private static final String ROOT_DOC_COUNT_NAME = "root_doc_count";
+	private static final JsonAccessor<JsonObject> REQUEST_AGGREGATIONS_ROOT_DOC_COUNT_ACCESSOR =
+			JsonAccessor.root().property( "aggregations" ).property( ROOT_DOC_COUNT_NAME ).asObject();
+	private static final JsonAccessor<Long> RESPONSE_DOC_COUNT_ACCESSOR =
+			JsonAccessor.root().property( "doc_count" ).asLong();
+	private static final JsonAccessor<Long> RESPONSE_ROOT_DOC_COUNT_ACCESSOR =
+			JsonAccessor.root().property( ROOT_DOC_COUNT_NAME ).property( "doc_count" ).asLong();
+
 	AbstractElasticsearchBucketAggregation(AbstractBuilder<K, V> builder) {
 		super( builder );
 	}
@@ -30,6 +47,14 @@ public abstract class AbstractElasticsearchBucketAggregation<K, V>
 		JsonObject innerObject = new JsonObject();
 
 		doRequest( context, outerObject, innerObject );
+
+		if ( isNested() ) {
+			JsonObject rootDocCountSubAggregationOuterObject = new JsonObject();
+			JsonObject rootDocCountSubAggregationInnerObject = new JsonObject();
+
+			REQUEST_REVERSE_NESTED_ACCESSOR.set( rootDocCountSubAggregationOuterObject, rootDocCountSubAggregationInnerObject );
+			REQUEST_AGGREGATIONS_ROOT_DOC_COUNT_ACCESSOR.set( outerObject, rootDocCountSubAggregationOuterObject );
+		}
 
 		return outerObject;
 	}
@@ -45,6 +70,19 @@ public abstract class AbstractElasticsearchBucketAggregation<K, V>
 
 	protected abstract Map<K, V> doExtract(AggregationExtractContext context,
 			JsonObject outerObject, JsonElement buckets);
+
+	protected final long getBucketDocCount(JsonObject bucket) {
+		if ( isNested() ) {
+			// We must return the number of root documents,
+			// not the number of leaf documents that Elasticsearch returns by default.
+			return RESPONSE_ROOT_DOC_COUNT_ACCESSOR.get( bucket )
+					.orElseThrow( log::elasticsearchResponseMissingData );
+		}
+		else {
+			return RESPONSE_DOC_COUNT_ACCESSOR.get( bucket )
+					.orElseThrow( log::elasticsearchResponseMissingData );
+		}
+	}
 
 	public abstract static class AbstractBuilder<K, V>
 			extends AbstractElasticsearchNestableAggregation.AbstractBuilder<Map<K, V>> {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/impl/AbstractElasticsearchNestableAggregation.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/impl/AbstractElasticsearchNestableAggregation.java
@@ -74,6 +74,10 @@ public abstract class AbstractElasticsearchNestableAggregation<A> extends Abstra
 
 	protected abstract A doExtract(JsonObject aggregationResult, AggregationExtractContext context);
 
+	protected final boolean isNested() {
+		return !nestedPathHierarchy.isEmpty();
+	}
+
 	public abstract static class AbstractBuilder<A> extends AbstractElasticsearchAggregation.AbstractBuilder<A> {
 
 		public AbstractBuilder(ElasticsearchSearchContext searchContext) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/impl/ElasticsearchRangeAggregation.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/impl/ElasticsearchRangeAggregation.java
@@ -66,7 +66,7 @@ public class ElasticsearchRangeAggregation<F, K>
 		for ( int i = 0; i < rangesJson.size(); i++ ) {
 			JsonObject bucket = bucketMap.get( String.valueOf( i ) ).getAsJsonObject();
 			Range<K> range = rangesInOrder.get( i );
-			long documentCount = bucket.get( "doc_count" ).getAsLong();
+			long documentCount = getBucketDocCount( bucket );
 			result.put( range, documentCount );
 		}
 		return result;

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/impl/ElasticsearchTermsAggregation.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/aggregation/impl/ElasticsearchTermsAggregation.java
@@ -59,8 +59,7 @@ public class ElasticsearchTermsAggregation<F, K>
 	}
 
 	@Override
-	protected Map<K, Long> doExtract(AggregationExtractContext context, JsonObject outerObject,
-			JsonElement buckets) {
+	protected Map<K, Long> doExtract(AggregationExtractContext context, JsonObject outerObject, JsonElement buckets) {
 		JsonArray bucketArray = buckets.getAsJsonArray();
 		Map<K, Long> result = CollectionHelper.newLinkedHashMap( bucketArray.size() );
 		FromDocumentFieldValueConvertContext convertContext = context.getConvertContext();
@@ -72,7 +71,7 @@ public class ElasticsearchTermsAggregation<F, K>
 					codec.decodeAggregationKey( keyJson, keyAsStringJson ),
 					convertContext
 			);
-			long documentCount = bucket.get( "doc_count" ).getAsLong();
+			long documentCount = getBucketDocCount( bucket );
 			result.put( key, documentCount );
 		}
 		return result;

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/SingleFieldAggregationBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/SingleFieldAggregationBaseIT.java
@@ -439,9 +439,15 @@ public class SingleFieldAggregationBaseIT<F> {
 					}
 					break;
 				case IN_NESTED:
-					DocumentElement nestedObject = document.addObject( binding.nestedObject.self );
-					for ( F value : values ) {
-						nestedObject.addValue(
+					// Make sure to create multiple nested documents here, to test all the scenarios.
+					DocumentElement nestedObject1 = document.addObject( binding.nestedObject.self );
+					nestedObject1.addValue(
+							binding.nestedObject.fieldWithMultipleValuesModels.get( fieldType ).reference,
+							values.get( 0 )
+					);
+					DocumentElement nestedObject2 = document.addObject( binding.nestedObject.self );
+					for ( F value : values.subList( 1, values.size() ) ) {
+						nestedObject2.addValue(
 								binding.nestedObject.fieldWithMultipleValuesModels.get( fieldType ).reference,
 								value
 						);
@@ -484,7 +490,7 @@ public class SingleFieldAggregationBaseIT<F> {
 		IndexBinding(IndexSchemaElement root) {
 			super( root );
 			flattenedObject = FirstLevelObjectBinding.create( root, "flattenedObject", ObjectFieldStorage.FLATTENED );
-			nestedObject = FirstLevelObjectBinding.create( root, "nestedObject", ObjectFieldStorage.NESTED );
+			nestedObject = FirstLevelObjectBinding.create( root, "nestedObject", ObjectFieldStorage.NESTED, true );
 		}
 	}
 


### PR DESCRIPTION
* [HSEARCH-3893](https://hibernate.atlassian.net/browse/HSEARCH-3893): Elasticsearch aggregations return the count of nested (leaf) documents
* [HSEARCH-3894](https://hibernate.atlassian.net/browse/HSEARCH-3894): Lucene text aggregations count nested documents twice when they include the same term multiple times

