### PR TITLE
HSEARCH-4026 Raise timeout for reaching yellow status when testing on AWS Elasticsearch Service

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -603,9 +603,12 @@ stage('Non-default environments') {
 							// Tests may fail because of hourly AWS snapshots,
 							// which prevent deleting indexes while they are being executed.
 							// So if this fails, we re-try twice.
+							// Note that because we expect frequent failure and retries,
+							// we use --fail-fast here, to make sure we don't waste time.
 							retry(count: 3) {
 								mavenNonDefaultBuild buildEnv, """ \
 										clean install \
+										--fail-fast \
 										-pl org.hibernate.search:hibernate-search-integrationtest-backend-elasticsearch,org.hibernate.search:hibernate-search-integrationtest-showcase-library \
 										${toElasticsearchVersionArgs(buildEnv.mavenProfile, buildEnv.version)} \
 										-Dtest.elasticsearch.connection.hosts=$buildEnv.endpointHostAndPort \
@@ -629,9 +632,12 @@ stage('Non-default environments') {
 								// Tests may fail because of hourly AWS snapshots,
 								// which prevent deleting indexes while they are being executed.
 								// So if this fails, we re-try twice.
+								// Note that because we expect frequent failure and retries,
+								// we use --fail-fast here, to make sure we don't waste time.
 								retry(count: 3) {
 									mavenNonDefaultBuild buildEnv, """ \
 										clean install \
+										--fail-fast \
 										-pl org.hibernate.search:hibernate-search-integrationtest-backend-elasticsearch,org.hibernate.search:hibernate-search-integrationtest-showcase-library \
 										${toElasticsearchVersionArgs(buildEnv.mavenProfile, buildEnv.version)} \
 										-Dtest.elasticsearch.connection.hosts=$buildEnv.endpointHostAndPort \

--- a/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/ElasticsearchTestHostConnectionConfiguration.java
+++ b/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/ElasticsearchTestHostConnectionConfiguration.java
@@ -8,6 +8,8 @@ package org.hibernate.search.util.impl.integrationtest.backend.elasticsearch;
 
 import java.util.Map;
 
+import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
+
 import org.jboss.logging.Logger;
 
 public class ElasticsearchTestHostConnectionConfiguration {
@@ -60,5 +62,11 @@ public class ElasticsearchTestHostConnectionConfiguration {
 		properties.put( "aws.credentials.type", awsCredentialsType );
 		properties.put( "aws.credentials.access_key_id", awsCredentialsAccessKeyId );
 		properties.put( "aws.credentials.secret_access_key", awsCredentialsSecretAccessKey );
+		if ( awsSigningEnabled ) {
+			// AWS Elasticsearch Service is (sometimes) super slow for index creation.
+			// Just raise the default timeout so that we don't fail a full 30-min
+			// test run just for one small freeze.
+			properties.put( ElasticsearchIndexSettings.SCHEMA_MANAGEMENT_MINIMAL_REQUIRED_STATUS_WAIT_TIMEOUT, "60000" );
+		}
 	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4026
