### PR TITLE
HSEARCH-3901 Expose metadata about the annotated type in the context passed to PropertyMappingAnnotationProcessor/TypeMappingAnnotationProcessor

### DIFF
--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/MappingAnnotatedElement.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/MappingAnnotatedElement.java
@@ -1,0 +1,24 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing;
+
+import java.lang.annotation.Annotation;
+import java.util.stream.Stream;
+
+/**
+ * An element in the entity model annotated with a mapping annotation.
+ *
+ * @see MappingAnnotatedType
+ * @see MappingAnnotatedProperty
+ */
+public interface MappingAnnotatedElement {
+
+	Class<?> javaClass();
+
+	Stream<Annotation> allAnnotations();
+
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/MappingAnnotatedProperty.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/MappingAnnotatedProperty.java
@@ -1,0 +1,19 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing;
+
+/**
+ * A property in the entity model annotated with a mapping annotation.
+ *
+ * @see MappingAnnotatedElement
+ * @see PropertyMappingAnnotationProcessorContext#annotatedElement()
+ */
+public interface MappingAnnotatedProperty extends MappingAnnotatedElement {
+
+	String name();
+
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/MappingAnnotatedType.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/MappingAnnotatedType.java
@@ -1,0 +1,17 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing;
+
+/**
+ * A type in the entity model annotated with a mapping annotation.
+ *
+ * @see MappingAnnotatedElement
+ * @see TypeMappingAnnotationProcessorContext#annotatedElement()
+ */
+public interface MappingAnnotatedType extends MappingAnnotatedElement {
+
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/MappingAnnotationProcessorContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/MappingAnnotationProcessorContext.java
@@ -20,6 +20,11 @@ import org.hibernate.search.mapper.pojo.model.path.PojoModelPathValueNode;
 public interface MappingAnnotationProcessorContext {
 
 	/**
+	 * @return A representation of the annotated element.
+	 */
+	MappingAnnotatedElement annotatedElement();
+
+	/**
 	 * Convert an {@link ObjectPath} annotation to a {@link PojoModelPathValueNode}.
 	 * @param objectPath The annotation to convert.
 	 * @return The corresponding path, or an empty optional if the path was empty.

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/PropertyMappingAnnotationProcessorContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/PropertyMappingAnnotationProcessorContext.java
@@ -14,4 +14,8 @@ import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.Property
  * The context passed to {@link PropertyMappingAnnotationProcessor#process(PropertyMappingStep, Annotation, PropertyMappingAnnotationProcessorContext)}.
  */
 public interface PropertyMappingAnnotationProcessorContext extends MappingAnnotationProcessorContext {
+
+	@Override
+	MappingAnnotatedProperty annotatedElement();
+
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/TypeMappingAnnotationProcessorContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/TypeMappingAnnotationProcessorContext.java
@@ -14,4 +14,8 @@ import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMapp
  * The context passed to {@link TypeMappingAnnotationProcessor#process(TypeMappingStep, Annotation, TypeMappingAnnotationProcessorContext)}.
  */
 public interface TypeMappingAnnotationProcessorContext extends MappingAnnotationProcessorContext {
+
+	@Override
+	MappingAnnotatedType annotatedElement();
+
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/AbstractMappingAnnotationProcessorContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/AbstractMappingAnnotationProcessorContext.java
@@ -1,0 +1,42 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.impl;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Optional;
+
+import org.hibernate.search.engine.environment.bean.BeanReference;
+import org.hibernate.search.mapper.pojo.extractor.mapping.annotation.ContainerExtraction;
+import org.hibernate.search.mapper.pojo.extractor.mapping.programmatic.ContainerExtractorPath;
+import org.hibernate.search.mapper.pojo.logging.impl.Log;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ObjectPath;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.MappingAnnotationProcessorContext;
+import org.hibernate.search.mapper.pojo.model.path.PojoModelPathValueNode;
+import org.hibernate.search.util.common.logging.impl.LoggerFactory;
+
+public abstract class AbstractMappingAnnotationProcessorContext
+		implements MappingAnnotationProcessorContext {
+
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+
+	@Override
+	public Optional<PojoModelPathValueNode> toPojoModelPathValueNode(ObjectPath objectPath) {
+		return MappingAnnotationProcessorUtils.toPojoModelPathValueNode( objectPath );
+	}
+
+	@Override
+	public ContainerExtractorPath toContainerExtractorPath(ContainerExtraction extraction) {
+		return MappingAnnotationProcessorUtils.toContainerExtractorPath( extraction );
+	}
+
+	@Override
+	public <T> Optional<BeanReference<? extends T>> toBeanReference(Class<T> expectedType, Class<?> undefinedTypeMarker,
+			Class<? extends T> type, String name) {
+		return MappingAnnotationProcessorUtils.toBeanReference( expectedType, undefinedTypeMarker, type, name );
+	}
+
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/AnnotationProcessorProvider.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/AnnotationProcessorProvider.java
@@ -17,7 +17,6 @@ import org.hibernate.search.engine.environment.bean.BeanReference;
 import org.hibernate.search.engine.environment.bean.BeanResolver;
 import org.hibernate.search.engine.reporting.spi.FailureCollector;
 import org.hibernate.search.mapper.pojo.logging.impl.Log;
-import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.MappingAnnotationProcessorContext;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMapping;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMappingAnnotationProcessor;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMappingAnnotationProcessorRef;
@@ -37,18 +36,15 @@ public class AnnotationProcessorProvider {
 
 	private final BeanResolver beanResolver;
 	private final FailureCollector rootFailureCollector;
-	private final MappingAnnotationProcessorContext context;
 
 	private final Map<Class<? extends Annotation>, Optional<BeanReference<? extends TypeMappingAnnotationProcessor>>>
 			typeAnnotationProcessorReferenceCache = new HashMap<>();
 	private final Map<Class<? extends Annotation>, Optional<BeanReference<? extends PropertyMappingAnnotationProcessor>>>
 			propertyAnnotationProcessorReferenceCache = new HashMap<>();
 
-	public AnnotationProcessorProvider(BeanResolver beanResolver, FailureCollector rootFailureCollector,
-			MappingAnnotationProcessorContext context) {
+	public AnnotationProcessorProvider(BeanResolver beanResolver, FailureCollector rootFailureCollector) {
 		this.beanResolver = beanResolver;
 		this.rootFailureCollector = rootFailureCollector;
-		this.context = context;
 	}
 
 	@SuppressWarnings("unchecked") // Checked using reflection in createProcessorBean
@@ -133,7 +129,7 @@ public class AnnotationProcessorProvider {
 
 		TypeMappingAnnotationProcessorRef referenceAnnotation = mapping.processor();
 		Optional<BeanReference<? extends TypeMappingAnnotationProcessor>> processorReference =
-				context.toBeanReference(
+				MappingAnnotationProcessorUtils.toBeanReference(
 						TypeMappingAnnotationProcessor.class,
 						TypeMappingAnnotationProcessorRef.UndefinedProcessorImplementationType.class,
 						referenceAnnotation.type(), referenceAnnotation.name()
@@ -154,7 +150,7 @@ public class AnnotationProcessorProvider {
 
 		PropertyMappingAnnotationProcessorRef referenceAnnotation = mapping.processor();
 		Optional<BeanReference<? extends PropertyMappingAnnotationProcessor>> processorReference =
-				context.toBeanReference(
+				MappingAnnotationProcessorUtils.toBeanReference(
 						PropertyMappingAnnotationProcessor.class,
 						PropertyMappingAnnotationProcessorRef.UndefinedProcessorImplementationType.class,
 						referenceAnnotation.type(), referenceAnnotation.name()

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/MappingAnnotationProcessorUtils.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/MappingAnnotationProcessorUtils.java
@@ -17,20 +17,19 @@ import org.hibernate.search.mapper.pojo.extractor.mapping.programmatic.Container
 import org.hibernate.search.mapper.pojo.logging.impl.Log;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ObjectPath;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.PropertyValue;
-import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMappingAnnotationProcessorContext;
-import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.TypeMappingAnnotationProcessorContext;
 import org.hibernate.search.mapper.pojo.model.path.PojoModelPath;
 import org.hibernate.search.mapper.pojo.model.path.PojoModelPathValueNode;
 import org.hibernate.search.util.common.AssertionFailure;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
-public class MappingAnnotationProcessorContextImpl
-		implements TypeMappingAnnotationProcessorContext, PropertyMappingAnnotationProcessorContext {
+public final class MappingAnnotationProcessorUtils {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	@Override
-	public Optional<PojoModelPathValueNode> toPojoModelPathValueNode(ObjectPath objectPath) {
+	private MappingAnnotationProcessorUtils() {
+	}
+
+	public static Optional<PojoModelPathValueNode> toPojoModelPathValueNode(ObjectPath objectPath) {
 		PropertyValue[] inversePathElements = objectPath.value();
 		PojoModelPath.Builder inversePathBuilder = PojoModelPath.builder();
 		for ( PropertyValue element : inversePathElements ) {
@@ -41,8 +40,7 @@ public class MappingAnnotationProcessorContextImpl
 		return Optional.ofNullable( inversePathBuilder.toValuePathOrNull() );
 	}
 
-	@Override
-	public ContainerExtractorPath toContainerExtractorPath(ContainerExtraction extraction) {
+	public static ContainerExtractorPath toContainerExtractorPath(ContainerExtraction extraction) {
 		ContainerExtract extract = extraction.extract();
 		String[] extractors = extraction.value();
 		switch ( extract ) {
@@ -65,8 +63,7 @@ public class MappingAnnotationProcessorContextImpl
 		}
 	}
 
-	@Override
-	public <T> Optional<BeanReference<? extends T>> toBeanReference(Class<T> expectedType, Class<?> undefinedTypeMarker,
+	public static <T> Optional<BeanReference<? extends T>> toBeanReference(Class<T> expectedType, Class<?> undefinedTypeMarker,
 			Class<? extends T> type, String name) {
 		String cleanedUpName = name.isEmpty() ? null : name;
 		Class<? extends T> cleanedUpType = undefinedTypeMarker.equals( type ) ? null : type;

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/PropertyMappingAnnotationProcessorContextImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/PropertyMappingAnnotationProcessorContextImpl.java
@@ -1,0 +1,44 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.impl;
+
+import java.lang.annotation.Annotation;
+import java.util.stream.Stream;
+
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.MappingAnnotatedProperty;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMappingAnnotationProcessorContext;
+import org.hibernate.search.mapper.pojo.model.spi.PojoPropertyModel;
+
+public class PropertyMappingAnnotationProcessorContextImpl
+		extends AbstractMappingAnnotationProcessorContext
+		implements PropertyMappingAnnotationProcessorContext, MappingAnnotatedProperty {
+	private final PojoPropertyModel<?> propertyModel;
+
+	public PropertyMappingAnnotationProcessorContextImpl(PojoPropertyModel<?> propertyModel) {
+		this.propertyModel = propertyModel;
+	}
+
+	@Override
+	public MappingAnnotatedProperty annotatedElement() {
+		return this; // Not a lot to implement, so we just implement everything in the same class
+	}
+
+	@Override
+	public Class<?> javaClass() {
+		return propertyModel.getTypeModel().getRawType().getTypeIdentifier().getJavaClass();
+	}
+
+	@Override
+	public String name() {
+		return propertyModel.getName();
+	}
+
+	@Override
+	public Stream<Annotation> allAnnotations() {
+		return propertyModel.getAnnotations();
+	}
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/TypeMappingAnnotationProcessorContextImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/TypeMappingAnnotationProcessorContextImpl.java
@@ -1,0 +1,39 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.impl;
+
+import java.lang.annotation.Annotation;
+import java.util.stream.Stream;
+
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.MappingAnnotatedType;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.TypeMappingAnnotationProcessorContext;
+import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeModel;
+
+public class TypeMappingAnnotationProcessorContextImpl
+		extends AbstractMappingAnnotationProcessorContext
+		implements TypeMappingAnnotationProcessorContext, MappingAnnotatedType {
+	private final PojoRawTypeModel<?> typeModel;
+
+	public TypeMappingAnnotationProcessorContextImpl(PojoRawTypeModel<?> typeModel) {
+		this.typeModel = typeModel;
+	}
+
+	@Override
+	public MappingAnnotatedType annotatedElement() {
+		return this; // Not a lot to implement, so we just implement everything in the same class
+	}
+
+	@Override
+	public Class<?> javaClass() {
+		return typeModel.getTypeIdentifier().getJavaClass();
+	}
+
+	@Override
+	public Stream<Annotation> allAnnotations() {
+		return typeModel.getAnnotations();
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3901

Turns out we cannot use markers, or the existing `PojoModelElement` which relies on markers, because markers are derived from mapping annotations; essentially it's a problem of circular dependency.

Anyway, I managed to expose the annotations directly, which should be good enough.