### PR TITLE
HSEARCH-3925 Move away from session.byId for entity loading (+ HSEARCH-3772)

### DIFF
--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/common/impl/HibernateOrmUtils.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/common/impl/HibernateOrmUtils.java
@@ -7,14 +7,22 @@
 package org.hibernate.search.mapper.orm.common.impl;
 
 import java.lang.invoke.MethodHandles;
+import java.util.Collection;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.ParameterExpression;
+import javax.persistence.criteria.Path;
+import javax.persistence.criteria.Root;
 
 import org.hibernate.AssertionFailure;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.metamodel.model.domain.spi.EntityTypeDescriptor;
 import org.hibernate.metamodel.spi.MetamodelImplementor;
 import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.query.Query;
 import org.hibernate.search.mapper.orm.logging.impl.Log;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
@@ -83,5 +91,35 @@ public final class HibernateOrmUtils {
 			);
 		}
 		return superTypeCandidate;
+	}
+
+	public static Query<?> createQueryForLoadByUniqueProperty(SessionImplementor session,
+			EntityPersister persister, String uniquePropertyName, String parameterName) {
+		MetamodelImplementor metamodel = session.getSessionFactory().getMetamodel();
+		EntityTypeDescriptor<?> typeDescriptorOrNull = metamodel.entity( persister.getEntityName() );
+		if ( typeDescriptorOrNull != null ) {
+			return createQueryForLoadByUniqueProperty( session, typeDescriptorOrNull, uniquePropertyName, parameterName );
+		}
+		else {
+			// Most likely this is a dynamic-map entity; they don't have a representation in the JPA metamodel
+			// and can't be queried using the Criteria API.
+			// Use a HQL query instead, even if it feels a bit dirty.
+			return session.createQuery(
+					"select e from " + persister.getEntityName()
+							+ " e where " + uniquePropertyName + " in (:" + parameterName + ")",
+					(Class<?>) persister.getMappedClass()
+			);
+		}
+	}
+
+	private static <E> Query<E> createQueryForLoadByUniqueProperty(SessionImplementor session,
+			EntityTypeDescriptor<E> typeDescriptor, String uniquePropertyName, String parameterName) {
+		CriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
+		ParameterExpression<Collection> idsParameter = criteriaBuilder.parameter( Collection.class, parameterName );
+		CriteriaQuery<E> criteriaQuery = criteriaBuilder.createQuery( typeDescriptor.getJavaType() );
+		Root<E> root = criteriaQuery.from( typeDescriptor );
+		Path<?> uniquePropertyInRoot = root.get( typeDescriptor.getSingularAttribute( uniquePropertyName ) );
+		criteriaQuery.where( uniquePropertyInRoot.in( idsParameter ) );
+		return session.createQuery( criteriaQuery );
 	}
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/common/impl/HibernateOrmUtils.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/common/impl/HibernateOrmUtils.java
@@ -10,8 +10,10 @@ import java.lang.invoke.MethodHandles;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 
+import org.hibernate.AssertionFailure;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.metamodel.spi.MetamodelImplementor;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.search.mapper.orm.logging.impl.Log;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
@@ -43,5 +45,43 @@ public final class HibernateOrmUtils {
 
 	public static boolean isSuperTypeOf(EntityPersister type1, EntityPersister type2) {
 		return type1.isSubclassEntityName( type2.getEntityName() );
+	}
+
+	public static EntityPersister toRootEntityType(SessionFactoryImplementor sessionFactory,
+			EntityPersister entityType) {
+		/*
+		 * We need to rely on Hibernate ORM's SPIs: this is complex stuff.
+		 * For example there may be class hierarchies such as A > B > C
+		 * where A and C are entity types and B is a mapped superclass.
+		 * So we need to exclude non-entity types, and for that we need the Hibernate ORM metamodel.
+		 */
+		MetamodelImplementor metamodel = sessionFactory.getMetamodel();
+		String rootEntityName = metamodel.entityPersister( entityType.getEntityName() ).getRootEntityName();
+		return metamodel.entityPersister( rootEntityName ).getEntityPersister();
+	}
+
+	public static EntityPersister toMostSpecificCommonEntitySuperType(MetamodelImplementor metamodel,
+			EntityPersister type1, EntityPersister type2) {
+		/*
+		 * We need to rely on Hibernate ORM's SPIs: this is complex stuff.
+		 * For example there may be class hierarchies such as A > B > C
+		 * where A and C are entity types and B is a mapped superclass.
+		 * So even if we know the two types have a common superclass,
+		 * we need to skip non-entity superclasses, and for that we need the Hibernate ORM metamodel.
+		 */
+		EntityPersister superTypeCandidate = type1;
+		while ( superTypeCandidate != null && !isSuperTypeOf( superTypeCandidate, type2 ) ) {
+			String superSuperTypeEntityName = superTypeCandidate.getEntityMetamodel().getSuperclass();
+			superTypeCandidate = superSuperTypeEntityName == null ? null
+					: metamodel.entityPersister( superSuperTypeEntityName ).getEntityPersister();
+		}
+		if ( superTypeCandidate == null ) {
+			throw new AssertionFailure(
+					"Cannot find a common entity supertype for " + type1.getEntityName()
+							+ " and " + type2.getEntityName() + "."
+							+ " There is a bug in Hibernate Search, please report it."
+			);
+		}
+		return superTypeCandidate;
 	}
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/common/impl/HibernateOrmUtils.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/common/impl/HibernateOrmUtils.java
@@ -64,8 +64,8 @@ public final class HibernateOrmUtils {
 		 * So we need to exclude non-entity types, and for that we need the Hibernate ORM metamodel.
 		 */
 		MetamodelImplementor metamodel = sessionFactory.getMetamodel();
-		String rootEntityName = metamodel.entityPersister( entityType.getEntityName() ).getRootEntityName();
-		return metamodel.entityPersister( rootEntityName ).getEntityPersister();
+		String rootEntityName = entityType.getRootEntityName();
+		return metamodel.entityPersister( rootEntityName );
 	}
 
 	public static EntityPersister toMostSpecificCommonEntitySuperType(MetamodelImplementor metamodel,

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmIndexedTypeContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmIndexedTypeContext.java
@@ -6,10 +6,7 @@
  */
 package org.hibernate.search.mapper.orm.mapping.impl;
 
-import javax.persistence.metamodel.SingularAttribute;
-
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.metamodel.model.domain.spi.EntityTypeDescriptor;
 import org.hibernate.search.engine.backend.index.IndexManager;
 import org.hibernate.search.engine.mapper.mapping.spi.MappedIndexManager;
 import org.hibernate.search.mapper.orm.mapping.SearchIndexedEntity;
@@ -46,11 +43,8 @@ class HibernateOrmIndexedTypeContext<E> extends AbstractHibernateOrmTypeContext<
 			// The entity ID is not the property used to generate the document ID
 			// We need to use a criteria query to load entities from the document IDs
 			documentIdIsEntityId = false;
-			EntityTypeDescriptor<E> typeDescriptor = entityTypeDescriptor();
-			SingularAttribute<? super E, ?> documentIdSourceAttribute =
-					typeDescriptor.getSingularAttribute( builder.documentIdSourcePropertyName );
 			loaderFactory = HibernateOrmNonEntityIdPropertyEntityLoader.factory(
-					typeDescriptor, documentIdSourceAttribute, builder.documentIdSourcePropertyHandle
+					entityPersister(), builder.documentIdSourcePropertyName, builder.documentIdSourcePropertyHandle
 			);
 		}
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmIndexedTypeContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmIndexedTypeContext.java
@@ -15,8 +15,8 @@ import org.hibernate.search.engine.mapper.mapping.spi.MappedIndexManager;
 import org.hibernate.search.mapper.orm.mapping.SearchIndexedEntity;
 import org.hibernate.search.mapper.orm.scope.impl.HibernateOrmScopeIndexedTypeContext;
 import org.hibernate.search.mapper.orm.search.loading.impl.EntityLoaderFactory;
-import org.hibernate.search.mapper.orm.search.loading.impl.HibernateOrmByIdEntityLoader;
-import org.hibernate.search.mapper.orm.search.loading.impl.HibernateOrmCriteriaEntityLoader;
+import org.hibernate.search.mapper.orm.search.loading.impl.HibernateOrmEntityIdEntityLoader;
+import org.hibernate.search.mapper.orm.search.loading.impl.HibernateOrmNonEntityIdPropertyEntityLoader;
 import org.hibernate.search.mapper.orm.session.impl.HibernateOrmSessionIndexedTypeContext;
 import org.hibernate.search.mapper.pojo.bridge.runtime.spi.IdentifierMapping;
 import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoIndexedTypeExtendedMappingCollector;
@@ -38,7 +38,7 @@ class HibernateOrmIndexedTypeContext<E> extends AbstractHibernateOrmTypeContext<
 
 		if ( entityPersister().getIdentifierPropertyName().equals( builder.documentIdSourcePropertyName ) ) {
 			documentIdIsEntityId = true;
-			loaderFactory = HibernateOrmByIdEntityLoader.factory(
+			loaderFactory = HibernateOrmEntityIdEntityLoader.factory(
 					sessionFactory, entityPersister()
 			);
 		}
@@ -49,7 +49,7 @@ class HibernateOrmIndexedTypeContext<E> extends AbstractHibernateOrmTypeContext<
 			EntityTypeDescriptor<E> typeDescriptor = entityTypeDescriptor();
 			SingularAttribute<? super E, ?> documentIdSourceAttribute =
 					typeDescriptor.getSingularAttribute( builder.documentIdSourcePropertyName );
-			loaderFactory = HibernateOrmCriteriaEntityLoader.factory(
+			loaderFactory = HibernateOrmNonEntityIdPropertyEntityLoader.factory(
 					typeDescriptor, documentIdSourceAttribute, builder.documentIdSourcePropertyHandle
 			);
 		}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/EntityLoadingCacheLookupStrategyImplementor.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/EntityLoadingCacheLookupStrategyImplementor.java
@@ -6,12 +6,14 @@
  */
 package org.hibernate.search.mapper.orm.search.loading.impl;
 
-public interface EntityLoadingCacheLookupStrategyImplementor<E> {
+import org.hibernate.engine.spi.EntityKey;
+
+public interface EntityLoadingCacheLookupStrategyImplementor {
 
 	/**
-	 * @param entityId The ID of an entity.
+	 * @param entityKey The key of an entity.
 	 * @return The entity, loaded from the cache, or {@code null} if not found.
 	 */
-	E lookup(Object entityId);
+	Object lookup(EntityKey entityKey);
 
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/HibernateOrmEntityIdEntityLoader.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/HibernateOrmEntityIdEntityLoader.java
@@ -23,7 +23,12 @@ import org.hibernate.search.mapper.orm.common.EntityReference;
 import org.hibernate.search.mapper.orm.common.impl.HibernateOrmUtils;
 import org.hibernate.search.mapper.orm.search.loading.EntityLoadingCacheLookupStrategy;
 
-public class HibernateOrmByIdEntityLoader<E> implements HibernateOrmComposableEntityLoader<E> {
+/**
+ * An entity loader for indexed entities whose document ID is the entity ID.
+ *
+ * @param <E> The type of loaded entities.
+ */
+public class HibernateOrmEntityIdEntityLoader<E> implements HibernateOrmComposableEntityLoader<E> {
 
 	public static EntityLoaderFactory factory(SessionFactoryImplementor sessionFactory,
 			EntityPersister entityType) {
@@ -35,7 +40,7 @@ public class HibernateOrmByIdEntityLoader<E> implements HibernateOrmComposableEn
 	private final EntityLoadingCacheLookupStrategyImplementor<?> cacheLookupStrategyImplementor;
 	private final MutableEntityLoadingOptions loadingOptions;
 
-	private HibernateOrmByIdEntityLoader(
+	private HibernateOrmEntityIdEntityLoader(
 			EntityPersister targetEntityType,
 			Session session,
 			EntityLoadingCacheLookupStrategyImplementor<E> cacheLookupStrategyImplementor,
@@ -290,7 +295,7 @@ public class HibernateOrmByIdEntityLoader<E> implements HibernateOrmComposableEn
 					throw new AssertionFailure( "Unexpected cache lookup strategy: " + cacheLookupStrategy );
 			}
 
-			return new HibernateOrmByIdEntityLoader<>(
+			return new HibernateOrmEntityIdEntityLoader<>(
 					targetEntityType, session, cacheLookupStrategyImplementor, loadingOptions
 			);
 		}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/HibernateOrmEntityIdEntityLoader.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/HibernateOrmEntityIdEntityLoader.java
@@ -143,11 +143,8 @@ public class HibernateOrmEntityIdEntityLoader<E> implements HibernateOrmComposab
 	}
 
 	private Query<?> createQuery(int fetchSize) {
-		// We can't use the criteria API here, because it doesn't work for dynamic-map entities.
-		Query<?> query = session.createQuery(
-				"select e from " + entityPersister.getEntityName()
-						+ " e where " + entityPersister.getIdentifierPropertyName() + " in (:" + IDS_PARAMETER_NAME + ")",
-				(Class<?>) entityPersister.getMappedClass()
+		Query<?> query = HibernateOrmUtils.createQueryForLoadByUniqueProperty(
+				session, entityPersister, entityPersister.getIdentifierPropertyName(), IDS_PARAMETER_NAME
 		);
 
 		query.setFetchSize( fetchSize );

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/HibernateOrmLoadingIndexedTypeContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/HibernateOrmLoadingIndexedTypeContext.java
@@ -16,6 +16,11 @@ public interface HibernateOrmLoadingIndexedTypeContext {
 	String jpaEntityName();
 
 	/**
+	 * @return The name of the entity in the Hibernate ORM metamodel.
+	 */
+	String hibernateOrmEntityName();
+
+	/**
 	 * @return The entity persister, giving access to a representation of the entity type in the Hibernate ORM metamodel.
 	 */
 	EntityPersister entityPersister();

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/HibernateOrmNonEntityIdPropertyEntityLoader.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/HibernateOrmNonEntityIdPropertyEntityLoader.java
@@ -33,7 +33,13 @@ import org.hibernate.search.mapper.orm.search.loading.EntityLoadingCacheLookupSt
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 import org.hibernate.search.util.common.reflect.spi.ValueReadHandle;
 
-public class HibernateOrmCriteriaEntityLoader<E> implements HibernateOrmComposableEntityLoader<E> {
+/**
+ * An entity loader for indexed entities whose document ID is not the entity ID,
+ * but another property.
+ *
+ * @param <E> The type of loaded entities.
+ */
+public class HibernateOrmNonEntityIdPropertyEntityLoader<E> implements HibernateOrmComposableEntityLoader<E> {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
@@ -49,7 +55,7 @@ public class HibernateOrmCriteriaEntityLoader<E> implements HibernateOrmComposab
 	private final Session session;
 	private final MutableEntityLoadingOptions loadingOptions;
 
-	private HibernateOrmCriteriaEntityLoader(
+	private HibernateOrmNonEntityIdPropertyEntityLoader(
 			EntityTypeDescriptor<? extends E> entityType,
 			SingularAttribute<? super E, ?> documentIdSourceAttribute,
 			ValueReadHandle<?> documentIdSourceHandle,
@@ -209,7 +215,7 @@ public class HibernateOrmCriteriaEntityLoader<E> implements HibernateOrmComposab
 			 */
 			@SuppressWarnings("unchecked")
 			HibernateOrmComposableEntityLoader<E2> result =
-					(HibernateOrmComposableEntityLoader<E2>) new HibernateOrmCriteriaEntityLoader<>(
+					(HibernateOrmComposableEntityLoader<E2>) new HibernateOrmNonEntityIdPropertyEntityLoader<>(
 							entityType, documentIdSourceAttribute, documentIdSourceHandle,
 							session, loadingOptions
 					);

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/PersistenceContextLookupStrategy.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/PersistenceContextLookupStrategy.java
@@ -6,12 +6,9 @@
  */
 package org.hibernate.search.mapper.orm.search.loading.impl;
 
-import java.io.Serializable;
-
 import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.engine.spi.SessionImplementor;
-import org.hibernate.persister.entity.EntityPersister;
 
 /**
  * A lookup strategy that checks the persistence context (first level cache).
@@ -20,36 +17,21 @@ import org.hibernate.persister.entity.EntityPersister;
  *
  * @author Emmanuel Bernard
  */
-class PersistenceContextLookupStrategy<E>
-		implements EntityLoadingCacheLookupStrategyImplementor<E> {
+class PersistenceContextLookupStrategy
+		implements EntityLoadingCacheLookupStrategyImplementor {
 
-	static PersistenceContextLookupStrategy<?> create(EntityPersister commonEntitySuperTypePersister,
-			SessionImplementor session) {
-		return new PersistenceContextLookupStrategy<>(
-				commonEntitySuperTypePersister, session
-		);
+	static PersistenceContextLookupStrategy create(SessionImplementor session) {
+		return new PersistenceContextLookupStrategy( session );
 	}
 
-	private final EntityPersister persister;
-	private final SessionImplementor session;
 	private final PersistenceContext persistenceContext;
 
-	private PersistenceContextLookupStrategy(EntityPersister persister,
-			SessionImplementor session) {
-		this.persister = persister;
-		this.session = session;
+	private PersistenceContextLookupStrategy(SessionImplementor session) {
 		this.persistenceContext = session.getPersistenceContext();
 	}
 
 	@Override
-	public E lookup(Object entityId) {
-		EntityKey entityKey = session.generateEntityKey( (Serializable) entityId, persister );
-		/*
-		 * The key was obtained from the persister for E,
-		 * so the key may only match an instance of E.
-		 */
-		@SuppressWarnings("unchecked")
-		E loadedEntityOrNull = (E) persistenceContext.getEntity( entityKey );
-		return loadedEntityOrNull;
+	public Object lookup(EntityKey entityKey) {
+		return persistenceContext.getEntity( entityKey );
 	}
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/PersistenceContextLookupStrategy.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/PersistenceContextLookupStrategy.java
@@ -23,7 +23,7 @@ import org.hibernate.persister.entity.EntityPersister;
 class PersistenceContextLookupStrategy<E>
 		implements EntityLoadingCacheLookupStrategyImplementor<E> {
 
-	static EntityLoadingCacheLookupStrategyImplementor<?> create(EntityPersister commonEntitySuperTypePersister,
+	static PersistenceContextLookupStrategy<?> create(EntityPersister commonEntitySuperTypePersister,
 			SessionImplementor session) {
 		return new PersistenceContextLookupStrategy<>(
 				commonEntitySuperTypePersister, session


### PR DESCRIPTION
* [HSEARCH-3925](https://hibernate.atlassian.net/browse/HSEARCH-3925): Move away from session.byId for entity loading

And because it came naturally from the changes in this PR:

* [HSEARCH-3772](https://hibernate.atlassian.net/browse/HSEARCH-3772): Allow mapping the document id to non-entity-id properties for ORM's dynamic-map entity types

This PR is based on #2291 ([HSEARCH-962](https://hibernate.atlassian.net/browse/HSEARCH-962)), which must be merged first.
