### PR TITLE
 HSEARCH-3940 + HSEARCH-3941 Fixes related to sorts on multi-valued fields

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/sort/impl/AbstractElasticsearchFieldSortBuilderFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/sort/impl/AbstractElasticsearchFieldSortBuilderFactory.java
@@ -39,7 +39,7 @@ public abstract class AbstractElasticsearchFieldSortBuilderFactory<F>
 			return false;
 		}
 
-		ElasticsearchStandardFieldSortBuilderFactory<?> other = (ElasticsearchStandardFieldSortBuilderFactory<?>) obj;
+		AbstractElasticsearchFieldSortBuilderFactory<?> other = (AbstractElasticsearchFieldSortBuilderFactory<?>) obj;
 		return sortable == other.sortable && codec.isCompatibleWith( other.codec );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/SingleFieldAggregationTypeCheckingAndConversionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/aggregation/SingleFieldAggregationTypeCheckingAndConversionIT.java
@@ -21,11 +21,8 @@ import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectField;
 import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
 import org.hibernate.search.engine.backend.types.Aggregable;
-import org.hibernate.search.engine.backend.types.Projectable;
 import org.hibernate.search.engine.backend.types.converter.FromDocumentFieldValueConverter;
 import org.hibernate.search.engine.backend.types.converter.runtime.FromDocumentFieldValueConvertContext;
-import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeFactory;
-import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeOptionsStep;
 import org.hibernate.search.engine.search.aggregation.AggregationKey;
 import org.hibernate.search.engine.search.aggregation.SearchAggregation;
 import org.hibernate.search.engine.search.aggregation.dsl.AggregationFinalStep;
@@ -37,8 +34,8 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.operations.A
 import org.hibernate.search.integrationtest.backend.tck.testsupport.operations.expectations.AggregationScenario;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.operations.expectations.SupportedSingleFieldAggregationExpectations;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldTypeDescriptor;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.SimpleFieldModel;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.SimpleFieldModelsByType;
-import org.hibernate.search.integrationtest.backend.tck.testsupport.util.StandardFieldMapper;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TypeAssertionHelper;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.ValueWrapper;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
@@ -662,26 +659,9 @@ public class SingleFieldAggregationTypeCheckingAndConversionIT<F> {
 
 		private static void mapFieldsWithIncompatibleType(IndexSchemaElement parent) {
 			supportedFieldTypes.forEach( typeDescriptor ->
-					IncompatibleFieldModel.mapper( FieldTypeDescriptor.getIncompatible( typeDescriptor )::configure )
+					SimpleFieldModel.mapper( FieldTypeDescriptor.getIncompatible( typeDescriptor ) )
 							.map( parent, "" + typeDescriptor.getUniqueName() )
 			);
-		}
-	}
-
-	private static class IncompatibleFieldModel {
-		static <F> StandardFieldMapper<F, IncompatibleFieldModel> mapper(
-				Function<IndexFieldTypeFactory, StandardIndexFieldTypeOptionsStep<?, F>> configuration) {
-			return StandardFieldMapper.of(
-					configuration,
-					c -> c.projectable( Projectable.YES ),
-					(reference, name) -> new IncompatibleFieldModel( name )
-			);
-		}
-
-		final String relativeFieldName;
-
-		private IncompatibleFieldModel(String relativeFieldName) {
-			this.relativeFieldName = relativeFieldName;
 		}
 	}
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/DistanceSearchSortBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/DistanceSearchSortBaseIT.java
@@ -355,7 +355,7 @@ public class DistanceSearchSortBaseIT {
 					asList( getSingle().get( 3 ), getSingle().get( 5 ) ), // ~6km
 					asList( getSingle().get( 4 ), getSingle().get( 6 ) ), // ~8km
 					asList( getSingle().get( 4 ), getSingle().get( 7 ) ), // ~10km
-					asList( getSingle().get( 7 ),getSingle().get( 7 ), getSingle().get( 7 ) ) // ~14km
+					asList( getSingle().get( 7 ), getSingle().get( 7 ), getSingle().get( 7 ) ) // ~14km
 			);
 		}
 	}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/DistanceSearchSortBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/DistanceSearchSortBaseIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.backend.tck.search.sort;
 
-import static java.util.Arrays.asList;
+import static org.hibernate.search.integrationtest.backend.tck.testsupport.types.values.AscendingUniqueDistanceFromCenterValues.CENTER_POINT;
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
 import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.documentProvider;
 
@@ -27,7 +27,7 @@ import org.hibernate.search.engine.spatial.GeoPoint;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.model.singlefield.SingleFieldIndexBinding;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldTypeDescriptor;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.GeoPointFieldTypeDescriptor;
-import org.hibernate.search.integrationtest.backend.tck.testsupport.types.values.AscendingUniqueTermValues;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.values.AscendingUniqueDistanceFromCenterValues;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TestedFieldStructure;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
@@ -78,8 +78,6 @@ public class DistanceSearchSortBaseIT {
 		}
 		return parameters.toArray( new Object[0][] );
 	}
-
-	private static final GeoPoint CENTER_POINT = GeoPoint.of( 46.038673, 3.978563 );
 
 	// TODO HSEARCH-3863 use the other ordinals when we implement.missing().use/last/first for distance sorts
 	private static final int BEFORE_DOCUMENT_1_ORDINAL = 0;
@@ -322,42 +320,4 @@ public class DistanceSearchSortBaseIT {
 			}
 		}
 	}
-
-	private static class AscendingUniqueDistanceFromCenterValues extends AscendingUniqueTermValues<GeoPoint> {
-		private static final AscendingUniqueDistanceFromCenterValues INSTANCE = new AscendingUniqueDistanceFromCenterValues();
-
-		@Override
-		protected List<GeoPoint> createSingle() {
-			return asList(
-					CENTER_POINT, // ~0km
-					GeoPoint.of( 46.038683, 3.964652 ), // ~1km
-					GeoPoint.of( 46.059852, 3.978235 ), // ~2km
-					GeoPoint.of( 46.039763, 3.914977 ), // ~4km
-					GeoPoint.of( 46.000833, 3.931265 ), // ~6km
-					GeoPoint.of( 46.094712, 4.044507 ), // ~8km
-					GeoPoint.of( 46.018378, 4.196792 ), // ~10km
-					GeoPoint.of( 46.123025, 3.845305 ) // ~14km
-			);
-		}
-
-		@Override
-		protected List<List<GeoPoint>> createMultiResultingInSingleAfterSum() {
-			return valuesThatWontBeUsed();
-		}
-
-		@Override
-		protected List<List<GeoPoint>> createMultiResultingInSingleAfterAvg() {
-			return asList(
-					asList( CENTER_POINT, CENTER_POINT ), // ~0km
-					asList( getSingle().get( 0 ), getSingle().get( 2 ) ), // ~1km
-					asList( getSingle().get( 1 ), getSingle().get( 1 ), getSingle().get( 4 ) ), // ~2km
-					asList( getSingle().get( 2 ), getSingle().get( 4 ) ), // ~4km
-					asList( getSingle().get( 3 ), getSingle().get( 5 ) ), // ~6km
-					asList( getSingle().get( 4 ), getSingle().get( 6 ) ), // ~8km
-					asList( getSingle().get( 4 ), getSingle().get( 7 ) ), // ~10km
-					asList( getSingle().get( 7 ), getSingle().get( 7 ), getSingle().get( 7 ) ) // ~14km
-			);
-		}
-	}
-
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/DistanceSearchSortTypeCheckingAndConversionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/DistanceSearchSortTypeCheckingAndConversionIT.java
@@ -1,0 +1,283 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.tck.search.sort;
+
+import static org.hibernate.search.integrationtest.backend.tck.testsupport.types.values.AscendingUniqueDistanceFromCenterValues.CENTER_POINT;
+import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.hibernate.search.engine.backend.common.DocumentReference;
+import org.hibernate.search.engine.backend.document.DocumentElement;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.types.Sortable;
+import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeOptionsStep;
+import org.hibernate.search.engine.reporting.spi.EventContexts;
+import org.hibernate.search.engine.search.query.SearchQuery;
+import org.hibernate.search.engine.search.sort.dsl.SearchSortFactory;
+import org.hibernate.search.engine.search.sort.dsl.SortFinalStep;
+import org.hibernate.search.engine.spatial.GeoPoint;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldTypeDescriptor;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.GeoPointFieldTypeDescriptor;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.values.AscendingUniqueDistanceFromCenterValues;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.SimpleFieldModel;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.ValueWrapper;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
+import org.hibernate.search.util.common.SearchException;
+import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.BulkIndexer;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.assertj.core.api.Assertions;
+
+/**
+ * Tests behavior related to type checking and type conversion of DSL arguments
+ * for sorts by field value.
+ */
+public class DistanceSearchSortTypeCheckingAndConversionIT {
+
+	private static final GeoPointFieldTypeDescriptor fieldType = GeoPointFieldTypeDescriptor.INSTANCE;
+
+	private static final String DOCUMENT_1 = "1";
+	private static final String DOCUMENT_2 = "2";
+	private static final String DOCUMENT_3 = "3";
+
+	private static final String EMPTY = "empty";
+
+	private static final String COMPATIBLE_INDEX_DOCUMENT_1 = "compatible_1";
+	private static final String RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 = "raw_field_compatible_1";
+
+	// TODO HSEARCH-3863 use the other ordinals when we implement.missing().use/last/first for distance sorts
+	private static final int BEFORE_DOCUMENT_1_ORDINAL = 0;
+	private static final int DOCUMENT_1_ORDINAL = 1;
+	private static final int BETWEEN_DOCUMENT_1_AND_2_ORDINAL = 2;
+	private static final int DOCUMENT_2_ORDINAL = 3;
+	private static final int BETWEEN_DOCUMENT_2_AND_3_ORDINAL = 4;
+	private static final int DOCUMENT_3_ORDINAL = 5;
+	private static final int AFTER_DOCUMENT_3_ORDINAL = 6;
+
+	@ClassRule
+	public static SearchSetupHelper setupHelper = new SearchSetupHelper();
+
+	private static final SimpleMappedIndex<IndexBinding> mainIndex =
+			SimpleMappedIndex.of( IndexBinding::new ).name( "main" );
+	private static final SimpleMappedIndex<IndexBinding> compatibleIndex =
+			SimpleMappedIndex.of( IndexBinding::new ).name( "compatible" );
+	private static final SimpleMappedIndex<RawFieldCompatibleIndexBinding> rawFieldCompatibleIndex =
+			SimpleMappedIndex.of( RawFieldCompatibleIndexBinding::new ).name( "rawFieldCompatible" );
+	private static final SimpleMappedIndex<IncompatibleIndexBinding> incompatibleIndex =
+			SimpleMappedIndex.of( IncompatibleIndexBinding::new ).name( "incompatible" );
+
+	@BeforeClass
+	public static void setup() {
+		setupHelper.start()
+				.withIndexes( mainIndex, compatibleIndex, rawFieldCompatibleIndex, incompatibleIndex )
+				.setup();
+
+		initData();
+	}
+
+	// TODO HSEARCH-3863 implement tests related to DSL converters when we implement.missing().use/last/first for distance sorts
+	//   See test methods in FieldSearchSortTypeCheckingAndConversionIT
+
+	@Test
+	public void unsortable() {
+		StubMappingScope scope = mainIndex.createScope();
+		String fieldPath = getNonSortableFieldPath();
+
+		Assertions.assertThatThrownBy( () -> {
+				scope.sort().distance( fieldPath, CENTER_POINT );
+		} )
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Sorting is not enabled for field" )
+				.hasMessageContaining( fieldPath );
+	}
+
+	@Test
+	public void multiIndex_withCompatibleIndex() {
+		StubMappingScope scope = mainIndex.createScope( compatibleIndex );
+
+		SearchQuery<DocumentReference> query;
+		String fieldPath = getFieldPath();
+
+		query = matchAllQuery( f -> f.distance( fieldPath, CENTER_POINT ), scope );
+
+		assertThat( query ).hasDocRefHitsAnyOrder( b -> {
+			b.doc( mainIndex.typeName(), EMPTY );
+			b.doc( mainIndex.typeName(), DOCUMENT_1 );
+			b.doc( compatibleIndex.typeName(), COMPATIBLE_INDEX_DOCUMENT_1 );
+			b.doc( mainIndex.typeName(), DOCUMENT_2 );
+			b.doc( mainIndex.typeName(), DOCUMENT_3 );
+		} );
+	}
+
+	@Test
+	public void multiIndex_withRawFieldCompatibleIndex() {
+		StubMappingScope scope = mainIndex.createScope( rawFieldCompatibleIndex );
+
+		SearchQuery<DocumentReference> query;
+		String fieldPath = getFieldWithDslConverterPath();
+
+		query = matchAllQuery( f -> f.distance( fieldPath, CENTER_POINT ), scope );
+
+		assertThat( query ).hasDocRefHitsAnyOrder( b -> {
+			b.doc( mainIndex.typeName(), EMPTY );
+			b.doc( mainIndex.typeName(), DOCUMENT_1 );
+			b.doc( rawFieldCompatibleIndex.typeName(), RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 );
+			b.doc( mainIndex.typeName(), DOCUMENT_2 );
+			b.doc( mainIndex.typeName(), DOCUMENT_3 );
+		} );
+	}
+
+	@Test
+	public void multiIndex_withNoCompatibleIndex_dslConverterEnabled() {
+		StubMappingScope scope = mainIndex.createScope( incompatibleIndex );
+
+		String fieldPath = getFieldPath();
+
+		Assertions.assertThatThrownBy(
+				() -> {
+					matchAllQuery( f -> f.distance( fieldPath, CENTER_POINT ), scope );
+				}
+		)
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Multiple conflicting types to build a sort" )
+				.hasMessageContaining( "'" + fieldPath + "'" )
+				.satisfies( FailureReportUtils.hasContext(
+						EventContexts.fromIndexNames( mainIndex.name(), incompatibleIndex.name() )
+				) );
+	}
+
+	@Test
+	public void multiIndex_withNoCompatibleIndex_dslConverterDisabled() {
+		StubMappingScope scope = mainIndex.createScope( incompatibleIndex );
+
+		String fieldPath = getFieldPath();
+
+		Assertions.assertThatThrownBy(
+				() -> {
+					matchAllQuery( f -> f.distance( fieldPath, CENTER_POINT ), scope );
+				}
+		)
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Multiple conflicting types to build a sort" )
+				.hasMessageContaining( "'" + fieldPath + "'" )
+				.satisfies( FailureReportUtils.hasContext(
+						EventContexts.fromIndexNames( mainIndex.name(), incompatibleIndex.name() )
+				) );
+	}
+
+	private SearchQuery<DocumentReference> matchAllQuery(
+			Function<? super SearchSortFactory, ? extends SortFinalStep> sortContributor, StubMappingScope scope) {
+		return scope.query()
+				.where( f -> f.matchAll() )
+				.sort( sortContributor )
+				.toQuery();
+	}
+
+	private String getFieldPath() {
+		return mainIndex.binding().fieldModel.relativeFieldName;
+	}
+
+	private String getFieldWithDslConverterPath() {
+		return mainIndex.binding().fieldWithDslConverterModel.relativeFieldName;
+	}
+
+	private String getNonSortableFieldPath() {
+		return mainIndex.binding().nonSortableFieldModel.relativeFieldName;
+	}
+
+	private static void initDocument(IndexBinding indexBinding, DocumentElement document, Integer ordinal) {
+		addValue( indexBinding.fieldModel, document, ordinal );
+		addValue( indexBinding.fieldWithDslConverterModel, document, ordinal );
+	}
+
+	private static void addValue(SimpleFieldModel<GeoPoint> fieldModel, DocumentElement documentElement, Integer ordinal) {
+		if ( ordinal == null ) {
+			return;
+		}
+		documentElement.addValue(
+				fieldModel.reference,
+				AscendingUniqueDistanceFromCenterValues.INSTANCE.getSingle().get( ordinal )
+		);
+	}
+
+	private static void initData() {
+		BulkIndexer mainIndexer = mainIndex.bulkIndexer()
+				// Important: do not index the documents in the expected order after sorts (1, 2, 3)
+				.add( DOCUMENT_2, document -> initDocument( mainIndex.binding(), document, DOCUMENT_2_ORDINAL ) )
+				.add( EMPTY, document -> initDocument( mainIndex.binding(), document, null ) )
+				.add( DOCUMENT_1, document -> initDocument( mainIndex.binding(), document, DOCUMENT_1_ORDINAL ) )
+				.add( DOCUMENT_3, document -> initDocument( mainIndex.binding(), document, DOCUMENT_3_ORDINAL ) );
+		BulkIndexer compatibleIndexer = compatibleIndex.bulkIndexer()
+				.add( COMPATIBLE_INDEX_DOCUMENT_1,
+						document -> initDocument( compatibleIndex.binding(), document, BETWEEN_DOCUMENT_1_AND_2_ORDINAL ) );
+		BulkIndexer rawFieldCompatibleIndexer = rawFieldCompatibleIndex.bulkIndexer()
+				.add( RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1,
+						document -> initDocument( rawFieldCompatibleIndex.binding(), document, BETWEEN_DOCUMENT_1_AND_2_ORDINAL ) );
+		mainIndexer.join( compatibleIndexer, rawFieldCompatibleIndexer );
+	}
+
+	private static class IndexBinding {
+		final SimpleFieldModel<GeoPoint> fieldModel;
+		final SimpleFieldModel<GeoPoint> fieldWithDslConverterModel;
+		final SimpleFieldModel<GeoPoint> nonSortableFieldModel;
+
+		IndexBinding(IndexSchemaElement root) {
+			this( root, ignored -> { } );
+		}
+
+		IndexBinding(IndexSchemaElement root,
+				Consumer<StandardIndexFieldTypeOptionsStep<?, ?>> additionalConfiguration) {
+			fieldModel = SimpleFieldModel.mapper( fieldType )
+					.map( root, "unconverted", c -> c.sortable( Sortable.YES ), additionalConfiguration );
+			fieldWithDslConverterModel = SimpleFieldModel.mapper( fieldType )
+					.map(
+							root, "converted", c -> c.sortable( Sortable.YES ),
+							additionalConfiguration.andThen(
+									c -> c.dslConverter( ValueWrapper.class, ValueWrapper.toIndexFieldConverter() ) )
+					);
+			nonSortableFieldModel = SimpleFieldModel.mapper( fieldType )
+					.map(
+							root, "nonSortable", c -> c.sortable( Sortable.YES ),
+							additionalConfiguration.andThen( c -> c.sortable( Sortable.NO ) )
+					);
+		}
+	}
+
+	private static class RawFieldCompatibleIndexBinding extends IndexBinding {
+		RawFieldCompatibleIndexBinding(IndexSchemaElement root) {
+			/*
+			 * Add fields with the same name as the fieldModel from IndexBinding,
+			 * but with an incompatible DSL converter.
+			 */
+			super( root, c -> c.dslConverter( ValueWrapper.class, ValueWrapper.toIndexFieldConverter() ) );
+		}
+	}
+
+	private static class IncompatibleIndexBinding {
+		IncompatibleIndexBinding(IndexSchemaElement root) {
+			/*
+			 * Add fields with the same name as the fieldModel from IndexBinding,
+			 * but with an incompatible type.
+			 */
+			mapFieldsWithIncompatibleType( root );
+		}
+
+		private static void mapFieldsWithIncompatibleType(IndexSchemaElement parent) {
+			SimpleFieldModel.mapper( FieldTypeDescriptor.getIncompatible( fieldType ) )
+					.map( parent, "unconverted", c -> c.sortable( Sortable.YES ) );
+		}
+	}
+
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSearchSortBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSearchSortBaseIT.java
@@ -7,46 +7,39 @@
 package org.hibernate.search.integrationtest.backend.tck.search.sort;
 
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.documentProvider;
 
 import java.time.MonthDay;
 import java.time.temporal.Temporal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.function.Consumer;
+import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Stream;
 
 import org.hibernate.search.engine.backend.common.DocumentReference;
-import org.hibernate.search.engine.backend.document.DocumentElement;
-import org.hibernate.search.engine.backend.document.IndexFieldReference;
-import org.hibernate.search.engine.backend.document.IndexObjectFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
-import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectField;
-import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
 import org.hibernate.search.engine.backend.types.Sortable;
-import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeOptionsStep;
 import org.hibernate.search.engine.search.common.SortMode;
 import org.hibernate.search.engine.search.predicate.dsl.PredicateFinalStep;
 import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
 import org.hibernate.search.engine.search.query.SearchQuery;
 import org.hibernate.search.engine.search.sort.dsl.FieldSortOptionsStep;
 import org.hibernate.search.engine.search.sort.dsl.SearchSortFactory;
-import org.hibernate.search.engine.search.sort.dsl.SortOrder;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.model.singlefield.SingleFieldIndexBinding;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldTypeDescriptor;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.NormalizedStringFieldTypeDescriptor;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.ExpectationsAlternative;
-import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TestedFieldStructure;
-import org.hibernate.search.integrationtest.backend.tck.testsupport.util.SimpleFieldModel;
-import org.hibernate.search.integrationtest.backend.tck.testsupport.util.SimpleFieldModelsByType;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConfiguration;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TestedFieldStructure;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.BulkIndexer;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
-import org.assertj.core.api.Assertions;
 import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Assume;
@@ -56,42 +49,47 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import org.assertj.core.api.Assertions;
+
 /**
  * Tests basic behavior of sorts by field value common to all supported types.
  */
 @RunWith(Parameterized.class)
 public class FieldSearchSortBaseIT<F> {
 
-	private static Stream<FieldTypeDescriptor<?>> supportedTypeDescriptors() {
-		return FieldTypeDescriptor.getAll().stream()
-				.filter( typeDescriptor -> typeDescriptor.getFieldSortExpectations().isSupported() );
-	}
+	private static Set<FieldTypeDescriptor<?>> supportedFieldTypes;
+	private static List<DataSet<?>> dataSets;
 
 	@Parameterized.Parameters(name = "{0} - {2} - {1}")
 	public static Object[][] parameters() {
+		supportedFieldTypes = new LinkedHashSet<>();
+		dataSets = new ArrayList<>();
 		List<Object[]> parameters = new ArrayList<>();
-		supportedTypeDescriptors().forEach( fieldTypeDescriptor -> {
-			ExpectationsAlternative<?, ?> expectations = fieldTypeDescriptor.getFieldSortExpectations();
+		for ( FieldTypeDescriptor<?> fieldType : FieldTypeDescriptor.getAll() ) {
+			ExpectationsAlternative<?, ?> expectations = fieldType.getFieldSortExpectations();
 			if ( expectations.isSupported() ) {
+				supportedFieldTypes.add( fieldType );
 				for ( TestedFieldStructure fieldStructure : TestedFieldStructure.all() ) {
-					parameters.add( new Object[] { fieldStructure, fieldTypeDescriptor, null } );
+					// We need two separate datasets when the sort mode is not defined,
+					// because then the sort mode will be inferred automatically to
+					// MIN for desc order, or MAX for asc order.
+					DataSet<?> dataSetForAsc = new DataSet<>( fieldStructure, fieldType, null, SortMode.MIN );
+					dataSets.add( dataSetForAsc );
+					DataSet<?> dataSetForDesc = new DataSet<>( fieldStructure, fieldType, null, SortMode.MAX );
+					dataSets.add( dataSetForDesc );
+					parameters.add( new Object[] { fieldStructure, fieldType, null, dataSetForAsc, dataSetForDesc } );
 					for ( SortMode sortMode : SortMode.values() ) {
-						parameters.add( new Object[] { fieldStructure, fieldTypeDescriptor, sortMode } );
+						// When the sort mode is defined, we only need one dataset.
+						dataSetForAsc = new DataSet<>( fieldStructure, fieldType, sortMode, sortMode );
+						dataSets.add( dataSetForAsc );
+						dataSetForDesc = dataSetForAsc;
+						parameters.add( new Object[] { fieldStructure, fieldType, sortMode, dataSetForAsc, dataSetForDesc } );
 					}
 				}
 			}
-		} );
+		}
 		return parameters.toArray( new Object[0][] );
 	}
-
-	private static final String DOCUMENT_1 = "1";
-	private static final String DOCUMENT_2 = "2";
-	private static final String DOCUMENT_3 = "3";
-
-	private static final String EMPTY_1 = "empty1";
-	private static final String EMPTY_2 = "empty2";
-	private static final String EMPTY_3 = "empty3";
-	private static final String EMPTY_4 = "empty4";
 
 	private static final int BEFORE_DOCUMENT_1_ORDINAL = 0;
 	private static final int DOCUMENT_1_ORDINAL = 1;
@@ -104,23 +102,36 @@ public class FieldSearchSortBaseIT<F> {
 	@ClassRule
 	public static SearchSetupHelper setupHelper = new SearchSetupHelper();
 
-	private static final SimpleMappedIndex<IndexBinding> index = SimpleMappedIndex.of( IndexBinding::new );
+	private static final Function<IndexSchemaElement, SingleFieldIndexBinding> bindingFactory =
+			root -> new SingleFieldIndexBinding( root, supportedFieldTypes, c -> c.sortable( Sortable.YES ) );
+
+	private static final SimpleMappedIndex<SingleFieldIndexBinding> index = SimpleMappedIndex.of( bindingFactory );
 
 	@BeforeClass
 	public static void setup() {
 		setupHelper.start().withIndex( index ).setup();
-		initData();
+
+		BulkIndexer indexer = index.bulkIndexer();
+		for ( DataSet<?> dataSet : dataSets ) {
+			dataSet.contribute( indexer );
+		}
+		indexer.join();
 	}
 
 	private final TestedFieldStructure fieldStructure;
-	private final FieldTypeDescriptor<F> fieldTypeDescriptor;
+	private final FieldTypeDescriptor<F> fieldType;
 	private final SortMode sortMode;
+	private final DataSet<F> dataSetForAsc;
+	private final DataSet<F> dataSetForDesc;
 
 	public FieldSearchSortBaseIT(TestedFieldStructure fieldStructure,
-			FieldTypeDescriptor<F> fieldTypeDescriptor, SortMode sortMode) {
+			FieldTypeDescriptor<F> fieldType, SortMode sortMode,
+			DataSet<F> dataSetForAsc, DataSet<F> dataSetForDesc) {
 		this.fieldStructure = fieldStructure;
-		this.fieldTypeDescriptor = fieldTypeDescriptor;
+		this.fieldType = fieldType;
 		this.sortMode = sortMode;
+		this.dataSetForAsc = dataSetForAsc;
+		this.dataSetForDesc = dataSetForDesc;
 	}
 
 	@Test
@@ -128,22 +139,25 @@ public class FieldSearchSortBaseIT<F> {
 	public void simple() {
 		assumeTestParametersWork();
 
+		DataSet<F> dataSet;
 		SearchQuery<DocumentReference> query;
-		String fieldPathForAscendingOrderTests = getFieldPath( SortOrder.ASC );
-		String fieldPathForDescendingOrderTests = getFieldPath( SortOrder.DESC );
+		String fieldPath = getFieldPath();
 
 		// Default order
-		query = matchNonEmptyQuery( b -> b.field( fieldPathForAscendingOrderTests ) );
+		dataSet = dataSetForAsc;
+		query = matchNonEmptyQuery( dataSet, b -> b.field( fieldPath ) );
 		assertThat( query )
-				.hasDocRefHitsExactOrder( index.typeName(), DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
+				.hasDocRefHitsExactOrder( index.typeName(), dataSet.doc1Id, dataSet.doc2Id, dataSet.doc3Id );
 
 		// Explicit order
-		query = matchNonEmptyQuery( b -> b.field( fieldPathForAscendingOrderTests ).asc() );
+		dataSet = dataSetForAsc;
+		query = matchNonEmptyQuery( dataSet, b -> b.field( fieldPath ).asc() );
 		assertThat( query )
-				.hasDocRefHitsExactOrder( index.typeName(), DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
-		query = matchNonEmptyQuery( b -> b.field( fieldPathForDescendingOrderTests ).desc() );
+				.hasDocRefHitsExactOrder( index.typeName(), dataSet.doc1Id, dataSet.doc2Id, dataSet.doc3Id );
+		dataSet = dataSetForDesc;
+		query = matchNonEmptyQuery( dataSet, b -> b.field( fieldPath ).desc() );
 		assertThat( query )
-				.hasDocRefHitsExactOrder( index.typeName(), DOCUMENT_3, DOCUMENT_2, DOCUMENT_1 );
+				.hasDocRefHitsExactOrder( index.typeName(), dataSet.doc3Id, dataSet.doc2Id, dataSet.doc1Id );
 	}
 
 	@Test
@@ -154,9 +168,9 @@ public class FieldSearchSortBaseIT<F> {
 				isMedianWithNestedField() && !isSumOrAvgOrMedianWithStringField()
 		);
 
-		String fieldPath = getFieldPath( SortOrder.ASC );
+		String fieldPath = getFieldPath();
 
-		Assertions.assertThatThrownBy( () -> matchNonEmptyQuery( b -> b.field( fieldPath ) ) )
+		Assertions.assertThatThrownBy( () -> matchNonEmptyQuery( dataSetForAsc, b -> b.field( fieldPath ) ) )
 				.isInstanceOf( SearchException.class )
 				.hasMessageContainingAll(
 						"Cannot compute the median across nested documents",
@@ -172,9 +186,9 @@ public class FieldSearchSortBaseIT<F> {
 				isSumOrAvgOrMedianWithStringField()
 		);
 
-		String fieldPath = getFieldPath( SortOrder.ASC );
+		String fieldPath = getFieldPath();
 
-		Assertions.assertThatThrownBy( () -> matchNonEmptyQuery( b -> b.field( fieldPath ) ) )
+		Assertions.assertThatThrownBy( () -> matchNonEmptyQuery( dataSetForAsc, b -> b.field( fieldPath ) ) )
 				.isInstanceOf( SearchException.class )
 				.hasMessageContainingAll(
 						"Cannot compute the sum, average or median of a text field",
@@ -191,9 +205,9 @@ public class FieldSearchSortBaseIT<F> {
 				isSumWithTemporalField()
 		);
 
-		String fieldPath = getFieldPath( SortOrder.ASC );
+		String fieldPath = getFieldPath();
 
-		Assertions.assertThatThrownBy( () -> matchNonEmptyQuery( b -> b.field( fieldPath ) ) )
+		Assertions.assertThatThrownBy( () -> matchNonEmptyQuery( dataSetForAsc, b -> b.field( fieldPath ) ) )
 				.isInstanceOf( SearchException.class )
 				.hasMessageContainingAll(
 						"Cannot compute the sum of a temporal field",
@@ -207,68 +221,79 @@ public class FieldSearchSortBaseIT<F> {
 	public void missingValue_default() {
 		assumeTestParametersWork();
 
+		DataSet<F> dataSet;
 		SearchQuery<DocumentReference> query;
 
-		String fieldPathForAscendingOrderTests = getFieldPath( SortOrder.ASC );
-		String fieldPathForDescendingOrderTests = getFieldPath( SortOrder.DESC );
+		String fieldPath = getFieldPath();
 
 		// Default for missing values is last, regardless of the order
 
-		query = matchNonEmptyAndEmpty1Query( f -> f.field( fieldPathForAscendingOrderTests ) );
+		dataSet = dataSetForAsc;
+		query = matchNonEmptyAndEmpty1Query( dataSet, f -> f.field( fieldPath ) );
 		assertThat( query )
-				.hasDocRefHitsExactOrder( index.typeName(), DOCUMENT_1, DOCUMENT_2, DOCUMENT_3, EMPTY_1 );
+				.hasDocRefHitsExactOrder( index.typeName(), dataSet.doc1Id, dataSet.doc2Id, dataSet.doc3Id, dataSet.emptyDoc1Id );
 
-		query = matchNonEmptyAndEmpty1Query( f -> f.field( fieldPathForAscendingOrderTests ).asc() );
+		dataSet = dataSetForAsc;
+		query = matchNonEmptyAndEmpty1Query( dataSet, f -> f.field( fieldPath ).asc() );
 		assertThat( query )
-				.hasDocRefHitsExactOrder( index.typeName(), DOCUMENT_1, DOCUMENT_2, DOCUMENT_3, EMPTY_1 );
+				.hasDocRefHitsExactOrder( index.typeName(), dataSet.doc1Id, dataSet.doc2Id, dataSet.doc3Id, dataSet.emptyDoc1Id );
 
-		query = matchNonEmptyAndEmpty1Query( f -> f.field( fieldPathForDescendingOrderTests ).desc() );
+		dataSet = dataSetForDesc;
+		query = matchNonEmptyAndEmpty1Query( dataSet, f -> f.field( fieldPath ).desc() );
 		assertThat( query )
-				.hasDocRefHitsExactOrder( index.typeName(), DOCUMENT_3, DOCUMENT_2, DOCUMENT_1, EMPTY_1 );
+				.hasDocRefHitsExactOrder( index.typeName(), dataSet.doc3Id, dataSet.doc2Id, dataSet.doc1Id, dataSet.emptyDoc1Id );
 	}
 
 	@Test
 	public void missingValue_explicit() {
 		assumeTestParametersWork();
 
+		DataSet<F> dataSet;
 		SearchQuery<DocumentReference> query;
 
-		String fieldPathForAscendingOrderTests = getFieldPath( SortOrder.ASC );
-		String fieldPathForDescendingOrderTests = getFieldPath( SortOrder.DESC );
+		String fieldPath = getFieldPath();
 
 		// Explicit order with missing().last()
-		query = matchNonEmptyAndEmpty1Query( f -> f.field( fieldPathForAscendingOrderTests ).asc().missing().last() );
+		dataSet = dataSetForAsc;
+		query = matchNonEmptyAndEmpty1Query( dataSet, f -> f.field( fieldPath ).asc().missing().last() );
 		assertThat( query )
-				.hasDocRefHitsExactOrder( index.typeName(), DOCUMENT_1, DOCUMENT_2, DOCUMENT_3, EMPTY_1 );
-		query = matchNonEmptyAndEmpty1Query( f -> f.field( fieldPathForDescendingOrderTests ).desc().missing().last() );
+				.hasDocRefHitsExactOrder( index.typeName(), dataSet.doc1Id, dataSet.doc2Id, dataSet.doc3Id, dataSet.emptyDoc1Id );
+		dataSet = dataSetForDesc;
+		query = matchNonEmptyAndEmpty1Query( dataSet, f -> f.field( fieldPath ).desc().missing().last() );
 		assertThat( query )
-				.hasDocRefHitsExactOrder( index.typeName(), DOCUMENT_3, DOCUMENT_2, DOCUMENT_1, EMPTY_1 );
+				.hasDocRefHitsExactOrder( index.typeName(), dataSet.doc3Id, dataSet.doc2Id, dataSet.doc1Id, dataSet.emptyDoc1Id );
 
 		// Explicit order with missing().first()
-		query = matchNonEmptyAndEmpty1Query( f -> f.field( fieldPathForAscendingOrderTests ).asc().missing().first() );
+		dataSet = dataSetForAsc;
+		query = matchNonEmptyAndEmpty1Query( dataSet, f -> f.field( fieldPath ).asc().missing().first() );
 		assertThat( query )
-				.hasDocRefHitsExactOrder( index.typeName(), EMPTY_1, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
-		query = matchNonEmptyAndEmpty1Query( f -> f.field( fieldPathForDescendingOrderTests ).desc().missing().first() );
+				.hasDocRefHitsExactOrder( index.typeName(), dataSet.emptyDoc1Id, dataSet.doc1Id, dataSet.doc2Id, dataSet.doc3Id );
+		dataSet = dataSetForDesc;
+		query = matchNonEmptyAndEmpty1Query( dataSet, f -> f.field( fieldPath ).desc().missing().first() );
 		assertThat( query )
-				.hasDocRefHitsExactOrder( index.typeName(), EMPTY_1, DOCUMENT_3, DOCUMENT_2, DOCUMENT_1 );
+				.hasDocRefHitsExactOrder( index.typeName(), dataSet.emptyDoc1Id, dataSet.doc3Id, dataSet.doc2Id, dataSet.doc1Id );
 
 		// Explicit order with missing().use( ... )
-		query = matchNonEmptyAndEmpty1Query( f -> f.field( fieldPathForAscendingOrderTests ).asc()
+		dataSet = dataSetForAsc;
+		query = matchNonEmptyAndEmpty1Query( dataSet, f -> f.field( fieldPath ).asc()
 				.missing().use( getSingleValueForMissingUse( BEFORE_DOCUMENT_1_ORDINAL ) ) );
 		assertThat( query )
-				.hasDocRefHitsExactOrder( index.typeName(), EMPTY_1, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
-		query = matchNonEmptyAndEmpty1Query( f -> f.field( fieldPathForAscendingOrderTests ).asc()
+				.hasDocRefHitsExactOrder( index.typeName(), dataSet.emptyDoc1Id, dataSet.doc1Id, dataSet.doc2Id, dataSet.doc3Id );
+		dataSet = dataSetForAsc;
+		query = matchNonEmptyAndEmpty1Query( dataSet, f -> f.field( fieldPath ).asc()
 				.missing().use( getSingleValueForMissingUse( BETWEEN_DOCUMENT_1_AND_2_ORDINAL ) ) );
 		assertThat( query )
-				.hasDocRefHitsExactOrder( index.typeName(), DOCUMENT_1, EMPTY_1, DOCUMENT_2, DOCUMENT_3 );
-		query = matchNonEmptyAndEmpty1Query( f -> f.field( fieldPathForAscendingOrderTests ).asc()
+				.hasDocRefHitsExactOrder( index.typeName(), dataSet.doc1Id, dataSet.emptyDoc1Id, dataSet.doc2Id, dataSet.doc3Id );
+		dataSet = dataSetForAsc;
+		query = matchNonEmptyAndEmpty1Query( dataSet, f -> f.field( fieldPath ).asc()
 				.missing().use( getSingleValueForMissingUse( BETWEEN_DOCUMENT_2_AND_3_ORDINAL ) ) );
 		assertThat( query )
-				.hasDocRefHitsExactOrder( index.typeName(), DOCUMENT_1, DOCUMENT_2, EMPTY_1, DOCUMENT_3 );
-		query = matchNonEmptyAndEmpty1Query( f -> f.field( fieldPathForAscendingOrderTests ).asc()
+				.hasDocRefHitsExactOrder( index.typeName(), dataSet.doc1Id, dataSet.doc2Id, dataSet.emptyDoc1Id, dataSet.doc3Id );
+		dataSet = dataSetForAsc;
+		query = matchNonEmptyAndEmpty1Query( dataSet, f -> f.field( fieldPath ).asc()
 				.missing().use( getSingleValueForMissingUse( AFTER_DOCUMENT_3_ORDINAL ) ) );
 		assertThat( query )
-				.hasDocRefHitsExactOrder( index.typeName(), DOCUMENT_1, DOCUMENT_2, DOCUMENT_3, EMPTY_1 );
+				.hasDocRefHitsExactOrder( index.typeName(), dataSet.doc1Id, dataSet.doc2Id, dataSet.doc3Id, dataSet.emptyDoc1Id );
 	}
 
 	@Test
@@ -276,47 +301,52 @@ public class FieldSearchSortBaseIT<F> {
 	public void missingValue_explicit_multipleEmpty() {
 		assumeTestParametersWork();
 
+		DataSet<F> dataSet = dataSetForAsc; // We're only using ascending order
 		List<DocumentReference> docRefHits;
-		String fieldPathForAscendingOrderTests = getFieldPath( SortOrder.ASC );
+		String fieldPath = getFieldPath();
 
 		// using before 1 value
-		docRefHits = matchAllQuery( f -> f.field( fieldPathForAscendingOrderTests ).asc()
+		docRefHits = matchAllQuery( dataSet, f -> f.field( fieldPath ).asc()
 				.missing().use( getSingleValueForMissingUse( BEFORE_DOCUMENT_1_ORDINAL ) ) )
 				.fetchAllHits();
 		assertThat( docRefHits ).ordinals( 0, 1, 2, 3 )
-				.hasDocRefHitsAnyOrder( index.typeName(), EMPTY_1, EMPTY_2, EMPTY_3, EMPTY_4 );
-		assertThat( docRefHits ).ordinal( 4 ).isDocRefHit( index.typeName(), DOCUMENT_1 );
-		assertThat( docRefHits ).ordinal( 5 ).isDocRefHit( index.typeName(), DOCUMENT_2 );
-		assertThat( docRefHits ).ordinal( 6 ).isDocRefHit( index.typeName(), DOCUMENT_3 );
+				.hasDocRefHitsAnyOrder( index.typeName(), dataSet.emptyDoc1Id, dataSet.emptyDoc2Id,
+						dataSet.emptyDoc3Id, dataSet.emptyDoc4Id );
+		assertThat( docRefHits ).ordinal( 4 ).isDocRefHit( index.typeName(), dataSet.doc1Id );
+		assertThat( docRefHits ).ordinal( 5 ).isDocRefHit( index.typeName(), dataSet.doc2Id );
+		assertThat( docRefHits ).ordinal( 6 ).isDocRefHit( index.typeName(), dataSet.doc3Id );
 
 		// using between 1 and 2 value
-		docRefHits = matchAllQuery( f -> f.field( fieldPathForAscendingOrderTests ).asc()
+		docRefHits = matchAllQuery( dataSet, f -> f.field( fieldPath ).asc()
 				.missing().use( getSingleValueForMissingUse( BETWEEN_DOCUMENT_1_AND_2_ORDINAL ) ) )
 				.fetchAllHits();
-		assertThat( docRefHits ).ordinal( 0 ).isDocRefHit( index.typeName(), DOCUMENT_1 );
+		assertThat( docRefHits ).ordinal( 0 ).isDocRefHit( index.typeName(), dataSet.doc1Id );
 		assertThat( docRefHits ).ordinals( 1, 2, 3, 4 )
-				.hasDocRefHitsAnyOrder( index.typeName(), EMPTY_1, EMPTY_2, EMPTY_3, EMPTY_4 );
-		assertThat( docRefHits ).ordinal( 5 ).isDocRefHit( index.typeName(), DOCUMENT_2 );
-		assertThat( docRefHits ).ordinal( 6 ).isDocRefHit( index.typeName(), DOCUMENT_3 );
+				.hasDocRefHitsAnyOrder( index.typeName(), dataSet.emptyDoc1Id, dataSet.emptyDoc2Id,
+						dataSet.emptyDoc3Id, dataSet.emptyDoc4Id );
+		assertThat( docRefHits ).ordinal( 5 ).isDocRefHit( index.typeName(), dataSet.doc2Id );
+		assertThat( docRefHits ).ordinal( 6 ).isDocRefHit( index.typeName(), dataSet.doc3Id );
 
 		// using between 2 and 3 value
-		docRefHits = matchAllQuery( f -> f.field( fieldPathForAscendingOrderTests ).asc().missing()
-				.use( getSingleValueForMissingUse( BETWEEN_DOCUMENT_2_AND_3_ORDINAL ) ) )
+		docRefHits = matchAllQuery( dataSet, f -> f.field( fieldPath ).asc()
+				.missing().use( getSingleValueForMissingUse( BETWEEN_DOCUMENT_2_AND_3_ORDINAL ) ) )
 				.fetchAllHits();
-		assertThat( docRefHits ).ordinal( 0 ).isDocRefHit( index.typeName(), DOCUMENT_1 );
-		assertThat( docRefHits ).ordinal( 1 ).isDocRefHit( index.typeName(), DOCUMENT_2 );
+		assertThat( docRefHits ).ordinal( 0 ).isDocRefHit( index.typeName(), dataSet.doc1Id );
+		assertThat( docRefHits ).ordinal( 1 ).isDocRefHit( index.typeName(), dataSet.doc2Id );
 		assertThat( docRefHits ).ordinals( 2, 3, 4, 5 )
-				.hasDocRefHitsAnyOrder( index.typeName(), EMPTY_1, EMPTY_2, EMPTY_3, EMPTY_4 );
-		assertThat( docRefHits ).ordinal( 6 ).isDocRefHit( index.typeName(), DOCUMENT_3 );
+				.hasDocRefHitsAnyOrder( index.typeName(), dataSet.emptyDoc1Id, dataSet.emptyDoc2Id,
+						dataSet.emptyDoc3Id, dataSet.emptyDoc4Id );
+		assertThat( docRefHits ).ordinal( 6 ).isDocRefHit( index.typeName(), dataSet.doc3Id );
 
 		// using after 3 value
-		docRefHits = matchAllQuery( f -> f.field( fieldPathForAscendingOrderTests ).asc()
+		docRefHits = matchAllQuery( dataSet, f -> f.field( fieldPath ).asc()
 				.missing().use( getSingleValueForMissingUse( AFTER_DOCUMENT_3_ORDINAL ) ) ).fetchAllHits();
-		assertThat( docRefHits ).ordinal( 0 ).isDocRefHit( index.typeName(), DOCUMENT_1 );
-		assertThat( docRefHits ).ordinal( 1 ).isDocRefHit( index.typeName(), DOCUMENT_2 );
-		assertThat( docRefHits ).ordinal( 2 ).isDocRefHit( index.typeName(), DOCUMENT_3 );
+		assertThat( docRefHits ).ordinal( 0 ).isDocRefHit( index.typeName(), dataSet.doc1Id );
+		assertThat( docRefHits ).ordinal( 1 ).isDocRefHit( index.typeName(), dataSet.doc2Id );
+		assertThat( docRefHits ).ordinal( 2 ).isDocRefHit( index.typeName(), dataSet.doc3Id );
 		assertThat( docRefHits ).ordinals( 3, 4, 5, 6 )
-				.hasDocRefHitsAnyOrder( index.typeName(), EMPTY_1, EMPTY_2, EMPTY_3, EMPTY_4 );
+				.hasDocRefHitsAnyOrder( index.typeName(), dataSet.emptyDoc1Id, dataSet.emptyDoc2Id,
+						dataSet.emptyDoc3Id, dataSet.emptyDoc4Id );
 	}
 
 	@Test
@@ -324,82 +354,92 @@ public class FieldSearchSortBaseIT<F> {
 	public void missingValue_multipleEmpty_useExistingDocumentValue() {
 		assumeTestParametersWork();
 
+		DataSet<F> dataSet = dataSetForAsc; // We're only using ascending order
 		List<DocumentReference> docRefHits;
-		String fieldPathForAscendingOrderTests = getFieldPath( SortOrder.ASC );
+		String fieldPath = getFieldPath();
 
 		Object docValue1 = getSingleValueForMissingUse( DOCUMENT_1_ORDINAL );
 		Object docValue2 = getSingleValueForMissingUse( DOCUMENT_2_ORDINAL );
 		Object docValue3 = getSingleValueForMissingUse( DOCUMENT_3_ORDINAL );
 
 		// using doc 1 value
-		docRefHits = matchAllQuery( f -> f.field( fieldPathForAscendingOrderTests ).asc()
-				.missing().use( docValue1 ) ).fetchAllHits();
+		docRefHits = matchAllQuery( dataSet, f -> f.field( fieldPath ).asc()
+				.missing().use( docValue1 ) )
+				.fetchAllHits();
 		assertThat( docRefHits ).ordinals( 0, 1, 2, 3, 4 )
-				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1, EMPTY_1, EMPTY_2, EMPTY_3, EMPTY_4 );
-		assertThat( docRefHits ).ordinal( 5 ).isDocRefHit( index.typeName(), DOCUMENT_2 );
-		assertThat( docRefHits ).ordinal( 6 ).isDocRefHit( index.typeName(), DOCUMENT_3 );
+				.hasDocRefHitsAnyOrder( index.typeName(), dataSet.doc1Id, dataSet.emptyDoc1Id,
+						dataSet.emptyDoc2Id, dataSet.emptyDoc3Id, dataSet.emptyDoc4Id );
+		assertThat( docRefHits ).ordinal( 5 ).isDocRefHit( index.typeName(), dataSet.doc2Id );
+		assertThat( docRefHits ).ordinal( 6 ).isDocRefHit( index.typeName(), dataSet.doc3Id );
 
 		// using doc 2 value
-		docRefHits = matchAllQuery( f -> f.field( fieldPathForAscendingOrderTests ).asc()
-				.missing().use( docValue2 ) ).fetchAllHits();
-		assertThat( docRefHits ).ordinal( 0 ).isDocRefHit( index.typeName(), DOCUMENT_1 );
+		docRefHits = matchAllQuery( dataSet, f -> f.field( fieldPath ).asc()
+				.missing().use( docValue2 ) )
+				.fetchAllHits();
+		assertThat( docRefHits ).ordinal( 0 ).isDocRefHit( index.typeName(), dataSet.doc1Id );
 		assertThat( docRefHits ).ordinals( 1, 2, 3, 4, 5 )
-				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_2, EMPTY_1, EMPTY_2, EMPTY_3, EMPTY_4 );
-		assertThat( docRefHits ).ordinal( 6 ).isDocRefHit( index.typeName(), DOCUMENT_3 );
+				.hasDocRefHitsAnyOrder( index.typeName(), dataSet.doc2Id, dataSet.emptyDoc1Id,
+						dataSet.emptyDoc2Id, dataSet.emptyDoc3Id, dataSet.emptyDoc4Id );
+		assertThat( docRefHits ).ordinal( 6 ).isDocRefHit( index.typeName(), dataSet.doc3Id );
 
 		// using doc 3 value
-		docRefHits = matchAllQuery( f -> f.field( fieldPathForAscendingOrderTests ).asc()
-				.missing().use( docValue3 ) ).fetchAllHits();
-		assertThat( docRefHits ).ordinal( 0 ).isDocRefHit( index.typeName(), DOCUMENT_1 );
-		assertThat( docRefHits ).ordinal( 1 ).isDocRefHit( index.typeName(), DOCUMENT_2 );
+		docRefHits = matchAllQuery( dataSet, f -> f.field( fieldPath ).asc()
+				.missing().use( docValue3 ) )
+				.fetchAllHits();
+		assertThat( docRefHits ).ordinal( 0 ).isDocRefHit( index.typeName(), dataSet.doc1Id );
+		assertThat( docRefHits ).ordinal( 1 ).isDocRefHit( index.typeName(), dataSet.doc2Id );
 		assertThat( docRefHits ).ordinals( 2, 3, 4, 5, 6 )
-				.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_3, EMPTY_1, EMPTY_2, EMPTY_3, EMPTY_4 );
+				.hasDocRefHitsAnyOrder( index.typeName(), dataSet.doc3Id, dataSet.emptyDoc1Id,
+						dataSet.emptyDoc2Id, dataSet.emptyDoc3Id, dataSet.emptyDoc4Id );
 	}
 
-	private SearchQuery<DocumentReference> matchNonEmptyQuery(
+	private SearchQuery<DocumentReference> matchNonEmptyQuery(DataSet<F> dataSet,
 			Function<? super SearchSortFactory, ? extends FieldSortOptionsStep<?, ?>> sortContributor) {
-		return matchNonEmptyQuery( sortContributor, index.createScope() );
+		return matchNonEmptyQuery( dataSet, sortContributor, index.createScope() );
 	}
 
-	private SearchQuery<DocumentReference> matchNonEmptyQuery(
+	private SearchQuery<DocumentReference> matchNonEmptyQuery(DataSet<F> dataSet,
 			Function<? super SearchSortFactory, ? extends FieldSortOptionsStep<?, ?>> sortContributor, StubMappingScope scope) {
 		return query(
-				f -> f.matchAll().except( f.id().matchingAny( Arrays.asList( EMPTY_1, EMPTY_2, EMPTY_3, EMPTY_4 ) ) ),
+				dataSet,
+				f -> f.matchAll().except( f.id().matchingAny( Arrays.asList( dataSet.emptyDoc1Id, dataSet.emptyDoc2Id, dataSet.emptyDoc3Id, dataSet.emptyDoc4Id ) ) ),
 				sortContributor,
 				scope
 		);
 	}
 
-	private SearchQuery<DocumentReference> matchNonEmptyAndEmpty1Query(
+	private SearchQuery<DocumentReference> matchNonEmptyAndEmpty1Query(DataSet<F> dataSet,
 			Function<? super SearchSortFactory, ? extends FieldSortOptionsStep<?, ?>> sortContributor) {
-		return matchNonEmptyAndEmpty1Query( sortContributor, index.createScope() );
+		return matchNonEmptyAndEmpty1Query( dataSet, sortContributor, index.createScope() );
 	}
 
-	private SearchQuery<DocumentReference> matchNonEmptyAndEmpty1Query(
+	private SearchQuery<DocumentReference> matchNonEmptyAndEmpty1Query(DataSet<F> dataSet,
 			Function<? super SearchSortFactory, ? extends FieldSortOptionsStep<?, ?>> sortContributor, StubMappingScope scope) {
 		return query(
-				f -> f.matchAll().except( f.id().matchingAny( Arrays.asList( EMPTY_2, EMPTY_3, EMPTY_4 ) ) ),
+				dataSet,
+				f -> f.matchAll().except( f.id().matchingAny( Arrays.asList( dataSet.emptyDoc2Id, dataSet.emptyDoc3Id, dataSet.emptyDoc4Id ) ) ),
 				sortContributor,
 				scope
 		);
 	}
 
-	private SearchQuery<DocumentReference> matchAllQuery(
+	private SearchQuery<DocumentReference> matchAllQuery(DataSet<F> dataSet,
 			Function<? super SearchSortFactory, ? extends FieldSortOptionsStep<?, ?>> sortContributor) {
-		return matchAllQuery( sortContributor, index.createScope() );
+		return matchAllQuery( dataSet, sortContributor, index.createScope() );
 	}
 
-	private SearchQuery<DocumentReference> matchAllQuery(
+	private SearchQuery<DocumentReference> matchAllQuery(DataSet<F> dataSet,
 			Function<? super SearchSortFactory, ? extends FieldSortOptionsStep<?, ?>> sortContributor, StubMappingScope scope) {
-		return query( f -> f.matchAll(), sortContributor, scope );
+		return query( dataSet, f -> f.matchAll(), sortContributor, scope );
 	}
 
-	private SearchQuery<DocumentReference> query(
+	private SearchQuery<DocumentReference> query(DataSet<F> dataSet,
 			Function<? super SearchPredicateFactory, ? extends PredicateFinalStep> predicateContributor,
 			Function<? super SearchSortFactory, ? extends FieldSortOptionsStep<?, ?>> sortContributor,
 			StubMappingScope scope) {
 		return scope.query()
 				.where( predicateContributor )
+				.routing( dataSet.routingKey )
 				.sort( sortContributor.andThen( this::applySortMode ).andThen( this::applyFilter ) )
 				.toQuery();
 	}
@@ -416,7 +456,7 @@ public class FieldSearchSortBaseIT<F> {
 	private FieldSortOptionsStep<?, ?> applyFilter(FieldSortOptionsStep<?, ?> optionsStep) {
 		if ( fieldStructure.isInNested() ) {
 			return optionsStep.filter( f -> f.match()
-					.field( getFieldPath( parent -> "discriminator" ) )
+					.field( index.binding().getDiscriminatorFieldPath( fieldStructure ) )
 					.matching( "included" ) );
 		}
 		else {
@@ -432,20 +472,20 @@ public class FieldSearchSortBaseIT<F> {
 		Assume.assumeTrue(
 				"This combination is buggy with this backend",
 				TckConfiguration.get().getBackendFeatures()
-						.sortByFieldValue( fieldStructure, fieldTypeDescriptor.getJavaType(), sortMode )
+						.sortByFieldValue( fieldStructure, fieldType.getJavaType(), sortMode )
 		);
 	}
 
 	private boolean isSumOrAvgOrMedianWithStringField() {
 		return EnumSet.of( SortMode.SUM, SortMode.AVG, SortMode.MEDIAN ).contains( sortMode )
-				&& String.class.equals( fieldTypeDescriptor.getJavaType() );
+				&& String.class.equals( fieldType.getJavaType() );
 	}
 
 	private boolean isSumWithTemporalField() {
 		return SortMode.SUM.equals( sortMode )
 				&& (
-						Temporal.class.isAssignableFrom( fieldTypeDescriptor.getJavaType() )
-						|| MonthDay.class.equals( fieldTypeDescriptor.getJavaType() )
+						Temporal.class.isAssignableFrom( fieldType.getJavaType() )
+						|| MonthDay.class.equals( fieldType.getJavaType() )
 				);
 	}
 
@@ -454,173 +494,15 @@ public class FieldSearchSortBaseIT<F> {
 				&& fieldStructure.isInNested();
 	}
 
-	private String getFieldPath(SortOrder expectedOrder) {
-		return getFieldPath( parentMapping -> getRelativeFieldName( parentMapping, expectedOrder ) );
-	}
-
-	private String getFieldPath(Function<AbstractObjectMapping, String> relativeFieldNameFunction) {
-		switch ( fieldStructure.location ) {
-			case ROOT:
-				return relativeFieldNameFunction.apply( index.binding() );
-			case IN_FLATTENED:
-				return index.binding().flattenedObject.relativeFieldName
-						+ "." + relativeFieldNameFunction.apply( index.binding().flattenedObject );
-			case IN_NESTED:
-				return index.binding().nestedObject.relativeFieldName
-						+ "." + relativeFieldNameFunction.apply( index.binding().nestedObject );
-			case IN_NESTED_TWICE:
-				return index.binding().nestedObject.relativeFieldName
-						+ "." + index.binding().nestedObject.nestedObject.relativeFieldName
-						+ "." + relativeFieldNameFunction.apply( index.binding().nestedObject.nestedObject );
-			default:
-				throw new IllegalStateException( "Unexpected value: " + fieldStructure.location );
-		}
-	}
-
-	private String getRelativeFieldName(AbstractObjectMapping mapping, SortOrder expectedOrder) {
-		return getFieldModelsByType( mapping, expectedOrder ).get( fieldTypeDescriptor ).relativeFieldName;
-	}
-
-	private SimpleFieldModelsByType getFieldModelsByType(AbstractObjectMapping mapping, SortOrder expectedOrder) {
-		if ( fieldStructure.isSingleValued() ) {
-			return mapping.fieldWithSingleValueModels;
-		}
-		else {
-			// We must chose the field carefuly so that documents are in the expected order for the configured sort mode.
-			if ( sortMode == null ) {
-				// Default sort mode: min in ascending order, max in descending order
-				switch ( expectedOrder ) {
-					case ASC:
-						return mapping.fieldWithAscendingMinModels;
-					case DESC:
-						return mapping.fieldWithAscendingMaxModels;
-					default:
-						throw new IllegalStateException( "Unexpected sort order: " + expectedOrder );
-				}
-			}
-			else {
-				switch ( sortMode ) {
-					case SUM:
-						return mapping.fieldWithAscendingSumModels;
-					case MIN:
-						return mapping.fieldWithAscendingMinModels;
-					case MAX:
-						return mapping.fieldWithAscendingMaxModels;
-					case AVG:
-						return mapping.fieldWithAscendingAvgModels;
-					case MEDIAN:
-						return mapping.fieldWithAscendingMedianModels;
-					default:
-						throw new IllegalStateException( "Unexpected sort mode: " + sortMode );
-				}
-			}
-		}
-	}
-
-	private static void initDocument(IndexBinding indexBinding, DocumentElement document, Integer ordinal) {
-		initAllFields( indexBinding, document, ordinal );
-
-		DocumentElement flattenedObject = document.addObject( indexBinding.flattenedObject.self );
-		initAllFields( indexBinding.flattenedObject, flattenedObject, ordinal );
-
-		// The nested object is split into four objects:
-		// the first two are included by the filter and each hold part of the values that will be sorted on,
-		// and the last two are excluded by the filter and hold garbage values that, if they were taken into account,
-		// would mess with the sort order and eventually fail at least *some* tests.
-
-		DocumentElement nestedObject0 = document.addObject( indexBinding.nestedObject.self );
-		nestedObject0.addValue( indexBinding.nestedObject.discriminator, "included" );
-		initAllFields( indexBinding.nestedObject, nestedObject0, ordinal, ValueSelection.FIRST_PARTITION );
-
-		DocumentElement nestedObject1 = document.addObject( indexBinding.nestedObject.self );
-		nestedObject1.addValue( indexBinding.nestedObject.discriminator, "included" );
-		initAllFields( indexBinding.nestedObject, nestedObject1, ordinal, ValueSelection.SECOND_PARTITION );
-
-		DocumentElement nestedObject2 = document.addObject( indexBinding.nestedObject.self );
-		nestedObject2.addValue( indexBinding.nestedObject.discriminator, "excluded" );
-		initAllFields( indexBinding.nestedObject, nestedObject2, ordinal == null ? null : ordinal - 1 );
-
-		DocumentElement nestedObject3 = document.addObject( indexBinding.nestedObject.self );
-		nestedObject3.addValue( indexBinding.nestedObject.discriminator, "excluded" );
-		initAllFields( indexBinding.nestedObject, nestedObject3, ordinal == null ? null : ordinal + 1 );
-
-		// Same for the second level of nesting
-
-		DocumentElement nestedNestedObject0 = nestedObject0.addObject( indexBinding.nestedObject.nestedObject.self );
-		nestedNestedObject0.addValue( indexBinding.nestedObject.nestedObject.discriminator, "included" );
-		initAllFields( indexBinding.nestedObject.nestedObject, nestedNestedObject0, ordinal, ValueSelection.FIRST_PARTITION );
-
-		DocumentElement nestedNestedObject1 = nestedObject1.addObject( indexBinding.nestedObject.nestedObject.self );
-		nestedNestedObject1.addValue( indexBinding.nestedObject.nestedObject.discriminator, "included" );
-		initAllFields( indexBinding.nestedObject.nestedObject, nestedNestedObject1, ordinal, ValueSelection.SECOND_PARTITION );
-
-		DocumentElement nestedNestedObject2 = nestedObject0.addObject( indexBinding.nestedObject.nestedObject.self );
-		nestedNestedObject2.addValue( indexBinding.nestedObject.nestedObject.discriminator, "excluded" );
-		initAllFields( indexBinding.nestedObject.nestedObject, nestedNestedObject2, ordinal == null ? null : ordinal - 1 );
-
-		DocumentElement nestedNestedObject3 = nestedObject1.addObject( indexBinding.nestedObject.nestedObject.self );
-		nestedNestedObject3.addValue( indexBinding.nestedObject.nestedObject.discriminator, "excluded" );
-		initAllFields( indexBinding.nestedObject.nestedObject, nestedNestedObject3, ordinal == null ? null : ordinal + 1 );
-	}
-
-	private static void initAllFields(AbstractObjectMapping mapping, DocumentElement document, Integer ordinal) {
-		initAllFields( mapping, document, ordinal, ValueSelection.ALL );
-	}
-
-	private static void initAllFields(AbstractObjectMapping mapping, DocumentElement document, Integer ordinal,
-			ValueSelection valueSelection) {
-		if ( EnumSet.of( ValueSelection.ALL, ValueSelection.FIRST_PARTITION ).contains( valueSelection ) ) {
-			mapping.fieldWithSingleValueModels.forEach(
-					fieldModel -> addSingleValue( fieldModel, document, ordinal )
-			);
-		}
-
-		Integer startIndexForMultiValued;
-		Integer endIndexForMultiValued;
-
-		switch ( valueSelection ) {
-			case FIRST_PARTITION:
-				startIndexForMultiValued = 0;
-				endIndexForMultiValued = 1;
-				break;
-			case SECOND_PARTITION:
-				startIndexForMultiValued = 1;
-				endIndexForMultiValued = null;
-				break;
-			case ALL:
-			default:
-				startIndexForMultiValued = null;
-				endIndexForMultiValued = null;
-				break;
-		}
-
-		mapping.fieldWithAscendingMinModels.forEach(
-				fieldModel -> addMultipleValues( fieldModel, document, SortMode.MIN, ordinal,
-						startIndexForMultiValued, endIndexForMultiValued )
-		);
-		mapping.fieldWithAscendingMaxModels.forEach(
-				fieldModel -> addMultipleValues( fieldModel, document, SortMode.MAX, ordinal,
-						startIndexForMultiValued, endIndexForMultiValued )
-		);
-		mapping.fieldWithAscendingSumModels.forEach(
-				fieldModel -> addMultipleValues( fieldModel, document, SortMode.SUM, ordinal,
-						startIndexForMultiValued, endIndexForMultiValued )
-		);
-		mapping.fieldWithAscendingAvgModels.forEach(
-				fieldModel -> addMultipleValues( fieldModel, document, SortMode.AVG, ordinal,
-						startIndexForMultiValued, endIndexForMultiValued )
-		);
-		mapping.fieldWithAscendingMedianModels.forEach(
-				fieldModel -> addMultipleValues( fieldModel, document, SortMode.MEDIAN, ordinal,
-						startIndexForMultiValued, endIndexForMultiValued )
-		);
+	private String getFieldPath() {
+		return index.binding().getFieldPath( fieldStructure, fieldType );
 	}
 
 	@SuppressWarnings("unchecked")
 	private F getSingleValueForMissingUse(int ordinal) {
-		F value = fieldTypeDescriptor.getAscendingUniqueTermValues().getSingle().get( ordinal );
+		F value = fieldType.getAscendingUniqueTermValues().getSingle().get( ordinal );
 
-		if ( fieldTypeDescriptor instanceof NormalizedStringFieldTypeDescriptor
+		if ( fieldType instanceof NormalizedStringFieldTypeDescriptor
 				&& !TckConfiguration.get().getBackendFeatures().normalizesStringMissingValues() ) {
 			// The backend doesn't normalize missing value replacements automatically, we have to do it ourselves
 			// TODO HSEARCH-3387 Remove this once all backends correctly normalize missing value replacements
@@ -630,154 +512,98 @@ public class FieldSearchSortBaseIT<F> {
 		return value;
 	}
 
-	private static <F> void addSingleValue(SimpleFieldModel<F> fieldModel, DocumentElement documentElement, Integer ordinal) {
-		if ( ordinal == null ) {
-			return;
-		}
-		documentElement.addValue(
-				fieldModel.reference,
-				fieldModel.typeDescriptor.getAscendingUniqueTermValues().getSingle().get( ordinal )
-		);
-	}
+	private static class DataSet<F> {
+		private final TestedFieldStructure fieldStructure;
+		private final FieldTypeDescriptor<F> fieldType;
+		private final SortMode expectedSortMode;
+		private final String routingKey;
 
-	private static <F> void addMultipleValues(SimpleFieldModel<F> fieldModel, DocumentElement documentElement,
-			SortMode sortMode, Integer ordinal,
-			Integer startIndex, Integer endIndex) {
-		if ( ordinal == null ) {
-			return;
-		}
-		List<F> values = fieldModel.typeDescriptor.getAscendingUniqueTermValues().getMultiResultingInSingle( sortMode )
-				.get( ordinal );
-		if ( values.isEmpty() ) {
-			return;
-		}
-		if ( startIndex == null ) {
-			startIndex = 0;
-		}
-		if ( endIndex == null ) {
-			endIndex = values.size();
-		}
-		for ( int i = startIndex; i < endIndex; i++ ) {
-			documentElement.addValue( fieldModel.reference, values.get( i ) );
-		}
-	}
+		private final String doc1Id;
+		private final String doc2Id;
+		private final String doc3Id;
 
-	private static void initData() {
-		index.bulkIndexer()
+		private final String emptyDoc1Id;
+		private final String emptyDoc2Id;
+		private final String emptyDoc3Id;
+		private final String emptyDoc4Id;
+
+		private DataSet(TestedFieldStructure fieldStructure, FieldTypeDescriptor<F> fieldType, SortMode sortModeOrNull,
+				SortMode expectedSortMode) {
+			this.fieldStructure = fieldStructure;
+			this.fieldType = fieldType;
+			this.expectedSortMode = expectedSortMode;
+			this.routingKey = fieldType.getUniqueName() + "_" + fieldStructure.getUniqueName()
+					+ "_" + sortModeOrNull + "_" + expectedSortMode;
+			this.doc1Id = docId( 1 );
+			this.doc2Id = docId( 2 );
+			this.doc3Id = docId( 3 );
+			this.emptyDoc1Id = emptyDocId( 1 );
+			this.emptyDoc2Id = emptyDocId( 2 );
+			this.emptyDoc3Id = emptyDocId( 3 );
+			this.emptyDoc4Id = emptyDocId( 4 );
+		}
+
+		private String docId(int docNumber) {
+			return routingKey + "_doc_" + docNumber;
+		}
+
+		private String emptyDocId(int docNumber) {
+			return routingKey + "_emptyDoc_" + docNumber;
+		}
+
+		private void contribute(BulkIndexer indexer) {
+			if ( fieldStructure.isSingleValued() ) {
+				List<F> values = fieldType.getAscendingUniqueTermValues().getSingle();
 				// Important: do not index the documents in the expected order after sorts (1, 2, 3)
-				.add( EMPTY_4, document -> initDocument( index.binding(), document, null ) )
-				.add( DOCUMENT_2, document -> initDocument( index.binding(), document, DOCUMENT_2_ORDINAL ) )
-				.add( EMPTY_1, document -> initDocument( index.binding(), document, null ) )
-				.add( DOCUMENT_1, document -> initDocument( index.binding(), document, DOCUMENT_1_ORDINAL ) )
-				.add( EMPTY_2, document -> initDocument( index.binding(), document, null ) )
-				.add( DOCUMENT_3, document -> initDocument( index.binding(), document, DOCUMENT_3_ORDINAL ) )
-				.add( EMPTY_3, document -> initDocument( index.binding(), document, null ) )
-				.join();
-	}
-
-	private static class AbstractObjectMapping {
-		final SimpleFieldModelsByType fieldWithSingleValueModels;
-		final SimpleFieldModelsByType fieldWithAscendingSumModels;
-		final SimpleFieldModelsByType fieldWithAscendingMinModels;
-		final SimpleFieldModelsByType fieldWithAscendingMaxModels;
-		final SimpleFieldModelsByType fieldWithAscendingAvgModels;
-		final SimpleFieldModelsByType fieldWithAscendingMedianModels;
-
-		AbstractObjectMapping(IndexSchemaElement self,
-				Consumer<StandardIndexFieldTypeOptionsStep<?, ?>> additionalConfiguration) {
-			fieldWithSingleValueModels = SimpleFieldModelsByType.mapAll( supportedTypeDescriptors(), self,
-					"single_", c -> c.sortable( Sortable.YES ), additionalConfiguration );
-			fieldWithAscendingSumModels = SimpleFieldModelsByType.mapAllMultiValued( supportedTypeDescriptors(), self,
-					"multi_ascendingsum_", c -> c.sortable( Sortable.YES ), additionalConfiguration );
-			fieldWithAscendingMinModels = SimpleFieldModelsByType.mapAllMultiValued( supportedTypeDescriptors(), self,
-					"multi_ascendingmin_", c -> c.sortable( Sortable.YES ), additionalConfiguration );
-			fieldWithAscendingMaxModels = SimpleFieldModelsByType.mapAllMultiValued( supportedTypeDescriptors(), self,
-					"multi_ascendingmax_", c -> c.sortable( Sortable.YES ), additionalConfiguration );
-			fieldWithAscendingAvgModels = SimpleFieldModelsByType.mapAllMultiValued( supportedTypeDescriptors(), self,
-					"multi_ascendingavg_", c -> c.sortable( Sortable.YES ), additionalConfiguration );
-			fieldWithAscendingMedianModels = SimpleFieldModelsByType.mapAllMultiValued( supportedTypeDescriptors(), self,
-					"multi_ascendingmedian_", c -> c.sortable( Sortable.YES ), additionalConfiguration );
-		}
-	}
-
-	private static class IndexBinding extends AbstractObjectMapping {
-		final FirstLevelObjectMapping flattenedObject;
-		final FirstLevelObjectMapping nestedObject;
-
-		IndexBinding(IndexSchemaElement root) {
-			this( root, ignored -> { } );
-		}
-
-		IndexBinding(IndexSchemaElement root,
-				Consumer<StandardIndexFieldTypeOptionsStep<?, ?>> additionalConfiguration) {
-			super( root, additionalConfiguration );
-
-			flattenedObject = FirstLevelObjectMapping.create( root, "flattenedObject",
-					ObjectFieldStorage.FLATTENED, false, additionalConfiguration );
-			nestedObject = FirstLevelObjectMapping.create( root, "nestedObject",
-					ObjectFieldStorage.NESTED, true, additionalConfiguration );
-		}
-	}
-
-	private static class FirstLevelObjectMapping extends AbstractObjectMapping {
-		final String relativeFieldName;
-		final IndexObjectFieldReference self;
-
-		final IndexFieldReference<String> discriminator;
-
-		final SecondLevelObjectMapping nestedObject;
-
-		public static FirstLevelObjectMapping create(IndexSchemaElement parent, String relativeFieldName,
-				ObjectFieldStorage storage,
-				boolean multiValued,
-				Consumer<StandardIndexFieldTypeOptionsStep<?, ?>> additionalConfiguration) {
-			IndexSchemaObjectField objectField = parent.objectField( relativeFieldName, storage );
-			if ( multiValued ) {
-				objectField.multiValued();
+				indexer.add( documentProvider( emptyDoc4Id, routingKey,
+						document -> index.binding().initSingleValued( fieldType, fieldStructure.location,
+								document, null, null ) ) );
+				indexer.add( documentProvider( doc2Id, routingKey,
+						document -> index.binding().initSingleValued( fieldType, fieldStructure.location,
+								document, values.get( DOCUMENT_2_ORDINAL ), values.get( DOCUMENT_3_ORDINAL ) ) ) );
+				indexer.add( documentProvider( emptyDoc1Id, routingKey,
+						document -> index.binding().initSingleValued( fieldType, fieldStructure.location,
+								document, null, null ) ) );
+				indexer.add( documentProvider( doc1Id, routingKey,
+						document -> index.binding().initSingleValued( fieldType, fieldStructure.location,
+								document, values.get( DOCUMENT_1_ORDINAL ), values.get( DOCUMENT_2_ORDINAL ) ) ) );
+				indexer.add( documentProvider( emptyDoc2Id, routingKey,
+						document -> index.binding().initSingleValued( fieldType, fieldStructure.location,
+								document, null, null ) ) );
+				indexer.add( documentProvider( doc3Id, routingKey,
+						document -> index.binding().initSingleValued( fieldType, fieldStructure.location,
+								document, values.get( DOCUMENT_3_ORDINAL ), values.get( DOCUMENT_1_ORDINAL ) ) ) );
+				indexer.add( documentProvider( emptyDoc3Id, routingKey,
+						document -> index.binding().initSingleValued( fieldType, fieldStructure.location,
+								document, null, null ) ) );
 			}
-			return new FirstLevelObjectMapping( relativeFieldName, objectField, additionalConfiguration );
-		}
-
-		private FirstLevelObjectMapping(String relativeFieldName, IndexSchemaObjectField objectField,
-				Consumer<StandardIndexFieldTypeOptionsStep<?, ?>> additionalConfiguration) {
-			super( objectField, additionalConfiguration );
-			this.relativeFieldName = relativeFieldName;
-			self = objectField.toReference();
-
-			discriminator = objectField.field( "discriminator", f -> f.asString() ).toReference();
-
-			nestedObject = SecondLevelObjectMapping.create( objectField, "nestedObject",
-					ObjectFieldStorage.NESTED, additionalConfiguration );
-		}
-	}
-
-	private static class SecondLevelObjectMapping extends AbstractObjectMapping {
-		final String relativeFieldName;
-		final IndexObjectFieldReference self;
-
-		final IndexFieldReference<String> discriminator;
-
-		public static SecondLevelObjectMapping create(IndexSchemaElement parent, String relativeFieldName,
-				ObjectFieldStorage storage,
-				Consumer<StandardIndexFieldTypeOptionsStep<?, ?>> additionalConfiguration) {
-			IndexSchemaObjectField objectField = parent.objectField( relativeFieldName, storage );
-			objectField.multiValued();
-			return new SecondLevelObjectMapping( relativeFieldName, objectField, additionalConfiguration );
-		}
-
-		private SecondLevelObjectMapping(String relativeFieldName, IndexSchemaObjectField objectField,
-				Consumer<StandardIndexFieldTypeOptionsStep<?, ?>> additionalConfiguration) {
-			super( objectField, additionalConfiguration );
-			this.relativeFieldName = relativeFieldName;
-			self = objectField.toReference();
-
-			discriminator = objectField.field( "discriminator", f -> f.asString() ).toReference();
+			else {
+				List<List<F>> values = fieldType.getAscendingUniqueTermValues()
+						.getMultiResultingInSingle( expectedSortMode );
+				// Important: do not index the documents in the expected order after sorts (1, 2, 3)
+				indexer.add( documentProvider( emptyDoc4Id, routingKey,
+						document -> index.binding().initSingleValued( fieldType, fieldStructure.location,
+								document, null, null ) ) );
+				indexer.add( documentProvider( doc2Id, routingKey,
+						document -> index.binding().initMultiValued( fieldType, fieldStructure.location,
+								document, values.get( DOCUMENT_2_ORDINAL ), values.get( DOCUMENT_3_ORDINAL ) ) ) );
+				indexer.add( documentProvider( emptyDoc1Id, routingKey,
+						document -> index.binding().initSingleValued( fieldType, fieldStructure.location,
+								document, null, null ) ) );
+				indexer.add( documentProvider( doc1Id, routingKey,
+						document -> index.binding().initMultiValued( fieldType, fieldStructure.location,
+								document, values.get( DOCUMENT_1_ORDINAL ), values.get( DOCUMENT_2_ORDINAL ) ) ) );
+				indexer.add( documentProvider( emptyDoc2Id, routingKey,
+						document -> index.binding().initSingleValued( fieldType, fieldStructure.location,
+								document, null, null ) ) );
+				indexer.add( documentProvider( doc3Id, routingKey,
+						document -> index.binding().initMultiValued( fieldType, fieldStructure.location,
+								document, values.get( DOCUMENT_3_ORDINAL ), values.get( DOCUMENT_1_ORDINAL ) ) ) );
+				indexer.add( documentProvider( emptyDoc3Id, routingKey,
+						document -> index.binding().initSingleValued( fieldType, fieldStructure.location,
+								document, null, null ) ) );
+			}
 		}
 	}
 
-	private enum ValueSelection {
-		FIRST_PARTITION,
-		SECOND_PARTITION,
-		ALL
-	}
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSearchSortTypeCheckingAndConversionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSearchSortTypeCheckingAndConversionIT.java
@@ -19,7 +19,6 @@ import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.types.Sortable;
-import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeFactory;
 import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeOptionsStep;
 import org.hibernate.search.engine.reporting.spi.EventContexts;
 import org.hibernate.search.engine.search.common.ValueConvert;
@@ -32,7 +31,6 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.util.Expecta
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.InvalidType;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.SimpleFieldModel;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.SimpleFieldModelsByType;
-import org.hibernate.search.integrationtest.backend.tck.testsupport.util.StandardFieldMapper;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConfiguration;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.ValueWrapper;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
@@ -41,13 +39,14 @@ import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.BulkIndexer;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
-import org.assertj.core.api.Assertions;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import org.assertj.core.api.Assertions;
 
 /**
  * Tests behavior related to type checking and type conversion of DSL arguments
@@ -437,39 +436,17 @@ public class FieldSearchSortTypeCheckingAndConversionIT<F> {
 	private static class IncompatibleIndexBinding {
 		IncompatibleIndexBinding(IndexSchemaElement root) {
 			/*
-			 * Add fields with the same name as the supportedFieldModels from IndexBinding,
+			 * Add fields with the same name as the fieldModels from IndexBinding,
 			 * but with an incompatible type.
 			 */
 			mapFieldsWithIncompatibleType( root );
 		}
 
 		private static void mapFieldsWithIncompatibleType(IndexSchemaElement parent) {
-			supportedTypeDescriptors().forEach( typeDescriptor -> {
-				StandardFieldMapper<?, IncompatibleFieldModel> mapper;
-				if ( Integer.class.equals( typeDescriptor.getJavaType() ) ) {
-					mapper = IncompatibleFieldModel.mapper( context -> context.asLong() );
-				}
-				else {
-					mapper = IncompatibleFieldModel.mapper( context -> context.asInteger() );
-				}
-				mapper.map( parent, "" + typeDescriptor.getUniqueName() );
-			} );
-		}
-	}
-
-	private static class IncompatibleFieldModel {
-		static <F> StandardFieldMapper<F, IncompatibleFieldModel> mapper(
-				Function<IndexFieldTypeFactory, StandardIndexFieldTypeOptionsStep<?, F>> configuration) {
-			return StandardFieldMapper.of(
-					configuration,
-					(reference, name) -> new IncompatibleFieldModel( name )
+			supportedTypeDescriptors().forEach( typeDescriptor ->
+					SimpleFieldModel.mapper( FieldTypeDescriptor.getIncompatible( typeDescriptor ) )
+							.map( parent, "" + typeDescriptor.getUniqueName() )
 			);
-		}
-
-		final String relativeFieldName;
-
-		private IncompatibleFieldModel(String relativeFieldName) {
-			this.relativeFieldName = relativeFieldName;
 		}
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/model/singlefield/AbstractObjectBinding.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/model/singlefield/AbstractObjectBinding.java
@@ -1,0 +1,41 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.tck.testsupport.model.singlefield;
+
+import java.util.Collection;
+import java.util.function.Consumer;
+
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeOptionsStep;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldTypeDescriptor;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.SimpleFieldModelsByType;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TestedFieldStructure;
+
+public class AbstractObjectBinding {
+	public final SimpleFieldModelsByType fieldWithSingleValueModels;
+	public final SimpleFieldModelsByType fieldWithMultipleValuesModels;
+
+	AbstractObjectBinding(IndexSchemaElement self, Collection<? extends FieldTypeDescriptor<?>> supportedFieldTypes,
+			Consumer<StandardIndexFieldTypeOptionsStep<?, ?>> additionalConfiguration) {
+		fieldWithSingleValueModels = SimpleFieldModelsByType.mapAll( supportedFieldTypes, self,
+				"", additionalConfiguration );
+		fieldWithMultipleValuesModels = SimpleFieldModelsByType.mapAllMultiValued( supportedFieldTypes, self,
+				"multiValued_", additionalConfiguration );
+	}
+
+	protected final String getRelativeFieldName(TestedFieldStructure fieldStructure, FieldTypeDescriptor<?> fieldType) {
+		SimpleFieldModelsByType fieldModelsByType;
+		if ( fieldStructure.isSingleValued() ) {
+			fieldModelsByType = fieldWithSingleValueModels;
+		}
+		else {
+			fieldModelsByType = fieldWithMultipleValuesModels;
+		}
+		return fieldModelsByType.get( fieldType ).relativeFieldName;
+	}
+
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/model/singlefield/FirstLevelObjectBinding.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/model/singlefield/FirstLevelObjectBinding.java
@@ -1,0 +1,52 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.tck.testsupport.model.singlefield;
+
+import java.util.Collection;
+import java.util.function.Consumer;
+
+import org.hibernate.search.engine.backend.document.IndexFieldReference;
+import org.hibernate.search.engine.backend.document.IndexObjectFieldReference;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectField;
+import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
+import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeOptionsStep;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldTypeDescriptor;
+
+public class FirstLevelObjectBinding extends AbstractObjectBinding {
+	public final String relativeFieldName;
+	public final IndexObjectFieldReference self;
+
+	public final IndexFieldReference<String> discriminator;
+
+	public final SecondLevelObjectBinding nestedObject;
+
+	public static FirstLevelObjectBinding create(IndexSchemaElement parent, String relativeFieldName,
+			ObjectFieldStorage storage, boolean multiValued,
+			Collection<? extends FieldTypeDescriptor<?>> supportedFieldTypes,
+			Consumer<StandardIndexFieldTypeOptionsStep<?, ?>> additionalConfiguration) {
+		IndexSchemaObjectField objectField = parent.objectField( relativeFieldName, storage );
+		if ( multiValued ) {
+			objectField.multiValued();
+		}
+		return new FirstLevelObjectBinding( relativeFieldName, objectField,
+				supportedFieldTypes, additionalConfiguration );
+	}
+
+	FirstLevelObjectBinding(String relativeFieldName, IndexSchemaObjectField objectField,
+			Collection<? extends FieldTypeDescriptor<?>> supportedFieldTypes,
+			Consumer<StandardIndexFieldTypeOptionsStep<?, ?>> additionalConfiguration) {
+		super( objectField, supportedFieldTypes, additionalConfiguration );
+		this.relativeFieldName = relativeFieldName;
+		self = objectField.toReference();
+		discriminator = objectField.field( "discriminator", f -> f.asString() ).toReference();
+		nestedObject = SecondLevelObjectBinding.create(
+				objectField, "nestedObject", ObjectFieldStorage.NESTED,
+				supportedFieldTypes, additionalConfiguration
+		);
+	}
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/model/singlefield/SecondLevelObjectBinding.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/model/singlefield/SecondLevelObjectBinding.java
@@ -1,0 +1,43 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.tck.testsupport.model.singlefield;
+
+import java.util.Collection;
+import java.util.function.Consumer;
+
+import org.hibernate.search.engine.backend.document.IndexFieldReference;
+import org.hibernate.search.engine.backend.document.IndexObjectFieldReference;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectField;
+import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
+import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeOptionsStep;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldTypeDescriptor;
+
+public class SecondLevelObjectBinding extends AbstractObjectBinding {
+	public final String relativeFieldName;
+	public final IndexObjectFieldReference self;
+
+	public final IndexFieldReference<String> discriminator;
+
+	public static SecondLevelObjectBinding create(IndexSchemaElement parent, String relativeFieldName,
+			ObjectFieldStorage storage, Collection<? extends FieldTypeDescriptor<?>> supportedFieldTypes,
+			Consumer<StandardIndexFieldTypeOptionsStep<?, ?>> additionalConfiguration) {
+		IndexSchemaObjectField objectField = parent.objectField( relativeFieldName, storage );
+		objectField.multiValued();
+		return new SecondLevelObjectBinding( relativeFieldName, objectField,
+				supportedFieldTypes, additionalConfiguration );
+	}
+
+	SecondLevelObjectBinding(String relativeFieldName, IndexSchemaObjectField objectField,
+			Collection<? extends FieldTypeDescriptor<?>> supportedFieldTypes,
+			Consumer<StandardIndexFieldTypeOptionsStep<?, ?>> additionalConfiguration) {
+		super( objectField, supportedFieldTypes, additionalConfiguration );
+		this.relativeFieldName = relativeFieldName;
+		self = objectField.toReference();
+		discriminator = objectField.field( "discriminator", f -> f.asString() ).toReference();
+	}
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/model/singlefield/SingleFieldIndexBinding.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/model/singlefield/SingleFieldIndexBinding.java
@@ -1,0 +1,216 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.tck.testsupport.model.singlefield;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.hibernate.search.engine.backend.document.DocumentElement;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
+import org.hibernate.search.engine.backend.types.dsl.StandardIndexFieldTypeOptionsStep;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldTypeDescriptor;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.IndexFieldLocation;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TestedFieldStructure;
+
+/**
+ * An index binding for tests focusing on a single field at a time.
+ */
+public class SingleFieldIndexBinding extends AbstractObjectBinding {
+	public static final String DISCRIMINATOR_VALUE_INCLUDED = "included";
+	public static final String DISCRIMINATOR_VALUE_EXCLUDED = "excluded";
+
+	public final FirstLevelObjectBinding flattenedObject;
+	public final FirstLevelObjectBinding nestedObject;
+
+	public SingleFieldIndexBinding(IndexSchemaElement root, Collection<? extends FieldTypeDescriptor<?>> supportedFieldTypes,
+			Consumer<StandardIndexFieldTypeOptionsStep<?, ?>> additionalConfiguration) {
+		super( root, supportedFieldTypes, additionalConfiguration );
+		flattenedObject = FirstLevelObjectBinding.create(
+				root, "flattenedObject", ObjectFieldStorage.FLATTENED, false,
+				supportedFieldTypes, additionalConfiguration
+		);
+		nestedObject = FirstLevelObjectBinding.create(
+				root, "nestedObject", ObjectFieldStorage.NESTED, true,
+				supportedFieldTypes, additionalConfiguration
+		);
+	}
+
+	public final String getFieldPath(TestedFieldStructure fieldStructure, FieldTypeDescriptor<?> fieldType) {
+		return getFieldPath( fieldStructure, binding -> binding.getRelativeFieldName( fieldStructure, fieldType ) );
+	}
+
+	public final String getDiscriminatorFieldPath(TestedFieldStructure fieldStructure) {
+		return getFieldPath( fieldStructure, binding -> "discriminator" );
+	}
+
+	private String getFieldPath(TestedFieldStructure fieldStructure,
+			Function<AbstractObjectBinding, String> relativeFieldNameFunction) {
+		switch ( fieldStructure.location ) {
+			case ROOT:
+				return relativeFieldNameFunction.apply( this );
+			case IN_FLATTENED:
+				return flattenedObject.relativeFieldName
+						+ "." + relativeFieldNameFunction.apply( flattenedObject );
+			case IN_NESTED:
+				return nestedObject.relativeFieldName
+						+ "." + relativeFieldNameFunction.apply( nestedObject );
+			case IN_NESTED_TWICE:
+				return nestedObject.relativeFieldName
+						+ "." + nestedObject.nestedObject.relativeFieldName
+						+ "." + relativeFieldNameFunction.apply( nestedObject.nestedObject );
+			default:
+				throw new IllegalStateException( "Unexpected value: " + fieldStructure.location );
+		}
+	}
+
+	public <F> void initSingleValued(FieldTypeDescriptor<F> fieldType, IndexFieldLocation location,
+			DocumentElement document, F value, F garbageValue) {
+		switch ( location ) {
+			case ROOT:
+				document.addValue( fieldWithSingleValueModels.get( fieldType ).reference, value );
+				break;
+			case IN_FLATTENED:
+				DocumentElement flattenedObject0 = document.addObject( flattenedObject.self );
+				flattenedObject0.addValue( flattenedObject.fieldWithSingleValueModels.get( fieldType ).reference,
+						value
+				);
+				break;
+			case IN_NESTED:
+				// Make sure to create multiple nested documents here, to test all the scenarios.
+				DocumentElement nestedObject0 = document.addObject( nestedObject.self );
+				nestedObject0.addValue( nestedObject.discriminator, DISCRIMINATOR_VALUE_INCLUDED );
+				nestedObject0.addValue(
+						nestedObject.fieldWithSingleValueModels.get( fieldType ).reference,
+						value
+				);
+				DocumentElement nestedObject1 = document.addObject( nestedObject.self );
+				nestedObject1.addValue( nestedObject.discriminator, DISCRIMINATOR_VALUE_EXCLUDED );
+				nestedObject1.addValue(
+						nestedObject.fieldWithSingleValueModels.get( fieldType ).reference,
+						garbageValue
+				);
+			case IN_NESTED_TWICE:
+				// Same as for IN_NESTED, but one level deeper
+				DocumentElement nestedObjectFirstLevel = document.addObject( nestedObject.self );
+				DocumentElement nestedNestedObject0 = nestedObjectFirstLevel.addObject( nestedObject.nestedObject.self );
+				nestedNestedObject0.addValue( nestedObject.nestedObject.discriminator, DISCRIMINATOR_VALUE_INCLUDED );
+				nestedNestedObject0.addValue(
+						nestedObject.nestedObject.fieldWithSingleValueModels.get( fieldType ).reference,
+						value
+				);
+				DocumentElement nestedNestedObject1 = nestedObjectFirstLevel.addObject( nestedObject.nestedObject.self );
+				nestedNestedObject1.addValue( nestedObject.nestedObject.discriminator, DISCRIMINATOR_VALUE_EXCLUDED );
+				nestedNestedObject1.addValue(
+						nestedObject.nestedObject.fieldWithSingleValueModels.get( fieldType ).reference,
+						garbageValue
+				);
+				break;
+		}
+	}
+
+	public <F> void initMultiValued(FieldTypeDescriptor<F> fieldType, IndexFieldLocation location,
+			DocumentElement document, List<F> values, List<F> garbageValues) {
+		switch ( location ) {
+			case ROOT:
+				for ( F value : values ) {
+					document.addValue( fieldWithMultipleValuesModels.get( fieldType ).reference, value );
+				}
+				break;
+			case IN_FLATTENED:
+				DocumentElement flattenedObject0 = document.addObject( flattenedObject.self );
+				for ( F value : values ) {
+					flattenedObject0.addValue(
+							flattenedObject.fieldWithMultipleValuesModels.get( fieldType ).reference,
+							value
+					);
+				}
+				break;
+			case IN_NESTED:
+				// The nested object requiring filters is split into four objects:
+				// the first two are included by the filter and each hold part of the values that will be sorted on,
+				// and the last two are excluded by the filter and hold garbage values that, if they were taken into account,
+				// would mess with the sort order and eventually fail at least *some* tests.
+				DocumentElement nestedObject0 = document.addObject( nestedObject.self );
+				nestedObject0.addValue( nestedObject.discriminator, DISCRIMINATOR_VALUE_INCLUDED );
+				if ( !values.isEmpty() ) {
+					nestedObject0.addValue(
+							nestedObject.fieldWithMultipleValuesModels.get( fieldType ).reference,
+							values.get( 0 )
+					);
+				}
+				DocumentElement nestedObject1 = document.addObject( nestedObject.self );
+				nestedObject1.addValue( nestedObject.discriminator, DISCRIMINATOR_VALUE_INCLUDED );
+				if ( values.size() > 1 ) {
+					for ( F value : values.subList( 1, values.size() ) ) {
+						nestedObject1.addValue(
+								nestedObject.fieldWithMultipleValuesModels.get( fieldType ).reference,
+								value
+						);
+					}
+				}
+				DocumentElement nestedObject2 = document.addObject( nestedObject.self );
+				nestedObject2.addValue( nestedObject.discriminator, DISCRIMINATOR_VALUE_EXCLUDED );
+				for ( F value : garbageValues ) {
+					nestedObject2.addValue(
+							nestedObject.fieldWithMultipleValuesModels.get( fieldType ).reference,
+							value
+					);
+				}
+				DocumentElement nestedObject3 = document.addObject( nestedObject.self );
+				nestedObject3.addValue( nestedObject.discriminator, DISCRIMINATOR_VALUE_EXCLUDED );
+				for ( F value : garbageValues ) {
+					nestedObject3.addValue(
+							nestedObject.fieldWithMultipleValuesModels.get( fieldType ).reference,
+							value
+					);
+				}
+				break;
+			case IN_NESTED_TWICE:
+				// Same as for IN_NESTED, but one level deeper
+				DocumentElement nestedObjectFirstLevel0 = document.addObject( nestedObject.self );
+				DocumentElement nestedObjectFirstLevel1 = document.addObject( nestedObject.self );
+				DocumentElement nestedNestedObject0 = nestedObjectFirstLevel0.addObject( nestedObject.nestedObject.self );
+				nestedNestedObject0.addValue( nestedObject.nestedObject.discriminator, DISCRIMINATOR_VALUE_INCLUDED );
+				if ( !values.isEmpty() ) {
+					nestedNestedObject0.addValue(
+							nestedObject.nestedObject.fieldWithMultipleValuesModels.get( fieldType ).reference,
+							values.get( 0 )
+					);
+				}
+				DocumentElement nestedNestedObject1 = nestedObjectFirstLevel1.addObject( nestedObject.nestedObject.self );
+				nestedNestedObject1.addValue( nestedObject.nestedObject.discriminator, DISCRIMINATOR_VALUE_INCLUDED );
+				if ( values.size() > 1 ) {
+					for ( F value : values.subList( 1, values.size() ) ) {
+						nestedNestedObject1.addValue(
+								nestedObject.nestedObject.fieldWithMultipleValuesModels.get( fieldType ).reference,
+								value
+						);
+					}
+				}
+				DocumentElement nestedNestedObject2 = nestedObjectFirstLevel0.addObject( nestedObject.nestedObject.self );
+				nestedNestedObject2.addValue( nestedObject.nestedObject.discriminator, DISCRIMINATOR_VALUE_EXCLUDED );
+				for ( F value : garbageValues ) {
+					nestedNestedObject2.addValue(
+							nestedObject.nestedObject.fieldWithMultipleValuesModels.get( fieldType ).reference,
+							value
+					);
+				}
+				DocumentElement nestedNestedObject3 = nestedObjectFirstLevel1.addObject( nestedObject.nestedObject.self );
+				nestedNestedObject3.addValue( nestedObject.nestedObject.discriminator, DISCRIMINATOR_VALUE_EXCLUDED );
+				for ( F value : garbageValues ) {
+					nestedNestedObject3.addValue(
+							nestedObject.nestedObject.fieldWithMultipleValuesModels.get( fieldType ).reference,
+							value
+					);
+				}
+				break;
+		}
+	}
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/AnalyzedStringFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/AnalyzedStringFieldTypeDescriptor.java
@@ -24,7 +24,9 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.util.Expecta
 
 public class AnalyzedStringFieldTypeDescriptor extends FieldTypeDescriptor<String> {
 
-	AnalyzedStringFieldTypeDescriptor() {
+	public static final AnalyzedStringFieldTypeDescriptor INSTANCE = new AnalyzedStringFieldTypeDescriptor();
+
+	private AnalyzedStringFieldTypeDescriptor() {
 		super( String.class, "analyzedString" );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/BigDecimalFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/BigDecimalFieldTypeDescriptor.java
@@ -24,9 +24,11 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.types.values
 
 public class BigDecimalFieldTypeDescriptor extends FieldTypeDescriptor<BigDecimal> {
 
+	public static final BigDecimalFieldTypeDescriptor INSTANCE = new BigDecimalFieldTypeDescriptor();
+
 	private static final int DECIMAL_SCALE = 2;
 
-	BigDecimalFieldTypeDescriptor() {
+	private BigDecimalFieldTypeDescriptor() {
 		super( BigDecimal.class );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/BigIntegerFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/BigIntegerFieldTypeDescriptor.java
@@ -23,9 +23,11 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.types.values
 
 public class BigIntegerFieldTypeDescriptor extends FieldTypeDescriptor<BigInteger> {
 
+	public static final BigIntegerFieldTypeDescriptor INSTANCE = new BigIntegerFieldTypeDescriptor();
+
 	private static final int DECIMAL_SCALE = -2;
 
-	BigIntegerFieldTypeDescriptor() {
+	private BigIntegerFieldTypeDescriptor() {
 		super( BigInteger.class );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/BooleanFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/BooleanFieldTypeDescriptor.java
@@ -21,7 +21,9 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.util.Expecta
 
 public class BooleanFieldTypeDescriptor extends FieldTypeDescriptor<Boolean> {
 
-	BooleanFieldTypeDescriptor() {
+	public static final BooleanFieldTypeDescriptor INSTANCE = new BooleanFieldTypeDescriptor();
+
+	private BooleanFieldTypeDescriptor() {
 		super( Boolean.class );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/ByteFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/ByteFieldTypeDescriptor.java
@@ -20,7 +20,9 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.types.values
 
 public class ByteFieldTypeDescriptor extends FieldTypeDescriptor<Byte> {
 
-	ByteFieldTypeDescriptor() {
+	public static final ByteFieldTypeDescriptor INSTANCE = new ByteFieldTypeDescriptor();
+
+	private ByteFieldTypeDescriptor() {
 		super( Byte.class );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/DoubleFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/DoubleFieldTypeDescriptor.java
@@ -20,7 +20,9 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.types.values
 
 public class DoubleFieldTypeDescriptor extends FieldTypeDescriptor<Double> {
 
-	DoubleFieldTypeDescriptor() {
+	public static final DoubleFieldTypeDescriptor INSTANCE = new DoubleFieldTypeDescriptor();
+
+	private DoubleFieldTypeDescriptor() {
 		super( Double.class );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/FieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/FieldTypeDescriptor.java
@@ -29,40 +29,40 @@ public abstract class FieldTypeDescriptor<F> {
 	public static List<FieldTypeDescriptor<?>> getAll() {
 		if ( all == null ) {
 			all = Collections.unmodifiableList( Arrays.asList(
-					new KeywordStringFieldTypeDescriptor(),
-					new AnalyzedStringFieldTypeDescriptor(),
-					new NormalizedStringFieldTypeDescriptor(),
-					new IntegerFieldTypeDescriptor(),
-					new FloatFieldTypeDescriptor(),
-					new LongFieldTypeDescriptor(),
-					new BooleanFieldTypeDescriptor(),
-					new ByteFieldTypeDescriptor(),
-					new ShortFieldTypeDescriptor(),
-					new DoubleFieldTypeDescriptor(),
-					new InstantFieldTypeDescriptor(),
-					new LocalDateFieldTypeDescriptor(),
-					new LocalDateTimeFieldTypeDescriptor(),
-					new LocalTimeFieldTypeDescriptor(),
-					new ZonedDateTimeFieldTypeDescriptor(),
-					new YearFieldTypeDescriptor(),
-					new YearMonthFieldTypeDescriptor(),
-					new MonthDayFieldTypeDescriptor(),
-					new OffsetDateTimeFieldTypeDescriptor(),
-					new OffsetTimeFieldTypeDescriptor(),
-					new GeoPointFieldTypeDescriptor(),
-					new BigDecimalFieldTypeDescriptor(),
-					new BigIntegerFieldTypeDescriptor()
+					KeywordStringFieldTypeDescriptor.INSTANCE,
+					AnalyzedStringFieldTypeDescriptor.INSTANCE,
+					NormalizedStringFieldTypeDescriptor.INSTANCE,
+					IntegerFieldTypeDescriptor.INSTANCE,
+					FloatFieldTypeDescriptor.INSTANCE,
+					LongFieldTypeDescriptor.INSTANCE,
+					BooleanFieldTypeDescriptor.INSTANCE,
+					ByteFieldTypeDescriptor.INSTANCE,
+					ShortFieldTypeDescriptor.INSTANCE,
+					DoubleFieldTypeDescriptor.INSTANCE,
+					InstantFieldTypeDescriptor.INSTANCE,
+					LocalDateFieldTypeDescriptor.INSTANCE,
+					LocalDateTimeFieldTypeDescriptor.INSTANCE,
+					LocalTimeFieldTypeDescriptor.INSTANCE,
+					ZonedDateTimeFieldTypeDescriptor.INSTANCE,
+					YearFieldTypeDescriptor.INSTANCE,
+					YearMonthFieldTypeDescriptor.INSTANCE,
+					MonthDayFieldTypeDescriptor.INSTANCE,
+					OffsetDateTimeFieldTypeDescriptor.INSTANCE,
+					OffsetTimeFieldTypeDescriptor.INSTANCE,
+					GeoPointFieldTypeDescriptor.INSTANCE,
+					BigDecimalFieldTypeDescriptor.INSTANCE,
+					BigIntegerFieldTypeDescriptor.INSTANCE
 			) );
 		}
 		return all;
 	}
 
 	public static FieldTypeDescriptor<?> getIncompatible(FieldTypeDescriptor<?> typeDescriptor) {
-		if ( Integer.class.equals( typeDescriptor.getJavaType() ) ) {
-			return new LongFieldTypeDescriptor();
+		if ( IntegerFieldTypeDescriptor.INSTANCE.equals( typeDescriptor ) ) {
+			return LongFieldTypeDescriptor.INSTANCE;
 		}
 		else {
-			return new IntegerFieldTypeDescriptor();
+			return IntegerFieldTypeDescriptor.INSTANCE;
 		}
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/FloatFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/FloatFieldTypeDescriptor.java
@@ -20,7 +20,9 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.types.values
 
 public class FloatFieldTypeDescriptor extends FieldTypeDescriptor<Float> {
 
-	FloatFieldTypeDescriptor() {
+	public static final FloatFieldTypeDescriptor INSTANCE = new FloatFieldTypeDescriptor();
+
+	private FloatFieldTypeDescriptor() {
 		super( Float.class );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/GeoPointFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/GeoPointFieldTypeDescriptor.java
@@ -20,7 +20,9 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.util.Expecta
 
 public class GeoPointFieldTypeDescriptor extends FieldTypeDescriptor<GeoPoint> {
 
-	GeoPointFieldTypeDescriptor() {
+	public static final GeoPointFieldTypeDescriptor INSTANCE = new GeoPointFieldTypeDescriptor();
+
+	private GeoPointFieldTypeDescriptor() {
 		super( GeoPoint.class );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/InstantFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/InstantFieldTypeDescriptor.java
@@ -24,7 +24,9 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.types.values
 
 public class InstantFieldTypeDescriptor extends FieldTypeDescriptor<Instant> {
 
-	InstantFieldTypeDescriptor() {
+	public static final InstantFieldTypeDescriptor INSTANCE = new InstantFieldTypeDescriptor();
+
+	private InstantFieldTypeDescriptor() {
 		super( Instant.class );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/IntegerFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/IntegerFieldTypeDescriptor.java
@@ -20,7 +20,9 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.types.values
 
 public class IntegerFieldTypeDescriptor extends FieldTypeDescriptor<Integer> {
 
-	IntegerFieldTypeDescriptor() {
+	public static final IntegerFieldTypeDescriptor INSTANCE = new IntegerFieldTypeDescriptor();
+
+	private IntegerFieldTypeDescriptor() {
 		super( Integer.class );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/KeywordStringFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/KeywordStringFieldTypeDescriptor.java
@@ -20,7 +20,9 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.types.values
 
 public class KeywordStringFieldTypeDescriptor extends FieldTypeDescriptor<String> {
 
-	KeywordStringFieldTypeDescriptor() {
+	public static final KeywordStringFieldTypeDescriptor INSTANCE = new KeywordStringFieldTypeDescriptor();
+
+	private KeywordStringFieldTypeDescriptor() {
 		super( String.class, "keywordString" );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/LocalDateFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/LocalDateFieldTypeDescriptor.java
@@ -22,7 +22,9 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.types.values
 
 public class LocalDateFieldTypeDescriptor extends FieldTypeDescriptor<LocalDate> {
 
-	LocalDateFieldTypeDescriptor() {
+	public static final LocalDateFieldTypeDescriptor INSTANCE = new LocalDateFieldTypeDescriptor();
+
+	private LocalDateFieldTypeDescriptor() {
 		super( LocalDate.class );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/LocalDateTimeFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/LocalDateTimeFieldTypeDescriptor.java
@@ -45,7 +45,9 @@ public class LocalDateTimeFieldTypeDescriptor extends FieldTypeDescriptor<LocalD
 		);
 	}
 
-	LocalDateTimeFieldTypeDescriptor() {
+	public static final LocalDateTimeFieldTypeDescriptor INSTANCE = new LocalDateTimeFieldTypeDescriptor();
+
+	private LocalDateTimeFieldTypeDescriptor() {
 		super( LocalDateTime.class );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/LocalTimeFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/LocalTimeFieldTypeDescriptor.java
@@ -31,7 +31,9 @@ public class LocalTimeFieldTypeDescriptor extends FieldTypeDescriptor<LocalTime>
 		);
 	}
 
-	LocalTimeFieldTypeDescriptor() {
+	public static final LocalTimeFieldTypeDescriptor INSTANCE = new LocalTimeFieldTypeDescriptor();
+
+	private LocalTimeFieldTypeDescriptor() {
 		super( LocalTime.class );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/LongFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/LongFieldTypeDescriptor.java
@@ -20,7 +20,9 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.types.values
 
 public class LongFieldTypeDescriptor extends FieldTypeDescriptor<Long> {
 
-	LongFieldTypeDescriptor() {
+	public static final LongFieldTypeDescriptor INSTANCE = new LongFieldTypeDescriptor();
+
+	private LongFieldTypeDescriptor() {
 		super( Long.class );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/MonthDayFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/MonthDayFieldTypeDescriptor.java
@@ -26,7 +26,9 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.types.values
 
 public class MonthDayFieldTypeDescriptor extends FieldTypeDescriptor<MonthDay> {
 
-	MonthDayFieldTypeDescriptor() {
+	public static final MonthDayFieldTypeDescriptor INSTANCE = new MonthDayFieldTypeDescriptor();
+
+	private MonthDayFieldTypeDescriptor() {
 		super( MonthDay.class );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/NormalizedStringFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/NormalizedStringFieldTypeDescriptor.java
@@ -24,7 +24,9 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.types.values
 
 public class NormalizedStringFieldTypeDescriptor extends FieldTypeDescriptor<String> {
 
-	NormalizedStringFieldTypeDescriptor() {
+	public static final NormalizedStringFieldTypeDescriptor INSTANCE = new NormalizedStringFieldTypeDescriptor();
+
+	private NormalizedStringFieldTypeDescriptor() {
 		super( String.class, "normalizedString" );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/OffsetDateTimeFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/OffsetDateTimeFieldTypeDescriptor.java
@@ -38,7 +38,9 @@ public class OffsetDateTimeFieldTypeDescriptor extends FieldTypeDescriptor<Offse
 		);
 	}
 
-	OffsetDateTimeFieldTypeDescriptor() {
+	public static final OffsetDateTimeFieldTypeDescriptor INSTANCE = new OffsetDateTimeFieldTypeDescriptor();
+
+	private OffsetDateTimeFieldTypeDescriptor() {
 		super( OffsetDateTime.class );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/OffsetTimeFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/OffsetTimeFieldTypeDescriptor.java
@@ -25,7 +25,9 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.types.values
 
 public class OffsetTimeFieldTypeDescriptor extends FieldTypeDescriptor<OffsetTime> {
 
-	OffsetTimeFieldTypeDescriptor() {
+	public static final OffsetTimeFieldTypeDescriptor INSTANCE = new OffsetTimeFieldTypeDescriptor();
+
+	private OffsetTimeFieldTypeDescriptor() {
 		super( OffsetTime.class );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/ShortFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/ShortFieldTypeDescriptor.java
@@ -20,7 +20,9 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.types.values
 
 public class ShortFieldTypeDescriptor extends FieldTypeDescriptor<Short> {
 
-	ShortFieldTypeDescriptor() {
+	public static final ShortFieldTypeDescriptor INSTANCE = new ShortFieldTypeDescriptor();
+
+	private ShortFieldTypeDescriptor() {
 		super( Short.class );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/YearFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/YearFieldTypeDescriptor.java
@@ -42,7 +42,9 @@ public class YearFieldTypeDescriptor extends FieldTypeDescriptor<Year> {
 		);
 	}
 
-	YearFieldTypeDescriptor() {
+	public static final YearFieldTypeDescriptor INSTANCE = new YearFieldTypeDescriptor();
+
+	private YearFieldTypeDescriptor() {
 		super( Year.class );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/YearMonthFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/YearMonthFieldTypeDescriptor.java
@@ -24,7 +24,9 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.types.values
 
 public class YearMonthFieldTypeDescriptor extends FieldTypeDescriptor<YearMonth> {
 
-	YearMonthFieldTypeDescriptor() {
+	public static final YearMonthFieldTypeDescriptor INSTANCE = new YearMonthFieldTypeDescriptor();
+
+	private YearMonthFieldTypeDescriptor() {
 		super( YearMonth.class );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/ZonedDateTimeFieldTypeDescriptor.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/ZonedDateTimeFieldTypeDescriptor.java
@@ -42,7 +42,9 @@ public class ZonedDateTimeFieldTypeDescriptor extends FieldTypeDescriptor<ZonedD
 		);
 	}
 
-	ZonedDateTimeFieldTypeDescriptor() {
+	public static final ZonedDateTimeFieldTypeDescriptor INSTANCE = new ZonedDateTimeFieldTypeDescriptor();
+
+	private ZonedDateTimeFieldTypeDescriptor() {
 		super( ZonedDateTime.class );
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/values/AscendingUniqueDistanceFromCenterValues.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/types/values/AscendingUniqueDistanceFromCenterValues.java
@@ -1,0 +1,52 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.tck.testsupport.types.values;
+
+import static java.util.Arrays.asList;
+
+import java.util.List;
+
+import org.hibernate.search.engine.spatial.GeoPoint;
+
+public class AscendingUniqueDistanceFromCenterValues extends AscendingUniqueTermValues<GeoPoint> {
+	public static final GeoPoint CENTER_POINT = GeoPoint.of( 46.038673, 3.978563 );
+
+	public static final AscendingUniqueDistanceFromCenterValues INSTANCE = new AscendingUniqueDistanceFromCenterValues();
+
+	@Override
+	protected List<GeoPoint> createSingle() {
+		return asList(
+				CENTER_POINT, // ~0km
+				GeoPoint.of( 46.038683, 3.964652 ), // ~1km
+				GeoPoint.of( 46.059852, 3.978235 ), // ~2km
+				GeoPoint.of( 46.039763, 3.914977 ), // ~4km
+				GeoPoint.of( 46.000833, 3.931265 ), // ~6km
+				GeoPoint.of( 46.094712, 4.044507 ), // ~8km
+				GeoPoint.of( 46.018378, 4.196792 ), // ~10km
+				GeoPoint.of( 46.123025, 3.845305 ) // ~14km
+		);
+	}
+
+	@Override
+	protected List<List<GeoPoint>> createMultiResultingInSingleAfterSum() {
+		return valuesThatWontBeUsed();
+	}
+
+	@Override
+	protected List<List<GeoPoint>> createMultiResultingInSingleAfterAvg() {
+		return asList(
+				asList( CENTER_POINT, CENTER_POINT ), // ~0km
+				asList( getSingle().get( 0 ), getSingle().get( 2 ) ), // ~1km
+				asList( getSingle().get( 1 ), getSingle().get( 1 ), getSingle().get( 4 ) ), // ~2km
+				asList( getSingle().get( 2 ), getSingle().get( 4 ) ), // ~4km
+				asList( getSingle().get( 3 ), getSingle().get( 5 ) ), // ~6km
+				asList( getSingle().get( 4 ), getSingle().get( 6 ) ), // ~8km
+				asList( getSingle().get( 4 ), getSingle().get( 7 ) ), // ~10km
+				asList( getSingle().get( 7 ), getSingle().get( 7 ), getSingle().get( 7 ) ) // ~14km
+		);
+	}
+}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/SimpleFieldModel.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/SimpleFieldModel.java
@@ -14,6 +14,10 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldT
 
 public class SimpleFieldModel<F> {
 
+	public static <F> StandardFieldMapper<F, SimpleFieldModel<F>> mapper(FieldTypeDescriptor<F> typeDescriptor) {
+		return mapper( typeDescriptor, ignored -> { } );
+	}
+
 	public static <F> StandardFieldMapper<F, SimpleFieldModel<F>> mapper(FieldTypeDescriptor<F> typeDescriptor,
 			Consumer<? super StandardIndexFieldTypeOptionsStep<?, F>> configurationAdjustment) {
 		return StandardFieldMapper.of(

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/SimpleFieldModelsByType.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/SimpleFieldModelsByType.java
@@ -18,14 +18,14 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldT
 
 public class SimpleFieldModelsByType {
 	@SafeVarargs
-	public static SimpleFieldModelsByType mapAll(Collection<FieldTypeDescriptor<?>> typeDescriptors,
+	public static SimpleFieldModelsByType mapAll(Collection<? extends FieldTypeDescriptor<?>> typeDescriptors,
 			IndexSchemaElement parent, String prefix,
 			Consumer<StandardIndexFieldTypeOptionsStep<?, ?>> ... additionalConfiguration) {
 		return mapAll( typeDescriptors.stream(), parent, prefix, additionalConfiguration );
 	}
 
 	@SafeVarargs
-	public static SimpleFieldModelsByType mapAll(Stream<FieldTypeDescriptor<?>> typeDescriptors,
+	public static SimpleFieldModelsByType mapAll(Stream<? extends FieldTypeDescriptor<?>> typeDescriptors,
 			IndexSchemaElement parent, String prefix,
 			Consumer<StandardIndexFieldTypeOptionsStep<?, ?>> ... additionalConfiguration) {
 		SimpleFieldModelsByType result = new SimpleFieldModelsByType();
@@ -40,14 +40,14 @@ public class SimpleFieldModelsByType {
 	}
 
 	@SafeVarargs
-	public static SimpleFieldModelsByType mapAllMultiValued(Collection<FieldTypeDescriptor<?>> typeDescriptors,
+	public static SimpleFieldModelsByType mapAllMultiValued(Collection<? extends FieldTypeDescriptor<?>> typeDescriptors,
 			IndexSchemaElement parent, String prefix,
 			Consumer<StandardIndexFieldTypeOptionsStep<?, ?>> ... additionalConfiguration) {
 		return mapAllMultiValued( typeDescriptors.stream(), parent, prefix, additionalConfiguration );
 	}
 
 	@SafeVarargs
-	public static SimpleFieldModelsByType mapAllMultiValued(Stream<FieldTypeDescriptor<?>> typeDescriptors,
+	public static SimpleFieldModelsByType mapAllMultiValued(Stream<? extends FieldTypeDescriptor<?>> typeDescriptors,
 			IndexSchemaElement parent, String prefix,
 			Consumer<StandardIndexFieldTypeOptionsStep<?, ?>> ... additionalConfiguration) {
 		SimpleFieldModelsByType result = new SimpleFieldModelsByType();

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchDocumentRepositoryImpl.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchDocumentRepositoryImpl.java
@@ -130,8 +130,7 @@ public class IndexSearchDocumentRepositoryImpl implements IndexSearchDocumentRep
 				} ) )
 				.sort( f -> f.composite( b -> {
 					if ( myLocation != null ) {
-						// TODO HSEARCH-3103 sort by distance once we implement nested support for sorts ("copies" is a nested object field)
-						//b.add( f.byDistance( "copies.library.location", myLocation ) );
+						b.add( f.distance( "copies.library.location", myLocation ) );
 					}
 					b.add( f.score() );
 				} ) )

--- a/integrationtest/showcase/library/src/test/java/org/hibernate/search/integrationtest/showcase/library/LibraryShowcaseBaseIT.java
+++ b/integrationtest/showcase/library/src/test/java/org/hibernate/search/integrationtest/showcase/library/LibraryShowcaseBaseIT.java
@@ -209,14 +209,15 @@ public class LibraryShowcaseBaseIT {
 				null,
 				0, 10
 		);
-		// Should only include content from university
-		// TODO HSEARCH-3103 check results are sorted by distance once we do sort them (see the query implementation)
+		// Should only include content from university (my location).
 		assertThat( documents ).extracting( Document::getId ).containsExactlyInAnyOrder(
 				INDONESIAN_ECONOMY_ID,
 				JAVA_FOR_DUMMIES_ID,
 				ART_OF_COMPUTER_PROG_ID,
 				THESAURUS_OF_LANGUAGES_ID
 		);
+		// Should be sorted by increasing distance,
+		// but here all hits are in a library right at my location, so the sort doesn't matter.
 
 		documents = documentService.searchAroundMe(
 				null, null,
@@ -224,8 +225,7 @@ public class LibraryShowcaseBaseIT {
 				null,
 				0, 10
 		);
-		// Should only include content from suburb1 or university
-		// TODO HSEARCH-3103 check results are sorted by distance once we do sort them (see the query implementation)
+		// Should only include content from suburb1 or university.
 		assertThat( documents ).extracting( Document::getId ).containsExactlyInAnyOrder(
 				CALLIGRAPHY_ID,
 				INDONESIAN_ECONOMY_ID,
@@ -233,6 +233,12 @@ public class LibraryShowcaseBaseIT {
 				ART_OF_COMPUTER_PROG_ID,
 				THESAURUS_OF_LANGUAGES_ID
 		);
+		// Should be sorted by increasing distance.
+		// All books are in the university library right at my location,
+		// except the book about calligraphy, which is in "suburb1".
+		// So it should appear last.
+		assertThat( documents ).extracting( Document::getId )
+				.element( 4 ).isEqualTo( CALLIGRAPHY_ID );
 
 		documents = documentService.searchAroundMe(
 				"calligraphy", null,
@@ -240,8 +246,7 @@ public class LibraryShowcaseBaseIT {
 				null,
 				0, 10
 		);
-		// Should only include content from suburb1 or university with "calligraphy" in it
-		// TODO HSEARCH-3103 check results are sorted by distance once we do sort them (see the query implementation)
+		// Should only include content from suburb1 or university with "calligraphy" in it.
 		assertThat( documents ).extracting( Document::getId ).containsExactlyInAnyOrder(
 				CALLIGRAPHY_ID
 		);
@@ -253,8 +258,7 @@ public class LibraryShowcaseBaseIT {
 				null,
 				0, 10
 		);
-		// Should only include content from university
-		// TODO HSEARCH-3103 check results are sorted by distance once we do sort them (see the query implementation)
+		// Should only include content from university.
 		assertThat( documents ).extracting( Document::getId ).containsExactlyInAnyOrder(
 				INDONESIAN_ECONOMY_ID,
 				JAVA_FOR_DUMMIES_ID,


### PR DESCRIPTION
* [HSEARCH-3940](https://hibernate.atlassian.net/browse/HSEARCH-3940): Restore sort by distance on (nested) field in the Library showcase
* [HSEARCH-3941](https://hibernate.atlassian.net/browse/HSEARCH-3941): ClassCastException: org.hibernate.search.backend.elasticsearch.types.sort.impl.ElasticsearchGeoPointFieldSortBuilderFactory cannot be cast to org.hibernate.search.backend.elasticsearch.types.sort.impl.ElasticsearchStandardFieldSortBuilderFactory

@fax4ever Please don't bother reviewing this, it's a lot of low-value changes. The test refactoring in particular is quite big, but was needed for these fixes, but also for another fix I'm currently working on.

I'll merge as soon as the CI build passes.