### PR TITLE
HSEARCH-2836 Timeouts start when the request is submitted to the client, leading to systematic timeout when client is under heavy load

### DIFF
--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/client/ElasticsearchClientFactoryImplIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/client/ElasticsearchClientFactoryImplIT.java
@@ -101,11 +101,11 @@ public class ElasticsearchClientFactoryImplIT {
 	@Rule
 	public TestConfigurationProvider testConfigurationProvider = new TestConfigurationProvider();
 
-	private ThreadPoolProviderImpl threadPoolProvider = new ThreadPoolProviderImpl(
+	private final ThreadPoolProviderImpl threadPoolProvider = new ThreadPoolProviderImpl(
 			BeanHolder.of( new DefaultThreadProvider( ElasticsearchClientFactoryImplIT.class.getName() + ": " ) )
 	);
 
-	private ScheduledExecutorService timeoutExecutorService =
+	private final ScheduledExecutorService timeoutExecutorService =
 			threadPoolProvider.newScheduledExecutor( 1, "Timeout - " );
 
 	@After


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-2836

As it turns out:

* The Elasticsearch client no longer enforces a request timeout.
* Our own request timeout is only enforced when the user asks for it explicitly, typically for search queries.

As a result, the problem mentioned in this ticket no longer exists.

I added a few tests to demonstrate that even when the REST client is clogged up with many pending requests, the new requests won't incur a read timeout (because the read timeout starts when the request is actually sent).

They will incur a request timeout, but that's working as intended, since the request timeout is opt-in.