### PR TITLE
HSEARCH-4055 + HSEARCH-4063 Build fix and upgrades

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -144,7 +144,7 @@
                             <sourcepath>
                                 ${basedir}/../engine/src/main/java;
                                 ${basedir}/../util/common/src/main/java;
-                                ${basedir}/../mapper/pojo/src/main/java;
+                                ${basedir}/../mapper/pojo-base/src/main/java;
                                 ${basedir}/../mapper/orm/src/main/java;
                                 ${basedir}/../backend/elasticsearch/src/main/java;
                                 ${basedir}/../backend/elasticsearch-aws/src/main/java;

--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@
         <version.javax.persistence>2.2</version.javax.persistence>
 
         <!-- >>> JSR 352 -->
-        <version.javax.batch>1.0</version.javax.batch>
+        <version.javax.batch>1.0.1</version.javax.batch>
         <version.org.jberet>1.3.7.Final</version.org.jberet>
 
         <!-- >>> JSR 352 test -->

--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
         <!-- Main dependencies -->
 
         <!-- >>> Common -->
-        <version.org.jboss.logging.jboss-logging>3.4.0.Final</version.org.jboss.logging.jboss-logging>
+        <version.org.jboss.logging.jboss-logging>3.4.1.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>2.2.0.Final</version.org.jboss.logging.jboss-logging-tools>
         <javadoc.org.hibernate.search.url>https://docs.jboss.org/hibernate/search/${parsed-version.org.hibernate.search.majorVersion}.${parsed-version.org.hibernate.search.minorVersion}/api/</javadoc.org.hibernate.search.url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
 
         <!-- >>> JSR 352 -->
         <version.javax.batch>1.0.1</version.javax.batch>
-        <version.org.jberet>1.3.7.Final</version.org.jberet>
+        <version.org.jberet>1.4.0.Final</version.org.jberet>
 
         <!-- >>> JSR 352 test -->
         <version.com.ibm.jbatch>1.0</version.com.ibm.jbatch>

--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
 
         <!-- >>> Common -->
         <version.org.jboss.logging.jboss-logging>3.4.1.Final</version.org.jboss.logging.jboss-logging>
-        <version.org.jboss.logging.jboss-logging-tools>2.2.0.Final</version.org.jboss.logging.jboss-logging-tools>
+        <version.org.jboss.logging.jboss-logging-tools>2.2.1.Final</version.org.jboss.logging.jboss-logging-tools>
         <javadoc.org.hibernate.search.url>https://docs.jboss.org/hibernate/search/${parsed-version.org.hibernate.search.majorVersion}.${parsed-version.org.hibernate.search.minorVersion}/api/</javadoc.org.hibernate.search.url>
 
         <!-- >>> Engine -->


### PR DESCRIPTION
* [HSEARCH-4063](https://hibernate.atlassian.net/browse/HSEARCH-4063): Upgrade all publicly exposed dependencies to their latest available version
* [HSEARCH-4055](https://hibernate.atlassian.net/browse/HSEARCH-4055): Add the mapper-pojo-base module to the javadoc

