### PR TITLE
HSEARCH-4002 + HSEARCH-4003 + HSEARCH-4004 MappingAnnotatedElement improvements

### DIFF
--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/impl/JavaBeanTypeConfigurationContributor.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/impl/JavaBeanTypeConfigurationContributor.java
@@ -15,6 +15,7 @@ import org.hibernate.search.mapper.javabean.log.impl.Log;
 import org.hibernate.search.mapper.javabean.model.impl.JavaBeanBootstrapIntrospector;
 import org.hibernate.search.engine.mapper.mapping.building.spi.MappingConfigurationCollector;
 import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoTypeMetadataContributor;
+import org.hibernate.search.mapper.pojo.mapping.spi.PojoMappingConfigurationContext;
 import org.hibernate.search.mapper.pojo.mapping.spi.PojoMappingConfigurationContributor;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeModel;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
@@ -34,7 +35,7 @@ class JavaBeanTypeConfigurationContributor implements PojoMappingConfigurationCo
 	}
 
 	@Override
-	public void configure(MappingBuildContext buildContext,
+	public void configure(MappingBuildContext buildContext, PojoMappingConfigurationContext configurationContext,
 			MappingConfigurationCollector<PojoTypeMetadataContributor> configurationCollector) {
 		for ( Map.Entry<Class<?>, String> entry : entityNameByType.entrySet() ) {
 			PojoRawTypeModel<?> typeModel = introspector.typeModel( entry.getKey() );

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMetatadaContributor.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMetatadaContributor.java
@@ -32,6 +32,7 @@ import org.hibernate.search.mapper.pojo.extractor.builtin.BuiltinContainerExtrac
 import org.hibernate.search.mapper.pojo.extractor.mapping.programmatic.ContainerExtractorPath;
 import org.hibernate.search.mapper.pojo.mapping.building.spi.ErrorCollectingPojoTypeMetadataContributor;
 import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoTypeMetadataContributor;
+import org.hibernate.search.mapper.pojo.mapping.spi.PojoMappingConfigurationContext;
 import org.hibernate.search.mapper.pojo.mapping.spi.PojoMappingConfigurationContributor;
 import org.hibernate.search.mapper.pojo.model.path.PojoModelPath;
 import org.hibernate.search.mapper.pojo.model.path.PojoModelPathValueNode;
@@ -48,7 +49,7 @@ public final class HibernateOrmMetatadaContributor implements PojoMappingConfigu
 	}
 
 	@Override
-	public void configure(MappingBuildContext buildContext,
+	public void configure(MappingBuildContext buildContext, PojoMappingConfigurationContext configurationContext,
 			MappingConfigurationCollector<PojoTypeMetadataContributor> configurationCollector) {
 		PropertyDelegatesCollector delegatesCollector = new PropertyDelegatesCollector();
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/impl/AnnotationMappingConfigurationContextImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/impl/AnnotationMappingConfigurationContextImpl.java
@@ -61,7 +61,8 @@ public class AnnotationMappingConfigurationContextImpl implements AnnotationMapp
 		FailureCollector failureCollector = buildContext.failureCollector();
 		AnnotationHelper annotationHelper = new AnnotationHelper( introspector.annotationValueReadHandleFactory() );
 		AnnotationPojoTypeMetadataContributorFactory contributorFactory =
-				new AnnotationPojoTypeMetadataContributorFactory( beanResolver, failureCollector, annotationHelper );
+				new AnnotationPojoTypeMetadataContributorFactory( beanResolver, failureCollector, configurationContext,
+						annotationHelper );
 
 		/*
 		 * For types that were explicitly requested for annotation scanning and their supertypes,

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/impl/AnnotationMappingConfigurationContextImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/impl/AnnotationMappingConfigurationContextImpl.java
@@ -19,6 +19,7 @@ import org.hibernate.search.engine.mapper.model.spi.MappableTypeModel;
 import org.hibernate.search.engine.reporting.spi.FailureCollector;
 import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoTypeMetadataContributor;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.AnnotationMappingConfigurationContext;
+import org.hibernate.search.mapper.pojo.mapping.spi.PojoMappingConfigurationContext;
 import org.hibernate.search.mapper.pojo.mapping.spi.PojoMappingConfigurationContributor;
 import org.hibernate.search.mapper.pojo.model.spi.PojoBootstrapIntrospector;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeModel;
@@ -54,7 +55,7 @@ public class AnnotationMappingConfigurationContextImpl implements AnnotationMapp
 	}
 
 	@Override
-	public void configure(MappingBuildContext buildContext,
+	public void configure(MappingBuildContext buildContext, PojoMappingConfigurationContext configurationContext,
 			MappingConfigurationCollector<PojoTypeMetadataContributor> collector) {
 		BeanResolver beanResolver = buildContext.beanResolver();
 		FailureCollector failureCollector = buildContext.failureCollector();

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/impl/AnnotationPojoTypeMetadataContributorFactory.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/impl/AnnotationPojoTypeMetadataContributorFactory.java
@@ -104,7 +104,8 @@ class AnnotationPojoTypeMetadataContributorFactory {
 			return false;
 		}
 
-		TypeMappingAnnotationProcessorContext context = new TypeMappingAnnotationProcessorContextImpl( typeModel );
+		TypeMappingAnnotationProcessorContext context = new TypeMappingAnnotationProcessorContextImpl(
+				typeModel, annotationHelper );
 
 		try ( BeanHolder<? extends TypeMappingAnnotationProcessor<? super A>> processorHolder =
 				processorOptional.get() ) {
@@ -130,7 +131,7 @@ class AnnotationPojoTypeMetadataContributorFactory {
 		}
 
 		PropertyMappingAnnotationProcessorContext context =
-				new PropertyMappingAnnotationProcessorContextImpl( propertyModel, configurationContext );
+				new PropertyMappingAnnotationProcessorContextImpl( propertyModel, annotationHelper, configurationContext );
 
 		try ( BeanHolder<? extends PropertyMappingAnnotationProcessor<? super A>> processorHolder =
 				processorOptional.get() ) {

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/impl/AnnotationPojoTypeMetadataContributorFactory.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/impl/AnnotationPojoTypeMetadataContributorFactory.java
@@ -25,6 +25,7 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.PropertyMappingStep;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.impl.TypeMappingStepImpl;
+import org.hibernate.search.mapper.pojo.mapping.spi.PojoMappingConfigurationContext;
 import org.hibernate.search.mapper.pojo.model.path.PojoModelPath;
 import org.hibernate.search.mapper.pojo.model.spi.PojoPropertyModel;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeModel;
@@ -34,12 +35,14 @@ import org.hibernate.search.util.common.reflect.spi.AnnotationHelper;
 class AnnotationPojoTypeMetadataContributorFactory {
 
 	private final FailureCollector rootFailureCollector;
+	private final PojoMappingConfigurationContext configurationContext;
 	private final AnnotationHelper annotationHelper;
 	private final AnnotationProcessorProvider annotationProcessorProvider;
 
 	AnnotationPojoTypeMetadataContributorFactory(BeanResolver beanResolver, FailureCollector rootFailureCollector,
-			AnnotationHelper annotationHelper) {
+			PojoMappingConfigurationContext configurationContext, AnnotationHelper annotationHelper) {
 		this.rootFailureCollector = rootFailureCollector;
+		this.configurationContext = configurationContext;
 		this.annotationHelper = annotationHelper;
 		this.annotationProcessorProvider = new AnnotationProcessorProvider( beanResolver, rootFailureCollector );
 	}
@@ -127,7 +130,7 @@ class AnnotationPojoTypeMetadataContributorFactory {
 		}
 
 		PropertyMappingAnnotationProcessorContext context =
-				new PropertyMappingAnnotationProcessorContextImpl( propertyModel );
+				new PropertyMappingAnnotationProcessorContextImpl( propertyModel, configurationContext );
 
 		try ( BeanHolder<? extends PropertyMappingAnnotationProcessor<? super A>> processorHolder =
 				processorOptional.get() ) {

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/MappingAnnotatedElement.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/MappingAnnotatedElement.java
@@ -17,8 +17,14 @@ import java.util.stream.Stream;
  */
 public interface MappingAnnotatedElement {
 
+	/**
+	 * @return The Java class corresponding to the raw type of the annotated element.
+	 */
 	Class<?> javaClass();
 
+	/**
+	 * @return All annotations declared on the annotated element.
+	 */
 	Stream<Annotation> allAnnotations();
 
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/MappingAnnotatedProperty.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/MappingAnnotatedProperty.java
@@ -6,6 +6,10 @@
  */
 package org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing;
 
+import java.util.Optional;
+
+import org.hibernate.search.mapper.pojo.extractor.mapping.programmatic.ContainerExtractorPath;
+
 /**
  * A property in the entity model annotated with a mapping annotation.
  *
@@ -20,5 +24,13 @@ public interface MappingAnnotatedProperty extends MappingAnnotatedElement {
 	 * and the first character is lowercased.
 	 */
 	String name();
+
+	/**
+	 * @param extractorPath A container extractor path, possibly just {@link ContainerExtractorPath#defaultExtractors()}.
+	 * @return The raw type of values one would obtain
+	 * by using the given container extractor path to extract values from this property,
+	 * or {@link Optional#empty()} if the container extractor path cannot be applied.
+	 */
+	Optional<Class<?>> javaClass(ContainerExtractorPath extractorPath);
 
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/MappingAnnotatedProperty.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/MappingAnnotatedProperty.java
@@ -14,6 +14,11 @@ package org.hibernate.search.mapper.pojo.mapping.definition.annotation.processin
  */
 public interface MappingAnnotatedProperty extends MappingAnnotatedElement {
 
+	/**
+	 * @return The name of the annotated property.
+	 * In the case of a getter method, the name does not include the "get" prefix
+	 * and the first character is lowercased.
+	 */
 	String name();
 
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/MappingAnnotationProcessorContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/MappingAnnotationProcessorContext.java
@@ -13,6 +13,7 @@ import org.hibernate.search.mapper.pojo.extractor.mapping.annotation.ContainerEx
 import org.hibernate.search.mapper.pojo.extractor.mapping.programmatic.ContainerExtractorPath;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ObjectPath;
 import org.hibernate.search.mapper.pojo.model.path.PojoModelPathValueNode;
+import org.hibernate.search.util.common.reporting.EventContext;
 
 /**
  * A superinterface for contexts passed to mapping annotation processors.
@@ -62,5 +63,11 @@ public interface MappingAnnotationProcessorContext {
 	 */
 	<T> Optional<BeanReference<? extends T>> toBeanReference(Class<T> expectedType, Class<?> undefinedTypeMarker,
 			Class<? extends T> type, String name);
+
+	/**
+	 * @return An event context describing the annotation being processed and its location,
+	 * for use in log messages and exception messages.
+	 */
+	EventContext eventContext();
 
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/AbstractMappingAnnotationProcessorContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/AbstractMappingAnnotationProcessorContext.java
@@ -14,9 +14,16 @@ import org.hibernate.search.mapper.pojo.extractor.mapping.programmatic.Container
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ObjectPath;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.MappingAnnotationProcessorContext;
 import org.hibernate.search.mapper.pojo.model.path.PojoModelPathValueNode;
+import org.hibernate.search.util.common.reflect.spi.AnnotationHelper;
 
 public abstract class AbstractMappingAnnotationProcessorContext
 		implements MappingAnnotationProcessorContext {
+
+	protected final AnnotationHelper annotationHelper;
+
+	protected AbstractMappingAnnotationProcessorContext(AnnotationHelper annotationHelper) {
+		this.annotationHelper = annotationHelper;
+	}
 
 	@Override
 	public Optional<PojoModelPathValueNode> toPojoModelPathValueNode(ObjectPath objectPath) {

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/PropertyMappingAnnotationProcessorContextImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/PropertyMappingAnnotationProcessorContextImpl.java
@@ -7,19 +7,25 @@
 package org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.impl;
 
 import java.lang.annotation.Annotation;
+import java.util.Optional;
 import java.util.stream.Stream;
 
+import org.hibernate.search.mapper.pojo.extractor.mapping.programmatic.ContainerExtractorPath;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.MappingAnnotatedProperty;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMappingAnnotationProcessorContext;
+import org.hibernate.search.mapper.pojo.mapping.spi.PojoMappingConfigurationContext;
 import org.hibernate.search.mapper.pojo.model.spi.PojoPropertyModel;
 
 public class PropertyMappingAnnotationProcessorContextImpl
 		extends AbstractMappingAnnotationProcessorContext
 		implements PropertyMappingAnnotationProcessorContext, MappingAnnotatedProperty {
 	private final PojoPropertyModel<?> propertyModel;
+	private final PojoMappingConfigurationContext configurationContext;
 
-	public PropertyMappingAnnotationProcessorContextImpl(PojoPropertyModel<?> propertyModel) {
+	public PropertyMappingAnnotationProcessorContextImpl(PojoPropertyModel<?> propertyModel,
+			PojoMappingConfigurationContext configurationContext) {
 		this.propertyModel = propertyModel;
+		this.configurationContext = configurationContext;
 	}
 
 	@Override
@@ -30,6 +36,12 @@ public class PropertyMappingAnnotationProcessorContextImpl
 	@Override
 	public Class<?> javaClass() {
 		return propertyModel.typeModel().rawType().typeIdentifier().javaClass();
+	}
+
+	@Override
+	public Optional<Class<?>> javaClass(ContainerExtractorPath extractorPath) {
+		return configurationContext.extractedValueType( propertyModel.typeModel(), extractorPath )
+				.map( type -> type.rawType().typeIdentifier().javaClass() );
 	}
 
 	@Override

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/PropertyMappingAnnotationProcessorContextImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/PropertyMappingAnnotationProcessorContextImpl.java
@@ -15,6 +15,7 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMappingAnnotationProcessorContext;
 import org.hibernate.search.mapper.pojo.mapping.spi.PojoMappingConfigurationContext;
 import org.hibernate.search.mapper.pojo.model.spi.PojoPropertyModel;
+import org.hibernate.search.util.common.reflect.spi.AnnotationHelper;
 
 public class PropertyMappingAnnotationProcessorContextImpl
 		extends AbstractMappingAnnotationProcessorContext
@@ -23,7 +24,8 @@ public class PropertyMappingAnnotationProcessorContextImpl
 	private final PojoMappingConfigurationContext configurationContext;
 
 	public PropertyMappingAnnotationProcessorContextImpl(PojoPropertyModel<?> propertyModel,
-			PojoMappingConfigurationContext configurationContext) {
+			AnnotationHelper annotationHelper, PojoMappingConfigurationContext configurationContext) {
+		super( annotationHelper );
 		this.propertyModel = propertyModel;
 		this.configurationContext = configurationContext;
 	}
@@ -51,6 +53,6 @@ public class PropertyMappingAnnotationProcessorContextImpl
 
 	@Override
 	public Stream<Annotation> allAnnotations() {
-		return propertyModel.annotations();
+		return propertyModel.annotations().flatMap( annotationHelper::expandRepeatableContainingAnnotation );
 	}
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/PropertyMappingAnnotationProcessorContextImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/PropertyMappingAnnotationProcessorContextImpl.java
@@ -13,26 +13,42 @@ import java.util.stream.Stream;
 import org.hibernate.search.mapper.pojo.extractor.mapping.programmatic.ContainerExtractorPath;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.MappingAnnotatedProperty;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.PropertyMappingAnnotationProcessorContext;
+import org.hibernate.search.mapper.pojo.model.path.PojoModelPath;
 import org.hibernate.search.mapper.pojo.mapping.spi.PojoMappingConfigurationContext;
 import org.hibernate.search.mapper.pojo.model.spi.PojoPropertyModel;
 import org.hibernate.search.util.common.reflect.spi.AnnotationHelper;
+import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeModel;
+import org.hibernate.search.mapper.pojo.reporting.impl.PojoEventContexts;
+import org.hibernate.search.util.common.reporting.EventContext;
 
 public class PropertyMappingAnnotationProcessorContextImpl
 		extends AbstractMappingAnnotationProcessorContext
 		implements PropertyMappingAnnotationProcessorContext, MappingAnnotatedProperty {
+	private final PojoRawTypeModel<?> typeModel;
 	private final PojoPropertyModel<?> propertyModel;
+	private final Annotation annotation;
 	private final PojoMappingConfigurationContext configurationContext;
 
-	public PropertyMappingAnnotationProcessorContextImpl(PojoPropertyModel<?> propertyModel,
+	public PropertyMappingAnnotationProcessorContextImpl(PojoRawTypeModel<?> typeModel, PojoPropertyModel<?> propertyModel,
+			Annotation annotation,
 			AnnotationHelper annotationHelper, PojoMappingConfigurationContext configurationContext) {
 		super( annotationHelper );
+		this.typeModel = typeModel;
 		this.propertyModel = propertyModel;
+		this.annotation = annotation;
 		this.configurationContext = configurationContext;
 	}
 
 	@Override
 	public MappingAnnotatedProperty annotatedElement() {
 		return this; // Not a lot to implement, so we just implement everything in the same class
+	}
+
+	@Override
+	public EventContext eventContext() {
+		return PojoEventContexts.fromType( typeModel )
+				.append( PojoEventContexts.fromPath( PojoModelPath.ofProperty( propertyModel.name() ) ) )
+				.append( PojoEventContexts.fromAnnotation( annotation ) );
 	}
 
 	@Override
@@ -55,4 +71,5 @@ public class PropertyMappingAnnotationProcessorContextImpl
 	public Stream<Annotation> allAnnotations() {
 		return propertyModel.annotations().flatMap( annotationHelper::expandRepeatableContainingAnnotation );
 	}
+
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/TypeMappingAnnotationProcessorContextImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/TypeMappingAnnotationProcessorContextImpl.java
@@ -12,21 +12,32 @@ import java.util.stream.Stream;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.MappingAnnotatedType;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.TypeMappingAnnotationProcessorContext;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeModel;
+import org.hibernate.search.mapper.pojo.reporting.impl.PojoEventContexts;
+import org.hibernate.search.util.common.reporting.EventContext;
 import org.hibernate.search.util.common.reflect.spi.AnnotationHelper;
 
 public class TypeMappingAnnotationProcessorContextImpl
 		extends AbstractMappingAnnotationProcessorContext
 		implements TypeMappingAnnotationProcessorContext, MappingAnnotatedType {
 	private final PojoRawTypeModel<?> typeModel;
+	private final Annotation annotation;
 
-	public TypeMappingAnnotationProcessorContextImpl(PojoRawTypeModel<?> typeModel, AnnotationHelper annotationHelper) {
+	public TypeMappingAnnotationProcessorContextImpl(PojoRawTypeModel<?> typeModel, Annotation annotation,
+			AnnotationHelper annotationHelper) {
 		super( annotationHelper );
 		this.typeModel = typeModel;
+		this.annotation = annotation;
 	}
 
 	@Override
 	public MappingAnnotatedType annotatedElement() {
 		return this; // Not a lot to implement, so we just implement everything in the same class
+	}
+
+	@Override
+	public EventContext eventContext() {
+		return PojoEventContexts.fromType( typeModel )
+				.append( PojoEventContexts.fromAnnotation( annotation ) );
 	}
 
 	@Override

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/TypeMappingAnnotationProcessorContextImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/annotation/processing/impl/TypeMappingAnnotationProcessorContextImpl.java
@@ -12,13 +12,15 @@ import java.util.stream.Stream;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.MappingAnnotatedType;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.processing.TypeMappingAnnotationProcessorContext;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeModel;
+import org.hibernate.search.util.common.reflect.spi.AnnotationHelper;
 
 public class TypeMappingAnnotationProcessorContextImpl
 		extends AbstractMappingAnnotationProcessorContext
 		implements TypeMappingAnnotationProcessorContext, MappingAnnotatedType {
 	private final PojoRawTypeModel<?> typeModel;
 
-	public TypeMappingAnnotationProcessorContextImpl(PojoRawTypeModel<?> typeModel) {
+	public TypeMappingAnnotationProcessorContextImpl(PojoRawTypeModel<?> typeModel, AnnotationHelper annotationHelper) {
+		super( annotationHelper );
 		this.typeModel = typeModel;
 	}
 
@@ -34,6 +36,6 @@ public class TypeMappingAnnotationProcessorContextImpl
 
 	@Override
 	public Stream<Annotation> allAnnotations() {
-		return typeModel.annotations();
+		return typeModel.annotations().flatMap( annotationHelper::expandRepeatableContainingAnnotation );
 	}
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/ProgrammaticMappingConfigurationContextImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/ProgrammaticMappingConfigurationContextImpl.java
@@ -14,6 +14,7 @@ import org.hibernate.search.engine.mapper.mapping.building.spi.MappingConfigurat
 import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoTypeMetadataContributor;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.ProgrammaticMappingConfigurationContext;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
+import org.hibernate.search.mapper.pojo.mapping.spi.PojoMappingConfigurationContext;
 import org.hibernate.search.mapper.pojo.mapping.spi.PojoMappingConfigurationContributor;
 import org.hibernate.search.mapper.pojo.model.spi.PojoBootstrapIntrospector;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeModel;
@@ -31,10 +32,10 @@ public class ProgrammaticMappingConfigurationContextImpl
 	}
 
 	@Override
-	public void configure(MappingBuildContext buildContext,
+	public void configure(MappingBuildContext buildContext, PojoMappingConfigurationContext configurationContext,
 			MappingConfigurationCollector<PojoTypeMetadataContributor> configurationCollector) {
 		for ( TypeMappingStepImpl typeMappingContributor : typeMappingContributors.values() ) {
-			typeMappingContributor.configure( buildContext, configurationCollector );
+			typeMappingContributor.configure( buildContext, configurationContext, configurationCollector );
 		}
 	}
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/TypeMappingStepImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/TypeMappingStepImpl.java
@@ -15,6 +15,7 @@ import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoTypeMetadataCon
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.PropertyMappingStep;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingIndexedStep;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
+import org.hibernate.search.mapper.pojo.mapping.spi.PojoMappingConfigurationContext;
 import org.hibernate.search.mapper.pojo.mapping.spi.PojoMappingConfigurationContributor;
 import org.hibernate.search.mapper.pojo.model.additionalmetadata.building.spi.PojoAdditionalMetadataCollectorTypeNode;
 import org.hibernate.search.mapper.pojo.model.spi.PojoPropertyModel;
@@ -32,7 +33,7 @@ public class TypeMappingStepImpl
 	}
 
 	@Override
-	public void configure(MappingBuildContext buildContext,
+	public void configure(MappingBuildContext buildContext, PojoMappingConfigurationContext configurationContext,
 			MappingConfigurationCollector<PojoTypeMetadataContributor> configurationCollector) {
 		configurationCollector.collectContributor( typeModel, this );
 	}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoMappingConfigurationContextImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoMappingConfigurationContextImpl.java
@@ -1,0 +1,32 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.mapping.impl;
+
+import java.util.Optional;
+
+import org.hibernate.search.mapper.pojo.extractor.impl.BoundContainerExtractorPath;
+import org.hibernate.search.mapper.pojo.extractor.impl.ContainerExtractorBinder;
+import org.hibernate.search.mapper.pojo.extractor.mapping.programmatic.ContainerExtractorPath;
+import org.hibernate.search.mapper.pojo.mapping.spi.PojoMappingConfigurationContext;
+import org.hibernate.search.mapper.pojo.model.spi.PojoGenericTypeModel;
+
+public final class PojoMappingConfigurationContextImpl implements PojoMappingConfigurationContext {
+
+	private final ContainerExtractorBinder extractorBinder;
+
+	public PojoMappingConfigurationContextImpl(ContainerExtractorBinder extractorBinder) {
+		this.extractorBinder = extractorBinder;
+	}
+
+	@Override
+	public Optional<PojoGenericTypeModel<?>> extractedValueType(PojoGenericTypeModel<?> sourceType,
+				ContainerExtractorPath extractorPath) {
+		return extractorBinder.tryBindPath( sourceType, extractorPath )
+				.map( BoundContainerExtractorPath::getExtractedType );
+	}
+
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/spi/PojoMappingConfigurationContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/spi/PojoMappingConfigurationContext.java
@@ -1,0 +1,25 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.mapping.spi;
+
+import java.util.Optional;
+
+import org.hibernate.search.mapper.pojo.extractor.mapping.programmatic.ContainerExtractorPath;
+import org.hibernate.search.mapper.pojo.model.spi.PojoGenericTypeModel;
+
+public interface PojoMappingConfigurationContext {
+
+	/**
+	 * @param sourceType A source type, typically a container type such as Collection.
+	 * @param extractorPath A container extractor path, possibly just {@link ContainerExtractorPath#defaultExtractors()}.
+	 * @return The type of values extracted from the given source type with the given container extractor path,
+	 * or {@link Optional#empty()} if the path cannot be applied.
+	 */
+	Optional<PojoGenericTypeModel<?>> extractedValueType(PojoGenericTypeModel<?> sourceType,
+				ContainerExtractorPath extractorPath);
+
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/spi/PojoMappingConfigurationContributor.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/spi/PojoMappingConfigurationContributor.java
@@ -12,7 +12,7 @@ import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoTypeMetadataCon
 
 public interface PojoMappingConfigurationContributor {
 
-	void configure(MappingBuildContext buildContext,
+	void configure(MappingBuildContext buildContext, PojoMappingConfigurationContext configurationContext,
 			MappingConfigurationCollector<PojoTypeMetadataContributor> configurationCollector);
 
 }

--- a/util/common/src/main/java/org/hibernate/search/util/common/reporting/EventContext.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/reporting/EventContext.java
@@ -86,6 +86,8 @@ public final class EventContext {
 
 	/**
 	 * @return A human-readable representation of this context.
+	 * This representation may change without prior notice in new versions of Hibernate Search:
+	 * callers should not try to parse it.
 	 */
 	public String render() {
 		StringJoiner contextJoiner = new StringJoiner( MESSAGES.contextSeparator() );
@@ -97,6 +99,8 @@ public final class EventContext {
 
 	/**
 	 * @return A human-readable representation of this context, with a "Context: " prefix.
+	 * This representation may change without prior notice in new versions of Hibernate Search:
+	 * callers should not try to parse it.
 	 */
 	public String renderWithPrefix() {
 		return MESSAGES.contextPrefix() + render();

--- a/util/common/src/main/java/org/hibernate/search/util/common/reporting/EventContextElement.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/reporting/EventContextElement.java
@@ -16,6 +16,8 @@ public interface EventContextElement {
 	 * @return A human-readable representation of this context.
 	 * The representation should use brief, natural language to refer to objects rather than class names,
 	 * e.g. "index 'myIndexName'" rather than "ElasticsearchIndexManager{name = 'myIndexName'}".
+	 * The representation may change without prior notice in new versions of Hibernate Search:
+	 * callers should not try to parse it.
 	 */
 	String render();
 


### PR DESCRIPTION
* [HSEARCH-4003](https://hibernate.atlassian.net/browse/HSEARCH-4003): Automatically expand repeatable annotations in MappingAnnotatedElement
* [HSEARCH-4002](https://hibernate.atlassian.net/browse/HSEARCH-4002): Expose the type of a property for a given ContainerExtractorPath in MappingAnnotatedProperty
* [HSEARCH-4004](https://hibernate.atlassian.net/browse/HSEARCH-4004): Expose an eventContext from MappingAnnotationProcessorContext

Necessary for the Search 5 compatibility layer.