### PR TITLE
HSEARCH-3905 exists() predicate ignores dynamic fields among children of the targeted object field with the Lucene backend

### DIFF
--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/AbstractLuceneDocumentBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/AbstractLuceneDocumentBuilder.java
@@ -18,6 +18,7 @@ import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexSchema
 import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexSchemaObjectNode;
 import org.hibernate.search.backend.lucene.logging.impl.Log;
 import org.hibernate.search.backend.lucene.multitenancy.impl.MultiTenancyStrategy;
+import org.hibernate.search.backend.lucene.types.codec.impl.LuceneDocumentBuilder;
 import org.hibernate.search.backend.lucene.types.impl.LuceneIndexValueFieldType;
 import org.hibernate.search.engine.backend.document.DocumentElement;
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
@@ -29,7 +30,7 @@ import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 import org.apache.lucene.document.Document;
 
 
-abstract class AbstractLuceneDocumentBuilder implements LuceneDocumentBuilder {
+abstract class AbstractLuceneDocumentBuilder implements LuceneDocumentBuilder, DocumentElement {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/AbstractLuceneNonFlattenedDocumentBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/AbstractLuceneNonFlattenedDocumentBuilder.java
@@ -16,6 +16,7 @@ import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexSchema
 import org.hibernate.search.backend.lucene.logging.impl.Log;
 import org.hibernate.search.backend.lucene.multitenancy.impl.MultiTenancyStrategy;
 import org.hibernate.search.backend.lucene.lowlevel.common.impl.MetadataFields;
+import org.hibernate.search.backend.lucene.types.codec.impl.LuceneDocumentBuilder;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
 import org.apache.lucene.document.Document;

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/AbstractLuceneObjectFieldBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/AbstractLuceneObjectFieldBuilder.java
@@ -1,0 +1,31 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.document.impl;
+
+import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexModel;
+import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexSchemaObjectFieldNode;
+
+class AbstractLuceneObjectFieldBuilder extends AbstractLuceneDocumentElementBuilder {
+
+	private final AbstractLuceneDocumentElementBuilder parent;
+
+	AbstractLuceneObjectFieldBuilder(LuceneIndexModel model, LuceneIndexSchemaObjectFieldNode schemaNode,
+			AbstractLuceneDocumentElementBuilder parent, LuceneDocumentContentImpl documentContent) {
+		super( model, schemaNode, documentContent );
+		this.parent = parent;
+	}
+
+	@Override
+	void ensureDynamicValueDetectedByExistsPredicateOnObjectField() {
+		documentContent.addFieldName( schemaNode.absolutePath() );
+		if ( schemaNode.dynamic() ) {
+			// If this object field is dynamic,
+			// the parent object's metadata will not include it, so we must propagate the information.
+			parent.ensureDynamicValueDetectedByExistsPredicateOnObjectField();
+		}
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneFlattenedObjectFieldBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneFlattenedObjectFieldBuilder.java
@@ -15,35 +15,22 @@ import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexSchema
 import org.hibernate.search.backend.lucene.logging.impl.Log;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
-import org.apache.lucene.index.IndexableField;
-
-
-class LuceneFlattenedObjectDocumentBuilder extends AbstractLuceneDocumentBuilder {
+class LuceneFlattenedObjectFieldBuilder extends AbstractLuceneDocumentElementBuilder {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private final AbstractLuceneDocumentBuilder parent;
-
 	private final Set<String> encounteredFields = new HashSet<>();
 
-	LuceneFlattenedObjectDocumentBuilder(LuceneIndexModel model, LuceneIndexSchemaObjectFieldNode schemaNode,
-			AbstractLuceneDocumentBuilder parent) {
-		super( model, schemaNode );
-		this.parent = parent;
-	}
-
-	@Override
-	public void addField(IndexableField field) {
-		parent.addField( field );
-	}
-
-	@Override
-	public void addFieldName(String absoluteFieldPath) {
-		parent.addFieldName( absoluteFieldPath );
+	LuceneFlattenedObjectFieldBuilder(LuceneIndexModel model, LuceneIndexSchemaObjectFieldNode schemaNode,
+			LuceneDocumentContentImpl documentContent) {
+		// The document content is not ours: it's the parent's.
+		super( model, schemaNode, documentContent );
 	}
 
 	@Override
 	void checkNoValueYetForSingleValued(String absoluteFieldPath) {
+		// We cannot rely on the document content which is shared between all flattened objects,
+		// because the single-valued field may have one value for each flattened object.
 		boolean firstEncounter = encounteredFields.add( absoluteFieldPath );
 		if ( !firstEncounter ) {
 			throw log.multipleValuesForSingleValuedField( absoluteFieldPath );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneFlattenedObjectFieldBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneFlattenedObjectFieldBuilder.java
@@ -15,16 +15,16 @@ import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexSchema
 import org.hibernate.search.backend.lucene.logging.impl.Log;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
-class LuceneFlattenedObjectFieldBuilder extends AbstractLuceneDocumentElementBuilder {
+class LuceneFlattenedObjectFieldBuilder extends AbstractLuceneObjectFieldBuilder {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private final Set<String> encounteredFields = new HashSet<>();
 
 	LuceneFlattenedObjectFieldBuilder(LuceneIndexModel model, LuceneIndexSchemaObjectFieldNode schemaNode,
-			LuceneDocumentContentImpl documentContent) {
+			AbstractLuceneDocumentElementBuilder parent, LuceneDocumentContentImpl documentContent) {
 		// The document content is not ours: it's the parent's.
-		super( model, schemaNode, documentContent );
+		super( model, schemaNode, parent, documentContent );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneNestedObjectFieldBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneNestedObjectFieldBuilder.java
@@ -16,10 +16,11 @@ import org.hibernate.search.backend.lucene.lowlevel.common.impl.MetadataFields;
 import org.apache.lucene.document.Document;
 
 
-class LuceneNestedObjectFieldBuilder extends AbstractLuceneDocumentElementBuilder {
+class LuceneNestedObjectFieldBuilder extends AbstractLuceneObjectFieldBuilder {
 
-	LuceneNestedObjectFieldBuilder(LuceneIndexModel model, LuceneIndexSchemaObjectFieldNode schemaNode) {
-		super( model, schemaNode, new LuceneDocumentContentImpl() );
+	LuceneNestedObjectFieldBuilder(LuceneIndexModel model, LuceneIndexSchemaObjectFieldNode schemaNode,
+			AbstractLuceneDocumentElementBuilder parent) {
+		super( model, schemaNode, parent, new LuceneDocumentContentImpl() );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneRootDocumentBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/impl/LuceneRootDocumentBuilder.java
@@ -32,6 +32,11 @@ public class LuceneRootDocumentBuilder extends AbstractLuceneDocumentElementBuil
 		);
 	}
 
+	@Override
+	void ensureDynamicValueDetectedByExistsPredicateOnObjectField() {
+		// This is not an object field: nothing to do.
+	}
+
 	private List<Document> assembleDocuments(MultiTenancyStrategy multiTenancyStrategy,
 			String tenantId, String id, String routingKey) {
 		// We own the document content, so we finalize it ourselves.

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/dsl/impl/LuceneIndexSchemaObjectFieldNodeBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/dsl/impl/LuceneIndexSchemaObjectFieldNodeBuilder.java
@@ -77,7 +77,7 @@ class LuceneIndexSchemaObjectFieldNodeBuilder extends AbstractLuceneIndexSchemaO
 
 		Map<String, AbstractLuceneIndexSchemaFieldNode> staticChildrenByName = new TreeMap<>();
 		LuceneIndexSchemaObjectFieldNode node = new LuceneIndexSchemaObjectFieldNode(
-				parentNode, relativeFieldName, inclusion, structure, multiValued, staticChildrenByName
+				parentNode, relativeFieldName, inclusion, structure, multiValued, false, staticChildrenByName
 		);
 
 		staticChildrenByNameForParent.put( relativeFieldName, node );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/dsl/impl/LuceneIndexSchemaValueFieldNodeBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/dsl/impl/LuceneIndexSchemaValueFieldNodeBuilder.java
@@ -77,7 +77,7 @@ class LuceneIndexSchemaValueFieldNodeBuilder<F>
 			throw log.incompleteFieldDefinition( eventContext() );
 		}
 		LuceneIndexSchemaValueFieldNode<F> fieldNode = new LuceneIndexSchemaValueFieldNode<>(
-				parentNode, relativeFieldName, inclusion, multiValued, type
+				parentNode, relativeFieldName, inclusion, multiValued, false, type
 		);
 
 		staticChildrenByNameForParent.put( relativeFieldName, fieldNode );

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/impl/AbstractLuceneIndexSchemaFieldNode.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/impl/AbstractLuceneIndexSchemaFieldNode.java
@@ -25,15 +25,17 @@ public abstract class AbstractLuceneIndexSchemaFieldNode implements IndexFieldDe
 	protected final IndexFieldInclusion inclusion;
 	protected final boolean multiValued;
 	protected final boolean multiValuedInRoot;
+	protected final boolean dynamic;
 
 	public AbstractLuceneIndexSchemaFieldNode(LuceneIndexSchemaObjectNode parent, String relativeName,
-			IndexFieldInclusion inclusion, boolean multiValued) {
+			IndexFieldInclusion inclusion, boolean multiValued, boolean dynamic) {
 		this.parent = parent;
 		this.absolutePath = parent.absolutePath( relativeName );
 		this.relativeName = relativeName;
 		this.inclusion = parent.inclusion().compose( inclusion );
 		this.multiValued = multiValued;
 		this.multiValuedInRoot = multiValued || parent.multiValuedInRoot();
+		this.dynamic = dynamic;
 	}
 
 	@Override
@@ -74,5 +76,9 @@ public abstract class AbstractLuceneIndexSchemaFieldNode implements IndexFieldDe
 	@Override
 	public EventContext eventContext() {
 		return EventContexts.fromIndexFieldAbsolutePath( absolutePath );
+	}
+
+	public boolean dynamic() {
+		return dynamic;
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/impl/LuceneIndexSchemaObjectFieldNode.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/impl/LuceneIndexSchemaObjectFieldNode.java
@@ -36,9 +36,9 @@ public class LuceneIndexSchemaObjectFieldNode extends AbstractLuceneIndexSchemaF
 	private final Map<String, AbstractLuceneIndexSchemaFieldNode> staticChildrenByName;
 
 	public LuceneIndexSchemaObjectFieldNode(LuceneIndexSchemaObjectNode parent, String relativeName,
-			IndexFieldInclusion inclusion, ObjectStructure structure, boolean multiValued,
+			IndexFieldInclusion inclusion, ObjectStructure structure, boolean multiValued, boolean dynamic,
 			Map<String, AbstractLuceneIndexSchemaFieldNode> notYetInitializedStaticChildren) {
-		super( parent, relativeName, inclusion, multiValued );
+		super( parent, relativeName, inclusion, multiValued, dynamic );
 		List<String> theNestedPathHierarchy = parent.nestedPathHierarchy();
 		if ( ObjectStructure.NESTED.equals( structure ) ) {
 			// if we found a nested object, we add it to the nestedPathHierarchy

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/impl/LuceneIndexSchemaObjectFieldTemplate.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/impl/LuceneIndexSchemaObjectFieldTemplate.java
@@ -29,7 +29,7 @@ public class LuceneIndexSchemaObjectFieldTemplate
 	protected LuceneIndexSchemaObjectFieldNode createNode(LuceneIndexSchemaObjectNode parent,
 			String relativePath, IndexFieldInclusion inclusion, boolean multiValued) {
 		return new LuceneIndexSchemaObjectFieldNode(
-				parent, relativePath, inclusion, structure, multiValued,
+				parent, relativePath, inclusion, structure, multiValued, true,
 				// TODO HSEARCH-3905 we don't know the children, so we should find another way to implement the exists predicate
 				Collections.emptyMap()
 		);

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/impl/LuceneIndexSchemaObjectNode.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/impl/LuceneIndexSchemaObjectNode.java
@@ -34,4 +34,6 @@ public interface LuceneIndexSchemaObjectNode extends IndexCompositeElementDescri
 
 	boolean multiValuedInRoot();
 
+	boolean dynamic();
+
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/impl/LuceneIndexSchemaRootNode.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/impl/LuceneIndexSchemaRootNode.java
@@ -77,4 +77,9 @@ public class LuceneIndexSchemaRootNode implements LuceneIndexSchemaObjectNode {
 	public boolean multiValuedInRoot() {
 		return false;
 	}
+
+	@Override
+	public boolean dynamic() {
+		return false;
+	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/impl/LuceneIndexSchemaValueFieldNode.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/impl/LuceneIndexSchemaValueFieldNode.java
@@ -32,8 +32,8 @@ public class LuceneIndexSchemaValueFieldNode<F> extends AbstractLuceneIndexSchem
 	private final LuceneIndexValueFieldType<F> type;
 
 	public LuceneIndexSchemaValueFieldNode(LuceneIndexSchemaObjectNode parent, String relativeName,
-			IndexFieldInclusion inclusion, boolean multiValued, LuceneIndexValueFieldType<F> type) {
-		super( parent, relativeName, inclusion, multiValued );
+			IndexFieldInclusion inclusion, boolean multiValued, boolean dynamic, LuceneIndexValueFieldType<F> type) {
+		super( parent, relativeName, inclusion, multiValued, dynamic );
 		this.nestedPathHierarchy = parent.nestedPathHierarchy();
 		this.type = type;
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/impl/LuceneIndexSchemaValueFieldTemplate.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/impl/LuceneIndexSchemaValueFieldTemplate.java
@@ -26,6 +26,6 @@ public class LuceneIndexSchemaValueFieldTemplate
 	@Override
 	protected LuceneIndexSchemaValueFieldNode<?> createNode(LuceneIndexSchemaObjectNode parent,
 			String relativePath, IndexFieldInclusion inclusion, boolean multiValued) {
-		return new LuceneIndexSchemaValueFieldNode<>( parent, relativePath, inclusion, multiValued, type );
+		return new LuceneIndexSchemaValueFieldNode<>( parent, relativePath, inclusion, multiValued, true, type );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/AbstractLuceneNumericFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/AbstractLuceneNumericFieldCodec.java
@@ -25,7 +25,7 @@ public abstract class AbstractLuceneNumericFieldCodec<F, E extends Number>
 	}
 
 	@Override
-	public final void addToDocument(LuceneDocumentBuilder documentBuilder, String absoluteFieldPath, F value) {
+	public final void addToDocument(LuceneDocumentContent documentBuilder, String absoluteFieldPath, F value) {
 		if ( value == null && indexNullAsValue != null ) {
 			value = indexNullAsValue;
 		}
@@ -67,7 +67,7 @@ public abstract class AbstractLuceneNumericFieldCodec<F, E extends Number>
 
 	public abstract LuceneNumericDomain<E> getDomain();
 
-	abstract void addStoredToDocument(LuceneDocumentBuilder documentBuilder, String absoluteFieldPath,
+	abstract void addStoredToDocument(LuceneDocumentContent documentBuilder, String absoluteFieldPath,
 			F value, E encodedValue);
 
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/AbstractLuceneNumericFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/AbstractLuceneNumericFieldCodec.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.backend.lucene.types.codec.impl;
 
-import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneNumericDomain;
 
 public abstract class AbstractLuceneNumericFieldCodec<F, E extends Number>

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneBigDecimalFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneBigDecimalFieldCodec.java
@@ -11,7 +11,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
 
-import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
 import org.hibernate.search.backend.lucene.logging.impl.Log;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneLongDomain;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneNumericDomain;

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneBigDecimalFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneBigDecimalFieldCodec.java
@@ -44,7 +44,7 @@ public final class LuceneBigDecimalFieldCodec extends AbstractLuceneNumericField
 	}
 
 	@Override
-	void addStoredToDocument(LuceneDocumentBuilder documentBuilder, String absoluteFieldPath, BigDecimal value,
+	void addStoredToDocument(LuceneDocumentContent documentBuilder, String absoluteFieldPath, BigDecimal value,
 			Long encodedValue) {
 		documentBuilder.addField( new StoredField( absoluteFieldPath, value.toString() ) );
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneBigIntegerFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneBigIntegerFieldCodec.java
@@ -11,7 +11,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
 
-import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
 import org.hibernate.search.backend.lucene.logging.impl.Log;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneLongDomain;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneNumericDomain;

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneBigIntegerFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneBigIntegerFieldCodec.java
@@ -44,7 +44,7 @@ public final class LuceneBigIntegerFieldCodec extends AbstractLuceneNumericField
 	}
 
 	@Override
-	void addStoredToDocument(LuceneDocumentBuilder documentBuilder, String absoluteFieldPath, BigInteger value,
+	void addStoredToDocument(LuceneDocumentContent documentBuilder, String absoluteFieldPath, BigInteger value,
 			Long encodedValue) {
 		documentBuilder.addField( new StoredField( absoluteFieldPath, value.toString() ) );
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneBooleanFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneBooleanFieldCodec.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.backend.lucene.types.codec.impl;
 
-import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneIntegerDomain;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneNumericDomain;
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneBooleanFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneBooleanFieldCodec.java
@@ -20,7 +20,7 @@ public final class LuceneBooleanFieldCodec extends AbstractLuceneNumericFieldCod
 	}
 
 	@Override
-	void addStoredToDocument(LuceneDocumentBuilder documentBuilder, String absoluteFieldPath, Boolean value,
+	void addStoredToDocument(LuceneDocumentContent documentBuilder, String absoluteFieldPath, Boolean value,
 			Integer encodedValue) {
 		documentBuilder.addField( new StoredField( absoluteFieldPath, encodedValue ) );
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneByteFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneByteFieldCodec.java
@@ -20,7 +20,7 @@ public final class LuceneByteFieldCodec extends AbstractLuceneNumericFieldCodec<
 	}
 
 	@Override
-	void addStoredToDocument(LuceneDocumentBuilder documentBuilder, String absoluteFieldPath, Byte value,
+	void addStoredToDocument(LuceneDocumentContent documentBuilder, String absoluteFieldPath, Byte value,
 			Integer encodedValue) {
 		documentBuilder.addField( new StoredField( absoluteFieldPath, encodedValue ) );
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneByteFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneByteFieldCodec.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.backend.lucene.types.codec.impl;
 
-import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneIntegerDomain;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneNumericDomain;
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneDocumentBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneDocumentBuilder.java
@@ -4,14 +4,12 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.backend.lucene.document.impl;
-
-import org.hibernate.search.engine.backend.document.DocumentElement;
+package org.hibernate.search.backend.lucene.types.codec.impl;
 
 import org.apache.lucene.index.IndexableField;
 
 
-public interface LuceneDocumentBuilder extends DocumentElement {
+public interface LuceneDocumentBuilder {
 
 	/**
 	 * Add a field to this document.

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneDocumentContent.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneDocumentContent.java
@@ -9,7 +9,7 @@ package org.hibernate.search.backend.lucene.types.codec.impl;
 import org.apache.lucene.index.IndexableField;
 
 
-public interface LuceneDocumentBuilder {
+public interface LuceneDocumentContent {
 
 	/**
 	 * Add a field to this document.

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneDoubleFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneDoubleFieldCodec.java
@@ -20,7 +20,7 @@ public final class LuceneDoubleFieldCodec extends AbstractLuceneNumericFieldCode
 	}
 
 	@Override
-	void addStoredToDocument(LuceneDocumentBuilder documentBuilder, String absoluteFieldPath, Double value,
+	void addStoredToDocument(LuceneDocumentContent documentBuilder, String absoluteFieldPath, Double value,
 			Double encodedValue) {
 		documentBuilder.addField( new StoredField( absoluteFieldPath, encodedValue ) );
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneDoubleFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneDoubleFieldCodec.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.backend.lucene.types.codec.impl;
 
-import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneDoubleDomain;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneNumericDomain;
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneFieldCodec.java
@@ -26,7 +26,7 @@ public interface LuceneFieldCodec<F> {
 	 * @param absoluteFieldPath The absolute path of the field.
 	 * @param value The value to encode.
 	 */
-	void addToDocument(LuceneDocumentBuilder documentBuilder, String absoluteFieldPath, F value);
+	void addToDocument(LuceneDocumentContent documentBuilder, String absoluteFieldPath, F value);
 
 	/**
 	 * Extract the value from the given stored field.
@@ -43,9 +43,9 @@ public interface LuceneFieldCodec<F> {
 	 * i.e. whether its {@link #decode(IndexableField)}
 	 * and {@link LuceneStandardFieldCodec#encode(Object)} methods behave the same way.
 	 * <p>
-	 * NOTE: {@link #addToDocument(LuceneDocumentBuilder, String, Object)} may behave differently,
+	 * NOTE: {@link #addToDocument(LuceneDocumentContent, String, Object)} may behave differently,
 	 * e.g. it may add docvalues while this codec does not.
-	 * The behavior of {@link #addToDocument(LuceneDocumentBuilder, String, Object)}
+	 * The behavior of {@link #addToDocument(LuceneDocumentContent, String, Object)}
 	 * is considered irrelevant when checking the equivalence of encoding,
 	 * because such differences should be accounted for through other ways
 	 * (fields being assigned incompatible predicate factories, etc.).

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneFieldCodec.java
@@ -7,8 +7,6 @@
 package org.hibernate.search.backend.lucene.types.codec.impl;
 
 
-import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
-
 import org.apache.lucene.index.IndexableField;
 
 /**

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneFieldFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneFieldFieldCodec.java
@@ -11,7 +11,6 @@ import java.util.Objects;
 
 import org.apache.lucene.index.IndexableField;
 
-import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
 import org.hibernate.search.backend.lucene.types.converter.LuceneFieldContributor;
 import org.hibernate.search.backend.lucene.types.converter.LuceneFieldValueExtractor;
 import org.hibernate.search.backend.lucene.logging.impl.Log;

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneFieldFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneFieldFieldCodec.java
@@ -31,7 +31,7 @@ public final class LuceneFieldFieldCodec<F> implements LuceneFieldCodec<F> {
 	}
 
 	@Override
-	public void addToDocument(LuceneDocumentBuilder documentBuilder, String absoluteFieldPath, F value) {
+	public void addToDocument(LuceneDocumentContent documentBuilder, String absoluteFieldPath, F value) {
 		if ( value == null ) {
 			return;
 		}
@@ -63,7 +63,7 @@ public final class LuceneFieldFieldCodec<F> implements LuceneFieldCodec<F> {
 		return Objects.equals( fieldValueExtractor, other.fieldValueExtractor );
 	}
 
-	private static void contributeField(LuceneDocumentBuilder documentBuilder, String absoluteFieldPath, IndexableField field) {
+	private static void contributeField(LuceneDocumentContent documentBuilder, String absoluteFieldPath, IndexableField field) {
 		if ( !absoluteFieldPath.equals( field.name() ) ) {
 			throw log.invalidFieldPath( absoluteFieldPath, field.name() );
 		}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneFloatFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneFloatFieldCodec.java
@@ -20,7 +20,7 @@ public final class LuceneFloatFieldCodec extends AbstractLuceneNumericFieldCodec
 	}
 
 	@Override
-	void addStoredToDocument(LuceneDocumentBuilder documentBuilder, String absoluteFieldPath, Float value,
+	void addStoredToDocument(LuceneDocumentContent documentBuilder, String absoluteFieldPath, Float value,
 			Float encodedValue) {
 		documentBuilder.addField( new StoredField( absoluteFieldPath, encodedValue ) );
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneFloatFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneFloatFieldCodec.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.backend.lucene.types.codec.impl;
 
-import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneFloatDomain;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneNumericDomain;
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneGeoPointFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneGeoPointFieldCodec.java
@@ -31,7 +31,7 @@ public final class LuceneGeoPointFieldCodec implements LuceneFieldCodec<GeoPoint
 	}
 
 	@Override
-	public void addToDocument(LuceneDocumentBuilder documentBuilder, String absoluteFieldPath, GeoPoint value) {
+	public void addToDocument(LuceneDocumentContent documentBuilder, String absoluteFieldPath, GeoPoint value) {
 		if ( value == null && indexNullAsValue != null ) {
 			value = indexNullAsValue;
 		}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneGeoPointFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneGeoPointFieldCodec.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.backend.lucene.types.codec.impl;
 
-import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
 import org.hibernate.search.engine.spatial.GeoPoint;
 
 import org.apache.lucene.document.DoublePoint;

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneInstantFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneInstantFieldCodec.java
@@ -25,7 +25,7 @@ public final class LuceneInstantFieldCodec extends AbstractLuceneNumericFieldCod
 	}
 
 	@Override
-	void addStoredToDocument(LuceneDocumentBuilder documentBuilder, String absoluteFieldPath, Instant value,
+	void addStoredToDocument(LuceneDocumentContent documentBuilder, String absoluteFieldPath, Instant value,
 			Long encodedValue) {
 		documentBuilder.addField( new StoredField( absoluteFieldPath, FORMATTER.format( value ) ) );
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneInstantFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneInstantFieldCodec.java
@@ -9,7 +9,6 @@ package org.hibernate.search.backend.lucene.types.codec.impl;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 
-import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneLongDomain;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneNumericDomain;
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneIntegerFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneIntegerFieldCodec.java
@@ -20,7 +20,7 @@ public final class LuceneIntegerFieldCodec extends AbstractLuceneNumericFieldCod
 	}
 
 	@Override
-	void addStoredToDocument(LuceneDocumentBuilder documentBuilder, String absoluteFieldPath, Integer value,
+	void addStoredToDocument(LuceneDocumentContent documentBuilder, String absoluteFieldPath, Integer value,
 			Integer encodedValue) {
 		documentBuilder.addField( new StoredField( absoluteFieldPath, encodedValue ) );
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneIntegerFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneIntegerFieldCodec.java
@@ -8,7 +8,7 @@ package org.hibernate.search.backend.lucene.types.codec.impl;
 
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexableField;
-import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
+
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneIntegerDomain;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneNumericDomain;
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneLocalDateFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneLocalDateFieldCodec.java
@@ -16,7 +16,7 @@ import java.util.Locale;
 
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexableField;
-import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
+
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneLongDomain;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneNumericDomain;
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneLocalDateFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneLocalDateFieldCodec.java
@@ -35,7 +35,7 @@ public final class LuceneLocalDateFieldCodec extends AbstractLuceneNumericFieldC
 	}
 
 	@Override
-	void addStoredToDocument(LuceneDocumentBuilder documentBuilder, String absoluteFieldPath, LocalDate value,
+	void addStoredToDocument(LuceneDocumentContent documentBuilder, String absoluteFieldPath, LocalDate value,
 			Long encodedValue) {
 		documentBuilder.addField( new StoredField( absoluteFieldPath, FORMATTER.format( value ) ) );
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneLocalDateTimeFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneLocalDateTimeFieldCodec.java
@@ -14,7 +14,6 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.ResolverStyle;
 import java.util.Locale;
 
-import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneLongDomain;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneNumericDomain;
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneLocalDateTimeFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneLocalDateTimeFieldCodec.java
@@ -35,7 +35,7 @@ public final class LuceneLocalDateTimeFieldCodec extends AbstractLuceneNumericFi
 	}
 
 	@Override
-	void addStoredToDocument(LuceneDocumentBuilder documentBuilder, String absoluteFieldPath, LocalDateTime value,
+	void addStoredToDocument(LuceneDocumentContent documentBuilder, String absoluteFieldPath, LocalDateTime value,
 			Long encodedValue) {
 		documentBuilder.addField( new StoredField( absoluteFieldPath, FORMATTER.format( value ) ) );
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneLocalTimeFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneLocalTimeFieldCodec.java
@@ -17,7 +17,6 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.ResolverStyle;
 import java.util.Locale;
 
-import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneLongDomain;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneNumericDomain;
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneLocalTimeFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneLocalTimeFieldCodec.java
@@ -43,7 +43,7 @@ public final class LuceneLocalTimeFieldCodec extends AbstractLuceneNumericFieldC
 	}
 
 	@Override
-	void addStoredToDocument(LuceneDocumentBuilder documentBuilder, String absoluteFieldPath, LocalTime value,
+	void addStoredToDocument(LuceneDocumentContent documentBuilder, String absoluteFieldPath, LocalTime value,
 			Long encodedValue) {
 		documentBuilder.addField( new StoredField( absoluteFieldPath, FORMATTER.format( value ) ) );
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneLongFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneLongFieldCodec.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.backend.lucene.types.codec.impl;
 
-import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneLongDomain;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneNumericDomain;
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneLongFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneLongFieldCodec.java
@@ -20,7 +20,7 @@ public final class LuceneLongFieldCodec extends AbstractLuceneNumericFieldCodec<
 	}
 
 	@Override
-	void addStoredToDocument(LuceneDocumentBuilder documentBuilder, String absoluteFieldPath, Long value,
+	void addStoredToDocument(LuceneDocumentContent documentBuilder, String absoluteFieldPath, Long value,
 			Long encodedValue) {
 		documentBuilder.addField( new StoredField( absoluteFieldPath, encodedValue ) );
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneMonthDayFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneMonthDayFieldCodec.java
@@ -15,7 +15,6 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.ResolverStyle;
 import java.util.Locale;
 
-import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneIntegerDomain;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneNumericDomain;
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneMonthDayFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneMonthDayFieldCodec.java
@@ -37,7 +37,7 @@ public final class LuceneMonthDayFieldCodec extends AbstractLuceneNumericFieldCo
 	}
 
 	@Override
-	void addStoredToDocument(LuceneDocumentBuilder documentBuilder, String absoluteFieldPath, MonthDay value,
+	void addStoredToDocument(LuceneDocumentContent documentBuilder, String absoluteFieldPath, MonthDay value,
 			Integer encodedValue) {
 		documentBuilder.addField( new StoredField( absoluteFieldPath, FORMATTER.format( value ) ) );
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneOffsetDateTimeFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneOffsetDateTimeFieldCodec.java
@@ -35,7 +35,7 @@ public final class LuceneOffsetDateTimeFieldCodec extends AbstractLuceneNumericF
 	}
 
 	@Override
-	void addStoredToDocument(LuceneDocumentBuilder documentBuilder, String absoluteFieldPath, OffsetDateTime value,
+	void addStoredToDocument(LuceneDocumentContent documentBuilder, String absoluteFieldPath, OffsetDateTime value,
 			Long encodedValue) {
 		documentBuilder.addField( new StoredField( absoluteFieldPath, FORMATTER.format( value ) ) );
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneOffsetDateTimeFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneOffsetDateTimeFieldCodec.java
@@ -14,7 +14,6 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.ResolverStyle;
 import java.util.Locale;
 
-import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneLongDomain;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneNumericDomain;
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneOffsetTimeFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneOffsetTimeFieldCodec.java
@@ -36,7 +36,7 @@ public final class LuceneOffsetTimeFieldCodec extends AbstractLuceneNumericField
 	}
 
 	@Override
-	void addStoredToDocument(LuceneDocumentBuilder documentBuilder, String absoluteFieldPath, OffsetTime value,
+	void addStoredToDocument(LuceneDocumentContent documentBuilder, String absoluteFieldPath, OffsetTime value,
 			Long encodedValue) {
 		documentBuilder.addField( new StoredField( absoluteFieldPath, FORMATTER.format( value ) ) );
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneOffsetTimeFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneOffsetTimeFieldCodec.java
@@ -15,7 +15,6 @@ import java.time.format.ResolverStyle;
 import java.time.temporal.ChronoUnit;
 import java.util.Locale;
 
-import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneLongDomain;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneNumericDomain;
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneShortFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneShortFieldCodec.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.backend.lucene.types.codec.impl;
 
-import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneIntegerDomain;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneNumericDomain;
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneShortFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneShortFieldCodec.java
@@ -20,7 +20,7 @@ public final class LuceneShortFieldCodec extends AbstractLuceneNumericFieldCodec
 	}
 
 	@Override
-	void addStoredToDocument(LuceneDocumentBuilder documentBuilder, String absoluteFieldPath, Short value,
+	void addStoredToDocument(LuceneDocumentContent documentBuilder, String absoluteFieldPath, Short value,
 			Integer encodedValue) {
 		documentBuilder.addField( new StoredField( absoluteFieldPath, encodedValue ) );
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneStringFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneStringFieldCodec.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.backend.lucene.types.codec.impl;
 
-import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
 import org.hibernate.search.backend.lucene.lowlevel.common.impl.AnalyzerConstants;
 
 import org.apache.lucene.analysis.Analyzer;

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneStringFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneStringFieldCodec.java
@@ -31,7 +31,7 @@ public final class LuceneStringFieldCodec implements LuceneStandardFieldCodec<St
 	}
 
 	@Override
-	public void addToDocument(LuceneDocumentBuilder documentBuilder, String absoluteFieldPath, String value) {
+	public void addToDocument(LuceneDocumentContent documentBuilder, String absoluteFieldPath, String value) {
 		if ( value == null && indexNullAsValue != null ) {
 			value = indexNullAsValue;
 		}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneYearFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneYearFieldCodec.java
@@ -8,7 +8,6 @@ package org.hibernate.search.backend.lucene.types.codec.impl;
 
 import java.time.Year;
 
-import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneIntegerDomain;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneNumericDomain;
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneYearFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneYearFieldCodec.java
@@ -22,7 +22,7 @@ public final class LuceneYearFieldCodec extends AbstractLuceneNumericFieldCodec<
 	}
 
 	@Override
-	void addStoredToDocument(LuceneDocumentBuilder documentBuilder, String absoluteFieldPath, Year value,
+	void addStoredToDocument(LuceneDocumentContent documentBuilder, String absoluteFieldPath, Year value,
 			Integer encodedValue) {
 		documentBuilder.addField( new StoredField( absoluteFieldPath, encodedValue ) );
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneYearMonthFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneYearMonthFieldCodec.java
@@ -43,7 +43,7 @@ public final class LuceneYearMonthFieldCodec extends AbstractLuceneNumericFieldC
 	}
 
 	@Override
-	void addStoredToDocument(LuceneDocumentBuilder documentBuilder, String absoluteFieldPath, YearMonth value,
+	void addStoredToDocument(LuceneDocumentContent documentBuilder, String absoluteFieldPath, YearMonth value,
 			Long encodedValue) {
 		documentBuilder.addField( new StoredField( absoluteFieldPath, FORMATTER.format( value ) ) );
 	}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneYearMonthFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneYearMonthFieldCodec.java
@@ -17,7 +17,6 @@ import java.time.format.SignStyle;
 import java.time.temporal.ChronoField;
 import java.util.Locale;
 
-import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneLongDomain;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneNumericDomain;
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneZonedDateTimeFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneZonedDateTimeFieldCodec.java
@@ -14,7 +14,6 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.ResolverStyle;
 import java.util.Locale;
 
-import org.hibernate.search.backend.lucene.document.impl.LuceneDocumentBuilder;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneLongDomain;
 import org.hibernate.search.backend.lucene.types.lowlevel.impl.LuceneNumericDomain;
 import org.hibernate.search.util.common.impl.TimeHelper;

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneZonedDateTimeFieldCodec.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/types/codec/impl/LuceneZonedDateTimeFieldCodec.java
@@ -41,7 +41,7 @@ public final class LuceneZonedDateTimeFieldCodec extends AbstractLuceneNumericFi
 	}
 
 	@Override
-	void addStoredToDocument(LuceneDocumentBuilder documentBuilder, String absoluteFieldPath, ZonedDateTime value,
+	void addStoredToDocument(LuceneDocumentContent documentBuilder, String absoluteFieldPath, ZonedDateTime value,
 			Long encodedValue) {
 		documentBuilder.addField( new StoredField( absoluteFieldPath, FORMATTER.format( value ) ) );
 	}

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/testsupport/util/LuceneTckBackendFeatures.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/testsupport/util/LuceneTckBackendFeatures.java
@@ -17,12 +17,6 @@ class LuceneTckBackendFeatures extends TckBackendFeatures {
 	}
 
 	@Override
-	public boolean supportsDynamicChildFieldsInExistsPredicate() {
-		// See https://hibernate.atlassian.net/browse/HSEARCH-3905
-		return false;
-	}
-
-	@Override
 	public boolean projectionPreservesNulls() {
 		return false;
 	}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/dynamic/ObjectFieldTemplateIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/dynamic/ObjectFieldTemplateIT.java
@@ -8,7 +8,6 @@ package org.hibernate.search.integrationtest.backend.tck.dynamic;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatQuery;
-import static org.junit.Assume.assumeTrue;
 
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -23,7 +22,6 @@ import org.hibernate.search.engine.common.spi.SearchIntegration;
 import org.hibernate.search.engine.search.predicate.dsl.PredicateFinalStep;
 import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
 import org.hibernate.search.engine.search.query.SearchQuery;
-import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConfiguration;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingSchemaManagementStrategy;
@@ -363,10 +361,8 @@ public class ObjectFieldTemplateIT {
 	 * The {@code exists} predicate should detect static object fields even if all their sub-fields are dynamic.
 	 */
 	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3273")
+	@TestForIssue(jiraKey = { "HSEARCH-3273", "HSEARCH-3905" })
 	public void exists_staticObjectField() {
-		assumeBackendSupportsDynamicChildFieldsInExistsPredicate();
-
 		Consumer<IndexSchemaElement> rootTemplatesBinder = root -> { };
 		Consumer<IndexSchemaElement> staticObjectTemplatesBinder = staticObject -> {
 			staticObject.fieldTemplate( "fieldTemplate", f -> f.asString() )
@@ -428,10 +424,8 @@ public class ObjectFieldTemplateIT {
 	 * The {@code exists} predicate should detect dynamic object fields even if all their sub-fields are dynamic.
 	 */
 	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3273")
+	@TestForIssue(jiraKey = { "HSEARCH-3273", "HSEARCH-3905" })
 	public void exists_dynamicObjectField() {
-		assumeBackendSupportsDynamicChildFieldsInExistsPredicate();
-
 		Consumer<IndexSchemaElement> templatesBinder = root -> {
 			root.fieldTemplate( "fieldTemplate", f -> f.asString() )
 					.matchingPathGlob( VALUE_FIELD_PATH_GLOB );
@@ -485,13 +479,6 @@ public class ObjectFieldTemplateIT {
 				.hasDocRefHitsAnyOrder( index.typeName(), documentWhereObjectFieldExistsId );
 		assertThatQuery( query( f -> f.exists().field( "foo_flattened" ) ) )
 				.hasDocRefHitsAnyOrder( index.typeName(), documentWhereObjectFieldExistsId );
-	}
-
-	private void assumeBackendSupportsDynamicChildFieldsInExistsPredicate() {
-		assumeTrue(
-				"This backend doesn't take dynamic child fields into account when creating exists predicates on object fields.",
-				TckConfiguration.get().getBackendFeatures().supportsDynamicChildFieldsInExistsPredicate()
-		);
 	}
 
 	private SearchQuery<DocumentReference> query(

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
@@ -51,10 +51,6 @@ public class TckBackendFeatures {
 		return true;
 	}
 
-	public boolean supportsDynamicChildFieldsInExistsPredicate() {
-		return true;
-	}
-
 	public boolean supportsValuesForDynamicField(Class<?> javaType) {
 		return true;
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3905

Based on #2400 , which must be merged first.