### PR TITLE
HSEARCH-3880 Add query cache and query cache policy definition

### DIFF
--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/cache/QueryCachingConfigurationContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/cache/QueryCachingConfigurationContext.java
@@ -1,0 +1,33 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.cache;
+
+import org.apache.lucene.search.QueryCache;
+import org.apache.lucene.search.QueryCachingPolicy;
+import org.apache.lucene.util.Version;
+
+/**
+ * A context allowing the configuration of query caching in a Lucene backend.
+ */
+public interface QueryCachingConfigurationContext {
+
+	/**
+	 * @return The Lucene version in use in the configured backend.
+	 */
+	Version luceneVersion();
+
+	/**
+	 * @param cache The {@link QueryCache} to use when searching.
+	 */
+	void queryCache(QueryCache cache);
+
+	/**
+	 * @param policy The {@link QueryCachingPolicy} to use when searching.
+	 */
+	void queryCachingPolicy(QueryCachingPolicy policy);
+
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/cache/QueryCachingConfigurer.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/cache/QueryCachingConfigurer.java
@@ -1,0 +1,25 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.cache;
+
+import org.hibernate.search.backend.lucene.cfg.LuceneBackendSettings;
+
+/**
+ * A configurer for query caching.
+ * <p>
+ * Users can select a configurer through the
+ * {@link LuceneBackendSettings#QUERY_CACHING_CONFIGURER configuration properties}.
+ */
+public interface QueryCachingConfigurer {
+
+	/**
+	 * Configures query caching as necessary using the given {@code context}.
+	 * @param context A context exposing methods to configure caching.
+	 */
+	void configure(QueryCachingConfigurationContext context);
+
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/cache/impl/LuceneQueryCachingContext.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/cache/impl/LuceneQueryCachingContext.java
@@ -1,0 +1,48 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.lucene.cache.impl;
+
+import java.util.Optional;
+import org.apache.lucene.search.QueryCache;
+import org.apache.lucene.search.QueryCachingPolicy;
+import org.apache.lucene.util.Version;
+import org.hibernate.search.backend.lucene.cache.QueryCachingConfigurationContext;
+
+public class LuceneQueryCachingContext implements QueryCachingConfigurationContext {
+
+	private final Version luceneVersion;
+	private QueryCache cache;
+	private QueryCachingPolicy policy;
+
+	public LuceneQueryCachingContext(Version luceneVersion) {
+		this.luceneVersion = luceneVersion;
+	}
+
+	@Override
+	public Version luceneVersion() {
+		return this.luceneVersion;
+	}
+
+	@Override
+	public void queryCache(QueryCache cache) {
+		this.cache = cache;
+	}
+
+	public Optional<QueryCache> queryCache() {
+		return Optional.ofNullable( cache );
+	}
+
+	@Override
+	public void queryCachingPolicy(QueryCachingPolicy policy) {
+		this.policy = policy;
+	}
+
+	public Optional<QueryCachingPolicy> queryCachingPolicy() {
+		return Optional.ofNullable( policy );
+	}
+
+}

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/cfg/LuceneBackendSettings.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/cfg/LuceneBackendSettings.java
@@ -66,6 +66,18 @@ public final class LuceneBackendSettings {
 	public static final String ANALYSIS_CONFIGURER = "analysis.configurer";
 
 	/**
+	 * The analysis configurer to use.
+	 * <p>
+	 * Expects a reference to a bean of type {@link LuceneAnalysisConfigurer}.
+	 * <p>
+	 * Defaults to no value.
+	 *
+	 * @see org.hibernate.search.engine.cfg The core documentation of configuration properties,
+	 * which includes a description of the "bean reference" properties and accepted values.
+	 */
+	public static final String QUERY_CACHING_CONFIGURER = "caching.configurer";
+
+	/**
 	 * The size of the thread pool assigned to the backend.
 	 * <p>
 	 * Expects a strictly positive integer value,

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/cfg/LuceneBackendSettings.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/cfg/LuceneBackendSettings.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.backend.lucene.cfg;
 
 import org.hibernate.search.backend.lucene.analysis.LuceneAnalysisConfigurer;
+import org.hibernate.search.backend.lucene.cache.QueryCachingConfigurer;
 import org.hibernate.search.backend.lucene.multitenancy.MultiTenancyStrategyName;
 
 import org.apache.lucene.util.Version;
@@ -66,9 +67,9 @@ public final class LuceneBackendSettings {
 	public static final String ANALYSIS_CONFIGURER = "analysis.configurer";
 
 	/**
-	 * The analysis configurer to use.
+	 * The query caching configurer to use.
 	 * <p>
-	 * Expects a reference to a bean of type {@link LuceneAnalysisConfigurer}.
+	 * Expects a reference to a bean of type {@link QueryCachingConfigurer}.
 	 * <p>
 	 * Defaults to no value.
 	 *

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/cfg/LuceneBackendSettings.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/cfg/LuceneBackendSettings.java
@@ -76,7 +76,7 @@ public final class LuceneBackendSettings {
 	 * @see org.hibernate.search.engine.cfg The core documentation of configuration properties,
 	 * which includes a description of the "bean reference" properties and accepted values.
 	 */
-	public static final String QUERY_CACHING_CONFIGURER = "caching.configurer";
+	public static final String QUERY_CACHING_CONFIGURER = "query.caching.configurer";
 
 	/**
 	 * The size of the thread pool assigned to the backend.

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/impl/LuceneBackendImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/impl/LuceneBackendImpl.java
@@ -35,6 +35,7 @@ import org.hibernate.search.util.common.reporting.EventContext;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.similarities.Similarity;
+import org.hibernate.search.backend.lucene.cache.impl.LuceneQueryCachingContext;
 
 
 public class LuceneBackendImpl implements BackendImplementor, LuceneBackend {
@@ -56,6 +57,7 @@ public class LuceneBackendImpl implements BackendImplementor, LuceneBackend {
 			BackendThreads threads,
 			LuceneWorkFactory workFactory,
 			LuceneAnalysisDefinitionRegistry analysisDefinitionRegistry,
+			LuceneQueryCachingContext cachingContext,
 			MultiTenancyStrategy multiTenancyStrategy,
 			TimingSource timingSource,
 			FailureHandler failureHandler) {
@@ -66,7 +68,7 @@ public class LuceneBackendImpl implements BackendImplementor, LuceneBackend {
 		Similarity similarity = analysisDefinitionRegistry.getSimilarity();
 
 		this.readOrchestrator = new LuceneSyncWorkOrchestratorImpl(
-				"Lucene read work orchestrator - " + eventContext.render(), similarity
+				"Lucene read work orchestrator - " + eventContext.render(), similarity, cachingContext
 		);
 		this.multiTenancyStrategy = multiTenancyStrategy;
 

--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/logging/impl/Log.java
@@ -650,4 +650,8 @@ public interface Log extends BasicLogger {
 	@Message(id = ID_OFFSET + 145,
 		value = "Unknown nmaed predicate definition '%1$s'.")
 	SearchException unknownNamedPredicateForSearch(String name, @Param EventContext context);
+
+	@Message(id = ID_OFFSET + 146,
+			value = "Unable to apply query caching configuration: %1$s")
+	SearchException unableToApplyQueryCacheConfiguration(String errorMessage, @Cause Exception e);
 }

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/cache/LuceneQueryCacheConfigurerIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/cache/LuceneQueryCacheConfigurerIT.java
@@ -6,34 +6,34 @@
  */
 package org.hibernate.search.integrationtest.backend.lucene.cache;
 
-import java.io.IOException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.documentProvider;
 
+import java.io.IOException;
 import java.util.function.Consumer;
+
+import org.hibernate.search.backend.lucene.cache.QueryCachingConfigurationContext;
+import org.hibernate.search.backend.lucene.cache.QueryCachingConfigurer;
+import org.hibernate.search.backend.lucene.cfg.LuceneBackendSettings;
+import org.hibernate.search.engine.backend.common.DocumentReference;
+import org.hibernate.search.engine.backend.document.IndexFieldReference;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.types.Sortable;
+import org.hibernate.search.engine.mapper.mapping.building.spi.IndexBindingContext;
+import org.hibernate.search.engine.search.query.SearchQuery;
+import org.hibernate.search.engine.search.query.dsl.SearchQueryOptionsStep;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
+
+import org.junit.Rule;
+import org.junit.Test;
+
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryCache;
 import org.apache.lucene.search.QueryCachingPolicy;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.Version;
-
-import org.hibernate.search.backend.lucene.cfg.LuceneBackendSettings;
-import org.hibernate.search.engine.mapper.mapping.building.spi.IndexBindingContext;
-import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
-
-import org.junit.Rule;
-import org.junit.Test;
-
-import org.hibernate.search.backend.lucene.cache.QueryCachingConfigurationContext;
-import org.hibernate.search.backend.lucene.cache.QueryCachingConfigurer;
-import org.hibernate.search.engine.backend.common.DocumentReference;
-import org.hibernate.search.engine.backend.document.IndexFieldReference;
-import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
-import org.hibernate.search.engine.backend.types.Sortable;
-import org.hibernate.search.engine.search.query.SearchQuery;
-import org.hibernate.search.engine.search.query.dsl.SearchQueryOptionsStep;
-import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
-import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.documentProvider;
-import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
 
 public class LuceneQueryCacheConfigurerIT {
 
@@ -50,11 +50,11 @@ public class LuceneQueryCacheConfigurerIT {
 		StubMappingScope scope = index.createScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-			.where( f -> f.match().field( "string" ).matching( "platypus" ) )
-			.toQuery();
+				.where( f -> f.match().field( "string" ).matching( "platypus" ) )
+				.toQuery();
 
 		assertThatThrownBy( () -> query.fetchAll() )
-			.isInstanceOf( SimulatedFailure.class );
+				.isInstanceOf( SimulatedFailure.class );
 	}
 
 	public static class FailingQueryCasheConfigurer implements QueryCachingConfigurer {
@@ -62,7 +62,8 @@ public class LuceneQueryCacheConfigurerIT {
 
 		@Override
 		public void configure(QueryCachingConfigurationContext context) {
-			context.queryCache( new TestQueryCache( context.luceneVersion(), new SimulatedFailure( FAILURE_MESSAGE ) ) );
+			context.queryCache(
+					new TestQueryCache( context.luceneVersion(), new SimulatedFailure( FAILURE_MESSAGE ) ) );
 		}
 	}
 
@@ -74,11 +75,11 @@ public class LuceneQueryCacheConfigurerIT {
 		StubMappingScope scope = index.createScope();
 
 		SearchQuery<DocumentReference> query = scope.query()
-			.where( f -> f.match().field( "string" ).matching( "platypus" ) )
-			.toQuery();
+				.where( f -> f.match().field( "string" ).matching( "platypus" ) )
+				.toQuery();
 
 		assertThatThrownBy( () -> query.fetchAll() )
-			.isInstanceOf( SimulatedFailure.class );
+				.isInstanceOf( SimulatedFailure.class );
 	}
 
 	public static class FailingCashePolicyExceptionQueryCacheConfigurer implements QueryCachingConfigurer {
@@ -86,7 +87,8 @@ public class LuceneQueryCacheConfigurerIT {
 
 		@Override
 		public void configure(QueryCachingConfigurationContext context) {
-			context.queryCachingPolicy( new TestQueryCachingPolicy( context.luceneVersion(), new SimulatedFailure( FAILURE_MESSAGE ) ) );
+			context.queryCachingPolicy(
+					new TestQueryCachingPolicy( context.luceneVersion(), new SimulatedFailure( FAILURE_MESSAGE ) ) );
 		}
 	}
 
@@ -97,24 +99,24 @@ public class LuceneQueryCacheConfigurerIT {
 
 	private void setup(String queryCacheConfigurer, Consumer<IndexBindingContext> binder) {
 		setupHelper.start()
-			.expectCustomBeans()
-			.withBackendProperty( LuceneBackendSettings.QUERY_CACHING_CONFIGURER, queryCacheConfigurer )
-			.withIndex( index )
-			.setup();
+				.expectCustomBeans()
+				.withBackendProperty( LuceneBackendSettings.QUERY_CACHING_CONFIGURER, queryCacheConfigurer )
+				.withIndex( index )
+				.setup();
 	}
 
 	private SearchQueryOptionsStep<?, DocumentReference, ?, ?, ?> matchAllQuery() {
 		return index.query()
-			.where( f -> f.matchAll() );
+				.where( f -> f.matchAll() );
 	}
 
 	private void initData(int documentCount) {
 		index.bulkIndexer()
-			.add( documentCount, i -> documentProvider(
-			String.valueOf( i ),
-			document -> document.addValue( index.binding().string, "value" + i )
-		) )
-			.join();
+				.add( documentCount, i -> documentProvider(
+						String.valueOf( i ),
+						document -> document.addValue( index.binding().string, "value" + i )
+				) )
+				.join();
 	}
 
 	private static class IndexBinding {
@@ -122,7 +124,7 @@ public class LuceneQueryCacheConfigurerIT {
 
 		IndexBinding(IndexSchemaElement root) {
 			string = root.field( "string", f -> f.asString().sortable( Sortable.YES ) )
-				.toReference();
+					.toReference();
 		}
 	}
 

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/cache/LuceneQueryCacheConfigurerIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/cache/LuceneQueryCacheConfigurerIT.java
@@ -1,0 +1,169 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.lucene.cache;
+
+import java.io.IOException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.function.Consumer;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryCache;
+import org.apache.lucene.search.QueryCachingPolicy;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.Version;
+
+import org.hibernate.search.backend.lucene.cfg.LuceneBackendSettings;
+import org.hibernate.search.engine.mapper.mapping.building.spi.IndexBindingContext;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.hibernate.search.backend.lucene.cache.QueryCachingConfigurationContext;
+import org.hibernate.search.backend.lucene.cache.QueryCachingConfigurer;
+import org.hibernate.search.engine.backend.common.DocumentReference;
+import org.hibernate.search.engine.backend.document.IndexFieldReference;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.types.Sortable;
+import org.hibernate.search.engine.search.query.SearchQuery;
+import org.hibernate.search.engine.search.query.dsl.SearchQueryOptionsStep;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
+import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.documentProvider;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
+
+public class LuceneQueryCacheConfigurerIT {
+
+	private final SimpleMappedIndex<IndexBinding> index = SimpleMappedIndex.of( IndexBinding::new );
+
+	@Rule
+	public final SearchSetupHelper setupHelper = new SearchSetupHelper();
+
+	@Test
+	public void error_failingQueryCacheConfigurer() {
+		setup( FailingQueryCasheConfigurer.class.getName() );
+		initData( 10 );
+
+		StubMappingScope scope = index.createScope();
+
+		SearchQuery<DocumentReference> query = scope.query()
+			.where( f -> f.match().field( "string" ).matching( "platypus" ) )
+			.toQuery();
+
+		assertThatThrownBy( () -> query.fetchAll() )
+			.isInstanceOf( SimulatedFailure.class );
+	}
+
+	public static class FailingQueryCasheConfigurer implements QueryCachingConfigurer {
+		private static final String FAILURE_MESSAGE = "Simulated failure for " + FailingQueryCasheConfigurer.class.getName();
+
+		@Override
+		public void configure(QueryCachingConfigurationContext context) {
+			context.queryCache( new TestQueryCache( context.luceneVersion(), new SimulatedFailure( FAILURE_MESSAGE ) ) );
+		}
+	}
+
+	@Test
+	public void error_failingQueryCachingPolicyConfigurer() {
+		setup( FailingCashePolicyExceptionQueryCacheConfigurer.class.getName() );
+		initData( 10 );
+
+		StubMappingScope scope = index.createScope();
+
+		SearchQuery<DocumentReference> query = scope.query()
+			.where( f -> f.match().field( "string" ).matching( "platypus" ) )
+			.toQuery();
+
+		assertThatThrownBy( () -> query.fetchAll() )
+			.isInstanceOf( SimulatedFailure.class );
+	}
+
+	public static class FailingCashePolicyExceptionQueryCacheConfigurer implements QueryCachingConfigurer {
+		private static final String FAILURE_MESSAGE = "Simulated failure for " + FailingCashePolicyExceptionQueryCacheConfigurer.class.getName();
+
+		@Override
+		public void configure(QueryCachingConfigurationContext context) {
+			context.queryCachingPolicy( new TestQueryCachingPolicy( context.luceneVersion(), new SimulatedFailure( FAILURE_MESSAGE ) ) );
+		}
+	}
+
+	private void setup(String queryCacheConfigurer) {
+		setup( queryCacheConfigurer, c -> {
+		} );
+	}
+
+	private void setup(String queryCacheConfigurer, Consumer<IndexBindingContext> binder) {
+		setupHelper.start()
+			.expectCustomBeans()
+			.withBackendProperty( LuceneBackendSettings.QUERY_CACHING_CONFIGURER, queryCacheConfigurer )
+			.withIndex( index )
+			.setup();
+	}
+
+	private SearchQueryOptionsStep<?, DocumentReference, ?, ?, ?> matchAllQuery() {
+		return index.query()
+			.where( f -> f.matchAll() );
+	}
+
+	private void initData(int documentCount) {
+		index.bulkIndexer()
+			.add( documentCount, i -> documentProvider(
+			String.valueOf( i ),
+			document -> document.addValue( index.binding().string, "value" + i )
+		) )
+			.join();
+	}
+
+	private static class IndexBinding {
+		final IndexFieldReference<String> string;
+
+		IndexBinding(IndexSchemaElement root) {
+			string = root.field( "string", f -> f.asString().sortable( Sortable.YES ) )
+				.toReference();
+		}
+	}
+
+	private static class SimulatedFailure extends RuntimeException {
+		SimulatedFailure(String message) {
+			super( message );
+		}
+	}
+
+	static class TestQueryCache implements QueryCache {
+
+		private final SimulatedFailure failure;
+
+		TestQueryCache(Version luceneVersion, SimulatedFailure failure) {
+			this.failure = failure;
+		}
+
+		@Override
+		public Weight doCache(Weight weight, QueryCachingPolicy policy) {
+			throw failure;
+		}
+
+	}
+
+	static class TestQueryCachingPolicy implements QueryCachingPolicy {
+
+		private final SimulatedFailure failure;
+
+		TestQueryCachingPolicy(Version luceneVersion, SimulatedFailure failure) {
+			this.failure = failure;
+		}
+
+		@Override
+		public void onUse(Query query) {
+			throw failure;
+		}
+
+		@Override
+		public boolean shouldCache(Query query) throws IOException {
+			return true;
+		}
+	}
+
+}

--- a/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/cache/LuceneQueryCacheConfigurerIT.java
+++ b/integrationtest/backend/lucene/src/test/java/org/hibernate/search/integrationtest/backend/lucene/cache/LuceneQueryCacheConfigurerIT.java
@@ -44,7 +44,7 @@ public class LuceneQueryCacheConfigurerIT {
 
 	@Test
 	public void error_failingQueryCacheConfigurer() {
-		setup( FailingQueryCasheConfigurer.class.getName() );
+		setup( FailingQueryCacheConfigurer.class.getName() );
 		initData( 10 );
 
 		StubMappingScope scope = index.createScope();
@@ -57,8 +57,8 @@ public class LuceneQueryCacheConfigurerIT {
 				.isInstanceOf( SimulatedFailure.class );
 	}
 
-	public static class FailingQueryCasheConfigurer implements QueryCachingConfigurer {
-		private static final String FAILURE_MESSAGE = "Simulated failure for " + FailingQueryCasheConfigurer.class.getName();
+	public static class FailingQueryCacheConfigurer implements QueryCachingConfigurer {
+		private static final String FAILURE_MESSAGE = "Simulated failure for " + FailingQueryCacheConfigurer.class.getName();
 
 		@Override
 		public void configure(QueryCachingConfigurationContext context) {
@@ -69,7 +69,7 @@ public class LuceneQueryCacheConfigurerIT {
 
 	@Test
 	public void error_failingQueryCachingPolicyConfigurer() {
-		setup( FailingCashePolicyExceptionQueryCacheConfigurer.class.getName() );
+		setup( FailingCachePolicyExceptionQueryCacheConfigurer.class.getName() );
 		initData( 10 );
 
 		StubMappingScope scope = index.createScope();
@@ -82,8 +82,8 @@ public class LuceneQueryCacheConfigurerIT {
 				.isInstanceOf( SimulatedFailure.class );
 	}
 
-	public static class FailingCashePolicyExceptionQueryCacheConfigurer implements QueryCachingConfigurer {
-		private static final String FAILURE_MESSAGE = "Simulated failure for " + FailingCashePolicyExceptionQueryCacheConfigurer.class.getName();
+	public static class FailingCachePolicyExceptionQueryCacheConfigurer implements QueryCachingConfigurer {
+		private static final String FAILURE_MESSAGE = "Simulated failure for " + FailingCachePolicyExceptionQueryCacheConfigurer.class.getName();
 
 		@Override
 		public void configure(QueryCachingConfigurationContext context) {


### PR DESCRIPTION
### Defining QueryCache and QueryCachingPolicy for hibernate search.

https://hibernate.atlassian.net/browse/HSEARCH-3880

The extension allows you to define a custom implementation for QueryCache and QueryCachingPolicy. 

**Definitions are possible:** 

- Define with JPA parametr:

```
hibernate.search.backends.portal.cache.query_cache_provider=PortalQueryCachingPolicyProvider.class
hibernate.search.backends.portal.cache.query_caching_policy_provider=PortalQueryCachingPolicyProvider.class
```
Exemple custom implementation for QueryCache and QueryCachingPolicy:

```java
public class PortalQueryCacheProvider  implements QueryCacheProvider {

    public QueryCache getQueryCache(BackendBuildContext context, ConfigurationPropertySource properties, Version luceneVersion) {
        final int maxCachedQueries = 1000;
        // min of 32MB or 5% of the heap size
        final long maxRamBytesUsed = Math.min(1L << 25, Runtime.getRuntime().maxMemory() / 20);
        
        return new LRUQueryCache(maxCachedQueries, maxRamBytesUsed, new MinSegmentSizePredicate(0, .03f), 250);
    }

    static class MinSegmentSizePredicate implements Predicate<LeafReaderContext> {

        private final int minSize;
        private final float minSizeRatio;

        MinSegmentSizePredicate(int minSize, float minSizeRatio) {
            this.minSize = minSize;
            this.minSizeRatio = minSizeRatio;
        }

        @Override
        public boolean test(LeafReaderContext context) {
            final int maxDoc = context.reader().maxDoc();
            if (maxDoc < minSize) {
                return false;
            }
            final IndexReaderContext topLevelContext = ReaderUtil.getTopLevelContext(context);
            final float sizeRatio = (float) context.reader().maxDoc() / topLevelContext.reader().maxDoc();
            return sizeRatio >= minSizeRatio;
        }
    }
}
```
```java
public class PortalQueryCachingPolicyProvider implements QueryCachingPolicyProvider {

    public QueryCachingPolicy getQueryCachingPolicy(BackendBuildContext context, ConfigurationPropertySource properties, Version luceneVersion) {
        return new PortalQueryCachingPolicy();
    }

    public static class PortalQueryCachingPolicy extends UsageTrackingQueryCachingPolicy {

        @Override
        protected int minFrequencyToCache(Query query) {
            if (isCostly(query)) {
                return 2;
            } else {
                return super.minFrequencyToCache(query);
            }
        }

        private boolean isCostly(Query query) {
            return true;
        }
    }
}
```




- Define with Hibernate ORM parametr with StrategyRegistrationProvider:
```
hibernate.search.backend.cache.query_cache_class=portal
hibernate.search.backend.cache.query_caching_policy_class=portal
```
```java
@MetaInfServices(StrategyRegistrationProvider.class)
public class StrategyRegistrationProviderImpl implements StrategyRegistrationProvider {

    @Override
    public Iterable<StrategyRegistration> getStrategyRegistrations() {
      List<StrategyRegistration> strategyRegistrations = new ArrayList<>();
      
      strategyRegistrations.add(
            new SimpleStrategyRegistrationImpl<>(
                  QueryCachingPolicy.class,
                  PortalQueryCachingPolicy.class,
                  "portal",
                  PortalQueryCachingPolicy.class.getName(),
                  PortalQueryCachingPolicy.class.getSimpleName()
            )
      );
      
      strategyRegistrations.add(
            new SimpleStrategyRegistrationImpl<>(
                  QueryCache.class,
                  PortalQueryCache.class,
                  "portal",
                  PortalQueryCache.class.getName(),
                  PortalQueryCache.class.getSimpleName()
            )
      );
      
      return strategyRegistrations;
    }
}
```
Exemple custom implementation for QueryCache and QueryCachingPolicy:

```java
public class PortalQueryCache implements QueryCache {

    private final LRUQueryCache delegate;

    public PortalQueryCache(ConfigurationPropertySource properties, Version luceneVersion) {
        final int maxCachedQueries = 1000;
        // min of 32MB or 5% of the heap size
        final long maxRamBytesUsed = Math.min(1L << 25, Runtime.getRuntime().maxMemory() / 20);

        delegate = new LRUQueryCache(maxCachedQueries, maxRamBytesUsed, new MinSegmentSizePredicate(0, .03f), 250);
    }

    @Override
    public Weight doCache(Weight weight, QueryCachingPolicy policy) {
        return delegate.doCache(weight, policy);
    }

    static class MinSegmentSizePredicate implements Predicate<LeafReaderContext> {

        private final int minSize;
        private final float minSizeRatio;

        MinSegmentSizePredicate(int minSize, float minSizeRatio) {
            this.minSize = minSize;
            this.minSizeRatio = minSizeRatio;
        }

        @Override
        public boolean test(LeafReaderContext context) {
            final int maxDoc = context.reader().maxDoc();
            if (maxDoc < minSize) {
                return false;
            }
            final IndexReaderContext topLevelContext = ReaderUtil.getTopLevelContext(context);
            final float sizeRatio = (float) context.reader().maxDoc() / topLevelContext.reader().maxDoc();
            return sizeRatio >= minSizeRatio;
        }
    }
}
```



```java
public class PortalQueryCachingPolicy implements QueryCachingPolicy {

    private final UsageTrackingQueryCachingPolicy delegate;

    public PortalQueryCachingPolicy(ConfigurationPropertySource properties, Version luceneVersion) {
        delegate = new UsageTrackingQueryCachingPolicy();
    }

    @Override
    public void onUse(Query query) {
        delegate.onUse(query);
    }

    @Override
    public boolean shouldCache(Query query) throws IOException {
        return delegate.shouldCache(query);
    }
}
```



