### PR TITLE
HSEARCH-4068 Skip non-competitive hits when running a MatchAllDocsQuery with descending score sort with Lucene

### DIFF
--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/extraction/impl/LuceneCollectors.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/extraction/impl/LuceneCollectors.java
@@ -83,7 +83,6 @@ public class LuceneCollectors {
 			return;
 		}
 
-		// Phase 1: collect top docs and aggregations
 		try {
 			Collector composed = collectorsForAllMatchingDocs.getComposed();
 			if ( composed != null ) {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/extraction/impl/LuceneCollectors.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/extraction/impl/LuceneCollectors.java
@@ -111,7 +111,7 @@ public class LuceneCollectors {
 		}
 
 		if ( requireFieldDocRescoring ) {
-			handleRescoring( indexSearcher, luceneQuery );
+			handleRescoring();
 		}
 	}
 
@@ -179,7 +179,7 @@ public class LuceneCollectors {
 		}
 	}
 
-	private void handleRescoring(IndexSearcher indexSearcher, Query luceneQuery) throws IOException {
+	private void handleRescoring() throws IOException {
 		if ( scoreSortFieldIndexForRescoring != null ) {
 			// If there's a SCORE sort field, just get the score value from the sort field
 			for ( ScoreDoc scoreDoc : topDocs.scoreDocs ) {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/extraction/impl/LuceneCollectors.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/extraction/impl/LuceneCollectors.java
@@ -119,6 +119,12 @@ public class LuceneCollectors {
 					SimpleSearchResultTotal.exact( topDocs.totalHits.value ) :
 					SimpleSearchResultTotal.lowerBound( topDocs.totalHits.value );
 		}
+		else if ( resultTotal.isHitCountExact() ) {
+			// Update the total hit count of the topDocs, which might not be precise enough,
+			// and might be consumed by callers of LuceneSearchResult.topDocs()
+			// (Useful for Infinispan in particular)
+			topDocs.totalHits = new TotalHits( resultTotal.hitCount(), TotalHits.Relation.EQUAL_TO );
+		}
 
 		if ( requireFieldDocRescoring ) {
 			handleRescoring();

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneSearchTopDocsTotalHitCountOnMatchAllDocsIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/search/LuceneSearchTopDocsTotalHitCountOnMatchAllDocsIT.java
@@ -1,0 +1,86 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.lucene.search;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatResult;
+
+import org.hibernate.search.backend.lucene.LuceneExtension;
+import org.hibernate.search.backend.lucene.search.query.LuceneSearchResult;
+import org.hibernate.search.engine.backend.common.DocumentReference;
+import org.hibernate.search.engine.backend.document.IndexFieldReference;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils;
+import org.hibernate.search.util.impl.test.annotation.TestForIssue;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TotalHits;
+
+/**
+ * Test that one can use {@link TopDocs#totalHits}
+ * on the {@link LuceneSearchResult#topDocs() topDocs returned by Lucene search queries}
+ * and get the correct total hit count,
+ * even when Hibernate Search relies on internal optimizations to compute the total hit count through other means.
+ * <p>
+ * This is a use case in Infinispan, in particular.
+ */
+public class LuceneSearchTopDocsTotalHitCountOnMatchAllDocsIT {
+
+	private static final int DOCUMENT_COUNT = 2000;
+
+	@ClassRule
+	public static final SearchSetupHelper setupHelper = new SearchSetupHelper();
+
+	private static final SimpleMappedIndex<IndexBinding> index = SimpleMappedIndex.of( IndexBinding::new );
+
+	@BeforeClass
+	public static void setup() {
+		setupHelper.start().withIndex( index ).setup();
+
+		index.bulkIndexer()
+				.add( DOCUMENT_COUNT, i -> StubMapperUtils.documentProvider(
+						String.valueOf( i ),
+						document -> {
+							document.addValue( index.binding().text, "Hooray" );
+						} ) )
+				.join();
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4068") // The regression was spotted early, while introducing it in HSEARCH-4068
+	public void matchAllDocs_sortByScoreDesc() {
+		LuceneSearchResult<DocumentReference> result = index.query().extension( LuceneExtension.get() )
+				.where( f -> f.matchAll() )
+				.fetch( 10 );
+
+		assertThatResult( result ).hasTotalHitCount( DOCUMENT_COUNT );
+
+		TopDocs topDocs = result.topDocs();
+		assertThat( topDocs.totalHits.relation ).isEqualTo( TotalHits.Relation.EQUAL_TO );
+		assertThat( topDocs.totalHits.value ).isEqualTo( DOCUMENT_COUNT );
+	}
+
+	private static class IndexBinding {
+		final IndexFieldReference<String> text;
+
+		IndexBinding(IndexSchemaElement root) {
+			text = root.field(
+					"text" ,
+					f -> f.asString()
+							.analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD_ENGLISH.name )
+			)
+					.toReference();
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4068

This PR is based on #2414 , which should be merged first.

After this patch, when a user runs a `MatchAllDocsQuery` (and there are no nested documents), we automatically set the `totalHitCountThreshold` to 0 and compute the total hit count in constant time.

What's interesting about this? Well, if the user requested a sort by descending score, we are now able to skip non-competitive hits. Which means for example that if the index contains 500,000 documents and the user requested the first 10, we will go through 10 hits instead of 500,000.

Judging from performance tests in Infinispan, the impact on performance is not huge, but still not negligible.

Search 5.11:

```
[Done in 60.010000s] 1 node(s), 10 thread(s) per node: Query 90th: 3.850239, QPS: 743.742710
```


Search 6.0 before this patch:

```
[Done in 60.012000s] 1 node(s), 10 thread(s) per node: Query 90th: 3.473407, QPS: 775.578218
```

Search 6.0 after this patch:

```
[Done in 60.011000s] 1 node(s), 10 thread(s) per node: Query 90th: 1.261567, QPS: 899.818367
```