### PR TITLE
HSEARCH-4135 + HSEARCH-4136 Use hibernate.search.backend.uris and upgrade to ES 7.8 in Jenkinsfile of backend performance tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,17 +210,16 @@ A list of available versions for `test.elasticsearch.connection.version` can be 
 
 Alternatively, you can prevent the build from launching an Elasticsearch server automatically
 and run Elasticsearch-related tests against your own server using the
-`test.elasticsearch.connection.hosts` properties:
+`test.elasticsearch.connection.uris` property:
 
 ```bash
-./mvnw clean install -Dtest.elasticsearch.connection.hosts=localhost:9200
+./mvnw clean install -Dtest.elasticsearch.connection.uris=http://localhost:9200
 ```
 
 If you want to use HTTPS:
 
 ```bash
-./mvnw clean install -Dtest.elasticsearch.connection.hosts=localhost:9200 \
-        -Dtest.elasticsearch.connection.protocol=https
+./mvnw clean install -Dtest.elasticsearch.connection.uris=https://localhost:9200
 ```
 
 If you want to run tests against a different Elasticsearch version  (6.x for instance),
@@ -228,13 +227,13 @@ you will still have to select a profile among those listed above, and specify th
 
 ```bash
 ./mvnw clean install -Pelasticsearch-6.0 -Dtest.elasticsearch.connection.version=6.0.0 \
-        -Dtest.elasticsearch.connection.hosts=localhost:9200
+        -Dtest.elasticsearch.connection.uris=http://localhost:9200
 ```
 
 You may also use authentication:
 
 ```bash
-./mvnw clean install -Dtest.elasticsearch.connection.hosts=localhost:9200 \
+./mvnw clean install -Dtest.elasticsearch.connection.uris=http://localhost:9200 \
         -Dtest.elasticsearch.connection.username=ironman \
         -Dtest.elasticsearch.connection.password=j@rV1s
 ```
@@ -244,7 +243,7 @@ against an Elasticsearch service on AWS.
 You will need to execute something along the lines of:
 
 ```bash
-./mvnw clean install -Dtest.elasticsearch.connection.hosts=<host:port> \
+./mvnw clean install -Dtest.elasticsearch.connection.uris=http://<host:port> \
         -Dtest.elasticsearch.connection.aws.signing.enabled=true \
         -Dtest.elasticsearch.connection.aws.region=<Your AWS region ID> \
         -Dtest.elasticsearch.connection.aws.credentials.type=static \
@@ -255,7 +254,7 @@ You will need to execute something along the lines of:
 Or more simply, if your AWS credentials are already stored in `~/.aws/credentials`:
 
 ```bash
-./mvnw clean install -Dtest.elasticsearch.connection.hosts=<host:port> \
+./mvnw clean install -Dtest.elasticsearch.connection.uris=http://<host:port> \
         -Dtest.elasticsearch.connection.aws.signing.enabled=true \
         -Dtest.elasticsearch.connection.aws.region=<Your AWS region ID>
 ```

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -109,7 +109,7 @@
     <build>
         <testResources>
             <testResource>
-                <filtering>true</filtering>
+                <filtering>false</filtering>
                 <directory>src/test/resources</directory>
             </testResource>
         </testResources>

--- a/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withhsearch/customanalysis/GettingStartedCustomAnalysisIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withhsearch/customanalysis/GettingStartedCustomAnalysisIT.java
@@ -8,21 +8,21 @@ package org.hibernate.search.documentation.gettingstarted.withhsearch.customanal
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.util.impl.integrationtest.common.rule.BackendConfiguration.BACKEND_TYPE;
-import static org.hibernate.search.util.impl.integrationtest.common.rule.BackendConfiguration.IS_IDE;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 
+import org.hibernate.search.documentation.testsupport.JpaConfiguration;
 import org.hibernate.search.engine.search.query.SearchResult;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
+import org.hibernate.search.util.impl.integrationtest.common.TestConfigurationProvider;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class GettingStartedCustomAnalysisIT {
@@ -31,17 +31,13 @@ public class GettingStartedCustomAnalysisIT {
 
 	private EntityManagerFactory entityManagerFactory;
 
+	@Rule
+	public TestConfigurationProvider configurationProvider = new TestConfigurationProvider();
+
 	@Before
 	public void setup() {
-		if ( IS_IDE ) {
-			Map<String, String> properties = new HashMap<>();
-			// More than one backend type in the classpath, we have to set it explicitly.
-			properties.put( "hibernate.search.backend.type", BACKEND_TYPE );
-			entityManagerFactory = Persistence.createEntityManagerFactory( persistenceUnitName, properties );
-		}
-		else {
-			entityManagerFactory = Persistence.createEntityManagerFactory( persistenceUnitName );
-		}
+		entityManagerFactory = Persistence.createEntityManagerFactory( persistenceUnitName,
+				JpaConfiguration.properties( configurationProvider ) );
 	}
 
 	@After

--- a/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withhsearch/defaultanalysis/GettingStartedDefaultAnalysisIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/gettingstarted/withhsearch/defaultanalysis/GettingStartedDefaultAnalysisIT.java
@@ -8,25 +8,25 @@ package org.hibernate.search.documentation.gettingstarted.withhsearch.defaultana
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.util.impl.integrationtest.common.rule.BackendConfiguration.BACKEND_TYPE;
-import static org.hibernate.search.util.impl.integrationtest.common.rule.BackendConfiguration.IS_IDE;
 import static org.junit.Assert.assertEquals;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 
+import org.hibernate.search.documentation.testsupport.JpaConfiguration;
 import org.hibernate.search.engine.search.query.SearchResult;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.massindexing.MassIndexer;
 import org.hibernate.search.mapper.orm.scope.SearchScope;
 import org.hibernate.search.mapper.orm.session.SearchSession;
+import org.hibernate.search.util.impl.integrationtest.common.TestConfigurationProvider;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class GettingStartedDefaultAnalysisIT {
@@ -35,17 +35,13 @@ public class GettingStartedDefaultAnalysisIT {
 
 	private EntityManagerFactory entityManagerFactory;
 
+	@Rule
+	public TestConfigurationProvider configurationProvider = new TestConfigurationProvider();
+
 	@Before
 	public void setup() {
-		if ( IS_IDE ) {
-			Map<String, String> properties = new HashMap<>();
-			// More than one backend type in the classpath, we have to set it explicitly.
-			properties.put( "hibernate.search.backend.type", BACKEND_TYPE );
-			entityManagerFactory = Persistence.createEntityManagerFactory( persistenceUnitName, properties );
-		}
-		else {
-			entityManagerFactory = Persistence.createEntityManagerFactory( persistenceUnitName );
-		}
+		entityManagerFactory = Persistence.createEntityManagerFactory( persistenceUnitName,
+				JpaConfiguration.properties( configurationProvider ) );
 	}
 
 	@After

--- a/documentation/src/test/java/org/hibernate/search/documentation/testsupport/BackendConfigurations.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/testsupport/BackendConfigurations.java
@@ -9,6 +9,8 @@ package org.hibernate.search.documentation.testsupport;
 import static org.hibernate.search.util.impl.integrationtest.common.rule.BackendConfiguration.BACKEND_TYPE;
 
 import org.hibernate.search.backend.lucene.cfg.LuceneIndexSettings;
+import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.ElasticsearchBackendConfiguration;
+import org.hibernate.search.util.impl.integrationtest.backend.lucene.LuceneBackendConfiguration;
 import org.hibernate.search.util.impl.integrationtest.common.TestConfigurationProvider;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendConfiguration;
 import org.hibernate.search.util.impl.integrationtest.common.rule.MappingSetupHelper;
@@ -16,6 +18,18 @@ import org.hibernate.search.util.impl.integrationtest.common.rule.MappingSetupHe
 public final class BackendConfigurations {
 
 	private BackendConfigurations() {
+	}
+
+	// Plain configuration, without analysis configurers
+	public static BackendConfiguration plain() {
+		switch ( BACKEND_TYPE ) {
+			case "lucene":
+				return new LuceneBackendConfiguration();
+			case "elasticsearch":
+				return new ElasticsearchBackendConfiguration();
+			default:
+				throw new IllegalStateException( "Unknown backend type: " + BACKEND_TYPE );
+		}
 	}
 
 	public static BackendConfiguration simple() {

--- a/documentation/src/test/java/org/hibernate/search/documentation/testsupport/DocumentationElasticsearchBackendConfiguration.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/testsupport/DocumentationElasticsearchBackendConfiguration.java
@@ -13,7 +13,7 @@ import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.Elas
 public class DocumentationElasticsearchBackendConfiguration extends ElasticsearchBackendConfiguration {
 
 	@Override
-	protected Map<String, String> rawBackendProperties() {
+	public Map<String, String> rawBackendProperties() {
 		Map<String, String> properties = super.rawBackendProperties();
 		properties.put(
 				"analysis.configurer",

--- a/documentation/src/test/java/org/hibernate/search/documentation/testsupport/DocumentationElasticsearchBackendConfiguration.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/testsupport/DocumentationElasticsearchBackendConfiguration.java
@@ -13,11 +13,11 @@ import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.Elas
 public class DocumentationElasticsearchBackendConfiguration extends ElasticsearchBackendConfiguration {
 
 	@Override
-	protected Map<String, Object> backendProperties() {
-		Map<String, Object> properties = super.backendProperties();
+	protected Map<String, String> rawBackendProperties() {
+		Map<String, String> properties = super.rawBackendProperties();
 		properties.put(
 				"analysis.configurer",
-				new ElasticsearchSimpleMappingAnalysisConfigurer()
+				"constructor:" + ElasticsearchSimpleMappingAnalysisConfigurer.class.getName()
 		);
 		return properties;
 	}

--- a/documentation/src/test/java/org/hibernate/search/documentation/testsupport/DocumentationLuceneBackendConfiguration.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/testsupport/DocumentationLuceneBackendConfiguration.java
@@ -12,11 +12,11 @@ import org.hibernate.search.util.impl.integrationtest.backend.lucene.LuceneBacke
 
 public class DocumentationLuceneBackendConfiguration extends LuceneBackendConfiguration {
 	@Override
-	protected Map<String, Object> backendProperties() {
-		Map<String, Object> properties = super.backendProperties();
+	protected Map<String, String> rawBackendProperties() {
+		Map<String, String> properties = super.rawBackendProperties();
 		properties.put(
 				"analysis.configurer",
-				new LuceneSimpleMappingAnalysisConfigurer()
+				"constructor:" + LuceneSimpleMappingAnalysisConfigurer.class.getName()
 		);
 		return properties;
 	}

--- a/documentation/src/test/java/org/hibernate/search/documentation/testsupport/DocumentationLuceneBackendConfiguration.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/testsupport/DocumentationLuceneBackendConfiguration.java
@@ -12,7 +12,7 @@ import org.hibernate.search.util.impl.integrationtest.backend.lucene.LuceneBacke
 
 public class DocumentationLuceneBackendConfiguration extends LuceneBackendConfiguration {
 	@Override
-	protected Map<String, String> rawBackendProperties() {
+	public Map<String, String> rawBackendProperties() {
 		Map<String, String> properties = super.rawBackendProperties();
 		properties.put(
 				"analysis.configurer",

--- a/documentation/src/test/java/org/hibernate/search/documentation/testsupport/ElasticsearchSimpleMappingAnalysisConfigurer.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/testsupport/ElasticsearchSimpleMappingAnalysisConfigurer.java
@@ -9,7 +9,7 @@ package org.hibernate.search.documentation.testsupport;
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurationContext;
 import org.hibernate.search.backend.elasticsearch.analysis.ElasticsearchAnalysisConfigurer;
 
-class ElasticsearchSimpleMappingAnalysisConfigurer implements ElasticsearchAnalysisConfigurer {
+public class ElasticsearchSimpleMappingAnalysisConfigurer implements ElasticsearchAnalysisConfigurer {
 	@Override
 	public void configure(ElasticsearchAnalysisConfigurationContext context) {
 		context.analyzer( "english" ).custom()

--- a/documentation/src/test/java/org/hibernate/search/documentation/testsupport/JpaConfiguration.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/testsupport/JpaConfiguration.java
@@ -30,6 +30,11 @@ public final class JpaConfiguration {
 		}
 		properties.put( "hibernate.search.schema_management.strategy", "drop-and-create-and-drop" );
 		properties.put( "hibernate.search.automatic_indexing.synchronization.strategy", "sync" );
+
+		// Hack: override example properties from persistence.xml
+		properties.put( "hibernate.search.backend.hosts", "" );
+		properties.put( "hibernate.search.backend.protocol", "" );
+
 		return properties;
 	}
 

--- a/documentation/src/test/java/org/hibernate/search/documentation/testsupport/JpaConfiguration.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/testsupport/JpaConfiguration.java
@@ -1,0 +1,36 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.documentation.testsupport;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hibernate.search.util.impl.integrationtest.common.TestConfigurationProvider;
+
+public final class JpaConfiguration {
+
+	private JpaConfiguration() {
+	}
+
+	/**
+	 * @param configurationProvider A test configuration provider.
+	 *
+	 * @return Configuration properties to use when bootstrapping Hibernate ORM with JPA.
+	 */
+	public static Map<String, String> properties(TestConfigurationProvider configurationProvider) {
+		Map<String, String> properties = new HashMap<>();
+		Map<String, String> backendProperties = BackendConfigurations.plain()
+				.backendProperties( configurationProvider );
+		for ( Map.Entry<String, String> entry : backendProperties.entrySet() ) {
+			properties.put( "hibernate.search.backend." + entry.getKey(), entry.getValue() );
+		}
+		properties.put( "hibernate.search.schema_management.strategy", "drop-and-create-and-drop" );
+		properties.put( "hibernate.search.automatic_indexing.synchronization.strategy", "sync" );
+		return properties;
+	}
+
+}

--- a/documentation/src/test/java/org/hibernate/search/documentation/testsupport/LuceneSimpleMappingAnalysisConfigurer.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/testsupport/LuceneSimpleMappingAnalysisConfigurer.java
@@ -17,7 +17,7 @@ import org.apache.lucene.analysis.pattern.PatternReplaceCharFilterFactory;
 import org.apache.lucene.analysis.snowball.SnowballPorterFilterFactory;
 import org.apache.lucene.analysis.standard.StandardTokenizerFactory;
 
-class LuceneSimpleMappingAnalysisConfigurer implements LuceneAnalysisConfigurer {
+public class LuceneSimpleMappingAnalysisConfigurer implements LuceneAnalysisConfigurer {
 	@Override
 	public void configure(LuceneAnalysisConfigurationContext context) {
 		context.analyzer( "english" ).custom()

--- a/documentation/src/test/resources/META-INF/persistence.xml
+++ b/documentation/src/test/resources/META-INF/persistence.xml
@@ -25,17 +25,6 @@
             <property name="hibernate.search.backend.directory.root"
                       value="some/filesystem/path"/> <!--1-->
             <!-- end::gettingstarted-configuration-orm_lucene[] -->
-
-            <!--
-                Not to be included in the documentation:
-                this configuration is only relevant in our own testing infrastructure.
-                WARNING: if you update the property name below,
-                take care to also update the name of the commented property just above.
-             -->
-            <property name="hibernate.search.schema_management.strategy"
-                      value="drop-and-create-and-drop"/>
-            <property name="hibernate.search.backend.directory.root"
-                      value="${project.build.directory}/test-indexes/gettingstarted/defaultanalysis/"/>
         </properties>
     </persistence-unit>
 
@@ -54,35 +43,6 @@
             <property name="hibernate.search.backend.password"
                       value="j@rV1s"/>
             <!-- end::gettingstarted-configuration-orm_elasticsearch[] -->
-
-            <!--
-                Not to be included in the documentation:
-                this configuration is only relevant in our own testing infrastructure.
-                WARNING: if you update the property names below,
-                take care to also update the name of the commented properties just above.
-             -->
-            <property name="hibernate.search.schema_management.strategy"
-                      value="drop-and-create-and-drop"/>
-            <property name="hibernate.search.backend.hosts"
-                      value="${test.elasticsearch.connection.hosts}"/>
-            <property name="hibernate.search.backend.protocol"
-                      value="${test.elasticsearch.connection.protocol}"/>
-            <property name="hibernate.search.backend.username"
-                      value="${test.elasticsearch.connection.username}"/>
-            <property name="hibernate.search.backend.password"
-                      value="${test.elasticsearch.connection.password}"/>
-            <property name="hibernate.search.backend.aws.signing.enabled"
-                      value="${test.elasticsearch.connection.aws.signing.enabled}"/>
-            <property name="hibernate.search.backend.aws.region"
-                      value="${test.elasticsearch.connection.aws.region}"/>
-            <property name="hibernate.search.backend.aws.credentials.type"
-                      value="${test.elasticsearch.connection.aws.credentials.type}"/>
-            <property name="hibernate.search.backend.aws.credentials.access_key_id"
-                      value="${test.elasticsearch.connection.aws.credentials.access_key_id}"/>
-            <property name="hibernate.search.backend.aws.credentials.secret_access_key"
-                      value="${test.elasticsearch.connection.aws.credentials.secret_access_key}"/>
-            <property name="hibernate.search.automatic_indexing.synchronization.strategy"
-                      value="sync"/>
         </properties>
     </persistence-unit>
 
@@ -95,17 +55,6 @@
             <property name="hibernate.search.backend.analysis.configurer"
                       value="class:org.hibernate.search.documentation.gettingstarted.withhsearch.customanalysis.MyLuceneAnalysisConfigurer"/> <!--6-->
             <!-- end::gettingstarted-configuration-orm_lucene-analysis[] -->
-
-            <!--
-                Not to be included in the documentation:
-                this configuration is only relevant in our own testing infrastructure.
-                WARNING: if you update the property name below,
-                take care to also update the name of the commented property just above.
-             -->
-            <property name="hibernate.search.schema_management.strategy"
-                      value="drop-and-create-and-drop"/>
-            <property name="hibernate.search.backend.directory.root"
-                      value="${project.build.directory}/test-indexes/gettingstarted/customanalysis/"/>
         </properties>
     </persistence-unit>
 
@@ -118,36 +67,6 @@
             <property name="hibernate.search.backend.analysis.configurer"
                       value="class:org.hibernate.search.documentation.gettingstarted.withhsearch.customanalysis.MyElasticsearchAnalysisConfigurer"/> <!--7-->
             <!-- end::gettingstarted-configuration-orm_elasticsearch-analysis[] -->
-
-            <!--
-                Not to be included in the documentation:
-                this configuration is only relevant in our own testing in
-                frastructure.
-                WARNING: if you update the property names below,
-                take care to also update the name of the commented properties just above.
-             -->
-            <property name="hibernate.search.schema_management.strategy"
-                      value="drop-and-create-and-drop"/>
-            <property name="hibernate.search.backend.hosts"
-                      value="${test.elasticsearch.connection.hosts}"/>
-            <property name="hibernate.search.backend.protocol"
-                      value="${test.elasticsearch.connection.protocol}"/>
-            <property name="hibernate.search.backend.username"
-                      value="${test.elasticsearch.connection.username}"/>
-            <property name="hibernate.search.backend.password"
-                      value="${test.elasticsearch.connection.password}"/>
-            <property name="hibernate.search.backend.aws.signing.enabled"
-                      value="${test.elasticsearch.connection.aws.signing.enabled}"/>
-            <property name="hibernate.search.backend.aws.region"
-                      value="${test.elasticsearch.connection.aws.region}"/>
-            <property name="hibernate.search.backend.aws.credentials.type"
-                      value="${test.elasticsearch.connection.aws.credentials.type}"/>
-            <property name="hibernate.search.backend.aws.credentials.access_key_id"
-                      value="${test.elasticsearch.connection.aws.credentials.access_key_id}"/>
-            <property name="hibernate.search.backend.aws.credentials.secret_access_key"
-                      value="${test.elasticsearch.connection.aws.credentials.secret_access_key}"/>
-            <property name="hibernate.search.automatic_indexing.synchronization.strategy"
-                      value="sync"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/documentation/src/test/resources/analysis/elasticsearch-simple.properties
+++ b/documentation/src/test/resources/analysis/elasticsearch-simple.properties
@@ -1,2 +1,2 @@
 # <1>
-hibernate.search.backend.analysis.configurer = org.hibernate.search.documentation.analysis.MyElasticsearchAnalysisConfigurer
+hibernate.search.backend.analysis.configurer = class:org.hibernate.search.documentation.analysis.MyElasticsearchAnalysisConfigurer

--- a/documentation/src/test/resources/analysis/lucene-simple.properties
+++ b/documentation/src/test/resources/analysis/lucene-simple.properties
@@ -1,2 +1,2 @@
 # <1>
-hibernate.search.backend.analysis.configurer = org.hibernate.search.documentation.analysis.MyLuceneAnalysisConfigurer
+hibernate.search.backend.analysis.configurer = class:org.hibernate.search.documentation.analysis.MyLuceneAnalysisConfigurer

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/bootstrap/ElasticsearchBootstrapFailureIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/bootstrap/ElasticsearchBootstrapFailureIT.java
@@ -36,9 +36,9 @@ public class ElasticsearchBootstrapFailureIT {
 		assertThatThrownBy(
 				() -> setupHelper.start()
 						.withBackendProperty(
-								ElasticsearchBackendSettings.HOSTS,
+								ElasticsearchBackendSettings.URIS,
 								// We just need a closed port, hopefully this one will generally be closed
-								"localhost:9199"
+								"http://localhost:9199"
 						)
 						.withIndex( StubMappedIndex.withoutFields() )
 						.setup(),

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/client/ElasticsearchContentLengthIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/client/ElasticsearchContentLengthIT.java
@@ -194,11 +194,16 @@ public class ElasticsearchContentLengthIT {
 				new ElasticsearchTckBackendHelper().createDefaultBackendSetupStrategy()
 						.createBackendConfigurationProperties( testConfigurationProvider );
 
-		// Redirect requests to Wiremock
 		Map<String, Object> clientProperties = new HashMap<>( defaultBackendProperties );
-		// Redirect requests to Wiremock (rule 1 only by default)
-		clientProperties.put( ElasticsearchBackendSettings.HOSTS, hostAndPortFor( wireMockRule ) );
-		clientProperties.put( ElasticsearchBackendSettings.PROTOCOL, "http" );
+
+		// We won't target the provided ES instance, but Wiremock
+		clientProperties.remove( ElasticsearchBackendSettings.HOSTS );
+		clientProperties.remove( ElasticsearchBackendSettings.PROTOCOL );
+		clientProperties.remove( ElasticsearchBackendSettings.URIS );
+
+		// Target the Wiremock server using HTTP
+		clientProperties.put( ElasticsearchBackendSettings.URIS, httpUriFor( wireMockRule ) );
+
 		ConfigurationPropertySource clientPropertySource = ConfigurationPropertySource.fromMap( clientProperties );
 
 		BeanResolver beanResolver = testConfigurationProvider.createBeanResolverForTest();
@@ -228,8 +233,8 @@ public class ElasticsearchContentLengthIT {
 		return builder.build();
 	}
 
-	private static String hostAndPortFor(WireMockRule rule) {
-		return "localhost:" + rule.port();
+	private static String httpUriFor(WireMockRule rule) {
+		return "http://localhost:" + rule.port();
 	}
 
 	private static UrlPathPattern urlPathLike(String path) {

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendSetupStrategy.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchTckBackendSetupStrategy.java
@@ -6,51 +6,19 @@
  */
 package org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Optional;
-
 import org.hibernate.search.engine.environment.bean.BeanReference;
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.configuration.DefaultITAnalysisConfigurer;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBackendAccessor;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBackendSetupStrategy;
-import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.ElasticsearchTestHostConnectionConfiguration;
+import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.ElasticsearchBackendConfiguration;
 import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.rule.TestElasticsearchClient;
 import org.hibernate.search.util.impl.integrationtest.common.TestConfigurationProvider;
 
-import org.junit.rules.TestRule;
-
-class ElasticsearchTckBackendSetupStrategy implements TckBackendSetupStrategy {
-
-	private final Map<String, Object> properties = new LinkedHashMap<>();
-	private boolean expectCustomBeans = false;
+class ElasticsearchTckBackendSetupStrategy extends TckBackendSetupStrategy<ElasticsearchBackendConfiguration> {
 
 	ElasticsearchTckBackendSetupStrategy() {
-		setProperty( "log.json_pretty_printing", "true" );
+		super( new ElasticsearchBackendConfiguration() );
 		setProperty( "analysis.configurer", BeanReference.ofInstance( new DefaultITAnalysisConfigurer() ) );
-		// Always add configuration options that allow to connect to Elasticsearch
-		ElasticsearchTestHostConnectionConfiguration.get().addToBackendProperties( properties );
-	}
-
-	ElasticsearchTckBackendSetupStrategy expectCustomBeans() {
-		expectCustomBeans = true;
-		return this;
-	}
-
-	ElasticsearchTckBackendSetupStrategy setProperty(String key, Object value) {
-		properties.put( key, value );
-		return this;
-	}
-
-	@Override
-	public Optional<TestRule> getTestRule() {
-		return Optional.empty();
-	}
-
-	@Override
-	public Map<String, ?> createBackendConfigurationProperties(TestConfigurationProvider configurationProvider) {
-		return configurationProvider.interpolateProperties( properties );
 	}
 
 	@Override
@@ -60,11 +28,4 @@ class ElasticsearchTckBackendSetupStrategy implements TckBackendSetupStrategy {
 		return new ElasticsearchTckBackendAccessor( client );
 	}
 
-	@Override
-	public SearchSetupHelper.SetupContext startSetup(SearchSetupHelper.SetupContext setupContext) {
-		if ( expectCustomBeans ) {
-			setupContext = setupContext.expectCustomBeans();
-		}
-		return setupContext;
-	}
 }

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/sharding/ShardingExplicitIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/sharding/ShardingExplicitIT.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import org.hibernate.search.backend.lucene.cfg.LuceneIndexSettings;
 import org.hibernate.search.integrationtest.backend.lucene.testsupport.util.LuceneTckBackendSetupStrategy;
 import org.hibernate.search.integrationtest.backend.tck.sharding.AbstractShardingRoutingKeyIT;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBackendSetupStrategy;
 import org.hibernate.search.util.common.impl.CollectionHelper;
 
 /**
@@ -18,7 +19,7 @@ import org.hibernate.search.util.common.impl.CollectionHelper;
  */
 public class ShardingExplicitIT extends AbstractShardingRoutingKeyIT {
 
-	protected static LuceneTckBackendSetupStrategy explicitShardingBackendSetupStrategy(Set<String> shardIds) {
+	protected static TckBackendSetupStrategy<?> explicitShardingBackendSetupStrategy(Set<String> shardIds) {
 		return new LuceneTckBackendSetupStrategy()
 				.setProperty( LuceneIndexSettings.SHARDING_STRATEGY, "explicit" )
 				.setProperty( LuceneIndexSettings.SHARDING_SHARD_IDENTIFIERS, String.join( ",", shardIds ) );

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/testsupport/util/LuceneTckBackendHelper.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/testsupport/util/LuceneTckBackendHelper.java
@@ -22,51 +22,51 @@ public class LuceneTckBackendHelper implements TckBackendHelper {
 	}
 
 	@Override
-	public TckBackendSetupStrategy createDefaultBackendSetupStrategy() {
+	public TckBackendSetupStrategy<?> createDefaultBackendSetupStrategy() {
 		return new LuceneTckBackendSetupStrategy();
 	}
 
 	@Override
-	public TckBackendSetupStrategy createMultiTenancyBackendSetupStrategy() {
+	public TckBackendSetupStrategy<?> createMultiTenancyBackendSetupStrategy() {
 		return new LuceneTckBackendSetupStrategy()
 				.setProperty( "multi_tenancy.strategy", "discriminator" );
 	}
 
 	@Override
-	public TckBackendSetupStrategy createAnalysisCustomBackendSetupStrategy() {
+	public TckBackendSetupStrategy<?> createAnalysisCustomBackendSetupStrategy() {
 		return new LuceneTckBackendSetupStrategy()
 				.expectCustomBeans()
 				.setProperty( "analysis.configurer", AnalysisCustomITAnalysisConfigurer.class.getName() );
 	}
 
 	@Override
-	public TckBackendSetupStrategy createAnalysisNotConfiguredBackendSetupStrategy() {
+	public TckBackendSetupStrategy<?> createAnalysisNotConfiguredBackendSetupStrategy() {
 		return new LuceneTckBackendSetupStrategy()
 				.setProperty( "analysis.configurer", null );
 	}
 
 	@Override
-	public TckBackendSetupStrategy createAnalysisBuiltinOverridesBackendSetupStrategy() {
+	public TckBackendSetupStrategy<?> createAnalysisBuiltinOverridesBackendSetupStrategy() {
 		return new LuceneTckBackendSetupStrategy()
 				.expectCustomBeans()
 				.setProperty( "analysis.configurer", AnalysisBuiltinOverrideITAnalysisConfigurer.class.getName() );
 	}
 
 	@Override
-	public TckBackendSetupStrategy createNoShardingBackendSetupStrategy() {
+	public TckBackendSetupStrategy<?> createNoShardingBackendSetupStrategy() {
 		// Sharding is disabled by default
 		return createDefaultBackendSetupStrategy();
 	}
 
 	@Override
-	public TckBackendSetupStrategy createHashBasedShardingBackendSetupStrategy(int shardCount) {
+	public TckBackendSetupStrategy<?> createHashBasedShardingBackendSetupStrategy(int shardCount) {
 		return new LuceneTckBackendSetupStrategy()
 				.setProperty( "sharding.strategy", "hash" )
 				.setProperty( "sharding.number_of_shards", String.valueOf( shardCount ) );
 	}
 
 	@Override
-	public TckBackendSetupStrategy createPeriodicRefreshBackendSetupStrategy(int refreshIntervalMs) {
+	public TckBackendSetupStrategy<?> createPeriodicRefreshBackendSetupStrategy(int refreshIntervalMs) {
 		return new LuceneTckBackendSetupStrategy()
 				.setProperty( "io.refresh_interval", String.valueOf( refreshIntervalMs ) );
 	}

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/testsupport/util/LuceneTckBackendSetupStrategy.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/testsupport/util/LuceneTckBackendSetupStrategy.java
@@ -8,49 +8,19 @@ package org.hibernate.search.integrationtest.backend.lucene.testsupport.util;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Optional;
 
 import org.hibernate.search.engine.environment.bean.BeanReference;
 import org.hibernate.search.integrationtest.backend.lucene.testsupport.configuration.DefaultITAnalysisConfigurer;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBackendAccessor;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBackendSetupStrategy;
-import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
-import org.hibernate.search.util.impl.integrationtest.backend.lucene.LuceneTestIndexesPathConfiguration;
+import org.hibernate.search.util.impl.integrationtest.backend.lucene.LuceneBackendConfiguration;
 import org.hibernate.search.util.impl.integrationtest.common.TestConfigurationProvider;
 
-import org.junit.rules.TestRule;
-
-public class LuceneTckBackendSetupStrategy implements TckBackendSetupStrategy {
-
-	private final Map<String, Object> properties = new LinkedHashMap<>();
-	private boolean expectCustomBeans = false;
+public class LuceneTckBackendSetupStrategy extends TckBackendSetupStrategy<LuceneBackendConfiguration> {
 
 	public LuceneTckBackendSetupStrategy() {
-		setProperty( "directory.root", LuceneTestIndexesPathConfiguration.get().getPath()
-				+ "/#{test.startup.timestamp}/#{test.id}/" );
+		super( new LuceneBackendConfiguration() );
 		setProperty( "analysis.configurer", BeanReference.ofInstance( new DefaultITAnalysisConfigurer() ) );
-	}
-
-	LuceneTckBackendSetupStrategy expectCustomBeans() {
-		expectCustomBeans = true;
-		return this;
-	}
-
-	public LuceneTckBackendSetupStrategy setProperty(String key, Object value) {
-		properties.put( key, value );
-		return this;
-	}
-
-	@Override
-	public Optional<TestRule> getTestRule() {
-		return Optional.empty();
-	}
-
-	@Override
-	public Map<String, ?> createBackendConfigurationProperties(TestConfigurationProvider configurationProvider) {
-		return configurationProvider.interpolateProperties( properties );
 	}
 
 	@Override
@@ -59,13 +29,5 @@ public class LuceneTckBackendSetupStrategy implements TckBackendSetupStrategy {
 				(String) configurationProvider.interpolateProperties( properties ).get( "directory.root" )
 		);
 		return new LuceneTckBackendAccessor( indexesPath );
-	}
-
-	@Override
-	public SearchSetupHelper.SetupContext startSetup(SearchSetupHelper.SetupContext setupContext) {
-		if ( expectCustomBeans ) {
-			setupContext = setupContext.expectCustomBeans();
-		}
-		return setupContext;
 	}
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/sharding/AbstractShardingRoutingKeyIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/sharding/AbstractShardingRoutingKeyIT.java
@@ -43,7 +43,7 @@ public abstract class AbstractShardingRoutingKeyIT extends AbstractShardingIT {
 
 	private final Map<String, List<String>> docIdByRoutingKey = new HashMap<>();
 
-	public AbstractShardingRoutingKeyIT(Function<TckBackendHelper, TckBackendSetupStrategy> setupStrategyFunction,
+	public AbstractShardingRoutingKeyIT(Function<TckBackendHelper, TckBackendSetupStrategy<?>> setupStrategyFunction,
 			Set<String> routingKeys) {
 		super( RoutingMode.EXPLICIT_ROUTING_KEYS );
 		this.setupHelper = new SearchSetupHelper( setupStrategyFunction );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendHelper.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendHelper.java
@@ -10,29 +10,29 @@ public interface TckBackendHelper {
 
 	TckBackendFeatures getBackendFeatures();
 
-	TckBackendSetupStrategy createDefaultBackendSetupStrategy();
+	TckBackendSetupStrategy<?> createDefaultBackendSetupStrategy();
 
-	TckBackendSetupStrategy createMultiTenancyBackendSetupStrategy();
+	TckBackendSetupStrategy<?> createMultiTenancyBackendSetupStrategy();
 
 	/**
 	 * @return A setup strategy for {@link org.hibernate.search.integrationtest.backend.tck.analysis.AnalysisBuiltinIT}.
 	 */
-	TckBackendSetupStrategy createAnalysisNotConfiguredBackendSetupStrategy();
+	TckBackendSetupStrategy<?> createAnalysisNotConfiguredBackendSetupStrategy();
 
 	/**
 	 * @return A setup strategy for {@link org.hibernate.search.integrationtest.backend.tck.analysis.AnalysisBuiltinOverrideIT}.
 	 */
-	TckBackendSetupStrategy createAnalysisBuiltinOverridesBackendSetupStrategy();
+	TckBackendSetupStrategy<?> createAnalysisBuiltinOverridesBackendSetupStrategy();
 
 	/**
 	 * @return A setup strategy for {@link org.hibernate.search.integrationtest.backend.tck.analysis.AnalysisCustomIT}.
 	 */
-	TckBackendSetupStrategy createAnalysisCustomBackendSetupStrategy();
+	TckBackendSetupStrategy<?> createAnalysisCustomBackendSetupStrategy();
 
-	TckBackendSetupStrategy createNoShardingBackendSetupStrategy();
+	TckBackendSetupStrategy<?> createNoShardingBackendSetupStrategy();
 
-	TckBackendSetupStrategy createHashBasedShardingBackendSetupStrategy(int shardCount);
+	TckBackendSetupStrategy<?> createHashBasedShardingBackendSetupStrategy(int shardCount);
 
-	TckBackendSetupStrategy createPeriodicRefreshBackendSetupStrategy(int refreshIntervalMs);
+	TckBackendSetupStrategy<?> createPeriodicRefreshBackendSetupStrategy(int refreshIntervalMs);
 
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/rule/SearchSetupHelper.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/rule/SearchSetupHelper.java
@@ -52,7 +52,7 @@ public class SearchSetupHelper implements TestRule {
 	private final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private final TestConfigurationProvider configurationProvider;
-	private final TckBackendSetupStrategy setupStrategy;
+	private final TckBackendSetupStrategy<?> setupStrategy;
 	private final TestRule delegateRule;
 
 	private final List<SearchIntegrationPartialBuildState> integrationPartialBuildStates = new ArrayList<>();
@@ -63,10 +63,10 @@ public class SearchSetupHelper implements TestRule {
 		this( TckBackendHelper::createDefaultBackendSetupStrategy );
 	}
 
-	public SearchSetupHelper(Function<TckBackendHelper, TckBackendSetupStrategy> setupStrategyFunction) {
+	public SearchSetupHelper(Function<TckBackendHelper, TckBackendSetupStrategy<?>> setupStrategyFunction) {
 		this.configurationProvider = new TestConfigurationProvider();
 		this.setupStrategy = setupStrategyFunction.apply( TckConfiguration.get().getBackendHelper() );
-		Optional<TestRule> setupStrategyTestRule = setupStrategy.getTestRule();
+		Optional<TestRule> setupStrategyTestRule = setupStrategy.testRule();
 		this.delegateRule = setupStrategyTestRule
 				.<TestRule>map( rule -> RuleChain.outerRule( configurationProvider ).around( rule ) )
 				.orElse( configurationProvider );

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexIndexingPlanIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexIndexingPlanIT.java
@@ -51,12 +51,12 @@ public class IndexIndexingPlanIT {
 		return new Object[][] {
 				{
 						"No multi-tenancy",
-						(Function<TckBackendHelper, TckBackendSetupStrategy>) TckBackendHelper::createDefaultBackendSetupStrategy,
+						(Function<TckBackendHelper, TckBackendSetupStrategy<?>>) TckBackendHelper::createDefaultBackendSetupStrategy,
 						new StubBackendSessionContext()
 				},
 				{
 						"Multi-tenancy enabled explicitly",
-						(Function<TckBackendHelper, TckBackendSetupStrategy>) TckBackendHelper::createMultiTenancyBackendSetupStrategy,
+						(Function<TckBackendHelper, TckBackendSetupStrategy<?>>) TckBackendHelper::createMultiTenancyBackendSetupStrategy,
 						new StubBackendSessionContext( "tenant_1" )
 				}
 		};
@@ -69,7 +69,7 @@ public class IndexIndexingPlanIT {
 
 	private final SimpleMappedIndex<IndexBinding> index = SimpleMappedIndex.of( IndexBinding::new );
 
-	public IndexIndexingPlanIT(String label, Function<TckBackendHelper, TckBackendSetupStrategy> setupStrategyFunction,
+	public IndexIndexingPlanIT(String label, Function<TckBackendHelper, TckBackendSetupStrategy<?>> setupStrategyFunction,
 			StubBackendSessionContext sessionContext) {
 		this.setupHelper = new SearchSetupHelper( setupStrategyFunction );
 		this.sessionContext = sessionContext;

--- a/integrationtest/jdk/java-modules/src/main/resources/hibernate.properties
+++ b/integrationtest/jdk/java-modules/src/main/resources/hibernate.properties
@@ -15,7 +15,7 @@ hibernate.max_fetch_depth = 5
 
 # Hibernate Search properties:
 hibernate.search.automatic_indexing.synchronization.strategy = sync
-hibernate.search.backend.hosts = ${test.elasticsearch.connection.hosts}
+hibernate.search.backend.uris = ${test.elasticsearch.connection.uris}
 hibernate.search.backend.username = ${test.elasticsearch.connection.username}
 hibernate.search.backend.password = ${test.elasticsearch.connection.password}
 hibernate.search.backend.aws.signing.enabled = ${test.elasticsearch.connection.aws.signing.enabled}

--- a/integrationtest/mapper/orm-batch-jsr352/src/test/resources/META-INF/persistence.xml
+++ b/integrationtest/mapper/orm-batch-jsr352/src/test/resources/META-INF/persistence.xml
@@ -39,7 +39,7 @@
             <property name="hibernate.search.automatic_indexing.strategy" value="none"/>
             <property name="hibernate.search.schema_management.strategy" value="drop-and-create-and-drop"/>
             <property name="hibernate.search.backend.type" value="elasticsearch" />
-            <property name="hibernate.search.backend.hosts" value="${test.elasticsearch.connection.hosts}" />
+            <property name="hibernate.search.backend.uris" value="${test.elasticsearch.connection.uris}" />
             <property name="hibernate.search.backend.username" value="${test.elasticsearch.connection.username}" />
             <property name="hibernate.search.backend.password" value="${test.elasticsearch.connection.password}" />
             <property name="hibernate.search.backend.aws.signing.enabled" value="${test.elasticsearch.connection.aws.signing.enabled}" />

--- a/integrationtest/performance/backend/README.md
+++ b/integrationtest/performance/backend/README.md
@@ -27,7 +27,7 @@ You may set parameters:
 
 ```
 java -jar integrationtest/performance/backend/elasticsearch/benchmarks.jar \
-    -jvmArgsPrepend -Dhosts=es1.mycompany.com \
+    -jvmArgsPrepend -Duris=http://es1.mycompany.com \
     -jvmArgsPrepend -Dprotocol=https \
     -i 10 -p batchSize=50
 ```

--- a/integrationtest/performance/backend/elasticsearch/src/main/java/org/hibernate/search/integrationtest/performance/backend/elasticsearch/testsupport/ElasticsearchBackendHolder.java
+++ b/integrationtest/performance/backend/elasticsearch/src/main/java/org/hibernate/search/integrationtest/performance/backend/elasticsearch/testsupport/ElasticsearchBackendHolder.java
@@ -39,7 +39,7 @@ public class ElasticsearchBackendHolder extends AbstractBackendHolder {
 		Map<String, Object> map = new LinkedHashMap<>();
 
 		// Custom connection info is provided by setting system properties,
-		// e.g. "hosts" or "aws.signing.enabled".
+		// e.g. "uris" or "aws.signing.enabled".
 		map.put( ElasticsearchIndexSettings.ANALYSIS_CONFIGURER, ElasticsearchPerformanceAnalysisConfigurer.class );
 
 		map.put( ElasticsearchIndexSettings.SCHEMA_MANAGEMENT_MINIMAL_REQUIRED_STATUS, IndexStatus.YELLOW );

--- a/integrationtest/showcase/library/pom.xml
+++ b/integrationtest/showcase/library/pom.xml
@@ -131,8 +131,7 @@
                         <JDBC_USERNAME>${jdbc.user}</JDBC_USERNAME>
                         <JDBC_PASSWORD>${jdbc.pass}</JDBC_PASSWORD>
                         <JDBC_ISOLATION>${jdbc.isolation}</JDBC_ISOLATION>
-                        <ELASTICSEARCH_HOSTS>${test.elasticsearch.connection.hosts}</ELASTICSEARCH_HOSTS>
-                        <ELASTICSEARCH_PROTOCOL>${test.elasticsearch.connection.protocol}</ELASTICSEARCH_PROTOCOL>
+                        <ELASTICSEARCH_URIS>${test.elasticsearch.connection.uris}</ELASTICSEARCH_URIS>
                         <ELASTICSEARCH_USERNAME>${test.elasticsearch.connection.username}</ELASTICSEARCH_USERNAME>
                         <ELASTICSEARCH_PASSWORD>${test.elasticsearch.connection.password}</ELASTICSEARCH_PASSWORD>
                         <ELASTICSEARCH_AWS_SIGNING_ENABLED>${test.elasticsearch.connection.aws.signing.enabled}</ELASTICSEARCH_AWS_SIGNING_ENABLED>

--- a/integrationtest/showcase/library/src/main/resources/application-elasticsearch.yaml
+++ b/integrationtest/showcase/library/src/main/resources/application-elasticsearch.yaml
@@ -3,8 +3,7 @@ spring.jpa:
     hibernate.search:
       backend:
         type: elasticsearch # Only necessary because we have both the Elasticsearch and Lucene backend in the classpath
-        hosts: ${ELASTICSEARCH_HOSTS} # From environment variable
-        protocol: ${ELASTICSEARCH_PROTOCOL} # From environment variable
+        uris: ${ELASTICSEARCH_URIS} # From environment variable
         username: ${ELASTICSEARCH_USERNAME} # From environment variable
         password: ${ELASTICSEARCH_PASSWORD} # From environment variable
         aws:

--- a/jenkins/performance-elasticsearch.groovy
+++ b/jenkins/performance-elasticsearch.groovy
@@ -52,8 +52,8 @@ stage('Configure') {
 			helper.generateNotificationProperty()
 	])
 
-	esAwsBuildEnv.endpointUrl = env.getProperty(esAwsBuildEnv.endpointVariableName)
-	if (!esAwsBuildEnv.endpointUrl) {
+	esAwsBuildEnv.endpointUris = env.getProperty(esAwsBuildEnv.endpointVariableName)
+	if (!esAwsBuildEnv.endpointUris) {
 		throw new IllegalStateException(
 				"Cannot run performance test because environment variable '$esAwsBuildEnv.endpointVariableName' is not defined."
 		)
@@ -101,8 +101,7 @@ lock(label: esAwsBuildEnv.lockedResourcesLabel) {
 					sh """ \
 							java \
 							-jar benchmarks.jar \
-							-jvmArgsAppend -Dhosts=$esAwsBuildEnv.endpointHostAndPort \
-							-jvmArgsAppend -Dprotocol=$esAwsBuildEnv.endpointProtocol \
+							-jvmArgsAppend -Duris=$esAwsBuildEnv.endpointUris \
 							-jvmArgsAppend -Daws.signing.enabled=true \
 							-jvmArgsAppend -Daws.region=$esAwsBuildEnv.awsRegion \
 							-jvmArgsAppend -Daws.credentials.type=static \
@@ -125,9 +124,7 @@ lock(label: esAwsBuildEnv.lockedResourcesLabel) {
 
 class EsAwsBuildEnvironment {
 	String version
-	String endpointUrl = null
-	String endpointHostAndPort = null
-	String endpointProtocol = null
+	String endpointUris = null
 	String awsRegion = null
 	String getNameEmbeddableVersion() {
 		version.replaceAll('\\.', '')
@@ -137,17 +134,5 @@ class EsAwsBuildEnvironment {
 	}
 	String getLockedResourcesLabel() {
 		"es-aws-${nameEmbeddableVersion}"
-	}
-	String setEndpointUrl(String url) {
-		this.endpointUrl = url
-		if ( endpointUrl ) {
-			def matcher = endpointUrl =~ /^(?:(https?):\/\/)?(.*)$/
-			endpointProtocol = matcher[0][1]
-			endpointHostAndPort = matcher[0][2]
-		}
-		else {
-			endpointProtocol = null
-			endpointHostAndPort = null
-		}
 	}
 }

--- a/jenkins/performance-elasticsearch.groovy
+++ b/jenkins/performance-elasticsearch.groovy
@@ -24,7 +24,7 @@ import org.hibernate.jenkins.pipeline.helpers.job.JobHelper
 
 @Field JobHelper helper
 
-@Field EsAwsBuildEnvironment esAwsBuildEnv = new EsAwsBuildEnvironment(version: "7.1")
+@Field EsAwsBuildEnvironment esAwsBuildEnv = new EsAwsBuildEnvironment(version: "7.8")
 
 this.helper = new JobHelper(this)
 

--- a/parents/integrationtest/pom.xml
+++ b/parents/integrationtest/pom.xml
@@ -267,23 +267,22 @@
         <profile>
             <id>elasticsearch-run</id>
             <activation>
-                <!-- Activate by default, i.e. if test.elasticsearch.connection.hosts has not been defined explicitly -->
+                <!-- Activate by default, i.e. if test.elasticsearch.connection.uris has not been defined explicitly -->
                 <property>
-                    <name>!test.elasticsearch.connection.hosts</name>
+                    <name>!test.elasticsearch.connection.uris</name>
                 </property>
             </activation>
             <properties>
-                <test.elasticsearch.connection.hosts>localhost:9200</test.elasticsearch.connection.hosts>
-                <test.elasticsearch.connection.protocol>http</test.elasticsearch.connection.protocol>
+                <test.elasticsearch.connection.uris>http://localhost:9200</test.elasticsearch.connection.uris>
             </properties>
         </profile>
         <!-- Profile enabled when an Elasticsearch instance must NOT be run by Maven -->
         <profile>
             <id>elasticsearch-do-not-run</id>
             <activation>
-                <!-- Activate if test.elasticsearch.connection.hosts has been defined explicitly -->
+                <!-- Activate if test.elasticsearch.connection.uris has been defined explicitly -->
                 <property>
-                    <name>test.elasticsearch.connection.hosts</name>
+                    <name>test.elasticsearch.connection.uris</name>
                 </property>
             </activation>
             <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -473,8 +473,7 @@
              because we will be able to change the configuration without re-compiling the configuration file
              (which is located in a dependency of the integration tests modules).
          -->
-        <test.elasticsearch.connection.hosts></test.elasticsearch.connection.hosts>
-        <test.elasticsearch.connection.protocol></test.elasticsearch.connection.protocol>
+        <test.elasticsearch.connection.uris></test.elasticsearch.connection.uris>
         <test.elasticsearch.connection.username></test.elasticsearch.connection.username>
         <test.elasticsearch.connection.password></test.elasticsearch.connection.password>
         <test.elasticsearch.connection.aws.signing.enabled>false</test.elasticsearch.connection.aws.signing.enabled>

--- a/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/ElasticsearchBackendConfiguration.java
+++ b/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/ElasticsearchBackendConfiguration.java
@@ -29,8 +29,12 @@ public class ElasticsearchBackendConfiguration extends BackendConfiguration {
 		return Optional.of( testElasticsearchClient );
 	}
 
+	public TestElasticsearchClient testElasticsearchClient() {
+		return testElasticsearchClient;
+	}
+
 	@Override
-	protected Map<String, String> rawBackendProperties() {
+	public Map<String, String> rawBackendProperties() {
 		Map<String, String> properties = new LinkedHashMap<>();
 		properties.put( "log.json_pretty_printing", "true" );
 		ElasticsearchTestHostConnectionConfiguration.get().addToBackendProperties( properties );

--- a/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/ElasticsearchBackendConfiguration.java
+++ b/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/ElasticsearchBackendConfiguration.java
@@ -30,8 +30,8 @@ public class ElasticsearchBackendConfiguration extends BackendConfiguration {
 	}
 
 	@Override
-	protected Map<String, Object> backendProperties() {
-		Map<String, Object> properties = new LinkedHashMap<>();
+	protected Map<String, String> rawBackendProperties() {
+		Map<String, String> properties = new LinkedHashMap<>();
 		properties.put( "log.json_pretty_printing", "true" );
 		ElasticsearchTestHostConnectionConfiguration.get().addToBackendProperties( properties );
 		return properties;

--- a/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/ElasticsearchTestHostConnectionConfiguration.java
+++ b/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/ElasticsearchTestHostConnectionConfiguration.java
@@ -25,8 +25,7 @@ public class ElasticsearchTestHostConnectionConfiguration {
 		return instance;
 	}
 
-	private final String hosts;
-	private final String protocol;
+	private final String uris;
 	private final String username;
 	private final String password;
 	private final Boolean awsSigningEnabled;
@@ -36,8 +35,7 @@ public class ElasticsearchTestHostConnectionConfiguration {
 	private final String awsCredentialsSecretAccessKey;
 
 	private ElasticsearchTestHostConnectionConfiguration() {
-		this.hosts = System.getProperty( "test.elasticsearch.connection.hosts" );
-		this.protocol = System.getProperty( "test.elasticsearch.connection.protocol" );
+		this.uris = System.getProperty( "test.elasticsearch.connection.uris" );
 		this.username = System.getProperty( "test.elasticsearch.connection.username" );
 		this.password = System.getProperty( "test.elasticsearch.connection.password" );
 		String enabledAsString = System.getProperty( "test.elasticsearch.connection.aws.signing.enabled" );
@@ -48,8 +46,8 @@ public class ElasticsearchTestHostConnectionConfiguration {
 		this.awsCredentialsSecretAccessKey = System.getProperty( "test.elasticsearch.connection.aws.credentials.secret_access_key" );
 
 		log.infof(
-				"Integration tests will connect to '%s' using protocol '%s' (AWS signing enabled: '%s')",
-				hosts, protocol, awsSigningEnabled
+				"Integration tests will connect to '%s' (AWS signing enabled: '%s')",
+				uris, awsSigningEnabled
 		);
 	}
 
@@ -58,8 +56,7 @@ public class ElasticsearchTestHostConnectionConfiguration {
 	}
 
 	public void addToBackendProperties(Map<String, ? super String> properties) {
-		properties.put( "hosts", hosts );
-		properties.put( "protocol", protocol );
+		properties.put( "uris", uris );
 		properties.put( "username", username );
 		properties.put( "password", password );
 		properties.put( "aws.signing.enabled", awsSigningEnabled == null ? null : awsSigningEnabled.toString() );

--- a/util/internal/integrationtest/backend/lucene/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/lucene/LuceneBackendConfiguration.java
+++ b/util/internal/integrationtest/backend/lucene/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/lucene/LuceneBackendConfiguration.java
@@ -18,8 +18,8 @@ public class LuceneBackendConfiguration extends BackendConfiguration {
 	}
 
 	@Override
-	protected Map<String, Object> backendProperties() {
-		Map<String, Object> properties = new LinkedHashMap<>();
+	protected Map<String, String> rawBackendProperties() {
+		Map<String, String> properties = new LinkedHashMap<>();
 		properties.put(
 				"directory.root",
 				LuceneTestIndexesPathConfiguration.get().getPath()

--- a/util/internal/integrationtest/backend/lucene/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/lucene/LuceneBackendConfiguration.java
+++ b/util/internal/integrationtest/backend/lucene/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/lucene/LuceneBackendConfiguration.java
@@ -18,7 +18,7 @@ public class LuceneBackendConfiguration extends BackendConfiguration {
 	}
 
 	@Override
-	protected Map<String, String> rawBackendProperties() {
+	public Map<String, String> rawBackendProperties() {
 		Map<String, String> properties = new LinkedHashMap<>();
 		properties.put(
 				"directory.root",

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/TestConfigurationProvider.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/TestConfigurationProvider.java
@@ -85,14 +85,15 @@ public final class TestConfigurationProvider implements TestRule {
 		return interpolateProperties( propertiesAsMap );
 	}
 
-	public Map<String, Object> interpolateProperties(Map<String, Object> properties) {
-		Map<String, Object> interpolatedProperties = new LinkedHashMap<>();
+	@SuppressWarnings("unchecked")
+	public <V> Map<String, V> interpolateProperties(Map<String, V> properties) {
+		Map<String, V> interpolatedProperties = new LinkedHashMap<>();
 
 		properties.forEach( (k, v) -> {
 			if ( v instanceof String ) {
 				interpolatedProperties.put(
 						k,
-						( (String) v ).replace( "#{test.id}", testId )
+						(V) ( (String) v ).replace( "#{test.id}", testId )
 								.replace( "#{test.startup.timestamp}", STARTUP_TIMESTAMP ) );
 			}
 			else {

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendConfiguration.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendConfiguration.java
@@ -76,6 +76,6 @@ public abstract class BackendConfiguration {
 		return configurationProvider.interpolateProperties( rawBackendProperties );
 	}
 
-	protected abstract Map<String, String> rawBackendProperties();
+	public abstract Map<String, String> rawBackendProperties();
 
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendConfiguration.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendConfiguration.java
@@ -62,18 +62,20 @@ public abstract class BackendConfiguration {
 	public <C extends MappingSetupHelper<C, ?, ?>.AbstractSetupContext> C setup(C setupContext,
 			String backendNameOrNull, TestConfigurationProvider configurationProvider) {
 		setupContext = setupContext
-				.withBackendProperties(
-						backendNameOrNull,
-						configurationProvider.interpolateProperties( backendProperties() )
-				);
-		if ( IS_IDE ) {
-			// More than one backend type in the classpath, we have to set it explicitly.
-			setupContext = setupContext.withBackendProperty( backendNameOrNull,
-					BackendSettings.TYPE, BACKEND_TYPE );
-		}
+				.withBackendProperties( backendNameOrNull, backendProperties( configurationProvider ) );
+
 		return setupContext;
 	}
 
-	protected abstract Map<String, Object> backendProperties();
+	public final Map<String, String> backendProperties(TestConfigurationProvider configurationProvider) {
+		Map<String, String> rawBackendProperties = rawBackendProperties();
+		if ( IS_IDE ) {
+			// More than one backend type in the classpath, we have to set it explicitly.
+			rawBackendProperties.put( BackendSettings.TYPE, BACKEND_TYPE );
+		}
+		return configurationProvider.interpolateProperties( rawBackendProperties );
+	}
+
+	protected abstract Map<String, String> rawBackendProperties();
 
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/MappingSetupHelper.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/MappingSetupHelper.java
@@ -82,7 +82,7 @@ public abstract class MappingSetupHelper<C extends MappingSetupHelper<C, B, R>.A
 
 		public abstract C withProperty(String keyRadical, Object value);
 
-		public final C withProperties(Map<String, Object> properties) {
+		public final C withProperties(Map<String, ?> properties) {
 			properties.forEach( this::withProperty );
 			return thisAsC();
 		}
@@ -104,7 +104,7 @@ public abstract class MappingSetupHelper<C extends MappingSetupHelper<C, B, R>.A
 			}
 		}
 
-		public final C withBackendProperties(String backendName, Map<String, Object> relativeProperties) {
+		public final C withBackendProperties(String backendName, Map<String, ?> relativeProperties) {
 			relativeProperties.forEach( (k, v) -> withBackendProperty( backendName, k, v ) );
 			return thisAsC();
 		}

--- a/util/internal/integrationtest/v5migrationhelper/src/main/java/org/hibernate/search/testsupport/configuration/V5MigrationHelperTestDefaultLuceneAnalysisConfigurer.java
+++ b/util/internal/integrationtest/v5migrationhelper/src/main/java/org/hibernate/search/testsupport/configuration/V5MigrationHelperTestDefaultLuceneAnalysisConfigurer.java
@@ -21,7 +21,7 @@ import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.analysis.standard.StandardTokenizerFactory;
 import org.apache.lucene.search.similarities.ClassicSimilarity;
 
-class V5MigrationHelperTestDefaultLuceneAnalysisConfigurer implements LuceneAnalysisConfigurer {
+public class V5MigrationHelperTestDefaultLuceneAnalysisConfigurer implements LuceneAnalysisConfigurer {
 	@Override
 	public void configure(LuceneAnalysisConfigurationContext context) {
 		context.similarity( new ClassicSimilarity() );

--- a/util/internal/integrationtest/v5migrationhelper/src/main/java/org/hibernate/search/testsupport/configuration/V5MigrationHelperTestLuceneBackendConfiguration.java
+++ b/util/internal/integrationtest/v5migrationhelper/src/main/java/org/hibernate/search/testsupport/configuration/V5MigrationHelperTestLuceneBackendConfiguration.java
@@ -12,11 +12,11 @@ import org.hibernate.search.util.impl.integrationtest.backend.lucene.LuceneBacke
 
 public class V5MigrationHelperTestLuceneBackendConfiguration extends LuceneBackendConfiguration {
 	@Override
-	protected Map<String, Object> backendProperties() {
-		Map<String, Object> properties = super.backendProperties();
+	protected Map<String, String> rawBackendProperties() {
+		Map<String, String> properties = super.rawBackendProperties();
 		properties.put(
 				"analysis.configurer",
-				new V5MigrationHelperTestDefaultLuceneAnalysisConfigurer()
+				"constructor:" + V5MigrationHelperTestDefaultLuceneAnalysisConfigurer.class.getName()
 		);
 		return properties;
 	}

--- a/util/internal/integrationtest/v5migrationhelper/src/main/java/org/hibernate/search/testsupport/configuration/V5MigrationHelperTestLuceneBackendConfiguration.java
+++ b/util/internal/integrationtest/v5migrationhelper/src/main/java/org/hibernate/search/testsupport/configuration/V5MigrationHelperTestLuceneBackendConfiguration.java
@@ -12,7 +12,7 @@ import org.hibernate.search.util.impl.integrationtest.backend.lucene.LuceneBacke
 
 public class V5MigrationHelperTestLuceneBackendConfiguration extends LuceneBackendConfiguration {
 	@Override
-	protected Map<String, String> rawBackendProperties() {
+	public Map<String, String> rawBackendProperties() {
 		Map<String, String> properties = super.rawBackendProperties();
 		properties.put(
 				"analysis.configurer",


### PR DESCRIPTION
* [HSEARCH-4136](https://hibernate.atlassian.net/browse/HSEARCH-4136): Use hibernate.search.backend.uris rather than hibernate.search.backend.hosts for tests in POMs
* [HSEARCH-4135](https://hibernate.atlassian.net/browse/HSEARCH-4135): Upgrade to ES 7.8 in Jenkinsfile of backend performance tests

