### PR TITLE
HSEARCH-3325 Introduce NamedPredicates, similar to Hibernate Search 5's full-text filters

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/dsl/impl/ElasticsearchIndexSchemaNamedPredicateFactoryBuilder.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/dsl/impl/ElasticsearchIndexSchemaNamedPredicateFactoryBuilder.java
@@ -1,0 +1,58 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.document.model.dsl.impl;
+
+import java.util.Map;
+import org.hibernate.search.backend.elasticsearch.document.model.impl.AbstractElasticsearchIndexSchemaFieldNode;
+import org.hibernate.search.backend.elasticsearch.document.model.impl.ElasticsearchIndexSchemaNamedPredicateNode;
+import org.hibernate.search.backend.elasticsearch.document.model.impl.ElasticsearchIndexSchemaNodeCollector;
+import org.hibernate.search.backend.elasticsearch.document.model.impl.ElasticsearchIndexSchemaNodeContributor;
+import org.hibernate.search.backend.elasticsearch.document.model.impl.ElasticsearchIndexSchemaObjectNode;
+import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.AbstractTypeMapping;
+import org.hibernate.search.engine.backend.common.spi.FieldPaths;
+import org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaBuildContext;
+import org.hibernate.search.engine.reporting.spi.EventContexts;
+import org.hibernate.search.util.common.reporting.EventContext;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaNamedPredicateOptionsStep;
+import org.hibernate.search.engine.search.predicate.factories.NamedPredicateFactory;
+
+public class ElasticsearchIndexSchemaNamedPredicateFactoryBuilder implements IndexSchemaNamedPredicateOptionsStep,
+		ElasticsearchIndexSchemaNodeContributor, IndexSchemaBuildContext {
+
+	private final AbstractElasticsearchIndexSchemaObjectNodeBuilder parent;
+	private final String relativeNamedPredicateName;
+	private final String absoluteNamedPredicatePath;
+	private final NamedPredicateFactory factory;
+
+	ElasticsearchIndexSchemaNamedPredicateFactoryBuilder(AbstractElasticsearchIndexSchemaObjectNodeBuilder parent, String relativeNamedPredicateName,
+			NamedPredicateFactory factory) {
+		this.parent = parent;
+		this.relativeNamedPredicateName = relativeNamedPredicateName;
+		this.absoluteNamedPredicatePath = FieldPaths.compose( parent.getAbsolutePath(), relativeNamedPredicateName );
+		this.factory = factory;
+	}
+
+	@Override
+	public void contribute(ElasticsearchIndexSchemaNodeCollector collector,
+			ElasticsearchIndexSchemaObjectNode parentNode,
+			Map<String, AbstractElasticsearchIndexSchemaFieldNode> staticChildrenByNameForParent,
+			AbstractTypeMapping parentMapping) {
+
+		ElasticsearchIndexSchemaNamedPredicateNode namedPredicateNode = new ElasticsearchIndexSchemaNamedPredicateNode(
+				parentNode, relativeNamedPredicateName, factory
+		);
+
+		collector.collect( absoluteNamedPredicatePath, namedPredicateNode );
+	}
+
+	@Override
+	public EventContext eventContext() {
+		return parent.getRootNodeBuilder().getIndexEventContext()
+				.append( EventContexts.fromIndexFieldAbsolutePath( absoluteNamedPredicatePath ) );
+	}
+
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/dsl/impl/ElasticsearchIndexSchemaRootNodeBuilder.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/dsl/impl/ElasticsearchIndexSchemaRootNodeBuilder.java
@@ -18,6 +18,7 @@ import org.hibernate.search.backend.elasticsearch.document.model.impl.AbstractEl
 import org.hibernate.search.backend.elasticsearch.document.model.impl.ElasticsearchIndexModel;
 import org.hibernate.search.backend.elasticsearch.document.model.impl.ElasticsearchIndexSchemaValueFieldNode;
 import org.hibernate.search.backend.elasticsearch.document.model.impl.ElasticsearchIndexSchemaValueFieldTemplate;
+import org.hibernate.search.backend.elasticsearch.document.model.impl.ElasticsearchIndexSchemaNamedPredicateNode;
 import org.hibernate.search.backend.elasticsearch.document.model.impl.ElasticsearchIndexSchemaNodeCollector;
 import org.hibernate.search.backend.elasticsearch.document.model.impl.ElasticsearchIndexSchemaObjectFieldNode;
 import org.hibernate.search.backend.elasticsearch.document.model.impl.ElasticsearchIndexSchemaObjectFieldTemplate;
@@ -108,6 +109,7 @@ public class ElasticsearchIndexSchemaRootNodeBuilder extends AbstractElasticsear
 
 		Map<String, AbstractElasticsearchIndexSchemaFieldNode> staticFields = new HashMap<>();
 		List<AbstractElasticsearchIndexSchemaFieldTemplate<?>> fieldTemplates = new ArrayList<>();
+		final Map<String, ElasticsearchIndexSchemaNamedPredicateNode> namedPredicateNodes = new HashMap<>();
 
 		ElasticsearchIndexSchemaNodeCollector collector = new ElasticsearchIndexSchemaNodeCollector() {
 			@Override
@@ -134,6 +136,11 @@ public class ElasticsearchIndexSchemaRootNodeBuilder extends AbstractElasticsear
 			public void collect(NamedDynamicTemplate templateForMapping) {
 				mapping.addDynamicTemplate( templateForMapping );
 			}
+
+			@Override
+			public void collect(String absoluteNamedPredicatePath, ElasticsearchIndexSchemaNamedPredicateNode node) {
+				namedPredicateNodes.put( absoluteNamedPredicatePath, node );
+			}
 		};
 
 		Map<String, AbstractElasticsearchIndexSchemaFieldNode> staticChildrenByName = new TreeMap<>();
@@ -146,7 +153,7 @@ public class ElasticsearchIndexSchemaRootNodeBuilder extends AbstractElasticsear
 				analysisDefinitionRegistry, customIndexSettings,
 				mapping,
 				idDslConverter == null ? new StringToDocumentIdentifierValueConverter() : idDslConverter,
-				rootNode, staticFields, fieldTemplates
+				rootNode, staticFields, fieldTemplates, namedPredicateNodes
 		);
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/impl/ElasticsearchIndexModel.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/impl/ElasticsearchIndexModel.java
@@ -29,7 +29,6 @@ import org.hibernate.search.engine.reporting.spi.EventContexts;
 import org.hibernate.search.util.common.impl.CollectionHelper;
 import org.hibernate.search.util.common.reporting.EventContext;
 
-
 public class ElasticsearchIndexModel implements IndexDescriptor, ElasticsearchSearchIndexContext {
 
 	private final IndexNames names;
@@ -46,6 +45,7 @@ public class ElasticsearchIndexModel implements IndexDescriptor, ElasticsearchSe
 	private final List<IndexFieldDescriptor> includedStaticFields;
 	private final List<AbstractElasticsearchIndexSchemaFieldTemplate<?>> fieldTemplates;
 	private final ConcurrentMap<String, AbstractElasticsearchIndexSchemaFieldNode> dynamicFieldsCache = new ConcurrentHashMap<>();
+	private final Map<String, ElasticsearchIndexSchemaNamedPredicateNode> namedPredicateNodes;
 
 	public ElasticsearchIndexModel(IndexNames names,
 			String mappedTypeName,
@@ -53,7 +53,8 @@ public class ElasticsearchIndexModel implements IndexDescriptor, ElasticsearchSe
 			RootTypeMapping mapping, ToDocumentIdentifierValueConverter<?> idDslConverter,
 			ElasticsearchIndexSchemaObjectNode rootNode,
 			Map<String, AbstractElasticsearchIndexSchemaFieldNode> staticFields,
-			List<AbstractElasticsearchIndexSchemaFieldTemplate<?>> fieldTemplates) {
+			List<AbstractElasticsearchIndexSchemaFieldTemplate<?>> fieldTemplates,
+			Map<String, ElasticsearchIndexSchemaNamedPredicateNode> namedPredicateNodes) {
 		this.names = names;
 		this.mappedTypeName = mappedTypeName;
 		this.eventContext = EventContexts.fromIndexName( hibernateSearchName() );
@@ -67,6 +68,7 @@ public class ElasticsearchIndexModel implements IndexDescriptor, ElasticsearchSe
 				.filter( field -> IndexFieldInclusion.INCLUDED.equals( field.inclusion() ) )
 				.collect( Collectors.toList() ) );
 		this.fieldTemplates = fieldTemplates;
+		this.namedPredicateNodes = namedPredicateNodes;
 	}
 
 	@Override
@@ -115,6 +117,10 @@ public class ElasticsearchIndexModel implements IndexDescriptor, ElasticsearchSe
 
 	public EventContext getEventContext() {
 		return eventContext;
+	}
+
+	public ElasticsearchIndexSchemaNamedPredicateNode namedPredicateNode(String absoluteNamedPredicatePath) {
+		return namedPredicateNodes.get( absoluteNamedPredicatePath );
 	}
 
 	public void contributeLowLevelMetadata(LowLevelIndexMetadataBuilder builder) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/impl/ElasticsearchIndexSchemaNamedPredicateNode.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/impl/ElasticsearchIndexSchemaNamedPredicateNode.java
@@ -1,0 +1,44 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.document.model.impl;
+
+import org.hibernate.search.engine.search.predicate.factories.NamedPredicateFactory;
+
+public class ElasticsearchIndexSchemaNamedPredicateNode {
+
+	private final ElasticsearchIndexSchemaObjectNode parent;
+	private final String relativeNamedPredicateName;
+	private final String absoluteNamedPredicatePath;
+
+	private final NamedPredicateFactory factory;
+
+	public ElasticsearchIndexSchemaNamedPredicateNode(ElasticsearchIndexSchemaObjectNode parent,
+			String relativeNamedPredicateName,
+			NamedPredicateFactory factory) {
+		this.parent = parent;
+		this.relativeNamedPredicateName = relativeNamedPredicateName;
+		this.absoluteNamedPredicatePath = parent.absolutePath( relativeNamedPredicateName );
+		this.factory = factory;
+	}
+
+	public ElasticsearchIndexSchemaObjectNode parent() {
+		return parent;
+	}
+
+	public String absoluteNamedPredicatePath() {
+		return absoluteNamedPredicatePath;
+	}
+
+	public NamedPredicateFactory getFactory() {
+		return factory;
+	}
+
+	@Override
+	public String toString() {
+		return getClass().getSimpleName() + "[" + "parent=" + parent + ", relativeFieldName=" + relativeNamedPredicateName + "]";
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/impl/ElasticsearchIndexSchemaNodeCollector.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/impl/ElasticsearchIndexSchemaNodeCollector.java
@@ -21,4 +21,5 @@ public interface ElasticsearchIndexSchemaNodeCollector {
 
 	void collect(NamedDynamicTemplate templateForMapping);
 
+	void collect(String absoluteNamedPredicatePath, ElasticsearchIndexSchemaNamedPredicateNode node);
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
@@ -725,4 +725,12 @@ public interface Log extends BasicLogger {
 	@Message(id = ID_OFFSET + 136, value = "Invalid use of 'missing().use(...)' for a distance sort. Elasticsearch always assumes missing values have a distance of '+Infinity', and this behavior cannot be customized.")
 	SearchException missingAsOnSortNotSupported(@Param EventContext context);
 
+	@Message(id = ID_OFFSET + 137, value = "The index schema named predicate '%1$s' was added twice.")
+	SearchException indexSchemaNamedPredicateNameConflict(String relativeFilterName, @Param EventContext context);
+
+	@Message(id = ID_OFFSET + 138, value = "Multiple conflicting models for filter definition name '%1$s'.")
+	SearchException conflictingNamedPredicateModel(String name, @Param EventContext context);
+
+	@Message(id = ID_OFFSET + 139, value = "Unknown filter definition '%1$s'.")
+	SearchException unknownNamedPredicateForSearch(String name, @Param EventContext context);
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/scope/model/impl/ElasticsearchScopeSearchIndexesContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/scope/model/impl/ElasticsearchScopeSearchIndexesContext.java
@@ -17,6 +17,7 @@ import java.util.Set;
 
 import org.hibernate.search.backend.elasticsearch.document.model.impl.AbstractElasticsearchIndexSchemaFieldNode;
 import org.hibernate.search.backend.elasticsearch.document.model.impl.ElasticsearchIndexModel;
+import org.hibernate.search.backend.elasticsearch.document.model.impl.ElasticsearchIndexSchemaNamedPredicateNode;
 import org.hibernate.search.backend.elasticsearch.logging.impl.Log;
 import org.hibernate.search.backend.elasticsearch.search.impl.ElasticsearchMultiIndexSearchObjectFieldContext;
 import org.hibernate.search.backend.elasticsearch.search.impl.ElasticsearchMultiIndexSearchValueFieldContext;
@@ -101,6 +102,21 @@ public class ElasticsearchScopeSearchIndexesContext implements ElasticsearchSear
 		return resultOrNull;
 	}
 
+	@Override
+	public ElasticsearchIndexSchemaNamedPredicateNode namedPredicate(String absoluteNamedPredicatePath) {
+		ElasticsearchIndexSchemaNamedPredicateNode resultOrNull;
+		if ( elements().size() == 1 ) {
+			resultOrNull = indexModels.iterator().next().namedPredicateNode( absoluteNamedPredicatePath );
+		}
+		else {
+			resultOrNull = createMultiIndexNamedPredicateNode( absoluteNamedPredicatePath );
+		}
+		if ( resultOrNull == null ) {
+			throw log.unknownNamedPredicateForSearch( absoluteNamedPredicatePath, indexesEventContext() );
+		}
+		return resultOrNull;
+	}
+
 	private EventContext indexesEventContext() {
 		return EventContexts.fromIndexNames( hibernateSearchIndexNames() );
 	}
@@ -143,5 +159,29 @@ public class ElasticsearchScopeSearchIndexesContext implements ElasticsearchSear
 			return new ElasticsearchMultiIndexSearchValueFieldContext<>( hibernateSearchIndexNames, absoluteFieldPath,
 					(List) fieldForEachIndex );
 		}
+	}
+
+	@SuppressWarnings({"rawtypes", "unchecked"}) // We check types using reflection
+	private ElasticsearchIndexSchemaNamedPredicateNode createMultiIndexNamedPredicateNode(String absoluteNamedPredicatePath) {
+		List<ElasticsearchIndexSchemaNamedPredicateNode> nodeForEachIndex = new ArrayList<>();
+		ElasticsearchIndexSchemaNamedPredicateNode firstNode = null;
+		for ( ElasticsearchIndexModel indexModel : indexModels ) {
+			ElasticsearchIndexSchemaNamedPredicateNode nodeForCurrentIndex =
+					indexModel.namedPredicateNode( absoluteNamedPredicatePath );
+			if ( nodeForCurrentIndex == null ) {
+				continue;
+			}
+			if ( firstNode == null ) {
+				firstNode = nodeForCurrentIndex;
+			}
+			nodeForEachIndex.add( nodeForCurrentIndex );
+		}
+		if ( nodeForEachIndex.isEmpty() ) {
+			return null;
+		}
+		if ( nodeForEachIndex.size() > 1 ) {
+			throw log.conflictingNamedPredicateModel( absoluteNamedPredicatePath, indexesEventContext() );
+		}
+		return firstNode;
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/impl/ElasticsearchSearchIndexesContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/impl/ElasticsearchSearchIndexesContext.java
@@ -9,6 +9,7 @@ package org.hibernate.search.backend.elasticsearch.search.impl;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+import org.hibernate.search.backend.elasticsearch.document.model.impl.ElasticsearchIndexSchemaNamedPredicateNode;
 
 import org.hibernate.search.engine.backend.types.converter.spi.ToDocumentIdentifierValueConverter;
 import org.hibernate.search.engine.search.common.ValueConvert;
@@ -29,4 +30,5 @@ public interface ElasticsearchSearchIndexesContext {
 
 	ElasticsearchSearchFieldContext field(String absoluteFieldPath);
 
+	ElasticsearchIndexSchemaNamedPredicateNode namedPredicate(String absoluteNamedPredicatePath);
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchNamedPredicate.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchNamedPredicate.java
@@ -1,0 +1,108 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.search.predicate.impl;
+
+import java.util.Map;
+
+import org.hibernate.search.backend.elasticsearch.search.impl.ElasticsearchSearchContext;
+import org.hibernate.search.engine.search.predicate.SearchPredicate;
+
+import com.google.gson.JsonObject;
+import java.util.LinkedHashMap;
+import org.hibernate.search.backend.elasticsearch.document.model.impl.ElasticsearchIndexSchemaNamedPredicateNode;
+import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
+import org.hibernate.search.engine.search.predicate.factories.NamedPredicateFactoryContext;
+import org.hibernate.search.engine.search.predicate.factories.NamedPredicateFactory;
+import org.hibernate.search.engine.search.predicate.spi.NamedPredicateBuilder;
+
+class ElasticsearchNamedPredicate extends AbstractElasticsearchSingleFieldPredicate {
+
+	private final ElasticsearchSearchPredicate buildPredicate;
+
+	private ElasticsearchNamedPredicate(Builder builder) {
+		super( builder );
+		this.buildPredicate = builder.buildPredicate;
+		// Ensure illegal attempts to mutate the predicate will fail
+		builder.namedPredicate = null;
+		builder.params = null;
+		builder.buildPredicate = null;
+	}
+
+	@Override
+	public void checkNestableWithin(String expectedParentNestedPath) {
+		buildPredicate.checkNestableWithin( expectedParentNestedPath );
+		super.checkNestableWithin( expectedParentNestedPath );
+	}
+
+	@Override
+	protected JsonObject doToJsonQuery(PredicateRequestContext context,
+			JsonObject outerObject, JsonObject innerObject) {
+		return buildPredicate.toJsonQuery( context );
+	}
+
+	static class Builder extends AbstractBuilder implements NamedPredicateBuilder {
+		private Map<String, Object> params = new LinkedHashMap<>();
+		private ElasticsearchIndexSchemaNamedPredicateNode namedPredicate;
+		private ElasticsearchSearchPredicate buildPredicate;
+		private final SearchPredicateFactory predicateFactory;
+
+		Builder(ElasticsearchSearchContext searchContext, SearchPredicateFactory predicateFactory,
+				ElasticsearchIndexSchemaNamedPredicateNode filter) {
+			super( searchContext, filter.absoluteNamedPredicatePath(), filter.parent().nestedPathHierarchy() );
+			this.namedPredicate = filter;
+			this.predicateFactory = predicateFactory;
+		}
+
+		@Override
+		public void param(String name, Object value) {
+			params.put( name, value );
+		}
+
+		@Override
+		public SearchPredicate build() {
+			ElasticsearchNamedPredicateFactoryContext ctx = new ElasticsearchNamedPredicateFactoryContext( namedPredicate,
+					predicateFactory,
+					params );
+
+			NamedPredicateFactory namedPredicateFactory = (NamedPredicateFactory) namedPredicate.getFactory();
+
+			buildPredicate = (ElasticsearchSearchPredicate) namedPredicateFactory.create( ctx );
+
+			return new ElasticsearchNamedPredicate( this );
+		}
+	}
+
+	public static class ElasticsearchNamedPredicateFactoryContext implements NamedPredicateFactoryContext {
+
+		private final ElasticsearchIndexSchemaNamedPredicateNode namedPredicate;
+		private final SearchPredicateFactory predicate;
+		private final Map<String, Object> params;
+
+		public ElasticsearchNamedPredicateFactoryContext(ElasticsearchIndexSchemaNamedPredicateNode namedPredicate,
+				SearchPredicateFactory predicate,
+				Map<String, Object> params) {
+			this.namedPredicate = namedPredicate;
+			this.predicate = predicate;
+			this.params = params;
+		}
+
+		@Override
+		public SearchPredicateFactory predicate() {
+			return predicate;
+		}
+
+		@Override
+		public Object param(String name) {
+			return params.get( name );
+		}
+
+		@Override
+		public String resolvePath(String relativeFieldName) {
+			return namedPredicate.parent().absolutePath( relativeFieldName );
+		}
+	}
+}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchSearchPredicateBuilderFactoryImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchSearchPredicateBuilderFactoryImpl.java
@@ -31,6 +31,9 @@ import org.hibernate.search.engine.search.predicate.spi.WildcardPredicateBuilder
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
 import com.google.gson.JsonObject;
+import org.hibernate.search.backend.elasticsearch.document.model.impl.ElasticsearchIndexSchemaNamedPredicateNode;
+import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
+import org.hibernate.search.engine.search.predicate.spi.NamedPredicateBuilder;
 
 public class ElasticsearchSearchPredicateBuilderFactoryImpl implements ElasticsearchSearchPredicateBuilderFactory {
 
@@ -141,5 +144,11 @@ public class ElasticsearchSearchPredicateBuilderFactoryImpl implements Elasticse
 	@Override
 	public ElasticsearchSearchPredicate fromJson(String jsonString) {
 		return fromJson( searchContext.userFacingGson().fromJson( jsonString, JsonObject.class ) );
+	}
+
+	@Override
+	public NamedPredicateBuilder named(SearchPredicateFactory predicateFactory, String name) {
+		ElasticsearchIndexSchemaNamedPredicateNode namedPredicate = indexes.namedPredicate( name );
+		return new ElasticsearchNamedPredicate.Builder( searchContext, predicateFactory, namedPredicate );
 	}
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/dsl/impl/LuceneIndexSchemaNamedPredicateFactoryBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/dsl/impl/LuceneIndexSchemaNamedPredicateFactoryBuilder.java
@@ -1,0 +1,54 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.document.model.dsl.impl;
+
+import java.util.Map;
+import org.hibernate.search.backend.lucene.document.model.impl.AbstractLuceneIndexSchemaFieldNode;
+import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexSchemaNamedPredicateNode;
+import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexSchemaNodeCollector;
+import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexSchemaNodeContributor;
+import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexSchemaObjectNode;
+import org.hibernate.search.engine.backend.common.spi.FieldPaths;
+import org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaBuildContext;
+import org.hibernate.search.engine.reporting.spi.EventContexts;
+import org.hibernate.search.util.common.reporting.EventContext;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaNamedPredicateOptionsStep;
+import org.hibernate.search.engine.search.predicate.factories.NamedPredicateFactory;
+
+public class LuceneIndexSchemaNamedPredicateFactoryBuilder implements IndexSchemaNamedPredicateOptionsStep,
+		LuceneIndexSchemaNodeContributor, IndexSchemaBuildContext {
+
+	private final AbstractLuceneIndexSchemaObjectNodeBuilder parent;
+	private final String relativeNamedPredicateName;
+	private final String absoluteNamedPredicatePath;
+	private final NamedPredicateFactory factory;
+
+	LuceneIndexSchemaNamedPredicateFactoryBuilder(AbstractLuceneIndexSchemaObjectNodeBuilder parent, String relativeNamedPredicateName, NamedPredicateFactory factory) {
+		this.parent = parent;
+		this.relativeNamedPredicateName = relativeNamedPredicateName;
+		this.absoluteNamedPredicatePath = FieldPaths.compose( parent.getAbsolutePath(), relativeNamedPredicateName );
+		this.factory = factory;
+	}
+
+	@Override
+	public void contribute(LuceneIndexSchemaNodeCollector collector, LuceneIndexSchemaObjectNode parentNode,
+			Map<String, AbstractLuceneIndexSchemaFieldNode> staticChildrenByNameForParent) {
+
+		LuceneIndexSchemaNamedPredicateNode namedPredicateNode = new LuceneIndexSchemaNamedPredicateNode(
+				parentNode, relativeNamedPredicateName, factory
+		);
+
+		collector.collect( absoluteNamedPredicatePath, namedPredicateNode );
+	}
+
+	@Override
+	public EventContext eventContext() {
+		return parent.getRootNodeBuilder().getIndexEventContext()
+				.append( EventContexts.fromIndexFieldAbsolutePath( absoluteNamedPredicatePath ) );
+	}
+
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/dsl/impl/LuceneIndexSchemaRootNodeBuilder.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/dsl/impl/LuceneIndexSchemaRootNodeBuilder.java
@@ -16,6 +16,7 @@ import org.hibernate.search.backend.lucene.analysis.model.impl.LuceneAnalysisDef
 import org.hibernate.search.backend.lucene.document.model.impl.AbstractLuceneIndexSchemaFieldNode;
 import org.hibernate.search.backend.lucene.document.model.impl.AbstractLuceneIndexSchemaFieldTemplate;
 import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexModel;
+import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexSchemaNamedPredicateNode;
 import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexSchemaValueFieldNode;
 import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexSchemaValueFieldTemplate;
 import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexSchemaNodeCollector;
@@ -78,6 +79,7 @@ public class LuceneIndexSchemaRootNodeBuilder extends AbstractLuceneIndexSchemaO
 	public LuceneIndexModel build(String indexName) {
 		Map<String, AbstractLuceneIndexSchemaFieldNode> staticFields = new HashMap<>();
 		List<AbstractLuceneIndexSchemaFieldTemplate<?>> fieldTemplates = new ArrayList<>();
+		Map<String, LuceneIndexSchemaNamedPredicateNode> namedPredicateNodes = new HashMap<>();
 		// Initializing a one-element array so that we can mutate the boolean below.
 		// Alternatively we could use AtomicBoolean, but we don't need concurrent access here.
 		boolean[] hasNestedDocument = new boolean[1];
@@ -105,6 +107,11 @@ public class LuceneIndexSchemaRootNodeBuilder extends AbstractLuceneIndexSchemaO
 			}
 
 			@Override
+			public void collect(String absoluteFilterPath, LuceneIndexSchemaNamedPredicateNode node) {
+				namedPredicateNodes.put( absoluteFilterPath, node );
+			}
+
+			@Override
 			public void collect(LuceneIndexSchemaValueFieldTemplate template) {
 				fieldTemplates.add( template );
 			}
@@ -118,7 +125,7 @@ public class LuceneIndexSchemaRootNodeBuilder extends AbstractLuceneIndexSchemaO
 				indexName,
 				mappedTypeName,
 				idDslConverter == null ? new StringToDocumentIdentifierValueConverter() : idDslConverter,
-				rootNode, staticFields, fieldTemplates, hasNestedDocument[0]
+				rootNode, staticFields, fieldTemplates, namedPredicateNodes, hasNestedDocument[0]
 		);
 	}
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/impl/LuceneIndexModel.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/impl/LuceneIndexModel.java
@@ -40,6 +40,7 @@ public class LuceneIndexModel implements AutoCloseable, IndexDescriptor {
 	private final Map<String, AbstractLuceneIndexSchemaFieldNode> staticFields;
 	private final List<IndexFieldDescriptor> includedStaticFields;
 	private final List<AbstractLuceneIndexSchemaFieldTemplate<?>> fieldTemplates;
+	private final Map<String, LuceneIndexSchemaNamedPredicateNode> namedPredicateNodes;
 	private final boolean hasNestedDocuments;
 	private final ConcurrentMap<String, AbstractLuceneIndexSchemaFieldNode> dynamicFieldsCache = new ConcurrentHashMap<>();
 
@@ -52,6 +53,7 @@ public class LuceneIndexModel implements AutoCloseable, IndexDescriptor {
 			LuceneIndexSchemaObjectNode rootNode,
 			Map<String, AbstractLuceneIndexSchemaFieldNode> staticFields,
 			List<AbstractLuceneIndexSchemaFieldTemplate<?>> fieldTemplates,
+			Map<String, LuceneIndexSchemaNamedPredicateNode> namedPredicateNodes,
 			boolean hasNestedDocuments) {
 		this.indexName = indexName;
 		this.mappedTypeName = mappedTypeName;
@@ -64,6 +66,7 @@ public class LuceneIndexModel implements AutoCloseable, IndexDescriptor {
 		this.indexingAnalyzer = new IndexingScopedAnalyzer();
 		this.searchAnalyzer = new SearchScopedAnalyzer();
 		this.fieldTemplates = fieldTemplates;
+		this.namedPredicateNodes = namedPredicateNodes;
 		this.hasNestedDocuments = hasNestedDocuments;
 	}
 
@@ -123,6 +126,10 @@ public class LuceneIndexModel implements AutoCloseable, IndexDescriptor {
 
 	public Analyzer getSearchAnalyzer() {
 		return searchAnalyzer;
+	}
+
+	public LuceneIndexSchemaNamedPredicateNode namedPredicateNode(String absoluteNamedPredicateName) {
+		return namedPredicateNodes.get( absoluteNamedPredicateName );
 	}
 
 	@Override

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/impl/LuceneIndexSchemaNamedPredicateNode.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/impl/LuceneIndexSchemaNamedPredicateNode.java
@@ -1,0 +1,45 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.document.model.impl;
+
+import org.hibernate.search.engine.search.predicate.factories.NamedPredicateFactory;
+
+public class LuceneIndexSchemaNamedPredicateNode {
+
+	private final LuceneIndexSchemaObjectNode parent;
+	private final String relativeNamedPredicateName;
+	private final String absoluteNamedPredicatePath;
+
+	private final NamedPredicateFactory factory;
+
+	public LuceneIndexSchemaNamedPredicateNode(LuceneIndexSchemaObjectNode parent,
+			String relativeNamedPredicateName,
+			NamedPredicateFactory factory) {
+		this.parent = parent;
+		this.relativeNamedPredicateName = relativeNamedPredicateName;
+		this.absoluteNamedPredicatePath = parent.absolutePath( relativeNamedPredicateName );
+		this.factory = factory;
+	}
+
+	public LuceneIndexSchemaObjectNode parent() {
+		return parent;
+	}
+
+	public String absoluteNamedPredicatePath() {
+		return absoluteNamedPredicatePath;
+	}
+
+	public NamedPredicateFactory factory() {
+		return factory;
+	}
+
+	@Override
+	public String toString() {
+		return getClass().getSimpleName() + "[" + "parent=" + parent + ", relativeFieldName=" + relativeNamedPredicateName + "]";
+	}
+
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/impl/LuceneIndexSchemaNodeCollector.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/document/model/impl/LuceneIndexSchemaNodeCollector.java
@@ -15,4 +15,6 @@ public interface LuceneIndexSchemaNodeCollector {
 	void collect(LuceneIndexSchemaObjectFieldTemplate template);
 
 	void collect(LuceneIndexSchemaValueFieldTemplate template);
+
+	void collect(String absoluteNamedPredicatePath, LuceneIndexSchemaNamedPredicateNode schemaNamedPredicateNode);
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
@@ -636,4 +636,18 @@ public interface Log extends BasicLogger {
 			value = "Unable to create instance of analysis component '%1$s': %2$s")
 	SearchException unableToCreateAnalysisComponent(@FormatWith(ClassFormatter.class) Class<?> type, String causeMessage,
 			@Cause Exception cause);
+
+	@Message(id = ID_OFFSET + 143,
+			value = "The index schema named predicate '%1$s' was added twice.")
+	SearchException indexSchemaNamedPredicateNameConflict(String relativeFilterName,
+			@Param EventContext context);
+
+	@Message(id = ID_OFFSET + 144,
+
+		value = "Multiple conflicting models for named predicate definition name '%1$s'.")
+	SearchException conflictingNamedPredicateModel(String name, @Param EventContext context);
+
+	@Message(id = ID_OFFSET + 145,
+		value = "Unknown nmaed predicate definition '%1$s'.")
+	SearchException unknownNamedPredicateForSearch(String name, @Param EventContext context);
 }

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/impl/LuceneSearchIndexesContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/impl/LuceneSearchIndexesContext.java
@@ -10,6 +10,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
+import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexSchemaNamedPredicateNode;
 import org.hibernate.search.engine.backend.types.converter.spi.ToDocumentIdentifierValueConverter;
 import org.hibernate.search.engine.search.common.ValueConvert;
 
@@ -24,6 +25,8 @@ public interface LuceneSearchIndexesContext {
 	ToDocumentIdentifierValueConverter<?> idDslConverter(ValueConvert valueConvert);
 
 	LuceneSearchFieldContext field(String absoluteFieldPath);
+
+	LuceneIndexSchemaNamedPredicateNode namedPredicate(String absoluteNamedPredicatePath);
 
 	boolean hasNestedDocuments();
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/LuceneNamedPredicate.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/LuceneNamedPredicate.java
@@ -1,0 +1,106 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.search.predicate.impl;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.hibernate.search.backend.lucene.search.impl.LuceneSearchContext;
+import org.hibernate.search.engine.search.predicate.SearchPredicate;
+
+import org.apache.lucene.search.Query;
+import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexSchemaNamedPredicateNode;
+import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
+import org.hibernate.search.engine.search.predicate.factories.NamedPredicateFactoryContext;
+import org.hibernate.search.engine.search.predicate.factories.NamedPredicateFactory;
+import org.hibernate.search.engine.search.predicate.spi.NamedPredicateBuilder;
+
+class LuceneNamedPredicate extends AbstractLuceneSingleFieldPredicate {
+
+	private final LuceneSearchPredicate buildPredicate;
+
+	private LuceneNamedPredicate(Builder builder) {
+		super( builder );
+		buildPredicate = builder.buildPredicate;
+		// Ensure illegal attempts to mutate the predicate will fail
+		builder.namedPredicate = null;
+		builder.params = null;
+		builder.buildPredicate = null;
+	}
+
+	@Override
+	public void checkNestableWithin(String expectedParentNestedPath) {
+		buildPredicate.checkNestableWithin( expectedParentNestedPath );
+		super.checkNestableWithin( expectedParentNestedPath );
+	}
+
+	@Override
+	protected Query doToQuery(PredicateRequestContext context) {
+		return buildPredicate.toQuery( context );
+	}
+
+	static class Builder extends AbstractBuilder implements NamedPredicateBuilder {
+		private Map<String, Object> params = new LinkedHashMap<>();
+		private LuceneIndexSchemaNamedPredicateNode namedPredicate;
+		private LuceneSearchPredicate buildPredicate;
+		private final SearchPredicateFactory predicateFactory;
+
+		Builder(LuceneSearchContext searchContext, SearchPredicateFactory predicateFactory,
+				LuceneIndexSchemaNamedPredicateNode namedPredicate) {
+			super( searchContext, namedPredicate.absoluteNamedPredicatePath(), namedPredicate.parent().nestedPathHierarchy() );
+			this.namedPredicate = namedPredicate;
+			this.predicateFactory = predicateFactory;
+		}
+
+		@Override
+		public void param(String name, Object value) {
+			params.put( name, value );
+		}
+
+		@Override
+		public SearchPredicate build() {
+			LuceneNamedPredicateFactoryContext ctx = new LuceneNamedPredicateFactoryContext(
+					namedPredicate,
+					predicateFactory, params );
+
+			NamedPredicateFactory namedPredicateFactory = (NamedPredicateFactory) namedPredicate.factory();
+
+			buildPredicate = (LuceneSearchPredicate) namedPredicateFactory.create( ctx );
+
+			return new LuceneNamedPredicate( this );
+		}
+	}
+
+	public static class LuceneNamedPredicateFactoryContext implements NamedPredicateFactoryContext {
+
+		private final SearchPredicateFactory predicate;
+		private final LuceneIndexSchemaNamedPredicateNode namedPredicate;
+		private final Map<String, Object> params;
+
+		public LuceneNamedPredicateFactoryContext(LuceneIndexSchemaNamedPredicateNode namedPredicate,
+				SearchPredicateFactory predicate, Map<String, Object> params) {
+			this.namedPredicate = namedPredicate;
+			this.predicate = predicate;
+			this.params = params;
+		}
+
+		@Override
+		public SearchPredicateFactory predicate() {
+			return predicate;
+		}
+
+		@Override
+		public Object param(String name) {
+			return params.get( name );
+		}
+
+		@Override
+		public String resolvePath(String relativeFieldName) {
+			return namedPredicate.parent().absolutePath( relativeFieldName );
+		}
+	}
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/LuceneSearchPredicateBuilderFactoryImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/search/predicate/impl/LuceneSearchPredicateBuilderFactoryImpl.java
@@ -30,6 +30,9 @@ import org.hibernate.search.engine.search.predicate.spi.WildcardPredicateBuilder
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
 import org.apache.lucene.search.Query;
+import org.hibernate.search.backend.lucene.document.model.impl.LuceneIndexSchemaNamedPredicateNode;
+import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
+import org.hibernate.search.engine.search.predicate.spi.NamedPredicateBuilder;
 
 
 public class LuceneSearchPredicateBuilderFactoryImpl implements LuceneSearchPredicateBuilderFactory {
@@ -78,6 +81,12 @@ public class LuceneSearchPredicateBuilderFactoryImpl implements LuceneSearchPred
 	@Override
 	public PhrasePredicateBuilder phrase(String absoluteFieldPath) {
 		return indexes.field( absoluteFieldPath ).queryElement( PredicateTypeKeys.PHRASE, searchContext );
+	}
+
+	@Override
+	public NamedPredicateBuilder named(SearchPredicateFactory namedPredicateFactory, String name) {
+		LuceneIndexSchemaNamedPredicateNode namedPredicate = indexes.namedPredicate( name );
+		return new LuceneNamedPredicate.Builder( searchContext, namedPredicateFactory, namedPredicate );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/IndexSchemaElement.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/IndexSchemaElement.java
@@ -14,6 +14,7 @@ import org.hibernate.search.engine.backend.types.ObjectStructure;
 import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeFactory;
 import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeFinalStep;
 import org.hibernate.search.engine.backend.types.IndexFieldType;
+import org.hibernate.search.engine.search.predicate.factories.NamedPredicateFactory;
 
 /**
  * An element of the index schema,
@@ -62,6 +63,17 @@ public interface IndexSchemaElement {
 	 */
 	<F> IndexSchemaFieldOptionsStep<?, IndexFieldReference<F>> field(String relativeFieldName,
 			Function<? super IndexFieldTypeFactory, ? extends IndexFieldTypeFinalStep<F>> typeContributor);
+
+	/**
+	 * Add a named predicate factory to this index schema element.
+	 *
+	 * @param relativeNamedPredicateName The relative name of the new named predicate.
+	 * @param factory The named predicate factory.
+	 * @return A DSL step where the named predicate can be defined in more details,
+	 * @see NamedPredicateFactory
+	 */
+	IndexSchemaNamedPredicateOptionsStep namedPredicate(
+			String relativeNamedPredicateName, NamedPredicateFactory factory);
 
 	/**
 	 * Add an object field to this index schema element with the default structure.

--- a/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/IndexSchemaNamedPredicateOptionsStep.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/IndexSchemaNamedPredicateOptionsStep.java
@@ -1,0 +1,16 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.backend.document.model.dsl;
+
+/**
+ * The final step in the definition of a named predicate in the index schema.
+ *
+ */
+public interface IndexSchemaNamedPredicateOptionsStep {
+
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/spi/IndexSchemaObjectNodeBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/engine/backend/document/model/dsl/spi/IndexSchemaObjectNodeBuilder.java
@@ -12,6 +12,8 @@ import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaFieldTe
 import org.hibernate.search.engine.backend.types.ObjectStructure;
 import org.hibernate.search.engine.backend.document.model.spi.IndexFieldInclusion;
 import org.hibernate.search.engine.backend.types.IndexFieldType;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaNamedPredicateOptionsStep;
+import org.hibernate.search.engine.search.predicate.factories.NamedPredicateFactory;
 
 public interface IndexSchemaObjectNodeBuilder extends IndexSchemaBuildContext {
 
@@ -26,6 +28,17 @@ public interface IndexSchemaObjectNodeBuilder extends IndexSchemaBuildContext {
 	 */
 	<F> IndexSchemaFieldOptionsStep<?, IndexFieldReference<F>> addField(String relativeFieldName,
 			IndexFieldInclusion inclusion, IndexFieldType<F> indexFieldType);
+
+	/**
+	 * Create a new named predicate and add it to the current builder.
+	 *
+	 * @param relativeNamedPredicateName The relative name of the new named predicate
+	 * @param inclusion Whether fields matching this template should be included, provided their parent is included.
+	 * @param factory The factory of the new object named predicate
+	 * @return A DSL step where the named predicate can be defined in more details.
+	 */
+	IndexSchemaNamedPredicateOptionsStep addNamedPredicate(String relativeNamedPredicateName,
+			IndexFieldInclusion inclusion, NamedPredicateFactory factory);
 
 	/**
 	 * Create a new object field and add it to the current builder.

--- a/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/engine/logging/impl/Log.java
@@ -391,4 +391,14 @@ public interface Log extends BasicLogger {
 			+ " Otherwise, use a valid bean retrieval prefix among the following: %3$s.")
 	BeanNotFoundException invalidBeanRetrieval(String beanReference, String invalidPrefix,
 			List<String> validPrefixes, @Cause Exception e);
+	@Message(id = ID_OFFSET + 93,
+		value = "Named predicate name '%1$s' is invalid: field names cannot be null or empty.")
+	SearchException relativeNamedPredicateNameCannotBeNullOrEmpty(String relativeNamedPredicateName,
+		@Param EventContext context);
+
+	@Message(id = ID_OFFSET + 94,
+		value = "Named predicate name '%1$s' is invalid: field names cannot contain a dot ('.')."
+		+ " Remove the dot from your named predicate name.")
+	SearchException relativeNamedPredicateNameCannotContainDot(String relativeNamedPredicateName,
+		@Param EventContext context);
 }

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/NamedPredicateOptionsStep.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/NamedPredicateOptionsStep.java
@@ -1,0 +1,16 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.predicate.dsl;
+
+/**
+ * The initial and final step in named predicate definition.
+ */
+public interface NamedPredicateOptionsStep extends PredicateFinalStep {
+
+	NamedPredicateOptionsStep param(String name, Object value);
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/SearchPredicateFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/SearchPredicateFactory.java
@@ -139,6 +139,15 @@ public interface SearchPredicateFactory {
 	SpatialPredicateInitialStep spatial();
 
 	/**
+	 * Match documents if they match a combination of defined named predicate clauses.
+	 *
+	 * @param name the name of definied named predicate
+	 * @return The initial step of a DSL where named predicate predicates can be defined.
+	 * @see NamedPredicateOptionsStep
+	 */
+	NamedPredicateOptionsStep named(String name);
+
+	/**
 	 * Extend the current factory with the given extension,
 	 * resulting in an extended factory offering different types of predicates.
 	 *

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/impl/DefaultSearchPredicateFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/impl/DefaultSearchPredicateFactory.java
@@ -14,6 +14,7 @@ import org.hibernate.search.engine.search.predicate.dsl.ExistsPredicateFieldStep
 import org.hibernate.search.engine.search.predicate.dsl.MatchAllPredicateOptionsStep;
 import org.hibernate.search.engine.search.predicate.dsl.MatchIdPredicateMatchingStep;
 import org.hibernate.search.engine.search.predicate.dsl.MatchPredicateFieldStep;
+import org.hibernate.search.engine.search.predicate.dsl.NamedPredicateOptionsStep;
 import org.hibernate.search.engine.search.predicate.dsl.NestedPredicateFieldStep;
 import org.hibernate.search.engine.search.predicate.dsl.PhrasePredicateFieldStep;
 import org.hibernate.search.engine.search.predicate.dsl.RangePredicateFieldStep;
@@ -95,6 +96,11 @@ public class DefaultSearchPredicateFactory implements SearchPredicateFactory {
 	@Override
 	public SpatialPredicateInitialStep spatial() {
 		return new SpatialPredicateInitialStepImpl( dslContext );
+	}
+
+	@Override
+	public NamedPredicateOptionsStep named(String name) {
+		return new NamedPredicateOptionsStepImpl( this, dslContext, name );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/impl/NamedPredicateOptionsStepImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/impl/NamedPredicateOptionsStepImpl.java
@@ -1,0 +1,37 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.predicate.dsl.impl;
+
+import org.hibernate.search.engine.search.predicate.SearchPredicate;
+import org.hibernate.search.engine.search.predicate.dsl.spi.AbstractPredicateFinalStep;
+import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
+import org.hibernate.search.engine.search.predicate.dsl.spi.SearchPredicateDslContext;
+import org.hibernate.search.engine.search.predicate.dsl.NamedPredicateOptionsStep;
+import org.hibernate.search.engine.search.predicate.spi.NamedPredicateBuilder;
+
+public class NamedPredicateOptionsStepImpl
+	extends AbstractPredicateFinalStep
+	implements NamedPredicateOptionsStep {
+
+	private final NamedPredicateBuilder builder;
+
+	public NamedPredicateOptionsStepImpl(SearchPredicateFactory predicateFactory, SearchPredicateDslContext<?> dslContext, String name) {
+		super( dslContext );
+		this.builder = dslContext.builderFactory().named( predicateFactory, name );
+	}
+
+	@Override
+	public NamedPredicateOptionsStep param(String name, Object value) {
+		builder.param( name, value );
+		return this;
+	}
+
+	@Override
+	protected SearchPredicate build() {
+		return builder.build();
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/spi/DelegatingSearchPredicateFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/dsl/spi/DelegatingSearchPredicateFactory.java
@@ -23,6 +23,7 @@ import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactoryEx
 import org.hibernate.search.engine.search.predicate.dsl.SimpleQueryStringPredicateFieldStep;
 import org.hibernate.search.engine.search.predicate.dsl.SpatialPredicateInitialStep;
 import org.hibernate.search.engine.search.predicate.dsl.WildcardPredicateFieldStep;
+import org.hibernate.search.engine.search.predicate.dsl.NamedPredicateOptionsStep;
 
 /**
  * A delegating {@link SearchPredicateFactory}.
@@ -95,6 +96,11 @@ public class DelegatingSearchPredicateFactory implements SearchPredicateFactory 
 	@Override
 	public SpatialPredicateInitialStep spatial() {
 		return delegate.spatial();
+	}
+
+	@Override
+	public NamedPredicateOptionsStep named(String name) {
+		return delegate.named( name );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/factories/NamedPredicateFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/factories/NamedPredicateFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.predicate.factories;
+
+import org.hibernate.search.engine.search.predicate.SearchPredicate;
+import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
+
+/**
+ * A factory for predicates, which is given a name and assigned to an element in the index schema.
+ * <p>
+ * This factory takes advantage of provided metadata
+ * to pick, configure and create a {@link SearchPredicate}.
+ *
+ * @see SearchPredicate
+ *
+ */
+public interface NamedPredicateFactory {
+
+	/**
+	 * Creates a named predicate.
+	 * @param ctx The context, exposing in particular a {@link SearchPredicateFactory}.
+	 * @return The created {@link SearchPredicate}.
+	 */
+	SearchPredicate create(NamedPredicateFactoryContext ctx);
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/factories/NamedPredicateFactoryContext.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/factories/NamedPredicateFactoryContext.java
@@ -1,0 +1,36 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.predicate.factories;
+
+import org.hibernate.search.engine.search.predicate.dsl.NamedPredicateOptionsStep;
+import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
+
+/**
+ * The context provided to the {@link NamedPredicateFactory}.
+ * @see NamedPredicateFactory#create(NamedPredicateFactoryContext)
+ */
+public interface NamedPredicateFactoryContext {
+
+	/**
+	 * @return A predicate factory. This factory is only valid in the present context and must not be used after {@link NamedPredicateFactory#create(NamedPredicateFactoryContext)} returns.
+	 * @see SearchPredicateFactory
+	 */
+	SearchPredicateFactory predicate();
+
+	/**
+	 * @param name a name of parameter
+	 * @return parameter of the named predicate factory
+	 * @see NamedPredicateOptionsStep#param(java.lang.String, java.lang.Object)
+	 */
+	Object param(String name);
+
+	/**
+	 * @param relative relative name
+	 * @return absolute path.
+	 */
+	String resolvePath(String relative);
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/NamedPredicateBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/NamedPredicateBuilder.java
@@ -1,0 +1,13 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.search.predicate.spi;
+
+public interface NamedPredicateBuilder extends SearchPredicateBuilder {
+
+	void param(String name, Object value);
+
+}

--- a/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/SearchPredicateBuilderFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/predicate/spi/SearchPredicateBuilderFactory.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.engine.search.predicate.spi;
 
 import org.hibernate.search.engine.search.predicate.SearchPredicate;
+import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
 
 /**
  * A factory for search predicate builders.
@@ -53,4 +54,6 @@ public interface SearchPredicateBuilderFactory<C> {
 	SpatialWithinPolygonPredicateBuilder spatialWithinPolygon(String absoluteFieldPath);
 
 	SpatialWithinBoundingBoxPredicateBuilder spatialWithinBoundingBox(String absoluteFieldPath);
+
+	NamedPredicateBuilder named(SearchPredicateFactory namedPredicateFactory, String name);
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/NamedPredicateBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/NamedPredicateBaseIT.java
@@ -1,0 +1,181 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.tck.search.predicate;
+
+import java.util.function.Function;
+import org.hibernate.search.engine.backend.common.DocumentReference;
+import org.hibernate.search.engine.backend.document.DocumentElement;
+import org.hibernate.search.engine.backend.document.IndexObjectFieldReference;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectField;
+import org.hibernate.search.engine.backend.types.ObjectStructure;
+import org.hibernate.search.engine.search.predicate.SearchPredicate;
+import org.hibernate.search.engine.search.predicate.factories.NamedPredicateFactory;
+import org.hibernate.search.engine.search.predicate.factories.NamedPredicateFactoryContext;
+import org.hibernate.search.engine.search.query.dsl.SearchQueryFinalStep;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.configuration.DefaultAnalysisDefinitions;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.types.AnalyzedStringFieldTypeDescriptor;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.SimpleFieldModel;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
+import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatQuery;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.BulkIndexer;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class NamedPredicateBaseIT {
+
+	private static final String DOCUMENT_1 = "document1";
+	private static final String DOCUMENT_2 = "document2";
+	private static final String DOCUMENT_3 = "document3";
+	private static final String DOCUMENT_4 = "document4";
+	private static final String EMPTY = "empty";
+
+	private static final String TEXT_MATCHING_1 = "Localization in English is a must-have.";
+	private static final String TEXT_MATCHING_2 = "Internationalization allows to adapt the application to multiple locales.";
+	private static final String TEXT_MATCHING_3 = "A had to call the land lord.";
+	private static final String TEXT_MATCHING_4 = "I had some interaction with that lad.";
+
+	private static final String TERM_PATTERN_1 = "Localization";
+	private static final String TERM_PATTERN_2 = "Internationalization";
+	private static final String TERM_PATTERN_3 = "call";
+	private static final String TERM_PATTERN_4 = "interaction";
+
+	@ClassRule
+	public static final SearchSetupHelper setupHelper = new SearchSetupHelper();
+
+	private static final SimpleMappedIndex<IndexBinding> index = SimpleMappedIndex.of( IndexBinding::new );
+
+	private static final DataSet dataSet = new DataSet();
+
+	@BeforeClass
+	public static void setup() {
+		setupHelper.start().withIndex( index ).setup();
+
+		BulkIndexer indexer = index.bulkIndexer();
+		dataSet.contribute( indexer );
+		indexer.join();
+	}
+
+	@Test
+	public void searchNamedPredicateInRoot() {
+		StubMappingScope scope = index.createScope();
+		Function<String, SearchQueryFinalStep<DocumentReference>> createQuery = queryString -> scope.query()
+			.where( f -> f.named( "match_predicate" )
+			.param( "query", queryString ) );
+
+		assertThatQuery( createQuery.apply( TERM_PATTERN_1 ) )
+			.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
+
+		assertThatQuery( createQuery.apply( TERM_PATTERN_2 ) )
+			.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_2 );
+
+		assertThatQuery( createQuery.apply( TERM_PATTERN_3 ) )
+			.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_3 );
+
+		assertThatQuery( createQuery.apply( TERM_PATTERN_4 ) )
+			.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_4 );
+	}
+
+	@Test
+	public void searchNamedPredicateInNested() {
+		StubMappingScope scope = index.createScope();
+		Function<String, SearchQueryFinalStep<DocumentReference>> createQuery = queryString -> scope.query()
+			.where( f -> f.named( "nested.match_predicate" )
+			.param( "query", queryString ) );
+
+		assertThatQuery( createQuery.apply( TERM_PATTERN_1 ) )
+			.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_1 );
+
+		assertThatQuery( createQuery.apply( TERM_PATTERN_2 ) )
+			.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_2 );
+
+		assertThatQuery( createQuery.apply( TERM_PATTERN_3 ) )
+			.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_3 );
+
+		assertThatQuery( createQuery.apply( TERM_PATTERN_4 ) )
+			.hasDocRefHitsAnyOrder( index.typeName(), DOCUMENT_4 );
+	}
+
+	private static class IndexBinding {
+		final SimpleFieldModel<String> field1;
+		final SimpleFieldModel<String> field2;
+		final IndexObjectFieldReference nested;
+
+		IndexBinding(IndexSchemaElement root) {
+			field1 = SimpleFieldModel.mapperWithOverride( AnalyzedStringFieldTypeDescriptor.INSTANCE,
+				c -> c.asString().analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD_ENGLISH.name ) )
+				.map( root, "tested_field" );
+
+			IndexSchemaObjectField nest = root.objectField( "nested", ObjectStructure.NESTED ).multiValued();
+			nested = nest.toReference();
+
+			field2 = SimpleFieldModel.mapperWithOverride( AnalyzedStringFieldTypeDescriptor.INSTANCE,
+				c -> c.asString().analyzer( DefaultAnalysisDefinitions.ANALYZER_STANDARD_ENGLISH.name ) )
+				.map( nest, "tested_field" );
+
+			root.namedPredicate( "match_predicate", new TestNamedPredicateFactory() );
+
+			nest.namedPredicate( "match_predicate", new TestNamedPredicateFactory() );
+		}
+	}
+
+	private static final class DataSet extends AbstractPredicateDataSet {
+		public DataSet() {
+			super( null );
+		}
+
+		public void contribute(BulkIndexer indexer) {
+			indexer
+				.add( DOCUMENT_1, document -> {
+					document.addValue( index.binding().field1.reference, TEXT_MATCHING_1 );
+					IndexObjectFieldReference level1 = index.binding().nested;
+					DocumentElement nested = document.addObject( level1 );
+					nested.addValue( index.binding().field2.reference, TEXT_MATCHING_1 );
+
+				} )
+				.add( DOCUMENT_2, document -> {
+					document.addValue( index.binding().field1.reference, TEXT_MATCHING_2 );
+					IndexObjectFieldReference level1 = index.binding().nested;
+					DocumentElement nested = document.addObject( level1 );
+					nested.addValue( index.binding().field2.reference, TEXT_MATCHING_2 );
+				} )
+				.add( DOCUMENT_3, document -> {
+					document.addValue( index.binding().field1.reference, TEXT_MATCHING_3 );
+					IndexObjectFieldReference level1 = index.binding().nested;
+					DocumentElement nested = document.addObject( level1 );
+					nested.addValue( index.binding().field2.reference, TEXT_MATCHING_3 );
+				} )
+				.add( DOCUMENT_4, document -> {
+					document.addValue( index.binding().field1.reference, TEXT_MATCHING_4 );
+					IndexObjectFieldReference level1 = index.binding().nested;
+					DocumentElement nested = document.addObject( level1 );
+					nested.addValue( index.binding().field2.reference, TEXT_MATCHING_4 );
+				} )
+				.add( EMPTY, document -> {
+				} );
+		}
+	}
+
+	public static class TestNamedPredicateFactory implements NamedPredicateFactory {
+
+		@Override
+		public SearchPredicate create(NamedPredicateFactoryContext ctx) {
+			String absoluteFieldPath = ctx.resolvePath( "tested_field" );
+			String queryString = (String) ctx.param( "query" );
+			SearchPredicate predicate = ctx.predicate()
+				.match().field( absoluteFieldPath )
+				.matching( queryString )
+				.toPredicate();
+			return predicate;
+		}
+	}
+
+}

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/document/model/StubIndexSchemaNode.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/document/model/StubIndexSchemaNode.java
@@ -18,6 +18,7 @@ import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.engine.backend.types.Projectable;
 import org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaBuildContext;
 import org.hibernate.search.engine.reporting.spi.EventContexts;
+import org.hibernate.search.engine.search.predicate.factories.NamedPredicateFactory;
 import org.hibernate.search.util.common.reporting.EventContext;
 import org.hibernate.search.util.impl.integrationtest.common.stub.StubTreeNode;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.types.converter.impl.StubFieldConverter;
@@ -27,6 +28,7 @@ public final class StubIndexSchemaNode extends StubTreeNode<StubIndexSchemaNode>
 	private enum Type {
 		ROOT,
 		OBJECT_FIELD,
+		NAMED_PREDICATE,
 		NON_OBJECT_FIELD,
 		OBJECT_FIELD_TEMPLATE,
 		NON_OBJECT_FIELD_TEMPLATE
@@ -52,6 +54,10 @@ public final class StubIndexSchemaNode extends StubTreeNode<StubIndexSchemaNode>
 
 	public static Builder fieldTemplate(Builder parent, String templateName) {
 		return new Builder( parent, templateName, Type.NON_OBJECT_FIELD_TEMPLATE );
+	}
+
+	public static Builder namedPredicate(Builder parent, String relativeNamedPredicateName) {
+		return new Builder( parent, relativeNamedPredicateName, Type.NAMED_PREDICATE );
 	}
 
 	/*
@@ -96,7 +102,14 @@ public final class StubIndexSchemaNode extends StubTreeNode<StubIndexSchemaNode>
 
 		public Builder field(String relativeFieldName, Class<?> inputType, Consumer<Builder> contributor) {
 			Builder builder = StubIndexSchemaNode.field( this, relativeFieldName )
-					.inputType( inputType );
+				.inputType( inputType );
+			contributor.accept( builder );
+			child( builder );
+			return this;
+		}
+
+		public Builder namedPredicate(String relativeNamedPredicateName, Consumer<Builder> contributor) {
+			Builder builder = StubIndexSchemaNode.namedPredicate( this, relativeNamedPredicateName );
 			contributor.accept( builder );
 			child( builder );
 			return this;
@@ -159,6 +172,11 @@ public final class StubIndexSchemaNode extends StubTreeNode<StubIndexSchemaNode>
 
 		public Builder multiValued(boolean multiValued) {
 			attribute( "multiValued", multiValued );
+			return this;
+		}
+
+		public Builder namedPredicateFactory(NamedPredicateFactory factory) {
+			attribute( "factory", factory );
 			return this;
 		}
 

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/document/model/impl/AbstractStubIndexSchemaObjectNodeBuilder.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/document/model/impl/AbstractStubIndexSchemaObjectNodeBuilder.java
@@ -14,8 +14,10 @@ import org.hibernate.search.engine.backend.document.model.spi.IndexFieldInclusio
 import org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaObjectFieldNodeBuilder;
 import org.hibernate.search.engine.backend.document.model.dsl.spi.IndexSchemaObjectNodeBuilder;
 import org.hibernate.search.engine.backend.types.IndexFieldType;
+import org.hibernate.search.engine.search.predicate.factories.NamedPredicateFactory;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.document.model.StubIndexSchemaNode;
 import org.hibernate.search.util.impl.integrationtest.common.stub.backend.types.impl.StubIndexFieldType;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaNamedPredicateOptionsStep;
 
 abstract class AbstractStubIndexSchemaObjectNodeBuilder implements IndexSchemaObjectNodeBuilder {
 
@@ -54,6 +56,18 @@ abstract class AbstractStubIndexSchemaObjectNodeBuilder implements IndexSchemaOb
 			builder.child( childBuilder );
 		}
 		return new StubIndexSchemaObjectFieldNodeBuilder( this, childBuilder, inclusion );
+	}
+
+	@Override
+	public IndexSchemaNamedPredicateOptionsStep addNamedPredicate(String relativeNamedPredicateName,
+		IndexFieldInclusion inclusion, NamedPredicateFactory factory) {
+		StubIndexSchemaNode.Builder childBuilder =
+				StubIndexSchemaNode.namedPredicate( builder, relativeNamedPredicateName )
+					.namedPredicateFactory( factory );
+		if ( IndexFieldInclusion.INCLUDED.equals( inclusion ) ) {
+			builder.child( childBuilder );
+		}
+		return new StubIndexSchemaNamedPredicateBuilder( childBuilder, true );
 	}
 
 	@Override

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/document/model/impl/StubIndexSchemaNamedPredicateBuilder.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/document/model/impl/StubIndexSchemaNamedPredicateBuilder.java
@@ -1,0 +1,21 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.impl.integrationtest.common.stub.backend.document.model.impl;
+
+import org.hibernate.search.util.impl.integrationtest.common.stub.backend.document.model.StubIndexSchemaNode;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaNamedPredicateOptionsStep;
+
+class StubIndexSchemaNamedPredicateBuilder
+	implements IndexSchemaNamedPredicateOptionsStep {
+
+	private final StubIndexSchemaNode.Builder builder;
+
+	StubIndexSchemaNamedPredicateBuilder(StubIndexSchemaNode.Builder builder, boolean included) {
+		this.builder = builder;
+	}
+
+}

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubPredicateBuilder.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubPredicateBuilder.java
@@ -13,6 +13,7 @@ import org.hibernate.search.engine.search.predicate.SearchPredicate;
 import org.hibernate.search.engine.search.predicate.dsl.SimpleQueryFlag;
 import org.hibernate.search.engine.search.predicate.spi.BooleanPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.ExistsPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.NamedPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.MatchAllPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.MatchIdPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.MatchPredicateBuilder;
@@ -42,7 +43,8 @@ public class StubPredicateBuilder implements MatchAllPredicateBuilder,
 		ExistsPredicateBuilder,
 		SpatialWithinCirclePredicateBuilder,
 		SpatialWithinPolygonPredicateBuilder,
-		SpatialWithinBoundingBoxPredicateBuilder {
+		SpatialWithinBoundingBoxPredicateBuilder,
+		NamedPredicateBuilder {
 
 	@Override
 	public SearchPredicate build() {
@@ -168,6 +170,11 @@ public class StubPredicateBuilder implements MatchAllPredicateBuilder,
 	public void nested(SearchPredicate nestedPredicate) {
 		// No-op, just check the type
 		StubSearchPredicate.from( nestedPredicate );
+	}
+
+	@Override
+	public void param(String name, Object value) {
+		// No-op, just simulates a call on this object
 	}
 
 	@Override

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubSearchPredicateBuilderFactory.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubSearchPredicateBuilderFactory.java
@@ -7,10 +7,12 @@
 package org.hibernate.search.util.impl.integrationtest.common.stub.backend.search.predicate.impl;
 
 import org.hibernate.search.engine.search.predicate.SearchPredicate;
+import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
 import org.hibernate.search.engine.search.predicate.spi.BooleanPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.ExistsPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.MatchAllPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.MatchIdPredicateBuilder;
+import org.hibernate.search.engine.search.predicate.spi.NamedPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.MatchPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.NestedPredicateBuilder;
 import org.hibernate.search.engine.search.predicate.spi.PhrasePredicateBuilder;
@@ -94,6 +96,11 @@ public class StubSearchPredicateBuilderFactory
 
 	@Override
 	public NestedPredicateBuilder nested(String absoluteFieldPath) {
+		return new StubPredicateBuilder();
+	}
+
+	@Override
+	public NamedPredicateBuilder named(SearchPredicateFactory namedPredicateFactory, String name) {
 		return new StubPredicateBuilder();
 	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3325

Full-text search filter mapping for SNAPSHOT 6.1. 

The extension allows you to build predefined filters. 

Example:
```java
 BooleanPredicateClausesStep pricesFilter = spf.bool()
          .filter(spf.def("prices.is-active"))
          .filter(spf.def("prices.has-permission", "share", identity.getAccount())
                    .param("operation", "share")
                    .param("user", identity.getAccount())
          );
.....
  sort.add(sorter.field("prices.bruttoPrice_sort")
          .asc()
          .mode(SortMode.MIN)
          .missing().last()
          .filter(pricesFilter));
......
  SearchQuery<Assortment> query = session.search(scope)
          .where((f) -> f.bool().must(select)
          .filter(searchFilter))
          .aggregation(countsByCategoryKey, (t) -> {
                 return t.terms().field("productCategory.id", String.class);
          })
          .sort(sort.toSort())
          .toQuery();
```
Defined example:
```java
public class PricesActiveFilterFactory implements FilterFactory {

    @Override
    public SearchPredicate create(FilterFactoryContext ctx) {
        SearchPredicate filter;
        String fieldPath = ctx.resolvePath("active");

        filter = ctx.predicate()
                .match().field(fieldPath)
                .matching(true)
                .toPredicate();

        return filter;
    }
}
```
```java
public class PermissionsBinder implements TypeBinder {

    private String fieldName = "permissions";
    private String operationName = "read";
    private String filterName = "has-permission";

    public PermissionsBinder fieldName(String fieldName) {
        this.fieldName = fieldName;
        return this;
    }

    public PermissionsBinder operationName(String operationName) {
        this.operationName = operationName;
        return this;
    }

    public PermissionsBinder filterName(String filterName) {
        this.filterName = filterName;
        return this;
    }

    @Override
    public void bind(TypeBindingContext context) {
        context.dependencies().useRootOnly();

        IndexFieldReference<String> permissionsField = context.indexSchemaElement()
                .field(this.fieldName, f -> f.asString()
                .aggregable(Aggregable.NO)
                .sortable(Sortable.NO)
                .searchable(Searchable.YES)
                .analyzer("permissions"))
                .toReference();

        context.indexSchemaElement().filter(this.filterName, new Filter())
                .param("operation", operationName)
                .param("field", this.fieldName)
                .toReference();

        context.bridge(new Bridge(
                permissionsField
        ));
    }

    private static class Bridge implements TypeBridge {

        private final IndexFieldReference<String> permissionsField;

        protected IdentityStoreResolver getIdentityService() {
            IdentityStoreResolver isr = ServiceLocator.getService(IdentityStoreResolver.class, IdentityStoreResolver.JNDI_NAME);
            return isr;
        }

        private Bridge(IndexFieldReference<String> permissionsField) {
            this.permissionsField = permissionsField;
        }

        @Override
        public void write(DocumentElement target, Object bridgedElement, TypeBridgeWriteContext context) {
            StringBuilder brules = new StringBuilder();

            IdentityStoreResolver isr = getIdentityService();
            PermissionManager pm = isr.getPermissionManager();

            List<Permission> permissions = pm.listPermissions(bridgedElement);
            for (Permission permission : permissions) {
                IdentityType assignee = permission.getAssignee();

                if (assignee instanceof Group) {
                    String[] roles = permission.getRoles();
                    if (roles == null || roles.length < 1) {
                        roles = new String[]{"*"};
                    }
                    for (String role : roles) {
                        brules.append(permission.isAllow() ? "+" : "-");
                        brules.append(permission.getOperation()).append(":");
                        brules.append(permission.getContext()).append(":");
                        brules.append(role).append(":");
                        brules.append(permission.getPath());
                        brules.append("\n");
                    }
                } else {
                    brules.append(permission.isAllow() ? "+" : "-");
                    brules.append(permission.getOperation()).append(":");
                    brules.append(permission.getContext()).append(":");
                    brules.append("*").append(":");
                    brules.append(permission.getPath());
                    brules.append("\n");
                }
            }

            String rules = brules.toString();
            target.addValue(this.permissionsField, rules);
        }
    }

    private static class Filter implements FilterFactory {

        @Override
        public SearchPredicate create(FilterFactoryContext ctx) {
            SearchPredicate filter;
            Account user = ctx.param("user");
            String fieldPath = ctx.resolvePath(ctx.param("field"));
            String operation = ctx.param("operation");

            if (operation == null) {
                operation = "read";
            }

            SearchPredicateFactory predicate = ctx.predicate();

            PermissionQuery allowQuery = new PermissionQuery(fieldPath, operation, user, true);
            PermissionQuery dannyQuery = new PermissionQuery(fieldPath, operation, user, false);

            BooleanQuery query = new BooleanQuery.Builder()
                    .add(allowQuery, BooleanClause.Occur.MUST)
                    .add(dannyQuery, BooleanClause.Occur.MUST_NOT)
                    .build();

            filter = predicate.extension(LuceneExtension.get())
                    .fromLuceneQuery(query)
                    .toPredicate();

            return filter;
        }
    }
}
```
```java
@Retention(RetentionPolicy.RUNTIME)
@Target({ElementType.TYPE})
@TypeMapping(processor = @TypeMappingAnnotationProcessorRef(
        type = PermissionsBinding.Processor.class
))
@Documented
public @interface PermissionsBinding {

    String fieldName() default "permissions";
    String defaultOperation() default "read";
    String filterName() default "has-permission";

    class Processor implements TypeMappingAnnotationProcessor<PermissionsBinding> {

        @Override
        public void process(TypeMappingStep mapping, PermissionsBinding annotation,
                TypeMappingAnnotationProcessorContext context) {

            PermissionsBinder binder = new PermissionsBinder();

            if (!annotation.fieldName().isEmpty()) {
                binder.fieldName(annotation.fieldName());
            }
            if (!annotation.defaultOperation().isEmpty()) {
                binder.operationName(annotation.defaultOperation());
            }
            if (!annotation.filterName().isEmpty()) {
                binder.filterName(annotation.filterName());
            }
            mapping.binder(binder);
        }
    }
}
```
Annotated search bean example:
```java
@FullTextFilter(name = "is-active", factory = @FilterFactoryRef(type = PricesActiveFilterFactory.class))
@PermissionsBinding(defaultOperation = "share")
public class AssortmentPrice implements Serializable {
......
    @GenericField
    @Column(name = "Active")
    private boolean active = true;
....
}
```
```java
public class Assortment implements Serializable {
......
    @IndexedEmbedded(structure = ObjectStructure.NESTED)
    @AssociationInverseSide(
            extraction = @ContainerExtraction(BuiltinContainerExtractors.COLLECTION),
            inversePath = @ObjectPath(
                    @PropertyValue(propertyName = "assortment"))
    )
    @IndexingDependency
    @OneToMany(mappedBy = "assortment", orphanRemoval = true, fetch = FetchType.EAGER, cascade = CascadeType.ALL)
    private List<AssortmentPrice> prices = new ArrayList<>();
........

}
```













