### PR TITLE
Backport HSEARCH-4189 to branch 6.0 - Test Hibernate Search against JDK 17

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -184,7 +184,7 @@ stage('Configure') {
 							condition: TestCondition.BEFORE_MERGE,
 							isDefault: true),
 					new JdkBuildEnvironment(version: '14', buildJdkTool: 'OpenJDK 14 Latest',
-							condition: TestCondition.AFTER_MERGE),
+							condition: TestCondition.ON_DEMAND),
 					new JdkBuildEnvironment(version: '15', buildJdkTool: 'OpenJDK 15 Latest',
 							condition: TestCondition.AFTER_MERGE),
 					new JdkBuildEnvironment(version: '16', buildJdkTool: 'OpenJDK 16 Latest',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -188,6 +188,8 @@ stage('Configure') {
 					new JdkBuildEnvironment(version: '15', buildJdkTool: 'OpenJDK 15 Latest',
 							condition: TestCondition.AFTER_MERGE),
 					new JdkBuildEnvironment(version: '16', buildJdkTool: 'OpenJDK 16 Latest',
+							condition: TestCondition.AFTER_MERGE),
+					new JdkBuildEnvironment(version: '17', buildJdkTool: 'OpenJDK 17 Latest',
 							condition: TestCondition.AFTER_MERGE)
 			],
 			compiler: [


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4189

Backport of #2526

Build for all JDKs: https://ci.hibernate.org/blue/organizations/jenkins/hibernate-search-personal-yoann/detail/HSEARCH-4189-6.0/2/pipeline