### PR TITLE
HSEARCH-4207 Clarify in README that Hibernate Search is licensed under LGPL v2.1 *or later*

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,10 @@ long totalHitCount = result.total().hitCount();
 
 ## License
 
-This software and its documentation are distributed under the terms of the FSF Lesser GNU Public
-License (see lgpl.txt).
+This software and its documentation are distributed under the terms of
+the GNU Lesser General Public License (LGPL), version 2.1 or later.
+
+See the `lgpl.txt` file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
 
 ## Getting started
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4207

It's really just a clarification, as source file headers already state that.

See https://github.com/hibernate/hibernate-orm/discussions/3903