### PR TITLE
HSEARCH-3937 + HSEARCH-3938 Fix bootstrap when using an EnvironmentSynchronizer

### DIFF
--- a/integrationtest/mapper/orm-cdi/src/test/java/org/hibernate/search/integrationtest/mapper/orm/cdi/CdiBeanResolutionIT.java
+++ b/integrationtest/mapper/orm-cdi/src/test/java/org/hibernate/search/integrationtest/mapper/orm/cdi/CdiBeanResolutionIT.java
@@ -52,7 +52,7 @@ import org.assertj.core.api.InstanceOfAssertFactories;
 		"org.hibernate.search.test.integration.wildfly.cdi.CDIInjectionIT",
 		"org.hibernate.search.test.integration.wildfly.cdi.CDIInjectionLifecycleEventsIT"
 })
-public class CdiIT {
+public class CdiBeanResolutionIT {
 
 	@Rule
 	public BackendMock backendMock = new BackendMock( "stubBackend" );

--- a/integrationtest/mapper/orm-cdi/src/test/java/org/hibernate/search/integrationtest/mapper/orm/cdi/CdiExtendedBeanManagerBootstrapShutdownIT.java
+++ b/integrationtest/mapper/orm-cdi/src/test/java/org/hibernate/search/integrationtest/mapper/orm/cdi/CdiExtendedBeanManagerBootstrapShutdownIT.java
@@ -1,0 +1,246 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.orm.cdi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.Dependent;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.search.engine.environment.bean.BeanHolder;
+import org.hibernate.search.engine.environment.bean.BeanReference;
+import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.util.common.SearchException;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.integrationtest.common.rule.StubSearchWorkBehavior;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
+import org.hibernate.search.util.impl.test.annotation.TestForIssue;
+import org.hibernate.search.util.impl.test.rule.StaticCounters;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Check that Hibernate Search will be able to boot and shut down
+ * when using an {@link org.hibernate.resource.beans.container.spi.ExtendedBeanManager} in Hibernate ORM.
+ */
+@TestForIssue(jiraKey = { "HSEARCH-3938" })
+public class CdiExtendedBeanManagerBootstrapShutdownIT {
+
+	@Rule
+	public final BackendMock backendMock = new BackendMock( "stubBackend" );
+
+	@Rule
+	public final OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+
+	@Rule
+	public final StaticCounters counters = new StaticCounters();
+
+	private final StubExtendedBeanManager extendedBeanManager = new StubExtendedBeanManager();
+
+	@After
+	public void tearDown() {
+		extendedBeanManager.cleanUp();
+	}
+
+	@Test
+	public void successfulBoot() {
+		List<BeanHolder<DependentBean>> retrievedBeans = new ArrayList<>();
+
+		backendMock.onCreate( context -> {
+			BeanHolder<DependentBean> retrievedBean = context.beanResolver().resolve( BeanReference.of( DependentBean.class ) );
+			retrievedBeans.add( retrievedBean );
+		} );
+		backendMock.onStop( () -> {
+			for ( BeanHolder<DependentBean> retrievedBean : retrievedBeans ) {
+				retrievedBean.close();
+			}
+		} );
+
+		try ( @SuppressWarnings("unused") SessionFactory sessionFactory = ormSetupHelper.start()
+				.withProperty( AvailableSettings.CDI_BEAN_MANAGER, extendedBeanManager )
+				.setup( IndexedEntity.class ) ) {
+			// Hibernate Search should not have booted yet.
+			backendMock.verifyExpectationsMet();
+			assertThat( retrievedBeans ).isEmpty();
+
+			// But once the bean manager is ready...
+			backendMock.expectAnySchema( IndexedEntity.NAME );
+			extendedBeanManager.simulateBoot( DependentBean.class );
+
+			// Hibernate Search should have booted.
+			backendMock.verifyExpectationsMet();
+			assertThat( retrievedBeans )
+					.hasSize( 1 )
+					.element( 0 ).isNotNull()
+					.extracting( BeanHolder::get ).isNotNull();
+			assertThat( StaticCounters.get().get( DependentBean.KEYS.instantiate ) ).isEqualTo( 1 );
+			assertThat( StaticCounters.get().get( DependentBean.KEYS.postConstruct ) ).isEqualTo( 1 );
+			assertThat( StaticCounters.get().get( DependentBean.KEYS.preDestroy ) ).isEqualTo( 0 );
+
+			// We should be able to use Hibernate Search
+			try ( Session session = sessionFactory.openSession() ) {
+				backendMock.expectSearchObjects( IndexedEntity.NAME, StubSearchWorkBehavior.empty() );
+				Search.session( session ).search( IndexedEntity.class )
+						.where( f -> f.matchAll() )
+						.fetchAll();
+				backendMock.verifyExpectationsMet();
+			}
+
+			// The bean manager shuts down.
+			extendedBeanManager.simulateShutdown();
+
+			// Hibernate Search should have shut down.
+			assertThat( StaticCounters.get().get( DependentBean.KEYS.preDestroy ) ).isEqualTo( 1 );
+		}
+	}
+
+	@Test
+	public void failedBoot() {
+		List<BeanHolder<DependentBean>> retrievedBeans = new ArrayList<>();
+
+		SearchException bootFailedException = new SearchException( "Simulated boot failure" );
+
+		backendMock.onCreate( context -> {
+			BeanHolder<DependentBean> retrievedBean = context.beanResolver().resolve( BeanReference.of( DependentBean.class ) );
+			retrievedBeans.add( retrievedBean );
+			throw bootFailedException;
+		} );
+		backendMock.onStop( () -> {
+			for ( BeanHolder<DependentBean> retrievedBean : retrievedBeans ) {
+				retrievedBean.close();
+			}
+		} );
+
+		try ( @SuppressWarnings("unused") SessionFactory sessionFactory = ormSetupHelper.start()
+				.withProperty( AvailableSettings.CDI_BEAN_MANAGER, extendedBeanManager )
+				.setup( IndexedEntity.class ) ) {
+			// Hibernate Search should not have booted yet.
+			backendMock.verifyExpectationsMet();
+			assertThat( retrievedBeans ).isEmpty();
+
+			// But once the bean manager is ready...
+			extendedBeanManager.simulateBoot( DependentBean.class );
+
+			// Hibernate Search should have started to boot, then shut down.
+			backendMock.verifyExpectationsMet();
+			assertThat( retrievedBeans )
+					.hasSize( 1 )
+					.element( 0 ).isNotNull()
+					.extracting( BeanHolder::get ).isNotNull();
+
+			assertThat( StaticCounters.get().get( DependentBean.KEYS.instantiate ) ).isEqualTo( 1 );
+			assertThat( StaticCounters.get().get( DependentBean.KEYS.postConstruct ) ).isEqualTo( 1 );
+			assertThat( StaticCounters.get().get( DependentBean.KEYS.preDestroy ) ).isEqualTo( 0 );
+
+			// Attempts to use Hibernate Search should throw an exception.
+			try ( Session session = sessionFactory.openSession() ) {
+				assertThatThrownBy( () -> Search.session( session ).search( IndexedEntity.class )
+						.where( f -> f.matchAll() )
+						.fetchAll() )
+						.hasMessageContaining( "Hibernate Search was not initialized" );
+			}
+
+			// The bean manager's shutdown event should be ignored.
+			extendedBeanManager.simulateShutdown();
+			backendMock.verifyExpectationsMet();
+			assertThat( StaticCounters.get().get( DependentBean.KEYS.preDestroy ) ).isEqualTo( 1 );
+		}
+	}
+
+	@Test
+	public void cancelledBoot() {
+		List<BeanHolder<DependentBean>> retrievedBeans = new ArrayList<>();
+
+		backendMock.onCreate( context -> {
+			BeanHolder<DependentBean> retrievedBean = context.beanResolver().resolve( BeanReference.of( DependentBean.class ) );
+			retrievedBeans.add( retrievedBean );
+		} );
+		backendMock.onStop( () -> {
+			for ( BeanHolder<DependentBean> retrievedBean : retrievedBeans ) {
+				retrievedBean.close();
+			}
+		} );
+
+		try ( @SuppressWarnings("unused") SessionFactory sessionFactory = ormSetupHelper.start()
+				.withProperty( AvailableSettings.CDI_BEAN_MANAGER, extendedBeanManager )
+				.setup( IndexedEntity.class ) ) {
+			// Hibernate Search should not have booted yet.
+			backendMock.verifyExpectationsMet();
+			assertThat( retrievedBeans ).isEmpty();
+
+			// The extended bean manager fails to boot and cancels Hibernate Search's boot...
+			extendedBeanManager.simulateCancelledBoot( DependentBean.class );
+
+			// Hibernate Search still should not have booted.
+			backendMock.verifyExpectationsMet();
+			assertThat( retrievedBeans ).isEmpty();
+
+			// Attempts to use Hibernate Search should throw an exception.
+			try ( Session session = sessionFactory.openSession() ) {
+				assertThatThrownBy( () -> Search.session( session ).search( IndexedEntity.class )
+						.where( f -> f.matchAll() )
+						.fetchAll() )
+						.hasMessageContaining( "Hibernate Search was not initialized" );
+			}
+		}
+	}
+
+	@Entity(name = IndexedEntity.NAME)
+	@Indexed(index = IndexedEntity.NAME)
+	public static final class IndexedEntity {
+
+		static final String NAME = "indexed";
+
+		@Id
+		private Integer id;
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+	}
+
+	@Dependent
+	public static class DependentBean {
+		public static final CounterKeys KEYS = new CounterKeys();
+
+		protected DependentBean() {
+			StaticCounters.get().increment( KEYS.instantiate );
+		}
+
+		@PostConstruct
+		public void postConstruct() {
+			StaticCounters.get().increment( KEYS.postConstruct );
+		}
+
+		@PreDestroy
+		public void preDestroy() {
+			StaticCounters.get().increment( KEYS.preDestroy );
+		}
+	}
+
+	private static class CounterKeys {
+		final StaticCounters.Key instantiate = StaticCounters.createKey();
+		final StaticCounters.Key postConstruct = StaticCounters.createKey();
+		final StaticCounters.Key preDestroy = StaticCounters.createKey();
+	}
+}

--- a/integrationtest/mapper/orm-cdi/src/test/java/org/hibernate/search/integrationtest/mapper/orm/cdi/StubExtendedBeanManager.java
+++ b/integrationtest/mapper/orm-cdi/src/test/java/org/hibernate/search/integrationtest/mapper/orm/cdi/StubExtendedBeanManager.java
@@ -1,0 +1,65 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.orm.cdi;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.enterprise.inject.se.SeContainer;
+import javax.enterprise.inject.se.SeContainerInitializer;
+
+import org.hibernate.resource.beans.container.spi.ExtendedBeanManager;
+
+class StubExtendedBeanManager implements ExtendedBeanManager {
+
+	private SeContainer cdiContainer;
+
+	private final List<LifecycleListener> lifecycleListeners = new ArrayList<>();
+
+	@Override
+	public void registerLifecycleListener(LifecycleListener lifecycleListener) {
+		this.lifecycleListeners.add( lifecycleListener );
+	}
+
+	public void simulateBoot(Class<?>... beanClasses) {
+		SeContainerInitializer cdiInitializer = SeContainerInitializer.newInstance()
+				.disableDiscovery()
+				.addBeanClasses( beanClasses );
+		this.cdiContainer = cdiInitializer.initialize();
+		for ( LifecycleListener lifecycleListener : lifecycleListeners ) {
+			lifecycleListener.beanManagerInitialized( cdiContainer.getBeanManager() );
+		}
+	}
+
+	public void simulateCancelledBoot(Class<?>... beanClasses) {
+		SeContainerInitializer cdiInitializer = SeContainerInitializer.newInstance()
+				.disableDiscovery()
+				.addBeanClasses( beanClasses );
+		this.cdiContainer = cdiInitializer.initialize();
+		// Let's say some other bean fails to initialize: we will effectively cancel Hibernate Search's boot.
+		// Notify Hibernate Search of the destruction before we even notify of initialization.
+		for ( LifecycleListener lifecycleListener : lifecycleListeners ) {
+			lifecycleListener.beforeBeanManagerDestroyed( cdiContainer.getBeanManager() );
+		}
+		cdiContainer.close();
+		cdiContainer = null;
+	}
+
+	public void simulateShutdown() {
+		for ( LifecycleListener lifecycleListener : lifecycleListeners ) {
+			lifecycleListener.beforeBeanManagerDestroyed( cdiContainer.getBeanManager() );
+		}
+		cdiContainer.close();
+		cdiContainer = null;
+	}
+
+	public void cleanUp() {
+		if ( cdiContainer != null ) {
+			cdiContainer.close();
+			cdiContainer = null;
+		}
+	}
+}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/ShutdownFailureIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/ShutdownFailureIT.java
@@ -1,0 +1,76 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.orm.bootstrap;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.search.mapper.pojo.bridge.ValueBridge;
+import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.ValueBridgeRef;
+import org.hibernate.search.mapper.pojo.bridge.runtime.ValueBridgeToIndexedValueContext;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
+import org.hibernate.search.util.impl.test.rule.ExpectedLog4jLog;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Check that a failing boot correctly propagates exceptions,
+ * despite the complex asynchronous code used during boot.
+ */
+public class ShutdownFailureIT {
+
+	@Rule
+	public BackendMock backendMock = new BackendMock( "stubBackend" );
+
+	@Rule
+	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+
+	@Rule
+	public final ExpectedLog4jLog logged = ExpectedLog4jLog.create();
+
+	@Test
+	public void logException() {
+		backendMock.expectAnySchema( FailingIndexedEntity.NAME );
+		SessionFactory sessionFactory = ormSetupHelper.start().setup( FailingIndexedEntity.class );
+
+		logged.expectMessage( "Simulated shutdown failure" );
+		sessionFactory.close();
+	}
+
+	@Entity(name = FailingIndexedEntity.NAME)
+	@Indexed(index = FailingIndexedEntity.NAME)
+	private static class FailingIndexedEntity {
+		static final String NAME = "failingIndexed";
+
+		@Id
+		private Integer id;
+
+		// This should trigger a failure at shutdown
+		@GenericField(valueBridge = @ValueBridgeRef(type = FailingCloseBridge.class))
+		private String field;
+	}
+
+	public static class FailingCloseBridge implements ValueBridge<String, String> {
+		public FailingCloseBridge() {
+		}
+
+		@Override
+		public String toIndexedValue(String value, ValueBridgeToIndexedValueContext context) {
+			throw new IllegalStateException( "Should not be called" );
+		}
+
+		@Override
+		public void close() {
+			throw new RuntimeException( "Simulated shutdown failure" );
+		}
+	}
+}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/bootstrap/impl/HibernateOrmBeanContainerBeanProvider.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/bootstrap/impl/HibernateOrmBeanContainerBeanProvider.java
@@ -6,18 +6,25 @@
  */
 package org.hibernate.search.mapper.orm.bootstrap.impl;
 
+import java.lang.invoke.MethodHandles;
+
 import org.hibernate.resource.beans.container.spi.BeanContainer;
 import org.hibernate.resource.beans.container.spi.ContainedBean;
 import org.hibernate.resource.beans.spi.BeanInstanceProducer;
 import org.hibernate.search.engine.environment.bean.BeanHolder;
 import org.hibernate.search.engine.environment.bean.spi.BeanProvider;
 import org.hibernate.search.engine.environment.bean.spi.ReflectionBeanProvider;
+import org.hibernate.search.mapper.orm.logging.impl.Log;
 import org.hibernate.search.util.common.impl.Contracts;
+import org.hibernate.search.util.common.impl.SuppressingCloser;
+import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
 /**
  * A {@link BeanProvider} relying on a Hibernate ORM {@link BeanContainer} to resolve beans.
  */
 final class HibernateOrmBeanContainerBeanProvider implements BeanProvider {
+
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private static final BeanContainer.LifecycleOptions LIFECYCLE_OPTIONS = new BeanContainer.LifecycleOptions() {
 		@Override
@@ -65,7 +72,27 @@ final class HibernateOrmBeanContainerBeanProvider implements BeanProvider {
 		ContainedBean<T> containedBean = beanContainer.getBean(
 				typeReference, LIFECYCLE_OPTIONS, fallbackInstanceProducer
 		);
-		return new HibernateOrmContainedBeanBeanHolderAdapter<>( containedBean );
+		BeanHolder<T> result = new HibernateOrmContainedBeanBeanHolderAdapter<>( containedBean );
+		// In some cases (ExtendedBeanManager in particular), the bean is retrieved lazily.
+		// This means the fallback instance producer is never called, which is a problem.
+		// Since we don't need lazy retrieval in our case (all beans are retrieved at bootstrap),
+		// we trigger initialization ourselves and use the fallback if necessary.
+		try {
+			result.get();
+		}
+		catch (Exception e) {
+			new SuppressingCloser( e ).push( result );
+			log.debugf( e, "Error resolving bean of type [%s] - using fallback", typeReference );
+			try {
+				result = BeanHolder.of( fallbackInstanceProducer.produceBeanInstance( typeReference ) );
+			}
+			catch (Exception e2) {
+				// Keep track of the original failure to retrieve the bean from the bean container.
+				e2.addSuppressed( e );
+				throw e2;
+			}
+		}
+		return result;
 	}
 
 	@Override
@@ -73,7 +100,27 @@ final class HibernateOrmBeanContainerBeanProvider implements BeanProvider {
 		ContainedBean<T> containedBean = beanContainer.getBean(
 				nameReference, typeReference, LIFECYCLE_OPTIONS, fallbackInstanceProducer
 		);
-		return new HibernateOrmContainedBeanBeanHolderAdapter<>( containedBean );
+		BeanHolder<T> result = new HibernateOrmContainedBeanBeanHolderAdapter<>( containedBean );
+		// In some cases (ExtendedBeanManager in particular), the bean is retrieved lazily.
+		// This means the fallback instance producer is never called, which is a problem.
+		// Since we don't need lazy retrieval in our case (all beans are retrieved at bootstrap),
+		// we trigger initialization ourselves and use the fallback if necessary.
+		try {
+			result.get();
+		}
+		catch (Exception e) {
+			new SuppressingCloser( e ).push( result );
+			log.debugf( e, "Error resolving bean [%s] of type [%s] - using fallback", nameReference, typeReference );
+			try {
+				result = BeanHolder.of( fallbackInstanceProducer.produceBeanInstance( nameReference, typeReference ) );
+			}
+			catch (Exception e2) {
+				// Keep track of the original failure to retrieve the bean from the bean container.
+				e2.addSuppressed( e );
+				throw e2;
+			}
+		}
+		return result;
 	}
 
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/bootstrap/impl/HibernateOrmIntegrationBooterImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/bootstrap/impl/HibernateOrmIntegrationBooterImpl.java
@@ -136,8 +136,8 @@ public class HibernateOrmIntegrationBooterImpl implements HibernateOrmIntegratio
 		CompletableFuture<Void> environmentSynchronizerStartedDestroyingStage = new CompletableFuture<>();
 
 		if ( environmentSynchronizer.isPresent() ) {
-			environmentSynchronizer.get().whenEnvironmentDestroying( () -> environmentSynchronizerReadyStage.complete( null ) );
-			environmentSynchronizer.get().whenEnvironmentReady( () -> environmentSynchronizerStartedDestroyingStage.complete( null ) );
+			environmentSynchronizer.get().whenEnvironmentDestroying( () -> environmentSynchronizerStartedDestroyingStage.complete( null ) );
+			environmentSynchronizer.get().whenEnvironmentReady( () -> environmentSynchronizerReadyStage.complete( null ) );
 		}
 		else {
 			/*

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/bootstrap/impl/HibernateSearchIntegrator.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/bootstrap/impl/HibernateSearchIntegrator.java
@@ -88,9 +88,7 @@ public class HibernateSearchIntegrator implements Integrator {
 
 		// Listen to the session factory lifecycle to boot/shutdown Hibernate Search at the right time
 		HibernateSearchSessionFactoryObserver observer = new HibernateSearchSessionFactoryObserver(
-				sessionFactoryCreatedFuture,
-				sessionFactoryClosingFuture,
-				contextFuture
+				contextFuture, sessionFactoryCreatedFuture, sessionFactoryClosingFuture
 		);
 		sessionFactory.addObserver( observer );
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/bootstrap/impl/HibernateSearchSessionFactoryObserver.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/bootstrap/impl/HibernateSearchSessionFactoryObserver.java
@@ -22,17 +22,17 @@ import org.hibernate.search.util.common.impl.Futures;
  */
 class HibernateSearchSessionFactoryObserver implements SessionFactoryObserver {
 
+	private final CompletableFuture<?> contextFuture;
 	private final CompletableFuture<SessionFactoryImplementor> sessionFactoryCreatedFuture;
 	private final CompletableFuture<?> sessionFactoryClosingFuture;
-	private final CompletableFuture<?> contextFuture;
 
 	HibernateSearchSessionFactoryObserver(
+			CompletableFuture<?> contextFuture,
 			CompletableFuture<SessionFactoryImplementor> sessionFactoryCreatedFuture,
-			CompletableFuture<?> sessionFactoryClosingFuture,
-			CompletableFuture<?> contextFuture) {
+			CompletableFuture<?> sessionFactoryClosingFuture) {
+		this.contextFuture = contextFuture;
 		this.sessionFactoryCreatedFuture = sessionFactoryCreatedFuture;
 		this.sessionFactoryClosingFuture = sessionFactoryClosingFuture;
-		this.contextFuture = contextFuture;
 	}
 
 	@Override
@@ -48,6 +48,7 @@ class HibernateSearchSessionFactoryObserver implements SessionFactoryObserver {
 	@Override
 	public synchronized void sessionFactoryClosing(SessionFactory factory) {
 		sessionFactoryClosingFuture.complete( null );
+		// If the above triggered shutdown and it failed, the exception will be logged.
 	}
 
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/logging/impl/Log.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/logging/impl/Log.java
@@ -272,4 +272,9 @@ public interface Log extends BasicLogger {
 
 	@Message(id = ID_OFFSET_2 + 34, value = "Entity '%1$s' is not indexed.")
 	SearchException notIndexedEntityName(String name);
+
+	@LogMessage(level = Logger.Level.ERROR)
+	@Message(id = ID_OFFSET_2 + 35, value = "Hibernate Search shutdown failed: %1$s")
+	void shutdownFailed(String causeMessage, @Cause Throwable cause);
+
 }


### PR DESCRIPTION
* [HSEARCH-3937](https://hibernate.atlassian.net/browse/HSEARCH-3937): Error messages on boot/shutdown are hidden or unclear when using an EnvironmentSynchronizer
* [HSEARCH-3938](https://hibernate.atlassian.net/browse/HSEARCH-3938): HibernateOrmIntegrationBooterImpl confuses the startup event for a shutdown event, and vice-versa

