### PR TITLE
HSEARCH-4172 Ignore relative ordering of works on different documents in BackendMock

### DIFF
--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingConcurrentModificationInSameTypeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/AutomaticIndexingConcurrentModificationInSameTypeIT.java
@@ -72,7 +72,7 @@ public class AutomaticIndexingConcurrentModificationInSameTypeIT {
 			session.persist( entity2 );
 			session.persist( entity3 );
 
-			backendMock.expectWorksAnyOrder( IndexedEntity.INDEX )
+			backendMock.expectWorks( IndexedEntity.INDEX )
 					.add( String.valueOf( 1 ), b -> b
 							.field( "name", "edouard" )
 							.field( "firstName", "zobocare" ) )
@@ -101,7 +101,7 @@ public class AutomaticIndexingConcurrentModificationInSameTypeIT {
 			IndexedEntity entity3 = session.load( IndexedEntity.class, 3 );
 			entity3.setName( "updated" );
 
-			backendMock.expectWorksAnyOrder( IndexedEntity.INDEX )
+			backendMock.expectWorks( IndexedEntity.INDEX )
 					.addOrUpdate( String.valueOf( 1 ), b -> b
 							.field( "name", "updated" )
 							.field( "firstName", "zobocare" ) )

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/dynamicmap/DynamicMapBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/dynamicmap/DynamicMapBaseIT.java
@@ -238,7 +238,7 @@ public class DynamicMapBaseIT {
 
 			for ( int i = 0; i < 100; i++ ) {
 				int id = i;
-				backendMock.expectWorksAnyOrder( INDEX1_NAME, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE )
+				backendMock.expectWorks( INDEX1_NAME, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE )
 						.add( String.valueOf( id ), b -> b.field( "title","Hyperion " + id ) )
 						.createdThenExecuted();
 			}

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/AbstractMassIndexingErrorIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/AbstractMassIndexingErrorIT.java
@@ -384,7 +384,7 @@ public abstract class AbstractMassIndexingErrorIT {
 		return () -> {
 			switch ( workTwoExecutionExpectation ) {
 				case SUCCEED:
-					backendMock.expectWorksAnyOrder(
+					backendMock.expectWorks(
 							Book.NAME, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE
 					)
 							.add( "1", b -> b
@@ -404,7 +404,7 @@ public abstract class AbstractMassIndexingErrorIT {
 				case ERROR:
 					CompletableFuture<?> failingFuture = new CompletableFuture<>();
 					failingFuture.completeExceptionally( new SimulatedError( "Indexing error" ) );
-					backendMock.expectWorksAnyOrder(
+					backendMock.expectWorks(
 							Book.NAME, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE
 					)
 							.add( "1", b -> b
@@ -416,7 +416,7 @@ public abstract class AbstractMassIndexingErrorIT {
 									.field( "author", AUTHOR_3 )
 							)
 							.createdThenExecuted();
-					backendMock.expectWorksAnyOrder(
+					backendMock.expectWorks(
 							Book.NAME, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE
 					)
 							.add( "2", b -> b
@@ -426,7 +426,7 @@ public abstract class AbstractMassIndexingErrorIT {
 							.createdThenExecuted( failingFuture );
 					break;
 				case STOP:
-					backendMock.expectWorksAnyOrder(
+					backendMock.expectWorks(
 							Book.NAME, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE
 					)
 							.add( "1", b -> b

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/AbstractMassIndexingFailureIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/AbstractMassIndexingFailureIT.java
@@ -576,7 +576,7 @@ public abstract class AbstractMassIndexingFailureIT {
 		return () -> {
 			switch ( workTwoExecutionExpectation ) {
 				case SUCCEED:
-					backendMock.expectWorksAnyOrder(
+					backendMock.expectWorks(
 							Book.NAME, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE
 					)
 							.add( "1", b -> b
@@ -596,7 +596,7 @@ public abstract class AbstractMassIndexingFailureIT {
 				case FAIL:
 					CompletableFuture<?> failingFuture = new CompletableFuture<>();
 					failingFuture.completeExceptionally( new SimulatedFailure( "Indexing failure" ) );
-					backendMock.expectWorksAnyOrder(
+					backendMock.expectWorks(
 							Book.NAME, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE
 					)
 							.add( "1", b -> b
@@ -608,7 +608,7 @@ public abstract class AbstractMassIndexingFailureIT {
 									.field( "author", AUTHOR_3 )
 							)
 							.createdThenExecuted();
-					backendMock.expectWorksAnyOrder(
+					backendMock.expectWorks(
 							Book.NAME, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE
 					)
 							.add( "2", b -> b
@@ -618,7 +618,7 @@ public abstract class AbstractMassIndexingFailureIT {
 							.createdThenExecuted( failingFuture );
 					break;
 				case SKIP:
-					backendMock.expectWorksAnyOrder(
+					backendMock.expectWorks(
 							Book.NAME, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE
 					)
 							.add( "1", b -> b

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingBaseIT.java
@@ -76,7 +76,7 @@ public class MassIndexingBaseIT {
 
 			// add operations on indexes can follow any random order,
 			// since they are executed by different threads
-			backendMock.expectWorksAnyOrder(
+			backendMock.expectWorks(
 					Book.INDEX, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE
 			)
 					.add( "1", b -> b
@@ -121,7 +121,7 @@ public class MassIndexingBaseIT {
 
 			// add operations on indexes can follow any random order,
 			// since they are executed by different threads
-			backendMock.expectWorksAnyOrder(
+			backendMock.expectWorks(
 					Book.INDEX, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE
 			)
 					.add( "1", b -> b
@@ -169,7 +169,7 @@ public class MassIndexingBaseIT {
 
 			// add operations on indexes can follow any random order,
 			// since they are executed by different threads
-			backendMock.expectWorksAnyOrder(
+			backendMock.expectWorks(
 					Book.INDEX, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE
 			)
 					.add( "1", b -> b
@@ -215,7 +215,7 @@ public class MassIndexingBaseIT {
 
 		// add operations on indexes can follow any random order,
 		// since they are executed by different threads
-		backendMock.expectWorksAnyOrder(
+		backendMock.expectWorks(
 				Book.INDEX, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE
 		)
 				.add( "1", b -> b

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingComplexHierarchyIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingComplexHierarchyIT.java
@@ -80,7 +80,7 @@ public class MassIndexingComplexHierarchyIT {
 			SearchSession searchSession = Search.session( session );
 			MassIndexer indexer = searchSession.massIndexer( H1_Root_NotIndexed.class );
 
-			backendMock.expectWorksAnyOrder( H1_B_Indexed.NAME, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE )
+			backendMock.expectWorks( H1_B_Indexed.NAME, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE )
 					.add( "3", b -> b.field( "rootText", "text3" )
 							.field( "bText", "text3" ) )
 					.createdThenExecuted();
@@ -108,7 +108,7 @@ public class MassIndexingComplexHierarchyIT {
 			SearchSession searchSession = Search.session( session );
 			MassIndexer indexer = searchSession.massIndexer( H1_B_Indexed.class );
 
-			backendMock.expectWorksAnyOrder( H1_B_Indexed.NAME, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE )
+			backendMock.expectWorks( H1_B_Indexed.NAME, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE )
 					.add( "3", b -> b.field( "rootText", "text3" )
 							.field( "bText", "text3" ) )
 					.createdThenExecuted();
@@ -136,15 +136,15 @@ public class MassIndexingComplexHierarchyIT {
 			SearchSession searchSession = Search.session( session );
 			MassIndexer indexer = searchSession.massIndexer( H2_Root_Indexed.class );
 
-			backendMock.expectWorksAnyOrder( H2_Root_Indexed.NAME, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE )
+			backendMock.expectWorks( H2_Root_Indexed.NAME, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE )
 					.add( "1", b -> b.field( "rootText", "text1" ) )
 					.createdThenExecuted();
-			backendMock.expectWorksAnyOrder( H2_A_C_Indexed.NAME, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE )
+			backendMock.expectWorks( H2_A_C_Indexed.NAME, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE )
 					.add( "3", b -> b.field( "rootText", "text3" )
 							.field( "aText", "text3" )
 							.field( "cText", "text3" ) )
 					.createdThenExecuted();
-			backendMock.expectWorksAnyOrder( H2_B_Indexed.NAME, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE )
+			backendMock.expectWorks( H2_B_Indexed.NAME, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE )
 					.add( "4", b -> b.field( "rootText", "text4" )
 							.field( "bText", "text4" ) )
 					.createdThenExecuted();
@@ -182,7 +182,7 @@ public class MassIndexingComplexHierarchyIT {
 			SearchSession searchSession = Search.session( session );
 			MassIndexer indexer = searchSession.massIndexer( H2_B_Indexed.class );
 
-			backendMock.expectWorksAnyOrder( H2_B_Indexed.NAME, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE )
+			backendMock.expectWorks( H2_B_Indexed.NAME, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE )
 					.add( "4", b -> b.field( "rootText", "text4" )
 							.field( "bText", "text4" ) )
 					.createdThenExecuted();

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingEmbeddedIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingEmbeddedIdIT.java
@@ -82,7 +82,7 @@ public class MassIndexingEmbeddedIdIT {
 
 			// add operations on indexes can follow any random order,
 			// since they are executed by different threads
-			backendMock.expectWorksAnyOrder(
+			backendMock.expectWorks(
 					Book.INDEX, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE
 			)
 					.add( book1.getIdentity().toString(), b -> b

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingInterruptionIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingInterruptionIT.java
@@ -135,7 +135,7 @@ public class MassIndexingInterruptionIT {
 				.purge()
 				.mergeSegments();
 
-		backendMock.expectWorksAnyOrder(
+		backendMock.expectWorks(
 				Book.INDEX, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE
 		)
 				.add( "1", b -> b

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingMonitorIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingMonitorIT.java
@@ -66,7 +66,7 @@ public class MassIndexingMonitorIT {
 
 			// add operations on indexes can follow any random order,
 			// since they are executed by different threads
-			backendMock.expectWorksAnyOrder(
+			backendMock.expectWorks(
 					Book.INDEX, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE
 			)
 					.add( "1", b -> b
@@ -78,7 +78,7 @@ public class MassIndexingMonitorIT {
 							.field( "author", AUTHOR_3 )
 					)
 					.createdThenExecuted();
-			backendMock.expectWorksAnyOrder(
+			backendMock.expectWorks(
 					Book.INDEX, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE
 			)
 					.add( "2", b -> b

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingNonEntityIdDocumentIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingNonEntityIdDocumentIdIT.java
@@ -74,7 +74,7 @@ public class MassIndexingNonEntityIdDocumentIdIT {
 
 			// add operations on indexes can follow any random order,
 			// since they are executed by different threads
-			backendMock.expectWorksAnyOrder(
+			backendMock.expectWorks(
 					Book.INDEX, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE
 			)
 					.add( "41", b -> b

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingPrimitiveIdIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingPrimitiveIdIT.java
@@ -62,7 +62,7 @@ public class MassIndexingPrimitiveIdIT {
 
 			// add operations on indexes can follow any random order,
 			// since they are executed by different threads
-			backendMock.expectWorksAnyOrder(
+			backendMock.expectWorks(
 					EntityWithPrimitiveId.INDEX, DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE
 			)
 					.add( "1", b -> { } )

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendMock.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendMock.java
@@ -16,6 +16,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.backend.spi.BackendBuildContext;
@@ -167,27 +168,9 @@ public class BackendMock implements TestRule {
 
 	public DocumentWorkCallListContext expectWorks(String indexName, String tenantId,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
-		CallQueue<DocumentWorkCall> callQueue = backendBehavior().getDocumentWorkCalls( indexName );
 		return new DocumentWorkCallListContext(
 				indexName, tenantId,
-				commitStrategy, refreshStrategy,
-				callQueue::expectInOrder
-		);
-	}
-
-	public DocumentWorkCallListContext expectWorksAnyOrder(String indexName) {
-		// Default to force commit and no refresh, which is what the mapper should use by default
-		return expectWorksAnyOrder( indexName, DocumentCommitStrategy.FORCE, DocumentRefreshStrategy.NONE );
-	}
-
-	public DocumentWorkCallListContext expectWorksAnyOrder(String indexName,
-			DocumentCommitStrategy commitStrategy,
-			DocumentRefreshStrategy refreshStrategy) {
-		CallQueue<DocumentWorkCall> callQueue = backendBehavior().getDocumentWorkCalls( indexName );
-		return new DocumentWorkCallListContext(
-				indexName, null,
-				commitStrategy, refreshStrategy,
-				callQueue::expectOutOfOrder
+				commitStrategy, refreshStrategy
 		);
 	}
 
@@ -311,23 +294,20 @@ public class BackendMock implements TestRule {
 		}
 	}
 
-	public static class DocumentWorkCallListContext {
+	public class DocumentWorkCallListContext {
 		private final String indexName;
 		private final String tenantId;
 		private final DocumentCommitStrategy commitStrategyForDocumentWorks;
 		private final DocumentRefreshStrategy refreshStrategyForDocumentWorks;
-		private final Consumer<DocumentWorkCall> expectationConsumer;
 		private final List<StubDocumentWork> works = new ArrayList<>();
 
 		private DocumentWorkCallListContext(String indexName, String tenantId,
 				DocumentCommitStrategy commitStrategyForDocumentWorks,
-				DocumentRefreshStrategy refreshStrategyForDocumentWorks,
-				Consumer<DocumentWorkCall> expectationConsumer) {
+				DocumentRefreshStrategy refreshStrategyForDocumentWorks) {
 			this.indexName = indexName;
 			this.tenantId = tenantId;
 			this.commitStrategyForDocumentWorks = commitStrategyForDocumentWorks;
 			this.refreshStrategyForDocumentWorks = refreshStrategyForDocumentWorks;
-			this.expectationConsumer = expectationConsumer;
 		}
 
 		public DocumentWorkCallListContext add(Consumer<StubDocumentWork.Builder> contributor) {
@@ -382,12 +362,13 @@ public class BackendMock implements TestRule {
 		public DocumentWorkCallListContext createdThenExecuted(CompletableFuture<?> future) {
 			log.debugf( "Expecting %d works to be created, then executed", works.size() );
 			// First expect all works to be created, then expect all works to be executed
-			works.stream()
-					.map( work -> new DocumentWorkCall( indexName, DocumentWorkCall.WorkPhase.CREATE, work ) )
-					.forEach( expectationConsumer );
-			works.stream()
-					.map( work -> new DocumentWorkCall( indexName, DocumentWorkCall.WorkPhase.EXECUTE, work, future ) )
-					.forEach( expectationConsumer );
+			Stream.concat(
+					works.stream()
+							.map( work -> new DocumentWorkCall( indexName, DocumentWorkCall.WorkPhase.CREATE, work ) ),
+					works.stream()
+							.map( work -> new DocumentWorkCall( indexName, DocumentWorkCall.WorkPhase.EXECUTE, work, future ) )
+			)
+					.forEach( call -> expect( call ) );
 			works.clear();
 			return this;
 		}
@@ -400,7 +381,7 @@ public class BackendMock implements TestRule {
 			log.debugf( "Expecting %d works to be created", works.size() );
 			works.stream()
 					.map( work -> new DocumentWorkCall( indexName, DocumentWorkCall.WorkPhase.CREATE, work ) )
-					.forEach( expectationConsumer );
+					.forEach( this::expect );
 			return this;
 		}
 
@@ -408,7 +389,7 @@ public class BackendMock implements TestRule {
 			log.debugf( "Expecting %d works to be executed", works.size() );
 			works.stream()
 					.map( work -> new DocumentWorkCall( indexName, DocumentWorkCall.WorkPhase.EXECUTE, work, future ) )
-					.forEach( expectationConsumer );
+					.forEach( this::expect );
 			works.clear();
 			return this;
 		}
@@ -421,8 +402,12 @@ public class BackendMock implements TestRule {
 			log.debugf( "Expecting %d works to be discarded", works.size() );
 			works.stream()
 					.map( work -> new DocumentWorkCall( indexName, DocumentWorkCall.WorkPhase.DISCARD, work ) )
-					.forEach( expectationConsumer );
+					.forEach( this::expect );
 			return this;
+		}
+
+		private void expect(DocumentWorkCall call) {
+			backendBehavior().getDocumentWorkCalls( call.documentKey() ).expectInOrder( call );
 		}
 	}
 

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/DocumentKey.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/DocumentKey.java
@@ -1,0 +1,50 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.impl.integrationtest.common.rule;
+
+import java.util.Objects;
+
+class DocumentKey {
+	private final String indexName;
+	private final String tenantIdentifier;
+	private final String documentIdentifier;
+
+	DocumentKey(String indexName, String tenantIdentifier, String documentIdentifier) {
+		this.indexName = indexName;
+		this.tenantIdentifier = tenantIdentifier;
+		this.documentIdentifier = documentIdentifier;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append( indexName ).append( '#' ).append( documentIdentifier );
+		if ( tenantIdentifier != null ) {
+			builder.append( "(tenant:" ).append( tenantIdentifier ).append( ')' );
+		}
+		return builder.toString();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if ( this == o ) {
+			return true;
+		}
+		if ( o == null || getClass() != o.getClass() ) {
+			return false;
+		}
+		DocumentKey that = (DocumentKey) o;
+		return Objects.equals( indexName, that.indexName )
+				&& Objects.equals( tenantIdentifier, that.tenantIdentifier )
+				&& Objects.equals( documentIdentifier, that.documentIdentifier );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( indexName, tenantIdentifier, documentIdentifier );
+	}
+}

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/DocumentWorkCall.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/DocumentWorkCall.java
@@ -35,29 +35,29 @@ class DocumentWorkCall extends Call<DocumentWorkCall> {
 		DISCARD
 	}
 
-	private final String indexName;
+	private final DocumentKey documentKey;
 	private final WorkPhase phase;
 	private final StubDocumentWork work;
 	private final CompletableFuture<?> completableFuture;
 
 	DocumentWorkCall(String indexName, WorkPhase phase, StubDocumentWork work,
 			CompletableFuture<?> completableFuture) {
-		this.indexName = indexName;
+		this.documentKey = new DocumentKey( indexName, work.getTenantIdentifier(), work.getIdentifier() );
 		this.phase = phase;
 		this.work = work;
 		this.completableFuture = completableFuture;
 	}
 
 	DocumentWorkCall(String indexName, WorkPhase phase, StubDocumentWork work) {
-		this.indexName = indexName;
-		this.phase = phase;
-		this.work = work;
-		this.completableFuture = null;
+		this( indexName, phase, work, null );
+	}
+
+	public DocumentKey documentKey() {
+		return documentKey;
 	}
 
 	public CallBehavior<CompletableFuture<?>> verify(DocumentWorkCall actualCall) {
-		String whenThisWorkWasExpected = "when a " + phase + " call for a document work on index '" + indexName
-				+ "', identifier '" + work.getIdentifier() + "' was expected";
+		String whenThisWorkWasExpected = "when a " + phase + " call for a work on document '" + documentKey + "' was expected";
 		if ( !Objects.equals( phase, actualCall.phase ) ) {
 			fail( "Incorrect work phase " + whenThisWorkWasExpected + ".\n\tExpected: "
 					+ phase + ", actual: " + actualCall.phase
@@ -72,14 +72,11 @@ class DocumentWorkCall extends Call<DocumentWorkCall> {
 	@Override
 	protected boolean isSimilarTo(DocumentWorkCall other) {
 		return Objects.equals( phase, other.phase )
-				&& Objects.equals( indexName, other.indexName )
-				&& Objects.equals( work.getTenantIdentifier(), other.work.getTenantIdentifier() )
-				&& Objects.equals( work.getIdentifier(), other.work.getIdentifier() );
+				&& Objects.equals( documentKey, other.documentKey );
 	}
 
 	@Override
 	public String toString() {
-		return phase + " call for a work on index '" + indexName + "', identifier '" + work.getIdentifier()
-				+ "'; work = " + work;
+		return phase + " call for a work on document '" + documentKey + "'";
 	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4172

Should also fix https://hibernate.atlassian.net/browse/HSEARCH-4164