### PR TITLE
HSEARCH-962 HibernateOrmCriteriaEntityLoader needs to execute multiple queries in cases where the underlying database has a limit on the total amount of query parameters

### DIFF
--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/AbstractSearchQueryEntityLoadingSingleTypeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/AbstractSearchQueryEntityLoadingSingleTypeIT.java
@@ -93,8 +93,6 @@ public abstract class AbstractSearchQueryEntityLoadingSingleTypeIT<T> extends Ab
 
 		public abstract boolean isCacheLookupSupported();
 
-		public abstract boolean isFetchSizeSupported();
-
 		public abstract T newIndexed(int id);
 
 		public abstract String getDocumentIdForEntityId(int id);
@@ -125,11 +123,6 @@ public abstract class AbstractSearchQueryEntityLoadingSingleTypeIT<T> extends Ab
 
 		@Override
 		public boolean isCacheLookupSupported() {
-			return true;
-		}
-
-		@Override
-		public boolean isFetchSizeSupported() {
 			return true;
 		}
 
@@ -165,11 +158,6 @@ public abstract class AbstractSearchQueryEntityLoadingSingleTypeIT<T> extends Ab
 
 		@Override
 		public boolean isCacheLookupSupported() {
-			return false;
-		}
-
-		@Override
-		public boolean isFetchSizeSupported() {
 			return false;
 		}
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingFetchSizeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingFetchSizeIT.java
@@ -14,8 +14,6 @@ import org.hibernate.SessionFactory;
 import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
-import org.junit.Assume;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -36,16 +34,6 @@ public class SearchQueryEntityLoadingFetchSizeIT<T> extends AbstractSearchQueryE
 
 	public SearchQueryEntityLoadingFetchSizeIT(SingleTypeLoadingModelPrimitives<T> primitives) {
 		super( primitives );
-	}
-
-	@Before
-	public void checkFetchSizeSupported() {
-		// TODO HSEARCH-962 fetch size should be supported and testable even when the document id is not the entity id,
-		//  once we execute multiple queries in HibernateOrmSingleTypeCriteriaEntityLoader
-		Assume.assumeTrue(
-				"This test only makes sense if cache lookups are supported",
-				primitives.isFetchSizeSupported()
-		);
 	}
 
 	@Test

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/dsl/SearchLoadingOptionsStep.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/dsl/SearchLoadingOptionsStep.java
@@ -19,7 +19,10 @@ import org.hibernate.search.mapper.orm.search.loading.EntityLoadingCacheLookupSt
 public interface SearchLoadingOptionsStep {
 
 	/**
-	 * Set the JDBC fetch size for this query.
+	 * Set the fetch size for this query,
+	 * i.e. the amount of entities to load for each query to the database.
+	 * <p>
+	 * Higher numbers mean fewer queries, but larger result sets.
 	 *
 	 * @param fetchSize The fetch size. Must be positive or zero.
 	 * @return {@code this} for method chaining.


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-962

This simply changes the way `fetchSize` is handled for criteria queries: we now take care of not requesting more than `fetchSize` elements for each query execution, execute the query multiple times if necessary.
That's about the same behavior as in `HibernateOrmByIdEntityLoader` and should solve the problem in most cases as the default fetch size is `100`.