### PR TITLE
HSEARCH-3309 Allow per-index analyzer definitions in Elasticsearch

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/analysis/ElasticsearchAnalysisConfigurer.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/analysis/ElasticsearchAnalysisConfigurer.java
@@ -6,14 +6,14 @@
  */
 package org.hibernate.search.backend.elasticsearch.analysis;
 
-import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 
 /**
- * An object responsible for configuring analysis in an Elasticsearch backend,
+ * An object responsible for configuring analysis in an Elasticsearch index,
  * providing analysis-related definitions that can be referenced from the mapping.
  * <p>
  * Users can select an analysis configurer through the
- * {@link ElasticsearchBackendSettings#ANALYSIS_CONFIGURER configuration properties}.
+ * {@link ElasticsearchIndexSettings#ANALYSIS_CONFIGURER configuration properties}.
  */
 public interface ElasticsearchAnalysisConfigurer {
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchBackendSettings.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchBackendSettings.java
@@ -209,8 +209,12 @@ public final class ElasticsearchBackendSettings {
 	 *
 	 * @see org.hibernate.search.engine.cfg The core documentation of configuration properties,
 	 * which includes a description of the "bean reference" properties and accepted values.
+	 * @deprecated Use {@link ElasticsearchIndexSettings#ANALYSIS_CONFIGURER}.
+	 * The analysis configurer can still be configured at the backend level, as a default for all indexes,
+	 * but it can now also be configured at the index level, as an override for that particular index.
 	 */
-	public static final String ANALYSIS_CONFIGURER = "analysis.configurer";
+	@Deprecated
+	public static final String ANALYSIS_CONFIGURER = ElasticsearchIndexSettings.ANALYSIS_CONFIGURER;
 
 	/**
 	 * The layout strategy for indexes and their aliases.

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchIndexSettings.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchIndexSettings.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.backend.elasticsearch.cfg;
 
+import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurer;
 import org.hibernate.search.backend.elasticsearch.index.IndexStatus;
 
 /**
@@ -18,6 +19,18 @@ public final class ElasticsearchIndexSettings {
 
 	private ElasticsearchIndexSettings() {
 	}
+
+	/**
+	 * The analysis configurer applied to this index.
+	 * <p>
+	 * Expects a reference to a bean of type {@link ElasticsearchAnalysisConfigurer}.
+	 * <p>
+	 * Defaults to no value.
+	 *
+	 * @see org.hibernate.search.engine.cfg The core documentation of configuration properties,
+	 * which includes a description of the "bean reference" properties and accepted values.
+	 */
+	public static final String ANALYSIS_CONFIGURER = "analysis.configurer";
 
 	/**
 	 * The minimal required status of an index on startup, before Hibernate Search can start using it.

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
@@ -169,7 +169,8 @@ public interface Log extends BasicLogger {
 
 	@Message(id = ID_OFFSET_2 + 75,
 			value = "Error while applying analysis configuration: %1$s")
-	SearchException unableToApplyAnalysisConfiguration(String errorMessage, @Cause Exception e);
+	SearchException unableToApplyAnalysisConfiguration(String errorMessage, @Cause Exception e,
+			@Param EventContext eventContext);
 
 	@Message(id = ID_OFFSET_2 + 76,
 			value = "Invalid analyzer definition for name '%1$s'. Analyzer definitions must at least define the tokenizer.")

--- a/documentation/src/main/asciidoc/reference/backend-elasticsearch.asciidoc
+++ b/documentation/src/main/asciidoc/reference/backend-elasticsearch.asciidoc
@@ -712,6 +712,23 @@ include::{resourcesdir}/analysis/elasticsearch-simple.properties[]
 <1> Assign the configurer to the backend using a Hibernate Search configuration property.
 ====
 
+[NOTE]
+====
+A different analysis configurer can be assign to each index:
+
+[source]
+----
+# To set the default configurer for all indexes:
+hibernate.search.backend.analysis.configurer com.mycompany.MyAnalysisConfigurer
+# To assign a specific configurer to a specific index:
+hibernate.search.backend.indexes.<index name>.analysis.configurer com.mycompany.MySpecificAnalysisConfigurer
+----
+
+If a specific configurer is assigned to an index,
+the default configurer will be ignored for that index:
+only definitions from the specific configurer will be taken into account.
+====
+
 It is also possible to assign a name to a parameterized built-in analyzer:
 
 .Naming a parameterized built-in analyzer in the Elasticsearch backend

--- a/documentation/src/main/asciidoc/reference/backend-elasticsearch.asciidoc
+++ b/documentation/src/main/asciidoc/reference/backend-elasticsearch.asciidoc
@@ -674,9 +674,9 @@ analysis must be configured explicitly.
 ====
 Elasticsearch analysis configuration is not applied immediately on startup:
 it needs to be pushed to the Elasticsearch cluster.
-Hibernate Search will only push the configuration to the cluster if specific conditions are met,
-and only if instructed to do so
-through the <<backend-elasticsearch-index-lifecycle,lifecycle configuration>>.
+
+Hibernate Search will only push the configuration to the cluster if instructed to do so
+through <<mapper-orm-schema-management,schema management>>.
 ====
 
 To configure analysis in an Elasticsearch backend, you will need to:

--- a/documentation/src/main/asciidoc/reference/backend-elasticsearch.asciidoc
+++ b/documentation/src/main/asciidoc/reference/backend-elasticsearch.asciidoc
@@ -296,11 +296,11 @@ For Elasticsearch specifically, some fine-tuning is available through the follow
 [source]
 ----
 # To configure the defaults for all indexes:
-hibernate.search.backend.schema_management.minimal_required_status green (default)
-hibernate.search.backend.schema_management.minimal_required_status_wait_timeout 10000 (default)
+hibernate.search.backend.schema_management.minimal_required_status = green (default)
+hibernate.search.backend.schema_management.minimal_required_status_wait_timeout = 10000 (default)
 # To configure a specific index:
-hibernate.search.backend.indexes.<index name>.schema_management.minimal_required_status green (default)
-hibernate.search.backend.indexes.<index name>.schema_management.minimal_required_status_wait_timeout 10000 (default)
+hibernate.search.backend.indexes.<index name>.schema_management.minimal_required_status = green (default)
+hibernate.search.backend.indexes.<index name>.schema_management.minimal_required_status_wait_timeout = 10000 (default)
 ----
 
 * `minimal_required_status` defines the minimal required status of an index before creation is considered complete.
@@ -719,9 +719,9 @@ A different analysis configurer can be assign to each index:
 [source]
 ----
 # To set the default configurer for all indexes:
-hibernate.search.backend.analysis.configurer com.mycompany.MyAnalysisConfigurer
+hibernate.search.backend.analysis.configurer = com.mycompany.MyAnalysisConfigurer
 # To assign a specific configurer to a specific index:
-hibernate.search.backend.indexes.<index name>.analysis.configurer com.mycompany.MySpecificAnalysisConfigurer
+hibernate.search.backend.indexes.<index name>.analysis.configurer = com.mycompany.MySpecificAnalysisConfigurer
 ----
 
 If a specific configurer is assigned to an index,
@@ -814,13 +814,13 @@ This is done through the following configuration properties:
 [source]
 ----
 # To configure the defaults for all indexes:
-hibernate.search.backend.indexing.queue_count 10 (default)
-hibernate.search.backend.indexing.queue_size 1000 (default)
-hibernate.search.backend.indexing.max_bulk_size 100 (default)
+hibernate.search.backend.indexing.queue_count = 10 (default)
+hibernate.search.backend.indexing.queue_size = 1000 (default)
+hibernate.search.backend.indexing.max_bulk_size = 100 (default)
 # To configure a specific index:
-hibernate.search.backend.indexes.<index name>.indexing.queue_count 10 (default)
-hibernate.search.backend.indexes.<index name>.indexing.queue_size 1000 (default)
-hibernate.search.backend.indexes.<index name>.indexing.max_bulk_size 100 (default)
+hibernate.search.backend.indexes.<index name>.indexing.queue_count = 10 (default)
+hibernate.search.backend.indexes.<index name>.indexing.queue_size = 1000 (default)
+hibernate.search.backend.indexes.<index name>.indexing.max_bulk_size = 100 (default)
 ----
 
 * `indexing.queue_count` defines the number of queues.
@@ -915,7 +915,7 @@ Use the following configuration property at the backend level to configure the t
 
 [source]
 ----
-hibernate.search.backend.scroll_timeout 60 (default)
+hibernate.search.backend.scroll_timeout = 60 (default)
 ----
 
 [[backend-elasticsearch-access-client]]

--- a/documentation/src/main/asciidoc/reference/backend-lucene.asciidoc
+++ b/documentation/src/main/asciidoc/reference/backend-lucene.asciidoc
@@ -718,11 +718,11 @@ This is done through the following configuration properties:
 [source]
 ----
 # To configure the defaults for all indexes:
-hibernate.search.backend.indexing.queue_count 10 (default)
-hibernate.search.backend.indexing.queue_size 1000 (default)
+hibernate.search.backend.indexing.queue_count = 10 (default)
+hibernate.search.backend.indexing.queue_size = 1000 (default)
 # To configure a specific index:
-hibernate.search.backend.indexes.<index name>.indexing.queue_count 10 (default)
-hibernate.search.backend.indexes.<index name>.indexing.queue_size 1000 (default)
+hibernate.search.backend.indexes.<index name>.indexing.queue_count = 10 (default)
+hibernate.search.backend.indexes.<index name>.indexing.queue_size = 1000 (default)
 ----
 
 * `indexing.queue_count` defines the number of queues.

--- a/documentation/src/test/java/org/hibernate/search/documentation/analysis/ElasticsearchAnalysisIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/analysis/ElasticsearchAnalysisIT.java
@@ -13,7 +13,7 @@ import javax.persistence.EntityManagerFactory;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 
-import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.documentation.testsupport.BackendConfigurations;
 import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
 import org.hibernate.search.mapper.orm.Search;
@@ -35,7 +35,7 @@ public class ElasticsearchAnalysisIT {
 	public void advanced() {
 		EntityManagerFactory entityManagerFactory = setupHelper.start()
 				.withBackendProperty(
-						ElasticsearchBackendSettings.ANALYSIS_CONFIGURER,
+						ElasticsearchIndexSettings.ANALYSIS_CONFIGURER,
 						new AdvancedElasticsearchAnalysisConfigurer()
 				)
 				.withProperty(

--- a/documentation/src/test/resources/analysis/elasticsearch-simple.properties
+++ b/documentation/src/test/resources/analysis/elasticsearch-simple.properties
@@ -1,2 +1,2 @@
 # <1>
-hibernate.search.backend.analysis.configurer org.hibernate.search.documentation.analysis.MyElasticsearchAnalysisConfigurer
+hibernate.search.backend.analysis.configurer = org.hibernate.search.documentation.analysis.MyElasticsearchAnalysisConfigurer

--- a/documentation/src/test/resources/analysis/lucene-simple.properties
+++ b/documentation/src/test/resources/analysis/lucene-simple.properties
@@ -1,2 +1,2 @@
 # <1>
-hibernate.search.backend.analysis.configurer org.hibernate.search.documentation.analysis.MyLuceneAnalysisConfigurer
+hibernate.search.backend.analysis.configurer = org.hibernate.search.documentation.analysis.MyLuceneAnalysisConfigurer

--- a/documentation/src/test/resources/reporting/failurehandler.properties
+++ b/documentation/src/test/resources/reporting/failurehandler.properties
@@ -1,2 +1,2 @@
 # <1>
-hibernate.search.background_failure_handler org.hibernate.search.documentation.reporting.failurehandler.MyFailureHandler
+hibernate.search.background_failure_handler = org.hibernate.search.documentation.reporting.failurehandler.MyFailureHandler

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/analysis/ElasticsearchAnalysisConfigurerIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/analysis/ElasticsearchAnalysisConfigurerIT.java
@@ -10,7 +10,7 @@ import java.util.function.Consumer;
 
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurer;
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurationContext;
-import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.engine.mapper.mapping.building.spi.IndexBindingContext;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
@@ -26,6 +26,9 @@ public class ElasticsearchAnalysisConfigurerIT {
 
 	private static final String ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX = "Error while applying analysis configuration";
 
+	private static final String TYPE_NAME = "mainType";
+	private static final String INDEX_NAME = "mainIndex";
+
 	@Rule
 	public final SearchSetupHelper setupHelper = new SearchSetupHelper();
 
@@ -36,11 +39,12 @@ public class ElasticsearchAnalysisConfigurerIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.defaultBackendContext()
+						.typeContext( TYPE_NAME )
+						.indexContext( INDEX_NAME )
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
 								"Unable to convert configuration property 'hibernate.search.backend."
-										+ ElasticsearchBackendSettings.ANALYSIS_CONFIGURER + "'",
+										+ ElasticsearchIndexSettings.ANALYSIS_CONFIGURER + "'",
 								"'foobar'",
 								"Unable to find " + ElasticsearchAnalysisConfigurer.class.getName() + " implementation class: foobar"
 						)
@@ -55,7 +59,8 @@ public class ElasticsearchAnalysisConfigurerIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.defaultBackendContext()
+						.typeContext( TYPE_NAME )
+						.indexContext( INDEX_NAME )
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
 								FailingConfigurer.FAILURE_MESSAGE
@@ -85,7 +90,8 @@ public class ElasticsearchAnalysisConfigurerIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.defaultBackendContext()
+						.typeContext( TYPE_NAME )
+						.indexContext( INDEX_NAME )
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
 								"Multiple analyzer definitions with the same name",
@@ -111,7 +117,8 @@ public class ElasticsearchAnalysisConfigurerIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.defaultBackendContext()
+						.typeContext( TYPE_NAME )
+						.indexContext( INDEX_NAME )
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
 								"Multiple normalizer definitions with the same name",
@@ -137,7 +144,8 @@ public class ElasticsearchAnalysisConfigurerIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.defaultBackendContext()
+						.typeContext( TYPE_NAME )
+						.indexContext( INDEX_NAME )
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
 								"Multiple tokenizer definitions with the same name",
@@ -162,7 +170,8 @@ public class ElasticsearchAnalysisConfigurerIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.defaultBackendContext()
+						.typeContext( TYPE_NAME )
+						.indexContext( INDEX_NAME )
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
 								"Invalid tokenizer definition for name 'tokenizerName'",
@@ -186,7 +195,8 @@ public class ElasticsearchAnalysisConfigurerIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.defaultBackendContext()
+						.typeContext( TYPE_NAME )
+						.indexContext( INDEX_NAME )
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
 								"Multiple char filter definitions with the same name",
@@ -211,7 +221,8 @@ public class ElasticsearchAnalysisConfigurerIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.defaultBackendContext()
+						.typeContext( TYPE_NAME )
+						.indexContext( INDEX_NAME )
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
 								"Invalid char filter definition for name 'charFilterName'",
@@ -235,7 +246,8 @@ public class ElasticsearchAnalysisConfigurerIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.defaultBackendContext()
+						.typeContext( TYPE_NAME )
+						.indexContext( INDEX_NAME )
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
 								"Multiple token filter definitions with the same name",
@@ -260,7 +272,8 @@ public class ElasticsearchAnalysisConfigurerIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.defaultBackendContext()
+						.typeContext( TYPE_NAME )
+						.indexContext( INDEX_NAME )
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
 								"Invalid token filter definition for name 'tokenFilterName'",
@@ -284,7 +297,8 @@ public class ElasticsearchAnalysisConfigurerIT {
 		)
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
-						.defaultBackendContext()
+						.typeContext( TYPE_NAME )
+						.indexContext( INDEX_NAME )
 						.failure(
 								ANALYSIS_CONFIGURER_ERROR_MESSAGE_PREFIX,
 								"Multiple parameters with the same name",
@@ -312,8 +326,9 @@ public class ElasticsearchAnalysisConfigurerIT {
 
 	private void setup(String analysisConfigurer, Consumer<IndexBindingContext> mappingContributor) {
 		setupHelper.start()
-				.withBackendProperty( ElasticsearchBackendSettings.ANALYSIS_CONFIGURER, analysisConfigurer )
-				.withIndex( StubMappedIndex.ofAdvancedNonRetrievable( mappingContributor ) )
+				.withBackendProperty( ElasticsearchIndexSettings.ANALYSIS_CONFIGURER, analysisConfigurer )
+				.withIndex( StubMappedIndex.ofAdvancedNonRetrievable( mappingContributor )
+						.name( INDEX_NAME ).typeName( TYPE_NAME ) )
 				.setup();
 	}
 }

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/mapping/ElasticsearchTypeNameMappingSchemaIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/mapping/ElasticsearchTypeNameMappingSchemaIT.java
@@ -15,6 +15,7 @@ import static org.hibernate.search.util.impl.integrationtest.backend.elasticsear
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurationContext;
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurer;
 import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.backend.elasticsearch.cfg.spi.ElasticsearchBackendSpiSettings;
 import org.hibernate.search.backend.elasticsearch.client.spi.ElasticsearchRequest;
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchClientSpy;
@@ -84,7 +85,7 @@ public class ElasticsearchTypeNameMappingSchemaIT {
 				)
 				.withBackendProperty(
 						// Don't contribute any analysis definitions, it messes with our assertions
-						ElasticsearchBackendSettings.ANALYSIS_CONFIGURER,
+						ElasticsearchIndexSettings.ANALYSIS_CONFIGURER,
 						(ElasticsearchAnalysisConfigurer) (ElasticsearchAnalysisConfigurationContext context) -> {
 							// No-op
 						}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerCreationAliasesIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerCreationAliasesIT.java
@@ -19,6 +19,7 @@ import java.util.EnumSet;
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurationContext;
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurer;
 import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.backend.elasticsearch.index.layout.IndexLayoutStrategy;
 import org.hibernate.search.backend.elasticsearch.util.spi.URLEncodedString;
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.configuration.StubSingleIndexLayoutStrategy;
@@ -128,7 +129,7 @@ public class ElasticsearchIndexSchemaManagerCreationAliasesIT {
 				.withSchemaManagement( StubMappingSchemaManagementStrategy.DROP_ON_SHUTDOWN_ONLY )
 				.withBackendProperty(
 						// Don't contribute any analysis definitions, migration of those is tested in another test class
-						ElasticsearchBackendSettings.ANALYSIS_CONFIGURER,
+						ElasticsearchIndexSettings.ANALYSIS_CONFIGURER,
 						(ElasticsearchAnalysisConfigurer) (ElasticsearchAnalysisConfigurationContext context) -> {
 							// No-op
 						}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerCreationAnalyzerIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerCreationAnalyzerIT.java
@@ -9,8 +9,10 @@ package org.hibernate.search.integrationtest.backend.elasticsearch.schema.manage
 import static org.hibernate.search.util.impl.test.JsonHelper.assertJsonEquals;
 
 import java.util.EnumSet;
+import java.util.concurrent.CompletableFuture;
 
-import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
+import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurer;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.configuration.ElasticsearchIndexSchemaManagerAnalyzerITAnalysisConfigurer;
 import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.rule.TestElasticsearchClient;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
@@ -43,7 +45,8 @@ public class ElasticsearchIndexSchemaManagerCreationAnalyzerIT {
 	@Rule
 	public TestElasticsearchClient elasticSearchClient = new TestElasticsearchClient();
 
-	private final StubMappedIndex index = StubMappedIndex.withoutFields();
+	private final StubMappedIndex mainIndex = StubMappedIndex.withoutFields().name( "main" );
+	private final StubMappedIndex otherIndex = StubMappedIndex.withoutFields().name( "other" );
 
 	private final ElasticsearchIndexSchemaManagerOperation operation;
 
@@ -52,11 +55,18 @@ public class ElasticsearchIndexSchemaManagerCreationAnalyzerIT {
 	}
 
 	@Test
-	public void success_simple() throws Exception {
-		elasticSearchClient.index( index.name() )
+	public void success_simple() {
+		elasticSearchClient.index( mainIndex.name() )
 				.ensureDoesNotExist().registerForCleanup();
 
-		setupAndCreateIndex();
+		setupHelper.start()
+				.withSchemaManagement( StubMappingSchemaManagementStrategy.DROP_ON_SHUTDOWN_ONLY )
+				.withBackendProperty( ElasticsearchIndexSettings.ANALYSIS_CONFIGURER,
+						new ElasticsearchIndexSchemaManagerAnalyzerITAnalysisConfigurer() )
+				.withIndex( mainIndex )
+				.setup();
+
+		operation.apply( mainIndex.schemaManager() ).join();
 
 		assertJsonEquals(
 				"{"
@@ -104,21 +114,104 @@ public class ElasticsearchIndexSchemaManagerCreationAnalyzerIT {
 							+ "}"
 					+ "}"
 				+ "}",
-				elasticSearchClient.index( index.name() ).settings( "index.analysis" ).get()
+				elasticSearchClient.index( mainIndex.name() ).settings( "index.analysis" ).get()
 				);
 	}
 
-	private void setupAndCreateIndex() {
+	@Test
+	public void success_multiIndex() {
+		elasticSearchClient.index( mainIndex.name() )
+				.ensureDoesNotExist().registerForCleanup();
+		elasticSearchClient.index( otherIndex.name() )
+				.ensureDoesNotExist().registerForCleanup();
+
 		setupHelper.start()
 				.withSchemaManagement( StubMappingSchemaManagementStrategy.DROP_ON_SHUTDOWN_ONLY )
-				.withBackendProperty(
-						ElasticsearchBackendSettings.ANALYSIS_CONFIGURER,
-						new ElasticsearchIndexSchemaManagerAnalyzerITAnalysisConfigurer()
-				)
-				.withIndex( index )
+				.withBackendProperty( ElasticsearchIndexSettings.ANALYSIS_CONFIGURER,
+						new ElasticsearchIndexSchemaManagerAnalyzerITAnalysisConfigurer() )
+				.withIndexes( mainIndex, otherIndex )
+				.withIndexProperty( otherIndex.name(), ElasticsearchIndexSettings.ANALYSIS_CONFIGURER,
+						(ElasticsearchAnalysisConfigurer) context -> {
+							// Use a different definition for custom-analyzer
+							context.analyzer( "custom-analyzer" ).custom()
+									.tokenizer( "whitespace" )
+									.tokenFilters( "lowercase", "asciifolding" );
+							// Add an extra analyzer
+							context.analyzer( "custom-analyzer-2" ).custom()
+									.tokenizer( "whitespace" )
+									.tokenFilters( "lowercase" );
+						} )
 				.setup();
 
-		operation.apply( index.schemaManager() ).join();
+		CompletableFuture.allOf(
+				operation.apply( mainIndex.schemaManager() ),
+				operation.apply( otherIndex.schemaManager() )
+		)
+				.join();
+
+		assertJsonEquals( "{"
+					+ "'analyzer': {"
+							+ "'custom-analyzer': {"
+									+ "'type': 'custom',"
+									+ "'char_filter': ['custom-pattern-replace'],"
+									+ "'tokenizer': 'custom-edgeNGram',"
+									+ "'filter': ['custom-keep-types', 'custom-word-delimiter']"
+							+ "}"
+					+ "},"
+					+ "'char_filter': {"
+							+ "'custom-pattern-replace': {"
+									+ "'type': 'pattern_replace',"
+									+ "'pattern': '[^0-9]',"
+									+ "'replacement': '0',"
+									+ "'tags': 'CASE_INSENSITIVE|COMMENTS'"
+							+ "}"
+					+ "},"
+					+ "'tokenizer': {"
+							+ "'custom-edgeNGram': {"
+									+ "'type': 'edgeNGram',"
+									/*
+									 * Strangely enough, even if you send properly typed numbers
+									 * to Elasticsearch, when you ask for the current settings it
+									 * will spit back strings instead of numbers...
+									 */
+									+ "'min_gram': '1',"
+									+ "'max_gram': '10'"
+							+ "}"
+					+ "},"
+					+ "'filter': {"
+							+ "'custom-keep-types': {"
+									+ "'type': 'keep_types',"
+									+ "'types': ['<NUM>', '<DOUBLE>']"
+							+ "},"
+							+ "'custom-word-delimiter': {"
+									+ "'type': 'word_delimiter',"
+									/*
+									 * Strangely enough, even if you send properly typed booleans
+									 * to Elasticsearch, when you ask for the current settings it
+									 * will spit back strings instead of booleans...
+									 */
+									+ "'generate_word_parts': 'false'"
+							+ "}"
+					+ "}"
+				+ "}",
+				elasticSearchClient.index( mainIndex.name() ).settings( "index.analysis" ).get() );
+
+		assertJsonEquals( "{"
+					+ "'analyzer': {"
+							+ "'custom-analyzer': {"
+									+ "'type': 'custom',"
+									+ "'tokenizer': 'whitespace',"
+									+ "'filter': ['lowercase', 'asciifolding']"
+							+ "},"
+							+ "'custom-analyzer-2': {"
+									+ "'type': 'custom',"
+									+ "'tokenizer': 'whitespace',"
+									+ "'filter': ['lowercase']"
+							+ "}"
+							// elements defined in the default configurer shouldn't appear here: they've been overridden
+					+ "}"
+				+ "}",
+				elasticSearchClient.index( otherIndex.name() ).settings( "index.analysis" ).get() );
 	}
 
 }

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerCreationMappingBaseIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerCreationMappingBaseIT.java
@@ -12,7 +12,7 @@ import java.util.EnumSet;
 
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurer;
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurationContext;
-import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.engine.backend.types.Norms;
 import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.rule.TestElasticsearchClient;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
@@ -174,7 +174,7 @@ public class ElasticsearchIndexSchemaManagerCreationMappingBaseIT {
 				.withSchemaManagement( StubMappingSchemaManagementStrategy.DROP_ON_SHUTDOWN_ONLY )
 				.withBackendProperty(
 						// Don't contribute any analysis definitions, migration of those is tested in another test class
-						ElasticsearchBackendSettings.ANALYSIS_CONFIGURER,
+						ElasticsearchIndexSettings.ANALYSIS_CONFIGURER,
 						(ElasticsearchAnalysisConfigurer) (ElasticsearchAnalysisConfigurationContext context) -> {
 							// No-op
 						}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerCreationMappingFieldTemplatesIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerCreationMappingFieldTemplatesIT.java
@@ -14,7 +14,7 @@ import java.util.EnumSet;
 
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurationContext;
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurer;
-import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectField;
 import org.hibernate.search.engine.backend.types.ObjectStructure;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
@@ -152,7 +152,7 @@ public class ElasticsearchIndexSchemaManagerCreationMappingFieldTemplatesIT {
 				.withSchemaManagement( StubMappingSchemaManagementStrategy.DROP_ON_SHUTDOWN_ONLY )
 				.withBackendProperty(
 						// Don't contribute any analysis definitions, migration of those is tested in another test class
-						ElasticsearchBackendSettings.ANALYSIS_CONFIGURER,
+						ElasticsearchIndexSettings.ANALYSIS_CONFIGURER,
 						(ElasticsearchAnalysisConfigurer) (ElasticsearchAnalysisConfigurationContext context) -> {
 							// No-op
 						}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerCreationOrPreservationIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerCreationOrPreservationIT.java
@@ -15,7 +15,7 @@ import java.util.EnumSet;
 
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurer;
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurationContext;
-import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.util.common.impl.Futures;
 import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.rule.TestElasticsearchClient;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
@@ -124,7 +124,7 @@ public class ElasticsearchIndexSchemaManagerCreationOrPreservationIT {
 				.withSchemaManagement( StubMappingSchemaManagementStrategy.DROP_ON_SHUTDOWN_ONLY )
 				.withBackendProperty(
 						// Don't contribute any analysis definitions, migration of those is tested in another test class
-						ElasticsearchBackendSettings.ANALYSIS_CONFIGURER,
+						ElasticsearchIndexSettings.ANALYSIS_CONFIGURER,
 						(ElasticsearchAnalysisConfigurer) (ElasticsearchAnalysisConfigurationContext context) -> {
 							// No-op
 						}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerDropAndCreateIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerDropAndCreateIT.java
@@ -13,7 +13,7 @@ import static org.hibernate.search.util.impl.test.JsonHelper.assertJsonEquals;
 
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurationContext;
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurer;
-import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.impl.Futures;
 import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.rule.TestElasticsearchClient;
@@ -109,7 +109,7 @@ public class ElasticsearchIndexSchemaManagerDropAndCreateIT {
 				.withSchemaManagement( StubMappingSchemaManagementStrategy.DROP_ON_SHUTDOWN_ONLY )
 				.withBackendProperty(
 						// Don't contribute any analysis definitions, migration of those is tested in another test class
-						ElasticsearchBackendSettings.ANALYSIS_CONFIGURER,
+						ElasticsearchIndexSettings.ANALYSIS_CONFIGURER,
 						(ElasticsearchAnalysisConfigurer) (ElasticsearchAnalysisConfigurationContext context) -> {
 							// No-op
 						}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerDropIfExistingIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerDropIfExistingIT.java
@@ -11,7 +11,7 @@ import static org.hibernate.search.integrationtest.backend.elasticsearch.schema.
 
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurationContext;
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurer;
-import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.impl.Futures;
 import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.rule.TestElasticsearchClient;
@@ -79,7 +79,7 @@ public class ElasticsearchIndexSchemaManagerDropIfExistingIT {
 				.withSchemaManagement( StubMappingSchemaManagementStrategy.DROP_ON_SHUTDOWN_ONLY )
 				.withBackendProperty(
 						// Don't contribute any analysis definitions, migration of those is tested in another test class
-						ElasticsearchBackendSettings.ANALYSIS_CONFIGURER,
+						ElasticsearchIndexSettings.ANALYSIS_CONFIGURER,
 						(ElasticsearchAnalysisConfigurer) (ElasticsearchAnalysisConfigurationContext context) -> {
 							// No-op
 						}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerInspectionAliasesIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerInspectionAliasesIT.java
@@ -14,7 +14,7 @@ import java.util.EnumSet;
 
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurationContext;
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurer;
-import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.common.impl.Futures;
@@ -106,7 +106,7 @@ public class ElasticsearchIndexSchemaManagerInspectionAliasesIT {
 				.withSchemaManagement( StubMappingSchemaManagementStrategy.DROP_ON_SHUTDOWN_ONLY )
 				.withBackendProperty(
 						// Don't contribute any analysis definitions, migration of those is tested in another test class
-						ElasticsearchBackendSettings.ANALYSIS_CONFIGURER,
+						ElasticsearchIndexSettings.ANALYSIS_CONFIGURER,
 						(ElasticsearchAnalysisConfigurer) (ElasticsearchAnalysisConfigurationContext context) -> {
 							// No-op
 						}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerStatusCheckIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerStatusCheckIT.java
@@ -12,7 +12,6 @@ import java.util.EnumSet;
 
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurationContext;
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurer;
-import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
 import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.backend.elasticsearch.index.IndexStatus;
 import org.hibernate.search.util.common.impl.Futures;
@@ -127,7 +126,7 @@ public class ElasticsearchIndexSchemaManagerStatusCheckIT {
 		setupHelper.start()
 				.withBackendProperty(
 						// Don't contribute any analysis definitions, validation of those is tested in another test class
-						ElasticsearchBackendSettings.ANALYSIS_CONFIGURER,
+						ElasticsearchIndexSettings.ANALYSIS_CONFIGURER,
 						(ElasticsearchAnalysisConfigurer) (ElasticsearchAnalysisConfigurationContext context) -> {
 							// No-op
 						}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateAliasesIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateAliasesIT.java
@@ -13,7 +13,7 @@ import static org.hibernate.search.util.impl.test.JsonHelper.assertJsonEquals;
 
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurationContext;
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurer;
-import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.categories.RequiresIndexAliasIsWriteIndex;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.rule.TestElasticsearchClient;
@@ -186,7 +186,7 @@ public class ElasticsearchIndexSchemaManagerUpdateAliasesIT {
 				.withSchemaManagement( StubMappingSchemaManagementStrategy.DROP_ON_SHUTDOWN_ONLY )
 				.withBackendProperty(
 						// Don't contribute any analysis definitions, migration of those is tested in another test class
-						ElasticsearchBackendSettings.ANALYSIS_CONFIGURER,
+						ElasticsearchIndexSettings.ANALYSIS_CONFIGURER,
 						(ElasticsearchAnalysisConfigurer) (ElasticsearchAnalysisConfigurationContext context) -> {
 							// No-op
 						}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateAnalyzerIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateAnalyzerIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.integrationtest.backend.elasticsearch.schema.manage
 
 import static org.hibernate.search.util.impl.test.JsonHelper.assertJsonEquals;
 
-import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.categories.RequiresIndexOpenClose;
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.configuration.ElasticsearchIndexSchemaManagerAnalyzerITAnalysisConfigurer;
 import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.rule.TestElasticsearchClient;
@@ -485,7 +485,7 @@ public class ElasticsearchIndexSchemaManagerUpdateAnalyzerIT {
 		setupHelper.start()
 				.withSchemaManagement( StubMappingSchemaManagementStrategy.DROP_ON_SHUTDOWN_ONLY )
 				.withBackendProperty(
-						ElasticsearchBackendSettings.ANALYSIS_CONFIGURER,
+						ElasticsearchIndexSettings.ANALYSIS_CONFIGURER,
 						new ElasticsearchIndexSchemaManagerAnalyzerITAnalysisConfigurer()
 				)
 				.withIndex( index )

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateMappingBaseIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateMappingBaseIT.java
@@ -14,7 +14,7 @@ import static org.hibernate.search.util.impl.test.JsonHelper.assertJsonEquals;
 
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurationContext;
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurer;
-import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.common.impl.Futures;
@@ -392,7 +392,7 @@ public class ElasticsearchIndexSchemaManagerUpdateMappingBaseIT {
 				.withSchemaManagement( StubMappingSchemaManagementStrategy.DROP_ON_SHUTDOWN_ONLY )
 				.withBackendProperty(
 						// Don't contribute any analysis definitions, migration of those is tested in another test class
-						ElasticsearchBackendSettings.ANALYSIS_CONFIGURER,
+						ElasticsearchIndexSettings.ANALYSIS_CONFIGURER,
 						(ElasticsearchAnalysisConfigurer) (ElasticsearchAnalysisConfigurationContext context) -> {
 							// No-op
 						}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateMappingFieldTemplateIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateMappingFieldTemplateIT.java
@@ -12,7 +12,7 @@ import static org.hibernate.search.util.impl.test.JsonHelper.assertJsonEquals;
 
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurationContext;
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurer;
-import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.engine.backend.types.ObjectStructure;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.impl.Futures;
@@ -659,7 +659,7 @@ public class ElasticsearchIndexSchemaManagerUpdateMappingFieldTemplateIT {
 				.withSchemaManagement( StubMappingSchemaManagementStrategy.DROP_ON_SHUTDOWN_ONLY )
 				.withBackendProperty(
 						// Don't contribute any analysis definitions, migration of those is tested in another test class
-						ElasticsearchBackendSettings.ANALYSIS_CONFIGURER,
+						ElasticsearchIndexSettings.ANALYSIS_CONFIGURER,
 						(ElasticsearchAnalysisConfigurer) (ElasticsearchAnalysisConfigurationContext context) -> {
 							// No-op
 						}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateNormalizerIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerUpdateNormalizerIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.integrationtest.backend.elasticsearch.schema.manage
 
 import static org.hibernate.search.util.impl.test.JsonHelper.assertJsonEquals;
 
-import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.categories.RequiresIndexOpenClose;
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.configuration.ElasticsearchIndexSchemaManagerNormalizerITAnalysisConfigurer;
 import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.rule.TestElasticsearchClient;
@@ -304,7 +304,7 @@ public class ElasticsearchIndexSchemaManagerUpdateNormalizerIT {
 		setupHelper.start()
 				.withSchemaManagement( StubMappingSchemaManagementStrategy.DROP_ON_SHUTDOWN_ONLY )
 				.withBackendProperty(
-						ElasticsearchBackendSettings.ANALYSIS_CONFIGURER,
+						ElasticsearchIndexSettings.ANALYSIS_CONFIGURER,
 						new ElasticsearchIndexSchemaManagerNormalizerITAnalysisConfigurer()
 				)
 				.withIndex( index )

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerValidationAliasesIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerValidationAliasesIT.java
@@ -17,7 +17,7 @@ import java.util.EnumSet;
 
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurationContext;
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurer;
-import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.categories.RequiresIndexAliasIsWriteIndex;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
@@ -183,7 +183,7 @@ public class ElasticsearchIndexSchemaManagerValidationAliasesIT {
 				.withSchemaManagement( StubMappingSchemaManagementStrategy.DROP_ON_SHUTDOWN_ONLY )
 				.withBackendProperty(
 						// Don't contribute any analysis definitions, migration of those is tested in another test class
-						ElasticsearchBackendSettings.ANALYSIS_CONFIGURER,
+						ElasticsearchIndexSettings.ANALYSIS_CONFIGURER,
 						(ElasticsearchAnalysisConfigurer) (ElasticsearchAnalysisConfigurationContext context) -> {
 							// No-op
 						}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerValidationAnalyzerIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerValidationAnalyzerIT.java
@@ -11,7 +11,7 @@ import static org.hibernate.search.integrationtest.backend.elasticsearch.schema.
 
 import java.util.EnumSet;
 
-import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.configuration.ElasticsearchIndexSchemaManagerAnalyzerITAnalysisConfigurer;
 import org.hibernate.search.util.common.impl.Futures;
 import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.rule.TestElasticsearchClient;
@@ -647,7 +647,7 @@ public class ElasticsearchIndexSchemaManagerValidationAnalyzerIT {
 		setupHelper.start()
 				.withSchemaManagement( StubMappingSchemaManagementStrategy.DROP_ON_SHUTDOWN_ONLY )
 				.withBackendProperty(
-						ElasticsearchBackendSettings.ANALYSIS_CONFIGURER,
+						ElasticsearchIndexSettings.ANALYSIS_CONFIGURER,
 						new ElasticsearchIndexSchemaManagerAnalyzerITAnalysisConfigurer()
 				)
 				.withIndex( index )

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerValidationMappingAttributeIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerValidationMappingAttributeIT.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurationContext;
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurer;
-import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.engine.backend.types.Norms;
 import org.hibernate.search.engine.backend.types.Searchable;
 import org.hibernate.search.engine.backend.types.Sortable;
@@ -1050,7 +1050,7 @@ public class ElasticsearchIndexSchemaManagerValidationMappingAttributeIT {
 				.withSchemaManagement( StubMappingSchemaManagementStrategy.DROP_ON_SHUTDOWN_ONLY )
 				.withBackendProperty(
 						// Don't contribute any analysis definitions, migration of those is tested in another test class
-						ElasticsearchBackendSettings.ANALYSIS_CONFIGURER,
+						ElasticsearchIndexSettings.ANALYSIS_CONFIGURER,
 						(ElasticsearchAnalysisConfigurer) (ElasticsearchAnalysisConfigurationContext context) -> {
 							// No-op
 						}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerValidationMappingBaseIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerValidationMappingBaseIT.java
@@ -14,7 +14,7 @@ import java.util.EnumSet;
 
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurer;
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurationContext;
-import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectField;
 import org.hibernate.search.util.common.impl.Futures;
 import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.rule.TestElasticsearchClient;
@@ -304,7 +304,7 @@ public class ElasticsearchIndexSchemaManagerValidationMappingBaseIT {
 				.withSchemaManagement( StubMappingSchemaManagementStrategy.DROP_ON_SHUTDOWN_ONLY )
 				.withBackendProperty(
 						// Don't contribute any analysis definitions, migration of those is tested in another test class
-						ElasticsearchBackendSettings.ANALYSIS_CONFIGURER,
+						ElasticsearchIndexSettings.ANALYSIS_CONFIGURER,
 						(ElasticsearchAnalysisConfigurer) (ElasticsearchAnalysisConfigurationContext context) -> {
 							// No-op
 						}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerValidationMappingFieldTemplateIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerValidationMappingFieldTemplateIT.java
@@ -14,7 +14,7 @@ import java.util.EnumSet;
 
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurationContext;
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurer;
-import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.engine.backend.types.ObjectStructure;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
@@ -507,7 +507,7 @@ public class ElasticsearchIndexSchemaManagerValidationMappingFieldTemplateIT {
 				.withSchemaManagement( StubMappingSchemaManagementStrategy.DROP_ON_SHUTDOWN_ONLY )
 				.withBackendProperty(
 						// Don't contribute any analysis definitions, migration of those is tested in another test class
-						ElasticsearchBackendSettings.ANALYSIS_CONFIGURER,
+						ElasticsearchIndexSettings.ANALYSIS_CONFIGURER,
 						(ElasticsearchAnalysisConfigurer) (ElasticsearchAnalysisConfigurationContext context) -> {
 							// No-op
 						}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerValidationNormalizerIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerValidationNormalizerIT.java
@@ -11,7 +11,7 @@ import static org.hibernate.search.integrationtest.backend.elasticsearch.schema.
 
 import java.util.EnumSet;
 
-import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.configuration.ElasticsearchIndexSchemaManagerNormalizerITAnalysisConfigurer;
 import org.hibernate.search.util.common.impl.Futures;
 import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.rule.TestElasticsearchClient;
@@ -128,7 +128,7 @@ public class ElasticsearchIndexSchemaManagerValidationNormalizerIT {
 		setupHelper.start()
 				.withSchemaManagement( StubMappingSchemaManagementStrategy.DROP_ON_SHUTDOWN_ONLY )
 				.withBackendProperty(
-						ElasticsearchBackendSettings.ANALYSIS_CONFIGURER,
+						ElasticsearchIndexSettings.ANALYSIS_CONFIGURER,
 						new ElasticsearchIndexSchemaManagerNormalizerITAnalysisConfigurer()
 				)
 				.withIndex( index )

--- a/integrationtest/jdk/java-modules/src/main/resources/hibernate.properties
+++ b/integrationtest/jdk/java-modules/src/main/resources/hibernate.properties
@@ -1,27 +1,27 @@
 # Hibernate ORM properties:
-hibernate.dialect ${db.dialect}
-hibernate.connection.driver_class ${jdbc.driver}
-hibernate.connection.url ${jdbc.url}
-hibernate.connection.username ${jdbc.user}
-hibernate.connection.password ${jdbc.pass}
-hibernate.connection.isolation ${jdbc.isolation}
-hibernate.hbm2ddl.auto create-drop
-hibernate.show_sql true
-hibernate.format_sql true
-hibernate.max_fetch_depth 5
+hibernate.dialect = ${db.dialect}
+hibernate.connection.driver_class = ${jdbc.driver}
+hibernate.connection.url = ${jdbc.url}
+hibernate.connection.username = ${jdbc.user}
+hibernate.connection.password = ${jdbc.pass}
+hibernate.connection.isolation = ${jdbc.isolation}
+hibernate.hbm2ddl.auto = create-drop
+hibernate.show_sql = true
+hibernate.format_sql = true
+hibernate.max_fetch_depth = 5
 # We can't use classes from the hibernate-testing module unless we add an explicit dependency to that module.
 #hibernate.cache.region_prefix hibernate.test
-#hibernate.cache.region.factory_class org.hibernate.testing.cache.CachingRegionFactory
+#hibernate.cache.region.factory_class = org.hibernate.testing.cache.CachingRegionFactory
 
 # Hibernate Search properties:
-hibernate.search.automatic_indexing.synchronization.strategy sync
-hibernate.search.backend.hosts ${test.elasticsearch.connection.hosts}
-hibernate.search.backend.username ${test.elasticsearch.connection.username}
-hibernate.search.backend.password ${test.elasticsearch.connection.password}
-hibernate.search.backend.aws.signing.enabled ${test.elasticsearch.connection.aws.signing.enabled}
-hibernate.search.backend.aws.signing.access_key ${test.elasticsearch.connection.aws.signing.access_key}
-hibernate.search.backend.aws.signing.secret_key ${test.elasticsearch.connection.aws.signing.secret_key}
-hibernate.search.backend.aws.signing.region ${test.elasticsearch.connection.aws.signing.region}
-hibernate.search.backend.log.json_pretty_printing true
-hibernate.search.backend.schema_management.minimal_required_status yellow
-hibernate.search.backend.analysis.configurer org.hibernate.search.integrationtest.java.module.config.MyElasticsearchAnalysisConfigurer
+hibernate.search.automatic_indexing.synchronization.strategy = sync
+hibernate.search.backend.hosts = ${test.elasticsearch.connection.hosts}
+hibernate.search.backend.username = ${test.elasticsearch.connection.username}
+hibernate.search.backend.password = ${test.elasticsearch.connection.password}
+hibernate.search.backend.aws.signing.enabled = ${test.elasticsearch.connection.aws.signing.enabled}
+hibernate.search.backend.aws.signing.access_key = ${test.elasticsearch.connection.aws.signing.access_key}
+hibernate.search.backend.aws.signing.secret_key = ${test.elasticsearch.connection.aws.signing.secret_key}
+hibernate.search.backend.aws.signing.region = ${test.elasticsearch.connection.aws.signing.region}
+hibernate.search.backend.log.json_pretty_printing = true
+hibernate.search.backend.schema_management.minimal_required_status = yellow
+hibernate.search.backend.analysis.configurer = org.hibernate.search.integrationtest.java.module.config.MyElasticsearchAnalysisConfigurer

--- a/integrationtest/performance/backend/elasticsearch/src/main/java/org/hibernate/search/integrationtest/performance/backend/elasticsearch/testsupport/ElasticsearchBackendHolder.java
+++ b/integrationtest/performance/backend/elasticsearch/src/main/java/org/hibernate/search/integrationtest/performance/backend/elasticsearch/testsupport/ElasticsearchBackendHolder.java
@@ -9,7 +9,6 @@ package org.hibernate.search.integrationtest.performance.backend.elasticsearch.t
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
 import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.backend.elasticsearch.index.IndexStatus;
 import org.hibernate.search.engine.cfg.spi.ConfigurationPropertySource;
@@ -41,7 +40,7 @@ public class ElasticsearchBackendHolder extends AbstractBackendHolder {
 
 		// Custom connection info is provided by setting system properties,
 		// e.g. "hosts" or "aws.signing.enabled".
-		map.put( ElasticsearchBackendSettings.ANALYSIS_CONFIGURER, ElasticsearchPerformanceAnalysisConfigurer.class );
+		map.put( ElasticsearchIndexSettings.ANALYSIS_CONFIGURER, ElasticsearchPerformanceAnalysisConfigurer.class );
 
 		map.put( ElasticsearchIndexSettings.SCHEMA_MANAGEMENT_MINIMAL_REQUIRED_STATUS, IndexStatus.YELLOW );
 

--- a/util/internal/integrationtest/mapper/orm/src/main/resources/hibernate.properties
+++ b/util/internal/integrationtest/mapper/orm/src/main/resources/hibernate.properties
@@ -8,20 +8,20 @@
 # DB connection info is passed through JVM system properties in order to be able to change it dynamically.
 # See the root POM for more details.
 
-hibernate.hbm2ddl.auto create-drop
+hibernate.hbm2ddl.auto = create-drop
 
 # Some tests need 15 parallel open Sessions (e.g. org.hibernate.search.test.engine.worker.WorkerTestCase)
 # and some ID generation strategies will require 2 connections per session.
 # So use 15*2+1 connections at most.
-hibernate.connection.pool_size 31
+hibernate.connection.pool_size = 31
 
-hibernate.show_sql false
-hibernate.format_sql false
+hibernate.show_sql = false
+hibernate.format_sql = false
 
-hibernate.max_fetch_depth 5
+hibernate.max_fetch_depth = 5
 
-hibernate.cache.region_prefix hibernate.test
-hibernate.cache.region.factory_class org.hibernate.testing.cache.CachingRegionFactory
+hibernate.cache.region_prefix = hibernate.test
+hibernate.cache.region.factory_class = org.hibernate.testing.cache.CachingRegionFactory
 
-hibernate.implicit_naming_strategy component-path
+hibernate.implicit_naming_strategy = component-path
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3309

I chose a simpler approach than what was described in the ticket: I just moved the analysis configurer to the index level for Elasticsearch. That way, users are free to configure at the backend level or at the index level, and the way to configure at each level is similar (unlike what was suggested in the ticket).