### PR TITLE
HSEARCH-3998 Mass indexing a (non-abstract) parent class in a type hierarchy with a subclass annotated with @Indexed(enabled = false) still indexes that subclass

### DIFF
--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingComplexHierarchyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingComplexHierarchyIT.java
@@ -1,0 +1,353 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.orm.massindexing;
+
+import static org.assertj.core.api.Fail.fail;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
+import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
+import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.orm.automaticindexing.AutomaticIndexingStrategyName;
+import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
+import org.hibernate.search.mapper.orm.massindexing.MassIndexer;
+import org.hibernate.search.mapper.orm.session.SearchSession;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Test that the {@link MassIndexer} correctly indexes even complex entity hierarchies
+ * where superclasses are indexed but not all of their subclasses, and vice-versa.
+ */
+public class MassIndexingComplexHierarchyIT {
+
+	@Rule
+	public BackendMock backendMock = new BackendMock();
+
+	@Rule
+	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+
+	private SessionFactory sessionFactory;
+
+	@Before
+	public void setup() {
+		backendMock.expectAnySchema( H1_B_Indexed.NAME );
+		backendMock.expectAnySchema( H2_Root_Indexed.NAME );
+		backendMock.expectAnySchema( H2_A_C_Indexed.NAME );
+		backendMock.expectAnySchema( H2_B_Indexed.NAME );
+
+		sessionFactory = ormSetupHelper.start()
+				.withPropertyRadical( HibernateOrmMapperSettings.Radicals.AUTOMATIC_INDEXING_STRATEGY,
+						AutomaticIndexingStrategyName.NONE )
+				.setup(
+						H1_Root_NotIndexed.class, H1_A_NotIndexed.class, H1_B_Indexed.class,
+						H2_Root_Indexed.class,
+						H2_A_NotIndexed.class, H2_A_C_Indexed.class,
+						H2_B_Indexed.class, H2_B_D_NotIndexed.class
+				);
+
+		backendMock.verifyExpectationsMet();
+
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			session.persist( new H1_Root_NotIndexed( 1 ) );
+			session.persist( new H1_A_NotIndexed( 2 ) );
+			session.persist( new H1_B_Indexed( 3 ) );
+			session.persist( new H2_Root_Indexed( 1 ) );
+			session.persist( new H2_A_NotIndexed( 2 ) );
+			session.persist( new H2_A_C_Indexed( 3 ) );
+			session.persist( new H2_B_Indexed( 4 ) );
+			session.persist( new H2_B_D_NotIndexed( 5 ) );
+		} );
+	}
+
+	@Test
+	public void rootNotIndexed_someSubclassesIndexed_requestMassIndexingOnRoot() {
+		OrmUtils.withinSession( sessionFactory, session -> {
+			SearchSession searchSession = Search.session( session );
+			MassIndexer indexer = searchSession.massIndexer( H1_Root_NotIndexed.class );
+
+			backendMock.expectWorksAnyOrder( H1_B_Indexed.NAME, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE )
+					.add( "3", b -> b.field( "rootText", "text3" )
+							.field( "bText", "text3" ) )
+					.processedThenExecuted();
+
+			backendMock.expectIndexScaleWorks( H1_B_Indexed.NAME, session.getTenantIdentifier() )
+					.purge()
+					.mergeSegments()
+					.flush()
+					.refresh();
+
+			try {
+				indexer.startAndWait();
+			}
+			catch (InterruptedException e) {
+				fail( "Unexpected InterruptedException: " + e.getMessage() );
+			}
+		} );
+
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void rootNotIndexed_someSubclassesIndexed_requestMassIndexingOnIndexedSubclass() {
+		OrmUtils.withinSession( sessionFactory, session -> {
+			SearchSession searchSession = Search.session( session );
+			MassIndexer indexer = searchSession.massIndexer( H1_B_Indexed.class );
+
+			backendMock.expectWorksAnyOrder( H1_B_Indexed.NAME, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE )
+					.add( "3", b -> b.field( "rootText", "text3" )
+							.field( "bText", "text3" ) )
+					.processedThenExecuted();
+
+			backendMock.expectIndexScaleWorks( H1_B_Indexed.NAME, session.getTenantIdentifier() )
+					.purge()
+					.mergeSegments()
+					.flush()
+					.refresh();
+
+			try {
+				indexer.startAndWait();
+			}
+			catch (InterruptedException e) {
+				fail( "Unexpected InterruptedException: " + e.getMessage() );
+			}
+		} );
+
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void rootIndexed_someSubclassesIndexed_requestMassIndexingOnRoot() {
+		OrmUtils.withinSession( sessionFactory, session -> {
+			SearchSession searchSession = Search.session( session );
+			MassIndexer indexer = searchSession.massIndexer( H2_Root_Indexed.class );
+
+			backendMock.expectWorksAnyOrder( H2_Root_Indexed.NAME, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE )
+					.add( "1", b -> b.field( "rootText", "text1" ) )
+					.processedThenExecuted();
+			backendMock.expectWorksAnyOrder( H2_A_C_Indexed.NAME, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE )
+					.add( "3", b -> b.field( "rootText", "text3" )
+							.field( "aText", "text3" )
+							.field( "cText", "text3" ) )
+					.processedThenExecuted();
+			backendMock.expectWorksAnyOrder( H2_B_Indexed.NAME, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE )
+					.add( "4", b -> b.field( "rootText", "text4" )
+							.field( "bText", "text4" ) )
+					.processedThenExecuted();
+
+			backendMock.expectIndexScaleWorks( H2_Root_Indexed.NAME, session.getTenantIdentifier() )
+					.purge()
+					.mergeSegments()
+					.flush()
+					.refresh();
+			backendMock.expectIndexScaleWorks( H2_A_C_Indexed.NAME, session.getTenantIdentifier() )
+					.purge()
+					.mergeSegments()
+					.flush()
+					.refresh();
+			backendMock.expectIndexScaleWorks( H2_B_Indexed.NAME, session.getTenantIdentifier() )
+					.purge()
+					.mergeSegments()
+					.flush()
+					.refresh();
+
+			try {
+				indexer.startAndWait();
+			}
+			catch (InterruptedException e) {
+				fail( "Unexpected InterruptedException: " + e.getMessage() );
+			}
+		} );
+
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void rootIndexed_someSubclassesIndexed_requestMassIndexingOnIndexedSubclass() {
+		OrmUtils.withinSession( sessionFactory, session -> {
+			SearchSession searchSession = Search.session( session );
+			MassIndexer indexer = searchSession.massIndexer( H2_B_Indexed.class );
+
+			backendMock.expectWorksAnyOrder( H2_B_Indexed.NAME, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE )
+					.add( "4", b -> b.field( "rootText", "text4" )
+							.field( "bText", "text4" ) )
+					.processedThenExecuted();
+
+			backendMock.expectIndexScaleWorks( H2_B_Indexed.NAME, session.getTenantIdentifier() )
+					.purge()
+					.mergeSegments()
+					.flush()
+					.refresh();
+
+			try {
+				indexer.startAndWait();
+			}
+			catch (InterruptedException e) {
+				fail( "Unexpected InterruptedException: " + e.getMessage() );
+			}
+		} );
+
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Entity(name = H1_Root_NotIndexed.NAME)
+	public static class H1_Root_NotIndexed {
+
+		public static final String NAME = "H1_Root";
+
+		@Id
+		private Integer id;
+
+		@GenericField
+		private String rootText;
+
+		public H1_Root_NotIndexed() {
+		}
+
+		public H1_Root_NotIndexed(Integer id) {
+			this.id = id;
+			this.rootText = "text" + id;
+		}
+	}
+
+	@Entity(name = H1_A_NotIndexed.NAME)
+	public static class H1_A_NotIndexed extends H1_Root_NotIndexed {
+
+		public static final String NAME = "H1_A";
+
+		@GenericField
+		private String aText;
+
+		public H1_A_NotIndexed() {
+		}
+
+		public H1_A_NotIndexed(Integer id) {
+			super( id );
+			this.aText = "text" + id;
+		}
+	}
+
+	@Entity(name = H1_B_Indexed.NAME)
+	@Indexed
+	public static class H1_B_Indexed extends H1_Root_NotIndexed {
+
+		public static final String NAME = "H1_B";
+
+		@GenericField
+		private String bText;
+
+		public H1_B_Indexed() {
+		}
+
+		public H1_B_Indexed(Integer id) {
+			super( id );
+			this.bText = "text" + id;
+		}
+	}
+
+	@Entity(name = H2_Root_Indexed.NAME)
+	@Indexed
+	public static class H2_Root_Indexed {
+
+		public static final String NAME = "H2_Root";
+
+		@Id
+		private Integer id;
+
+		@GenericField
+		private String rootText;
+
+		public H2_Root_Indexed() {
+		}
+
+		public H2_Root_Indexed(Integer id) {
+			this.id = id;
+			this.rootText = "text" + id;
+		}
+	}
+
+	@Entity(name = H2_A_NotIndexed.NAME)
+	@Indexed(enabled = false)
+	public static class H2_A_NotIndexed extends H2_Root_Indexed {
+
+		public static final String NAME = "H2_A";
+
+		@GenericField
+		private String aText;
+
+		public H2_A_NotIndexed() {
+		}
+
+		public H2_A_NotIndexed(Integer id) {
+			super( id );
+			this.aText = "text" + id;
+		}
+	}
+
+	@Entity(name = H2_B_Indexed.NAME)
+	public static class H2_B_Indexed extends H2_Root_Indexed {
+
+		public static final String NAME = "H2_B";
+
+		@GenericField
+		private String bText;
+
+		public H2_B_Indexed() {
+		}
+
+		public H2_B_Indexed(Integer id) {
+			super( id );
+			this.bText = "text" + id;
+		}
+	}
+
+	@Entity(name = H2_A_C_Indexed.NAME)
+	@Indexed
+	public static class H2_A_C_Indexed extends H2_A_NotIndexed {
+
+		public static final String NAME = "H2_A_C";
+
+		@GenericField
+		private String cText;
+
+		public H2_A_C_Indexed() {
+		}
+
+		public H2_A_C_Indexed(Integer id) {
+			super( id );
+			this.cText = "text" + id;
+		}
+	}
+
+	@Entity(name = H2_B_D_NotIndexed.NAME)
+	@Indexed(enabled = false)
+	public static class H2_B_D_NotIndexed extends H2_B_Indexed {
+
+		public static final String NAME = "H2_B_D";
+
+		@GenericField
+		private String dText;
+
+		public H2_B_D_NotIndexed() {
+		}
+
+		public H2_B_D_NotIndexed(Integer id) {
+			super( id );
+			this.dText = "text" + id;
+		}
+	}
+}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingPrimitiveIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingPrimitiveIdIT.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.integrationtest.mapper.orm.nonregression.massindexing;
+package org.hibernate.search.integrationtest.mapper.orm.massindexing;
 
 import static org.assertj.core.api.Fail.fail;
 

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/batchindexing/IndexingGeneratedCorpusTest.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/batchindexing/IndexingGeneratedCorpusTest.java
@@ -32,7 +32,6 @@ import java.lang.invoke.MethodHandles;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -119,7 +118,6 @@ public class IndexingGeneratedCorpusTest {
 	}
 
 	@Test
-	@Ignore("HSEARCH-3998 needs to be solved first")
 	public void testBatchIndexing() throws InterruptedException, IOException {
 		verifyResultNumbers(); //initial count of entities should match expectations
 		purgeAll(); // empty indexes

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/mapping/impl/JavaBeanIndexedTypeContext.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/mapping/impl/JavaBeanIndexedTypeContext.java
@@ -30,6 +30,11 @@ class JavaBeanIndexedTypeContext<E>
 	}
 
 	@Override
+	public String toString() {
+		return typeIdentifier().toString();
+	}
+
+	@Override
 	public PojoRawTypeIdentifier<E> typeIdentifier() {
 		return typeIdentifier;
 	}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/AbstractHibernateOrmTypeContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/AbstractHibernateOrmTypeContext.java
@@ -39,6 +39,11 @@ abstract class AbstractHibernateOrmTypeContext<E>
 	}
 
 	@Override
+	public String toString() {
+		return typeIdentifier().toString();
+	}
+
+	@Override
 	public PojoRawTypeIdentifier<E> typeIdentifier() {
 		return typeIdentifier;
 	}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMapping.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMapping.java
@@ -58,7 +58,6 @@ import org.hibernate.search.mapper.pojo.mapping.spi.PojoMappingDelegate;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeIdentifier;
 import org.hibernate.search.mapper.pojo.schema.management.spi.PojoScopeSchemaManager;
 import org.hibernate.search.mapper.pojo.scope.spi.PojoScopeDelegate;
-import org.hibernate.search.mapper.pojo.work.spi.PojoIndexer;
 import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingPlan;
 import org.hibernate.search.util.common.impl.SuppressingCloser;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
@@ -242,11 +241,6 @@ public class HibernateOrmMapping extends AbstractPojoMappingImplementor<Hibernat
 	@Override
 	public HibernateOrmMapping toConcreteType() {
 		return this;
-	}
-
-	@Override
-	public PojoIndexer createIndexer(SessionImplementor sessionImplementor) {
-		return HibernateOrmSearchSession.get( this, sessionImplementor ).createIndexer();
 	}
 
 	@Override

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/BatchCoordinator.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/BatchCoordinator.java
@@ -151,7 +151,7 @@ public class BatchCoordinator extends FailureHandledRunnable {
 	private <E> BatchIndexingWorkspace<E, ?> createBatchIndexingWorkspace(MassIndexingIndexedTypeGroup<E> typeGroup) {
 		return new BatchIndexingWorkspace<>(
 				mappingContext, sessionContext, getNotifier(),
-				typeGroup.commonSuperType(), typeGroup.idAttribute(),
+				typeGroup.commonSuperType(), typeGroup.idAttribute(), typeGroup.includedIndexedTypesOrEmpty(),
 				documentBuilderThreads, cacheMode,
 				objectLoadingBatchSize,
 				objectsLimit, idFetchSize, transactionTimeout

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/BatchIndexingWorkspace.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/BatchIndexingWorkspace.java
@@ -9,6 +9,7 @@ package org.hibernate.search.mapper.orm.massindexing.impl;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -40,6 +41,7 @@ public class BatchIndexingWorkspace<E, I> extends FailureHandledRunnable {
 
 	private final HibernateOrmMassIndexingIndexedTypeContext<E> type;
 	private final SingularAttribute<? super E, I> idAttributeOfType;
+	private final Set<Class<? extends E>> includedTypesFilter;
 
 	private final ProducerConsumerQueue<List<I>> primaryKeyStream;
 
@@ -61,6 +63,7 @@ public class BatchIndexingWorkspace<E, I> extends FailureHandledRunnable {
 			DetachedBackendSessionContext sessionContext,
 			MassIndexingNotifier notifier,
 			HibernateOrmMassIndexingIndexedTypeContext<E> type, SingularAttribute<? super E, I> idAttributeOfType,
+			Set<Class<? extends E>> includedTypesFilter,
 			int objectLoadingThreads, CacheMode cacheMode, int objectLoadingBatchSize,
 			long objectsLimit,
 			int idFetchSize, Integer transactionTimeout) {
@@ -70,6 +73,7 @@ public class BatchIndexingWorkspace<E, I> extends FailureHandledRunnable {
 
 		this.type = type;
 		this.idAttributeOfType = idAttributeOfType;
+		this.includedTypesFilter = includedTypesFilter;
 		this.idFetchSize = idFetchSize;
 		this.transactionTimeout = transactionTimeout;
 
@@ -133,7 +137,7 @@ public class BatchIndexingWorkspace<E, I> extends FailureHandledRunnable {
 						getNotifier(),
 						primaryKeyStream,
 						objectLoadingBatchSize,
-						type, idAttributeOfType,
+						type, idAttributeOfType, includedTypesFilter,
 						objectsLimit,
 						idFetchSize
 				),

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/HibernateOrmMassIndexingMappingContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/HibernateOrmMassIndexingMappingContext.java
@@ -6,10 +6,11 @@
  */
 package org.hibernate.search.mapper.orm.massindexing.impl;
 
+import javax.persistence.EntityManager;
+
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.search.engine.reporting.FailureHandler;
-import org.hibernate.search.mapper.pojo.work.spi.PojoIndexer;
+import org.hibernate.search.mapper.orm.scope.impl.HibernateOrmScopeSessionContext;
 import org.hibernate.search.engine.environment.thread.spi.ThreadPoolProvider;
 
 public interface HibernateOrmMassIndexingMappingContext {
@@ -20,6 +21,6 @@ public interface HibernateOrmMassIndexingMappingContext {
 
 	FailureHandler failureHandler();
 
-	PojoIndexer createIndexer(SessionImplementor sessionImplementor);
+	HibernateOrmScopeSessionContext sessionContext(EntityManager entityManager);
 
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/HibernateOrmMassIndexingSessionContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/HibernateOrmMassIndexingSessionContext.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.mapper.orm.massindexing.impl;
 
 import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.search.mapper.pojo.model.spi.PojoRuntimeIntrospector;
 import org.hibernate.search.mapper.pojo.work.spi.PojoIndexer;
 
 public interface HibernateOrmMassIndexingSessionContext {
@@ -14,5 +15,7 @@ public interface HibernateOrmMassIndexingSessionContext {
 	SessionImplementor session();
 
 	PojoIndexer createIndexer();
+
+	PojoRuntimeIntrospector runtimeIntrospector();
 
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/HibernateOrmMassIndexingSessionContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/HibernateOrmMassIndexingSessionContext.java
@@ -1,0 +1,18 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.orm.massindexing.impl;
+
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.search.mapper.pojo.work.spi.PojoIndexer;
+
+public interface HibernateOrmMassIndexingSessionContext {
+
+	SessionImplementor session();
+
+	PojoIndexer createIndexer();
+
+}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/MassIndexingIndexedTypeGroup.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/MassIndexingIndexedTypeGroup.java
@@ -1,0 +1,117 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.orm.massindexing.impl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Set;
+import javax.persistence.metamodel.EntityType;
+import javax.persistence.metamodel.SingularAttribute;
+
+import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.search.mapper.orm.common.impl.HibernateOrmUtils;
+
+class MassIndexingIndexedTypeGroup<E> {
+
+	/**
+	 * Group indexed types by their closest common supertype,
+	 * ensuring returned groups are disjoint
+	 * (i.e. no two groups have any common indexed subtype among those provided).
+	 * <p>
+	 * This is necessary to avoid duplicate indexing.
+	 * <p>
+	 * For example, without this, we could end up reindexing type B in one thread,
+	 * and its superclass A (which will include all instances of B) in another.
+	 *
+	 * @param indexedTypeContexts A set of indexed types to group together.
+	 * @return One or more type groups that are guaranteed to be disjoint.
+	 */
+	public static List<MassIndexingIndexedTypeGroup<?>> disjoint(
+			Set<? extends HibernateOrmMassIndexingIndexedTypeContext<?>> indexedTypeContexts) {
+		List<MassIndexingIndexedTypeGroup<?>> typeGroups = new ArrayList<>();
+		for ( HibernateOrmMassIndexingIndexedTypeContext<?> typeContext : indexedTypeContexts ) {
+			MassIndexingIndexedTypeGroup<?> typeGroup = MassIndexingIndexedTypeGroup.single( typeContext );
+			// First try to merge this new type group with an existing one
+			ListIterator<MassIndexingIndexedTypeGroup<?>> iterator = typeGroups.listIterator();
+			while ( iterator.hasNext() ) {
+				MassIndexingIndexedTypeGroup<?> mergeResult = iterator.next().mergeOrNull( typeGroup );
+				if ( mergeResult != null ) {
+					// We found an existing group that can be merged with this one.
+					// Remove that group, we'll add the merge result to the list later.
+					typeGroup = mergeResult;
+					iterator.remove();
+					// Continue iterating through existing groups, as we may be able to merge with multiple groups.
+				}
+			}
+			typeGroups.add( typeGroup );
+		}
+		return typeGroups;
+	}
+
+	private static <E> MassIndexingIndexedTypeGroup<E> single(HibernateOrmMassIndexingIndexedTypeContext<E> typeContext) {
+		return new MassIndexingIndexedTypeGroup<>( typeContext, Collections.singleton( typeContext ) );
+	}
+
+	private final HibernateOrmMassIndexingIndexedTypeContext<E> commonSuperType;
+	private final Set<HibernateOrmMassIndexingIndexedTypeContext<? extends E>> includedTypes;
+
+	private MassIndexingIndexedTypeGroup(HibernateOrmMassIndexingIndexedTypeContext<E> commonSuperType,
+			Set<HibernateOrmMassIndexingIndexedTypeContext<? extends E>> includedTypes) {
+		this.commonSuperType = commonSuperType;
+		this.includedTypes = includedTypes;
+	}
+
+	@Override
+	public String toString() {
+		return getClass().getSimpleName() + "["
+				+ "commonSuperType=" + commonSuperType
+				+ ", includedSubTypes=" + includedTypes
+				+ "]";
+	}
+
+	public HibernateOrmMassIndexingIndexedTypeContext<E> commonSuperType() {
+		return commonSuperType;
+	}
+
+	public SingularAttribute<? super E, ?> idAttribute() {
+		EntityType<E> typeDescriptor = commonSuperType.entityTypeDescriptor();
+		return typeDescriptor.getId( typeDescriptor.getIdType().getJavaType() );
+	}
+
+	/**
+	 * Merge this group with the other group if
+	 * the other group's {@code commonSuperType} represents a supertype or subtype
+	 * of this group's {@code commonSuperType}.
+	 * @param other The other group to merge with (if possible).
+	 * @return The merged group, or {@code null} if
+	 * the other group's {@code commonSuperType} does <strong>not</strong> represent
+	 * a supertype or subtype of this group's {@code commonSuperType}.
+	 */
+	@SuppressWarnings("unchecked") // The casts are guarded by reflection checks
+	private MassIndexingIndexedTypeGroup<?> mergeOrNull(MassIndexingIndexedTypeGroup<?> other) {
+		EntityPersister entityPersister = commonSuperType.entityPersister();
+		EntityPersister otherEntityPersister = other.commonSuperType.entityPersister();
+		if ( HibernateOrmUtils.isSuperTypeOf( entityPersister, otherEntityPersister ) ) {
+			return withAdditionalTypes( ( (MassIndexingIndexedTypeGroup<? extends E>) other ).includedTypes );
+		}
+		if ( HibernateOrmUtils.isSuperTypeOf( otherEntityPersister, entityPersister ) ) {
+			return ( (MassIndexingIndexedTypeGroup<? super E>) other ).withAdditionalTypes( includedTypes );
+		}
+		return null;
+	}
+
+	private MassIndexingIndexedTypeGroup<E> withAdditionalTypes(
+			Set<? extends HibernateOrmMassIndexingIndexedTypeContext<? extends E>> otherIncludedSubTypes) {
+		Set<HibernateOrmMassIndexingIndexedTypeContext<? extends E>> mergedIncludedSubTypes =
+				new HashSet<>( includedTypes );
+		mergedIncludedSubTypes.addAll( otherIncludedSubTypes );
+		return new MassIndexingIndexedTypeGroup<>( commonSuperType, mergedIncludedSubTypes );
+	}
+}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/MassIndexingIndexedTypeGroup.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/MassIndexingIndexedTypeGroup.java
@@ -85,6 +85,20 @@ class MassIndexingIndexedTypeGroup<E> {
 		return typeDescriptor.getId( typeDescriptor.getIdType().getJavaType() );
 	}
 
+	public Set<Class<? extends E>> includedIndexedTypesOrEmpty() {
+		if ( commonSuperType.entityPersister().getEntityMetamodel().getSubclassEntityNames().size()
+				== includedTypes.size() ) {
+			// All types are included, no need to filter.
+			return Collections.emptySet();
+		}
+
+		Set<Class<? extends E>> classes = new HashSet<>( includedTypes.size() );
+		for ( HibernateOrmMassIndexingIndexedTypeContext<? extends E> includedType : includedTypes ) {
+			classes.add( includedType.entityTypeDescriptor().getJavaType() );
+		}
+		return classes;
+	}
+
 	/**
 	 * Merge this group with the other group if
 	 * the other group's {@code commonSuperType} represents a supertype or subtype

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/scope/impl/HibernateOrmScopeMappingContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/scope/impl/HibernateOrmScopeMappingContext.java
@@ -15,6 +15,7 @@ import org.hibernate.search.mapper.orm.search.loading.impl.HibernateOrmLoadingMa
 public interface HibernateOrmScopeMappingContext
 		extends HibernateOrmMassIndexingMappingContext, HibernateOrmLoadingMappingContext {
 
+	@Override
 	HibernateOrmScopeSessionContext sessionContext(EntityManager entityManager);
 
 	DetachedBackendSessionContext detachedBackendSessionContext(String tenantId);

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/scope/impl/HibernateOrmScopeSessionContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/scope/impl/HibernateOrmScopeSessionContext.java
@@ -7,10 +7,11 @@
 package org.hibernate.search.mapper.orm.scope.impl;
 
 import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
+import org.hibernate.search.mapper.orm.massindexing.impl.HibernateOrmMassIndexingSessionContext;
 import org.hibernate.search.mapper.orm.search.loading.impl.HibernateOrmLoadingSessionContext;
 
 public interface HibernateOrmScopeSessionContext
-		extends HibernateOrmLoadingSessionContext {
+		extends HibernateOrmLoadingSessionContext, HibernateOrmMassIndexingSessionContext {
 
 	BackendSessionContext backendSessionContext();
 

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendMock.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendMock.java
@@ -169,7 +169,7 @@ public class BackendMock implements TestRule {
 	}
 
 	public IndexScaleWorkCallListContext expectIndexScaleWorks(String indexName, String tenantId) {
-		CallQueue<IndexScaleWorkCall> callQueue = backendBehavior().getIndexScaleWorkCalls();
+		CallQueue<IndexScaleWorkCall> callQueue = backendBehavior().getIndexScaleWorkCalls( indexName );
 		return new IndexScaleWorkCallListContext(
 				indexName, tenantId,
 				callQueue::expectInOrder

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/IndexScaleWorkCall.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/IndexScaleWorkCall.java
@@ -32,7 +32,7 @@ class IndexScaleWorkCall extends Call<IndexScaleWorkCall> {
 	}
 
 	public CallBehavior<CompletableFuture<?>> verify(IndexScaleWorkCall actualCall) {
-		String whenThisWorkWasExpected = "when an index-scope work on index '" + indexName
+		String whenThisWorkWasExpected = "when an index-scale work on index '" + indexName
 				+ "' was expected";
 		StubIndexScaleWorkAssert.assertThat( actualCall.work )
 				.as( "Incorrect work " + whenThisWorkWasExpected + ":\n" )
@@ -48,6 +48,6 @@ class IndexScaleWorkCall extends Call<IndexScaleWorkCall> {
 
 	@Override
 	public String toString() {
-		return "index-scope work on index " + indexName + "'; work = " + work;
+		return "index-scale work on index '" + indexName + "'; work = " + work;
 	}
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/SchemaManagementWorkCall.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/SchemaManagementWorkCall.java
@@ -37,7 +37,7 @@ class SchemaManagementWorkCall extends Call<SchemaManagementWorkCall> {
 	}
 
 	public CallBehavior<CompletableFuture<?>> verify(SchemaManagementWorkCall actualCall) {
-		String whenThisWorkWasExpected = "when an index-scope work on index '" + indexName
+		String whenThisWorkWasExpected = "when a schema management work on index '" + indexName
 				+ "' was expected";
 		StubSchemaManagementWorkAssert.assertThat( actualCall.work )
 				.as( "Incorrect work " + whenThisWorkWasExpected + ":\n" )
@@ -52,6 +52,6 @@ class SchemaManagementWorkCall extends Call<SchemaManagementWorkCall> {
 
 	@Override
 	public String toString() {
-		return "index-scope work on index " + indexName + "'; work = " + work;
+		return "schema management work on index '" + indexName + "'; work = " + work;
 	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3998
