### PR TITLE
HSEARCH-4127 + HSEARCH-4129 Migration guide fixes

### DIFF
--- a/documentation/src/main/asciidoc/migration/index.asciidoc
+++ b/documentation/src/main/asciidoc/migration/index.asciidoc
@@ -46,10 +46,10 @@ Hibernate Search 6 is still compatible with both JDK8 and JDK11.
 
 The required versions of dependencies changed:
 
-* The Hibernate ORM mapper now requires Hibernate ORM 5.4.4.Final or later
+* The Hibernate ORM mapper now requires Hibernate ORM {hibernateVersion}
 (5.4.3.Final and earlier won't work correctly).
-* The Elasticsearch backend now requires Elasticsearch 5.6, 6.8 or 7.9.
-* The Lucene backend now requires Lucene 8.6.
+* The Elasticsearch backend now requires Elasticsearch {elasticsearchCompatibleVersions}.
+* The Lucene backend now requires Lucene {luceneVersion}.
 
 [[maven-coordinates]]
 == Maven coordinates changes

--- a/documentation/src/main/asciidoc/migration/index.asciidoc
+++ b/documentation/src/main/asciidoc/migration/index.asciidoc
@@ -2156,6 +2156,7 @@ f.spatial().within()
                 DistanceUnit.KILOMETERS)
 
 |qb.moreLikeThis()
+|-
 |No equivalent in Hibernate Search 6.
 
 If you need more-like-this predicates,


### PR DESCRIPTION
* [HSEARCH-4129](https://hibernate.atlassian.net/browse/HSEARCH-4129): Mention More Like This queries in the migration guide
* [HSEARCH-4127](https://hibernate.atlassian.net/browse/HSEARCH-4127): Update out of date dependency versions in migration guide

