### PR TITLE
HSEARCH-4116 Ignore empty, blank or null configuration properties when detecting unused properties

### DIFF
--- a/engine/src/main/java/org/hibernate/search/engine/cfg/impl/MapConfigurationPropertySource.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/impl/MapConfigurationPropertySource.java
@@ -6,10 +6,11 @@
  */
 package org.hibernate.search.engine.cfg.impl;
 
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.stream.Collectors;
 
 import org.hibernate.search.engine.cfg.spi.AllAwareConfigurationPropertySource;
 
@@ -33,17 +34,11 @@ public class MapConfigurationPropertySource implements AllAwareConfigurationProp
 	}
 
 	@Override
-	public Set<String> resolveAll(String prefix) {
-		Set<String> prefixedPropertyKeys = new HashSet<>();
-		for ( Object key : map.keySet() ) {
-			if ( key instanceof String ) {
-				String stringKey = (String) key;
-				if ( stringKey.startsWith( prefix ) ) {
-					prefixedPropertyKeys.add( stringKey );
-				}
-			}
-		}
-		return prefixedPropertyKeys;
+	public Set<String> resolveAll(BiPredicate<String, Object> predicate) {
+		return map.entrySet().stream()
+				.filter( e -> predicate.test( e.getKey(), e.getValue() ) )
+				.map( Map.Entry::getKey )
+				.collect( Collectors.toSet() );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/cfg/impl/SystemConfigurationPropertySource.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/impl/SystemConfigurationPropertySource.java
@@ -6,10 +6,10 @@
  */
 package org.hibernate.search.engine.cfg.impl;
 
-import java.util.HashSet;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.stream.Collectors;
 
 import org.hibernate.search.engine.cfg.spi.AllAwareConfigurationPropertySource;
 
@@ -36,18 +36,17 @@ public class SystemConfigurationPropertySource implements AllAwareConfigurationP
 	}
 
 	@Override
-	public Set<String> resolveAll(String prefix) {
-		Set<String> prefixedPropertyKeys = new HashSet<>();
-		for ( Map.Entry<Object, Object> entry : System.getProperties().entrySet() ) {
-			Object key = entry.getKey();
-			if ( key instanceof String ) {
-				String stringKey = (String) key;
-				if ( stringKey.startsWith( prefix ) ) {
-					prefixedPropertyKeys.add( stringKey );
-				}
-			}
-		}
-		return prefixedPropertyKeys;
+	public Set<String> resolveAll(BiPredicate<String, Object> predicate) {
+		return System.getProperties().entrySet().stream()
+				.filter( e -> {
+					Object key = e.getKey();
+					if ( ! ( key instanceof String ) ) {
+						return false;
+					}
+					return predicate.test( (String) key, e.getValue() );
+				} )
+				.map( e -> (String) e.getKey() )
+				.collect( Collectors.toSet() );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/cfg/spi/AllAwareConfigurationPropertySource.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/spi/AllAwareConfigurationPropertySource.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.engine.cfg.spi;
 
 import java.util.Set;
+import java.util.function.BiPredicate;
 
 /**
  * A source of property values for Hibernate Search with knowledge of the full set of properties.
@@ -17,6 +18,6 @@ import java.util.Set;
  */
 public interface AllAwareConfigurationPropertySource extends ConfigurationPropertySource {
 
-	Set<String> resolveAll(String prefix);
+	Set<String> resolveAll(BiPredicate<String, Object> predicate);
 
 }

--- a/engine/src/main/java/org/hibernate/search/engine/cfg/spi/ConfigurationPropertyChecker.java
+++ b/engine/src/main/java/org/hibernate/search/engine/cfg/spi/ConfigurationPropertyChecker.java
@@ -39,6 +39,11 @@ public final class ConfigurationPropertyChecker {
 		return new ConfigurationPropertyChecker();
 	}
 
+	private static boolean isRelevantPropertyEntry(String key, Object value) {
+		return key.startsWith( EngineSettings.PREFIX )
+				&& ConvertUtils.trimIfString( value ) != null;
+	}
+
 	private String configurationPropertyCheckingStrategyPropertyName;
 
 	private final Set<String> availablePropertyKeys = ConcurrentHashMap.newKeySet();
@@ -61,7 +66,7 @@ public final class ConfigurationPropertyChecker {
 		switch ( checkingStrategy ) {
 			case WARN:
 				this.warn = true;
-				availablePropertyKeys.addAll( source.resolveAll( EngineSettings.PREFIX ) );
+				availablePropertyKeys.addAll( source.resolveAll( ConfigurationPropertyChecker::isRelevantPropertyEntry ) );
 				return trackingSource;
 			case IGNORE:
 				return source;

--- a/engine/src/test/java/org/hibernate/search/engine/cfg/MapConfigurationPropertySourceTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/cfg/MapConfigurationPropertySourceTest.java
@@ -9,7 +9,6 @@ package org.hibernate.search.engine.cfg;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -38,17 +37,7 @@ public class MapConfigurationPropertySourceTest extends AbstractAllAwareConfigur
 	}
 
 	@Override
-	protected AllAwareConfigurationPropertySource createPropertySource(String key, String value) {
-		Map<String, Object> map = Collections.singletonMap( key, value );
-		return ConfigurationPropertySource.fromMap( map );
-	}
-
-	@Override
-	protected AllAwareConfigurationPropertySource createPropertySource(String key, String value,
-			String key2, String value2) {
-		Map<String, Object> map = new LinkedHashMap<>();
-		map.put( key, value );
-		map.put( key2, value2 );
-		return ConfigurationPropertySource.fromMap( map );
+	protected AllAwareConfigurationPropertySource createPropertySource(Map<String, String> content) {
+		return ConfigurationPropertySource.fromMap( content );
 	}
 }

--- a/engine/src/test/java/org/hibernate/search/engine/cfg/SystemConfigurationPropertySourceTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/cfg/SystemConfigurationPropertySourceTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.hibernate.search.engine.cfg.spi.AllAwareConfigurationPropertySource;
 import org.hibernate.search.engine.cfg.spi.ConfigurationPropertySource;
@@ -34,21 +35,14 @@ public class SystemConfigurationPropertySourceTest extends AbstractAllAwareConfi
 	}
 
 	@Override
-	protected AllAwareConfigurationPropertySource createPropertySource(String key, String value) {
+	protected AllAwareConfigurationPropertySource createPropertySource(Map<String, String> content) {
 		clearSystemProperties();
-		toClear.add( key );
-		System.setProperty( key, value );
-		return ConfigurationPropertySource.system();
-	}
-
-	@Override
-	protected AllAwareConfigurationPropertySource createPropertySource(String key, String value,
-			String key2, String value2) {
-		clearSystemProperties();
-		toClear.add( key );
-		toClear.add( key2 );
-		System.setProperty( key, value );
-		System.setProperty( key2, value2 );
+		for ( Map.Entry<String, String> entry : content.entrySet() ) {
+			String key = entry.getKey();
+			String value = entry.getValue();
+			toClear.add( key );
+			System.setProperty( key, value );
+		}
 		return ConfigurationPropertySource.system();
 	}
 }

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/UnusedPropertiesIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/bootstrap/UnusedPropertiesIT.java
@@ -26,6 +26,10 @@ import org.junit.Test;
 import org.apache.logging.log4j.Level;
 
 public class UnusedPropertiesIT {
+	private static final String KEY_UNUSED = "hibernate.search.indexes.myIndex.foo";
+	private static final String KEY_UNUSED_BUT_EMPTY_VALUE = "hibernate.search.indexes.myIndex.emptyValue";
+	private static final String KEY_UNUSED_BUT_BLANK_VALUE = "hibernate.search.indexes.myIndex.blankValue";
+	private static final String KEY_UNUSED_BUT_NULL_VALUE = "hibernate.search.indexes.myIndex.nullValue";
 
 	@Rule
 	public BackendMock backendMock = new BackendMock();
@@ -38,24 +42,26 @@ public class UnusedPropertiesIT {
 
 	@Test
 	public void checkDisabled_unusedProperty() {
-		String unusedPropertyKey = "hibernate.search.indexes.myIndex.foo";
 		logged.expectMessage( "some properties in the given configuration are not used" )
 				.never();
 		logged.expectEvent( Level.INFO, "Configuration property tracking is disabled" )
 				.once();
 		setup( builder -> {
 			builder.setProperty( EngineSettings.CONFIGURATION_PROPERTY_CHECKING_STRATEGY, "ignore" );
-			builder.setProperty( unusedPropertyKey, "bar" );
+			builder.setProperty( KEY_UNUSED, "bar" );
+			// These properties should be ignored
+			builder.setProperty( KEY_UNUSED_BUT_EMPTY_VALUE, "" );
+			builder.setProperty( KEY_UNUSED_BUT_BLANK_VALUE, "   " );
+			builder.setProperty( KEY_UNUSED_BUT_NULL_VALUE, null );
 		} );
 	}
 
 	@Test
 	public void checkEnabledByDefault_unusedProperty() {
-		String unusedPropertyKey = "hibernate.search.indexes.myIndex.foo";
 		logged.expectEvent( Level.WARN,
 				"Invalid configuration passed to Hibernate Search",
 				"some properties in the given configuration are not used",
-				"[" + unusedPropertyKey + "]",
+				"[" + KEY_UNUSED + "]",
 				"To disable this warning, set the property '"
 						+ EngineSettings.CONFIGURATION_PROPERTY_CHECKING_STRATEGY + "' to 'ignore'" )
 				.once();
@@ -66,8 +72,12 @@ public class UnusedPropertiesIT {
 				.never();
 
 		setup( builder -> {
-			builder.setProperty( unusedPropertyKey, "bar" );
+			builder.setProperty( KEY_UNUSED, "bar" );
 			builder.setProperty( HibernateOrmMapperSettings.QUERY_LOADING_FETCH_SIZE, 2 );
+			// These properties should be ignored
+			builder.setProperty( KEY_UNUSED_BUT_EMPTY_VALUE, "" );
+			builder.setProperty( KEY_UNUSED_BUT_BLANK_VALUE, "   " );
+			builder.setProperty( KEY_UNUSED_BUT_NULL_VALUE, null );
 		} );
 	}
 
@@ -84,6 +94,10 @@ public class UnusedPropertiesIT {
 				.never();
 		setup( builder -> {
 			builder.setProperty( EngineSettings.CONFIGURATION_PROPERTY_CHECKING_STRATEGY, "warn" );
+			// These properties should be ignored
+			builder.setProperty( KEY_UNUSED_BUT_EMPTY_VALUE, "" );
+			builder.setProperty( KEY_UNUSED_BUT_BLANK_VALUE, "   " );
+			builder.setProperty( KEY_UNUSED_BUT_NULL_VALUE, null );
 		} );
 	}
 

--- a/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/ElasticsearchTestHostConnectionConfiguration.java
+++ b/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/ElasticsearchTestHostConnectionConfiguration.java
@@ -29,7 +29,7 @@ public class ElasticsearchTestHostConnectionConfiguration {
 	private final String protocol;
 	private final String username;
 	private final String password;
-	private final boolean awsSigningEnabled;
+	private final Boolean awsSigningEnabled;
 	private final String awsRegion;
 	private final String awsCredentialsType;
 	private final String awsCredentialsAccessKeyId;
@@ -40,7 +40,8 @@ public class ElasticsearchTestHostConnectionConfiguration {
 		this.protocol = System.getProperty( "test.elasticsearch.connection.protocol" );
 		this.username = System.getProperty( "test.elasticsearch.connection.username" );
 		this.password = System.getProperty( "test.elasticsearch.connection.password" );
-		this.awsSigningEnabled = Boolean.getBoolean( "test.elasticsearch.connection.aws.signing.enabled" );
+		String enabledAsString = System.getProperty( "test.elasticsearch.connection.aws.signing.enabled" );
+		this.awsSigningEnabled = enabledAsString == null ? null : Boolean.parseBoolean( enabledAsString );
 		this.awsRegion = System.getProperty( "test.elasticsearch.connection.aws.region" );
 		this.awsCredentialsType = System.getProperty( "test.elasticsearch.connection.aws.credentials.type" );
 		this.awsCredentialsAccessKeyId = System.getProperty( "test.elasticsearch.connection.aws.credentials.access_key_id" );
@@ -53,7 +54,7 @@ public class ElasticsearchTestHostConnectionConfiguration {
 	}
 
 	public boolean isAws() {
-		return awsSigningEnabled;
+		return awsSigningEnabled != null && awsSigningEnabled;
 	}
 
 	public void addToBackendProperties(Map<String, ? super String> properties) {
@@ -61,12 +62,12 @@ public class ElasticsearchTestHostConnectionConfiguration {
 		properties.put( "protocol", protocol );
 		properties.put( "username", username );
 		properties.put( "password", password );
-		properties.put( "aws.signing.enabled", String.valueOf( awsSigningEnabled ) );
+		properties.put( "aws.signing.enabled", awsSigningEnabled == null ? null : awsSigningEnabled.toString() );
 		properties.put( "aws.region", awsRegion );
 		properties.put( "aws.credentials.type", awsCredentialsType );
 		properties.put( "aws.credentials.access_key_id", awsCredentialsAccessKeyId );
 		properties.put( "aws.credentials.secret_access_key", awsCredentialsSecretAccessKey );
-		if ( awsSigningEnabled ) {
+		if ( awsSigningEnabled != null && awsSigningEnabled ) {
 			// AWS Elasticsearch Service is (sometimes) super slow for index creation.
 			// Just raise the default timeout so that we don't fail a full 30-min
 			// test run just for one small freeze.

--- a/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/ElasticsearchTestHostConnectionConfiguration.java
+++ b/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/ElasticsearchTestHostConnectionConfiguration.java
@@ -67,7 +67,7 @@ public class ElasticsearchTestHostConnectionConfiguration {
 		properties.put( "aws.credentials.type", awsCredentialsType );
 		properties.put( "aws.credentials.access_key_id", awsCredentialsAccessKeyId );
 		properties.put( "aws.credentials.secret_access_key", awsCredentialsSecretAccessKey );
-		if ( awsSigningEnabled != null && awsSigningEnabled ) {
+		if ( isAws() ) {
 			// AWS Elasticsearch Service is (sometimes) super slow for index creation.
 			// Just raise the default timeout so that we don't fail a full 30-min
 			// test run just for one small freeze.

--- a/util/internal/test/src/main/java/org/hibernate/search/util/impl/test/rule/log4j/LogChecker.java
+++ b/util/internal/test/src/main/java/org/hibernate/search/util/impl/test/rule/log4j/LogChecker.java
@@ -72,6 +72,10 @@ public class LogChecker {
 	}
 
 	private static void appendEvents(Description description, String newline, List<LogEvent> events) {
+		if ( events == null || events.isEmpty() ) {
+			description.appendText( "<none>" );
+			return;
+		}
 		for ( LogEvent event : events ) {
 			description.appendText( newline );
 			description.appendText( "\t - " );


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4116
