### PR TITLE
HSEARCH-3947 Avoid creating huge arrays for collectors when a query does not have an upper bound limit

### DIFF
--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearcherImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearcherImpl.java
@@ -70,11 +70,8 @@ class LuceneSearcherImpl<H> implements LuceneSearcher<LuceneLoadableSearchResult
 		// TODO HSEARCH-3947 Check (and in case avoid) huge arrays are created for collectors when a query does not have an upper bound limit
 		int maxDocs = getMaxDocs( indexSearcher.getIndexReader(), offset, limit );
 
-		LuceneCollectors luceneCollectors = buildCollectors( indexSearcher, metadataResolver, maxDocs,
-				totalHitCountThreshold
-		);
-
-		luceneCollectors.collectMatchingDocs( offset, limit );
+		LuceneCollectors luceneCollectors = collectMatchingDocs(
+				indexSearcher, metadataResolver, offset, limit, maxDocs, totalHitCountThreshold );
 
 		LuceneExtractableSearchResult<H> extractableSearchResult = new LuceneExtractableSearchResult<>(
 				requestContext, indexSearcher,
@@ -93,10 +90,8 @@ class LuceneSearcherImpl<H> implements LuceneSearcher<LuceneLoadableSearchResult
 		int offset = 0;
 		int maxDocs = getMaxDocs( indexSearcher.getIndexReader(), offset, limit );
 
-		LuceneCollectors luceneCollectors = buildCollectors( indexSearcher, metadataResolver, maxDocs,
-				Integer.MAX_VALUE );
-
-		luceneCollectors.collectMatchingDocs( offset, limit );
+		LuceneCollectors luceneCollectors = collectMatchingDocs(
+				indexSearcher, metadataResolver, offset, limit, maxDocs, Integer.MAX_VALUE );
 
 		return new LuceneExtractableSearchResult<>(
 				requestContext, indexSearcher,
@@ -133,6 +128,15 @@ class LuceneSearcherImpl<H> implements LuceneSearcher<LuceneLoadableSearchResult
 	@Override
 	public void setTimeoutManager(LuceneTimeoutManager timeoutManager) {
 		this.timeoutManager = timeoutManager;
+	}
+
+	private LuceneCollectors collectMatchingDocs(IndexSearcher indexSearcher,
+			IndexReaderMetadataResolver metadataResolver, int offset, Integer limit,
+			int maxDocs, int totalHitCountThreshold) throws IOException {
+		LuceneCollectors luceneCollectors = buildCollectors( indexSearcher, metadataResolver,
+				maxDocs, totalHitCountThreshold );
+		luceneCollectors.collectMatchingDocs( offset, limit );
+		return luceneCollectors;
 	}
 
 	private LuceneCollectors buildCollectors(IndexSearcher indexSearcher, IndexReaderMetadataResolver metadataResolver,

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneNoLimitSearchIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneNoLimitSearchIT.java
@@ -54,6 +54,39 @@ public class LuceneNoLimitSearchIT {
 	}
 
 	@Test
+	public void fetchAll_lessThan100Matches() {
+		SearchQuery<DocumentReference> query = index.createScope().query()
+				.where( f -> f.range().field( "field" ).between( "73979", "73997" ) )
+				.toQuery();
+
+		SearchResult<DocumentReference> documentReferences = query.fetchAll();
+
+		assertThat( documentReferences ).hasTotalHitCount( 21L );
+	}
+
+	@Test
+	public void fetchAll_between100And10000Matches() {
+		SearchQuery<DocumentReference> query = index.createScope().query()
+				.where( f -> f.range().field( "field" ).between( "73937", "79397" ) )
+				.toQuery();
+
+		SearchResult<DocumentReference> documentReferences = query.fetchAll();
+
+		assertThat( documentReferences ).hasTotalHitCount( 6067L );
+	}
+
+	@Test
+	public void fetchAll_moreThan10000Matches() {
+		SearchQuery<DocumentReference> query = index.createScope().query()
+				.where( f -> f.range().field( "field" ).between( "37973", "73937" ) )
+				.toQuery();
+
+		SearchResult<DocumentReference> documentReferences = query.fetchAll();
+
+		assertThat( documentReferences ).hasTotalHitCount( 39961L );
+	}
+
+	@Test
 	public void fetchAll_totalHitCountThreshold() {
 		SearchQuery<DocumentReference> query = index.createScope().query()
 				.where( f -> f.match().field( "field" ).matching( "739" ) )

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneNoLimitSearchIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneNoLimitSearchIT.java
@@ -1,0 +1,97 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.lucene.search;
+
+import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.documentProvider;
+
+import java.util.List;
+
+import org.hibernate.search.engine.backend.common.DocumentReference;
+import org.hibernate.search.engine.backend.document.IndexFieldReference;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.search.query.SearchQuery;
+import org.hibernate.search.engine.search.query.SearchResult;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
+import org.hibernate.search.util.impl.test.annotation.TestForIssue;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+@TestForIssue(jiraKey = "HSEARCH-3947")
+public class LuceneNoLimitSearchIT {
+
+	public static final int INDEX_SIZE = 100_000;
+
+	@ClassRule
+	public static final SearchSetupHelper setupHelper = new SearchSetupHelper();
+
+	private static final SimpleMappedIndex<IndexBinding> index = SimpleMappedIndex.of( IndexBinding::new );
+
+	@BeforeClass
+	public static void setup() {
+		setupHelper.start().withIndex( index ).setup();
+		initData();
+	}
+
+	@Test
+	public void fetchAll() {
+		SearchQuery<DocumentReference> query = index.createScope().query()
+				.where( f -> f.match().field( "field" ).matching( "739" ) )
+				.toQuery();
+
+		SearchResult<DocumentReference> documentReferences = query.fetchAll();
+
+		assertThat( documentReferences )
+				.hasDocRefHitsAnyOrder( index.typeName(), "739" )
+				.hasTotalHitCount( 1L );
+	}
+
+	@Test
+	public void fetchAll_totalHitCountThreshold() {
+		SearchQuery<DocumentReference> query = index.createScope().query()
+				.where( f -> f.match().field( "field" ).matching( "739" ) )
+				.totalHitCountThreshold( 5 )
+				.toQuery();
+
+		SearchResult<DocumentReference> documentReferences = query.fetchAll();
+
+		assertThat( documentReferences )
+				.hasDocRefHitsAnyOrder( index.typeName(), "739" )
+				.hasTotalHitCount( 1L );
+	}
+
+	@Test
+	public void fetchAllHits() {
+		SearchQuery<DocumentReference> query = index.createScope().query()
+				.where( f -> f.match().field( "field" ).matching( "739" ) )
+				.toQuery();
+
+		List<DocumentReference> documentReferences = query.fetchAllHits();
+
+		assertThat( documentReferences ).hasDocRefHitsAnyOrder( index.typeName(), "739" );
+	}
+
+	private static void initData() {
+		index.bulkIndexer()
+				.add( INDEX_SIZE, i -> documentProvider(
+						String.valueOf( i ),
+						document -> document.addValue( index.binding().field, String.valueOf( i ) )
+				) )
+				.join();
+	}
+
+	private static class IndexBinding {
+		final IndexFieldReference<String> field;
+
+		IndexBinding(IndexSchemaElement root) {
+			field = root.field( "field", c -> c.asString() ).toReference();
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3947