### PR TITLE
HSEARCH-4185 Fix cast type when searching in mapper-javabean.

### DIFF
--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/session/SearchSession.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/session/SearchSession.java
@@ -34,7 +34,7 @@ public interface SearchSession extends AutoCloseable {
 	 * @return The initial step of a DSL where the search query can be defined.
 	 * @see SearchQuerySelectStep
 	 */
-	default <T> SearchQuerySelectStep<?, EntityReference, ?, ?, ?, ?> search(Class<T> type) {
+	default <T> SearchQuerySelectStep<?, EntityReference, T, ?, ?, ?> search(Class<T> type) {
 		return search( Collections.singleton( type ) );
 	}
 
@@ -48,7 +48,7 @@ public interface SearchSession extends AutoCloseable {
 	 * @return The initial step of a DSL where the search query can be defined.
 	 * @see SearchQuerySelectStep
 	 */
-	<T> SearchQuerySelectStep<?, EntityReference, ?, ?, ?, ?> search(Collection<? extends Class<? extends T>> types);
+	<T> SearchQuerySelectStep<?, EntityReference, T, ?, ?, ?> search(Collection<? extends Class<? extends T>> types);
 
 	/**
 	 * Initiate the building of a search query.
@@ -60,7 +60,7 @@ public interface SearchSession extends AutoCloseable {
 	 * @return The initial step of a DSL where the search query can be defined.
 	 * @see SearchQuerySelectStep
 	 */
-	<T> SearchQuerySelectStep<?, EntityReference, ?, ?, ?, ?> search(SearchScope<T> scope);
+	<T> SearchQuerySelectStep<?, EntityReference, T, ?, ?, ?> search(SearchScope<T> scope);
 
 	/**
 	 * Create a {@link SearchScope} limited to the given type.

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/session/impl/JavaBeanSearchSession.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/session/impl/JavaBeanSearchSession.java
@@ -78,12 +78,12 @@ public class JavaBeanSearchSession extends AbstractPojoSearchSession
 	}
 
 	@Override
-	public <T> SearchQuerySelectStep<?, EntityReference, ?, ?, ?, ?> search(Collection<? extends Class<? extends T>> types) {
+	public <T> SearchQuerySelectStep<?, EntityReference, T, ?, ?, ?> search(Collection<? extends Class<? extends T>> types) {
 		return search( scope( types ) );
 	}
 
 	@Override
-	public <T> SearchQuerySelectStep<?, EntityReference, ?, ?, ?, ?> search(SearchScope<T> scope) {
+	public <T> SearchQuerySelectStep<?, EntityReference, T, ?, ?, ?> search(SearchScope<T> scope) {
 		return search( (SearchScopeImpl<T>) scope );
 	}
 
@@ -135,7 +135,7 @@ public class JavaBeanSearchSession extends AbstractPojoSearchSession
 		return loadingContextBuilder().build();
 	}
 
-	private <T> SearchQuerySelectStep<?, EntityReference, ?, ?, ?, ?> search(SearchScopeImpl<T> scope) {
+	private <T> SearchQuerySelectStep<?, EntityReference, T, ?, ?, ?> search(SearchScopeImpl<T> scope) {
 		return scope.search( this, this, loadingContextBuilder() );
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/jira/software/c/projects/HSEARCH/issues/HSEARCH-4185
Fix cast type when searching in mapper-javabean.

```java
SearchResult<Book> result /*not cast*/ = session.search( scope )
					.where( (t) -> t.matchAll() )
					.fetchAll();
```