### PR TITLE
HSEARCH-4137 Reindexing is skipped when a contained entity change follows a change that is irrelevant to indexing

### DIFF
--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AssociationModelPrimitives.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AssociationModelPrimitives.java
@@ -29,6 +29,8 @@ public interface AssociationModelPrimitives<
 
 	TContained newContained(int id);
 
+	void setContainingEntityNonIndexedField(TContaining containing, String value);
+
 	void setChild(TContaining parent, TContaining child);
 
 	void setParent(TContaining child, TContaining parent);

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingSingleAssociationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/AutomaticIndexingSingleAssociationIT.java
@@ -850,6 +850,11 @@ public class AutomaticIndexingSingleAssociationIT extends AbstractAutomaticIndex
 		}
 
 		@Override
+		public void setContainingEntityNonIndexedField(ContainingEntity containingEntity, String value) {
+			containingEntity.setNonIndexedField( value );
+		}
+
+		@Override
 		public void setChild(ContainingEntity parent, ContainingEntity child) {
 			parent.setChild( child );
 		}
@@ -962,6 +967,8 @@ public class AutomaticIndexingSingleAssociationIT extends AbstractAutomaticIndex
 		@Id
 		private Integer id;
 
+		private String nonIndexedField;
+
 		@OneToOne
 		private ContainingEntity parent;
 
@@ -1011,6 +1018,14 @@ public class AutomaticIndexingSingleAssociationIT extends AbstractAutomaticIndex
 
 		public void setId(Integer id) {
 			this.id = id;
+		}
+
+		public String getNonIndexedField() {
+			return nonIndexedField;
+		}
+
+		public void setNonIndexedField(String nonIndexedField) {
+			this.nonIndexedField = nonIndexedField;
 		}
 
 		public ContainingEntity getParent() {

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/multi/AutomaticIndexingListAssociationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/multi/AutomaticIndexingListAssociationIT.java
@@ -93,6 +93,11 @@ public class AutomaticIndexingListAssociationIT extends AbstractAutomaticIndexin
 		}
 
 		@Override
+		public void setContainingEntityNonIndexedField(ContainingEntity containingEntity, String value) {
+			containingEntity.setNonIndexedField( value );
+		}
+
+		@Override
 		public void setChild(ContainingEntity parent, ContainingEntity child) {
 			parent.setChild( child );
 		}
@@ -272,6 +277,8 @@ public class AutomaticIndexingListAssociationIT extends AbstractAutomaticIndexin
 		@Id
 		private Integer id;
 
+		private String nonIndexedField;
+
 		@OneToOne
 		private ContainingEntity parent;
 
@@ -327,6 +334,14 @@ public class AutomaticIndexingListAssociationIT extends AbstractAutomaticIndexin
 
 		public void setId(Integer id) {
 			this.id = id;
+		}
+
+		public String getNonIndexedField() {
+			return nonIndexedField;
+		}
+
+		public void setNonIndexedField(String nonIndexedField) {
+			this.nonIndexedField = nonIndexedField;
 		}
 
 		public ContainingEntity getParent() {

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/multi/AutomaticIndexingMapKeysAssociationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/multi/AutomaticIndexingMapKeysAssociationIT.java
@@ -102,6 +102,11 @@ public class AutomaticIndexingMapKeysAssociationIT extends AbstractAutomaticInde
 		}
 
 		@Override
+		public void setContainingEntityNonIndexedField(ContainingEntity containingEntity, String value) {
+			containingEntity.setNonIndexedField( value );
+		}
+
+		@Override
 		public void setChild(ContainingEntity parent, ContainingEntity child) {
 			parent.setChild( child );
 		}
@@ -281,6 +286,8 @@ public class AutomaticIndexingMapKeysAssociationIT extends AbstractAutomaticInde
 		@Id
 		private Integer id;
 
+		private String nonIndexedField;
+
 		@OneToOne
 		private ContainingEntity parent;
 
@@ -392,6 +399,14 @@ public class AutomaticIndexingMapKeysAssociationIT extends AbstractAutomaticInde
 
 		public void setId(Integer id) {
 			this.id = id;
+		}
+
+		public String getNonIndexedField() {
+			return nonIndexedField;
+		}
+
+		public void setNonIndexedField(String nonIndexedField) {
+			this.nonIndexedField = nonIndexedField;
 		}
 
 		public ContainingEntity getParent() {

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/multi/AutomaticIndexingMapValuesAssociationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/multi/AutomaticIndexingMapValuesAssociationIT.java
@@ -97,6 +97,11 @@ public class AutomaticIndexingMapValuesAssociationIT extends AbstractAutomaticIn
 		}
 
 		@Override
+		public void setContainingEntityNonIndexedField(ContainingEntity containingEntity, String value) {
+			containingEntity.setNonIndexedField( value );
+		}
+
+		@Override
 		public void setChild(ContainingEntity parent, ContainingEntity child) {
 			parent.setChild( child );
 		}
@@ -276,6 +281,8 @@ public class AutomaticIndexingMapValuesAssociationIT extends AbstractAutomaticIn
 		@Id
 		private Integer id;
 
+		private String nonIndexedField;
+
 		@OneToOne
 		private ContainingEntity parent;
 
@@ -367,6 +374,14 @@ public class AutomaticIndexingMapValuesAssociationIT extends AbstractAutomaticIn
 
 		public void setId(Integer id) {
 			this.id = id;
+		}
+
+		public String getNonIndexedField() {
+			return nonIndexedField;
+		}
+
+		public void setNonIndexedField(String nonIndexedField) {
+			this.nonIndexedField = nonIndexedField;
 		}
 
 		public ContainingEntity getParent() {

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/multi/AutomaticIndexingSortedMapValuesAssociationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/multi/AutomaticIndexingSortedMapValuesAssociationIT.java
@@ -100,6 +100,11 @@ public class AutomaticIndexingSortedMapValuesAssociationIT extends AbstractAutom
 		}
 
 		@Override
+		public void setContainingEntityNonIndexedField(ContainingEntity containingEntity, String value) {
+			containingEntity.setNonIndexedField( value );
+		}
+
+		@Override
 		public void setChild(ContainingEntity parent, ContainingEntity child) {
 			parent.setChild( child );
 		}
@@ -280,6 +285,8 @@ public class AutomaticIndexingSortedMapValuesAssociationIT extends AbstractAutom
 		@Id
 		private Integer id;
 
+		private String nonIndexedField;
+
 		@OneToOne
 		private ContainingEntity parent;
 
@@ -371,6 +378,14 @@ public class AutomaticIndexingSortedMapValuesAssociationIT extends AbstractAutom
 
 		public void setId(Integer id) {
 			this.id = id;
+		}
+
+		public String getNonIndexedField() {
+			return nonIndexedField;
+		}
+
+		public void setNonIndexedField(String nonIndexedField) {
+			this.nonIndexedField = nonIndexedField;
 		}
 
 		public ContainingEntity getParent() {

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/multi/AutomaticIndexingSortedSetAssociationIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/association/multi/AutomaticIndexingSortedSetAssociationIT.java
@@ -98,6 +98,11 @@ public class AutomaticIndexingSortedSetAssociationIT extends AbstractAutomaticIn
 		}
 
 		@Override
+		public void setContainingEntityNonIndexedField(ContainingEntity containingEntity, String value) {
+			containingEntity.setNonIndexedField( value );
+		}
+
+		@Override
 		public void setChild(ContainingEntity parent, ContainingEntity child) {
 			parent.setChild( child );
 		}
@@ -277,6 +282,8 @@ public class AutomaticIndexingSortedSetAssociationIT extends AbstractAutomaticIn
 		@Id
 		private Integer id;
 
+		private String nonIndexedField;
+
 		@OneToOne
 		private ContainingEntity parent;
 
@@ -338,6 +345,14 @@ public class AutomaticIndexingSortedSetAssociationIT extends AbstractAutomaticIn
 
 		public void setId(Integer id) {
 			this.id = id;
+		}
+
+		public String getNonIndexedField() {
+			return nonIndexedField;
+		}
+
+		public void setNonIndexedField(String nonIndexedField) {
+			this.nonIndexedField = nonIndexedField;
 		}
 
 		public ContainingEntity getParent() {

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexedTypeIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexedTypeIndexingPlan.java
@@ -46,10 +46,7 @@ public class PojoIndexedTypeIndexingPlan<I, E, R>
 	void updateBecauseOfContained(Object entity) {
 		Supplier<E> entitySupplier = typeContext.toEntitySupplier( sessionContext, entity );
 		I identifier = typeContext.identifierMapping().getIdentifier( null, entitySupplier );
-		if ( !statesPerId.containsKey( identifier ) ) {
-			getState( identifier ).updateBecauseOfContained( entitySupplier );
-		}
-		// If the entry is already there, no need for an additional update
+		getState( identifier ).updateBecauseOfContained( entitySupplier );
 	}
 
 	@Override
@@ -131,6 +128,12 @@ public class PojoIndexedTypeIndexingPlan<I, E, R>
 		}
 
 		void updateBecauseOfContained(Supplier<E> entitySupplier) {
+			if ( currentStatus == EntityStatus.ABSENT ) {
+				// This entity was deleted, but a containing entity still has a reference to it.
+				// Someone probably just forgot to clear an association.
+				// Just ignore the call.
+				return;
+			}
 			doUpdate( entitySupplier, null );
 			updatedBecauseOfContained = true;
 			// We don't want contained entities that haven't been modified to trigger an update of their


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4137
