### PR TITLE
Backport HSEARCH-4213 to branch 6.0 - Upgrade to Jackson 2.12.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
         <version.com.google.code.gson>2.8.5</version.com.google.code.gson>
         <version.software.amazon.awssdk>2.14.18</version.software.amazon.awssdk>
         <!-- Jackson: used by the Elasticsearch REST client, the AWS SDK and in tests (wiremock, ...) -->
-        <version.com.fasterxml.jackson>2.10.4</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.12.3</version.com.fasterxml.jackson>
         <!--
              In the past, there has been jackson-databind bugfix releases without any jackson-core release,
              so we had to use different versions, e.g. jackson-core 2.9.9 and jackson-databind 2.9.9.3.


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4213

Backport of #2547