### PR TITLE
HSEARCH-3898 Change the explain API so that the type name is used

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
@@ -487,8 +487,8 @@ public interface Log extends BasicLogger {
 	SearchException explainRequiresIndexName(Set<String> targetedIndexNames);
 
 	@Message(id = ID_OFFSET_3 + 65,
-			value = "The given index name '%2$s' is not among the indexes targeted by this query: %1$s." )
-	SearchException explainRequiresIndexTargetedByQuery(Set<String> targetedIndexNames, String indexName);
+			value = "The given mapped type name '%2$s' is not among the mapped type targeted by this query: %1$s." )
+	SearchException explainRequiresTypeTargetedByQuery(Set<String> targetedTypeNames, String typeName);
 
 	@Message(id = ID_OFFSET_3 + 66,
 			value = "Document with id '%1$s' does not exist in the targeted index and thus its match cannot be explained." )

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/scope/model/impl/ElasticsearchScopeModel.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/scope/model/impl/ElasticsearchScopeModel.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.backend.elasticsearch.scope.model.impl;
 
 import java.lang.invoke.MethodHandles;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -33,30 +34,34 @@ public class ElasticsearchScopeModel {
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private final Set<ElasticsearchIndexModel> indexModels;
-	private final Map<String, URLEncodedString> hibernateSearchIndexNamesToIndexReadNames;
-	private final Set<String> mappedTypeNames;
+	private final Set<String> hibernateSearchIndexNames;
+	private final Map<String, URLEncodedString> mappedTypeToElasticsearchIndexNames;
 
 	public ElasticsearchScopeModel(Set<ElasticsearchIndexModel> indexModels) {
 		this.indexModels = indexModels;
 		// Use LinkedHashMap/LinkedHashSet to ensure stable order when generating requests
-		this.hibernateSearchIndexNamesToIndexReadNames = new LinkedHashMap<>();
-		this.mappedTypeNames = new LinkedHashSet<>();
+		this.hibernateSearchIndexNames = new LinkedHashSet<>();
+		this.mappedTypeToElasticsearchIndexNames = new LinkedHashMap<>();
 		for ( ElasticsearchIndexModel model : indexModels ) {
-			hibernateSearchIndexNamesToIndexReadNames.put( model.getHibernateSearchIndexName(), model.getNames().getRead() );
-			mappedTypeNames.add( model.getMappedTypeName() );
+			hibernateSearchIndexNames.add( model.getHibernateSearchIndexName() );
+			mappedTypeToElasticsearchIndexNames.put( model.getMappedTypeName(), model.getNames().getRead() );
 		}
 	}
 
-	public Set<String> getHibernateSearchIndexNames() {
-		return hibernateSearchIndexNamesToIndexReadNames.keySet();
-	}
-
-	public Map<String, URLEncodedString> getHibernateSearchIndexNamesToIndexReadNames() {
-		return hibernateSearchIndexNamesToIndexReadNames;
-	}
-
 	public Set<String> getMappedTypeNames() {
-		return mappedTypeNames;
+		return mappedTypeToElasticsearchIndexNames.keySet();
+	}
+
+	public Set<String> getHibernateSearchIndexNames() {
+		return hibernateSearchIndexNames;
+	}
+
+	public Collection<URLEncodedString> getElasticsearchIndexNames() {
+		return mappedTypeToElasticsearchIndexNames.values();
+	}
+
+	public Map<String, URLEncodedString> getMappedTypeToElasticsearchIndexNames() {
+		return mappedTypeToElasticsearchIndexNames;
 	}
 
 	public EventContext getIndexesEventContext() {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/impl/ElasticsearchSearchContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/impl/ElasticsearchSearchContext.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.backend.elasticsearch.search.impl;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
@@ -68,16 +69,20 @@ public final class ElasticsearchSearchContext {
 		return multiTenancyStrategy.toElasticsearchId( tenantId, id );
 	}
 
-	public Map<String, URLEncodedString> getHibernateSearchIndexNamesToIndexReadNames() {
-		return scopeModel.getHibernateSearchIndexNamesToIndexReadNames();
+	public Set<String> getMappedTypeNames() {
+		return scopeModel.getMappedTypeNames();
 	}
 
 	public Set<String> getHibernateSearchIndexNames() {
 		return scopeModel.getHibernateSearchIndexNames();
 	}
 
-	public Set<String> getMappedTypeNames() {
-		return scopeModel.getMappedTypeNames();
+	public Collection<URLEncodedString> getElasticsearchIndexNames() {
+		return scopeModel.getElasticsearchIndexNames();
+	}
+
+	public Map<String, URLEncodedString> getMappedTypeToElasticsearchIndexNames() {
+		return scopeModel.getMappedTypeToElasticsearchIndexNames();
 	}
 
 	public JsonObject getFilterOrNull(String tenantId) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/ElasticsearchSearchQuery.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/ElasticsearchSearchQuery.java
@@ -26,16 +26,17 @@ public interface ElasticsearchSearchQuery<H>
 	JsonObject explain(String id);
 
 	/**
-	 * Explain score computation of this query for the document with the given id in the given index.
+	 * Explain score computation of this query for the document with the given id in the given mapped type.
 	 * <p>
 	 * This feature is relatively expensive, use it only sparingly and when you need to debug a slow query.
 	 *
-	 * @param indexName The name of the index containing the document to test.
+	 * @param typeName The name of the mapped type containing the document to test.
 	 * @param id The id of the document to test.
 	 * @return A {@link JsonObject} describing the score computation for the hit.
-	 * @throws org.hibernate.search.util.common.SearchException If the given index name does not refer to an index targeted by this query,
+	 * @throws org.hibernate.search.util.common.SearchException If the given mapped type name does not refer to a mapped name targeted by this query,
 	 * or if the explain request fails.
 	 */
-	JsonObject explain(String indexName, String id);
+	// TODO HSEARCH-3899 avoiding merging index concepts (e.g.: documentId) and entity concepts (e.g.: mapped type)
+	JsonObject explain(String typeName, String id);
 
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
@@ -461,18 +461,20 @@ public interface Log extends BasicLogger {
 	)
 	SearchException multipleValuesForSingleValuedField(String absoluteFieldPath);
 
+	// TODO HSEARCH-3899 avoiding merging index concepts (e.g.: documentId) and entity concepts (e.g.: mapped type)
 	@Message(id = ID_OFFSET_2 + 75,
-			value = "explain(String id) cannot be used when the query targets multiple indexes."
-					+ " Use explain(String indexName, String id) and pass one of %1$s as the index name." )
-	SearchException explainRequiresIndexName(Set<String> targetedIndexNames);
+			value = "explain(String id) cannot be used when the query targets multiple mapped types."
+					+ " Use explain(String typeName, String id) and pass one of %1$s as the mapped type name." )
+	SearchException explainRequiresTypeName(Set<String> targetedTypeNames);
 
 	@Message(id = ID_OFFSET_2 + 76,
-			value = "The given index name '%2$s' is not among the indexes targeted by this query: %1$s." )
-	SearchException explainRequiresIndexTargetedByQuery(Set<String> targetedIndexNames, String indexName);
+			value = "The given mapped type name '%2$s' is not among the mapped types targeted by this query: %1$s." )
+	SearchException explainRequiresTypeTargetedByQuery(Set<String> targetedTypeNames, String typeName);
 
+	// TODO HSEARCH-3899 avoiding merging index concepts (e.g.: documentId) and entity concepts (e.g.: mapped type)
 	@Message(id = ID_OFFSET_2 + 77,
-			value = "Document with id '%2$s' does not exist in index '%1$s' and thus its match cannot be explained." )
-	SearchException explainUnkownDocument(String indexName, String d);
+			value = "Document with id '%2$s' does not exist for the mapped type '%1$s' and thus its match cannot be explained." )
+	SearchException explainUnkownDocument(String typeName, String id);
 
 	@Message(id = ID_OFFSET_2 + 78,
 			value = "Unable to merge index segments.")

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/scope/model/impl/LuceneScopeModel.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/scope/model/impl/LuceneScopeModel.java
@@ -9,11 +9,11 @@ package org.hibernate.search.backend.lucene.scope.model.impl;
 import java.lang.invoke.MethodHandles;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexModel;
 import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexSchemaFieldNode;
@@ -32,16 +32,26 @@ public class LuceneScopeModel {
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private final Set<LuceneIndexModel> indexModels;
+	private final Set<String> typeNames;
 	private final Set<String> indexNames;
 	private final Set<LuceneScopeIndexManagerContext> indexManagerContexts;
 
 	public LuceneScopeModel(Set<LuceneIndexModel> indexModels,
 			Set<LuceneScopeIndexManagerContext> indexManagerContexts) {
 		this.indexModels = indexModels;
-		this.indexNames = indexModels.stream()
-				.map( LuceneIndexModel::getIndexName )
-				.collect( Collectors.toSet() );
+		// Use LinkedHashSet to ensure stable order when generating requests
+		this.typeNames = new LinkedHashSet<>();
+		this.indexNames = new LinkedHashSet<>();
 		this.indexManagerContexts = indexManagerContexts;
+
+		for ( LuceneIndexModel model : indexModels ) {
+			this.typeNames.add( model.getMappedTypeName() );
+			this.indexNames.add( model.getIndexName() );
+		}
+	}
+
+	public Set<String> getTypeNames() {
+		return typeNames;
 	}
 
 	public Set<String> getIndexNames() {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/impl/LuceneSearchContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/impl/LuceneSearchContext.java
@@ -64,6 +64,10 @@ public final class LuceneSearchContext {
 		return analysisDefinitionRegistry;
 	}
 
+	public Set<String> getTypeNames() {
+		return scopeModel.getTypeNames();
+	}
+
 	public Set<String> getIndexNames() {
 		return scopeModel.getIndexNames();
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/LuceneSearchQuery.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/LuceneSearchQuery.java
@@ -16,25 +16,26 @@ public interface LuceneSearchQuery<H>
 	/**
 	 * Explain score computation of this query for the document with the given id.
 	 * <p>
-	 * This is a shorthand for {@link #explain(String, String)} when the query only targets one index.
+	 * This is a shorthand for {@link #explain(String, String)} when the query only targets one mapped type.
 	 *
 	 * @param id The id of the document to test.
 	 * @return An {@link org.apache.lucene.search.Explanation} describing the score computation for the hit.
-	 * @throws org.hibernate.search.util.common.SearchException If the query targets multiple indexes,
+	 * @throws org.hibernate.search.util.common.SearchException If the query targets multiple mapped types,
 	 * or if the explain request fails.
 	 */
 	Explanation explain(String id);
 
 	/**
-	 * Explain score computation of this query for the document with the given id in the given index.
+	 * Explain score computation of this query for the document with the given id in the given mapped type.
 	 * <p>
 	 * This feature is relatively expensive, use it only sparingly and when you need to debug a slow query.
 	 *
-	 * @param indexName The name of the index containing the document to test.
+	 * @param typeName The name of the mapped type containing the document to test.
 	 * @param id The id of the document to test.
 	 * @return An {@link org.apache.lucene.search.Explanation} describing the score computation for the hit.
-	 * @throws org.hibernate.search.util.common.SearchException If the given index name does not refer to an index targeted by this query,
+	 * @throws org.hibernate.search.util.common.SearchException If the given index name does not refer to a mapped name targeted by this query,
 	 * or if the explain request fails.
 	 */
-	Explanation explain(String indexName, String id);
+	// TODO HSEARCH-3899 avoiding merging index concepts (e.g.: documentId) and entity concepts (e.g.: mapped type)
+	Explanation explain(String typeName, String id);
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryImpl.java
@@ -116,7 +116,7 @@ public class LuceneSearchQueryImpl<H> extends AbstractSearchQuery<H, LuceneSearc
 	public Explanation explain(String id) {
 		Contracts.assertNotNull( id, "id" );
 
-		Set<String> targetedIndexNames = searchContext.getIndexNames();
+		Set<String> targetedIndexNames = searchContext.getTypeNames();
 		if ( targetedIndexNames.size() != 1 ) {
 			throw log.explainRequiresIndexName( targetedIndexNames );
 		}
@@ -129,7 +129,7 @@ public class LuceneSearchQueryImpl<H> extends AbstractSearchQuery<H, LuceneSearc
 		Contracts.assertNotNull( indexName, "indexName" );
 		Contracts.assertNotNull( id, "id" );
 
-		Set<String> targetedIndexNames = searchContext.getIndexNames();
+		Set<String> targetedIndexNames = searchContext.getTypeNames();
 		if ( !targetedIndexNames.contains( indexName ) ) {
 			throw log.explainRequiresIndexTargetedByQuery( targetedIndexNames, indexName );
 		}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryImpl.java
@@ -116,25 +116,25 @@ public class LuceneSearchQueryImpl<H> extends AbstractSearchQuery<H, LuceneSearc
 	public Explanation explain(String id) {
 		Contracts.assertNotNull( id, "id" );
 
-		Set<String> targetedIndexNames = searchContext.getTypeNames();
-		if ( targetedIndexNames.size() != 1 ) {
-			throw log.explainRequiresIndexName( targetedIndexNames );
+		Set<String> targetedTypeNames = searchContext.getTypeNames();
+		if ( targetedTypeNames.size() != 1 ) {
+			throw log.explainRequiresTypeName( targetedTypeNames );
 		}
 
-		return doExplain( targetedIndexNames.iterator().next(), id );
+		return doExplain( targetedTypeNames.iterator().next(), id );
 	}
 
 	@Override
-	public Explanation explain(String indexName, String id) {
-		Contracts.assertNotNull( indexName, "indexName" );
+	public Explanation explain(String typeName, String id) {
+		Contracts.assertNotNull( typeName, "typeName" );
 		Contracts.assertNotNull( id, "id" );
 
 		Set<String> targetedIndexNames = searchContext.getTypeNames();
-		if ( !targetedIndexNames.contains( indexName ) ) {
-			throw log.explainRequiresIndexTargetedByQuery( targetedIndexNames, indexName );
+		if ( !targetedIndexNames.contains( typeName ) ) {
+			throw log.explainRequiresTypeTargetedByQuery( targetedIndexNames, typeName );
 		}
 
-		return doExplain( indexName, id );
+		return doExplain( typeName, id );
 	}
 
 	private <T> T doSubmit(ReadWork<T> work) {

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
@@ -314,7 +314,7 @@ public class ElasticsearchExtensionIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageContaining(
-						"index name 'NotAnIndexName' is not among the indexes targeted by this query: ["
+						"type name 'NotAnIndexName' is not among the mapped type targeted by this query: ["
 						+ INDEX_NAME + ", " + OTHER_INDEX_NAME + "]"
 				);
 	}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
@@ -77,8 +77,12 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 public class ElasticsearchExtensionIT {
 
 	private static final String BACKEND_NAME = "myElasticsearchBackend";
-	private static final String INDEX_NAME = "IndexName";
-	private static final String OTHER_INDEX_NAME = "OtherIndexName";
+
+	private static final String INDEX_NAME = "indexName";
+	private static final String TYPE_NAME = "typeName";
+
+	private static final String OTHER_INDEX_NAME = "otherIndexName";
+	private static final String OTHER_TYPE_NAME = "otherTypeName";
 
 	private static final String FIRST_ID = "1";
 	private static final String SECOND_ID = "2";
@@ -104,11 +108,13 @@ public class ElasticsearchExtensionIT {
 		this.integration = setupHelper.start( BACKEND_NAME )
 				.withIndex(
 						INDEX_NAME,
+						options -> options.mappedType( TYPE_NAME ),
 						ctx -> this.indexMapping = new IndexMapping( ctx.getSchemaElement() ),
 						indexManager -> this.indexManager = indexManager
 				)
 				.withIndex(
 						OTHER_INDEX_NAME,
+						options -> options.mappedType( OTHER_TYPE_NAME ),
 						ctx -> new IndexMapping( ctx.getSchemaElement() ),
 						indexManager -> this.otherIndexManager = indexManager
 				)
@@ -144,7 +150,7 @@ public class ElasticsearchExtensionIT {
 		ElasticsearchSearchResult<DocumentReference> result = query.fetchAll();
 
 		assertThat( result ).fromQuery( query )
-				.hasDocRefHitsAnyOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID, FOURTH_ID, FIFTH_ID, EMPTY_ID )
+				.hasDocRefHitsAnyOrder( TYPE_NAME, FIRST_ID, SECOND_ID, THIRD_ID, FOURTH_ID, FIFTH_ID, EMPTY_ID )
 				.hasTotalHitCount( 6 );
 
 		// Also check (at compile time) the context type for other asXXX() methods, since we need to override each method explicitly
@@ -174,7 +180,7 @@ public class ElasticsearchExtensionIT {
 		ElasticsearchSearchQuery<DocumentReference> query = genericQuery.extension( ElasticsearchExtension.get() );
 		ElasticsearchSearchResult<DocumentReference> result = query.fetchAll();
 		assertThat( result ).fromQuery( query )
-				.hasDocRefHitsAnyOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID, FOURTH_ID, FIFTH_ID, EMPTY_ID )
+				.hasDocRefHitsAnyOrder( TYPE_NAME, FIRST_ID, SECOND_ID, THIRD_ID, FOURTH_ID, FIFTH_ID, EMPTY_ID )
 				.hasTotalHitCount( 6 );
 
 		// Unsupported extension
@@ -273,13 +279,13 @@ public class ElasticsearchExtensionIT {
 				.toQuery();
 
 		// Matching document
-		Assertions.assertThat( query.explain( INDEX_NAME, FIRST_ID ) )
+		Assertions.assertThat( query.explain( TYPE_NAME, FIRST_ID ) )
 				.asString()
 				.contains( "\"description\":" )
 				.contains( "\"details\":" );
 
 		// Non-matching document
-		Assertions.assertThat( query.explain( INDEX_NAME, FIFTH_ID ) )
+		Assertions.assertThat( query.explain( TYPE_NAME, FIFTH_ID ) )
 				.asString()
 				.contains( "\"description\":" )
 				.contains( "\"details\":" );
@@ -310,12 +316,12 @@ public class ElasticsearchExtensionIT {
 				.toQuery();
 
 		Assertions.assertThatThrownBy(
-				() -> query.explain( "NotAnIndexName", FIRST_ID )
+				() -> query.explain( "NotAMappedName", FIRST_ID )
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageContaining(
-						"type name 'NotAnIndexName' is not among the mapped type targeted by this query: ["
-						+ INDEX_NAME + ", " + OTHER_INDEX_NAME + "]"
+						"type name 'NotAMappedName' is not among the mapped type targeted by this query: ["
+						+ TYPE_NAME + ", " + OTHER_TYPE_NAME + "]"
 				);
 	}
 
@@ -328,7 +334,7 @@ public class ElasticsearchExtensionIT {
 						.matching( new JsonPrimitive( "2018:01:12" ) ) )
 				.toQuery();
 		assertThat( query )
-				.hasDocRefHitsAnyOrder( INDEX_NAME, FOURTH_ID )
+				.hasDocRefHitsAnyOrder( TYPE_NAME, FOURTH_ID )
 				.hasTotalHitCount( 1 );
 	}
 
@@ -341,7 +347,7 @@ public class ElasticsearchExtensionIT {
 						.matching( new ValueWrapper<>( new JsonPrimitive( 2 ) ) ) )
 				.toQuery();
 		assertThat( query )
-				.hasDocRefHitsAnyOrder( INDEX_NAME, SECOND_ID )
+				.hasDocRefHitsAnyOrder( TYPE_NAME, SECOND_ID )
 				.hasTotalHitCount( 1 );
 	}
 
@@ -354,7 +360,7 @@ public class ElasticsearchExtensionIT {
 						.matching( new JsonPrimitive( 2 ), ValueConvert.NO ) )
 				.toQuery();
 		assertThat( query )
-				.hasDocRefHitsAnyOrder( INDEX_NAME, SECOND_ID )
+				.hasDocRefHitsAnyOrder( TYPE_NAME, SECOND_ID )
 				.hasTotalHitCount( 1 );
 	}
 
@@ -388,7 +394,7 @@ public class ElasticsearchExtensionIT {
 				)
 				.toQuery();
 		assertThat( query )
-				.hasDocRefHitsAnyOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID )
+				.hasDocRefHitsAnyOrder( TYPE_NAME, FIRST_ID, SECOND_ID, THIRD_ID )
 				.hasTotalHitCount( 3 );
 	}
 
@@ -424,7 +430,7 @@ public class ElasticsearchExtensionIT {
 				.where( booleanPredicate )
 				.toQuery();
 		assertThat( query )
-				.hasDocRefHitsAnyOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID )
+				.hasDocRefHitsAnyOrder( TYPE_NAME, FIRST_ID, SECOND_ID, THIRD_ID )
 				.hasTotalHitCount( 3 );
 	}
 
@@ -456,7 +462,7 @@ public class ElasticsearchExtensionIT {
 				)
 				.toQuery();
 		assertThat( query )
-				.hasDocRefHitsAnyOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID )
+				.hasDocRefHitsAnyOrder( TYPE_NAME, FIRST_ID, SECOND_ID, THIRD_ID )
 				.hasTotalHitCount( 3 );
 	}
 
@@ -491,7 +497,7 @@ public class ElasticsearchExtensionIT {
 				.where( booleanPredicate )
 				.toQuery();
 		assertThat( query )
-				.hasDocRefHitsAnyOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID )
+				.hasDocRefHitsAnyOrder( TYPE_NAME, FIRST_ID, SECOND_ID, THIRD_ID )
 				.hasTotalHitCount( 3 );
 	}
 
@@ -509,7 +515,7 @@ public class ElasticsearchExtensionIT {
 				)
 				.toQuery();
 		assertThat( query ).hasDocRefHitsExactOrder(
-				INDEX_NAME,
+				TYPE_NAME,
 				FIRST_ID, SECOND_ID, THIRD_ID, FOURTH_ID, EMPTY_ID, FIFTH_ID
 		);
 
@@ -523,7 +529,7 @@ public class ElasticsearchExtensionIT {
 				)
 				.toQuery();
 		assertThat( query ).hasDocRefHitsExactOrder(
-				INDEX_NAME,
+				TYPE_NAME,
 				FOURTH_ID, THIRD_ID, SECOND_ID, FIRST_ID, EMPTY_ID, FIFTH_ID
 		);
 	}
@@ -553,7 +559,7 @@ public class ElasticsearchExtensionIT {
 				)
 				.toQuery();
 		assertThat( query ).hasDocRefHitsExactOrder(
-				INDEX_NAME,
+				TYPE_NAME,
 				FIRST_ID, SECOND_ID, THIRD_ID, FOURTH_ID, EMPTY_ID, FIFTH_ID
 		);
 
@@ -578,7 +584,7 @@ public class ElasticsearchExtensionIT {
 				)
 				.toQuery();
 		assertThat( query ).hasDocRefHitsExactOrder(
-				INDEX_NAME,
+				TYPE_NAME,
 				FOURTH_ID, THIRD_ID, SECOND_ID, FIRST_ID, EMPTY_ID, FIFTH_ID
 		);
 	}
@@ -613,7 +619,7 @@ public class ElasticsearchExtensionIT {
 				.sort( f -> f.composite().add( sort1Asc ).add( sort2Asc ).add( sort3Asc ).add( sort4Asc ) )
 				.toQuery();
 		assertThat( query )
-				.hasDocRefHitsExactOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID, FOURTH_ID, EMPTY_ID, FIFTH_ID );
+				.hasDocRefHitsExactOrder( TYPE_NAME, FIRST_ID, SECOND_ID, THIRD_ID, FOURTH_ID, EMPTY_ID, FIFTH_ID );
 
 		SearchSort sort1Desc = scope.sort().extension( ElasticsearchExtension.get() ).fromJson( gson.fromJson(
 						"{'nativeField_sort1': 'desc'}", JsonObject.class
@@ -641,7 +647,7 @@ public class ElasticsearchExtensionIT {
 				.sort( f -> f.composite().add( sort1Desc ).add( sort2Desc ).add( sort3Desc ).add( sort4Desc ) )
 				.toQuery();
 		assertThat( query )
-				.hasDocRefHitsExactOrder( INDEX_NAME, FOURTH_ID, THIRD_ID, SECOND_ID, FIRST_ID, EMPTY_ID, FIFTH_ID );
+				.hasDocRefHitsExactOrder( TYPE_NAME, FOURTH_ID, THIRD_ID, SECOND_ID, FIRST_ID, EMPTY_ID, FIFTH_ID );
 	}
 
 	@Test
@@ -664,7 +670,7 @@ public class ElasticsearchExtensionIT {
 				)
 				.toQuery();
 		assertThat( query ).hasDocRefHitsExactOrder(
-				INDEX_NAME,
+				TYPE_NAME,
 				FIRST_ID, SECOND_ID, THIRD_ID, FOURTH_ID, EMPTY_ID, FIFTH_ID
 		);
 
@@ -684,7 +690,7 @@ public class ElasticsearchExtensionIT {
 				)
 				.toQuery();
 		assertThat( query ).hasDocRefHitsExactOrder(
-				INDEX_NAME,
+				TYPE_NAME,
 				FOURTH_ID, THIRD_ID, SECOND_ID, FIRST_ID, EMPTY_ID, FIFTH_ID
 		);
 	}
@@ -714,7 +720,7 @@ public class ElasticsearchExtensionIT {
 				.sort( f -> f.composite().add( sort1Asc ).add( sort2Asc ).add( sort3Asc ).add( sort4Asc ) )
 				.toQuery();
 		assertThat( query )
-				.hasDocRefHitsExactOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID, FOURTH_ID, EMPTY_ID, FIFTH_ID );
+				.hasDocRefHitsExactOrder( TYPE_NAME, FIRST_ID, SECOND_ID, THIRD_ID, FOURTH_ID, EMPTY_ID, FIFTH_ID );
 
 		SearchSort sort1Desc = scope.sort().extension( ElasticsearchExtension.get() )
 				.fromJson( "{'nativeField_sort1': 'desc'}" )
@@ -737,7 +743,7 @@ public class ElasticsearchExtensionIT {
 				.sort( f -> f.composite().add( sort1Desc ).add( sort2Desc ).add( sort3Desc ).add( sort4Desc ) )
 				.toQuery();
 		assertThat( query )
-				.hasDocRefHitsExactOrder( INDEX_NAME, FOURTH_ID, THIRD_ID, SECOND_ID, FIRST_ID, EMPTY_ID, FIFTH_ID );
+				.hasDocRefHitsExactOrder( TYPE_NAME, FOURTH_ID, THIRD_ID, SECOND_ID, FIRST_ID, EMPTY_ID, FIFTH_ID );
 	}
 
 	@Test
@@ -757,7 +763,7 @@ public class ElasticsearchExtensionIT {
 				)
 				.toQuery();
 		assertThat( query ).hasDocRefHitsExactOrder(
-				INDEX_NAME,
+				TYPE_NAME,
 				FIRST_ID, SECOND_ID, THIRD_ID, FOURTH_ID, FIFTH_ID, EMPTY_ID
 		);
 
@@ -775,7 +781,7 @@ public class ElasticsearchExtensionIT {
 				)
 				.toQuery();
 		assertThat( query ).hasDocRefHitsExactOrder(
-				INDEX_NAME,
+				TYPE_NAME,
 				FIFTH_ID, FOURTH_ID, THIRD_ID, SECOND_ID, FIRST_ID, EMPTY_ID
 		);
 	}
@@ -1205,7 +1211,7 @@ public class ElasticsearchExtensionIT {
 				.where( f -> f.matchAll() )
 				.toQuery();
 		assertThat( query ).hasDocRefHitsAnyOrder(
-				INDEX_NAME,
+				TYPE_NAME,
 				FIRST_ID, SECOND_ID, THIRD_ID, FOURTH_ID, FIFTH_ID, EMPTY_ID
 		);
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3897
https://hibernate.atlassian.net/browse/HSEARCH-3898

I created the follow up (not solved here): HSEARCH-3899.
To use the entity id instead of the document id for the same API.