### PR TITLE
HSEARCH-3402 + HSEARCH-4083 Replace CompletableFuture with CompletionStage in APIs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -288,7 +288,7 @@ You can also inspect the created Neo4j datastore after a build,
 provided that build had the `jqassistant` profile enabled:
 
 ```bash
-./mvnw jqassistant:server -Pjqassistant-server -pl reports
+./mvnw jqassistant:server -Pjqassistant
 ```
 
 The Neo4j web UI will be accessible from http://localhost:7474/.

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/LuceneIndexManager.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/LuceneIndexManager.java
@@ -33,8 +33,13 @@ public interface LuceneIndexManager extends IndexManager {
 	Analyzer searchAnalyzer();
 
 	/**
+	 * @return The size of the index on its storage support, in bytes.
+	 */
+	long computeSizeInBytes();
+
+	/**
 	 * @return A future that will ultimately provide the size of the index on its storage support, in bytes.
 	 */
-	CompletableFuture<Long> computeSizeInBytes();
+	CompletableFuture<Long> computeSizeInBytesAsync();
 
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/LuceneIndexManager.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/LuceneIndexManager.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.backend.lucene.index;
 
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.hibernate.search.backend.lucene.LuceneBackend;
 import org.hibernate.search.engine.backend.index.IndexManager;
@@ -40,6 +40,6 @@ public interface LuceneIndexManager extends IndexManager {
 	/**
 	 * @return A future that will ultimately provide the size of the index on its storage support, in bytes.
 	 */
-	CompletableFuture<Long> computeSizeInBytesAsync();
+	CompletionStage<Long> computeSizeInBytesAsync();
 
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/LuceneIndexManagerImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/index/impl/LuceneIndexManagerImpl.java
@@ -36,6 +36,7 @@ import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrateg
 import org.hibernate.search.engine.backend.mapping.spi.BackendMappingContext;
 import org.hibernate.search.engine.backend.session.spi.DetachedBackendSessionContext;
 import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
+import org.hibernate.search.util.common.impl.Futures;
 import org.hibernate.search.util.common.reporting.EventContext;
 import org.hibernate.search.engine.reporting.spi.EventContexts;
 import org.hibernate.search.util.common.impl.Closer;
@@ -187,7 +188,12 @@ public class LuceneIndexManagerImpl
 	}
 
 	@Override
-	public CompletableFuture<Long> computeSizeInBytes() {
+	public long computeSizeInBytes() {
+		return Futures.unwrappedExceptionJoin( computeSizeInBytesAsync() );
+	}
+
+	@Override
+	public CompletableFuture<Long> computeSizeInBytesAsync() {
 		return schemaManager.computeSizeInBytes();
 	}
 

--- a/documentation/src/main/asciidoc/reference/backend-lucene.asciidoc
+++ b/documentation/src/main/asciidoc/reference/backend-lucene.asciidoc
@@ -1167,7 +1167,6 @@ include::{sourcedir}/org/hibernate/search/documentation/backend/lucene/indexmana
 <1> Retrieve the `SearchMapping`.
 <2> Retrieve the `IndexManager`.
 <3> Narrow down the index manager to the `LuceneIndexManager` type.
-<4> Request computation of the index size.
-The size is computed in a background thread, so this call is non-blocking and returns a `CompletableFuture`.
-<5> Wait until the index size is computed, then get the index size.
+<4> Compute the index size and get the result.
+<5> An asynchronous version of the method is also available.
 ====

--- a/documentation/src/main/asciidoc/reference/mapper-orm-indexing-manual.asciidoc
+++ b/documentation/src/main/asciidoc/reference/mapper-orm-indexing-manual.asciidoc
@@ -296,7 +296,7 @@ Delete all documents from indexes targeted by this workspace.
 With multi-tenancy enabled, only documents of the current tenant will be removed:
 the tenant of the session from which this workspace originated.
 `purgeAsync()`::
-Asynchronous version of `purge()` returning a `CompletableFuture`.
+Asynchronous version of `purge()` returning a `CompletionStage`.
 `purge(Set<String> routingKeys)`::
 Delete documents from indexes targeted by this workspace
 that were indexed with any of the given routing keys.
@@ -304,7 +304,7 @@ that were indexed with any of the given routing keys.
 With multi-tenancy enabled, only documents of the current tenant will be removed:
 the tenant of the session from which this workspace originated.
 `purgeAsync(Set<String> routingKeys)`::
-Asynchronous version of `purge(Set<String>)` returning a `CompletableFuture`.
+Asynchronous version of `purge(Set<String>)` returning a `CompletionStage`.
 [[mapper-orm-indexing-manual-flush]]`flush()`::
 Flush to disk the changes to indexes that have not been committed yet.
 In the case of backends with a transaction log (Elasticsearch),
@@ -313,19 +313,19 @@ also apply operations from the transaction log that were not applied yet.
 This is generally not useful as Hibernate Search commits changes automatically.
 See <<concepts-commit-refresh>> for more information.
 `flushAsync()`::
-Asynchronous version of `flush()` returning a `CompletableFuture`.
+Asynchronous version of `flush()` returning a `CompletionStage`.
 [[mapper-orm-indexing-manual-refresh]]`refresh()`::
 Refresh the indexes so that all changes executed so far will be visible in search queries.
 +
 This is generally not useful as indexes are refreshed automatically.
 See <<concepts-commit-refresh>> for more information.
 `refreshAsync()`::
-Asynchronous version of `refresh()` returning a `CompletableFuture`.
+Asynchronous version of `refresh()` returning a `CompletionStage`.
 [[mapper-orm-indexing-manual-merge]]`mergeSegments()`::
 Merge each index targeted by this workspace into a single segment.
 This operation does not always improve performance: see <<mapper-orm-indexing-merge-segments>>.
 `mergeSegmentsAsync()`::
-Asynchronous version of `mergeSegments()` returning a `CompletableFuture`.
+Asynchronous version of `mergeSegments()` returning a `CompletionStage`.
 This operation does not always improve performance: see <<mapper-orm-indexing-merge-segments>>.
 
 [NOTE]

--- a/documentation/src/main/asciidoc/reference/mapper-orm-indexing-massindexer.asciidoc
+++ b/documentation/src/main/asciidoc/reference/mapper-orm-indexing-massindexer.asciidoc
@@ -79,7 +79,7 @@ include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/indexing/Hibe
 
 It is possible to run the mass indexer asynchronously,
 because, the mass indexer does not rely on the original Hibernate ORM session.
-When used asynchronously, the mass indexer will return a future
+When used asynchronously, the mass indexer will return a completion stage
 to track the completion of mass indexing:
 
 .Reindexing asynchronously using a `MassIndexer`
@@ -90,7 +90,9 @@ include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/indexing/Hibe
 ----
 <1> Create a `MassIndexer`.
 <2> Start the mass indexing process, but do not wait for the process to finish.
-A `CompletableFuture` is returned.
+A `CompletionStage` is returned.
+<3> The `CompletionStage` exposes methods to execute more code after indexing is complete.
+<4> Alternatively, call `toCompletableFuture()` on the returned object to get a `Future`.
 ====
 
 Although the `MassIndexer` is simple to use, some tweaking is recommended to speed up the process.

--- a/documentation/src/test/java/org/hibernate/search/documentation/backend/lucene/indexmanager/LuceneGetIndexSizeIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/backend/lucene/indexmanager/LuceneGetIndexSizeIT.java
@@ -8,8 +8,6 @@ package org.hibernate.search.documentation.backend.lucene.indexmanager;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import javax.persistence.EntityManagerFactory;
 
 import org.hibernate.search.backend.lucene.index.LuceneIndexManager;
@@ -44,10 +42,12 @@ public class LuceneGetIndexSizeIT {
 		IndexManager indexManager = mapping.indexManager( "Book" ); // <2>
 		LuceneIndexManager luceneIndexManager = indexManager.unwrap( LuceneIndexManager.class ); // <3>
 		long size = luceneIndexManager.computeSizeInBytes(); // <4>
-		CompletableFuture<Long> sizeFuture = luceneIndexManager.computeSizeInBytesAsync(); // <5>
+		luceneIndexManager.computeSizeInBytesAsync() // <5>
+				.thenAccept( sizeInBytes -> {
+					// ...
+				} );
 		//end::computeIndexSize[]
 		assertThat( size ).isGreaterThanOrEqualTo( 0L );
-		assertThat( sizeFuture.join() ).isGreaterThanOrEqualTo( 0L );
 	}
 
 }

--- a/documentation/src/test/java/org/hibernate/search/documentation/backend/lucene/indexmanager/LuceneGetIndexSizeIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/backend/lucene/indexmanager/LuceneGetIndexSizeIT.java
@@ -9,6 +9,7 @@ package org.hibernate.search.documentation.backend.lucene.indexmanager;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import javax.persistence.EntityManagerFactory;
 
 import org.hibernate.search.backend.lucene.index.LuceneIndexManager;
@@ -42,10 +43,11 @@ public class LuceneGetIndexSizeIT {
 		SearchMapping mapping = Search.mapping( entityManagerFactory ); // <1>
 		IndexManager indexManager = mapping.indexManager( "Book" ); // <2>
 		LuceneIndexManager luceneIndexManager = indexManager.unwrap( LuceneIndexManager.class ); // <3>
-		CompletableFuture<Long> sizeFuture = luceneIndexManager.computeSizeInBytes(); // <4>
-		long size = sizeFuture.join(); // <5>
+		long size = luceneIndexManager.computeSizeInBytes(); // <4>
+		CompletableFuture<Long> sizeFuture = luceneIndexManager.computeSizeInBytesAsync(); // <5>
 		//end::computeIndexSize[]
 		assertThat( size ).isGreaterThanOrEqualTo( 0L );
+		assertThat( sizeFuture.join() ).isGreaterThanOrEqualTo( 0L );
 	}
 
 }

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/index/LuceneIndexManagerIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/index/LuceneIndexManagerIT.java
@@ -107,7 +107,7 @@ public class LuceneIndexManagerIT {
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3589")
 	public void computeSizeInBytesAsync() {
-		CompletableFuture<Long> initialSizeFuture = indexApi.computeSizeInBytesAsync();
+		CompletableFuture<Long> initialSizeFuture = indexApi.computeSizeInBytesAsync().toCompletableFuture();
 		await().untilAsserted( () -> assertThat( initialSizeFuture ).isCompleted() );
 		long initialSize = initialSizeFuture.join();
 		assertThat( initialSize ).isGreaterThanOrEqualTo( 0L );
@@ -122,7 +122,7 @@ public class LuceneIndexManagerIT {
 
 		index.createWorkspace().flush().join();
 
-		CompletableFuture<Long> finalSizeFuture = indexApi.computeSizeInBytesAsync();
+		CompletableFuture<Long> finalSizeFuture = indexApi.computeSizeInBytesAsync().toCompletableFuture();
 		await().untilAsserted( () -> assertThat( finalSizeFuture ).isCompleted() );
 		long finalSize = finalSizeFuture.join();
 		assertThat( finalSize ).isGreaterThan( 0L );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingInterruptionIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingInterruptionIT.java
@@ -115,7 +115,7 @@ public class MassIndexingInterruptionIT {
 				+ 1; // Entity loading
 
 		MassIndexer massIndexer = prepareMassIndexingThatWillNotTerminate();
-		CompletableFuture<?> future = massIndexer.start();
+		CompletableFuture<?> future = massIndexer.start().toCompletableFuture();
 
 		waitForMassIndexingThreadsToSpawn( expectedThreadCount );
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/workspace/AbstractSearchWorkspaceSimpleOperationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/workspace/AbstractSearchWorkspaceSimpleOperationIT.java
@@ -12,6 +12,7 @@ import static org.hibernate.search.util.impl.test.FutureAssert.assertThatFuture;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
@@ -57,7 +58,7 @@ public abstract class AbstractSearchWorkspaceSimpleOperationIT {
 			CompletableFuture<Object> futureFromBackend = new CompletableFuture<>();
 			expectWork( defaultBackendMock, IndexedEntity1.INDEX_NAME, futureFromBackend );
 
-			CompletableFuture<?> futureFromWorkspace = executeAsync( workspace );
+			CompletionStage<?> futureFromWorkspace = executeAsync( workspace );
 			defaultBackendMock.verifyExpectationsMet();
 			assertThatFuture( futureFromWorkspace ).isPending();
 
@@ -76,7 +77,7 @@ public abstract class AbstractSearchWorkspaceSimpleOperationIT {
 			CompletableFuture<Object> futureFromBackend = new CompletableFuture<>();
 			expectWork( defaultBackendMock, IndexedEntity1.INDEX_NAME, futureFromBackend );
 
-			CompletableFuture<?> futureFromWorkspace = executeAsync( workspace );
+			CompletionStage<?> futureFromWorkspace = executeAsync( workspace );
 			defaultBackendMock.verifyExpectationsMet();
 			assertThatFuture( futureFromWorkspace ).isPending();
 
@@ -134,7 +135,7 @@ public abstract class AbstractSearchWorkspaceSimpleOperationIT {
 			expectWork( defaultBackendMock, IndexedEntity1.INDEX_NAME, future1FromBackend );
 			expectWork( backend2Mock, IndexedEntity2.INDEX_NAME, future2FromBackend );
 
-			CompletableFuture<?> futureFromWorkspace = executeAsync( workspace );
+			CompletionStage<?> futureFromWorkspace = executeAsync( workspace );
 			defaultBackendMock.verifyExpectationsMet();
 			backend2Mock.verifyExpectationsMet();
 			assertThatFuture( futureFromWorkspace ).isPending();
@@ -159,7 +160,7 @@ public abstract class AbstractSearchWorkspaceSimpleOperationIT {
 		CompletableFuture<Object> futureFromBackend = new CompletableFuture<>();
 		expectWork( defaultBackendMock, IndexedEntity1.INDEX_NAME, futureFromBackend );
 
-		CompletableFuture<?> futureFromWorkspace = executeAsync( workspace );
+		CompletionStage<?> futureFromWorkspace = executeAsync( workspace );
 		defaultBackendMock.verifyExpectationsMet();
 		assertThatFuture( futureFromWorkspace ).isPending();
 
@@ -176,7 +177,7 @@ public abstract class AbstractSearchWorkspaceSimpleOperationIT {
 		CompletableFuture<Object> futureFromBackend = new CompletableFuture<>();
 		expectWork( defaultBackendMock, IndexedEntity1.INDEX_NAME, futureFromBackend );
 
-		CompletableFuture<?> futureFromWriter = executeAsync( workspace );
+		CompletionStage<?> futureFromWriter = executeAsync( workspace );
 		defaultBackendMock.verifyExpectationsMet();
 		assertThatFuture( futureFromWriter ).isPending();
 
@@ -188,7 +189,7 @@ public abstract class AbstractSearchWorkspaceSimpleOperationIT {
 
 	protected abstract void executeSync(SearchWorkspace workspace);
 
-	protected abstract CompletableFuture<?> executeAsync(SearchWorkspace workspace);
+	protected abstract CompletionStage<?> executeAsync(SearchWorkspace workspace);
 
 	private SessionFactory setup() {
 		defaultBackendMock.expectAnySchema( IndexedEntity1.INDEX_NAME );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/workspace/SearchWorkspaceFlushIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/workspace/SearchWorkspaceFlushIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.workspace;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.hibernate.search.mapper.orm.work.SearchWorkspace;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
@@ -26,7 +27,7 @@ public class SearchWorkspaceFlushIT extends AbstractSearchWorkspaceSimpleOperati
 	}
 
 	@Override
-	protected CompletableFuture<?> executeAsync(SearchWorkspace workspace) {
+	protected CompletionStage<?> executeAsync(SearchWorkspace workspace) {
 		return workspace.flushAsync();
 	}
 }

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/workspace/SearchWorkspaceMergeSegmentsIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/workspace/SearchWorkspaceMergeSegmentsIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.workspace;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.hibernate.search.mapper.orm.work.SearchWorkspace;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
@@ -26,7 +27,7 @@ public class SearchWorkspaceMergeSegmentsIT extends AbstractSearchWorkspaceSimpl
 	}
 
 	@Override
-	protected CompletableFuture<?> executeAsync(SearchWorkspace workspace) {
+	protected CompletionStage<?> executeAsync(SearchWorkspace workspace) {
 		return workspace.mergeSegmentsAsync();
 	}
 }

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/workspace/SearchWorkspacePurgeBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/workspace/SearchWorkspacePurgeBaseIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.workspace;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.hibernate.search.mapper.orm.work.SearchWorkspace;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
@@ -26,7 +27,7 @@ public class SearchWorkspacePurgeBaseIT extends AbstractSearchWorkspaceSimpleOpe
 	}
 
 	@Override
-	protected CompletableFuture<?> executeAsync(SearchWorkspace workspace) {
+	protected CompletionStage<?> executeAsync(SearchWorkspace workspace) {
 		return workspace.purgeAsync();
 	}
 }

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/workspace/SearchWorkspacePurgeRoutingKeyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/workspace/SearchWorkspacePurgeRoutingKeyIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.integrationtest.mapper.orm.workspace;
 
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.hibernate.search.mapper.orm.work.SearchWorkspace;
 import org.hibernate.search.util.common.impl.CollectionHelper;
@@ -31,7 +32,7 @@ public class SearchWorkspacePurgeRoutingKeyIT extends AbstractSearchWorkspaceSim
 	}
 
 	@Override
-	protected CompletableFuture<?> executeAsync(SearchWorkspace workspace) {
+	protected CompletionStage<?> executeAsync(SearchWorkspace workspace) {
 		return workspace.purgeAsync( ROUTING_KEYS );
 	}
 }

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/workspace/SearchWorkspaceRefreshIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/workspace/SearchWorkspaceRefreshIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.workspace;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.hibernate.search.mapper.orm.work.SearchWorkspace;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
@@ -26,7 +27,7 @@ public class SearchWorkspaceRefreshIT extends AbstractSearchWorkspaceSimpleOpera
 	}
 
 	@Override
-	protected CompletableFuture<?> executeAsync(SearchWorkspace workspace) {
+	protected CompletionStage<?> executeAsync(SearchWorkspace workspace) {
 		return workspace.refreshAsync();
 	}
 }

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/AbstractPojoIndexingOperationIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/AbstractPojoIndexingOperationIT.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
 
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
@@ -111,7 +112,7 @@ public abstract class AbstractPojoIndexingOperationIT {
 			SearchIndexer indexer = session.indexer();
 
 			expectOperation( futureFromBackend, 1, null, "1" );
-			CompletableFuture<?> returnedFuture = execute( indexer, 1 );
+			CompletionStage<?> returnedFuture = execute( indexer, 1 );
 			backendMock.verifyExpectationsMet();
 			assertThatFuture( returnedFuture ).isPending();
 
@@ -127,7 +128,7 @@ public abstract class AbstractPojoIndexingOperationIT {
 			SearchIndexer indexer = session.indexer();
 
 			expectOperation( futureFromBackend, 42, null, "1" );
-			CompletableFuture<?> returnedFuture = execute( indexer, 42, 1 );
+			CompletionStage<?> returnedFuture = execute( indexer, 42, 1 );
 			backendMock.verifyExpectationsMet();
 			assertThatFuture( returnedFuture ).isPending();
 
@@ -155,7 +156,7 @@ public abstract class AbstractPojoIndexingOperationIT {
 					},
 					// And only then, expect the actual operation.
 					42, "UE-123", "1" );
-			CompletableFuture<?> returnedFuture = execute( indexer, 42, "UE-123", 1 );
+			CompletionStage<?> returnedFuture = execute( indexer, 42, "UE-123", 1 );
 			backendMock.verifyExpectationsMet();
 			assertThatFuture( returnedFuture ).isPending();
 
@@ -187,7 +188,7 @@ public abstract class AbstractPojoIndexingOperationIT {
 					// And only then, expect the actual operation.
 					1, null, "1"
 			);
-			CompletableFuture<?> returnedFuture = execute( indexer, 1 );
+			CompletionStage<?> returnedFuture = execute( indexer, 1 );
 			backendMock.verifyExpectationsMet();
 			assertThatFuture( returnedFuture ).isPending();
 
@@ -223,7 +224,7 @@ public abstract class AbstractPojoIndexingOperationIT {
 					// And only then, expect the actual operation.
 					1, null, "1"
 			);
-			CompletableFuture<?> returnedFuture = execute( indexer, 1 );
+			CompletionStage<?> returnedFuture = execute( indexer, 1 );
 			backendMock.verifyExpectationsMet();
 			assertThatFuture( returnedFuture ).isPending();
 
@@ -243,7 +244,7 @@ public abstract class AbstractPojoIndexingOperationIT {
 			MyRoutingBridge.indexed = false;
 			MyRoutingBridge.previouslyIndexed = false;
 			// We don't expect the actual operation, which should be skipped because the entity is not indexed.
-			CompletableFuture<?> returnedFuture = execute( indexer, 1 );
+			CompletionStage<?> returnedFuture = execute( indexer, 1 );
 			backendMock.verifyExpectationsMet();
 			assertThatFuture( returnedFuture ).isSuccessful();
 		}
@@ -267,7 +268,7 @@ public abstract class AbstractPojoIndexingOperationIT {
 						.processedThenExecuted();
 			}
 			// However, we don't expect the actual operation, which should be skipped because the entity is not indexed.
-			CompletableFuture<?> returnedFuture = execute( indexer, 1 );
+			CompletionStage<?> returnedFuture = execute( indexer, 1 );
 			backendMock.verifyExpectationsMet();
 			assertThatFuture( returnedFuture ).isSuccessful();
 		}
@@ -300,7 +301,7 @@ public abstract class AbstractPojoIndexingOperationIT {
 						.processedThenExecuted();
 			}
 			// However, we don't expect the actual operation, which should be skipped because the entity is not indexed.
-			CompletableFuture<?> returnedFuture = execute( indexer, 1 );
+			CompletionStage<?> returnedFuture = execute( indexer, 1 );
 			backendMock.verifyExpectationsMet();
 			assertThatFuture( returnedFuture ).isSuccessful();
 		}
@@ -314,7 +315,7 @@ public abstract class AbstractPojoIndexingOperationIT {
 			SearchIndexer indexer = session.indexer();
 
 			expectOperation( futureFromBackend, 1, null, "1" );
-			CompletableFuture<?> returnedFuture = execute( indexer, 1 );
+			CompletionStage<?> returnedFuture = execute( indexer, 1 );
 			backendMock.verifyExpectationsMet();
 			assertThatFuture( returnedFuture ).isPending();
 
@@ -331,7 +332,7 @@ public abstract class AbstractPojoIndexingOperationIT {
 			SearchIndexer indexer = session.indexer();
 
 			expectOperation( futureFromBackend, 1, null, "1" );
-			CompletableFuture<?> returnedFuture = execute( indexer, 1 );
+			CompletionStage<?> returnedFuture = execute( indexer, 1 );
 			backendMock.verifyExpectationsMet();
 			assertThatFuture( returnedFuture ).isPending();
 
@@ -578,11 +579,11 @@ public abstract class AbstractPojoIndexingOperationIT {
 
 	protected abstract void addTo(SearchIndexingPlan indexingPlan, Object providedId, String providedRoutingKey, int id);
 
-	protected abstract CompletableFuture<?> execute(SearchIndexer indexer, int id);
+	protected abstract CompletionStage<?> execute(SearchIndexer indexer, int id);
 
-	protected abstract CompletableFuture<?> execute(SearchIndexer indexer, Object providedId, int id);
+	protected abstract CompletionStage<?> execute(SearchIndexer indexer, Object providedId, int id);
 
-	protected abstract CompletableFuture<?> execute(SearchIndexer indexer, Object providedId, String providedRoutingKey, int id);
+	protected abstract CompletionStage<?> execute(SearchIndexer indexer, Object providedId, String providedRoutingKey, int id);
 
 	protected final IndexedEntity createEntity(int id) {
 		IndexedEntity entity = new IndexedEntity();

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/PojoIndexingAddIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/PojoIndexingAddIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.mapper.pojo.work;
 
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.hibernate.search.mapper.javabean.work.SearchIndexer;
 import org.hibernate.search.mapper.javabean.work.SearchIndexingPlan;
@@ -41,17 +41,17 @@ public class PojoIndexingAddIT extends AbstractPojoIndexingOperationIT {
 	}
 
 	@Override
-	protected CompletableFuture<?> execute(SearchIndexer indexer, int id) {
+	protected CompletionStage<?> execute(SearchIndexer indexer, int id) {
 		return indexer.add( createEntity( id ) );
 	}
 
 	@Override
-	protected CompletableFuture<?> execute(SearchIndexer indexer, Object providedId, int id) {
+	protected CompletionStage<?> execute(SearchIndexer indexer, Object providedId, int id) {
 		return indexer.add( providedId, createEntity( id ) );
 	}
 
 	@Override
-	protected CompletableFuture<?> execute(SearchIndexer indexer, Object providedId, String providedRoutingKey, int id) {
+	protected CompletionStage<?> execute(SearchIndexer indexer, Object providedId, String providedRoutingKey, int id) {
 		return indexer.add( providedId, providedRoutingKey, createEntity( id ) );
 	}
 }

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/PojoIndexingAddOrUpdateIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/PojoIndexingAddOrUpdateIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.mapper.pojo.work;
 
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.hibernate.search.mapper.javabean.work.SearchIndexer;
 import org.hibernate.search.mapper.javabean.work.SearchIndexingPlan;
@@ -36,17 +36,17 @@ public class PojoIndexingAddOrUpdateIT extends AbstractPojoIndexingOperationIT {
 	}
 
 	@Override
-	protected CompletableFuture<?> execute(SearchIndexer indexer, int id) {
+	protected CompletionStage<?> execute(SearchIndexer indexer, int id) {
 		return indexer.addOrUpdate( createEntity( id ) );
 	}
 
 	@Override
-	protected CompletableFuture<?> execute(SearchIndexer indexer, Object providedId, int id) {
+	protected CompletionStage<?> execute(SearchIndexer indexer, Object providedId, int id) {
 		return indexer.addOrUpdate( providedId, createEntity( id ) );
 	}
 
 	@Override
-	protected CompletableFuture<?> execute(SearchIndexer indexer, Object providedId, String providedRoutingKey, int id) {
+	protected CompletionStage<?> execute(SearchIndexer indexer, Object providedId, String providedRoutingKey, int id) {
 		return indexer.addOrUpdate( providedId, providedRoutingKey, createEntity( id ) );
 	}
 }

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/PojoIndexingDeleteIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/PojoIndexingDeleteIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.mapper.pojo.work;
 
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.hibernate.search.mapper.javabean.work.SearchIndexer;
 import org.hibernate.search.mapper.javabean.work.SearchIndexingPlan;
@@ -36,17 +36,17 @@ public class PojoIndexingDeleteIT extends AbstractPojoIndexingOperationIT {
 	}
 
 	@Override
-	protected CompletableFuture<?> execute(SearchIndexer indexer, int id) {
+	protected CompletionStage<?> execute(SearchIndexer indexer, int id) {
 		return indexer.delete( createEntity( id ) );
 	}
 
 	@Override
-	protected CompletableFuture<?> execute(SearchIndexer indexer, Object providedId, int id) {
+	protected CompletionStage<?> execute(SearchIndexer indexer, Object providedId, int id) {
 		return indexer.delete( providedId, createEntity( id ) );
 	}
 
 	@Override
-	protected CompletableFuture<?> execute(SearchIndexer indexer, Object providedId, String providedRoutingKey, int id) {
+	protected CompletionStage<?> execute(SearchIndexer indexer, Object providedId, String providedRoutingKey, int id) {
 		return indexer.delete( providedId, providedRoutingKey, createEntity( id ) );
 	}
 }

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/PojoIndexingPurgeIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/PojoIndexingPurgeIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.integrationtest.mapper.pojo.work;
 
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.hibernate.search.mapper.javabean.work.SearchIndexer;
 import org.hibernate.search.mapper.javabean.work.SearchIndexingPlan;
@@ -41,17 +41,17 @@ public class PojoIndexingPurgeIT extends AbstractPojoIndexingOperationIT {
 	}
 
 	@Override
-	protected CompletableFuture<?> execute(SearchIndexer indexer, int id) {
+	protected CompletionStage<?> execute(SearchIndexer indexer, int id) {
 		return indexer.purge( IndexedEntity.class, id, null );
 	}
 
 	@Override
-	protected CompletableFuture<?> execute(SearchIndexer indexer, Object providedId, int id) {
+	protected CompletionStage<?> execute(SearchIndexer indexer, Object providedId, int id) {
 		return indexer.purge( IndexedEntity.class, providedId, null );
 	}
 
 	@Override
-	protected CompletableFuture<?> execute(SearchIndexer indexer, Object providedId, String providedRoutingKey, int id) {
+	protected CompletionStage<?> execute(SearchIndexer indexer, Object providedId, String providedRoutingKey, int id) {
 		return indexer.purge( IndexedEntity.class, providedId, providedRoutingKey );
 	}
 }

--- a/integrationtest/v5migrationhelper/engine/src/test/java/org/hibernate/search/testsupport/junit/SearchITHelper.java
+++ b/integrationtest/v5migrationhelper/engine/src/test/java/org/hibernate/search/testsupport/junit/SearchITHelper.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -186,7 +187,7 @@ public class SearchITHelper {
 				SearchIndexer indexer = session.indexer();
 				CompletableFuture<?>[] futures = new CompletableFuture[works.size()];
 				for ( int i = 0; i < works.size(); i++ ) {
-					futures[i] = executeWork( indexer, works.get( i ) );
+					futures[i] = executeWork( indexer, works.get( i ) ).toCompletableFuture();
 				}
 				CompletableFuture.allOf( futures ).join();
 			}
@@ -195,7 +196,7 @@ public class SearchITHelper {
 			}
 		}
 
-		private CompletableFuture<?> executeWork(SearchIndexer indexer, Work w) {
+		private CompletionStage<?> executeWork(SearchIndexer indexer, Work w) {
 			switch ( w.workType ) {
 				case ADD:
 					return indexer.add( w.providedId, w.entity );

--- a/jqassistant/rules.xml
+++ b/jqassistant/rules.xml
@@ -265,53 +265,43 @@
         ]]></cypher>
     </concept>
 
-    <constraint id="hsearch:PublicTypesMayNotExtendInternalTypes">
+    <constraint id="hsearch:PublicTypesMayNotExposeInternalTypes">
         <requiresConcept refId="hsearch:Public" />
         <requiresConcept refId="hsearch:Impl" />
-        <description>API/SPI types must not extend/implement internal types.</description>
+        <description>API/SPI types must not expose internal types.</description>
         <cypher><![CDATA[
+            // supertypes
             MATCH
-                (type:Type:Public)-[:EXTENDS|:IMPLEMENTS]->(supertype:Type:Impl)
+                (type:Type:Public)-[:EXTENDS|:IMPLEMENTS]->(superType:Type:Impl)
             RETURN
-                type
-        ]]></cypher>
-    </constraint>
+                type AS ExposingSite, superType AS ExposedType
 
-    <constraint id="hsearch:PublicMethodsMayNotExposeInternalTypes">
-        <requiresConcept refId="hsearch:Public" />
-        <requiresConcept refId="hsearch:Impl" />
-        <description>API/SPI methods must not expose internal types.</description>
-        <cypher><![CDATA[
             // return values
+            UNION ALL
             MATCH
-                (type:Type:Public)-[:DECLARES]->(method)-[:RETURNS]->(returntype:Type:Impl)
+                (type:Type:Public)-[:DECLARES]->(method)-[:RETURNS]->(returnType:Type:Impl)
             WHERE
                 (method.visibility="public" OR method.visibility="protected")
             RETURN
-                method
+                method AS ExposingSite, returnType AS ExposedType
 
             // parameters
             UNION ALL
             MATCH
-                (type:Type:Public)-[:DECLARES]->(method)-[:HAS]->(parameter)-[:OF_TYPE]->(parametertype:Type:Impl)
+                (type:Type:Public)-[:DECLARES]->(method)-[:HAS]->(parameter)-[:OF_TYPE]->(parameterType:Type:Impl)
             WHERE
                 (method.visibility="public" OR method.visibility="protected")
             RETURN
-                method
-        ]]></cypher>
-    </constraint>
+                method AS ExposingSite, parameterType AS ExposedType
 
-    <constraint id="hsearch:PublicFieldsMayNotExposeInternalTypes">
-        <requiresConcept refId="hsearch:Public" />
-        <requiresConcept refId="hsearch:Impl" />
-        <description>API/SPI fields must not expose internal types.</description>
-        <cypher><![CDATA[
+            // fields
+            UNION ALL
             MATCH
-                (type:Type:Public)-[:DECLARES]->(field)-[:OF_TYPE]->(fieldtype:Type:Impl)
+                (type:Type:Public)-[:DECLARES]->(field)-[:OF_TYPE]->(fieldType:Type:Impl)
             WHERE
                 (field.visibility="public" OR field.visibility="protected")
             RETURN
-                field
+                field AS ExposingSite, fieldType AS ExposedType
         ]]></cypher>
     </constraint>
 
@@ -350,57 +340,47 @@
         ]]></cypher>
     </constraint>
 
-    <constraint id="hsearch:APITypesMayNotExtendSPITypes">
+    <constraint id="hsearch:APITypesMayNotExposeSPITypes">
         <requiresConcept refId="hsearch:Api" />
         <requiresConcept refId="hsearch:Spi" />
-        <description>API types must not extend/implement SPI types.</description>
+        <description>API types must not expose SPI types.</description>
         <cypher><![CDATA[
+            // supertypes
             MATCH
-                (type:Type:Api)-[:EXTENDS|:IMPLEMENTS]->(supertype:Type:Spi)
+                (type:Type:Api)-[:EXTENDS|:IMPLEMENTS]->(superType:Type:Spi)
             RETURN
-                type
-        ]]></cypher>
-    </constraint>
+                type AS ExposingSite, superType AS ExposedType
 
-    <constraint id="hsearch:APIMethodsMayNotExposeSPITypes">
-        <requiresConcept refId="hsearch:Api" />
-        <requiresConcept refId="hsearch:Spi" />
-        <description>API methods must not expose SPI types.</description>
-        <cypher><![CDATA[
-            // return values
-            MATCH
-                (type:Type:Api)-[:DECLARES]->(method)-[:RETURNS]->(returntype:Type:Spi)
-            WHERE
-                (method.visibility="public" OR method.visibility="protected")
-                // Exclude extensions from SPI leak rules: they are *meant* to allow SPI leaks
-                AND NOT type.name =~ ".*Extension"
-            RETURN
-                method
-
-            // parameters
+            // method return values
             UNION ALL
             MATCH
-                (type:Type:Api)-[:DECLARES]->(method)-[:HAS]->(parameter)-[:OF_TYPE]->(parametertype:Type:Spi)
+                (type:Type:Api)-[:DECLARES]->(method)-[:RETURNS]->(returnType:Type:Spi)
             WHERE
                 (method.visibility="public" OR method.visibility="protected")
                 // Exclude extensions from SPI leak rules: they are *meant* to allow SPI leaks
                 AND NOT type.name =~ ".*Extension"
             RETURN
-                method
-        ]]></cypher>
-    </constraint>
+                method AS ExposingSite, returnType AS ExposedType
 
-    <constraint id="hsearch:APIFieldsMayNotExposeSPITypes">
-        <requiresConcept refId="hsearch:Api" />
-        <requiresConcept refId="hsearch:Spi" />
-        <description>API fields must not expose SPI types.</description>
-        <cypher><![CDATA[
+            // method parameters
+            UNION ALL
             MATCH
-                (type:Type:Api)-[:DECLARES]->(field)-[:OF_TYPE]->(fieldtype:Type:Spi)
+                (type:Type:Api)-[:DECLARES]->(method)-[:HAS]->(parameter)-[:OF_TYPE]->(parameterType:Type:Spi)
+            WHERE
+                (method.visibility="public" OR method.visibility="protected")
+                // Exclude extensions from SPI leak rules: they are *meant* to allow SPI leaks
+                AND NOT type.name =~ ".*Extension"
+            RETURN
+                method AS ExposingSite, parameterType AS ExposedType
+
+            // fields
+            UNION ALL
+            MATCH
+                (type:Type:Api)-[:DECLARES]->(field)-[:OF_TYPE]->(fieldType:Type:Spi)
             WHERE
                 (field.visibility="public" OR field.visibility="protected")
             RETURN
-                field
+                field AS ExposingSite, fieldType AS ExposedType
         ]]></cypher>
     </constraint>
 
@@ -659,13 +639,9 @@
     </constraint>
 
     <group id="default">
-        <includeConstraint refId="hsearch:PublicTypesMayNotExtendInternalTypes" />
-        <includeConstraint refId="hsearch:PublicMethodsMayNotExposeInternalTypes" />
-        <includeConstraint refId="hsearch:PublicFieldsMayNotExposeInternalTypes" />
+        <includeConstraint refId="hsearch:PublicTypesMayNotExposeInternalTypes" />
         <includeConstraint refId="hsearch:PublicTypesMayNotDeclareMethodsWithGetOrSetPrefix" />
-        <includeConstraint refId="hsearch:APITypesMayNotExtendSPITypes" />
-        <includeConstraint refId="hsearch:APIMethodsMayNotExposeSPITypes" />
-        <includeConstraint refId="hsearch:APIFieldsMayNotExposeSPITypes" />
+        <includeConstraint refId="hsearch:APITypesMayNotExposeSPITypes" />
         <includeConstraint refId="hsearch:TypesMayNotDependOnImplementationTypeFromOtherModules" />
         <includeConstraint refId="hsearch:TypesShouldUseImplSuffixWithRestraint" />
         <includeConstraint refId="hsearch:AbstractTypesShouldUseAbstractPrefix" />

--- a/jqassistant/rules.xml
+++ b/jqassistant/rules.xml
@@ -384,6 +384,59 @@
         ]]></cypher>
     </constraint>
 
+
+    <constraint id="hsearch:APITypesMayNotExposeForbiddenTypes">
+        <requiresConcept refId="hsearch:Api" />
+        <requiresConcept refId="hsearch:Spi" />
+        <description>
+            API types must not expose forbidden types:
+            - CompletableFuture: expose CompletionStage instead.
+              The corresponding CompletableFuture can be retrieved with '.toCompletableFuture()'.
+        </description>
+        <cypher><![CDATA[
+            // supertypes
+            MATCH
+                (type:Type:Api)-[:EXTENDS|:IMPLEMENTS*]->(superType:Type)
+            WHERE
+                superType.fqn = "java.util.concurrent.CompletableFuture"
+            RETURN
+                type AS ExposingSite, superType AS ExposedType
+
+            // method return values
+            UNION ALL
+            MATCH
+                (type:Type:Api)-[:DECLARES]->(method)-[:RETURNS]->(returnType:Type)
+                        -[:EXTENDS|:IMPLEMENTS*0..]->(returnTypeOrSuperType:Type)
+            WHERE
+                (method.visibility="public" OR method.visibility="protected")
+                AND returnTypeOrSuperType.fqn = "java.util.concurrent.CompletableFuture"
+            RETURN
+                method AS ExposingSite, returnTypeOrSuperType AS ExposedType
+
+            // method parameters
+            UNION ALL
+            MATCH
+                (type:Type:Api)-[:DECLARES]->(method)-[:HAS]->(parameter)-[:OF_TYPE]->(parameterType:Type)
+                        -[:EXTENDS|:IMPLEMENTS*0..]->(parameterTypeOrSuperType:Type)
+            WHERE
+                (method.visibility="public" OR method.visibility="protected")
+                AND parameterTypeOrSuperType.fqn = "java.util.concurrent.CompletableFuture"
+            RETURN
+                method AS ExposingSite, parameterTypeOrSuperType AS ExposedType
+
+            // fields
+            UNION ALL
+            MATCH
+                (type:Type:Api)-[:DECLARES]->(field)-[:OF_TYPE]->(fieldType:Type)
+                        -[:EXTENDS|:IMPLEMENTS*0..]->(fieldTypeOrSuperType:Type)
+            WHERE
+                (field.visibility="public" OR field.visibility="protected")
+                AND fieldTypeOrSuperType.fqn = "java.util.concurrent.CompletableFuture"
+            RETURN
+                field AS ExposingSite, fieldTypeOrSuperType AS ExposedType
+        ]]></cypher>
+    </constraint>
+
     <constraint id="hsearch:TypesMayNotDependOnImplementationTypeFromOtherModules">
         <requiresConcept refId="hsearch:UtilArtifacts" />
         <requiresConcept refId="hsearch:Main" />
@@ -642,6 +695,7 @@
         <includeConstraint refId="hsearch:PublicTypesMayNotExposeInternalTypes" />
         <includeConstraint refId="hsearch:PublicTypesMayNotDeclareMethodsWithGetOrSetPrefix" />
         <includeConstraint refId="hsearch:APITypesMayNotExposeSPITypes" />
+        <includeConstraint refId="hsearch:APITypesMayNotExposeForbiddenTypes" />
         <includeConstraint refId="hsearch:TypesMayNotDependOnImplementationTypeFromOtherModules" />
         <includeConstraint refId="hsearch:TypesShouldUseImplSuffixWithRestraint" />
         <includeConstraint refId="hsearch:AbstractTypesShouldUseAbstractPrefix" />

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/SearchIndexer.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/SearchIndexer.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.mapper.javabean.work;
 
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * An interface for indexing entities in the context of a session.
@@ -25,9 +25,9 @@ public interface SearchIndexer {
 	 * Shorthand for {@code add(null, null)}; see {@link #add(Object, String, Object)}.
 	 *
 	 * @param entity The entity to add to the index.
-	 * @return A {@link CompletableFuture} reflecting the completion state of the operation.
+	 * @return A {@link CompletionStage} reflecting the completion state of the operation.
 	 */
-	default CompletableFuture<?> add(Object entity) {
+	default CompletionStage<?> add(Object entity) {
 		return add( null, null, entity );
 	}
 
@@ -42,9 +42,9 @@ public interface SearchIndexer {
 	 * Generally the expected value is the entity ID, but a different value may be expected depending on the mapping.
 	 * If {@code null}, Hibernate Search will attempt to extract the ID from the entity.
 	 * @param entity The entity to add to the index.
-	 * @return A {@link CompletableFuture} reflecting the completion state of the operation.
+	 * @return A {@link CompletionStage} reflecting the completion state of the operation.
 	 */
-	default CompletableFuture<?> add(Object providedId, Object entity) {
+	default CompletionStage<?> add(Object providedId, Object entity) {
 		return add( providedId, null, entity );
 	}
 
@@ -63,9 +63,9 @@ public interface SearchIndexer {
 	 * Leave {@code null} if sharding is disabled
 	 * or to have Hibernate Search compute the value through the assigned {@link org.hibernate.search.mapper.pojo.bridge.RoutingBridge}.
 	 * @param entity The entity to add to the index.
-	 * @return A {@link CompletableFuture} reflecting the completion state of the operation.
+	 * @return A {@link CompletionStage} reflecting the completion state of the operation.
 	 */
-	CompletableFuture<?> add(Object providedId, String providedRoutingKey, Object entity);
+	CompletionStage<?> add(Object providedId, String providedRoutingKey, Object entity);
 
 	/**
 	 * Update an entity in the index, or add it if it's absent from the index.
@@ -75,9 +75,9 @@ public interface SearchIndexer {
 	 * Shorthand for {@code addOrUpdate(null, null, entity)}; see {@link #addOrUpdate(Object, String, Object)}.
 	 *
 	 * @param entity The entity to add to the index.
-	 * @return A {@link CompletableFuture} reflecting the completion state of the operation.
+	 * @return A {@link CompletionStage} reflecting the completion state of the operation.
 	 */
-	default CompletableFuture<?> addOrUpdate(Object entity) {
+	default CompletionStage<?> addOrUpdate(Object entity) {
 		return addOrUpdate( null, null, entity );
 	}
 
@@ -92,9 +92,9 @@ public interface SearchIndexer {
 	 * Generally the expected value is the entity ID, but a different value may be expected depending on the mapping.
 	 * If {@code null}, Hibernate Search will attempt to extract the ID from the entity.
 	 * @param entity The entity to update in the index.
-	 * @return A {@link CompletableFuture} reflecting the completion state of the operation.
+	 * @return A {@link CompletionStage} reflecting the completion state of the operation.
 	 */
-	default CompletableFuture<?> addOrUpdate(Object providedId, Object entity) {
+	default CompletionStage<?> addOrUpdate(Object providedId, Object entity) {
 		return addOrUpdate( providedId, null, entity );
 	}
 
@@ -110,9 +110,9 @@ public interface SearchIndexer {
 	 * Leave {@code null} if sharding is disabled
 	 * or to have Hibernate Search compute the value through the assigned {@link org.hibernate.search.mapper.pojo.bridge.RoutingBridge}.
 	 * @param entity The entity to update in the index.
-	 * @return A {@link CompletableFuture} reflecting the completion state of the operation.
+	 * @return A {@link CompletionStage} reflecting the completion state of the operation.
 	 */
-	CompletableFuture<?> addOrUpdate(Object providedId, String providedRoutingKey, Object entity);
+	CompletionStage<?> addOrUpdate(Object providedId, String providedRoutingKey, Object entity);
 
 	/**
 	 * Delete an entity from the index.
@@ -122,9 +122,9 @@ public interface SearchIndexer {
 	 * Shorthand for {@code delete(null, null, entity)}; see {@link #delete(Object, String, Object)}.
 	 *
 	 * @param entity The entity to add to the index.
-	 * @return A {@link CompletableFuture} reflecting the completion state of the operation.
+	 * @return A {@link CompletionStage} reflecting the completion state of the operation.
 	 */
-	default CompletableFuture<?> delete(Object entity) {
+	default CompletionStage<?> delete(Object entity) {
 		return delete( null, entity );
 	}
 
@@ -139,9 +139,9 @@ public interface SearchIndexer {
 	 * Generally the expected value is the entity ID, but a different value may be expected depending on the mapping.
 	 * If {@code null}, Hibernate Search will attempt to extract the ID from the entity.
 	 * @param entity The entity to delete from the index.
-	 * @return A {@link CompletableFuture} reflecting the completion state of the operation.
+	 * @return A {@link CompletionStage} reflecting the completion state of the operation.
 	 */
-	default CompletableFuture<?> delete(Object providedId, Object entity) {
+	default CompletionStage<?> delete(Object providedId, Object entity) {
 		return delete( providedId, null, entity );
 	}
 
@@ -159,9 +159,9 @@ public interface SearchIndexer {
 	 * Leave {@code null} if sharding is disabled
 	 * or to have Hibernate Search compute the value through the assigned {@link org.hibernate.search.mapper.pojo.bridge.RoutingBridge}.
 	 * @param entity The entity to delete from the index.
-	 * @return A {@link CompletableFuture} reflecting the completion state of the operation.
+	 * @return A {@link CompletionStage} reflecting the completion state of the operation.
 	 */
-	CompletableFuture<?> delete(Object providedId, String providedRoutingKey, Object entity);
+	CompletionStage<?> delete(Object providedId, String providedRoutingKey, Object entity);
 
 	/**
 	 * Purge an entity from the index.
@@ -174,8 +174,8 @@ public interface SearchIndexer {
 	 * @param providedId A value to extract the document ID from.
 	 * @param providedRoutingKey The routing key to route the purge request to the appropriate index shard.
 	 * Leave {@code null} if sharding is disabled or if you don't use a custom {@link org.hibernate.search.mapper.pojo.bridge.RoutingBridge}.
-	 * @return A {@link CompletableFuture} reflecting the completion state of the operation.
+	 * @return A {@link CompletionStage} reflecting the completion state of the operation.
 	 */
-	CompletableFuture<?> purge(Class<?> entityClass, Object providedId, String providedRoutingKey);
+	CompletionStage<?> purge(Class<?> entityClass, Object providedId, String providedRoutingKey);
 
 }

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexerImpl.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexerImpl.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.mapper.javabean.work.impl;
 
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
@@ -32,25 +32,25 @@ public class SearchIndexerImpl implements SearchIndexer {
 	}
 
 	@Override
-	public CompletableFuture<?> add(Object providedId, String providedRoutingKey, Object entity) {
+	public CompletionStage<?> add(Object providedId, String providedRoutingKey, Object entity) {
 		return delegate.add( getTypeIdentifier( entity ), providedId, providedRoutingKey, entity,
 				commitStrategy, refreshStrategy );
 	}
 
 	@Override
-	public CompletableFuture<?> addOrUpdate(Object providedId, String providedRoutingKey, Object entity) {
+	public CompletionStage<?> addOrUpdate(Object providedId, String providedRoutingKey, Object entity) {
 		return delegate.addOrUpdate( getTypeIdentifier( entity ), providedId, providedRoutingKey, entity,
 				commitStrategy, refreshStrategy );
 	}
 
 	@Override
-	public CompletableFuture<?> delete(Object providedId, String providedRoutingKey, Object entity) {
+	public CompletionStage<?> delete(Object providedId, String providedRoutingKey, Object entity) {
 		return delegate.delete( getTypeIdentifier( entity ), providedId, providedRoutingKey, entity,
 				commitStrategy, refreshStrategy );
 	}
 
 	@Override
-	public CompletableFuture<?> purge(Class<?> entityClass, Object providedId, String providedRoutingKey) {
+	public CompletionStage<?> purge(Class<?> entityClass, Object providedId, String providedRoutingKey) {
 		return delegate.purge( getTypeIdentifier( entityClass ), providedId, providedRoutingKey,
 				commitStrategy, refreshStrategy );
 	}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/MassIndexer.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/MassIndexer.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.mapper.orm.massindexing;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.hibernate.CacheMode;
 import org.hibernate.search.util.common.annotation.Incubating;
@@ -121,9 +122,11 @@ public interface MassIndexer {
 	 * Starts the indexing process in background (asynchronous).
 	 * <p>
 	 * May only be called once.
-	 * @return a Future to control the indexing task.
+	 * @return a {@link java.util.concurrent.CompletionStage} to react to the completion of the indexing task.
+	 * Call {@link CompletionStage#toCompletableFuture()} on the returned object
+	 * to convert it to a {@link CompletableFuture} (which implements {@link java.util.concurrent.Future}).
 	 */
-	CompletableFuture<?> start();
+	CompletionStage<?> start();
 
 	/**
 	 * Starts the indexing process, and then block until it's finished.

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/SearchWorkspace.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/SearchWorkspace.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.mapper.orm.work;
 
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * The entry point for explicit index operations.
@@ -34,10 +34,10 @@ public interface SearchWorkspace {
 	/**
 	 * Asynchronous version of {@link #purge()}, returning as soon as the operation is queued.
 	 *
-	 * @return A {@link CompletableFuture} reflecting the completion state of the operation.
+	 * @return A {@link CompletionStage} reflecting the completion state of the operation.
 	 * @see #purge()
 	 */
-	CompletableFuture<?> purgeAsync();
+	CompletionStage<?> purgeAsync();
 
 	/**
 	 * Delete documents from indexes targeted by this workspace
@@ -56,10 +56,10 @@ public interface SearchWorkspace {
 	 * Asynchronous version of {@link #purge(Set)}, returning as soon as the operation is queued.
 	 *
 	 * @param routingKeys The set of routing keys.
-	 * @return A {@link CompletableFuture} reflecting the completion state of the operation.
+	 * @return A {@link CompletionStage} reflecting the completion state of the operation.
 	 * @see #purge(Set)
 	 */
-	CompletableFuture<?> purgeAsync(Set<String> routingKeys);
+	CompletionStage<?> purgeAsync(Set<String> routingKeys);
 
 	/**
 	 * Flush to disk the changes to indexes that were not committed yet.
@@ -80,10 +80,10 @@ public interface SearchWorkspace {
 	/**
 	 * Asynchronous version of {@link #flush()}, returning as soon as the operation is queued.
 	 *
-	 * @return A {@link CompletableFuture} reflecting the completion state of the operation.
+	 * @return A {@link CompletionStage} reflecting the completion state of the operation.
 	 * @see #flush()
 	 */
-	CompletableFuture<?> flushAsync();
+	CompletionStage<?> flushAsync();
 
 	/**
 	 * Refresh the indexes so that all changes executed so far will be visible in search queries.
@@ -104,10 +104,10 @@ public interface SearchWorkspace {
 	/**
 	 * Asynchronous version of {@link #refresh()}, returning as soon as the operation is queued.
 	 *
-	 * @return A {@link CompletableFuture} reflecting the completion state of the operation.
+	 * @return A {@link CompletionStage} reflecting the completion state of the operation.
 	 * @see #refresh()
 	 */
-	CompletableFuture<?> refreshAsync();
+	CompletionStage<?> refreshAsync();
 
 	/**
 	 * Merge all segments of the indexes targeted by this workspace into a single one.
@@ -123,9 +123,9 @@ public interface SearchWorkspace {
 	 * Note this operation may affect performance positively as well as negatively.
 	 * See the reference documentation for more information.
 	 *
-	 * @return A {@link CompletableFuture} reflecting the completion state of the operation.
+	 * @return A {@link CompletionStage} reflecting the completion state of the operation.
 	 * @see #mergeSegments()
 	 */
-	CompletableFuture<?> mergeSegmentsAsync();
+	CompletionStage<?> mergeSegmentsAsync();
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -2131,20 +2131,6 @@
                         <groupId>com.buschmais.jqassistant</groupId>
                         <artifactId>jqassistant-maven-plugin</artifactId>
                         <version>${version.com.buschmais.jqassistant.plugin}</version>
-                        <!--
-                            HSEARCH-3437: ALWAYS use extensions, otherwise the build of each module uses
-                            a different classloader to load classes,
-                            and we end up with some executions using a different definition of internal classes,
-                            and it wreaks havoc in the context shared between the executions.
-                            In particular it messes up the "executedModules" map,
-                            because keys that should be equal no longer are due to their class not being equal.
-                            In short: don't change this without extensive testing.
-
-                            An unfortunate side-effect is that commands such as
-                                mvn jqassistant:server -Pjqassistant -pl reports
-                            will not work anymore, so we need to use a different profile for that (see jqassistant-server).
-                         -->
-                        <extensions>true</extensions>
                         <executions>
                             <execution>
                                 <goals>
@@ -2152,8 +2138,6 @@
                                     <goal>analyze</goal>
                                 </goals>
                                 <configuration>
-                                    <!-- Necessary when using extensions (see above) -->
-                                    <storeLifecycle>MODULE</storeLifecycle>
                                     <warnOnSeverity>INFO</warnOnSeverity>
                                     <failOnSeverity>MAJOR</failOnSeverity>
                                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -2148,30 +2148,6 @@
             </build>
         </profile>
 
-        <!--
-            A profile for debugging the jqassistant rules.
-            This is only necessary because we have to use extensions in the jqassistant profile (above),
-            and extensions seem to mess with explicit use of the jqassistant:server goal,
-            which doesn't work anymore.
-            So this profile just enables jqassistant, but without extensions.
-        -->
-        <profile>
-            <id>jqassistant-server</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.buschmais.jqassistant</groupId>
-                        <artifactId>jqassistant-maven-plugin</artifactId>
-                        <version>${version.com.buschmais.jqassistant.plugin}</version>
-                        <!--
-                             Do NOT enable extensions.
-                         -->
-                        <extensions>false</extensions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
         <profile>
             <id>owasp</id>
             <build>

--- a/util/common/src/main/java/org/hibernate/search/util/common/impl/Futures.java
+++ b/util/common/src/main/java/org/hibernate/search/util/common/impl/Futures.java
@@ -12,6 +12,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
@@ -201,7 +202,7 @@ public final class Futures {
 	 * @throws RuntimeException If the future fails.
 	 * @throws InterruptedException If the thread is interrupted.
 	 */
-	public static <T> T unwrappedExceptionGet(CompletableFuture<T> future) throws InterruptedException {
+	public static <T> T unwrappedExceptionGet(Future<T> future) throws InterruptedException {
 		try {
 			return future.get();
 		}

--- a/util/internal/test/src/main/java/org/hibernate/search/util/impl/test/FutureAssert.java
+++ b/util/internal/test/src/main/java/org/hibernate/search/util/impl/test/FutureAssert.java
@@ -9,6 +9,8 @@ package org.hibernate.search.util.impl.test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -24,6 +26,14 @@ public class FutureAssert<T> extends AbstractObjectAssert<FutureAssert<T>, Futur
 
 	public static <T> FutureAssert<T> assertThatFuture(Future<T> future) {
 		return new FutureAssert<>( future );
+	}
+
+	public static <T> FutureAssert<T> assertThatFuture(CompletableFuture<T> future) {
+		return assertThatFuture( (Future<T>) future );
+	}
+
+	public static <T> FutureAssert<T> assertThatFuture(CompletionStage<T> stage) {
+		return assertThatFuture( stage.toCompletableFuture() );
 	}
 
 	protected FutureAssert(Future<T> actual) {

--- a/v5migrationhelper/orm/src/main/java/org/hibernate/search/massindexing/impl/V5MigrationMassIndexerAdapter.java
+++ b/v5migrationhelper/orm/src/main/java/org/hibernate/search/massindexing/impl/V5MigrationMassIndexerAdapter.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.massindexing.impl;
 
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 
 import org.hibernate.CacheMode;
 import org.hibernate.search.MassIndexer;
@@ -71,8 +71,8 @@ public class V5MigrationMassIndexerAdapter implements MassIndexer {
 	}
 
 	@Override
-	public CompletableFuture<?> start() {
-		return delegate.start();
+	public Future<?> start() {
+		return delegate.start().toCompletableFuture();
 	}
 
 	@Override


### PR DESCRIPTION
* [HSEARCH-4083](https://hibernate.atlassian.net/browse/HSEARCH-4083): JQassistant does not collect any information from modules
* [HSEARCH-3402](https://hibernate.atlassian.net/browse/HSEARCH-3402): Search 6 groundwork - Apply recommendations from Async/reactive development experts for our async APIs

