### PR TITLE
HSEARCH-4051 Restore support for configuring a path prefix for Elasticsearch backend

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchBackendSettings.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchBackendSettings.java
@@ -59,6 +59,14 @@ public final class ElasticsearchBackendSettings {
 	public static final String PROTOCOL = "protocol";
 
 	/**
+	 * Property for specifying the path prefix prepended to the request end point.
+	 * Use the path prefix if your Elasticsearch instance is located at a specific context path.
+	 * <p>
+	 * Defaults to {@link Defaults#PATH_PREFIX}.
+	 */
+	public static final String PATH_PREFIX = "path_prefix";
+
+	/**
 	 * The version of Elasticsearch running on the Elasticsearch cluster.
 	 * <p>
 	 * Expects either an {@link ElasticsearchVersion} object,
@@ -250,6 +258,7 @@ public final class ElasticsearchBackendSettings {
 
 		public static final List<String> HOSTS = Collections.singletonList( "localhost:9200" );
 		public static final String PROTOCOL = "http";
+		public static final String PATH_PREFIX = "";
 		public static final int READ_TIMEOUT = 30000;
 		public static final int CONNECTION_TIMEOUT = 1000;
 		public static final int MAX_CONNECTIONS = 20;

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/impl/ElasticsearchClientFactoryImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/client/impl/ElasticsearchClientFactoryImpl.java
@@ -75,6 +75,12 @@ public class ElasticsearchClientFactoryImpl implements ElasticsearchClientFactor
 					.withDefault( ElasticsearchBackendSettings.Defaults.PROTOCOL )
 					.build();
 
+	private static final ConfigurationProperty<String> PATH_PREFIX =
+			ConfigurationProperty.forKey( ElasticsearchBackendSettings.PATH_PREFIX )
+					.asString()
+					.withDefault( ElasticsearchBackendSettings.Defaults.PATH_PREFIX )
+					.build();
+
 	private static final OptionalConfigurationProperty<String> USERNAME =
 			ConfigurationProperty.forKey( ElasticsearchBackendSettings.USERNAME )
 					.asString()

--- a/documentation/src/main/asciidoc/reference/backend-elasticsearch.asciidoc
+++ b/documentation/src/main/asciidoc/reference/backend-elasticsearch.asciidoc
@@ -102,6 +102,15 @@ hibernate.search.backend.protocol = http (default)
 
 This property may be set to either `http` or `https`.
 
+Optional you may provide a path prefix for the Elasticsearch instance.
+
+[source]
+----
+hibernate.search.backend.path_prefix = # default empty string
+----
+
+The path will be added at each http request path, just after the protocol.
+
 [[backend-elasticsearch-configuration-discovery]]
 === Node discovery
 

--- a/documentation/src/main/asciidoc/reference/backend-elasticsearch.asciidoc
+++ b/documentation/src/main/asciidoc/reference/backend-elasticsearch.asciidoc
@@ -79,6 +79,7 @@ which needs to be enabled explicitly.
 An Elasticsearch backend communicates with an Elasticsearch cluster through a REST client.
 Below are the options that affect this client.
 
+[[backend-elasticsearch-configuration-hosts]]
 === Target hosts
 
 The following property configures the Elasticsearch host (or hosts)
@@ -102,14 +103,24 @@ hibernate.search.backend.protocol = http (default)
 
 This property may be set to either `http` or `https`.
 
-Optional you may provide a path prefix for the Elasticsearch instance.
+[[backend-elasticsearch-configuration-path-prefix]]
+=== Path prefix
+
+By default, the REST API is expected to be available to the root path (`/`).
+For example a search query target all indexes will be sent to path `/_search`.
+This is what you need for a standard Elasticsearch setup.
+
+If your setup is non-standard, for example because of a non-transparent proxy
+between the application and the Elasticsearch cluster,
+you can use a configuration similar to this:
 
 [source]
 ----
-hibernate.search.backend.path_prefix = # default empty string
+hibernate.search.backend.path_prefix = my/path
 ----
 
-The path will be added at each http request path, just after the protocol.
+With the above, a search query targeting all indexes will be sent to path `/my/path/_search` instead of `/_search`.
+The path will be prefixed similarly for all requests sent to Elasticsearch.
 
 [[backend-elasticsearch-configuration-discovery]]
 === Node discovery


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4051