### PR TITLE
Backport HSEARCH-4214 to branch 6.0 - hibernate.search.backend.version_check.enabled should be evaluated on backend startup

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchLinkImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/impl/ElasticsearchLinkImpl.java
@@ -6,7 +6,9 @@
  */
 package org.hibernate.search.backend.elasticsearch.impl;
 
-import com.google.gson.GsonBuilder;
+import java.lang.invoke.MethodHandles;
+import java.util.Optional;
+
 import org.hibernate.search.backend.elasticsearch.ElasticsearchVersion;
 import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchBackendSettings;
 import org.hibernate.search.backend.elasticsearch.client.impl.ElasticsearchClientUtils;
@@ -25,17 +27,28 @@ import org.hibernate.search.backend.elasticsearch.search.query.impl.Elasticsearc
 import org.hibernate.search.backend.elasticsearch.work.builder.factory.impl.ElasticsearchWorkBuilderFactory;
 import org.hibernate.search.engine.cfg.spi.ConfigurationProperty;
 import org.hibernate.search.engine.cfg.spi.ConfigurationPropertySource;
+import org.hibernate.search.engine.cfg.spi.OptionalConfigurationProperty;
 import org.hibernate.search.engine.environment.bean.BeanHolder;
 import org.hibernate.search.engine.environment.bean.BeanResolver;
 import org.hibernate.search.util.common.AssertionFailure;
 import org.hibernate.search.util.common.impl.Closer;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
-import java.lang.invoke.MethodHandles;
-import java.util.Optional;
+import com.google.gson.GsonBuilder;
 
 class ElasticsearchLinkImpl implements ElasticsearchLink {
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+
+	static final OptionalConfigurationProperty<ElasticsearchVersion> VERSION =
+			ConfigurationProperty.forKey( ElasticsearchBackendSettings.VERSION )
+					.as( ElasticsearchVersion.class, ElasticsearchVersion::of )
+					.build();
+
+	private static final ConfigurationProperty<Boolean> VERSION_CHECK_ENABLED =
+			ConfigurationProperty.forKey( ElasticsearchBackendSettings.VERSION_CHECK_ENABLED )
+					.asBoolean()
+					.withDefault( ElasticsearchBackendSettings.Defaults.VERSION_CHECK_ENABLED )
+					.build();
 
 	private static final ConfigurationProperty<Integer> SCROLL_TIMEOUT =
 			ConfigurationProperty.forKey( ElasticsearchBackendSettings.SCROLL_TIMEOUT )
@@ -48,8 +61,7 @@ class ElasticsearchLinkImpl implements ElasticsearchLink {
 	private final GsonProvider defaultGsonProvider;
 	private final boolean logPrettyPrinting;
 	private final ElasticsearchDialectFactory dialectFactory;
-	private final Optional<ElasticsearchVersion> configuredVersionOptional;
-	private final boolean versionCheckEnabled;
+	private final Optional<ElasticsearchVersion> configuredVersionOnBackendCreationOptional;
 
 	private ElasticsearchClientImplementor clientImplementor;
 	private ElasticsearchVersion elasticsearchVersion;
@@ -63,15 +75,13 @@ class ElasticsearchLinkImpl implements ElasticsearchLink {
 	ElasticsearchLinkImpl(BeanHolder<? extends ElasticsearchClientFactory> clientFactoryHolder,
 			BackendThreads threads, GsonProvider defaultGsonProvider, boolean logPrettyPrinting,
 			ElasticsearchDialectFactory dialectFactory,
-			Optional<ElasticsearchVersion> configuredVersionOptional,
-			boolean versionCheckEnabled) {
+			Optional<ElasticsearchVersion> configuredVersionOnBackendCreationOptional) {
 		this.clientFactoryHolder = clientFactoryHolder;
 		this.threads = threads;
 		this.defaultGsonProvider = defaultGsonProvider;
 		this.logPrettyPrinting = logPrettyPrinting;
 		this.dialectFactory = dialectFactory;
-		this.configuredVersionOptional = configuredVersionOptional;
-		this.versionCheckEnabled = versionCheckEnabled;
+		this.configuredVersionOnBackendCreationOptional = configuredVersionOnBackendCreationOptional;
 	}
 
 	@Override
@@ -129,18 +139,7 @@ class ElasticsearchLinkImpl implements ElasticsearchLink {
 			);
 			clientFactoryHolder.close(); // We won't need it anymore
 
-			if ( versionCheckEnabled ) {
-				elasticsearchVersion = ElasticsearchClientUtils.getElasticsearchVersion( clientImplementor );
-				if ( configuredVersionOptional.isPresent() ) {
-					ElasticsearchVersion configuredVersion = configuredVersionOptional.get();
-					if ( !configuredVersion.matches( elasticsearchVersion ) ) {
-						throw log.unexpectedElasticsearchVersion( configuredVersion, elasticsearchVersion );
-					}
-				}
-			}
-			else {
-				configuredVersionOptional.ifPresent( version -> elasticsearchVersion = version );
-			}
+			elasticsearchVersion = initVersion( propertySource );
 
 			ElasticsearchProtocolDialect protocolDialect = dialectFactory.createProtocolDialect( elasticsearchVersion );
 			gsonProvider = GsonProvider.create( GsonBuilder::new, logPrettyPrinting );
@@ -164,6 +163,52 @@ class ElasticsearchLinkImpl implements ElasticsearchLink {
 			throw new AssertionFailure(
 					"Attempt to retrieve Elasticsearch client or related information before the backend was started."
 			);
+		}
+	}
+
+	private ElasticsearchVersion initVersion(ConfigurationPropertySource propertySource) {
+		boolean versionCheckEnabled = VERSION_CHECK_ENABLED.get( propertySource );
+		Optional<ElasticsearchVersion> configuredVersionOptional = VERSION.getAndTransform( propertySource,
+				configuredVersionOnStartOptional -> {
+					Optional<ElasticsearchVersion> resultOptional;
+					if ( configuredVersionOnStartOptional.isPresent() ) {
+						// Allow overriding the version on start,
+						// but expect it to match the version configured on backend creation (if any)
+						if ( configuredVersionOnBackendCreationOptional.isPresent()
+								&& !configuredVersionOnBackendCreationOptional.get()
+								.matches( configuredVersionOnStartOptional.get() ) ) {
+							throw log.incompatibleElasticsearchVersionOnStart(
+									configuredVersionOnBackendCreationOptional.get(),
+									configuredVersionOnStartOptional.get() );
+						}
+						resultOptional = configuredVersionOnStartOptional;
+					}
+					else {
+						// Default to the version configured when the backend was created
+						resultOptional = configuredVersionOnBackendCreationOptional;
+					}
+					if ( !versionCheckEnabled
+							&& ( !resultOptional.isPresent() || !resultOptional.get().minor().isPresent() ) ) {
+						throw log.impreciseElasticsearchVersionWhenNoVersionCheck(
+								VERSION_CHECK_ENABLED.resolveOrRaw( propertySource ) );
+					}
+					return resultOptional;
+				} );
+
+		if ( versionCheckEnabled ) {
+			ElasticsearchVersion versionFromCluster =
+					ElasticsearchClientUtils.getElasticsearchVersion( clientImplementor );
+			if ( configuredVersionOptional.isPresent() ) {
+				ElasticsearchVersion configuredVersion = configuredVersionOptional.get();
+				if ( !configuredVersion.matches( versionFromCluster ) ) {
+					throw log.unexpectedElasticsearchVersion( configuredVersion, versionFromCluster );
+				}
+			}
+			return versionFromCluster;
+		}
+		else {
+			// In this case we know the optional is non-empty, see above.
+			return configuredVersionOptional.get();
 		}
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/logging/impl/Log.java
@@ -704,4 +704,13 @@ public interface Log extends BasicLogger {
 	@Message(id = ID_OFFSET + 130,
 			value = "Invalid target hosts configuration: the list of URIs must not be empty.")
 	SearchException emptyListOfUris();
+
+	@Message(id = ID_OFFSET + 141,
+			value = "Incompatible Elasticsearch version:"
+					+ " version '%2$s' does not match version '%1$s' that was provided "
+					+ " when the backend was created."
+					+ " You can provide a more precise version on startup,"
+					+ " but you cannot override the version that was provided when the backend was created.")
+	SearchException incompatibleElasticsearchVersionOnStart(ElasticsearchVersion versionOnCreation,
+			ElasticsearchVersion versionOnStart);
 }

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchClientSpy.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/util/ElasticsearchClientSpy.java
@@ -29,6 +29,7 @@ import org.junit.runners.model.Statement;
 
 public class ElasticsearchClientSpy implements TestRule {
 	private final AtomicInteger createdClientCount = new AtomicInteger();
+	private final AtomicInteger requestCount = new AtomicInteger();
 	private final CallQueue<ElasticsearchClientSubmitCall> expectations = new CallQueue<>();
 
 	@Override
@@ -65,6 +66,10 @@ public class ElasticsearchClientSpy implements TestRule {
 
 	public int getCreatedClientCount() {
 		return createdClientCount.get();
+	}
+
+	public int getRequestCount() {
+		return requestCount.get();
 	}
 
 	public BeanReference<ElasticsearchClientFactory> factoryReference() {
@@ -120,6 +125,7 @@ public class ElasticsearchClientSpy implements TestRule {
 
 		@Override
 		public CompletableFuture<ElasticsearchResponse> submit(ElasticsearchRequest request) {
+			requestCount.incrementAndGet();
 			return expectations.verify(
 					new ElasticsearchClientSubmitCall( request ),
 					// If there was an expectation, check it is met and forward the request to the actual client

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/rule/SearchSetupHelper.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/rule/SearchSetupHelper.java
@@ -20,8 +20,8 @@ import java.util.function.Function;
 import org.hibernate.search.engine.cfg.BackendSettings;
 import org.hibernate.search.engine.cfg.EngineSettings;
 import org.hibernate.search.engine.cfg.spi.AllAwareConfigurationPropertySource;
-import org.hibernate.search.engine.cfg.spi.ConfigurationPropertyChecker;
 import org.hibernate.search.engine.cfg.spi.ConfigurationPropertySource;
+import org.hibernate.search.engine.cfg.spi.ConfigurationPropertyChecker;
 import org.hibernate.search.engine.common.spi.SearchIntegration;
 import org.hibernate.search.engine.common.spi.SearchIntegrationBuilder;
 import org.hibernate.search.engine.common.spi.SearchIntegrationFinalizer;
@@ -241,9 +241,9 @@ public class SearchSetupHelper implements TestRule {
 			SearchIntegrationPartialBuildState integrationPartialBuildState = integrationBuilder.prepareBuild();
 			integrationPartialBuildStates.add( integrationPartialBuildState );
 
-			return () -> {
+			return overrides -> {
 				SearchIntegrationFinalizer finalizer =
-						integrationPartialBuildState.finalizer( propertySource, unusedPropertyChecker );
+						integrationPartialBuildState.finalizer( propertySource.withOverride( overrides ), unusedPropertyChecker );
 				StubMapping mapping = finalizer.finalizeMapping(
 						mappingKey,
 						(context, partialMapping) -> partialMapping.finalizeMapping( schemaManagementStrategy )
@@ -265,7 +265,11 @@ public class SearchSetupHelper implements TestRule {
 
 	public interface PartialSetup {
 
-		SearchIntegration doSecondPhase();
+		default SearchIntegration doSecondPhase() {
+			return doSecondPhase( ConfigurationPropertySource.empty() );
+		}
+
+		SearchIntegration doSecondPhase(ConfigurationPropertySource overrides);
 
 	}
 }


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4214

Backport of #2550