### PR TITLE
Backport HSEARCH-4161 to branch 6.0 - LuceneIndexManager.computeSizeInBytes() may fail if a file is deleted while computing size

### DIFF
--- a/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/index/impl/IndexAccessorImpl.java
+++ b/backend/lucene/src/main/java/org/hibernate/search/backend/lucene/lowlevel/index/impl/IndexAccessorImpl.java
@@ -9,6 +9,7 @@ package org.hibernate.search.backend.lucene.lowlevel.index.impl;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
+import java.nio.file.NoSuchFileException;
 
 import org.hibernate.search.backend.lucene.logging.impl.Log;
 import org.hibernate.search.backend.lucene.lowlevel.common.impl.AnalyzerConstants;
@@ -193,7 +194,7 @@ public class IndexAccessorImpl implements AutoCloseable, IndexAccessor {
 				try {
 					totalSize += directory.fileLength( fileName );
 				}
-				catch (FileNotFoundException ignored) {
+				catch (FileNotFoundException | NoSuchFileException ignored) {
 					// Ignore: the file was probably removed since the call to listAll
 				}
 			}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4161

Must be merged after #2499 