### PR TITLE
HSEARCH-3950 Simpler configuration syntax for single-backend applications

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/spi/ElasticsearchHttpClientConfigurer.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/spi/ElasticsearchHttpClientConfigurer.java
@@ -37,7 +37,7 @@ public interface ElasticsearchHttpClientConfigurer {
 	 *
 	 * @param builder An Apache HTTP client builder, to set the configuration to be applied.
 	 * @param propertySource The property source for the Elasticsearch backend being configured.
-	 * Properties are masked, i.e. {@code hibernate.search.backends.es.my.property}
+	 * Properties are masked, i.e. {@code hibernate.search.backend.my.property}
 	 * will be accessed as simply {@code my.property}.
 	 *
 	 * @see <a href="http://hc.apache.org/httpcomponents-client-ga/">the Apache HTTP Client documentation</a>

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchBackendImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchBackendImpl.java
@@ -49,7 +49,7 @@ class ElasticsearchBackendImpl implements BackendImplementor,
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private final String name;
+	private final EventContext eventContext;
 
 	private final BackendThreads threads;
 	private final ElasticsearchLinkImpl link;
@@ -62,12 +62,10 @@ class ElasticsearchBackendImpl implements BackendImplementor,
 	private final BeanHolder<? extends IndexLayoutStrategy> indexLayoutStrategyHolder;
 	private final TypeNameMapping typeNameMapping;
 
-	private final EventContext eventContext;
-
 	private final IndexManagerBackendContext indexManagerBackendContext;
 	private final IndexNamesRegistry indexNamesRegistry;
 
-	ElasticsearchBackendImpl(String name,
+	ElasticsearchBackendImpl(EventContext eventContext,
 			BackendThreads threads,
 			ElasticsearchLinkImpl link,
 			ElasticsearchIndexFieldTypeFactoryProvider typeFactoryProvider,
@@ -77,12 +75,12 @@ class ElasticsearchBackendImpl implements BackendImplementor,
 			BeanHolder<? extends IndexLayoutStrategy> indexLayoutStrategyHolder,
 			TypeNameMapping typeNameMapping,
 			FailureHandler failureHandler) {
-		this.name = name;
+		this.eventContext = eventContext;
 		this.threads = threads;
 		this.link = link;
 
 		this.generalPurposeOrchestrator = new ElasticsearchSimpleWorkOrchestrator(
-				"Elasticsearch general purpose orchestrator for backend " + name,
+				"Elasticsearch general purpose orchestrator - " + eventContext.render(),
 				link
 		);
 		this.analysisDefinitionRegistry = analysisDefinitionRegistry;
@@ -91,7 +89,6 @@ class ElasticsearchBackendImpl implements BackendImplementor,
 		this.indexLayoutStrategyHolder = indexLayoutStrategyHolder;
 		this.typeNameMapping = typeNameMapping;
 
-		this.eventContext = EventContexts.fromBackendName( name );
 		this.indexManagerBackendContext = new IndexManagerBackendContext(
 				this, eventContext, threads, link,
 				userFacingGson,
@@ -106,11 +103,7 @@ class ElasticsearchBackendImpl implements BackendImplementor,
 
 	@Override
 	public String toString() {
-		return new StringBuilder( getClass().getSimpleName() )
-				.append( "[" )
-				.append( "name=" ).append( name )
-				.append( "]" )
-				.toString();
+		return getClass().getSimpleName() + "[" + eventContext.render() + "]";
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/impl/LuceneBackendFactory.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/impl/LuceneBackendFactory.java
@@ -37,7 +37,6 @@ import org.hibernate.search.engine.environment.bean.BeanResolver;
 import org.hibernate.search.engine.environment.bean.BeanReference;
 import org.hibernate.search.util.common.impl.SuppressingCloser;
 import org.hibernate.search.util.common.reporting.EventContext;
-import org.hibernate.search.engine.reporting.spi.EventContexts;
 import org.hibernate.search.util.common.AssertionFailure;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
@@ -66,19 +65,17 @@ public class LuceneBackendFactory implements BackendFactory {
 					.build();
 
 	@Override
-	public BackendImplementor create(String name, BackendBuildContext buildContext,
+	public BackendImplementor create(EventContext eventContext, BackendBuildContext buildContext,
 			ConfigurationPropertySource propertySource) {
-		EventContext backendContext = EventContexts.fromBackendName( name );
-
 		BackendThreads backendThreads = null;
 		BeanHolder<? extends DirectoryProvider> directoryProviderHolder = null;
 
 		try {
-			backendThreads = new BackendThreads( "Backend " + name );
+			backendThreads = new BackendThreads( eventContext.render() );
 
-			Version luceneVersion = getLuceneVersion( backendContext, propertySource );
+			Version luceneVersion = getLuceneVersion( eventContext, propertySource );
 
-			directoryProviderHolder = getDirectoryProvider( backendContext, buildContext, propertySource );
+			directoryProviderHolder = getDirectoryProvider( eventContext, buildContext, propertySource );
 
 			MultiTenancyStrategy multiTenancyStrategy = getMultiTenancyStrategy( propertySource );
 
@@ -87,7 +84,7 @@ public class LuceneBackendFactory implements BackendFactory {
 			);
 
 			return new LuceneBackendImpl(
-					name,
+					eventContext,
 					backendThreads,
 					directoryProviderHolder,
 					new LuceneWorkFactoryImpl( multiTenancyStrategy ),

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/impl/LuceneBackendImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/impl/LuceneBackendImpl.java
@@ -43,7 +43,7 @@ public class LuceneBackendImpl implements BackendImplementor, LuceneBackend {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private final String name;
+	private final EventContext eventContext;
 
 	private final BackendThreads threads;
 	private final BeanHolder<? extends DirectoryProvider> directoryProviderHolder;
@@ -54,10 +54,9 @@ public class LuceneBackendImpl implements BackendImplementor, LuceneBackend {
 	private final MultiTenancyStrategy multiTenancyStrategy;
 	private final TimingSource timingSource;
 
-	private final EventContext eventContext;
 	private final IndexManagerBackendContext indexManagerBackendContext;
 
-	LuceneBackendImpl(String name,
+	LuceneBackendImpl(EventContext eventContext,
 			BackendThreads threads,
 			BeanHolder<? extends DirectoryProvider> directoryProviderHolder,
 			LuceneWorkFactory workFactory,
@@ -65,7 +64,7 @@ public class LuceneBackendImpl implements BackendImplementor, LuceneBackend {
 			MultiTenancyStrategy multiTenancyStrategy,
 			TimingSource timingSource,
 			FailureHandler failureHandler) {
-		this.name = name;
+		this.eventContext = eventContext;
 		this.threads = threads;
 		this.directoryProviderHolder = directoryProviderHolder;
 
@@ -73,12 +72,11 @@ public class LuceneBackendImpl implements BackendImplementor, LuceneBackend {
 		Similarity similarity = analysisDefinitionRegistry.getSimilarity();
 
 		this.readOrchestrator = new LuceneSyncWorkOrchestratorImpl(
-				"Lucene read work orchestrator for backend " + name, similarity
+				"Lucene read work orchestrator - " + eventContext.render(), similarity
 		);
 		this.multiTenancyStrategy = multiTenancyStrategy;
 		this.timingSource = timingSource;
 
-		this.eventContext = EventContexts.fromBackendName( name );
 		this.indexManagerBackendContext = new IndexManagerBackendContext(
 				this, eventContext, threads, directoryProviderHolder.get(), similarity,
 				workFactory, multiTenancyStrategy,
@@ -92,7 +90,7 @@ public class LuceneBackendImpl implements BackendImplementor, LuceneBackend {
 	public String toString() {
 		return new StringBuilder( getClass().getSimpleName() )
 				.append( "[" )
-				.append( "name=" ).append( name ).append( ", " )
+				.append( eventContext.render() ).append( ", " )
 				.append( "directoryProvider=" ).append( directoryProviderHolder.get() )
 				.append( "]" )
 				.toString();

--- a/documentation/src/main/asciidoc/reference/backend-elasticsearch.asciidoc
+++ b/documentation/src/main/asciidoc/reference/backend-elasticsearch.asciidoc
@@ -51,7 +51,7 @@ and <<mapper-orm-indexing-massindexer,reindex your data>>.
 [[elasticsearch-integration-configuration]]
 
 In order to define an Elasticsearch backend,
-the `hibernate.search.backends.<backend name>.type` property must be set to `elasticsearch`.
+the property `hibernate.search.backend.type` must be set to `elasticsearch`.
 
 All other configuration properties are optional,
 but the defaults might not suit everyone.
@@ -89,7 +89,7 @@ to send indexing requests and search queries to:
 
 [source]
 ----
-hibernate.search.backends.<backend name>.hosts = localhost:9200 (default)
+hibernate.search.backend.hosts = localhost:9200 (default)
 ----
 
 This property may be set to a String representing a host and port such as `localhost` or `es.mycompany.com:4400`,
@@ -100,7 +100,7 @@ You may change the protocol used to communicate with the hosts using this config
 
 [source]
 ----
-hibernate.search.backends.<backend name>.protocol = http (default)
+hibernate.search.backend.protocol = http (default)
 ----
 
 This property may be set to either `http` or `https`.
@@ -115,8 +115,8 @@ Automatic discovery is controlled by the following properties:
 
 [source]
 ----
-hibernate.search.backends.<backend name>.discovery.enabled = false (default)
-hibernate.search.backends.<backend name>.discovery.refresh_interval = 10 (default)
+hibernate.search.backend.discovery.enabled = false (default)
+hibernate.search.backend.discovery.refresh_interval = 10 (default)
 ----
 
 * `discovery.enabled` defines whether the feature is enabled.
@@ -132,8 +132,8 @@ but may be enabled by setting the following configuration properties:
 
 [source]
 ----
-hibernate.search.backends.<backend name>.username = ironman (default is empty)
-hibernate.search.backends.<backend name>.password = j@rv1s (default is empty)
+hibernate.search.backend.username = ironman (default is empty)
+hibernate.search.backend.password = j@rv1s (default is empty)
 ----
 
 The username and password to send when connecting to the Elasticsearch servers.
@@ -173,10 +173,10 @@ Hibernate Search will be able to understand the following configuration properti
 
 [source]
 ----
-hibernate.search.backends.<backend name>.aws.signing.enabled = false (default)
-hibernate.search.backends.<backend name>.aws.signing.access_key = AKIDEXAMPLE (no default)
-hibernate.search.backends.<backend name>.aws.signing.secret_key = wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY (no default)
-hibernate.search.backends.<backend name>.aws.signing.region = us-east-1 (no default)
+hibernate.search.backend.aws.signing.enabled = false (default)
+hibernate.search.backend.aws.signing.access_key = AKIDEXAMPLE (no default)
+hibernate.search.backend.aws.signing.secret_key = wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY (no default)
+hibernate.search.backend.aws.signing.region = us-east-1 (no default)
 ----
 
 * `aws.signing.enabled` defines whether request signing is enabled.
@@ -204,9 +204,9 @@ Timeouts::
 +
 [source]
 ----
-hibernate.search.backends.<backend name>.request_timeout = 60000 (default)
-hibernate.search.backends.<backend name>.connection_timeout = 3000 (default)
-hibernate.search.backends.<backend name>.read_timeout = 60000 (default)
+hibernate.search.backend.request_timeout = 60000 (default)
+hibernate.search.backend.connection_timeout = 3000 (default)
+hibernate.search.backend.read_timeout = 60000 (default)
 ----
 
 * `request_timeout` defines the timeout when executing a request.
@@ -222,8 +222,8 @@ Connection pool::
 +
 [source]
 ----
-hibernate.search.backends.<backend name>.max_connections = 20 (default)
-hibernate.search.backends.<backend name>.max_connections_per_route = 10 (default)
+hibernate.search.backend.max_connections = 20 (default)
+hibernate.search.backend.max_connections_per_route = 10 (default)
 ----
 
 * `max_connections` defines maximum number of simultaneous connections
@@ -247,8 +247,8 @@ By default, Hibernate Search will query the Elasticsearch cluster at boot time t
 and will infer the correct behavior to adopt.
 
 If necessary, you can disable the call to the Elasticsearch cluster for version checks on startup.
-To do that, set `hibernate.search.backends.<backend name>.version_check.enabled` to `false`,
-and set the property `hibernate.search.backends.<backend name>.version`
+To do that, set `hibernate.search.backend.version_check.enabled` to `false`,
+and set the property `hibernate.search.backend.version`
 to a string following the format `x.y.z-qualifier`,
 where `x`, `y` and `z` are integers
 and `qualifier` is an optional string of word characters (alphanumeric or `_`).
@@ -258,8 +258,8 @@ but other numbers are optional.
 
 [TIP]
 ====
-The property `hibernate.search.backends.<backend name>.version` can also be set
-when `hibernate.search.backends.<backend name>.version_check.enabled` is `true` (the default).
+The property `hibernate.search.backend.version` can also be set
+when `hibernate.search.backend.version_check.enabled` is `true` (the default).
 
 In that case,
 Hibernate Search will still query the Elasticsearch cluster to know the actual version of the cluster,
@@ -272,7 +272,7 @@ This can be helpful while developing, in particular.
 // Search 5 anchors backward compatibility
 [[elasticsearch-log-json-pretty-printing]]
 
-The `hibernate.search.backends.<backend name>.log.json_pretty_printing` <<configuration-property-types,boolean property>>
+The `hibernate.search.backend.log.json_pretty_printing` <<configuration-property-types,boolean property>>
 defines whether JSON included in logs should be pretty-printed (indented, with line breaks).
 It defaults to `false`.
 
@@ -298,11 +298,11 @@ For Elasticsearch specifically, some fine-tuning is available through the follow
 
 [source]
 ----
-hibernate.search.backends.<backend name>.indexes.<index name>.schema_management.minimal_required_status green (default)
-hibernate.search.backends.<backend name>.indexes.<index name>.schema_management.minimal_required_status_wait_timeout 10000 (default)
+hibernate.search.backend.indexes.<index name>.schema_management.minimal_required_status green (default)
+hibernate.search.backend.indexes.<index name>.schema_management.minimal_required_status_wait_timeout 10000 (default)
 # OR
-hibernate.search.backends.<backend name>.index_defaults.schema_management.minimal_required_status green (default)
-hibernate.search.backends.<backend name>.index_defaults.schema_management.minimal_required_status_wait_timeout 10000 (default)
+hibernate.search.backend.index_defaults.schema_management.minimal_required_status green (default)
+hibernate.search.backend.index_defaults.schema_management.minimal_required_status_wait_timeout 10000 (default)
 ----
 
 * `minimal_required_status` defines the minimal required status of an index before creation is considered complete.
@@ -362,7 +362,7 @@ you can define a custom layout in two simple steps:
 
 1. Define a class that implements the interface `org.hibernate.search.backend.elasticsearch.index.layout.IndexLayoutStrategy`.
 2. Configure the backend to use that implementation by setting the configuration property
-`hibernate.search.backends.<backend name>.layout.strategy`
+`hibernate.search.backend.layout.strategy`
 to a <<configuration-property-types,bean reference>> pointing to the implementation.
 
 For example, the implementation below will lead to the following layout for an index named `myIndex`:
@@ -572,7 +572,7 @@ The strategy is set a the backend level:
 
 [source]
 ----
-hibernate.search.backends.<backend-name>.mapping.type_name.strategy = discriminator (default)
+hibernate.search.backend.mapping.type_name.strategy = discriminator (default)
 ----
 
 See the following subsections for details about available strategies.
@@ -629,7 +629,7 @@ The multi-tenancy strategy is set a the backend level:
 
 [source]
 ----
-hibernate.search.backends.<backend name>.multi_tenancy.strategy = none (default)
+hibernate.search.backend.multi_tenancy.strategy = none (default)
 ----
 
 See the following subsections for details about available strategies.
@@ -685,7 +685,7 @@ To configure analysis in an Elasticsearch backend, you will need to:
 
 * Define a class that implements the `org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurer` interface.
 * Configure the backend to use that implementation by setting the configuration property
-`hibernate.search.backends.<backend name>.analysis.configurer`
+`hibernate.search.backend.analysis.configurer`
 to a <<configuration-property-types,bean reference>> pointing to the implementation.
 
 Hibernate Search will call the `configure` method of this implementation on startup,
@@ -750,7 +750,7 @@ That can be changed using a configuration property:
 
 [source]
 ----
-hibernate.search.backends.<backend-name>.thread_pool.size = 4
+hibernate.search.backend.thread_pool.size = 4
 ----
 
 [NOTE]
@@ -798,13 +798,13 @@ This is done through the following configuration properties, at the index level:
 
 [source]
 ----
-hibernate.search.backends.<backend name>.indexes.<index name>.indexing.queue_count 10 (default)
-hibernate.search.backends.<backend name>.indexes.<index name>.indexing.queue_size 1000 (default)
-hibernate.search.backends.<backend name>.indexes.<index name>.indexing.max_bulk_size 100 (default)
+hibernate.search.backend.indexes.<index name>.indexing.queue_count 10 (default)
+hibernate.search.backend.indexes.<index name>.indexing.queue_size 1000 (default)
+hibernate.search.backend.indexes.<index name>.indexing.max_bulk_size 100 (default)
 # OR
-hibernate.search.backends.<backend name>.index_defaults.indexing.queue_count 10 (default)
-hibernate.search.backends.<backend name>.index_defaults.indexing.queue_size 1000 (default)
-hibernate.search.backends.<backend name>.index_defaults.indexing.max_bulk_size 100 (default)
+hibernate.search.backend.index_defaults.indexing.queue_count 10 (default)
+hibernate.search.backend.index_defaults.indexing.queue_size 1000 (default)
+hibernate.search.backend.index_defaults.indexing.max_bulk_size 100 (default)
 ----
 
 * `indexing.queue_count` defines the number of queues.

--- a/documentation/src/main/asciidoc/reference/backend-lucene.asciidoc
+++ b/documentation/src/main/asciidoc/reference/backend-lucene.asciidoc
@@ -7,7 +7,7 @@
 == Basic configuration
 
 In order to define a Lucene backend,
-the `hibernate.search.backends.<backend name>.type` property must be set to `lucene`.
+the property `hibernate.search.backend.type` must be set to `lucene`.
 
 All other configuration properties are optional,
 but the defaults might not suit everyone.
@@ -38,7 +38,7 @@ The type of directory is set a the backend level:
 [[example-configuring-directory-providers]]
 [source]
 ----
-hibernate.search.backends.<backend-name>.directory.type = local-filesystem
+hibernate.search.backend.directory.type = local-filesystem
 ----
 
 // Search 5 anchors backward compatibility
@@ -85,7 +85,7 @@ It can be configured at the backend level:
 
 [source]
 ----
-hibernate.search.backends.<backend-name>.directory.root = /path/to/my/root
+hibernate.search.backend.directory.root = /path/to/my/root
 ----
 
 For example, with the configuration above,
@@ -107,7 +107,7 @@ Hibernate Search exposes a configuration property at the backend level:
 
 [source]
 ----
-hibernate.search.backends.<backend-name>.directory.filesystem_access.strategy = auto (default)
+hibernate.search.backend.directory.filesystem_access.strategy = auto (default)
 ----
 
 Allowed values are:
@@ -166,7 +166,7 @@ Hibernate Search exposes a configuration property at the backend level:
 
 [source]
 ----
-hibernate.search.backends.<backend-name>.directory.locking.strategy = native-filesystem
+hibernate.search.backend.directory.locking.strategy = native-filesystem
 ----
 
 The following strategies are available:
@@ -223,11 +223,11 @@ Multiple strategies are available:
 +
 [source]
 ----
-hibernate.search.backends.<backend name>.indexes.<index name>.sharding.strategy = hash
-hibernate.search.backends.<backend name>.indexes.<index name>.sharding.number_of_shards = 2 (no default)
+hibernate.search.backend.indexes.<index name>.sharding.strategy = hash
+hibernate.search.backend.indexes.<index name>.sharding.number_of_shards = 2 (no default)
 # OR
-hibernate.search.backends.<backend name>.index_defaults.sharding.strategy = hash
-hibernate.search.backends.<backend name>.index_defaults.sharding.number_of_shards = 2 (no default)
+hibernate.search.backend.index_defaults.sharding.strategy = hash
+hibernate.search.backend.index_defaults.sharding.number_of_shards = 2 (no default)
 ----
 +
 The `hash` strategy requires to set a number of shards through the `number_of_shards` property.
@@ -248,11 +248,11 @@ to be brought down to a smaller number (e.g. "all integers").
 +
 [source]
 ----
-hibernate.search.backends.<backend name>.indexes.<index name>.sharding.strategy = explicit
-hibernate.search.backends.<backend name>.indexes.<index name>.sharding.shard_identifiers = fr,en,de (no default)
+hibernate.search.backend.indexes.<index name>.sharding.strategy = explicit
+hibernate.search.backend.indexes.<index name>.sharding.shard_identifiers = fr,en,de (no default)
 # OR
-hibernate.search.backends.<backend name>.index_defaults.sharding.strategy = explicit
-hibernate.search.backends.<backend name>.index_defaults.sharding.shard_identifiers = fr,en,de (no default)
+hibernate.search.backend.index_defaults.sharding.strategy = explicit
+hibernate.search.backend.index_defaults.sharding.shard_identifiers = fr,en,de (no default)
 ----
 +
 The `explicit` strategy requires to set a list of shard identifiers through the `shard_identifiers` property.
@@ -295,7 +295,7 @@ This configuration property is set at the backend level:
 
 [source]
 ----
-hibernate.search.backends.<backend-name>.lucene_version = LUCENE_8_1_1
+hibernate.search.backend.lucene_version = LUCENE_8_1_1
 ----
 
 Depending on the specific version of Lucene you're using,
@@ -489,7 +489,7 @@ The multi-tenancy strategy is set a the backend level:
 
 [source]
 ----
-hibernate.search.backends.<backend name>.multi_tenancy.strategy = none (default)
+hibernate.search.backend.multi_tenancy.strategy = none (default)
 ----
 
 See the following subsections for details about available strategies.
@@ -526,7 +526,7 @@ To configure analysis in a Lucene backend, you will need to:
 
 * Define a class that implements the `org.hibernate.search.backend.lucene.analysis.LuceneAnalysisConfigurer` interface.
 * Configure the backend to use that implementation by setting the configuration property
-`hibernate.search.backends.<backend name>.analysis.configurer`
+`hibernate.search.backend.analysis.configurer`
 to a <<configuration-property-types,bean reference>> pointing to the implementation.
 
 Hibernate Search will call the `configure` method of this implementation on startup,
@@ -628,7 +628,7 @@ That can be changed using a configuration property:
 
 [source]
 ----
-hibernate.search.backends.<backend-name>.thread_pool.size = 4
+hibernate.search.backend.thread_pool.size = 4
 ----
 
 [NOTE]
@@ -668,11 +668,11 @@ This is done through the following configuration properties, at the index level:
 
 [source]
 ----
-hibernate.search.backends.<backend name>.indexes.<index name>.indexing.queue_count 10 (default)
-hibernate.search.backends.<backend name>.indexes.<index name>.indexing.queue_size 1000 (default)
+hibernate.search.backend.indexes.<index name>.indexing.queue_count 10 (default)
+hibernate.search.backend.indexes.<index name>.indexing.queue_size 1000 (default)
 # OR
-hibernate.search.backends.<backend name>.index_defaults.indexing.queue_count 10 (default)
-hibernate.search.backends.<backend name>.index_defaults.indexing.queue_size 1000 (default)
+hibernate.search.backend.index_defaults.indexing.queue_count 10 (default)
+hibernate.search.backend.index_defaults.indexing.queue_size 1000 (default)
 ----
 
 * `indexing.queue_count` defines the number of queues.
@@ -758,9 +758,9 @@ by setting the commit interval (in milliseconds) at the index level:
 
 [source]
 ----
-hibernate.search.backends.<backend name>.indexes.<index name>.io.commit_interval = 1000 (default)
+hibernate.search.backend.indexes.<index name>.io.commit_interval = 1000 (default)
 # OR
-hibernate.search.backends.<backend name>.index_defaults.io.commit_interval = 1000 (default)
+hibernate.search.backend.index_defaults.io.commit_interval = 1000 (default)
 ----
 
 [WARNING]
@@ -808,9 +808,9 @@ The refresh interval is set at the index level:
 
 [source]
 ----
-hibernate.search.backends.<backend name>.indexes.<index name>.io.refresh_interval = 0 (default)
+hibernate.search.backend.indexes.<index name>.io.refresh_interval = 0 (default)
 # OR
-hibernate.search.backends.<backend name>.index_defaults.io.refresh_interval = 0 (default)
+hibernate.search.backend.index_defaults.io.refresh_interval = 0 (default)
 ----
 
 [[backend-lucene-io-writer]]
@@ -831,9 +831,9 @@ For example, `io.writer.ram_buffer_size` can be set like this:
 
 [source]
 ----
-hibernate.search.backends.<backend name>.indexes.<index name>.io.writer.ram_buffer_size = 32
+hibernate.search.backend.indexes.<index name>.io.writer.ram_buffer_size = 32
 # OR
-hibernate.search.backends.<backend name>.index_defaults.io.writer.ram_buffer_size = 32
+hibernate.search.backend.index_defaults.io.writer.ram_buffer_size = 32
 ----
 
 [[table-performance-parameters]]
@@ -900,9 +900,9 @@ For example, `io.merge.factor` can be set like this:
 
 [source]
 ----
-hibernate.search.backends.<backend name>.indexes.<index name>.io.merge.factor = 10
+hibernate.search.backend.indexes.<index name>.io.merge.factor = 10
 # OR
-hibernate.search.backends.<backend name>.index_defaults.io.merge.factor = 10
+hibernate.search.backend.index_defaults.io.merge.factor = 10
 ----
 
 [cols="1,2a", options="header"]
@@ -990,9 +990,9 @@ use something like this:
 
 [source]
 ----
-hibernate.search.backends.<backend name>.index_defaults.io.writer.ram_buffer_size = 10
-hibernate.search.backends.<backend name>.index_defaults.io.merge.max_size = 7
-hibernate.search.backends.<backend name>.index_defaults.io.merge.max_forced_size = 7
+hibernate.search.backend.index_defaults.io.writer.ram_buffer_size = 10
+hibernate.search.backend.index_defaults.io.merge.max_size = 7
+hibernate.search.backend.index_defaults.io.merge.max_forced_size = 7
 ----
 ========
 

--- a/documentation/src/main/asciidoc/reference/configuration.asciidoc
+++ b/documentation/src/main/asciidoc/reference/configuration.asciidoc
@@ -121,21 +121,34 @@ or a reference by type as a `java.lang.Class`
 === Configuration Builders
 Both `BackendSettings` and `IndexSettings` provide tools to help build the configuration property keys.
 
-
 BackendSettings::
 +
-`BackendSettings.backendKey("myBackend", ElasticsearchBackendSettings.HOSTS)` is equivalent to `hibernate.search.backends.myBackend.host`.
+`BackendSettings.backendKey(ElasticsearchBackendSettings.HOSTS)`
+is equivalent to `hibernate.search.backend.hosts`.
 +
-For a list of available property keys, see link:{hibernateSearchJavadocUrl}/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchBackendSettings.html[ElasticsearchBackendSettings] or link:{hibernateSearchJavadocUrl}/org/hibernate/search/backend/lucene/cfg/LuceneBackendSettings.html[LuceneBackendSettings]
+`BackendSettings.backendKey("myBackend", ElasticsearchBackendSettings.HOSTS)`
+is equivalent to `hibernate.search.backends.myBackend.hosts`.
++
+For a list of available property keys,
+see link:{hibernateSearchJavadocUrl}/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchBackendSettings.html[ElasticsearchBackendSettings]
+or link:{hibernateSearchJavadocUrl}/org/hibernate/search/backend/lucene/cfg/LuceneBackendSettings.html[LuceneBackendSettings]
 
 IndexSettings::
 +
-`IndexSettings.indexDefaultsKey("myBackend", ElasticsearchIndexSettings.LIFECYCLE_MINIMAL_REQUIRED_STATUS)` is equivalent to `hibernate.search.backends.signature.index_defaults.lifecycle.minimal_required_status`.
+`IndexSettings.indexDefaultsKey(ElasticsearchIndexSettings.LIFECYCLE_MINIMAL_REQUIRED_STATUS)`
+is equivalent to `hibernate.search.backend.index_defaults.lifecycle.minimal_required_status`.
 +
-For a list of available property keys, see link:{hibernateSearchJavadocUrl}/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchIndexSettings.html[ElasticsearchIndexSettings] or link:{hibernateSearchJavadocUrl}/org/hibernate/search/backend/lucene/cfg/LuceneIndexSettings.html[LuceneIndexSettings]
+`IndexSettings.indexDefaultsKey("myBackend", ElasticsearchIndexSettings.LIFECYCLE_MINIMAL_REQUIRED_STATUS)`
+is equivalent to `hibernate.search.backends.myBackend.index_defaults.lifecycle.minimal_required_status`.
++
+For a list of available property keys,
+see link:{hibernateSearchJavadocUrl}/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchIndexSettings.html[ElasticsearchIndexSettings]
+or link:{hibernateSearchJavadocUrl}/org/hibernate/search/backend/lucene/cfg/LuceneIndexSettings.html[LuceneIndexSettings]
 [TIP]
 ====
-You can also use the `IndexSettings.indexKey("myBackend", "myIndex", ElasticsearchIndexSettings.LIFECYCLE_MINIMAL_REQUIRED_STATUS)` to apply a configuration to a specific index.
+You can also use `IndexSettings.indexKey("myIndex", ElasticsearchIndexSettings.LIFECYCLE_MINIMAL_REQUIRED_STATUS)`
+or `IndexSettings.indexKey("myBackend", "myIndex", ElasticsearchIndexSettings.LIFECYCLE_MINIMAL_REQUIRED_STATUS)`
+to apply a configuration to a specific index.
 ====
 
 .Using the helper to build hibernate configuration

--- a/documentation/src/main/asciidoc/reference/configuration.asciidoc
+++ b/documentation/src/main/asciidoc/reference/configuration.asciidoc
@@ -31,24 +31,21 @@ Global properties::
 These properties potentially affect all Hibernate Search.
 They are generally located just under the `hibernate.search` root.
 +
-Notable properties:
-
-* `hibernate.search.default_backend`: defines the name of the backend used by default on all indexes.
-
-+
-Other global properties are explained in the relevant parts of this documentation:
+Global properties are explained in the relevant parts of this documentation:
 
 * <<mapper-orm-mapping-configuration,Hibernate ORM mapping>>
 
 Backend properties::
 These properties affect a single backend.
-They are grouped under a common root that includes the backend name: `hibernate.search.backends.<backend name>`.
-The backend name is arbitrarily defined by the user: just pick a string, such as `myBackend` or `elasticsearch`,
-and make sure to use it consistently.
+They are grouped under a common root:
+
+* `hibernate.search.backend` for the default backend (most common usage).
+* `hibernate.search.backends.<backend name>` for a named backend (advanced usage).
+
 +
 Notable properties:
 
-* `hibernate.search.backends.<backend name>.type`: the type of the backend.
+* `hibernate.search.backend.type`: the type of the backend.
 Set this to either `lucene` or `elasticsearch`.
 
 +
@@ -60,24 +57,31 @@ Other backend properties are explained in the relevant parts of this documentati
 Index properties::
 These properties affect either one or multiple indexes, depending on the root.
 +
-With the root `hibernate.search.backends.<backend name>.index_defaults`,
+With the root `hibernate.search.backend.index_defaults`,
 they set defaults for all indexes of the referenced backend.
 The backend name must match the name defined in the mapping.
 +
-With the root `hibernate.search.backends.<backend name>.indexes.<index name>`,
+With the root `hibernate.search.backend.indexes.<index name>`,
 they set the value for a specific index, overriding the defaults (if any).
 The backend and index names must match the names defined in the mapping.
 For ORM entities, the default index name is the name of the indexed class, without the package:
 `org.mycompany.Book` will have `Book` as its default index name.
 Index names can be customized in the mapping.
-
++
+Alternatively, the backend can also be referenced by name,
+i.e. the roots above can also be `hibernate.search.backends.<backend name>.index_defaults`
+or `hibernate.search.backends.<backend name>.indexes.<index name>`.
 +
 Examples:
 
+* `hibernate.search.backend.index_defaults.io.commit_interval = 500`
+sets the `io.commit_interval` property for all indexes of the default backend.
+* `hibernate.search.backend.indexes.Product.io.commit_interval = 2000`
+sets the `io.commit_interval` property for the `Product` index of the default backend.
 * `hibernate.search.backends.myBackend.index_defaults.io.commit_interval = 500`
-sets the `io.commit_interval` property for all indexes of the backend `myBackend`.
+sets the `io.commit_interval` property for all indexes of backend `myBackend`.
 * `hibernate.search.backends.myBackend.indexes.Product.io.commit_interval = 2000`
-sets the `io.commit_interval` property for the `Product` index of the backend `myBackend`.
+sets the `io.commit_interval` property for the `Product` index of backend `myBackend`.
 
 +
 Other index properties are explained in the relevant parts of this documentation:

--- a/documentation/src/main/asciidoc/reference/getting-started.asciidoc
+++ b/documentation/src/main/asciidoc/reference/getting-started.asciidoc
@@ -157,7 +157,6 @@ include::{resourcesdir}/META-INF/persistence.xml[tags=gettingstarted-configurati
 <2> The backend will store indexes in the current working directory by default.
 If you want to store the indexes elsewhere,
 uncomment this line and set the value of the property.
-<3> Make sure to use the backend we just defined for all indexes.
 ====
 
 .Hibernate Search properties in `persistence.xml` for a "Hibernate ORM + Elasticsearch" setup
@@ -171,7 +170,6 @@ include::{resourcesdir}/META-INF/persistence.xml[tags=gettingstarted-configurati
 If you want to connect to another URL, uncomment these lines
 and set the value for the "hosts" property,
 and optionally the username and password.
-<3> Make sure to use the backend we just defined for all indexes.
 ====
 
 [[getting-started-mapping]]

--- a/documentation/src/main/asciidoc/reference/mapper-orm-mapping-entityindexmapping.asciidoc
+++ b/documentation/src/main/asciidoc/reference/mapper-orm-mapping-entityindexmapping.asciidoc
@@ -54,7 +54,7 @@ include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/entityindexma
 ----
 ====
 
-If you defined multiple backends, you can map entities to another backend than the default one.
+If you <<configuration-structure,defined named backends>>, you can map entities to another backend than the default one.
 By setting `@Indexed(backend = "backend2")` you inform Hibernate Search that the index
 for your entity must be created in the backend named "backend2".
 This may be useful if your model has clearly defined sub-parts with very different indexing requirements.

--- a/documentation/src/test/java/org/hibernate/search/documentation/analysis/AnalysisIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/analysis/AnalysisIT.java
@@ -33,11 +33,9 @@ import org.junit.runners.Parameterized;
 @RunWith(Parameterized.class)
 public class AnalysisIT {
 
-	private static final String BACKEND_NAME = "myBackend"; // Don't change, the same name is used in property files
-
 	@Parameterized.Parameters(name = "{0}")
 	public static List<?> params() {
-		return DocumentationSetupHelper.testParamsWithSingleBackend( BACKEND_NAME, BackendConfigurations.simple() );
+		return DocumentationSetupHelper.testParamsWithSingleBackend( BackendConfigurations.simple() );
 	}
 
 	@Parameterized.Parameter
@@ -111,7 +109,7 @@ public class AnalysisIT {
 
 		EntityManagerFactory entityManagerFactory = setupHelper.start()
 				.withBackendProperty(
-						BACKEND_NAME, LuceneBackendSettings.ANALYSIS_CONFIGURER,
+						LuceneBackendSettings.ANALYSIS_CONFIGURER,
 						new AdvancedLuceneAnalysisConfigurer()
 				)
 				.withProperty(
@@ -150,7 +148,7 @@ public class AnalysisIT {
 
 		EntityManagerFactory entityManagerFactory = setupHelper.start()
 				.withBackendProperty(
-						BACKEND_NAME, LuceneBackendSettings.ANALYSIS_CONFIGURER,
+						LuceneBackendSettings.ANALYSIS_CONFIGURER,
 						new CustomSimilarityLuceneAnalysisConfigurer()
 				)
 				.withProperty(
@@ -189,7 +187,7 @@ public class AnalysisIT {
 
 		EntityManagerFactory entityManagerFactory = setupHelper.start()
 				.withBackendProperty(
-						BACKEND_NAME, ElasticsearchBackendSettings.ANALYSIS_CONFIGURER,
+						ElasticsearchBackendSettings.ANALYSIS_CONFIGURER,
 						new AdvancedElasticsearchAnalysisConfigurer()
 				)
 				.withProperty(

--- a/documentation/src/test/java/org/hibernate/search/documentation/backend/elasticsearch/client/ElasticsearchGetClientIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/backend/elasticsearch/client/ElasticsearchGetClientIT.java
@@ -30,7 +30,7 @@ public class ElasticsearchGetClientIT {
 
 	@Rule
 	public DocumentationSetupHelper setupHelper =
-			DocumentationSetupHelper.withSingleBackend( "myBackend", new ElasticsearchBackendConfiguration() );
+			DocumentationSetupHelper.withSingleBackend( new ElasticsearchBackendConfiguration() );
 
 	private EntityManagerFactory entityManagerFactory;
 
@@ -43,7 +43,7 @@ public class ElasticsearchGetClientIT {
 	public void client() throws IOException {
 		//tag::client[]
 		SearchMapping mapping = Search.mapping( entityManagerFactory ); // <1>
-		Backend backend = mapping.backend( "myBackend" ); // <2>
+		Backend backend = mapping.backend(); // <2>
 		ElasticsearchBackend elasticsearchBackend = backend.unwrap( ElasticsearchBackend.class ); // <3>
 		RestClient client = elasticsearchBackend.client( RestClient.class ); // <4>
 		//end::client[]

--- a/documentation/src/test/java/org/hibernate/search/documentation/backend/elasticsearch/layout/ElasticsearchCustomLayoutStrategyIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/backend/elasticsearch/layout/ElasticsearchCustomLayoutStrategyIT.java
@@ -31,10 +31,8 @@ import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
 public class ElasticsearchCustomLayoutStrategyIT {
-	private static final String BACKEND_NAME = "testBackend";
-
 	@Rule
-	public DocumentationSetupHelper setupHelper = DocumentationSetupHelper.withSingleBackend( BACKEND_NAME, new ElasticsearchBackendConfiguration() );
+	public DocumentationSetupHelper setupHelper = DocumentationSetupHelper.withSingleBackend( new ElasticsearchBackendConfiguration() );
 
 	@Rule
 	public TestElasticsearchClient elasticsearchClient = new TestElasticsearchClient();
@@ -51,7 +49,6 @@ public class ElasticsearchCustomLayoutStrategyIT {
 
 		EntityManagerFactory entityManagerFactory = setupHelper.start()
 				.withBackendProperty(
-						BACKEND_NAME,
 						ElasticsearchBackendSettings.LAYOUT_STRATEGY,
 						CustomLayoutStrategy.class.getName()
 				)

--- a/documentation/src/test/java/org/hibernate/search/documentation/backend/lucene/analyzer/LuceneGetAnalyzerIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/backend/lucene/analyzer/LuceneGetAnalyzerIT.java
@@ -30,7 +30,7 @@ public class LuceneGetAnalyzerIT {
 
 	@Rule
 	public DocumentationSetupHelper setupHelper =
-			DocumentationSetupHelper.withSingleBackend( "myBackend", new LuceneBackendConfiguration() );
+			DocumentationSetupHelper.withSingleBackend( new LuceneBackendConfiguration() );
 
 	private EntityManagerFactory entityManagerFactory;
 
@@ -43,7 +43,7 @@ public class LuceneGetAnalyzerIT {
 	public void fromBackend() {
 		//tag::fromBackend[]
 		SearchMapping mapping = Search.mapping( entityManagerFactory ); // <1>
-		Backend backend = mapping.backend( "myBackend" ); // <2>
+		Backend backend = mapping.backend(); // <2>
 		LuceneBackend luceneBackend = backend.unwrap( LuceneBackend.class ); // <3>
 		Optional<? extends Analyzer> analyzer = luceneBackend.analyzer( "english" ); // <4>
 		Optional<? extends Analyzer> normalizer = luceneBackend.normalizer( "isbn" ); // <5>

--- a/documentation/src/test/java/org/hibernate/search/documentation/configuration/MyConfigurationIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/configuration/MyConfigurationIT.java
@@ -27,23 +27,21 @@ public class MyConfigurationIT {
 	// tag::build-hibernate-configuration[]
 	private Properties buildHibernateConfiguration() {
 		Properties config = new Properties();
-		// add hibernate configuration
-		String myBackend = "myBackend";
 		// backend configuration
-		config.put( BackendSettings.backendKey( myBackend, ElasticsearchBackendSettings.HOSTS ), "127.0.0.1:9200" );
-		config.put( BackendSettings.backendKey( myBackend, ElasticsearchBackendSettings.PROTOCOL ), "http" );
+		config.put( BackendSettings.backendKey( ElasticsearchBackendSettings.HOSTS ), "127.0.0.1:9200" );
+		config.put( BackendSettings.backendKey( ElasticsearchBackendSettings.PROTOCOL ), "http" );
 		config.put(
-				BackendSettings.backendKey( myBackend, BackendSettings.TYPE ), ElasticsearchBackendSettings.TYPE_NAME );
+				BackendSettings.backendKey( BackendSettings.TYPE ), ElasticsearchBackendSettings.TYPE_NAME );
 		config.put(
-				BackendSettings.backendKey( myBackend, ElasticsearchBackendSettings.MULTI_TENANCY_STRATEGY ),
+				BackendSettings.backendKey( ElasticsearchBackendSettings.MULTI_TENANCY_STRATEGY ),
 				MultiTenancyStrategyName.DISCRIMINATOR.externalRepresentation()
 		);
-		config.put( BackendSettings.backendKey( myBackend, ElasticsearchBackendSettings.VERSION ), "7.8" );
+		config.put( BackendSettings.backendKey( ElasticsearchBackendSettings.VERSION ), "7.8" );
 		config.put(
-				BackendSettings.backendKey( myBackend, ElasticsearchBackendSettings.VERSION_CHECK_ENABLED ), "false" );
+				BackendSettings.backendKey( ElasticsearchBackendSettings.VERSION_CHECK_ENABLED ), "false" );
 		// index configuration
 		config.put(
-				IndexSettings.indexDefaultsKey( myBackend, ElasticsearchIndexSettings.SCHEMA_MANAGEMENT_MINIMAL_REQUIRED_STATUS ),
+				IndexSettings.indexDefaultsKey( ElasticsearchIndexSettings.SCHEMA_MANAGEMENT_MINIMAL_REQUIRED_STATUS ),
 				IndexStatus.YELLOW.externalRepresentation()
 		);
 		// orm configuration
@@ -53,7 +51,6 @@ public class MyConfigurationIT {
 		);
 		// engine configuration
 		config.put( EngineSettings.BACKGROUND_FAILURE_HANDLER, "myFailureHandler" );
-		config.put( EngineSettings.DEFAULT_BACKEND, myBackend );
 		return config;
 	}
 	// end::build-hibernate-configuration[]
@@ -62,16 +59,15 @@ public class MyConfigurationIT {
 	public void shouldBuildHibernateConfiguration() {
 		assertThat( buildHibernateConfiguration() )
 				.containsOnly(
-						entry( "hibernate.search.backends.myBackend.hosts", "127.0.0.1:9200" ),
-						entry( "hibernate.search.backends.myBackend.protocol", "http" ),
-						entry( "hibernate.search.backends.myBackend.type", "elasticsearch" ),
-						entry( "hibernate.search.backends.myBackend.multi_tenancy.strategy", "discriminator" ),
-						entry( "hibernate.search.backends.myBackend.version", "7.8" ),
-						entry( "hibernate.search.backends.myBackend.version_check.enabled", "false" ),
-						entry( "hibernate.search.backends.myBackend.index_defaults.schema_management.minimal_required_status", "yellow" ),
+						entry( "hibernate.search.backend.hosts", "127.0.0.1:9200" ),
+						entry( "hibernate.search.backend.protocol", "http" ),
+						entry( "hibernate.search.backend.type", "elasticsearch" ),
+						entry( "hibernate.search.backend.multi_tenancy.strategy", "discriminator" ),
+						entry( "hibernate.search.backend.version", "7.8" ),
+						entry( "hibernate.search.backend.version_check.enabled", "false" ),
+						entry( "hibernate.search.backend.index_defaults.schema_management.minimal_required_status", "yellow" ),
 						entry( "hibernate.search.automatic_indexing.synchronization.strategy", "async" ),
-						entry( "hibernate.search.background_failure_handler", "myFailureHandler" ),
-						entry( "hibernate.search.default_backend", "myBackend" )
+						entry( "hibernate.search.background_failure_handler", "myFailureHandler" )
 				);
 	}
 }

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/entityindexmapping/HibernateOrmIndexedIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/entityindexmapping/HibernateOrmIndexedIT.java
@@ -38,10 +38,10 @@ import org.assertj.core.api.Assertions;
 @RunWith(Parameterized.class)
 public class HibernateOrmIndexedIT {
 
-	private static final String BACKEND_1 = "backend1";
 	private static final String BACKEND_2 = "backend2";
 
-	private static final Map<String, BackendConfiguration> BACKEND_CONFIGURATIONS;
+	private static final BackendConfiguration DEFAULT_BACKEND_CONFIGURATION;
+	private static final Map<String, BackendConfiguration> NAMED_BACKEND_CONFIGURATIONS;
 	static {
 		List<BackendConfiguration> backendConfigurations = BackendConfigurations.simple();
 		if ( backendConfigurations.size() != 2 ) {
@@ -50,17 +50,17 @@ public class HibernateOrmIndexedIT {
 							+ " If this changed, please update this test to add/remove entity types mapped to each backend as necessary."
 			);
 		}
+		DEFAULT_BACKEND_CONFIGURATION = backendConfigurations.get( 0 );
 		Map<String, BackendConfiguration> map = new HashMap<>();
-		map.put( BACKEND_1, backendConfigurations.get( 0 ) );
 		map.put( BACKEND_2, backendConfigurations.get( 1 ) );
-		BACKEND_CONFIGURATIONS = map;
+		NAMED_BACKEND_CONFIGURATIONS = map;
 	}
 
 	@Parameterized.Parameters(name = "{0}")
 	public static List<?> params() {
 		return Arrays.asList(
-				DocumentationSetupHelper.withMultipleBackends( BACKEND_1, BACKEND_CONFIGURATIONS, null ),
-				DocumentationSetupHelper.withMultipleBackends( BACKEND_1, BACKEND_CONFIGURATIONS,
+				DocumentationSetupHelper.withMultipleBackends( DEFAULT_BACKEND_CONFIGURATION, NAMED_BACKEND_CONFIGURATIONS, null ),
+				DocumentationSetupHelper.withMultipleBackends( DEFAULT_BACKEND_CONFIGURATION, NAMED_BACKEND_CONFIGURATIONS,
 						new HibernateOrmSearchMappingConfigurer() {
 							@Override
 							public void configure(HibernateOrmMappingConfigurationContext context) {

--- a/documentation/src/test/java/org/hibernate/search/documentation/testsupport/AbstractDocumentationBackendConfiguration.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/testsupport/AbstractDocumentationBackendConfiguration.java
@@ -15,11 +15,11 @@ import org.hibernate.search.util.impl.integrationtest.common.rule.MappingSetupHe
 abstract class AbstractDocumentationBackendConfiguration implements BackendConfiguration {
 
 	@Override
-	public <C extends MappingSetupHelper<C, ?, ?>.AbstractSetupContext> C setupWithName(C setupContext,
-			String backendName, TestConfigurationProvider configurationProvider) {
+	public <C extends MappingSetupHelper<C, ?, ?>.AbstractSetupContext> C setup(C setupContext,
+			String backendNameOrNull, TestConfigurationProvider configurationProvider) {
 		return setupContext
 				.withBackendProperties(
-						backendName,
+						backendNameOrNull,
 						configurationProvider.interpolateProperties( getBackendProperties() )
 				);
 	}

--- a/documentation/src/test/java/org/hibernate/search/documentation/testsupport/BackendConfigurations.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/testsupport/BackendConfigurations.java
@@ -30,21 +30,21 @@ public final class BackendConfigurations {
 		return Arrays.asList(
 				new LuceneBackendConfiguration() {
 					@Override
-					public <C extends MappingSetupHelper<C, ?, ?>.AbstractSetupContext> C setupWithName(C setupContext,
-							String backendName, TestConfigurationProvider configurationProvider) {
-						return super.setupWithName( setupContext, backendName, configurationProvider )
+					public <C extends MappingSetupHelper<C, ?, ?>.AbstractSetupContext> C setup(C setupContext,
+							String backendNameOrNull, TestConfigurationProvider configurationProvider) {
+						return super.setup( setupContext, backendNameOrNull, configurationProvider )
 								.withIndexDefaultsProperty(
-										backendName, LuceneIndexSettings.SHARDING_STRATEGY, "hash"
+										backendNameOrNull, LuceneIndexSettings.SHARDING_STRATEGY, "hash"
 								)
 								.withIndexDefaultsProperty(
-										backendName, LuceneIndexSettings.SHARDING_NUMBER_OF_SHARDS, shardCount
+										backendNameOrNull, LuceneIndexSettings.SHARDING_NUMBER_OF_SHARDS, shardCount
 								);
 					}
 				},
 				new ElasticsearchBackendConfiguration() {
 					@Override
-					public <C extends MappingSetupHelper<C, ?, ?>.AbstractSetupContext> C setupWithName(C setupContext,
-							String backendName, TestConfigurationProvider configurationProvider) {
+					public <C extends MappingSetupHelper<C, ?, ?>.AbstractSetupContext> C setup(C setupContext,
+							String backendNameOrNull, TestConfigurationProvider configurationProvider) {
 						// Make sure automatically created indexes will have an appropriate number of shards
 						testElasticsearchClient.template( "sharded_index" )
 								.create(
@@ -52,7 +52,7 @@ public final class BackendConfigurations {
 										99999, // Override other templates, if any
 										"{'number_of_shards': " + shardCount + "}"
 								);
-						return super.setupWithName( setupContext, backendName, configurationProvider );
+						return super.setup( setupContext, backendNameOrNull, configurationProvider );
 					}
 				}
 		);

--- a/documentation/src/test/java/org/hibernate/search/documentation/testsupport/DocumentationSetupHelper.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/testsupport/DocumentationSetupHelper.java
@@ -30,17 +30,10 @@ import org.junit.Assume;
 public final class DocumentationSetupHelper
 		extends MappingSetupHelper<DocumentationSetupHelper.SetupContext, SimpleSessionFactoryBuilder, SessionFactory> {
 
-	private static final String DEFAULT_BACKEND_NAME = "backendName";
-
 	public static List<DocumentationSetupHelper> testParamsWithSingleBackend(
 			List<BackendConfiguration> backendConfigurations) {
-		return testParamsWithSingleBackend( DEFAULT_BACKEND_NAME, backendConfigurations );
-	}
-
-	public static List<DocumentationSetupHelper> testParamsWithSingleBackend(String backendName,
-			List<BackendConfiguration> backendConfigurations) {
 		return backendConfigurations.stream()
-				.map( config -> withSingleBackend( backendName, config ) )
+				.map( DocumentationSetupHelper::withSingleBackend )
 				.collect( Collectors.toList() );
 	}
 
@@ -52,40 +45,36 @@ public final class DocumentationSetupHelper
 		List<DocumentationSetupHelper> result = new ArrayList<>();
 		for ( BackendConfiguration configuration : backendConfigurations ) {
 			// Annotation-based mapping
-			result.add( withSingleBackend( DEFAULT_BACKEND_NAME, configuration, null ) );
+			result.add( withSingleBackend( configuration, null ) );
 			// Programmatic mapping
-			result.add( withSingleBackend( DEFAULT_BACKEND_NAME, configuration, mappingConfigurer ) );
+			result.add( withSingleBackend( configuration, mappingConfigurer ) );
 		}
 		return result;
 	}
 
 	public static DocumentationSetupHelper withSingleBackend(BackendConfiguration backendConfiguration) {
-		return withSingleBackend( DEFAULT_BACKEND_NAME, backendConfiguration );
-	}
-
-	public static DocumentationSetupHelper withSingleBackend(String backendName, BackendConfiguration backendConfiguration) {
 		return new DocumentationSetupHelper(
-				BackendSetupStrategy.withSingleBackend( backendName, backendConfiguration ),
+				BackendSetupStrategy.withSingleBackend( backendConfiguration ),
 				backendConfiguration,
 				null
 		);
 	}
 
-	public static DocumentationSetupHelper withSingleBackend(String backendName, BackendConfiguration backendConfiguration,
+	public static DocumentationSetupHelper withSingleBackend(BackendConfiguration backendConfiguration,
 			HibernateOrmSearchMappingConfigurer mappingConfigurerOrNull) {
 		return new DocumentationSetupHelper(
-				BackendSetupStrategy.withSingleBackend( backendName, backendConfiguration ),
+				BackendSetupStrategy.withSingleBackend( backendConfiguration ),
 				backendConfiguration,
 				mappingConfigurerOrNull
 		);
 	}
 
-	public static DocumentationSetupHelper withMultipleBackends(String defaultBackendName,
-			Map<String, BackendConfiguration> backendConfigurations,
+	public static DocumentationSetupHelper withMultipleBackends(BackendConfiguration defaultBackendConfiguration,
+			Map<String, BackendConfiguration> namedBackendConfigurations,
 			HibernateOrmSearchMappingConfigurer mappingConfigurerOrNull) {
 		return new DocumentationSetupHelper(
-				BackendSetupStrategy.withMultipleBackends( defaultBackendName, backendConfigurations ),
-				backendConfigurations.get( defaultBackendName ),
+				BackendSetupStrategy.withMultipleBackends( defaultBackendConfiguration, namedBackendConfigurations ),
+				defaultBackendConfiguration,
 				mappingConfigurerOrNull
 		);
 	}

--- a/documentation/src/test/resources/META-INF/persistence.xml
+++ b/documentation/src/test/resources/META-INF/persistence.xml
@@ -22,14 +22,12 @@
         <exclude-unlisted-classes />
         <properties>
             <!-- tag::gettingstarted-configuration-orm_lucene[] -->
-            <property name="hibernate.search.backends.myBackend.type"
+            <property name="hibernate.search.backend.type"
                       value="lucene"/> <!--1-->
             <!--
-            <property name="hibernate.search.backends.myBackend.directory.root"
+            <property name="hibernate.search.backend.directory.root"
                       value="some/filesystem/path"/>
              --> <!--2-->
-            <property name="hibernate.search.default_backend"
-                      value="myBackend"/> <!--3-->
             <!-- end::gettingstarted-configuration-orm_lucene[] -->
 
             <!--
@@ -40,7 +38,7 @@
              -->
             <property name="hibernate.search.schema_management.strategy"
                       value="drop-and-create-and-drop"/>
-            <property name="hibernate.search.backends.myBackend.directory.root"
+            <property name="hibernate.search.backend.directory.root"
                       value="${project.build.directory}/test-indexes/gettingstarted/withoutanalysis/"/>
         </properties>
     </persistence-unit>
@@ -51,20 +49,18 @@
         <exclude-unlisted-classes />
         <properties>
             <!-- tag::gettingstarted-configuration-orm_elasticsearch[] -->
-            <property name="hibernate.search.backends.myBackend.type"
+            <property name="hibernate.search.backend.type"
                       value="elasticsearch" /> <!--1-->
             <!--
-            <property name="hibernate.search.backends.myBackend.hosts"
+            <property name="hibernate.search.backend.hosts"
                       value="elasticsearch.mycompany.com"/>
-            <property name="hibernate.search.backends.myBackend.protocol"
+            <property name="hibernate.search.backend.protocol"
                       value="https"/>
-            <property name="hibernate.search.backends.myBackend.username"
+            <property name="hibernate.search.backend.username"
                       value="ironman"/>
-            <property name="hibernate.search.backends.myBackend.password"
+            <property name="hibernate.search.backend.password"
                       value="j@rV1s"/>
              --> <!--2-->
-            <property name="hibernate.search.default_backend"
-                      value="myBackend"/> <!--3-->
             <!-- end::gettingstarted-configuration-orm_elasticsearch[] -->
 
             <!--
@@ -75,24 +71,24 @@
              -->
             <property name="hibernate.search.schema_management.strategy"
                       value="drop-and-create-and-drop"/>
-            <property name="hibernate.search.backends.myBackend.hosts"
+            <property name="hibernate.search.backend.hosts"
                       value="${test.elasticsearch.connection.hosts}"/>
-            <property name="hibernate.search.backends.myBackend.protocol"
+            <property name="hibernate.search.backend.protocol"
                       value="${test.elasticsearch.connection.protocol}"/>
-            <property name="hibernate.search.backends.myBackend.username"
+            <property name="hibernate.search.backend.username"
                       value="${test.elasticsearch.connection.username}"/>
-            <property name="hibernate.search.backends.myBackend.password"
+            <property name="hibernate.search.backend.password"
                       value="${test.elasticsearch.connection.password}"/>
-            <property name="hibernate.search.backends.myBackend.aws.signing.enabled"
+            <property name="hibernate.search.backend.aws.signing.enabled"
                       value="${test.elasticsearch.connection.aws.signing.enabled}"/>
-            <property name="hibernate.search.backends.myBackend.aws.signing.access_key"
+            <property name="hibernate.search.backend.aws.signing.access_key"
                       value="${test.elasticsearch.connection.aws.signing.access_key}"/>
-            <property name="hibernate.search.backends.myBackend.aws.signing.secret_key"
+            <property name="hibernate.search.backend.aws.signing.secret_key"
                       value="${test.elasticsearch.connection.aws.signing.secret_key}"/>
-            <property name="hibernate.search.backends.myBackend.aws.signing.region"
+            <property name="hibernate.search.backend.aws.signing.region"
                       value="${test.elasticsearch.connection.aws.signing.region}"/>
             <!-- Make this test work even if there is only a single node in the cluster -->
-            <property name="hibernate.search.backends.myBackend.index_defaults.schema_management.minimal_required_status"
+            <property name="hibernate.search.backend.index_defaults.schema_management.minimal_required_status"
                       value="yellow"/>
             <property name="hibernate.search.automatic_indexing.synchronization.strategy"
                       value="sync"/>
@@ -104,14 +100,12 @@
         <class>org.hibernate.search.documentation.gettingstarted.withhsearch.withanalysis.Book</class>
         <exclude-unlisted-classes />
         <properties>
-            <property name="hibernate.search.backends.myBackend.type"
+            <property name="hibernate.search.backend.type"
                       value="lucene"/>
             <!-- tag::gettingstarted-configuration-orm_lucene-analysis[] -->
-            <property name="hibernate.search.backends.myBackend.analysis.configurer"
+            <property name="hibernate.search.backend.analysis.configurer"
                       value="org.hibernate.search.documentation.gettingstarted.withhsearch.withanalysis.MyLuceneAnalysisConfigurer"/> <!--6-->
             <!-- end::gettingstarted-configuration-orm_lucene-analysis[] -->
-            <property name="hibernate.search.default_backend"
-                      value="myBackend"/>
 
             <!--
                 Not to be included in the documentation:
@@ -121,7 +115,7 @@
              -->
             <property name="hibernate.search.schema_management.strategy"
                       value="drop-and-create-and-drop"/>
-            <property name="hibernate.search.backends.myBackend.directory.root"
+            <property name="hibernate.search.backend.directory.root"
                       value="${project.build.directory}/test-indexes/gettingstarted/withanalysis/"/>
         </properties>
     </persistence-unit>
@@ -131,14 +125,12 @@
         <class>org.hibernate.search.documentation.gettingstarted.withhsearch.withanalysis.Book</class>
         <exclude-unlisted-classes />
         <properties>
-            <property name="hibernate.search.backends.myBackend.type"
+            <property name="hibernate.search.backend.type"
                       value="elasticsearch" />
             <!-- tag::gettingstarted-configuration-orm_elasticsearch-analysis[] -->
-            <property name="hibernate.search.backends.myBackend.analysis.configurer"
+            <property name="hibernate.search.backend.analysis.configurer"
                       value="org.hibernate.search.documentation.gettingstarted.withhsearch.withanalysis.MyElasticsearchAnalysisConfigurer"/> <!--7-->
             <!-- end::gettingstarted-configuration-orm_elasticsearch-analysis[] -->
-            <property name="hibernate.search.default_backend"
-                      value="myBackend"/>
 
             <!--
                 Not to be included in the documentation:
@@ -148,24 +140,24 @@
              -->
             <property name="hibernate.search.schema_management.strategy"
                       value="drop-and-create-and-drop"/>
-            <property name="hibernate.search.backends.myBackend.hosts"
+            <property name="hibernate.search.backend.hosts"
                       value="${test.elasticsearch.connection.hosts}"/>
-            <property name="hibernate.search.backends.myBackend.protocol"
+            <property name="hibernate.search.backend.protocol"
                       value="${test.elasticsearch.connection.protocol}"/>
-            <property name="hibernate.search.backends.myBackend.username"
+            <property name="hibernate.search.backend.username"
                       value="${test.elasticsearch.connection.username}"/>
-            <property name="hibernate.search.backends.myBackend.password"
+            <property name="hibernate.search.backend.password"
                       value="${test.elasticsearch.connection.password}"/>
-            <property name="hibernate.search.backends.myBackend.aws.signing.enabled"
+            <property name="hibernate.search.backend.aws.signing.enabled"
                       value="${test.elasticsearch.connection.aws.signing.enabled}"/>
-            <property name="hibernate.search.backends.myBackend.aws.signing.access_key"
+            <property name="hibernate.search.backend.aws.signing.access_key"
                       value="${test.elasticsearch.connection.aws.signing.access_key}"/>
-            <property name="hibernate.search.backends.myBackend.aws.signing.secret_key"
+            <property name="hibernate.search.backend.aws.signing.secret_key"
                       value="${test.elasticsearch.connection.aws.signing.secret_key}"/>
-            <property name="hibernate.search.backends.myBackend.aws.signing.region"
+            <property name="hibernate.search.backend.aws.signing.region"
                       value="${test.elasticsearch.connection.aws.signing.region}"/>
             <!-- Make this test work even if there is only a single node in the cluster -->
-            <property name="hibernate.search.backends.myBackend.index_defaults.schema_management.minimal_required_status"
+            <property name="hibernate.search.backend.index_defaults.schema_management.minimal_required_status"
                       value="yellow"/>
             <property name="hibernate.search.automatic_indexing.synchronization.strategy"
                       value="sync"/>

--- a/documentation/src/test/resources/analysis/elasticsearch-simple.properties
+++ b/documentation/src/test/resources/analysis/elasticsearch-simple.properties
@@ -1,2 +1,2 @@
 # <1>
-hibernate.search.backends.myBackend.analysis.configurer org.hibernate.search.documentation.analysis.MyElasticsearchAnalysisConfigurer
+hibernate.search.backend.analysis.configurer org.hibernate.search.documentation.analysis.MyElasticsearchAnalysisConfigurer

--- a/documentation/src/test/resources/analysis/lucene-simple.properties
+++ b/documentation/src/test/resources/analysis/lucene-simple.properties
@@ -1,2 +1,2 @@
 # <1>
-hibernate.search.backends.myBackend.analysis.configurer org.hibernate.search.documentation.analysis.MyLuceneAnalysisConfigurer
+hibernate.search.backend.analysis.configurer org.hibernate.search.documentation.analysis.MyLuceneAnalysisConfigurer

--- a/engine/src/main/java/org/hibernate/search/engine/backend/spi/BackendFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/spi/BackendFactory.java
@@ -8,12 +8,13 @@ package org.hibernate.search.engine.backend.spi;
 
 import org.hibernate.search.engine.cfg.spi.ConfigurationPropertySource;
 import org.hibernate.search.engine.cfg.BackendSettings;
+import org.hibernate.search.util.common.reporting.EventContext;
 
 
 public interface BackendFactory {
 
 	/**
-	 * @param name The name of the backend.
+	 * @param eventContext An {@link org.hibernate.search.util.common.reporting.EventContext} representing the backend.
 	 * @param context The build context.
 	 * @param propertySource A configuration property source, appropriately masked so that the backend
 	 * doesn't need to care about Hibernate Search prefixes (hibernate.search.*, etc.). All the properties
@@ -23,6 +24,6 @@ public interface BackendFactory {
 	 * are reserved for use by the engine.
 	 * @return A backend.
 	 */
-	BackendImplementor create(String name, BackendBuildContext context, ConfigurationPropertySource propertySource);
+	BackendImplementor create(EventContext eventContext, BackendBuildContext context, ConfigurationPropertySource propertySource);
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/cfg/BackendSettings.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/BackendSettings.java
@@ -41,6 +41,17 @@ public final class BackendSettings {
 	public static final String INDEXES = "indexes";
 
 	/**
+	 * Builds a configuration property key for the default backend, with the given radical.
+	 *
+	 * @param radical The radical of the configuration property (see constants in
+	 * 	 * {@code ElasticsearchBackendSettings}, {@code ElasticsearchBackendSettings}, etc.)
+	 * @return the concatenated prefix + radical
+	 */
+	public static String backendKey(String radical) {
+		return join( ".", EngineSettings.BACKEND, radical );
+	}
+
+	/**
 	 * Builds a configuration property key for the given backend, with the given radical.
 	 *
 	 * @param backendName Expect the backendName
@@ -49,8 +60,6 @@ public final class BackendSettings {
 	 * @return the concatenated prefix + backend name + radical
 	 */
 	public static String backendKey(String backendName, String radical) {
-		return join( ".",
-				EngineSettings.BACKENDS, backendName, radical
-		);
+		return join( ".", EngineSettings.BACKENDS, backendName, radical );
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/cfg/BackendSettings.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/BackendSettings.java
@@ -60,6 +60,9 @@ public final class BackendSettings {
 	 * @return the concatenated prefix + backend name + radical
 	 */
 	public static String backendKey(String backendName, String radical) {
+		if ( backendName == null ) {
+			return backendKey( radical );
+		}
 		return join( ".", EngineSettings.BACKENDS, backendName, radical );
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/cfg/EngineSettings.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/EngineSettings.java
@@ -32,7 +32,12 @@ public final class EngineSettings {
 	public static final String DEFAULT_BACKEND = PREFIX + Radicals.DEFAULT_BACKEND;
 
 	/**
-	 * The root property whose children are backend names, e.g. "hibernate.search.backends.myBackend.type = elasticsearch".
+	 * The root property for properties of the default backend, e.g. "hibernate.search.backend.type = elasticsearch".
+	 */
+	public static final String BACKEND = PREFIX + Radicals.BACKEND;
+
+	/**
+	 * The root property for properties of named backends, e.g. "hibernate.search.backends.myBackend.type = elasticsearch".
 	 */
 	public static final String BACKENDS = PREFIX + Radicals.BACKENDS;
 
@@ -70,6 +75,7 @@ public final class EngineSettings {
 		}
 
 		public static final String DEFAULT_BACKEND = "default_backend";
+		public static final String BACKEND = "backend";
 		public static final String BACKENDS = "backends";
 		public static final String CONFIGURATION_PROPERTY_CHECKING_STRATEGY = "configuration_property_checking.strategy";
 		public static final String BACKGROUND_FAILURE_HANDLER = "background_failure_handler";

--- a/engine/src/main/java/org/hibernate/search/engine/cfg/EngineSettings.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/EngineSettings.java
@@ -28,7 +28,10 @@ public final class EngineSettings {
 	 * Expects a String.
 	 * <p>
 	 * Defaults to no value, meaning a backend must be set in the mapping for every single index.
+	 * @deprecated The default backend shouldn't be assigned a name;
+	 * just prefix its properties with {@link #BACKEND} instead of {@link #BACKENDS} + a name.
 	 */
+	@Deprecated
 	public static final String DEFAULT_BACKEND = PREFIX + Radicals.DEFAULT_BACKEND;
 
 	/**
@@ -74,6 +77,7 @@ public final class EngineSettings {
 		private Radicals() {
 		}
 
+		@Deprecated
 		public static final String DEFAULT_BACKEND = "default_backend";
 		public static final String BACKEND = "backend";
 		public static final String BACKENDS = "backends";

--- a/engine/src/main/java/org/hibernate/search/engine/cfg/IndexSettings.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/IndexSettings.java
@@ -68,6 +68,9 @@ public final class IndexSettings {
 	 * @return the concatenated default index settings key
 	 */
 	public static String indexDefaultsKey(String backendName, String radical) {
+		if ( backendName == null ) {
+			return indexDefaultsKey( radical );
+		}
 		return join( ".", EngineSettings.BACKENDS, backendName, BackendSettings.INDEX_DEFAULTS, radical );
 	}
 
@@ -86,6 +89,9 @@ public final class IndexSettings {
 	 * @return the concatenated index settings key
 	 */
 	public static String indexKey(String backendName, String indexName, String radical) {
+		if ( backendName == null ) {
+			return indexKey( indexName, radical );
+		}
 		return join( ".", EngineSettings.BACKENDS, backendName, BackendSettings.INDEXES, indexName, radical );
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/cfg/IndexSettings.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/IndexSettings.java
@@ -22,9 +22,42 @@ public final class IndexSettings {
 	}
 
 	/**
+	 * Builds a configuration property key for the index defaults of the default backend, with the given radical.
+	 * <p>
+	 * See the javadoc of your backend for available radicals.
+	 * </p>
+	 * Example result: "{@code hibernate.search.backend.index_defaults.lifecycle.strategy}"
+	 *
+	 * @param radical The radical of the configuration property (see constants in
+	 * {@code ElasticsearchIndexSettings}, {@code LuceneIndexSettings}, etc.)
+	 *
+	 * @return the concatenated default index settings key
+	 */
+	public static String indexDefaultsKey(String radical) {
+		return join( ".", EngineSettings.BACKEND, BackendSettings.INDEX_DEFAULTS, radical );
+	}
+
+	/**
+	 * Builds a configuration property key for the index of the given backend, with the given radical.
+	 * <p>
+	 * See the javadoc of your backend for available radicals.
+	 * </p>
+	 * Example result: "{@code hibernate.search.backend.indexes.<indexName>.lifecycle.strategy}"
+	 *
+	 * @param indexName Expect the specific targeted index name
+	 * @param radical The radical of the configuration property (see constants in
+	 * {@code ElasticsearchIndexSettings}, {@code LuceneIndexSettings}, etc.)
+	 *
+	 * @return the concatenated index settings key
+	 */
+	public static String indexKey(String indexName, String radical) {
+		return join( ".", EngineSettings.BACKEND, BackendSettings.INDEXES, indexName, radical );
+	}
+
+	/**
 	 * Builds a configuration property key for the index defaults of the given backend, with the given radical.
 	 * <p>
-	 * See the javadoc of your backend for avalaible radicals.
+	 * See the javadoc of your backend for available radicals.
 	 * </p>
 	 * Example result: "{@code hibernate.search.backends.<backendName>.index_defaults.lifecycle.strategy}"
 	 *
@@ -35,15 +68,13 @@ public final class IndexSettings {
 	 * @return the concatenated default index settings key
 	 */
 	public static String indexDefaultsKey(String backendName, String radical) {
-		return join( ".",
-				EngineSettings.BACKENDS, backendName, BackendSettings.INDEX_DEFAULTS, radical
-		);
+		return join( ".", EngineSettings.BACKENDS, backendName, BackendSettings.INDEX_DEFAULTS, radical );
 	}
 
 	/**
 	 * Builds a configuration property key for the index of the given backend, with the given radical.
 	 * <p>
-	 * See the javadoc of your backend for avalaible radicals.
+	 * See the javadoc of your backend for available radicals.
 	 * </p>
 	 * Example result: "{@code hibernate.search.backends.<backendName>.indexes.<indexName>.lifecycle.strategy}"
 	 *
@@ -55,9 +86,7 @@ public final class IndexSettings {
 	 * @return the concatenated index settings key
 	 */
 	public static String indexKey(String backendName, String indexName, String radical) {
-		return join( ".",
-				EngineSettings.BACKENDS, backendName, BackendSettings.INDEXES, indexName, radical
-		);
+		return join( ".", EngineSettings.BACKENDS, backendName, BackendSettings.INDEXES, indexName, radical );
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/cfg/impl/ConfigurationPropertySourceExtractor.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/impl/ConfigurationPropertySourceExtractor.java
@@ -1,0 +1,15 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.cfg.impl;
+
+import org.hibernate.search.engine.cfg.spi.ConfigurationPropertySource;
+
+public interface ConfigurationPropertySourceExtractor {
+
+	ConfigurationPropertySource extract(ConfigurationPropertySource parentSource);
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/cfg/impl/EngineConfigurationUtils.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/impl/EngineConfigurationUtils.java
@@ -15,7 +15,11 @@ public final class EngineConfigurationUtils {
 	private EngineConfigurationUtils() {
 	}
 
-	public static ConfigurationPropertySource getBackend(ConfigurationPropertySource engineSource, String backendName) {
+	public static ConfigurationPropertySource getDefaultBackend(ConfigurationPropertySource engineSource) {
+		return engineSource.withMask( EngineSettings.Radicals.BACKEND );
+	}
+
+	public static ConfigurationPropertySource getBackendByName(ConfigurationPropertySource engineSource, String backendName) {
 		return engineSource.withMask( EngineSettings.Radicals.BACKENDS ).withMask( backendName );
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/BackendNonStartedState.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/BackendNonStartedState.java
@@ -7,21 +7,24 @@
 package org.hibernate.search.engine.common.impl;
 
 import org.hibernate.search.engine.backend.spi.BackendImplementor;
+import org.hibernate.search.engine.cfg.impl.ConfigurationPropertySourceExtractor;
 import org.hibernate.search.engine.cfg.spi.ConfigurationPropertySource;
-import org.hibernate.search.engine.cfg.impl.EngineConfigurationUtils;
 import org.hibernate.search.engine.environment.bean.BeanResolver;
 import org.hibernate.search.engine.environment.thread.spi.ThreadPoolProvider;
-import org.hibernate.search.engine.reporting.spi.RootFailureCollector;
 import org.hibernate.search.engine.reporting.spi.ContextualFailureCollector;
-import org.hibernate.search.engine.reporting.spi.EventContexts;
+import org.hibernate.search.engine.reporting.spi.RootFailureCollector;
+import org.hibernate.search.util.common.reporting.EventContext;
 
 class BackendNonStartedState {
 
-	private final String backendName;
+	private final EventContext eventContext;
+	private final ConfigurationPropertySourceExtractor propertySourceExtractor;
 	private final BackendImplementor backend;
 
-	BackendNonStartedState(String backendName, BackendImplementor backend) {
-		this.backendName = backendName;
+	BackendNonStartedState(EventContext eventContext, ConfigurationPropertySourceExtractor propertySourceExtractor,
+			BackendImplementor backend) {
+		this.eventContext = eventContext;
+		this.propertySourceExtractor = propertySourceExtractor;
 		this.backend = backend;
 	}
 
@@ -33,10 +36,8 @@ class BackendNonStartedState {
 			BeanResolver beanResolver,
 			ConfigurationPropertySource rootPropertySource,
 			ThreadPoolProvider threadPoolProvider) {
-		ContextualFailureCollector backendFailureCollector =
-				rootFailureCollector.withContext( EventContexts.fromBackendName( backendName ) );
-		ConfigurationPropertySource backendPropertySource =
-				EngineConfigurationUtils.getBackendByName( rootPropertySource, backendName );
+		ContextualFailureCollector backendFailureCollector = rootFailureCollector.withContext( eventContext );
+		ConfigurationPropertySource backendPropertySource = propertySourceExtractor.extract( rootPropertySource );
 		BackendStartContextImpl startContext = new BackendStartContextImpl(
 				backendFailureCollector,
 				beanResolver,

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/BackendNonStartedState.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/BackendNonStartedState.java
@@ -36,7 +36,7 @@ class BackendNonStartedState {
 		ContextualFailureCollector backendFailureCollector =
 				rootFailureCollector.withContext( EventContexts.fromBackendName( backendName ) );
 		ConfigurationPropertySource backendPropertySource =
-				EngineConfigurationUtils.getBackend( rootPropertySource, backendName );
+				EngineConfigurationUtils.getBackendByName( rootPropertySource, backendName );
 		BackendStartContextImpl startContext = new BackendStartContextImpl(
 				backendFailureCollector,
 				beanResolver,

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/IndexManagerBuildingStateHolder.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/IndexManagerBuildingStateHolder.java
@@ -40,9 +40,9 @@ class IndexManagerBuildingStateHolder {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private static final ConfigurationProperty<String> EXPLICIT_DEFAULT_BACKEND_NAME =
-			ConfigurationProperty.forKey( EngineSettings.Radicals.DEFAULT_BACKEND ).asString()
-					.withDefault( "default" ).build();
+	@SuppressWarnings("deprecation")
+	private static final OptionalConfigurationProperty<String> EXPLICIT_DEFAULT_BACKEND_NAME =
+			ConfigurationProperty.forKey( EngineSettings.Radicals.DEFAULT_BACKEND ).asString().build();
 
 	private static final OptionalConfigurationProperty<BeanReference<? extends BackendFactory>> BACKEND_TYPE =
 			ConfigurationProperty.forKey( BackendSettings.TYPE ).asBeanReference( BackendFactory.class )
@@ -64,7 +64,15 @@ class IndexManagerBuildingStateHolder {
 		this.beanResolver = beanResolver;
 		this.propertySource = propertySource;
 		this.rootBuildContext = rootBuildContext;
-		defaultBackendName = EXPLICIT_DEFAULT_BACKEND_NAME.get( propertySource );
+		Optional<String> explicitDefaultBackendName = EXPLICIT_DEFAULT_BACKEND_NAME.get( propertySource );
+		if ( explicitDefaultBackendName.isPresent() ) {
+			defaultBackendName = explicitDefaultBackendName.get();
+			log.deprecatedExplicitDefaultBackendName( EXPLICIT_DEFAULT_BACKEND_NAME.resolveOrRaw( propertySource ),
+					defaultBackendName );
+		}
+		else {
+			defaultBackendName = "default";
+		}
 	}
 
 	void createBackends(Set<Optional<String>> backendNames) {

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/IndexManagerBuildingStateHolder.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/IndexManagerBuildingStateHolder.java
@@ -128,8 +128,17 @@ class IndexManagerBuildingStateHolder {
 	}
 
 	private BackendInitialBuildState createBackend(String backendName) {
-		ConfigurationPropertySource backendPropertySource =
-				EngineConfigurationUtils.getBackend( propertySource, backendName );
+		ConfigurationPropertySource backendPropertySource;
+		if ( backendName.equals( defaultBackendName ) ) {
+			backendPropertySource = EngineConfigurationUtils.getDefaultBackend( propertySource )
+					// Fall back to the syntax "hibernate.search.backends.default.foo".
+					// Mostly supported for consistency and backward compatibility.
+					// Ideally, we'd drop it, but that may be surprising since the default backend does have a name.
+					.withFallback( EngineConfigurationUtils.getBackendByName( propertySource, backendName ) );
+		}
+		else {
+			backendPropertySource = EngineConfigurationUtils.getBackendByName( propertySource, backendName );
+		}
 		try ( BeanHolder<? extends BackendFactory> backendFactoryHolder =
 				BACKEND_TYPE.getAndMapOrThrow(
 						backendPropertySource,

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/IndexManagerNonStartedState.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/IndexManagerNonStartedState.java
@@ -37,7 +37,7 @@ class IndexManagerNonStartedState {
 		ContextualFailureCollector indexFailureCollector =
 				rootFailureCollector.withContext( EventContexts.fromIndexName( indexName ) );
 		ConfigurationPropertySource backendPropertySource =
-				EngineConfigurationUtils.getBackend( rootPropertySource, backendName );
+				EngineConfigurationUtils.getBackendByName( rootPropertySource, backendName );
 		ConfigurationPropertySource indexPropertySource =
 				EngineConfigurationUtils.getIndex(
 						backendPropertySource,

--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/SearchIntegrationImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/SearchIntegrationImpl.java
@@ -56,6 +56,15 @@ public class SearchIntegrationImpl implements SearchIntegration {
 	}
 
 	@Override
+	public Backend backend() {
+		BackendImplementor backend = backends.get( null );
+		if ( backend == null ) {
+			throw log.noDefaultBackendRegistered();
+		}
+		return backend.toAPI();
+	}
+
+	@Override
 	public Backend backend(String backendName) {
 		BackendImplementor backend = backends.get( backendName );
 		if ( backend == null ) {

--- a/engine/src/main/java/org/hibernate/search/engine/common/spi/SearchIntegration.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/spi/SearchIntegration.java
@@ -14,6 +14,8 @@ import org.hibernate.search.engine.common.impl.SearchIntegrationBuilderImpl;
 
 public interface SearchIntegration extends AutoCloseable {
 
+	Backend backend();
+
 	Backend backend(String backendName);
 
 	IndexManager indexManager(String indexManagerName);

--- a/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
@@ -301,4 +301,12 @@ public interface Log extends BasicLogger {
 					+ " Obsolete properties: %1$s.")
 	SearchException obsoleteConfigurationPropertiesFromSearch5(Set<String> propertyKeys);
 
+	@LogMessage(level = Logger.Level.WARN)
+	@Message(id = ID_OFFSET_2 + 74,
+			value = "Using configuration property '%1$s' to set the name of the default backend to '%2$s'."
+					+ " This configuration property is deprecated and shouldn't be used anymore."
+					+ " Instead, do not assign a name your default backend"
+					+ " and configure it using the 'hibernate.search.backend' prefix,"
+					+ " e.g. hibernate.search.backend.type = elasticsearch.")
+	void deprecatedExplicitDefaultBackendName(String propertyKey, String explicitDefaultBackendName);
 }

--- a/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
@@ -203,10 +203,9 @@ public interface Log extends BasicLogger {
 			@FormatWith(ClassFormatter.class) Class<?> actualType);
 
 	@Message(id = ID_OFFSET_2 + 49,
-			value = "Missing backend type for backend '%1$s'."
-					+ " Set the property '%2$s' to a supported value."
+			value = "Missing backend type. Set the property '%1$s' to a supported value."
 	)
-	SearchException backendTypeCannotBeNullOrEmpty(String backendName, String key);
+	SearchException backendTypeCannotBeNullOrEmpty(String key);
 
 	@Message(id = ID_OFFSET_2 + 51,
 			value = "It is not possible to use per-field boosts together with withConstantScore option"
@@ -309,4 +308,7 @@ public interface Log extends BasicLogger {
 					+ " and configure it using the 'hibernate.search.backend' prefix,"
 					+ " e.g. hibernate.search.backend.type = elasticsearch.")
 	void deprecatedExplicitDefaultBackendName(String propertyKey, String explicitDefaultBackendName);
+
+	@Message(id = ID_OFFSET_2 + 75, value = "No default backend registered.")
+	SearchException noDefaultBackendRegistered();
 }

--- a/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
@@ -208,13 +208,6 @@ public interface Log extends BasicLogger {
 	)
 	SearchException backendTypeCannotBeNullOrEmpty(String backendName, String key);
 
-	@Message(id = ID_OFFSET_2 + 50,
-			value = "The name of the default backend is not set."
-					+ " Set it through the configuration property '%1$s',"
-					+ " or set the backend name explicitly for each indexed type in your mapping."
-	)
-	SearchException defaultBackendNameNotSet(String defaultKey);
-
 	@Message(id = ID_OFFSET_2 + 51,
 			value = "It is not possible to use per-field boosts together with withConstantScore option"
 	)

--- a/engine/src/main/java/org/hibernate/search/engine/reporting/impl/EngineEventContextMessages.java
+++ b/engine/src/main/java/org/hibernate/search/engine/reporting/impl/EngineEventContextMessages.java
@@ -57,6 +57,9 @@ public interface EngineEventContextMessages {
 	@Message(value = "type '%1$s'")
 	String type(String name);
 
+	@Message(value = "default backend")
+	String defaultBackend();
+
 	@Message(value = "backend '%1$s'")
 	String backend(String name);
 

--- a/engine/src/main/java/org/hibernate/search/engine/reporting/spi/EventContexts.java
+++ b/engine/src/main/java/org/hibernate/search/engine/reporting/spi/EventContexts.java
@@ -35,6 +35,20 @@ public class EventContexts {
 			}
 	);
 
+	private static final EventContext DEFAULT_BACKEND = EventContext.create(
+			new EventContextElement() {
+				@Override
+				public String toString() {
+					return "EventContextElement[" + render() + "]";
+				}
+
+				@Override
+				public String render() {
+					return MESSAGES.defaultBackend();
+				}
+			}
+	);
+
 	private static final EventContext INDEX_SCHEMA_ROOT = EventContext.create(
 			new EventContextElement() {
 				@Override
@@ -80,13 +94,22 @@ public class EventContexts {
 		} );
 	}
 
+	public static EventContext defaultBackend() {
+		return DEFAULT_BACKEND;
+	}
+
 	public static EventContext fromBackendName(String name) {
-		return EventContext.create( new AbstractSimpleEventContextElement<String>( name ) {
-			@Override
-			public String render(String param) {
-				return MESSAGES.backend( param );
-			}
-		} );
+		if ( name == null ) {
+			return DEFAULT_BACKEND;
+		}
+		else {
+			return EventContext.create( new AbstractSimpleEventContextElement<String>( name ) {
+				@Override
+				public String render(String param) {
+					return MESSAGES.backend( param );
+				}
+			} );
+		}
 	}
 
 	public static EventContext fromIndexName(String name) {

--- a/engine/src/test/java/org/hibernate/search/engine/common/impl/IndexManagerBuildingStateHolderTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/common/impl/IndexManagerBuildingStateHolderTest.java
@@ -36,13 +36,13 @@ import org.easymock.EasyMockSupport;
 @SuppressWarnings({ "unchecked", "rawtypes" })
 public class IndexManagerBuildingStateHolderTest extends EasyMockSupport {
 
-	private RootBuildContext rootBuildContextMock = createMock( RootBuildContext.class );
-	private ConfigurationPropertySource configurationSourceMock =
+	private final RootBuildContext rootBuildContextMock = createMock( RootBuildContext.class );
+	private final ConfigurationPropertySource configurationSourceMock =
 			partialMockBuilder( AbstractConfigurationPropertySourcePartialMock.class ).mock();
-	private BeanResolver beanResolverMock =
+	private final BeanResolver beanResolverMock =
 			partialMockBuilder( AbstractBeanResolverPartialMock.class ).mock();
 
-	private IndexManagerBuildingStateHolder holder =
+	private final IndexManagerBuildingStateHolder holder =
 			new IndexManagerBuildingStateHolder( beanResolverMock, configurationSourceMock, rootBuildContextMock );
 
 	@Test
@@ -65,7 +65,7 @@ public class IndexManagerBuildingStateHolderTest extends EasyMockSupport {
 				EasyMock.anyObject(),
 				EasyMock.capture( backendPropertySourceCapture )
 		) )
-				.andReturn( (BackendImplementor) backendMock );
+				.andReturn( backendMock );
 		replayAll();
 		holder.createBackends( CollectionHelper.asSet( Optional.of( "myBackend" ) ) );
 		verifyAll();
@@ -78,7 +78,7 @@ public class IndexManagerBuildingStateHolderTest extends EasyMockSupport {
 				EasyMock.anyObject(),
 				EasyMock.capture( indexPropertySourceCapture )
 		) )
-				.andReturn( (IndexManagerBuilder) indexManagerBuilderMock );
+				.andReturn( indexManagerBuilderMock );
 		EasyMock.expect( indexManagerBuilderMock.schemaRootNodeBuilder() )
 				.andStubReturn( indexSchemaRootNodeBuilderMock );
 		replayAll();

--- a/engine/src/test/java/org/hibernate/search/engine/common/impl/IndexManagerBuildingStateHolderTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/common/impl/IndexManagerBuildingStateHolderTest.java
@@ -24,7 +24,9 @@ import org.hibernate.search.engine.testsupport.util.AbstractBeanResolverPartialM
 import org.hibernate.search.engine.testsupport.util.AbstractConfigurationPropertySourcePartialMock;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.common.impl.CollectionHelper;
+import org.hibernate.search.util.impl.test.rule.ExpectedLog4jLog;
 
+import org.junit.Rule;
 import org.junit.Test;
 
 import org.easymock.Capture;
@@ -34,6 +36,9 @@ import org.easymock.EasyMockSupport;
 // We have to use raw types to mock methods returning generic types with wildcards
 @SuppressWarnings({ "unchecked", "rawtypes" })
 public class IndexManagerBuildingStateHolderTest extends EasyMockSupport {
+
+	@Rule
+	public ExpectedLog4jLog logged = ExpectedLog4jLog.create();
 
 	private final RootBuildContext rootBuildContextMock = createMock( RootBuildContext.class );
 	private final ConfigurationPropertySource configurationSourceMock =
@@ -147,9 +152,14 @@ public class IndexManagerBuildingStateHolderTest extends EasyMockSupport {
 		Capture<ConfigurationPropertySource> backendPropertySourceCapture = Capture.newInstance();
 		Capture<ConfigurationPropertySource> indexPropertySourceCapture = Capture.newInstance();
 
+		logged.expectMessage(
+				"Using configuration property 'hibernate.search.default_backend' to set the name of the default backend to 'myBackend'.",
+				"This configuration property is deprecated and shouldn't be used anymore" );
 		resetAll();
 		EasyMock.expect( configurationSourceMock.get( "default_backend" ) )
 				.andReturn( (Optional) Optional.of( "myBackend" ) );
+		EasyMock.expect( configurationSourceMock.resolve( "default_backend" ) )
+				.andStubReturn( Optional.of( "hibernate.search.default_backend" ) );
 		replayAll();
 		IndexManagerBuildingStateHolder holder =
 				new IndexManagerBuildingStateHolder( beanResolverMock, configurationSourceMock, rootBuildContextMock );

--- a/engine/src/test/java/org/hibernate/search/engine/common/impl/IndexManagerBuildingStateHolderTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/common/impl/IndexManagerBuildingStateHolderTest.java
@@ -70,7 +70,7 @@ public class IndexManagerBuildingStateHolderTest extends EasyMockSupport {
 		EasyMock.expect( beanResolverMock.resolve( BackendFactory.class, "someBackendType" ) )
 				.andReturn( BeanHolder.of( backendFactoryMock ) );
 		EasyMock.expect( backendFactoryMock.create(
-				EasyMock.eq( "default" ),
+				EasyMock.eq( EventContexts.defaultBackend() ),
 				EasyMock.anyObject(),
 				EasyMock.capture( backendPropertySourceCapture )
 		) )
@@ -99,20 +99,9 @@ public class IndexManagerBuildingStateHolderTest extends EasyMockSupport {
 		// Check that configuration property sources behave as expected
 		Optional result;
 
-		// Backend configuration - syntax "hibernate.search.backend.foo"
+		// Backend configuration
 		resetAll();
 		EasyMock.expect( configurationSourceMock.get( "backend.foo" ) )
-				.andReturn( (Optional) Optional.of( "bar" ) );
-		replayAll();
-		result = backendPropertySourceCapture.getValue().get( "foo" );
-		verifyAll();
-		assertThat( result ).contains( "bar" );
-
-		// Backend configuration - syntax "hibernate.search.backends.default.foo"
-		resetAll();
-		EasyMock.expect( configurationSourceMock.get( "backend.foo" ) )
-				.andReturn( (Optional) Optional.empty() );
-		EasyMock.expect( configurationSourceMock.get( "backends.default.foo" ) )
 				.andReturn( (Optional) Optional.of( "bar" ) );
 		replayAll();
 		result = backendPropertySourceCapture.getValue().get( "foo" );
@@ -131,8 +120,6 @@ public class IndexManagerBuildingStateHolderTest extends EasyMockSupport {
 		// Index configuration defaults
 		resetAll();
 		EasyMock.expect( configurationSourceMock.get( "backend.indexes.myIndex.foo" ) )
-				.andReturn( Optional.empty() );
-		EasyMock.expect( configurationSourceMock.get( "backends.default.indexes.myIndex.foo" ) )
 				.andReturn( Optional.empty() );
 		EasyMock.expect( configurationSourceMock.get( "backend.index_defaults.foo" ) )
 				.andReturn( (Optional) Optional.of( "bar" ) );
@@ -173,7 +160,7 @@ public class IndexManagerBuildingStateHolderTest extends EasyMockSupport {
 		EasyMock.expect( beanResolverMock.resolve( BackendFactory.class, "someBackendType" ) )
 				.andReturn( BeanHolder.of( backendFactoryMock ) );
 		EasyMock.expect( backendFactoryMock.create(
-				EasyMock.eq( "myBackend" ),
+				EasyMock.eq( EventContexts.fromBackendName( "myBackend" ) ),
 				EasyMock.anyObject(),
 				EasyMock.capture( backendPropertySourceCapture )
 		) )
@@ -273,7 +260,7 @@ public class IndexManagerBuildingStateHolderTest extends EasyMockSupport {
 		EasyMock.expect( beanResolverMock.resolve( BackendFactory.class, "someBackendType" ) )
 				.andReturn( BeanHolder.of( backendFactoryMock ) );
 		EasyMock.expect( backendFactoryMock.create(
-				EasyMock.eq( "myBackend" ),
+				EasyMock.eq( EventContexts.fromBackendName( "myBackend" ) ),
 				EasyMock.anyObject(),
 				EasyMock.capture( backendPropertySourceCapture )
 		) )
@@ -374,7 +361,7 @@ public class IndexManagerBuildingStateHolderTest extends EasyMockSupport {
 
 		assertThat( throwableCapture.getValue() )
 				.isInstanceOf( SearchException.class )
-				.hasMessageContaining( "Missing backend type for backend 'backendName'" )
+				.hasMessageContaining( "Missing backend type" )
 				.hasMessageContaining( "Set the property 'somePrefix.backends.backendName.type' to a supported value" );
 	}
 
@@ -411,7 +398,7 @@ public class IndexManagerBuildingStateHolderTest extends EasyMockSupport {
 
 		assertThat( throwableCapture.getValue() )
 				.isInstanceOf( SearchException.class )
-				.hasMessageContaining( "Missing backend type for backend 'backendName'" )
+				.hasMessageContaining( "Missing backend type" )
 				.hasMessageContaining( "Set the property 'somePrefix.backends.backendName.type' to a supported value" );
 	}
 

--- a/engine/src/test/java/org/hibernate/search/engine/common/impl/IndexManagerBuildingStateHolderTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/common/impl/IndexManagerBuildingStateHolderTest.java
@@ -60,7 +60,7 @@ public class IndexManagerBuildingStateHolderTest extends EasyMockSupport {
 		resetAll();
 
 		resetAll();
-		EasyMock.expect( configurationSourceMock.get( "backends.default.type" ) )
+		EasyMock.expect( configurationSourceMock.get( "backend.type" ) )
 				.andReturn( (Optional) Optional.of( "someBackendType" ) );
 		EasyMock.expect( beanResolverMock.resolve( BackendFactory.class, "someBackendType" ) )
 				.andReturn( BeanHolder.of( backendFactoryMock ) );
@@ -94,8 +94,19 @@ public class IndexManagerBuildingStateHolderTest extends EasyMockSupport {
 		// Check that configuration property sources behave as expected
 		Optional result;
 
-		// Backend configuration
+		// Backend configuration - syntax "hibernate.search.backend.foo"
 		resetAll();
+		EasyMock.expect( configurationSourceMock.get( "backend.foo" ) )
+				.andReturn( (Optional) Optional.of( "bar" ) );
+		replayAll();
+		result = backendPropertySourceCapture.getValue().get( "foo" );
+		verifyAll();
+		assertThat( result ).contains( "bar" );
+
+		// Backend configuration - syntax "hibernate.search.backends.default.foo"
+		resetAll();
+		EasyMock.expect( configurationSourceMock.get( "backend.foo" ) )
+				.andReturn( (Optional) Optional.empty() );
 		EasyMock.expect( configurationSourceMock.get( "backends.default.foo" ) )
 				.andReturn( (Optional) Optional.of( "bar" ) );
 		replayAll();
@@ -105,7 +116,7 @@ public class IndexManagerBuildingStateHolderTest extends EasyMockSupport {
 
 		// Index configuration
 		resetAll();
-		EasyMock.expect( configurationSourceMock.get( "backends.default.indexes.myIndex.foo" ) )
+		EasyMock.expect( configurationSourceMock.get( "backend.indexes.myIndex.foo" ) )
 				.andReturn( (Optional) Optional.of( "bar" ) );
 		replayAll();
 		result = indexPropertySourceCapture.getValue().get( "foo" );
@@ -114,9 +125,11 @@ public class IndexManagerBuildingStateHolderTest extends EasyMockSupport {
 
 		// Index configuration defaults
 		resetAll();
+		EasyMock.expect( configurationSourceMock.get( "backend.indexes.myIndex.foo" ) )
+				.andReturn( Optional.empty() );
 		EasyMock.expect( configurationSourceMock.get( "backends.default.indexes.myIndex.foo" ) )
 				.andReturn( Optional.empty() );
-		EasyMock.expect( configurationSourceMock.get( "backends.default.index_defaults.foo" ) )
+		EasyMock.expect( configurationSourceMock.get( "backend.index_defaults.foo" ) )
 				.andReturn( (Optional) Optional.of( "bar" ) );
 		replayAll();
 		result = indexPropertySourceCapture.getValue().get( "foo" );
@@ -143,6 +156,8 @@ public class IndexManagerBuildingStateHolderTest extends EasyMockSupport {
 		resetAll();
 
 		resetAll();
+		EasyMock.expect( configurationSourceMock.get( "backend.type" ) )
+				.andReturn( (Optional) Optional.empty() );
 		EasyMock.expect( configurationSourceMock.get( "backends.myBackend.type" ) )
 				.andReturn( (Optional) Optional.of( "someBackendType" ) );
 		EasyMock.expect( beanResolverMock.resolve( BackendFactory.class, "someBackendType" ) )
@@ -177,8 +192,19 @@ public class IndexManagerBuildingStateHolderTest extends EasyMockSupport {
 		// Check that configuration property sources behave as expected
 		Optional result;
 
+		// Backend configuration - syntax "hibernate.search.backend.foo"
+		resetAll();
+		EasyMock.expect( configurationSourceMock.get( "backend.foo" ) )
+				.andReturn( (Optional) Optional.of( "bar" ) );
+		replayAll();
+		result = backendPropertySourceCapture.getValue().get( "foo" );
+		verifyAll();
+		assertThat( result ).contains( "bar" );
+
 		// Backend configuration - syntax "hibernate.search.backends.myBackend.foo"
 		resetAll();
+		EasyMock.expect( configurationSourceMock.get( "backend.foo" ) )
+				.andReturn( (Optional) Optional.empty() );
 		EasyMock.expect( configurationSourceMock.get( "backends.myBackend.foo" ) )
 				.andReturn( (Optional) Optional.of( "bar" ) );
 		replayAll();
@@ -188,6 +214,8 @@ public class IndexManagerBuildingStateHolderTest extends EasyMockSupport {
 
 		// Index configuration
 		resetAll();
+		EasyMock.expect( configurationSourceMock.get( "backend.indexes.myIndex.foo" ) )
+				.andReturn( (Optional) Optional.empty() );
 		EasyMock.expect( configurationSourceMock.get( "backends.myBackend.indexes.myIndex.foo" ) )
 				.andReturn( (Optional) Optional.of( "bar" ) );
 		replayAll();
@@ -197,8 +225,12 @@ public class IndexManagerBuildingStateHolderTest extends EasyMockSupport {
 
 		// Index configuration defaults
 		resetAll();
+		EasyMock.expect( configurationSourceMock.get( "backend.indexes.myIndex.foo" ) )
+				.andReturn( (Optional) Optional.empty() );
 		EasyMock.expect( configurationSourceMock.get( "backends.myBackend.indexes.myIndex.foo" ) )
 				.andReturn( Optional.empty() );
+		EasyMock.expect( configurationSourceMock.get( "backend.index_defaults.foo" ) )
+				.andReturn( (Optional) Optional.empty() );
 		EasyMock.expect( configurationSourceMock.get( "backends.myBackend.index_defaults.foo" ) )
 				.andReturn( (Optional) Optional.of( "bar" ) );
 		replayAll();

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/ElasticsearchExtensionIT.java
@@ -74,8 +74,6 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 
 public class ElasticsearchExtensionIT {
 
-	private static final String BACKEND_NAME = "myElasticsearchBackend";
-
 	private static final String FIRST_ID = "1";
 	private static final String SECOND_ID = "2";
 	private static final String THIRD_ID = "3";
@@ -95,7 +93,7 @@ public class ElasticsearchExtensionIT {
 
 	@Before
 	public void setup() {
-		this.integration = setupHelper.start( BACKEND_NAME ).withIndexes( mainIndex, otherIndex ).setup();
+		this.integration = setupHelper.start().withIndexes( mainIndex, otherIndex ).setup();
 
 		initData();
 	}
@@ -1006,14 +1004,14 @@ public class ElasticsearchExtensionIT {
 
 	@Test
 	public void backend_unwrap() {
-		Backend backend = integration.backend( BACKEND_NAME );
+		Backend backend = integration.backend();
 		Assertions.assertThat( backend.unwrap( ElasticsearchBackend.class ) )
 				.isNotNull();
 	}
 
 	@Test
 	public void backend_unwrap_error_unknownType() {
-		Backend backend = integration.backend( BACKEND_NAME );
+		Backend backend = integration.backend();
 
 		assertThatThrownBy( () -> backend.unwrap( String.class ) )
 				.isInstanceOf( SearchException.class )
@@ -1025,7 +1023,7 @@ public class ElasticsearchExtensionIT {
 
 	@Test
 	public void backend_getClient() throws Exception {
-		Backend backend = integration.backend( BACKEND_NAME );
+		Backend backend = integration.backend();
 		ElasticsearchBackend elasticsearchBackend = backend.unwrap( ElasticsearchBackend.class );
 		RestClient restClient = elasticsearchBackend.client( RestClient.class );
 
@@ -1036,7 +1034,7 @@ public class ElasticsearchExtensionIT {
 
 	@Test
 	public void backend_getClient_error_invalidClass() {
-		Backend backend = integration.backend( BACKEND_NAME );
+		Backend backend = integration.backend();
 		ElasticsearchBackend elasticsearchBackend = backend.unwrap( ElasticsearchBackend.class );
 
 		assertThatThrownBy( () -> elasticsearchBackend.client( HttpAsyncClient.class ) )

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/analysis/ElasticsearchAnalysisConfigurerIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/analysis/ElasticsearchAnalysisConfigurerIT.java
@@ -41,8 +41,8 @@ public class ElasticsearchAnalysisConfigurerIT {
 						.backendContext( BACKEND_NAME )
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
-								"Unable to convert configuration property 'hibernate.search.backends." + BACKEND_NAME
-										+ "." + ElasticsearchBackendSettings.ANALYSIS_CONFIGURER + "'",
+								"Unable to convert configuration property 'hibernate.search.backend."
+										+ ElasticsearchBackendSettings.ANALYSIS_CONFIGURER + "'",
 								"'foobar'",
 								"Unable to find " + ElasticsearchAnalysisConfigurer.class.getName() + " implementation class: foobar"
 						)

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/analysis/ElasticsearchAnalysisConfigurerIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/analysis/ElasticsearchAnalysisConfigurerIT.java
@@ -24,8 +24,6 @@ import org.junit.Test;
 
 public class ElasticsearchAnalysisConfigurerIT {
 
-	private static final String BACKEND_NAME = "BackendName";
-
 	private static final String ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX = "Error while applying analysis configuration";
 
 	@Rule
@@ -38,7 +36,7 @@ public class ElasticsearchAnalysisConfigurerIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.backendContext( BACKEND_NAME )
+						.defaultBackendContext()
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
 								"Unable to convert configuration property 'hibernate.search.backend."
@@ -57,7 +55,7 @@ public class ElasticsearchAnalysisConfigurerIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.backendContext( BACKEND_NAME )
+						.defaultBackendContext()
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
 								FailingConfigurer.FAILURE_MESSAGE
@@ -87,7 +85,7 @@ public class ElasticsearchAnalysisConfigurerIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.backendContext( BACKEND_NAME )
+						.defaultBackendContext()
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
 								"Multiple analyzer definitions with the same name",
@@ -113,7 +111,7 @@ public class ElasticsearchAnalysisConfigurerIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.backendContext( BACKEND_NAME )
+						.defaultBackendContext()
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
 								"Multiple normalizer definitions with the same name",
@@ -139,7 +137,7 @@ public class ElasticsearchAnalysisConfigurerIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.backendContext( BACKEND_NAME )
+						.defaultBackendContext()
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
 								"Multiple tokenizer definitions with the same name",
@@ -164,7 +162,7 @@ public class ElasticsearchAnalysisConfigurerIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.backendContext( BACKEND_NAME )
+						.defaultBackendContext()
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
 								"Invalid tokenizer definition for name 'tokenizerName'",
@@ -188,7 +186,7 @@ public class ElasticsearchAnalysisConfigurerIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.backendContext( BACKEND_NAME )
+						.defaultBackendContext()
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
 								"Multiple char filter definitions with the same name",
@@ -213,7 +211,7 @@ public class ElasticsearchAnalysisConfigurerIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.backendContext( BACKEND_NAME )
+						.defaultBackendContext()
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
 								"Invalid char filter definition for name 'charFilterName'",
@@ -237,7 +235,7 @@ public class ElasticsearchAnalysisConfigurerIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.backendContext( BACKEND_NAME )
+						.defaultBackendContext()
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
 								"Multiple token filter definitions with the same name",
@@ -262,7 +260,7 @@ public class ElasticsearchAnalysisConfigurerIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.backendContext( BACKEND_NAME )
+						.defaultBackendContext()
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
 								"Invalid token filter definition for name 'tokenFilterName'",
@@ -286,7 +284,7 @@ public class ElasticsearchAnalysisConfigurerIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.backendContext( BACKEND_NAME )
+						.defaultBackendContext()
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
 								"Multiple parameters with the same name",
@@ -313,11 +311,8 @@ public class ElasticsearchAnalysisConfigurerIT {
 	}
 
 	private void setup(String analysisConfigurer, Consumer<IndexBindingContext> mappingContributor) {
-		setupHelper.start( BACKEND_NAME )
-				.withPropertyRadical(
-						"backends." + BACKEND_NAME + "." + ElasticsearchBackendSettings.ANALYSIS_CONFIGURER,
-						analysisConfigurer
-				)
+		setupHelper.start()
+				.withBackendProperty( ElasticsearchBackendSettings.ANALYSIS_CONFIGURER, analysisConfigurer )
 				.withIndex( StubMappedIndex.ofAdvancedNonRetrievable( mappingContributor ) )
 				.setup();
 	}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/bootstrap/ElasticsearchBootstrapFailureIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/bootstrap/ElasticsearchBootstrapFailureIT.java
@@ -21,8 +21,6 @@ import org.junit.Test;
 
 public class ElasticsearchBootstrapFailureIT {
 
-	private static final String BACKEND_NAME = "BackendName";
-
 	@Rule
 	public final SearchSetupHelper setupHelper = new SearchSetupHelper();
 
@@ -36,7 +34,7 @@ public class ElasticsearchBootstrapFailureIT {
 	@TestForIssue(jiraKey = "HSEARCH-3621")
 	public void cannotConnect() {
 		Assertions.assertThatThrownBy(
-				() -> setupHelper.start( BACKEND_NAME )
+				() -> setupHelper.start()
 						.withBackendProperty(
 								ElasticsearchBackendSettings.HOSTS,
 								// We just need a closed port, hopefully this one will generally be closed
@@ -48,7 +46,7 @@ public class ElasticsearchBootstrapFailureIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.backendContext( BACKEND_NAME )
+						.defaultBackendContext()
 						.failure(
 								"Failed to detect the Elasticsearch version running on the cluster",
 								"Elasticsearch request failed",

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/bootstrap/ElasticsearchBootstrapIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/bootstrap/ElasticsearchBootstrapIT.java
@@ -27,8 +27,6 @@ import org.junit.Test;
 
 public class ElasticsearchBootstrapIT {
 
-	private static final String BACKEND_NAME = "BackendName";
-
 	@Rule
 	public final SearchSetupHelper setupHelper = new SearchSetupHelper();
 
@@ -73,7 +71,7 @@ public class ElasticsearchBootstrapIT {
 	@TestForIssue(jiraKey = "HSEARCH-3841")
 	public void explicitProtocolDialect_noVersionCheck() {
 		Assertions.assertThatThrownBy(
-				() -> setupHelper.start( BACKEND_NAME )
+				() -> setupHelper.start()
 						.withBackendProperty(
 								ElasticsearchBackendSettings.VERSION_CHECK_ENABLED, false
 						)
@@ -88,7 +86,7 @@ public class ElasticsearchBootstrapIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.backendContext( BACKEND_NAME )
+						.defaultBackendContext()
 						.failure(
 								"Invalid Elasticsearch version",
 								"When version_check.enabled is set to false",
@@ -105,7 +103,7 @@ public class ElasticsearchBootstrapIT {
 	@TestForIssue(jiraKey = "HSEARCH-3841")
 	public void explicitProtocolDialect_noVersionCheck_incompleteVersion() {
 		Assertions.assertThatThrownBy(
-				() -> setupHelper.start( BACKEND_NAME )
+				() -> setupHelper.start()
 						.withBackendProperty(
 								ElasticsearchBackendSettings.VERSION_CHECK_ENABLED, false
 						)
@@ -123,7 +121,7 @@ public class ElasticsearchBootstrapIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.backendContext( BACKEND_NAME )
+						.defaultBackendContext()
 						.failure(
 								"Invalid Elasticsearch version",
 								"When version_check.enabled is set to false",
@@ -139,7 +137,7 @@ public class ElasticsearchBootstrapIT {
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3841")
 	public void explicitProtocolDialect_noVersionCheck_completeVersion() {
-		SearchSetupHelper.PartialSetup partialSetup = setupHelper.start( BACKEND_NAME )
+		SearchSetupHelper.PartialSetup partialSetup = setupHelper.start()
 				.withBackendProperty(
 						ElasticsearchBackendSettings.VERSION_CHECK_ENABLED, false
 				)

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/index/lifecycle/ElasticsearchIndexLifecycleStrategyIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/index/lifecycle/ElasticsearchIndexLifecycleStrategyIT.java
@@ -39,7 +39,7 @@ public class ElasticsearchIndexLifecycleStrategyIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageContainingAll(
-						"Unable to convert configuration property 'hibernate.search.backends.testedBackend.indexes." + index.name()
+						"Unable to convert configuration property 'hibernate.search.backend.indexes." + index.name()
 								+ ".lifecycle.strategy' with value 'update'",
 						"The lifecycle strategy cannot be set at the index level anymore",
 						"Set the schema management strategy via the property 'hibernate.search.schema_management.strategy' instead"

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneBackendIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneBackendIT.java
@@ -26,8 +26,6 @@ import org.apache.lucene.analysis.standard.StandardAnalyzer;
 
 public class LuceneBackendIT {
 
-	private static final String BACKEND_NAME = "MyBackend";
-
 	@ClassRule
 	public static final SearchSetupHelper setupHelper = new SearchSetupHelper();
 
@@ -37,10 +35,10 @@ public class LuceneBackendIT {
 
 	@BeforeClass
 	public static void setup() {
-		SearchIntegration integration = setupHelper.start( BACKEND_NAME ).withIndex( index )
+		SearchIntegration integration = setupHelper.start().withIndex( index )
 				.withSchemaManagement( StubMappingSchemaManagementStrategy.NONE )
 				.setup();
-		backend = integration.backend( BACKEND_NAME ).unwrap( LuceneBackend.class );
+		backend = integration.backend().unwrap( LuceneBackend.class );
 	}
 
 	@Test

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneExtensionIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/LuceneExtensionIT.java
@@ -80,8 +80,6 @@ import org.junit.Test;
 
 public class LuceneExtensionIT {
 
-	private static final String BACKEND_NAME = "myLuceneBackend";
-
 	private static final String FIRST_ID = "1";
 	private static final String SECOND_ID = "2";
 	private static final String THIRD_ID = "3";
@@ -98,7 +96,7 @@ public class LuceneExtensionIT {
 
 	@Before
 	public void setup() {
-		this.integration = setupHelper.start( BACKEND_NAME ).withIndexes( mainIndex, otherIndex ).setup();
+		this.integration = setupHelper.start().withIndexes( mainIndex, otherIndex ).setup();
 
 		initData();
 	}
@@ -719,14 +717,14 @@ public class LuceneExtensionIT {
 
 	@Test
 	public void backend_unwrap() {
-		Backend backend = integration.backend( BACKEND_NAME );
+		Backend backend = integration.backend();
 		Assertions.assertThat( backend.unwrap( LuceneBackend.class ) )
 				.isNotNull();
 	}
 
 	@Test
 	public void backend_unwrap_error_unknownType() {
-		Backend backend = integration.backend( BACKEND_NAME );
+		Backend backend = integration.backend();
 
 		assertThatThrownBy( () -> backend.unwrap( String.class ) )
 				.isInstanceOf( SearchException.class )

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/analysis/LuceneAnalysisConfigurerIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/analysis/LuceneAnalysisConfigurerIT.java
@@ -44,7 +44,7 @@ public class LuceneAnalysisConfigurerIT {
 						.backendContext( BACKEND_NAME )
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
-								"Unable to convert configuration property 'hibernate.search.backends." + BACKEND_NAME + "."
+								"Unable to convert configuration property 'hibernate.search.backend."
 										+ LuceneBackendSettings.ANALYSIS_CONFIGURER + "'",
 								"'foobar'",
 								"Unable to find " + LuceneAnalysisConfigurer.class.getName() + " implementation class: foobar"

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/analysis/LuceneAnalysisConfigurerIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/analysis/LuceneAnalysisConfigurerIT.java
@@ -27,8 +27,6 @@ import org.apache.lucene.analysis.standard.StandardAnalyzer;
 
 public class LuceneAnalysisConfigurerIT {
 
-	private static final String BACKEND_NAME = "BackendName";
-
 	private static final String ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX = "Error while applying analysis configuration";
 
 	@Rule
@@ -41,7 +39,7 @@ public class LuceneAnalysisConfigurerIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.backendContext( BACKEND_NAME )
+						.defaultBackendContext()
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
 								"Unable to convert configuration property 'hibernate.search.backend."
@@ -60,7 +58,7 @@ public class LuceneAnalysisConfigurerIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.backendContext( BACKEND_NAME )
+						.defaultBackendContext()
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
 								FailingConfigurer.FAILURE_MESSAGE
@@ -90,7 +88,7 @@ public class LuceneAnalysisConfigurerIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.backendContext( BACKEND_NAME )
+						.defaultBackendContext()
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
 								"Multiple analyzer definitions with the same name",
@@ -116,7 +114,7 @@ public class LuceneAnalysisConfigurerIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.backendContext( BACKEND_NAME )
+						.defaultBackendContext()
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
 								"Multiple normalizer definitions with the same name",
@@ -142,7 +140,7 @@ public class LuceneAnalysisConfigurerIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.backendContext( BACKEND_NAME )
+						.defaultBackendContext()
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
 								"Multiple parameters with the same name",
@@ -171,11 +169,8 @@ public class LuceneAnalysisConfigurerIT {
 
 	private void setup(String analysisConfigurer, Consumer<IndexBindingContext> binder) {
 		StubMappedIndex index = StubMappedIndex.ofAdvancedNonRetrievable( binder );
-		setupHelper.start( BACKEND_NAME )
-				.withPropertyRadical(
-						"backends." + BACKEND_NAME + "." + LuceneBackendSettings.ANALYSIS_CONFIGURER,
-						analysisConfigurer
-				)
+		setupHelper.start()
+				.withBackendProperty( LuceneBackendSettings.ANALYSIS_CONFIGURER, analysisConfigurer )
 				.withIndex( index )
 				.setup();
 	}

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/directory/AbstractBuiltInDirectoryIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/directory/AbstractBuiltInDirectoryIT.java
@@ -87,7 +87,7 @@ public abstract class AbstractBuiltInDirectoryIT extends AbstractDirectoryIT {
 		) ) )
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.backendContext( BACKEND_NAME )
+						.defaultBackendContext()
 						.failure(
 								"Invalid locking strategy name",
 								"'some_invalid_name'",

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/directory/AbstractDirectoryIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/directory/AbstractDirectoryIT.java
@@ -27,8 +27,6 @@ import org.junit.rules.TemporaryFolder;
 
 public abstract class AbstractDirectoryIT {
 
-	protected static final String BACKEND_NAME = "BackendName";
-
 	private static final String DOCUMENT_1 = "1";
 	private static final String DOCUMENT_2 = "2";
 	private static final String DOCUMENT_3 = "3";
@@ -70,7 +68,7 @@ public abstract class AbstractDirectoryIT {
 	protected final void setup(Object directoryType,
 			Function<SearchSetupHelper.SetupContext, SearchSetupHelper.SetupContext> additionalConfiguration) {
 		searchIntegration = additionalConfiguration.apply(
-				setupHelper.start( BACKEND_NAME )
+				setupHelper.start()
 						.withIndex( index )
 						.withBackendProperty(
 								LuceneBackendSettings.DIRECTORY_TYPE, directoryType

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/directory/CustomDirectoryIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/directory/CustomDirectoryIT.java
@@ -71,7 +71,7 @@ public class CustomDirectoryIT extends AbstractDirectoryIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.backendContext( BACKEND_NAME )
+						.defaultBackendContext()
 						.failure(
 								"Unable to convert configuration property 'hibernate.search.backend.directory.type'"
 										+ " with value '" + invalidDirectoryType + "'",

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/directory/CustomDirectoryIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/directory/CustomDirectoryIT.java
@@ -73,7 +73,7 @@ public class CustomDirectoryIT extends AbstractDirectoryIT {
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
 						.backendContext( BACKEND_NAME )
 						.failure(
-								"Unable to convert configuration property 'hibernate.search.backends." + BACKEND_NAME + ".directory.type'"
+								"Unable to convert configuration property 'hibernate.search.backend.directory.type'"
 										+ " with value '" + invalidDirectoryType + "'",
 								"Unable to find " + DirectoryProvider.class.getName() + " implementation class: "
 										+ invalidDirectoryType

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/directory/LuceneLocalFileSystemDirectoryIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/lowlevel/directory/LuceneLocalFileSystemDirectoryIT.java
@@ -107,7 +107,7 @@ public class LuceneLocalFileSystemDirectoryIT extends AbstractBuiltInDirectoryIT
 		) ) )
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.backendContext( BACKEND_NAME )
+						.defaultBackendContext()
 						.failure(
 								"Invalid filesystem access strategy name",
 								"'some_invalid_name'",

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/index/IndexManagerIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/index/IndexManagerIT.java
@@ -22,8 +22,6 @@ import org.junit.Test;
 
 public class IndexManagerIT {
 
-	private static final String BACKEND_NAME = "MyBackend";
-
 	@ClassRule
 	public static final SearchSetupHelper setupHelper = new SearchSetupHelper();
 
@@ -34,10 +32,10 @@ public class IndexManagerIT {
 
 	@BeforeClass
 	public static void setup() {
-		SearchIntegration integration = setupHelper.start( BACKEND_NAME ).withIndex( index )
+		SearchIntegration integration = setupHelper.start().withIndex( index )
 				.withSchemaManagement( StubMappingSchemaManagementStrategy.NONE )
 				.setup();
-		backendApi = integration.backend( BACKEND_NAME );
+		backendApi = integration.backend();
 		indexApi = index.toApi();
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/SearchMultiIndexIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/SearchMultiIndexIT.java
@@ -64,11 +64,11 @@ public class SearchMultiIndexIT {
 	public final SearchSetupHelper setupHelper = new SearchSetupHelper();
 
 	private final SimpleMappedIndex<IndexBinding_1_1> index_1_1 =
-			SimpleMappedIndex.of( IndexBinding_1_1::new ).name( "index_1_1" );
+			SimpleMappedIndex.of( IndexBinding_1_1::new ).backendName( BACKEND_1 ).name( "index_1_1" );
 	private final SimpleMappedIndex<IndexBinding_1_2> index_1_2 =
-			SimpleMappedIndex.of( IndexBinding_1_2::new ).name( "index_1_2" );;
+			SimpleMappedIndex.of( IndexBinding_1_2::new ).backendName( BACKEND_1 ).name( "index_1_2" );;
 	private final SimpleMappedIndex<IndexBinding_2_1> index_2_1 =
-			SimpleMappedIndex.of( IndexBinding_2_1::new ).name( "index_2_1" );;
+			SimpleMappedIndex.of( IndexBinding_2_1::new ).backendName( BACKEND_2 ).name( "index_2_1" );;
 
 	@Before
 	public void setup() {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/rule/SearchSetupHelper.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/rule/SearchSetupHelper.java
@@ -74,6 +74,7 @@ public class SearchSetupHelper implements TestRule {
 		return start( "testedBackend" );
 	}
 
+	@SuppressWarnings("deprecation")
 	public SetupContext start(String backendName) {
 		Map<String, ?> backendRelativeProperties =
 				setupStrategy.createBackendConfigurationProperties( configurationProvider );

--- a/integrationtest/jdk/java-modules/src/main/resources/hibernate.properties
+++ b/integrationtest/jdk/java-modules/src/main/resources/hibernate.properties
@@ -15,15 +15,14 @@ hibernate.max_fetch_depth 5
 
 # Hibernate Search properties:
 hibernate.search.automatic_indexing.synchronization.strategy sync
-hibernate.search.default_backend backendName
-hibernate.search.backends.backendName.type elasticsearch
-hibernate.search.backends.backendName.hosts ${test.elasticsearch.connection.hosts}
-hibernate.search.backends.backendName.username ${test.elasticsearch.connection.username}
-hibernate.search.backends.backendName.password ${test.elasticsearch.connection.password}
-hibernate.search.backends.backendName.aws.signing.enabled ${test.elasticsearch.connection.aws.signing.enabled}
-hibernate.search.backends.backendName.aws.signing.access_key ${test.elasticsearch.connection.aws.signing.access_key}
-hibernate.search.backends.backendName.aws.signing.secret_key ${test.elasticsearch.connection.aws.signing.secret_key}
-hibernate.search.backends.backendName.aws.signing.region ${test.elasticsearch.connection.aws.signing.region}
-hibernate.search.backends.backendName.log.json_pretty_printing true
-hibernate.search.backends.backendName.index_defaults.schema_management.minimal_required_status yellow
-hibernate.search.backends.backendName.analysis.configurer org.hibernate.search.integrationtest.java.module.config.MyElasticsearchAnalysisConfigurer
+hibernate.search.backend.type elasticsearch
+hibernate.search.backend.hosts ${test.elasticsearch.connection.hosts}
+hibernate.search.backend.username ${test.elasticsearch.connection.username}
+hibernate.search.backend.password ${test.elasticsearch.connection.password}
+hibernate.search.backend.aws.signing.enabled ${test.elasticsearch.connection.aws.signing.enabled}
+hibernate.search.backend.aws.signing.access_key ${test.elasticsearch.connection.aws.signing.access_key}
+hibernate.search.backend.aws.signing.secret_key ${test.elasticsearch.connection.aws.signing.secret_key}
+hibernate.search.backend.aws.signing.region ${test.elasticsearch.connection.aws.signing.region}
+hibernate.search.backend.log.json_pretty_printing true
+hibernate.search.backend.index_defaults.schema_management.minimal_required_status yellow
+hibernate.search.backend.analysis.configurer org.hibernate.search.integrationtest.java.module.config.MyElasticsearchAnalysisConfigurer

--- a/integrationtest/mapper/orm-cdi/src/test/java/org/hibernate/search/integrationtest/mapper/orm/cdi/CdiBeanResolutionIT.java
+++ b/integrationtest/mapper/orm-cdi/src/test/java/org/hibernate/search/integrationtest/mapper/orm/cdi/CdiBeanResolutionIT.java
@@ -55,7 +55,7 @@ import org.assertj.core.api.InstanceOfAssertFactories;
 public class CdiBeanResolutionIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm-cdi/src/test/java/org/hibernate/search/integrationtest/mapper/orm/cdi/CdiExtendedBeanManagerBootstrapShutdownIT.java
+++ b/integrationtest/mapper/orm-cdi/src/test/java/org/hibernate/search/integrationtest/mapper/orm/cdi/CdiExtendedBeanManagerBootstrapShutdownIT.java
@@ -143,7 +143,7 @@ public class CdiExtendedBeanManagerBootstrapShutdownIT {
 			assertThatThrownBy( () -> extendedBeanManager.simulateBoot( DependentBean.class ) )
 					// Hibernate Search should have attempted to boot, but failed.
 					.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-							.backendContext( backendMock.getBackendName() )
+							.defaultBackendContext()
 							.failure( bootFailedException.getMessage() )
 							.build() );
 

--- a/integrationtest/mapper/orm-cdi/src/test/java/org/hibernate/search/integrationtest/mapper/orm/cdi/CdiExtendedBeanManagerBootstrapShutdownIT.java
+++ b/integrationtest/mapper/orm-cdi/src/test/java/org/hibernate/search/integrationtest/mapper/orm/cdi/CdiExtendedBeanManagerBootstrapShutdownIT.java
@@ -45,7 +45,7 @@ import org.junit.Test;
 public class CdiExtendedBeanManagerBootstrapShutdownIT {
 
 	@Rule
-	public final BackendMock backendMock = new BackendMock( "stubBackend" );
+	public final BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public final OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm-envers/src/test/java/org/hibernate/search/integrationtest/mapper/orm/envers/EnversIT.java
+++ b/integrationtest/mapper/orm-envers/src/test/java/org/hibernate/search/integrationtest/mapper/orm/envers/EnversIT.java
@@ -43,7 +43,7 @@ import org.assertj.core.api.SoftAssertions;
 public class EnversIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AbstractAutomaticIndexingAssociationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AbstractAutomaticIndexingAssociationIT.java
@@ -91,7 +91,7 @@ public abstract class AbstractAutomaticIndexingAssociationIT<
 		> {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AbstractAutomaticIndexingBridgeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AbstractAutomaticIndexingBridgeIT.java
@@ -41,7 +41,7 @@ import org.junit.Test;
 public abstract class AbstractAutomaticIndexingBridgeIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingBasicIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingBasicIT.java
@@ -44,7 +44,7 @@ import org.junit.Test;
 public class AutomaticIndexingBasicIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingBridgeExplicitReindexingFunctionalIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingBridgeExplicitReindexingFunctionalIT.java
@@ -48,7 +48,7 @@ import org.junit.Test;
 public class AutomaticIndexingBridgeExplicitReindexingFunctionalIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingConcurrentModificationInDifferentTypeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingConcurrentModificationInDifferentTypeIT.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 
 public class AutomaticIndexingConcurrentModificationInDifferentTypeIT {
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingConcurrentModificationInSameTypeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingConcurrentModificationInSameTypeIT.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 
 public class AutomaticIndexingConcurrentModificationInSameTypeIT {
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingEmbeddableIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingEmbeddableIT.java
@@ -45,7 +45,7 @@ import org.junit.Test;
 public class AutomaticIndexingEmbeddableIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingEmbeddedBridgeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingEmbeddedBridgeIT.java
@@ -46,7 +46,7 @@ import org.junit.Test;
 public class AutomaticIndexingEmbeddedBridgeIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingGenericPolymorphicAssociationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingGenericPolymorphicAssociationIT.java
@@ -36,7 +36,7 @@ import org.junit.Test;
 public class AutomaticIndexingGenericPolymorphicAssociationIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingMappedSuperclassIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingMappedSuperclassIT.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 public class AutomaticIndexingMappedSuperclassIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingNonEntityIdDocumentIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingNonEntityIdDocumentIdIT.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 public class AutomaticIndexingNonEntityIdDocumentIdIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingOutOfTransactionIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingOutOfTransactionIT.java
@@ -32,7 +32,7 @@ public class AutomaticIndexingOutOfTransactionIT {
 	public BackendMock backendMock = new BackendMock();
 
 	@Rule
-	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMocks( backendMock );
+	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
 
 	private SessionFactory sessionFactory;
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingOutOfTransactionIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingOutOfTransactionIT.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 public class AutomaticIndexingOutOfTransactionIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "myBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMocks( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingOverReindexingIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingOverReindexingIT.java
@@ -77,7 +77,7 @@ import org.junit.Test;
 public class AutomaticIndexingOverReindexingIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingPolymorphicInverseSideAssociationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingPolymorphicInverseSideAssociationIT.java
@@ -37,7 +37,7 @@ import org.junit.Test;
 public class AutomaticIndexingPolymorphicInverseSideAssociationIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingPolymorphicOriginalSideAssociationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingPolymorphicOriginalSideAssociationIT.java
@@ -37,7 +37,7 @@ import org.junit.Test;
 public class AutomaticIndexingPolymorphicOriginalSideAssociationIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingSynchronizationStrategyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingSynchronizationStrategyIT.java
@@ -64,7 +64,7 @@ public class AutomaticIndexingSynchronizationStrategyIT {
 	private static final int ENTITY_2_ID = 2;
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/SearchSessionFlushIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/SearchSessionFlushIT.java
@@ -38,7 +38,7 @@ public class SearchSessionFlushIT {
 	public BackendMock backendMock = new BackendMock();
 
 	@Rule
-	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMocks( backendMock );
+	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
 
 	private SessionFactory sessionFactory;
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/SearchSessionFlushIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/SearchSessionFlushIT.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 public class SearchSessionFlushIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "myBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMocks( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/BootstrapFailureIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/BootstrapFailureIT.java
@@ -30,7 +30,7 @@ public class BootstrapFailureIT {
 	private static final String INDEX_NAME = "IndexName";
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/BootstrapLogsIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/BootstrapLogsIT.java
@@ -48,7 +48,7 @@ public class BootstrapLogsIT {
 	);
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/HibernateOrmIntegrationBooterIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/HibernateOrmIntegrationBooterIT.java
@@ -108,6 +108,7 @@ public class HibernateOrmIntegrationBooterIT {
 		}
 	}
 
+	@SuppressWarnings("deprecation")
 	private HibernateOrmIntegrationBooter createBooter(Class<?> ... entityClasses) {
 		StandardServiceRegistryBuilder registryBuilder = new StandardServiceRegistryBuilder();
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/HibernateOrmIntegrationBooterIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/HibernateOrmIntegrationBooterIT.java
@@ -31,7 +31,6 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.util.common.impl.Closer;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.index.StubSchemaManagementWork;
-import org.hibernate.search.util.impl.integrationtest.common.stub.backend.index.impl.StubBackendFactory;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.SimpleSessionFactoryBuilder;
 
@@ -120,7 +119,7 @@ public class HibernateOrmIntegrationBooterIT {
 		registryBuilder.applySetting(
 				EngineSettings.BACKENDS
 						+ "." + backendMock.getBackendName() + "." + BackendSettings.TYPE,
-				StubBackendFactory.class.getName()
+				backendMock.factory()
 		);
 
 		StandardServiceRegistry serviceRegistry = registryBuilder.build();

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/HibernateOrmIntegrationBooterIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/HibernateOrmIntegrationBooterIT.java
@@ -48,7 +48,7 @@ public class HibernateOrmIntegrationBooterIT {
 	private final List<AutoCloseable> toClose = new ArrayList<>();
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@After
 	public void cleanup() throws Exception {

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/HibernateOrmIntegrationBooterIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/HibernateOrmIntegrationBooterIT.java
@@ -107,18 +107,12 @@ public class HibernateOrmIntegrationBooterIT {
 		}
 	}
 
-	@SuppressWarnings("deprecation")
 	private HibernateOrmIntegrationBooter createBooter(Class<?> ... entityClasses) {
 		StandardServiceRegistryBuilder registryBuilder = new StandardServiceRegistryBuilder();
 
 		// Configure the backend
 		registryBuilder.applySetting(
-				EngineSettings.DEFAULT_BACKEND,
-				backendMock.getBackendName()
-		);
-		registryBuilder.applySetting(
-				EngineSettings.BACKENDS
-						+ "." + backendMock.getBackendName() + "." + BackendSettings.TYPE,
+				EngineSettings.BACKEND + "." + BackendSettings.TYPE,
 				backendMock.factory()
 		);
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/ObsoletePropertiesIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/ObsoletePropertiesIT.java
@@ -100,7 +100,7 @@ public class ObsoletePropertiesIT {
 	);
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/ShutdownFailureIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/ShutdownFailureIT.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 public class ShutdownFailureIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/UnusedPropertiesIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/UnusedPropertiesIT.java
@@ -12,6 +12,7 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 
 import org.hibernate.search.engine.cfg.EngineSettings;
+import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
@@ -49,7 +50,6 @@ public class UnusedPropertiesIT {
 	}
 
 	@Test
-	@SuppressWarnings("deprecation")
 	public void checkEnabledByDefault_unusedProperty() {
 		String unusedPropertyKey = "hibernate.search.indexes.myIndex.foo";
 		logged.expectMessage(
@@ -62,11 +62,12 @@ public class UnusedPropertiesIT {
 		logged.expectMessage( "Configuration property tracking is disabled" )
 				.never();
 		// Also check that used properties are not reported as unused
-		logged.expectMessage( "not used", EngineSettings.DEFAULT_BACKEND )
+		logged.expectMessage( "not used", HibernateOrmMapperSettings.QUERY_LOADING_FETCH_SIZE )
 				.never();
 
 		setup( builder -> {
 			builder.setProperty( unusedPropertyKey, "bar" );
+			builder.setProperty( HibernateOrmMapperSettings.QUERY_LOADING_FETCH_SIZE, 2 );
 		} );
 	}
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/UnusedPropertiesIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/UnusedPropertiesIT.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 public class UnusedPropertiesIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/UnusedPropertiesIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/UnusedPropertiesIT.java
@@ -49,6 +49,7 @@ public class UnusedPropertiesIT {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void checkEnabledByDefault_unusedProperty() {
 		String unusedPropertyKey = "hibernate.search.indexes.myIndex.foo";
 		logged.expectMessage(

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/dynamicmap/DynamicMapBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/dynamicmap/DynamicMapBaseIT.java
@@ -54,7 +54,7 @@ public class DynamicMapBaseIT {
 	private static final String INDEX2_NAME = "Index2Name";
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToHibernateOrmIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToHibernateOrmIT.java
@@ -53,7 +53,7 @@ import org.junit.Test;
 public class ToHibernateOrmIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToJpaIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToJpaIT.java
@@ -56,7 +56,7 @@ import org.junit.Test;
 public class ToJpaIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/mapping/definition/AnnotationMappingDiscoveryIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/mapping/definition/AnnotationMappingDiscoveryIT.java
@@ -45,7 +45,7 @@ import org.junit.Test;
 public class AnnotationMappingDiscoveryIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/AbstractMassIndexingFailureIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/AbstractMassIndexingFailureIT.java
@@ -53,7 +53,7 @@ public abstract class AbstractMassIndexingFailureIT {
 	public static final String AUTHOR_3 = "Mary Shelley";
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingBaseIT.java
@@ -48,7 +48,7 @@ public class MassIndexingBaseIT {
 	public static final String AUTHOR_3 = "Mary Shelley";
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingEmbeddedIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingEmbeddedIdIT.java
@@ -51,7 +51,7 @@ public class MassIndexingEmbeddedIdIT {
 	public static final String AUTHOR_3 = "Mary Shelley";
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingInterruptionIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingInterruptionIT.java
@@ -45,7 +45,7 @@ public class MassIndexingInterruptionIT {
 	public static final String AUTHOR_1 = "Charles Dickens";
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingMonitorIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingMonitorIT.java
@@ -45,7 +45,7 @@ public class MassIndexingMonitorIT {
 	public static final String AUTHOR_3 = "Mary Shelley";
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingNonEntityIdDocumentIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingNonEntityIdDocumentIdIT.java
@@ -45,7 +45,7 @@ public class MassIndexingNonEntityIdDocumentIdIT {
 	private static final String AUTHOR_3 = "Mary Shelley";
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/AnnotationMappingAccessTypeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/AnnotationMappingAccessTypeIT.java
@@ -42,7 +42,7 @@ import org.junit.Test;
 public class AnnotationMappingAccessTypeIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BindingUsingPropertyMarkerAccessIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BindingUsingPropertyMarkerAccessIT.java
@@ -58,7 +58,7 @@ public class BindingUsingPropertyMarkerAccessIT<TIndexed> {
 	}
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BytecodeEnhancementIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BytecodeEnhancementIT.java
@@ -50,7 +50,7 @@ import org.junit.runner.RunWith;
 public class BytecodeEnhancementIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/DefaultDecimalScaleMappingIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/DefaultDecimalScaleMappingIT.java
@@ -27,7 +27,7 @@ public class DefaultDecimalScaleMappingIT {
 	private static final String INDEX_NAME = "IndexName";
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/GenericPropertyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/GenericPropertyIT.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 public class GenericPropertyIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/MappedSuperclassIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/MappedSuperclassIT.java
@@ -30,7 +30,7 @@ public class MappedSuperclassIT {
 	private static final String INDEX_NAME = "IndexedEntity";
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/ProgrammaticMappingAccessTypeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/ProgrammaticMappingAccessTypeIT.java
@@ -44,7 +44,7 @@ import org.junit.Test;
 public class ProgrammaticMappingAccessTypeIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/PropertyInheritanceIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/PropertyInheritanceIT.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 public class PropertyInheritanceIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/ProxyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/ProxyIT.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 public class ProxyIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/TransientPropertyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/TransientPropertyIT.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 public class TransientPropertyIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/automaticindexing/ContainedInThroughNonContainingIndexedTypeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/automaticindexing/ContainedInThroughNonContainingIndexedTypeIT.java
@@ -41,7 +41,7 @@ import org.junit.Test;
 public class ContainedInThroughNonContainingIndexedTypeIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/automaticindexing/ContainedInTriggerUnnecessaryCollectionInitializationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/automaticindexing/ContainedInTriggerUnnecessaryCollectionInitializationIT.java
@@ -38,7 +38,7 @@ import org.junit.Test;
 public class ContainedInTriggerUnnecessaryCollectionInitializationIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/automaticindexing/FlushClearEvictAllIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/automaticindexing/FlushClearEvictAllIT.java
@@ -40,7 +40,7 @@ import org.junit.Test;
 public class FlushClearEvictAllIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/automaticindexing/IndexingProcessorProxiedAssociatedEntityIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/automaticindexing/IndexingProcessorProxiedAssociatedEntityIT.java
@@ -42,7 +42,7 @@ import org.junit.Test;
 public class IndexingProcessorProxiedAssociatedEntityIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/automaticindexing/ReindexingResolverProxiedAssociatedEntityIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/automaticindexing/ReindexingResolverProxiedAssociatedEntityIT.java
@@ -42,7 +42,7 @@ import org.junit.Test;
 public class ReindexingResolverProxiedAssociatedEntityIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/massindexing/MassIndexingPrimitiveIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/massindexing/MassIndexingPrimitiveIdIT.java
@@ -34,7 +34,7 @@ import org.junit.Test;
 public class MassIndexingPrimitiveIdIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/model/IdClassIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/model/IdClassIT.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 public class IdClassIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/schema/management/manager/AbstractSearchSchemaManagerSimpleOperationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/schema/management/manager/AbstractSearchSchemaManagerSimpleOperationIT.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 public abstract class AbstractSearchSchemaManagerSimpleOperationIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper setupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/schema/management/strategy/AbstractSchemaManagementStrategyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/schema/management/strategy/AbstractSchemaManagementStrategyIT.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 public abstract class AbstractSchemaManagementStrategyIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper setupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/schema/management/strategy/SchemaManagementStrategyNoneIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/schema/management/strategy/SchemaManagementStrategyNoneIT.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 public class SchemaManagementStrategyNoneIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper setupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/SearchQueryBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/SearchQueryBaseIT.java
@@ -71,7 +71,7 @@ public class SearchQueryBaseIT {
 	private static final String AUTHOR_AVENUE_OF_MYSTERIES = "John Irving";
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/AbstractSearchQueryEntityLoadingIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/AbstractSearchQueryEntityLoadingIT.java
@@ -33,7 +33,7 @@ import org.junit.Rule;
 public abstract class AbstractSearchQueryEntityLoadingIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/session/SearchIndexingPlanNonEntityIdDocumentIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/session/SearchIndexingPlanNonEntityIdDocumentIdIT.java
@@ -31,10 +31,8 @@ import org.junit.Test;
  */
 public class SearchIndexingPlanNonEntityIdDocumentIdIT {
 
-	private static final String BACKEND_NAME = "stubBackend";
-
 	@Rule
-	public BackendMock backendMock = new BackendMock( BACKEND_NAME );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/session/SearchIndexingPlanPersistBatchIndexingIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/session/SearchIndexingPlanPersistBatchIndexingIT.java
@@ -33,14 +33,12 @@ import org.junit.Test;
 @TestForIssue(jiraKey = "HSEARCH-3049")
 public class SearchIndexingPlanPersistBatchIndexingIT {
 
-	private static final String BACKEND_NAME = "stubBackend";
-
-	private static int BATCH_SIZE = 100;
+	private static final int BATCH_SIZE = 100;
 	// Make sure that entity count is not a multiple of batch size, to test for corner cases
-	private static int ENTITY_COUNT = BATCH_SIZE * 200 + BATCH_SIZE / 2;
+	private static final int ENTITY_COUNT = BATCH_SIZE * 200 + BATCH_SIZE / 2;
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( BACKEND_NAME );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
@@ -154,7 +152,7 @@ public class SearchIndexingPlanPersistBatchIndexingIT {
 	}
 
 	@Entity(name = "indexed1")
-	@Indexed(backend = BACKEND_NAME, index = IndexedEntity.INDEX_NAME)
+	@Indexed(index = IndexedEntity.INDEX_NAME)
 	public static class IndexedEntity {
 
 		static final String INDEX_NAME = "index1Name";

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/smoke/AnnotationMappingSmokeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/smoke/AnnotationMappingSmokeIT.java
@@ -54,7 +54,7 @@ import org.junit.Test;
 public class AnnotationMappingSmokeIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/smoke/ProgrammaticMappingSmokeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/smoke/ProgrammaticMappingSmokeIT.java
@@ -52,7 +52,7 @@ import org.junit.Test;
 public class ProgrammaticMappingSmokeIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/spi/DifferentSessionFactoriesIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/spi/DifferentSessionFactoriesIT.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 public class DifferentSessionFactoriesIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/automaticindexing/DefaultReindexOnUpdateIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/automaticindexing/DefaultReindexOnUpdateIT.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 public class DefaultReindexOnUpdateIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/bootstrap/FailureReportIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/bootstrap/FailureReportIT.java
@@ -36,7 +36,7 @@ public class FailureReportIT {
 			+ "    JavaBean mapping: \n";
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public ExpectedLog4jLog logged = ExpectedLog4jLog.create();

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/lifecycle/CleanupIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/lifecycle/CleanupIT.java
@@ -60,7 +60,7 @@ public class CleanupIT {
 	private static final StartupStubBridge.CounterKeys VALUE_BRIDGE_COUNTER_KEYS = StartupStubBridge.createKeys();
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/annotation/processing/CustomPropertyMappingAnnotationBaseIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/annotation/processing/CustomPropertyMappingAnnotationBaseIT.java
@@ -45,7 +45,7 @@ public class CustomPropertyMappingAnnotationBaseIT {
 	private static final String INDEX_NAME = "IndexName";
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/annotation/processing/CustomTypeMappingAnnotationBaseIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/annotation/processing/CustomTypeMappingAnnotationBaseIT.java
@@ -42,7 +42,7 @@ public class CustomTypeMappingAnnotationBaseIT {
 	private static final String INDEX_NAME = "IndexName";
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/AbstractFieldContainerExtractorIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/AbstractFieldContainerExtractorIT.java
@@ -50,7 +50,7 @@ public abstract class AbstractFieldContainerExtractorIT {
 	static final String STRING_VALUE_6 = "6 - The last string";
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/AnnotationMappingDiscoveryIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/AnnotationMappingDiscoveryIT.java
@@ -39,7 +39,7 @@ import org.junit.Test;
 public class AnnotationMappingDiscoveryIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/DependencyIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/DependencyIT.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 public class DependencyIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/DocumentIdBaseIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/DocumentIdBaseIT.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 public class DocumentIdBaseIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/DocumentIdDefaultBridgeIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/DocumentIdDefaultBridgeIT.java
@@ -53,7 +53,7 @@ public class DocumentIdDefaultBridgeIT<I> {
 	}
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/FieldBaseIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/FieldBaseIT.java
@@ -40,7 +40,7 @@ public class FieldBaseIT {
 	private static final String INDEX_NAME = "IndexName";
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/FieldContainerExtractorBaseIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/FieldContainerExtractorBaseIT.java
@@ -43,7 +43,7 @@ public class FieldContainerExtractorBaseIT {
 	private static final String INDEX_NAME = "IndexName";
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/FieldDefaultBridgeIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/FieldDefaultBridgeIT.java
@@ -59,7 +59,7 @@ public class FieldDefaultBridgeIT<V, F> {
 	}
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/FullTextFieldIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/FullTextFieldIT.java
@@ -52,7 +52,7 @@ public class FullTextFieldIT {
 	private static final String SEARCH_ANALYZER_NAME = "mySearchAnalyzer";
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/GenericFieldIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/GenericFieldIT.java
@@ -38,7 +38,7 @@ public class GenericFieldIT {
 	private static final String INDEX_NAME = "IndexName";
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/IndexNullAsErrorIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/IndexNullAsErrorIT.java
@@ -40,7 +40,7 @@ public class IndexNullAsErrorIT<V, F> {
 	}
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/IndexedEmbeddedBaseIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/IndexedEmbeddedBaseIT.java
@@ -59,7 +59,7 @@ public class IndexedEmbeddedBaseIT {
 	private static final String INDEX_NAME = "IndexName";
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/IndexedIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/IndexedIT.java
@@ -7,6 +7,8 @@
 package org.hibernate.search.integrationtest.mapper.pojo.mapping.definition;
 
 import java.lang.invoke.MethodHandles;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import org.hibernate.search.integrationtest.mapper.pojo.testsupport.util.rule.JavaBeanMappingSetupHelper;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
@@ -25,23 +27,29 @@ import org.junit.Test;
 public class IndexedIT {
 
 	@Rule
-	public BackendMock defaultBackendMock = new BackendMock( "defaultBackend" );
+	public BackendMock defaultBackendMock = new BackendMock();
 
 	@Rule
-	public BackendMock backend2Mock = new BackendMock( "backend2" );
+	public BackendMock backend2Mock = new BackendMock();
 
 	@Rule
-	public BackendMock backend3Mock = new BackendMock( "backend3" );
+	public BackendMock backend3Mock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper =
 			JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), defaultBackendMock );
 
 	@Rule
-	public JavaBeanMappingSetupHelper multiBackendSetupHelper =
-			JavaBeanMappingSetupHelper.withBackendMocks(
-					MethodHandles.lookup(), defaultBackendMock, backend2Mock, backend3Mock
-			);
+	public JavaBeanMappingSetupHelper multiBackendSetupHelper;
+
+	public IndexedIT() {
+		Map<String, BackendMock> namedBackendMocks = new LinkedHashMap<>();
+		namedBackendMocks.put( "backend2", backend2Mock );
+		namedBackendMocks.put( "backend3", backend3Mock );
+		multiBackendSetupHelper = JavaBeanMappingSetupHelper.withBackendMocks(
+				MethodHandles.lookup(), defaultBackendMock, namedBackendMocks
+		);
+	}
 
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3705")

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/KeywordFieldIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/KeywordFieldIT.java
@@ -51,7 +51,7 @@ public class KeywordFieldIT {
 	private static final String NORMALIZER_NAME = "myNormalizer";
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/NonStandardFieldIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/NonStandardFieldIT.java
@@ -43,7 +43,7 @@ public class NonStandardFieldIT {
 	private static final String INDEX_NAME = "IndexName";
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/PropertyBindingBaseIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/PropertyBindingBaseIT.java
@@ -38,7 +38,7 @@ public class PropertyBindingBaseIT {
 	private static final String INDEX_NAME = "IndexName";
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/PropertyBridgeBaseIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/PropertyBridgeBaseIT.java
@@ -53,7 +53,7 @@ public class PropertyBridgeBaseIT {
 	private static final String INDEX_NAME = "IndexName";
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/RoutingKeyBindingBaseIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/RoutingKeyBindingBaseIT.java
@@ -36,7 +36,7 @@ public class RoutingKeyBindingBaseIT {
 	private static final String INDEX_NAME = "IndexName";
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/ScaledNumberFieldIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/ScaledNumberFieldIT.java
@@ -37,7 +37,7 @@ public class ScaledNumberFieldIT {
 	private static final String INDEX_NAME = "IndexName";
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/TypeBindingBaseIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/TypeBindingBaseIT.java
@@ -38,7 +38,7 @@ public class TypeBindingBaseIT {
 	private static final String INDEX_NAME = "IndexName";
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/TypeBridgeBaseIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/TypeBridgeBaseIT.java
@@ -46,7 +46,7 @@ public class TypeBridgeBaseIT {
 	private static final String INDEX_NAME = "IndexName";
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/model/GenericPropertyIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/model/GenericPropertyIT.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 public class GenericPropertyIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/model/ImplementedInterfaceIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/model/ImplementedInterfaceIT.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 public class ImplementedInterfaceIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/model/PropertyInheritanceIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/model/PropertyInheritanceIT.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 public class PropertyInheritanceIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/nonregression/mapping/definition/IndexNullAsOnNumericContainerIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/nonregression/mapping/definition/IndexNullAsOnNumericContainerIT.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 public class IndexNullAsOnNumericContainerIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/nonregression/mapping/definition/IndexedEmbeddedDepthIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/nonregression/mapping/definition/IndexedEmbeddedDepthIT.java
@@ -24,7 +24,7 @@ public class IndexedEmbeddedDepthIT {
 	private static final String INDEX_NAME = "IndexName";
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/providedid/ProvidedIdIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/providedid/ProvidedIdIT.java
@@ -36,7 +36,7 @@ import org.junit.Test;
 public class ProvidedIdIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/routing/RoutingBaseIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/routing/RoutingBaseIT.java
@@ -36,7 +36,7 @@ import org.junit.Test;
 public class RoutingBaseIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/smoke/AnnotationMappingSmokeIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/smoke/AnnotationMappingSmokeIT.java
@@ -56,7 +56,7 @@ import org.junit.Test;
 public class AnnotationMappingSmokeIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/smoke/ProgrammaticMappingSmokeIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/smoke/ProgrammaticMappingSmokeIT.java
@@ -47,7 +47,7 @@ import org.junit.Test;
 public class ProgrammaticMappingSmokeIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/spatial/AnnotationMappingGeoPointBindingIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/spatial/AnnotationMappingGeoPointBindingIT.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 public class AnnotationMappingGeoPointBindingIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/spatial/ProgrammaticMappingGeoPointBindingIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/spatial/ProgrammaticMappingGeoPointBindingIT.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 public class ProgrammaticMappingGeoPointBindingIT {
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/util/rule/JavaBeanMappingSetupHelper.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/testsupport/util/rule/JavaBeanMappingSetupHelper.java
@@ -29,14 +29,14 @@ public final class JavaBeanMappingSetupHelper
 	 * @param backendMock A backend mock.
 	 */
 	public static JavaBeanMappingSetupHelper withBackendMock(MethodHandles.Lookup lookup, BackendMock backendMock) {
-		return new JavaBeanMappingSetupHelper( lookup, BackendSetupStrategy.withBackendMocks( backendMock ) );
+		return new JavaBeanMappingSetupHelper( lookup, BackendSetupStrategy.withSingleBackendMock( backendMock ) );
 	}
 
 	public static JavaBeanMappingSetupHelper withBackendMocks(MethodHandles.Lookup lookup,
-			BackendMock defaultBackendMock, BackendMock ... otherBackendMocks) {
+			BackendMock defaultBackendMock, Map<String, BackendMock> namedBackendMocks) {
 		return new JavaBeanMappingSetupHelper(
 				lookup,
-				BackendSetupStrategy.withBackendMocks( defaultBackendMock, otherBackendMocks )
+				BackendSetupStrategy.withMultipleBackendMocks( defaultBackendMock, namedBackendMocks )
 		);
 	}
 

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/timeout/SearchTimeoutIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/timeout/SearchTimeoutIT.java
@@ -33,7 +33,7 @@ public class SearchTimeoutIT {
 	private static final String INDEX_NAME = "IndexName";
 
 	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
+	public BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/AbstractPojoIndexingOperationIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/AbstractPojoIndexingOperationIT.java
@@ -54,7 +54,7 @@ public abstract class AbstractPojoIndexingOperationIT {
 	}
 
 	@Rule
-	public final BackendMock backendMock = new BackendMock( "stubBackend" );
+	public final BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public final JavaBeanMappingSetupHelper setupHelper =

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/PojoIndexingPlanBaseIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/PojoIndexingPlanBaseIT.java
@@ -34,7 +34,7 @@ import org.junit.Test;
 public class PojoIndexingPlanBaseIT {
 
 	@Rule
-	public final BackendMock backendMock = new BackendMock( "stubBackend" );
+	public final BackendMock backendMock = new BackendMock();
 
 	@Rule
 	public final JavaBeanMappingSetupHelper setupHelper =

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/index/AbstractBackendHolder.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/index/AbstractBackendHolder.java
@@ -37,16 +37,12 @@ public abstract class AbstractBackendHolder {
 
 	public static final int INDEX_COUNT = 3;
 
-	private static final String BACKEND_NAME = "testedBackend";
-
 	private SearchIntegration integration;
 	private List<MappedIndex> indexes;
 
 	@Setup(Level.Trial)
-	@SuppressWarnings("deprecation")
 	public void startHibernateSearch(TemporaryFileHolder temporaryFileHolder) throws IOException {
 		Map<String, Object> baseProperties = new LinkedHashMap<>();
-		baseProperties.put( EngineSettings.DEFAULT_BACKEND, BACKEND_NAME );
 
 		ConfigurationPropertySource configurationFromParameter =
 				ConfigurationPropertySource.fromMap( stringToMap( getConfigurationParameter() ) );
@@ -61,7 +57,7 @@ public abstract class AbstractBackendHolder {
 								.withOverride( configurationFromParameter )
 								// > Apply the configuration at the index level (for convenience)
 								.withOverride( configurationFromParameter.withPrefix( BackendSettings.INDEX_DEFAULTS ) )
-								.withPrefix( EngineSettings.BACKENDS + "." + BACKEND_NAME )
+								.withPrefix( EngineSettings.BACKEND )
 				);
 
 		ConfigurationPropertyChecker unusedPropertyChecker = ConfigurationPropertyChecker.create();
@@ -75,7 +71,7 @@ public abstract class AbstractBackendHolder {
 
 		indexes = new ArrayList<>();
 		for ( int i = 0; i < INDEX_COUNT; ++i ) {
-			MappedIndex index = new MappedIndex( BACKEND_NAME, i );
+			MappedIndex index = new MappedIndex( i );
 			initiator.add( index );
 			indexes.add( index );
 		}

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/index/AbstractBackendHolder.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/index/AbstractBackendHolder.java
@@ -43,6 +43,7 @@ public abstract class AbstractBackendHolder {
 	private List<MappedIndex> indexes;
 
 	@Setup(Level.Trial)
+	@SuppressWarnings("deprecation")
 	public void startHibernateSearch(TemporaryFileHolder temporaryFileHolder) throws IOException {
 		Map<String, Object> baseProperties = new LinkedHashMap<>();
 		baseProperties.put( EngineSettings.DEFAULT_BACKEND, BACKEND_NAME );

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/index/MappedIndex.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/index/MappedIndex.java
@@ -27,8 +27,7 @@ public class MappedIndex extends StubMappedIndex {
 	private IndexFieldReference<String> longTextField;
 	private IndexFieldReference<Long> numericField;
 
-	public MappedIndex(String backendName, int indexId) {
-		backendName( backendName );
+	public MappedIndex(int indexId) {
 		name( "index_" + indexId );
 		typeName( "type_" + indexId );
 	}

--- a/integrationtest/performance/pom.xml
+++ b/integrationtest/performance/pom.xml
@@ -14,8 +14,8 @@
 
     <modules>
         <module>backend/base</module>
-        <module>backend/elasticsearch</module>
         <module>backend/lucene</module>
+        <module>backend/elasticsearch</module>
     </modules>
 
     <dependencyManagement>

--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -15,8 +15,8 @@
 
     <modules>
         <module>backend/tck</module>
-        <module>backend/elasticsearch</module>
         <module>backend/lucene</module>
+        <module>backend/elasticsearch</module>
         <module>mapper/pojo-base</module>
         <module>mapper/orm</module>
         <module>mapper/orm-cdi</module>

--- a/integrationtest/showcase/library/src/main/resources/application-elasticsearch.yaml
+++ b/integrationtest/showcase/library/src/main/resources/application-elasticsearch.yaml
@@ -1,18 +1,16 @@
 spring.jpa:
   properties:
     hibernate.search:
-      default_backend: elasticsearch1
-      backends:
-        elasticsearch1:
-          type: elasticsearch
-          hosts: ${ELASTICSEARCH_HOSTS} # From environment variable
-          protocol: ${ELASTICSEARCH_PROTOCOL} # From environment variable
-          username: ${ELASTICSEARCH_USERNAME} # From environment variable
-          password: ${ELASTICSEARCH_PASSWORD} # From environment variable
-          aws.signing:
-            enabled: ${ELASTICSEARCH_AWS_SIGNING_ENABLED} # From environment variable
-            access_key: ${ELASTICSEARCH_AWS_SIGNING_ACCESS_KEY} # From environment variable
-            secret_key: ${ELASTICSEARCH_AWS_SIGNING_SECRET_LEY} # From environment variable
-            region: ${ELASTICSEARCH_AWS_SIGNING_REGION} # From environment variable
-          discovery.enabled: true
-          analysis.configurer: elasticsearchAnalysisConfigurer
+      backend:
+        type: elasticsearch
+        hosts: ${ELASTICSEARCH_HOSTS} # From environment variable
+        protocol: ${ELASTICSEARCH_PROTOCOL} # From environment variable
+        username: ${ELASTICSEARCH_USERNAME} # From environment variable
+        password: ${ELASTICSEARCH_PASSWORD} # From environment variable
+        aws.signing:
+          enabled: ${ELASTICSEARCH_AWS_SIGNING_ENABLED} # From environment variable
+          access_key: ${ELASTICSEARCH_AWS_SIGNING_ACCESS_KEY} # From environment variable
+          secret_key: ${ELASTICSEARCH_AWS_SIGNING_SECRET_LEY} # From environment variable
+          region: ${ELASTICSEARCH_AWS_SIGNING_REGION} # From environment variable
+        discovery.enabled: true
+        analysis.configurer: elasticsearchAnalysisConfigurer

--- a/integrationtest/showcase/library/src/main/resources/application-lucene.yaml
+++ b/integrationtest/showcase/library/src/main/resources/application-lucene.yaml
@@ -1,9 +1,7 @@
 spring.jpa:
   properties:
     hibernate.search:
-      default_backend: lucene1
-      backends:
-        lucene1:
-          type: lucene
-          analysis.configurer: luceneAnalysisConfigurer
-          directory.root: ${LUCENE_ROOT_PATH} # From environment variable
+      backend:
+        type: lucene
+        analysis.configurer: luceneAnalysisConfigurer
+        directory.root: ${LUCENE_ROOT_PATH} # From environment variable

--- a/integrationtest/showcase/library/src/test/java/org/hibernate/search/integrationtest/showcase/library/TestActiveProfilesResolver.java
+++ b/integrationtest/showcase/library/src/test/java/org/hibernate/search/integrationtest/showcase/library/TestActiveProfilesResolver.java
@@ -22,7 +22,7 @@ public class TestActiveProfilesResolver implements ActiveProfilesResolver {
 			 */
 			testBackend = "lucene";
 		}
-		// The test profile must be mentioned last, to allow it to override properties
-		return new String[] { testBackend, "test" };
+		// The test profiles must be mentioned last, to allow them to override properties
+		return new String[] { testBackend, "test", "test-" + testBackend };
 	}
 }

--- a/integrationtest/showcase/library/src/test/resources/application-test-elasticsearch.yaml
+++ b/integrationtest/showcase/library/src/test/resources/application-test-elasticsearch.yaml
@@ -1,0 +1,7 @@
+spring.jpa:
+  properties:
+    hibernate.search:
+      backend:
+        index_defaults:
+          schema_management.minimal_required_status: yellow
+        log.json_pretty_printing: true

--- a/integrationtest/showcase/library/src/test/resources/application-test-lucene.yaml
+++ b/integrationtest/showcase/library/src/test/resources/application-test-lucene.yaml
@@ -1,15 +1,9 @@
 spring.jpa:
-  hibernate:
-    ddl-auto: create-drop
   properties:
     hibernate.search:
-      # Overridden in some tests
-      schema_management.strategy: drop-and-create-and-drop
-      automatic_indexing:
-        # This really is only for tests:
-        # it makes documents searchable directly upon returning from a transaction,
-        # but it also hurts performance.
-        synchronization.strategy: sync
+      backend:
+        # Hack to use a different directory for each test
+        directory.root: ${LUCENE_ROOT_PATH}/${random.uuid} # LUCENE_ROOT_PATH is an environment variable
 
 logging.level:
   org.hibernate.SQL: DEBUG
@@ -20,4 +14,4 @@ logging.level:
 
 # Default environment variable values for IDEs that are unable to extract them from the maven-failsafe configuration
 # These values are overridden when running tests from Intellij IDEA or directly from Maven
-JDBC_URL: jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1
+LUCENE_ROOT_PATH: target/test-indexes

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/SearchMapping.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/SearchMapping.java
@@ -15,6 +15,7 @@ import org.hibernate.SessionFactory;
 import org.hibernate.search.engine.backend.Backend;
 import org.hibernate.search.engine.backend.index.IndexManager;
 import org.hibernate.search.mapper.orm.scope.SearchScope;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 
 /**
  * The Hibernate Search mapping between the Hibernate ORM model and the backend(s).
@@ -100,13 +101,13 @@ public interface SearchMapping {
 	Collection<? extends SearchIndexedEntity> allIndexedEntities();
 
 	/**
-	 * @param indexName The key to get the required {@link IndexManager} instance.
+	 * @param indexName The name of an index. See {@link Indexed#index()}.
 	 * @return The index manager for the index having {@code indexName} as name.
 	 */
 	IndexManager indexManager(String indexName);
 
 	/**
-	 * @param indexName The key to get the required {@link IndexManager} instance.
+	 * @param indexName The name of an index. See {@link Indexed#index()}.
 	 * @return The index manager for the index having {@code indexName} as name.
 	 * @deprecated Use {@link #indexManager(String)} instead.
 	 */
@@ -116,13 +117,18 @@ public interface SearchMapping {
 	}
 
 	/**
-	 * @param backendName The key to get the required {@link Backend} instance.
+	 * @return The default backend, if any.
+	 */
+	Backend backend();
+
+	/**
+	 * @param backendName The name of a backend. See {@link Indexed#backend()}.
 	 * @return The backend having {@code backendName} as name.
 	 */
 	Backend backend(String backendName);
 
 	/**
-	 * @param backendName The key to get the required {@link Backend} instance.
+	 * @param backendName The name of a backend. See {@link Indexed#backend()}.
 	 * @return The backend having {@code backendName} as name.
 	 * @deprecated Use {@link #backend(String)} instead.
 	 */

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMapping.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMapping.java
@@ -230,6 +230,11 @@ public class HibernateOrmMapping extends AbstractPojoMappingImplementor<Hibernat
 	}
 
 	@Override
+	public Backend backend() {
+		return searchIntegration().backend();
+	}
+
+	@Override
 	public Backend backend(String backendName) {
 		return searchIntegration().backend( backendName );
 	}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/Indexed.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/Indexed.java
@@ -27,7 +27,7 @@ public @interface Indexed {
 
 	/**
 	 * @return The name of the backend.
-	 * Defaults to the {@link org.hibernate.search.engine.cfg.EngineSettings#DEFAULT_BACKEND default backend}.
+	 * Defaults to the {@link org.hibernate.search.engine.cfg.EngineSettings#BACKEND default backend}.
 	 */
 	String backend() default "";
 

--- a/pom.xml
+++ b/pom.xml
@@ -156,9 +156,9 @@
         <module>util/common</module>
         <module>util/internal/test</module>
         <module>engine</module>
+        <module>backend/lucene</module>
         <module>backend/elasticsearch</module>
         <module>backend/elasticsearch-aws</module>
-        <module>backend/lucene</module>
         <module>mapper/pojo-base</module>
         <module>mapper/javabean</module>
         <module>mapper/orm</module>

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/FailureReportUtils.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/FailureReportUtils.java
@@ -91,6 +91,10 @@ public final class FailureReportUtils {
 			return contextLiteral( "index schema root" );
 		}
 
+		public FailureReportPatternBuilder defaultBackendContext() {
+			return contextLiteral( "default backend" );
+		}
+
 		public FailureReportPatternBuilder backendContext(String exactBackendName) {
 			return contextLiteral( "backend '" + exactBackendName + "'" );
 		}

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/ActualBackendSetupStrategy.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/ActualBackendSetupStrategy.java
@@ -41,6 +41,7 @@ class ActualBackendSetupStrategy implements BackendSetupStrategy {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public <C extends MappingSetupHelper<C, ?, ?>.AbstractSetupContext> C start(C setupContext,
 			TestConfigurationProvider configurationProvider) {
 		for ( Map.Entry<String, BackendConfiguration> entry : backendConfigurations.entrySet() ) {

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendConfiguration.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendConfiguration.java
@@ -18,7 +18,7 @@ public interface BackendConfiguration {
 		return Optional.empty();
 	}
 
-	<C extends MappingSetupHelper<C, ?, ?>.AbstractSetupContext> C setupWithName(C setupContext,
+	<C extends MappingSetupHelper<C, ?, ?>.AbstractSetupContext> C setup(C setupContext,
 			String backendName, TestConfigurationProvider configurationProvider);
 
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendMock.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendMock.java
@@ -44,6 +44,10 @@ public class BackendMock implements TestRule {
 	private final String backendName;
 	private final VerifyingStubBackendBehavior behaviorMock = new VerifyingStubBackendBehavior();
 
+	public BackendMock() {
+		this( "stubBackend" );
+	}
+
 	public BackendMock(String backendName) {
 		this.backendName = backendName;
 	}

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendMock.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendMock.java
@@ -42,23 +42,9 @@ public class BackendMock implements TestRule {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private final String backendName;
-
 	private final VerifyingStubBackendBehavior backendBehavior = new VerifyingStubBackendBehavior();
 
 	private boolean started = false;
-
-	public BackendMock() {
-		this( "stubBackend" );
-	}
-
-	public BackendMock(String backendName) {
-		this.backendName = backendName;
-	}
-
-	public String getBackendName() {
-		return backendName;
-	}
 
 	@Override
 	public Statement apply(Statement base, Description description) {

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendMockSetupStrategy.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendMockSetupStrategy.java
@@ -6,29 +6,28 @@
  */
 package org.hibernate.search.util.impl.integrationtest.common.rule;
 
-import java.util.List;
+import java.util.Map;
 
-import org.hibernate.search.engine.cfg.EngineSettings;
-import org.hibernate.search.util.common.impl.CollectionHelper;
 import org.hibernate.search.util.impl.integrationtest.common.TestConfigurationProvider;
 
 class BackendMockSetupStrategy implements BackendSetupStrategy {
-	private final String defaultBackendName;
-	private final List<BackendMock> backendMocks;
+	private final BackendMock defaultBackendMock;
+	private final Map<String, BackendMock> namedBackendMocks;
 
-	BackendMockSetupStrategy(BackendMock defaultBackendMock, BackendMock ... otherBackendMocks) {
-		this.defaultBackendName = defaultBackendMock.getBackendName();
-		this.backendMocks = CollectionHelper.asList( defaultBackendMock, otherBackendMocks );
+	BackendMockSetupStrategy(BackendMock defaultBackendMock, Map<String, BackendMock> namedBackendMocks) {
+		this.defaultBackendMock = defaultBackendMock;
+		this.namedBackendMocks = namedBackendMocks;
 	}
 
 	@Override
-	@SuppressWarnings("deprecation")
 	public <C extends MappingSetupHelper<C, ?, ?>.AbstractSetupContext> C start(C setupContext,
 			TestConfigurationProvider configurationProvider) {
-		for ( BackendMock backendMock : backendMocks ) {
-			setupContext = setupContext.withBackendProperty( backendMock.getBackendName(),
-					"type", backendMock.factory() );
+		setupContext = setupContext.withBackendProperty( "type",
+				defaultBackendMock.factory() );
+		for ( Map.Entry<String, BackendMock> entry : namedBackendMocks.entrySet() ) {
+			setupContext = setupContext.withBackendProperty( entry.getKey(),
+					"type", entry.getValue().factory() );
 		}
-		return setupContext.withProperty( EngineSettings.DEFAULT_BACKEND, defaultBackendName );
+		return setupContext;
 	}
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendMockSetupStrategy.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendMockSetupStrategy.java
@@ -23,6 +23,7 @@ class BackendMockSetupStrategy implements BackendSetupStrategy {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public <C extends MappingSetupHelper<C, ?, ?>.AbstractSetupContext> C start(C setupContext,
 			TestConfigurationProvider configurationProvider) {
 		for ( BackendMock backendMock : backendMocks ) {

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendMockSetupStrategy.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendMockSetupStrategy.java
@@ -11,7 +11,6 @@ import java.util.List;
 import org.hibernate.search.engine.cfg.EngineSettings;
 import org.hibernate.search.util.common.impl.CollectionHelper;
 import org.hibernate.search.util.impl.integrationtest.common.TestConfigurationProvider;
-import org.hibernate.search.util.impl.integrationtest.common.stub.backend.index.impl.StubBackendFactory;
 
 class BackendMockSetupStrategy implements BackendSetupStrategy {
 	private final String defaultBackendName;
@@ -27,9 +26,8 @@ class BackendMockSetupStrategy implements BackendSetupStrategy {
 	public <C extends MappingSetupHelper<C, ?, ?>.AbstractSetupContext> C start(C setupContext,
 			TestConfigurationProvider configurationProvider) {
 		for ( BackendMock backendMock : backendMocks ) {
-			setupContext = setupContext.withBackendProperty(
-					backendMock.getBackendName(), "type", StubBackendFactory.class.getName()
-			);
+			setupContext = setupContext.withBackendProperty( backendMock.getBackendName(),
+					"type", backendMock.factory() );
 		}
 		return setupContext.withProperty( EngineSettings.DEFAULT_BACKEND, defaultBackendName );
 	}

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendSetupStrategy.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendSetupStrategy.java
@@ -23,17 +23,22 @@ public interface BackendSetupStrategy {
 	<C extends MappingSetupHelper<C, ?, ?>.AbstractSetupContext> C start(C setupContext,
 			TestConfigurationProvider configurationProvider);
 
-	static BackendSetupStrategy withBackendMocks(BackendMock defaultBackendMock, BackendMock ... otherBackendMocks) {
-		return new BackendMockSetupStrategy( defaultBackendMock, otherBackendMocks );
+	static BackendSetupStrategy withSingleBackendMock(BackendMock defaultBackendMock) {
+		return new BackendMockSetupStrategy( defaultBackendMock, Collections.emptyMap() );
 	}
 
-	static BackendSetupStrategy withSingleBackend(String backendName, BackendConfiguration backendConfiguration) {
-		return withMultipleBackends( backendName, Collections.singletonMap( backendName, backendConfiguration ) );
+	static BackendSetupStrategy withMultipleBackendMocks(BackendMock defaultBackendMock,
+			Map<String, BackendMock> namedBackendMocks) {
+		return new BackendMockSetupStrategy( defaultBackendMock, namedBackendMocks );
 	}
 
-	static BackendSetupStrategy withMultipleBackends(String defaultBackendName,
-			Map<String, BackendConfiguration> backendConfigurations) {
-		return new ActualBackendSetupStrategy( defaultBackendName, backendConfigurations );
+	static BackendSetupStrategy withSingleBackend(BackendConfiguration backendConfiguration) {
+		return withMultipleBackends( backendConfiguration, Collections.emptyMap() );
+	}
+
+	static BackendSetupStrategy withMultipleBackends(BackendConfiguration defaultBackendConfiguration,
+			Map<String, BackendConfiguration> namedBackendConfigurations) {
+		return new ActualBackendSetupStrategy( defaultBackendConfiguration, namedBackendConfigurations );
 	}
 
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/MappingSetupHelper.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/MappingSetupHelper.java
@@ -92,8 +92,21 @@ public abstract class MappingSetupHelper<C extends MappingSetupHelper<C, B, R>.A
 			return withProperties( configurationProvider.getPropertiesFromFile( propertyFilePath ) );
 		}
 
+		public final C withBackendProperty(String keyRadical, Object value) {
+			return withBackendProperty( null, keyRadical, value );
+		}
+
 		public final C withBackendProperty(String backendName, String keyRadical, Object value) {
-			return withPropertyRadical( "backends." + backendName + "." + keyRadical, value );
+			if ( backendName == null ) {
+				return withPropertyRadical( EngineSettings.Radicals.BACKEND + "." + keyRadical, value );
+			}
+			else {
+				return withPropertyRadical( EngineSettings.Radicals.BACKENDS + "." + backendName + "." + keyRadical, value );
+			}
+		}
+
+		public final C withBackendProperties(Map<String, Object> relativeProperties) {
+			return withBackendProperties( null, relativeProperties );
 		}
 
 		public final C withBackendProperties(String backendName, Map<String, Object> relativeProperties) {
@@ -101,12 +114,12 @@ public abstract class MappingSetupHelper<C extends MappingSetupHelper<C, B, R>.A
 			return thisAsC();
 		}
 
+		public C withIndexDefaultsProperty(String keyRadical, Object value) {
+			return withIndexDefaultsProperty( null, keyRadical, value );
+		}
+
 		public C withIndexDefaultsProperty(String backendName, String keyRadical, Object value) {
-			return withProperty(
-					EngineSettings.BACKENDS + "." + backendName
-							+ "." + BackendSettings.INDEX_DEFAULTS + "." + keyRadical,
-					value
-			);
+			return withBackendProperty( backendName, BackendSettings.INDEX_DEFAULTS + "." + keyRadical, value );
 		}
 
 		/**

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/StubBackendBehavior.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/StubBackendBehavior.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.search.util.impl.integrationtest.common.stub.backend;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
@@ -24,95 +22,6 @@ import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.projection.impl.StubSearchProjectionContext;
 
 public abstract class StubBackendBehavior {
-
-	private static final StubBackendBehavior DEFAULT = new StubBackendBehavior() {
-		@Override
-		public void onCreateBackend(BackendBuildContext context) {
-			throw new IllegalStateException( "The stub backend behavior was not set when creating a backend." );
-		}
-
-		@Override
-		public void onStopBackend() {
-			// This is acceptable: we probably just ended the test before the backend was stopped.
-		}
-
-		@Override
-		public void onAddField(String indexName, String absoluteFieldPath) {
-			throw new IllegalStateException( "The stub backend behavior was not set when a field was added to index '"
-					+ indexName + "': " + absoluteFieldPath );
-		}
-
-		@Override
-		public void defineSchema(String indexName, StubIndexSchemaNode rootSchemaNode) {
-			throw new IllegalStateException( "The stub backend behavior was not set when a schema was pushed for index '"
-					+ indexName + "': " + rootSchemaNode );
-		}
-
-		@Override
-		public CompletableFuture<?> executeSchemaManagementWork(String indexName, StubSchemaManagementWork work,
-				ContextualFailureCollector failureCollector) {
-			throw new IllegalStateException( "The stub backend behavior was not set during execution of a schema management work for index "
-					+ indexName + ": " + work );
-		}
-
-		@Override
-		public void processDocumentWork(String indexName, StubDocumentWork work) {
-			throw new IllegalStateException( "The stub backend behavior was not set when a work was prepared for index '"
-					+ indexName + "': " + work );
-		}
-
-		@Override
-		public void discardDocumentWork(String indexName, StubDocumentWork work) {
-			throw new IllegalStateException( "The stub backend behavior was not set when a work was discarded from index '"
-					+ indexName + "': " + work );
-		}
-
-		@Override
-		public CompletableFuture<?> executeDocumentWork(String indexName, StubDocumentWork work) {
-			throw new IllegalStateException( "The stub backend behavior was not set when a work was executed for index '"
-					+ indexName + "': " + work );
-		}
-
-		@Override
-		public CompletableFuture<?> processAndExecuteDocumentWork(String indexName, StubDocumentWork work) {
-			throw new IllegalStateException( "The stub backend behavior was not set when work were prepared and executed for index '"
-					+ indexName + "': " + work );
-		}
-
-		@Override
-		public <T> SearchResult<T> executeSearchWork(Set<String> indexNames, StubSearchWork work,
-				StubSearchProjectionContext projectionContext,
-				LoadingContext<?, ?> loadingContext, StubSearchProjection<T> rootProjection) {
-			throw new IllegalStateException( "The stub backend behavior was not set when a search work was executed for indexes "
-					+ indexNames + ": " + work );
-		}
-
-		@Override
-		public CompletableFuture<?> executeIndexScaleWork(String indexName, StubIndexScaleWork work) {
-			throw new IllegalStateException( "The stub backend behavior was not set during execution of an index-scale work for index "
-					+ indexName + ": " + work );
-		}
-
-		@Override
-		public long executeCountWork(Set<String> indexNames) {
-			throw new IllegalStateException( "The stub backend behavior was not set when a count work was executed for indexes "
-					+ indexNames );
-		}
-	};
-
-	private static final Map<String, StubBackendBehavior> BEHAVIORS = new HashMap<>();
-
-	public static void set(String backendName, StubBackendBehavior behavior) {
-		BEHAVIORS.put( backendName, behavior );
-	}
-
-	public static void unset(String backendName, StubBackendBehavior behavior) {
-		BEHAVIORS.remove( backendName, behavior );
-	}
-
-	public static StubBackendBehavior get(String backendName) {
-		return BEHAVIORS.getOrDefault( backendName, DEFAULT );
-	}
 
 	protected StubBackendBehavior() {
 	}

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubBackend.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubBackend.java
@@ -20,10 +20,12 @@ import org.hibernate.search.util.impl.integrationtest.common.stub.backend.StubBa
 public class StubBackend implements BackendImplementor, Backend {
 
 	private final String name;
+	private final StubBackendBehavior behavior;
 
-	StubBackend(String name, BackendBuildContext context) {
+	StubBackend(String name, BackendBuildContext context, StubBackendBehavior behavior) {
 		this.name = name;
-		getBehavior().onCreateBackend( context );
+		this.behavior = behavior;
+		behavior.onCreateBackend( context );
 	}
 
 	@Override
@@ -48,7 +50,7 @@ public class StubBackend implements BackendImplementor, Backend {
 
 	@Override
 	public void stop() {
-		getBehavior().onStopBackend();
+		behavior.onStopBackend();
 	}
 
 	@Override
@@ -62,7 +64,7 @@ public class StubBackend implements BackendImplementor, Backend {
 	}
 
 	public StubBackendBehavior getBehavior() {
-		return StubBackendBehavior.get( name );
+		return behavior;
 	}
 
 	@Override

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubBackend.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubBackend.java
@@ -15,26 +15,27 @@ import org.hibernate.search.engine.backend.spi.BackendStartContext;
 import org.hibernate.search.engine.cfg.spi.ConfigurationPropertySource;
 import org.hibernate.search.engine.backend.spi.BackendBuildContext;
 import org.hibernate.search.util.common.AssertionFailure;
+import org.hibernate.search.util.common.reporting.EventContext;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.StubBackendBehavior;
 
 public class StubBackend implements BackendImplementor, Backend {
 
-	private final String name;
+	private final EventContext eventContext;
 	private final StubBackendBehavior behavior;
 
-	StubBackend(String name, BackendBuildContext context, StubBackendBehavior behavior) {
-		this.name = name;
+	StubBackend(EventContext eventContext, BackendBuildContext context, StubBackendBehavior behavior) {
+		this.eventContext = eventContext;
 		this.behavior = behavior;
 		behavior.onCreateBackend( context );
 	}
 
 	@Override
 	public String toString() {
-		return StubBackend.class.getSimpleName() + "[" + name + "]";
+		return StubBackend.class.getSimpleName() + "[" + eventContext + "]";
 	}
 
-	public String getName() {
-		return name;
+	public EventContext eventContext() {
+		return eventContext;
 	}
 
 	@Override

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubBackendFactory.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubBackendFactory.java
@@ -10,10 +10,18 @@ import org.hibernate.search.engine.backend.spi.BackendImplementor;
 import org.hibernate.search.engine.backend.spi.BackendFactory;
 import org.hibernate.search.engine.cfg.spi.ConfigurationPropertySource;
 import org.hibernate.search.engine.backend.spi.BackendBuildContext;
+import org.hibernate.search.util.impl.integrationtest.common.stub.backend.StubBackendBehavior;
 
 public class StubBackendFactory implements BackendFactory {
+
+	private final StubBackendBehavior behavior;
+
+	public StubBackendFactory(StubBackendBehavior behavior) {
+		this.behavior = behavior;
+	}
+
 	@Override
 	public BackendImplementor create(String name, BackendBuildContext context, ConfigurationPropertySource propertySource) {
-		return new StubBackend( name, context );
+		return new StubBackend( name, context, behavior );
 	}
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubBackendFactory.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/index/impl/StubBackendFactory.java
@@ -10,6 +10,7 @@ import org.hibernate.search.engine.backend.spi.BackendImplementor;
 import org.hibernate.search.engine.backend.spi.BackendFactory;
 import org.hibernate.search.engine.cfg.spi.ConfigurationPropertySource;
 import org.hibernate.search.engine.backend.spi.BackendBuildContext;
+import org.hibernate.search.util.common.reporting.EventContext;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.StubBackendBehavior;
 
 public class StubBackendFactory implements BackendFactory {
@@ -21,7 +22,8 @@ public class StubBackendFactory implements BackendFactory {
 	}
 
 	@Override
-	public BackendImplementor create(String name, BackendBuildContext context, ConfigurationPropertySource propertySource) {
-		return new StubBackend( name, context, behavior );
+	public BackendImplementor create(EventContext eventContext, BackendBuildContext context,
+			ConfigurationPropertySource propertySource) {
+		return new StubBackend( eventContext, context, behavior );
 	}
 }

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/OrmSetupHelper.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/OrmSetupHelper.java
@@ -21,40 +21,35 @@ import org.hibernate.search.util.impl.integrationtest.common.rule.MappingSetupHe
 public final class OrmSetupHelper
 		extends MappingSetupHelper<OrmSetupHelper.SetupContext, SimpleSessionFactoryBuilder, SessionFactory> {
 
-	private static final String DEFAULT_BACKEND_NAME = "backendName";
-
 	public static OrmSetupHelper withBackendMock(BackendMock backendMock) {
 		return new OrmSetupHelper(
-				BackendSetupStrategy.withBackendMocks( backendMock ),
+				BackendSetupStrategy.withSingleBackendMock( backendMock ),
 				// Mock backend => avoid schema management unless we want to test it
 				SchemaManagementStrategyName.NONE
 		);
 	}
 
-	public static OrmSetupHelper withBackendMocks(BackendMock defaultBackendMock, BackendMock ... otherBackendMocks) {
+	public static OrmSetupHelper withBackendMocks(BackendMock defaultBackendMock,
+			Map<String, BackendMock> namedBackendMocks) {
 		return new OrmSetupHelper(
-				BackendSetupStrategy.withBackendMocks( defaultBackendMock, otherBackendMocks ),
+				BackendSetupStrategy.withMultipleBackendMocks( defaultBackendMock, namedBackendMocks ),
 				// Mock backend => avoid schema management unless we want to test it
 				SchemaManagementStrategyName.NONE
 		);
 	}
 
 	public static OrmSetupHelper withSingleBackend(BackendConfiguration backendConfiguration) {
-		return withSingleBackend( DEFAULT_BACKEND_NAME, backendConfiguration );
-	}
-
-	public static OrmSetupHelper withSingleBackend(String backendName, BackendConfiguration backendConfiguration) {
 		return new OrmSetupHelper(
-				BackendSetupStrategy.withSingleBackend( backendName, backendConfiguration ),
+				BackendSetupStrategy.withSingleBackend( backendConfiguration ),
 				// Real backend => ensure we clean up everything before and after the tests
 				SchemaManagementStrategyName.DROP_AND_CREATE_AND_DROP
 		);
 	}
 
-	public static OrmSetupHelper withMultipleBackends(String defaultBackendName,
-			Map<String, BackendConfiguration> backendConfigurations) {
+	public static OrmSetupHelper withMultipleBackends(BackendConfiguration defaultBackendConfiguration,
+			Map<String, BackendConfiguration> namedBackendConfigurations) {
 		return new OrmSetupHelper(
-				BackendSetupStrategy.withMultipleBackends( defaultBackendName, backendConfigurations ),
+				BackendSetupStrategy.withMultipleBackends( defaultBackendConfiguration, namedBackendConfigurations ),
 				// Real backend => ensure to clean up everything
 				SchemaManagementStrategyName.DROP_AND_CREATE_AND_DROP
 		);

--- a/util/internal/integrationtest/pom.xml
+++ b/util/internal/integrationtest/pom.xml
@@ -28,8 +28,8 @@
 
     <modules>
         <module>common</module>
-        <module>backend/elasticsearch</module>
         <module>backend/lucene</module>
+        <module>backend/elasticsearch</module>
         <module>mapper/orm</module>
         <module>mapper/stub</module>
         <module>sharedresources</module>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3950

Basically this change the configuration scheme for single-backend applications from:

```
hibernate.search.default_backend = myBackend
hibernate.search.backends.myBackend.type elasticsearch
hibernate.search.backends.myBackend.foo.bar foobar
hibernate.search.backends.myBackend.index_defaults.foo2.bar2 foobar2
``` 

... to:

```
hibernate.search.backend.type elasticsearch
hibernate.search.backend.foo.bar foobar
hibernate.search.backend.index_defaults.foo2.bar2 foobar2
``` 

The old configuration scheme should still work, for now, but "default_backend" is deprecated and ultimately will be removed.