### PR TITLE
HSEARCH-3311 Test (and document) alternatives to analyzer discriminators in Search 6

### DIFF
--- a/documentation/src/main/asciidoc/reference/mapper-orm-mapping-alternatives.asciidoc
+++ b/documentation/src/main/asciidoc/reference/mapper-orm-mapping-alternatives.asciidoc
@@ -1,0 +1,116 @@
+[[mapper-orm-alternatives]]
+= Mapping multiple alternatives
+// Search 5 anchors backward compatibility
+[[_dynamic_analyzer_selection]]
+
+== Basics
+
+In some situations, it is necessary for a particular property to be indexed differently
+depending on the value of another property.
+
+For example there may be an entity that has text properties whose content
+is in a different language depending on the value of another property, say `language`.
+In that case, you probably want to analyze the text differently depending on the language.
+
+While this could definitely be solved with a custom <<mapper-orm-bridge-typebridge,type bridge>>,
+a convenient solution to that problem is to use the `AlternativeBinder`.
+This binder solves the problem this way:
+
+* at bootstrap, declare one index field per language, assigning a different analyzer to each field;
+* at runtime, put the content of the text property in a different field based on the language.
+
+In order to use this binder, you will need to:
+
+* annotate a property with `@AlternativeDiscriminator` (e.g. the `language` property);
+* implement an `AlternativeBinderDelegate` that will declare the index fields
+(e.g. one field per language) and create an `AlternativeValueBridge`.
+This bridge is responsible for passing the property value to the relevant field at runtime.
+* apply the `AlternativeBinder` to the type hosting the properties
+(e.g. the type declaring the `language` property and the multi-language text properties).
+Generally you will want to create your own annotation for that.
+
+Below is an example of how to use the binder.
+
+[[example-analyzer-discriminator]]
+.Mapping a property to a different index field based on a `language` property using `AlternativeBinder`
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/alternative/alternativebinder/Language.java[tags=include]
+----
+<1> A `Language` enum defines supported languages.
+
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/alternative/alternativebinder/BlogEntry.java[tags=include;!getters-setters]
+----
+<1> Mark the `language` property as the discriminator which will be used to determine the language.
+<2> Map the `text` property to multiple fields using a custom annotation.
+
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/alternative/alternativebinder/MultiLanguageField.java[tags=include]
+----
+<1> Define an annotation with retention `RUNTIME`.
+*Any other retention policy will cause the annotation to be ignored by Hibernate Search*.
+<2> Allow the annotation to target either methods (getters) or fields.
+<3> Mark this annotation as a property mapping,
+and instruct Hibernate Search to apply the given processor whenever it finds this annotation.
+It is also possible to reference the processor by its name, in the case of a CDI/Spring bean.
+<4> Optionally, mark the annotation as documented,
+so that it is included in the javadoc of your entities.
+<5> Optionally, define parameters. Here we allow to customize the field name
+(which will default to the property name, see further down).
+<6> The processor must implement the `PropertyMappingAnnotationProcessor` interface,
+setting its generic type argument to the type of the corresponding annotation.
+Here the processor class is nested in the annotation class,
+because it is more convenient,
+but you are obviously free to implement it in a separate Java file.
+<7> In the annotation processor, instantiate a custom binder delegate
+(see below for the implementation).
+<8> Access the mapping of the type hosting the property (in this example, `BlogEntry`).
+<9> Apply the `AlternativeBinder` to the type hosting the property (in this example, `BlogEntry`).
+<10> Pass to `AlternativeBinder` the expected type of discriminator values.
+<11> Pass to `AlternativeBinder` the name of the property from which field values should be extracted
+(in this example, `text`).
+<12> Pass to `AlternativeBinder` the expected type of the property from which index field values are extracted.
+<13> Pass to `AlternativeBinder` the binder delegate.
+
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/alternative/alternativebinder/LanguageAlternativeBinderDelegate.java[tags=include]
+----
+<1> The binder delegate must implement `AlternativeBinderDelegate`.
+The first type parameter is the expected type of discriminator values (in this example, `Language`);
+the second type parameter is the expected type of the property from which field values are extracted
+(in this example, `String`).
+<2> Any (custom) parameter can be passed through the constructor.
+<3> Implement `bind`, to bind a property to index fields.
+<4> Define one field per language.
+<5> Make sure to give a different name to each field.
+Here we're using the language code as a suffix, i.e. `text_en`, `text_fr`, `text_de`, ...
+<6> Assign a different analyzer to each field.
+The analyzers `text_en`, `text_fr`, `text_de` must have been defined in the backend;
+see <<concepts-analysis>>.
+<7> Return a bridge.
+<8> The bridge must implement the `AlternativeValueBridge` interface.
+Here the bridge class is nested in the binder class,
+because it is more convenient,
+but you are obviously free to implement it in a separate java file.
+<9> The bridge is called when indexing; it selects the field to write to based on the discriminator value,
+then writes the value to index to that field.
+====
+
+[[mapper-orm-alternatives-programmatic]]
+== Programmatic mapping
+
+You can apply `AlternativeBinder` through the <<mapper-orm-programmatic-mapping,programmatic mapping>> too.
+Behavior and options are identical to annotation-based mapping.
+
+.Mapping a property to a different index field based on a `language` property using `AlternativeBinder`
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/alternative/alternativebinder/AlternativeBinderIT.java[tags=programmatic]
+----
+====

--- a/documentation/src/main/asciidoc/reference/mapper-orm-mapping.asciidoc
+++ b/documentation/src/main/asciidoc/reference/mapper-orm-mapping.asciidoc
@@ -21,6 +21,8 @@ include::mapper-orm-mapping-containerextractor.asciidoc[]
 
 include::mapper-orm-mapping-geopoint.asciidoc[]
 
+include::mapper-orm-mapping-alternatives.asciidoc[]
+
 include::mapper-orm-mapping-reindexing.asciidoc[]
 
 include::mapper-orm-mapping-changes.asciidoc[]

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/alternative/alternativebinder/AlternativeBinderIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/alternative/alternativebinder/AlternativeBinderIT.java
@@ -1,0 +1,94 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.documentation.mapper.orm.alternative.alternativebinder;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import javax.persistence.EntityManagerFactory;
+
+import org.hibernate.search.documentation.testsupport.BackendConfigurations;
+import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
+import org.hibernate.search.engine.environment.bean.BeanReference;
+import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.orm.session.SearchSession;
+import org.hibernate.search.mapper.pojo.bridge.builtin.programmatic.AlternativeBinder;
+import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class AlternativeBinderIT {
+	@Parameterized.Parameters(name = "{0}")
+	public static List<?> params() {
+		return DocumentationSetupHelper.testParamsForBothAnnotationsAndProgrammatic(
+				BackendConfigurations.simple(),
+				mapping -> {
+					//tag::programmatic[]
+					TypeMappingStep blogEntryMapping = mapping.type( BlogEntry.class );
+					blogEntryMapping.indexed();
+					blogEntryMapping.property( "language" )
+							.marker( AlternativeBinder.alternativeDiscriminator() );
+					LanguageAlternativeBinderDelegate delegate = new LanguageAlternativeBinderDelegate( null );
+					blogEntryMapping.binder( AlternativeBinder.create( Language.class,
+							"text", String.class, BeanReference.ofInstance( delegate ) ) );
+					//end::programmatic[]
+				} );
+	}
+
+	@Parameterized.Parameter
+	@Rule
+	public DocumentationSetupHelper setupHelper;
+
+	private EntityManagerFactory entityManagerFactory;
+
+	@Before
+	public void setup() {
+		entityManagerFactory = setupHelper.start().setup( BlogEntry.class );
+	}
+
+	@Test
+	public void smoke() {
+		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+			BlogEntry entry1 = new BlogEntry();
+			entry1.setId( 1 );
+			entry1.setLanguage( Language.GERMAN );
+			entry1.setText( "Auf Französisch ist „Wiedervereinigung“ „réunification“" );
+			BlogEntry entry2 = new BlogEntry();
+			entry2.setId( 2 );
+			entry2.setLanguage( Language.FRENCH );
+			entry2.setText( "En Allemand, « réunification » se dit « Wierdervereinigung »" );
+
+			entityManager.persist( entry1 );
+			entityManager.persist( entry2 );
+		} );
+
+		OrmUtils.withinJPATransaction( entityManagerFactory, entityManager -> {
+			SearchSession searchSession = Search.session( entityManager );
+
+			// Only matches the german text, because the word is decomposed
+			assertThat( searchSession.search( BlogEntry.class )
+					.where( f -> f.match().fields( "text_en", "text_de", "text_fr" )
+							.matching( "vereinigung" ) )
+					.fetchHits( 20 ) )
+					.extracting( BlogEntry::getId ).containsExactly( 1 );
+			// Better score for the german text, because the word is decomposed
+			assertThat( searchSession.search( BlogEntry.class )
+					.where( f -> f.match().fields( "text_en", "text_de", "text_fr" )
+							.matching( "Wierdervereinigung" ) )
+					.fetchHits( 20 ) )
+					.extracting( BlogEntry::getId ).containsExactly( 1, 2 );
+		} );
+	}
+
+}

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/alternative/alternativebinder/BlogEntry.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/alternative/alternativebinder/BlogEntry.java
@@ -1,0 +1,61 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.documentation.mapper.orm.alternative.alternativebinder;
+
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Id;
+
+import org.hibernate.search.mapper.pojo.bridge.builtin.annotation.AlternativeDiscriminator;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+//tag::include[]
+@Entity
+@Indexed
+public class BlogEntry {
+
+	@Id
+	private Integer id;
+
+	@AlternativeDiscriminator // <1>
+	@Enumerated(EnumType.STRING)
+	private Language language;
+
+	@MultiLanguageField // <2>
+	private String text;
+
+	// Getters and setters
+	// ...
+
+	//tag::getters-setters[]
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public Language getLanguage() {
+		return language;
+	}
+
+	public void setLanguage(Language language) {
+		this.language = language;
+	}
+
+	public String getText() {
+		return text;
+	}
+
+	public void setText(String text) {
+		this.text = text;
+	}
+	//end::getters-setters[]
+}
+//end::include[]

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/alternative/alternativebinder/Language.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/alternative/alternativebinder/Language.java
@@ -1,0 +1,22 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.documentation.mapper.orm.alternative.alternativebinder;
+
+//tag::include[]
+public enum Language { // <1>
+
+	ENGLISH( "en" ),
+	FRENCH( "fr" ),
+	GERMAN( "de" );
+
+	public final String code;
+
+	Language(String code) {
+		this.code = code;
+	}
+}
+//end::include[]

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/alternative/alternativebinder/LanguageAlternativeBinderDelegate.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/alternative/alternativebinder/LanguageAlternativeBinderDelegate.java
@@ -1,0 +1,59 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.documentation.mapper.orm.alternative.alternativebinder;
+
+import java.util.EnumMap;
+
+import org.hibernate.search.engine.backend.document.DocumentElement;
+import org.hibernate.search.engine.backend.document.IndexFieldReference;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.mapper.pojo.bridge.builtin.programmatic.AlternativeBinderDelegate;
+import org.hibernate.search.mapper.pojo.bridge.builtin.programmatic.AlternativeValueBridge;
+import org.hibernate.search.mapper.pojo.model.PojoModelProperty;
+
+//tag::include[]
+public class LanguageAlternativeBinderDelegate implements AlternativeBinderDelegate<Language, String> { // <1>
+
+	private final String name;
+
+	public LanguageAlternativeBinderDelegate(String name) { // <2>
+		this.name = name;
+	}
+
+	@Override
+	public AlternativeValueBridge<Language, String> bind(IndexSchemaElement indexSchemaElement, // <3>
+			PojoModelProperty fieldValueSource) {
+		EnumMap<Language, IndexFieldReference<String>> fields = new EnumMap<>( Language.class );
+		String fieldNamePrefix = ( name != null ? name : fieldValueSource.name() ) + "_";
+
+		for ( Language language : Language.values() ) { // <4>
+			String languageCode = language.code;
+			IndexFieldReference<String> field = indexSchemaElement.field(
+					fieldNamePrefix + languageCode, // <5>
+					f -> f.asString().analyzer( "text_" + languageCode ) // <6>
+			)
+					.toReference();
+			fields.put( language, field );
+		}
+
+		return new Bridge( fields ); // <7>
+	}
+
+	private static class Bridge implements AlternativeValueBridge<Language, String> { // <8>
+		private final EnumMap<Language, IndexFieldReference<String>> fields;
+
+		private Bridge(EnumMap<Language, IndexFieldReference<String>> fields) {
+			this.fields = fields;
+		}
+
+		@Override
+		public void write(DocumentElement target, Language discriminator, String bridgedElement) {
+			target.addValue( fields.get( discriminator ), bridgedElement ); // <9>
+		}
+	}
+}
+//end::include[]

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/alternative/alternativebinder/MultiLanguageField.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/alternative/alternativebinder/MultiLanguageField.java
@@ -1,0 +1,51 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.documentation.mapper.orm.alternative.alternativebinder;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.hibernate.search.engine.environment.bean.BeanReference;
+import org.hibernate.search.mapper.pojo.bridge.builtin.programmatic.AlternativeBinder;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMapping;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMappingAnnotationProcessor;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMappingAnnotationProcessorContext;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMappingAnnotationProcessorRef;
+import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.PropertyMappingStep;
+
+//tag::include[]
+@Retention(RetentionPolicy.RUNTIME) // <1>
+@Target({ ElementType.METHOD, ElementType.FIELD }) // <2>
+@PropertyMapping(processor = @PropertyMappingAnnotationProcessorRef( // <3>
+		type = MultiLanguageField.Processor.class
+))
+@Documented // <4>
+public @interface MultiLanguageField {
+
+	String name() default ""; // <5>
+
+	class Processor implements PropertyMappingAnnotationProcessor<MultiLanguageField> { // <6>
+		@Override
+		public void process(PropertyMappingStep mapping, MultiLanguageField annotation,
+				PropertyMappingAnnotationProcessorContext context) {
+			LanguageAlternativeBinderDelegate delegate = new LanguageAlternativeBinderDelegate( // <7>
+					annotation.name().isEmpty() ? null : annotation.name()
+			);
+			mapping.hostingType() // <8>
+					.binder( AlternativeBinder.create( // <9>
+							Language.class, // <10>
+							context.annotatedElement().name(), // <11>
+							String.class, // <12>
+							BeanReference.ofInstance( delegate ) // <13>
+					) );
+		}
+	}
+}
+//end::include[]

--- a/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/parameter/PropertyBridgeParameterIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/parameter/PropertyBridgeParameterIT.java
@@ -34,9 +34,9 @@ public class PropertyBridgeParameterIT {
 				BackendConfigurations.simple(),
 				mapping -> {
 					//tag::programmatic[]
-					TypeMappingStep bookMapping = mapping.type( Invoice.class );
-					bookMapping.indexed();
-					bookMapping.property( "lineItems" )
+					TypeMappingStep invoiceMapping = mapping.type( Invoice.class );
+					invoiceMapping.indexed();
+					invoiceMapping.property( "lineItems" )
 							.binder( new InvoiceLineItemsSummaryBinder().fieldName( "itemSummary" ) );
 					//end::programmatic[]
 				} );

--- a/documentation/src/test/java/org/hibernate/search/documentation/testsupport/ElasticsearchSimpleMappingAnalysisConfigurer.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/testsupport/ElasticsearchSimpleMappingAnalysisConfigurer.java
@@ -52,5 +52,29 @@ class ElasticsearchSimpleMappingAnalysisConfigurer implements ElasticsearchAnaly
 		context.charFilter( "removeHyphens" ).type( "pattern_replace" )
 				.param( "pattern", "-+" )
 				.param( "replacement", "" );
+
+		// For AlternativeBinderIT
+
+		context.analyzer( "text_en" ).custom()
+				.tokenizer( "standard" )
+				.tokenFilters( "lowercase", "snowball_english", "asciifolding" );
+		context.analyzer( "text_fr" ).custom()
+				.tokenizer( "standard" )
+				.tokenFilters( "lowercase", "snowball_french", "asciifolding" );
+		context.analyzer( "text_de" ).custom()
+				.tokenizer( "standard" )
+				.tokenFilters( "lowercase", "decompounder_german", "snowball_german", "asciifolding" );
+
+		context.tokenFilter( "snowball_french" )
+				.type( "snowball" )
+				.param( "language", "French" );
+
+		context.tokenFilter( "decompounder_german" )
+				.type( "dictionary_decompounder" )
+				.param( "word_list", "wieder", "vereinigung" );
+
+		context.tokenFilter( "snowball_german" )
+				.type( "snowball" )
+				.param( "language", "German" );
 	}
 }

--- a/documentation/src/test/java/org/hibernate/search/documentation/testsupport/LuceneSimpleMappingAnalysisConfigurer.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/testsupport/LuceneSimpleMappingAnalysisConfigurer.java
@@ -9,6 +9,7 @@ package org.hibernate.search.documentation.testsupport;
 import org.hibernate.search.backend.lucene.analysis.LuceneAnalysisConfigurationContext;
 import org.hibernate.search.backend.lucene.analysis.LuceneAnalysisConfigurer;
 
+import org.apache.lucene.analysis.compound.DictionaryCompoundWordTokenFilterFactory;
 import org.apache.lucene.analysis.core.LowerCaseFilterFactory;
 import org.apache.lucene.analysis.miscellaneous.ASCIIFoldingFilterFactory;
 import org.apache.lucene.analysis.ngram.EdgeNGramFilterFactory;
@@ -63,5 +64,28 @@ class LuceneSimpleMappingAnalysisConfigurer implements LuceneAnalysisConfigurer 
 				.charFilter( PatternReplaceCharFilterFactory.class )
 						.param( "pattern", "-+" )
 						.param( "replacement", "" );
+
+		// For AlternativeBinderIT
+
+		context.analyzer( "text_en" ).custom()
+				.tokenizer( StandardTokenizerFactory.class )
+				.tokenFilter( LowerCaseFilterFactory.class )
+				.tokenFilter( SnowballPorterFilterFactory.class )
+						.param( "language", "English" )
+				.tokenFilter( ASCIIFoldingFilterFactory.class );
+		context.analyzer( "text_fr" ).custom()
+				.tokenizer( StandardTokenizerFactory.class )
+				.tokenFilter( LowerCaseFilterFactory.class )
+				.tokenFilter( SnowballPorterFilterFactory.class )
+						.param( "language", "French" )
+				.tokenFilter( ASCIIFoldingFilterFactory.class );
+		context.analyzer( "text_de" ).custom()
+				.tokenizer( StandardTokenizerFactory.class )
+				.tokenFilter( LowerCaseFilterFactory.class )
+				.tokenFilter( DictionaryCompoundWordTokenFilterFactory.class )
+						.param( "dictionary", "AlternativeBinderIT/dictionary_de.txt" )
+				.tokenFilter( SnowballPorterFilterFactory.class )
+						.param( "language", "German" )
+				.tokenFilter( ASCIIFoldingFilterFactory.class );
 	}
 }

--- a/documentation/src/test/resources/AlternativeBinderIT/dictionary_de.txt
+++ b/documentation/src/test/resources/AlternativeBinderIT/dictionary_de.txt
@@ -1,0 +1,2 @@
+wieder
+vereinigung

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/alternative/AlternativeBinderIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/alternative/AlternativeBinderIT.java
@@ -1,0 +1,203 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.mapping.alternative;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.lang.invoke.MethodHandles;
+
+import org.hibernate.search.engine.backend.types.Projectable;
+import org.hibernate.search.mapper.pojo.bridge.builtin.annotation.AlternativeDiscriminator;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.util.rule.JavaBeanMappingSetupHelper;
+import org.hibernate.search.mapper.javabean.mapping.SearchMapping;
+import org.hibernate.search.mapper.javabean.session.SearchSession;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.util.common.SearchException;
+import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.test.annotation.TestForIssue;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Test a particular use case for type bridges to provide a feature similar to
+ * {@code @AnalyzerDiscriminator} from Hibernate Search 5.
+ */
+@TestForIssue(jiraKey = "HSEARCH-3311")
+public class AlternativeBinderIT {
+
+	private static final String INDEX_NAME = "IndexName";
+
+	@Rule
+	public BackendMock backendMock = new BackendMock();
+
+	@Rule
+	public JavaBeanMappingSetupHelper setupHelper = JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );
+
+	@Test
+	public void smoke() {
+		@Indexed(index = INDEX_NAME)
+		class IndexedEntity {
+			Integer id;
+			Language language;
+			String title;
+			String text;
+			@DocumentId
+			public Integer getId() {
+				return id;
+			}
+
+			@AlternativeDiscriminator
+			public Language getLanguage() {
+				return language;
+			}
+
+			@MultiLanguageField(projectable = Projectable.YES)
+			public String getTitle() {
+				return title;
+			}
+
+			@MultiLanguageField(name = "content")
+			public String getText() {
+				return text;
+			}
+		}
+
+		backendMock.expectSchema( INDEX_NAME, b -> b
+				.field( "title_en", String.class,
+						b2 -> b2.analyzerName( "text_en" ).projectable( Projectable.YES ) )
+				.field( "title_fr", String.class,
+						b2 -> b2.analyzerName( "text_fr" ).projectable( Projectable.YES ) )
+				.field( "title_de", String.class,
+						b2 -> b2.analyzerName( "text_de" ).projectable( Projectable.YES ) )
+				.field( "content_en", String.class,
+						b2 -> b2.analyzerName( "text_en" ).projectable( Projectable.DEFAULT ) )
+				.field( "content_fr", String.class,
+						b2 -> b2.analyzerName( "text_fr" ).projectable( Projectable.DEFAULT ) )
+				.field( "content_de", String.class,
+						b2 -> b2.analyzerName( "text_de" ).projectable( Projectable.DEFAULT ) )
+		);
+
+		SearchMapping mapping = setupHelper.start().setup( IndexedEntity.class );
+		backendMock.verifyExpectationsMet();
+
+		IndexedEntity entity1 = new IndexedEntity();
+		entity1.id = 1;
+		entity1.language = Language.ENGLISH;
+		entity1.title = "A title in English";
+		entity1.text = "Some content in English";
+		IndexedEntity entity2 = new IndexedEntity();
+		entity2.id = 2;
+		entity2.language = Language.FRENCH;
+		entity2.title = "Un titre en Français";
+		entity2.text = "Du contenu en Français";
+
+		try ( SearchSession session = mapping.createSession() ) {
+			session.indexingPlan().add( entity1 );
+			session.indexingPlan().add( entity2 );
+
+			backendMock.expectWorks( INDEX_NAME )
+					.add( "1", b -> b
+							.field( "title_en", entity1.title )
+							.field( "content_en", entity1.text ) )
+					.add( "2", b -> b
+							.field( "title_fr", entity2.title )
+							.field( "content_fr", entity2.text ) )
+					.processedThenExecuted();
+		}
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void discriminator_missing() {
+		@Indexed(index = INDEX_NAME)
+		class IndexedEntity {
+			Integer id;
+			Language language;
+			String title;
+			String text;
+			@DocumentId
+			public Integer getId() {
+				return id;
+			}
+
+			public Language getLanguage() {
+				return language;
+			}
+
+			@MultiLanguageField(projectable = Projectable.YES)
+			public String getTitle() {
+				return title;
+			}
+
+			@MultiLanguageField(name = "content")
+			public String getText() {
+				return text;
+			}
+		}
+
+		assertThatThrownBy( () -> setupHelper.start().setup( IndexedEntity.class ) )
+				.isInstanceOf( SearchException.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.typeContext( IndexedEntity.class.getName() )
+						.failure( "Could not find any property marked with @Alternative(id = null).",
+								"There must be exactly one such property in order to map property 'text' to multi-alternative fields." )
+						.failure( "Could not find any property marked with @Alternative(id = null).",
+								"There must be exactly one such property in order to map property 'title' to multi-alternative fields." )
+						.build()
+				);
+	}
+
+	@Test
+	public void discriminator_conflict() {
+		@Indexed(index = INDEX_NAME)
+		class IndexedEntity {
+			Integer id;
+			Language language;
+			Language otherLanguage;
+			String title;
+			String text;
+			@DocumentId
+			public Integer getId() {
+				return id;
+			}
+
+			@AlternativeDiscriminator
+			public Language getLanguage() {
+				return language;
+			}
+
+			@AlternativeDiscriminator
+			public Language getOtherLanguage() {
+				return otherLanguage;
+			}
+
+			@MultiLanguageField(projectable = Projectable.YES)
+			public String getTitle() {
+				return title;
+			}
+
+			@MultiLanguageField(name = "content")
+			public String getText() {
+				return text;
+			}
+		}
+
+		assertThatThrownBy( () -> setupHelper.start().setup( IndexedEntity.class ) )
+				.isInstanceOf( SearchException.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.typeContext( IndexedEntity.class.getName() )
+						.failure( "Found multiple properties marked with @Alternative(id = null).",
+								"There must be exactly one such property in order to map property 'text' to multi-alternative fields." )
+						.failure( "Found multiple properties marked with @Alternative(id = null).",
+								"There must be exactly one such property in order to map property 'title' to multi-alternative fields." )
+						.build()
+				);
+	}
+}

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/alternative/Language.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/alternative/Language.java
@@ -1,0 +1,20 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.mapping.alternative;
+
+public enum Language {
+
+	ENGLISH( "en" ),
+	FRENCH( "fr" ),
+	GERMAN( "de" );
+
+	public final String code;
+
+	Language(String code) {
+		this.code = code;
+	}
+}

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/alternative/LanguageAlternativeBinderDelegate.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/alternative/LanguageAlternativeBinderDelegate.java
@@ -1,0 +1,59 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.mapping.alternative;
+
+import java.util.EnumMap;
+
+import org.hibernate.search.engine.backend.document.DocumentElement;
+import org.hibernate.search.engine.backend.document.IndexFieldReference;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.types.Projectable;
+import org.hibernate.search.mapper.pojo.bridge.builtin.programmatic.AlternativeBinderDelegate;
+import org.hibernate.search.mapper.pojo.bridge.builtin.programmatic.AlternativeValueBridge;
+import org.hibernate.search.mapper.pojo.model.PojoModelProperty;
+
+public class LanguageAlternativeBinderDelegate implements AlternativeBinderDelegate<Language, String> {
+
+	private final String name;
+	private final Projectable projectable;
+
+	public LanguageAlternativeBinderDelegate(String name, Projectable projectable) {
+		this.name = name;
+		this.projectable = projectable;
+	}
+
+	@Override
+	public AlternativeValueBridge<Language, String> bind(IndexSchemaElement indexSchemaElement,
+			PojoModelProperty fieldValueSource) {
+		EnumMap<Language, IndexFieldReference<String>> fields = new EnumMap<>( Language.class );
+		String fieldNamePrefix = ( name != null ? name : fieldValueSource.name() ) + "_";
+
+		for ( Language language : Language.values() ) {
+			IndexFieldReference<String> field = indexSchemaElement.field(
+					fieldNamePrefix + language.code,
+					f -> f.asString().analyzer( "text_" + language.code ).projectable( projectable )
+			)
+					.toReference();
+			fields.put( language, field );
+		}
+
+		return new Bridge( fields );
+	}
+
+	private static class Bridge implements AlternativeValueBridge<Language, String> {
+		private final EnumMap<Language, IndexFieldReference<String>> fields;
+
+		private Bridge(EnumMap<Language, IndexFieldReference<String>> fields) {
+			this.fields = fields;
+		}
+
+		@Override
+		public void write(DocumentElement target, Language discriminator, String bridgedElement) {
+			target.addValue( fields.get( discriminator ), bridgedElement );
+		}
+	}
+}

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/alternative/MultiLanguageField.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/alternative/MultiLanguageField.java
@@ -1,0 +1,55 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.mapping.alternative;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.hibernate.search.engine.backend.types.Projectable;
+import org.hibernate.search.engine.environment.bean.BeanReference;
+import org.hibernate.search.mapper.pojo.bridge.builtin.programmatic.AlternativeBinder;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMapping;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMappingAnnotationProcessor;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMappingAnnotationProcessorContext;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMappingAnnotationProcessorRef;
+import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.PropertyMappingStep;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.FIELD })
+@Documented
+@PropertyMapping(processor = @PropertyMappingAnnotationProcessorRef(type = MultiLanguageField.Processor.class))
+public @interface MultiLanguageField {
+
+	/**
+	 * @return The field name, if any.
+	 *
+	 * @see FullTextField#name()
+	 */
+	String name() default "";
+
+	/**
+	 * @return The field name, if any.
+	 *
+	 * @see FullTextField#projectable()
+	 */
+	Projectable projectable() default Projectable.DEFAULT;
+
+	class Processor implements PropertyMappingAnnotationProcessor<MultiLanguageField> {
+		@Override
+		public void process(PropertyMappingStep mapping, MultiLanguageField annotation,
+				PropertyMappingAnnotationProcessorContext context) {
+			LanguageAlternativeBinderDelegate delegate = new LanguageAlternativeBinderDelegate(
+					annotation.name().isEmpty() ? null : annotation.name(), annotation.projectable() );
+			mapping.hostingType().binder( AlternativeBinder.create( Language.class,
+					context.annotatedElement().name(), String.class, BeanReference.ofInstance( delegate ) ) );
+		}
+	}
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/alternative/impl/AlternativeBinderImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/alternative/impl/AlternativeBinderImpl.java
@@ -1,0 +1,113 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.bridge.builtin.alternative.impl;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Objects;
+
+import org.hibernate.search.engine.backend.document.DocumentElement;
+import org.hibernate.search.engine.environment.bean.BeanHolder;
+import org.hibernate.search.engine.environment.bean.BeanReference;
+import org.hibernate.search.mapper.pojo.bridge.TypeBridge;
+import org.hibernate.search.mapper.pojo.bridge.binding.TypeBindingContext;
+import org.hibernate.search.mapper.pojo.bridge.builtin.programmatic.AlternativeBinder;
+import org.hibernate.search.mapper.pojo.bridge.builtin.programmatic.AlternativeBinderDelegate;
+import org.hibernate.search.mapper.pojo.bridge.builtin.programmatic.AlternativeValueBridge;
+import org.hibernate.search.mapper.pojo.bridge.runtime.TypeBridgeWriteContext;
+import org.hibernate.search.mapper.pojo.logging.impl.Log;
+import org.hibernate.search.mapper.pojo.model.PojoElementAccessor;
+import org.hibernate.search.mapper.pojo.model.PojoModelProperty;
+import org.hibernate.search.mapper.pojo.model.PojoModelType;
+import org.hibernate.search.util.common.impl.StreamHelper;
+import org.hibernate.search.util.common.logging.impl.LoggerFactory;
+
+public final class AlternativeBinderImpl<D, P> implements AlternativeBinder {
+
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+
+	private final Class<D> discriminatorType;
+	private final String fieldValueSourcePropertyName;
+	private final Class<P> fieldValueSourcePropertyType;
+	private final BeanReference<? extends AlternativeBinderDelegate<D, P>> delegateRef;
+
+	private String alternativeId;
+
+	public AlternativeBinderImpl(Class<D> discriminatorType,
+			String fieldValueSourcePropertyName, Class<P> fieldValueSourcePropertyType,
+			BeanReference<? extends AlternativeBinderDelegate<D, P>> delegateRef) {
+		this.discriminatorType = discriminatorType;
+		this.fieldValueSourcePropertyName = fieldValueSourcePropertyName;
+		this.fieldValueSourcePropertyType = fieldValueSourcePropertyType;
+		this.delegateRef = delegateRef;
+	}
+
+	@Override
+	public AlternativeBinder alternativeId(String id) {
+		alternativeId = id;
+		return this;
+	}
+
+	@Override
+	public void bind(TypeBindingContext context) {
+		PojoModelType bridgedElement = context.bridgedElement();
+
+		PojoElementAccessor<D> discriminatorAccessor;
+		PojoElementAccessor<P> fieldValueSourceAccessor;
+		AlternativeValueBridge<D, P> bridgeDelegate;
+
+		try ( BeanHolder<? extends AlternativeBinderDelegate<D, P>> alternativeBinderHolder =
+				delegateRef.resolve( context.beanResolver() ) ) {
+			AlternativeBinderDelegate<D, P> delegate = alternativeBinderHolder.get();
+			discriminatorAccessor = findAlternativeDiscriminatorProperty( bridgedElement )
+					.createAccessor( discriminatorType );
+			PojoModelProperty fieldValueSource = bridgedElement.property( fieldValueSourcePropertyName );
+			fieldValueSourceAccessor = fieldValueSource.createAccessor( fieldValueSourcePropertyType );
+			bridgeDelegate = delegate.bind( context.indexSchemaElement(), fieldValueSource );
+		}
+
+		context.bridge( new Bridge<>( discriminatorAccessor, fieldValueSourceAccessor, bridgeDelegate ) );
+	}
+
+	private PojoModelProperty findAlternativeDiscriminatorProperty(PojoModelType bridgedElement) {
+		return bridgedElement.properties()
+				.filter( p -> p.markers( AlternativeDiscriminatorBinderImpl.Marker.class )
+						.anyMatch( m -> Objects.equals( m.id(), alternativeId ) ) )
+				.collect( StreamHelper.singleElement(
+						() -> log.cannotFindAlternativeDiscriminator( alternativeId, fieldValueSourcePropertyName ),
+						() -> log.conflictingAlternativeDiscriminators( alternativeId, fieldValueSourcePropertyName )
+				) );
+	}
+
+	private static final class Bridge<D, P> implements TypeBridge {
+		private final PojoElementAccessor<D> discriminatorAccessor;
+		private final PojoElementAccessor<P> fieldValueSourceAccessor;
+		private final AlternativeValueBridge<D, P> delegate;
+
+		private Bridge(PojoElementAccessor<D> discriminatorAccessor,
+				PojoElementAccessor<P> fieldValueSourceAccessor,
+				AlternativeValueBridge<D, P> delegate) {
+			this.discriminatorAccessor = discriminatorAccessor;
+			this.fieldValueSourceAccessor = fieldValueSourceAccessor;
+			this.delegate = delegate;
+		}
+
+		@Override
+		public String toString() {
+			return getClass().getSimpleName() + "["
+					+ "discriminatorAccessor=" + discriminatorAccessor
+					+ ", fieldValueSourceAccessor=" + fieldValueSourceAccessor
+					+ ", delegate=" + delegate
+					+ "]";
+		}
+
+		@Override
+		public void write(DocumentElement target, Object bridgedElement, TypeBridgeWriteContext context) {
+			delegate.write( target, discriminatorAccessor.read( bridgedElement ),
+					fieldValueSourceAccessor.read( bridgedElement ) );
+		}
+	}
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/alternative/impl/AlternativeDiscriminatorBinderImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/alternative/impl/AlternativeDiscriminatorBinderImpl.java
@@ -1,0 +1,40 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.bridge.builtin.alternative.impl;
+
+import org.hibernate.search.mapper.pojo.bridge.binding.MarkerBindingContext;
+import org.hibernate.search.mapper.pojo.bridge.builtin.programmatic.AlternativeDiscriminatorBinder;
+
+public final class AlternativeDiscriminatorBinderImpl implements AlternativeDiscriminatorBinder {
+
+	private String id;
+
+	@Override
+	public AlternativeDiscriminatorBinder id(String id) {
+		this.id = id;
+		return this;
+	}
+
+	@Override
+	public void bind(MarkerBindingContext context) {
+		context.marker( new Marker( id ) );
+	}
+
+	public static final class Marker {
+
+		private final String id;
+
+		private Marker(String id) {
+			this.id = id;
+		}
+
+		public String id() {
+			return id;
+		}
+
+	}
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/annotation/AlternativeDiscriminator.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/annotation/AlternativeDiscriminator.java
@@ -1,0 +1,38 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.bridge.builtin.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.hibernate.search.mapper.pojo.bridge.builtin.annotation.processor.impl.AlternativeDiscriminatorProcessor;
+import org.hibernate.search.mapper.pojo.bridge.builtin.programmatic.AlternativeBinder;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMapping;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMappingAnnotationProcessorRef;
+import org.hibernate.search.util.common.annotation.Incubating;
+
+/**
+ * Mark the property as an alternative discriminator for use in {@link AlternativeBinder}.
+ *
+ * @see AlternativeBinder
+ */
+@Incubating
+@Target( { ElementType.FIELD, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@PropertyMapping(processor = @PropertyMappingAnnotationProcessorRef(type = AlternativeDiscriminatorProcessor.class))
+public @interface AlternativeDiscriminator {
+
+	/**
+	 * @return identifier of the alternative.
+	 * This is used to differentiate between multiple alternative discriminators.
+	 * @see AlternativeBinder#alternativeId(String)
+	 */
+	String id() default "";
+
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/annotation/processor/impl/AlternativeDiscriminatorProcessor.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/annotation/processor/impl/AlternativeDiscriminatorProcessor.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.bridge.builtin.annotation.processor.impl;
+
+import org.hibernate.search.mapper.pojo.bridge.builtin.annotation.AlternativeDiscriminator;
+import org.hibernate.search.mapper.pojo.bridge.builtin.programmatic.AlternativeBinder;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMappingAnnotationProcessor;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMappingAnnotationProcessorContext;
+import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.PropertyMappingStep;
+
+public class AlternativeDiscriminatorProcessor implements PropertyMappingAnnotationProcessor<AlternativeDiscriminator> {
+
+	@Override
+	public void process(PropertyMappingStep mapping, AlternativeDiscriminator annotation,
+			PropertyMappingAnnotationProcessorContext context) {
+		mapping.marker( AlternativeBinder.alternativeDiscriminator()
+				.id( annotation.id().isEmpty() ? null : annotation.id() ) );
+	}
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/programmatic/AlternativeBinder.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/programmatic/AlternativeBinder.java
@@ -1,0 +1,88 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.bridge.builtin.programmatic;
+
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.environment.bean.BeanReference;
+import org.hibernate.search.mapper.pojo.bridge.builtin.alternative.impl.AlternativeBinderImpl;
+import org.hibernate.search.mapper.pojo.bridge.builtin.alternative.impl.AlternativeDiscriminatorBinderImpl;
+import org.hibernate.search.mapper.pojo.bridge.builtin.annotation.AlternativeDiscriminator;
+import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.MarkerBinder;
+import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.TypeBinder;
+import org.hibernate.search.mapper.pojo.model.PojoModelProperty;
+import org.hibernate.search.util.common.annotation.Incubating;
+
+/**
+ * The binder that sets up {@link AlternativeValueBridge}s.
+ * <p>
+ * Alternative field bridges solve the problem of mapping one property to multiple fields
+ * depending on the value of another property.
+ * <p>
+ * One use case is when an entity has text properties whose content
+ * is in a different language depending on the value of another property, say {@code language}.
+ * In that case, you probably want to analyze the text differently depending on the language.
+ * This binder solves the problem this way:
+ * <ul>
+ * <li>at bootstrap, declare one index field per language ({@code title_en}, {@code title_fr}, etc.),
+ * assigning a different analyzer to each field;</li>
+ * <li>at runtime, put the content of the text property in a different field based on the language.
+ * </ul>
+ * <p>
+ * In order to use this binder, you will need to:
+ * <ul>
+ *     <li>annotate a property with {@link AlternativeDiscriminator} (e.g. the {@code language} property)</li>
+ *     <li>implement an {@link AlternativeBinderDelegate} that will declare the index fields
+ *     (e.g. one field per language) and create an {@link AlternativeValueBridge}.
+ *     This bridge is responsible for passing the property value to the relevant field at runtime</li>
+ *     <li>apply the {@link AlternativeBinder} to the type hosting the properties
+ *     (e.g. the type declaring the {@code language} property and the multi-language text properties).
+ *     Generally you will want to create your own annotation for that.</li>
+ * </ul>
+ *
+ * @see AlternativeBinder
+ * @see AlternativeBinderDelegate#bind(IndexSchemaElement, PojoModelProperty)
+ */
+@Incubating
+public interface AlternativeBinder extends TypeBinder {
+
+	/**
+	 * @param id The identifier of the alternative.
+	 * This is used to differentiate between multiple alternative discriminators:
+	 * {@link AlternativeDiscriminatorBinder#id(String) assign an id when building each discriminator marker},
+	 * then select the same id here.
+	 * @return {@code this}, for method chaining.
+	 */
+	AlternativeBinder alternativeId(String id);
+
+	/**
+	 * @param discriminatorType The expected type of alternative discriminator values.
+	 * The alternative discriminator is designated through the {@link #alternativeDiscriminator()} marker.
+	 * @param fieldValueSourcePropertyName The expected type of the field value source,
+	 * i.e. the property bound to a different field based on the discriminator.
+	 * @param fieldValueSourcePropertyType The expected type of the field value source.
+	 * @param delegateRef A reference to the {@link AlternativeBinderDelegate},
+	 * responsible for binding one field per alternative and creating an {@link AlternativeValueBridge}.
+	 * @return An {@link AlternativeBinder}.
+	 * @param <D> The expected type of alternative discriminator values.
+	 * @param <P> The expected type of the field value source.
+	 */
+	static <D, P> AlternativeBinder create(Class<D> discriminatorType,
+			String fieldValueSourcePropertyName, Class<P> fieldValueSourcePropertyType,
+			BeanReference<? extends AlternativeBinderDelegate<D, P>> delegateRef) {
+		return new AlternativeBinderImpl<>( discriminatorType, fieldValueSourcePropertyName,
+				fieldValueSourcePropertyType, delegateRef );
+	}
+
+	/**
+	 * @return A {@link MarkerBinder} for the alternative discriminator, to be applied on a property.
+	 * @see LatitudeLongitudeMarkerBinder
+	 */
+	static AlternativeDiscriminatorBinder alternativeDiscriminator() {
+		return new AlternativeDiscriminatorBinderImpl();
+	}
+
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/programmatic/AlternativeBinderDelegate.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/programmatic/AlternativeBinderDelegate.java
@@ -1,0 +1,42 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.bridge.builtin.programmatic;
+
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.environment.bean.BeanReference;
+import org.hibernate.search.mapper.pojo.model.PojoModelProperty;
+import org.hibernate.search.util.common.annotation.Incubating;
+
+/**
+ * The component responsible for binding one field per alternative,
+ * and creating an {@link AlternativeValueBridge}.
+ *
+ * @param <D> The expected type of alternative discriminator values.
+ * The alternative discriminator is designated through the {@link AlternativeBinder#alternativeDiscriminator()} marker.
+ * @param <P> The expected type of the field value source, i.e. the property bound to multiple index fields.
+ * The field value source is designated through the property name and type passed to
+ * {@link AlternativeBinder#create(Class, String, Class, BeanReference)}.
+ *
+ * @see AlternativeBinder
+ */
+@Incubating
+public interface AlternativeBinderDelegate<D, P> {
+
+	/**
+	 * Binds the given field value source to multiple field, i.e.:
+	 * <ul>
+	 *     <li>Declares one field per alternative.</li>
+	 *     <li>Creates a bridge that will route field values to the appropriate field based on a discriminator.</li>
+	 * </ul>
+	 * @param indexSchemaElement The index schema element to add fields to.
+	 * @param fieldValueSource The source of field values, passed to allow looking up metadata (name, exact type, ...).
+	 * @return The {@link AlternativeValueBridge} bound to the given property.
+	 * @see AlternativeValueBridge
+	 */
+	AlternativeValueBridge<D, P> bind(IndexSchemaElement indexSchemaElement, PojoModelProperty fieldValueSource);
+
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/programmatic/AlternativeDiscriminatorBinder.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/programmatic/AlternativeDiscriminatorBinder.java
@@ -1,0 +1,29 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.bridge.builtin.programmatic;
+
+import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.MarkerBinder;
+import org.hibernate.search.util.common.annotation.Incubating;
+
+/**
+ * A binder for markers that mark a property as the discriminator
+ * for alternatives for an {@link AlternativeBinder Alternative bridge}.
+ *
+ * @see AlternativeBinder#alternativeDiscriminator()
+ */
+@Incubating
+public interface AlternativeDiscriminatorBinder extends MarkerBinder {
+
+	/**
+	 * @param id The identifier of the alternative.
+	 * This is used to differentiate between multiple alternative discriminators.
+	 * @return {@code this}, for method chaining.
+	 * @see AlternativeBinder#alternativeId(String)
+	 */
+	AlternativeDiscriminatorBinder id(String id);
+
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/programmatic/AlternativeValueBridge.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/bridge/builtin/programmatic/AlternativeValueBridge.java
@@ -1,0 +1,33 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.bridge.builtin.programmatic;
+
+import org.hibernate.search.engine.backend.document.DocumentElement;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.environment.bean.BeanReference;
+import org.hibernate.search.mapper.pojo.model.PojoModelProperty;
+import org.hibernate.search.util.common.annotation.Incubating;
+
+/**
+ * A component that routes field values to one of multiple index fields
+ * based on a discriminator.
+ *
+ * @param <D> The expected type of alternative discriminator values.
+ * The alternative discriminator is designated through the {@link AlternativeBinder#alternativeDiscriminator()} marker.
+ * @param <P> The expected type of the field value source, i.e. the property bound to multiple index fields.
+ * The field value source is designated through the property name and type passed to
+ * {@link AlternativeBinder#create(Class, String, Class, BeanReference)}.
+ *
+ * @see AlternativeBinder
+ * @see AlternativeBinderDelegate#bind(IndexSchemaElement, PojoModelProperty)
+ */
+@Incubating
+public interface AlternativeValueBridge<D, P> {
+
+	void write(DocumentElement target, D discriminator, P bridgedElement);
+
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
@@ -422,4 +422,12 @@ public interface Log extends BasicLogger {
 	@Message(id = ID_OFFSET_2 + 70,
 			value = "Index field name '%1$s' is invalid: field names cannot contain a dot ('.').")
 	SearchException invalidFieldNameDotNotAllowed(String relativeFieldName);
+
+	@Message(id = ID_OFFSET_2 + 71, value = "Could not find any property marked with @Alternative(id = %1$s)."
+			+ " There must be exactly one such property in order to map property '%2$s' to multi-alternative fields.")
+	SearchException cannotFindAlternativeDiscriminator(String alternativeId, String fieldValueSourcePropertyName);
+
+	@Message(id = ID_OFFSET_2 + 72, value = "Found multiple properties marked with @Alternative(id = %1$s)."
+			+ " There must be exactly one such property in order to map property '%2$s' to multi-alternative fields.")
+	SearchException conflictingAlternativeDiscriminators(String alternativeId, String fieldValueSourcePropertyName);
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/PropertyMappingStep.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/PropertyMappingStep.java
@@ -28,6 +28,12 @@ import org.hibernate.search.mapper.pojo.model.path.PojoModelPathValueNode;
 public interface PropertyMappingStep {
 
 	/**
+	 * @return A DSL step where the mapping can be defined
+	 * for the type hosting this property.
+	 */
+	TypeMappingStep hostingType();
+
+	/**
 	 * Maps the property to the identifier of documents in the index.
 	 * <p>
 	 * This is only taken into account on {@link Indexed} types.

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/DelegatingPropertyMappingStep.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/DelegatingPropertyMappingStep.java
@@ -18,6 +18,7 @@ import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.Property
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.PropertyMappingKeywordFieldOptionsStep;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.PropertyMappingStep;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.PropertyMappingScaledNumberFieldOptionsStep;
+import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
 import org.hibernate.search.mapper.pojo.model.path.PojoModelPathValueNode;
 
 
@@ -28,6 +29,11 @@ class DelegatingPropertyMappingStep implements PropertyMappingStep {
 
 	DelegatingPropertyMappingStep(PropertyMappingStep delegate) {
 		this.delegate = delegate;
+	}
+
+	@Override
+	public TypeMappingStep hostingType() {
+		return delegate.hostingType();
 	}
 
 	@Override

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/InitialPropertyMappingStep.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/InitialPropertyMappingStep.java
@@ -22,6 +22,7 @@ import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.Property
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.PropertyMappingKeywordFieldOptionsStep;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.PropertyMappingScaledNumberFieldOptionsStep;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.PropertyMappingStep;
+import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
 import org.hibernate.search.mapper.pojo.model.additionalmetadata.building.spi.PojoAdditionalMetadataCollectorPropertyNode;
 import org.hibernate.search.mapper.pojo.model.additionalmetadata.building.spi.PojoAdditionalMetadataCollectorTypeNode;
 import org.hibernate.search.mapper.pojo.model.path.PojoModelPathValueNode;
@@ -39,6 +40,11 @@ class InitialPropertyMappingStep
 	InitialPropertyMappingStep(TypeMappingStepImpl parent, PojoPropertyModel<?> propertyModel) {
 		this.parent = parent;
 		this.propertyModel = propertyModel;
+	}
+
+	@Override
+	public TypeMappingStep hostingType() {
+		return parent;
 	}
 
 	@Override

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/impl/PojoModelNestedCompositeElement.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/impl/PojoModelNestedCompositeElement.java
@@ -62,7 +62,7 @@ class PojoModelNestedCompositeElement<T, P> extends AbstractPojoModelCompositeEl
 
 	@Override
 	PojoElementAccessor<P> doCreateAccessor() {
-		return new PojoPropertyElementAccessor<>( parent.createAccessor(), getHandle() );
+		return new PojoPropertyElementAccessor<>( parent.createAccessor(), getHandle(), modelPath.toUnboundPath() );
 	}
 
 	@Override

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/impl/PojoPropertyElementAccessor.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/impl/PojoPropertyElementAccessor.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.mapper.pojo.model.impl;
 
 import org.hibernate.search.mapper.pojo.model.PojoElementAccessor;
+import org.hibernate.search.mapper.pojo.model.path.PojoModelPathValueNode;
 import org.hibernate.search.util.common.reflect.spi.ValueReadHandle;
 
 /**
@@ -16,10 +17,20 @@ class PojoPropertyElementAccessor<P> implements PojoElementAccessor<P> {
 
 	private final PojoElementAccessor<?> parent;
 	private final ValueReadHandle<P> handle;
+	private final PojoModelPathValueNode path;
 
-	PojoPropertyElementAccessor(PojoElementAccessor<?> parent, ValueReadHandle<P> handle) {
+	PojoPropertyElementAccessor(PojoElementAccessor<?> parent, ValueReadHandle<P> handle,
+			PojoModelPathValueNode path) {
 		this.parent = parent;
 		this.handle = handle;
+		this.path = path;
+	}
+
+	@Override
+	public String toString() {
+		return getClass().getSimpleName() + "["
+				+ "path=" + path
+				+ "]";
 	}
 
 	@Override

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/impl/PojoRootElementAccessor.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/impl/PojoRootElementAccessor.java
@@ -17,6 +17,11 @@ class PojoRootElementAccessor<T> implements PojoElementAccessor<T> {
 	}
 
 	@Override
+	public String toString() {
+		return getClass().getSimpleName();
+	}
+
+	@Override
 	@SuppressWarnings("unchecked") // By construction, this accessor will only be passed PojoElement returning type T
 	public T read(Object parentElement) {
 		return (T) parentElement;


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3311

I also included an experimental implementation, annotated with `@Incubating`. I think it's worth it, be it only to reduce the amount of code users need to write.

I believe the solution will evolve in the future, in particular if we address [HSEARCH-3903](https://hibernate.atlassian.net/browse/HSEARCH-3903). But for the time being... it works.