### PR TITLE
HSEARCH-4024 Upgrade integration tests to the latest version of Spring Boot

### DIFF
--- a/integrationtest/showcase/library/pom.xml
+++ b/integrationtest/showcase/library/pom.xml
@@ -44,6 +44,12 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${version.legacy.junit}</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,14 @@
         <!-- >>> Common -->
         <version.log4j>1.2.17</version.log4j>
         <version.junit>4.13.1</version.junit>
+
+        <!--
+            junit-vintage-engine 5.5.2 version does not support junit 4.13.1.
+            If we try to use it, a parsing error is thrown.
+            So we downgrade JUnit, so that junit-vintage-engine will handle it.
+        -->
+        <version.legacy.junit>4.13</version.legacy.junit>
+
         <version.org.hamcrest>2.2</version.org.hamcrest>
         <version.org.mockito>3.5.13</version.org.mockito>
         <version.org.assertj.assertj-core>3.15.0</version.org.assertj.assertj-core>

--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,7 @@
         <version.org.openjdk.jmh>1.23</version.org.openjdk.jmh>
 
         <!-- >>> Spring integration tests -->
-        <version.org.springframework.boot>2.2.0.RELEASE</version.org.springframework.boot>
+        <version.org.springframework.boot>2.3.4.RELEASE</version.org.springframework.boot>
 
         <!-- Maven plugins versions -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -1843,10 +1843,6 @@
             <activation>
                 <jdk>[14,)</jdk>
             </activation>
-            <properties>
-                <!-- Spring isn't ready for JDK14 yet: https://github.com/spring-projects/spring-framework/issues/23678 -->
-                <failsafe.spring.skip>true</failsafe.spring.skip>
-            </properties>
         </profile>
 
         <profile>
@@ -1869,6 +1865,8 @@
                     ${surefire.jvm.args.java-version.lenient}
                     --illegal-access=deny
                 </surefire.jvm.args.java-version.strict>
+                <!-- Spring isn't ready for JDK16 yet -->
+                <failsafe.spring.skip>true</failsafe.spring.skip>
             </properties>
         </profile>
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4024

According to [this page](https://docs.spring.io/spring-boot/docs/current/reference/html/getting-started.html#:~:text=Spring%20Boot%202.3.,Spring%20Framework%205.2.) the new version of Spring Boot should support JDK-14.