### PR TITLE
HSEARCH-4038 Assign more memory to the JVM used to run Elasticsearch locally in tests

### DIFF
--- a/util/internal/integrationtest/sharedresources/src/main/elasticsearch-maven-plugin/5.0/configuration/jvm.options
+++ b/util/internal/integrationtest/sharedresources/src/main/elasticsearch-maven-plugin/5.0/configuration/jvm.options
@@ -19,11 +19,12 @@
 # Xms represents the initial size of total heap space
 # Xmx represents the maximum size of total heap space
 
-# For Hibernate Search, we don't need as much as the default 1g
-# Let's keep it low, so that we'll be able to run tests
-# on memory-constrained CI slaves
--Xms512m
--Xmx512m
+# For Hibernate Search, a few tests require slightly more than 512MB of memory
+# because they index a lot of data.
+# Let's stay on the safe side and keep the default of 1GB,
+# since it's not 2010 anymore and CI instances have more than enough memory.
+-Xms1g
+-Xmx1g
 
 ################################################################
 ## Expert settings

--- a/util/internal/integrationtest/sharedresources/src/main/elasticsearch-maven-plugin/6.0/configuration/jvm.options
+++ b/util/internal/integrationtest/sharedresources/src/main/elasticsearch-maven-plugin/6.0/configuration/jvm.options
@@ -19,11 +19,12 @@
 # Xms represents the initial size of total heap space
 # Xmx represents the maximum size of total heap space
 
-# For Hibernate Search, we don't need as much as the default 1g
-# Let's keep it low, so that we'll be able to run tests
-# on memory-constrained CI slaves
--Xms512m
--Xmx512m
+# For Hibernate Search, a few tests require slightly more than 512MB of memory
+# because they index a lot of data.
+# Let's stay on the safe side and keep the default of 1GB,
+# since it's not 2010 anymore and CI instances have more than enough memory.
+-Xms1g
+-Xmx1g
 
 ################################################################
 ## Expert settings

--- a/util/internal/integrationtest/sharedresources/src/main/elasticsearch-maven-plugin/7.0/configuration/jvm.options
+++ b/util/internal/integrationtest/sharedresources/src/main/elasticsearch-maven-plugin/7.0/configuration/jvm.options
@@ -19,11 +19,12 @@
 # Xms represents the initial size of total heap space
 # Xmx represents the maximum size of total heap space
 
-# For Hibernate Search, we don't need as much as the default 1g
-# Let's keep it low, so that we'll be able to run tests
-# on memory-constrained CI slaves
--Xms512m
--Xmx512m
+# For Hibernate Search, a few tests require slightly more than 512MB of memory
+# because they index a lot of data.
+# Let's stay on the safe side and keep the default of 1GB,
+# since it's not 2010 anymore and CI instances have more than enough memory.
+-Xms1g
+-Xmx1g
 
 ################################################################
 ## Expert settings


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4038
