### PR TITLE
HSEARCH-4106 + HSEARCH-4107 + HSEARCH-4108 Session proxy fixes

### DIFF
--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/DelegationWrapper.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/DelegationWrapper.java
@@ -1,0 +1,40 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.orm.hibernateormapis;
+
+import java.io.Serializable;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.hibernate.Session;
+
+/**
+ * @author Emmanuel Bernard
+ */
+public class DelegationWrapper implements InvocationHandler, Serializable {
+	Object realSession;
+
+	public DelegationWrapper(Session session) {
+		this.realSession = session;
+	}
+
+	@Override
+	public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+		try {
+			return method.invoke( realSession, args );
+		}
+		catch (InvocationTargetException e) {
+			if ( e.getTargetException() instanceof RuntimeException ) {
+				throw (RuntimeException) e.getTargetException();
+			}
+			else {
+				throw e;
+			}
+		}
+	}
+}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToHibernateOrmSessionIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToHibernateOrmSessionIT.java
@@ -68,26 +68,6 @@ public class ToHibernateOrmSessionIT {
 	}
 
 	@Test
-	public void toHibernateOrmSession_withClosedSession() {
-		Session session = null;
-		try {
-			session = sessionFactory.openSession();
-		}
-		finally {
-			if ( session != null ) {
-				session.close();
-			}
-		}
-
-		Session closedSession = session;
-		assertThatThrownBy( () -> {
-			Search.session( closedSession );
-		} )
-				.isInstanceOf( SearchException.class )
-				.hasMessageContaining( "Unable to access Hibernate ORM session" );
-	}
-
-	@Test
 	@TestForIssue( jiraKey = "HSEARCH-1857" )
 	public void reuseSearchSessionAfterOrmSessionIsClosed_noMatching() {
 		Session session = sessionFactory.openSession();
@@ -99,7 +79,7 @@ public class ToHibernateOrmSessionIT {
 
 		assertThatThrownBy( () -> createSimpleQuery( searchSession ) )
 				.isInstanceOf( SearchException.class )
-				.hasMessage( "HSEARCH800017: Underlying Hibernate ORM Session is closed." );
+				.hasMessageContainingAll( "Unable to access Hibernate ORM session", "is closed" );
 	}
 
 	@Test
@@ -111,7 +91,7 @@ public class ToHibernateOrmSessionIT {
 
 		assertThatThrownBy( () -> createSimpleQuery( searchSession ) )
 				.isInstanceOf( SearchException.class )
-				.hasMessage( "HSEARCH800017: Underlying Hibernate ORM Session is closed." );
+				.hasMessageContainingAll( "Unable to access Hibernate ORM session", "is closed" );
 	}
 
 	@Test
@@ -131,7 +111,7 @@ public class ToHibernateOrmSessionIT {
 
 		assertThatThrownBy( () -> query.fetchAllHits() )
 				.isInstanceOf( SearchException.class )
-				.hasMessage( "HSEARCH800017: Underlying Hibernate ORM Session is closed." );
+				.hasMessageContaining( "Underlying Hibernate ORM Session is closed." );
 	}
 
 	private SearchQuery<IndexedEntity> createSimpleQuery(SearchSession searchSession) {

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToJpaEntityManagerIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToJpaEntityManagerIT.java
@@ -96,7 +96,7 @@ public class ToJpaEntityManagerIT {
 
 		assertThatThrownBy( () -> createSimpleQuery( searchSession ) )
 				.isInstanceOf( SearchException.class )
-				.hasMessage( "HSEARCH800017: Underlying Hibernate ORM Session is closed." );
+				.hasMessageContainingAll( "Unable to access Hibernate ORM session", "is closed" );
 	}
 
 	@Test
@@ -108,7 +108,7 @@ public class ToJpaEntityManagerIT {
 
 		assertThatThrownBy( () -> createSimpleQuery( searchSession ) )
 				.isInstanceOf( SearchException.class )
-				.hasMessage( "HSEARCH800017: Underlying Hibernate ORM Session is closed." );
+				.hasMessageContainingAll( "Unable to access Hibernate ORM session", "is closed" );
 	}
 
 	private SearchQuery<IndexedEntity> createSimpleQuery(SearchSession searchSession) {

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToSearchSessionFromSessionProxyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/hibernateormapis/ToSearchSessionFromSessionProxyIT.java
@@ -1,0 +1,202 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.orm.hibernateormapis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.with;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import java.lang.reflect.Proxy;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.SharedSessionContract;
+import org.hibernate.context.internal.ThreadLocalSessionContext;
+import org.hibernate.engine.jdbc.LobCreationContext;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.event.spi.EventSource;
+import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.orm.session.SearchSession;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.util.common.impl.Futures;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
+import org.hibernate.search.util.impl.test.annotation.PortedFromSearch5;
+import org.hibernate.search.util.impl.test.annotation.TestForIssue;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Emmanuel Bernard
+ */
+@PortedFromSearch5(original = "org.hibernate.search.test.session.SessionTest")
+@TestForIssue(jiraKey = "HSEARCH-4108")
+public class ToSearchSessionFromSessionProxyIT {
+
+	//EventSource, org.hibernate.Session, LobCreationContext
+	private static final Class<?>[] SESS_PROXY_INTERFACES = new Class[] {
+			Session.class,
+			LobCreationContext.class,
+			EventSource.class,
+			SessionImplementor.class,
+			SharedSessionContract.class
+	};
+
+	@Rule
+	public BackendMock backendMock = new BackendMock();
+
+	@Rule
+	public OrmSetupHelper setupHelper = OrmSetupHelper.withBackendMock( backendMock );
+
+	private SessionFactory sessionFactory;
+
+	@Before
+	public void setup() {
+		backendMock.expectAnySchema( IndexedEntity.NAME );
+		sessionFactory = setupHelper.start()
+				// for this test we explicitly set the auto commit mode since we are not explicitly starting a transaction
+				// which could be a problem in some databases.
+				.withProperty( "hibernate.connection.autocommit", "true" )
+				//needed for testThreadBoundSessionWrappingOutOfTransaction
+				.withProperty( "hibernate.current_session_context_class", "thread" )
+				.setup( IndexedEntity.class );
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void testSessionWrapper() {
+		with( sessionFactory ).runNoTransaction( s -> {
+			DelegationWrapper wrapper = new DelegationWrapper( s );
+			Session wrapped = (Session) Proxy.newProxyInstance(
+					Session.class.getClassLoader(),
+					SESS_PROXY_INTERFACES,
+					wrapper
+			);
+			try {
+				SearchSession searchSession = Search.session( wrapped );
+				assertNotNull( searchSession );
+				assertThat( searchSession.toEntityManager() ).isSameAs( wrapped );
+				assertThat( searchSession.toOrmSession() ).isSameAs( wrapped );
+			}
+			catch (ClassCastException e) {
+				e.printStackTrace();
+				fail( e.toString() );
+			}
+			wrapped.close();
+		} );
+	}
+
+	@Test
+	public void testThreadBoundSessionWrappingInTransaction() {
+		final Session sessionFromFirstThread = sessionFactory.getCurrentSession();
+		try {
+			OrmUtils.withinTransaction( sessionFromFirstThread, ignored -> {
+				SearchSession searchSessionFromFirstThread = Search.session( sessionFromFirstThread );
+				assertNotNull( searchSessionFromFirstThread );
+				assertThat( searchSessionFromFirstThread.toEntityManager() ).isSameAs( sessionFromFirstThread );
+				assertThat( searchSessionFromFirstThread.toOrmSession() ).isSameAs( sessionFromFirstThread );
+				ThreadPoolExecutor executorService = new ThreadPoolExecutor(
+						1, 1, 0L, TimeUnit.MILLISECONDS,
+						new LinkedBlockingQueue<>( 10 )
+				);
+				CompletableFuture<?> future = Futures.runAsync(
+						() -> {
+							Session sessionFromOtherThread = sessionFactory.getCurrentSession();
+							assertThat( sessionFromOtherThread ).isNotSameAs( sessionFromFirstThread );
+							SearchSession searchSessionFromOtherThread = Search.session( sessionFromOtherThread );
+							assertNotNull( searchSessionFromOtherThread );
+							assertThat( searchSessionFromOtherThread.toEntityManager() ).isSameAs( sessionFromOtherThread );
+							assertThat( searchSessionFromOtherThread.toOrmSession() ).isSameAs( sessionFromOtherThread );
+						},
+						executorService
+				);
+				Futures.unwrappedExceptionJoin( future );
+			} );
+		}
+		finally {
+			//clean up after the mess
+			ThreadLocalSessionContext.unbind( sessionFactory );
+		}
+	}
+
+	@Test
+	public void testThreadBoundSessionWrappingOutOfTransaction() {
+		final Session sessionFromFirstThread = sessionFactory.getCurrentSession();
+		try {
+			SearchSession searchSessionFromFirstThread = Search.session( sessionFromFirstThread );
+			assertNotNull( searchSessionFromFirstThread );
+			assertThat( searchSessionFromFirstThread.toEntityManager() ).isSameAs( sessionFromFirstThread );
+			assertThat( searchSessionFromFirstThread.toOrmSession() ).isSameAs( sessionFromFirstThread );
+			ThreadPoolExecutor executorService = new ThreadPoolExecutor(
+					1, 1, 0L, TimeUnit.MILLISECONDS,
+					new LinkedBlockingQueue<>( 10 )
+			);
+			CompletableFuture<?> future = Futures.runAsync(
+					() -> {
+						Session sessionFromOtherThread = sessionFactory.getCurrentSession();
+						assertThat( sessionFromOtherThread ).isNotSameAs( sessionFromFirstThread );
+						SearchSession searchSessionFromOtherThread = Search.session( sessionFromOtherThread );
+						assertNotNull( searchSessionFromOtherThread );
+						assertThat( searchSessionFromOtherThread.toEntityManager() ).isSameAs( sessionFromOtherThread );
+						assertThat( searchSessionFromOtherThread.toOrmSession() ).isSameAs( sessionFromOtherThread );
+					},
+					executorService
+			);
+			Futures.unwrappedExceptionJoin( future );
+		}
+		finally {
+			//clean up after the mess
+			ThreadLocalSessionContext.unbind( sessionFactory );
+		}
+	}
+
+	@Entity(name = IndexedEntity.NAME)
+	@Indexed
+	public static class IndexedEntity {
+
+		public static final String NAME = "indexed";
+
+		@Id
+		private Integer id;
+
+		@FullTextField
+		private String text;
+
+		@Override
+		public String toString() {
+			return "IndexedEntity[id=" + id + "]";
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getText() {
+			return text;
+		}
+
+		public void setText(String text) {
+			this.text = text;
+		}
+
+	}
+}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingBaseIT.java
@@ -263,7 +263,7 @@ public class MassIndexingBaseIT {
 			searchSession.massIndexer();
 		} )
 				.isInstanceOf( SearchException.class )
-				.hasMessage( "HSEARCH800017: Underlying Hibernate ORM Session is closed." );
+				.hasMessageContainingAll( "Unable to access Hibernate ORM session", "is closed" );
 	}
 
 	@Test
@@ -277,7 +277,7 @@ public class MassIndexingBaseIT {
 			searchSession.massIndexer();
 		} )
 				.isInstanceOf( SearchException.class )
-				.hasMessage( "HSEARCH800017: Underlying Hibernate ORM Session is closed." );
+				.hasMessageContainingAll( "Unable to access Hibernate ORM session", "is closed" );
 	}
 
 	private void initData() {

--- a/integrationtest/showcase/library/pom.xml
+++ b/integrationtest/showcase/library/pom.xml
@@ -44,18 +44,6 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-            <!--
-                junit-vintage-engine 5.5.2 version does not support junit 4.13.1.
-                If we try to use it, a parsing error is thrown.
-                So we downgrade JUnit, so that junit-vintage-engine will handle it.
-                See https://stackoverflow.com/a/64371503/1812965
-            -->
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${version.junit.junit-platform-workaround}</version>
-                <scope>test</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/integrationtest/showcase/library/src/test/java/org/hibernate/search/integrationtest/showcase/library/LibraryShowcaseSessionProxyIT.java
+++ b/integrationtest/showcase/library/src/test/java/org/hibernate/search/integrationtest/showcase/library/LibraryShowcaseSessionProxyIT.java
@@ -1,0 +1,131 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.showcase.library;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import javax.persistence.EntityManager;
+
+import org.hibernate.search.integrationtest.showcase.library.model.Book;
+import org.hibernate.search.integrationtest.showcase.library.service.TestDataService;
+import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.orm.session.SearchSession;
+import org.hibernate.search.util.common.impl.Futures;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.stereotype.Service;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Test that when using an EntityManager proxy that relies on a different underlying EntityManager for each thread,
+ *  one can create a single SearchSession for all threads, and it will correctly use the correct EntityManager
+ *  depending on the current thread.
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@ActiveProfiles(resolver = TestActiveProfilesResolver.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
+public class LibraryShowcaseSessionProxyIT {
+
+	private static boolean needsInit;
+
+	@Autowired
+	private TestDataService testDataService;
+
+	@Autowired
+	private SingleSearchSessionService singleSearchSessionService;
+
+	@Autowired
+	private PlatformTransactionManager transactionManager;
+
+	@BeforeClass
+	public static void beforeClass() {
+		needsInit = true;
+	}
+
+	@Before
+	public void before() {
+		if ( needsInit ) {
+			testDataService.initDefaultDataSet();
+			needsInit = false;
+		}
+	}
+
+	@Test
+	public void search_library() {
+		TransactionTemplate template = new TransactionTemplate( transactionManager );
+
+		template.execute( status -> {
+			Book bookFromThread1_1 = singleSearchSessionService.simulateSearch();
+			assertThat( bookFromThread1_1 ).returns( true, singleSearchSessionService.entityManager::contains );
+
+			// Same call from the same thread and transaction:
+			// the same underlying session is used, so we should get the same entity instance
+			Book bookFromThread1_2 = singleSearchSessionService.simulateSearch();
+			assertThat( bookFromThread1_2 ).returns( bookFromThread1_1.getId(), Book::getId );
+			assertThat( bookFromThread1_2 ).isSameAs( bookFromThread1_1 );
+
+			// Same call from another thread: another underlying session is used, so we should a different entity instance
+			ThreadPoolExecutor executorService = new ThreadPoolExecutor(
+					1, 1, 0L, TimeUnit.MILLISECONDS,
+					new LinkedBlockingQueue<>( 10 )
+			);
+			CompletableFuture<Book> future = CompletableFuture.supplyAsync(
+					() -> template.execute( status2 -> {
+						Book bookFromThread2 = singleSearchSessionService.simulateSearch();
+						assertThat( bookFromThread2 ).returns( true, singleSearchSessionService.entityManager::contains );
+						assertThat( bookFromThread2 ).returns( bookFromThread1_1.getId(), Book::getId );
+						assertThat( bookFromThread2 ).isNotSameAs( bookFromThread1_1 );
+						return bookFromThread2;
+					} ),
+					executorService
+			);
+			Book bookFromThread2 = Futures.unwrappedExceptionJoin( future );
+			assertThat( bookFromThread2 ).returns( false, singleSearchSessionService.entityManager::contains );
+
+			return null;
+		} );
+	}
+
+	@Service
+	public static class SingleSearchSessionService {
+
+		public EntityManager entityManager;
+
+		// Use the SAME SearchSession instance from all threads
+		// This will only work if Hibernate Search takes care of fetching the thread-local ORM Session
+		// every time a method is called on the SearchSession.
+		public SearchSession searchSession;
+
+		@Autowired
+		public void init(EntityManager entityManager) {
+			this.entityManager = entityManager;
+			this.searchSession = Search.session( entityManager );
+		}
+
+		public Book simulateSearch() {
+			return searchSession.search( Book.class ).where( f -> f.matchAll() )
+					.sort( f -> f.field( "title_sort" ) )
+					.fetchHits( 1 ).get( 0 );
+		}
+
+	}
+}

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/session/SessionTest.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/session/SessionTest.java
@@ -23,12 +23,15 @@ import org.hibernate.event.spi.EventSource;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
 import org.hibernate.search.test.SearchTestBase;
+import org.hibernate.search.testsupport.junit.PortedToSearch6;
 
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * @author Emmanuel Bernard
  */
+@Category(PortedToSearch6.class)
 public class SessionTest extends SearchTestBase {
 
 	//EventSource, org.hibernate.Session, LobCreationContext

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/common/impl/HibernateOrmUtils.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/common/impl/HibernateOrmUtils.java
@@ -17,6 +17,7 @@ import javax.persistence.criteria.Path;
 import javax.persistence.criteria.Root;
 
 import org.hibernate.AssertionFailure;
+import org.hibernate.Session;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.metamodel.model.domain.spi.EntityTypeDescriptor;
@@ -39,6 +40,15 @@ public final class HibernateOrmUtils {
 		}
 		catch (IllegalStateException e) {
 			throw log.hibernateSessionFactoryAccessError( e.getMessage(), e );
+		}
+	}
+
+	public static Session toSession(EntityManager entityManager) {
+		try {
+			return entityManager.unwrap( Session.class );
+		}
+		catch (IllegalStateException e) {
+			throw log.hibernateSessionAccessError( e.getMessage(), e );
 		}
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -250,14 +250,6 @@
         <version.log4j>2.13.3</version.log4j>
         <version.junit>4.13.1</version.junit>
 
-        <!--
-            junit-vintage-engine 5.5.2 version does not support junit 4.13.1.
-            If we try to use it, a parsing error is thrown.
-            So we downgrade JUnit, so that junit-vintage-engine will handle it.
-            See https://stackoverflow.com/a/64371503/1812965
-        -->
-        <version.junit.junit-platform-workaround>4.13</version.junit.junit-platform-workaround>
-
         <version.org.hamcrest>2.2</version.org.hamcrest>
         <version.org.mockito>3.5.13</version.org.mockito>
         <version.org.assertj.assertj-core>3.15.0</version.org.assertj.assertj-core>
@@ -1573,6 +1565,17 @@
                         <argLine>${surefire.jvm.args}</argLine>
                         <reportNameSuffix>${surefire.environment}-${surefire.executing-module}</reportNameSuffix>
                     </configuration>
+                    <dependencies>
+                        <!--
+                             Force tests to execute with JUnit 4
+                             See http://maven.apache.org/surefire/maven-failsafe-plugin/examples/junit.html
+                         -->
+                        <dependency>
+                            <groupId>org.apache.maven.surefire</groupId>
+                            <artifactId>surefire-junit47</artifactId>
+                            <version>${version.failsafe.plugin}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -1599,6 +1602,17 @@
                         <argLine>${failsafe.jvm.args}</argLine>
                         <reportNameSuffix>${surefire.environment}-${surefire.executing-module}</reportNameSuffix>
                     </configuration>
+                    <dependencies>
+                        <!--
+                             Force tests to execute with JUnit 4
+                             See http://maven.apache.org/surefire/maven-failsafe-plugin/examples/junit.html
+                         -->
+                        <dependency>
+                            <groupId>org.apache.maven.surefire</groupId>
+                            <artifactId>surefire-junit47</artifactId>
+                            <version>${version.failsafe.plugin}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>com.github.alexcojocaru</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -274,7 +274,7 @@
         <version.org.google.guava>30.0-jre</version.org.google.guava>
 
         <!-- >>> Spring integration tests -->
-        <version.org.springframework.boot>2.3.4.RELEASE</version.org.springframework.boot>
+        <version.org.springframework.boot>2.4.0</version.org.springframework.boot>
 
         <!-- Maven plugins versions -->
 

--- a/v5migrationhelper/orm/src/main/java/org/hibernate/search/impl/FullTextSessionImpl.java
+++ b/v5migrationhelper/orm/src/main/java/org/hibernate/search/impl/FullTextSessionImpl.java
@@ -7,9 +7,12 @@
 package org.hibernate.search.impl;
 
 import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
 
+import org.hibernate.Session;
 import org.hibernate.engine.spi.SessionDelegatorBaseImpl;
 import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.event.spi.EventSource;
 import org.hibernate.search.FullTextQuery;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.FullTextSharedSessionBuilder;
@@ -26,6 +29,8 @@ import org.hibernate.search.scope.spi.V5MigrationSearchScope;
 import org.hibernate.search.query.engine.spi.V5MigrationSearchSession;
 import org.hibernate.search.query.hibernate.impl.FullTextQueryImpl;
 import org.hibernate.search.scope.impl.V5MigrationOrmSearchScopeAdapter;
+import org.hibernate.search.util.logging.impl.Log;
+import org.hibernate.search.util.logging.impl.LoggerFactory;
 
 /**
  * Lucene full text search aware session.
@@ -37,11 +42,33 @@ import org.hibernate.search.scope.impl.V5MigrationOrmSearchScopeAdapter;
 final class FullTextSessionImpl extends SessionDelegatorBaseImpl
 		implements FullTextSession, SessionImplementor, V5MigrationSearchSession<SearchLoadingOptionsStep> {
 
+	private static final Log log = LoggerFactory.make( MethodHandles.lookup() );
+
+	private static SessionImplementor doUnwrap(Session session) {
+		if ( session == null ) {
+			throw log.getNullSessionPassedToFullTextSessionCreationException();
+		}
+		// Keeping both instanceofs in case the interface hierarchy changes.
+		else if ( session instanceof SessionImplementor && session instanceof EventSource ) {
+			// A session proxied with ThreadLocalSessionContext will implement all the interfaces we need,
+			// but won't allow a call to .unwrap() outside of a transaction.
+			// Thus we need to proceed with the cast.
+			return (EventSource) session;
+		}
+		else {
+			// Other proxies (such as Spring's after version 2.4),
+			// only implement Session, not SessionImplementor,
+			// but allow a call to .unwrap().
+			return session.unwrap( SessionImplementor.class );
+		}
+	}
+
+
 	private transient V5MigrationOrmSearchIntegratorAdapter searchIntegrator;
 	private transient SearchFactory searchFactoryAPI;
 
 	public FullTextSessionImpl(org.hibernate.Session session) {
-		super( (SessionImplementor) session );
+		super( doUnwrap( session ) );
 	}
 
 	@Override


### PR DESCRIPTION
* [HSEARCH-4106](https://hibernate.atlassian.net/browse/HSEARCH-4106): Force tests to execute with JUnit 4
* [HSEARCH-4108](https://hibernate.atlassian.net/browse/HSEARCH-4108): Search.session() does not work with session proxies 
* [HSEARCH-4107](https://hibernate.atlassian.net/browse/HSEARCH-4107): Session cast fails when creating a FullTextSession with Spring 2.4.0

