### PR TITLE
HSEARCH-3918 + HSEARCH-3919 Upgrade to Elasticsearch 7.7.0 and AWS ES 7.4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -220,7 +220,8 @@ stage('Configure') {
 					new EsAwsBuildEnvironment(version: '6.4', mavenProfile: 'elasticsearch-6.4', status: BuildEnvironmentStatus.SUPPORTED),
 					new EsAwsBuildEnvironment(version: '6.5', mavenProfile: 'elasticsearch-6.4', status: BuildEnvironmentStatus.SUPPORTED),
 					new EsAwsBuildEnvironment(version: '6.7', mavenProfile: 'elasticsearch-6.7', status: BuildEnvironmentStatus.SUPPORTED),
-					new EsAwsBuildEnvironment(version: '7.1', mavenProfile: 'elasticsearch-7.0', status: BuildEnvironmentStatus.SUPPORTED)
+					new EsAwsBuildEnvironment(version: '7.1', mavenProfile: 'elasticsearch-7.0', status: BuildEnvironmentStatus.SUPPORTED),
+					new EsAwsBuildEnvironment(version: '7.4', mavenProfile: 'elasticsearch-7.0', status: BuildEnvironmentStatus.SUPPORTED)
 			]
 	])
 

--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
@@ -229,7 +229,7 @@ public class ElasticsearchDialectFactoryTest {
 	@TestForIssue(jiraKey = "HSEARCH-3563")
 	public void es7() {
 		testSuccess(
-				"7", "7.6.0",
+				"7", "7.7.0",
 				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
 		);
 	}
@@ -356,6 +356,33 @@ public class ElasticsearchDialectFactoryTest {
 	public void es760() {
 		testSuccess(
 				"7.6.0", "7.6.0",
+				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-3918")
+	public void es762() {
+		testSuccess(
+				"7.6.2", "7.6.2",
+				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-3918")
+	public void es77() {
+		testSuccess(
+				"7.7", "7.7.0",
+				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-3918")
+	public void es770() {
+		testSuccess(
+				"7.7.0", "7.7.0",
 				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
 		);
 	}

--- a/documentation/src/test/java/org/hibernate/search/documentation/configuration/MyConfigurationIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/configuration/MyConfigurationIT.java
@@ -38,7 +38,7 @@ public class MyConfigurationIT {
 				BackendSettings.backendKey( myBackend, ElasticsearchBackendSettings.MULTI_TENANCY_STRATEGY ),
 				MultiTenancyStrategyName.DISCRIMINATOR.getExternalRepresentation()
 		);
-		config.put( BackendSettings.backendKey( myBackend, ElasticsearchBackendSettings.VERSION ), "7.6" );
+		config.put( BackendSettings.backendKey( myBackend, ElasticsearchBackendSettings.VERSION ), "7.7" );
 		config.put(
 				BackendSettings.backendKey( myBackend, ElasticsearchBackendSettings.VERSION_CHECK_ENABLED ), "false" );
 		// index configuration
@@ -66,7 +66,7 @@ public class MyConfigurationIT {
 						entry( "hibernate.search.backends.myBackend.protocol", "http" ),
 						entry( "hibernate.search.backends.myBackend.type", "elasticsearch" ),
 						entry( "hibernate.search.backends.myBackend.multi_tenancy.strategy", "discriminator" ),
-						entry( "hibernate.search.backends.myBackend.version", "7.6" ),
+						entry( "hibernate.search.backends.myBackend.version", "7.7" ),
 						entry( "hibernate.search.backends.myBackend.version_check.enabled", "false" ),
 						entry( "hibernate.search.backends.myBackend.index_defaults.schema_management.minimal_required_status", "yellow" ),
 						entry( "hibernate.search.automatic_indexing.synchronization.strategy", "async" ),

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/bootstrap/ElasticsearchBootstrapIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/bootstrap/ElasticsearchBootstrapIT.java
@@ -155,7 +155,7 @@ public class ElasticsearchBootstrapIT {
 						ElasticsearchBackendSettings.VERSION_CHECK_ENABLED, false
 				)
 				.withBackendProperty(
-						ElasticsearchBackendSettings.VERSION, "7.6"
+						ElasticsearchBackendSettings.VERSION, "7.7"
 				)
 				.withBackendProperty(
 						ElasticsearchBackendSpiSettings.CLIENT_FACTORY,

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
         <!-- When updating the following versions you will likely need to update the
              matching test profile as well, e.g. elasticsearch-6.0 for the 6.0+ series -->
         <!-- The main version of Elasticsearch targeted by Hibernate Search, tested in the default profile -->
-        <version.org.elasticsearch.main>7.6.1</version.org.elasticsearch.main>
+        <version.org.elasticsearch.main>7.7.0</version.org.elasticsearch.main>
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently from the version of the remote cluster -->
         <version.org.elasticsearch.client>${version.org.elasticsearch.main}</version.org.elasticsearch.client>
         <documentation.org.elasticsearch.url>https://www.elastic.co/guide/en/elasticsearch/reference/${parsed-version.org.elasticsearch.main.majorVersion}.${parsed-version.org.elasticsearch.main.minorVersion}</documentation.org.elasticsearch.url>


### PR DESCRIPTION
* [HSEARCH-3918](https://hibernate.atlassian.net/browse/HSEARCH-3918): Upgrade to Elasticsearch 7.7.0
* [HSEARCH-3919](https://hibernate.atlassian.net/browse/HSEARCH-3919): Add test configuration to test AWS Elasticsearch Service 7.4

AWS build in progress here: https://ci.hibernate.org/blue/organizations/jenkins/hibernate-search-personal-yoann/detail/HSEARCH-3918/3/pipeline