### PR TITLE
HSEARCH-3842 Expose a global option to use ReindexOnUpdate.NO as a default

### DIFF
--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/automaticindexing/DefaultReindexOnUpdateIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/automaticindexing/DefaultReindexOnUpdateIT.java
@@ -1,0 +1,325 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.automaticindexing;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.lang.invoke.MethodHandles;
+
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.util.rule.JavaBeanMappingSetupHelper;
+import org.hibernate.search.mapper.javabean.mapping.SearchMapping;
+import org.hibernate.search.mapper.javabean.session.SearchSession;
+import org.hibernate.search.mapper.pojo.automaticindexing.ReindexOnUpdate;
+import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.ProgrammaticMappingConfigurationContext;
+import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
+import org.hibernate.search.mapper.pojo.model.path.PojoModelPath;
+import org.hibernate.search.util.common.SearchException;
+import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Test for {@link org.hibernate.search.mapper.pojo.mapping.spi.AbstractPojoMappingInitiator#setDefaultReindexOnUpdate(ReindexOnUpdate)}.
+ */
+public class DefaultReindexOnUpdateIT {
+
+	@Rule
+	public BackendMock backendMock = new BackendMock( "stubBackend" );
+
+	@Rule
+	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );
+
+	private SearchMapping mapping;
+
+	@Before
+	public void setup() {
+	}
+
+	/**
+	 * If ReindexOnUpdate.DEFAULT is the default,
+	 * and the inverse side of associations is correctly set up,
+	 * then Hibernate Search will handle embedding *and* automatic reindexing.
+	 */
+	@Test
+	public void default_associationInverseSideKnown() {
+		backendMock.expectSchema( "ParentEntity", b -> b
+				.field( "value", String.class )
+				.objectField( "child", b2 -> b2
+						.field( "value", String.class )
+				)
+		);
+		backendMock.expectSchema( "ChildEntity", b -> b
+				.field( "value", String.class )
+		);
+
+		mapping = setupHelper.start()
+				.withConfiguration(
+						builder -> {
+							builder.setDefaultReindexOnUpdate( ReindexOnUpdate.DEFAULT );
+
+							builder.addEntityType( ParentEntity.class );
+							builder.addEntityType( ChildEntity.class );
+
+							ProgrammaticMappingConfigurationContext mappingDefinition = builder.programmaticMapping();
+							TypeMappingStep parentMapping = mappingDefinition.type( ParentEntity.class );
+							parentMapping.indexed();
+							parentMapping.property( "id" ).documentId();
+							parentMapping.property( "value" ).genericField();
+							parentMapping.property( "child" )
+									.associationInverseSide( PojoModelPath.ofValue( "parent" ) )
+									.indexedEmbedded();
+							TypeMappingStep childMapping = mappingDefinition.type( ChildEntity.class );
+							childMapping.indexed();
+							childMapping.property( "id" ).documentId();
+							childMapping.property( "value" ).genericField();
+						}
+				)
+				.setup();
+
+		backendMock.verifyExpectationsMet();
+
+		ParentEntity parent = new ParentEntity();
+		parent.setId( 1 );
+		parent.setValue( "val1" );
+
+		ChildEntity child = new ChildEntity();
+		child.setId( 2 );
+		child.setValue( "val2" );
+
+		parent.setChild( child );
+		child.setParent( parent );
+
+		// Test indexed-embedding
+		try ( SearchSession session = mapping.createSession() ) {
+			session.indexingPlan().add( parent );
+
+			backendMock.expectWorks( "ParentEntity" )
+					.add( "1", b -> b
+							.field( "value", "val1" )
+							.objectField( "child", b2 -> b2
+									.field( "value", "val2" )
+							)
+					)
+					.processedThenExecuted();
+		}
+
+		// Test automatic reindexing
+		try ( SearchSession session = mapping.createSession() ) {
+			session.indexingPlan().addOrUpdate( child );
+
+			backendMock.expectWorks( "ChildEntity" )
+					.update( "2", b -> b
+							.field( "value", "val2" )
+					)
+					.processedThenExecuted();
+			// The child was updated, thus the parent (which index-embeds the childs) is reindexed.
+			backendMock.expectWorks( "ParentEntity" )
+					.update( "1", b -> b
+							.field( "value", "val1" )
+							.objectField( "child", b2 -> b2
+									.field( "value", "val2" )
+							)
+					)
+					.processedThenExecuted();
+		}
+	}
+
+	/**
+	 * If ReindexOnUpdate.DEFAULT is the default,
+	 * and the inverse side of associations is NOT correctly set up,
+	 * then Hibernate Search bootstrap will fail.
+	 */
+	@Test
+	public void default_associationInverseSideUnknown() {
+		assertThatThrownBy( () -> setupHelper.start()
+				.withConfiguration(
+						builder -> {
+							builder.setDefaultReindexOnUpdate( ReindexOnUpdate.DEFAULT );
+
+							builder.addEntityType( ParentEntity.class );
+							builder.addEntityType( ChildEntity.class );
+
+							ProgrammaticMappingConfigurationContext mappingDefinition = builder.programmaticMapping();
+							TypeMappingStep parentMapping = mappingDefinition.type( ParentEntity.class );
+							parentMapping.indexed();
+							parentMapping.property( "id" ).documentId();
+							parentMapping.property( "value" ).genericField();
+							parentMapping.property( "child" )
+									// Do NOT mention the inverse side of the association here.
+									.indexedEmbedded();
+							TypeMappingStep childMapping = mappingDefinition.type( ChildEntity.class );
+							childMapping.indexed();
+							childMapping.property( "id" ).documentId();
+							childMapping.property( "value" ).genericField();
+						}
+				)
+				.setup()
+		)
+				.isInstanceOf( SearchException.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.typeContext( ParentEntity.class.getName() )
+						.pathContext( ".child<no value extractors>.value<no value extractors>" )
+						.failure(
+								"Cannot find the inverse side of the association on type '" + ParentEntity.class.getName() + "'"
+										+ " at path '.child<no value extractors>'",
+								"Hibernate Search needs this information in order to reindex '"
+										+ ParentEntity.class.getName() + "' when '"
+										+ ChildEntity.class.getName() + "' is modified."
+						)
+						.build()
+				);
+	}
+	/**
+	 * If ReindexOnUpdate.NO is the default,
+	 * even if the inverse side of associations is not correctly set up,
+	 * then Hibernate Search will handle embedding, but not automatic reindexing.
+	 */
+	@Test
+	public void no_associationInverseSideUnknown() {
+		backendMock.expectSchema( "ParentEntity", b -> b
+				.field( "value", String.class )
+				.objectField( "child", b2 -> b2
+						.field( "value", String.class )
+				)
+		);
+		backendMock.expectSchema( "ChildEntity", b -> b
+				.field( "value", String.class )
+		);
+
+		mapping = setupHelper.start()
+				.withConfiguration(
+						builder -> {
+							builder.setDefaultReindexOnUpdate( ReindexOnUpdate.NO );
+
+							builder.addEntityType( ParentEntity.class );
+							builder.addEntityType( ChildEntity.class );
+
+							ProgrammaticMappingConfigurationContext mappingDefinition = builder.programmaticMapping();
+							TypeMappingStep parentMapping = mappingDefinition.type( ParentEntity.class );
+							parentMapping.indexed();
+							parentMapping.property( "id" ).documentId();
+							parentMapping.property( "value" ).genericField();
+							parentMapping.property( "child" )
+									// Do NOT mention the inverse side of the association here.
+									.indexedEmbedded();
+							TypeMappingStep childMapping = mappingDefinition.type( ChildEntity.class );
+							childMapping.indexed();
+							childMapping.property( "id" ).documentId();
+							childMapping.property( "value" ).genericField();
+						}
+				)
+				.setup();
+
+		backendMock.verifyExpectationsMet();
+
+		ParentEntity parent = new ParentEntity();
+		parent.setId( 1 );
+		parent.setValue( "val1" );
+
+		ChildEntity child = new ChildEntity();
+		child.setId( 2 );
+		child.setValue( "val2" );
+
+		parent.setChild( child );
+		child.setParent( parent );
+
+		// Test indexed-embedding
+		try ( SearchSession session = mapping.createSession() ) {
+			session.indexingPlan().add( parent );
+
+			backendMock.expectWorks( "ParentEntity" )
+					.add( "1", b -> b
+							.field( "value", "val1" )
+							.objectField( "child", b2 -> b2
+									.field( "value", "val2" )
+							)
+					)
+					.processedThenExecuted();
+		}
+
+		// Test automatic reindexing
+		try ( SearchSession session = mapping.createSession() ) {
+			session.indexingPlan().addOrUpdate( child );
+
+			backendMock.expectWorks( "ChildEntity" )
+					.update( "2", b -> b
+							.field( "value", "val2" )
+					)
+					.processedThenExecuted();
+			// The child was updated, but automatic reindexing is disabled,
+			// thus the parent (which index-embeds the childs) will NOT be reindexed.
+		}
+	}
+
+	public static final class ParentEntity {
+
+		private Integer id;
+		private String value;
+		private ChildEntity child;
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getValue() {
+			return value;
+		}
+
+		public void setValue(String value) {
+			this.value = value;
+		}
+
+		public ChildEntity getChild() {
+			return child;
+		}
+
+		public void setChild(ChildEntity child) {
+			this.child = child;
+		}
+	}
+
+	public static final class ChildEntity {
+
+		public static final String INDEX = "IndexedEntity";
+
+		private Integer id;
+		private String value;
+		private ParentEntity parent;
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getValue() {
+			return value;
+		}
+
+		public void setValue(String value) {
+			this.value = value;
+		}
+
+		public ParentEntity getParent() {
+			return parent;
+		}
+
+		public void setParent(ParentEntity parent) {
+			this.parent = parent;
+		}
+	}
+
+}

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/mapping/SearchMappingBuilder.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/mapping/SearchMappingBuilder.java
@@ -23,6 +23,7 @@ import org.hibernate.search.mapper.javabean.mapping.impl.JavaBeanMapping;
 import org.hibernate.search.mapper.javabean.mapping.impl.JavaBeanMappingKey;
 import org.hibernate.search.mapper.javabean.model.impl.JavaBeanBootstrapIntrospector;
 import org.hibernate.search.mapper.javabean.session.SearchSession;
+import org.hibernate.search.mapper.pojo.automaticindexing.ReindexOnUpdate;
 import org.hibernate.search.mapper.pojo.bridge.IdentifierBridge;
 import org.hibernate.search.mapper.pojo.extractor.ContainerExtractorConfigurationContext;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.AnnotationMappingConfigurationContext;
@@ -104,6 +105,10 @@ public final class SearchMappingBuilder {
 	public SearchMappingBuilder setMultiTenancyEnabled(boolean multiTenancyEnabled) {
 		mappingInitiator.setMultiTenancyEnabled( multiTenancyEnabled );
 		return this;
+	}
+
+	public void setDefaultReindexOnUpdate(ReindexOnUpdate defaultReindexOnUpdate) {
+		mappingInitiator.setDefaultReindexOnUpdate( defaultReindexOnUpdate );
 	}
 
 	public SearchMappingBuilder setProvidedIdentifierBridge(BeanReference<? extends IdentifierBridge<Object>> providedIdentifierBridge) {

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/building/impl/PojoImplicitReindexingResolverBuildingHelper.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/building/impl/PojoImplicitReindexingResolverBuildingHelper.java
@@ -34,6 +34,8 @@ public final class PojoImplicitReindexingResolverBuildingHelper {
 	private final PojoTypeAdditionalMetadataProvider typeAdditionalMetadataProvider;
 	private final PojoAssociationPathInverter pathInverter;
 	private final Set<PojoRawTypeModel<?>> entityTypes;
+	private final ReindexOnUpdate defaultReindexOnUpdate;
+
 	private final Map<PojoRawTypeModel<?>, Set<PojoRawTypeModel<?>>> concreteEntitySubTypesByEntitySuperType =
 			new HashMap<>();
 	private final Map<PojoRawTypeModel<?>, PojoImplicitReindexingResolverBuilder<?>> builderByType =
@@ -43,11 +45,13 @@ public final class PojoImplicitReindexingResolverBuildingHelper {
 			ContainerExtractorBinder extractorBinder,
 			PojoTypeAdditionalMetadataProvider typeAdditionalMetadataProvider,
 			PojoAssociationPathInverter pathInverter,
-			Set<PojoRawTypeModel<?>> entityTypes) {
+			Set<PojoRawTypeModel<?>> entityTypes,
+			ReindexOnUpdate defaultReindexOnUpdate) {
 		this.extractorBinder = extractorBinder;
 		this.typeAdditionalMetadataProvider = typeAdditionalMetadataProvider;
 		this.pathInverter = pathInverter;
 		this.entityTypes = entityTypes;
+		this.defaultReindexOnUpdate = defaultReindexOnUpdate;
 
 		for ( PojoRawTypeModel<?> entityType : entityTypes ) {
 			if ( !entityType.isAbstract() ) {
@@ -161,7 +165,7 @@ public final class PojoImplicitReindexingResolverBuildingHelper {
 				}
 			}
 
-			return reindexOnUpdateOptional.orElse( ReindexOnUpdate.DEFAULT );
+			return reindexOnUpdateOptional.orElse( defaultReindexOnUpdate );
 		}
 	}
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/impl/PojoMapper.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/impl/PojoMapper.java
@@ -31,6 +31,7 @@ import org.hibernate.search.engine.mapper.mapping.building.spi.MappingPartialBui
 import org.hibernate.search.engine.mapper.model.spi.MappableTypeModel;
 import org.hibernate.search.engine.reporting.spi.ContextualFailureCollector;
 import org.hibernate.search.engine.reporting.spi.EventContexts;
+import org.hibernate.search.mapper.pojo.automaticindexing.ReindexOnUpdate;
 import org.hibernate.search.mapper.pojo.bridge.IdentifierBridge;
 import org.hibernate.search.mapper.pojo.bridge.mapping.impl.BridgeResolver;
 import org.hibernate.search.mapper.pojo.automaticindexing.building.impl.PojoAssociationPathInverter;
@@ -72,6 +73,7 @@ public class PojoMapper<MPBS extends MappingPartialBuildState> implements Mapper
 	private final BeanReference<? extends IdentifierBridge<Object>> providedIdentifierBridge;
 	private final BeanResolver beanResolver;
 	private final boolean multiTenancyEnabled;
+	private final ReindexOnUpdate defaultReindexOnUpdate;
 
 	private final FailureHandler failureHandler;
 	private final ThreadPoolProvider threadPoolProvider;
@@ -97,11 +99,12 @@ public class PojoMapper<MPBS extends MappingPartialBuildState> implements Mapper
 			PojoBootstrapIntrospector introspector,
 			ContainerExtractorRegistry containerExtractorRegistry,
 			BeanReference<? extends IdentifierBridge<Object>> providedIdentifierBridge,
-			boolean multiTenancyEnabled,
+			boolean multiTenancyEnabled, ReindexOnUpdate defaultReindexOnUpdate,
 			PojoMapperDelegate<MPBS> delegate) {
 		this.failureCollector = buildContext.getFailureCollector();
 		this.contributorProvider = contributorProvider;
 		this.multiTenancyEnabled = multiTenancyEnabled;
+		this.defaultReindexOnUpdate = defaultReindexOnUpdate;
 
 		this.failureHandler = buildContext.getFailureHandler();
 		this.threadPoolProvider = buildContext.getThreadPoolProvider();
@@ -241,7 +244,8 @@ public class PojoMapper<MPBS extends MappingPartialBuildState> implements Mapper
 		);
 		PojoImplicitReindexingResolverBuildingHelper reindexingResolverBuildingHelper =
 				new PojoImplicitReindexingResolverBuildingHelper(
-						extractorBinder, typeAdditionalMetadataProvider, pathInverter, entityTypes
+						extractorBinder, typeAdditionalMetadataProvider, pathInverter, entityTypes,
+						defaultReindexOnUpdate
 				);
 
 		PojoMappingDelegate mappingDelegate;

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/spi/AbstractPojoMappingInitiator.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/spi/AbstractPojoMappingInitiator.java
@@ -16,6 +16,7 @@ import org.hibernate.search.engine.mapper.mapping.building.spi.MappingInitiator;
 import org.hibernate.search.engine.mapper.mapping.building.spi.TypeMetadataContributorProvider;
 import org.hibernate.search.engine.mapper.mapping.building.spi.MappingBuildContext;
 import org.hibernate.search.engine.mapper.mapping.building.spi.MappingPartialBuildState;
+import org.hibernate.search.mapper.pojo.automaticindexing.ReindexOnUpdate;
 import org.hibernate.search.mapper.pojo.bridge.IdentifierBridge;
 import org.hibernate.search.mapper.pojo.extractor.ContainerExtractorConfigurationContext;
 import org.hibernate.search.mapper.pojo.extractor.spi.ContainerExtractorRegistry;
@@ -35,6 +36,7 @@ public abstract class AbstractPojoMappingInitiator<MPBS extends MappingPartialBu
 
 	private BeanReference<? extends IdentifierBridge<Object>> providedIdentifierBridge;
 	private boolean multiTenancyEnabled;
+	private ReindexOnUpdate defaultReindexOnUpdate = ReindexOnUpdate.DEFAULT;
 
 	private final AnnotationMappingConfigurationContextImpl annotationMappingConfiguration;
 
@@ -80,6 +82,10 @@ public abstract class AbstractPojoMappingInitiator<MPBS extends MappingPartialBu
 		this.multiTenancyEnabled = multiTenancyEnabled;
 	}
 
+	public void setDefaultReindexOnUpdate(ReindexOnUpdate defaultReindexOnUpdate) {
+		this.defaultReindexOnUpdate = defaultReindexOnUpdate;
+	}
+
 	public void setAnnotatedTypeDiscoveryEnabled(boolean annotatedTypeDiscoveryEnabled) {
 		annotationMappingConfiguration.setAnnotatedTypeDiscoveryEnabled( annotatedTypeDiscoveryEnabled );
 	}
@@ -101,6 +107,7 @@ public abstract class AbstractPojoMappingInitiator<MPBS extends MappingPartialBu
 				containerExtractorRegistryBuilder.build(),
 				providedIdentifierBridge,
 				multiTenancyEnabled,
+				defaultReindexOnUpdate,
 				createMapperDelegate()
 		);
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3842

@fax4ever Thanks to this, you shouldn't have to use `ReindexOnUpdate` in Infinispan at all, except in one specific place to set the default to `NO`.