### PR TITLE
HSEARCH-3821 Improve test coverage for Elasticsearch schema validation

### DIFF
--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerValidationMappingAttributeIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/schema/management/ElasticsearchIndexSchemaManagerValidationMappingAttributeIT.java
@@ -212,6 +212,26 @@ public class ElasticsearchIndexSchemaManagerValidationMappingAttributeIT {
 	}
 
 	@Test
+	public void attribute_index_valid() {
+		StubMappedIndex index = StubMappedIndex.ofNonRetrievable(
+				root -> root.field( "myField", f -> f.asInteger().searchable( Searchable.YES ) ).toReference()
+		);
+
+		elasticSearchClient.index( index.name() ).deleteAndCreate();
+		elasticSearchClient.index( index.name() ).type().putMapping(
+				simpleMappingForInitialization(
+						"'myField': {"
+								+ "'type': 'integer',"
+								+ "'index': true"
+						+ "}"
+				)
+		);
+
+		// the expected value true is the default
+		setupAndValidate( index );
+	}
+
+	@Test
 	public void attribute_index_invalid() {
 		StubMappedIndex index = StubMappedIndex.ofNonRetrievable(
 				root -> root.field( "myField", f -> f.asInteger() ).toReference()


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3821

I also spent some time searching for some cases to cover [JsonElementEquivalence#isObjectEquivalent](https://sonarcloud.io/code?id=org.hibernate.search%3Ahibernate-search-parent&selected=org.hibernate.search%3Ahibernate-search-parent%3Abackend%2Felasticsearch%2Fsrc%2Fmain%2Fjava%2Forg%2Fhibernate%2Fsearch%2Fbackend%2Felasticsearch%2Fvalidation%2Fimpl%2FJsonElementEquivalence.java).
But I didn't find a case for which we have to compare JSON objects, according to the use cases we have had so far.