### PR TITLE
HSEARCH-3917 + HSEARCH-4018 + HSEARCH-4019 Performance improvements for queries matching many documents

### DIFF
--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/dsl/impl/LuceneIndexSchemaObjectFieldNodeBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/dsl/impl/LuceneIndexSchemaObjectFieldNodeBuilder.java
@@ -81,7 +81,7 @@ class LuceneIndexSchemaObjectFieldNodeBuilder extends AbstractLuceneIndexSchemaO
 		);
 
 		staticChildrenForParent.add( node );
-		collector.collectObjectFieldNode( absoluteFieldPath, node );
+		collector.collect( absoluteFieldPath, node );
 
 		reference.setSchemaNode( node );
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/dsl/impl/LuceneIndexSchemaRootNodeBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/dsl/impl/LuceneIndexSchemaRootNodeBuilder.java
@@ -80,12 +80,12 @@ public class LuceneIndexSchemaRootNodeBuilder extends AbstractLuceneIndexSchemaO
 
 		LuceneIndexSchemaNodeCollector collector = new LuceneIndexSchemaNodeCollector() {
 			@Override
-			public void collectFieldNode(String absoluteFieldPath, LuceneIndexSchemaValueFieldNode<?> node) {
+			public void collect(String absoluteFieldPath, LuceneIndexSchemaValueFieldNode<?> node) {
 				fieldNodes.put( absoluteFieldPath, node );
 			}
 
 			@Override
-			public void collectObjectFieldNode(String absolutePath, LuceneIndexSchemaObjectFieldNode node) {
+			public void collect(String absolutePath, LuceneIndexSchemaObjectFieldNode node) {
 				objectFieldNodes.put( absolutePath, node );
 			}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/dsl/impl/LuceneIndexSchemaValueFieldNodeBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/dsl/impl/LuceneIndexSchemaValueFieldNodeBuilder.java
@@ -81,7 +81,7 @@ class LuceneIndexSchemaValueFieldNodeBuilder<F>
 		);
 
 		staticChildrenForParent.add( fieldNode );
-		collector.collectFieldNode( fieldNode.absolutePath(), fieldNode );
+		collector.collect( fieldNode.absolutePath(), fieldNode );
 
 		reference.setSchemaNode( fieldNode );
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/impl/LuceneIndexSchemaNodeCollector.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/impl/LuceneIndexSchemaNodeCollector.java
@@ -8,9 +8,9 @@ package org.hibernate.search.backend.lucene.document.model.impl;
 
 
 public interface LuceneIndexSchemaNodeCollector {
-	void collectObjectFieldNode(String absolutePath, LuceneIndexSchemaObjectFieldNode node);
+	void collect(String absolutePath, LuceneIndexSchemaObjectFieldNode node);
 
-	void collectFieldNode(String absoluteFieldPath, LuceneIndexSchemaValueFieldNode<?> node);
+	void collect(String absoluteFieldPath, LuceneIndexSchemaValueFieldNode<?> node);
 
 	void collect(LuceneIndexSchemaObjectFieldTemplate template);
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/impl/LuceneIndexSchemaObjectFieldTemplate.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/impl/LuceneIndexSchemaObjectFieldTemplate.java
@@ -6,11 +6,11 @@
  */
 package org.hibernate.search.backend.lucene.document.model.impl;
 
-import java.util.Collections;
-
-import org.hibernate.search.engine.backend.types.ObjectStructure;
 import org.hibernate.search.engine.backend.document.model.spi.IndexFieldInclusion;
+import org.hibernate.search.engine.backend.types.ObjectStructure;
 import org.hibernate.search.util.common.pattern.spi.SimpleGlobPattern;
+
+import java.util.Collections;
 
 
 public class LuceneIndexSchemaObjectFieldTemplate
@@ -33,5 +33,9 @@ public class LuceneIndexSchemaObjectFieldTemplate
 				// TODO HSEARCH-3905 we don't know the children, so we should find another way to implement the exists predicate
 				Collections.emptyList()
 		);
+	}
+
+	public ObjectStructure structure() {
+		return structure;
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/scope/model/impl/LuceneScopeSearchIndexesContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/scope/model/impl/LuceneScopeSearchIndexesContext.java
@@ -19,17 +19,17 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexModel;
-import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexSchemaValueFieldNode;
 import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexSchemaObjectFieldNode;
+import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexSchemaValueFieldNode;
 import org.hibernate.search.backend.lucene.logging.impl.Log;
 import org.hibernate.search.backend.lucene.search.impl.LuceneMultiIndexSearchValueFieldContext;
 import org.hibernate.search.backend.lucene.search.impl.LuceneSearchIndexContext;
-import org.hibernate.search.backend.lucene.search.impl.LuceneSearchValueFieldContext;
 import org.hibernate.search.backend.lucene.search.impl.LuceneSearchIndexesContext;
+import org.hibernate.search.backend.lucene.search.impl.LuceneSearchValueFieldContext;
 import org.hibernate.search.backend.lucene.types.predicate.impl.LuceneObjectPredicateBuilderFactory;
 import org.hibernate.search.backend.lucene.types.predicate.impl.LuceneObjectPredicateBuilderFactoryImpl;
-import org.hibernate.search.engine.backend.types.ObjectStructure;
 import org.hibernate.search.engine.backend.document.model.spi.IndexFieldFilter;
+import org.hibernate.search.engine.backend.types.ObjectStructure;
 import org.hibernate.search.engine.backend.types.converter.spi.StringToDocumentIdentifierValueConverter;
 import org.hibernate.search.engine.backend.types.converter.spi.ToDocumentIdentifierValueConverter;
 import org.hibernate.search.engine.reporting.spi.EventContexts;
@@ -179,6 +179,16 @@ public class LuceneScopeSearchIndexesContext implements LuceneSearchIndexesConte
 			throw log.unknownFieldForSearch( absoluteFieldPath, indexesEventContext() );
 		}
 		return resultOrNull;
+	}
+
+	@Override
+	public boolean hasNestedDocuments() {
+		for ( LuceneScopeIndexManagerContext element : elements() ) {
+			if ( element.model().hasNestedDocuments() ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/extraction/impl/ExtractionRequirements.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/extraction/impl/ExtractionRequirements.java
@@ -47,7 +47,7 @@ public final class ExtractionRequirements {
 			IndexReaderMetadataResolver metadataResolver, int maxDocs, LuceneTimeoutManager timeoutManager,
 			int totalHitCountThreshold)
 			throws IOException {
-		TopDocsCollector<?> topDocsCollector;
+		TopDocsCollector<?> topDocsCollector = null;
 		Integer scoreSortFieldIndexForRescoring = null;
 		boolean requireFieldDocRescoring = false;
 
@@ -79,7 +79,11 @@ public final class ExtractionRequirements {
 			collectorsForAllMatchingDocsBuilder.add( LuceneCollectors.TOP_DOCS_KEY, topDocsCollector );
 		}
 
-		if ( totalHitCountThreshold == Integer.MAX_VALUE ) {
+		if ( topDocsCollector == null ) {
+			// Normally the topDocsCollector collects the total hit count,
+			// but if it's not there, we need a separate collector.
+			// Note that adding this collector can have a significant cost in some situations
+			// (e.g. for queries matching many hits), so we only add it if it's really necessary.
 			TotalHitCountCollector totalHitCountCollector = new TotalHitCountCollector();
 			collectorsForAllMatchingDocsBuilder.add( LuceneCollectors.TOTAL_HIT_COUNT_KEY, totalHitCountCollector );
 		}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/extraction/impl/ExtractionRequirements.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/extraction/impl/ExtractionRequirements.java
@@ -58,10 +58,8 @@ public final class ExtractionRequirements {
 				new CollectorSet.Builder( executionContext, timeoutManager );
 
 		if ( maxDocs > 0 ) {
-			if ( sort == null ) {
-				topDocsCollector = TopScoreDocCollector.create(
-						maxDocs, totalHitCountThreshold
-				);
+			if ( sort == null || isDescendingScoreSort( sort ) ) {
+				topDocsCollector = TopScoreDocCollector.create( maxDocs, totalHitCountThreshold );
 			}
 			else {
 				if ( requireScore ) {
@@ -99,6 +97,15 @@ public final class ExtractionRequirements {
 				requiredCollectorForTopDocsFactories,
 				timeoutManager
 		);
+	}
+
+	private boolean isDescendingScoreSort(Sort sort) {
+		SortField[] fields = sort.getSort();
+		return fields.length == 1 && isDescendingScoreSort( fields[0] );
+	}
+
+	private boolean isDescendingScoreSort(SortField sortField) {
+		return SortField.Type.SCORE == sortField.getType() && !sortField.getReverse();
 	}
 
 	private Integer getScoreSortFieldIndexOrNull(Sort sort) {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/impl/LuceneSearchIndexesContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/impl/LuceneSearchIndexesContext.java
@@ -29,6 +29,8 @@ public interface LuceneSearchIndexesContext {
 
 	LuceneSearchValueFieldContext<?> field(String absoluteFieldPath);
 
+	boolean hasNestedDocuments();
+
 	void checkNestedField(String absoluteFieldPath);
 
 	List<String> nestedPathHierarchyForObject(String absoluteFieldPath);

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/query/impl/LuceneSearchQueryBuilder.java
@@ -174,7 +174,10 @@ public class LuceneSearchQueryBuilder<H>
 
 		BooleanQuery.Builder luceneQueryBuilder = new BooleanQuery.Builder();
 		luceneQueryBuilder.add( luceneQuery, Occur.MUST );
-		luceneQueryBuilder.add( Queries.mainDocumentQuery(), Occur.FILTER );
+		if ( searchContext.indexes().hasNestedDocuments() ) {
+			// HSEARCH-4018: this filter has a (small) cost, so we only add it if necessary.
+			luceneQueryBuilder.add( Queries.mainDocumentQuery(), Occur.FILTER );
+		}
 		if ( !routingKeys.isEmpty() ) {
 			Query routingKeysQuery = Queries.anyTerm( MetadataFields.routingKeyFieldName(), routingKeys );
 			luceneQueryBuilder.add( routingKeysQuery, Occur.FILTER );

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneSearchTopDocsMergeScoreSortIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneSearchTopDocsMergeScoreSortIT.java
@@ -65,8 +65,8 @@ public class LuceneSearchTopDocsMergeScoreSortIT {
 	public void desc() {
 		LuceneSearchQuery<DocumentReference> segment0Query = matchTextSortedByScoreQuery( SortOrder.DESC, SEGMENT_0 );
 		LuceneSearchQuery<DocumentReference> segment1Query = matchTextSortedByScoreQuery( SortOrder.DESC, SEGMENT_1 );
-		LuceneSearchResult segment0Result = segment0Query.fetch( 10 );
-		LuceneSearchResult segment1Result = segment1Query.fetch( 10 );
+		LuceneSearchResult<DocumentReference> segment0Result = segment0Query.fetch( 10 );
+		LuceneSearchResult<DocumentReference> segment1Result = segment1Query.fetch( 10 );
 		assertThat( segment0Result )
 				.hasDocRefHitsExactOrder( index.typeName(), SEGMENT_0_DOC_0, SEGMENT_0_DOC_1 );
 		assertThat( segment1Result )
@@ -87,8 +87,8 @@ public class LuceneSearchTopDocsMergeScoreSortIT {
 	public void asc() {
 		LuceneSearchQuery<DocumentReference> segment0Query = matchTextSortedByScoreQuery( SortOrder.ASC, SEGMENT_0 );
 		LuceneSearchQuery<DocumentReference> segment1Query = matchTextSortedByScoreQuery( SortOrder.ASC, SEGMENT_1 );
-		LuceneSearchResult segment0Result = segment0Query.fetch( 10 );
-		LuceneSearchResult segment1Result = segment1Query.fetch( 10 );
+		LuceneSearchResult<DocumentReference> segment0Result = segment0Query.fetch( 10 );
+		LuceneSearchResult<DocumentReference> segment1Result = segment1Query.fetch( 10 );
 		assertThat( segment0Result )
 				.hasDocRefHitsExactOrder( index.typeName(), SEGMENT_0_DOC_1, SEGMENT_0_DOC_0 );
 		assertThat( segment1Result )
@@ -113,7 +113,8 @@ public class LuceneSearchTopDocsMergeScoreSortIT {
 				.toQuery();
 	}
 
-	private TopFieldDocs[] retrieveTopDocs(LuceneSearchQuery<?> query, LuceneSearchResult ... results) {
+	@SafeVarargs
+	private TopFieldDocs[] retrieveTopDocs(LuceneSearchQuery<?> query, LuceneSearchResult<DocumentReference> ... results) {
 		Sort sort = query.luceneSort();
 		TopFieldDocs[] allTopDocs = new TopFieldDocs[results.length];
 		for ( int i = 0; i < results.length; i++ ) {

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneSearchTopDocsMergeScoreSortIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneSearchTopDocsMergeScoreSortIT.java
@@ -73,7 +73,7 @@ public class LuceneSearchTopDocsMergeScoreSortIT {
 				.hasDocRefHitsExactOrder( index.typeName(), SEGMENT_1_DOC_0, SEGMENT_1_DOC_1 );
 
 		TopFieldDocs[] allTopDocs = retrieveTopDocs( segment0Query, segment0Result, segment1Result );
-		Assertions.assertThat( TopDocs.merge( segment0Query.luceneSort(), 10, allTopDocs ).scoreDocs )
+		Assertions.assertThat( TopDocs.merge( 10, allTopDocs ).scoreDocs )
 				.containsExactly(
 						allTopDocs[1].scoreDocs[0], // SEGMENT_1_DOC_0
 						allTopDocs[0].scoreDocs[0], // SEGMENT_0_DOC_0
@@ -82,7 +82,9 @@ public class LuceneSearchTopDocsMergeScoreSortIT {
 				);
 	}
 
-	// Also check ascending order, to be sure the above didn't just pass by chance
+	// Also check ascending order:
+	// 1. to be sure the above didn't just pass by chance;
+	// 2. because the TopDocs merging method is not the same in that case.
 	@Test
 	public void asc() {
 		LuceneSearchQuery<DocumentReference> segment0Query = matchTextSortedByScoreQuery( SortOrder.ASC, SEGMENT_0 );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryFetchIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryFetchIT.java
@@ -14,12 +14,13 @@ import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMap
 import java.util.Locale;
 import java.util.Optional;
 
+import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.engine.backend.types.Sortable;
-import org.hibernate.search.engine.backend.common.DocumentReference;
-import org.hibernate.search.engine.search.query.dsl.SearchQueryOptionsStep;
 import org.hibernate.search.engine.search.query.SearchQuery;
+import org.hibernate.search.engine.search.query.dsl.SearchQueryOptionsStep;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
@@ -50,7 +51,7 @@ public class SearchQueryFetchIT {
 
 	@Test
 	public void fetchAll() {
-		assertThat( matchAllQuery().fetchAll() )
+		assertThat( matchAllQuerySortByField().fetchAll() )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasDocRefHitsExactOrder( builder -> {
 					for ( int i = 0; i < DOCUMENT_COUNT; i++ ) {
@@ -69,7 +70,7 @@ public class SearchQueryFetchIT {
 
 	@Test
 	public void fetch_limit() {
-		assertThat( matchAllQuery().fetch( null ) )
+		assertThat( matchAllQuerySortByField().fetch( null ) )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasDocRefHitsExactOrder( builder -> {
 					for ( int i = 0; i < DOCUMENT_COUNT; i++ ) {
@@ -77,18 +78,18 @@ public class SearchQueryFetchIT {
 					}
 				} );
 
-		assertThat( matchAllQuery().fetch( 1 ) )
+		assertThat( matchAllQuerySortByField().fetch( 1 ) )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasDocRefHitsExactOrder( index.typeName(), docId( 0 ) );
 
-		assertThat( matchAllQuery().fetch( 2 ) )
+		assertThat( matchAllQuerySortByField().fetch( 2 ) )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasDocRefHitsExactOrder( index.typeName(), docId( 0 ), docId( 1 ) );
 	}
 
 	@Test
 	public void fetch_offset_limit() {
-		assertThat( matchAllQuery().fetch( 1, null ) )
+		assertThat( matchAllQuerySortByField().fetch( 1, null ) )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasDocRefHitsExactOrder( builder -> {
 					for ( int i = 1; i < DOCUMENT_COUNT; i++ ) {
@@ -96,15 +97,15 @@ public class SearchQueryFetchIT {
 					}
 				} );
 
-		assertThat( matchAllQuery().fetch( 1, 1 ) )
+		assertThat( matchAllQuerySortByField().fetch( 1, 1 ) )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasDocRefHitsExactOrder( index.typeName(), docId( 1 ) );
 
-		assertThat( matchAllQuery().fetch( null, 2 ) )
+		assertThat( matchAllQuerySortByField().fetch( null, 2 ) )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasDocRefHitsExactOrder( index.typeName(), docId( 0 ), docId( 1 ) );
 
-		assertThat( matchAllQuery().fetch( null, null ) )
+		assertThat( matchAllQuerySortByField().fetch( null, null ) )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasDocRefHitsExactOrder( builder -> {
 					for ( int i = 0; i < DOCUMENT_COUNT; i++ ) {
@@ -113,14 +114,52 @@ public class SearchQueryFetchIT {
 				} );
 
 		// Fetch beyond the total hit count
-		assertThat( matchAllQuery().fetch( DOCUMENT_COUNT + 1, null ) )
+		assertThat( matchAllQuerySortByField().fetch( DOCUMENT_COUNT + 1, null ) )
+				.hasTotalHitCount( DOCUMENT_COUNT )
+				.hasNoHits();
+	}
+
+	/**
+	 * Same as the test above, but with the default, score sort.
+	 * This is important in the Lucene implementation in particular,
+	 * where the TopDocsCollector implementation will be different.
+	 */
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4019")
+	public void fetch_offset_limit_defaultSort() {
+		assertThat( matchAllQuerySortByDefault().fetch( 1, null ) )
+				.hasTotalHitCount( DOCUMENT_COUNT )
+				.hasDocRefHitsAnyOrder( builder -> {
+					for ( int i = 1; i < DOCUMENT_COUNT; i++ ) {
+						builder.doc( index.typeName(), docId( i ) );
+					}
+				} );
+
+		assertThat( matchAllQuerySortByDefault().fetch( 1, 1 ) )
+				.hasTotalHitCount( DOCUMENT_COUNT )
+				.hasDocRefHitsAnyOrder( index.typeName(), docId( 1 ) );
+
+		assertThat( matchAllQuerySortByDefault().fetch( null, 2 ) )
+				.hasTotalHitCount( DOCUMENT_COUNT )
+				.hasDocRefHitsAnyOrder( index.typeName(), docId( 0 ), docId( 1 ) );
+
+		assertThat( matchAllQuerySortByDefault().fetch( null, null ) )
+				.hasTotalHitCount( DOCUMENT_COUNT )
+				.hasDocRefHitsAnyOrder( builder -> {
+					for ( int i = 0; i < DOCUMENT_COUNT; i++ ) {
+						builder.doc( index.typeName(), docId( i ) );
+					}
+				} );
+
+		// Fetch beyond the total hit count
+		assertThat( matchAllQuerySortByDefault().fetch( DOCUMENT_COUNT + 1, null ) )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasNoHits();
 	}
 
 	@Test
 	public void fetchAllHits() {
-		assertThat( matchAllQuery().fetchAllHits() )
+		assertThat( matchAllQuerySortByField().fetchAllHits() )
 				.hasDocRefHitsExactOrder( builder -> {
 					for ( int i = 0; i < DOCUMENT_COUNT; i++ ) {
 						builder.doc( index.typeName(), docId( i ) );
@@ -137,36 +176,36 @@ public class SearchQueryFetchIT {
 
 	@Test
 	public void fetchHits_limit() {
-		assertThat( matchAllQuery().fetchHits( null ) )
+		assertThat( matchAllQuerySortByField().fetchHits( null ) )
 				.hasDocRefHitsExactOrder( builder -> {
 					for ( int i = 0; i < DOCUMENT_COUNT; i++ ) {
 						builder.doc( index.typeName(), docId( i ) );
 					}
 				} );
 
-		assertThat( matchAllQuery().fetchHits( 1 ) )
+		assertThat( matchAllQuerySortByField().fetchHits( 1 ) )
 				.hasDocRefHitsExactOrder( index.typeName(), docId( 0 ) );
 
-		assertThat( matchAllQuery().fetchHits( 2 ) )
+		assertThat( matchAllQuerySortByField().fetchHits( 2 ) )
 				.hasDocRefHitsExactOrder( index.typeName(), docId( 0 ), docId( 1 ) );
 	}
 
 	@Test
-	public void fetchHits_offset_limit() {
-		assertThat( matchAllQuery().fetchHits( 1, null ) )
+	public void fetchHits_offset_limit_fieldSort() {
+		assertThat( matchAllQuerySortByField().fetchHits( 1, null ) )
 				.hasDocRefHitsExactOrder( builder -> {
 					for ( int i = 1; i < DOCUMENT_COUNT; i++ ) {
 						builder.doc( index.typeName(), docId( i ) );
 					}
 				} );
 
-		assertThat( matchAllQuery().fetchHits( 1, 1 ) )
+		assertThat( matchAllQuerySortByField().fetchHits( 1, 1 ) )
 				.hasDocRefHitsExactOrder( index.typeName(), docId( 1 ) );
 
-		assertThat( matchAllQuery().fetchHits( null, 2 ) )
+		assertThat( matchAllQuerySortByField().fetchHits( null, 2 ) )
 				.hasDocRefHitsExactOrder( index.typeName(), docId( 0 ), docId( 1 ) );
 
-		assertThat( matchAllQuery().fetchHits( null, null ) )
+		assertThat( matchAllQuerySortByField().fetchHits( null, null ) )
 				.hasDocRefHitsExactOrder( builder -> {
 					for ( int i = 0; i < DOCUMENT_COUNT; i++ ) {
 						builder.doc( index.typeName(), docId( i ) );
@@ -174,13 +213,46 @@ public class SearchQueryFetchIT {
 				} );
 
 		// Fetch beyond the total hit count
-		assertThat( matchAllQuery().fetchHits( DOCUMENT_COUNT + 1, null ) )
+		assertThat( matchAllQuerySortByField().fetchHits( DOCUMENT_COUNT + 1, null ) )
+				.isEmpty();
+	}
+
+	/**
+	 * Same as the test above, but with the default, score sort.
+	 * This is important in the Lucene implementation in particular,
+	 * where the TopDocsCollector implementation will be different.
+	 */
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4019")
+	public void fetchHits_offset_limit_defaultSort() {
+		assertThat( matchAllQuerySortByDefault().fetchHits( 1, null ) )
+				.hasDocRefHitsAnyOrder( builder -> {
+					for ( int i = 1; i < DOCUMENT_COUNT; i++ ) {
+						builder.doc( index.typeName(), docId( i ) );
+					}
+				} );
+
+		assertThat( matchAllQuerySortByDefault().fetchHits( 1, 1 ) )
+				.hasDocRefHitsAnyOrder( index.typeName(), docId( 1 ) );
+
+		assertThat( matchAllQuerySortByDefault().fetchHits( null, 2 ) )
+				.hasDocRefHitsAnyOrder( index.typeName(), docId( 0 ), docId( 1 ) );
+
+		assertThat( matchAllQuerySortByDefault().fetchHits( null, null ) )
+				.hasDocRefHitsAnyOrder( builder -> {
+					for ( int i = 0; i < DOCUMENT_COUNT; i++ ) {
+						builder.doc( index.typeName(), docId( i ) );
+					}
+				} );
+
+		// Fetch beyond the total hit count
+		assertThat( matchAllQuerySortByDefault().fetchHits( DOCUMENT_COUNT + 1, null ) )
 				.isEmpty();
 	}
 
 	@Test
 	public void fetchTotalHitCount() {
-		Assertions.assertThat( matchAllQuery().fetchTotalHitCount() ).isEqualTo( DOCUMENT_COUNT );
+		Assertions.assertThat( matchAllQuerySortByField().fetchTotalHitCount() ).isEqualTo( DOCUMENT_COUNT );
 
 		Assertions.assertThat( matchFirstHalfQuery().fetchTotalHitCount() ).isEqualTo( DOCUMENT_COUNT / 2 );
 	}
@@ -196,14 +268,14 @@ public class SearchQueryFetchIT {
 		Assertions.assertThat( result ).isEmpty();
 
 		Assertions.assertThatThrownBy( () -> {
-			matchAllQuery().fetchSingleHit();
+			matchAllQuerySortByField().fetchSingleHit();
 		} )
 				.isInstanceOf( SearchException.class );
 	}
 
 	@Test
 	public void fetch_limitAndOffset_reuseQuery() {
-		SearchQuery<DocumentReference> query = matchAllQuery().toQuery();
+		SearchQuery<DocumentReference> query = matchAllQuerySortByField().toQuery();
 		assertThat( query.fetch( 1, null ) ).fromQuery( query )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasDocRefHitsExactOrder( builder -> {
@@ -240,16 +312,21 @@ public class SearchQueryFetchIT {
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3389")
 	public void maxResults_zero() {
-		assertThat( matchAllQuery().fetch( 0, 0 ) )
+		assertThat( matchAllQuerySortByField().fetch( 0, 0 ) )
 				.hasTotalHitCount( DOCUMENT_COUNT )
 				.hasNoHits();
 	}
 
-	private SearchQueryOptionsStep<?, DocumentReference, ?, ?, ?> matchAllQuery() {
+	private SearchQueryOptionsStep<?, DocumentReference, ?, ?, ?> matchAllQuerySortByField() {
 		StubMappingScope scope = index.createScope();
 		return scope.query()
 				.where( f -> f.matchAll() )
 				.sort( f -> f.field( "integer" ).asc() );
+	}
+
+	private SearchQueryOptionsStep<?, DocumentReference, ?, ?, ?> matchAllQuerySortByDefault() {
+		StubMappingScope scope = index.createScope();
+		return scope.query().where( f -> f.match().field( "text" ).matching( "someword" ) );
 	}
 
 	private SearchQueryOptionsStep<?, DocumentReference, ?, ?, ?> matchFirstHalfQuery() {
@@ -275,7 +352,24 @@ public class SearchQueryFetchIT {
 		index.bulkIndexer()
 				.add( DOCUMENT_COUNT, i -> documentProvider(
 						docId( i ),
-						document -> document.addValue( index.binding().integer, i )
+						document -> {
+							// Ensure strictly decreasing score for tests relying on score sort,
+							// at least for the first three documents.
+							String text = null;
+							switch ( i ) {
+								case 0:
+									text = "someword someword someword someword and something else";
+									break;
+								case 1:
+									text = "someword someword and something else";
+									break;
+								default:
+									text = "something else something else and well finally someword";
+									break;
+							}
+							document.addValue( index.binding().text, text );
+							document.addValue( index.binding().integer, i );
+						}
 				) )
 				.join();
 	}
@@ -285,9 +379,13 @@ public class SearchQueryFetchIT {
 	}
 
 	private static class IndexBinding {
+		final IndexFieldReference<String> text;
 		final IndexFieldReference<Integer> integer;
 
 		IndexBinding(IndexSchemaElement root) {
+			text = root.field( "text", f -> f.asString()
+					.analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD_ENGLISH.name ) )
+					.toReference();
 			integer = root.field( "integer", f -> f.asInteger().sortable( Sortable.YES ) )
 					.toReference();
 		}


### PR DESCRIPTION
* [HSEARCH-4019](https://hibernate.atlassian.net/browse/HSEARCH-4019): Avoid adding a TotalHitCountCollector to Lucene queries unless absolutely necessary
* [HSEARCH-4018](https://hibernate.atlassian.net/browse/HSEARCH-4018): Avoid filtering out nested documents in Lucene queries when we know there are none
* [HSEARCH-3917](https://hibernate.atlassian.net/browse/HSEARCH-3917): Use TopScoreDocCollector when a descending score sort is requested explicitly

These pages are mostly about executing as little as possible for each hit, when collecting the topdocs.

Together, these patches bring significant performance improvements in @gustavonalle 's performance test that repeatedly and concurrently executes projections for a `MatchAllDocsQuery` on an index of 500,000 documents.

Note there aren't many new tests because I didn't add any feature, and for the most part the code I changed should already be covered by existing tests.

Before:

```
[Done in 60.025000s] 1 node(s), 10 thread(s) per node: Query 90th: 18.087935, QPS: 435.501874
```

After:

```
[Done in 60.013000s] 1 node(s), 10 thread(s) per node: Query 90th: 4.079615, QPS: 756.886008
```

Infinispan 11 / Search 5 (for reference):

```
[Done in 60.013000s] 1 node(s), 10 thread(s) per node: Query 90th: 3.686399, QPS: 792.444970
```
