### PR TITLE
HSEARCH-4019 Follow-up: fix tests for sharded indexes (AWS Elasticsearch Service in particular)

### DIFF
--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryFetchIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryFetchIT.java
@@ -326,7 +326,8 @@ public class SearchQueryFetchIT {
 
 	private SearchQueryOptionsStep<?, DocumentReference, ?, ?, ?> matchAllQuerySortByDefault() {
 		StubMappingScope scope = index.createScope();
-		return scope.query().where( f -> f.match().field( "text" ).matching( "someword" ) );
+		return scope.query().where( f -> f.simpleQueryString().field( "text" )
+				.matching( "mostimportantword^100 lessimportantword^10 leastimportantword^0.1" ) );
 	}
 
 	private SearchQueryOptionsStep<?, DocumentReference, ?, ?, ?> matchFirstHalfQuery() {
@@ -358,13 +359,13 @@ public class SearchQueryFetchIT {
 							String text = null;
 							switch ( i ) {
 								case 0:
-									text = "someword someword someword someword and something else";
+									text = "leastimportantword lessimportantword mostimportantword";
 									break;
 								case 1:
-									text = "someword someword and something else";
+									text = "leastimportantword lessimportantword";
 									break;
 								default:
-									text = "something else something else and well finally someword";
+									text = "leastimportantword";
 									break;
 							}
 							document.addValue( index.binding().text, text );


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4019

This should fix this kind of failures: https://ci.hibernate.org/job/hibernate-search/job/master/863/testReport/junit/org.hibernate.search.integrationtest.backend.tck.search.query/SearchQueryFetchIT(elasticsearch-aws-7_7-it-elasticsearch)/Non_default_environments___elasticsearch_aws_7_7___fetch_offset_limit_defaultSort_3/

I'll start an AWS build and merge if the build passes.