### PR TITLE
Backport HSEARCH-4173 to branch 6.0 - Multi-index Elasticsearch query fails (sometimes silently) when field is present in only one index

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,7 +198,8 @@ The following profiles are available:
  * `elasticsearch-6.0` for 6.0.x to 6.2.x
  * `elasticsearch-6.3` for 6.3.x
  * `elasticsearch-6.4` for 6.4.x to 6.6.x
- * `elasticsearch-6.7` for 6.7 and later 6.x
+ * `elasticsearch-6.7` for 6.7.x
+ * `elasticsearch-6.8` for 6.8 and later 6.x
  * `elasticsearch-7.0` for 7.0 to 7.2
  * `elasticsearch-7.3` for 7.3 to 7.6
  * `elasticsearch-7.7` for 7.7

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -220,7 +220,12 @@ stage('Configure') {
 					new EsLocalBuildEnvironment(versionRange: '[6.4,6.7)', mavenProfile: 'elasticsearch-6.4',
 							jdkTool: 'OpenJDK 8 Latest',
 							condition: TestCondition.AFTER_MERGE),
-					new EsLocalBuildEnvironment(versionRange: '[6.7,7.0)', mavenProfile: 'elasticsearch-6.7',
+					// Not testing 6.7 to make the build quicker.
+					// The only difference with 6.8+ is a bug in field sorts that is already present in earlier versions.
+					new EsLocalBuildEnvironment(versionRange: '[6.7,6.8)', mavenProfile: 'elasticsearch-6.7',
+							jdkTool: 'OpenJDK 8 Latest',
+							condition: TestCondition.ON_DEMAND),
+					new EsLocalBuildEnvironment(versionRange: '[6.8,7.0)', mavenProfile: 'elasticsearch-6.8',
 							jdkTool: 'OpenJDK 8 Latest',
 							condition: TestCondition.AFTER_MERGE),
 					// Not testing 7.0/7.1/7.2 to make the build quicker.
@@ -268,7 +273,7 @@ stage('Configure') {
 							condition: TestCondition.AFTER_MERGE),
 					new EsAwsBuildEnvironment(version: '6.7', mavenProfile: 'elasticsearch-6.7',
 							condition: TestCondition.AFTER_MERGE),
-					new EsAwsBuildEnvironment(version: '6.8', mavenProfile: 'elasticsearch-6.7',
+					new EsAwsBuildEnvironment(version: '6.8', mavenProfile: 'elasticsearch-6.8',
 							condition: TestCondition.AFTER_MERGE),
 					new EsAwsBuildEnvironment(version: '7.1', mavenProfile: 'elasticsearch-7.0',
 							condition: TestCondition.AFTER_MERGE),

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/lowlevel/syntax/search/impl/Elasticsearch60SearchSyntax.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/lowlevel/syntax/search/impl/Elasticsearch60SearchSyntax.java
@@ -28,4 +28,12 @@ public class Elasticsearch60SearchSyntax extends Elasticsearch64SearchSyntax {
 		// So we just don't specify a format.
 		DOCVALUE_FIELDS_ACCESSOR.addElementIfAbsent( requestBody, fieldName );
 	}
+
+	@Override
+	public void requestGeoDistanceSortIgnoreUnmapped(JsonObject innerObject) {
+		// Support for ignore_unmapped in geo_distance sorts added in 6.4:
+		// https://github.com/elastic/elasticsearch/pull/31153
+		// In 6.3 and below, we just can't ignore unmapped fields,
+		// which means sorts will fail when the geo_point field is not present in all indexes.
+	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/lowlevel/syntax/search/impl/Elasticsearch7SearchSyntax.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/lowlevel/syntax/search/impl/Elasticsearch7SearchSyntax.java
@@ -26,6 +26,8 @@ public class Elasticsearch7SearchSyntax implements ElasticsearchSearchSyntax {
 	private static final JsonAccessor<JsonElement> NESTED_ACCESSOR = JsonAccessor.root().property( "nested" );
 	private static final JsonAccessor<JsonElement> PATH_ACCESSOR = JsonAccessor.root().property( "path" );
 	private static final JsonAccessor<JsonElement> FILTER_ACCESSOR = JsonAccessor.root().property( "filter" );
+	private static final JsonAccessor<Boolean> IGNORE_UNMAPPED_ACCESSOR =
+			JsonAccessor.root().property( "ignore_unmapped" ).asBoolean();
 
 	@Override
 	public String getTermAggregationOrderByTermToken() {
@@ -54,5 +56,10 @@ public class Elasticsearch7SearchSyntax implements ElasticsearchSearchSyntax {
 			// the new api requires a recursion on the path hierarchy
 			nextNestedObjectTarget = nestedObject;
 		}
+	}
+
+	@Override
+	public void requestGeoDistanceSortIgnoreUnmapped(JsonObject innerObject) {
+		IGNORE_UNMAPPED_ACCESSOR.set( innerObject, true );
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/lowlevel/syntax/search/impl/ElasticsearchSearchSyntax.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/lowlevel/syntax/search/impl/ElasticsearchSearchSyntax.java
@@ -19,4 +19,6 @@ public interface ElasticsearchSearchSyntax {
 
 	void requestNestedSort(List<String> nestedPathHierarchy, JsonObject innerObject, JsonObject filterOrNull);
 
+	void requestGeoDistanceSortIgnoreUnmapped(JsonObject innerObject);
+
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/impl/ElasticsearchMultiIndexSearchValueFieldContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/impl/ElasticsearchMultiIndexSearchValueFieldContext.java
@@ -21,6 +21,8 @@ import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 import org.hibernate.search.util.common.reporting.EventContext;
 
+import com.google.gson.JsonPrimitive;
+
 public class ElasticsearchMultiIndexSearchValueFieldContext<F>
 		implements ElasticsearchSearchValueFieldContext<F>, ElasticsearchSearchValueFieldTypeContext<F> {
 
@@ -96,6 +98,12 @@ public class ElasticsearchMultiIndexSearchValueFieldContext<F>
 			throw log.cannotUseQueryElementForField( absolutePath(), key.toString(), eventContext() );
 		}
 		return factory.create( searchContext, this );
+	}
+
+	@Override
+	public JsonPrimitive elasticsearchTypeAsJson() {
+		return getFromTypeIfCompatible( ElasticsearchSearchValueFieldTypeContext::elasticsearchTypeAsJson, Object::equals,
+				"elasticsearchType" );
 	}
 
 	@Override

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/impl/ElasticsearchSearchValueFieldTypeContext.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/impl/ElasticsearchSearchValueFieldTypeContext.java
@@ -12,6 +12,8 @@ import org.hibernate.search.engine.backend.types.converter.spi.DslConverter;
 import org.hibernate.search.engine.backend.types.converter.spi.ProjectionConverter;
 import org.hibernate.search.engine.search.common.ValueConvert;
 
+import com.google.gson.JsonPrimitive;
+
 /**
  * Information about the type of a value (non-object) field targeted by search,
  * be it in a projection, a predicate, a sort, ...
@@ -19,6 +21,8 @@ import org.hibernate.search.engine.search.common.ValueConvert;
  * @param <F> The indexed field value type.
  */
 public interface ElasticsearchSearchValueFieldTypeContext<F> {
+
+	JsonPrimitive elasticsearchTypeAsJson();
 
 	DslConverter<?, F> dslConverter();
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchNestedPredicate.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/ElasticsearchNestedPredicate.java
@@ -20,6 +20,8 @@ class ElasticsearchNestedPredicate extends AbstractElasticsearchSingleFieldPredi
 
 	private static final JsonAccessor<String> PATH_ACCESSOR = JsonAccessor.root().property( "path" ).asString();
 	private static final JsonAccessor<JsonObject> QUERY_ACCESSOR = JsonAccessor.root().property( "query" ).asObject();
+	private static final JsonAccessor<Boolean> IGNORE_UNMAPPED_ACCESSOR =
+			JsonAccessor.root().property( "ignore_unmapped" ).asBoolean();
 
 	private final ElasticsearchSearchPredicate nestedPredicate;
 
@@ -35,7 +37,13 @@ class ElasticsearchNestedPredicate extends AbstractElasticsearchSingleFieldPredi
 
 		PATH_ACCESSOR.set( innerObject, absoluteFieldPath );
 		QUERY_ACCESSOR.set( innerObject, nestedPredicate.toJsonQuery( nestedContext ) );
+		if ( indexNames().size() > 1 ) {
+			// There are multiple target indexes; some of them may not declare the nested field.
+			// Instruct ES to behave as if the nested field had no value in that case.
+			IGNORE_UNMAPPED_ACCESSOR.set( innerObject, true );
+		}
 		outerObject.add( "nested", innerObject );
+
 		return outerObject;
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchDistanceToFieldProjection.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/projection/impl/ElasticsearchDistanceToFieldProjection.java
@@ -51,12 +51,14 @@ public class ElasticsearchDistanceToFieldProjection<E, P> extends AbstractElasti
 	private static final Pattern NON_DIGITS_PATTERN = Pattern.compile( "\\D" );
 
 	private static final String DISTANCE_PROJECTION_SCRIPT =
-		// Use ".size() != 0" to check whether this field has a value. ".value != null" won't work on ES7+
-		" if (doc[params.fieldPath].size() != 0) {" +
-			" return doc[params.fieldPath].arcDistance(params.lat, params.lon);" +
-		" } else {" +
-			" return null;" +
-		" }";
+			// Check whether the field exists first with "containsKey";
+			// in a multi-index search, it may not exist for all indexes.
+			// Use ".size() != 0" to check whether this field has a value. ".value != null" won't work on ES7+
+			" if (doc.containsKey(params.fieldPath) && doc[params.fieldPath].size() != 0) {" +
+				" return doc[params.fieldPath].arcDistance(params.lat, params.lon);" +
+			" } else {" +
+				" return null;" +
+			" }";
 
 	private final String absoluteFieldPath;
 	private final boolean multiValued;

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchGeoPointSpatialWithinBoundingBoxPredicate.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchGeoPointSpatialWithinBoundingBoxPredicate.java
@@ -24,7 +24,10 @@ import com.google.gson.JsonObject;
 
 public class ElasticsearchGeoPointSpatialWithinBoundingBoxPredicate extends AbstractElasticsearchSingleFieldPredicate {
 
-	private static final JsonObjectAccessor GEO_BOUNDING_BOX_ACCESSOR = JsonAccessor.root().property( "geo_bounding_box" ).asObject();
+	private static final JsonObjectAccessor GEO_BOUNDING_BOX_ACCESSOR =
+			JsonAccessor.root().property( "geo_bounding_box" ).asObject();
+	private static final JsonAccessor<Boolean> IGNORE_UNMAPPED_ACCESSOR =
+			JsonAccessor.root().property( "ignore_unmapped" ).asBoolean();
 
 	private static final String TOP_LEFT_PROPERTY_NAME = "top_left";
 	private static final String BOTTOM_RIGHT_PROPERTY_NAME = "bottom_right";
@@ -46,6 +49,12 @@ public class ElasticsearchGeoPointSpatialWithinBoundingBoxPredicate extends Abst
 		boundingBoxObject.add( BOTTOM_RIGHT_PROPERTY_NAME, bottomRight );
 
 		innerObject.add( absoluteFieldPath, boundingBoxObject );
+
+		if ( indexNames().size() > 1 ) {
+			// There are multiple target indexes; some of them may not declare the field.
+			// Instruct ES to behave as if the field had no value in that case.
+			IGNORE_UNMAPPED_ACCESSOR.set( innerObject, true );
+		}
 
 		GEO_BOUNDING_BOX_ACCESSOR.set( outerObject, innerObject );
 		return outerObject;

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchGeoPointSpatialWithinCirclePredicate.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchGeoPointSpatialWithinCirclePredicate.java
@@ -24,9 +24,12 @@ import com.google.gson.JsonObject;
 
 public class ElasticsearchGeoPointSpatialWithinCirclePredicate extends AbstractElasticsearchSingleFieldPredicate {
 
-	private static final JsonObjectAccessor GEO_DISTANCE_ACCESSOR = JsonAccessor.root().property( "geo_distance" ).asObject();
-
-	private static final JsonAccessor<Double> DISTANCE_ACCESSOR = JsonAccessor.root().property( "distance" ).asDouble();
+	private static final JsonObjectAccessor GEO_DISTANCE_ACCESSOR =
+			JsonAccessor.root().property( "geo_distance" ).asObject();
+	private static final JsonAccessor<Double> DISTANCE_ACCESSOR =
+			JsonAccessor.root().property( "distance" ).asDouble();
+	private static final JsonAccessor<Boolean> IGNORE_UNMAPPED_ACCESSOR =
+			JsonAccessor.root().property( "ignore_unmapped" ).asBoolean();
 
 	private final double distanceInMeters;
 	private final JsonElement center;
@@ -42,6 +45,12 @@ public class ElasticsearchGeoPointSpatialWithinCirclePredicate extends AbstractE
 			JsonObject innerObject) {
 		DISTANCE_ACCESSOR.set( innerObject, distanceInMeters );
 		innerObject.add( absoluteFieldPath, center );
+
+		if ( indexNames().size() > 1 ) {
+			// There are multiple target indexes; some of them may not declare the field.
+			// Instruct ES to behave as if the field had no value in that case.
+			IGNORE_UNMAPPED_ACCESSOR.set( innerObject, true );
+		}
 
 		GEO_DISTANCE_ACCESSOR.set( outerObject, innerObject );
 		return outerObject;

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchGeoPointSpatialWithinPolygonPredicate.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/predicate/impl/ElasticsearchGeoPointSpatialWithinPolygonPredicate.java
@@ -25,7 +25,10 @@ import com.google.gson.JsonObject;
 
 public class ElasticsearchGeoPointSpatialWithinPolygonPredicate extends AbstractElasticsearchSingleFieldPredicate {
 
-	private static final JsonObjectAccessor GEO_POLYGON_ACCESSOR = JsonAccessor.root().property( "geo_polygon" ).asObject();
+	private static final JsonObjectAccessor GEO_POLYGON_ACCESSOR =
+			JsonAccessor.root().property( "geo_polygon" ).asObject();
+	private static final JsonAccessor<Boolean> IGNORE_UNMAPPED_ACCESSOR =
+			JsonAccessor.root().property( "ignore_unmapped" ).asBoolean();
 
 	private static final String POINTS_PROPERTY_NAME = "points";
 
@@ -50,6 +53,13 @@ public class ElasticsearchGeoPointSpatialWithinPolygonPredicate extends Abstract
 		pointsObject.add( POINTS_PROPERTY_NAME, pointsArray );
 
 		innerObject.add( absoluteFieldPath, pointsObject );
+
+		if ( indexNames().size() > 1 ) {
+			// There are multiple target indexes; some of them may not declare the field.
+			// Instruct ES to behave as if the field had no value in that case.
+			IGNORE_UNMAPPED_ACCESSOR.set( innerObject, true );
+		}
+
 		GEO_POLYGON_ACCESSOR.set( outerObject, innerObject );
 		return outerObject;
 	}

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/sort/impl/AbstractElasticsearchDocumentValueSort.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/sort/impl/AbstractElasticsearchDocumentValueSort.java
@@ -40,7 +40,7 @@ abstract class AbstractElasticsearchDocumentValueSort extends AbstractElasticsea
 
 	protected final String absoluteFieldPath;
 	protected final List<String> nestedPathHierarchy;
-	private final ElasticsearchSearchSyntax searchSyntax;
+	protected final ElasticsearchSearchSyntax searchSyntax;
 
 	private final JsonPrimitive mode;
 	private final ElasticsearchSearchPredicate filter;

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/sort/impl/ElasticsearchDistanceSort.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/types/sort/impl/ElasticsearchDistanceSort.java
@@ -40,6 +40,11 @@ public class ElasticsearchDistanceSort extends AbstractElasticsearchDocumentValu
 	@Override
 	protected void doToJsonSorts(ElasticsearchSearchSortCollector collector, JsonObject innerObject) {
 		innerObject.add( absoluteFieldPath, ElasticsearchGeoPointFieldCodec.INSTANCE.encode( center ) );
+		if ( indexNames.size() > 1 ) {
+			// There are multiple target indexes; some of them may not declare the field.
+			// Instruct ES to behave as if the field had no value in that case.
+			searchSyntax.requestGeoDistanceSortIgnoreUnmapped( innerObject );
+		}
 
 		JsonObject outerObject = new JsonObject();
 		GEO_DISTANCE_ACCESSOR.add( outerObject, innerObject );

--- a/integrationtest/backend/elasticsearch/pom.xml
+++ b/integrationtest/backend/elasticsearch/pom.xml
@@ -170,9 +170,19 @@
             </properties>
         </profile>
 
-        <!-- Elasticsearch 6.7 to 6.8 test environment -->
+        <!-- Elasticsearch 6.7 test environment -->
         <profile>
             <id>elasticsearch-6.7</id>
+            <properties>
+                <failsafe.excludedGroups.elasticsearch.version>
+                    <!-- Nothing here -->
+                </failsafe.excludedGroups.elasticsearch.version>
+            </properties>
+        </profile>
+
+        <!-- Elasticsearch 6.8 test environment -->
+        <profile>
+            <id>elasticsearch-6.8</id>
             <properties>
                 <failsafe.excludedGroups.elasticsearch.version>
                     <!-- Nothing here -->

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/AbstractPredicateTypeCheckingAndConversionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/AbstractPredicateTypeCheckingAndConversionIT.java
@@ -31,6 +31,7 @@ import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.BulkIndexer;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
+import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Test;
 
@@ -39,17 +40,20 @@ public abstract class AbstractPredicateTypeCheckingAndConversionIT<V extends Abs
 	private final SimpleMappedIndex<IndexBinding> index;
 	private final SimpleMappedIndex<CompatibleIndexBinding> compatibleIndex;
 	private final SimpleMappedIndex<RawFieldCompatibleIndexBinding> rawFieldCompatibleIndex;
+	private final SimpleMappedIndex<MissingFieldIndexBinding> missingFieldIndex;
 	private final SimpleMappedIndex<IncompatibleIndexBinding> incompatibleIndex;
 	protected final DataSet<?, V> dataSet;
 
 	protected AbstractPredicateTypeCheckingAndConversionIT(SimpleMappedIndex<IndexBinding> index,
 			SimpleMappedIndex<CompatibleIndexBinding> compatibleIndex,
 			SimpleMappedIndex<RawFieldCompatibleIndexBinding> rawFieldCompatibleIndex,
+			SimpleMappedIndex<MissingFieldIndexBinding> missingFieldIndex,
 			SimpleMappedIndex<IncompatibleIndexBinding> incompatibleIndex,
 			DataSet<?, V> dataSet) {
 		this.index = index;
 		this.compatibleIndex = compatibleIndex;
 		this.rawFieldCompatibleIndex = rawFieldCompatibleIndex;
+		this.missingFieldIndex = missingFieldIndex;
 		this.incompatibleIndex = incompatibleIndex;
 		this.dataSet = dataSet;
 	}
@@ -263,6 +267,68 @@ public abstract class AbstractPredicateTypeCheckingAndConversionIT<V extends Abs
 				} );
 	}
 
+	/**
+	 * Test that no failure occurs when a predicate targets a field
+	 * that only exists in one of the targeted indexes.
+	 */
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4173")
+	public void multiIndex_withMissingFieldIndex_valueConvertYes() {
+		StubMappingScope scope = index.createScope( missingFieldIndex );
+
+		// The predicate should not match anything in missingFieldIndex
+		assertThatQuery( scope.query()
+				.where( f -> predicate( f, defaultDslConverterField0Path(), unwrappedMatchingParam( 0 ),
+						ValueConvert.YES ) )
+				.routing( dataSet.routingKey ) )
+				.hasDocRefHitsAnyOrder( b -> {
+					b.doc( index.typeName(), dataSet.docId( 0 ) );
+				} );
+
+		// ... but it should not prevent the query from executing either:
+		// if the predicate is optional, it should be ignored for missingFieldIndex.
+		assertThatQuery( scope.query()
+				.where( f -> f.bool()
+						.should( predicate( f, defaultDslConverterField0Path(), unwrappedMatchingParam( 0 ),
+								ValueConvert.YES ) )
+						.should( f.id().matching( dataSet.docId( DataSet.MISSING_FIELD_INDEX_DOC_ORDINAL ) ) ) ) )
+				.hasDocRefHitsAnyOrder( c -> c
+						.doc( index.typeName(), dataSet.docId( 0 ) )
+						.doc( missingFieldIndex.typeName(), dataSet.docId( DataSet.MISSING_FIELD_INDEX_DOC_ORDINAL ) ) )
+				.hasTotalHitCount( 2 );
+	}
+
+	/**
+	 * Test that no failure occurs when a predicate targets a field
+	 * that only exists in one of the targeted indexes.
+	 */
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4173")
+	public void multiIndex_withMissingFieldIndex_valueConvertNo() {
+		StubMappingScope scope = index.createScope( missingFieldIndex );
+
+		// The predicate should not match anything in missingFieldIndex
+		assertThatQuery( scope.query()
+				.where( f -> predicate( f, defaultDslConverterField0Path(), unwrappedMatchingParam( 0 ),
+						ValueConvert.NO ) )
+				.routing( dataSet.routingKey ) )
+				.hasDocRefHitsAnyOrder( b -> {
+					b.doc( index.typeName(), dataSet.docId( 0 ) );
+				} );
+
+		// ... but it should not prevent the query from executing either:
+		// if the predicate is optional, it should be ignored for missingFieldIndex.
+		assertThatQuery( scope.query()
+				.where( f -> f.bool()
+						.should( predicate( f, defaultDslConverterField0Path(), unwrappedMatchingParam( 0 ),
+								ValueConvert.NO ) )
+						.should( f.id().matching( dataSet.docId( DataSet.MISSING_FIELD_INDEX_DOC_ORDINAL ) ) ) ) )
+				.hasDocRefHitsAnyOrder( c -> c
+						.doc( index.typeName(), dataSet.docId( 0 ) )
+						.doc( missingFieldIndex.typeName(), dataSet.docId( DataSet.MISSING_FIELD_INDEX_DOC_ORDINAL ) ) )
+				.hasTotalHitCount( 2 );
+	}
+
 	@Test
 	public void multiIndex_withIncompatibleIndex_valueConvertYes() {
 		StubMappingScope scope = index.createScope( incompatibleIndex );
@@ -401,15 +467,23 @@ public abstract class AbstractPredicateTypeCheckingAndConversionIT<V extends Abs
 		}
 	}
 
+	public static class MissingFieldIndexBinding {
+		public MissingFieldIndexBinding(IndexSchemaElement root, Collection<? extends FieldTypeDescriptor<?>> fieldTypes) {
+		}
+	}
+
 	public static final class DataSet<F, V extends AbstractPredicateTestValues<F>>
 			extends AbstractPerFieldTypePredicateDataSet<F, V> {
+		public static final int MISSING_FIELD_INDEX_DOC_ORDINAL = 100;
+
 		public DataSet(V values) {
 			super( values );
 		}
 
 		public void contribute(SimpleMappedIndex<IndexBinding> mainIndex, BulkIndexer mainIndexer,
 				SimpleMappedIndex<CompatibleIndexBinding> compatibleIndex, BulkIndexer compatibleIndexer,
-				SimpleMappedIndex<RawFieldCompatibleIndexBinding> rawFieldCompatibleIndex, BulkIndexer rawFieldCompatibleIndexer) {
+				SimpleMappedIndex<RawFieldCompatibleIndexBinding> rawFieldCompatibleIndex, BulkIndexer rawFieldCompatibleIndexer,
+				SimpleMappedIndex<MissingFieldIndexBinding> missingFieldIndex, BulkIndexer missingFieldIndexer) {
 			mainIndexer.add( docId( 0 ), routingKey,
 					document -> initDocument( mainIndex, document, values.fieldValue( 0 ) ) );
 			mainIndexer.add( docId( 1 ), routingKey,
@@ -422,6 +496,7 @@ public abstract class AbstractPredicateTypeCheckingAndConversionIT<V extends Abs
 					document -> initRawFieldCompatibleDocument( rawFieldCompatibleIndex, document, values.fieldValue( 0 ) ) );
 			rawFieldCompatibleIndexer.add( docId( 1 ), routingKey,
 					document -> initRawFieldCompatibleDocument( rawFieldCompatibleIndex, document, values.fieldValue( 1 ) ) );
+			missingFieldIndexer.add( docId( MISSING_FIELD_INDEX_DOC_ORDINAL ), routingKey, document -> { } );
 		}
 
 		private void initDocument(SimpleMappedIndex<IndexBinding> index, DocumentElement document,

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/ExistsPredicateBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/ExistsPredicateBaseIT.java
@@ -44,7 +44,8 @@ public class ExistsPredicateBaseIT {
 						InvalidFieldIT.index,
 						SearchableIT.searchableYesIndex, SearchableIT.searchableNoIndex,
 						TypeCheckingNoConversionIT.index, TypeCheckingNoConversionIT.compatibleIndex,
-						TypeCheckingNoConversionIT.rawFieldCompatibleIndex, TypeCheckingNoConversionIT.incompatibleIndex,
+						TypeCheckingNoConversionIT.rawFieldCompatibleIndex, TypeCheckingNoConversionIT.missingFieldIndex,
+						TypeCheckingNoConversionIT.incompatibleIndex,
 						ScaleCheckingIT.index, ScaleCheckingIT.compatibleIndex, ScaleCheckingIT.incompatibleIndex
 				)
 				.setup();
@@ -61,9 +62,11 @@ public class ExistsPredicateBaseIT {
 		final BulkIndexer typeCheckingMainIndexer = TypeCheckingNoConversionIT.index.bulkIndexer();
 		final BulkIndexer typeCheckingCompatibleIndexer = TypeCheckingNoConversionIT.compatibleIndex.bulkIndexer();
 		final BulkIndexer typeCheckingRawFieldCompatibleIndexer = TypeCheckingNoConversionIT.rawFieldCompatibleIndex.bulkIndexer();
+		final BulkIndexer typeCheckingMissingFieldIndexer = TypeCheckingNoConversionIT.missingFieldIndex.bulkIndexer();
 		TypeCheckingNoConversionIT.dataSets.forEach( d -> d.contribute( TypeCheckingNoConversionIT.index, typeCheckingMainIndexer,
 				TypeCheckingNoConversionIT.compatibleIndex, typeCheckingCompatibleIndexer,
-				TypeCheckingNoConversionIT.rawFieldCompatibleIndex, typeCheckingRawFieldCompatibleIndexer ) );
+				TypeCheckingNoConversionIT.rawFieldCompatibleIndex, typeCheckingRawFieldCompatibleIndexer,
+				TypeCheckingNoConversionIT.missingFieldIndex, typeCheckingMissingFieldIndexer ) );
 
 		final BulkIndexer scaleCheckingMainIndexer = ScaleCheckingIT.index.bulkIndexer();
 		final BulkIndexer scaleCheckingCompatibleIndexer = ScaleCheckingIT.compatibleIndex.bulkIndexer();
@@ -72,7 +75,8 @@ public class ExistsPredicateBaseIT {
 
 		singleFieldIndexer.join(
 				nestingIndexer, scoreIndexer,
-				typeCheckingMainIndexer, typeCheckingCompatibleIndexer, typeCheckingRawFieldCompatibleIndexer,
+				typeCheckingMainIndexer, typeCheckingCompatibleIndexer,
+				typeCheckingRawFieldCompatibleIndexer, typeCheckingMissingFieldIndexer,
 				scaleCheckingMainIndexer, scaleCheckingCompatibleIndexer
 		);
 	}
@@ -349,12 +353,15 @@ public class ExistsPredicateBaseIT {
 		private static final SimpleMappedIndex<RawFieldCompatibleIndexBinding> rawFieldCompatibleIndex =
 				SimpleMappedIndex.of( root -> new RawFieldCompatibleIndexBinding( root, supportedFieldTypes ) )
 						.name( "typeChecking_rawFieldCompatible" );
+		private static final SimpleMappedIndex<MissingFieldIndexBinding> missingFieldIndex =
+				SimpleMappedIndex.of( root -> new MissingFieldIndexBinding( root, supportedFieldTypes ) )
+						.name( "typeChecking_missingField" );
 		private static final SimpleMappedIndex<IncompatibleIndexBinding> incompatibleIndex =
 				SimpleMappedIndex.of( root -> new IncompatibleIndexBinding( root, supportedFieldTypes ) )
 						.name( "typeChecking_incompatible" );
 
 		public TypeCheckingNoConversionIT(DataSet<F, ExistsPredicateTestValues<F>> dataSet) {
-			super( index, compatibleIndex, rawFieldCompatibleIndex, incompatibleIndex, dataSet );
+			super( index, compatibleIndex, rawFieldCompatibleIndex, missingFieldIndex, incompatibleIndex, dataSet );
 		}
 
 		@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchPredicateBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchPredicateBaseIT.java
@@ -57,7 +57,8 @@ public class MatchPredicateBaseIT {
 						SearchableIT.searchableYesIndex, SearchableIT.searchableNoIndex,
 						ArgumentCheckingIT.index,
 						TypeCheckingAndConversionIT.index, TypeCheckingAndConversionIT.compatibleIndex,
-						TypeCheckingAndConversionIT.rawFieldCompatibleIndex, TypeCheckingAndConversionIT.incompatibleIndex,
+						TypeCheckingAndConversionIT.rawFieldCompatibleIndex, TypeCheckingAndConversionIT.missingFieldIndex,
+						TypeCheckingAndConversionIT.incompatibleIndex,
 						ScaleCheckingIT.index, ScaleCheckingIT.compatibleIndex, ScaleCheckingIT.incompatibleIndex
 				)
 				.setup();
@@ -84,9 +85,11 @@ public class MatchPredicateBaseIT {
 		final BulkIndexer typeCheckingMainIndexer = TypeCheckingAndConversionIT.index.bulkIndexer();
 		final BulkIndexer typeCheckingCompatibleIndexer = TypeCheckingAndConversionIT.compatibleIndex.bulkIndexer();
 		final BulkIndexer typeCheckingRawFieldCompatibleIndexer = TypeCheckingAndConversionIT.rawFieldCompatibleIndex.bulkIndexer();
+		final BulkIndexer typeCheckingMissingFieldIndexer = TypeCheckingAndConversionIT.missingFieldIndex.bulkIndexer();
 		TypeCheckingAndConversionIT.dataSets.forEach( d -> d.contribute( TypeCheckingAndConversionIT.index, typeCheckingMainIndexer,
 				TypeCheckingAndConversionIT.compatibleIndex, typeCheckingCompatibleIndexer,
-				TypeCheckingAndConversionIT.rawFieldCompatibleIndex, typeCheckingRawFieldCompatibleIndexer ) );
+				TypeCheckingAndConversionIT.rawFieldCompatibleIndex, typeCheckingRawFieldCompatibleIndexer,
+				TypeCheckingAndConversionIT.missingFieldIndex, typeCheckingMissingFieldIndexer ) );
 
 		final BulkIndexer scaleCheckingMainIndexer = ScaleCheckingIT.index.bulkIndexer();
 		final BulkIndexer scaleCheckingCompatibleIndexer = ScaleCheckingIT.compatibleIndex.bulkIndexer();
@@ -97,7 +100,8 @@ public class MatchPredicateBaseIT {
 				multiFieldIndexer, nestingIndexer,
 				analysisMainIndexIndexer, analysisCompatibleIndexIndexer, analysisIncompatibleIndexIndexer,
 				scoreIndexer,
-				typeCheckingMainIndexer, typeCheckingCompatibleIndexer, typeCheckingRawFieldCompatibleIndexer,
+				typeCheckingMainIndexer, typeCheckingCompatibleIndexer,
+				typeCheckingRawFieldCompatibleIndexer, typeCheckingMissingFieldIndexer,
 				scaleCheckingMainIndexer, scaleCheckingCompatibleIndexer
 		);
 	}
@@ -462,6 +466,9 @@ public class MatchPredicateBaseIT {
 		private static final SimpleMappedIndex<RawFieldCompatibleIndexBinding> rawFieldCompatibleIndex =
 				SimpleMappedIndex.of( root -> new RawFieldCompatibleIndexBinding( root, supportedFieldTypes ) )
 						.name( "typeChecking_rawFieldCompatible" );
+		private static final SimpleMappedIndex<MissingFieldIndexBinding> missingFieldIndex =
+				SimpleMappedIndex.of( root -> new MissingFieldIndexBinding( root, supportedFieldTypes ) )
+						.name( "typeChecking_missingField" );
 		private static final SimpleMappedIndex<IncompatibleIndexBinding> incompatibleIndex =
 				SimpleMappedIndex.of( root -> new IncompatibleIndexBinding( root, supportedFieldTypes ) )
 						.name( "typeChecking_incompatible" );
@@ -472,7 +479,7 @@ public class MatchPredicateBaseIT {
 		}
 
 		public TypeCheckingAndConversionIT(DataSet<F, MatchPredicateTestValues<F>> dataSet) {
-			super( index, compatibleIndex, rawFieldCompatibleIndex, incompatibleIndex, dataSet );
+			super( index, compatibleIndex, rawFieldCompatibleIndex, missingFieldIndex, incompatibleIndex, dataSet );
 		}
 
 		@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/PhrasePredicateBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/PhrasePredicateBaseIT.java
@@ -59,7 +59,8 @@ public class PhrasePredicateBaseIT {
 						SearchableIT.searchableYesIndex, SearchableIT.searchableNoIndex,
 						ArgumentCheckingIT.index,
 						TypeCheckingNoConversionIT.index, TypeCheckingNoConversionIT.compatibleIndex,
-						TypeCheckingNoConversionIT.rawFieldCompatibleIndex, TypeCheckingNoConversionIT.incompatibleIndex
+						TypeCheckingNoConversionIT.rawFieldCompatibleIndex, TypeCheckingNoConversionIT.missingFieldIndex,
+						TypeCheckingNoConversionIT.incompatibleIndex
 				)
 				.setup();
 
@@ -85,15 +86,18 @@ public class PhrasePredicateBaseIT {
 		final BulkIndexer typeCheckingMainIndexer = TypeCheckingNoConversionIT.index.bulkIndexer();
 		final BulkIndexer typeCheckingCompatibleIndexer = TypeCheckingNoConversionIT.compatibleIndex.bulkIndexer();
 		final BulkIndexer typeCheckingRawFieldCompatibleIndexer = TypeCheckingNoConversionIT.rawFieldCompatibleIndex.bulkIndexer();
+		final BulkIndexer typeCheckingMissingFieldIndexer = TypeCheckingNoConversionIT.missingFieldIndex.bulkIndexer();
 		TypeCheckingNoConversionIT.dataSets.forEach( d -> d.contribute( TypeCheckingNoConversionIT.index, typeCheckingMainIndexer,
 				TypeCheckingNoConversionIT.compatibleIndex, typeCheckingCompatibleIndexer,
-				TypeCheckingNoConversionIT.rawFieldCompatibleIndex, typeCheckingRawFieldCompatibleIndexer ) );
+				TypeCheckingNoConversionIT.rawFieldCompatibleIndex, typeCheckingRawFieldCompatibleIndexer,
+				TypeCheckingNoConversionIT.missingFieldIndex, typeCheckingMissingFieldIndexer ) );
 
 		singleFieldIndexer.join(
 				multiFieldIndexer, nestingIndexer,
 				analysisMainIndexIndexer, analysisCompatibleIndexIndexer, analysisIncompatibleIndexIndexer,
 				scoreIndexer,
-				typeCheckingMainIndexer, typeCheckingCompatibleIndexer, typeCheckingRawFieldCompatibleIndexer
+				typeCheckingMainIndexer, typeCheckingCompatibleIndexer,
+				typeCheckingRawFieldCompatibleIndexer, typeCheckingMissingFieldIndexer
 		);
 	}
 
@@ -490,12 +494,15 @@ public class PhrasePredicateBaseIT {
 		private static final SimpleMappedIndex<RawFieldCompatibleIndexBinding> rawFieldCompatibleIndex =
 				SimpleMappedIndex.of( root -> new RawFieldCompatibleIndexBinding( root, supportedFieldTypes ) )
 						.name( "typeChecking_rawFieldCompatible" );
+		private static final SimpleMappedIndex<MissingFieldIndexBinding> missingFieldIndex =
+				SimpleMappedIndex.of( root -> new MissingFieldIndexBinding( root, supportedFieldTypes ) )
+						.name( "typeChecking_missingField" );
 		private static final SimpleMappedIndex<IncompatibleIndexBinding> incompatibleIndex =
 				SimpleMappedIndex.of( root -> new IncompatibleIndexBinding( root, supportedFieldTypes ) )
 						.name( "typeChecking_incompatible" );
 
 		public TypeCheckingNoConversionIT(DataSet<String, PhrasePredicateTestValues> dataSet) {
-			super( index, compatibleIndex, rawFieldCompatibleIndex, incompatibleIndex, dataSet );
+			super( index, compatibleIndex, rawFieldCompatibleIndex, missingFieldIndex, incompatibleIndex, dataSet );
 		}
 
 		@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/RangePredicateBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/RangePredicateBaseIT.java
@@ -61,7 +61,8 @@ public class RangePredicateBaseIT {
 						SearchableIT.searchableYesIndex, SearchableIT.searchableNoIndex,
 						ArgumentCheckingIT.index,
 						TypeCheckingAndConversionIT.index, TypeCheckingAndConversionIT.compatibleIndex,
-						TypeCheckingAndConversionIT.rawFieldCompatibleIndex, TypeCheckingAndConversionIT.incompatibleIndex,
+						TypeCheckingAndConversionIT.rawFieldCompatibleIndex, TypeCheckingAndConversionIT.missingFieldIndex,
+						TypeCheckingAndConversionIT.incompatibleIndex,
 						ScaleCheckingIT.index, ScaleCheckingIT.compatibleIndex, ScaleCheckingIT.incompatibleIndex
 				)
 				.setup();
@@ -88,9 +89,11 @@ public class RangePredicateBaseIT {
 		final BulkIndexer typeCheckingMainIndexer = TypeCheckingAndConversionIT.index.bulkIndexer();
 		final BulkIndexer typeCheckingCompatibleIndexer = TypeCheckingAndConversionIT.compatibleIndex.bulkIndexer();
 		final BulkIndexer typeCheckingRawFieldCompatibleIndexer = TypeCheckingAndConversionIT.rawFieldCompatibleIndex.bulkIndexer();
+		final BulkIndexer typeCheckingMissingFieldIndexer = TypeCheckingAndConversionIT.missingFieldIndex.bulkIndexer();
 		TypeCheckingAndConversionIT.dataSets.forEach( d -> d.contribute( TypeCheckingAndConversionIT.index, typeCheckingMainIndexer,
 				TypeCheckingAndConversionIT.compatibleIndex, typeCheckingCompatibleIndexer,
-				TypeCheckingAndConversionIT.rawFieldCompatibleIndex, typeCheckingRawFieldCompatibleIndexer ) );
+				TypeCheckingAndConversionIT.rawFieldCompatibleIndex, typeCheckingRawFieldCompatibleIndexer,
+				TypeCheckingAndConversionIT.missingFieldIndex, typeCheckingMissingFieldIndexer ) );
 
 		final BulkIndexer scaleCheckingMainIndexer = ScaleCheckingIT.index.bulkIndexer();
 		final BulkIndexer scaleCheckingCompatibleIndexer = ScaleCheckingIT.compatibleIndex.bulkIndexer();
@@ -101,7 +104,8 @@ public class RangePredicateBaseIT {
 				multiFieldIndexer, nestingIndexer,
 				analysisMainIndexIndexer, analysisCompatibleIndexIndexer, analysisIncompatibleIndexIndexer,
 				scoreIndexer,
-				typeCheckingMainIndexer, typeCheckingCompatibleIndexer, typeCheckingRawFieldCompatibleIndexer,
+				typeCheckingMainIndexer, typeCheckingCompatibleIndexer,
+				typeCheckingRawFieldCompatibleIndexer, typeCheckingMissingFieldIndexer,
 				scaleCheckingMainIndexer, scaleCheckingCompatibleIndexer
 		);
 	}
@@ -467,6 +471,9 @@ public class RangePredicateBaseIT {
 		private static final SimpleMappedIndex<RawFieldCompatibleIndexBinding> rawFieldCompatibleIndex =
 				SimpleMappedIndex.of( root -> new RawFieldCompatibleIndexBinding( root, supportedFieldTypes ) )
 						.name( "typeChecking_rawFieldCompatible" );
+		private static final SimpleMappedIndex<MissingFieldIndexBinding> missingFieldIndex =
+				SimpleMappedIndex.of( root -> new MissingFieldIndexBinding( root, supportedFieldTypes ) )
+						.name( "typeChecking_missingField" );
 		private static final SimpleMappedIndex<IncompatibleIndexBinding> incompatibleIndex =
 				SimpleMappedIndex.of( root -> new IncompatibleIndexBinding( root, supportedFieldTypes ) )
 						.name( "typeChecking_incompatible" );
@@ -477,7 +484,7 @@ public class RangePredicateBaseIT {
 		}
 
 		public TypeCheckingAndConversionIT(DataSet<F, RangePredicateTestValues<F>> dataSet) {
-			super( index, compatibleIndex, rawFieldCompatibleIndex, incompatibleIndex, dataSet );
+			super( index, compatibleIndex, rawFieldCompatibleIndex, missingFieldIndex, incompatibleIndex, dataSet );
 		}
 
 		@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SimpleQueryStringPredicateBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SimpleQueryStringPredicateBaseIT.java
@@ -56,7 +56,8 @@ public class SimpleQueryStringPredicateBaseIT {
 						SearchableIT.searchableYesIndex, SearchableIT.searchableNoIndex,
 						ArgumentCheckingIT.index,
 						TypeCheckingNoConversionIT.index, TypeCheckingNoConversionIT.compatibleIndex,
-						TypeCheckingNoConversionIT.rawFieldCompatibleIndex, TypeCheckingNoConversionIT.incompatibleIndex
+						TypeCheckingNoConversionIT.rawFieldCompatibleIndex, TypeCheckingNoConversionIT.missingFieldIndex,
+						TypeCheckingNoConversionIT.incompatibleIndex
 				)
 				.setup();
 
@@ -82,15 +83,18 @@ public class SimpleQueryStringPredicateBaseIT {
 		final BulkIndexer typeCheckingMainIndexer = TypeCheckingNoConversionIT.index.bulkIndexer();
 		final BulkIndexer typeCheckingCompatibleIndexer = TypeCheckingNoConversionIT.compatibleIndex.bulkIndexer();
 		final BulkIndexer typeCheckingRawFieldCompatibleIndexer = TypeCheckingNoConversionIT.rawFieldCompatibleIndex.bulkIndexer();
+		final BulkIndexer typeCheckingMissingFieldIndexer = TypeCheckingNoConversionIT.missingFieldIndex.bulkIndexer();
 		TypeCheckingNoConversionIT.dataSets.forEach( d -> d.contribute( TypeCheckingNoConversionIT.index, typeCheckingMainIndexer,
 				TypeCheckingNoConversionIT.compatibleIndex, typeCheckingCompatibleIndexer,
-				TypeCheckingNoConversionIT.rawFieldCompatibleIndex, typeCheckingRawFieldCompatibleIndexer ) );
+				TypeCheckingNoConversionIT.rawFieldCompatibleIndex, typeCheckingRawFieldCompatibleIndexer,
+				TypeCheckingNoConversionIT.missingFieldIndex, typeCheckingMissingFieldIndexer ) );
 
 		singleFieldIndexer.join(
 				multiFieldIndexer, nestingIndexer,
 				analysisMainIndexIndexer, analysisCompatibleIndexIndexer, analysisIncompatibleIndexIndexer,
 				scoreIndexer,
-				typeCheckingMainIndexer, typeCheckingCompatibleIndexer, typeCheckingRawFieldCompatibleIndexer
+				typeCheckingMainIndexer, typeCheckingCompatibleIndexer,
+				typeCheckingRawFieldCompatibleIndexer, typeCheckingMissingFieldIndexer
 		);
 	}
 
@@ -466,12 +470,15 @@ public class SimpleQueryStringPredicateBaseIT {
 		private static final SimpleMappedIndex<RawFieldCompatibleIndexBinding> rawFieldCompatibleIndex =
 				SimpleMappedIndex.of( root -> new RawFieldCompatibleIndexBinding( root, supportedFieldTypes ) )
 						.name( "typeChecking_rawFieldCompatible" );
+		private static final SimpleMappedIndex<MissingFieldIndexBinding> missingFieldIndex =
+				SimpleMappedIndex.of( root -> new MissingFieldIndexBinding( root, supportedFieldTypes ) )
+						.name( "typeChecking_missingField" );
 		private static final SimpleMappedIndex<IncompatibleIndexBinding> incompatibleIndex =
 				SimpleMappedIndex.of( root -> new IncompatibleIndexBinding( root, supportedFieldTypes ) )
 						.name( "typeChecking_incompatible" );
 
 		public TypeCheckingNoConversionIT(DataSet<String, SimpleQueryStringPredicateTestValues> dataSet) {
-			super( index, compatibleIndex, rawFieldCompatibleIndex, incompatibleIndex, dataSet );
+			super( index, compatibleIndex, rawFieldCompatibleIndex, missingFieldIndex, incompatibleIndex, dataSet );
 		}
 
 		@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SpatialWithinBoundingBoxPredicateBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SpatialWithinBoundingBoxPredicateBaseIT.java
@@ -54,7 +54,8 @@ public class SpatialWithinBoundingBoxPredicateBaseIT {
 						SearchableIT.searchableYesIndex, SearchableIT.searchableNoIndex,
 						ArgumentCheckingIT.index,
 						TypeCheckingNoConversionIT.index, TypeCheckingNoConversionIT.compatibleIndex,
-						TypeCheckingNoConversionIT.rawFieldCompatibleIndex, TypeCheckingNoConversionIT.incompatibleIndex
+						TypeCheckingNoConversionIT.rawFieldCompatibleIndex, TypeCheckingNoConversionIT.missingFieldIndex,
+						TypeCheckingNoConversionIT.incompatibleIndex
 				)
 				.setup();
 
@@ -73,14 +74,17 @@ public class SpatialWithinBoundingBoxPredicateBaseIT {
 		final BulkIndexer typeCheckingMainIndexer = TypeCheckingNoConversionIT.index.bulkIndexer();
 		final BulkIndexer typeCheckingCompatibleIndexer = TypeCheckingNoConversionIT.compatibleIndex.bulkIndexer();
 		final BulkIndexer typeCheckingRawFieldCompatibleIndexer = TypeCheckingNoConversionIT.rawFieldCompatibleIndex.bulkIndexer();
+		final BulkIndexer typeCheckingMissingFieldIndexer = TypeCheckingNoConversionIT.missingFieldIndex.bulkIndexer();
 		TypeCheckingNoConversionIT.dataSet.contribute( TypeCheckingNoConversionIT.index, typeCheckingMainIndexer,
 				TypeCheckingNoConversionIT.compatibleIndex, typeCheckingCompatibleIndexer,
-				TypeCheckingNoConversionIT.rawFieldCompatibleIndex, typeCheckingRawFieldCompatibleIndexer );
+				TypeCheckingNoConversionIT.rawFieldCompatibleIndex, typeCheckingRawFieldCompatibleIndexer,
+				TypeCheckingNoConversionIT.missingFieldIndex, typeCheckingMissingFieldIndexer );
 
 		singleFieldIndexer.join(
 				multiFieldIndexer, nestingIndexer,
 				scoreIndexer,
-				typeCheckingMainIndexer, typeCheckingCompatibleIndexer, typeCheckingRawFieldCompatibleIndexer
+				typeCheckingMainIndexer, typeCheckingCompatibleIndexer,
+				typeCheckingRawFieldCompatibleIndexer, typeCheckingMissingFieldIndexer
 		);
 	}
 
@@ -330,12 +334,15 @@ public class SpatialWithinBoundingBoxPredicateBaseIT {
 		private static final SimpleMappedIndex<RawFieldCompatibleIndexBinding> rawFieldCompatibleIndex =
 				SimpleMappedIndex.of( root -> new RawFieldCompatibleIndexBinding( root, supportedFieldTypes ) )
 						.name( "typeChecking_rawFieldCompatible" );
+		private static final SimpleMappedIndex<MissingFieldIndexBinding> missingFieldIndex =
+				SimpleMappedIndex.of( root -> new MissingFieldIndexBinding( root, supportedFieldTypes ) )
+						.name( "typeChecking_missingField" );
 		private static final SimpleMappedIndex<IncompatibleIndexBinding> incompatibleIndex =
 				SimpleMappedIndex.of( root -> new IncompatibleIndexBinding( root, supportedFieldTypes ) )
 						.name( "typeChecking_incompatible" );
 
 		public TypeCheckingNoConversionIT() {
-			super( index, compatibleIndex, rawFieldCompatibleIndex, incompatibleIndex, dataSet );
+			super( index, compatibleIndex, rawFieldCompatibleIndex, missingFieldIndex, incompatibleIndex, dataSet );
 		}
 
 		@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SpatialWithinCirclePredicateBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SpatialWithinCirclePredicateBaseIT.java
@@ -56,7 +56,8 @@ public class SpatialWithinCirclePredicateBaseIT {
 						SearchableIT.searchableYesIndex, SearchableIT.searchableNoIndex,
 						ArgumentCheckingIT.index,
 						TypeCheckingNoConversionIT.index, TypeCheckingNoConversionIT.compatibleIndex,
-						TypeCheckingNoConversionIT.rawFieldCompatibleIndex, TypeCheckingNoConversionIT.incompatibleIndex
+						TypeCheckingNoConversionIT.rawFieldCompatibleIndex, TypeCheckingNoConversionIT.missingFieldIndex,
+						TypeCheckingNoConversionIT.incompatibleIndex
 				)
 				.setup();
 
@@ -75,14 +76,17 @@ public class SpatialWithinCirclePredicateBaseIT {
 		final BulkIndexer typeCheckingMainIndexer = TypeCheckingNoConversionIT.index.bulkIndexer();
 		final BulkIndexer typeCheckingCompatibleIndexer = TypeCheckingNoConversionIT.compatibleIndex.bulkIndexer();
 		final BulkIndexer typeCheckingRawFieldCompatibleIndexer = TypeCheckingNoConversionIT.rawFieldCompatibleIndex.bulkIndexer();
+		final BulkIndexer typeCheckingMissingFieldIndexer = TypeCheckingNoConversionIT.missingFieldIndex.bulkIndexer();
 		TypeCheckingNoConversionIT.dataSet.contribute( TypeCheckingNoConversionIT.index, typeCheckingMainIndexer,
 				TypeCheckingNoConversionIT.compatibleIndex, typeCheckingCompatibleIndexer,
-				TypeCheckingNoConversionIT.rawFieldCompatibleIndex, typeCheckingRawFieldCompatibleIndexer );
+				TypeCheckingNoConversionIT.rawFieldCompatibleIndex, typeCheckingRawFieldCompatibleIndexer,
+				TypeCheckingNoConversionIT.missingFieldIndex, typeCheckingMissingFieldIndexer );
 
 		singleFieldIndexer.join(
 				multiFieldIndexer, nestingIndexer,
 				scoreIndexer,
-				typeCheckingMainIndexer, typeCheckingCompatibleIndexer, typeCheckingRawFieldCompatibleIndexer
+				typeCheckingMainIndexer, typeCheckingCompatibleIndexer,
+				typeCheckingRawFieldCompatibleIndexer, typeCheckingMissingFieldIndexer
 		);
 	}
 
@@ -360,12 +364,15 @@ public class SpatialWithinCirclePredicateBaseIT {
 		private static final SimpleMappedIndex<RawFieldCompatibleIndexBinding> rawFieldCompatibleIndex =
 				SimpleMappedIndex.of( root -> new RawFieldCompatibleIndexBinding( root, supportedFieldTypes ) )
 						.name( "typeChecking_rawFieldCompatible" );
+		private static final SimpleMappedIndex<MissingFieldIndexBinding> missingFieldIndex =
+				SimpleMappedIndex.of( root -> new MissingFieldIndexBinding( root, supportedFieldTypes ) )
+						.name( "typeChecking_missingField" );
 		private static final SimpleMappedIndex<IncompatibleIndexBinding> incompatibleIndex =
 				SimpleMappedIndex.of( root -> new IncompatibleIndexBinding( root, supportedFieldTypes ) )
 						.name( "typeChecking_incompatible" );
 
 		public TypeCheckingNoConversionIT() {
-			super( index, compatibleIndex, rawFieldCompatibleIndex, incompatibleIndex, dataSet );
+			super( index, compatibleIndex, rawFieldCompatibleIndex, missingFieldIndex, incompatibleIndex, dataSet );
 		}
 
 		@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SpatialWithinPolygonPredicateBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SpatialWithinPolygonPredicateBaseIT.java
@@ -55,7 +55,8 @@ public class SpatialWithinPolygonPredicateBaseIT {
 						SearchableIT.searchableYesIndex, SearchableIT.searchableNoIndex,
 						ArgumentCheckingIT.index,
 						TypeCheckingNoConversionIT.index, TypeCheckingNoConversionIT.compatibleIndex,
-						TypeCheckingNoConversionIT.rawFieldCompatibleIndex, TypeCheckingNoConversionIT.incompatibleIndex
+						TypeCheckingNoConversionIT.rawFieldCompatibleIndex, TypeCheckingNoConversionIT.missingFieldIndex,
+						TypeCheckingNoConversionIT.incompatibleIndex
 				)
 				.setup();
 
@@ -74,14 +75,17 @@ public class SpatialWithinPolygonPredicateBaseIT {
 		final BulkIndexer typeCheckingMainIndexer = TypeCheckingNoConversionIT.index.bulkIndexer();
 		final BulkIndexer typeCheckingCompatibleIndexer = TypeCheckingNoConversionIT.compatibleIndex.bulkIndexer();
 		final BulkIndexer typeCheckingRawFieldCompatibleIndexer = TypeCheckingNoConversionIT.rawFieldCompatibleIndex.bulkIndexer();
+		final BulkIndexer typeCheckingMissingFieldIndexer = TypeCheckingNoConversionIT.missingFieldIndex.bulkIndexer();
 		TypeCheckingNoConversionIT.dataSet.contribute( TypeCheckingNoConversionIT.index, typeCheckingMainIndexer,
 				TypeCheckingNoConversionIT.compatibleIndex, typeCheckingCompatibleIndexer,
-				TypeCheckingNoConversionIT.rawFieldCompatibleIndex, typeCheckingRawFieldCompatibleIndexer );
+				TypeCheckingNoConversionIT.rawFieldCompatibleIndex, typeCheckingRawFieldCompatibleIndexer,
+				TypeCheckingNoConversionIT.missingFieldIndex, typeCheckingMissingFieldIndexer );
 
 		singleFieldIndexer.join(
 				multiFieldIndexer, nestingIndexer,
 				scoreIndexer,
-				typeCheckingMainIndexer, typeCheckingCompatibleIndexer, typeCheckingRawFieldCompatibleIndexer
+				typeCheckingMainIndexer, typeCheckingCompatibleIndexer,
+				typeCheckingRawFieldCompatibleIndexer, typeCheckingMissingFieldIndexer
 		);
 	}
 
@@ -336,12 +340,15 @@ public class SpatialWithinPolygonPredicateBaseIT {
 		private static final SimpleMappedIndex<RawFieldCompatibleIndexBinding> rawFieldCompatibleIndex =
 				SimpleMappedIndex.of( root -> new RawFieldCompatibleIndexBinding( root, supportedFieldTypes ) )
 						.name( "typeChecking_rawFieldCompatible" );
+		private static final SimpleMappedIndex<MissingFieldIndexBinding> missingFieldIndex =
+				SimpleMappedIndex.of( root -> new MissingFieldIndexBinding( root, supportedFieldTypes ) )
+						.name( "typeChecking_missingField" );
 		private static final SimpleMappedIndex<IncompatibleIndexBinding> incompatibleIndex =
 				SimpleMappedIndex.of( root -> new IncompatibleIndexBinding( root, supportedFieldTypes ) )
 						.name( "typeChecking_incompatible" );
 
 		public TypeCheckingNoConversionIT() {
-			super( index, compatibleIndex, rawFieldCompatibleIndex, incompatibleIndex, dataSet );
+			super( index, compatibleIndex, rawFieldCompatibleIndex, missingFieldIndex, incompatibleIndex, dataSet );
 		}
 
 		@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/WildcardPredicateBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/WildcardPredicateBaseIT.java
@@ -54,7 +54,8 @@ public class WildcardPredicateBaseIT {
 						SearchableIT.searchableYesIndex, SearchableIT.searchableNoIndex,
 						ArgumentCheckingIT.index,
 						TypeCheckingNoConversionIT.index, TypeCheckingNoConversionIT.compatibleIndex,
-						TypeCheckingNoConversionIT.rawFieldCompatibleIndex, TypeCheckingNoConversionIT.incompatibleIndex
+						TypeCheckingNoConversionIT.rawFieldCompatibleIndex, TypeCheckingNoConversionIT.missingFieldIndex,
+						TypeCheckingNoConversionIT.incompatibleIndex
 				)
 				.setup();
 
@@ -73,14 +74,18 @@ public class WildcardPredicateBaseIT {
 		final BulkIndexer typeCheckingMainIndexer = TypeCheckingNoConversionIT.index.bulkIndexer();
 		final BulkIndexer typeCheckingCompatibleIndexer = TypeCheckingNoConversionIT.compatibleIndex.bulkIndexer();
 		final BulkIndexer typeCheckingRawFieldCompatibleIndexer = TypeCheckingNoConversionIT.rawFieldCompatibleIndex.bulkIndexer();
+		final BulkIndexer typeCheckingMissingFieldIndexer = TypeCheckingNoConversionIT.missingFieldIndex.bulkIndexer();
 		TypeCheckingNoConversionIT.dataSets.forEach( d -> d.contribute( TypeCheckingNoConversionIT.index, typeCheckingMainIndexer,
 				TypeCheckingNoConversionIT.compatibleIndex, typeCheckingCompatibleIndexer,
-				TypeCheckingNoConversionIT.rawFieldCompatibleIndex, typeCheckingRawFieldCompatibleIndexer ) );
+				TypeCheckingNoConversionIT.rawFieldCompatibleIndex, typeCheckingRawFieldCompatibleIndexer,
+				TypeCheckingNoConversionIT.missingFieldIndex, typeCheckingMissingFieldIndexer ) );
+
 
 		singleFieldIndexer.join(
 				multiFieldIndexer, nestingIndexer,
 				scoreIndexer,
-				typeCheckingMainIndexer, typeCheckingCompatibleIndexer, typeCheckingRawFieldCompatibleIndexer
+				typeCheckingMainIndexer, typeCheckingCompatibleIndexer,
+				typeCheckingRawFieldCompatibleIndexer, typeCheckingMissingFieldIndexer
 		);
 	}
 
@@ -417,12 +422,15 @@ public class WildcardPredicateBaseIT {
 		private static final SimpleMappedIndex<RawFieldCompatibleIndexBinding> rawFieldCompatibleIndex =
 				SimpleMappedIndex.of( root -> new RawFieldCompatibleIndexBinding( root, supportedFieldTypes ) )
 						.name( "typeChecking_rawFieldCompatible" );
+		private static final SimpleMappedIndex<MissingFieldIndexBinding> missingFieldIndex =
+				SimpleMappedIndex.of( root -> new MissingFieldIndexBinding( root, supportedFieldTypes ) )
+						.name( "typeChecking_missingField" );
 		private static final SimpleMappedIndex<IncompatibleIndexBinding> incompatibleIndex =
 				SimpleMappedIndex.of( root -> new IncompatibleIndexBinding( root, supportedFieldTypes ) )
 						.name( "typeChecking_incompatible" );
 
 		public TypeCheckingNoConversionIT(DataSet<String, WildcardPredicateTestValues> dataSet) {
-			super( index, compatibleIndex, rawFieldCompatibleIndex, incompatibleIndex, dataSet );
+			super( index, compatibleIndex, rawFieldCompatibleIndex, missingFieldIndex, incompatibleIndex, dataSet );
 		}
 
 		@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/DistanceSearchSortTypeCheckingAndConversionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/DistanceSearchSortTypeCheckingAndConversionIT.java
@@ -9,14 +9,18 @@ package org.hibernate.search.integrationtest.backend.tck.search.sort;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hibernate.search.integrationtest.backend.tck.testsupport.types.values.AscendingUniqueDistanceFromCenterValues.CENTER_POINT;
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatQuery;
+import static org.junit.Assume.assumeTrue;
 
 import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.backend.document.DocumentElement;
+import org.hibernate.search.engine.backend.document.IndexObjectFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectField;
 import org.hibernate.search.engine.backend.types.Aggregable;
+import org.hibernate.search.engine.backend.types.ObjectStructure;
 import org.hibernate.search.engine.backend.types.Projectable;
 import org.hibernate.search.engine.backend.types.Searchable;
 import org.hibernate.search.engine.backend.types.Sortable;
@@ -30,6 +34,7 @@ import org.hibernate.search.integrationtest.backend.tck.testsupport.types.FieldT
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.GeoPointFieldTypeDescriptor;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.types.values.AscendingUniqueDistanceFromCenterValues;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.SimpleFieldModel;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckConfiguration;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.ValueWrapper;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
 import org.hibernate.search.util.common.SearchException;
@@ -37,6 +42,7 @@ import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.BulkIndexer;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
+import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -58,6 +64,7 @@ public class DistanceSearchSortTypeCheckingAndConversionIT {
 
 	private static final String COMPATIBLE_INDEX_DOCUMENT_1 = "compatible_1";
 	private static final String RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 = "raw_field_compatible_1";
+	private static final String MISSING_FIELD_INDEX_DOCUMENT_1 = "missing_field_1";
 
 	// TODO HSEARCH-3863 use the other ordinals when we implement.missing().use/last/first for distance sorts
 	private static final int BEFORE_DOCUMENT_1_ORDINAL = 0;
@@ -77,13 +84,15 @@ public class DistanceSearchSortTypeCheckingAndConversionIT {
 			SimpleMappedIndex.of( CompatibleIndexBinding::new ).name( "compatible" );
 	private static final SimpleMappedIndex<RawFieldCompatibleIndexBinding> rawFieldCompatibleIndex =
 			SimpleMappedIndex.of( RawFieldCompatibleIndexBinding::new ).name( "rawFieldCompatible" );
+	private static final SimpleMappedIndex<MissingFieldIndexBinding> missingFieldIndex =
+			SimpleMappedIndex.of( MissingFieldIndexBinding::new ).name( "missingField" );
 	private static final SimpleMappedIndex<IncompatibleIndexBinding> incompatibleIndex =
 			SimpleMappedIndex.of( IncompatibleIndexBinding::new ).name( "incompatible" );
 
 	@BeforeClass
 	public static void setup() {
 		setupHelper.start()
-				.withIndexes( mainIndex, compatibleIndex, rawFieldCompatibleIndex, incompatibleIndex )
+				.withIndexes( mainIndex, compatibleIndex, rawFieldCompatibleIndex, missingFieldIndex, incompatibleIndex )
 				.setup();
 
 		initData();
@@ -144,6 +153,68 @@ public class DistanceSearchSortTypeCheckingAndConversionIT {
 	}
 
 	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4173")
+	public void multiIndex_withMissingFieldIndex() {
+		assumeTrue(
+				"This backend doesn't support distance sorts on a field that is missing from some of the target indexes.",
+				TckConfiguration.get().getBackendFeatures().supportsDistanceSortWhenFieldMissingInSomeTargetIndexes()
+		);
+
+		StubMappingScope scope = mainIndex.createScope( missingFieldIndex );
+
+		SearchQuery<DocumentReference> query;
+		String fieldPath = getFieldPath();
+
+		query = matchNonEmptyQuery( f -> f.distance( fieldPath, CENTER_POINT ), scope );
+
+		/*
+		 * Not testing the ordering of results here because it's not what we are interested in:
+		 * we just want to check that fields are correctly detected as compatible,
+		 * that no exception is thrown and that the query is correctly executed on all indexes
+		 * with no silent error (HSEARCH-4173).
+		 */
+		assertThatQuery( query ).hasDocRefHitsAnyOrder( b -> {
+			b.doc( missingFieldIndex.typeName(), MISSING_FIELD_INDEX_DOCUMENT_1 );
+			b.doc( mainIndex.typeName(), DOCUMENT_1 );
+			b.doc( mainIndex.typeName(), DOCUMENT_2 );
+			b.doc( mainIndex.typeName(), DOCUMENT_3 );
+		} );
+	}
+
+	/**
+	 * Test the behavior when even the <strong>parent</strong> field of the field to sort on is missing,
+	 * and that parent field is <strong>nested</strong> in the main index.
+	 */
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4173")
+	public void multiIndex_withMissingFieldIndex_nested() {
+		assumeTrue(
+				"This backend doesn't support distance sorts on a nested field that is missing from some of the target indexes.",
+				TckConfiguration.get().getBackendFeatures().supportsDistanceSortWhenNestedFieldMissingInSomeTargetIndexes()
+		);
+
+		StubMappingScope scope = mainIndex.createScope( missingFieldIndex );
+
+		SearchQuery<DocumentReference> query;
+		String fieldPath = getFieldInNestedPath();
+
+		query = matchNonEmptyQuery( f -> f.distance( fieldPath, CENTER_POINT ), scope );
+
+		/*
+		 * Not testing the ordering of results here because it's not what we are interested in:
+		 * we just want to check that fields are correctly detected as compatible,
+		 * that no exception is thrown and that the query is correctly executed on all indexes
+		 * with no silent error (HSEARCH-4173).
+		 */
+		assertThatQuery( query ).hasDocRefHitsAnyOrder( b -> {
+			b.doc( missingFieldIndex.typeName(), MISSING_FIELD_INDEX_DOCUMENT_1 );
+			b.doc( mainIndex.typeName(), DOCUMENT_1 );
+			b.doc( mainIndex.typeName(), DOCUMENT_2 );
+			b.doc( mainIndex.typeName(), DOCUMENT_3 );
+		} );
+	}
+
+	@Test
 	public void multiIndex_withIncompatibleIndex() {
 		StubMappingScope scope = mainIndex.createScope( incompatibleIndex );
 
@@ -172,8 +243,21 @@ public class DistanceSearchSortTypeCheckingAndConversionIT {
 				.toQuery();
 	}
 
+	private SearchQuery<DocumentReference> matchNonEmptyQuery(
+			Function<? super SearchSortFactory, ? extends SortFinalStep> sortContributor, StubMappingScope scope) {
+		return scope.query()
+				.where( f -> f.matchAll().except( f.id().matching( EMPTY ) ) )
+				.sort( sortContributor )
+				.toQuery();
+	}
+
 	private String getFieldPath() {
 		return mainIndex.binding().fieldModel.relativeFieldName;
+	}
+
+	private String getFieldInNestedPath() {
+		return mainIndex.binding().nested.relativeFieldName
+				+ '.' + mainIndex.binding().nested.fieldModel.relativeFieldName;
 	}
 
 	private String getFieldWithDslConverterPath() {
@@ -187,6 +271,10 @@ public class DistanceSearchSortTypeCheckingAndConversionIT {
 	private static void initDocument(IndexBinding indexBinding, DocumentElement document, Integer ordinal) {
 		addValue( indexBinding.fieldModel, document, ordinal );
 		addValue( indexBinding.fieldWithDslConverterModel, document, ordinal );
+
+		DocumentElement nested = document.addObject( indexBinding.nested.self );
+		addValue( indexBinding.nested.fieldModel, nested, ordinal );
+		addValue( indexBinding.nested.fieldWithDslConverterModel, nested, ordinal );
 	}
 
 	private static void addValue(SimpleFieldModel<GeoPoint> fieldModel, DocumentElement documentElement, Integer ordinal) {
@@ -215,19 +303,17 @@ public class DistanceSearchSortTypeCheckingAndConversionIT {
 		BulkIndexer rawFieldCompatibleIndexer = rawFieldCompatibleIndex.bulkIndexer()
 				.add( RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1,
 						document -> initDocument( rawFieldCompatibleIndex.binding(), document, BETWEEN_DOCUMENT_1_AND_2_ORDINAL ) );
-		mainIndexer.join( compatibleIndexer, rawFieldCompatibleIndexer );
+		BulkIndexer missingFieldIndexer = missingFieldIndex.bulkIndexer()
+				.add( MISSING_FIELD_INDEX_DOCUMENT_1, document -> { } );
+		mainIndexer.join( compatibleIndexer, rawFieldCompatibleIndexer, missingFieldIndexer );
 	}
 
-	private static class IndexBinding {
+	private static class AbstractObjectMapping {
 		final SimpleFieldModel<GeoPoint> fieldModel;
 		final SimpleFieldModel<GeoPoint> fieldWithDslConverterModel;
 		final SimpleFieldModel<GeoPoint> nonSortableFieldModel;
 
-		IndexBinding(IndexSchemaElement root) {
-			this( root, ignored -> { } );
-		}
-
-		IndexBinding(IndexSchemaElement root,
+		AbstractObjectMapping(IndexSchemaElement root,
 				Consumer<StandardIndexFieldTypeOptionsStep<?, ?>> additionalConfiguration) {
 			fieldModel = SimpleFieldModel.mapper( fieldType )
 					.map( root, "unconverted", c -> c.sortable( Sortable.YES ), additionalConfiguration );
@@ -242,6 +328,40 @@ public class DistanceSearchSortTypeCheckingAndConversionIT {
 							root, "nonSortable", c -> c.sortable( Sortable.YES ),
 							additionalConfiguration.andThen( c -> c.sortable( Sortable.NO ) )
 					);
+		}
+	}
+
+	private static class IndexBinding extends AbstractObjectMapping {
+		private final FirstLevelObjectMapping nested;
+
+		IndexBinding(IndexSchemaElement root) {
+			this( root, ignored -> { } );
+		}
+
+		IndexBinding(IndexSchemaElement root,
+				Consumer<StandardIndexFieldTypeOptionsStep<?, ?>> additionalConfiguration) {
+			super( root, additionalConfiguration );
+			nested = FirstLevelObjectMapping.create( root, "nested", ObjectStructure.NESTED,
+					additionalConfiguration );
+		}
+	}
+
+	private static class FirstLevelObjectMapping extends AbstractObjectMapping {
+		final String relativeFieldName;
+		final IndexObjectFieldReference self;
+
+		public static FirstLevelObjectMapping create(IndexSchemaElement parent, String relativeFieldName,
+				ObjectStructure structure,
+				Consumer<StandardIndexFieldTypeOptionsStep<?, ?>> additionalConfiguration) {
+			IndexSchemaObjectField objectField = parent.objectField( relativeFieldName, structure );
+			return new FirstLevelObjectMapping( relativeFieldName, objectField, additionalConfiguration );
+		}
+
+		private FirstLevelObjectMapping(String relativeFieldName, IndexSchemaObjectField objectField,
+				Consumer<StandardIndexFieldTypeOptionsStep<?, ?>> additionalConfiguration) {
+			super( objectField, additionalConfiguration );
+			this.relativeFieldName = relativeFieldName;
+			self = objectField.toReference();
 		}
 	}
 
@@ -286,6 +406,11 @@ public class DistanceSearchSortTypeCheckingAndConversionIT {
 			 * but with an incompatible DSL converter.
 			 */
 			super( root, c -> c.dslConverter( ValueWrapper.class, ValueWrapper.toIndexFieldConverter() ) );
+		}
+	}
+
+	private static class MissingFieldIndexBinding {
+		MissingFieldIndexBinding(IndexSchemaElement root) {
 		}
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSearchSortTypeCheckingAndConversionIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/sort/FieldSearchSortTypeCheckingAndConversionIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.integrationtest.backend.tck.search.sort;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatQuery;
+import static org.junit.Assume.assumeTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,8 +18,11 @@ import java.util.function.Function;
 
 import org.hibernate.search.engine.backend.common.DocumentReference;
 import org.hibernate.search.engine.backend.document.DocumentElement;
+import org.hibernate.search.engine.backend.document.IndexObjectFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaObjectField;
 import org.hibernate.search.engine.backend.types.Aggregable;
+import org.hibernate.search.engine.backend.types.ObjectStructure;
 import org.hibernate.search.engine.backend.types.Projectable;
 import org.hibernate.search.engine.backend.types.Searchable;
 import org.hibernate.search.engine.backend.types.Sortable;
@@ -41,6 +45,7 @@ import org.hibernate.search.util.impl.integrationtest.common.FailureReportUtils;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.BulkIndexer;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
+import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -77,6 +82,7 @@ public class FieldSearchSortTypeCheckingAndConversionIT<F> {
 
 	private static final String COMPATIBLE_INDEX_DOCUMENT_1 = "compatible_1";
 	private static final String RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1 = "raw_field_compatible_1";
+	private static final String MISSING_FIELD_INDEX_DOCUMENT_1 = "missing_field_1";
 
 	private static final int BEFORE_DOCUMENT_1_ORDINAL = 0;
 	private static final int DOCUMENT_1_ORDINAL = 1;
@@ -95,13 +101,15 @@ public class FieldSearchSortTypeCheckingAndConversionIT<F> {
 			SimpleMappedIndex.of( CompatibleIndexBinding::new ).name( "compatible" );
 	private static final SimpleMappedIndex<RawFieldCompatibleIndexBinding> rawFieldCompatibleIndex =
 			SimpleMappedIndex.of( RawFieldCompatibleIndexBinding::new ).name( "rawFieldCompatible" );
+	private static final SimpleMappedIndex<MissingFieldIndexBinding> missingFieldIndex =
+			SimpleMappedIndex.of( MissingFieldIndexBinding::new ).name( "missingField" );
 	private static final SimpleMappedIndex<IncompatibleIndexBinding> incompatibleIndex =
 			SimpleMappedIndex.of( IncompatibleIndexBinding::new ).name( "incompatible" );
 
 	@BeforeClass
 	public static void setup() {
 		setupHelper.start()
-				.withIndexes( mainIndex, compatibleIndex, rawFieldCompatibleIndex, incompatibleIndex )
+				.withIndexes( mainIndex, compatibleIndex, rawFieldCompatibleIndex, missingFieldIndex, incompatibleIndex )
 				.setup();
 
 		initData();
@@ -287,6 +295,110 @@ public class FieldSearchSortTypeCheckingAndConversionIT<F> {
 	}
 
 	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4173")
+	public void multiIndex_withMissingFieldIndex_dslConverterEnabled() {
+		assumeTrue(
+				"This backend doesn't support sorts on a field of type '" + fieldTypeDescriptor
+						+ "' that is missing from some of the target indexes.",
+				TckConfiguration.get().getBackendFeatures()
+						.supportsFieldSortWhenFieldMissingInSomeTargetIndexes( fieldTypeDescriptor.getJavaType() )
+		);
+
+		StubMappingScope scope = mainIndex.createScope( missingFieldIndex );
+
+		SearchQuery<DocumentReference> query;
+		String fieldPath = getFieldPath();
+
+		query = matchNonEmptyQuery( f -> f.field( fieldPath ).asc().missing()
+				.use( getSingleValueForMissingUse( BEFORE_DOCUMENT_1_ORDINAL ) ), scope );
+
+		/*
+		 * Not testing the ordering of results here because it's not what we are interested in:
+		 * we just want to check that fields are correctly detected as compatible,
+		 * that no exception is thrown and that the query is correctly executed on all indexes
+		 * with no silent error (HSEARCH-4173).
+		 */
+		assertThatQuery( query ).hasDocRefHitsAnyOrder( b -> {
+			b.doc( missingFieldIndex.typeName(), MISSING_FIELD_INDEX_DOCUMENT_1 );
+			b.doc( mainIndex.typeName(), DOCUMENT_1 );
+			b.doc( mainIndex.typeName(), DOCUMENT_2 );
+			b.doc( mainIndex.typeName(), DOCUMENT_3 );
+		} );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4173")
+	public void multiIndex_withMissingFieldIndex_dslConverterDisabled() {
+		assumeTrue(
+				"This backend doesn't support sorts on a field of type '" + fieldTypeDescriptor
+						+ "' that is missing from some of the target indexes.",
+				TckConfiguration.get().getBackendFeatures()
+						.supportsFieldSortWhenFieldMissingInSomeTargetIndexes( fieldTypeDescriptor.getJavaType() )
+		);
+
+		StubMappingScope scope = mainIndex.createScope( missingFieldIndex );
+
+		SearchQuery<DocumentReference> query;
+		String fieldPath = getFieldPath();
+
+		query = matchNonEmptyQuery( f -> f.field( fieldPath ).asc().missing()
+				.use( getSingleValueForMissingUse( BEFORE_DOCUMENT_1_ORDINAL ), ValueConvert.NO ), scope );
+
+		/*
+		 * Not testing the ordering of results here because it's not what we are interested in:
+		 * we just want to check that fields are correctly detected as compatible,
+		 * that no exception is thrown and that the query is correctly executed on all indexes
+		 * with no silent error (HSEARCH-4173).
+		 */
+		assertThatQuery( query ).hasDocRefHitsAnyOrder( b -> {
+			b.doc( missingFieldIndex.typeName(), MISSING_FIELD_INDEX_DOCUMENT_1 );
+			b.doc( mainIndex.typeName(), DOCUMENT_1 );
+			b.doc( mainIndex.typeName(), DOCUMENT_2 );
+			b.doc( mainIndex.typeName(), DOCUMENT_3 );
+		} );
+	}
+
+	/**
+	 * Test the behavior when even the <strong>parent</strong> field of the field to sort on is missing,
+	 * and that parent field is <strong>nested</strong> in the main index.
+	 */
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4173")
+	public void multiIndex_withMissingFieldIndex_nested() {
+		assumeTrue(
+				"This backend doesn't support sorts on a field of type '" + fieldTypeDescriptor
+						+ "' that is missing from some of the target indexes.",
+				TckConfiguration.get().getBackendFeatures()
+						.supportsFieldSortWhenFieldMissingInSomeTargetIndexes( fieldTypeDescriptor.getJavaType() )
+		);
+		assumeTrue(
+				"This backend doesn't support field sorts on a nested field that is missing from some of the target indexes.",
+				TckConfiguration.get().getBackendFeatures().supportsFieldSortWhenNestedFieldMissingInSomeTargetIndexes()
+		);
+
+		StubMappingScope scope = mainIndex.createScope( missingFieldIndex );
+
+		SearchQuery<DocumentReference> query;
+		String fieldPath = getFieldInNestedPath();
+
+		query = matchNonEmptyQuery( f -> f.field( fieldPath ).asc().missing()
+				.use( getSingleValueForMissingUse( BEFORE_DOCUMENT_1_ORDINAL ) ), scope );
+
+		/*
+		 * Not testing the ordering of results here because it's not what we are interested in:
+		 * we just want to check that fields are correctly detected as compatible,
+		 * that no exception is thrown and that the query is correctly executed on all indexes
+		 * with no silent error (HSEARCH-4173).
+		 */
+		assertThatQuery( query ).hasDocRefHitsAnyOrder( b -> {
+			b.doc( missingFieldIndex.typeName(), MISSING_FIELD_INDEX_DOCUMENT_1 );
+			b.doc( mainIndex.typeName(), DOCUMENT_1 );
+			b.doc( mainIndex.typeName(), DOCUMENT_2 );
+			b.doc( mainIndex.typeName(), DOCUMENT_3 );
+		} );
+	}
+
+	@Test
 	public void multiIndex_withIncompatibleIndex_dslConverterEnabled() {
 		StubMappingScope scope = mainIndex.createScope( incompatibleIndex );
 
@@ -341,8 +453,21 @@ public class FieldSearchSortTypeCheckingAndConversionIT<F> {
 				.toQuery();
 	}
 
+	private SearchQuery<DocumentReference> matchNonEmptyQuery(
+			Function<? super SearchSortFactory, ? extends SortFinalStep> sortContributor, StubMappingScope scope) {
+		return scope.query()
+				.where( f -> f.matchAll().except( f.id().matching( EMPTY ) ) )
+				.sort( sortContributor )
+				.toQuery();
+	}
+
 	private String getFieldPath() {
 		return mainIndex.binding().fieldModels.get( fieldTypeDescriptor ).relativeFieldName;
+	}
+
+	private String getFieldInNestedPath() {
+		return mainIndex.binding().nested.relativeFieldName
+				+ '.' + mainIndex.binding().nested.fieldModels.get( fieldTypeDescriptor ).relativeFieldName;
 	}
 
 	private String getFieldWithDslConverterPath() {
@@ -356,6 +481,10 @@ public class FieldSearchSortTypeCheckingAndConversionIT<F> {
 	private static void initDocument(IndexBinding indexBinding, DocumentElement document, Integer ordinal) {
 		indexBinding.fieldModels.forEach( fieldModel -> addValue( fieldModel, document, ordinal ) );
 		indexBinding.fieldWithDslConverterModels.forEach( fieldModel -> addValue( fieldModel, document, ordinal ) );
+
+		DocumentElement nested = document.addObject( indexBinding.nested.self );
+		indexBinding.nested.fieldModels.forEach( fieldModel -> addValue( fieldModel, nested, ordinal ) );
+		indexBinding.nested.fieldWithDslConverterModels.forEach( fieldModel -> addValue( fieldModel, nested, ordinal ) );
 	}
 
 	@SuppressWarnings("unchecked")
@@ -398,19 +527,17 @@ public class FieldSearchSortTypeCheckingAndConversionIT<F> {
 		BulkIndexer rawFieldCompatibleIndexer = rawFieldCompatibleIndex.bulkIndexer()
 				.add( RAW_FIELD_COMPATIBLE_INDEX_DOCUMENT_1,
 						document -> initDocument( rawFieldCompatibleIndex.binding(), document, DOCUMENT_1_ORDINAL ) );
-		mainIndexer.join( compatibleIndexer, rawFieldCompatibleIndexer );
+		BulkIndexer missingFieldIndexer = missingFieldIndex.bulkIndexer()
+				.add( MISSING_FIELD_INDEX_DOCUMENT_1, document -> { } );
+		mainIndexer.join( compatibleIndexer, rawFieldCompatibleIndexer, missingFieldIndexer );
 	}
 
-	private static class IndexBinding {
+	private static class AbstractObjectMapping {
 		final SimpleFieldModelsByType fieldModels;
 		final SimpleFieldModelsByType fieldWithDslConverterModels;
 		final SimpleFieldModelsByType nonSortableFieldModels;
 
-		IndexBinding(IndexSchemaElement root) {
-			this( root, ignored -> { } );
-		}
-
-		IndexBinding(IndexSchemaElement root,
+		AbstractObjectMapping(IndexSchemaElement root,
 				Consumer<StandardIndexFieldTypeOptionsStep<?, ?>> additionalConfiguration) {
 			fieldModels = SimpleFieldModelsByType.mapAll(
 					supportedFieldTypes,
@@ -428,6 +555,40 @@ public class FieldSearchSortTypeCheckingAndConversionIT<F> {
 					c -> c.sortable( Sortable.YES ),
 					additionalConfiguration.andThen( c -> c.sortable( Sortable.NO ) )
 			);
+		}
+	}
+
+	private static class IndexBinding extends AbstractObjectMapping {
+		final FirstLevelObjectMapping nested;
+
+		IndexBinding(IndexSchemaElement root) {
+			this( root, ignored -> { } );
+		}
+
+		IndexBinding(IndexSchemaElement root,
+				Consumer<StandardIndexFieldTypeOptionsStep<?, ?>> additionalConfiguration) {
+			super( root, additionalConfiguration );
+			nested = FirstLevelObjectMapping.create( root, "nested", ObjectStructure.NESTED,
+					additionalConfiguration );
+		}
+	}
+
+	private static class FirstLevelObjectMapping extends AbstractObjectMapping {
+		final String relativeFieldName;
+		final IndexObjectFieldReference self;
+
+		public static FirstLevelObjectMapping create(IndexSchemaElement parent, String relativeFieldName,
+				ObjectStructure structure,
+				Consumer<StandardIndexFieldTypeOptionsStep<?, ?>> additionalConfiguration) {
+			IndexSchemaObjectField objectField = parent.objectField( relativeFieldName, structure );
+			return new FirstLevelObjectMapping( relativeFieldName, objectField, additionalConfiguration );
+		}
+
+		private FirstLevelObjectMapping(String relativeFieldName, IndexSchemaObjectField objectField,
+				Consumer<StandardIndexFieldTypeOptionsStep<?, ?>> additionalConfiguration) {
+			super( objectField, additionalConfiguration );
+			this.relativeFieldName = relativeFieldName;
+			self = objectField.toReference();
 		}
 	}
 
@@ -469,6 +630,11 @@ public class FieldSearchSortTypeCheckingAndConversionIT<F> {
 			 * but with an incompatible DSL converter.
 			 */
 			super( root, c -> c.dslConverter( ValueWrapper.class, ValueWrapper.toIndexFieldConverter() ) );
+		}
+	}
+
+	private static class MissingFieldIndexBinding {
+		MissingFieldIndexBinding(IndexSchemaElement root) {
 		}
 	}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/TckBackendFeatures.java
@@ -74,4 +74,20 @@ public class TckBackendFeatures {
 	public boolean supportsExistsForFieldWithoutDocValues(Class<?> fieldType) {
 		return true;
 	}
+
+	public boolean supportsDistanceSortWhenFieldMissingInSomeTargetIndexes() {
+		return true;
+	}
+
+	public boolean supportsDistanceSortWhenNestedFieldMissingInSomeTargetIndexes() {
+		return true;
+	}
+
+	public boolean supportsFieldSortWhenFieldMissingInSomeTargetIndexes(Class<?> fieldType) {
+		return true;
+	}
+
+	public boolean supportsFieldSortWhenNestedFieldMissingInSomeTargetIndexes() {
+		return true;
+	}
 }

--- a/parents/integrationtest/pom.xml
+++ b/parents/integrationtest/pom.xml
@@ -405,12 +405,36 @@
             </build>
         </profile>
 
-        <!-- Elasticsearch 6.7 to 6.8 test environment -->
+        <!-- Elasticsearch 6.7 test environment -->
         <profile>
             <id>elasticsearch-6.7</id>
             <properties>
-                <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-6.8}</test.elasticsearch.connection.version>
+                <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-6.7}</test.elasticsearch.connection.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch67TestDialect</test.elasticsearch.testdialect>
+            </properties>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>com.github.alexcojocaru</groupId>
+                            <artifactId>elasticsearch-maven-plugin</artifactId>
+                            <version>${version.com.github.alexcojocaru.elasticsearch.plugin}</version>
+                            <configuration>
+                                <pathConf>${project.build.directory}/elasticsearch-maven-plugin/6.0/configuration/</pathConf>
+                                <pathInitScript>${project.build.directory}/elasticsearch-maven-plugin/6.0/init/init.script</pathInitScript>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+
+        <!-- Elasticsearch 6.8 test environment -->
+        <profile>
+            <id>elasticsearch-6.8</id>
+            <properties>
+                <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-6.8}</test.elasticsearch.connection.version>
+                <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch68TestDialect</test.elasticsearch.testdialect>
             </properties>
             <build>
                 <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -215,6 +215,7 @@
         <version.org.elasticsearch.latest-7.6>7.6.2</version.org.elasticsearch.latest-7.6>
         <version.org.elasticsearch.latest-7.2>7.2.1</version.org.elasticsearch.latest-7.2>
         <version.org.elasticsearch.latest-6.8>6.8.9</version.org.elasticsearch.latest-6.8>
+        <version.org.elasticsearch.latest-6.7>6.7.2</version.org.elasticsearch.latest-6.7>
         <version.org.elasticsearch.latest-6.6>6.6.2</version.org.elasticsearch.latest-6.6>
         <version.org.elasticsearch.latest-6.3>6.3.2</version.org.elasticsearch.latest-6.3>
         <version.org.elasticsearch.latest-6.2>6.2.4</version.org.elasticsearch.latest-6.2>

--- a/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/dialect/Elasticsearch63TestDialect.java
+++ b/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/dialect/Elasticsearch63TestDialect.java
@@ -12,4 +12,13 @@ public class Elasticsearch63TestDialect extends Elasticsearch64TestDialect {
 	public boolean supportsIsWriteIndex() {
 		return false;
 	}
+
+	@Override
+	public boolean supportsIgnoreUnmappedForGeoPointField() {
+		// Support for ignore_unmapped in geo_distance sorts added in 6.4:
+		// https://github.com/elastic/elasticsearch/pull/31153
+		// In 6.3 and below, we just can't ignore unmapped fields,
+		// which means sorts will fail when the geo_point field is not present in all indexes.
+		return false;
+	}
 }

--- a/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/dialect/Elasticsearch67TestDialect.java
+++ b/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/dialect/Elasticsearch67TestDialect.java
@@ -8,6 +8,13 @@ package org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dia
 
 public class Elasticsearch67TestDialect extends Elasticsearch68TestDialect {
 
-	// TODO HSEARCH-4173 add behavior specific to 6.7 here
+	@Override
+	public boolean ignoresFieldSortWhenNestedFieldMissing() {
+		// Support for ignoring field sorts when a nested field is missing was added in 6.8.1/7.1.2:
+		// https://github.com/elastic/elasticsearch/pull/42451
+		// In 6.8.0 and below, we just can't ignore unmapped nested fields in field sorts,
+		// which means sorts will fail when the nested field is not present in all indexes.
+		return false;
+	}
 
 }

--- a/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/dialect/Elasticsearch67TestDialect.java
+++ b/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/dialect/Elasticsearch67TestDialect.java
@@ -6,48 +6,8 @@
  */
 package org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
+public class Elasticsearch67TestDialect extends Elasticsearch68TestDialect {
 
-import org.hibernate.search.backend.elasticsearch.client.impl.Paths;
-import org.hibernate.search.backend.elasticsearch.util.spi.URLEncodedString;
+	// TODO HSEARCH-4173 add behavior specific to 6.7 here
 
-@SuppressWarnings("deprecation") // We use Paths.DOC on purpose
-public class Elasticsearch67TestDialect extends Elasticsearch70TestDialect {
-
-	@Override
-	public boolean isEmptyMappingPossible() {
-		return true;
-	}
-
-	@Override
-	public URLEncodedString getTypeKeywordForNonMappingApi() {
-		return Paths.DOC;
-	}
-
-	@Override
-	public Optional<URLEncodedString> getTypeNameForMappingAndBulkApi() {
-		return Optional.of( Paths.DOC );
-	}
-
-	@Override
-	public Boolean getIncludeTypeNameParameterForMappingApi() {
-		return true;
-	}
-
-	@Override
-	public List<String> getAllLocalDateDefaultMappingFormats() {
-		return Arrays.asList( "yyyy-MM-dd", "yyyyyyyyy-MM-dd" );
-	}
-
-	@Override
-	public boolean zonedDateTimeDocValueHasUTCZoneId() {
-		return true;
-	}
-
-	@Override
-	public boolean supportsSkipOrLimitingTotalHitCount() {
-		return false;
-	}
 }

--- a/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/dialect/Elasticsearch68TestDialect.java
+++ b/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/dialect/Elasticsearch68TestDialect.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 
 import org.hibernate.search.backend.elasticsearch.client.impl.Paths;
 import org.hibernate.search.backend.elasticsearch.util.spi.URLEncodedString;
+import org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.ElasticsearchTestHostConnectionConfiguration;
 
 @SuppressWarnings("deprecation") // We use Paths.DOC on purpose
 public class Elasticsearch68TestDialect extends Elasticsearch70TestDialect {
@@ -49,5 +50,14 @@ public class Elasticsearch68TestDialect extends Elasticsearch70TestDialect {
 	@Override
 	public boolean supportsSkipOrLimitingTotalHitCount() {
 		return false;
+	}
+
+	@Override
+	public boolean ignoresFieldSortWhenNestedFieldMissing() {
+		// AWS apparently didn't apply this patch, which solves the problem in 6.8.1/7.1.2,
+		// to their 6.8 branch:
+		// https://github.com/elastic/elasticsearch/pull/42451
+		return !ElasticsearchTestHostConnectionConfiguration.get().isAws()
+				&& super.ignoresFieldSortWhenNestedFieldMissing();
 	}
 }

--- a/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/dialect/Elasticsearch68TestDialect.java
+++ b/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/dialect/Elasticsearch68TestDialect.java
@@ -1,0 +1,53 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.hibernate.search.backend.elasticsearch.client.impl.Paths;
+import org.hibernate.search.backend.elasticsearch.util.spi.URLEncodedString;
+
+@SuppressWarnings("deprecation") // We use Paths.DOC on purpose
+public class Elasticsearch68TestDialect extends Elasticsearch70TestDialect {
+
+	@Override
+	public boolean isEmptyMappingPossible() {
+		return true;
+	}
+
+	@Override
+	public URLEncodedString getTypeKeywordForNonMappingApi() {
+		return Paths.DOC;
+	}
+
+	@Override
+	public Optional<URLEncodedString> getTypeNameForMappingAndBulkApi() {
+		return Optional.of( Paths.DOC );
+	}
+
+	@Override
+	public Boolean getIncludeTypeNameParameterForMappingApi() {
+		return true;
+	}
+
+	@Override
+	public List<String> getAllLocalDateDefaultMappingFormats() {
+		return Arrays.asList( "yyyy-MM-dd", "yyyyyyyyy-MM-dd" );
+	}
+
+	@Override
+	public boolean zonedDateTimeDocValueHasUTCZoneId() {
+		return true;
+	}
+
+	@Override
+	public boolean supportsSkipOrLimitingTotalHitCount() {
+		return false;
+	}
+}

--- a/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/dialect/Elasticsearch710TestDialect.java
+++ b/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/dialect/Elasticsearch710TestDialect.java
@@ -161,4 +161,14 @@ public class Elasticsearch710TestDialect implements ElasticsearchTestDialect {
 	public boolean hasBugForExistsOnNullGeoPointFieldWithoutDocValues() {
 		return true;
 	}
+
+	@Override
+	public boolean supportsIgnoreUnmappedForGeoPointField() {
+		return true;
+	}
+
+	@Override
+	public boolean ignoresFieldSortWhenNestedFieldMissing() {
+		return true;
+	}
 }

--- a/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/dialect/ElasticsearchTestDialect.java
+++ b/util/internal/integrationtest/backend/elasticsearch/src/main/java/org/hibernate/search/util/impl/integrationtest/backend/elasticsearch/dialect/ElasticsearchTestDialect.java
@@ -76,4 +76,9 @@ public interface ElasticsearchTestDialect {
 	boolean supportsSkipOrLimitingTotalHitCount();
 
 	boolean hasBugForExistsOnNullGeoPointFieldWithoutDocValues();
+
+	boolean supportsIgnoreUnmappedForGeoPointField();
+
+	boolean ignoresFieldSortWhenNestedFieldMissing();
+
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4173
