### PR TITLE
HSEARCH-4077 + HSEARCH-4078 Avoid extra logging when using ExpectedLog4jLog

### DIFF
--- a/backend/lucene/src/test/java/org/hibernate/search/backend/lucene/lowlevel/writer/impl/LoggerInfoStreamTest.java
+++ b/backend/lucene/src/test/java/org/hibernate/search/backend/lucene/lowlevel/writer/impl/LoggerInfoStreamTest.java
@@ -27,11 +27,13 @@ import org.apache.lucene.store.ByteBuffersDirectory;
 
 public class LoggerInfoStreamTest {
 
+	private static final String LOGGER_NAME = LuceneLogCategories.INFOSTREAM_LOGGER_CATEGORY.getName();
+
 	private final Log4j2ConfigurationAccessor programmaticConfig;
 	private TestAppender testAppender;
 
 	public LoggerInfoStreamTest() {
-		programmaticConfig = new Log4j2ConfigurationAccessor();
+		programmaticConfig = new Log4j2ConfigurationAccessor( LOGGER_NAME );
 	}
 
 	@Before
@@ -61,9 +63,7 @@ public class LoggerInfoStreamTest {
 		indexWriter.commit();
 		indexWriter.close();
 
-		List<String> logEvents = testAppender.searchByLoggerAndMessage(
-				LuceneLogCategories.INFOSTREAM_LOGGER_CATEGORY.getName(), "IW:"
-		);
+		List<String> logEvents = testAppender.searchByLoggerAndMessage( LOGGER_NAME, "IW:" );
 
 		assertFalse( logEvents.isEmpty() );
 	}

--- a/util/internal/integrationtest/v5migrationhelper/src/main/java/org/hibernate/search/test/util/impl/ExpectedLog4jLog.java
+++ b/util/internal/integrationtest/v5migrationhelper/src/main/java/org/hibernate/search/test/util/impl/ExpectedLog4jLog.java
@@ -31,19 +31,32 @@ import org.hamcrest.TypeSafeMatcher;
  */
 public class ExpectedLog4jLog implements TestRule {
 
+	private static final String DEFAULT_LOGGER_NAME = "org.hibernate.search";
+
 	/**
-	 * Returns a {@linkplain TestRule rule} that does not mandate any particular log to be produced (identical to
-	 * behavior without this rule).
+	 * @return a {@linkplain TestRule rule} targeting the logger named '{@value DEFAULT_LOGGER_NAME}',
+	 * that originally does not mandate any particular log to be produced (identical to behavior without this rule).
 	 */
 	public static ExpectedLog4jLog create() {
-		return new ExpectedLog4jLog();
+		return create( DEFAULT_LOGGER_NAME );
 	}
+
+	/**
+	 * @return a {@linkplain TestRule rule} targeting the logger whose name is given by {@code loggerName},
+	 * that originally does not mandate any particular log to be produced (identical to behavior without this rule).
+	 */
+	public static ExpectedLog4jLog create(String loggerName) {
+		return new ExpectedLog4jLog( loggerName );
+	}
+
+	private final String loggerName;
 
 	protected List<Matcher<?>> expectations = new ArrayList<>();
 
 	protected List<Matcher<?>> absenceExpectations = new ArrayList<>();
 
-	private ExpectedLog4jLog() {
+	private ExpectedLog4jLog(String loggerName) {
+		this.loggerName = loggerName;
 	}
 
 	@Override
@@ -158,7 +171,7 @@ public class ExpectedLog4jLog implements TestRule {
 
 		@Override
 		public void evaluate() throws Throwable {
-			Log4j2ConfigurationAccessor programmaticConfig = new Log4j2ConfigurationAccessor();
+			Log4j2ConfigurationAccessor programmaticConfig = new Log4j2ConfigurationAccessor( loggerName );
 			TestAppender appender = new TestAppender( "TestAppender", ExpectedLog4jLog.this );
 			programmaticConfig.addAppender( appender );
 			try {

--- a/util/internal/test/src/main/java/org/hibernate/search/util/impl/test/rule/ExpectedLog4jLog.java
+++ b/util/internal/test/src/main/java/org/hibernate/search/util/impl/test/rule/ExpectedLog4jLog.java
@@ -31,18 +31,31 @@ import org.hamcrest.TypeSafeMatcher;
 
 public class ExpectedLog4jLog implements TestRule {
 
+	private static final String DEFAULT_LOGGER_NAME = "org.hibernate.search";
+
 	/**
-	 * Returns a {@linkplain TestRule rule} that does not mandate any particular log to be produced (identical to
-	 * behavior without this rule).
+	 * @return a {@linkplain TestRule rule} targeting the logger named '{@value DEFAULT_LOGGER_NAME}',
+	 * that originally does not mandate any particular log to be produced (identical to behavior without this rule).
 	 */
 	public static ExpectedLog4jLog create() {
-		return new ExpectedLog4jLog();
+		return create( DEFAULT_LOGGER_NAME );
 	}
+
+	/**
+	 * @return a {@linkplain TestRule rule} targeting the logger whose name is given by {@code loggerName},
+	 * that originally does not mandate any particular log to be produced (identical to behavior without this rule).
+	 */
+	public static ExpectedLog4jLog create(String loggerName) {
+		return new ExpectedLog4jLog( loggerName );
+	}
+
+	private final String loggerName;
 
 	private final List<LogExpectation> expectations = new ArrayList<>();
 	private TestAppender currentAppender;
 
-	private ExpectedLog4jLog() {
+	private ExpectedLog4jLog(String loggerName) {
+		this.loggerName = loggerName;
 	}
 
 	@Override
@@ -235,7 +248,7 @@ public class ExpectedLog4jLog implements TestRule {
 
 		@Override
 		public void evaluate() throws Throwable {
-			Log4j2ConfigurationAccessor programmaticConfig = new Log4j2ConfigurationAccessor();
+			Log4j2ConfigurationAccessor programmaticConfig = new Log4j2ConfigurationAccessor( loggerName );
 			TestAppender appender = new TestAppender( "TestAppender" );
 			programmaticConfig.addAppender( appender );
 

--- a/util/internal/test/src/main/java/org/hibernate/search/util/impl/test/rule/log4j/LogChecker.java
+++ b/util/internal/test/src/main/java/org/hibernate/search/util/impl/test/rule/log4j/LogChecker.java
@@ -53,7 +53,7 @@ public class LogChecker {
 				if ( extraEvents == null ) {
 					extraEvents = new ArrayList<>();
 				}
-				extraEvents.add( event );
+				extraEvents.add( event.toImmutable() );
 			}
 		}
 	}

--- a/util/internal/test/src/main/java/org/hibernate/search/util/impl/test/rule/log4j/LogChecker.java
+++ b/util/internal/test/src/main/java/org/hibernate/search/util/impl/test/rule/log4j/LogChecker.java
@@ -43,7 +43,8 @@ public class LogChecker {
 		}
 	}
 
-	void process(LogEvent event) {
+	// This must be synchronized to avoid problems when multiple threads issue log events concurrently
+	synchronized void process(LogEvent event) {
 		if ( expectation.getMaxExpectedCount() == null && expectation.getMinExpectedCount() <= count ) {
 			// We don't care about events anymore, expectations are met and it won't change
 			return;

--- a/util/internal/test/src/main/java/org/hibernate/search/util/impl/test/rule/log4j/LogChecker.java
+++ b/util/internal/test/src/main/java/org/hibernate/search/util/impl/test/rule/log4j/LogChecker.java
@@ -16,6 +16,7 @@ public class LogChecker {
 
 	private final LogExpectation expectation;
 	private int count = 0;
+	private List<LogEvent> matchingEvents;
 	private List<LogEvent> extraEvents;
 
 	LogChecker(LogExpectation expectation) {
@@ -28,17 +29,17 @@ public class LogChecker {
 			description.appendText( "Expected at least " + expectation.getMinExpectedCount() + " time(s) " );
 			expectation.getMatcher().describeTo( description );
 			description.appendText( " but only got " + count + " such event(s)." );
+			description.appendText( " Matching events: " );
+			appendEvents( description, newline, matchingEvents );
 		}
 		if ( expectation.getMaxExpectedCount() != null && expectation.getMaxExpectedCount() < count ) {
 			description.appendText( "Expected at most " + expectation.getMaxExpectedCount() + " time(s) " );
 			expectation.getMatcher().describeTo( description );
 			description.appendText( " but got " + count + " such event(s)." );
 			description.appendText( " Extra events: " );
-			for ( LogEvent extraEvent : extraEvents ) {
-				description.appendText( newline );
-				description.appendText( "\t - " );
-				description.appendText( extraEvent.getMessage().getFormattedMessage() );
-			}
+			appendEvents( description, newline, extraEvents );
+			description.appendText( " Matching events: " );
+			appendEvents( description, newline, matchingEvents );
 		}
 	}
 
@@ -55,11 +56,25 @@ public class LogChecker {
 				}
 				extraEvents.add( event.toImmutable() );
 			}
+			else {
+				if ( matchingEvents == null ) {
+					matchingEvents = new ArrayList<>();
+				}
+				matchingEvents.add( event.toImmutable() );
+			}
 		}
 	}
 
 	boolean areExpectationsMet() {
 		return expectation.getMinExpectedCount() <= count
 				&& ( expectation.getMaxExpectedCount() == null || count <= expectation.getMaxExpectedCount() );
+	}
+
+	private static void appendEvents(Description description, String newline, List<LogEvent> events) {
+		for ( LogEvent event : events ) {
+			description.appendText( newline );
+			description.appendText( "\t - " );
+			description.appendText( event.getMessage().getFormattedMessage() );
+		}
 	}
 }


### PR DESCRIPTION
* [HSEARCH-4078](https://hibernate.atlassian.net/browse/HSEARCH-4078): Fix transient failure in LibraryShowcaseMassIndexingIT
* [HSEARCH-4077](https://hibernate.atlassian.net/browse/HSEARCH-4077): Avoid extra logging when using ExpectedLog4jLog

This should fix the build for the master branch, in particular.