### PR TITLE
Backport HSEARCH-4173 to branch 6.0 - Multi-index Elasticsearch query fails (sometimes silently) when field is present in only one index

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/AbstractElasticsearchNestablePredicate.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/search/predicate/impl/AbstractElasticsearchNestablePredicate.java
@@ -10,7 +10,6 @@ import java.lang.invoke.MethodHandles;
 import java.util.List;
 import java.util.Objects;
 
-import org.hibernate.search.backend.elasticsearch.gson.impl.JsonAccessor;
 import org.hibernate.search.backend.elasticsearch.logging.impl.Log;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
@@ -19,8 +18,6 @@ import com.google.gson.JsonObject;
 public abstract class AbstractElasticsearchNestablePredicate extends AbstractElasticsearchPredicate {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
-	private static final JsonAccessor<String> PATH_ACCESSOR = JsonAccessor.root().property( "path" ).asString();
-	private static final JsonAccessor<JsonObject> QUERY_ACCESSOR = JsonAccessor.root().property( "query" ).asObject();
 
 	AbstractElasticsearchNestablePredicate(AbstractElasticsearchPredicate.AbstractBuilder builder) {
 		super( builder );
@@ -66,13 +63,9 @@ public abstract class AbstractElasticsearchNestablePredicate extends AbstractEla
 				break;
 			}
 
-			JsonObject innerObject = new JsonObject();
-
-			PATH_ACCESSOR.set( innerObject, path );
-			QUERY_ACCESSOR.set( innerObject, result );
-
 			JsonObject outerObject = new JsonObject();
-			outerObject.add( "nested", innerObject );
+			JsonObject innerObject = new JsonObject();
+			ElasticsearchNestedPredicate.wrap( indexNames(), path, outerObject, innerObject, result );
 			result = outerObject;
 		}
 

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/AbstractPredicateFieldNestingIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/AbstractPredicateFieldNestingIT.java
@@ -16,8 +16,9 @@ public abstract class AbstractPredicateFieldNestingIT<V extends AbstractPredicat
 
 	protected final DataSet<?, V> dataSet;
 
-	public AbstractPredicateFieldNestingIT(SimpleMappedIndex<IndexBinding> index, DataSet<?, V> dataSet) {
-		super( index, dataSet );
+	public AbstractPredicateFieldNestingIT(SimpleMappedIndex<IndexBinding> mainIndex,
+			SimpleMappedIndex<MissingFieldIndexBinding> missingFieldIndex, DataSet<?, V> dataSet) {
+		super( mainIndex, missingFieldIndex, dataSet );
 		this.dataSet = dataSet;
 	}
 
@@ -35,12 +36,16 @@ public abstract class AbstractPredicateFieldNestingIT<V extends AbstractPredicat
 			super( values );
 		}
 
-		public void contribute(SimpleMappedIndex<IndexBinding> index, BulkIndexer indexer) {
+		public void contribute(SimpleMappedIndex<IndexBinding> mainIndex, BulkIndexer mainIndexer,
+				SimpleMappedIndex<MissingFieldIndexBinding> missingFieldIndex, BulkIndexer missingFieldIndexer) {
 			F fieldValue = values.fieldValue( 0 );
-			indexer.add( docId( 0 ), routingKey,
-					document -> index.binding().initDocument( document, fieldType, fieldValue ) );
+			mainIndexer.add( docId( 0 ), routingKey,
+					document -> mainIndex.binding().initDocument( document, fieldType, fieldValue ) );
 			// Also add an empty document that shouldn't match
-			indexer.add( docId( 1 ), routingKey, document -> { } );
+			mainIndexer.add( docId( 1 ), routingKey, document -> { } );
+
+			missingFieldIndexer.add( docId( MISSING_FIELD_INDEX_DOC_ORDINAL ), routingKey,
+					document -> missingFieldIndex.binding().initDocument() );
 		}
 	}
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/ExistsPredicateBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/ExistsPredicateBaseIT.java
@@ -39,7 +39,8 @@ public class ExistsPredicateBaseIT {
 	public static void setup() {
 		setupHelper.start()
 				.withIndexes(
-						NestingIT.index, SingleFieldIT.index,
+						SingleFieldIT.index,
+						NestingIT.mainIndex, NestingIT.missingFieldIndex,
 						ScoreIT.index,
 						InvalidFieldIT.index,
 						SearchableIT.searchableYesIndex, SearchableIT.searchableNoIndex,
@@ -53,8 +54,10 @@ public class ExistsPredicateBaseIT {
 		final BulkIndexer singleFieldIndexer = SingleFieldIT.index.bulkIndexer();
 		SingleFieldIT.dataSets.forEach( d -> d.contribute( SingleFieldIT.index, singleFieldIndexer ) );
 
-		final BulkIndexer nestingIndexer = NestingIT.index.bulkIndexer();
-		NestingIT.dataSets.forEach( d -> d.contribute( NestingIT.index, nestingIndexer ) );
+		final BulkIndexer nestingMainIndexer = NestingIT.mainIndex.bulkIndexer();
+		final BulkIndexer nestingMissingFieldIndexer = NestingIT.missingFieldIndex.bulkIndexer();
+		NestingIT.dataSets.forEach( d -> d.contribute( NestingIT.mainIndex, nestingMainIndexer,
+				NestingIT.missingFieldIndex, nestingMissingFieldIndexer ) );
 
 		final BulkIndexer scoreIndexer = ScoreIT.index.bulkIndexer();
 		ScoreIT.dataSets.forEach( d -> d.contribute( scoreIndexer ) );
@@ -74,7 +77,7 @@ public class ExistsPredicateBaseIT {
 				ScaleCheckingIT.compatibleIndex, scaleCheckingCompatibleIndexer );
 
 		singleFieldIndexer.join(
-				nestingIndexer, scoreIndexer,
+				nestingMainIndexer, nestingMissingFieldIndexer, scoreIndexer,
 				typeCheckingMainIndexer, typeCheckingCompatibleIndexer,
 				typeCheckingRawFieldCompatibleIndexer, typeCheckingMissingFieldIndexer,
 				scaleCheckingMainIndexer, scaleCheckingCompatibleIndexer
@@ -226,9 +229,13 @@ public class ExistsPredicateBaseIT {
 			}
 		}
 
-		private static final SimpleMappedIndex<IndexBinding> index =
+		private static final SimpleMappedIndex<IndexBinding> mainIndex =
 				SimpleMappedIndex.of( root -> new IndexBinding( root, supportedFieldTypes ) )
 						.name( "nesting" );
+
+		private static final SimpleMappedIndex<MissingFieldIndexBinding> missingFieldIndex =
+				SimpleMappedIndex.of( root -> new MissingFieldIndexBinding( root, supportedFieldTypes ) )
+						.name( "nesting_missingField" );
 
 		@Parameterized.Parameters(name = "{0}")
 		public static List<Object[]> parameters() {
@@ -236,7 +243,7 @@ public class ExistsPredicateBaseIT {
 		}
 
 		public NestingIT(DataSet<F, ExistsPredicateTestValues<F>> dataSet) {
-			super( index, dataSet );
+			super( mainIndex, missingFieldIndex, dataSet );
 		}
 
 		@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchAllPredicateBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchAllPredicateBaseIT.java
@@ -35,17 +35,19 @@ public class MatchAllPredicateBaseIT {
 	public static void setup() {
 		setupHelper.start()
 				.withIndexes(
-						NestingIT.index, ScoreIT.index
+						NestingIT.mainIndex, NestingIT.missingFieldIndex,
+						ScoreIT.index
 				)
 				.setup();
 
-		final BulkIndexer nestingIndexer = NestingIT.index.bulkIndexer();
-		NestingIT.dataSet.contribute( nestingIndexer );
+		final BulkIndexer nestingMainIndexer = NestingIT.mainIndex.bulkIndexer();
+		final BulkIndexer nestingMissingFieldIndexer = NestingIT.missingFieldIndex.bulkIndexer();
+		NestingIT.dataSet.contribute( nestingMainIndexer, nestingMissingFieldIndexer );
 
 		final BulkIndexer scoreIndexer = ScoreIT.index.bulkIndexer();
 		ScoreIT.dataSet.contribute( scoreIndexer );
 
-		nestingIndexer.join( scoreIndexer );
+		nestingMainIndexer.join( nestingMissingFieldIndexer, scoreIndexer );
 	}
 
 	@Test
@@ -56,12 +58,16 @@ public class MatchAllPredicateBaseIT {
 	public static class NestingIT extends AbstractPredicateNestingIT {
 		private static final DataSet dataSet = new DataSet();
 
-		private static final SimpleMappedIndex<IndexBinding> index =
+		private static final SimpleMappedIndex<IndexBinding> mainIndex =
 				SimpleMappedIndex.of( root -> new IndexBinding( root, FieldTypeDescriptor.getAll() ) )
 						.name( "nesting" );
 
+		private static final SimpleMappedIndex<MissingFieldIndexBinding> missingFieldIndex =
+				SimpleMappedIndex.of( root -> new MissingFieldIndexBinding( root, FieldTypeDescriptor.getAll() ) )
+						.name( "nesting_missingField" );
+
 		public NestingIT() {
-			super( index, dataSet );
+			super( mainIndex, missingFieldIndex, dataSet );
 		}
 
 		@Override
@@ -75,15 +81,20 @@ public class MatchAllPredicateBaseIT {
 				super( "singleRoutingKey" );
 			}
 
-			public void contribute(BulkIndexer scoreIndexer) {
-				scoreIndexer.add( docId( 0 ), routingKey, document -> index.binding()
+			public void contribute(BulkIndexer mainIndexer, BulkIndexer missingFieldIndexer) {
+				mainIndexer.add( docId( 0 ), routingKey, document -> mainIndex.binding()
 						.initDocument( document, AnalyzedStringFieldTypeDescriptor.INSTANCE, "irrelevant" ) );
-				scoreIndexer.add( docId( 1 ), routingKey, document -> index.binding()
+				mainIndexer.add( docId( 1 ), routingKey, document -> mainIndex.binding()
 						.initDocument( document, AnalyzedStringFieldTypeDescriptor.INSTANCE, "irrelevant" ) );
+				missingFieldIndexer.add( docId( MISSING_FIELD_INDEX_DOC_ORDINAL ), routingKey,
+						document -> missingFieldIndex.binding().initDocument() );
 			}
 
 			public List<String> docIdsExcept(int docOrdinal) {
-				return IntStream.range( 0, 3 ).filter( i -> i != docOrdinal )
+				return IntStream.concat(
+						IntStream.range( 0, 3 ).filter( i -> i != docOrdinal ),
+						IntStream.of( MISSING_FIELD_INDEX_DOC_ORDINAL )
+				)
 						.mapToObj( this::docId ).collect( Collectors.toList() );
 			}
 		}

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchPredicateBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/MatchPredicateBaseIT.java
@@ -50,7 +50,8 @@ public class MatchPredicateBaseIT {
 	public static void setup() {
 		setupHelper.start()
 				.withIndexes(
-						SingleFieldIT.index, MultiFieldIT.index, NestingIT.index,
+						SingleFieldIT.index, MultiFieldIT.index,
+						NestingIT.mainIndex, NestingIT.missingFieldIndex,
 						AnalysisIT.index, AnalysisIT.compatibleIndex, AnalysisIT.incompatibleIndex,
 						ScoreIT.index,
 						InvalidFieldIT.index, UnsupportedTypeIT.index,
@@ -69,8 +70,10 @@ public class MatchPredicateBaseIT {
 		final BulkIndexer multiFieldIndexer = MultiFieldIT.index.bulkIndexer();
 		MultiFieldIT.dataSets.forEach( d -> d.contribute( MultiFieldIT.index, multiFieldIndexer ) );
 
-		final BulkIndexer nestingIndexer = NestingIT.index.bulkIndexer();
-		NestingIT.dataSets.forEach( d -> d.contribute( NestingIT.index, nestingIndexer ) );
+		final BulkIndexer nestingMainIndexer = NestingIT.mainIndex.bulkIndexer();
+		final BulkIndexer nestingMissingFieldIndexer = NestingIT.missingFieldIndex.bulkIndexer();
+		NestingIT.dataSets.forEach( d -> d.contribute( NestingIT.mainIndex, nestingMainIndexer,
+				NestingIT.missingFieldIndex, nestingMissingFieldIndexer ) );
 
 		final BulkIndexer analysisMainIndexIndexer = AnalysisIT.index.bulkIndexer();
 		final BulkIndexer analysisCompatibleIndexIndexer = AnalysisIT.compatibleIndex.bulkIndexer();
@@ -97,7 +100,7 @@ public class MatchPredicateBaseIT {
 				ScaleCheckingIT.compatibleIndex, scaleCheckingCompatibleIndexer );
 
 		singleFieldIndexer.join(
-				multiFieldIndexer, nestingIndexer,
+				multiFieldIndexer, nestingMainIndexer, nestingMissingFieldIndexer,
 				analysisMainIndexIndexer, analysisCompatibleIndexIndexer, analysisIncompatibleIndexIndexer,
 				scoreIndexer,
 				typeCheckingMainIndexer, typeCheckingCompatibleIndexer,
@@ -203,9 +206,13 @@ public class MatchPredicateBaseIT {
 			}
 		}
 
-		private static final SimpleMappedIndex<IndexBinding> index =
+		private static final SimpleMappedIndex<IndexBinding> mainIndex =
 				SimpleMappedIndex.of( root -> new IndexBinding( root, supportedFieldTypes ) )
 						.name( "nesting" );
+
+		private static final SimpleMappedIndex<MissingFieldIndexBinding> missingFieldIndex =
+				SimpleMappedIndex.of( root -> new MissingFieldIndexBinding( root, supportedFieldTypes ) )
+						.name( "nesting_missingField" );
 
 		@Parameterized.Parameters(name = "{0}")
 		public static List<Object[]> parameters() {
@@ -213,7 +220,7 @@ public class MatchPredicateBaseIT {
 		}
 
 		public NestingIT(DataSet<F, MatchPredicateTestValues<F>> dataSet) {
-			super( index, dataSet );
+			super( mainIndex, missingFieldIndex, dataSet );
 		}
 
 		@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/PhrasePredicateBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/PhrasePredicateBaseIT.java
@@ -52,7 +52,8 @@ public class PhrasePredicateBaseIT {
 	public static void setup() {
 		setupHelper.start()
 				.withIndexes(
-						SingleFieldIT.index, MultiFieldIT.index, NestingIT.index,
+						SingleFieldIT.index, MultiFieldIT.index,
+						NestingIT.mainIndex, NestingIT.missingFieldIndex,
 						AnalysisIT.index, AnalysisIT.compatibleIndex, AnalysisIT.incompatibleIndex,
 						ScoreIT.index,
 						InvalidFieldIT.index, UnsupportedTypeIT.index,
@@ -70,8 +71,10 @@ public class PhrasePredicateBaseIT {
 		final BulkIndexer multiFieldIndexer = MultiFieldIT.index.bulkIndexer();
 		MultiFieldIT.dataSets.forEach( d -> d.contribute( MultiFieldIT.index, multiFieldIndexer ) );
 
-		final BulkIndexer nestingIndexer = NestingIT.index.bulkIndexer();
-		NestingIT.dataSets.forEach( d -> d.contribute( NestingIT.index, nestingIndexer ) );
+		final BulkIndexer nestingMainIndexer = NestingIT.mainIndex.bulkIndexer();
+		final BulkIndexer nestingMissingFieldIndexer = NestingIT.missingFieldIndex.bulkIndexer();
+		NestingIT.dataSets.forEach( d -> d.contribute( NestingIT.mainIndex, nestingMainIndexer,
+				NestingIT.missingFieldIndex, nestingMissingFieldIndexer ) );
 
 		final BulkIndexer analysisMainIndexIndexer = AnalysisIT.index.bulkIndexer();
 		final BulkIndexer analysisCompatibleIndexIndexer = AnalysisIT.compatibleIndex.bulkIndexer();
@@ -93,7 +96,7 @@ public class PhrasePredicateBaseIT {
 				TypeCheckingNoConversionIT.missingFieldIndex, typeCheckingMissingFieldIndexer ) );
 
 		singleFieldIndexer.join(
-				multiFieldIndexer, nestingIndexer,
+				multiFieldIndexer, nestingMainIndexer, nestingMissingFieldIndexer,
 				analysisMainIndexIndexer, analysisCompatibleIndexIndexer, analysisIncompatibleIndexIndexer,
 				scoreIndexer,
 				typeCheckingMainIndexer, typeCheckingCompatibleIndexer,
@@ -198,9 +201,13 @@ public class PhrasePredicateBaseIT {
 			}
 		}
 
-		private static final SimpleMappedIndex<IndexBinding> index =
+		private static final SimpleMappedIndex<IndexBinding> mainIndex =
 				SimpleMappedIndex.of( root -> new IndexBinding( root, supportedFieldTypes ) )
 						.name( "nesting" );
+
+		private static final SimpleMappedIndex<MissingFieldIndexBinding> missingFieldIndex =
+				SimpleMappedIndex.of( root -> new MissingFieldIndexBinding( root, supportedFieldTypes ) )
+						.name( "nesting_missingField" );
 
 		@Parameterized.Parameters(name = "{0}")
 		public static List<Object[]> parameters() {
@@ -208,7 +215,7 @@ public class PhrasePredicateBaseIT {
 		}
 
 		public NestingIT(DataSet<String, PhrasePredicateTestValues> dataSet) {
-			super( index, dataSet );
+			super( mainIndex, missingFieldIndex, dataSet );
 		}
 
 		@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/RangePredicateBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/RangePredicateBaseIT.java
@@ -54,7 +54,8 @@ public class RangePredicateBaseIT {
 	public static void setup() {
 		setupHelper.start()
 				.withIndexes(
-						SingleFieldIT.index, MultiFieldIT.index, NestingIT.index,
+						SingleFieldIT.index, MultiFieldIT.index,
+						NestingIT.mainIndex, NestingIT.missingFieldIndex,
 						AnalysisIT.index, AnalysisIT.compatibleIndex, AnalysisIT.incompatibleIndex,
 						ScoreIT.index,
 						InvalidFieldIT.index, UnsupportedTypeIT.index,
@@ -73,8 +74,10 @@ public class RangePredicateBaseIT {
 		final BulkIndexer multiFieldIndexer = MultiFieldIT.index.bulkIndexer();
 		MultiFieldIT.dataSets.forEach( d -> d.contribute( MultiFieldIT.index, multiFieldIndexer ) );
 
-		final BulkIndexer nestingIndexer = NestingIT.index.bulkIndexer();
-		NestingIT.dataSets.forEach( d -> d.contribute( NestingIT.index, nestingIndexer ) );
+		final BulkIndexer nestingMainIndexer = NestingIT.mainIndex.bulkIndexer();
+		final BulkIndexer nestingMissingFieldIndexer = NestingIT.missingFieldIndex.bulkIndexer();
+		NestingIT.dataSets.forEach( d -> d.contribute( NestingIT.mainIndex, nestingMainIndexer,
+				NestingIT.missingFieldIndex, nestingMissingFieldIndexer ) );
 
 		final BulkIndexer analysisMainIndexIndexer = AnalysisIT.index.bulkIndexer();
 		final BulkIndexer analysisCompatibleIndexIndexer = AnalysisIT.compatibleIndex.bulkIndexer();
@@ -101,7 +104,7 @@ public class RangePredicateBaseIT {
 				ScaleCheckingIT.compatibleIndex, scaleCheckingCompatibleIndexer );
 
 		singleFieldIndexer.join(
-				multiFieldIndexer, nestingIndexer,
+				multiFieldIndexer, nestingMainIndexer, nestingMissingFieldIndexer,
 				analysisMainIndexIndexer, analysisCompatibleIndexIndexer, analysisIncompatibleIndexIndexer,
 				scoreIndexer,
 				typeCheckingMainIndexer, typeCheckingCompatibleIndexer,
@@ -207,9 +210,13 @@ public class RangePredicateBaseIT {
 			}
 		}
 
-		private static final SimpleMappedIndex<IndexBinding> index =
+		private static final SimpleMappedIndex<IndexBinding> mainIndex =
 				SimpleMappedIndex.of( root -> new IndexBinding( root, supportedFieldTypes ) )
 						.name( "nesting" );
+
+		private static final SimpleMappedIndex<MissingFieldIndexBinding> missingFieldIndex =
+				SimpleMappedIndex.of( root -> new MissingFieldIndexBinding( root, supportedFieldTypes ) )
+						.name( "nesting_missingField" );
 
 		@Parameterized.Parameters(name = "{0}")
 		public static List<Object[]> parameters() {
@@ -217,7 +224,7 @@ public class RangePredicateBaseIT {
 		}
 
 		public NestingIT(DataSet<F, RangePredicateTestValues<F>> dataSet) {
-			super( index, dataSet );
+			super( mainIndex, missingFieldIndex, dataSet );
 		}
 
 		@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SimpleQueryStringPredicateBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SimpleQueryStringPredicateBaseIT.java
@@ -49,7 +49,8 @@ public class SimpleQueryStringPredicateBaseIT {
 	public static void setup() {
 		setupHelper.start()
 				.withIndexes(
-						SingleFieldIT.index, MultiFieldIT.index, NestingIT.index,
+						SingleFieldIT.index, MultiFieldIT.index,
+						NestingIT.mainIndex, NestingIT.missingFieldIndex,
 						AnalysisIT.index, AnalysisIT.compatibleIndex, AnalysisIT.incompatibleIndex,
 						ScoreIT.index,
 						InvalidFieldIT.index, UnsupportedTypeIT.index,
@@ -67,8 +68,10 @@ public class SimpleQueryStringPredicateBaseIT {
 		final BulkIndexer multiFieldIndexer = MultiFieldIT.index.bulkIndexer();
 		MultiFieldIT.dataSets.forEach( d -> d.contribute( MultiFieldIT.index, multiFieldIndexer ) );
 
-		final BulkIndexer nestingIndexer = NestingIT.index.bulkIndexer();
-		NestingIT.dataSets.forEach( d -> d.contribute( NestingIT.index, nestingIndexer ) );
+		final BulkIndexer nestingMainIndexer = NestingIT.mainIndex.bulkIndexer();
+		final BulkIndexer nestingMissingFieldIndexer = NestingIT.missingFieldIndex.bulkIndexer();
+		NestingIT.dataSets.forEach( d -> d.contribute( NestingIT.mainIndex, nestingMainIndexer,
+				NestingIT.missingFieldIndex, nestingMissingFieldIndexer ) );
 
 		final BulkIndexer analysisMainIndexIndexer = AnalysisIT.index.bulkIndexer();
 		final BulkIndexer analysisCompatibleIndexIndexer = AnalysisIT.compatibleIndex.bulkIndexer();
@@ -90,7 +93,7 @@ public class SimpleQueryStringPredicateBaseIT {
 				TypeCheckingNoConversionIT.missingFieldIndex, typeCheckingMissingFieldIndexer ) );
 
 		singleFieldIndexer.join(
-				multiFieldIndexer, nestingIndexer,
+				multiFieldIndexer, nestingMainIndexer, nestingMissingFieldIndexer,
 				analysisMainIndexIndexer, analysisCompatibleIndexIndexer, analysisIncompatibleIndexIndexer,
 				scoreIndexer,
 				typeCheckingMainIndexer, typeCheckingCompatibleIndexer,
@@ -195,9 +198,13 @@ public class SimpleQueryStringPredicateBaseIT {
 			}
 		}
 
-		private static final SimpleMappedIndex<IndexBinding> index =
+		private static final SimpleMappedIndex<IndexBinding> mainIndex =
 				SimpleMappedIndex.of( root -> new IndexBinding( root, supportedFieldTypes ) )
 						.name( "nesting" );
+
+		private static final SimpleMappedIndex<MissingFieldIndexBinding> missingFieldIndex =
+				SimpleMappedIndex.of( root -> new MissingFieldIndexBinding( root, supportedFieldTypes ) )
+						.name( "nesting_missingField" );
 
 		@Parameterized.Parameters(name = "{0}")
 		public static List<Object[]> parameters() {
@@ -205,7 +212,7 @@ public class SimpleQueryStringPredicateBaseIT {
 		}
 
 		public NestingIT(DataSet<String, SimpleQueryStringPredicateTestValues> dataSet) {
-			super( index, dataSet );
+			super( mainIndex, missingFieldIndex, dataSet );
 		}
 
 		@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SpatialWithinBoundingBoxPredicateBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SpatialWithinBoundingBoxPredicateBaseIT.java
@@ -48,7 +48,8 @@ public class SpatialWithinBoundingBoxPredicateBaseIT {
 	public static void setup() {
 		setupHelper.start()
 				.withIndexes(
-						SingleFieldIT.index, MultiFieldIT.index, NestingIT.index,
+						SingleFieldIT.index, MultiFieldIT.index,
+						NestingIT.mainIndex, NestingIT.missingFieldIndex,
 						ScoreIT.index,
 						InvalidFieldIT.index, UnsupportedTypeIT.index,
 						SearchableIT.searchableYesIndex, SearchableIT.searchableNoIndex,
@@ -65,8 +66,10 @@ public class SpatialWithinBoundingBoxPredicateBaseIT {
 		final BulkIndexer multiFieldIndexer = MultiFieldIT.index.bulkIndexer();
 		MultiFieldIT.dataSet.contribute( MultiFieldIT.index, multiFieldIndexer );
 
-		final BulkIndexer nestingIndexer = NestingIT.index.bulkIndexer();
-		NestingIT.dataSet.contribute( NestingIT.index, nestingIndexer );
+		final BulkIndexer nestingMainIndexer = NestingIT.mainIndex.bulkIndexer();
+		final BulkIndexer nestingMissingFieldIndexer = NestingIT.missingFieldIndex.bulkIndexer();
+		NestingIT.dataSet.contribute( NestingIT.mainIndex, nestingMainIndexer,
+				NestingIT.missingFieldIndex, nestingMissingFieldIndexer );
 
 		final BulkIndexer scoreIndexer = ScoreIT.index.bulkIndexer();
 		ScoreIT.dataSet.contribute( ScoreIT.index, scoreIndexer );
@@ -81,7 +84,7 @@ public class SpatialWithinBoundingBoxPredicateBaseIT {
 				TypeCheckingNoConversionIT.missingFieldIndex, typeCheckingMissingFieldIndexer );
 
 		singleFieldIndexer.join(
-				multiFieldIndexer, nestingIndexer,
+				multiFieldIndexer, nestingMainIndexer, nestingMissingFieldIndexer,
 				scoreIndexer,
 				typeCheckingMainIndexer, typeCheckingCompatibleIndexer,
 				typeCheckingRawFieldCompatibleIndexer, typeCheckingMissingFieldIndexer
@@ -151,12 +154,16 @@ public class SpatialWithinBoundingBoxPredicateBaseIT {
 		private static final DataSet<GeoPoint, SpatialWithinBoundingBoxPredicateTestValues> dataSet =
 				new DataSet<>( testValues() );
 
-		private static final SimpleMappedIndex<IndexBinding> index =
+		private static final SimpleMappedIndex<IndexBinding> mainIndex =
 				SimpleMappedIndex.of( root -> new IndexBinding( root, supportedFieldTypes ) )
 						.name( "nesting" );
 
+		private static final SimpleMappedIndex<MissingFieldIndexBinding> missingFieldIndex =
+				SimpleMappedIndex.of( root -> new MissingFieldIndexBinding( root, supportedFieldTypes ) )
+						.name( "nesting_missingField" );
+
 		public NestingIT() {
-			super( index, dataSet );
+			super( mainIndex, missingFieldIndex, dataSet );
 		}
 
 		@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SpatialWithinCirclePredicateBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SpatialWithinCirclePredicateBaseIT.java
@@ -50,7 +50,8 @@ public class SpatialWithinCirclePredicateBaseIT {
 	public static void setup() {
 		setupHelper.start()
 				.withIndexes(
-						SingleFieldIT.index, MultiFieldIT.index, NestingIT.index,
+						SingleFieldIT.index, MultiFieldIT.index,
+						NestingIT.mainIndex, NestingIT.missingFieldIndex,
 						ScoreIT.index,
 						InvalidFieldIT.index, UnsupportedTypeIT.index,
 						SearchableIT.searchableYesIndex, SearchableIT.searchableNoIndex,
@@ -67,8 +68,10 @@ public class SpatialWithinCirclePredicateBaseIT {
 		final BulkIndexer multiFieldIndexer = MultiFieldIT.index.bulkIndexer();
 		MultiFieldIT.dataSet.contribute( MultiFieldIT.index, multiFieldIndexer );
 
-		final BulkIndexer nestingIndexer = NestingIT.index.bulkIndexer();
-		NestingIT.dataSet.contribute( NestingIT.index, nestingIndexer );
+		final BulkIndexer nestingMainIndexer = NestingIT.mainIndex.bulkIndexer();
+		final BulkIndexer nestingMissingFieldIndexer = NestingIT.missingFieldIndex.bulkIndexer();
+		NestingIT.dataSet.contribute( NestingIT.mainIndex, nestingMainIndexer,
+				NestingIT.missingFieldIndex, nestingMissingFieldIndexer );
 
 		final BulkIndexer scoreIndexer = ScoreIT.index.bulkIndexer();
 		ScoreIT.dataSet.contribute( ScoreIT.index, scoreIndexer );
@@ -83,7 +86,7 @@ public class SpatialWithinCirclePredicateBaseIT {
 				TypeCheckingNoConversionIT.missingFieldIndex, typeCheckingMissingFieldIndexer );
 
 		singleFieldIndexer.join(
-				multiFieldIndexer, nestingIndexer,
+				multiFieldIndexer, nestingMainIndexer, nestingMissingFieldIndexer,
 				scoreIndexer,
 				typeCheckingMainIndexer, typeCheckingCompatibleIndexer,
 				typeCheckingRawFieldCompatibleIndexer, typeCheckingMissingFieldIndexer
@@ -157,12 +160,16 @@ public class SpatialWithinCirclePredicateBaseIT {
 		private static final DataSet<GeoPoint, SpatialWithinCirclePredicateTestValues> dataSet =
 				new DataSet<>( testValues() );
 
-		private static final SimpleMappedIndex<IndexBinding> index =
+		private static final SimpleMappedIndex<IndexBinding> mainIndex =
 				SimpleMappedIndex.of( root -> new IndexBinding( root, supportedFieldTypes ) )
 						.name( "nesting" );
 
+		private static final SimpleMappedIndex<MissingFieldIndexBinding> missingFieldIndex =
+				SimpleMappedIndex.of( root -> new MissingFieldIndexBinding( root, supportedFieldTypes ) )
+						.name( "nesting_missingField" );
+
 		public NestingIT() {
-			super( index, dataSet );
+			super( mainIndex, missingFieldIndex, dataSet );
 		}
 
 		@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SpatialWithinPolygonPredicateBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/SpatialWithinPolygonPredicateBaseIT.java
@@ -49,7 +49,8 @@ public class SpatialWithinPolygonPredicateBaseIT {
 	public static void setup() {
 		setupHelper.start()
 				.withIndexes(
-						SingleFieldIT.index, MultiFieldIT.index, NestingIT.index,
+						SingleFieldIT.index, MultiFieldIT.index,
+						NestingIT.mainIndex, NestingIT.missingFieldIndex,
 						ScoreIT.index,
 						InvalidFieldIT.index, UnsupportedTypeIT.index,
 						SearchableIT.searchableYesIndex, SearchableIT.searchableNoIndex,
@@ -66,8 +67,10 @@ public class SpatialWithinPolygonPredicateBaseIT {
 		final BulkIndexer multiFieldIndexer = MultiFieldIT.index.bulkIndexer();
 		MultiFieldIT.dataSet.contribute( MultiFieldIT.index, multiFieldIndexer );
 
-		final BulkIndexer nestingIndexer = NestingIT.index.bulkIndexer();
-		NestingIT.dataSet.contribute( NestingIT.index, nestingIndexer );
+		final BulkIndexer nestingMainIndexer = NestingIT.mainIndex.bulkIndexer();
+		final BulkIndexer nestingMissingFieldIndexer = NestingIT.missingFieldIndex.bulkIndexer();
+		NestingIT.dataSet.contribute( NestingIT.mainIndex, nestingMainIndexer,
+				NestingIT.missingFieldIndex, nestingMissingFieldIndexer );
 
 		final BulkIndexer scoreIndexer = ScoreIT.index.bulkIndexer();
 		ScoreIT.dataSet.contribute( ScoreIT.index, scoreIndexer );
@@ -82,7 +85,7 @@ public class SpatialWithinPolygonPredicateBaseIT {
 				TypeCheckingNoConversionIT.missingFieldIndex, typeCheckingMissingFieldIndexer );
 
 		singleFieldIndexer.join(
-				multiFieldIndexer, nestingIndexer,
+				multiFieldIndexer, nestingMainIndexer, nestingMissingFieldIndexer,
 				scoreIndexer,
 				typeCheckingMainIndexer, typeCheckingCompatibleIndexer,
 				typeCheckingRawFieldCompatibleIndexer, typeCheckingMissingFieldIndexer
@@ -156,12 +159,16 @@ public class SpatialWithinPolygonPredicateBaseIT {
 		private static final DataSet<GeoPoint, SpatialWithinPolygonPredicateTestValues> dataSet =
 				new DataSet<>( testValues() );
 
-		private static final SimpleMappedIndex<IndexBinding> index =
+		private static final SimpleMappedIndex<IndexBinding> mainIndex =
 				SimpleMappedIndex.of( root -> new IndexBinding( root, supportedFieldTypes ) )
 						.name( "nesting" );
 
+		private static final SimpleMappedIndex<MissingFieldIndexBinding> missingFieldIndex =
+				SimpleMappedIndex.of( root -> new MissingFieldIndexBinding( root, supportedFieldTypes ) )
+						.name( "nesting_missingField" );
+
 		public NestingIT() {
-			super( index, dataSet );
+			super( mainIndex, missingFieldIndex, dataSet );
 		}
 
 		@Override

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/WildcardPredicateBaseIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/search/predicate/WildcardPredicateBaseIT.java
@@ -48,7 +48,8 @@ public class WildcardPredicateBaseIT {
 	public static void setup() {
 		setupHelper.start()
 				.withIndexes(
-						SingleFieldIT.index, MultiFieldIT.index, NestingIT.index,
+						SingleFieldIT.index, MultiFieldIT.index,
+						NestingIT.mainIndex, NestingIT.missingFieldIndex,
 						ScoreIT.index,
 						InvalidFieldIT.index, UnsupportedTypeIT.index,
 						SearchableIT.searchableYesIndex, SearchableIT.searchableNoIndex,
@@ -65,8 +66,10 @@ public class WildcardPredicateBaseIT {
 		final BulkIndexer multiFieldIndexer = MultiFieldIT.index.bulkIndexer();
 		MultiFieldIT.dataSets.forEach( d -> d.contribute( MultiFieldIT.index, multiFieldIndexer ) );
 
-		final BulkIndexer nestingIndexer = NestingIT.index.bulkIndexer();
-		NestingIT.dataSets.forEach( d -> d.contribute( NestingIT.index, nestingIndexer ) );
+		final BulkIndexer nestingMainIndexer = NestingIT.mainIndex.bulkIndexer();
+		final BulkIndexer nestingMissingFieldIndexer = NestingIT.missingFieldIndex.bulkIndexer();
+		NestingIT.dataSets.forEach( d -> d.contribute( NestingIT.mainIndex, nestingMainIndexer,
+				NestingIT.missingFieldIndex, nestingMissingFieldIndexer ) );
 
 		final BulkIndexer scoreIndexer = ScoreIT.index.bulkIndexer();
 		ScoreIT.dataSets.forEach( d -> d.contribute( ScoreIT.index, scoreIndexer ) );
@@ -82,7 +85,7 @@ public class WildcardPredicateBaseIT {
 
 
 		singleFieldIndexer.join(
-				multiFieldIndexer, nestingIndexer,
+				multiFieldIndexer, nestingMainIndexer, nestingMissingFieldIndexer,
 				scoreIndexer,
 				typeCheckingMainIndexer, typeCheckingCompatibleIndexer,
 				typeCheckingRawFieldCompatibleIndexer, typeCheckingMissingFieldIndexer
@@ -186,9 +189,13 @@ public class WildcardPredicateBaseIT {
 			}
 		}
 
-		private static final SimpleMappedIndex<IndexBinding> index =
+		private static final SimpleMappedIndex<IndexBinding> mainIndex =
 				SimpleMappedIndex.of( root -> new IndexBinding( root, supportedFieldTypes ) )
 						.name( "nesting" );
+
+		private static final SimpleMappedIndex<MissingFieldIndexBinding> missingFieldIndex =
+				SimpleMappedIndex.of( root -> new MissingFieldIndexBinding( root, supportedFieldTypes ) )
+						.name( "nesting_missingField" );
 
 		@Parameterized.Parameters(name = "{0}")
 		public static List<Object[]> parameters() {
@@ -196,7 +203,7 @@ public class WildcardPredicateBaseIT {
 		}
 
 		public NestingIT(DataSet<String, WildcardPredicateTestValues> dataSet) {
-			super( index, dataSet );
+			super( mainIndex, missingFieldIndex, dataSet );
 		}
 
 		@Override


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4173

See #2522