### PR TITLE
HSEARCH-4064 + HSEARCH-4076 Document limitations and troubleshooting

### DIFF
--- a/documentation/src/main/asciidoc/reference/backend-elasticsearch.asciidoc
+++ b/documentation/src/main/asciidoc/reference/backend-elasticsearch.asciidoc
@@ -287,7 +287,7 @@ This can be helpful while developing, in particular.
 [[elasticsearch-log-json-pretty-printing]]
 
 The `hibernate.search.backend.log.json_pretty_printing` <<configuration-property-types,boolean property>>
-defines whether JSON included in logs should be pretty-printed (indented, with line breaks).
+defines whether JSON included in <<troubleshooting-logging,logs>> should be pretty-printed (indented, with line breaks).
 It defaults to `false`.
 
 [[backend-elasticsearch-configuration-sharding]]

--- a/documentation/src/main/asciidoc/reference/backend-lucene.asciidoc
+++ b/documentation/src/main/asciidoc/reference/backend-lucene.asciidoc
@@ -969,10 +969,11 @@ Generally for faster indexing performance it's best to use this setting rather t
 
 When used together with `max_buffered_docs` a flush occurs for whichever event happens first.
 
-|`[...].io.writer.infostream`
+|[[backend-lucene-io-writer-infostream]]`[...].io.writer.infostream`
 |Enables low level trace information about Lucene's internal components; `true` or `false`.
 
-Logs will be appended to the logger `org.hibernate.search.backend.lucene.infostream` at the TRACE level.
+Logs will be appended to the logger
+<<troubleshooting-logging-lucene-infostream,`org.hibernate.search.backend.lucene.infostream`>> at the `TRACE` level.
 
 This may cause significant performance degradation, even if the logger ignores the TRACE level,
 so this should only be used for troubleshooting purposes.

--- a/documentation/src/main/asciidoc/reference/components/explanation-warning.asciidoc
+++ b/documentation/src/main/asciidoc/reference/components/explanation-warning.asciidoc
@@ -1,0 +1,5 @@
+[WARNING]
+====
+Regardless of the API used, explanations are rather costly performance-wise:
+only use them for debugging purposes.
+====

--- a/documentation/src/main/asciidoc/reference/index.asciidoc
+++ b/documentation/src/main/asciidoc/reference/index.asciidoc
@@ -39,6 +39,8 @@ include::backend-lucene.asciidoc[]
 
 include::backend-elasticsearch.asciidoc[]
 
+include::troubleshooting.asciidoc[]
+
 include::further-reading.asciidoc[]
 
 include::credits.asciidoc[]

--- a/documentation/src/main/asciidoc/reference/index.asciidoc
+++ b/documentation/src/main/asciidoc/reference/index.asciidoc
@@ -21,6 +21,8 @@ include::concepts.asciidoc[]
 
 include::architecture.asciidoc[]
 
+include::limitations.asciidoc[]
+
 include::configuration.asciidoc[]
 
 include::mapper-orm-mapping.asciidoc[]

--- a/documentation/src/main/asciidoc/reference/limitations.asciidoc
+++ b/documentation/src/main/asciidoc/reference/limitations.asciidoc
@@ -1,0 +1,79 @@
+[[limitations]]
+= Limitations
+// Search 5 anchors backward compatibility
+[[elasticsearch-limitations]]
+
+[[limitations-parallel-embedded-update]]
+== In rare cases, automatic indexing involving `@IndexedEmbedded` may lead to out-of sync indexes
+
+=== Description
+
+If two entity instances are <<mapper-orm-indexedembedded,indexed-embedded>> in the same "index-embedding" entity,
+and these two entity instance are updated in parallel transactions,
+there is a small risk that the transaction commits happen in just the wrong way,
+leading to the index-embedding entity being reindexed with only part of the updates.
+
+For example, consider indexed entity A, which index-embeds B and C.
+The following course of events involving two parallel transactions (T1 and T2)
+will lead to an out of date index:
+
+* T1: Load B.
+* T1: Change B in a way that will require reindexing A.
+* T2: Load C.
+* T2: Change C in a way that will require reindexing A.
+* T2: Request the transaction commit.
+  Hibernate Search builds the document for A.
+  While doing so, it automatically loads B. B appears unmodified, as T1 wasn't committed yet.
+* T1: Request the transaction commit.
+  Hibernate Search builds documents to index.
+  While doing so, it automatically loads C. C appears unmodified, as T2 wasn't committed yet.
+* T1: Transaction is committed.
+  Hibernate Search automatically sends the updated A to the index.
+  In this version, B is updated, but C is not.
+* T2: Transaction is committed.
+  Hibernate Search automatically sends the updated A to the index.
+  In this version, C is updated, but B is not.
+
+This chain of events ends with the index containing a version of A where C is updated, but B is not.
+
+=== Workaround
+
+The following solutions can help circumvent this limitation:
+
+1. Avoid parallel updates to entities that are indexed-embedded in the same indexed entity.
+This is only possible in very specific setups.
+2. OR schedule a <<mapper-orm-indexing-massindexer,full reindexing>> of your database periodically (e.g. every night)
+to get the index back in sync with the database.
+
+=== Roadmap
+
+This problem cannot be solved using
+link:{elasticsearchDocUrl}/optimistic-concurrency-control.html[Elasticsearch's optimistic concurrency control]:
+when two conflicting versions of the same documents are created due to this issue,
+neither version is completely right.
+
+We plan to address this limitation in Hibernate Search 6.1 by offering fully asynchronous indexing,
+from entity loading to index updates.
+To track progress of this feature, see https://hibernate.atlassian.net/browse/HSEARCH-3281[HSEARCH-3281].
+
+In short, entities will no longer be indexed directly in the ORM session where the entity change occurred.
+Instead, "change events" will be sent to a queue, then consumed by a background process,
+which will load the entity from a separate session and perform the indexing.
+
+As long as events are sent to the queue after the original transaction is committed,
+and background indexing processes avoid concurrent reindexing of the same entity,
+the limitation will no longer apply:
+indexing will always get data from the latest committed state of the database,
+and out-of-date documents will never "overwrite" up-to-date documents.
+
+This feature will be opt-in, as it has both upsides and downsides.
+
+Upsides::
+* It will provide opportunities for scaling out indexing,
+  by sharding the event queue and distributing the process across multiple nodes.
+* It may even clear the way for new features such as https://hibernate.atlassian.net/browse/HSEARCH-1937[HSEARCH-1937].
+Downsides::
+* It may require additional infrastructure to store the indexing queue.
+However, we intend to provide a basic solution relying on the database exclusively.
+* It will most likely prevent any form of <<mapper-orm-indexing-automatic-synchronization,synchronous indexing>>
+(waiting for indexing to finish before releasing the application thread).

--- a/documentation/src/main/asciidoc/reference/search-dsl-projection.asciidoc
+++ b/documentation/src/main/asciidoc/reference/search-dsl-projection.asciidoc
@@ -352,14 +352,10 @@ are all added to same returned document.
 [[search-dsl-projection-extensions-lucene-explanation]]
 === Lucene: `explanation`
 
-The `.explanation()` projection returns an <<search-dsl-projection-extensions-lucene-explanation,explanation>>
+The `.explanation()` projection returns an <<troubleshooting-faq-search-score,explanation>>
 of the match as a native Lucene `Explanation`.
 
-[WARNING]
-====
-Explanations are rather costly performance-wise:
-only use them for <<search-dsl-query-debugging-scores,debugging>> purposes.
-====
+include::components/explanation-warning.asciidoc[]
 
 include::components/lucene-api-warning.asciidoc[]
 
@@ -390,14 +386,10 @@ include::{sourcedir}/org/hibernate/search/documentation/search/projection/Elasti
 [[search-dsl-projection-extensions-elasticsearch-explanation]]
 === Elasticsearch: `explanation`
 
-The `.explanation()` projection returns an <<search-dsl-projection-extensions-elasticsearch-explanation,explanation>>
+The `.explanation()` projection returns an <<troubleshooting-faq-search-score,explanation>>
 of the match as a `JsonObject`.
 
-[WARNING]
-====
-Explanations are rather costly performance-wise:
-only use them for <<search-dsl-query-debugging-scores,debugging>> purposes.
-====
+include::components/explanation-warning.asciidoc[]
 
 include::components/elasticsearch-json-warning.asciidoc[]
 

--- a/documentation/src/main/asciidoc/reference/search-dsl-query.asciidoc
+++ b/documentation/src/main/asciidoc/reference/search-dsl-query.asciidoc
@@ -642,7 +642,7 @@ include::{sourcedir}/org/hibernate/search/documentation/search/query/QueryDslIT.
 
 This query object supports all <<search-dsl-query-fetching-results,`fetch*` methods supported by the query DSL>>.
 The main advantage over calling these methods directly at the end of a query definition
-is mostly related to debugging (see <<search-dsl-query-debugging>>),
+is mostly related to <<troubleshooting,troubleshooting>>,
 but the query object can also be useful if you need an adapter to another API.
 
 Hibernate Search provides an adapter to JPA and Hibernate ORM's native APIs,
@@ -692,53 +692,17 @@ Use <<search-dsl-projection-composite,composite projections>> instead.
 * And more: this list is not exhaustive.
 ====
 
-[[search-dsl-query-debugging]]
-== Debugging a query
+[[search-dsl-query-explain]]
+== `explain(...)`: Explaining scores
 
-[[search-dsl-query-debugging-matches]]
-=== Explaining matches
-
-When some documents unexpectedly match or don't match,
-you will need information about the exact query being executed,
-and about the index content.
-
-To gain insight about what ends up being executed exactly,
-one option is to <<search-dsl-query-object,create a `SearchQuery` object>>
+In order to <<troubleshooting-faq-search-score,explain the score>> of a particular document,
+<<search-dsl-query-object,create a `SearchQuery` object>>
 using `toQuery()` at the end of the query definition,
-then call `toString()` to get a String representation of that query.
+and then use one of the backend-specific `explain(...)` methods;
+the result of these methods will include a human-readable description of
+how the score of a specific document was computed.
 
-Another option is to take advantage of logs:
-all executed search queries are logged to the log category `org.hibernate.search.query`
-at the `DEBUG` level.
-
-You may also need to inspect the content of the index.
-This is rather obvious with Elasticsearch: run simpler queries using either Hibernate Search or the REST APIs directly.
-For the Lucene backend,
-https://medium.com/@mocobeta/luke-become-an-apache-lucene-module-as-of-lucene-8-1-7d139c998b2[use the Luke tool]
-distributed as part of the https://lucene.apache.org/core/downloads.html[Lucene binary packages].
-
-[[search-dsl-query-debugging-scores]]
-=== Explaining scores
-// Search 5 anchors backward compatibility
-[[_understanding_results]]
-
-When the score of some documents is higher or lower than expected,
-the best way to gain insight is to <<search-dsl-query-object,create a `SearchQuery` object>>
-using `toQuery()` at the end of the query definition,
-and then use the backend-specific `explain` methods;
-the result of these methods will explain how the score of a specific document was computed.
-See below for examples.
-
-To retrieve an explanation for all matches in one call,
-`explanation` projections are available:
-see <<search-dsl-projection-extensions-lucene-explanation,here for Lucene>>
-and <<search-dsl-projection-extensions-elasticsearch-explanation,here for Elasticsearch>>.
-
-[WARNING]
-====
-Regardless of the API used, explanations are rather costly performance-wise:
-only use them for debugging purposes.
-====
+include::components/explanation-warning.asciidoc[]
 
 .Retrieving score explanation -- Lucene
 ====
@@ -773,8 +737,10 @@ but also by the name of its type.
 you can instead use the Elasticsearch extension on the `SearchQuery` to convert it after its creation.
 ====
 
+[[search-dsl-query-took-timedout]]
+== `took` and `timedOut`: finding out how long the query took
+// Legacy anchors backward compatibility
 [[search-dsl-query-debugging-took-timedout]]
-=== Query metadata in SearchResult: `took` and `timedOut`
 
 .Returning query execution time and whether a timeout occurred
 ====

--- a/documentation/src/main/asciidoc/reference/troubleshooting.asciidoc
+++ b/documentation/src/main/asciidoc/reference/troubleshooting.asciidoc
@@ -10,6 +10,13 @@ Alternatively, rely on the logs:
 <<troubleshooting-logging-query,`org.hibernate.search.query`>> will log every query at the `DEBUG` level
 before it is executed.
 
+For more general information about what is being executed, rely on loggers:
+
+* <<troubleshooting-logging-lucene-infostream,`org.hibernate.search.backend.lucene.infostream`>>
+for Lucene.
+* <<troubleshooting-logging-elasticsearch-request,`org.hibernate.search.elasticsearch.request`>>
+for Elasticsearch.
+
 [[troubleshooting-logging]]
 == Loggers
 

--- a/documentation/src/main/asciidoc/reference/troubleshooting.asciidoc
+++ b/documentation/src/main/asciidoc/reference/troubleshooting.asciidoc
@@ -19,6 +19,15 @@ Here are a few loggers that can be useful when debugging an application that use
 Available for all backends.
 +
 Logs every single search query at the `DEBUG` level, before its execution.
+[[troubleshooting-logging-elasticsearch-request]]`org.hibernate.search.elasticsearch.request`::
+Available for Elasticsearch backends only.
++
+Logs every single request sent to Elasticsearch at the `DEBUG` or `TRACE` level after its execution.
+Use the `DEBUG` level for compact information (method, path, execution time, status code, ...),
+or the `TRACE` level to also get the full request and response.
++
+You can enable pretty-printing (line breaks and indentation) for the request and response
+using a <<backend-elasticsearch-configuration-logging,configuration property>>.
 
 [[troubleshooting-faq]]
 == Frequently asked questions

--- a/documentation/src/main/asciidoc/reference/troubleshooting.asciidoc
+++ b/documentation/src/main/asciidoc/reference/troubleshooting.asciidoc
@@ -1,0 +1,80 @@
+[[troubleshooting]]
+= Troubleshooting
+
+[[troubleshooting-under-the-hood]]
+== Finding out what is executed under the hood
+
+For search queries, you can get a human-readable representation of a <<search-dsl-query-object,`SearchQuery` object>>
+by calling `toString()` or `queryString()`.
+Alternatively, rely on the logs:
+<<troubleshooting-logging-query,`org.hibernate.search.query`>> will log every query at the `DEBUG` level
+before it is executed.
+
+[[troubleshooting-logging]]
+== Loggers
+
+Here are a few loggers that can be useful when debugging an application that uses Hibernate Search:
+
+[[troubleshooting-logging-query]]`org.hibernate.search.query`::
+Available for all backends.
++
+Logs every single search query at the `DEBUG` level, before its execution.
+
+[[troubleshooting-faq]]
+== Frequently asked questions
+
+[[troubleshooting-faq-search-matches]]
+=== Unexpected or missing documents in search hits
+// Legacy anchors backward compatibility
+[[search-dsl-query-debugging-matches]]
+
+When some documents unexpectedly match or don't match a query,
+you will need information about the exact query being executed,
+and about the index content.
+
+To find out what the query being executed looks like exactly,
+see <<troubleshooting-under-the-hood>>.
+
+To inspect the content of the index:
+
+* With the Elasticsearch backend, run simpler queries using either Hibernate Search or the REST APIs directly.
+* With the Lucene backend, run simpler queries using Hibernate Search or
+https://medium.com/@mocobeta/luke-become-an-apache-lucene-module-as-of-lucene-8-1-7d139c998b2[use the Luke tool]
+distributed as part of the https://lucene.apache.org/core/downloads.html[Lucene binary packages].
+
+[[troubleshooting-faq-search-score]]
+=== Unsatisfying order of search hits when sorting by score
+// Legacy anchors backward compatibility
+[[_understanding_results]]
+[[search-dsl-query-debugging-score]]
+
+When sorting by score, if the documents don't appear in the order you expect,
+it means some documents have a score that is higher or lower than what you want.
+
+The best way to gain insight into these scores
+is to just ask the backend to explain how the score was computed.
+The returned explanation will include a human-readable description of
+how the score of a specific document was computed.
+
+include::components/explanation-warning.asciidoc[]
+
+There are two ways to retrieve explanations:
+
+* If you are interested in a particular entity and know its identifier: use the `explain(...)` method on the query.
+See <<search-dsl-query-explain>>.
+* If you just want an explanation for all the top hits: use an `explanation` projection.
+See <<search-dsl-projection-extensions-lucene-explanation,here for Lucene>>
+and <<search-dsl-projection-extensions-elasticsearch-explanation,here for Elasticsearch>>.
+
+[[troubleshooting-faq-search-time]]
+=== Search query execution takes too long
+
+When the execution of a search query is too long,
+you may need more information about how long it took exactly,
+and what was executed exactly.
+
+To find out how long a query execution took,
+use the <<search-dsl-query-took-timedout,`took()` method>> on the search result.
+
+To find out what the query being executed looks like exactly,
+see <<troubleshooting-under-the-hood>>.

--- a/documentation/src/main/asciidoc/reference/troubleshooting.asciidoc
+++ b/documentation/src/main/asciidoc/reference/troubleshooting.asciidoc
@@ -28,6 +28,13 @@ or the `TRACE` level to also get the full request and response.
 +
 You can enable pretty-printing (line breaks and indentation) for the request and response
 using a <<backend-elasticsearch-configuration-logging,configuration property>>.
+[[troubleshooting-logging-lucene-infostream]]`org.hibernate.search.backend.lucene.infostream`::
+Available for Lucene backends only.
++
+Logs low level trace information about Lucene's internal components, at the `TRACE` level.
++
+Enabling the `TRACE` level on this logger is not enough:
+you must also enable the infostream using a <<backend-lucene-io-writer-infostream,configuration property>>.
 
 [[troubleshooting-faq]]
 == Frequently asked questions

--- a/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/limitations/ConcurrentEmbeddedUpdateLimitationIT.java
+++ b/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/limitations/ConcurrentEmbeddedUpdateLimitationIT.java
@@ -1,0 +1,264 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.orm.realbackend.limitations;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToMany;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.search.integrationtest.mapper.orm.realbackend.testsupport.BackendConfigurations;
+import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.orm.cfg.HibernateOrmMapperSettings;
+import org.hibernate.search.mapper.orm.session.SearchSession;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
+import org.hibernate.search.util.common.impl.SuppressingCloser;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * See "limitations-parallel-embedded-update" in the documentation.
+ */
+public class ConcurrentEmbeddedUpdateLimitationIT {
+
+	@Rule
+	public OrmSetupHelper setupHelper = OrmSetupHelper.withSingleBackend( BackendConfigurations.simple() );
+
+	private SessionFactory sessionFactory;
+
+	@Before
+	public void setup() {
+		sessionFactory = setupHelper.start()
+				// This is absolutely necessary to avoid false positives in this test
+				.withProperty( HibernateOrmMapperSettings.AUTOMATIC_INDEXING_SYNCHRONIZATION_STRATEGY, "sync" )
+				.setup( Book.class, Author.class, BookEdition.class );
+	}
+
+	@Test
+	public void reproducer() {
+		with( sessionFactory ).run( session -> {
+			Book book = new Book();
+			book.setTitle( "The Caves Of Steel" );
+
+			Author author = new Author();
+			author.setName( "Isaac Asimov" );
+			book.getAuthors().add( author );
+			author.getBooks().add( book );
+
+			BookEdition edition1 = new BookEdition();
+			edition1.setLabel( "Mass Market Paperback, 12th Edition" );
+			edition1.setBook( book );
+			book.getEditions().add( edition1 );
+
+			BookEdition edition2 = new BookEdition();
+			edition2.setLabel( "Kindle Edition" );
+			edition2.setBook( book );
+			book.getEditions().add( edition2 );
+
+			session.persist( edition1 );
+			session.persist( edition2 );
+			session.persist( author );
+			session.persist( book );
+		} );
+
+		assertThat( countByEditionAndAuthor( "12th", "asimov" ) ).isEqualTo( 1L );
+
+		try ( Session session1 = sessionFactory.openSession(); Session session2 = sessionFactory.openSession() ) {
+			Transaction tx1 = null;
+			Transaction tx2 = null;
+			try {
+				tx1 = session1.beginTransaction();
+				tx2 = session2.beginTransaction();
+
+				Author author = session1.createQuery( "select a from Author a", Author.class )
+						.list().get( 0 );
+				author.setName( "Kurt Vonnegut" );
+
+				BookEdition bookEdition = session2.createQuery( "select e from BookEdition e", BookEdition.class )
+						.list().get( 0 );
+				bookEdition.setLabel( "Mass Market Paperback, 13th Edition" );
+
+				// Simulate tx.commit starting.
+				// Entities are loaded in session 2, including the author from the DB, still not modified.
+				// Documents are created in session 2 based on this data: author is not updated in the documents.
+				session2.flush();
+
+				// Entities are loaded in session 1, including the bookEdition from the DB, still not modified.
+				// Documents are created in session 1 based on this data: bookEdition is not updated in the documents.
+				// Indexing is performed in session 1: author is up-to-date, but not bookEdition.
+				tx1.commit();
+
+				// Indexing is performed in session 2: bookEdition is up-to-date, but not author.
+				// In particular, author is **restored to its previous state**!
+				tx2.commit();
+			}
+			catch (RuntimeException e) {
+				new SuppressingCloser( e )
+						.push( Transaction::rollback, tx1 )
+						.push( Transaction::rollback, tx2 );
+				throw e;
+			}
+		}
+
+		// The previous data isn't there: good.
+		assertThat( countByEditionAndAuthor( "12th", "asimov" ) ).isEqualTo( 0L );
+
+		// The new data isn't there either: bad!
+		assertThat( countByEditionAndAuthor( "13th", "vonnegut" ) ).isEqualTo( 0L );
+
+		// Turns out only half of the update came through...
+		assertThat( countByEditionAndAuthor( "13th", "asimov" ) ).isEqualTo( 1L );
+	}
+
+	long countByEditionAndAuthor(String editionLabel, String authorName) {
+		return with( sessionFactory ).apply( session -> {
+			SearchSession searchSession = Search.session( session );
+
+			return searchSession.search( Book.class )
+					.where( f -> f.bool()
+							.must( f.match().field( "editions.label" ).matching( editionLabel ) )
+							.must( f.match().field( "authors.name" ).matching( authorName ) ) )
+					.fetchTotalHitCount();
+		} );
+	}
+
+	@Entity(name = Author.NAME)
+	public static class Author {
+		public static final String NAME = "Author";
+
+		@Id
+		@GeneratedValue
+		private Integer id;
+
+		@FullTextField
+		private String name;
+
+		@ManyToMany(mappedBy = "authors")
+		private Set<Book> books = new HashSet<>();
+
+		public Integer getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public Set<Book> getBooks() {
+			return books;
+		}
+	}
+
+	@Entity(name = Book.NAME)
+	@Indexed
+	public static class Book {
+		public static final String NAME = "Book";
+
+		@Id
+		@GeneratedValue
+		private Integer id;
+
+		@FullTextField
+		private String title;
+
+		@ManyToMany
+		@IndexedEmbedded
+		private List<Author> authors = new ArrayList<>();
+
+		@OneToMany(mappedBy = "book")
+		@IndexedEmbedded
+		private List<BookEdition> editions = new ArrayList<>();
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getTitle() {
+			return title;
+		}
+
+		public void setTitle(String title) {
+			this.title = title;
+		}
+
+		public List<Author> getAuthors() {
+			return authors;
+		}
+
+		public List<BookEdition> getEditions() {
+			return editions;
+		}
+	}
+
+	@Entity(name = BookEdition.NAME)
+	public static class BookEdition {
+		public static final String NAME = "BookEdition";
+
+		@Id
+		@GeneratedValue
+		private Integer id;
+
+		@ManyToOne
+		private Book book;
+
+		@FullTextField
+		private String label;
+
+		public BookEdition() {
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public Book getBook() {
+			return book;
+		}
+
+		public void setBook(Book book) {
+			this.book = book;
+		}
+
+		public String getLabel() {
+			return label;
+		}
+
+		public void setLabel(String label) {
+			this.label = label;
+		}
+	}
+}

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/JPAPersistenceRunner.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/JPAPersistenceRunner.java
@@ -1,0 +1,43 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.impl.integrationtest.mapper.orm;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.EntityTransaction;
+
+import org.hibernate.search.util.common.impl.Closer;
+
+class JPAPersistenceRunner implements PersistenceRunner<EntityManager, EntityTransaction> {
+	private final EntityManagerFactory entityManagerFactory;
+
+	JPAPersistenceRunner(EntityManagerFactory entityManagerFactory) {
+		this.entityManagerFactory = entityManagerFactory;
+	}
+
+	@Override
+	public <R> R applyNoTransaction(Function<? super EntityManager, R> action) {
+		try ( Closer<RuntimeException> closer = new Closer<>() ) {
+			EntityManager entityManager = entityManagerFactory.createEntityManager();
+			try {
+				return action.apply( entityManager );
+			}
+			finally {
+				closer.push( EntityManager::close, entityManager );
+			}
+		}
+	}
+
+	@Override
+	public <R> R apply(BiFunction<? super EntityManager, ? super EntityTransaction, R> action) {
+		return applyNoTransaction( entityManager -> {
+			return OrmUtils.withinJPATransaction( entityManager, tx -> { return action.apply( entityManager, tx ); } );
+		} );
+	}
+}

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/NativePersistenceRunner.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/NativePersistenceRunner.java
@@ -1,0 +1,36 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.impl.integrationtest.mapper.orm;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+
+class NativePersistenceRunner implements PersistenceRunner<Session, Transaction> {
+	private final SessionFactory sessionFactory;
+
+	NativePersistenceRunner(SessionFactory sessionFactory) {
+		this.sessionFactory = sessionFactory;
+	}
+
+	@Override
+	public <R> R applyNoTransaction(Function<? super Session, R> action) {
+		try ( Session session = sessionFactory.openSession() ) {
+			return action.apply( session );
+		}
+	}
+
+	@Override
+	public <R> R apply(BiFunction<? super Session, ? super Transaction, R> action) {
+		return applyNoTransaction( session -> {
+			return OrmUtils.withinTransaction( session, tx -> { return action.apply( session, tx ); } );
+		} );
+	}
+}

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/PersistenceRunner.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/PersistenceRunner.java
@@ -1,0 +1,54 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.impl.integrationtest.mapper.orm;
+
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityTransaction;
+
+/**
+ * An easy way to run code in the context of an {@link EntityManager}/{@link org.hibernate.Session}
+ * and transaction (both instantiated by the runner).
+ *
+ * @param <C> The type of persistence context: {@link EntityManager} or {@link org.hibernate.Session}.
+ * @param <T> The type of transaction: {@link EntityTransaction} or {@link org.hibernate.Transaction}.
+ */
+public interface PersistenceRunner<C, T> {
+
+	<R> R applyNoTransaction(Function<? super C, R> action);
+
+	default void runNoTransaction(Consumer<? super C> action) {
+		applyNoTransaction( c -> {
+			action.accept( c );
+			return null;
+		} );
+	}
+
+	default <R> R apply(Function<? super C, R> action) {
+		return apply( (c, t) -> action.apply( c ) );
+	}
+
+	<R> R apply(BiFunction<? super C, ? super T, R> action);
+
+	default void run(Consumer<? super C> action) {
+		apply( c -> {
+			action.accept( c );
+			return null;
+		} );
+	}
+
+	default void run(BiConsumer<? super C, T> action) {
+		apply( (c, t) -> {
+			action.accept( c, t );
+			return null;
+		} );
+	}
+
+}


### PR DESCRIPTION
* [HSEARCH-4076](https://hibernate.atlassian.net/browse/HSEARCH-4076): Document loggers
* [HSEARCH-4064](https://hibernate.atlassian.net/browse/HSEARCH-4064): Add warnings in the documentation about concurrent updates to the same entity in a clustered application

