### PR TITLE
Backport HSEARCH-4117 to branch 6.0 - "AssertionFailure: Unexpected duplicate key" when an entity has two getters for the same property

### DIFF
--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/model/DuplicateGetterIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/model/DuplicateGetterIT.java
@@ -1,0 +1,109 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.model;
+
+import java.lang.invoke.MethodHandles;
+
+import org.hibernate.search.engine.backend.analysis.AnalyzerNames;
+import org.hibernate.search.integrationtest.mapper.pojo.testsupport.util.rule.JavaBeanMappingSetupHelper;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.util.impl.test.annotation.TestForIssue;
+import org.hibernate.search.util.impl.test.rule.ExpectedLog4jLog;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.apache.logging.log4j.Level;
+
+/**
+ * Test models with multiple getters for the same property.
+ */
+@TestForIssue(jiraKey = "HSEARCH-4117")
+public class DuplicateGetterIT {
+
+	@Rule
+	public BackendMock backendMock = new BackendMock();
+
+	@Rule
+	public JavaBeanMappingSetupHelper setupHelper =
+			JavaBeanMappingSetupHelper.withBackendMock( MethodHandles.lookup(), backendMock );
+
+	@Rule
+	public ExpectedLog4jLog logged = ExpectedLog4jLog.create();
+
+	@Test
+	public void duplicateGetter_unmapped() {
+		final String indexName = "indexName";
+		@Indexed(index = indexName)
+		class IndexedEntity {
+			@DocumentId
+			private Integer id;
+
+			@FullTextField
+			private String text;
+
+			private Boolean enabled;
+
+			public boolean isEnabled() {
+				return enabled != null && enabled;
+			}
+
+			public Boolean getEnabled() {
+				return enabled;
+			}
+		}
+
+		// Check that Hibernate Search starts correctly, ignoring the duplicate getter and not logging any warning
+		logged.expectLevel( Level.WARN ).never();
+		backendMock.expectSchema( indexName, b -> b
+				.field( "text", String.class, b2 -> b2.analyzerName( AnalyzerNames.DEFAULT ) ) );
+		setupHelper.start().setup( IndexedEntity.class );
+	}
+
+	@Test
+	public void duplicateGetter_mapped() {
+		final String indexName = "indexName";
+		@Indexed(index = indexName)
+		class IndexedEntity {
+			@DocumentId
+			private Integer id;
+
+			@FullTextField
+			private String text;
+
+			@GenericField
+			private Boolean enabled;
+
+			public boolean isEnabled() {
+				return enabled != null && enabled;
+			}
+
+			public Boolean getEnabled() {
+				return enabled;
+			}
+		}
+
+		// Check that Hibernate Search starts correctly, selecting whatever getter comes first
+		// but logging a warning
+		logged.expectEvent( Level.WARN,
+				"Multiple getters exist for property named 'enabled' on type '"
+						+ IndexedEntity.class.getName() + "'",
+				"Hibernate Search will use '", "'", " and ignore [", "]",
+				"The selected getter may change from one startup to the next",
+				"To get rid of this warning, either remove the extra getters"
+						+ " or configure the access type for this property to 'FIELD'." );
+		backendMock.expectSchema( indexName, b -> b
+				.field( "text", String.class, b2 -> b2.analyzerName( AnalyzerNames.DEFAULT ) )
+				.field( "enabled", Boolean.class ) );
+		setupHelper.start().setup( IndexedEntity.class );
+	}
+
+}

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/model/impl/JavaBeanPropertyModel.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/model/impl/JavaBeanPropertyModel.java
@@ -18,13 +18,13 @@ class JavaBeanPropertyModel<T> extends AbstractPojoHCAnnPropertyModel<T, JavaBea
 	JavaBeanPropertyModel(JavaBeanBootstrapIntrospector introspector,
 			JavaBeanRawTypeModel<?> holderTypeModel,
 			String name, List<XProperty> declaredXProperties,
-			Member member) {
-		super( introspector, holderTypeModel, name, declaredXProperties, member );
+			List<Member> members) {
+		super( introspector, holderTypeModel, name, declaredXProperties, members );
 	}
 
 	@Override
 	@SuppressWarnings("unchecked") // By construction, we know the member returns values of type T
-	protected ValueReadHandle<T> createHandle() throws IllegalAccessException {
+	protected ValueReadHandle<T> createHandle(Member member) throws IllegalAccessException {
 		return (ValueReadHandle<T>) introspector.createValueReadHandle( member );
 	}
 }

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/model/impl/JavaBeanRawTypeModel.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/model/impl/JavaBeanRawTypeModel.java
@@ -8,6 +8,7 @@ package org.hibernate.search.mapper.javabean.model.impl;
 
 import java.lang.reflect.Member;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
@@ -42,34 +43,33 @@ class JavaBeanRawTypeModel<T> extends AbstractPojoHCAnnRawTypeModel<T, JavaBeanB
 	@Override
 	protected JavaBeanPropertyModel<?> createPropertyModel(String propertyName) {
 		List<XProperty> declaredXProperties = new ArrayList<>( 2 );
-		XProperty methodAccessXProperty = declaredMethodAccessXPropertiesByName().get( propertyName );
-		if ( methodAccessXProperty != null ) {
-			declaredXProperties.add( methodAccessXProperty );
+		List<XProperty> methodAccessXProperties = declaredMethodAccessXPropertiesByName().get( propertyName );
+		if ( methodAccessXProperties != null ) {
+			declaredXProperties.addAll( methodAccessXProperties );
 		}
 		XProperty fieldAccessXProperty = declaredFieldAccessXPropertiesByName().get( propertyName );
 		if ( fieldAccessXProperty != null ) {
 			declaredXProperties.add( fieldAccessXProperty );
 		}
 
-		Member member = findPropertyMember( propertyName );
-		if ( member == null ) {
+		List<Member> members = findPropertyMember( propertyName );
+		if ( members == null ) {
 			return null;
 		}
 
-		return new JavaBeanPropertyModel<>(
-				introspector, this, propertyName,
-				declaredXProperties, member
-		);
+		return new JavaBeanPropertyModel<>( introspector, this, propertyName,
+				declaredXProperties, members );
 	}
 
-	private Member findPropertyMember(String propertyName) {
+	private List<Member> findPropertyMember(String propertyName) {
 		// Try using the getter first (if declared)...
-		Member getter = findInSelfOrParents( t -> t.declaredPropertyGetter( propertyName ) );
-		if ( getter != null ) {
-			return getter;
+		List<Member> getters = findInSelfOrParents( t -> t.declaredPropertyGetters( propertyName ) );
+		if ( getters != null ) {
+			return getters;
 		}
 		// ... and fall back to the field (or null if not found)
-		return findInSelfOrParents( t -> t.declaredPropertyField( propertyName ) );
+		Member field = findInSelfOrParents( t -> t.declaredPropertyField( propertyName ) );
+		return field == null ? null : Collections.singletonList( field );
 	}
 
 	private <T2> T2 findInSelfOrParents(Function<JavaBeanRawTypeModel<?>, T2> getter) {

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmClassPropertyModel.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/model/impl/HibernateOrmClassPropertyModel.java
@@ -22,14 +22,14 @@ class HibernateOrmClassPropertyModel<T>
 			HibernateOrmClassRawTypeModel<?> holderTypeModel,
 			String name, List<XProperty> declaredXProperties,
 			HibernateOrmBasicClassPropertyMetadata ormPropertyMetadata,
-			Member member) {
-		super( introspector, holderTypeModel, name, declaredXProperties, member );
+			List<Member> members) {
+		super( introspector, holderTypeModel, name, declaredXProperties, members );
 		this.ormPropertyMetadata = ormPropertyMetadata;
 	}
 
 	@Override
 	@SuppressWarnings("unchecked") // By construction, we know the member returns values of type T
-	protected ValueReadHandle<T> createHandle() throws IllegalAccessException {
+	protected ValueReadHandle<T> createHandle(Member member) throws IllegalAccessException {
 		return (ValueReadHandle<T>) introspector.createValueReadHandle( holderTypeModel.typeIdentifier().javaClass(),
 				member, ormPropertyMetadata );
 	}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
@@ -7,10 +7,12 @@
 package org.hibernate.search.mapper.pojo.logging.impl;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Member;
 import java.lang.reflect.Type;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 
 import org.hibernate.search.engine.backend.types.dsl.IndexFieldTypeOptionsStep;
@@ -535,4 +537,15 @@ public interface Log extends BasicLogger {
 			value = "Exception while resolving other entities to reindex as a result of changes on entity '%1$s': %2$s")
 	SearchException errorResolvingEntitiesToReindex(Object entityReference,
 			String message, @Cause Exception e);
+
+	@LogMessage(level = Logger.Level.WARN)
+	@Message(id = ID_OFFSET + 85,
+			value = "Multiple getters exist for property named '%2$s' on type '%1$s'."
+					+ " Hibernate Search will use '%3$s' and ignore %4$s."
+					+ " The selected getter may change from one startup to the next."
+					+ " To get rid of this warning, either remove the extra getters"
+					+ " or configure the access type for this property to 'FIELD'.")
+	void arbitraryMemberSelection(@FormatWith(PojoTypeModelFormatter.class) PojoRawTypeModel<?> typeModel,
+			String propertyName, Member selectedMember, List<Member> otherMembers);
+
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/spi/ErrorCollectingPojoPropertyMetadataContributor.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/spi/ErrorCollectingPojoPropertyMetadataContributor.java
@@ -17,7 +17,7 @@ public final class ErrorCollectingPojoPropertyMetadataContributor implements Poj
 
 	@Override
 	public void contributeAdditionalMetadata(PojoAdditionalMetadataCollectorPropertyNode collector) {
-		if ( children != null ) {
+		if ( hasContent() ) {
 			for ( PojoPropertyMetadataContributor child : children ) {
 				try {
 					child.contributeAdditionalMetadata( collector );
@@ -31,7 +31,7 @@ public final class ErrorCollectingPojoPropertyMetadataContributor implements Poj
 
 	@Override
 	public void contributeMapping(PojoMappingCollectorPropertyNode collector) {
-		if ( children != null ) {
+		if ( hasContent() ) {
 			for ( PojoPropertyMetadataContributor child : children ) {
 				try {
 					child.contributeMapping( collector );
@@ -47,6 +47,10 @@ public final class ErrorCollectingPojoPropertyMetadataContributor implements Poj
 		initChildren();
 		this.children.add( child );
 		return this;
+	}
+
+	public boolean hasContent() {
+		return children != null && !children.isEmpty();
 	}
 
 	private void initChildren() {

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/InitialPropertyMappingStep.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/definition/programmatic/impl/InitialPropertyMappingStep.java
@@ -49,15 +49,19 @@ class InitialPropertyMappingStep
 
 	@Override
 	public void contributeAdditionalMetadata(PojoAdditionalMetadataCollectorTypeNode collector) {
-		PojoAdditionalMetadataCollectorPropertyNode collectorPropertyNode =
-				collector.property( propertyModel.name() );
-		children.contributeAdditionalMetadata( collectorPropertyNode );
+		if ( children.hasContent() ) {
+			PojoAdditionalMetadataCollectorPropertyNode collectorPropertyNode =
+					collector.property( propertyModel.name() );
+			children.contributeAdditionalMetadata( collectorPropertyNode );
+		}
 	}
 
 	@Override
 	public void contributeMapping(PojoMappingCollectorTypeNode collector) {
-		PojoMappingCollectorPropertyNode collectorPropertyNode = collector.property( propertyModel.name() );
-		children.contributeMapping( collectorPropertyNode );
+		if ( children.hasContent() ) {
+			PojoMappingCollectorPropertyNode collectorPropertyNode = collector.property( propertyModel.name() );
+			children.contributeMapping( collectorPropertyNode );
+		}
 	}
 
 	@Override

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/hcann/spi/AbstractPojoHCAnnBootstrapIntrospector.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/hcann/spi/AbstractPojoHCAnnBootstrapIntrospector.java
@@ -8,10 +8,12 @@ package org.hibernate.search.mapper.pojo.model.hcann.spi;
 
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Collector;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.hibernate.annotations.common.reflection.ReflectionManager;
@@ -45,9 +47,9 @@ public abstract class AbstractPojoHCAnnBootstrapIntrospector implements PojoBoot
 				.collect( xPropertiesByNameNoDuplicate() );
 	}
 
-	public Map<String, XProperty> declaredMethodAccessXPropertiesByName(XClass xClass) {
+	public Map<String, List<XProperty>> declaredMethodAccessXPropertiesByName(XClass xClass) {
 		return xClass.getDeclaredProperties( XClass.ACCESS_PROPERTY ).stream()
-				.collect( xPropertiesByNameNoDuplicate() );
+				.collect( xPropertiesByName() );
 	}
 
 	public Stream<Class<?>> ascendingSuperClasses(XClass xClass) {
@@ -62,10 +64,16 @@ public abstract class AbstractPojoHCAnnBootstrapIntrospector implements PojoBoot
 		return reflectionManager.toClass( xClass );
 	}
 
-	private Collector<XProperty, ?, Map<String, XProperty>> xPropertiesByNameNoDuplicate() {
+	private static Collector<XProperty, ?, Map<String, XProperty>> xPropertiesByNameNoDuplicate() {
 		return StreamHelper.toMap(
 				XProperty::getName, Function.identity(),
 				TreeMap::new // Sort properties by name for deterministic iteration
 		);
+	}
+
+	private static Collector<XProperty, ?, Map<String, List<XProperty>>> xPropertiesByName() {
+		return Collectors.groupingBy( XProperty::getName,
+				TreeMap::new, // Sort properties by name for deterministic iteration
+				Collectors.toList() );
 	}
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/hcann/spi/AbstractPojoHCAnnBootstrapIntrospector.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/hcann/spi/AbstractPojoHCAnnBootstrapIntrospector.java
@@ -41,13 +41,11 @@ public abstract class AbstractPojoHCAnnBootstrapIntrospector implements PojoBoot
 	}
 
 	public Map<String, XProperty> declaredFieldAccessXPropertiesByName(XClass xClass) {
-		// TODO HSEARCH-3056 remove lambdas if possible
 		return xClass.getDeclaredProperties( XClass.ACCESS_FIELD ).stream()
 				.collect( xPropertiesByNameNoDuplicate() );
 	}
 
 	public Map<String, XProperty> declaredMethodAccessXPropertiesByName(XClass xClass) {
-		// TODO HSEARCH-3056 remove lambdas if possible
 		return xClass.getDeclaredProperties( XClass.ACCESS_PROPERTY ).stream()
 				.collect( xPropertiesByNameNoDuplicate() );
 	}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/hcann/spi/AbstractPojoHCAnnRawTypeModel.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/hcann/spi/AbstractPojoHCAnnRawTypeModel.java
@@ -8,7 +8,9 @@ package org.hibernate.search.mapper.pojo.model.hcann.spi;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Member;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.hibernate.annotations.common.reflection.XClass;
@@ -25,7 +27,7 @@ public abstract class AbstractPojoHCAnnRawTypeModel<T, I extends AbstractPojoHCA
 	final RawTypeDeclaringContext<T> rawTypeDeclaringContext;
 
 	private Map<String, XProperty> declaredFieldAccessXPropertiesByName;
-	private Map<String, XProperty> declaredMethodAccessXPropertiesByName;
+	private Map<String, List<XProperty>> declaredMethodAccessXPropertiesByName;
 
 	public AbstractPojoHCAnnRawTypeModel(I introspector, PojoRawTypeIdentifier<T> typeIdentifier,
 			RawTypeDeclaringContext<T> rawTypeDeclaringContext) {
@@ -67,7 +69,7 @@ public abstract class AbstractPojoHCAnnRawTypeModel<T, I extends AbstractPojoHCA
 		return declaredFieldAccessXPropertiesByName;
 	}
 
-	protected final Map<String, XProperty> declaredMethodAccessXPropertiesByName() {
+	protected final Map<String, List<XProperty>> declaredMethodAccessXPropertiesByName() {
 		if ( declaredMethodAccessXPropertiesByName == null ) {
 			declaredMethodAccessXPropertiesByName =
 					introspector.declaredMethodAccessXPropertiesByName( xClass );
@@ -75,11 +77,11 @@ public abstract class AbstractPojoHCAnnRawTypeModel<T, I extends AbstractPojoHCA
 		return declaredMethodAccessXPropertiesByName;
 	}
 
-	protected final Member declaredPropertyGetter(String propertyName) {
-		XProperty methodAccessXProperty = declaredMethodAccessXPropertiesByName().get( propertyName );
-		if ( methodAccessXProperty != null ) {
-			// Method access is available. Get values from the getter.
-			return PojoCommonsAnnotationsHelper.extractUnderlyingMember( methodAccessXProperty );
+	protected final List<Member> declaredPropertyGetters(String propertyName) {
+		List<XProperty> methodAccessXProperties = declaredMethodAccessXPropertiesByName().get( propertyName );
+		if ( methodAccessXProperties != null ) {
+			return methodAccessXProperties.stream().map( PojoCommonsAnnotationsHelper::extractUnderlyingMember )
+					.collect( Collectors.toList() );
 		}
 		return null;
 	}
@@ -87,7 +89,6 @@ public abstract class AbstractPojoHCAnnRawTypeModel<T, I extends AbstractPojoHCA
 	protected final Member declaredPropertyField(String propertyName) {
 		XProperty fieldAccessXProperty = declaredFieldAccessXPropertiesByName().get( propertyName );
 		if ( fieldAccessXProperty != null ) {
-			// Method access is available. Get values from the getter.
 			return PojoCommonsAnnotationsHelper.extractUnderlyingMember( fieldAccessXProperty );
 		}
 		return null;


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4117

See #2472 . 

I'll backport it after all, because the changes seem relatively safe, and the error is cryptic enough that we've had multiple reports of this bug.

The SPI changes are a bit annoying, but AFAIK only Infinispan will be affected, and we'll be able to handle that.

Will merge as soon as the build passes.