### PR TITLE
HSEARCH-2206 Avoid using deprecated Lucene APIs in internals

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/impl/GsonHttpEntity.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/impl/GsonHttpEntity.java
@@ -190,6 +190,7 @@ final class GsonHttpEntity implements HttpEntity, HttpAsyncContentProducer {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation") // javac warns about this method being deprecated, but we have to implement it
 	public void consumeContent() {
 		//not used (and deprecated)
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/orchestration/impl/LuceneSerialWorkOrchestratorImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/orchestration/impl/LuceneSerialWorkOrchestratorImpl.java
@@ -67,6 +67,7 @@ public class LuceneSerialWorkOrchestratorImpl
 	}
 
 	@Override
+	@SuppressWarnings("unchecked") // We aren't allowed to create generic arrays, so we have to use a raw type here.
 	protected void doStart(ConfigurationPropertySource propertySource) {
 		int queueCount = QUEUE_COUNT.get( propertySource );
 		int queueSize = QUEUE_SIZE.get( propertySource );

--- a/backend/lucene/src/test/java/org/hibernate/search/backend/lucene/lowlevel/writer/impl/LoggerInfoStreamTest.java
+++ b/backend/lucene/src/test/java/org/hibernate/search/backend/lucene/lowlevel/writer/impl/LoggerInfoStreamTest.java
@@ -25,7 +25,7 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
-import org.apache.lucene.store.RAMDirectory;
+import org.apache.lucene.store.ByteBuffersDirectory;
 
 public class LoggerInfoStreamTest {
 
@@ -52,7 +52,7 @@ public class LoggerInfoStreamTest {
 	public void testEnableInfoStream() throws Exception {
 		LoggerInfoStream infoStream = new LoggerInfoStream();
 
-		RAMDirectory directory = new RAMDirectory();
+		ByteBuffersDirectory directory = new ByteBuffersDirectory();
 		IndexWriterConfig indexWriterConfig = new IndexWriterConfig( new StandardAnalyzer() );
 		indexWriterConfig.setInfoStream( infoStream );
 

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/PredicateScoreStep.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/PredicateScoreStep.java
@@ -12,6 +12,7 @@ package org.hibernate.search.engine.search.predicate.dsl;
  *
  * @param <S> The "self" type (the actual exposed type of this step)
  */
+@SuppressWarnings("deprecation")
 public interface PredicateScoreStep<S> extends PredicateBoostStep<S> {
 
 	/**

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SearchPredicateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SearchPredicateIT.java
@@ -84,6 +84,7 @@ public class SearchPredicateIT {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void predicate_searchPredicate() {
 		StubMappingScope scope = mainIndex.createScope();
 
@@ -98,6 +99,7 @@ public class SearchPredicateIT {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void predicate_lambda() {
 		StubMappingScope scope = mainIndex.createScope();
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryResultLoadingOrTransformingIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryResultLoadingOrTransformingIT.java
@@ -408,6 +408,7 @@ public class SearchQueryResultLoadingOrTransformingIT extends EasyMockSupport {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void asEntityReference_noReferenceTransformer() {
 		StubMappingScope scope = index.createScope();
 
@@ -420,6 +421,7 @@ public class SearchQueryResultLoadingOrTransformingIT extends EasyMockSupport {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void asEntity_noEntityLoading() {
 		StubMappingScope scope = index.createScope();
 
@@ -432,6 +434,7 @@ public class SearchQueryResultLoadingOrTransformingIT extends EasyMockSupport {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void asProjection_hitTransformer() {
 		DocumentReference mainReference = reference( index.typeName(), MAIN_ID );
 		DocumentReference emptyReference = reference( index.typeName(), EMPTY_ID );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/ValueWrapper.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/ValueWrapper.java
@@ -25,6 +25,7 @@ public final class ValueWrapper<T> implements Normalizable<ValueWrapper<T>> {
 	public static <T> ToDocumentFieldValueConverter<ValueWrapper, T> toIndexFieldConverter() {
 		return new ToDocumentFieldValueConverter<ValueWrapper, T>() {
 			@Override
+			@SuppressWarnings("unchecked")
 			public T convert(ValueWrapper value, ToDocumentFieldValueConvertContext context) {
 				return (T) value.getValue();
 			}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingBridgeExplicitDependenciesIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingBridgeExplicitDependenciesIT.java
@@ -154,6 +154,7 @@ public class AutomaticIndexingBridgeExplicitDependenciesIT extends AbstractAutom
 		}
 
 		@Override
+		@SuppressWarnings("unchecked")
 		public void write(DocumentElement target, Object bridgedElement, PropertyBridgeWriteContext context) {
 			List<ContainingEntity> castedBridgedElement = (List<ContainingEntity>) bridgedElement;
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingBridgeExplicitReindexingBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingBridgeExplicitReindexingBaseIT.java
@@ -161,6 +161,7 @@ public class AutomaticIndexingBridgeExplicitReindexingBaseIT extends AbstractAut
 		}
 
 		@Override
+		@SuppressWarnings("unchecked")
 		public void write(DocumentElement target, Object bridgedElement, PropertyBridgeWriteContext context) {
 			List<ContainingEntity> castedBridgedElement = (List<ContainingEntity>) bridgedElement;
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/ObsoletePropertiesIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/ObsoletePropertiesIT.java
@@ -142,7 +142,7 @@ public class ObsoletePropertiesIT {
 					return Arrays.asList( matcher.group( 1 ).split( ", " ) );
 				} )
 				.asList()
-				.containsExactlyInAnyOrder( obsoletePropertyKeys.toArray( new String[0] ) );
+				.containsExactlyInAnyOrderElementsOf( obsoletePropertyKeys );
 	}
 
 	private void setup(Consumer<SimpleSessionFactoryBuilder> configurationContributor) {

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingCacheLookupIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingCacheLookupIT.java
@@ -272,6 +272,7 @@ public class SearchQueryEntityLoadingCacheLookupIT<T> extends AbstractSearchQuer
 		);
 	}
 
+	@SuppressWarnings({"unchecked", "deprecation"})
 	private void testLoadingCacheLookup(EntityLoadingCacheLookupStrategy overriddenLookupStrategy,
 			int entityCount,
 			List<Integer> entitiesToPutInSecondLevelCache,

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/IndexedEmbeddedBaseIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/IndexedEmbeddedBaseIT.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
 import org.hibernate.search.engine.backend.types.ObjectStructure;
 import org.hibernate.search.integrationtest.mapper.pojo.smoke.AnnotationMappingSmokeIT;
 import org.hibernate.search.integrationtest.mapper.pojo.smoke.ProgrammaticMappingSmokeIT;
@@ -825,6 +824,7 @@ public class IndexedEmbeddedBaseIT {
 	 * Check that the deprecated "storage" parameter is taken into account.
 	 */
 	@Test
+	@SuppressWarnings("deprecation")
 	public void storage() {
 		class IndexedEmbeddedLevel1 {
 			String level1Property;
@@ -846,7 +846,7 @@ public class IndexedEmbeddedBaseIT {
 			public Integer getId() {
 				return id;
 			}
-			@IndexedEmbedded(storage = ObjectFieldStorage.NESTED)
+			@IndexedEmbedded(storage = org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage.NESTED)
 			public IndexedEmbeddedLevel1 getLevel1() {
 				return level1;
 			}

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/PropertyBridgeBaseIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/PropertyBridgeBaseIT.java
@@ -19,7 +19,6 @@ import org.hibernate.search.integrationtest.mapper.pojo.testsupport.util.rule.Ja
 import org.hibernate.search.mapper.javabean.mapping.SearchMapping;
 import org.hibernate.search.mapper.javabean.session.SearchSession;
 import org.hibernate.search.mapper.pojo.bridge.PropertyBridge;
-import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.PropertyBinder;
 import org.hibernate.search.mapper.pojo.bridge.runtime.PropertyBridgeWriteContext;
 import org.hibernate.search.mapper.pojo.extractor.builtin.BuiltinContainerExtractors;
 import org.hibernate.search.mapper.pojo.extractor.builtin.impl.CollectionElementExtractor;
@@ -89,7 +88,7 @@ public class PropertyBridgeBaseIT {
 		SearchMapping mapping = setupHelper.start().withConfiguration(
 				b -> b.programmaticMapping().type( IndexedEntity.class )
 						.property( "stringProperty" )
-						.binder( (PropertyBinder) context -> {
+						.binder( context -> {
 							PojoElementAccessor<String> pojoPropertyAccessor = context.bridgedElement()
 									.createAccessor( String.class );
 							IndexFieldReference<String> indexFieldReference = context.indexSchemaElement().field(
@@ -168,7 +167,7 @@ public class PropertyBridgeBaseIT {
 		SearchMapping mapping = setupHelper.start().withConfiguration(
 				b -> b.programmaticMapping().type( IndexedEntity.class )
 						.property( "contained" )
-						.binder( (PropertyBinder) context -> {
+						.binder( context -> {
 							context.dependencies().use( "stringProperty" );
 							IndexFieldReference<String> indexFieldReference = context.indexSchemaElement().field(
 									"someField",
@@ -238,7 +237,7 @@ public class PropertyBridgeBaseIT {
 				() -> setupHelper.start().withConfiguration(
 						b -> b.programmaticMapping().type( IndexedEntity.class )
 								.property( "contained" )
-								.binder( (PropertyBinder) context -> {
+								.binder( context -> {
 									context.dependencies().use( "doesNotExist.stringProperty" );
 									context.bridge( new UnusedPropertyBridge() );
 								} )
@@ -283,7 +282,7 @@ public class PropertyBridgeBaseIT {
 				() -> setupHelper.start().withConfiguration(
 						b -> b.programmaticMapping().type( IndexedEntity.class )
 								.property( "contained" )
-								.binder( (PropertyBinder) context -> {
+								.binder( context -> {
 									context.dependencies()
 											.use(
 													ContainerExtractorPath.explicitExtractor( BuiltinContainerExtractors.COLLECTION ),
@@ -326,7 +325,7 @@ public class PropertyBridgeBaseIT {
 		SearchMapping mapping = setupHelper.start().withConfiguration(
 				b -> b.programmaticMapping().type( PropertyBridgeExplicitIndexingClasses.IndexedEntity.class )
 						.property( "child" )
-						.binder( (PropertyBinder) context -> {
+						.binder( context -> {
 							context.dependencies()
 									.fromOtherEntity( PropertyBridgeExplicitIndexingClasses.ContainedLevel2Entity.class, "parent" )
 									.use( "stringProperty" );
@@ -440,7 +439,7 @@ public class PropertyBridgeBaseIT {
 				() -> setupHelper.start().withConfiguration(
 						b -> b.programmaticMapping().type( PropertyBridgeExplicitIndexingClasses.IndexedEntity.class )
 								.property( "child" )
-								.binder( (PropertyBinder) context -> {
+								.binder( context -> {
 									context.dependencies()
 											.fromOtherEntity(
 													PropertyBridgeExplicitIndexingClasses.ContainedLevel2Entity.class,
@@ -475,7 +474,7 @@ public class PropertyBridgeBaseIT {
 				() -> setupHelper.start().withConfiguration(
 						b -> b.programmaticMapping().type( PropertyBridgeExplicitIndexingClasses.IndexedEntity.class )
 								.property( "child" )
-								.binder( (PropertyBinder) context -> {
+								.binder( context -> {
 									context.dependencies()
 											.fromOtherEntity(
 													PropertyBridgeExplicitIndexingClasses.ContainedLevel2Entity.class,
@@ -508,7 +507,7 @@ public class PropertyBridgeBaseIT {
 				() -> setupHelper.start().withConfiguration(
 						b -> b.programmaticMapping().type( PropertyBridgeExplicitIndexingClasses.IndexedEntity.class )
 								.property( "child" )
-								.binder( (PropertyBinder) context -> {
+								.binder( context -> {
 									context.dependencies()
 											.fromOtherEntity(
 													ContainerExtractorPath.explicitExtractor( BuiltinContainerExtractors.COLLECTION ),
@@ -545,7 +544,7 @@ public class PropertyBridgeBaseIT {
 				() -> setupHelper.start().withConfiguration(
 						b -> b.programmaticMapping().type( PropertyBridgeExplicitIndexingClasses.IndexedEntity.class )
 								.property( "notEntity" )
-								.binder( (PropertyBinder) context -> {
+								.binder( context -> {
 									context.dependencies()
 											.fromOtherEntity(
 													PropertyBridgeExplicitIndexingClasses.ContainedLevel2Entity.class,
@@ -581,7 +580,7 @@ public class PropertyBridgeBaseIT {
 				() -> setupHelper.start().withConfiguration(
 						b -> b.programmaticMapping().type( PropertyBridgeExplicitIndexingClasses.IndexedEntity.class )
 								.property( "child" )
-								.binder( (PropertyBinder) context -> {
+								.binder( context -> {
 									context.dependencies()
 											.fromOtherEntity(
 													PropertyBridgeExplicitIndexingClasses.NotEntity.class,
@@ -617,7 +616,7 @@ public class PropertyBridgeBaseIT {
 				() -> setupHelper.start().withConfiguration(
 						b -> b.programmaticMapping().type( PropertyBridgeExplicitIndexingClasses.IndexedEntity.class )
 								.property( "child" )
-								.binder( (PropertyBinder) context -> {
+								.binder( context -> {
 									context.dependencies()
 											.fromOtherEntity(
 													PropertyBridgeExplicitIndexingClasses.ContainedLevel2Entity.class,
@@ -671,7 +670,7 @@ public class PropertyBridgeBaseIT {
 				() -> setupHelper.start().withConfiguration(
 						b -> b.programmaticMapping().type( IndexedEntity.class )
 								.property( "contained" )
-								.binder( (PropertyBinder) context -> {
+								.binder( context -> {
 									// Do not declare any dependency
 									context.bridge( new UnusedPropertyBridge() );
 								} )
@@ -717,7 +716,7 @@ public class PropertyBridgeBaseIT {
 				() -> setupHelper.start().withConfiguration(
 						b -> b.programmaticMapping().type( IndexedEntity.class )
 								.property( "contained" )
-								.binder( (PropertyBinder) context -> {
+								.binder( context -> {
 									// Declare no dependency, but also a dependency: this is inconsistent.
 									context.dependencies()
 											.use( "stringProperty" )
@@ -741,6 +740,7 @@ public class PropertyBridgeBaseIT {
 
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3297")
+	@SuppressWarnings("unchecked")
 	public void useRootOnly() {
 		@Indexed(index = INDEX_NAME)
 		class IndexedEntity {
@@ -764,7 +764,7 @@ public class PropertyBridgeBaseIT {
 		SearchMapping mapping = setupHelper.start().withConfiguration(
 				b -> b.programmaticMapping().type( IndexedEntity.class )
 						.property( "stringProperty" )
-						.binder( (PropertyBinder) context -> {
+						.binder( context -> {
 							context.dependencies().useRootOnly();
 							IndexFieldReference<String> indexFieldReference = context.indexSchemaElement().field(
 									"someField",
@@ -834,7 +834,7 @@ public class PropertyBridgeBaseIT {
 
 		SearchMapping mapping = setupHelper.start().withConfiguration(
 				b -> b.programmaticMapping().type( IndexedEntity.class ).property( "contained" )
-						.binder( (PropertyBinder) context -> {
+						.binder( context -> {
 							context.dependencies().useRootOnly();
 							// Single-valued field
 							context.indexSchemaElement()
@@ -885,7 +885,7 @@ public class PropertyBridgeBaseIT {
 
 		SearchMapping mapping = setupHelper.start().withConfiguration(
 				b -> b.programmaticMapping().type( IndexedEntity.class ).property( "contained" )
-						.binder( (PropertyBinder) context -> {
+						.binder( context -> {
 							context.dependencies().useRootOnly();
 							// Single-valued field
 							IndexSchemaObjectField stringObjectField = context.indexSchemaElement()
@@ -940,7 +940,7 @@ public class PropertyBridgeBaseIT {
 
 		SearchMapping mapping = setupHelper.start().withConfiguration(
 				b -> b.programmaticMapping().type( IndexedEntity.class ).property( "contained" )
-						.binder( (PropertyBinder) context -> {
+						.binder( context -> {
 							context.dependencies().useRootOnly();
 							// Single-valued field
 							context.indexSchemaElement()
@@ -997,7 +997,7 @@ public class PropertyBridgeBaseIT {
 
 		SearchMapping mapping = setupHelper.start().withConfiguration(
 				b -> b.programmaticMapping().type( IndexedEntity.class ).property( "contained" )
-						.binder( (PropertyBinder) context -> {
+						.binder( context -> {
 							context.dependencies().useRootOnly();
 							// Single-valued field
 							context.indexSchemaElement()
@@ -1039,7 +1039,7 @@ public class PropertyBridgeBaseIT {
 				() -> setupHelper.start()
 						.withConfiguration( b -> b.programmaticMapping().type( IndexedEntity.class )
 								.property( "stringProperty" )
-								.binder( (PropertyBinder) context -> {
+								.binder( context -> {
 									context.bridgedElement().createAccessor( Integer.class );
 									context.bridge( new UnusedPropertyBridge() );
 								} )

--- a/jqassistant/rules.xml
+++ b/jqassistant/rules.xml
@@ -74,46 +74,6 @@
         ]]></cypher>
     </concept>
 
-    <concept id="hsearch:Spi">
-        <requiresConcept refId="hsearch:Test" />
-        <description>
-            Contributes the :Spi and :Public labels to SPI types
-        </description>
-        <cypher><![CDATA[
-            MATCH
-                (type:Type)
-            WHERE
-                NOT type:Test
-                AND type.fqn =~ ".*\\.spi\\..*"
-                AND type.visibility = "public"
-            SET
-                type:Spi, type:Public
-            RETURN
-                type
-        ]]></cypher>
-    </concept>
-
-    <concept id="hsearch:Impl">
-        <requiresConcept refId="hsearch:Test" />
-        <description>
-            Contributes the :Impl label to implementation types
-        </description>
-        <cypher><![CDATA[
-            MATCH
-                (type:Type)
-            WHERE
-                NOT type:Test
-                AND type.fqn =~ ".*\\.impl\\..*"
-                // Apache HTTP Client uses an impl package, but puts public classes in there... Such as the client builder.
-                AND NOT type.fqn STARTS WITH "org.apache.http.impl."
-                OR type.visibility <> "public"
-            SET
-                type:Impl
-            RETURN
-                type
-        ]]></cypher>
-    </concept>
-
     <concept id="hsearch:Test">
         <description>
             Contributes the :Test label to :Type nodes that exist for test purposes only.
@@ -133,22 +93,94 @@
         ]]></cypher>
     </concept>
 
-    <concept id="hsearch:Api">
+    <concept id="hsearch:Main">
         <requiresConcept refId="hsearch:Test" />
-        <requiresConcept refId="hsearch:Spi" />
-        <requiresConcept refId="hsearch:Impl" />
         <description>
-            Contributes the :Api and :Public labels to API types
+            Contributes the :Main label to non-test types
         </description>
         <cypher><![CDATA[
             MATCH
                 (type:Type)
             WHERE
                 NOT type:Test
-                AND NOT type:Impl
+            SET
+                type:Main
+            RETURN
+                type
+        ]]></cypher>
+    </concept>
+
+    <concept id="hsearch:Spi">
+        <requiresConcept refId="hsearch:Main" />
+        <description>
+            Contributes the :Spi label to SPI types
+        </description>
+        <cypher><![CDATA[
+            MATCH
+                (type:Type:Main)
+            WHERE
+                type.fqn =~ ".*\\.spi\\..*"
+                AND type.visibility = "public"
+            SET
+                type:Spi
+            RETURN
+                type
+        ]]></cypher>
+    </concept>
+
+    <concept id="hsearch:Impl">
+        <requiresConcept refId="hsearch:Main" />
+        <description>
+            Contributes the :Impl label to implementation types
+        </description>
+        <cypher><![CDATA[
+            MATCH
+                (type:Type:Main)
+            WHERE
+                type.fqn =~ ".*\\.impl\\..*"
+                // Apache HTTP Client uses an impl package, but puts public classes in there... Such as the client builder.
+                AND NOT type.fqn STARTS WITH "org.apache.http.impl."
+                OR type.visibility <> "public"
+            SET
+                type:Impl
+            RETURN
+                type
+        ]]></cypher>
+    </concept>
+
+    <concept id="hsearch:Api">
+        <requiresConcept refId="hsearch:Main" />
+        <requiresConcept refId="hsearch:Spi" />
+        <requiresConcept refId="hsearch:Impl" />
+        <description>
+            Contributes the :Api label to API types
+        </description>
+        <cypher><![CDATA[
+            MATCH
+                (type:Type:Main)
+            WHERE
+                NOT type:Impl
                 AND NOT type:Spi
             SET
-                type:Api, type:Public
+                type:Api
+            RETURN
+                type
+        ]]></cypher>
+    </concept>
+
+    <concept id="hsearch:Public">
+        <requiresConcept refId="hsearch:Api" />
+        <requiresConcept refId="hsearch:Spi" />
+        <description>
+            Contributes the :Public label to API and SPI types
+        </description>
+        <cypher><![CDATA[
+            MATCH
+                (type:Type)
+            WHERE
+                type:Api OR type:Spi
+            SET
+                type:Public
             RETURN
                 type
         ]]></cypher>
@@ -233,8 +265,7 @@
     </concept>
 
     <constraint id="hsearch:PublicTypesMayNotExtendInternalTypes">
-        <requiresConcept refId="hsearch:Api" />
-        <requiresConcept refId="hsearch:Spi" />
+        <requiresConcept refId="hsearch:Public" />
         <requiresConcept refId="hsearch:Impl" />
         <description>API/SPI types must not extend/implement internal types.</description>
         <cypher><![CDATA[
@@ -246,8 +277,7 @@
     </constraint>
 
     <constraint id="hsearch:PublicMethodsMayNotExposeInternalTypes">
-        <requiresConcept refId="hsearch:Api" />
-        <requiresConcept refId="hsearch:Spi" />
+        <requiresConcept refId="hsearch:Public" />
         <requiresConcept refId="hsearch:Impl" />
         <description>API/SPI methods must not expose internal types.</description>
         <cypher><![CDATA[
@@ -271,8 +301,7 @@
     </constraint>
 
     <constraint id="hsearch:PublicFieldsMayNotExposeInternalTypes">
-        <requiresConcept refId="hsearch:Api" />
-        <requiresConcept refId="hsearch:Spi" />
+        <requiresConcept refId="hsearch:Public" />
         <requiresConcept refId="hsearch:Impl" />
         <description>API/SPI fields must not expose internal types.</description>
         <cypher><![CDATA[
@@ -289,8 +318,7 @@
         <requiresConcept refId="java:Deprecated" />
         <requiresConcept refId="hsearch:MethodOverrides" />
         <requiresConcept refId="hsearch:HibernateSearch" />
-        <requiresConcept refId="hsearch:Api" />
-        <requiresConcept refId="hsearch:Spi" />
+        <requiresConcept refId="hsearch:Public" />
         <description>
             API or SPI methods must not start with "get" or "set".
             Exceptions are allowed when:
@@ -376,21 +404,20 @@
 
     <constraint id="hsearch:TypesMayNotDependOnImplementationTypeFromOtherModules">
         <requiresConcept refId="hsearch:UtilArtifacts" />
-        <requiresConcept refId="hsearch:Test" />
+        <requiresConcept refId="hsearch:Main" />
         <requiresConcept refId="hsearch:Impl" />
         <description>
-            Types must not depend on implementation types from other modules.
+            Main (non-test) types must not depend on implementation types from other modules.
             SPIs must be used for such dependencies.
             Exceptions are allowed only when the dependency type is in a util module,
             or the depending type is a test type.
         </description>
         <cypher><![CDATA[
-            MATCH (artifact1:Maven:Artifact)-[:CONTAINS]->(type1:Type)-[:DEPENDS_ON]->
+            MATCH (artifact1:Maven:Artifact)-[:CONTAINS]->(type1:Type:Main)-[:DEPENDS_ON]->
                 (type2:Type:Impl)<-[:CONTAINS]-(artifact2:Maven:Artifact)
             WHERE
                 artifact1 <> artifact2
                 // Exceptions
-                AND NOT type1:Test
                 AND NOT artifact2:Util
             RETURN
                 artifact1, type1, artifact2, type2
@@ -399,7 +426,7 @@
 
     <constraint id="hsearch:TypesShouldUseImplSuffixWithRestraint">
         <requiresConcept refId="hsearch:TypeMetadata" />
-        <requiresConcept refId="hsearch:Test" />
+        <requiresConcept refId="hsearch:Main" />
         <requiresConcept refId="hsearch:HibernateSearch" />
         <description>
             The 'Impl' suffix should only be used when naming classes that are the only implementation
@@ -408,19 +435,17 @@
         </description>
         <cypher><![CDATA[
             // Hibernate Search classes named "<prefix>Impl"
-            MATCH (implementingTypeEndingWithImpl:Class:HibernateSearch)
+            MATCH (implementingTypeEndingWithImpl:Class:Main:HibernateSearch)
             WHERE
                 implementingTypeEndingWithImpl.nameWithoutContainingTypeName =~ ".*Impl$"
-                AND NOT implementingTypeEndingWithImpl:Test // Ignore test types
             // The interface they implement, named "<prefix>" (if any)
             OPTIONAL MATCH (implementingTypeEndingWithImpl)-[:IMPLEMENTS|EXTENDS *]->(implementedType:Interface:HibernateSearch)
             WHERE
                 implementingTypeEndingWithImpl.nameWithoutContainingTypeName = (implementedType.nameWithoutContainingTypeName + "Impl")
             // All the implementing types that do not extend implementingTypeEndingWithImpl
-            OPTIONAL MATCH (topLevelImplementingType:Class)-[:IMPLEMENTS|EXTENDS *]->(implementedType)
+            OPTIONAL MATCH (topLevelImplementingType:Class:Main)-[:IMPLEMENTS|EXTENDS *]->(implementedType)
             WHERE
-                NOT topLevelImplementingType:Test // Ignore stubs
-                AND NOT (topLevelImplementingType)-[:EXTENDS *]->(implementingTypeEndingWithImpl)
+                NOT (topLevelImplementingType)-[:EXTENDS *]->(implementingTypeEndingWithImpl)
             WITH implementingTypeEndingWithImpl, implementedType, count(distinct topLevelImplementingType) AS topLevelImplementingTypeCount
             WHERE
                 implementedType IS NULL OR topLevelImplementingTypeCount > 1
@@ -466,22 +491,22 @@
         <requiresConcept refId="hsearch:TypeMetadata" />
         <requiresConcept refId="hsearch:Anonymous" />
         <requiresConcept refId="hsearch:Generated" />
-        <requiresConcept refId="hsearch:Test" />
+        <requiresConcept refId="hsearch:Main" />
         <requiresConcept refId="hsearch:HibernateSearch" />
         <requiresConcept refId="hsearch:ArtifactMetadata" />
         <description>
-            Types extending/implementing a Hibernate Search type from another module must have a module-specific keyword in their name,
+            Main (non-test) types extending/implementing a Hibernate Search type from another module must have a module-specific keyword in their name,
             either at the very start or just after "Abstract".
             This allows to more easily understand which module a given type comes from.
             Exceptions are allowed when:
-            - the misnamed type is an anonymous type, a generated type or a test type;
+            - the misnamed type is an anonymous type or a generated type;
             - or the misnamed type is an inner/nested type whose name ends with ".*Builder"
             and its surrounding type does use the module-specific keyword;
             - or the implemented type is in a util module,
             in which case the implemented interface may just be a detail.
         </description>
         <cypher><![CDATA[
-            MATCH (misnamedTypeArtifact:Maven:Artifact)-[:CONTAINS]->(misnamedType:Type)
+            MATCH (misnamedTypeArtifact:Maven:Artifact)-[:CONTAINS]->(misnamedType:Type:Main)
                     -[:IMPLEMENTS|EXTENDS *]->
                     (externalParentType:Type:HibernateSearch)<-[:CONTAINS]-(externalParentTypeArtifact:Maven:Artifact)
             WHERE
@@ -492,7 +517,6 @@
                 // Exceptions
                 AND NOT misnamedType:Anonymous
                 AND NOT misnamedType:Generated
-                AND NOT misnamedType:Test
                 AND NOT (
                         misnamedType.nameWithoutContainingTypeName ENDS WITH "Builder"
                         AND misnamedType.name =~ ("^(Abstract)?\\Q" + misnamedTypeArtifact.moduleSpecificKeyword + "\\E.*")
@@ -506,8 +530,7 @@
         <requiresConcept refId="java:Deprecated" />
         <requiresConcept refId="hsearch:TypeMetadata" />
         <requiresConcept refId="hsearch:HibernateSearch" />
-        <requiresConcept refId="hsearch:Api" />
-        <requiresConcept refId="hsearch:Spi" />
+        <requiresConcept refId="hsearch:Public" />
         <requiresConcept refId="hsearch:Impl" />
         <description>
             The simple (non-qualified) name of public Hibernate Search types should be unique.

--- a/legacy/pom.xml
+++ b/legacy/pom.xml
@@ -647,9 +647,7 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <configuration>
-                        <compilerArgs>
-                            <!-- Remove -Wall -->
-                        </compilerArgs>
+                        <failOnWarning>false</failOnWarning>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/legacy/pom.xml
+++ b/legacy/pom.xml
@@ -645,6 +645,15 @@
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <configuration>
+                        <compilerArgs>
+                            <!-- Remove -Wall -->
+                        </compilerArgs>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
                     <executions>
                         <execution>

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/event/impl/HibernateSearchEventListener.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/event/impl/HibernateSearchEventListener.java
@@ -267,6 +267,7 @@ public final class HibernateSearchEventListener implements PostDeleteEventListen
 	 * Required since Hibernate ORM 4.3
 	 */
 	@Override
+	@SuppressWarnings("deprecation") // Deprecated but abstract, so we have to implement it...
 	public boolean requiresPostCommitHanding(EntityPersister persister) {
 		// TODO Tests seem to pass using _false_ but we might be able to take
 		// advantage of this new hook?

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMetatadaContributor.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMetatadaContributor.java
@@ -162,7 +162,7 @@ public final class HibernateOrmMetatadaContributor implements PojoMappingConfigu
 				componentTypeModel = introspector.typeModel( componentValue.getRoleName() );
 			}
 			else {
-				componentTypeModel = introspector.typeModel( componentValue.getComponentClass() );
+				componentTypeModel = introspector.typeModel( (Class<?>) componentValue.getComponentClass() );
 			}
 			/*
 			 * Different Component instances for the same component class may carry different metadata

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/scope/impl/SearchScopeImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/scope/impl/SearchScopeImpl.java
@@ -16,7 +16,6 @@ import org.hibernate.search.mapper.orm.massindexing.impl.MassIndexerImpl;
 import org.hibernate.search.mapper.orm.schema.management.SearchSchemaManager;
 import org.hibernate.search.mapper.orm.schema.management.impl.SearchSchemaManagerImpl;
 import org.hibernate.search.mapper.orm.scope.SearchScope;
-import org.hibernate.search.mapper.orm.search.query.dsl.HibernateOrmSearchQuerySelectStep;
 import org.hibernate.search.mapper.orm.search.query.dsl.impl.HibernateOrmSearchQuerySelectStepImpl;
 import org.hibernate.search.mapper.orm.search.loading.context.impl.HibernateOrmLoadingContext;
 import org.hibernate.search.mapper.orm.work.SearchWorkspace;
@@ -36,7 +35,8 @@ public class SearchScopeImpl<E> implements SearchScope<E> {
 		this.delegate = delegate;
 	}
 
-	public HibernateOrmSearchQuerySelectStep<E> search(HibernateOrmScopeSessionContext sessionContext) {
+	@SuppressWarnings("deprecation")
+	public org.hibernate.search.mapper.orm.search.query.dsl.HibernateOrmSearchQuerySelectStep<E> search(HibernateOrmScopeSessionContext sessionContext) {
 		HibernateOrmLoadingContext.Builder<E> loadingContextBuilder = new HibernateOrmLoadingContext.Builder<>(
 				mappingContext, sessionContext, delegate.includedIndexedTypes()
 		);

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/query/dsl/impl/HibernateOrmSearchQuerySelectStepImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/query/dsl/impl/HibernateOrmSearchQuerySelectStepImpl.java
@@ -11,11 +11,11 @@ import org.hibernate.search.engine.search.query.dsl.spi.AbstractDelegatingSearch
 import org.hibernate.search.mapper.orm.common.EntityReference;
 import org.hibernate.search.mapper.orm.search.loading.EntityLoadingCacheLookupStrategy;
 import org.hibernate.search.mapper.orm.search.loading.dsl.SearchLoadingOptionsStep;
-import org.hibernate.search.mapper.orm.search.query.dsl.HibernateOrmSearchQuerySelectStep;
 
+@SuppressWarnings("deprecation")
 public class HibernateOrmSearchQuerySelectStepImpl<E>
 		extends AbstractDelegatingSearchQuerySelectStep<EntityReference, E, SearchLoadingOptionsStep>
-		implements HibernateOrmSearchQuerySelectStep<E> {
+		implements org.hibernate.search.mapper.orm.search.query.dsl.HibernateOrmSearchQuerySelectStep<E> {
 	private final SearchLoadingOptionsStep loadingOptions;
 
 	public HibernateOrmSearchQuerySelectStepImpl(
@@ -26,13 +26,15 @@ public class HibernateOrmSearchQuerySelectStepImpl<E>
 	}
 
 	@Override
-	public HibernateOrmSearchQuerySelectStep<E> fetchSize(int fetchSize) {
+	public org.hibernate.search.mapper.orm.search.query.dsl.HibernateOrmSearchQuerySelectStep<E> fetchSize(
+			int fetchSize) {
 		loadingOptions.fetchSize( fetchSize );
 		return this;
 	}
 
 	@Override
-	public HibernateOrmSearchQuerySelectStep<E> cacheLookupStrategy(EntityLoadingCacheLookupStrategy strategy) {
+	public org.hibernate.search.mapper.orm.search.query.dsl.HibernateOrmSearchQuerySelectStep<E> cacheLookupStrategy(
+			EntityLoadingCacheLookupStrategy strategy) {
 		loadingOptions.cacheLookupStrategy( strategy );
 		return this;
 	}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/SearchSession.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/SearchSession.java
@@ -21,7 +21,6 @@ import org.hibernate.search.mapper.orm.scope.SearchScope;
 import org.hibernate.search.mapper.orm.work.SearchIndexingPlan;
 import org.hibernate.search.mapper.orm.work.SearchWorkspace;
 import org.hibernate.search.mapper.orm.massindexing.MassIndexer;
-import org.hibernate.search.mapper.orm.search.query.dsl.HibernateOrmSearchQuerySelectStep;
 
 public interface SearchSession {
 
@@ -35,7 +34,9 @@ public interface SearchSession {
 	 * @return The initial step of a DSL where the search query can be defined.
 	 * @see SearchQuerySelectStep
 	 */
-	default <T> HibernateOrmSearchQuerySelectStep<T> search(Class<T> type) {
+	@SuppressWarnings("deprecation")
+	default <T> org.hibernate.search.mapper.orm.search.query.dsl.HibernateOrmSearchQuerySelectStep<T> search(
+			Class<T> type) {
 		return search( Collections.singleton( type ) );
 	}
 
@@ -49,7 +50,9 @@ public interface SearchSession {
 	 * @return The initial step of a DSL where the search query can be defined.
 	 * @see SearchQuerySelectStep
 	 */
-	<T> HibernateOrmSearchQuerySelectStep<T> search(Collection<? extends Class<? extends T>> types);
+	@SuppressWarnings("deprecation")
+	<T> org.hibernate.search.mapper.orm.search.query.dsl.HibernateOrmSearchQuerySelectStep<T> search(
+			Collection<? extends Class<? extends T>> types);
 
 	/**
 	 * Initiate the building of a search query.
@@ -61,7 +64,9 @@ public interface SearchSession {
 	 * @return The initial step of a DSL where the search query can be defined.
 	 * @see SearchQuerySelectStep
 	 */
-	<T> HibernateOrmSearchQuerySelectStep<T> search(SearchScope<T> scope);
+	@SuppressWarnings("deprecation")
+	<T> org.hibernate.search.mapper.orm.search.query.dsl.HibernateOrmSearchQuerySelectStep<T> search(
+			SearchScope<T> scope);
 
 	/**
 	 * Create a {@link SearchSchemaManager} for all indexes.

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/HibernateOrmSearchSession.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/HibernateOrmSearchSession.java
@@ -35,7 +35,6 @@ import org.hibernate.search.mapper.orm.schema.management.SearchSchemaManager;
 import org.hibernate.search.mapper.orm.scope.SearchScope;
 import org.hibernate.search.mapper.orm.scope.impl.HibernateOrmScopeSessionContext;
 import org.hibernate.search.mapper.orm.scope.impl.SearchScopeImpl;
-import org.hibernate.search.mapper.orm.search.query.dsl.HibernateOrmSearchQuerySelectStep;
 import org.hibernate.search.mapper.orm.automaticindexing.session.AutomaticIndexingSynchronizationStrategy;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.orm.session.context.HibernateOrmSessionContext;
@@ -131,16 +130,22 @@ public class HibernateOrmSearchSession extends AbstractPojoSearchSession<EntityR
 	}
 
 	@Override
-	public <T> HibernateOrmSearchQuerySelectStep<T> search(Collection<? extends Class<? extends T>> types) {
+	@SuppressWarnings("deprecation")
+	public <T> org.hibernate.search.mapper.orm.search.query.dsl.HibernateOrmSearchQuerySelectStep<T> search(
+			Collection<? extends Class<? extends T>> types) {
 		return search( scope( types ) );
 	}
 
 	@Override
-	public <T> HibernateOrmSearchQuerySelectStep<T> search(SearchScope<T> scope) {
+	@SuppressWarnings("deprecation")
+	public <T> org.hibernate.search.mapper.orm.search.query.dsl.HibernateOrmSearchQuerySelectStep<T> search(
+			SearchScope<T> scope) {
 		return search( (SearchScopeImpl<T>) scope );
 	}
 
-	private <T> HibernateOrmSearchQuerySelectStep<T> search(SearchScopeImpl<T> scope) {
+	@SuppressWarnings("deprecation")
+	private <T> org.hibernate.search.mapper.orm.search.query.dsl.HibernateOrmSearchQuerySelectStep<T> search(
+			SearchScopeImpl<T> scope) {
 		return scope.search( this );
 	}
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/LazyInitSearchSession.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/LazyInitSearchSession.java
@@ -16,7 +16,6 @@ import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.search.mapper.orm.massindexing.MassIndexer;
 import org.hibernate.search.mapper.orm.schema.management.SearchSchemaManager;
 import org.hibernate.search.mapper.orm.scope.SearchScope;
-import org.hibernate.search.mapper.orm.search.query.dsl.HibernateOrmSearchQuerySelectStep;
 import org.hibernate.search.mapper.orm.automaticindexing.session.AutomaticIndexingSynchronizationStrategy;
 import org.hibernate.search.mapper.orm.session.SearchSession;
 import org.hibernate.search.mapper.orm.work.SearchIndexingPlan;
@@ -41,12 +40,16 @@ public class LazyInitSearchSession implements SearchSession {
 	}
 
 	@Override
-	public <T> HibernateOrmSearchQuerySelectStep<T> search(Collection<? extends Class<? extends T>> types) {
+	@SuppressWarnings("deprecation")
+	public <T> org.hibernate.search.mapper.orm.search.query.dsl.HibernateOrmSearchQuerySelectStep<T> search(
+			Collection<? extends Class<? extends T>> types) {
 		return getDelegate().search( types );
 	}
 
 	@Override
-	public <T> HibernateOrmSearchQuerySelectStep<T> search(SearchScope<T> scope) {
+	@SuppressWarnings("deprecation")
+	public <T> org.hibernate.search.mapper.orm.search.query.dsl.HibernateOrmSearchQuerySelectStep<T> search(
+			SearchScope<T> scope) {
 		return getDelegate().search( scope );
 	}
 

--- a/mapper/orm/src/test/java/org/hibernate/search/mapper/orm/model/impl/AbstractHibernateOrmBootstrapIntrospectorPerReflectionStrategyTest.java
+++ b/mapper/orm/src/test/java/org/hibernate/search/mapper/orm/model/impl/AbstractHibernateOrmBootstrapIntrospectorPerReflectionStrategyTest.java
@@ -53,6 +53,7 @@ public abstract class AbstractHibernateOrmBootstrapIntrospectorPerReflectionStra
 		}
 	}
 
+	@SuppressWarnings("deprecation") // There's no other way to access the reflection manager
 	final HibernateOrmBootstrapIntrospector createIntrospector(Class<?> ... entityClasses) {
 		StandardServiceRegistryBuilder registryBuilder = new StandardServiceRegistryBuilder();
 		// Some properties that are not relevant to our test, but necessary to create the Metadata

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/IndexedEmbedded.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/IndexedEmbedded.java
@@ -13,7 +13,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage;
 import org.hibernate.search.engine.backend.types.ObjectStructure;
 import org.hibernate.search.mapper.pojo.extractor.mapping.annotation.ContainerExtraction;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMapping;
@@ -167,11 +166,13 @@ public @interface IndexedEmbedded {
 	/**
 	 * @return How the structure of the object field created for this indexed-embedded
 	 * is preserved upon indexing.
-	 * @see ObjectFieldStorage
+	 * @see org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage
 	 * @deprecated Use {@link #structure()} instead.
 	 */
 	@Deprecated
-	ObjectFieldStorage storage() default ObjectFieldStorage.DEFAULT;
+	@SuppressWarnings("deprecation")
+	org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage storage()
+			default org.hibernate.search.engine.backend.document.model.dsl.ObjectFieldStorage.DEFAULT;
 
 	/**
 	 * @return A definition of container extractors to be applied to the property,

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/IndexedEmbeddedProcessor.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/IndexedEmbeddedProcessor.java
@@ -20,6 +20,7 @@ import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.Property
 public class IndexedEmbeddedProcessor implements PropertyMappingAnnotationProcessor<IndexedEmbedded> {
 
 	@Override
+	@SuppressWarnings("deprecation") // For ObjectFieldStorage
 	public void process(PropertyMappingStep mappingContext, IndexedEmbedded annotation,
 			PropertyMappingAnnotationProcessorContext context) {
 		String cleanedUpPrefix = annotation.prefix();

--- a/pom.xml
+++ b/pom.xml
@@ -959,6 +959,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <showWarnings>true</showWarnings>
+                    <showDeprecation>true</showDeprecation>
+                    <failOnWarning>true</failOnWarning>
                     <release>${maven.compiler.release}</release>
                     <testRelease>${maven.compiler.testRelease}</testRelease>
                     <encoding>UTF-8</encoding>
@@ -1745,6 +1747,19 @@
             <modules>
                 <!-- Nothing at the moment -->
             </modules>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-compiler-plugin</artifactId>
+                            <configuration>
+                                <failOnWarning>false</failOnWarning>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
         </profile>
 
         <profile>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2206

This essentially fixes existing deprecations (not related to Lucene APIs) and makes the build fail if we ever rely on deprecated code again.