### PR TITLE
HSEARCH-3999 Deletion of contained entity whose elementCollection is indexed-embedded in the containing entity leads to LazyInitializationException

### DIFF
--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingAssociationDeletionIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingAssociationDeletionIT.java
@@ -1,0 +1,608 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.association;
+
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javax.persistence.Basic;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+import javax.persistence.OrderBy;
+import javax.persistence.OrderColumn;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
+import org.hibernate.search.util.impl.test.annotation.TestForIssue;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Test that Hibernate Search does not throw a {@link org.hibernate.LazyInitializationException}
+ * when executing automatic indexing after one side of an non-cascading associations was deleted,
+ * especially if that side of the association has an ElementCollection
+ * that will trigger a PostCollectionRemove event (which counts as an update for the deleted entity...).
+ * <p>
+ * This type of deletion used to trigger an update (because of the PostCollectionRemove event),
+ * and the deleted entity ended up being processed to find associated entities to reindex,
+ * which led to attempts to initialize association collections that no longer could be initialized
+ * due to one of the entities involved having been deleted.
+ */
+@TestForIssue(jiraKey = "HSEARCH-3999")
+public class AutomaticIndexingAssociationDeletionIT {
+
+	@Rule
+	public BackendMock backendMock = new BackendMock();
+
+	@Rule
+	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+
+	private SessionFactory sessionFactory;
+
+	@Before
+	public void before() {
+		backendMock.expectAnySchema( AssociationOwner.NAME );
+		backendMock.expectAnySchema( AssociationNonOwner.NAME );
+		sessionFactory = ormSetupHelper
+				.start()
+				.withProperty( AvailableSettings.ALLOW_UPDATE_OUTSIDE_TRANSACTION, true )
+				.setup( AssociationOwner.class, AssociationNonOwner.class );
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void optionalOneToOne_deleteOwner() {
+		initOptionalOneToOne();
+
+		withinTransaction( sessionFactory, session -> {
+			AssociationOwner owner1 = session.getReference( AssociationOwner.class, 1 );
+
+			session.delete( owner1 );
+
+			backendMock.expectWorks( AssociationOwner.NAME )
+					.delete( "1" )
+					.processedThenExecuted();
+
+			// We don't expect any update of the containing entity (id 2),
+			// since its association to 1 was not updated
+			// (the code above is technically incorrect).
+		} );
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void optionalOneToOne_deleteNonOwner() {
+		initOptionalOneToOne();
+
+		withinTransaction( sessionFactory, session -> {
+			AssociationOwner owner1 = session.getReference( AssociationOwner.class, 1 );
+			AssociationNonOwner nonOwner2 = session.getReference( AssociationNonOwner.class, 2 );
+
+			// Necessary because the foreign key will no longer reference an existing row.
+			owner1.setOptionalOneToOne( null );
+
+			session.delete( nonOwner2 );
+
+			// This update is caused by the call to owner1.setOptionalOneToOne;
+			// it has nothing to do with the deletion.
+			backendMock.expectWorks( AssociationOwner.NAME )
+					.update( "1", b -> b.field( "basic", "text 1" )
+							.field( "elementCollection", 1001, 2001 ) )
+					.processedThenExecuted();
+
+			backendMock.expectWorks( AssociationNonOwner.NAME )
+					.delete( "2" )
+					.processedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void optionalOneToOne_deleteBoth() {
+		initOptionalOneToOne();
+
+		withinTransaction( sessionFactory, session -> {
+			AssociationOwner owner1 = session.getReference( AssociationOwner.class, 1 );
+			AssociationNonOwner nonOwner2 = session.getReference( AssociationNonOwner.class, 2 );
+
+			session.delete( owner1 );
+			session.delete( nonOwner2 );
+
+			backendMock.expectWorks( AssociationOwner.NAME )
+					.delete( "1" )
+					.processedThenExecuted();
+
+			backendMock.expectWorks( AssociationNonOwner.NAME )
+					.delete( "2" )
+					.processedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+	}
+
+	private void initOptionalOneToOne() {
+		withinTransaction( sessionFactory, session -> {
+			AssociationOwner owner1 = new AssociationOwner( 1 );
+			AssociationNonOwner nonOwner2 = new AssociationNonOwner( 2 );
+
+			owner1.setOptionalOneToOne( nonOwner2 );
+			nonOwner2.setOptionalOneToOne( owner1 );
+
+			session.persist( owner1 );
+			session.persist( nonOwner2 );
+
+			backendMock.expectWorks( AssociationOwner.NAME )
+					.add( "1", b -> b.field( "basic", "text 1" )
+							.field( "elementCollection", 1001, 2001 )
+							.objectField( "optionalOneToOne", b2 -> b2
+									.field( "basic", "text 2" )
+									.field( "elementCollection", 1002, 2002 ) ) )
+					.processedThenExecuted();
+			backendMock.expectWorks( AssociationNonOwner.NAME )
+					.add( "2", b -> b.field( "basic", "text 2" )
+							.field( "elementCollection", 1002, 2002 )
+							.objectField( "optionalOneToOne", b2 -> b2
+									.field( "basic", "text 1" )
+									.field( "elementCollection", 1001, 2001 ) ) )
+					.processedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void manyToOne_deleteOwner() {
+		initManyToOne();
+
+		withinTransaction( sessionFactory, session -> {
+			AssociationOwner owner1 = session.getReference( AssociationOwner.class, 1 );
+
+			session.delete( owner1 );
+
+			backendMock.expectWorks( AssociationOwner.NAME )
+					.delete( "1" )
+					.processedThenExecuted();
+
+			// We don't expect any update of the containing entity (id 2),
+			// since its association to 1 was not updated
+			// (the code above is technically incorrect).
+		} );
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void manyToOne_deleteNonOwner() {
+		initManyToOne();
+
+		withinTransaction( sessionFactory, session -> {
+			AssociationOwner owner1 = session.getReference( AssociationOwner.class, 1 );
+			AssociationOwner owner3 = session.getReference( AssociationOwner.class, 3 );
+			AssociationNonOwner nonOwner2 = session.getReference( AssociationNonOwner.class, 2 );
+
+			// Necessary because the foreign key will no longer reference an existing row.
+			owner1.setManyToOne( null );
+			owner3.setManyToOne( null );
+
+			session.delete( nonOwner2 );
+
+			backendMock.expectWorks( AssociationOwner.NAME )
+					// This update is caused by the call to owner1.setManyToOne;
+					// it has nothing to do with the deletion.
+					.update( "1", b -> b.field( "basic", "text 1" )
+							.field( "elementCollection", 1001, 2001 ) )
+					// This update is caused by the call to owner3.setManyToOne;
+					// it has nothing to do with the deletion.
+					.update( "3", b -> b.field( "basic", "text 3" )
+							.field( "elementCollection", 1003, 2003 ) )
+					.processedThenExecuted();
+
+			backendMock.expectWorks( AssociationNonOwner.NAME )
+					.delete( "2" )
+					.processedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void manyToOne_deleteBoth() {
+		initManyToOne();
+
+		withinTransaction( sessionFactory, session -> {
+			AssociationOwner owner3 = session.getReference( AssociationOwner.class, 3 );
+			AssociationOwner owner1 = session.getReference( AssociationOwner.class, 1 );
+			AssociationNonOwner nonOwner2 = session.getReference( AssociationNonOwner.class, 2 );
+
+			// Necessary because the foreign key will no longer reference an existing row.
+			owner3.setManyToOne( null );
+
+			session.delete( owner1 );
+			session.delete( nonOwner2 );
+
+			backendMock.expectWorks( AssociationOwner.NAME )
+					// This update is caused by the call to owner3.setManyToOne;
+					// it has nothing to do with the deletion.
+					.update( "3", b -> b.field( "basic", "text 3" )
+							.field( "elementCollection", 1003, 2003 ) )
+					.delete( "1" )
+					.processedThenExecuted();
+
+			backendMock.expectWorks( AssociationNonOwner.NAME )
+					.delete( "2" )
+					.processedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+	}
+
+	private void initManyToOne() {
+		withinTransaction( sessionFactory, session -> {
+			AssociationOwner owner1 = new AssociationOwner( 1 );
+			AssociationNonOwner nonOwner2 = new AssociationNonOwner( 2 );
+			AssociationOwner owner3 = new AssociationOwner( 3 );
+
+			owner1.setManyToOne( nonOwner2 );
+			nonOwner2.getOneToMany().add( owner1 );
+			owner3.setManyToOne( nonOwner2 );
+			nonOwner2.getOneToMany().add( owner3 );
+
+			session.persist( owner1 );
+			session.persist( nonOwner2 );
+			session.persist( owner3 );
+
+			backendMock.expectWorks( AssociationOwner.NAME )
+					.add( "1", b -> b.field( "basic", "text 1" )
+							.field( "elementCollection", 1001, 2001 )
+							.objectField( "manyToOne", b2 -> b2
+									.field( "basic", "text 2" )
+									.field( "elementCollection", 1002, 2002 ) ) )
+					.add( "3", b -> b.field( "basic", "text 3" )
+							.field( "elementCollection", 1003, 2003 )
+							.objectField( "manyToOne", b2 -> b2
+									.field( "basic", "text 2" )
+									.field( "elementCollection", 1002, 2002 ) ) )
+					.processedThenExecuted();
+			backendMock.expectWorks( AssociationNonOwner.NAME )
+					.add( "2", b -> b.field( "basic", "text 2" )
+							.field( "elementCollection", 1002, 2002 )
+							.objectField( "oneToMany", b2 -> b2
+									.field( "basic", "text 1" )
+									.field( "elementCollection", 1001, 2001 ) )
+							.objectField( "oneToMany", b2 -> b2
+									.field( "basic", "text 3" )
+									.field( "elementCollection", 1003, 2003 ) ) )
+					.processedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void manyToMany_deleteOwner() {
+		initManyToMany();
+
+		withinTransaction( sessionFactory, session -> {
+			AssociationOwner owner1 = session.getReference( AssociationOwner.class, 1 );
+
+			session.delete( owner1 );
+
+			backendMock.expectWorks( AssociationOwner.NAME )
+					.delete( "1" )
+					.processedThenExecuted();
+
+			// We don't expect any update of the containing entity (id 2),
+			// since its association to 1 was not updated
+			// (the code above is technically incorrect).
+		} );
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void manyToMany_deleteNonOwner() {
+		initManyToMany();
+
+		withinTransaction( sessionFactory, session -> {
+			AssociationOwner owner1 = session.getReference( AssociationOwner.class, 1 );
+			AssociationOwner owner3 = session.getReference( AssociationOwner.class, 3 );
+			AssociationNonOwner nonOwner2 = session.getReference( AssociationNonOwner.class, 2 );
+
+			// Necessary because the foreign key will no longer reference an existing row.
+			owner1.getManyToMany().remove( nonOwner2 );
+			owner3.getManyToMany().remove( nonOwner2 );
+
+			session.delete( nonOwner2 );
+
+			backendMock.expectWorks( AssociationOwner.NAME )
+					// This update is caused by the call to owner1.getManyToMany().remove();
+					// it has nothing to do with the deletion.
+					.update( "1", b -> b.field( "basic", "text 1" )
+							.field( "elementCollection", 1001, 2001 )
+							.objectField( "manyToMany", b2 -> b2
+									.field( "basic", "text 4" )
+									.field( "elementCollection", 1004, 2004 ) ) )
+					// This update is caused by the call to owner3.getManyToMany().remove();
+					// it has nothing to do with the deletion.
+					.update( "3", b -> b.field( "basic", "text 3" )
+							.field( "elementCollection", 1003, 2003 )
+							.objectField( "manyToMany", b2 -> b2
+									.field( "basic", "text 4" )
+									.field( "elementCollection", 1004, 2004 ) ) )
+					.processedThenExecuted();
+
+			backendMock.expectWorks( AssociationNonOwner.NAME )
+					.delete( "2" )
+					.processedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void manyToMany_deleteBoth() {
+		initManyToMany();
+
+		withinTransaction( sessionFactory, session -> {
+			AssociationOwner owner3 = session.getReference( AssociationOwner.class, 3 );
+			AssociationOwner owner1 = session.getReference( AssociationOwner.class, 1 );
+			AssociationNonOwner nonOwner2 = session.getReference( AssociationNonOwner.class, 2 );
+
+			// Necessary because the foreign key will no longer reference an existing row.
+			owner3.getManyToMany().remove( nonOwner2 );
+
+			session.delete( owner1 );
+			session.delete( nonOwner2 );
+
+			backendMock.expectWorks( AssociationOwner.NAME )
+					.delete( "1" )
+					// This update is caused by the call to owner3.getManyToMany().remove;
+					// it has nothing to do with the deletion.
+					.update( "3", b -> b.field( "basic", "text 3" )
+							.field( "elementCollection", 1003, 2003 )
+							.objectField( "manyToMany", b2 -> b2
+									.field( "basic", "text 4" )
+									.field( "elementCollection", 1004, 2004 ) ) )
+					.processedThenExecuted();
+
+			backendMock.expectWorks( AssociationNonOwner.NAME )
+					.delete( "2" )
+					// We don't expect any update of the containing entity (id 4),
+					// since its association to 1 was not updated
+					// (the code above is technically incorrect).
+					.processedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+	}
+
+	private void initManyToMany() {
+		withinTransaction( sessionFactory, session -> {
+			AssociationOwner owner1 = new AssociationOwner( 1 );
+			AssociationNonOwner nonOwner2 = new AssociationNonOwner( 2 );
+			AssociationOwner owner3 = new AssociationOwner( 3 );
+			AssociationNonOwner nonOwner4 = new AssociationNonOwner( 4 );
+
+			owner1.getManyToMany().add( nonOwner2 );
+			owner1.getManyToMany().add( nonOwner4 );
+			nonOwner2.getManyToMany().add( owner1 );
+			nonOwner2.getManyToMany().add( owner3 );
+			owner3.getManyToMany().add( nonOwner2 );
+			owner3.getManyToMany().add( nonOwner4 );
+			nonOwner4.getManyToMany().add( owner1 );
+			nonOwner4.getManyToMany().add( owner3 );
+
+			session.persist( nonOwner2 );
+			session.persist( nonOwner4 );
+			session.persist( owner1 );
+			session.persist( owner3 );
+
+			backendMock.expectWorks( AssociationOwner.NAME )
+					.add( "1", b -> b.field( "basic", "text 1" )
+							.field( "elementCollection", 1001, 2001 )
+							.objectField( "manyToMany", b2 -> b2
+									.field( "basic", "text 2" )
+									.field( "elementCollection", 1002, 2002 ) )
+							.objectField( "manyToMany", b2 -> b2
+									.field( "basic", "text 4" )
+									.field( "elementCollection", 1004, 2004 ) ) )
+					.add( "3", b -> b.field( "basic", "text 3" )
+							.field( "elementCollection", 1003, 2003 )
+							.objectField( "manyToMany", b2 -> b2
+									.field( "basic", "text 2" )
+									.field( "elementCollection", 1002, 2002 ) )
+							.objectField( "manyToMany", b2 -> b2
+									.field( "basic", "text 4" )
+									.field( "elementCollection", 1004, 2004 ) ) )
+					.processedThenExecuted();
+			backendMock.expectWorks( AssociationNonOwner.NAME )
+					.add( "2", b -> b.field( "basic", "text 2" )
+							.field( "elementCollection", 1002, 2002 )
+							.objectField( "manyToMany", b2 -> b2
+									.field( "basic", "text 1" )
+									.field( "elementCollection", 1001, 2001 ) )
+							.objectField( "manyToMany", b2 -> b2
+									.field( "basic", "text 3" )
+									.field( "elementCollection", 1003, 2003 ) ) )
+					.add( "4", b -> b.field( "basic", "text 4" )
+							.field( "elementCollection", 1004, 2004 )
+							.objectField( "manyToMany", b2 -> b2
+									.field( "basic", "text 1" )
+									.field( "elementCollection", 1001, 2001 ) )
+							.objectField( "manyToMany", b2 -> b2
+									.field( "basic", "text 3" )
+									.field( "elementCollection", 1003, 2003 ) ) )
+					.processedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Entity(name = AssociationOwner.NAME)
+	@Indexed
+	public static class AssociationOwner {
+		static final String NAME = "owner";
+
+		@Id
+		private Integer id;
+
+		@GenericField
+		@Basic
+		private String basic;
+
+		// This triggers a PostCollectionRemove event upon deletion, which may impact HSearch's behavior.
+		@GenericField
+		@ElementCollection
+		@OrderBy
+		private List<Integer> elementCollection;
+
+		@IndexedEmbedded(includePaths = {"basic", "elementCollection"})
+		@OneToOne(fetch = FetchType.LAZY, optional = true)
+		private AssociationNonOwner optionalOneToOne;
+
+		@IndexedEmbedded(includePaths = {"basic", "elementCollection"})
+		@ManyToOne
+		private AssociationNonOwner manyToOne;
+
+		@IndexedEmbedded(includePaths = {"basic", "elementCollection"})
+		@ManyToMany
+		@JoinTable(joinColumns = @JoinColumn(name = "nonowner_id"),
+				inverseJoinColumns = @JoinColumn(name = "owner_id"))
+		@OrderColumn
+		private List<AssociationNonOwner> manyToMany = new ArrayList<>();
+
+		AssociationOwner() {
+		}
+
+		AssociationOwner(int id) {
+			this.id = id;
+			this.basic = "text " + id;
+			this.elementCollection = Arrays.asList( 1000 + id, 2000 + id );
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public String getBasic() {
+			return basic;
+		}
+
+		public void setBasic(String basic) {
+			this.basic = basic;
+		}
+
+		public AssociationNonOwner getOptionalOneToOne() {
+			return optionalOneToOne;
+		}
+
+		public void setOptionalOneToOne(AssociationNonOwner optionalOneToOne) {
+			this.optionalOneToOne = optionalOneToOne;
+		}
+
+		public AssociationNonOwner getManyToOne() {
+			return manyToOne;
+		}
+
+		public void setManyToOne(AssociationNonOwner manyToOne) {
+			this.manyToOne = manyToOne;
+		}
+
+		public List<AssociationNonOwner> getManyToMany() {
+			return manyToMany;
+		}
+
+		public void setManyToMany(List<AssociationNonOwner> manyToMany) {
+			this.manyToMany = manyToMany;
+		}
+	}
+
+	@Entity(name = AssociationNonOwner.NAME)
+	@Indexed
+	public static class AssociationNonOwner {
+		static final String NAME = "nonowner";
+
+		@Id
+		private Integer id;
+
+		@GenericField
+		@Basic
+		private String basic;
+
+		// This triggers a PostCollectionRemove event upon deletion, which may impact HSearch's behavior.
+		@GenericField
+		@ElementCollection
+		@OrderBy
+		private List<Integer> elementCollection;
+
+		@IndexedEmbedded(includePaths = {"basic", "elementCollection"})
+		@OneToOne(fetch = FetchType.LAZY, // Will probably be ignored: an optional one-to-one can hardly use lazy proxies on the non-owning side.
+				mappedBy = "optionalOneToOne", optional = true)
+		private AssociationOwner optionalOneToOne;
+
+		@IndexedEmbedded(includePaths = {"basic", "elementCollection"})
+		@OneToMany(mappedBy = "manyToOne")
+		@OrderColumn
+		private List<AssociationOwner> oneToMany = new ArrayList<>();
+
+		@IndexedEmbedded(includePaths = {"basic", "elementCollection"})
+		@ManyToMany(mappedBy = "manyToMany")
+		private List<AssociationOwner> manyToMany = new ArrayList<>();
+
+		AssociationNonOwner() {
+		}
+
+		AssociationNonOwner(int id) {
+			this.id = id;
+			this.basic = "text " + id;
+			this.elementCollection = Arrays.asList( 1000 + id, 2000 + id );
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public String getBasic() {
+			return basic;
+		}
+
+		public void setBasic(String basic) {
+			this.basic = basic;
+		}
+
+		public AssociationOwner getOptionalOneToOne() {
+			return optionalOneToOne;
+		}
+
+		public void setOptionalOneToOne(AssociationOwner optionalOneToOne) {
+			this.optionalOneToOne = optionalOneToOne;
+		}
+
+		public List<AssociationOwner> getOneToMany() {
+			return oneToMany;
+		}
+
+		public void setOneToMany(List<AssociationOwner> oneToMany) {
+			this.oneToMany = oneToMany;
+		}
+
+		public List<AssociationOwner> getManyToMany() {
+			return manyToMany;
+		}
+
+		public void setManyToMany(List<AssociationOwner> manyToMany) {
+			this.manyToMany = manyToMany;
+		}
+	}
+}

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/embedded/EmbeddedTest.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/embedded/EmbeddedTest.java
@@ -35,7 +35,6 @@ import org.junit.Test;
 public class EmbeddedTest extends SearchTestBase {
 
 	@Test
-	@Ignore("HSEARCH-3999: we need to get rid of the LazyInitializationException in the last transaction")
 	public void testEmbeddedIndexing() throws Exception {
 		Tower tower = new Tower();
 		tower.setName( "JBoss tower" );

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/embedded/EmbeddedTest.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/embedded/EmbeddedTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queryparser.classic.MultiFieldQueryParser;
 import org.apache.lucene.queryparser.classic.ParseException;
@@ -68,7 +69,7 @@ public class EmbeddedTest extends SearchTestBase {
 		result = session.createFullTextQuery( query, Tower.class ).list();
 		assertEquals( "unable to find property in embedded", 1, result.size() );
 
-		query = parser.parse( "address.id:" + a.getId().toString() );
+		query = LongPoint.newExactQuery( "address.id", a.getId() );
 		result = session.createFullTextQuery( query, Tower.class ).list();
 		assertEquals( "unable to find property by id of embedded", 1, result.size() );
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoIndexedTypeManager.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoIndexedTypeManager.java
@@ -147,7 +147,7 @@ public class PojoIndexedTypeManager<I, E>
 
 	@Override
 	public void resolveEntitiesToReindex(PojoReindexingCollector collector, PojoWorkSessionContext<?> sessionContext,
-			I identifier, Supplier<E> entitySupplier, Set<String> dirtyPaths) {
+			Object identifier, Supplier<E> entitySupplier, Set<String> dirtyPaths) {
 		try {
 			reindexingResolver.resolveEntitiesToReindex( collector, sessionContext.runtimeIntrospector(),
 					entitySupplier.get(), dirtyPaths );

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/AbstractPojoTypeIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/AbstractPojoTypeIndexingPlan.java
@@ -82,8 +82,8 @@ abstract class AbstractPojoTypeIndexingPlan<I, E, S extends AbstractPojoTypeInde
 		final I identifier;
 		Supplier<E> entitySupplier;
 
-		boolean delete;
-		boolean add;
+		boolean deleted;
+		boolean added;
 
 		boolean shouldResolveToReindex;
 		boolean considerAllDirty;
@@ -96,7 +96,7 @@ abstract class AbstractPojoTypeIndexingPlan<I, E, S extends AbstractPojoTypeInde
 		void add(Supplier<E> entitySupplier, String providedRoutingKey) {
 			this.entitySupplier = entitySupplier;
 			shouldResolveToReindex = true;
-			add = true;
+			added = true;
 		}
 
 		void update(Supplier<E> entitySupplier, String providedRoutingKey) {
@@ -118,9 +118,9 @@ abstract class AbstractPojoTypeIndexingPlan<I, E, S extends AbstractPojoTypeInde
 
 		void doUpdate(Supplier<E> entitySupplier, String providedRoutingKey) {
 			this.entitySupplier = entitySupplier;
-			if ( !add ) {
-				delete = true;
-				add = true;
+			if ( !added ) {
+				deleted = true;
+				added = true;
 			}
 			// else: If add is true, either this is already an update (in which case update + update = update)
 			// or we called add() in the same plan (in which case add + update = add).
@@ -129,17 +129,17 @@ abstract class AbstractPojoTypeIndexingPlan<I, E, S extends AbstractPojoTypeInde
 
 		void delete(Supplier<E> entitySupplier, String providedRoutingKey) {
 			this.entitySupplier = entitySupplier;
-			if ( add && !delete ) {
+			if ( added && !deleted ) {
 				// We called add() in the same plan, so the entity didn't exist.
 				// Don't delete, just cancel the addition.
-				add = false;
-				delete = false;
+				added = false;
+				deleted = false;
 			}
 			else {
 				// No add or update yet, or already deleted.
 				// Either way, delete.
-				add = false;
-				delete = true;
+				added = false;
+				deleted = true;
 			}
 
 			// Reindexing does not make sense for a deleted entity

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/AbstractPojoTypeIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/AbstractPojoTypeIndexingPlan.java
@@ -6,24 +6,165 @@
  */
 package org.hibernate.search.mapper.pojo.work.impl;
 
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.hibernate.search.mapper.pojo.automaticindexing.impl.PojoReindexingCollector;
 import org.hibernate.search.mapper.pojo.work.spi.PojoWorkSessionContext;
 
-abstract class AbstractPojoTypeIndexingPlan {
+/**
+ * @param <I> The type of identifiers of entities in this plan.
+ * @param <E> The type of entities in this plan.
+ * @param <S> The type of per-instance state.
+ */
+abstract class AbstractPojoTypeIndexingPlan<I, E, S extends AbstractPojoTypeIndexingPlan<I, E, S>.AbstractEntityState> {
 
 	final PojoWorkSessionContext<?> sessionContext;
+
+	// Use a LinkedHashMap for deterministic iteration
+	final Map<I, S> statesPerId = new LinkedHashMap<>();
 
 	AbstractPojoTypeIndexingPlan(PojoWorkSessionContext<?> sessionContext) {
 		this.sessionContext = sessionContext;
 	}
 
-	abstract void add(Object providedId, String providedRoutingKey, Object entity);
+	void add(Object providedId, String providedRoutingKey, Object entity) {
+		Supplier<E> entitySupplier = typeContext().toEntitySupplier( sessionContext, entity );
+		I identifier = toIdentifier( providedId, entitySupplier );
+		getState( identifier ).add( entitySupplier, providedRoutingKey );
+	}
 
-	abstract void update(Object providedId, String providedRoutingKey, Object entity);
+	void update(Object providedId, String providedRoutingKey, Object entity) {
+		Supplier<E> entitySupplier = typeContext().toEntitySupplier( sessionContext, entity );
+		I identifier = toIdentifier( providedId, entitySupplier );
+		getState( identifier ).update( entitySupplier, providedRoutingKey );
+	}
 
-	abstract void update(Object providedId, String providedRoutingKey, Object entity, String... dirtyPaths);
+	void update(Object providedId, String providedRoutingKey, Object entity, String... dirtyPaths) {
+		Supplier<E> entitySupplier = typeContext().toEntitySupplier( sessionContext, entity );
+		I identifier = toIdentifier( providedId, entitySupplier );
+		getState( identifier ).update( entitySupplier, providedRoutingKey, dirtyPaths );
+	}
 
-	abstract void delete(Object providedId, String providedRoutingKey, Object entity);
+	void delete(Object providedId, String providedRoutingKey, Object entity) {
+		Supplier<E> entitySupplier = typeContext().toEntitySupplier( sessionContext, entity );
+		I identifier = toIdentifier( providedId, entitySupplier );
+		getState( identifier ).delete( entitySupplier, providedRoutingKey );
+	}
 
 	abstract void purge(Object providedId, String providedRoutingKey);
+
+	void resolveDirty(PojoReindexingCollector containingEntityCollector) {
+		for ( S state : statesPerId.values() ) {
+			state.resolveDirty( containingEntityCollector );
+		}
+	}
+
+	abstract PojoWorkTypeContext<E> typeContext();
+
+	abstract I toIdentifier(Object providedId, Supplier<E> entitySupplier);
+
+	final S getState(I identifier) {
+		S state = statesPerId.get( identifier );
+		if ( state == null ) {
+			state = createState( identifier );
+			statesPerId.put( identifier, state );
+		}
+		return state;
+	}
+
+	protected abstract S createState(I identifier);
+
+	abstract class AbstractEntityState {
+		final I identifier;
+		Supplier<E> entitySupplier;
+
+		boolean delete;
+		boolean add;
+
+		boolean shouldResolveToReindex;
+		boolean considerAllDirty;
+		Set<String> dirtyPaths;
+
+		AbstractEntityState(I identifier) {
+			this.identifier = identifier;
+		}
+
+		void add(Supplier<E> entitySupplier, String providedRoutingKey) {
+			this.entitySupplier = entitySupplier;
+			shouldResolveToReindex = true;
+			add = true;
+		}
+
+		void update(Supplier<E> entitySupplier, String providedRoutingKey) {
+			doUpdate( entitySupplier, providedRoutingKey );
+			shouldResolveToReindex = true;
+			considerAllDirty = true;
+			dirtyPaths = null;
+		}
+
+		void update(Supplier<E> entitySupplier, String providedRoutingKey, String... dirtyPaths) {
+			doUpdate( entitySupplier, providedRoutingKey );
+			shouldResolveToReindex = true;
+			if ( !considerAllDirty ) {
+				for ( String dirtyPath : dirtyPaths ) {
+					addDirtyPath( dirtyPath );
+				}
+			}
+		}
+
+		void doUpdate(Supplier<E> entitySupplier, String providedRoutingKey) {
+			this.entitySupplier = entitySupplier;
+			if ( !add ) {
+				delete = true;
+				add = true;
+			}
+			// else: If add is true, either this is already an update (in which case update + update = update)
+			// or we called add() in the same plan (in which case add + update = add).
+			// In any case we don't need to change anything.
+		}
+
+		void delete(Supplier<E> entitySupplier, String providedRoutingKey) {
+			this.entitySupplier = entitySupplier;
+			if ( add && !delete ) {
+				// We called add() in the same plan, so the entity didn't exist.
+				// Don't delete, just cancel the addition.
+				add = false;
+				delete = false;
+			}
+			else {
+				// No add or update yet, or already deleted.
+				// Either way, delete.
+				add = false;
+				delete = true;
+			}
+
+			// Reindexing does not make sense for a deleted entity
+			shouldResolveToReindex = false;
+			considerAllDirty = false;
+			dirtyPaths = null;
+		}
+
+		void resolveDirty(PojoReindexingCollector containingEntityCollector) {
+			if ( shouldResolveToReindex ) {
+				shouldResolveToReindex = false; // Avoid infinite looping
+				typeContext().resolveEntitiesToReindex(
+						containingEntityCollector, sessionContext, identifier, entitySupplier,
+						considerAllDirty ? null : dirtyPaths
+				);
+			}
+		}
+
+		private void addDirtyPath(String dirtyPath) {
+			if ( dirtyPaths == null ) {
+				dirtyPaths = new HashSet<>();
+			}
+			dirtyPaths.add( dirtyPath );
+		}
+	}
+
 
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoContainedTypeIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoContainedTypeIndexingPlan.java
@@ -132,11 +132,13 @@ public class PojoContainedTypeIndexingPlan<E> extends AbstractPojoTypeIndexingPl
 				 * in existing documents.
 				 * Cancel everything.
 				 */
-				shouldResolveToReindex = false;
-				considerAllDirty = false;
-				dirtyPaths = null;
 				createdInThisPlan = null;
 			}
+
+			// Reindexing does not make sense for a deleted entity
+			shouldResolveToReindex = false;
+			considerAllDirty = false;
+			dirtyPaths = null;
 		}
 
 		void resolveDirty(PojoReindexingCollector containingEntityCollector) {

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexedTypeIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexedTypeIndexingPlan.java
@@ -155,13 +155,13 @@ public class PojoIndexedTypeIndexingPlan<I, E, R>
 			// This is a purge: force deletion even if it doesn't seem this document was added
 			considerAllDirty = false;
 			dirtyPaths = null;
-			add = false;
-			delete = true;
+			added = false;
+			deleted = true;
 		}
 
 		void sendCommandsToDelegate() {
-			if ( add ) {
-				if ( delete ) {
+			if ( added ) {
+				if ( deleted ) {
 					if ( considerAllDirty || updatedBecauseOfContained
 							|| typeContext.requiresSelfReindexing( dirtyPaths ) ) {
 						delegateUpdate();
@@ -171,7 +171,7 @@ public class PojoIndexedTypeIndexingPlan<I, E, R>
 					delegateAdd();
 				}
 			}
-			else if ( delete ) {
+			else if ( deleted ) {
 				delegateDelete();
 			}
 		}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexedTypeIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexedTypeIndexingPlan.java
@@ -198,10 +198,6 @@ public class PojoIndexedTypeIndexingPlan<I, E, R> extends AbstractPojoTypeIndexi
 				 * We called add() in the same plan, so we don't expect the document to be in the index.
 				 * Don't delete, just cancel the addition.
 				 */
-				shouldResolveToReindex = false;
-				considerAllDirty = false;
-				updatedBecauseOfContained = false;
-				dirtyPaths = null;
 				add = false;
 				delete = false;
 			}
@@ -209,6 +205,12 @@ public class PojoIndexedTypeIndexingPlan<I, E, R> extends AbstractPojoTypeIndexi
 				add = false;
 				delete = true;
 			}
+
+			// Reindexing does not make sense for a deleted entity
+			shouldResolveToReindex = false;
+			considerAllDirty = false;
+			updatedBecauseOfContained = false;
+			dirtyPaths = null;
 		}
 
 		void purge(String providedRoutingKey) {

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanImpl.java
@@ -57,31 +57,31 @@ public class PojoIndexingPlanImpl<R> implements PojoIndexingPlan<R> {
 
 	@Override
 	public void add(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, String providedRoutingKey, Object entity) {
-		AbstractPojoTypeIndexingPlan delegate = getDelegate( typeIdentifier );
+		AbstractPojoTypeIndexingPlan<?, ?, ?> delegate = getDelegate( typeIdentifier );
 		delegate.add( providedId, providedRoutingKey, entity );
 	}
 
 	@Override
 	public void addOrUpdate(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, String providedRoutingKey, Object entity) {
-		AbstractPojoTypeIndexingPlan delegate = getDelegate( typeIdentifier );
+		AbstractPojoTypeIndexingPlan<?, ?, ?> delegate = getDelegate( typeIdentifier );
 		delegate.update( providedId, providedRoutingKey, entity );
 	}
 
 	@Override
 	public void addOrUpdate(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, String providedRoutingKey, Object entity, String... dirtyPaths) {
-		AbstractPojoTypeIndexingPlan delegate = getDelegate( typeIdentifier );
+		AbstractPojoTypeIndexingPlan<?, ?, ?> delegate = getDelegate( typeIdentifier );
 		delegate.update( providedId, providedRoutingKey, entity, dirtyPaths );
 	}
 
 	@Override
 	public void delete(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, String providedRoutingKey, Object entity) {
-		AbstractPojoTypeIndexingPlan delegate = getDelegate( typeIdentifier );
+		AbstractPojoTypeIndexingPlan<?, ?, ?> delegate = getDelegate( typeIdentifier );
 		delegate.delete( providedId, providedRoutingKey, entity );
 	}
 
 	@Override
 	public void purge(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId, String providedRoutingKey) {
-		AbstractPojoTypeIndexingPlan delegate = getDelegate( typeIdentifier );
+		AbstractPojoTypeIndexingPlan<?, ?, ?> delegate = getDelegate( typeIdentifier );
 		delegate.purge( providedId, providedRoutingKey );
 	}
 
@@ -148,8 +148,8 @@ public class PojoIndexingPlanImpl<R> implements PojoIndexingPlan<R> {
 		return introspector;
 	}
 
-	private AbstractPojoTypeIndexingPlan getDelegate(PojoRawTypeIdentifier<?> typeIdentifier) {
-		AbstractPojoTypeIndexingPlan delegate = indexedTypeDelegates.get( typeIdentifier );
+	private AbstractPojoTypeIndexingPlan<?, ?, ?> getDelegate(PojoRawTypeIdentifier<?> typeIdentifier) {
+		AbstractPojoTypeIndexingPlan<?, ?, ?> delegate = indexedTypeDelegates.get( typeIdentifier );
 		if ( delegate == null ) {
 			delegate = containedTypeDelegates.get( typeIdentifier );
 			if ( delegate == null ) {
@@ -159,7 +159,7 @@ public class PojoIndexingPlanImpl<R> implements PojoIndexingPlan<R> {
 		return delegate;
 	}
 
-	private AbstractPojoTypeIndexingPlan createDelegate(PojoRawTypeIdentifier<?> typeIdentifier) {
+	private AbstractPojoTypeIndexingPlan<?, ?, ?> createDelegate(PojoRawTypeIdentifier<?> typeIdentifier) {
 		Optional<? extends PojoWorkIndexedTypeContext<?, ?>> indexedTypeContextOptional =
 				indexedTypeContextProvider.getByExactType( typeIdentifier );
 		if ( indexedTypeContextOptional.isPresent() ) {

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkContainedTypeContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkContainedTypeContext.java
@@ -6,24 +6,12 @@
  */
 package org.hibernate.search.mapper.pojo.work.impl;
 
-import java.util.Set;
-import java.util.function.Supplier;
-
-import org.hibernate.search.mapper.pojo.automaticindexing.impl.PojoReindexingCollector;
-import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeIdentifier;
 import org.hibernate.search.mapper.pojo.work.spi.PojoWorkSessionContext;
 
 /**
  * @param <E> The contained entity type.
  */
-public interface PojoWorkContainedTypeContext<E> {
-
-	PojoRawTypeIdentifier<E> typeIdentifier();
-
-	Supplier<E> toEntitySupplier(PojoWorkSessionContext<?> sessionContext, Object entity);
-
-	void resolveEntitiesToReindex(PojoReindexingCollector collector, PojoWorkSessionContext<?> sessionContext,
-			Object identifier, Supplier<E> entitySupplier, Set<String> dirtyPaths);
+public interface PojoWorkContainedTypeContext<E> extends PojoWorkTypeContext<E> {
 
 	PojoContainedTypeIndexingPlan<E> createIndexingPlan(PojoWorkSessionContext<?> sessionContext);
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkIndexedTypeContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkIndexedTypeContext.java
@@ -13,22 +13,16 @@ import org.hibernate.search.engine.backend.session.spi.DetachedBackendSessionCon
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
-import org.hibernate.search.mapper.pojo.automaticindexing.impl.PojoReindexingCollector;
 import org.hibernate.search.mapper.pojo.bridge.runtime.impl.IdentifierMappingImplementor;
-import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeIdentifier;
 import org.hibernate.search.mapper.pojo.work.spi.PojoWorkSessionContext;
 
 /**
  * @param <I> The identifier type for the mapped entity type.
  * @param <E> The entity type mapped to the index.
  */
-public interface PojoWorkIndexedTypeContext<I, E> {
-
-	PojoRawTypeIdentifier<E> typeIdentifier();
+public interface PojoWorkIndexedTypeContext<I, E> extends PojoWorkTypeContext<E> {
 
 	IdentifierMappingImplementor<I, E> identifierMapping();
-
-	Supplier<E> toEntitySupplier(PojoWorkSessionContext<?> sessionContext, Object entity);
 
 	String toDocumentIdentifier(PojoWorkSessionContext<?> sessionContext, I identifier);
 
@@ -38,9 +32,6 @@ public interface PojoWorkIndexedTypeContext<I, E> {
 			Supplier<E> entitySupplier);
 
 	boolean requiresSelfReindexing(Set<String> dirtyPaths);
-
-	void resolveEntitiesToReindex(PojoReindexingCollector collector, PojoWorkSessionContext<?> sessionContext,
-			I identifier, Supplier<E> entitySupplier, Set<String> dirtyPaths);
 
 	<R> PojoIndexedTypeIndexingPlan<I, E, R> createIndexingPlan(PojoWorkSessionContext<R> sessionContext,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy);

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkTypeContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkTypeContext.java
@@ -1,0 +1,28 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.work.impl;
+
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.hibernate.search.mapper.pojo.automaticindexing.impl.PojoReindexingCollector;
+import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeIdentifier;
+import org.hibernate.search.mapper.pojo.work.spi.PojoWorkSessionContext;
+
+/**
+ * @param <E> The contained entity type.
+ */
+public interface PojoWorkTypeContext<E> {
+
+	PojoRawTypeIdentifier<E> typeIdentifier();
+
+	Supplier<E> toEntitySupplier(PojoWorkSessionContext<?> sessionContext, Object entity);
+
+	void resolveEntitiesToReindex(PojoReindexingCollector collector, PojoWorkSessionContext<?> sessionContext,
+			Object identifier, Supplier<E> entitySupplier, Set<String> dirtyPaths);
+
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3999

I ended up disabling resolution of entities to reindex when a contained entity is deleted. It's a much smaller change than it sounds, since:

* In most cases, resolution of entities to reindex from a deleted entity will not work correctly (you'll get a `LazyInitializationException`).
* Even when it works, you'll need to update the other side of the relevant associations in order for the deleted entity to no longer appear in documents of index-embedding entities... so the index-embedding entities would have been reindexed anyway (because the association changed).

As a matter of fact, all our tests still pass even after this change. And we no longer have a `LazyInitializationException` when deleting contained entities.