### PR TITLE
HSEARCH-3976 + HSEARCH-3977 Documentation and bugfix for scrolling

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchQueryImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchQueryImpl.java
@@ -159,7 +159,7 @@ public class ElasticsearchSearchQueryImpl<H> extends AbstractSearchQuery<H, Elas
 	}
 
 	@Override
-	public SearchScroll<H> scroll(Integer pageSize) {
+	public SearchScroll<H> scroll(Integer chunkSize) {
 		String scrollTimeoutString = this.scrollTimeout + "s";
 
 		NonBulkableWork<ElasticsearchLoadableSearchResult<H>> firstScroll = workFactory.search( payload, searchResultExtractor )
@@ -168,7 +168,7 @@ public class ElasticsearchSearchQueryImpl<H> extends AbstractSearchQuery<H, Elas
 				.requestTransformer(
 						ElasticsearchSearchRequestTransformerContextImpl.createTransformerFunction( requestTransformer )
 				)
-				.scrolling( pageSize, scrollTimeoutString )
+				.scrolling( chunkSize, scrollTimeoutString )
 				.build();
 
 		return new ElasticsearchSearchScroll<>( queryOrchestrator, workFactory, searchResultExtractor, scrollTimeoutString, firstScroll );

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchQueryImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/ElasticsearchSearchQueryImpl.java
@@ -150,7 +150,7 @@ public class ElasticsearchSearchQueryImpl<H> extends AbstractSearchQuery<H, Elas
 	}
 
 	@Override
-	public SearchScroll<H> scroll(Integer chunkSize) {
+	public SearchScroll<H> scroll(int chunkSize) {
 		String scrollTimeoutString = this.scrollTimeout + "s";
 
 		NonBulkableWork<ElasticsearchLoadableSearchResult<H>> firstScroll = searchWorkBuilder()

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryImpl.java
@@ -119,7 +119,7 @@ public class LuceneSearchQueryImpl<H> extends AbstractSearchQuery<H, LuceneSearc
 	}
 
 	@Override
-	public SearchScroll<H> scroll(Integer chunkSize) {
+	public SearchScroll<H> scroll(int chunkSize) {
 		Set<String> indexNames = searchContext.indexes().indexNames();
 		HibernateSearchMultiReader indexReader = HibernateSearchMultiReader.open(
 				indexNames, searchContext.indexes().elements(), routingKeys );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryImpl.java
@@ -119,11 +119,12 @@ public class LuceneSearchQueryImpl<H> extends AbstractSearchQuery<H, LuceneSearc
 	}
 
 	@Override
-	public SearchScroll<H> scroll(Integer pageSize) {
+	public SearchScroll<H> scroll(Integer chunkSize) {
 		Set<String> indexNames = searchContext.indexes().indexNames();
 		HibernateSearchMultiReader indexReader = HibernateSearchMultiReader.open(
 				indexNames, searchContext.indexes().elements(), routingKeys );
-		return new LuceneSearchScroll<>( queryOrchestrator, workFactory, searchContext, routingKeys, timeoutManager, searcher, indexReader, pageSize );
+		return new LuceneSearchScroll<>( queryOrchestrator, workFactory, searchContext, routingKeys, timeoutManager,
+				searcher, indexReader, chunkSize );
 	}
 
 	@Override

--- a/documentation/src/main/asciidoc/reference/backend-elasticsearch.asciidoc
+++ b/documentation/src/main/asciidoc/reference/backend-elasticsearch.asciidoc
@@ -880,6 +880,27 @@ By default, the index reader is refreshed every second,
 but this can be customized on the Elasticsearch side through index settings:
 see the `refresh_interval` setting on link:{elasticsearchDocUrl}/index-modules.html[this page].
 
+[[backend-elasticsearch-search]]
+== Searching
+
+Searching with the Elasticsearch backend relies on the <<search-dsl,same APIs as any other backend>>.
+
+This section details Elasticsearch-specific configuration related to searching.
+
+[[backend-elasticsearch-search-scroll-timeout]]
+=== Scroll timeout
+
+With the Elasticsearch backend, <<search-dsl-query-fetching-results-scrolling,scrolls>> are subject to timeout.
+If `next()` is not called for a long period of time (default: 60 seconds),
+the scroll will be closed automatically and the next call to `next()` will fail.
+
+Use the following configuration property at the backend level to configure the timeout (in seconds):
+
+[source]
+----
+hibernate.search.backend.scroll_timeout 60 (default)
+----
+
 [[backend-elasticsearch-access-client]]
 == Retrieving the REST client
 // Search 5 anchors backward compatibility

--- a/documentation/src/main/asciidoc/reference/search-dsl-query.asciidoc
+++ b/documentation/src/main/asciidoc/reference/search-dsl-query.asciidoc
@@ -247,14 +247,57 @@ include::{sourcedir}/org/hibernate/search/documentation/search/query/QueryDslIT.
 <1> Set the offset to `40` and the limit to `20`.
 ====
 
+[NOTE]
+====
+The index may be modified between the retrieval of two pages.
+As a result of that modification, it is possible that some hits change position,
+and end up being present on two subsequent pages.
+
+If you're running a batch process and want to avoid this, use <<search-dsl-query-fetching-results-scrolling>>.
+====
+
 [[search-dsl-query-fetching-results-scrolling]]
 === Scrolling
 // Search 5 anchors backward compatibility
 [[_performance_considerations]]
 
-include::todo-placeholder.asciidoc[]
+Scrolling is the concept of keeping a cursor on the search query at the lowest level,
+and advancing that cursor progressively to collect subsequent "chunks" of search hits.
 
-// TODO https://docs.jboss.org/hibernate/search/5.11/reference/en-US/html_single/#_performance_considerations
+Scrolling relies on the internal state of the cursor (which must be closed at some point),
+and thus is not appropriate for stateless operations such as displaying a page of results to a user in a webpage.
+However, thanks to this internal state, scrolling is able to guarantee that all returned hits are consistent:
+there is absolutely no way for a given hit to appear twice.
+
+Scrolling is therefore most useful when processing a large result set as small chunks.
+
+Below is an example of using scrolling in Hibernate Search.
+
+CAUTION: `SearchScroll` exposes a `close()` method that *must* be called to avoid resource leaks.
+
+[NOTE]
+====
+With the Elasticsearch backend, scrolls can time out and become unusable after some time;
+See <<backend-elasticsearch-search-scroll-timeout,here>> for more information.
+====
+
+.Scrolling to retrieve search results in small chunks
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/search/query/QueryDslIT.java[tags=fetching-scrolling]
+----
+<1> Start a scroll that will return chunks of `20` hits.
+Note the scroll is used in a `try-with-resource` block to avoid resource leaks.
+<2> Retrieve the first chunk by calling `next()`.
+Each chunk will include at most 20 hits, since that was the selected chunk size.
+<3> Detect the end of the scroll by calling `hasHits()` on the last retrieved chunk,
+and retrieve the next chunk by calling `next()` again on the scroll.
+<4> Retrieve the hits of a chunk.
+<5> Optionally, if using Hibernate ORM and retrieving entities,
+you might want to use the link:{hibernateDocUrl}#batch-session-batch-insert[periodic "flush-clear" pattern]
+to ensure entities don't stay in the session taking more and more memory.
+====
 
 [[search-dsl-query-routing]]
 == Routing

--- a/documentation/src/test/java/org/hibernate/search/documentation/search/projection/ProjectionDslIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/search/projection/ProjectionDslIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.documentation.search.projection;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchHitsAssert.assertThatHits;
 
 import java.util.Arrays;
 import java.util.List;
@@ -28,7 +29,6 @@ import org.hibernate.search.mapper.orm.common.EntityReference;
 import org.hibernate.search.mapper.orm.common.impl.EntityReferenceImpl;
 import org.hibernate.search.mapper.orm.scope.SearchScope;
 import org.hibernate.search.mapper.orm.session.SearchSession;
-import org.hibernate.search.util.impl.integrationtest.common.assertion.SearchHitsAssert;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.Before;
@@ -106,7 +106,7 @@ public class ProjectionDslIT {
 					.where( f -> f.matchAll() )
 					.fetchHits( 20 );
 			// end::documentReference[]
-			SearchHitsAssert.assertThat( hits ).hasDocRefHitsAnyOrder(
+			assertThatHits( hits ).hasDocRefHitsAnyOrder(
 					BOOK_INDEX_NAME,
 					String.valueOf( BOOK1_ID ),
 					String.valueOf( BOOK2_ID ),

--- a/engine/src/main/java/org/hibernate/search/engine/search/query/SearchFetchable.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/query/SearchFetchable.java
@@ -149,6 +149,6 @@ public interface SearchFetchable<H> {
 	 * @return The {@link SearchScroll}.
 	 * @throws IllegalArgumentException if passed 0 or less for {@code chunkSize}.
 	 */
-	SearchScroll<H> scroll(Integer chunkSize);
+	SearchScroll<H> scroll(int chunkSize);
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/query/SearchFetchable.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/query/SearchFetchable.java
@@ -145,10 +145,10 @@ public interface SearchFetchable<H> {
 	 * <p>
 	 * Useful to process large datasets.
 	 *
-	 * @param pageSize The maximum number of hits to be returned for each call to {@link SearchScroll#next()}
+	 * @param chunkSize The maximum number of hits to be returned for each call to {@link SearchScroll#next()}
 	 * @return The {@link SearchScroll}.
-	 * @throws IllegalArgumentException if passed 0 or less for pageSize.
+	 * @throws IllegalArgumentException if passed 0 or less for {@code chunkSize}.
 	 */
-	SearchScroll<H> scroll(Integer pageSize);
+	SearchScroll<H> scroll(Integer chunkSize);
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/query/SearchScroll.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/query/SearchScroll.java
@@ -27,9 +27,9 @@ public interface SearchScroll<H> extends AutoCloseable {
 	void close();
 
 	/**
-	 * Returns the next page, with at most {@code pageSize} hits.
+	 * Returns the next chunk, with at most {@code chunkSize} hits.
 	 * <p>
-	 * May return a result with less than {@code pageSize} elements if only that many hits are left.
+	 * May return a result with less than {@code chunkSize} elements if only that many hits are left.
 	 *
 	 * @return The next {@link SearchScrollResult}.
 	 * @see SearchFetchable#scroll(Integer)

--- a/engine/src/main/java/org/hibernate/search/engine/search/query/SearchScroll.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/query/SearchScroll.java
@@ -32,7 +32,7 @@ public interface SearchScroll<H> extends AutoCloseable {
 	 * May return a result with less than {@code chunkSize} elements if only that many hits are left.
 	 *
 	 * @return The next {@link SearchScrollResult}.
-	 * @see SearchFetchable#scroll(Integer)
+	 * @see SearchFetchable#scroll(int)
 	 */
 	SearchScrollResult<H> next();
 

--- a/engine/src/main/java/org/hibernate/search/engine/search/query/dsl/spi/AbstractSearchQueryOptionsStep.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/query/dsl/spi/AbstractSearchQueryOptionsStep.java
@@ -202,7 +202,7 @@ public abstract class AbstractSearchQueryOptionsStep<
 	}
 
 	@Override
-	public SearchScroll<H> scroll(Integer chunkSize) {
+	public SearchScroll<H> scroll(int chunkSize) {
 		return toQuery().scroll( chunkSize );
 	}
 

--- a/engine/src/main/java/org/hibernate/search/engine/search/query/dsl/spi/AbstractSearchQueryOptionsStep.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/query/dsl/spi/AbstractSearchQueryOptionsStep.java
@@ -202,8 +202,8 @@ public abstract class AbstractSearchQueryOptionsStep<
 	}
 
 	@Override
-	public SearchScroll<H> scroll(Integer pageSize) {
-		return toQuery().scroll( pageSize );
+	public SearchScroll<H> scroll(Integer chunkSize) {
+		return toQuery().scroll( chunkSize );
 	}
 
 	private void contribute(SearchPredicateBuilderFactory<? super C> factory, SearchPredicate predicate) {

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/assertion/SearchHitsAssert.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/assertion/SearchHitsAssert.java
@@ -23,7 +23,7 @@ import org.assertj.core.internal.Failures;
 
 public class SearchHitsAssert<H> {
 
-	public static <H> SearchHitsAssert<H> assertThat(List<? extends H> actual) {
+	public static <H> SearchHitsAssert<H> assertThatHits(List<? extends H> actual) {
 		return new SearchHitsAssert<>( actual );
 	}
 

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/assertion/SearchResultAssert.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/assertion/SearchResultAssert.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.search.util.impl.integrationtest.common.assertion;
 
+import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchHitsAssert.assertThatHits;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
@@ -38,7 +40,7 @@ public class SearchResultAssert<H> {
 	}
 
 	public static <H> SearchHitsAssert<H> assertThat(List<? extends H> actual) {
-		return SearchHitsAssert.assertThat( actual );
+		return assertThatHits( actual );
 	}
 
 	private final SearchResult<? extends H> actual;
@@ -59,7 +61,7 @@ public class SearchResultAssert<H> {
 	}
 
 	public SearchHitsAssert<H> hits() {
-		return SearchHitsAssert.<H>assertThat( actual.hits() ).as( "Hits of " + queryDescription );
+		return SearchHitsAssert.<H>assertThatHits( actual.hits() ).as( "Hits of " + queryDescription );
 	}
 
 	public <A> ObjectAssert<A> aggregation(AggregationKey<A> key) {

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendMock.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendMock.java
@@ -226,24 +226,27 @@ public class BackendMock implements TestRule {
 		return backendBehavior;
 	}
 
-	public BackendMock expectScrollObjects(Collection<String> indexNames, int pageSize, Consumer<StubSearchWork.Builder> contributor) {
-		return expectScroll( indexNames, contributor, StubSearchWork.ResultType.OBJECTS, pageSize );
+	public BackendMock expectScrollObjects(Collection<String> indexNames, int chunkSize,
+			Consumer<StubSearchWork.Builder> contributor) {
+		return expectScroll( indexNames, contributor, StubSearchWork.ResultType.OBJECTS, chunkSize );
 	}
 
-	public BackendMock expectScrollProjections(Collection<String> indexNames, int pageSize, Consumer<StubSearchWork.Builder> contributor) {
-		return expectScroll( indexNames, contributor, StubSearchWork.ResultType.PROJECTIONS, pageSize );
+	public BackendMock expectScrollProjections(Collection<String> indexNames, int chunkSize,
+			Consumer<StubSearchWork.Builder> contributor) {
+		return expectScroll( indexNames, contributor, StubSearchWork.ResultType.PROJECTIONS, chunkSize );
 	}
 
-	public BackendMock expectScrollProjection(Collection<String> indexNames, int pageSize, Consumer<StubSearchWork.Builder> contributor) {
-		return expectScroll( indexNames, contributor, StubSearchWork.ResultType.PROJECTIONS, pageSize );
+	public BackendMock expectScrollProjection(Collection<String> indexNames, int chunkSize,
+			Consumer<StubSearchWork.Builder> contributor) {
+		return expectScroll( indexNames, contributor, StubSearchWork.ResultType.PROJECTIONS, chunkSize );
 	}
 
 	private BackendMock expectScroll(Collection<String> indexNames, Consumer<StubSearchWork.Builder> contributor,
-			StubSearchWork.ResultType resultType, Integer pageSize) {
+			StubSearchWork.ResultType resultType, Integer chunkSize) {
 		CallQueue<ScrollWorkCall<?>> callQueue = backendBehavior().getScrollCalls();
 		StubSearchWork.Builder builder = StubSearchWork.builder( resultType );
 		contributor.accept( builder );
-		callQueue.expectInOrder( new ScrollWorkCall<>( new LinkedHashSet<>( indexNames ), builder.build(), pageSize ) );
+		callQueue.expectInOrder( new ScrollWorkCall<>( new LinkedHashSet<>( indexNames ), builder.build(), chunkSize ) );
 		return this;
 	}
 

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendMock.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendMock.java
@@ -242,7 +242,7 @@ public class BackendMock implements TestRule {
 	}
 
 	private BackendMock expectScroll(Collection<String> indexNames, Consumer<StubSearchWork.Builder> contributor,
-			StubSearchWork.ResultType resultType, Integer chunkSize) {
+			StubSearchWork.ResultType resultType, int chunkSize) {
 		CallQueue<ScrollWorkCall<?>> callQueue = backendBehavior().getScrollCalls();
 		StubSearchWork.Builder builder = StubSearchWork.builder( resultType );
 		contributor.accept( builder );

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/NextScrollWorkCall.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/NextScrollWorkCall.java
@@ -51,7 +51,7 @@ public class NextScrollWorkCall<T> extends Call<NextScrollWorkCall<?>> {
 				.as( "NextScroll work did not target the expected indexes: " )
 				.isEqualTo( indexNames );
 
-		return () -> new SimpleSearchScrollResult( behavior.getTotalHitCount() > 0, SearchWorkCall.getResults(
+		return () -> new SimpleSearchScrollResult<>( behavior.getTotalHitCount() > 0, SearchWorkCall.getResults(
 				actualCall.projectionContext,
 				actualCall.loadingContext.createProjectionHitMapper(),
 				actualCall.rootProjection,

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/ScrollWorkCall.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/ScrollWorkCall.java
@@ -24,27 +24,27 @@ public class ScrollWorkCall<T> extends Call<ScrollWorkCall<?>> {
 
 	private final Set<String> indexNames;
 	private final StubSearchWork work;
-	private final Integer pageSize;
+	private final Integer chunkSize;
 	private final StubBackendBehavior behavior;
 	private final StubSearchProjectionContext projectionContext;
 	private final LoadingContext<?, ?> loadingContext;
 	private final StubSearchProjection<T> rootProjection;
 
-	ScrollWorkCall(Set<String> indexNames, StubSearchWork work, Integer pageSize, StubBackendBehavior behavior,
+	ScrollWorkCall(Set<String> indexNames, StubSearchWork work, Integer chunkSize, StubBackendBehavior behavior,
 			StubSearchProjectionContext projectionContext, LoadingContext<?, ?> loadingContext, StubSearchProjection<T> rootProjection) {
 		this.indexNames = indexNames;
 		this.work = work;
-		this.pageSize = pageSize;
+		this.chunkSize = chunkSize;
 		this.behavior = behavior;
 		this.projectionContext = projectionContext;
 		this.loadingContext = loadingContext;
 		this.rootProjection = rootProjection;
 	}
 
-	ScrollWorkCall(Set<String> indexNames, StubSearchWork work, Integer pageSize) {
+	ScrollWorkCall(Set<String> indexNames, StubSearchWork work, Integer chunkSize) {
 		this.indexNames = indexNames;
 		this.work = work;
-		this.pageSize = pageSize;
+		this.chunkSize = chunkSize;
 		this.behavior = null;
 		this.projectionContext = null;
 		this.loadingContext = null;
@@ -58,9 +58,9 @@ public class ScrollWorkCall<T> extends Call<ScrollWorkCall<?>> {
 		StubSearchWorkAssert.assertThat( actualCall.work )
 				.as( "Scroll work on indexes " + indexNames + " did not match: " )
 				.matches( work );
-		assertThat( actualCall.pageSize )
-				.as( "Scroll work pageSize did not match: " )
-				.isEqualTo( pageSize );
+		assertThat( actualCall.chunkSize )
+				.as( "Scroll work chunkSize did not match: " )
+				.isEqualTo( chunkSize );
 
 		return () -> new StubSearchScroll<>( actualCall.behavior, indexNames, actualCall.projectionContext,
 				actualCall.loadingContext, actualCall.rootProjection );

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/ScrollWorkCall.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/ScrollWorkCall.java
@@ -24,13 +24,13 @@ public class ScrollWorkCall<T> extends Call<ScrollWorkCall<?>> {
 
 	private final Set<String> indexNames;
 	private final StubSearchWork work;
-	private final Integer chunkSize;
+	private final int chunkSize;
 	private final StubBackendBehavior behavior;
 	private final StubSearchProjectionContext projectionContext;
 	private final LoadingContext<?, ?> loadingContext;
 	private final StubSearchProjection<T> rootProjection;
 
-	ScrollWorkCall(Set<String> indexNames, StubSearchWork work, Integer chunkSize, StubBackendBehavior behavior,
+	ScrollWorkCall(Set<String> indexNames, StubSearchWork work, int chunkSize, StubBackendBehavior behavior,
 			StubSearchProjectionContext projectionContext, LoadingContext<?, ?> loadingContext, StubSearchProjection<T> rootProjection) {
 		this.indexNames = indexNames;
 		this.work = work;
@@ -41,7 +41,7 @@ public class ScrollWorkCall<T> extends Call<ScrollWorkCall<?>> {
 		this.rootProjection = rootProjection;
 	}
 
-	ScrollWorkCall(Set<String> indexNames, StubSearchWork work, Integer chunkSize) {
+	ScrollWorkCall(Set<String> indexNames, StubSearchWork work, int chunkSize) {
 		this.indexNames = indexNames;
 		this.work = work;
 		this.chunkSize = chunkSize;

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/ScrollWorkCall.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/ScrollWorkCall.java
@@ -62,7 +62,8 @@ public class ScrollWorkCall<T> extends Call<ScrollWorkCall<?>> {
 				.as( "Scroll work pageSize did not match: " )
 				.isEqualTo( pageSize );
 
-		return () -> new StubSearchScroll( actualCall.behavior, indexNames, actualCall.projectionContext, actualCall.loadingContext, actualCall.rootProjection );
+		return () -> new StubSearchScroll<>( actualCall.behavior, indexNames, actualCall.projectionContext,
+				actualCall.loadingContext, actualCall.rootProjection );
 	}
 
 	@Override

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/VerifyingStubBackendBehavior.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/VerifyingStubBackendBehavior.java
@@ -275,7 +275,7 @@ class VerifyingStubBackendBehavior extends StubBackendBehavior {
 	public <T> SearchScroll<T> executeScrollWork(Set<String> indexNames, StubSearchWork work, Integer pageSize,
 			StubSearchProjectionContext projectionContext, LoadingContext<?, ?> loadingContext, StubSearchProjection<T> rootProjection) {
 		return scrollCalls.verify(
-				new ScrollWorkCall( indexNames, work, pageSize, this, projectionContext, loadingContext, rootProjection ),
+				new ScrollWorkCall<>( indexNames, work, pageSize, this, projectionContext, loadingContext, rootProjection ),
 				(call1, call2) -> call1.verify( call2 ),
 				noExpectationsBehavior( () -> new StubSearchScroll<>(
 						this, indexNames, null, null, null
@@ -296,10 +296,10 @@ class VerifyingStubBackendBehavior extends StubBackendBehavior {
 	public <T> SearchScrollResult<T> executeNextScrollWork(Set<String> indexNames, StubSearchProjectionContext projectionContext,
 			LoadingContext<?, ?> loadingContext, StubSearchProjection<T> rootProjection) {
 		return nextScrollCalls.verify(
-				new NextScrollWorkCall( indexNames, projectionContext, loadingContext, rootProjection ),
+				new NextScrollWorkCall<>( indexNames, projectionContext, loadingContext, rootProjection ),
 				(call1, call2) -> call1.verify( call2 ),
 				noExpectationsBehavior( () ->
-						new SimpleSearchScrollResult( false, Collections.emptyList(), Duration.ZERO, false ) )
+						new SimpleSearchScrollResult<>( false, Collections.emptyList(), Duration.ZERO, false ) )
 		);
 	}
 

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/VerifyingStubBackendBehavior.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/VerifyingStubBackendBehavior.java
@@ -272,7 +272,7 @@ class VerifyingStubBackendBehavior extends StubBackendBehavior {
 	}
 
 	@Override
-	public <T> SearchScroll<T> executeScrollWork(Set<String> indexNames, StubSearchWork work, Integer chunkSize,
+	public <T> SearchScroll<T> executeScrollWork(Set<String> indexNames, StubSearchWork work, int chunkSize,
 			StubSearchProjectionContext projectionContext, LoadingContext<?, ?> loadingContext, StubSearchProjection<T> rootProjection) {
 		return scrollCalls.verify(
 				new ScrollWorkCall<>( indexNames, work, chunkSize, this, projectionContext, loadingContext, rootProjection ),

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/VerifyingStubBackendBehavior.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/VerifyingStubBackendBehavior.java
@@ -272,10 +272,10 @@ class VerifyingStubBackendBehavior extends StubBackendBehavior {
 	}
 
 	@Override
-	public <T> SearchScroll<T> executeScrollWork(Set<String> indexNames, StubSearchWork work, Integer pageSize,
+	public <T> SearchScroll<T> executeScrollWork(Set<String> indexNames, StubSearchWork work, Integer chunkSize,
 			StubSearchProjectionContext projectionContext, LoadingContext<?, ?> loadingContext, StubSearchProjection<T> rootProjection) {
 		return scrollCalls.verify(
-				new ScrollWorkCall<>( indexNames, work, pageSize, this, projectionContext, loadingContext, rootProjection ),
+				new ScrollWorkCall<>( indexNames, work, chunkSize, this, projectionContext, loadingContext, rootProjection ),
 				(call1, call2) -> call1.verify( call2 ),
 				noExpectationsBehavior( () -> new StubSearchScroll<>(
 						this, indexNames, null, null, null

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/StubBackendBehavior.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/StubBackendBehavior.java
@@ -55,7 +55,7 @@ public abstract class StubBackendBehavior {
 
 	public abstract long executeCountWork(Set<String> indexNames);
 
-	public abstract <T> SearchScroll<T> executeScrollWork(Set<String> indexNames, StubSearchWork work, Integer pageSize,
+	public abstract <T> SearchScroll<T> executeScrollWork(Set<String> indexNames, StubSearchWork work, Integer chunkSize,
 			StubSearchProjectionContext projectionContext, LoadingContext<?, ?> loadingContext, StubSearchProjection<T> rootProjection);
 
 	public abstract void executeCloseScrollWork(Set<String> indexNames);

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/StubBackendBehavior.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/StubBackendBehavior.java
@@ -55,7 +55,7 @@ public abstract class StubBackendBehavior {
 
 	public abstract long executeCountWork(Set<String> indexNames);
 
-	public abstract <T> SearchScroll<T> executeScrollWork(Set<String> indexNames, StubSearchWork work, Integer chunkSize,
+	public abstract <T> SearchScroll<T> executeScrollWork(Set<String> indexNames, StubSearchWork work, int chunkSize,
 			StubSearchProjectionContext projectionContext, LoadingContext<?, ?> loadingContext, StubSearchProjection<T> rootProjection);
 
 	public abstract void executeCloseScrollWork(Set<String> indexNames);

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/StubSearchQuery.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/StubSearchQuery.java
@@ -67,7 +67,7 @@ final class StubSearchQuery<H> extends AbstractSearchQuery<H, SearchResult<H>>
 	}
 
 	@Override
-	public SearchScroll<H> scroll(Integer chunkSize) {
+	public SearchScroll<H> scroll(int chunkSize) {
 		return backend.getBehavior().executeScrollWork(
 				indexNames, workBuilder.build(), chunkSize, projectionContext, loadingContext, rootProjection
 		);

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/StubSearchQuery.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/StubSearchQuery.java
@@ -67,9 +67,9 @@ final class StubSearchQuery<H> extends AbstractSearchQuery<H, SearchResult<H>>
 	}
 
 	@Override
-	public SearchScroll<H> scroll(Integer pageSize) {
+	public SearchScroll<H> scroll(Integer chunkSize) {
 		return backend.getBehavior().executeScrollWork(
-				indexNames, workBuilder.build(), pageSize, projectionContext, loadingContext, rootProjection
+				indexNames, workBuilder.build(), chunkSize, projectionContext, loadingContext, rootProjection
 		);
 	}
 


### PR DESCRIPTION
* [HSEARCH-3976](https://hibernate.atlassian.net/browse/HSEARCH-3976): Document scrolling
* [HSEARCH-3977](https://hibernate.atlassian.net/browse/HSEARCH-3977): Scroll always targets all indexes

