### PR TITLE
HSEARCH-4215 Add information about session activity.

### DIFF
--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/session/SearchSession.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/session/SearchSession.java
@@ -27,6 +27,12 @@ public interface SearchSession extends AutoCloseable {
 	void close();
 
 	/**
+	 * Determine whether the search session is open.
+	 * @return true until the search session has been closed
+	 */
+	boolean isOpen();
+
+	/**
 	 * Creates a {@link MassIndexer} to rebuild the indexes of all indexed entity types.
 	 * <p>
 	 * {@link MassIndexer} instances cannot be reused.

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/session/impl/JavaBeanSearchSession.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/session/impl/JavaBeanSearchSession.java
@@ -84,6 +84,11 @@ public class JavaBeanSearchSession extends AbstractPojoSearchSession
 	}
 
 	@Override
+	public boolean isOpen() {
+		return active;
+	}
+
+	@Override
 	public MassIndexer massIndexer(Collection<? extends Class<?>> types) {
 		chackActiveAndThrow();
 		return scope( types ).massIndexer( this );


### PR DESCRIPTION
Session activity information is missing. This is very important if the previously opened session was opened by another code fragment in the same transaction. Elsewhere, the same session is accessed without knowing if a session shutdown was programmatically performed before. 

https://hibernate.atlassian.net/browse/HSEARCH-4215

Use case:
```java
        String key = "some key";
        if (key != null && TransactionHelper.isInTx()) {
            session = SearchTransactionUtil.get(key);
        }

        if (session == null || !session.isOpen()) {
            SearchMapping mapping = createMapping(unit, type, owner);

            session = mapping.createSessionWithOptions().
                    loading((options) -> {
   .........
                    }).build();
            SearchTransactionUtil.put(key, session);
        }
        return session;                        
                        
```
