### PR TITLE
HSEARCH-4025 Support Indexing entities with @IdClass if they have an explicit @DocumentId

### DIFF
--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/model/IdClassIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/nonregression/model/IdClassIT.java
@@ -79,6 +79,8 @@ public class IdClassIT {
 		backendMock.expectAnySchema( IdClassIndexedWithDocumentId.NAME );
 
 		SessionFactory sessionFactory = ormSetupHelper.start()
+				// See HHH-14241
+				.withProperty( "hibernate.implicit_naming_strategy", "default" )
 				.setup( IdClassIndexedWithDocumentId.class );
 		backendMock.verifyExpectationsMet();
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmIndexedTypeContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmIndexedTypeContext.java
@@ -34,7 +34,7 @@ class HibernateOrmIndexedTypeContext<E> extends AbstractHibernateOrmTypeContext<
 	private HibernateOrmIndexedTypeContext(Builder<E> builder, SessionFactoryImplementor sessionFactory) {
 		super( sessionFactory, builder.typeIdentifier, builder.jpaEntityName, builder.hibernateOrmEntityName );
 
-		if ( entityPersister().getIdentifierPropertyName().equals( builder.documentIdSourcePropertyName ) ) {
+		if ( builder.documentIdSourcePropertyName.equals( entityPersister().getIdentifierPropertyName() ) ) {
 			documentIdIsEntityId = true;
 			loaderFactory = HibernateOrmEntityIdEntityLoader.factory(
 					sessionFactory, entityPersister()


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4025