### PR TITLE
HSEARCH-4075 Upgrade to Hibernate Annotations 5.1.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,7 +228,7 @@
         <version.org.hibernate>5.4.22.Final</version.org.hibernate>
         <javadoc.org.hibernate.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.majorVersion}.${parsed-version.org.hibernate.minorVersion}/javadocs/</javadoc.org.hibernate.url>
         <documentation.org.hibernate.url>https://docs.jboss.org/hibernate/orm/${parsed-version.org.hibernate.majorVersion}.${parsed-version.org.hibernate.minorVersion}/userguide/html_single/Hibernate_User_Guide.html</documentation.org.hibernate.url>
-        <version.org.hibernate.commons.annotations>5.1.0.Final</version.org.hibernate.commons.annotations>
+        <version.org.hibernate.commons.annotations>5.1.1.Final</version.org.hibernate.commons.annotations>
         <version.javax.persistence>2.2</version.javax.persistence>
 
         <!-- >>> JSR 352 -->


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4075

This is especially important to support newer versions of Hibernate ORM,
which will rely on methods introduced in this version of HCANN.

This version of HCANN is apparently backwards compatible, so users
should still be able to rely on older versions of ORM, as long as *we*
refrain from using newer methods introduced in HCANN 5.1.1.Final.

Waiting for the CI build to pass, then I'll merge.