### PR TITLE
HSEARCH-3891 Allow POJO mapper implementations to pass explicit routing keys when indexing

### DIFF
--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/providedid/ProvidedIdIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/providedid/ProvidedIdIT.java
@@ -59,7 +59,7 @@ public class ProvidedIdIT {
 		try ( SearchSession session = mapping.createSession() ) {
 			IndexedEntity entity1 = new IndexedEntity();
 
-			session.indexingPlan().add( "42", entity1 );
+			session.indexingPlan().add( "42", null, entity1 );
 
 			backendMock.expectWorks( entityAndIndexName )
 					.add( "42", b -> { } )

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/PojoIndexingAddIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/PojoIndexingAddIT.java
@@ -34,7 +34,7 @@ public class PojoIndexingAddIT extends AbstractPojoIndexingOperationIT {
 
 	@Override
 	protected void addTo(SearchIndexingPlan indexingPlan, Object providedId, int id) {
-		indexingPlan.add( providedId, createEntity( id ) );
+		indexingPlan.add( providedId, null, createEntity( id ) );
 	}
 
 	@Override

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/PojoIndexingAddIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/PojoIndexingAddIT.java
@@ -23,8 +23,8 @@ public class PojoIndexingAddIT extends AbstractPojoIndexingOperationIT {
 
 	@Override
 	protected void expectOperation(BackendMock.DocumentWorkCallListContext context, String tenantId,
-			String id, String value) {
-		context.add( b -> addWorkInfoAndDocument( b, tenantId, id, value ) );
+			String id, String routingKey, String value) {
+		context.add( b -> addWorkInfoAndDocument( b, tenantId, id, routingKey, value ) );
 	}
 
 	@Override
@@ -38,6 +38,11 @@ public class PojoIndexingAddIT extends AbstractPojoIndexingOperationIT {
 	}
 
 	@Override
+	protected void addTo(SearchIndexingPlan indexingPlan, Object providedId, String providedRoutingKey, int id) {
+		indexingPlan.add( providedId, providedRoutingKey, createEntity( id ) );
+	}
+
+	@Override
 	protected CompletableFuture<?> execute(SearchIndexer indexer, int id) {
 		return indexer.add( createEntity( id ) );
 	}
@@ -45,5 +50,10 @@ public class PojoIndexingAddIT extends AbstractPojoIndexingOperationIT {
 	@Override
 	protected CompletableFuture<?> execute(SearchIndexer indexer, Object providedId, int id) {
 		return indexer.add( providedId, createEntity( id ) );
+	}
+
+	@Override
+	protected CompletableFuture<?> execute(SearchIndexer indexer, Object providedId, String providedRoutingKey, int id) {
+		return indexer.add( providedId, providedRoutingKey, createEntity( id ) );
 	}
 }

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/PojoIndexingAddOrUpdateIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/PojoIndexingAddOrUpdateIT.java
@@ -23,8 +23,8 @@ public class PojoIndexingAddOrUpdateIT extends AbstractPojoIndexingOperationIT {
 
 	@Override
 	protected void expectOperation(BackendMock.DocumentWorkCallListContext context, String tenantId,
-			String id, String value) {
-		context.update( b -> addWorkInfoAndDocument( b, tenantId, id, value ) );
+			String id, String routingKey, String value) {
+		context.update( b -> addWorkInfoAndDocument( b, tenantId, id, routingKey, value ) );
 	}
 
 	@Override
@@ -38,6 +38,11 @@ public class PojoIndexingAddOrUpdateIT extends AbstractPojoIndexingOperationIT {
 	}
 
 	@Override
+	protected void addTo(SearchIndexingPlan indexingPlan, Object providedId, String providedRoutingKey, int id) {
+		indexingPlan.addOrUpdate( providedId, providedRoutingKey, createEntity( id ) );
+	}
+
+	@Override
 	protected CompletableFuture<?> execute(SearchIndexer indexer, int id) {
 		return indexer.addOrUpdate( createEntity( id ) );
 	}
@@ -45,5 +50,10 @@ public class PojoIndexingAddOrUpdateIT extends AbstractPojoIndexingOperationIT {
 	@Override
 	protected CompletableFuture<?> execute(SearchIndexer indexer, Object providedId, int id) {
 		return indexer.addOrUpdate( providedId, createEntity( id ) );
+	}
+
+	@Override
+	protected CompletableFuture<?> execute(SearchIndexer indexer, Object providedId, String providedRoutingKey, int id) {
+		return indexer.addOrUpdate( providedId, providedRoutingKey, createEntity( id ) );
 	}
 }

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/PojoIndexingAddOrUpdateIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/PojoIndexingAddOrUpdateIT.java
@@ -34,7 +34,7 @@ public class PojoIndexingAddOrUpdateIT extends AbstractPojoIndexingOperationIT {
 
 	@Override
 	protected void addTo(SearchIndexingPlan indexingPlan, Object providedId, int id) {
-		indexingPlan.addOrUpdate( providedId, createEntity( id ) );
+		indexingPlan.addOrUpdate( providedId, null, createEntity( id ) );
 	}
 
 	@Override

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/PojoIndexingDeleteIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/PojoIndexingDeleteIT.java
@@ -34,7 +34,7 @@ public class PojoIndexingDeleteIT extends AbstractPojoIndexingOperationIT {
 
 	@Override
 	protected void addTo(SearchIndexingPlan indexingPlan, Object providedId, int id) {
-		indexingPlan.delete( providedId, createEntity( id ) );
+		indexingPlan.delete( providedId, null, createEntity( id ) );
 	}
 
 	@Override

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/PojoIndexingDeleteIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/PojoIndexingDeleteIT.java
@@ -23,8 +23,8 @@ public class PojoIndexingDeleteIT extends AbstractPojoIndexingOperationIT {
 
 	@Override
 	protected void expectOperation(BackendMock.DocumentWorkCallListContext context, String tenantId,
-			String id, String value) {
-		context.delete( b -> addWorkInfo( b, tenantId, id ) );
+			String id, String routingKey, String value) {
+		context.delete( b -> addWorkInfo( b, tenantId, id, routingKey ) );
 	}
 
 	@Override
@@ -38,6 +38,11 @@ public class PojoIndexingDeleteIT extends AbstractPojoIndexingOperationIT {
 	}
 
 	@Override
+	protected void addTo(SearchIndexingPlan indexingPlan, Object providedId, String providedRoutingKey, int id) {
+		indexingPlan.delete( providedId, providedRoutingKey, createEntity( id ) );
+	}
+
+	@Override
 	protected CompletableFuture<?> execute(SearchIndexer indexer, int id) {
 		return indexer.delete( createEntity( id ) );
 	}
@@ -45,5 +50,10 @@ public class PojoIndexingDeleteIT extends AbstractPojoIndexingOperationIT {
 	@Override
 	protected CompletableFuture<?> execute(SearchIndexer indexer, Object providedId, int id) {
 		return indexer.delete( providedId, createEntity( id ) );
+	}
+
+	@Override
+	protected CompletableFuture<?> execute(SearchIndexer indexer, Object providedId, String providedRoutingKey, int id) {
+		return indexer.delete( providedId, providedRoutingKey, createEntity( id ) );
 	}
 }

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/PojoIndexingPurgeIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/PojoIndexingPurgeIT.java
@@ -23,8 +23,8 @@ public class PojoIndexingPurgeIT extends AbstractPojoIndexingOperationIT {
 
 	@Override
 	protected void expectOperation(BackendMock.DocumentWorkCallListContext context, String tenantId,
-			String id, String value) {
-		context.delete( b -> addWorkInfo( b, tenantId, id ) );
+			String id, String routingKey, String value) {
+		context.delete( b -> addWorkInfo( b, tenantId, id, routingKey ) );
 	}
 
 	@Override
@@ -38,6 +38,11 @@ public class PojoIndexingPurgeIT extends AbstractPojoIndexingOperationIT {
 	}
 
 	@Override
+	protected void addTo(SearchIndexingPlan indexingPlan, Object providedId, String providedRoutingKey, int id) {
+		indexingPlan.purge( IndexedEntity.class, providedId, providedRoutingKey );
+	}
+
+	@Override
 	protected CompletableFuture<?> execute(SearchIndexer indexer, int id) {
 		return indexer.purge( IndexedEntity.class, id, null );
 	}
@@ -45,5 +50,10 @@ public class PojoIndexingPurgeIT extends AbstractPojoIndexingOperationIT {
 	@Override
 	protected CompletableFuture<?> execute(SearchIndexer indexer, Object providedId, int id) {
 		return indexer.purge( IndexedEntity.class, providedId, null );
+	}
+
+	@Override
+	protected CompletableFuture<?> execute(SearchIndexer indexer, Object providedId, String providedRoutingKey, int id) {
+		return indexer.purge( IndexedEntity.class, providedId, providedRoutingKey );
 	}
 }

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/SearchIndexer.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/SearchIndexer.java
@@ -22,13 +22,30 @@ public interface SearchIndexer {
 	 * <p>
 	 * Entities to reindex as a result of this operation will not be resolved.
 	 * <p>
-	 * Shorthand for {@code add(null, entity)}; see {@link #add(Object, Object)}.
+	 * Shorthand for {@code add(null, null)}; see {@link #add(Object, String, Object)}.
 	 *
 	 * @param entity The entity to add to the index.
 	 * @return A {@link CompletableFuture} reflecting the completion state of the operation.
 	 */
 	default CompletableFuture<?> add(Object entity) {
-		return add( null, entity );
+		return add( null, null, entity );
+	}
+
+	/**
+	 * Add an entity to the index, assuming that the entity is absent from the index.
+	 * <p>
+	 * Entities to reindex as a result of this operation will not be resolved.
+	 * <p>
+	 * Shorthand for {@code add(null, entity)}; see {@link #add(Object, String, Object)}.
+	 *
+	 * @param providedId A value to extract the document ID from.
+	 * Generally the expected value is the entity ID, but a different value may be expected depending on the mapping.
+	 * If {@code null}, Hibernate Search will attempt to extract the ID from the entity.
+	 * @param entity The entity to add to the index.
+	 * @return A {@link CompletableFuture} reflecting the completion state of the operation.
+	 */
+	default CompletableFuture<?> add(Object providedId, Object entity) {
+		return add( providedId, null, entity );
 	}
 
 	/**
@@ -42,10 +59,13 @@ public interface SearchIndexer {
 	 * @param providedId A value to extract the document ID from.
 	 * Generally the expected value is the entity ID, but a different value may be expected depending on the mapping.
 	 * If {@code null}, Hibernate Search will attempt to extract the ID from the entity.
+	 * @param providedRoutingKey The routing key to route the add request to the appropriate index shard.
+	 * Leave {@code null} if sharding is disabled
+	 * or to have Hibernate Search compute the value through the assigned {@link org.hibernate.search.mapper.pojo.bridge.RoutingKeyBridge}.
 	 * @param entity The entity to add to the index.
 	 * @return A {@link CompletableFuture} reflecting the completion state of the operation.
 	 */
-	CompletableFuture<?> add(Object providedId, Object entity);
+	CompletableFuture<?> add(Object providedId, String providedRoutingKey, Object entity);
 
 	/**
 	 * Update an entity in the index, or add it if it's absent from the index.

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/SearchIndexer.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/SearchIndexer.java
@@ -119,7 +119,7 @@ public interface SearchIndexer {
 	 * <p>
 	 * Entities to reindex as a result of this operation will not be resolved.
 	 * <p>
-	 * Shorthand for {@code delete(null, entity)}; see {@link #delete(Object, Object)}.
+	 * Shorthand for {@code delete(null, null, entity)}; see {@link #delete(Object, String, Object)}.
 	 *
 	 * @param entity The entity to add to the index.
 	 * @return A {@link CompletableFuture} reflecting the completion state of the operation.
@@ -133,7 +133,7 @@ public interface SearchIndexer {
 	 * <p>
 	 * Entities to reindex as a result of this operation will not be resolved.
 	 * <p>
-	 * No effect on the index if the entity is not in the index.
+	 * Shorthand for {@code delete(providedId, null, entity)}; see {@link #delete(Object, String, Object)}.
 	 *
 	 * @param providedId A value to extract the document ID from.
 	 * Generally the expected value is the entity ID, but a different value may be expected depending on the mapping.
@@ -141,7 +141,27 @@ public interface SearchIndexer {
 	 * @param entity The entity to delete from the index.
 	 * @return A {@link CompletableFuture} reflecting the completion state of the operation.
 	 */
-	CompletableFuture<?> delete(Object providedId, Object entity);
+	default CompletableFuture<?> delete(Object providedId, Object entity) {
+		return delete( providedId, null, entity );
+	}
+
+	/**
+	 * Delete an entity from the index.
+	 * <p>
+	 * Entities to reindex as a result of this operation will not be resolved.
+	 * <p>
+	 * No effect on the index if the entity is not in the index.
+	 *
+	 * @param providedId A value to extract the document ID from.
+	 * Generally the expected value is the entity ID, but a different value may be expected depending on the mapping.
+	 * If {@code null}, Hibernate Search will attempt to extract the ID from the entity.
+	 * @param providedRoutingKey The routing key to route the delete request to the appropriate index shard.
+	 * Leave {@code null} if sharding is disabled
+	 * or to have Hibernate Search compute the value through the assigned {@link org.hibernate.search.mapper.pojo.bridge.RoutingKeyBridge}.
+	 * @param entity The entity to delete from the index.
+	 * @return A {@link CompletableFuture} reflecting the completion state of the operation.
+	 */
+	CompletableFuture<?> delete(Object providedId, String providedRoutingKey, Object entity);
 
 	/**
 	 * Purge an entity from the index.

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/SearchIndexer.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/SearchIndexer.java
@@ -72,13 +72,30 @@ public interface SearchIndexer {
 	 * <p>
 	 * Entities to reindex as a result of this operation will not be resolved.
 	 * <p>
-	 * Shorthand for {@code addOrUpdate(null, entity)}; see {@link #addOrUpdate(Object, Object)}.
+	 * Shorthand for {@code addOrUpdate(null, null, entity)}; see {@link #addOrUpdate(Object, String, Object)}.
 	 *
 	 * @param entity The entity to add to the index.
 	 * @return A {@link CompletableFuture} reflecting the completion state of the operation.
 	 */
 	default CompletableFuture<?> addOrUpdate(Object entity) {
-		return addOrUpdate( null, entity );
+		return addOrUpdate( null, null, entity );
+	}
+
+	/**
+	 * Update an entity in the index, or add it if it's absent from the index.
+	 * <p>
+	 * Entities to reindex as a result of this operation will not be resolved.
+	 * <p>
+	 * Shorthand for {@code addOrUpdate(providedId, null, entity)}; see {@link #addOrUpdate(Object, String, Object)}.
+	 *
+	 * @param providedId A value to extract the document ID from.
+	 * Generally the expected value is the entity ID, but a different value may be expected depending on the mapping.
+	 * If {@code null}, Hibernate Search will attempt to extract the ID from the entity.
+	 * @param entity The entity to update in the index.
+	 * @return A {@link CompletableFuture} reflecting the completion state of the operation.
+	 */
+	default CompletableFuture<?> addOrUpdate(Object providedId, Object entity) {
+		return addOrUpdate( providedId, null, entity );
 	}
 
 	/**
@@ -89,10 +106,13 @@ public interface SearchIndexer {
 	 * @param providedId A value to extract the document ID from.
 	 * Generally the expected value is the entity ID, but a different value may be expected depending on the mapping.
 	 * If {@code null}, Hibernate Search will attempt to extract the ID from the entity.
+	 * @param providedRoutingKey The routing key to route the addOrUpdate request to the appropriate index shard.
+	 * Leave {@code null} if sharding is disabled
+	 * or to have Hibernate Search compute the value through the assigned {@link org.hibernate.search.mapper.pojo.bridge.RoutingKeyBridge}.
 	 * @param entity The entity to update in the index.
 	 * @return A {@link CompletableFuture} reflecting the completion state of the operation.
 	 */
-	CompletableFuture<?> addOrUpdate(Object providedId, Object entity);
+	CompletableFuture<?> addOrUpdate(Object providedId, String providedRoutingKey, Object entity);
 
 	/**
 	 * Delete an entity from the index.

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/SearchIndexingPlan.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/SearchIndexingPlan.java
@@ -98,7 +98,7 @@ public interface SearchIndexingPlan {
 	/**
 	 * Delete an entity from the index.
 	 * <p>
-	 * Shorthand for {@code delete(null, entity)}; see {@link #delete(Object, Object)}.
+	 * Shorthand for {@code delete(null, entity)}; see {@link #delete(Object, String, Object)}.
 	 *
 	 * @param entity The entity to delete from the index.
 	 */
@@ -112,9 +112,12 @@ public interface SearchIndexingPlan {
 	 * @param providedId A value to extract the document ID from.
 	 * Generally the expected value is the entity ID, but a different value may be expected depending on the mapping.
 	 * If {@code null}, Hibernate Search will attempt to extract the ID from the entity.
+	 * @param providedRoutingKey The routing key to route the addOrUpdate request to the appropriate index shard.
+	 * Leave {@code null} if sharding is disabled
+	 * or to have Hibernate Search compute the value through the assigned {@link org.hibernate.search.mapper.pojo.bridge.RoutingKeyBridge}.
 	 * @param entity The entity to delete from the index.
 	 */
-	void delete(Object providedId, Object entity);
+	void delete(Object providedId, String providedRoutingKey, Object entity);
 
 	/**
 	 * Delete the entity from the index.

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/SearchIndexingPlan.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/SearchIndexingPlan.java
@@ -18,7 +18,7 @@ public interface SearchIndexingPlan {
 	/**
 	 * Add an entity to the index, assuming that the entity is absent from the index.
 	 * <p>
-	 * Shorthand for {@code add(null, entity)}; see {@link #add(Object, Object)}.
+	 * Shorthand for {@code add(null, null, entity)}; see {@link #add(Object, String, Object)}.
 	 *
 	 * @param entity The entity to add to the index.
 	 */
@@ -34,9 +34,12 @@ public interface SearchIndexingPlan {
 	 * @param providedId A value to extract the document ID from.
 	 * Generally the expected value is the entity ID, but a different value may be expected depending on the mapping.
 	 * If {@code null}, Hibernate Search will attempt to extract the ID from the entity.
+	 * @param providedRoutingKey The routing key to route the add request to the appropriate index shard.
+	 * Leave {@code null} if sharding is disabled
+	 * or to have Hibernate Search compute the value through the assigned {@link org.hibernate.search.mapper.pojo.bridge.RoutingKeyBridge}.
 	 * @param entity The entity to add to the index.
 	 */
-	void add(Object providedId, Object entity);
+	void add(Object providedId, String providedRoutingKey, Object entity);
 
 	/**
 	 * Update an entity in the index, or add it if it's absent from the index.

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/SearchIndexingPlan.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/SearchIndexingPlan.java
@@ -29,7 +29,7 @@ public interface SearchIndexingPlan {
 	 * <p>
 	 * <strong>Note:</strong> depending on the backend, this may lead to errors or duplicate entries in the index
 	 * if the entity was actually already present in the index before this call.
-	 * When in doubt, you should rather use {@link #addOrUpdate(Object, Object)} or {@link #addOrUpdate(Object)}.
+	 * When in doubt, you should rather use {@link #addOrUpdate(Object, String, Object)} or {@link #addOrUpdate(Object)}.
 	 *
 	 * @param providedId A value to extract the document ID from.
 	 * Generally the expected value is the entity ID, but a different value may be expected depending on the mapping.
@@ -44,7 +44,7 @@ public interface SearchIndexingPlan {
 	/**
 	 * Update an entity in the index, or add it if it's absent from the index.
 	 * <p>
-	 * Shorthand for {@code update(null, entity)}; see {@link #addOrUpdate(Object, Object)}.
+	 * Shorthand for {@code update(null, entity)}; see {@link #addOrUpdate(Object, String, Object)}.
 	 *
 	 * @param entity The entity to update in the index.
 	 */
@@ -56,9 +56,12 @@ public interface SearchIndexingPlan {
 	 * @param providedId A value to extract the document ID from.
 	 * Generally the expected value is the entity ID, but a different value may be expected depending on the mapping.
 	 * If {@code null}, Hibernate Search will attempt to extract the ID from the entity.
+	 * @param providedRoutingKey The routing key to route the addOrUpdate request to the appropriate index shard.
+	 * Leave {@code null} if sharding is disabled
+	 * or to have Hibernate Search compute the value through the assigned {@link org.hibernate.search.mapper.pojo.bridge.RoutingKeyBridge}.
 	 * @param entity The entity to update in the index.
 	 */
-	void addOrUpdate(Object providedId, Object entity);
+	void addOrUpdate(Object providedId, String providedRoutingKey, Object entity);
 
 	/**
 	 * Update an entity in the index, or add it if it's absent from the index,
@@ -67,7 +70,7 @@ public interface SearchIndexingPlan {
 	 * <p>
 	 * Assumes that the entity may already be present in the index.
 	 * <p>
-	 * Shorthand for {@code update(null, entity, dirtyPaths)}; see {@link #addOrUpdate(Object, Object)}.
+	 * Shorthand for {@code update(null, entity, dirtyPaths)}; see {@link #addOrUpdate(Object, String, Object, String...)}.
 	 *
 	 * @param entity The entity to update in the index.
 	 * @param dirtyPaths The paths to consider dirty, formatted using the dot-notation
@@ -83,11 +86,14 @@ public interface SearchIndexingPlan {
 	 * @param providedId A value to extract the document ID from.
 	 * Generally the expected value is the entity ID, but a different value may be expected depending on the mapping.
 	 * If {@code null}, Hibernate Search will attempt to extract the ID from the entity.
+	 * @param providedRoutingKey The routing key to route the addOrUpdate request to the appropriate index shard.
+	 * Leave {@code null} if sharding is disabled
+	 * or to have Hibernate Search compute the value through the assigned {@link org.hibernate.search.mapper.pojo.bridge.RoutingKeyBridge}.
 	 * @param entity The entity to update in the index.
 	 * @param dirtyPaths The paths to consider dirty, formatted using the dot-notation
 	 * ("directEntityProperty.nestedPropery").
 	 */
-	void addOrUpdate(Object providedId, Object entity, String... dirtyPaths);
+	void addOrUpdate(Object providedId, String providedRoutingKey, Object entity, String... dirtyPaths);
 
 	/**
 	 * Delete an entity from the index.

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexerImpl.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexerImpl.java
@@ -32,9 +32,8 @@ public class SearchIndexerImpl implements SearchIndexer {
 	}
 
 	@Override
-	public CompletableFuture<?> add(Object providedId, Object entity) {
-		// TODO HSEARCH-3891 expose the providedRoutingKey
-		return delegate.add( getTypeIdentifier( entity ), providedId, null, entity,
+	public CompletableFuture<?> add(Object providedId, String providedRoutingKey, Object entity) {
+		return delegate.add( getTypeIdentifier( entity ), providedId, providedRoutingKey, entity,
 				commitStrategy, refreshStrategy );
 	}
 

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexerImpl.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexerImpl.java
@@ -33,7 +33,8 @@ public class SearchIndexerImpl implements SearchIndexer {
 
 	@Override
 	public CompletableFuture<?> add(Object providedId, Object entity) {
-		return delegate.add( getTypeIdentifier( entity ), providedId, entity,
+		// TODO HSEARCH-3891 expose the providedRoutingKey
+		return delegate.add( getTypeIdentifier( entity ), providedId, null, entity,
 				commitStrategy, refreshStrategy );
 	}
 

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexerImpl.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexerImpl.java
@@ -44,9 +44,8 @@ public class SearchIndexerImpl implements SearchIndexer {
 	}
 
 	@Override
-	public CompletableFuture<?> delete(Object providedId, Object entity) {
-		// TODO HSEARCH-3891 expose the providedRoutingKey
-		return delegate.delete( getTypeIdentifier( entity ), providedId, null, entity,
+	public CompletableFuture<?> delete(Object providedId, String providedRoutingKey, Object entity) {
+		return delegate.delete( getTypeIdentifier( entity ), providedId, providedRoutingKey, entity,
 				commitStrategy, refreshStrategy );
 	}
 

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexerImpl.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexerImpl.java
@@ -38,9 +38,8 @@ public class SearchIndexerImpl implements SearchIndexer {
 	}
 
 	@Override
-	public CompletableFuture<?> addOrUpdate(Object providedId, Object entity) {
-		// TODO HSEARCH-3891 expose the providedRoutingKey
-		return delegate.addOrUpdate( getTypeIdentifier( entity ), providedId, null, entity,
+	public CompletableFuture<?> addOrUpdate(Object providedId, String providedRoutingKey, Object entity) {
+		return delegate.addOrUpdate( getTypeIdentifier( entity ), providedId, providedRoutingKey, entity,
 				commitStrategy, refreshStrategy );
 	}
 

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexerImpl.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexerImpl.java
@@ -47,7 +47,8 @@ public class SearchIndexerImpl implements SearchIndexer {
 
 	@Override
 	public CompletableFuture<?> delete(Object providedId, Object entity) {
-		return delegate.delete( getTypeIdentifier( entity ), providedId, entity,
+		// TODO HSEARCH-3891 expose the providedRoutingKey
+		return delegate.delete( getTypeIdentifier( entity ), providedId, null, entity,
 				commitStrategy, refreshStrategy );
 	}
 

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexerImpl.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexerImpl.java
@@ -40,7 +40,8 @@ public class SearchIndexerImpl implements SearchIndexer {
 
 	@Override
 	public CompletableFuture<?> addOrUpdate(Object providedId, Object entity) {
-		return delegate.addOrUpdate( getTypeIdentifier( entity ), providedId, entity,
+		// TODO HSEARCH-3891 expose the providedRoutingKey
+		return delegate.addOrUpdate( getTypeIdentifier( entity ), providedId, null, entity,
 				commitStrategy, refreshStrategy );
 	}
 

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexingPlanImpl.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexingPlanImpl.java
@@ -43,7 +43,8 @@ public class SearchIndexingPlanImpl implements SearchIndexingPlan {
 
 	@Override
 	public void addOrUpdate(Object providedId, Object entity) {
-		delegate.addOrUpdate( getTypeIdentifier( entity ), providedId, entity );
+		// TODO HSEARCH-3891 expose the providedRoutingKey
+		delegate.addOrUpdate( getTypeIdentifier( entity ), providedId, null, entity );
 	}
 
 	@Override
@@ -53,7 +54,8 @@ public class SearchIndexingPlanImpl implements SearchIndexingPlan {
 
 	@Override
 	public void addOrUpdate(Object providedId, Object entity, String... dirtyPaths) {
-		delegate.addOrUpdate( getTypeIdentifier( entity ), providedId, entity, dirtyPaths );
+		// TODO HSEARCH-3891 expose the providedRoutingKey
+		delegate.addOrUpdate( getTypeIdentifier( entity ), providedId, null, entity, dirtyPaths );
 	}
 
 	@Override

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexingPlanImpl.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexingPlanImpl.java
@@ -65,7 +65,8 @@ public class SearchIndexingPlanImpl implements SearchIndexingPlan {
 
 	@Override
 	public void delete(Object providedId, Object entity) {
-		delegate.delete( getTypeIdentifier( entity ), providedId, entity );
+		// TODO HSEARCH-3891 expose the providedRoutingKey
+		delegate.delete( getTypeIdentifier( entity ), providedId, null, entity );
 	}
 
 	@Override

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexingPlanImpl.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexingPlanImpl.java
@@ -37,24 +37,22 @@ public class SearchIndexingPlanImpl implements SearchIndexingPlan {
 
 	@Override
 	public void addOrUpdate(Object entity) {
-		addOrUpdate( null, entity );
+		addOrUpdate( null, null, entity );
 	}
 
 	@Override
-	public void addOrUpdate(Object providedId, Object entity) {
-		// TODO HSEARCH-3891 expose the providedRoutingKey
-		delegate.addOrUpdate( getTypeIdentifier( entity ), providedId, null, entity );
+	public void addOrUpdate(Object providedId, String providedRoutingKey, Object entity) {
+		delegate.addOrUpdate( getTypeIdentifier( entity ), providedId, providedRoutingKey, entity );
 	}
 
 	@Override
 	public void addOrUpdate(Object entity, String... dirtyPaths) {
-		addOrUpdate( null, entity, dirtyPaths );
+		addOrUpdate( null, null, entity, dirtyPaths );
 	}
 
 	@Override
-	public void addOrUpdate(Object providedId, Object entity, String... dirtyPaths) {
-		// TODO HSEARCH-3891 expose the providedRoutingKey
-		delegate.addOrUpdate( getTypeIdentifier( entity ), providedId, null, entity, dirtyPaths );
+	public void addOrUpdate(Object providedId, String providedRoutingKey, Object entity, String... dirtyPaths) {
+		delegate.addOrUpdate( getTypeIdentifier( entity ), providedId, providedRoutingKey, entity, dirtyPaths );
 	}
 
 	@Override

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexingPlanImpl.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexingPlanImpl.java
@@ -57,13 +57,12 @@ public class SearchIndexingPlanImpl implements SearchIndexingPlan {
 
 	@Override
 	public void delete(Object entity) {
-		delete( null, entity );
+		delete( null, null, entity );
 	}
 
 	@Override
-	public void delete(Object providedId, Object entity) {
-		// TODO HSEARCH-3891 expose the providedRoutingKey
-		delegate.delete( getTypeIdentifier( entity ), providedId, null, entity );
+	public void delete(Object providedId, String providedRoutingKey, Object entity) {
+		delegate.delete( getTypeIdentifier( entity ), providedId, providedRoutingKey, entity );
 	}
 
 	@Override

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexingPlanImpl.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexingPlanImpl.java
@@ -27,13 +27,12 @@ public class SearchIndexingPlanImpl implements SearchIndexingPlan {
 
 	@Override
 	public void add(Object entity) {
-		add( null, entity );
+		add( null, null, entity );
 	}
 
 	@Override
-	public void add(Object providedId, Object entity) {
-		// TODO HSEARCH-3891 expose the providedRoutingKey
-		delegate.add( getTypeIdentifier( entity ), providedId, null, entity );
+	public void add(Object providedId, String providedRoutingKey, Object entity) {
+		delegate.add( getTypeIdentifier( entity ), providedId, providedRoutingKey, entity );
 	}
 
 	@Override

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexingPlanImpl.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexingPlanImpl.java
@@ -32,7 +32,8 @@ public class SearchIndexingPlanImpl implements SearchIndexingPlan {
 
 	@Override
 	public void add(Object providedId, Object entity) {
-		delegate.add( getTypeIdentifier( entity ), providedId, entity );
+		// TODO HSEARCH-3891 expose the providedRoutingKey
+		delegate.add( getTypeIdentifier( entity ), providedId, null, entity );
 	}
 
 	@Override

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/event/impl/HibernateSearchEventListener.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/event/impl/HibernateSearchEventListener.java
@@ -78,7 +78,7 @@ public final class HibernateSearchEventListener implements PostDeleteEventListen
 			// TODO Check whether deletes work with hibernate.use_identifier_rollback enabled (see HSEARCH-650)
 			// I think they should, but better safe than sorry
 			getCurrentIndexingPlan( contextProvider, event.getSession() )
-					.delete( typeContext.typeIdentifier(), providedId, entity );
+					.delete( typeContext.typeIdentifier(), providedId, null, entity );
 		}
 	}
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/event/impl/HibernateSearchEventListener.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/event/impl/HibernateSearchEventListener.java
@@ -90,7 +90,7 @@ public final class HibernateSearchEventListener implements PostDeleteEventListen
 		if ( typeContext != null ) {
 			Object providedId = typeContext.toIndexingPlanProvidedId( event.getId() );
 			getCurrentIndexingPlan( contextProvider, event.getSession() )
-					.add( typeContext.typeIdentifier(), providedId, entity );
+					.add( typeContext.typeIdentifier(), providedId, null, entity );
 		}
 	}
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/event/impl/HibernateSearchEventListener.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/event/impl/HibernateSearchEventListener.java
@@ -103,10 +103,10 @@ public final class HibernateSearchEventListener implements PostDeleteEventListen
 			PojoIndexingPlan<?> plan = getCurrentIndexingPlan( contextProvider, event.getSession() );
 			Object providedId = typeContext.toIndexingPlanProvidedId( event.getId() );
 			if ( dirtyCheckingEnabled ) {
-				plan.addOrUpdate( typeContext.typeIdentifier(), providedId, entity, getDirtyPropertyNames( event ) );
+				plan.addOrUpdate( typeContext.typeIdentifier(), providedId, null, entity, getDirtyPropertyNames( event ) );
 			}
 			else {
-				plan.addOrUpdate( typeContext.typeIdentifier(), providedId, entity );
+				plan.addOrUpdate( typeContext.typeIdentifier(), providedId, null, entity );
 			}
 		}
 	}
@@ -230,18 +230,18 @@ public final class HibernateSearchEventListener implements PostDeleteEventListen
 					 * which can then decide whether to reindex based on whether the collection
 					 * has any impact on indexing.
 					 */
-					plan.addOrUpdate( typeContext.typeIdentifier(), providedId, ownerEntity, collectionRole );
+					plan.addOrUpdate( typeContext.typeIdentifier(), providedId, null, ownerEntity, collectionRole );
 				}
 				else {
 					/*
 					 * We don't know which collection is being changed,
 					 * so we have to default to reindexing, just in case.
 					 */
-					plan.addOrUpdate( typeContext.typeIdentifier(), providedId, ownerEntity );
+					plan.addOrUpdate( typeContext.typeIdentifier(), providedId, null, ownerEntity );
 				}
 			}
 			else {
-				plan.addOrUpdate( typeContext.typeIdentifier(), providedId, ownerEntity );
+				plan.addOrUpdate( typeContext.typeIdentifier(), providedId, null, ownerEntity );
 			}
 		}
 	}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/IdentifierConsumerDocumentProducer.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/IdentifierConsumerDocumentProducer.java
@@ -238,7 +238,7 @@ public class IdentifierConsumerDocumentProducer<E, I> implements Runnable {
 
 		CompletableFuture<?> future;
 		try {
-			future = indexer.add( type.typeIdentifier(), null, entity,
+			future = indexer.add( type.typeIdentifier(), null, null, entity,
 					// Commit and refresh are handled globally after all documents are indexed.
 					DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE );
 		}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/impl/SearchIndexingPlanImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/impl/SearchIndexingPlanImpl.java
@@ -31,7 +31,7 @@ public final class SearchIndexingPlanImpl implements SearchIndexingPlan {
 	@Override
 	public void delete(Object entity) {
 		sessionContext.currentIndexingPlan( true )
-				.delete( getTypeIdentifier( entity ), null, entity );
+				.delete( getTypeIdentifier( entity ), null, null, entity );
 	}
 
 	@Override

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/impl/SearchIndexingPlanImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/impl/SearchIndexingPlanImpl.java
@@ -25,7 +25,7 @@ public final class SearchIndexingPlanImpl implements SearchIndexingPlan {
 	@Override
 	public void addOrUpdate(Object entity) {
 		sessionContext.currentIndexingPlan( true )
-				.addOrUpdate( getTypeIdentifier( entity ), null, entity );
+				.addOrUpdate( getTypeIdentifier( entity ), null, null, entity );
 	}
 
 	@Override

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoIndexedTypeManager.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoIndexedTypeManager.java
@@ -112,15 +112,16 @@ public class PojoIndexedTypeManager<I, E>
 
 	@Override
 	public DocumentReferenceProvider toDocumentReferenceProvider(PojoWorkSessionContext<?> sessionContext,
-			I identifier, Supplier<E> entitySupplier) {
+			I identifier, String providedRoutingKey, Supplier<E> entitySupplier) {
 		String documentIdentifier = identifierMapping.toDocumentIdentifier(
 				identifier, sessionContext.mappingContext()
 		);
-		String routingKey = routingKeyProvider.toRoutingKey(
-				identifier,
-				entitySupplier,
-				sessionContext
-		);
+		String routingKey = ( providedRoutingKey != null ) ? providedRoutingKey :
+				routingKeyProvider.toRoutingKey(
+						identifier,
+						entitySupplier,
+						sessionContext
+				);
 		return new PojoDocumentReferenceProvider(
 				documentIdentifier, routingKey, identifier
 		);

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/AbstractPojoTypeIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/AbstractPojoTypeIndexingPlan.java
@@ -18,9 +18,9 @@ abstract class AbstractPojoTypeIndexingPlan {
 
 	abstract void add(Object providedId, String providedRoutingKey, Object entity);
 
-	abstract void update(Object providedId, Object entity);
+	abstract void update(Object providedId, String providedRoutingKey, Object entity);
 
-	abstract void update(Object providedId, Object entity, String... dirtyPaths);
+	abstract void update(Object providedId, String providedRoutingKey, Object entity, String... dirtyPaths);
 
 	abstract void delete(Object providedId, Object entity);
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/AbstractPojoTypeIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/AbstractPojoTypeIndexingPlan.java
@@ -22,7 +22,7 @@ abstract class AbstractPojoTypeIndexingPlan {
 
 	abstract void update(Object providedId, String providedRoutingKey, Object entity, String... dirtyPaths);
 
-	abstract void delete(Object providedId, Object entity);
+	abstract void delete(Object providedId, String providedRoutingKey, Object entity);
 
 	abstract void purge(Object providedId, String providedRoutingKey);
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/AbstractPojoTypeIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/AbstractPojoTypeIndexingPlan.java
@@ -16,7 +16,7 @@ abstract class AbstractPojoTypeIndexingPlan {
 		this.sessionContext = sessionContext;
 	}
 
-	abstract void add(Object providedId, Object entity);
+	abstract void add(Object providedId, String providedRoutingKey, Object entity);
 
 	abstract void update(Object providedId, Object entity);
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoContainedTypeIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoContainedTypeIndexingPlan.java
@@ -43,13 +43,13 @@ public class PojoContainedTypeIndexingPlan<E> extends AbstractPojoTypeIndexingPl
 	}
 
 	@Override
-	void update(Object providedId, Object entity) {
+	void update(Object providedId, String providedRoutingKey, Object entity) {
 		Supplier<E> entitySupplier = typeContext.toEntitySupplier( sessionContext, entity );
 		getPlan( providedId ).update( entitySupplier );
 	}
 
 	@Override
-	void update(Object providedId, Object entity, String... dirtyPaths) {
+	void update(Object providedId, String providedRoutingKey, Object entity, String... dirtyPaths) {
 		Supplier<E> entitySupplier = typeContext.toEntitySupplier( sessionContext, entity );
 		getPlan( providedId ).update( entitySupplier, dirtyPaths );
 	}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoContainedTypeIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoContainedTypeIndexingPlan.java
@@ -37,7 +37,7 @@ public class PojoContainedTypeIndexingPlan<E> extends AbstractPojoTypeIndexingPl
 	}
 
 	@Override
-	void add(Object providedId, Object entity) {
+	void add(Object providedId, String providedRoutingKey, Object entity) {
 		Supplier<E> entitySupplier = typeContext.toEntitySupplier( sessionContext, entity );
 		getPlan( providedId ).add( entitySupplier );
 	}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoContainedTypeIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoContainedTypeIndexingPlan.java
@@ -55,7 +55,7 @@ public class PojoContainedTypeIndexingPlan<E> extends AbstractPojoTypeIndexingPl
 	}
 
 	@Override
-	void delete(Object providedId, Object entity) {
+	void delete(Object providedId, String providedRoutingKey, Object entity) {
 		Supplier<E> entitySupplier = typeContext.toEntitySupplier( sessionContext, entity );
 		getPlan( providedId ).delete( entitySupplier );
 	}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexedTypeIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexedTypeIndexingPlan.java
@@ -43,10 +43,10 @@ public class PojoIndexedTypeIndexingPlan<I, E, R> extends AbstractPojoTypeIndexi
 	}
 
 	@Override
-	void add(Object providedId, Object entity) {
+	void add(Object providedId, String providedRoutingKey, Object entity) {
 		Supplier<E> entitySupplier = typeContext.toEntitySupplier( sessionContext, entity );
 		I identifier = typeContext.getIdentifierMapping().getIdentifier( providedId, entitySupplier );
-		getPlan( identifier ).add( entitySupplier );
+		getPlan( identifier ).add( entitySupplier, providedRoutingKey );
 	}
 
 	@Override
@@ -155,9 +155,9 @@ public class PojoIndexedTypeIndexingPlan<I, E, R> extends AbstractPojoTypeIndexi
 			this.identifier = identifier;
 		}
 
-		void add(Supplier<E> entitySupplier) {
+		void add(Supplier<E> entitySupplier, String providedRoutingKey) {
 			this.entitySupplier = entitySupplier;
-			providedRoutingKey = null;
+			this.providedRoutingKey = providedRoutingKey;
 			shouldResolveToReindex = true;
 			add = true;
 		}
@@ -238,14 +238,14 @@ public class PojoIndexedTypeIndexingPlan<I, E, R> extends AbstractPojoTypeIndexi
 					if ( considerAllDirty || updatedBecauseOfContained || typeContext.requiresSelfReindexing(
 							dirtyPaths ) ) {
 						delegate.update(
-								typeContext.toDocumentReferenceProvider( sessionContext, identifier, entitySupplier ),
+								typeContext.toDocumentReferenceProvider( sessionContext, identifier, providedRoutingKey, entitySupplier ),
 								typeContext.toDocumentContributor( entitySupplier, sessionContext )
 						);
 					}
 				}
 				else {
 					delegate.add(
-							typeContext.toDocumentReferenceProvider( sessionContext, identifier, entitySupplier ),
+							typeContext.toDocumentReferenceProvider( sessionContext, identifier, providedRoutingKey, entitySupplier ),
 							typeContext.toDocumentContributor( entitySupplier, sessionContext )
 					);
 				}
@@ -255,7 +255,7 @@ public class PojoIndexedTypeIndexingPlan<I, E, R> extends AbstractPojoTypeIndexi
 						entitySupplier == null
 								? typeContext.toDocumentReferenceProvider(
 								sessionContext, identifier, providedRoutingKey )
-								: typeContext.toDocumentReferenceProvider( sessionContext, identifier, entitySupplier );
+								: typeContext.toDocumentReferenceProvider( sessionContext, identifier, providedRoutingKey, entitySupplier );
 				delegate.delete( referenceProvider );
 			}
 		}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexedTypeIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexedTypeIndexingPlan.java
@@ -64,10 +64,10 @@ public class PojoIndexedTypeIndexingPlan<I, E, R> extends AbstractPojoTypeIndexi
 	}
 
 	@Override
-	void delete(Object providedId, Object entity) {
+	void delete(Object providedId, String providedRoutingKey, Object entity) {
 		Supplier<E> entitySupplier = typeContext.toEntitySupplier( sessionContext, entity );
 		I identifier = typeContext.getIdentifierMapping().getIdentifier( providedId, entitySupplier );
-		getPlan( identifier ).delete( entitySupplier );
+		getPlan( identifier ).delete( entitySupplier, providedRoutingKey );
 	}
 
 	@Override
@@ -189,9 +189,9 @@ public class PojoIndexedTypeIndexingPlan<I, E, R> extends AbstractPojoTypeIndexi
 			 */
 		}
 
-		void delete(Supplier<E> entitySupplier) {
+		void delete(Supplier<E> entitySupplier, String providedRoutingKey) {
 			this.entitySupplier = entitySupplier;
-			providedRoutingKey = null;
+			this.providedRoutingKey = providedRoutingKey;
 			if ( add && !delete ) {
 				/*
 				 * We called add() in the same plan, so we don't expect the document to be in the index.

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexerImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexerImpl.java
@@ -36,10 +36,10 @@ public class PojoIndexerImpl implements PojoIndexer {
 	}
 
 	@Override
-	public CompletableFuture<?> add(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, Object entity,
+	public CompletableFuture<?> add(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, String providedRoutingKey, Object entity,
 			DocumentCommitStrategy commitStrategy,
 			DocumentRefreshStrategy refreshStrategy) {
-		return getDelegate( typeIdentifier ).add( providedId, entity, commitStrategy, refreshStrategy );
+		return getDelegate( typeIdentifier ).add( providedId, providedRoutingKey, entity, commitStrategy, refreshStrategy );
 	}
 
 	@Override

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexerImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexerImpl.java
@@ -49,9 +49,9 @@ public class PojoIndexerImpl implements PojoIndexer {
 	}
 
 	@Override
-	public CompletableFuture<?> delete(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, Object entity,
+	public CompletableFuture<?> delete(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, String providedRoutingKey, Object entity,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
-		return getDelegate( typeIdentifier ).delete( providedId, entity, commitStrategy, refreshStrategy );
+		return getDelegate( typeIdentifier ).delete( providedId, providedRoutingKey, entity, commitStrategy, refreshStrategy );
 	}
 
 	@Override

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexerImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexerImpl.java
@@ -43,9 +43,9 @@ public class PojoIndexerImpl implements PojoIndexer {
 	}
 
 	@Override
-	public CompletableFuture<?> addOrUpdate(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, Object entity,
+	public CompletableFuture<?> addOrUpdate(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, String providedRoutingKey, Object entity,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
-		return getDelegate( typeIdentifier ).addOrUpdate( providedId, entity, commitStrategy, refreshStrategy );
+		return getDelegate( typeIdentifier ).addOrUpdate( providedId, providedRoutingKey, entity, commitStrategy, refreshStrategy );
 	}
 
 	@Override

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanImpl.java
@@ -74,9 +74,9 @@ public class PojoIndexingPlanImpl<R> implements PojoIndexingPlan<R> {
 	}
 
 	@Override
-	public void delete(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, Object entity) {
+	public void delete(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, String providedRoutingKey, Object entity) {
 		AbstractPojoTypeIndexingPlan delegate = getDelegate( typeIdentifier );
-		delegate.delete( providedId, entity );
+		delegate.delete( providedId, providedRoutingKey, entity );
 	}
 
 	@Override

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanImpl.java
@@ -62,15 +62,15 @@ public class PojoIndexingPlanImpl<R> implements PojoIndexingPlan<R> {
 	}
 
 	@Override
-	public void addOrUpdate(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, Object entity) {
+	public void addOrUpdate(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, String providedRoutingKey, Object entity) {
 		AbstractPojoTypeIndexingPlan delegate = getDelegate( typeIdentifier );
-		delegate.update( providedId, entity );
+		delegate.update( providedId, providedRoutingKey, entity );
 	}
 
 	@Override
-	public void addOrUpdate(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, Object entity, String... dirtyPaths) {
+	public void addOrUpdate(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, String providedRoutingKey, Object entity, String... dirtyPaths) {
 		AbstractPojoTypeIndexingPlan delegate = getDelegate( typeIdentifier );
-		delegate.update( providedId, entity, dirtyPaths );
+		delegate.update( providedId, providedRoutingKey, entity, dirtyPaths );
 	}
 
 	@Override

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanImpl.java
@@ -56,9 +56,9 @@ public class PojoIndexingPlanImpl<R> implements PojoIndexingPlan<R> {
 	}
 
 	@Override
-	public void add(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, Object entity) {
+	public void add(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, String providedRoutingKey, Object entity) {
 		AbstractPojoTypeIndexingPlan delegate = getDelegate( typeIdentifier );
-		delegate.add( providedId, entity );
+		delegate.add( providedId, providedRoutingKey, entity );
 	}
 
 	@Override

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoTypeIndexer.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoTypeIndexer.java
@@ -29,14 +29,13 @@ public class PojoTypeIndexer<I, E> {
 		this.delegate = delegate;
 	}
 
-	CompletableFuture<?> add(Object providedId, Object entity,
+	CompletableFuture<?> add(Object providedId, String providedRoutingKey, Object entity,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
 		Supplier<E> entitySupplier = typeContext.toEntitySupplier( sessionContext, entity );
 		I identifier = typeContext.getIdentifierMapping().getIdentifier( providedId, entitySupplier );
 
 		DocumentReferenceProvider referenceProvider = typeContext.toDocumentReferenceProvider(
-				// TODO HSEARCH-3891 expose the providedRoutingKey
-				sessionContext, identifier, null, entitySupplier
+				sessionContext, identifier, providedRoutingKey, entitySupplier
 		);
 		return delegate.add( referenceProvider, typeContext.toDocumentContributor( entitySupplier, sessionContext ),
 				commitStrategy, refreshStrategy );

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoTypeIndexer.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoTypeIndexer.java
@@ -52,13 +52,12 @@ public class PojoTypeIndexer<I, E> {
 				commitStrategy, refreshStrategy );
 	}
 
-	CompletableFuture<?> delete(Object providedId, Object entity,
+	CompletableFuture<?> delete(Object providedId, String providedRoutingKey, Object entity,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
 		Supplier<E> entitySupplier = typeContext.toEntitySupplier( sessionContext, entity );
 		I identifier = typeContext.getIdentifierMapping().getIdentifier( providedId, entitySupplier );
 		DocumentReferenceProvider referenceProvider = typeContext.toDocumentReferenceProvider(
-				// TODO HSEARCH-3891 expose the providedRoutingKey
-				sessionContext, identifier, null, entitySupplier
+				sessionContext, identifier, providedRoutingKey, entitySupplier
 		);
 		return delegate.delete( referenceProvider, commitStrategy, refreshStrategy );
 	}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoTypeIndexer.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoTypeIndexer.java
@@ -41,13 +41,12 @@ public class PojoTypeIndexer<I, E> {
 				commitStrategy, refreshStrategy );
 	}
 
-	CompletableFuture<?> addOrUpdate(Object providedId, Object entity,
+	CompletableFuture<?> addOrUpdate(Object providedId, String providedRoutingKey, Object entity,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
 		Supplier<E> entitySupplier = typeContext.toEntitySupplier( sessionContext, entity );
 		I identifier = typeContext.getIdentifierMapping().getIdentifier( providedId, entitySupplier );
 		DocumentReferenceProvider referenceProvider = typeContext.toDocumentReferenceProvider(
-				// TODO HSEARCH-3891 expose the providedRoutingKey
-				sessionContext, identifier, null, entitySupplier
+				sessionContext, identifier, providedRoutingKey, entitySupplier
 		);
 		return delegate.update( referenceProvider, typeContext.toDocumentContributor( entitySupplier, sessionContext ),
 				commitStrategy, refreshStrategy );

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoTypeIndexer.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoTypeIndexer.java
@@ -33,8 +33,10 @@ public class PojoTypeIndexer<I, E> {
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
 		Supplier<E> entitySupplier = typeContext.toEntitySupplier( sessionContext, entity );
 		I identifier = typeContext.getIdentifierMapping().getIdentifier( providedId, entitySupplier );
+
 		DocumentReferenceProvider referenceProvider = typeContext.toDocumentReferenceProvider(
-				sessionContext, identifier, entitySupplier
+				// TODO HSEARCH-3891 expose the providedRoutingKey
+				sessionContext, identifier, null, entitySupplier
 		);
 		return delegate.add( referenceProvider, typeContext.toDocumentContributor( entitySupplier, sessionContext ),
 				commitStrategy, refreshStrategy );
@@ -45,7 +47,8 @@ public class PojoTypeIndexer<I, E> {
 		Supplier<E> entitySupplier = typeContext.toEntitySupplier( sessionContext, entity );
 		I identifier = typeContext.getIdentifierMapping().getIdentifier( providedId, entitySupplier );
 		DocumentReferenceProvider referenceProvider = typeContext.toDocumentReferenceProvider(
-				sessionContext, identifier, entitySupplier
+				// TODO HSEARCH-3891 expose the providedRoutingKey
+				sessionContext, identifier, null, entitySupplier
 		);
 		return delegate.update( referenceProvider, typeContext.toDocumentContributor( entitySupplier, sessionContext ),
 				commitStrategy, refreshStrategy );
@@ -56,7 +59,8 @@ public class PojoTypeIndexer<I, E> {
 		Supplier<E> entitySupplier = typeContext.toEntitySupplier( sessionContext, entity );
 		I identifier = typeContext.getIdentifierMapping().getIdentifier( providedId, entitySupplier );
 		DocumentReferenceProvider referenceProvider = typeContext.toDocumentReferenceProvider(
-				sessionContext, identifier, entitySupplier
+				// TODO HSEARCH-3891 expose the providedRoutingKey
+				sessionContext, identifier, null, entitySupplier
 		);
 		return delegate.delete( referenceProvider, commitStrategy, refreshStrategy );
 	}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkIndexedTypeContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkIndexedTypeContext.java
@@ -33,7 +33,7 @@ public interface PojoWorkIndexedTypeContext<I, E> {
 	Supplier<E> toEntitySupplier(PojoWorkSessionContext<?> sessionContext, Object entity);
 
 	DocumentReferenceProvider toDocumentReferenceProvider(PojoWorkSessionContext<?> sessionContext,
-			I identifier, Supplier<E> entitySupplier);
+			I identifier, String providedRoutingKey, Supplier<E> entitySupplier);
 
 	DocumentReferenceProvider toDocumentReferenceProvider(PojoWorkSessionContext<?> sessionContext,
 			I identifier, String providedRoutingKey);

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexer.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexer.java
@@ -33,12 +33,15 @@ public interface PojoIndexer {
 	 * @param providedId A value to extract the document ID from.
 	 * Generally the expected value is the entity ID, but a different value may be expected depending on the mapping.
 	 * If {@code null}, Hibernate Search will attempt to extract the ID from the entity.
+	 * @param providedRoutingKey The routing key to route the add request to the appropriate index shard.
+	 * Leave {@code null} if sharding is disabled
+	 * or to have Hibernate Search compute the value through the assigned {@link org.hibernate.search.mapper.pojo.bridge.RoutingKeyBridge}.
 	 * @param entity The entity to add to the index.
 	 * @param commitStrategy How to handle the commit.
 	 * @param refreshStrategy How to handle the refresh.
 	 * @return A {@link CompletableFuture} reflecting the completion state of the operation.
 	 */
-	CompletableFuture<?> add(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, Object entity,
+	CompletableFuture<?> add(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, String providedRoutingKey, Object entity,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy);
 
 	/**

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexer.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexer.java
@@ -75,12 +75,15 @@ public interface PojoIndexer {
 	 * @param providedId A value to extract the document ID from.
 	 * Generally the expected value is the entity ID, but a different value may be expected depending on the mapping.
 	 * If {@code null}, Hibernate Search will attempt to extract the ID from the entity.
+	 * @param providedRoutingKey The routing key to route the delete request to the appropriate index shard.
+	 * Leave {@code null} if sharding is disabled
+	 * or to have Hibernate Search compute the value through the assigned {@link org.hibernate.search.mapper.pojo.bridge.RoutingKeyBridge}.
 	 * @param entity The entity to delete from the index.
 	 * @param commitStrategy How to handle the commit.
 	 * @param refreshStrategy How to handle the refresh.
 	 * @return A {@link CompletableFuture} reflecting the completion state of the operation.
 	 */
-	CompletableFuture<?> delete(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, Object entity,
+	CompletableFuture<?> delete(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, String providedRoutingKey, Object entity,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy);
 
 	/**

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexer.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexer.java
@@ -53,12 +53,15 @@ public interface PojoIndexer {
 	 * @param providedId A value to extract the document ID from.
 	 * Generally the expected value is the entity ID, but a different value may be expected depending on the mapping.
 	 * If {@code null}, Hibernate Search will attempt to extract the ID from the entity.
+	 * @param providedRoutingKey The routing key to route the addOrUpdate request to the appropriate index shard.
+	 * Leave {@code null} if sharding is disabled
+	 * or to have Hibernate Search compute the value through the assigned {@link org.hibernate.search.mapper.pojo.bridge.RoutingKeyBridge}.
 	 * @param entity The entity to update in the index.
 	 * @param commitStrategy How to handle the commit.
 	 * @param refreshStrategy How to handle the refresh.
 	 * @return A {@link CompletableFuture} reflecting the completion state of the operation.
 	 */
-	CompletableFuture<?> addOrUpdate(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, Object entity,
+	CompletableFuture<?> addOrUpdate(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, String providedRoutingKey, Object entity,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy);
 
 	/**

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexingPlan.java
@@ -35,7 +35,7 @@ public interface PojoIndexingPlan<R> {
 	 * <p>
 	 * <strong>Note:</strong> depending on the backend, this may lead to errors or duplicate entries in the index
 	 * if the entity was actually already present in the index before this call.
-	 * When in doubt, you should rather use {@link #addOrUpdate(PojoRawTypeIdentifier, Object, Object)}.
+	 * When in doubt, you should rather use {@link #addOrUpdate(PojoRawTypeIdentifier, Object, String, Object)}.
 	 *
 	 * @param typeIdentifier The identifier of the entity type.
 	 * @param providedId A value to extract the document ID from.
@@ -55,9 +55,12 @@ public interface PojoIndexingPlan<R> {
 	 * @param providedId A value to extract the document ID from.
 	 * Generally the expected value is the entity ID, but a different value may be expected depending on the mapping.
 	 * If {@code null}, Hibernate Search will attempt to extract the ID from the entity.
+	 * @param providedRoutingKey The routing key to route the addOrUpdate request to the appropriate index shard.
+	 * Leave {@code null} if sharding is disabled
+	 * or to have Hibernate Search compute the value through the assigned {@link org.hibernate.search.mapper.pojo.bridge.RoutingKeyBridge}.
 	 * @param entity The entity to update in the index.
 	 */
-	void addOrUpdate(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, Object entity);
+	void addOrUpdate(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, String providedRoutingKey, Object entity);
 
 	/**
 	 * Update an entity in the index, or add it if it's absent from the index,
@@ -68,11 +71,14 @@ public interface PojoIndexingPlan<R> {
 	 * @param providedId A value to extract the document ID from.
 	 * Generally the expected value is the entity ID, but a different value may be expected depending on the mapping.
 	 * If {@code null}, Hibernate Search will attempt to extract the ID from the entity.
+	 * @param providedRoutingKey The routing key to route the addOrUpdate request to the appropriate index shard.
+	 * Leave {@code null} if sharding is disabled
+	 * or to have Hibernate Search compute the value through the assigned {@link org.hibernate.search.mapper.pojo.bridge.RoutingKeyBridge}.
 	 * @param entity The entity to update in the index.
 	 * @param dirtyPaths The paths to consider dirty, formatted using the dot-notation
 	 * ("directEntityProperty.nestedPropery").
 	 */
-	void addOrUpdate(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, Object entity, String... dirtyPaths);
+	void addOrUpdate(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, String providedRoutingKey, Object entity, String... dirtyPaths);
 
 	/**
 	 * Delete an entity from the index.

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexingPlan.java
@@ -89,9 +89,12 @@ public interface PojoIndexingPlan<R> {
 	 * @param providedId A value to extract the document ID from.
 	 * Generally the expected value is the entity ID, but a different value may be expected depending on the mapping.
 	 * If {@code null}, Hibernate Search will attempt to extract the ID from the entity.
+	 * @param providedRoutingKey The routing key to route the delete request to the appropriate index shard.
+	 * Leave {@code null} if sharding is disabled
+	 * or to have Hibernate Search compute the value through the assigned {@link org.hibernate.search.mapper.pojo.bridge.RoutingKeyBridge}.
 	 * @param entity The entity to delete from the index.
 	 */
-	void delete(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, Object entity);
+	void delete(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, String providedRoutingKey, Object entity);
 
 	/**
 	 * Purge an entity from the index.

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexingPlan.java
@@ -41,9 +41,12 @@ public interface PojoIndexingPlan<R> {
 	 * @param providedId A value to extract the document ID from.
 	 * Generally the expected value is the entity ID, but a different value may be expected depending on the mapping.
 	 * If {@code null}, Hibernate Search will attempt to extract the ID from the entity.
+	 * @param providedRoutingKey The routing key to route the add request to the appropriate index shard.
+	 * Leave {@code null} if sharding is disabled
+	 * or to have Hibernate Search compute the value through the assigned {@link org.hibernate.search.mapper.pojo.bridge.RoutingKeyBridge}.
 	 * @param entity The entity to add to the index.
 	 */
-	void add(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, Object entity);
+	void add(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, String providedRoutingKey, Object entity);
 
 	/**
 	 * Update an entity in the index, or add it if it's absent from the index.


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3891

~~draft since I haven't added the tests~~ done!