### PR TITLE
HSEARCH-4101 Change default required status for Elasticsearch indexes to "yellow"

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchIndexSettings.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/cfg/ElasticsearchIndexSettings.java
@@ -130,7 +130,7 @@ public final class ElasticsearchIndexSettings {
 		private Defaults() {
 		}
 
-		public static final IndexStatus SCHEMA_MANAGEMENT_MINIMAL_REQUIRED_STATUS = IndexStatus.GREEN;
+		public static final IndexStatus SCHEMA_MANAGEMENT_MINIMAL_REQUIRED_STATUS = IndexStatus.YELLOW;
 		public static final int SCHEMA_MANAGEMENT_MINIMAL_REQUIRED_STATUS_WAIT_TIMEOUT = 10_000;
 		public static final int INDEXING_QUEUE_COUNT = 10;
 		public static final int INDEXING_QUEUE_SIZE = 1000;

--- a/documentation/src/main/asciidoc/reference/backend-elasticsearch.asciidoc
+++ b/documentation/src/main/asciidoc/reference/backend-elasticsearch.asciidoc
@@ -348,7 +348,7 @@ hibernate.search.backend.indexes.<index name>.schema_management.minimal_required
 ----
 
 * `minimal_required_status` defines the minimal required status of an index before creation is considered complete.
-The default for this property is `green`.
+The default for this property is `yellow`.
 * `minimal_required_status_wait_timeout` defines the maximum time to wait for this status,
 as an <<configuration-property-types,integer value>> in milliseconds.
 The default for this property is `10000`.

--- a/documentation/src/test/resources/META-INF/persistence.xml
+++ b/documentation/src/test/resources/META-INF/persistence.xml
@@ -81,9 +81,6 @@
                       value="${test.elasticsearch.connection.aws.credentials.access_key_id}"/>
             <property name="hibernate.search.backend.aws.credentials.secret_access_key"
                       value="${test.elasticsearch.connection.aws.credentials.secret_access_key}"/>
-            <!-- Make this test work even if there is only a single node in the cluster -->
-            <property name="hibernate.search.backend.schema_management.minimal_required_status"
-                      value="yellow"/>
             <property name="hibernate.search.automatic_indexing.synchronization.strategy"
                       value="sync"/>
         </properties>
@@ -149,9 +146,6 @@
                       value="${test.elasticsearch.connection.aws.credentials.access_key_id}"/>
             <property name="hibernate.search.backend.aws.credentials.secret_access_key"
                       value="${test.elasticsearch.connection.aws.credentials.secret_access_key}"/>
-            <!-- Make this test work even if there is only a single node in the cluster -->
-            <property name="hibernate.search.backend.schema_management.minimal_required_status"
-                      value="yellow"/>
             <property name="hibernate.search.automatic_indexing.synchronization.strategy"
                       value="sync"/>
         </properties>

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendSetupStrategy.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendSetupStrategy.java
@@ -27,7 +27,6 @@ class ElasticsearchTckBackendSetupStrategy implements TckBackendSetupStrategy {
 	ElasticsearchTckBackendSetupStrategy() {
 		setProperty( "log.json_pretty_printing", "true" );
 		setProperty( "analysis.configurer", DefaultITAnalysisConfigurer.class.getName() );
-		setProperty( "schema_management.minimal_required_status", "yellow" );
 		// Always add configuration options that allow to connect to Elasticsearch
 		ElasticsearchTestHostConnectionConfiguration.get().addToBackendProperties( properties );
 	}

--- a/integrationtest/jdk/java-modules/src/main/resources/hibernate.properties
+++ b/integrationtest/jdk/java-modules/src/main/resources/hibernate.properties
@@ -24,5 +24,4 @@ hibernate.search.backend.aws.credentials.type = ${test.elasticsearch.connection.
 hibernate.search.backend.aws.credentials.access_key_id = ${test.elasticsearch.connection.aws.credentials.access_key_id}
 hibernate.search.backend.aws.credentials.secret_access_key = ${test.elasticsearch.connection.aws.credentials.secret_access_key}
 hibernate.search.backend.log.json_pretty_printing = true
-hibernate.search.backend.schema_management.minimal_required_status = yellow
 hibernate.search.backend.analysis.configurer = org.hibernate.search.integrationtest.java.module.config.MyElasticsearchAnalysisConfigurer

--- a/integrationtest/mapper/orm-batch-jsr352/src/test/resources/META-INF/persistence.xml
+++ b/integrationtest/mapper/orm-batch-jsr352/src/test/resources/META-INF/persistence.xml
@@ -48,7 +48,6 @@
             <property name="hibernate.search.backend.aws.credentials.access_key_id" value="${test.elasticsearch.connection.aws.credentials.access_key_id}" />
             <property name="hibernate.search.backend.aws.credentials.secret_access_key" value="${test.elasticsearch.connection.aws.credentials.secret_access_key}" />
 
-            <property name="hibernate.search.backend.schema_management.minimal_required_status" value="yellow" />
             <property name="hibernate.search.backend.log.json_pretty_printing" value="true" />
         </properties>
     </persistence-unit>

--- a/integrationtest/showcase/library/src/test/resources/application-test-elasticsearch.yaml
+++ b/integrationtest/showcase/library/src/test/resources/application-test-elasticsearch.yaml
@@ -2,5 +2,4 @@ spring.jpa:
   properties:
     hibernate.search:
       backend:
-        schema_management.minimal_required_status: yellow
         log.json_pretty_printing: true

--- a/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/ElasticsearchBackendConfiguration.java
+++ b/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/ElasticsearchBackendConfiguration.java
@@ -33,7 +33,6 @@ public class ElasticsearchBackendConfiguration extends BackendConfiguration {
 	protected Map<String, Object> backendProperties() {
 		Map<String, Object> properties = new LinkedHashMap<>();
 		properties.put( "log.json_pretty_printing", "true" );
-		properties.put( "schema_management.minimal_required_status", "yellow" );
 		ElasticsearchTestHostConnectionConfiguration.get().addToBackendProperties( properties );
 		return properties;
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4101