### PR TITLE
HSEARCH-4164 + HSEARCH-4165 Fix transient failure in AbstractAutomaticIndexingMultiAssociationIT

### DIFF
--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexedTypeIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexedTypeIndexingPlan.java
@@ -73,7 +73,6 @@ public class PojoIndexedTypeIndexingPlan<I, E>
 
 	<R> CompletableFuture<MultiEntityOperationExecutionReport<R>> executeAndReport(
 			EntityReferenceFactory<R> entityReferenceFactory) {
-		process();
 		return delegate.executeAndReport( entityReferenceFactory );
 	}
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanImpl.java
@@ -171,11 +171,18 @@ public class PojoIndexingPlanImpl implements PojoIndexingPlan, PojoReindexingCol
 			EntityReferenceFactory<R> entityReferenceFactory) {
 		try {
 			process();
-			List<CompletableFuture<MultiEntityOperationExecutionReport<R>>> futures = new ArrayList<>();
-			for ( PojoIndexedTypeIndexingPlan<?, ?> delegate : indexedTypeDelegates.values() ) {
-				futures.add( delegate.executeAndReport( entityReferenceFactory ) );
+			if ( sink != null ) {
+				// All types have the same delegate
+				return sink.sendAndReport( entityReferenceFactory );
 			}
-			return MultiEntityOperationExecutionReport.allOf( futures );
+			else {
+				List<CompletableFuture<MultiEntityOperationExecutionReport<R>>> futures = new ArrayList<>();
+				// Each type has its own delegate
+				for ( PojoIndexedTypeIndexingPlan<?, ?> delegate : indexedTypeDelegates.values() ) {
+					futures.add( delegate.executeAndReport( entityReferenceFactory ) );
+				}
+				return MultiEntityOperationExecutionReport.allOf( futures );
+			}
 		}
 		finally {
 			indexedTypeDelegates.clear();

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/automaticindexing/LocalHeapQueueIndexingEvent.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/automaticindexing/LocalHeapQueueIndexingEvent.java
@@ -29,6 +29,16 @@ public class LocalHeapQueueIndexingEvent implements BatchedWork<LocalHeapQueuePr
 	}
 
 	@Override
+	public String toString() {
+		return "LocalHeapQueueIndexingEvent{" +
+				"eventType=" + eventType +
+				", entityName='" + entityName + '\'' +
+				", identifier=" + identifier +
+				", future=" + future +
+				'}';
+	}
+
+	@Override
 	public void submitTo(LocalHeapQueueProcessor processor) {
 		processor.process( this );
 	}

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/automaticindexing/LocalHeapQueueIndexingEvent.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/automaticindexing/LocalHeapQueueIndexingEvent.java
@@ -6,17 +6,21 @@
  */
 package org.hibernate.search.util.impl.integrationtest.mapper.orm.automaticindexing;
 
-import java.util.concurrent.CompletableFuture;
+import java.lang.invoke.MethodHandles;
 
 import org.hibernate.search.engine.backend.orchestration.spi.BatchedWork;
+import org.hibernate.search.mapper.orm.logging.impl.Log;
+import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
 public class LocalHeapQueueIndexingEvent implements BatchedWork<LocalHeapQueueProcessor> {
+
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+
 	final Type eventType;
 	final String entityName;
 	final transient Object identifier;
 	final String serializedId;
 	final byte[] routes;
-	final CompletableFuture<?> future;
 
 	public LocalHeapQueueIndexingEvent(Type eventType, String entityName, Object identifier, String serializedId,
 			byte[] routes) {
@@ -25,7 +29,6 @@ public class LocalHeapQueueIndexingEvent implements BatchedWork<LocalHeapQueuePr
 		this.identifier = identifier;
 		this.serializedId = serializedId;
 		this.routes = routes;
-		future = new CompletableFuture<>();
 	}
 
 	@Override
@@ -34,7 +37,6 @@ public class LocalHeapQueueIndexingEvent implements BatchedWork<LocalHeapQueuePr
 				"eventType=" + eventType +
 				", entityName='" + entityName + '\'' +
 				", identifier=" + identifier +
-				", future=" + future +
 				'}';
 	}
 
@@ -45,8 +47,9 @@ public class LocalHeapQueueIndexingEvent implements BatchedWork<LocalHeapQueuePr
 
 	@Override
 	public void markAsFailed(Throwable t) {
-		future.completeExceptionally( t );
-		// We don't care about feedback
+		// In a real implementation we would put this event back into a queue, to re-try later.
+		// But here it's just for testing.
+		log.errorf( "Failed to process event '%s'", this, t );
 	}
 
 	public enum Type {

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/automaticindexing/LocalHeapQueueProcessor.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/automaticindexing/LocalHeapQueueProcessor.java
@@ -6,6 +6,9 @@
  */
 package org.hibernate.search.util.impl.integrationtest.mapper.orm.automaticindexing;
 
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.Session;
@@ -14,15 +17,21 @@ import org.hibernate.search.engine.backend.orchestration.spi.BatchedWorkProcesso
 import org.hibernate.search.mapper.orm.automaticindexing.spi.AutomaticIndexingMappingContext;
 import org.hibernate.search.mapper.orm.automaticindexing.spi.AutomaticIndexingQueueEventProcessingPlan;
 import org.hibernate.search.mapper.orm.common.EntityReference;
+import org.hibernate.search.mapper.orm.logging.impl.Log;
 import org.hibernate.search.mapper.pojo.route.DocumentRoutesDescriptor;
+import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 import org.hibernate.search.util.impl.test.SerializationUtils;
 
 public class LocalHeapQueueProcessor implements BatchedWorkProcessor {
+
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private final AutomaticIndexingMappingContext mapping;
 
 	private Session session;
 	private AutomaticIndexingQueueEventProcessingPlan plan;
+	private CompletableFuture<MultiEntityOperationExecutionReport<EntityReference>> batchReportFuture;
+	private List<LocalHeapQueueIndexingEvent> eventsInBatch = new ArrayList<>();
 
 	public LocalHeapQueueProcessor(AutomaticIndexingMappingContext mapping) {
 		this.mapping = mapping;
@@ -34,10 +43,12 @@ public class LocalHeapQueueProcessor implements BatchedWorkProcessor {
 			session = mapping.sessionFactory().openSession();
 			plan = mapping.createIndexingQueueEventProcessingPlan( session );
 		}
+		batchReportFuture = new CompletableFuture<>();
 	}
 
 	public void process(LocalHeapQueueIndexingEvent event) {
-		DocumentRoutesDescriptor routes = SerializationUtils.deserialize( DocumentRoutesDescriptor.class, event.routes );
+		DocumentRoutesDescriptor routes = SerializationUtils.deserialize(
+				DocumentRoutesDescriptor.class, event.routes );
 		switch ( event.eventType ) {
 			case ADD:
 				plan.add( event.entityName, event.serializedId, routes );
@@ -49,37 +60,75 @@ public class LocalHeapQueueProcessor implements BatchedWorkProcessor {
 				plan.delete( event.entityName, event.serializedId, routes );
 				break;
 		}
+		eventsInBatch.add( event );
 	}
 
 	@Override
 	public CompletableFuture<?> endBatch() {
-		return plan.executeAndReport().thenAccept( this::processReport )
-				.whenComplete( (ignored1, ignored2) -> {
-					// Make sure the next batch actually loads entities from the database:
-					// if it relied on the first-level cache from a previous batch,
-					// it could end up indexing out-of-date data.
-					session.clear();
-				} );
+		try {
+			return plan.executeAndReport()
+					.whenComplete( this::reportBackendResult );
+		}
+		catch (Throwable t) {
+			reportMapperFailure( t );
+			return CompletableFuture.completedFuture( null );
+		}
+		finally {
+			// We're sure no entity will be loaded after executeAndReport() returns a future.
+			// Make sure the next batch actually loads entities from the database:
+			// if it relied on the first-level cache from a previous batch,
+			// it could end up indexing out-of-date data.
+			if ( session != null ) {
+				session.clear();
+			}
+		}
 	}
 
-	private void processReport(MultiEntityOperationExecutionReport<EntityReference> report) {
-		if ( report.throwable().isPresent() ) {
-			Throwable cause = report.throwable().get();
-			try {
-				releaseSession();
-			}
-			catch (RuntimeException e) {
-				cause.addSuppressed( e );
-			}
-			throw new IllegalStateException( "Reindexing failed for entities " + report.failingEntityReferences(),
-					cause );
+	private void reportMapperFailure(Throwable throwable) {
+		try {
+			releaseSession();
+			// Something failed, but we don't know what.
+			// Assume all events failed.
+			reportAllEventsFailure( throwable );
 		}
+		catch (Throwable t) {
+			throwable.addSuppressed( t );
+		}
+	}
+
+	private void reportBackendResult(MultiEntityOperationExecutionReport<EntityReference> report,
+			Throwable throwable) {
+		if ( throwable != null ) {
+			// Something failed, but we don't know what.
+			// Assume all events failed.
+			reportAllEventsFailure( throwable );
+		}
+		else if ( report.throwable().isPresent() ) {
+			// Something failed, but we know which entities are affected.
+			Throwable reportThrowable = report.throwable().get();
+			reportSpecificEntitiesIndexingFailure( throwable, report.failingEntityReferences() );
+		}
+	}
+
+	private void reportAllEventsFailure(Throwable throwable) {
+		// Report that events weren't correctly processed
+		for ( LocalHeapQueueIndexingEvent event : eventsInBatch ) {
+			event.markAsFailed( throwable );
+		}
+	}
+
+	private void reportSpecificEntitiesIndexingFailure(Throwable throwable,
+			List<EntityReference> failingEntityReferences) {
+		// In a real implementation we would put these references in a queue, to re-try later.
+		// But here it's just for testing.
+		log.errorf( "Failed to reindex entities '%s'", failingEntityReferences, throwable );
 	}
 
 	@Override
 	public void complete() {
 		// Parking: release the session/connection
 		releaseSession();
+		eventsInBatch.clear();
 	}
 
 	private void releaseSession() {


### PR DESCRIPTION
* [HSEARCH-4165](https://hibernate.atlassian.net/browse/HSEARCH-4165): Avoid duplicate event sending when using PojoIndexingQueueEventSendingPlan
* [HSEARCH-4164](https://hibernate.atlassian.net/browse/HSEARCH-4164): Fix transient failure in AbstractAutomaticIndexingMultiAssociationIT

Follow-up on #2501 

Still unable to reproduce the issue locally... Let's see if it happens on CI when building this PR.