### PR TITLE
HSEARCH-4021 Flush after a purge in tests to ensure the purge is visible from tests

### DIFF
--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchDocumentRepositoryImpl.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/integrationtest/showcase/library/repository/indexsearch/IndexSearchDocumentRepositoryImpl.java
@@ -19,6 +19,7 @@ import org.hibernate.search.integrationtest.showcase.library.model.BookMedium;
 import org.hibernate.search.integrationtest.showcase.library.model.Document;
 import org.hibernate.search.integrationtest.showcase.library.model.LibraryServiceOption;
 import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.orm.work.SearchWorkspace;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -152,6 +153,8 @@ public class IndexSearchDocumentRepositoryImpl implements IndexSearchDocumentRep
 
 	@Override
 	public void purge() {
-		Search.session( entityManager ).workspace( Document.class ).purge();
+		SearchWorkspace workspace = Search.session( entityManager ).workspace( Document.class );
+		workspace.purge();
+		workspace.flush();
 	}
 }


### PR DESCRIPTION
Yet another follow-up on https://hibernate.atlassian.net/browse/HSEARCH-4021

This is necessary to avoid failures such as [this one](https://ci.hibernate.org/blue/organizations/jenkins/hibernate-search/detail/PR-2420/1/tests)