### PR TITLE
HSEARCH-4216 Fix "NullPointerException" when indexing no indexable entity

### DIFF
--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoMassIndexingTypeProcessor.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoMassIndexingTypeProcessor.java
@@ -142,14 +142,16 @@ class PojoMassIndexingTypeProcessor<E, O> {
 			return;
 		}
 
+		entities.removeIf( entity -> !typeGroup.includesInstance( sessionContext, entity ) );
+		if ( entities.isEmpty() ) {
+			return;
+		}
+
 		notifier.notifyEntitiesLoaded( entities.size() );
 		CompletableFuture<?>[] indexingFutures = new CompletableFuture<?>[entities.size()];
 
 		for ( int i = 0; i < entities.size(); i++ ) {
 			Object entity = entities.get( i );
-			if ( !typeGroup.includesInstance( sessionContext, entity ) ) {
-				continue;
-			}
 			indexingFutures[i] = index( sessionContext, indexer, entity );
 		}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4216

If an unindexed entity is found in the indexed list, indexing ends with an exception. 

```java
Loading and extracting entity data for entity 'StructureGroupRole,DefinedGrant,StructureGrant,GroupMembership,Grant,DefinedGroupRole,GroupRole' during mass indexing
: java.lang.NullPointerException
	at java.base/java.util.concurrent.CompletableFuture.andTree(CompletableFuture.java:1516)
	at java.base/java.util.concurrent.CompletableFuture.andTree(CompletableFuture.java:1515)
	at java.base/java.util.concurrent.CompletableFuture.andTree(CompletableFuture.java:1513)
	at java.base/java.util.concurrent.CompletableFuture.allOf(CompletableFuture.java:2409)
	at org.hibernate.search.mapper//org.hibernate.search.mapper.pojo.massindexing.impl.PojoMassIndexingTypeProcessor.indexList(PojoMassIndexingTypeProcessor.java:157)
	at org.hibernate.search.mapper//org.hibernate.search.mapper.pojo.massindexing.impl.PojoMassIndexingTypeProcessor.lambda$loadAndIndexList$3(PojoMassIndexingTypeProcessor.java:133)
	at org.hibernate.search.mapper//org.hibernate.search.mapper.pojo.intercepting.spi.PojoInterceptingHandler.invokeNextInvocations(PojoInterceptingHandler.java:65)
	at org.hibernate.search.mapper//org.hibernate.search.mapper.pojo.intercepting.spi.PojoInterceptingHandler.lambda$invokeNextInvocations$2(PojoInterceptingHandler.java:62)
	at com.azzumi.portal.kernel//com.azzumi.portal.kernel.storage.search.impl.WrapClassLoadingInterceptor.lambda$intercept$0(WrapClassLoadingInterceptor.java:40)
	at com.azzumi.portal.kernel//com.azzumi.portal.kernel.utils.SecurityHelper.with(SecurityHelper.java:183)
```