### PR TITLE
HSEARCH-4007 Throw an exception when the document ID turns out to be non-unique when loading entities during a search query

### DIFF
--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingNonUniqueDocumentIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingNonUniqueDocumentIdIT.java
@@ -1,0 +1,99 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.orm.search.loading;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.util.common.SearchException;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.integrationtest.common.rule.StubSearchWorkBehavior;
+import org.hibernate.search.util.impl.integrationtest.common.stub.backend.StubBackendUtils;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class SearchQueryEntityLoadingNonUniqueDocumentIdIT {
+
+	@Rule
+	public BackendMock backendMock = new BackendMock();
+
+	@Rule
+	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+
+	private SessionFactory sessionFactory;
+
+	@Before
+	public void setup() {
+		backendMock.expectAnySchema( IndexedEntity.NAME );
+		sessionFactory = ormSetupHelper.start().setup( IndexedEntity.class );
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void nonUniqueDocumentId() {
+		backendMock.inLenientMode( () -> OrmUtils.withinTransaction( sessionFactory, session -> {
+			for ( long i = 0; i < 2; i++ ) {
+				IndexedEntity entity = new IndexedEntity();
+				entity.setId( i );
+				entity.setNonUniqueProperty( 0L );
+				session.persist( entity );
+			}
+		} ) );
+
+		assertThatThrownBy( () -> OrmUtils.withinTransaction( sessionFactory, session -> {
+			backendMock.expectSearchObjects( IndexedEntity.NAME,
+					StubSearchWorkBehavior.of( 1, StubBackendUtils.reference( IndexedEntity.NAME, "0" ) ) );
+			Search.session( session ).search( IndexedEntity.class )
+					.where( f -> f.matchAll() )
+					.fetchAllHits();
+		} ) )
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Found multiple entities of type '" + IndexedEntity.NAME
+						+ "' with 'nonUniqueProperty' set to '0'."
+						+ " 'nonUniqueProperty' is the document ID and must be assigned unique values." );
+	}
+
+	@Entity(name = IndexedEntity.NAME)
+	@Indexed
+	private static class IndexedEntity {
+
+		private static final String NAME = "Indexed";
+
+		@Id
+		private Long id;
+
+		@DocumentId
+		private Long nonUniqueProperty;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public Long getNonUniqueProperty() {
+			return nonUniqueProperty;
+		}
+
+		public void setNonUniqueProperty(Long nonUniqueProperty) {
+			this.nonUniqueProperty = nonUniqueProperty;
+		}
+	}
+
+}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/logging/impl/Log.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/logging/impl/Log.java
@@ -292,4 +292,9 @@ public interface Log extends BasicLogger {
 
 	@Message(id = ID_OFFSET_2 + 39, value = "Cannot use this ScrollableResults instance: it is closed.")
 	SearchException cannotUseClosedScrollableResults();
+
+	@Message(id = ID_OFFSET_2 + 40, value = "Found multiple entities of type '%1$s' with '%2$s' set to '%3$s'."
+				+ " '%2$s' is the document ID and must be assigned unique values.")
+	SearchException foundMultipleEntitiesForDocumentId(String entityName, String documentIdSourcePropertyName,
+			Object id);
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/HibernateOrmNonEntityIdPropertyEntityLoader.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/search/loading/impl/HibernateOrmNonEntityIdPropertyEntityLoader.java
@@ -94,7 +94,11 @@ public class HibernateOrmNonEntityIdPropertyEntityLoader<E> implements Hibernate
 
 			EntityReference reference = documentIdSourceValueToReference.get( documentIdSourceValue );
 
-			entitiesByReference.put( reference, loadedEntity );
+			Object previous = entitiesByReference.put( reference, loadedEntity );
+			if ( previous != null ) {
+				throw log.foundMultipleEntitiesForDocumentId( reference.name(), documentIdSourcePropertyName,
+						reference.id() );
+			}
 		}
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4007
