### PR TITLE
HSEARCH-4214 hibernate.search.backend.version_check.enabled should be evaluated on backend startup

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchBackendFactory.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchBackendFactory.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.backend.elasticsearch.impl;
 
-import java.lang.invoke.MethodHandles;
 import java.util.Locale;
 import java.util.Optional;
 
@@ -18,7 +17,6 @@ import org.hibernate.search.backend.elasticsearch.dialect.impl.ElasticsearchDial
 import org.hibernate.search.backend.elasticsearch.dialect.model.impl.ElasticsearchModelDialect;
 import org.hibernate.search.backend.elasticsearch.gson.spi.GsonProvider;
 import org.hibernate.search.backend.elasticsearch.index.layout.IndexLayoutStrategy;
-import org.hibernate.search.backend.elasticsearch.logging.impl.Log;
 import org.hibernate.search.backend.elasticsearch.mapping.TypeNameMappingStrategyName;
 import org.hibernate.search.backend.elasticsearch.mapping.impl.DiscriminatorTypeNameMapping;
 import org.hibernate.search.backend.elasticsearch.mapping.impl.IndexNameTypeNameMapping;
@@ -34,13 +32,11 @@ import org.hibernate.search.engine.backend.spi.BackendFactory;
 import org.hibernate.search.engine.backend.spi.BackendImplementor;
 import org.hibernate.search.engine.cfg.spi.ConfigurationProperty;
 import org.hibernate.search.engine.cfg.ConfigurationPropertySource;
-import org.hibernate.search.engine.cfg.spi.OptionalConfigurationProperty;
 import org.hibernate.search.engine.environment.bean.BeanHolder;
 import org.hibernate.search.engine.environment.bean.BeanReference;
 import org.hibernate.search.engine.environment.bean.BeanResolver;
 import org.hibernate.search.util.common.AssertionFailure;
 import org.hibernate.search.util.common.impl.SuppressingCloser;
-import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 import org.hibernate.search.util.common.reporting.EventContext;
 
 import com.google.gson.Gson;
@@ -48,19 +44,6 @@ import com.google.gson.GsonBuilder;
 
 
 public class ElasticsearchBackendFactory implements BackendFactory {
-
-	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
-
-	private static final OptionalConfigurationProperty<ElasticsearchVersion> VERSION =
-			ConfigurationProperty.forKey( ElasticsearchBackendSettings.VERSION )
-					.as( ElasticsearchVersion.class, ElasticsearchVersion::of )
-					.build();
-
-	private static final ConfigurationProperty<Boolean> VERSION_CHECK_ENABLED =
-			ConfigurationProperty.forKey( ElasticsearchBackendSettings.VERSION_CHECK_ENABLED )
-					.asBoolean()
-					.withDefault( ElasticsearchBackendSettings.Defaults.VERSION_CHECK_ENABLED )
-					.build();
 
 	private static final ConfigurationProperty<MultiTenancyStrategyName> MULTI_TENANCY_STRATEGY =
 			ConfigurationProperty.forKey( ElasticsearchBackendSettings.MULTI_TENANCY_STRATEGY )
@@ -103,8 +86,7 @@ public class ElasticsearchBackendFactory implements BackendFactory {
 		 */
 		GsonProvider defaultGsonProvider = GsonProvider.create( GsonBuilder::new, logPrettyPrinting );
 
-		Optional<ElasticsearchVersion> configuredVersion = VERSION.get( propertySource );
-		boolean versionCheckEnabled = getVersionCheckEnabled( propertySource );
+		Optional<ElasticsearchVersion> configuredVersion = ElasticsearchLinkImpl.VERSION.get( propertySource );
 
 		BeanResolver beanResolver = buildContext.beanResolver();
 		BeanHolder<? extends ElasticsearchClientFactory> clientFactoryHolder = null;
@@ -119,7 +101,7 @@ public class ElasticsearchBackendFactory implements BackendFactory {
 			ElasticsearchDialectFactory dialectFactory = new ElasticsearchDialectFactory();
 			link = new ElasticsearchLinkImpl(
 					clientFactoryHolder, threads, defaultGsonProvider, logPrettyPrinting,
-					dialectFactory, configuredVersion, versionCheckEnabled
+					dialectFactory, configuredVersion
 			);
 
 			ElasticsearchModelDialect dialect;
@@ -163,20 +145,6 @@ public class ElasticsearchBackendFactory implements BackendFactory {
 					.push( BackendThreads::onStop, threads );
 			throw e;
 		}
-	}
-
-	private boolean getVersionCheckEnabled(ConfigurationPropertySource propertySource) {
-		boolean versionCheckEnabled = VERSION_CHECK_ENABLED.get( propertySource );
-		if ( !versionCheckEnabled ) {
-			VERSION.getAndTransform( propertySource, optionalValue -> {
-				if ( !optionalValue.isPresent() || optionalValue.isPresent() && !optionalValue.get().minor().isPresent() ) {
-					throw log.impreciseElasticsearchVersionWhenNoVersionCheck(
-							VERSION_CHECK_ENABLED.resolveOrRaw( propertySource ) );
-				}
-				return optionalValue;
-			} );
-		}
-		return versionCheckEnabled;
 	}
 
 	private MultiTenancyStrategy getMultiTenancyStrategy(ConfigurationPropertySource propertySource) {

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
@@ -740,4 +740,13 @@ public interface Log extends BasicLogger {
 			" hits. Refer to Elasticsearch's 'max_result_window_size' setting for more information." )
 	void defaultedLimitedHits(Integer defaultLimit, long hitCount);
 
+	@Message(id = ID_OFFSET + 141,
+			value = "Incompatible Elasticsearch version:"
+					+ " version '%2$s' does not match version '%1$s' that was provided "
+					+ " when the backend was created."
+					+ " You can provide a more precise version on startup,"
+					+ " but you cannot override the version that was provided when the backend was created.")
+	SearchException incompatibleElasticsearchVersionOnStart(ElasticsearchVersion versionOnCreation,
+			ElasticsearchVersion versionOnStart);
+
 }

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/bootstrap/ElasticsearchBootstrapIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/bootstrap/ElasticsearchBootstrapIT.java
@@ -10,10 +10,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hibernate.search.util.impl.integrationtest.common.assertion.SearchResultAssert.assertThatQuery;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.hibernate.search.backend.elasticsearch.ElasticsearchVersion;
 import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
 import org.hibernate.search.backend.elasticsearch.cfg.spi.ElasticsearchBackendSpiSettings;
 import org.hibernate.search.backend.elasticsearch.client.spi.ElasticsearchRequest;
+import org.hibernate.search.engine.cfg.BackendSettings;
+import org.hibernate.search.engine.cfg.spi.AllAwareConfigurationPropertySource;
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchClientSpy;
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchRequestAssertionMode;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
@@ -125,7 +130,7 @@ public class ElasticsearchBootstrapIT {
 						)
 						.withSchemaManagement( StubMappingSchemaManagementStrategy.DROP_ON_SHUTDOWN_ONLY )
 						.withIndex( StubMappedIndex.withoutFields() )
-						.setupFirstPhaseOnly(),
+						.setup(),
 				"NO version check with partial version number"
 		)
 				.isInstanceOf( SearchException.class )
@@ -151,9 +156,6 @@ public class ElasticsearchBootstrapIT {
 
 		SearchSetupHelper.PartialSetup partialSetup = setupHelper.start()
 				.withBackendProperty(
-						ElasticsearchBackendSettings.VERSION_CHECK_ENABLED, false
-				)
-				.withBackendProperty(
 						ElasticsearchBackendSettings.VERSION, versionWithMajorAndMinorOnly
 				)
 				.withBackendProperty(
@@ -166,7 +168,92 @@ public class ElasticsearchBootstrapIT {
 		// We do not expect the client to be created in the first phase
 		assertThat( elasticsearchClientSpy.getCreatedClientCount() ).isZero();
 
-		partialSetup.doSecondPhase();
+		Map<String, Object> runtimeProperties = new HashMap<>();
+		runtimeProperties.put( BackendSettings.backendKey( ElasticsearchBackendSettings.VERSION_CHECK_ENABLED ), false );
+		partialSetup.doSecondPhase( AllAwareConfigurationPropertySource.fromMap( runtimeProperties ) );
+		// We do not expect any request, since the version check is disabled
+		assertThat( elasticsearchClientSpy.getRequestCount() ).isZero();
+
+		checkBackendWorks();
+
+		assertThat( elasticsearchClientSpy.getRequestCount() ).isNotZero();
+	}
+
+	/**
+	 * Check that an exception is thrown when version_check.enabled is false
+	 * and specifying a version on backend creation, and a different one on backend start.
+	 */
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4214")
+	public void noVersionCheck_versionOverrideOnStart_incompatibleVersion() {
+		ElasticsearchVersion clusterVersion = ElasticsearchVersion.of( ElasticsearchTestDialect.getClusterVersion() );
+		String versionWithMajorOnly = String.valueOf( clusterVersion.major() );
+		String incompatibleVersionWithMajorAndMinorOnly = "2." + clusterVersion.minor().getAsInt();
+
+		SearchSetupHelper.PartialSetup partialSetup = setupHelper.start()
+				.withBackendProperty(
+						ElasticsearchBackendSettings.VERSION, versionWithMajorOnly
+				)
+				.withBackendProperty(
+						ElasticsearchBackendSpiSettings.CLIENT_FACTORY,
+						elasticsearchClientSpy.factoryReference()
+				)
+				.withSchemaManagement( StubMappingSchemaManagementStrategy.DROP_ON_SHUTDOWN_ONLY )
+				.withIndex( index )
+				.setupFirstPhaseOnly();
+		// We do not expect the client to be created in the first phase
+		assertThat( elasticsearchClientSpy.getCreatedClientCount() ).isZero();
+
+		Map<String, Object> runtimeProperties = new HashMap<>();
+		runtimeProperties.put( BackendSettings.backendKey( ElasticsearchBackendSettings.VERSION_CHECK_ENABLED ), false );
+		runtimeProperties.put( BackendSettings.backendKey( ElasticsearchBackendSettings.VERSION ), incompatibleVersionWithMajorAndMinorOnly );
+		assertThatThrownBy(
+				() -> partialSetup.doSecondPhase( AllAwareConfigurationPropertySource.fromMap( runtimeProperties ) ) )
+				.isInstanceOf( SearchException.class )
+				.hasMessageMatching( FailureReportUtils.buildFailureReportPattern()
+						.defaultBackendContext()
+						.failure(
+								"Invalid value for configuration property 'hibernate.search.backend.version': '"
+										+ incompatibleVersionWithMajorAndMinorOnly + "'",
+								"Incompatible Elasticsearch version:"
+										+ " version '" + incompatibleVersionWithMajorAndMinorOnly
+										+ "' does not match version '" + versionWithMajorOnly + "' that was provided "
+										+ " when the backend was created.",
+								"You can provide a more precise version on startup,"
+										+ " but you cannot override the version that was provided when the backend was created." )
+						.build()
+				);
+	}
+
+	/**
+	 * Check everything works fine when version_check.enabled is false
+	 * and specifying a version on backend creation, and a more precise one on backend start.
+	 */
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4214")
+	public void noVersionCheck_versionOverrideOnStart_compatibleVersion() {
+		ElasticsearchVersion clusterVersion = ElasticsearchVersion.of( ElasticsearchTestDialect.getClusterVersion() );
+		String versionWithMajorOnly = String.valueOf( clusterVersion.major() );
+		String versionWithMajorAndMinorOnly = clusterVersion.major() + "." + clusterVersion.minor().getAsInt();
+
+		SearchSetupHelper.PartialSetup partialSetup = setupHelper.start()
+				.withBackendProperty(
+						ElasticsearchBackendSettings.VERSION, versionWithMajorOnly
+				)
+				.withBackendProperty(
+						ElasticsearchBackendSpiSettings.CLIENT_FACTORY,
+						elasticsearchClientSpy.factoryReference()
+				)
+				.withSchemaManagement( StubMappingSchemaManagementStrategy.DROP_ON_SHUTDOWN_ONLY )
+				.withIndex( index )
+				.setupFirstPhaseOnly();
+		// We do not expect the client to be created in the first phase
+		assertThat( elasticsearchClientSpy.getCreatedClientCount() ).isZero();
+
+		Map<String, Object> runtimeProperties = new HashMap<>();
+		runtimeProperties.put( BackendSettings.backendKey( ElasticsearchBackendSettings.VERSION_CHECK_ENABLED ), false );
+		runtimeProperties.put( BackendSettings.backendKey( ElasticsearchBackendSettings.VERSION ), versionWithMajorAndMinorOnly );
+		partialSetup.doSecondPhase( AllAwareConfigurationPropertySource.fromMap( runtimeProperties ) );
 		// We do not expect any request, since the version check is disabled
 		assertThat( elasticsearchClientSpy.getRequestCount() ).isZero();
 

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchClientSpy.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchClientSpy.java
@@ -29,6 +29,7 @@ import org.junit.runners.model.Statement;
 
 public class ElasticsearchClientSpy implements TestRule {
 	private final AtomicInteger createdClientCount = new AtomicInteger();
+	private final AtomicInteger requestCount = new AtomicInteger();
 	private final CallQueue<ElasticsearchClientSubmitCall> expectations = new CallQueue<>();
 
 	@Override
@@ -65,6 +66,10 @@ public class ElasticsearchClientSpy implements TestRule {
 
 	public int getCreatedClientCount() {
 		return createdClientCount.get();
+	}
+
+	public int getRequestCount() {
+		return requestCount.get();
 	}
 
 	public BeanReference<ElasticsearchClientFactory> factoryReference() {
@@ -120,6 +125,7 @@ public class ElasticsearchClientSpy implements TestRule {
 
 		@Override
 		public CompletableFuture<ElasticsearchResponse> submit(ElasticsearchRequest request) {
+			requestCount.incrementAndGet();
 			return expectations.verify(
 					new ElasticsearchClientSubmitCall( request ),
 					// If there was an expectation, check it is met and forward the request to the actual client

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/rule/SearchSetupHelper.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/rule/SearchSetupHelper.java
@@ -18,10 +18,10 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import org.hibernate.search.engine.cfg.BackendSettings;
+import org.hibernate.search.engine.cfg.ConfigurationPropertySource;
 import org.hibernate.search.engine.cfg.EngineSettings;
 import org.hibernate.search.engine.cfg.spi.AllAwareConfigurationPropertySource;
 import org.hibernate.search.engine.cfg.spi.ConfigurationPropertyChecker;
-import org.hibernate.search.engine.cfg.ConfigurationPropertySource;
 import org.hibernate.search.engine.common.spi.SearchIntegration;
 import org.hibernate.search.engine.common.spi.SearchIntegrationBuilder;
 import org.hibernate.search.engine.common.spi.SearchIntegrationFinalizer;
@@ -241,9 +241,9 @@ public class SearchSetupHelper implements TestRule {
 			SearchIntegrationPartialBuildState integrationPartialBuildState = integrationBuilder.prepareBuild();
 			integrationPartialBuildStates.add( integrationPartialBuildState );
 
-			return () -> {
+			return overrides -> {
 				SearchIntegrationFinalizer finalizer =
-						integrationPartialBuildState.finalizer( propertySource, unusedPropertyChecker );
+						integrationPartialBuildState.finalizer( propertySource.withOverride( overrides ), unusedPropertyChecker );
 				StubMapping mapping = finalizer.finalizeMapping(
 						mappingKey,
 						(context, partialMapping) -> partialMapping.finalizeMapping( schemaManagementStrategy )
@@ -265,7 +265,11 @@ public class SearchSetupHelper implements TestRule {
 
 	public interface PartialSetup {
 
-		SearchIntegration doSecondPhase();
+		default SearchIntegration doSecondPhase() {
+			return doSecondPhase( ConfigurationPropertySource.empty() );
+		}
+
+		SearchIntegration doSecondPhase(ConfigurationPropertySource overrides);
 
 	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4214

Related: https://github.com/quarkusio/quarkus/pull/16655