### PR TITLE
HSEARCH-4079 + HSEARCH-4080 Query timeout fixes

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/Elasticsearch7SearchResultExtractor.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/query/impl/Elasticsearch7SearchResultExtractor.java
@@ -110,9 +110,9 @@ class Elasticsearch7SearchResultExtractor<H> implements ElasticsearchSearchResul
 	protected SearchResultTotal extractTotal(JsonObject responseBody) {
 		Long hitsTotal = HITS_TOTAL_ACCESSOR.get( responseBody ).orElse( 0L );
 		Optional<String> hitsTotalRelation = HITS_TOTAL_RELATION_ACCESSOR.get( responseBody );
-
-		return ( hitsTotalRelation.isPresent() && HITS_TOTAL_RELATION_EXACT_VALUE.equals( hitsTotalRelation.get() ) ) ?
-				SimpleSearchResultTotal.exact( hitsTotal ) : SimpleSearchResultTotal.lowerBound( hitsTotal );
+		boolean exact = hitsTotalRelation.isPresent()
+				&& HITS_TOTAL_RELATION_EXACT_VALUE.equals( hitsTotalRelation.get() );
+		return SimpleSearchResultTotal.of( hitsTotal, exact );
 	}
 
 	private List<Object> extractHits(ElasticsearchSearchQueryExtractContext extractContext) {

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/extraction/impl/LuceneCollectors.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/extraction/impl/LuceneCollectors.java
@@ -121,9 +121,8 @@ public class LuceneCollectors {
 
 		extractTopDocs( topDocsCollector, offset, limit );
 		if ( resultTotal == null ) {
-			resultTotal = ( TotalHits.Relation.EQUAL_TO.equals( topDocs.totalHits.relation ) ) ?
-					SimpleSearchResultTotal.exact( topDocs.totalHits.value ) :
-					SimpleSearchResultTotal.lowerBound( topDocs.totalHits.value );
+			boolean exact = TotalHits.Relation.EQUAL_TO.equals( topDocs.totalHits.relation );
+			resultTotal = SimpleSearchResultTotal.of( topDocs.totalHits.value, exact );
 		}
 		else if ( resultTotal.isHitCountExact() ) {
 			// Update the total hit count of the topDocs, which might not be precise enough,

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/extraction/impl/LuceneCollectors.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/extraction/impl/LuceneCollectors.java
@@ -107,7 +107,8 @@ public class LuceneCollectors {
 		else {
 			TotalHitCountCollector totalHitCountCollector = collectorsForAllMatchingDocs.get( TOTAL_HIT_COUNT_KEY );
 			if ( totalHitCountCollector != null ) {
-				resultTotal = SimpleSearchResultTotal.exact( totalHitCountCollector.getTotalHits() );
+				boolean exact = !timeoutManager.isTimedOut();
+				resultTotal = SimpleSearchResultTotal.of( totalHitCountCollector.getTotalHits(), exact );
 			}
 		}
 
@@ -121,7 +122,8 @@ public class LuceneCollectors {
 
 		extractTopDocs( topDocsCollector, offset, limit );
 		if ( resultTotal == null ) {
-			boolean exact = TotalHits.Relation.EQUAL_TO.equals( topDocs.totalHits.relation );
+			boolean exact = TotalHits.Relation.EQUAL_TO.equals( topDocs.totalHits.relation )
+					&& !timeoutManager.isTimedOut();
 			resultTotal = SimpleSearchResultTotal.of( topDocs.totalHits.value, exact );
 		}
 		else if ( resultTotal.isHitCountExact() ) {

--- a/engine/src/main/java/org/hibernate/search/engine/cfg/spi/ConvertUtils.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/spi/ConvertUtils.java
@@ -12,7 +12,6 @@ import java.math.BigInteger;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -25,8 +24,6 @@ import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 public final class ConvertUtils {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
-
-	private static final int ONE_MILLION = 1_000_000;
 
 	private ConvertUtils() {
 		// Private constructor, do not use
@@ -329,24 +326,5 @@ public final class ConvertUtils {
 		else {
 			return value;
 		}
-	}
-
-	/**
-	 * Converts in milliseconds a time duration expressed with {@code time} and {@code timeUnit}.
-	 * The result value is rounded up.
-	 * If either of the parameters is null, it will return null.
-	 *
-	 * @param time a time duration
-	 * @param timeUnit the time unit used to express the duration
-	 * @return rounded up duration in milliseconds
-	 */
-	public static Long toMilliseconds(Long time, TimeUnit timeUnit) {
-		if ( time == null || timeUnit == null ) {
-			return null;
-		}
-
-		long nanos = timeUnit.toNanos( time );
-		long millis = nanos / ONE_MILLION;
-		return ( nanos % ONE_MILLION == 0 ) ? millis : millis + 1;
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/query/spi/SimpleSearchResult.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/query/spi/SimpleSearchResult.java
@@ -28,13 +28,6 @@ public class SimpleSearchResult<H> implements SearchResult<H> {
 	private final Duration took;
 	private final boolean timedOut;
 
-	public SimpleSearchResult(boolean hitExact, long hitCount, List<H> hits,
-			Map<AggregationKey<?>, ?> aggregationResults, Duration took, Boolean timedOut) {
-		this( ( hitExact ) ? SimpleSearchResultTotal.exact( hitCount ) : SimpleSearchResultTotal.lowerBound( hitCount ),
-				hits, aggregationResults, took, timedOut
-		);
-	}
-
 	public SimpleSearchResult(SearchResultTotal resultTotal, List<H> hits, Map<AggregationKey<?>, ?> aggregationResults,
 			Duration took, Boolean timedOut) {
 		this.resultTotal = resultTotal;

--- a/engine/src/main/java/org/hibernate/search/engine/search/query/spi/SimpleSearchResultTotal.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/query/spi/SimpleSearchResultTotal.java
@@ -16,12 +16,16 @@ public class SimpleSearchResultTotal implements SearchResultTotal {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
+	public static SimpleSearchResultTotal of(long totalHitCount, boolean isExact) {
+		return new SimpleSearchResultTotal( totalHitCount, isExact );
+	}
+
 	public static SimpleSearchResultTotal exact(long totalHitCount) {
-		return new SimpleSearchResultTotal( totalHitCount, true );
+		return of( totalHitCount, true );
 	}
 
 	public static SimpleSearchResultTotal lowerBound(long totalHitCount) {
-		return new SimpleSearchResultTotal( totalHitCount, false );
+		return of( totalHitCount, false );
 	}
 
 	private final long totalHitCount;

--- a/engine/src/main/java/org/hibernate/search/engine/search/timeout/spi/TimeoutManager.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/timeout/spi/TimeoutManager.java
@@ -13,6 +13,7 @@ import java.util.concurrent.TimeUnit;
 import org.hibernate.search.engine.common.timing.spi.TimingSource;
 import org.hibernate.search.engine.logging.impl.Log;
 import org.hibernate.search.engine.common.timing.spi.Deadline;
+import org.hibernate.search.util.common.impl.TimeHelper;
 import org.hibernate.search.util.common.SearchTimeoutException;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
@@ -67,7 +68,7 @@ public class TimeoutManager {
 		this.timingSource = timingSource;
 		this.timeoutValue = timeoutValue;
 		this.timeoutUnit = timeoutUnit;
-		this.timeoutMs = timeoutUnit == null ? null : timeoutUnit.toMillis( timeoutValue );
+		this.timeoutMs = TimeHelper.toMillisecondsRoundedUp( timeoutValue, timeoutUnit );
 		this.type = type;
 		this.deadline = timeoutMs == null ? null : new DynamicDeadline();
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingBaseIT.java
@@ -98,7 +98,7 @@ public class SearchQueryEntityLoadingBaseIT<T> extends AbstractSearchQueryEntity
 				1, TimeUnit.MICROSECONDS
 		) )
 				.isInstanceOf( SearchTimeoutException.class )
-				.hasMessageContaining( "Operation exceeded the timeout of 0s, 1ms and 0ns" );
+				.hasMessageContaining( "Operation exceeded the timeout of 0s, 0ms and 1000ns" );
 	}
 
 	/**

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingMultipleTypesIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/search/loading/SearchQueryEntityLoadingMultipleTypesIT.java
@@ -275,7 +275,7 @@ public class SearchQueryEntityLoadingMultipleTypesIT extends AbstractSearchQuery
 				session -> SlowerLoadingListener.registerSlowerLoadingListener( session, 100 )
 		) )
 				.isInstanceOf( SearchTimeoutException.class )
-				.hasMessageContaining( "Operation exceeded the timeout of 0s, 1ms and 0ns" );
+				.hasMessageContaining( "Operation exceeded the timeout of 0s, 0ms and 1000ns" );
 	}
 
 	/**

--- a/util/common/src/main/java/org/hibernate/search/util/common/impl/TimeHelper.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/impl/TimeHelper.java
@@ -13,11 +13,14 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Helpers for classes in java.time.*
  */
 public final class TimeHelper {
+
+	private static final int NANOS_PER_MILLI = 1_000_000;
 
 	private TimeHelper() {
 		// not allowed
@@ -57,6 +60,25 @@ public final class TimeHelper {
 		ZoneOffset offset = ZoneOffset.from( temporal );
 		LocalDateTime ldt = LocalDateTime.from( temporal );
 		return ZonedDateTime.ofInstant( ldt, offset, zone );
+	}
+
+	/**
+	 * Converts in milliseconds a time duration expressed with {@code time} and {@code timeUnit}.
+	 * The result value is rounded up.
+	 * If either of the parameters is null, it will return null.
+	 *
+	 * @param time a time duration
+	 * @param timeUnit the time unit used to express the duration
+	 * @return rounded up duration in milliseconds
+	 */
+	public static Long toMillisecondsRoundedUp(Long time, TimeUnit timeUnit) {
+		if ( time == null || timeUnit == null ) {
+			return null;
+		}
+
+		long nanos = timeUnit.toNanos( time );
+		long millis = nanos / NANOS_PER_MILLI;
+		return ( nanos % NANOS_PER_MILLI == 0 ) ? millis : millis + 1;
 	}
 
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/SearchWorkCall.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/SearchWorkCall.java
@@ -22,6 +22,7 @@ import org.hibernate.search.engine.search.loading.spi.LoadingResult;
 import org.hibernate.search.engine.search.loading.spi.ProjectionHitMapper;
 import org.hibernate.search.engine.search.query.spi.SimpleSearchResult;
 import org.hibernate.search.engine.common.timing.spi.Deadline;
+import org.hibernate.search.engine.search.query.spi.SimpleSearchResultTotal;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.StubSearchWork;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.projection.impl.StubSearchProjection;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.projection.impl.StubSearchProjectionContext;
@@ -72,8 +73,7 @@ class SearchWorkCall<T> extends Call<SearchWorkCall<?>> {
 				.matches( work );
 
 		return () -> new SimpleSearchResult<>(
-				true,
-				behavior.getTotalHitCount(),
+				SimpleSearchResultTotal.exact( behavior.getTotalHitCount() ),
 				getResults(
 						actualCall.projectionContext,
 						actualCall.loadingContext.createProjectionHitMapper(),

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/VerifyingStubBackendBehavior.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/VerifyingStubBackendBehavior.java
@@ -251,9 +251,8 @@ class VerifyingStubBackendBehavior extends StubBackendBehavior {
 				new SearchWorkCall<>( indexNames, work, projectionContext, loadingContext, rootProjection,
 						deadline ),
 				(call1, call2) -> call1.verify( call2 ),
-				noExpectationsBehavior( () -> new SimpleSearchResult<>(
-						true, 0L, Collections.emptyList(), Collections.emptyMap(), Duration.ZERO, false
-				) )
+				noExpectationsBehavior( () -> new SimpleSearchResult<>( SimpleSearchResultTotal.exact( 0L ),
+						Collections.emptyList(), Collections.emptyMap(), Duration.ZERO, false ) )
 		);
 	}
 

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/timeout/impl/StubTimeoutManager.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/timeout/impl/StubTimeoutManager.java
@@ -8,15 +8,12 @@ package org.hibernate.search.util.impl.integrationtest.common.stub.backend.searc
 
 import java.util.concurrent.TimeUnit;
 
-import org.hibernate.search.engine.cfg.spi.ConvertUtils;
 import org.hibernate.search.engine.common.timing.spi.TimingSource;
 import org.hibernate.search.engine.search.timeout.spi.TimeoutManager;
 
 public class StubTimeoutManager extends TimeoutManager {
 
 	public StubTimeoutManager(TimingSource timingSource, Long timeoutValue, TimeUnit timeoutUnit) {
-		super( timingSource, ConvertUtils.toMilliseconds( timeoutValue, timeoutUnit ),
-				timeoutUnit == null ? null : TimeUnit.MILLISECONDS,
-				timeoutUnit == null ? null : Type.EXCEPTION );
+		super( timingSource, timeoutValue, timeoutUnit, timeoutUnit == null ? null : Type.EXCEPTION );
 	}
 }


### PR DESCRIPTION
* [HSEARCH-4080](https://hibernate.atlassian.net/browse/HSEARCH-4080): Lucene total hit count is wrongly considered exact on timeout
* [HSEARCH-4079](https://hibernate.atlassian.net/browse/HSEARCH-4079): Search query always times out when timeout is lower than 1ms

~Based on #2421 , which should be merged first.~ => Done
