### PR TITLE
HSEARCH-3785 + HSEARCH-4027 + HSEARCH-4028 Timeout tests and fixes

### DIFF
--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
@@ -68,12 +68,6 @@ class ElasticsearchTckBackendFeatures extends TckBackendFeatures {
 	}
 
 	@Override
-	public boolean fastTimeoutResolution() {
-		// TODO HSEARCH-3785 Elasticsearch timeout resolution is not very fast
-		return false;
-	}
-
-	@Override
 	public boolean sortByFieldValue(TestedFieldStructure fieldStructure, Class<?> fieldType, SortMode sortMode) {
 		if (
 				fieldStructure.isInNested()

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendFeatures.java
@@ -109,4 +109,10 @@ class ElasticsearchTckBackendFeatures extends TckBackendFeatures {
 	public boolean supportsTotalHitsThreshold() {
 		return dialect.supportsSkipOrLimitingTotalHitCount();
 	}
+
+	@Override
+	public boolean supportsTruncateAfterForScroll() {
+		// See https://hibernate.atlassian.net/browse/HSEARCH-4029
+		return false;
+	}
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryScrollIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryScrollIT.java
@@ -13,7 +13,6 @@ import static org.junit.Assert.assertNotNull;
 
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.TimeUnit;
 
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
@@ -22,12 +21,9 @@ import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.engine.search.query.SearchScroll;
 import org.hibernate.search.engine.search.query.SearchScrollResult;
 import org.hibernate.search.engine.search.query.dsl.SearchQueryOptionsStep;
-import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConfiguration;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
-import org.hibernate.search.util.common.SearchTimeoutException;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
 
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -84,25 +80,6 @@ public class SearchQueryScrollIT {
 	public void all_exactDivisorPageSize() {
 		try ( SearchScroll<DocumentReference> scroll = matchAllQuery().scroll( EXACT_DIVISOR_CHUNK_SIZE ) ) {
 			checkScrolling( scroll, DOCUMENT_COUNT, EXACT_DIVISOR_CHUNK_SIZE );
-		}
-	}
-
-	@Test
-	public void all_failAfter() {
-		Assertions.assertThatThrownBy( () -> matchAllQuery().failAfter( 1L, TimeUnit.NANOSECONDS ).scroll( CHUNK_SIZE ).next() )
-				.isInstanceOf( SearchTimeoutException.class )
-				.hasMessageContaining( " exceeded the timeout of 0s, 0ms and 1ns: " );
-	}
-
-	@Test
-	public void all_truncateAfter() {
-		Assume.assumeTrue(
-				"backend should have a fast timeout resolution in order to run this test correctly",
-				TckConfiguration.get().getBackendFeatures().fastTimeoutResolution()
-		);
-
-		try ( SearchScroll<DocumentReference> scroll = matchAllQuery().truncateAfter( 1L, TimeUnit.NANOSECONDS ).scroll( DOCUMENT_COUNT ) ) {
-			Assertions.assertThat( scroll.next().hits() ).hasSizeLessThan( DOCUMENT_COUNT );
 		}
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryTimeoutIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryTimeoutIT.java
@@ -193,6 +193,31 @@ public class SearchQueryTimeoutIT {
 		}
 	}
 
+	@Test
+	public void fetch_truncateAfter_fastQuery_largeTimeout() {
+		SearchResult<DocumentReference> result = startFastQuery()
+				.truncateAfter( 1, TimeUnit.DAYS )
+				.fetchAll();
+
+		assertThat( result.took() ).isLessThan( Duration.ofDays( 1L ) );
+		assertThat( result.timedOut() ).isFalse();
+	}
+
+	@Test
+	public void scroll_truncateAfter_fastQuery_largeTimeout() {
+		SearchQuery<DocumentReference> query = startFastQuery()
+				.truncateAfter( 1, TimeUnit.DAYS )
+				.toQuery();
+
+		try ( SearchScroll<DocumentReference> scroll = query.scroll( 5 ) ) {
+			SearchScrollResult<DocumentReference> result = scroll.next();
+			assertThat( result.took() ).isLessThan( Duration.ofDays( 1L ) );
+			assertThat( result.timedOut() ).isFalse();
+
+			assertThat( result.hits() ).hasSize( 0 );
+		}
+	}
+
 	private SearchQueryOptionsStep<?, DocumentReference, ?, ?, ?> startSlowQuery() {
 		return index.createScope().query()
 				.where( f -> f.bool( b -> {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryTimeoutIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryTimeoutIT.java
@@ -82,7 +82,7 @@ public class SearchQueryTimeoutIT {
 	}
 
 	@Test
-	public void timeout_slowQuery_smallTimeout_raiseAnException() {
+	public void fetch_failAfter_slowQuery_smallTimeout() {
 		SearchQuery<DocumentReference> query = startSlowQuery()
 				.failAfter( 1, TimeUnit.NANOSECONDS )
 				.toQuery();
@@ -93,7 +93,7 @@ public class SearchQueryTimeoutIT {
 	}
 
 	@Test
-	public void timeout_slowCount_smallTimeout_raiseAnException() {
+	public void fetchTotalHitCount_failAfter_slowQuery_smallTimeout() {
 		SearchQuery<DocumentReference> query = startSlowQuery()
 				.failAfter( 1, TimeUnit.NANOSECONDS )
 				.toQuery();
@@ -104,7 +104,7 @@ public class SearchQueryTimeoutIT {
 	}
 
 	@Test
-	public void timeout_slowScrolling_smallTimeout_raiseAnException() {
+	public void scroll_failAfter_slowQuery_smallTimeout() {
 		SearchQuery<DocumentReference> query = startSlowQuery()
 				.failAfter( 1, TimeUnit.NANOSECONDS )
 				.toQuery();
@@ -115,12 +115,11 @@ public class SearchQueryTimeoutIT {
 	}
 
 	@Test
-	public void timeout_slowQuery_smallTimeout_limitFetching() {
+	public void fetch_truncateAfter_slowQuery_smallTimeout() {
 		Assume.assumeTrue(
 				"backend should have a fast timeout resolution in order to run this test correctly",
 				TckConfiguration.get().getBackendFeatures().fastTimeoutResolution()
 		);
-
 		SearchResult<DocumentReference> result = startSlowQuery()
 				.truncateAfter( 1, TimeUnit.NANOSECONDS )
 				.fetchAll();
@@ -136,7 +135,7 @@ public class SearchQueryTimeoutIT {
 	}
 
 	@Test
-	public void timeout_fastQuery_largeTimeout() {
+	public void fetch_failAfter_fastQuery_largeTimeout() {
 		SearchResult<DocumentReference> result = startFastQuery()
 				.failAfter( 1, TimeUnit.DAYS )
 				.fetchAll();
@@ -148,7 +147,7 @@ public class SearchQueryTimeoutIT {
 	}
 
 	@Test
-	public void timeout_fastCount_largeTimeout() {
+	public void fetchTotalHitCount_failAfter_fastQuery_largeTimeout() {
 		SearchQuery<DocumentReference> query = startFastQuery()
 				.failAfter( 1, TimeUnit.DAYS )
 				.toQuery();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryTimeoutIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryTimeoutIT.java
@@ -27,14 +27,12 @@ import org.hibernate.search.engine.search.query.SearchScroll;
 import org.hibernate.search.engine.search.query.SearchScrollResult;
 import org.hibernate.search.engine.search.query.dsl.SearchQueryOptionsStep;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
-import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConfiguration;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.common.SearchTimeoutException;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils;
 
-import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -122,10 +120,6 @@ public class SearchQueryTimeoutIT {
 
 	@Test
 	public void fetch_truncateAfter_slowQuery_smallTimeout() {
-		Assume.assumeTrue(
-				"backend should have a fast timeout resolution in order to run this test correctly",
-				TckConfiguration.get().getBackendFeatures().fastTimeoutResolution()
-		);
 		SearchResult<DocumentReference> result = startSlowQuery()
 				.truncateAfter( 1, TimeUnit.NANOSECONDS )
 				.fetch( 20 );
@@ -142,10 +136,6 @@ public class SearchQueryTimeoutIT {
 
 	@Test
 	public void scroll_truncateAfter_slowQuery_smallTimeout() {
-		Assume.assumeTrue(
-				"backend should have a fast timeout resolution in order to run this test correctly",
-				TckConfiguration.get().getBackendFeatures().fastTimeoutResolution()
-		);
 		SearchQuery<DocumentReference> query = startSlowQuery()
 				.truncateAfter( 1, TimeUnit.NANOSECONDS )
 				.toQuery();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryTimeoutIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryTimeoutIT.java
@@ -28,7 +28,6 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConf
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.common.SearchTimeoutException;
-import org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils;
 
@@ -142,7 +141,7 @@ public class SearchQueryTimeoutIT {
 				.failAfter( 1, TimeUnit.DAYS )
 				.fetchAll();
 
-		SearchResultAssert.assertThat( result ).hasNoHits();
+		assertThat( result.hits() ).hasSize( 0 );
 
 		assertThat( result.took() ).isLessThan( Duration.ofDays( 1L ) );
 		assertThat( result.timedOut() ).isFalse();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryTimeoutIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryTimeoutIT.java
@@ -27,12 +27,14 @@ import org.hibernate.search.engine.search.query.SearchScroll;
 import org.hibernate.search.engine.search.query.SearchScrollResult;
 import org.hibernate.search.engine.search.query.dsl.SearchQueryOptionsStep;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConfiguration;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.common.SearchTimeoutException;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils;
 
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -136,6 +138,11 @@ public class SearchQueryTimeoutIT {
 
 	@Test
 	public void scroll_truncateAfter_slowQuery_smallTimeout() {
+		Assume.assumeTrue(
+				"The backend doesn't support truncateAfter() on scrolls",
+				TckConfiguration.get().getBackendFeatures().supportsTruncateAfterForScroll()
+		);
+
 		SearchQuery<DocumentReference> query = startSlowQuery()
 				.truncateAfter( 1, TimeUnit.NANOSECONDS )
 				.toQuery();

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryTimeoutIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryTimeoutIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.integrationtest.backend.tck.search.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -35,8 +36,6 @@ import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
-
-import org.assertj.core.api.Assertions;
 
 public class SearchQueryTimeoutIT {
 
@@ -89,7 +88,7 @@ public class SearchQueryTimeoutIT {
 				.failAfter( 1, TimeUnit.NANOSECONDS )
 				.toQuery();
 
-		Assertions.assertThatThrownBy( () -> query.fetchAll() )
+		assertThatThrownBy( () -> query.fetchAll() )
 				.isInstanceOf( SearchTimeoutException.class )
 				.hasMessageContaining( " exceeded the timeout of 0s, 0ms and 1ns: " );
 	}
@@ -100,7 +99,7 @@ public class SearchQueryTimeoutIT {
 				.failAfter( 1, TimeUnit.NANOSECONDS )
 				.toQuery();
 
-		Assertions.assertThatThrownBy( () -> query.fetchTotalHitCount() )
+		assertThatThrownBy( () -> query.fetchTotalHitCount() )
 				.isInstanceOf( SearchTimeoutException.class )
 				.hasMessageContaining( " exceeded the timeout of 0s, 0ms and 1ns: " );
 	}
@@ -111,7 +110,7 @@ public class SearchQueryTimeoutIT {
 				.failAfter( 1, TimeUnit.NANOSECONDS )
 				.toQuery();
 
-		Assertions.assertThatThrownBy( () -> query.scroll( 5 ).next() )
+		assertThatThrownBy( () -> query.scroll( 5 ).next() )
 				.isInstanceOf( SearchTimeoutException.class )
 				.hasMessageContaining( " exceeded the timeout of 0s, 0ms and 1ns: " );
 	}
@@ -132,7 +131,7 @@ public class SearchQueryTimeoutIT {
 
 		// we cannot have an exact hit count in case of limitFetching-timeout event
 		assertThat( result.total().hitCountLowerBound() ).isLessThan( DOCUMENT_COUNT );
-		Assertions.assertThatThrownBy( () -> result.total().hitCount() )
+		assertThatThrownBy( () -> result.total().hitCount() )
 				.isInstanceOf( SearchException.class )
 				.hasMessageContaining( "Trying to get the exact total hit count, but it is a lower bound" );
 	}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
@@ -66,4 +66,8 @@ public class TckBackendFeatures {
 	public boolean supportsTotalHitsThreshold() {
 		return true;
 	}
+
+	public boolean supportsTruncateAfterForScroll() {
+		return true;
+	}
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
@@ -47,10 +47,6 @@ public class TckBackendFeatures {
 		return false;
 	}
 
-	public boolean fastTimeoutResolution() {
-		return true;
-	}
-
 	public boolean sortByFieldValue(TestedFieldStructure fieldStructure, Class<?> fieldType, SortMode sortMode) {
 		return true;
 	}


### PR DESCRIPTION
* [HSEARCH-4028](https://hibernate.atlassian.net/browse/HSEARCH-4028): Elasticsearch's SearchResultTotal incorrectly reports an exact count after a timeout
* [HSEARCH-4027](https://hibernate.atlassian.net/browse/HSEARCH-4027): ScrollResult.timedOut() sometimes returns false even though a timeout occurred with Lucene
* [HSEARCH-3785](https://hibernate.atlassian.net/browse/HSEARCH-3785): Test soft timeout ( limiting fetching ) on Elasticsearch

