### PR TITLE
HSEARCH-4074 + HSEARCH-4113 Clarify how to pick a bridge type in the documentation

### DIFF
--- a/documentation/src/main/asciidoc/reference/limitations.asciidoc
+++ b/documentation/src/main/asciidoc/reference/limitations.asciidoc
@@ -77,3 +77,32 @@ Downsides::
 However, we intend to provide a basic solution relying on the database exclusively.
 * It will most likely prevent any form of <<mapper-orm-indexing-automatic-synchronization,synchronous indexing>>
 (waiting for indexing to finish before releasing the application thread).
+
+[[limitations-indexing-plan-serialization]]
+== Automatic indexing is not compatible with `Session` serialization
+
+=== Description
+
+When <<mapper-orm-indexing-automatic,automatic indexing>> is enabled,
+Hibernate Search collects entity change events
+to build an "indexing plan" inside the ORM `EntityManager`/`Session`.
+The indexing plan holds information relative to which entities need to be reindexed,
+and sometimes documents that have not been indexed yet.
+
+The indexing plan cannot be serialized.
+
+If the ORM `Session` gets serialized,
+all collected change events will be lost upon deserializing the session,
+and Hibernate Search will likely "forget" to reindex some entities.
+
+This is fine in most applications, since they do not rely on serializing the session,
+but it might be a problem with some JEE applications relying on Bean Passivation.
+
+=== Workaround
+
+Avoid serializing an ORM `EntityManager`/`Session` after changing entities.
+
+=== Roadmap
+
+There are no plans to address this limitation.
+We do not intend to support `Session` serialization when Hibernate Search is enabled.

--- a/documentation/src/main/asciidoc/reference/mapper-orm-bridge-basics.asciidoc
+++ b/documentation/src/main/asciidoc/reference/mapper-orm-bridge-basics.asciidoc
@@ -51,9 +51,13 @@ the following table may help:
 |Class
 
 |Maps to...
-|One index field
-|One index field or more
-|One index field or more
+|One index field.
+Value field only: integer, text, geopoint, etc.
+No <<mapper-orm-bridge-index-field-dsl-object,object field>> (composite).
+|One index field or more.
+Value fields as well as <<mapper-orm-bridge-index-field-dsl-object,object fields>> (composite).
+|One index field or more.
+Value fields as well as <<mapper-orm-bridge-index-field-dsl-object,object fields>> (composite).
 |Document identifier
 |Route (conditional indexing, <<concepts-sharding-routing,routing key>>)
 

--- a/documentation/src/main/asciidoc/reference/mapper-orm-bridge-basics.asciidoc
+++ b/documentation/src/main/asciidoc/reference/mapper-orm-bridge-basics.asciidoc
@@ -43,19 +43,12 @@ the following table may help:
 |<<mapper-orm-bridge-identifierbridge,`IdentifierBridge`>>
 |<<mapper-orm-bridge-routingbridge,`RoutingBridge`>>
 
-|Built-in annotation(s)
-|<<mapper-orm-directfieldmapping,`@GenericField`, `@FullTextField`, ...>>
-|`@PropertyBinding`
-|`@TypeBinding`
-|<<mapper-orm-identifiermapping,`@DocumentId`>>
-|`@Indexed(routingBinder = ...)`
-
-|Maps from...
-|One property
-|One property
-|One property or more
-|One property (usually the entity identifier)
-|One property or more
+|Applied to...
+|Class field or getter
+|Class field or getter
+|Class
+|Class field or getter (usually entity ID)
+|Class
 
 |Maps to...
 |One index field
@@ -63,6 +56,13 @@ the following table may help:
 |One index field or more
 |Document identifier
 |Route (conditional indexing, <<concepts-sharding-routing,routing key>>)
+
+|Built-in annotation(s)
+|<<mapper-orm-directfieldmapping,`@GenericField`, `@FullTextField`, ...>>
+|`@PropertyBinding`
+|`@TypeBinding`
+|<<mapper-orm-identifiermapping,`@DocumentId`>>
+|`@Indexed(routingBinder = ...)`
 
 |Supports <<mapper-orm-containerextractor,container extractors>>
 |Yes

--- a/documentation/src/main/asciidoc/reference/mapper-orm-bridge-identifierbridge.asciidoc
+++ b/documentation/src/main/asciidoc/reference/mapper-orm-bridge-identifierbridge.asciidoc
@@ -1,5 +1,5 @@
 [[mapper-orm-bridge-identifierbridge]]
-= Identifier bridges
+= Identifier bridge
 
 == Basics
 

--- a/documentation/src/main/asciidoc/reference/mapper-orm-bridge-index-field-dsl.asciidoc
+++ b/documentation/src/main/asciidoc/reference/mapper-orm-bridge-index-field-dsl.asciidoc
@@ -84,9 +84,10 @@ include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/bridge/docume
 <1> Declare the field as multi-valued.
 ====
 
+[[mapper-orm-bridge-index-field-dsl-object]]
 == Object fields
 
-The previous sections only presented flat schemas with atomic fields,
+The previous sections only presented flat schemas with value fields,
 but the index schema can actually be organized in a tree structure,
 with two categories of index fields:
 

--- a/documentation/src/main/asciidoc/reference/mapper-orm-bridge-propertybridge.asciidoc
+++ b/documentation/src/main/asciidoc/reference/mapper-orm-bridge-propertybridge.asciidoc
@@ -103,6 +103,19 @@ so we call `addValue` on `summaryValue` instead of `target`.
 include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/bridge/propertybridge/simple/Invoice.java[tags=include;!getters-setters]
 ----
 <1> Apply the bridge using the `@PropertyBinding` annotation.
+
+Here is an example of what an indexed document would look like, with the Elasticsearch backend:
+
+[source, JSON]
+----
+{
+  "summary": {
+    "total": 38.96,
+    "books": 30.97,
+    "shipping": 7.99
+  }
+}
+----
 ====
 
 [[mapper-orm-bridge-propertybridge-parameters]]

--- a/documentation/src/main/asciidoc/reference/mapper-orm-bridge-routingbridge.asciidoc
+++ b/documentation/src/main/asciidoc/reference/mapper-orm-bridge-routingbridge.asciidoc
@@ -1,5 +1,5 @@
 [[mapper-orm-bridge-routingbridge]]
-= Routing bridges
+= Routing bridge
 // Legacy anchor from earlier 6.0 beta versions
 [[mapper-orm-bridge-routingkeybridge]]
 

--- a/documentation/src/main/asciidoc/reference/mapper-orm-bridge-typebridge.asciidoc
+++ b/documentation/src/main/asciidoc/reference/mapper-orm-bridge-typebridge.asciidoc
@@ -88,6 +88,15 @@ include::{sourcedir}/org/hibernate/search/documentation/mapper/orm/bridge/typebr
 as long as index field names are distinct from the names used in the type binder.
 But no annotation is necessary on the `firstName` and `lastName` properties:
 these are already handled by the bridge.
+
+Here is an example of what an indexed document would look like, with the Elasticsearch backend:
+
+[source, JSON]
+----
+{
+  "fullName": "Asimov Isaac"
+}
+----
 ====
 
 [[mapper-orm-bridge-typebridge-parameters]]

--- a/documentation/src/main/asciidoc/reference/mapper-orm-bridge-valuebridge.asciidoc
+++ b/documentation/src/main/asciidoc/reference/mapper-orm-bridge-valuebridge.asciidoc
@@ -72,6 +72,15 @@ but necessary in order for Hibernate ORM to store the data correctly in the data
 <3> Instruct Hibernate Search to use our custom value bridge.
 It is also possible to reference the bridge by its name, in the case of a CDI/Spring bean.
 <4> Customize the field as usual.
+
+Here is an example of what an indexed document would look like, with the Elasticsearch backend:
+
+[source, JSON]
+----
+{
+  "isbn": "978-0-58-600835-5"
+}
+----
 ====
 
 The example above is just a minimal implementations.

--- a/documentation/src/main/asciidoc/reference/mapper-orm-bridge-valuebridge.asciidoc
+++ b/documentation/src/main/asciidoc/reference/mapper-orm-bridge-valuebridge.asciidoc
@@ -1,5 +1,5 @@
 [[mapper-orm-bridge-valuebridge]]
-= Value bridges
+= Value bridge
 // Search 5 anchors backward compatibility
 [[_stringbridge]]
 


### PR DESCRIPTION
* [HSEARCH-4113](https://hibernate.atlassian.net/browse/HSEARCH-4113): Document that serializing the indexing plan is not supported
* [HSEARCH-4074](https://hibernate.atlassian.net/browse/HSEARCH-4074): Clarify how to pick a bridge type in the documentation

