### PR TITLE
HSEARCH-4032 + HSEARCH-4039 Use "surefire.rerunFailingTestsCount"/"failsafe.rerunFailingTestsCount" to re-run failing tests when testing on AWS Elasticsearch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   # but we want the plugins to be skipped if they are not essential,
   # because they will be re-executed later and we don't want to waste time.
   - ./mvnw $BUILD_OPTIONS -B -q clean install
-    -DskipTests -Dmaven.javadoc.skip=true -Dcheckstyle.skip=true -Dforbiddenapis.skip=true -Djqassistant.skip=true
+    -DskipTests -DskipITs -Dmaven.javadoc.skip=true -Dcheckstyle.skip=true -Dforbiddenapis.skip=true -Djqassistant.skip=true
 script:
   # We run checks first to fail fast if there is a styling error, then we run the actual build.
   - ./mvnw $BUILD_OPTIONS checkstyle:check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -282,7 +282,7 @@ You can request static analysis and sanity checks with the `jqassistant` profile
 Tests do not need to be run for these checks.
 
 ```bash
-mvn clean install -Pjqassistant -DskipTests
+mvn clean install -Pjqassistant -DskipTests -DskipITs
 ```
 
 To also check cyclic dependencies between packages, use `-Djqassistant.groups=default,cycles`.
@@ -290,7 +290,7 @@ Cyclic dependency analysis is costly and may add significant overhead to the bui
 at least 10 seconds, maybe one minute or more depending on your setup.
 
 ```bash
-mvn clean install -Pjqassistant -DskipTests -Djqassistant.groups=default,cycles
+mvn clean install -Pjqassistant -DskipTests -DskipITs -Djqassistant.groups=default,cycles
 ```
 
 You can also inspect the created Neo4j datastore after a build,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -600,23 +600,15 @@ stage('Non-default environments') {
 						// By default, rely on credentials provided by the EC2 infrastructure
 
 						helper.withMavenWorkspace {
-							// Tests may fail because of hourly AWS snapshots,
-							// which prevent deleting indexes while they are being executed.
-							// So if this fails, we re-try twice.
-							// Note that because we expect frequent failure and retries,
-							// we use --fail-fast here, to make sure we don't waste time.
-							retry(count: 3) {
-								mavenNonDefaultBuild buildEnv, """ \
-										clean install \
-										--fail-fast \
-										-pl org.hibernate.search:hibernate-search-integrationtest-backend-elasticsearch,org.hibernate.search:hibernate-search-integrationtest-showcase-library \
-										${toElasticsearchVersionArgs(buildEnv.mavenProfile, buildEnv.version)} \
-										-Dtest.elasticsearch.connection.hosts=$buildEnv.endpointHostAndPort \
-										-Dtest.elasticsearch.connection.protocol=$buildEnv.endpointProtocol \
-										-Dtest.elasticsearch.connection.aws.signing.enabled=true \
-										-Dtest.elasticsearch.connection.aws.region=$buildEnv.awsRegion \
-									"""
-							}
+							mavenNonDefaultBuild buildEnv, """ \
+									clean install \
+									-pl org.hibernate.search:hibernate-search-integrationtest-backend-elasticsearch,org.hibernate.search:hibernate-search-integrationtest-showcase-library \
+									${toElasticsearchVersionArgs(buildEnv.mavenProfile, buildEnv.version)} \
+									-Dtest.elasticsearch.connection.hosts=$buildEnv.endpointHostAndPort \
+									-Dtest.elasticsearch.connection.protocol=$buildEnv.endpointProtocol \
+									-Dtest.elasticsearch.connection.aws.signing.enabled=true \
+									-Dtest.elasticsearch.connection.aws.region=$buildEnv.awsRegion \
+								"""
 						}
 					}
 					else {
@@ -629,26 +621,18 @@ stage('Non-default environments') {
 											  usernameVariable: 'AWS_ACCESS_KEY_ID',
 											  passwordVariable: 'AWS_SECRET_ACCESS_KEY'
 											 ]]) {
-								// Tests may fail because of hourly AWS snapshots,
-								// which prevent deleting indexes while they are being executed.
-								// So if this fails, we re-try twice.
-								// Note that because we expect frequent failure and retries,
-								// we use --fail-fast here, to make sure we don't waste time.
-								retry(count: 3) {
-									mavenNonDefaultBuild buildEnv, """ \
-										clean install \
-										--fail-fast \
-										-pl org.hibernate.search:hibernate-search-integrationtest-backend-elasticsearch,org.hibernate.search:hibernate-search-integrationtest-showcase-library \
-										${toElasticsearchVersionArgs(buildEnv.mavenProfile, buildEnv.version)} \
-										-Dtest.elasticsearch.connection.hosts=$buildEnv.endpointHostAndPort \
-										-Dtest.elasticsearch.connection.protocol=$buildEnv.endpointProtocol \
-										-Dtest.elasticsearch.connection.aws.signing.enabled=true \
-										-Dtest.elasticsearch.connection.aws.region=$buildEnv.awsRegion \
-										-Dtest.elasticsearch.connection.aws.credentials.type=static \
-										-Dtest.elasticsearch.connection.aws.credentials.access_key_id=$AWS_ACCESS_KEY_ID \
-										-Dtest.elasticsearch.connection.aws.credentials.secret_access_key=$AWS_SECRET_ACCESS_KEY \
-									"""
-								}
+								mavenNonDefaultBuild buildEnv, """ \
+									clean install \
+									-pl org.hibernate.search:hibernate-search-integrationtest-backend-elasticsearch,org.hibernate.search:hibernate-search-integrationtest-showcase-library \
+									${toElasticsearchVersionArgs(buildEnv.mavenProfile, buildEnv.version)} \
+									-Dtest.elasticsearch.connection.hosts=$buildEnv.endpointHostAndPort \
+									-Dtest.elasticsearch.connection.protocol=$buildEnv.endpointProtocol \
+									-Dtest.elasticsearch.connection.aws.signing.enabled=true \
+									-Dtest.elasticsearch.connection.aws.region=$buildEnv.awsRegion \
+									-Dtest.elasticsearch.connection.aws.credentials.type=static \
+									-Dtest.elasticsearch.connection.aws.credentials.access_key_id=$AWS_ACCESS_KEY_ID \
+									-Dtest.elasticsearch.connection.aws.credentials.secret_access_key=$AWS_SECRET_ACCESS_KEY \
+								"""
 							}
 						}
 					}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -540,7 +540,7 @@ stage('Non-default environments') {
 				helper.withMavenWorkspace {
 					mavenNonDefaultBuild buildEnv, """ \
 							clean install \
-							-DskipTests \
+							-DskipTests -DskipITs \
 							-P${buildEnv.mavenProfile},!javaModuleITs \
 					"""
 				}

--- a/distribution/src/main/assembly/dist.xml
+++ b/distribution/src/main/assembly/dist.xml
@@ -9,7 +9,7 @@
 <!--
   When updating this file, make sure we don't include duplicate jars in different subdirectories.
   Generate the distribution preview to see how it looks like:
-   mvn clean package assembly:assembly -DskipTests=true
+   mvn clean package assembly:assembly -DskipTests -DskipITs
   To inspect which jars are being distributed and look for duplicates this might be handy:
    tar -ztvf target/*-dist.tar.gz  | grep .jar | sed -e "s/.*\/dist//" -e "s/\(\/lib\/[^\/]*\)\/\(.*\)/\2 \t\t\t\1/" | sort
  -->

--- a/integrationtest/jdk/java-modules/pom.xml
+++ b/integrationtest/jdk/java-modules/pom.xml
@@ -18,6 +18,8 @@
 
     <properties>
         <maven.compiler.release>11</maven.compiler.release>
+        <!-- Override the default from the parent POM: here we really do want to use the modulepath -->
+        <failsafe.useModulePath>true</failsafe.useModulePath>
     </properties>
 
     <dependencies>
@@ -55,26 +57,14 @@
         </resources>
         <plugins>
             <plugin>
-                <!--
-                     Workaround for https://jira.apache.org/jira/browse/SUREFIRE-1570.
-                     Strangely enough, the surefire plugin supports running tests in the modulepath,
-                     but not the failsafe plugin.
-                     So we have to run our integration tests using the surefire plugin...
-                 -->
-                <artifactId>maven-surefire-plugin</artifactId>
+                <artifactId>maven-failsafe-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>verify</id>
+                        <id>it</id>
                         <goals>
-                            <goal>test</goal>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
                         </goals>
-                        <phase>integration-test</phase>
-                        <configuration>
-                            <skip>${skipITs}</skip>
-                            <includes>
-                                <include>**/*IT.java</include>
-                            </includes>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/integrationtest/performance/backend/README.md
+++ b/integrationtest/performance/backend/README.md
@@ -10,9 +10,9 @@ and find regressions in isolation from the various mappers.
 To build the performance tests:
 
 ```
-mvn clean install -pl integrationtest/performance/backend/elasticsearch -am -DskipTests
+mvn clean install -pl integrationtest/performance/backend/elasticsearch -am -DskipTests -DskipITs
 # OR
-mvn clean install -pl integrationtest/performance/backend/lucene -am -DskipTests
+mvn clean install -pl integrationtest/performance/backend/lucene -am -DskipTests -DskipITs
 ```
 
 ## Run it from command line

--- a/jenkins/performance-elasticsearch.groovy
+++ b/jenkins/performance-elasticsearch.groovy
@@ -77,7 +77,7 @@ lock(label: esAwsBuildEnv.lockedResourcesLabel) {
 				sh """ \
 						mvn clean install \
 						-U -am -pl :hibernate-search-integrationtest-performance-backend-elasticsearch \
-						-DskipTests \
+						-DskipTests -DskipITs \
 				"""
 				dir ('integrationtest/performance/backend/elasticsearch/target') {
 					stash name:'jar', includes:'benchmarks.jar'

--- a/jenkins/performance-lucene.groovy
+++ b/jenkins/performance-lucene.groovy
@@ -61,7 +61,7 @@ node (PERFORMANCE_NODE_PATTERN) {
 			sh """ \
 					mvn clean install \
 					-U -am -pl :hibernate-search-integrationtest-performance-backend-lucene \
-					-DskipTests \
+					-DskipTests -DskipITs \
 			"""
 			dir ('integrationtest/performance/backend/lucene/target') {
 				stash name:'jar', includes:'benchmarks.jar'

--- a/jenkins/performance-orm.groovy
+++ b/jenkins/performance-orm.groovy
@@ -6,7 +6,7 @@ node ('Performance') {
 	stage ('Build') {
 		sh "mvn clean install" +
 				" -U -am -pl :hibernate-search-performance-orm" +
-				" -DskipTests"
+				" -DskipTests -DskipITs"
 	}
 	
 	def scenarios

--- a/parents/integrationtest/pom.xml
+++ b/parents/integrationtest/pom.xml
@@ -47,6 +47,14 @@
          -->
         <sonar.sources>${rootProject.emptySubdirectory}</sonar.sources>
         <sonar.tests>${project.basedir}/src</sonar.tests>
+
+        <!-- For some reason, the failsafe plugin uses the modulepath
+             even when we didn't define a module-info.java,
+             and many things fail because of the modulepath.
+             In particular, the backend TCK fails to retrieve TckBackendHelper,
+             and Spring Boot ITs fail to detect configuration defined in the main (non-test) code.
+             So, disable the modulepath explicitly. -->
+        <failsafe.useModulePath>false</failsafe.useModulePath>
     </properties>
 
     <dependencyManagement>

--- a/parents/integrationtest/pom.xml
+++ b/parents/integrationtest/pom.xml
@@ -280,6 +280,24 @@
             </properties>
         </profile>
 
+        <profile>
+            <id>aws</id>
+            <activation>
+                <property>
+                    <name>test.elasticsearch.connection.aws.signing.enabled</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <!-- Tests may fail unexpectedly with AWS Elasticsearch.
+                     In particular, AWS may decide to snapshot an index, in which case deleting indexes will fail.
+                     Sometimes we also get timeouts, seemingly for no particular reason.
+                     Thus we need to retry tests when they fail, to be sure it's not just a transient failure.
+                 -->
+                <failsafe.rerunFailingTestsCount>4</failsafe.rerunFailingTestsCount>
+            </properties>
+        </profile>
+
         <!-- Elasticsearch 5.6 test environment -->
         <profile>
             <id>elasticsearch-5.6</id>

--- a/pom.xml
+++ b/pom.xml
@@ -293,7 +293,7 @@
         <version.site.plugin>3.6</version.site.plugin>
         <version.source.plugin>3.0.1</version.source.plugin>
         <!-- Surefire versions are a minefield of bugs: be careful with upgrades -->
-        <version.surefire.plugin>2.22.2</version.surefire.plugin>
+        <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
         <version.surefire.plugin.java-version.asm>7.3.1</version.surefire.plugin.java-version.asm>
         <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
         <version.jacoco.plugin>0.8.3</version.jacoco.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1103,7 +1103,7 @@
                 <artifactId>maven-release-plugin</artifactId>
                 <configuration>
                     <goals>deploy</goals>
-                    <arguments>-DskipTests</arguments>
+                    <arguments>-DskipTests -DskipITs</arguments>
                     <pushChanges>false</pushChanges>
                     <localCheckout>true</localCheckout>
                     <preparationGoals>clean install</preparationGoals>


### PR DESCRIPTION
* [HSEARCH-4039](https://hibernate.atlassian.net/browse/HSEARCH-4039): Upgrade to maven-surefire-plugin/maven-failsafe-plugin 3.0.0-M5
* [HSEARCH-4032](https://hibernate.atlassian.net/browse/HSEARCH-4032): Use "surefire.rerunFailingTestsCount"/"failsafe.rerunFailingTestsCount" to re-run failing tests when testing on AWS Elasticsearch

The usual: build changes, waiting for CI then I'll merge.