### PR TITLE
HSEARCH-4183 SearchResult.took() returns incorrect, very large value with the Lucene backend

### DIFF
--- a/engine/src/main/java/org/hibernate/search/engine/search/timeout/spi/TimeoutManager.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/timeout/spi/TimeoutManager.java
@@ -153,7 +153,7 @@ public class TimeoutManager {
 	 * @return high precision duration of took time.
 	 */
 	public Duration tookTime() {
-		return Duration.ofMillis( timingSource.nanoTime() - nanoTimeStart );
+		return Duration.ofNanos( timingSource.nanoTime() - nanoTimeStart );
 	}
 
 	protected long elapsedTimeEstimateMillis() {

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/query/SearchQueryBaseIT.java
@@ -11,10 +11,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatQuery;
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatResult;
 import static org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMapperUtils.documentProvider;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assume.assumeTrue;
 
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 
 import org.hibernate.search.engine.backend.common.DocumentReference;
@@ -39,6 +39,7 @@ import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubSearchLoadingContext;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingScope;
+import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -68,14 +69,15 @@ public class SearchQueryBaseIT {
 	}
 
 	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4183")
 	public void tookAndTimedOut() {
 		SearchQuery<DocumentReference> query = matchAllSortedByScoreQuery()
 				.toQuery();
 
 		SearchResult<DocumentReference> result = query.fetchAll();
 
-		assertNotNull( result.took() );
-		assertFalse( result.timedOut() );
+		assertThat( result.took() ).isBetween( Duration.ZERO, Duration.of( 1, ChronoUnit.MINUTES ) );
+		assertThat( result.timedOut() ).isFalse();
 	}
 
 	@Test


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4183
