### PR TITLE
HSEARCH-4156 Hibernate Search incorrectly adds synthetic Hibernate ORM properties to the metamodel, ultimately leading to a bootstrap failure

### DIFF
--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BackRefPropertyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/BackRefPropertyIT.java
@@ -1,0 +1,166 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.orm.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.OrderColumn;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.metamodel.spi.MetamodelImplementor;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.AssociationInverseSide;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ObjectPath;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.PropertyValue;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
+import org.hibernate.search.util.impl.test.annotation.TestForIssue;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Check that we correctly populate the metamodel when ORM generates a {@link org.hibernate.mapping.Backref}
+ * or {@link org.hibernate.mapping.IndexBackref} property,
+ * which happens in particular when there is a one-to-many
+ * whose referenced column is not the entity ID.
+ */
+@TestForIssue(jiraKey = "HSEARCH-4156")
+public class BackRefPropertyIT {
+
+	@Rule
+	public BackendMock backendMock = new BackendMock();
+
+	@Rule
+	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+
+	@Test
+	public void test() {
+		backendMock.expectSchema( IndexedEntity.NAME, b -> b
+				.objectField( "contained", b2 -> b2
+						.field( "text", String.class, b3 -> { } ) ) );
+
+		SessionFactory sessionFactory = ormSetupHelper.start()
+				.setup( IndexedEntity.class, ContainedEntity.class );
+		backendMock.verifyExpectationsMet();
+
+		// Hibernate Search started successfully.
+		// Check that there actually is a backref:
+		MetamodelImplementor metamodel = sessionFactory.unwrap( SessionFactoryImplementor.class ).getMetamodel();
+		assertThat( metamodel.entityPersister( IndexedEntity.class ).getEntityMetamodel().getPropertyNames() )
+				.contains( "_containing_fk_containingidBackref" )
+				.contains( "_containingIndexBackref" );
+
+		// If we get here the bug was solved, but let's at least check that indexing works
+
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			IndexedEntity containing1 = new IndexedEntity();
+			containing1.setId( 0 );
+			IndexedEntity containing2 = new IndexedEntity();
+			containing2.setId( 1 );
+			ContainedEntity contained1 = new ContainedEntity();
+			contained1.setId( 2 );
+			contained1.setText( "theText" );
+
+			containing1.setContained( contained1 );
+			contained1.getContaining().add( containing1 );
+			containing2.setContained( contained1 );
+			contained1.getContaining().add( containing2 );
+
+			session.persist( contained1 );
+			session.persist( containing1 );
+			session.persist( containing2 );
+
+			backendMock.expectWorks( IndexedEntity.NAME )
+					.add( "0", b -> b
+							.objectField( "contained", b2 -> b2
+									.field( "text", "theText" ) ) )
+					.add( "1", b -> b
+							.objectField( "contained", b2 -> b2
+									.field( "text", "theText" ) ) )
+					.createdThenExecuted();
+		} );
+	}
+
+	@Entity(name = IndexedEntity.NAME)
+	@Indexed
+	public static final class IndexedEntity {
+		static final String NAME = "indexed";
+
+		@Id
+		private Integer id;
+
+		@ManyToOne
+		@OrderColumn
+		@IndexedEmbedded
+		private ContainedEntity contained;
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public ContainedEntity getContained() {
+			return contained;
+		}
+
+		public void setContained(ContainedEntity contained) {
+			this.contained = contained;
+		}
+	}
+
+	@Entity(name = ContainedEntity.NAME)
+	public static final class ContainedEntity {
+		static final String NAME = "contained";
+
+		@Id
+		private Integer id;
+
+		@GenericField
+		private String text;
+
+		@OneToMany
+		@OrderColumn
+		@JoinColumn(name = "fk_containingid", referencedColumnName = "id", nullable = false)
+		@AssociationInverseSide(inversePath = @ObjectPath(@PropertyValue(propertyName = "contained")))
+		private List<IndexedEntity> containing = new ArrayList<>();
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getText() {
+			return text;
+		}
+
+		public void setText(String text) {
+			this.text = text;
+		}
+
+		public List<IndexedEntity> getContaining() {
+			return containing;
+		}
+	}
+}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/JpaIdAsDocumentIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/JpaIdAsDocumentIdIT.java
@@ -22,7 +22,6 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmb
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
-import org.hibernate.search.util.impl.test.rule.StaticCounters;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,9 +36,6 @@ public class JpaIdAsDocumentIdIT {
 
 	@Rule
 	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
-
-	@Rule
-	public StaticCounters counters = new StaticCounters();
 
 	@Test
 	public void test() {

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/SyntheticPropertyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/model/SyntheticPropertyIT.java
@@ -1,0 +1,158 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.orm.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.metamodel.spi.MetamodelImplementor;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils;
+import org.hibernate.search.util.impl.test.annotation.TestForIssue;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Check that we correctly populate the metamodel when ORM generates a {@link org.hibernate.mapping.SyntheticProperty},
+ * which happens in particular when there is a many-to-one whose referenced column is not the entity ID.
+ */
+@TestForIssue(jiraKey = "HSEARCH-4156")
+public class SyntheticPropertyIT {
+
+	@Rule
+	public BackendMock backendMock = new BackendMock();
+
+	@Rule
+	public OrmSetupHelper ormSetupHelper = OrmSetupHelper.withBackendMock( backendMock );
+
+	@Test
+	public void test() {
+		backendMock.expectSchema( IndexedEntity.NAME, b -> b
+				.objectField( "contained", b2 -> b2
+						.field( "ref", String.class, b3 -> { } ) ) );
+
+		SessionFactory sessionFactory = ormSetupHelper.start()
+				.setup( IndexedEntity.class, ContainedEntity.class );
+		backendMock.verifyExpectationsMet();
+
+		// Hibernate Search started successfully.
+		// Check that there actually is a synthetic property:
+		MetamodelImplementor metamodel = sessionFactory.unwrap( SessionFactoryImplementor.class ).getMetamodel();
+		assertThat( metamodel.entityPersister( ContainedEntity.class ).getEntityMetamodel().getPropertyNames() )
+				.contains( "_" + IndexedEntity.class.getName().replace( '.', '_' ) + "_contained" );
+
+		// If we get here the bug was solved, but let's at least check that indexing works
+
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			IndexedEntity containing1 = new IndexedEntity();
+			containing1.setId( 0 );
+			IndexedEntity containing2 = new IndexedEntity();
+			containing2.setId( 1 );
+			ContainedEntity contained1 = new ContainedEntity();
+			contained1.setId( 2 );
+			contained1.setRef( "theRef" );
+			containing1.setContained( contained1 );
+			contained1.getContaining().add( containing1 );
+			containing2.setContained( contained1 );
+			contained1.getContaining().add( containing2 );
+
+			session.persist( contained1 );
+			session.persist( containing1 );
+			session.persist( containing2 );
+
+			backendMock.expectWorks( IndexedEntity.NAME )
+					.add( "0", b -> b
+							.objectField( "contained", b2 -> b2
+									.field( "ref", "theRef" ) ) )
+					.add( "1", b -> b
+							.objectField( "contained", b2 -> b2
+									.field( "ref", "theRef" ) ) )
+					.createdThenExecuted();
+		} );
+	}
+
+	@Entity(name = IndexedEntity.NAME)
+	@Indexed
+	public static final class IndexedEntity {
+		static final String NAME = "indexed";
+
+		@Id
+		private Integer id;
+
+		@ManyToOne
+		@IndexedEmbedded
+		@JoinColumn(name = "ref", referencedColumnName = "ref")
+		private ContainedEntity contained;
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public ContainedEntity getContained() {
+			return contained;
+		}
+
+		public void setContained(ContainedEntity contained) {
+			this.contained = contained;
+		}
+	}
+
+	@Entity(name = ContainedEntity.NAME)
+	public static final class ContainedEntity
+			implements Serializable { // The entity must implement Serializable in this case, for some reason.
+		static final String NAME = "contained";
+
+		@Id
+		private Integer id;
+
+		@GenericField
+		private String ref;
+
+		@OneToMany(mappedBy = "contained")
+		private List<IndexedEntity> containing = new ArrayList<>();
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getRef() {
+			return ref;
+		}
+
+		public void setRef(String ref) {
+			this.ref = ref;
+		}
+
+		public List<IndexedEntity> getContaining() {
+			return containing;
+		}
+	}
+
+}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMetatadaContributor.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMetatadaContributor.java
@@ -17,6 +17,7 @@ import java.util.StringTokenizer;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Component;
 import org.hibernate.mapping.OneToMany;
+import org.hibernate.mapping.OneToOne;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.Selectable;
@@ -139,10 +140,12 @@ public final class HibernateOrmMetatadaContributor implements PojoMappingConfigu
 				);
 			}
 		}
-		else if ( value instanceof ToOne ) {
-			ToOne toOneValue = (ToOne) value;
+		else if ( value instanceof OneToOne ) {
+			// ManyToOne never carries any useful inverse side information:
+			// either it refers to nothing or to a synthetic property that we're not interested in.
+			// OneToOne, on the other hand, uses ReferencedPropertyName to store the "mappedBy" information.
+			OneToOne toOneValue = (OneToOne) value;
 			String referencedEntityName = toOneValue.getReferencedEntityName();
-			// For *ToOne, the "mappedBy" information is apparently stored in the ReferencedPropertyName
 			String mappedByPath = toOneValue.getReferencedPropertyName();
 			if ( mappedByPath != null && !mappedByPath.isEmpty() ) {
 				collector.collect(

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMetatadaContributor.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMetatadaContributor.java
@@ -102,7 +102,11 @@ public final class HibernateOrmMetatadaContributor implements PojoMappingConfigu
 		// Sort the properties before processing for deterministic iteration
 		List<Property> properties = new ArrayList<>();
 		while ( propertyIterator.hasNext() ) {
-			properties.add( (Property) propertyIterator.next() );
+			Property property = (Property) propertyIterator.next();
+			if ( property.isSynthetic() ) {
+				continue;
+			}
+			properties.add( property );
 		}
 		properties.sort( PropertyComparator.INSTANCE );
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmBasicTypeMetadataProvider.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmBasicTypeMetadataProvider.java
@@ -83,6 +83,9 @@ public class HibernateOrmBasicTypeMetadataProvider {
 		}
 		while ( propertyIterator.hasNext() ) {
 			Property property = propertyIterator.next();
+			if ( property.isSynthetic() ) {
+				continue;
+			}
 			collectClassProperty( metadataProviderBuilder, properties, javaClass, property, false );
 		}
 
@@ -103,6 +106,9 @@ public class HibernateOrmBasicTypeMetadataProvider {
 		}
 		while ( propertyIterator.hasNext() ) {
 			Property property = propertyIterator.next();
+			if ( property.isSynthetic() ) {
+				continue;
+			}
 			collectDynamicMapProperty( metadataProviderBuilder, properties, property );
 		}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4156
