### PR TITLE
HSEARCH-4184 A contained entity with only irrelevant changes may mistakenly trigger reindexing

### DIFF
--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/impl/PojoImplicitReindexingResolverDirtinessFilterNode.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/impl/PojoImplicitReindexingResolverDirtinessFilterNode.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.search.mapper.pojo.automaticindexing.impl;
 
-import java.util.BitSet;
-
 import org.hibernate.search.mapper.pojo.model.path.spi.PojoPathFilter;
 import org.hibernate.search.util.common.impl.Contracts;
 import org.hibernate.search.util.common.impl.ToStringTreeBuilder;
@@ -48,9 +46,7 @@ public class PojoImplicitReindexingResolverDirtinessFilterNode<T> extends PojoIm
 	@Override
 	public void resolveEntitiesToReindex(PojoReindexingCollector collector,
 			T dirty, PojoImplicitReindexingResolverRootContext context) {
-		BitSet dirtinessState = context.dirtinessState();
-		// See method javadoc: null means we must consider all paths as dirty
-		if ( dirtinessState == null || dirtyPathFilter.test( dirtinessState ) ) {
+		if ( context.isDirty( dirtyPathFilter ) ) {
 			nested.resolveEntitiesToReindex( collector, dirty, context );
 		}
 	}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/impl/PojoImplicitReindexingResolverNode.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/impl/PojoImplicitReindexingResolverNode.java
@@ -32,9 +32,8 @@ public abstract class PojoImplicitReindexingResolverNode<T> implements AutoClose
 	 * taking into account the given "dirtiness state".
 	 *  @param collector A collector for entities that should be reindexed.
 	 * @param dirty A value that is dirty to some extent.
-	 * @param context The set of dirty paths in the object passed to the root reindexing resolver
-	 * (resolvers may delegate to other resolvers, but they will always pass the same dirtiness state to delegates).
-	 * {@code null} can be passed to mean "no information", in which case all paths are considered dirty.
+	 * @param context A context representing the root entity, and including in particular information about dirty paths.
+	 * Resolvers should always pass this context as-is when delegating to other resolvers.
 	 */
 	public abstract void resolveEntitiesToReindex(PojoReindexingCollector collector,
 			T dirty, PojoImplicitReindexingResolverRootContext context);

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/impl/PojoImplicitReindexingResolverNode.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/impl/PojoImplicitReindexingResolverNode.java
@@ -33,8 +33,8 @@ public abstract class PojoImplicitReindexingResolverNode<T> implements AutoClose
 	 *  @param collector A collector for entities that should be reindexed.
 	 * @param dirty A value that is dirty to some extent.
 	 * @param context The set of dirty paths in the object passed to the root reindexing resolver
- * (resolvers may delegate to other resolvers, but they will always pass the same dirtiness state to delegates).
- * {@code null} can be passed to mean "no information", in which case all paths are considered dirty.
+	 * (resolvers may delegate to other resolvers, but they will always pass the same dirtiness state to delegates).
+	 * {@code null} can be passed to mean "no information", in which case all paths are considered dirty.
 	 */
 	public abstract void resolveEntitiesToReindex(PojoReindexingCollector collector,
 			T dirty, PojoImplicitReindexingResolverRootContext context);

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/impl/PojoImplicitReindexingResolverRootContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/impl/PojoImplicitReindexingResolverRootContext.java
@@ -6,9 +6,8 @@
  */
 package org.hibernate.search.mapper.pojo.automaticindexing.impl;
 
-import java.util.BitSet;
-
 import org.hibernate.search.mapper.pojo.automaticindexing.spi.PojoImplicitReindexingResolverSessionContext;
+import org.hibernate.search.mapper.pojo.model.path.spi.PojoPathFilter;
 
 /**
  * The context passed to a {@link PojoImplicitReindexingResolver}
@@ -26,9 +25,9 @@ public interface PojoImplicitReindexingResolverRootContext {
 	PojoImplicitReindexingResolverSessionContext sessionContext();
 
 	/**
-	 * @return The set of dirty paths in the root entity.
-	 * {@code null} means "no information", in which case all paths are considered dirty.
+	 * @param filter A path filter for dirty paths.
+	 * @return Whether the root is dirty according to the given filter.
 	 */
-	BitSet dirtinessState();
+	boolean isDirty(PojoPathFilter filter);
 
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/AbstractPojoTypeIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/AbstractPojoTypeIndexingPlan.java
@@ -13,6 +13,7 @@ import java.util.function.Supplier;
 
 import org.hibernate.search.mapper.pojo.automaticindexing.impl.PojoImplicitReindexingResolverRootContext;
 import org.hibernate.search.mapper.pojo.automaticindexing.spi.PojoImplicitReindexingResolverSessionContext;
+import org.hibernate.search.mapper.pojo.model.path.spi.PojoPathFilter;
 import org.hibernate.search.mapper.pojo.route.DocumentRoutesDescriptor;
 import org.hibernate.search.mapper.pojo.work.spi.PojoWorkSessionContext;
 
@@ -102,9 +103,9 @@ abstract class AbstractPojoTypeIndexingPlan<I, E, S extends AbstractPojoTypeInde
 		EntityStatus initialStatus = EntityStatus.UNKNOWN;
 		EntityStatus currentStatus = EntityStatus.UNKNOWN;
 
-		boolean shouldResolveToReindex;
-		boolean considerAllDirty;
-		BitSet dirtyPaths;
+		private boolean shouldResolveToReindex;
+		private boolean considerAllDirty;
+		private BitSet dirtyPaths;
 
 		AbstractEntityState(I identifier) {
 			this.identifier = identifier;
@@ -116,8 +117,8 @@ abstract class AbstractPojoTypeIndexingPlan<I, E, S extends AbstractPojoTypeInde
 		}
 
 		@Override
-		public BitSet dirtinessState() {
-			return dirtyPaths;
+		public boolean isDirty(PojoPathFilter filter) {
+			return considerAllDirty || dirtyPaths != null && filter.test( dirtyPaths );
 		}
 
 		void add(Supplier<E> entitySupplier) {

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/AbstractPojoTypeIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/AbstractPojoTypeIndexingPlan.java
@@ -174,6 +174,7 @@ abstract class AbstractPojoTypeIndexingPlan<I, E, S extends AbstractPojoTypeInde
 				loadingOrdinal = root.loadingPlan().planLoading( typeContext().typeIdentifier(), identifier );
 			}
 		}
+
 		void resolveDirty() {
 			if ( shouldResolveToReindex ) {
 				shouldResolveToReindex = false; // Avoid infinite looping
@@ -211,6 +212,6 @@ abstract class AbstractPojoTypeIndexingPlan<I, E, S extends AbstractPojoTypeInde
 	protected enum EntityStatus {
 		UNKNOWN,
 		PRESENT,
-		ABSENT;
+		ABSENT
 	}
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexedTypeIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexedTypeIndexingPlan.java
@@ -152,8 +152,7 @@ public class PojoIndexedTypeIndexingPlan<I, E>
 							return;
 						case PRESENT:
 						case UNKNOWN:
-							if ( considerAllDirty || updatedBecauseOfContained
-									|| dirtyPaths != null && typeContext.dirtySelfFilter().test( dirtyPaths ) ) {
+							if ( updatedBecauseOfContained || isDirty( typeContext.dirtySelfFilter() ) ) {
 								delegateAddOrUpdate();
 							}
 							return;


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4184
