### PR TITLE
Backport HSEARCH-4189 + HSEARCH-4190 to branch 5.11 - Test Hibernate Search against JDK 17

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -249,7 +249,6 @@ stage('Configure') {
 DEFAULT
 SUPPORTED
 ALL""",
-							defaultValue: 'AUTOMATIC',
 							description: """A set of environments that must be checked.
 'AUTOMATIC' picks a different set of environments based on the branch name and whether a release is being performed.
 'DEFAULT' means a single build with the default environment expected by the Maven configuration,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -176,6 +176,8 @@ stage('Configure') {
 					new JdkBuildEnvironment(version: '15', tool: 'OpenJDK 15 Latest',
 							condition: TestCondition.AFTER_MERGE),
 					new JdkBuildEnvironment(version: '16', tool: 'OpenJDK 16 Latest',
+							condition: TestCondition.AFTER_MERGE),
+					new JdkBuildEnvironment(version: '17', tool: 'OpenJDK 17 Latest',
 							condition: TestCondition.AFTER_MERGE)
 			],
 			compiler: [

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -602,6 +602,7 @@ class CompilerBuildEnvironment extends BuildEnvironment {
 class DatabaseBuildEnvironment extends BuildEnvironment {
 	String dbName
 	String mavenProfile
+	@Override
 	String getTag() { "database-$dbName" }
 }
 
@@ -609,6 +610,7 @@ class EsLocalBuildEnvironment extends BuildEnvironment {
 	String versionRange
 	String version
 	String mavenProfile
+	@Override
 	String getTag() { "elasticsearch-local-$versionRange${version ? "-as-$version" : ''}" }
 }
 
@@ -617,6 +619,7 @@ class EsAwsBuildEnvironment extends BuildEnvironment {
 	String mavenProfile
 	String endpointUrl = null
 	String awsRegion = null
+	@Override
 	String getTag() { "elasticsearch-aws-$version" }
 	String getNameEmbeddableVersion() {
 		version.replaceAll('\\.', '')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -164,39 +164,57 @@ stage('Configure') {
 			jdk: [
 					// This should not include every JDK; in particular let's not care too much about EOL'd JDKs like version 9
 					// See http://www.oracle.com/technetwork/java/javase/eol-135779.html
-					new JdkBuildEnvironment(version: '8', tool: 'OpenJDK 8 Latest', status: BuildEnvironmentStatus.USED_IN_DEFAULT_BUILD),
-					new JdkBuildEnvironment(version: '11', tool: 'OpenJDK 11 Latest', status: BuildEnvironmentStatus.SUPPORTED),
-					new JdkBuildEnvironment(version: '13', tool: 'OpenJDK 13 Latest', status: BuildEnvironmentStatus.SUPPORTED),
-					new JdkBuildEnvironment(version: '14', tool: 'OpenJDK 14 Latest', status: BuildEnvironmentStatus.SUPPORTED),
-					new JdkBuildEnvironment(version: '15', tool: 'OpenJDK 15 Latest', status: BuildEnvironmentStatus.SUPPORTED),
-					new JdkBuildEnvironment(version: '16', tool: 'OpenJDK 16 Latest', status: BuildEnvironmentStatus.SUPPORTED)
+					new JdkBuildEnvironment(version: '8', tool: 'OpenJDK 8 Latest',
+							condition: TestCondition.AFTER_MERGE,
+							isDefault: true),
+					new JdkBuildEnvironment(version: '11', tool: 'OpenJDK 11 Latest',
+							condition: TestCondition.BEFORE_MERGE),
+					new JdkBuildEnvironment(version: '13', tool: 'OpenJDK 13 Latest',
+							condition: TestCondition.AFTER_MERGE),
+					new JdkBuildEnvironment(version: '14', tool: 'OpenJDK 14 Latest',
+							condition: TestCondition.AFTER_MERGE),
+					new JdkBuildEnvironment(version: '15', tool: 'OpenJDK 15 Latest',
+							condition: TestCondition.AFTER_MERGE),
+					new JdkBuildEnvironment(version: '16', tool: 'OpenJDK 16 Latest',
+							condition: TestCondition.AFTER_MERGE)
 			],
 			compiler: [
-					new CompilerBuildEnvironment(name: 'eclipse', mavenProfile: 'compiler-eclipse', status: BuildEnvironmentStatus.SUPPORTED),
+					new CompilerBuildEnvironment(name: 'eclipse', mavenProfile: 'compiler-eclipse',
+							condition: TestCondition.AFTER_MERGE),
 			],
 			database: [
-					new DatabaseBuildEnvironment(dbName: 'h2', mavenProfile: 'h2', status: BuildEnvironmentStatus.USED_IN_DEFAULT_BUILD),
-					new DatabaseBuildEnvironment(dbName: 'mariadb', mavenProfile: 'ci-mariadb', status: BuildEnvironmentStatus.SUPPORTED),
-					new DatabaseBuildEnvironment(dbName: 'postgresql', mavenProfile: 'ci-postgresql', status: BuildEnvironmentStatus.SUPPORTED)
+					new DatabaseBuildEnvironment(dbName: 'h2', mavenProfile: 'h2',
+							condition: TestCondition.BEFORE_MERGE,
+							isDefault: true),
+					new DatabaseBuildEnvironment(dbName: 'mariadb', mavenProfile: 'ci-mariadb',
+							condition: TestCondition.AFTER_MERGE),
+					new DatabaseBuildEnvironment(dbName: 'postgresql', mavenProfile: 'ci-postgresql',
+							condition: TestCondition.AFTER_MERGE)
 			],
 			esLocal: [
 					new EsLocalBuildEnvironment(versionRange: '[2.0,2.2)', mavenProfile: 'elasticsearch-2.0',
-							jdkTool: 'OpenJDK 8 Latest', status: BuildEnvironmentStatus.SUPPORTED),
+							jdkTool: 'OpenJDK 8 Latest', condition: TestCondition.AFTER_MERGE),
 					new EsLocalBuildEnvironment(versionRange: '[2.2,5.0)', mavenProfile: 'elasticsearch-2.2',
-							jdkTool: 'OpenJDK 8 Latest', status: BuildEnvironmentStatus.SUPPORTED),
+							jdkTool: 'OpenJDK 8 Latest', condition: TestCondition.AFTER_MERGE),
 					// Use Elasticsearch 5.0.2 instead of the default 5.1.2, because a bug crashes ES on startup in our environment
 					// See https://github.com/elastic/elasticsearch/issues/23218
 					new EsLocalBuildEnvironment(versionRange: '[5.0,5.2)', version: '5.0.2', mavenProfile: 'elasticsearch-5.0',
-							jdkTool: 'OpenJDK 8 Latest', status: BuildEnvironmentStatus.SUPPORTED),
+							jdkTool: 'OpenJDK 8 Latest', condition: TestCondition.AFTER_MERGE),
 					new EsLocalBuildEnvironment(versionRange: '[5.2,6.0)', mavenProfile: 'elasticsearch-5.2',
-							jdkTool: 'OpenJDK 11 Latest', status: BuildEnvironmentStatus.USED_IN_DEFAULT_BUILD)
+							jdkTool: 'OpenJDK 11 Latest', condition: TestCondition.BEFORE_MERGE,
+							isDefault: true)
 			],
 			esAws: [
-					new EsAwsBuildEnvironment(version: '2.3', mavenProfile: 'elasticsearch-2.2', status: BuildEnvironmentStatus.SUPPORTED),
-					new EsAwsBuildEnvironment(version: '5.1', mavenProfile: 'elasticsearch-5.0', status: BuildEnvironmentStatus.SUPPORTED),
-					new EsAwsBuildEnvironment(version: '5.3', mavenProfile: 'elasticsearch-5.2', status: BuildEnvironmentStatus.SUPPORTED),
-					new EsAwsBuildEnvironment(version: '5.5', mavenProfile: 'elasticsearch-5.2', status: BuildEnvironmentStatus.SUPPORTED),
-					new EsAwsBuildEnvironment(version: '5.6', mavenProfile: 'elasticsearch-5.2', status: BuildEnvironmentStatus.SUPPORTED)
+					new EsAwsBuildEnvironment(version: '2.3', mavenProfile: 'elasticsearch-2.2',
+							condition: TestCondition.AFTER_MERGE),
+					new EsAwsBuildEnvironment(version: '5.1', mavenProfile: 'elasticsearch-5.0',
+							condition: TestCondition.AFTER_MERGE),
+					new EsAwsBuildEnvironment(version: '5.3', mavenProfile: 'elasticsearch-5.2',
+							condition: TestCondition.AFTER_MERGE),
+					new EsAwsBuildEnvironment(version: '5.5', mavenProfile: 'elasticsearch-5.2',
+							condition: TestCondition.AFTER_MERGE),
+					new EsAwsBuildEnvironment(version: '5.6', mavenProfile: 'elasticsearch-5.2',
+							condition: TestCondition.AFTER_MERGE)
 			]
 	])
 
@@ -230,7 +248,6 @@ stage('Configure') {
 							choices: """AUTOMATIC
 DEFAULT
 SUPPORTED
-EXPERIMENTAL
 ALL""",
 							defaultValue: 'AUTOMATIC',
 							description: """A set of environments that must be checked.
@@ -555,24 +572,31 @@ stage('Deploy') {
 
 // Job-specific helpers
 
-enum BuildEnvironmentStatus {
-	// For environments used as part of the default build (tested on all branches)
-	USED_IN_DEFAULT_BUILD,
-	// For environments that are expected to work correctly (tested on master and maintenance branches)
-	SUPPORTED,
-	// For environments that may not work correctly (only tested when explicitly requested through job parameters)
-	EXPERIMENTAL;
+enum TestCondition {
+	// For environments that are expected to work correctly
+	// before merging into master or maintenance branches.
+	// Tested on master and maintenance branches, on feature branches, and for PRs.
+	BEFORE_MERGE,
+	// For environments that are expected to work correctly,
+	// but are considered too resource-intensive to test them on pull requests.
+	// Tested on master and maintenance branches only.
+	// Not tested on feature branches or PRs.
+	AFTER_MERGE,
+	// For environments that may not work correctly.
+	// Only tested when explicitly requested through job parameters.
+	ON_DEMAND;
 
 	// Work around JENKINS-33023
 	// See https://issues.jenkins-ci.org/browse/JENKINS-33023?focusedCommentId=325738&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-325738
-	public BuildEnvironmentStatus() {}
+	public TestCondition() {}
 }
 
 abstract class BuildEnvironment {
-	BuildEnvironmentStatus status
+	boolean isDefault = false
+	TestCondition condition
 	String toString() { getTag() }
 	abstract String getTag()
-	boolean isDefault() { status == BuildEnvironmentStatus.USED_IN_DEFAULT_BUILD }
+	boolean isDefault() { isDefault }
 	boolean requiresDefaultBuildArtifacts() { true }
 
 	String getMavenJdkTool(def allEnvironments) {
@@ -659,38 +683,44 @@ void keepOnlyEnvironmentsMatchingFilter(String regex) {
 }
 
 void keepOnlyEnvironmentsFromSet(String environmentSetName) {
-	boolean enableDefaultBuildEnv = false
-	boolean enableNonDefaultSupportedBuildEnv = false
-	boolean enableExperimentalBuildEnv = false
+	boolean enableDefaultEnv = false
+	boolean enableBeforeMergeEnvs = false
+	boolean enableAfterMergeEnvs = false
+	boolean enableOnDemandEnvs = false
 	switch (environmentSetName) {
 		case 'DEFAULT':
-			enableDefaultBuildEnv = true
+			enableDefaultEnv = true
 			break
 		case 'SUPPORTED':
-			enableDefaultBuildEnv = true
-			enableNonDefaultSupportedBuildEnv = true
+			enableDefaultEnv = true
+			enableBeforeMergeEnvs = true
+			enableAfterMergeEnvs = true
 			break
 		case 'ALL':
-			enableDefaultBuildEnv = true
-			enableNonDefaultSupportedBuildEnv = true
-			enableExperimentalBuildEnv = true
+			enableDefaultEnv = true
+			enableBeforeMergeEnvs = true
+			enableAfterMergeEnvs = true
+			enableOptional = true
 			break
 		case 'EXPERIMENTAL':
-			enableExperimentalBuildEnv = true
+			enableOptional = true
 			break
 		case 'AUTOMATIC':
 			if (params.RELEASE_VERSION) {
-				echo "Skipping default build and integration tests to speed up the release of version $params.RELEASE_VERSION"
+				echo "Releasing version '$params.RELEASE_VERSION'."
 			} else if (helper.scmSource.pullRequest) {
-				echo "Enabling only the default build in the default environment for pull request $helper.scmSource.pullRequest.id"
-				enableDefaultBuildEnv = true
+				echo "Building pull request '$helper.scmSource.pullRequest.id'"
+				enableDefaultEnv = true
+				enableBeforeMergeEnvs = true
 			} else if (helper.scmSource.branch.primary) {
-				echo "Enabling builds on all supported environments for primary branch '$helper.scmSource.branch.name'"
-				enableDefaultBuildEnv = true
-				enableNonDefaultSupportedBuildEnv = true
+				echo "Building primary branch '$helper.scmSource.branch.name'"
+				enableDefaultEnv = true
+				enableBeforeMergeEnvs = true
+				enableAfterMergeEnvs = true
 			} else {
-				echo "Enabling only the default build in the default environment for feature branch $helper.scmSource.branch.name"
-				enableDefaultBuildEnv = true
+				echo "Building feature branch '$helper.scmSource.branch.name'"
+				enableDefaultEnv = true
+				enableBeforeMergeEnvs = true
 			}
 			break
 		default:
@@ -702,15 +732,11 @@ void keepOnlyEnvironmentsFromSet(String environmentSetName) {
 	// Filter environments
 
 	environments.content.each { key, envSet ->
-		if (!enableDefaultBuildEnv) {
-			envSet.enabled.remove(envSet.default)
-		}
-		if (!enableNonDefaultSupportedBuildEnv) {
-			envSet.enabled.removeAll { buildEnv -> buildEnv.status == BuildEnvironmentStatus.SUPPORTED }
-		}
-		if (!enableExperimentalBuildEnv) {
-			envSet.enabled.removeAll { buildEnv -> buildEnv.status == BuildEnvironmentStatus.EXPERIMENTAL }
-		}
+		envSet.enabled.removeAll { buildEnv -> ! (
+				enableDefaultEnv && buildEnv.isDefault ||
+				enableBeforeMergeEnvs && buildEnv.condition == TestCondition.BEFORE_MERGE ||
+				enableAfterMergeEnvs && buildEnv.condition == TestCondition.AFTER_MERGE ||
+						enableOnDemandEnvs && buildEnv.condition == TestCondition.ON_DEMAND ) }
 	}
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -172,7 +172,7 @@ stage('Configure') {
 					new JdkBuildEnvironment(version: '13', tool: 'OpenJDK 13 Latest',
 							condition: TestCondition.AFTER_MERGE),
 					new JdkBuildEnvironment(version: '14', tool: 'OpenJDK 14 Latest',
-							condition: TestCondition.AFTER_MERGE),
+							condition: TestCondition.ON_DEMAND),
 					new JdkBuildEnvironment(version: '15', tool: 'OpenJDK 15 Latest',
 							condition: TestCondition.AFTER_MERGE),
 					new JdkBuildEnvironment(version: '16', tool: 'OpenJDK 16 Latest',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -178,7 +178,8 @@ stage('Configure') {
 					new JdkBuildEnvironment(version: '16', tool: 'OpenJDK 16 Latest',
 							condition: TestCondition.AFTER_MERGE),
 					new JdkBuildEnvironment(version: '17', tool: 'OpenJDK 17 Latest',
-							condition: TestCondition.AFTER_MERGE)
+							// Byteman doesn't support JDK17 yet.
+							condition: TestCondition.ON_DEMAND)
 			],
 			compiler: [
 					new CompilerBuildEnvironment(name: 'eclipse', mavenProfile: 'compiler-eclipse',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -166,18 +166,10 @@ stage('Configure') {
 					// See http://www.oracle.com/technetwork/java/javase/eol-135779.html
 					new JdkBuildEnvironment(version: '8', tool: 'OpenJDK 8 Latest', status: BuildEnvironmentStatus.USED_IN_DEFAULT_BUILD),
 					new JdkBuildEnvironment(version: '11', tool: 'OpenJDK 11 Latest', status: BuildEnvironmentStatus.SUPPORTED),
-					new JdkBuildEnvironment(version: '13', tool: 'OpenJDK 13 Latest', status: BuildEnvironmentStatus.SUPPORTED,
-							// Elasticsearch won't run on JDK13+
-							elasticsearchTool: 'OpenJDK 11 Latest'),
-					new JdkBuildEnvironment(version: '14', tool: 'OpenJDK 14 Latest', status: BuildEnvironmentStatus.SUPPORTED,
-							// Elasticsearch won't run on JDK13+
-							elasticsearchTool: 'OpenJDK 11 Latest'),
-					new JdkBuildEnvironment(version: '15', tool: 'OpenJDK 15 Latest', status: BuildEnvironmentStatus.SUPPORTED,
-							// Elasticsearch won't run on JDK13+
-							elasticsearchTool: 'OpenJDK 11 Latest'),
-					new JdkBuildEnvironment(version: '16', tool: 'OpenJDK 16 Latest', status: BuildEnvironmentStatus.SUPPORTED,
-							// Elasticsearch won't run on JDK13+
-							elasticsearchTool: 'OpenJDK 11 Latest')
+					new JdkBuildEnvironment(version: '13', tool: 'OpenJDK 13 Latest', status: BuildEnvironmentStatus.SUPPORTED),
+					new JdkBuildEnvironment(version: '14', tool: 'OpenJDK 14 Latest', status: BuildEnvironmentStatus.SUPPORTED),
+					new JdkBuildEnvironment(version: '15', tool: 'OpenJDK 15 Latest', status: BuildEnvironmentStatus.SUPPORTED),
+					new JdkBuildEnvironment(version: '16', tool: 'OpenJDK 16 Latest', status: BuildEnvironmentStatus.SUPPORTED)
 			],
 			compiler: [
 					new CompilerBuildEnvironment(name: 'eclipse', mavenProfile: 'compiler-eclipse', status: BuildEnvironmentStatus.SUPPORTED),
@@ -188,12 +180,16 @@ stage('Configure') {
 					new DatabaseBuildEnvironment(dbName: 'postgresql', mavenProfile: 'ci-postgresql', status: BuildEnvironmentStatus.SUPPORTED)
 			],
 			esLocal: [
-					new EsLocalBuildEnvironment(versionRange: '[2.0,2.2)', mavenProfile: 'elasticsearch-2.0', status: BuildEnvironmentStatus.SUPPORTED),
-					new EsLocalBuildEnvironment(versionRange: '[2.2,5.0)', mavenProfile: 'elasticsearch-2.2', status: BuildEnvironmentStatus.SUPPORTED),
+					new EsLocalBuildEnvironment(versionRange: '[2.0,2.2)', mavenProfile: 'elasticsearch-2.0',
+							jdkTool: 'OpenJDK 8 Latest', status: BuildEnvironmentStatus.SUPPORTED),
+					new EsLocalBuildEnvironment(versionRange: '[2.2,5.0)', mavenProfile: 'elasticsearch-2.2',
+							jdkTool: 'OpenJDK 8 Latest', status: BuildEnvironmentStatus.SUPPORTED),
 					// Use Elasticsearch 5.0.2 instead of the default 5.1.2, because a bug crashes ES on startup in our environment
 					// See https://github.com/elastic/elasticsearch/issues/23218
-					new EsLocalBuildEnvironment(versionRange: '[5.0,5.2)', version: '5.0.2', mavenProfile: 'elasticsearch-5.0', status: BuildEnvironmentStatus.SUPPORTED),
-					new EsLocalBuildEnvironment(versionRange: '[5.2,6.0)', mavenProfile: 'elasticsearch-5.2', status: BuildEnvironmentStatus.USED_IN_DEFAULT_BUILD)
+					new EsLocalBuildEnvironment(versionRange: '[5.0,5.2)', version: '5.0.2', mavenProfile: 'elasticsearch-5.0',
+							jdkTool: 'OpenJDK 8 Latest', status: BuildEnvironmentStatus.SUPPORTED),
+					new EsLocalBuildEnvironment(versionRange: '[5.2,6.0)', mavenProfile: 'elasticsearch-5.2',
+							jdkTool: 'OpenJDK 11 Latest', status: BuildEnvironmentStatus.USED_IN_DEFAULT_BUILD)
 			],
 			esAws: [
 					new EsAwsBuildEnvironment(version: '2.3', mavenProfile: 'elasticsearch-2.2', status: BuildEnvironmentStatus.SUPPORTED),
@@ -366,6 +362,7 @@ stage('Default build') {
 					mvn clean install \
 					-Pdist -Pcoverage -Pjqassistant \
 					${enableDefaultBuildIT ? '' : '-DskipITs'} \
+					${toElasticsearchJdkArg(environments.content.jdk.default)} \
 			"""
 
 			// Don't try to report to Coveralls.io or SonarCloud if coverage data is missing
@@ -403,11 +400,9 @@ stage('Non-default environments') {
 	environments.content.jdk.enabled.each { JdkBuildEnvironment buildEnv ->
 		executions.put(buildEnv.tag, {
 			runBuildOnNode {
-				def elasticsearchJdkTool = buildEnv.elasticsearchTool ? tool(name: buildEnv.elasticsearchTool, type: 'jdk') : null
 				helper.withMavenWorkspace(jdk: buildEnv.tool) {
 					mavenNonDefaultBuild buildEnv, """ \
 							clean install --fail-at-end \
-							${elasticsearchJdkTool ? "-Dtest.elasticsearch.java_home=$elasticsearchJdkTool" : ""} \
 					"""
 				}
 			}
@@ -580,15 +575,26 @@ abstract class BuildEnvironment {
 	abstract String getTag()
 	boolean isDefault() { status == BuildEnvironmentStatus.USED_IN_DEFAULT_BUILD }
 	boolean requiresDefaultBuildArtifacts() { true }
+
+	String getMavenJdkTool(def allEnvironments) {
+		allEnvironments.content.jdk.default.tool
+	}
+
+	String getElasticsearchJdkTool(def allEnvironments) {
+		allEnvironments.content.esLocal.default.jdkTool
+	}
 }
 
 class JdkBuildEnvironment extends BuildEnvironment {
 	String version
 	String tool
-	String elasticsearchTool
 	String getTag() { "jdk-$version" }
 	@Override
 	boolean requiresDefaultBuildArtifacts() { false }
+	@Override
+	String getMavenJdkTool(def allEnvironments) {
+		tool
+	}
 }
 
 class CompilerBuildEnvironment extends BuildEnvironment {
@@ -610,8 +616,13 @@ class EsLocalBuildEnvironment extends BuildEnvironment {
 	String versionRange
 	String version
 	String mavenProfile
+	String jdkTool
 	@Override
 	String getTag() { "elasticsearch-local-$versionRange${version ? "-as-$version" : ''}" }
+	@Override
+	String getElasticsearchJdkTool(def allEnvironments) {
+		jdkTool
+	}
 }
 
 class EsAwsBuildEnvironment extends BuildEnvironment {
@@ -621,6 +632,10 @@ class EsAwsBuildEnvironment extends BuildEnvironment {
 	String awsRegion = null
 	@Override
 	String getTag() { "elasticsearch-aws-$version" }
+	@Override
+	String getElasticsearchJdkTool(def allEnvironments) {
+		null // No JDK needed for Elasticsearch: the Elasticsearch instance is remote.
+	}
 	String getNameEmbeddableVersion() {
 		version.replaceAll('\\.', '')
 	}
@@ -720,7 +735,11 @@ void mavenNonDefaultBuild(BuildEnvironment buildEnv, String args) {
 	// Add a suffix to tests to distinguish between different executions
 	// of the same test in different environments in reports
 	def testSuffix = buildEnv.tag.replaceAll('[^a-zA-Z0-9_\\-+]+', '_')
-	sh "mvn -Dsurefire.environment=$testSuffix $args"
+	sh """ \
+			mvn -Dsurefire.environment=$testSuffix \
+					${toElasticsearchJdkArg(buildEnv)} \
+					$args \
+	"""
 }
 
 String toMavenElasticsearchProfileArg(String mavenEsProfile) {
@@ -734,4 +753,15 @@ String toMavenElasticsearchProfileArg(String mavenEsProfile) {
 		// and Maven would end up disabling it.
 		''
 	}
+}
+
+String toElasticsearchJdkArg(BuildEnvironment buildEnv) {
+	String elasticsearchJdkTool = buildEnv.getElasticsearchJdkTool(environments)
+
+	if (elasticsearchJdkTool == null || buildEnv.getMavenJdkTool(environments) == elasticsearchJdkTool) {
+		return '' // No specific JDK needed
+	}
+
+	def elasticsearchJdkToolPath = tool(name: elasticsearchJdkTool, type: 'jdk')
+	return "-Dtest.elasticsearch.java_home=$elasticsearchJdkToolPath"
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -444,7 +444,7 @@ stage('Non-default environments') {
 				helper.withMavenWorkspace {
 					mavenNonDefaultBuild buildEnv, """ \
 							clean install -pl org.hibernate:hibernate-search-integrationtest-elasticsearch \
-							${toMavenElasticsearchProfileArg(buildEnv.mavenProfile)} \
+							${toElasticsearchVersionArgs(buildEnv.mavenProfile, null)} \
 							${buildEnv.version ? "-Dtest.elasticsearch.host.version=$buildEnv.version" : ''} \
 					"""
 				}
@@ -479,7 +479,7 @@ stage('Non-default environments') {
 							retry(count: 3) {
 								mavenNonDefaultBuild buildEnv, """ \
 									clean install -pl org.hibernate:hibernate-search-integrationtest-elasticsearch \
-									${toMavenElasticsearchProfileArg(buildEnv.mavenProfile)} \
+									${toElasticsearchVersionArgs(buildEnv.mavenProfile, buildEnv.version)} \
 									-Dtest.elasticsearch.host.provided=true \
 									-Dtest.elasticsearch.host.url=$buildEnv.endpointUrl \
 									-Dtest.elasticsearch.host.aws.signing.enabled=true \
@@ -742,9 +742,14 @@ void mavenNonDefaultBuild(BuildEnvironment buildEnv, String args) {
 	"""
 }
 
-String toMavenElasticsearchProfileArg(String mavenEsProfile) {
+String toElasticsearchVersionArgs(String mavenEsProfile, String version) {
 	String defaultEsProfile = environments.content.esLocal.default.mavenProfile
-	if (mavenEsProfile != defaultEsProfile) {
+	if ( version ) {
+		// The default profile is disabled, because a version is passed explicitly
+		// We just need to set the correct profile and pass the version
+		"-P$mavenEsProfile -Dtest.elasticsearch.host.version=$version"
+	}
+	else if ( mavenEsProfile != defaultEsProfile) {
 		// Disable the default profile to avoid conflicting configurations
 		"-P!$defaultEsProfile,$mavenEsProfile"
 	}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -480,7 +480,6 @@ stage('Non-default environments') {
 								mavenNonDefaultBuild buildEnv, """ \
 									clean install -pl org.hibernate:hibernate-search-integrationtest-elasticsearch \
 									${toElasticsearchVersionArgs(buildEnv.mavenProfile, buildEnv.version)} \
-									-Dtest.elasticsearch.host.provided=true \
 									-Dtest.elasticsearch.host.url=$buildEnv.endpointUrl \
 									-Dtest.elasticsearch.host.aws.signing.enabled=true \
 									-Dtest.elasticsearch.host.aws.access_key=$AWS_ACCESS_KEY_ID \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -180,7 +180,7 @@ stage('Configure') {
 			],
 			compiler: [
 					new CompilerBuildEnvironment(name: 'eclipse', mavenProfile: 'compiler-eclipse',
-							condition: TestCondition.AFTER_MERGE),
+							condition: TestCondition.BEFORE_MERGE),
 			],
 			database: [
 					new DatabaseBuildEnvironment(dbName: 'h2', mavenProfile: 'h2',
@@ -700,9 +700,6 @@ void keepOnlyEnvironmentsFromSet(String environmentSetName) {
 			enableDefaultEnv = true
 			enableBeforeMergeEnvs = true
 			enableAfterMergeEnvs = true
-			enableOptional = true
-			break
-		case 'EXPERIMENTAL':
 			enableOptional = true
 			break
 		case 'AUTOMATIC':

--- a/README.md
+++ b/README.md
@@ -83,24 +83,24 @@ A list of available versions for `test.elasticsearch.host.version` can be found 
 
 Alternatively, you can prevent the build from launching an Elasticsearch server automatically
 and run Elasticsearch-related tests against your own server using the
-`test.elasticsearch.host.provided` and `test.elasticsearch.host.url` properties:
+`test.elasticsearch.host.url` property:
 
-    > mvn clean install -Dtest.elasticsearch.host.provided=true -Dtest.elasticsearch.host.url=http://localhost:9200
+    > mvn clean install -Dtest.elasticsearch.host.url=http://localhost:9200
 
 If you want to run tests against an older Elasticsearch version  (2.x for instance),
 you will still have to select a profile among those listed above, and disable the default profile:
 
-    > mvn clean install -P!elasticsearch-5.2,elasticsearch-2.2 -Dtest.elasticsearch.host.provided=true -Dtest.elasticsearch.host.url=http://localhost:9200
+    > mvn clean install -P!elasticsearch-5.2,elasticsearch-2.2 -Dtest.elasticsearch.host.url=http://localhost:9200
 
 You may also use authentication:
 
-    > mvn clean install -Dtest.elasticsearch.host.provided=true -Dtest.elasticsearch.host.url=https://localhost:9200 -Dtest.elasticsearch.host.username=ironman -Dtest.elasticsearch.host.password=j@rV1s
+    > mvn clean install -Dtest.elasticsearch.host.url=https://localhost:9200 -Dtest.elasticsearch.host.username=ironman -Dtest.elasticsearch.host.password=j@rV1s
 
 Also, the elasticsearch module (and only this one) can execute its integration tests
 against an Elasticsearch service on AWS.
 You will need to execute something along the lines of:
 
-    > mvn integration-test -pl elasticsearch -Dtest.elasticsearch.host.provided=true -Dtest.elasticsearch.host.url=<The full URL of your Elasticsearch endpoint> -Dtest.elasticsearch.host.aws.access_key=<Your access key> -Dtest.elasticsearch.host.aws.secret_key=<Your secret key> -Dtest.elasticsearch.host.aws.region=<Your AWS region ID>
+    > mvn integration-test -pl elasticsearch -Dtest.elasticsearch.host.url=<The full URL of your Elasticsearch endpoint> -Dtest.elasticsearch.host.aws.access_key=<Your access key> -Dtest.elasticsearch.host.aws.secret_key=<Your secret key> -Dtest.elasticsearch.host.aws.region=<Your AWS region ID>
 
 When building Hibernate Search with new JDKs, you may want to run Elasticsearch with a different JDK than the one used by Maven.
 This can be done by setting a property

--- a/integrationtest/wildfly/pom.xml
+++ b/integrationtest/wildfly/pom.xml
@@ -475,7 +475,7 @@
                 <test.module-slot.org.hibernate.search>main</test.module-slot.org.hibernate.search>
                 <test.module-slot.org.hibernate>main</test.module-slot.org.hibernate>
                 <!-- WildFly doesn't package Hibernate Search ElasticSearch integration, no need to launch an instance -->
-                <test.elasticsearch.host.provided>true</test.elasticsearch.host.provided>
+                <test.elasticsearch.run.skip>true</test.elasticsearch.run.skip>
             </properties>
             <build>
                 <plugins>

--- a/jenkins/performance-elasticsearch.groovy
+++ b/jenkins/performance-elasticsearch.groovy
@@ -6,7 +6,7 @@ node ('Performance') {
 	stage ('Build') {
 		sh "mvn clean install" +
 				" -U -am -pl :hibernate-search-performance-engine-elasticsearch" +
-				" -DskipTests -Dtest.elasticsearch.host.provided=true"
+				" -DskipTests -Dtest.elasticsearch.run.skip=true"
 	}
 	
 	stage ('Performance test') {

--- a/jenkins/performance-orm.groovy
+++ b/jenkins/performance-orm.groovy
@@ -6,7 +6,7 @@ node ('Performance') {
 	stage ('Build') {
 		sh "mvn clean install" +
 				" -U -am -pl :hibernate-search-performance-orm" +
-				" -DskipTests -Dtest.elasticsearch.host.provided=true"
+				" -DskipTests -Dtest.elasticsearch.run.skip=true"
 	}
 	
 	def scenarios

--- a/pom.xml
+++ b/pom.xml
@@ -284,7 +284,7 @@
         <!-- Elasticsearch tests properties -->
 
         <test.elasticsearch.java_home>${java.home}</test.elasticsearch.java_home>
-        <test.elasticsearch.host.url>http://localhost:9200</test.elasticsearch.host.url>
+        <test.elasticsearch.host.url></test.elasticsearch.host.url><!-- The default is set in profiles -->
         <test.elasticsearch.host.username></test.elasticsearch.host.username>
         <test.elasticsearch.host.password></test.elasticsearch.host.password>
 
@@ -1798,6 +1798,7 @@
                     <artifactId>elasticsearch-maven-plugin</artifactId>
                     <version>${version.elasticsearch.plugin}</version>
                     <configuration>
+                        <skip>${test.elasticsearch.run.skip}</skip>
                         <clusterName>hsearchEsTestCluster</clusterName>
                         <httpPort>9200</httpPort>
                     </configuration>
@@ -1919,7 +1920,7 @@
             </activation>
             <properties>
                 <!-- This is to avoid starting an Elasticsearch node for each module needing integration test -->
-                <test.elasticsearch.host.provided>true</test.elasticsearch.host.provided>
+                <test.elasticsearch.run.skip>true</test.elasticsearch.run.skip>
                 <!-- And this to avoid unzipping any WildFly server, included modules, configurations and JDBC drivers -->
                 <skipWildFlyPreparation>true</skipWildFlyPreparation>
             </properties>
@@ -1933,7 +1934,7 @@
             </activation>
             <properties>
                 <!-- This is to avoid starting an Elasticsearch node for each module needing integration test -->
-                <test.elasticsearch.host.provided>true</test.elasticsearch.host.provided>
+                <test.elasticsearch.run.skip>true</test.elasticsearch.run.skip>
                 <!-- And this to avoid unzipping any WildFly server, included modules, configurations and JDBC drivers -->
                 <skipWildFlyPreparation>true</skipWildFlyPreparation>
             </properties>
@@ -2298,6 +2299,34 @@
                  mvn clean test -Pelasticsearch-2.0 -Dtest.elasticsearch.version=2.1.0
           -->
 
+        <!-- Profile enabled when an Elasticsearch instance must be run by Maven -->
+        <profile>
+            <id>elasticsearch-run</id>
+            <activation>
+                <!-- Activate by default, i.e. if test.elasticsearch.host.url has not been defined explicitly -->
+                <property>
+                    <name>!test.elasticsearch.host.url</name>
+                </property>
+            </activation>
+            <properties>
+                <test.elasticsearch.host.url>http://localhost:9200</test.elasticsearch.host.url>
+                <test.elasticsearch.run.skip>false</test.elasticsearch.run.skip>
+            </properties>
+        </profile>
+        <!-- Profile enabled when an Elasticsearch instance must NOT be run by Maven -->
+        <profile>
+            <id>elasticsearch-do-not-run</id>
+            <activation>
+                <!-- Activate if test.elasticsearch.host.url has been defined explicitly -->
+                <property>
+                    <name>test.elasticsearch.host.url</name>
+                </property>
+            </activation>
+            <properties>
+                <test.elasticsearch.run.skip>true</test.elasticsearch.run.skip>
+            </properties>
+        </profile>
+
         <!-- Elasticsearch [2.0,2.2) test environment -->
         <profile>
             <id>elasticsearch-2.0</id>
@@ -2318,7 +2347,7 @@
                                         <goal>unpack</goal>
                                     </goals>
                                     <configuration>
-                                        <skip>${test.elasticsearch.host.provided}</skip>
+                                        <skip>${test.elasticsearch.run.skip}</skip>
                                         <artifactItems>
                                             <!-- Delete-by-query is a plugin in Elasticsearch 2.x -->
                                             <artifactItem>
@@ -2339,7 +2368,7 @@
                             <artifactId>elasticsearch-maven-plugin</artifactId>
                             <version>${version.elasticsearch.plugin}</version>
                             <configuration>
-                                <skip>${test.elasticsearch.host.provided}</skip>
+                                <skip>${test.elasticsearch.run.skip}</skip>
                                 <tcpPort>9300</tcpPort>
                                 <pluginsPath>${project.build.directory}/_ES_PLUGINS_</pluginsPath>
                                 <outputDirectory>${project.build.directory}/elastisearch0</outputDirectory>
@@ -2405,7 +2434,7 @@
                                         <goal>unpack</goal>
                                     </goals>
                                     <configuration>
-                                        <skip>${test.elasticsearch.host.provided}</skip>
+                                        <skip>${test.elasticsearch.run.skip}</skip>
                                         <artifactItems>
                                             <!-- Delete-by-query is a plugin in Elasticsearch 2.x -->
                                             <artifactItem>
@@ -2435,7 +2464,7 @@
                             <artifactId>elasticsearch-maven-plugin</artifactId>
                             <version>${version.elasticsearch.plugin}</version>
                             <configuration>
-                                <skip>${test.elasticsearch.host.provided}</skip>
+                                <skip>${test.elasticsearch.run.skip}</skip>
                                 <tcpPort>9300</tcpPort>
                                 <pluginsPath>${project.build.directory}/_ES_PLUGINS_</pluginsPath>
                                 <outputDirectory>${project.build.directory}/elastisearch0</outputDirectory>
@@ -2485,7 +2514,7 @@
                             <artifactId>elasticsearch-maven-plugin</artifactId>
                             <version>${version.elasticsearch.plugin}</version>
                             <configuration>
-                                <skip>${test.elasticsearch.host.provided}</skip>
+                                <skip>${test.elasticsearch.run.skip}</skip>
                                 <version>${test.elasticsearch.host.version}</version>
                                 <timeout>90</timeout><!-- Make it work on our slow CI -->
                                 <pathConf>${project.build.directory}/elasticsearch-maven-plugin/5.0/configuration/</pathConf>
@@ -2539,7 +2568,7 @@
                             <artifactId>elasticsearch-maven-plugin</artifactId>
                             <version>${version.elasticsearch.plugin}</version>
                             <configuration>
-                                <skip>${test.elasticsearch.host.provided}</skip>
+                                <skip>${test.elasticsearch.run.skip}</skip>
                                 <version>${test.elasticsearch.host.version}</version>
                                 <timeout>90</timeout><!-- Make it work on our slow CI -->
                                 <pathConf>${project.build.directory}/elasticsearch-maven-plugin/5.0/configuration/</pathConf>


### PR DESCRIPTION
* [HSEARCH-4190](https://hibernate.atlassian.net/browse/HSEARCH-4190): Backport Jenkinsfile improvements to 5.10/5.11
* [HSEARCH-4189](https://hibernate.atlassian.net/browse/HSEARCH-4189): Test Hibernate Search against JDK 17

Backport of #2526

