### PR TITLE
Backport HSEARCH-4174 to branch 6.0 - Reorganize Elasticsearch version properties in POM

### DIFF
--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -320,8 +320,8 @@
                         <luceneJavadocUrl>${javadoc.org.apache.lucene.core.url}</luceneJavadocUrl>
                         <elasticsearchDocUrl>${documentation.org.elasticsearch.url}</elasticsearchDocUrl>
                         <elasticsearchClientVersions>${version.org.elasticsearch.client}</elasticsearchClientVersions>
-                        <elasticsearchCompatibleVersions>${version.org.elasticsearch.compatible.text}</elasticsearchCompatibleVersions>
-                        <elasticsearchOtherPotentiallyCompatibleVersions>${version.org.elasticsearch.compatible.potentially.text}</elasticsearchOtherPotentiallyCompatibleVersions>
+                        <elasticsearchCompatibleVersions>${version.org.elasticsearch.compatible.regularly-tested.text}</elasticsearchCompatibleVersions>
+                        <elasticsearchOtherPotentiallyCompatibleVersions>${version.org.elasticsearch.compatible.not-regularly-tested.text}</elasticsearchOtherPotentiallyCompatibleVersions>
                         <wildflyUrl>https://wildfly.org/</wildflyUrl>
                         <quarkusUrl>https://quarkus.io/</quarkusUrl>
                         <springUrl>https://spring.io/</springUrl>

--- a/documentation/src/test/java/org/hibernate/search/documentation/configuration/ElasticsearchConfigurationIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/configuration/ElasticsearchConfigurationIT.java
@@ -13,8 +13,6 @@ import java.util.Properties;
 
 import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
 import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
-import org.hibernate.search.backend.elasticsearch.index.IndexStatus;
-import org.hibernate.search.backend.elasticsearch.multitenancy.MultiTenancyStrategyName;
 import org.hibernate.search.engine.cfg.BackendSettings;
 import org.hibernate.search.engine.cfg.EngineSettings;
 import org.hibernate.search.engine.cfg.IndexSettings;
@@ -30,17 +28,6 @@ public class ElasticsearchConfigurationIT {
 		// backend configuration
 		config.put( BackendSettings.backendKey( ElasticsearchBackendSettings.HOSTS ), "127.0.0.1:9200" );
 		config.put( BackendSettings.backendKey( ElasticsearchBackendSettings.PROTOCOL ), "http" );
-		config.put(
-				BackendSettings.backendKey( ElasticsearchBackendSettings.MULTI_TENANCY_STRATEGY ),
-				MultiTenancyStrategyName.DISCRIMINATOR.externalRepresentation()
-		);
-		config.put( BackendSettings.backendKey( ElasticsearchBackendSettings.VERSION ), "7.10" );
-		config.put(
-				BackendSettings.backendKey( ElasticsearchBackendSettings.VERSION_CHECK_ENABLED ), "false" );
-		config.put(
-				BackendSettings.backendKey( ElasticsearchIndexSettings.SCHEMA_MANAGEMENT_MINIMAL_REQUIRED_STATUS ),
-				IndexStatus.YELLOW.externalRepresentation()
-		);
 		// index configuration
 		config.put(
 				IndexSettings.indexKey( "myIndex", ElasticsearchIndexSettings.INDEXING_MAX_BULK_SIZE ),
@@ -63,10 +50,6 @@ public class ElasticsearchConfigurationIT {
 				.containsOnly(
 						entry( "hibernate.search.backend.hosts", "127.0.0.1:9200" ),
 						entry( "hibernate.search.backend.protocol", "http" ),
-						entry( "hibernate.search.backend.multi_tenancy.strategy", "discriminator" ),
-						entry( "hibernate.search.backend.version", "7.10" ),
-						entry( "hibernate.search.backend.version_check.enabled", "false" ),
-						entry( "hibernate.search.backend.schema_management.minimal_required_status", "yellow" ),
 						entry( "hibernate.search.backend.indexes.myIndex.indexing.max_bulk_size", 20 ),
 						entry( "hibernate.search.automatic_indexing.synchronization.strategy", "async" ),
 						entry( "hibernate.search.background_failure_handler", "myFailureHandler" )

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/bootstrap/ElasticsearchBootstrapIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/bootstrap/ElasticsearchBootstrapIT.java
@@ -125,7 +125,7 @@ public class ElasticsearchBootstrapIT {
 				.isInstanceOf( SearchException.class )
 				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
 						.defaultBackendContext()
-						.failure( "Invalid value for configuration property 'hibernate.search.backend.version': '7'",
+						.failure( "Invalid value for configuration property 'hibernate.search.backend.version': '" + versionWithMajorOnly + "'",
 								"Missing or imprecise Elasticsearch version",
 								"when configuration property 'hibernate.search.backend.version_check.enabled' is set to 'false'",
 								"the version is mandatory and must be at least as precise as 'x.y', where 'x' and 'y' are integers" )

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/bootstrap/ElasticsearchBootstrapIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/bootstrap/ElasticsearchBootstrapIT.java
@@ -9,6 +9,7 @@ package org.hibernate.search.integrationtest.backend.elasticsearch.bootstrap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import org.hibernate.search.backend.elasticsearch.ElasticsearchVersion;
 import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
 import org.hibernate.search.backend.elasticsearch.cfg.spi.ElasticsearchBackendSpiSettings;
 import org.hibernate.search.backend.elasticsearch.client.spi.ElasticsearchRequest;
@@ -101,13 +102,16 @@ public class ElasticsearchBootstrapIT {
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3841")
 	public void explicitProtocolDialect_noVersionCheck_incompleteVersion() {
+		ElasticsearchVersion clusterVersion = ElasticsearchVersion.of( ElasticsearchTestDialect.getClusterVersion() );
+		String versionWithMajorOnly = String.valueOf( clusterVersion.major() );
+
 		assertThatThrownBy(
 				() -> setupHelper.start()
 						.withBackendProperty(
 								ElasticsearchBackendSettings.VERSION_CHECK_ENABLED, false
 						)
 						.withBackendProperty(
-								ElasticsearchBackendSettings.VERSION, "7"
+								ElasticsearchBackendSettings.VERSION, versionWithMajorOnly
 						)
 						.withBackendProperty(
 								ElasticsearchBackendSpiSettings.CLIENT_FACTORY,
@@ -135,12 +139,16 @@ public class ElasticsearchBootstrapIT {
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3841")
 	public void explicitProtocolDialect_noVersionCheck_completeVersion() {
+		ElasticsearchVersion clusterVersion = ElasticsearchVersion.of( ElasticsearchTestDialect.getClusterVersion() );
+		String versionWithMajorAndMinorOnly = String.valueOf( clusterVersion.major() )
+				+ "." + String.valueOf( clusterVersion.minor().getAsInt() );
+
 		SearchSetupHelper.PartialSetup partialSetup = setupHelper.start()
 				.withBackendProperty(
 						ElasticsearchBackendSettings.VERSION_CHECK_ENABLED, false
 				)
 				.withBackendProperty(
-						ElasticsearchBackendSettings.VERSION, "7.10"
+						ElasticsearchBackendSettings.VERSION, versionWithMajorAndMinorOnly
 				)
 				.withBackendProperty(
 						ElasticsearchBackendSpiSettings.CLIENT_FACTORY,

--- a/parents/integrationtest/pom.xml
+++ b/parents/integrationtest/pom.xml
@@ -313,7 +313,7 @@
         <profile>
             <id>elasticsearch-5.6</id>
             <properties>
-                <test.elasticsearch.connection.version>5.6.16</test.elasticsearch.connection.version>
+                <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-5.6}</test.elasticsearch.connection.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch5TestDialect</test.elasticsearch.testdialect>
             </properties>
             <build>
@@ -337,7 +337,7 @@
         <profile>
             <id>elasticsearch-6.0</id>
             <properties>
-                <test.elasticsearch.connection.version>6.2.4</test.elasticsearch.connection.version>
+                <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-6.2}</test.elasticsearch.connection.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch60TestDialect</test.elasticsearch.testdialect>
             </properties>
             <build>
@@ -361,7 +361,7 @@
         <profile>
             <id>elasticsearch-6.3</id>
             <properties>
-                <test.elasticsearch.connection.version>6.3.2</test.elasticsearch.connection.version>
+                <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-6.3}</test.elasticsearch.connection.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch63TestDialect</test.elasticsearch.testdialect>
             </properties>
             <build>
@@ -385,7 +385,7 @@
         <profile>
             <id>elasticsearch-6.4</id>
             <properties>
-                <test.elasticsearch.connection.version>6.6.2</test.elasticsearch.connection.version>
+                <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-6.6}</test.elasticsearch.connection.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch64TestDialect</test.elasticsearch.testdialect>
             </properties>
             <build>
@@ -409,7 +409,7 @@
         <profile>
             <id>elasticsearch-6.7</id>
             <properties>
-                <test.elasticsearch.connection.version>6.8.9</test.elasticsearch.connection.version>
+                <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-6.8}</test.elasticsearch.connection.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch67TestDialect</test.elasticsearch.testdialect>
             </properties>
             <build>
@@ -433,7 +433,7 @@
         <profile>
             <id>elasticsearch-7.0</id>
             <properties>
-                <test.elasticsearch.connection.version>7.2.1</test.elasticsearch.connection.version>
+                <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-7.2}</test.elasticsearch.connection.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch70TestDialect</test.elasticsearch.testdialect>
             </properties>
             <build>
@@ -457,7 +457,7 @@
         <profile>
             <id>elasticsearch-7.3</id>
             <properties>
-                <test.elasticsearch.connection.version>7.6.2</test.elasticsearch.connection.version>
+                <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-7.6}</test.elasticsearch.connection.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch73TestDialect</test.elasticsearch.testdialect>
             </properties>
             <build>
@@ -481,7 +481,7 @@
         <profile>
             <id>elasticsearch-7.7</id>
             <properties>
-                <test.elasticsearch.connection.version>7.7.1</test.elasticsearch.connection.version>
+                <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-7.7}</test.elasticsearch.connection.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch77TestDialect</test.elasticsearch.testdialect>
             </properties>
             <build>
@@ -505,7 +505,7 @@
         <profile>
             <id>elasticsearch-7.8</id>
             <properties>
-                <test.elasticsearch.connection.version>7.9.3</test.elasticsearch.connection.version>
+                <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-7.9}</test.elasticsearch.connection.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch78TestDialect</test.elasticsearch.testdialect>
             </properties>
             <build>
@@ -535,7 +535,7 @@
                 </property>
             </activation>
             <properties>
-                <test.elasticsearch.connection.version>${version.org.elasticsearch.main}</test.elasticsearch.connection.version>
+                <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-7.10}</test.elasticsearch.connection.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch710TestDialect</test.elasticsearch.testdialect>
             </properties>
             <build>

--- a/pom.xml
+++ b/pom.xml
@@ -197,17 +197,28 @@
         <javadoc.org.apache.lucene.queryparser.url>https://lucene.apache.org/core/${javadoc.org.apache.lucene.tag}/queryparser/</javadoc.org.apache.lucene.queryparser.url>
 
         <!-- >>> Elasticsearch -->
-        <!-- When updating the following versions you will likely need to update the
-             matching test profile as well, e.g. elasticsearch-6.0 for the 6.0+ series -->
-        <!-- The main version of Elasticsearch targeted by Hibernate Search, tested in the default profile -->
-        <version.org.elasticsearch.main>7.10.0</version.org.elasticsearch.main>
-        <!-- The versions of Elasticsearch advertised as compatible with Hibernate Search -->
-        <version.org.elasticsearch.compatible.text>5.6, 6.8 or 7.10</version.org.elasticsearch.compatible.text>
-        <!-- The versions of Elasticsearch that may work, but are not given priority for bugfixes and new features -->
-        <version.org.elasticsearch.compatible.potentially.text>6.0 or 7.0</version.org.elasticsearch.compatible.potentially.text>
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently from the version of the remote cluster -->
-        <version.org.elasticsearch.client>${version.org.elasticsearch.main}</version.org.elasticsearch.client>
-        <documentation.org.elasticsearch.url>https://www.elastic.co/guide/en/elasticsearch/reference/${parsed-version.org.elasticsearch.main.majorVersion}.${parsed-version.org.elasticsearch.main.minorVersion}</documentation.org.elasticsearch.url>
+        <version.org.elasticsearch.client>${version.org.elasticsearch.latest-7.10}</version.org.elasticsearch.client>
+        <!-- The main compatible version, advertised by default. Used in documentation links and as the default when testing. -->
+        <!-- When updating the following version you will likely need to update the test profiles as well,
+             to make sure the corresponding profile (e.g. elasticsearch-7.10) becomes the default. -->
+        <version.org.elasticsearch.compatible.main>${version.org.elasticsearch.latest-7.10}</version.org.elasticsearch.compatible.main>
+        <documentation.org.elasticsearch.url>https://www.elastic.co/guide/en/elasticsearch/reference/${parsed-version.org.elasticsearch.compatible.main.majorVersion}.${parsed-version.org.elasticsearch.compatible.main.minorVersion}</documentation.org.elasticsearch.url>
+        <!-- The versions of Elasticsearch advertised as compatible with Hibernate Search -->
+        <version.org.elasticsearch.compatible.regularly-tested.text>5.6, 6.8 or 7.10</version.org.elasticsearch.compatible.regularly-tested.text>
+        <!-- The versions of Elasticsearch that may work, but are not given priority for bugfixes and new features -->
+        <version.org.elasticsearch.compatible.not-regularly-tested.text>6.0 or 7.0</version.org.elasticsearch.compatible.not-regularly-tested.text>
+        <!-- The latest micro of each Elasticsearch branch -->
+        <version.org.elasticsearch.latest-7.10>7.10.0</version.org.elasticsearch.latest-7.10>
+        <version.org.elasticsearch.latest-7.9>7.9.3</version.org.elasticsearch.latest-7.9>
+        <version.org.elasticsearch.latest-7.7>7.7.1</version.org.elasticsearch.latest-7.7>
+        <version.org.elasticsearch.latest-7.6>7.6.2</version.org.elasticsearch.latest-7.6>
+        <version.org.elasticsearch.latest-7.2>7.2.1</version.org.elasticsearch.latest-7.2>
+        <version.org.elasticsearch.latest-6.8>6.8.9</version.org.elasticsearch.latest-6.8>
+        <version.org.elasticsearch.latest-6.6>6.6.2</version.org.elasticsearch.latest-6.6>
+        <version.org.elasticsearch.latest-6.3>6.3.2</version.org.elasticsearch.latest-6.3>
+        <version.org.elasticsearch.latest-6.2>6.2.4</version.org.elasticsearch.latest-6.2>
+        <version.org.elasticsearch.latest-5.6>5.6.16</version.org.elasticsearch.latest-5.6>
         <version.com.google.code.gson>2.8.5</version.com.google.code.gson>
         <version.software.amazon.awssdk>2.14.18</version.software.amazon.awssdk>
         <!-- Jackson: used by the Elasticsearch REST client, the AWS SDK and in tests (wiremock, ...) -->
@@ -1064,13 +1075,13 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>parse-elasticsearch-main-version</id>
+                        <id>parse-elasticsearch-main-compatible-version</id>
                         <goals>
                             <goal>parse-version</goal>
                         </goals>
                         <configuration>
-                            <propertyPrefix>parsed-version.org.elasticsearch.main</propertyPrefix>
-                            <versionString>${version.org.elasticsearch.main}</versionString>
+                            <propertyPrefix>parsed-version.org.elasticsearch.compatible.main</propertyPrefix>
+                            <versionString>${version.org.elasticsearch.compatible.main}</versionString>
                         </configuration>
                     </execution>
                     <execution>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4174

See #2508 ; I'm not upgrading to ES 7.11 in Search 6.0, but I still wanted to backport the small POM refactoring.