### PR TITLE
HSEARCH-3995 Add Lucene/Elasticsearch versions to the "Compatibility" section of the documentation

### DIFF
--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -261,8 +261,11 @@
                         <hibernateVersion>${version.org.hibernate}</hibernateVersion>
                         <hibernateDocUrl>${documentation.org.hibernate.url}</hibernateDocUrl>
                         <jpaVersion>${parsed-version.javax.persistence.majorVersion}.${parsed-version.javax.persistence.minorVersion}</jpaVersion>
+                        <luceneVersion>${version.org.apache.lucene}</luceneVersion>
                         <luceneJavadocUrl>${javadoc.org.apache.lucene.core.url}</luceneJavadocUrl>
                         <elasticsearchDocUrl>${documentation.org.elasticsearch.url}</elasticsearchDocUrl>
+                        <elasticsearchCompatibleVersions>${version.org.elasticsearch.compatible.text}</elasticsearchCompatibleVersions>
+                        <elasticsearchOtherPotentiallyCompatibleVersions>${version.org.elasticsearch.compatible.potentially.text}</elasticsearchOtherPotentiallyCompatibleVersions>
                         <wildflyUrl>https://wildfly.org/</wildflyUrl>
                         <quarkusUrl>https://quarkus.io/</quarkusUrl>
                         <springUrl>https://spring.io/</springUrl>

--- a/documentation/src/main/asciidoc/reference/getting-started.asciidoc
+++ b/documentation/src/main/asciidoc/reference/getting-started.asciidoc
@@ -28,6 +28,12 @@ for more detailed and up-to-date information.
 |Hibernate ORM *{hibernateVersion}*.
 |JPA (for the ORM mapper)
 |JPA *{jpaVersion}*.
+|Apache Lucene (for the Lucene backend)
+|Lucene *{luceneVersion}*.
+|Elasticsearch server (for the Elasticsearch backend)
+|Elasticsearch *{elasticsearchCompatibleVersions}*.
+Other minor versions (e.g. {elasticsearchOtherPotentiallyCompatibleVersions}) may work
+but are not given priority for bugfixes and new features.
 |===============
 
 [TIP]

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,10 @@
              matching test profile as well, e.g. elasticsearch-6.0 for the 6.0+ series -->
         <!-- The main version of Elasticsearch targeted by Hibernate Search, tested in the default profile -->
         <version.org.elasticsearch.main>7.9.0</version.org.elasticsearch.main>
+        <!-- The versions of Elasticsearch advertised as compatible with Hibernate Search -->
+        <version.org.elasticsearch.compatible.text>5.6, 6.8 or 7.9</version.org.elasticsearch.compatible.text>
+        <!-- The versions of Elasticsearch that may work, but are not given priority for bugfixes and new features -->
+        <version.org.elasticsearch.compatible.potentially.text>6.0 or 7.0</version.org.elasticsearch.compatible.potentially.text>
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently from the version of the remote cluster -->
         <version.org.elasticsearch.client>${version.org.elasticsearch.main}</version.org.elasticsearch.client>
         <documentation.org.elasticsearch.url>https://www.elastic.co/guide/en/elasticsearch/reference/${parsed-version.org.elasticsearch.main.majorVersion}.${parsed-version.org.elasticsearch.main.minorVersion}</documentation.org.elasticsearch.url>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3995
