### PR TITLE
HSEARCH-3912 + HSEARCH-3915 Increase the amount of RAM assigned to Elasticsearch in integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@
 # therefore deactivated. Activating Travis for your own fork is as easy as
 # activating it in the travis site of your fork.
 
-dist: trusty
+dist: bionic
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 cache:
   directories:
     - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
-# The main CI of Hibernate Search is https://ci.hibernate.org/job/hibernate-search/. Travis CI can be
-# used in github forks. https://travis-ci.org/hibernate/hibernate-search is
-# therefore deactivated. Activating Travis for your own fork is as easy as
-# activating it in the travis site of your fork.
+# The main CI of Hibernate Search is https://ci.hibernate.org/job/hibernate-search/.
+# However, Hibernate Search builds run on Travis CI regularly
+# to check that it still works and can be used in GitHub forks.
+# See https://github.com/marketplace/travis-ci to activate
+# Travis in your own fork of Hibernate Search.
 
 dist: bionic
 language: java

--- a/util/internal/integrationtest/sharedresources/src/main/elasticsearch-maven-plugin/5.0/configuration/jvm.options
+++ b/util/internal/integrationtest/sharedresources/src/main/elasticsearch-maven-plugin/5.0/configuration/jvm.options
@@ -22,8 +22,8 @@
 # For Hibernate Search, we don't need as much as the default 1g
 # Let's keep it low, so that we'll be able to run tests
 # on memory-constrained CI slaves
--Xms256m
--Xmx256m
+-Xms512m
+-Xmx512m
 
 ################################################################
 ## Expert settings

--- a/util/internal/integrationtest/sharedresources/src/main/elasticsearch-maven-plugin/6.0/configuration/jvm.options
+++ b/util/internal/integrationtest/sharedresources/src/main/elasticsearch-maven-plugin/6.0/configuration/jvm.options
@@ -22,8 +22,8 @@
 # For Hibernate Search, we don't need as much as the default 1g
 # Let's keep it low, so that we'll be able to run tests
 # on memory-constrained CI slaves
--Xms256m
--Xmx256m
+-Xms512m
+-Xmx512m
 
 ################################################################
 ## Expert settings

--- a/util/internal/integrationtest/sharedresources/src/main/elasticsearch-maven-plugin/7.0/configuration/jvm.options
+++ b/util/internal/integrationtest/sharedresources/src/main/elasticsearch-maven-plugin/7.0/configuration/jvm.options
@@ -22,8 +22,8 @@
 # For Hibernate Search, we don't need as much as the default 1g
 # Let's keep it low, so that we'll be able to run tests
 # on memory-constrained CI slaves
--Xms256m
--Xmx256m
+-Xms512m
+-Xmx512m
 
 ################################################################
 ## Expert settings


### PR DESCRIPTION
* [HSEARCH-3912](https://hibernate.atlassian.net/browse/HSEARCH-3912): Increase the amount of RAM assigned to Elasticsearch in integration tests
* [HSEARCH-3915](https://hibernate.atlassian.net/browse/HSEARCH-3915): Upgrade to the Ubuntu Bionic environment in .travis.yml

I verified the Travis build still works here: https://travis-ci.org/github/yrodiere/hibernate-search/jobs/684298909