### PR TITLE
HSEARCH-4195 Add continuous integration for OpenSearch / Open Distro for Elasticsearch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,7 +184,7 @@ To build the distribution bundle run:
 ### Elasticsearch
 
 The Elasticsearch integration tests run against one single version of Elasticsearch at a time,
-launching an Elasticsearch server automatically on port 9200.
+launching an Elasticsearch server automatically on port 9200 using Docker.
 You may redefine the version to use by specifying the right profile and using the
 `test.elasticsearch.connection.version` property:
 
@@ -194,21 +194,22 @@ You may redefine the version to use by specifying the right profile and using th
 
 The following profiles are available:
 
- * `elasticsearch-5.6` for 5.6.x and later 5.x
- * `elasticsearch-6.0` for 6.0.x to 6.2.x
- * `elasticsearch-6.3` for 6.3.x
- * `elasticsearch-6.4` for 6.4.x to 6.6.x
- * `elasticsearch-6.7` for 6.7.x
- * `elasticsearch-6.8` for 6.8 and later 6.x
- * `elasticsearch-7.0` for 7.0 to 7.2
- * `elasticsearch-7.3` for 7.3 to 7.6
- * `elasticsearch-7.7` for 7.7
- * `elasticsearch-7.8` for 7.8 to 7.9
- * `elasticsearch-7.10` for 7.10 (the default)
- * `elasticsearch-7.11` for 7.11+ ([not open-source](https://opensource.org/node/1099))
-
-A list of available versions for `test.elasticsearch.connection.version` can be found on
-[Maven Central](https://search.maven.org/search?q=g:org.elasticsearch%20AND%20a:elasticsearch&core=gav).
+* Elasticsearch distribution from Elastic
+  (see available version on [Maven Central](https://search.maven.org/search?q=g:org.elasticsearch%20AND%20a:elasticsearch&core=gav))
+  * `elasticsearch-5.6` for 5.6.x and later 5.x
+  * `elasticsearch-6.0` for 6.0.x to 6.2.x
+  * `elasticsearch-6.3` for 6.3.x
+  * `elasticsearch-6.4` for 6.4.x to 6.6.x
+  * `elasticsearch-6.7` for 6.7.x
+  * `elasticsearch-6.8` for 6.8 and later 6.x
+  * `elasticsearch-7.0` for 7.0 to 7.2
+  * `elasticsearch-7.3` for 7.3 to 7.6
+  * `elasticsearch-7.7` for 7.7
+  * `elasticsearch-7.8` for 7.8 to 7.9
+  * `elasticsearch-7.10` for 7.10 (**the default**)
+  * `elasticsearch-7.11` for 7.11+ ([not open-source](https://opensource.org/node/1099))
+* [Open Distro for Elasticsearch](https://opendistro.github.io/for-elasticsearch/):
+  * `opendistro-elasticsearch-1.13` for 1.13+
 
 Alternatively, you can prevent the build from launching an Elasticsearch server automatically
 and run Elasticsearch-related tests against your own server using the
@@ -229,6 +230,15 @@ you will still have to select a profile among those listed above, and specify th
 
 ```bash
 ./mvnw clean install -Pelasticsearch-6.0 -Dtest.elasticsearch.connection.version=6.0.0 \
+        -Dtest.elasticsearch.connection.uris=http://localhost:9200
+```
+
+You can specify the image tag independently of the Elasticsearch version,
+which can be useful for Open Distro for Elasticsearch:
+
+```bash
+./mvnw clean install -Popendistro-elasticsearch-1.13 -Dtest.elasticsearch.run.image.tag=1.13.1 \
+        -Dtest.elasticsearch.connection.version=7.10.2 \
         -Dtest.elasticsearch.connection.uris=http://localhost:9200
 ```
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -562,7 +562,8 @@ stage('Non-default environments') {
 							-pl ${[
 								'org.hibernate.search:hibernate-search-integrationtest-mapper-orm',
 								'org.hibernate.search:hibernate-search-integrationtest-mapper-orm-envers',
-								'org.hibernate.search:hibernate-search-integrationtest-showcase-library'
+								'org.hibernate.search:hibernate-search-integrationtest-showcase-library',
+								'org.hibernate.search:hibernate-search-integrationtest-mapper-orm-realbackend'
 								 ].join(',')} \
 							-P$buildEnv.mavenProfile \
 					"""
@@ -586,7 +587,8 @@ stage('Non-default environments') {
 							clean install \
 							-pl ${[
 								'org.hibernate.search:hibernate-search-integrationtest-backend-elasticsearch',
-								'org.hibernate.search:hibernate-search-integrationtest-showcase-library'
+								'org.hibernate.search:hibernate-search-integrationtest-showcase-library',
+								'org.hibernate.search:hibernate-search-integrationtest-mapper-orm-realbackend'
 								 ].join(',')} \
 							${toElasticsearchVersionArgs(buildEnv.mavenProfile, null)} \
 					"""

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -559,7 +559,11 @@ stage('Non-default environments') {
 				helper.withMavenWorkspace {
 					mavenNonDefaultBuild buildEnv, """ \
 							clean install \
-							-pl org.hibernate.search:hibernate-search-integrationtest-mapper-orm,org.hibernate.search:hibernate-search-integrationtest-mapper-orm-envers,org.hibernate.search:hibernate-search-integrationtest-showcase-library \
+							-pl ${[
+								'org.hibernate.search:hibernate-search-integrationtest-mapper-orm',
+								'org.hibernate.search:hibernate-search-integrationtest-mapper-orm-envers',
+								'org.hibernate.search:hibernate-search-integrationtest-showcase-library'
+								 ].join(',')} \
 							-P$buildEnv.mavenProfile \
 					"""
 				}
@@ -580,7 +584,10 @@ stage('Non-default environments') {
 				helper.withMavenWorkspace {
 					mavenNonDefaultBuild buildEnv, """ \
 							clean install \
-							-pl org.hibernate.search:hibernate-search-integrationtest-backend-elasticsearch,org.hibernate.search:hibernate-search-integrationtest-showcase-library \
+							-pl ${[
+								'org.hibernate.search:hibernate-search-integrationtest-backend-elasticsearch',
+								'org.hibernate.search:hibernate-search-integrationtest-showcase-library'
+								 ].join(',')} \
 							${toElasticsearchVersionArgs(buildEnv.mavenProfile, null)} \
 					"""
 				}
@@ -623,7 +630,10 @@ stage('Non-default environments') {
 								mavenNonDefaultBuild buildEnv, """ \
 										clean install \
 										--fail-fast \
-										-pl org.hibernate.search:hibernate-search-integrationtest-backend-elasticsearch,org.hibernate.search:hibernate-search-integrationtest-showcase-library \
+										-pl ${[
+											'org.hibernate.search:hibernate-search-integrationtest-backend-elasticsearch',
+											'org.hibernate.search:hibernate-search-integrationtest-showcase-library'
+											 ].join(',')} \
 										${toElasticsearchVersionArgs(buildEnv.mavenProfile, buildEnv.version)} \
 										-Dtest.elasticsearch.connection.uris=$buildEnv.endpointUris \
 										-Dtest.elasticsearch.connection.aws.signing.enabled=true \

--- a/integrationtest/backend/elasticsearch/pom.xml
+++ b/integrationtest/backend/elasticsearch/pom.xml
@@ -256,6 +256,16 @@
                 </failsafe.excludedGroups.elasticsearch.version>
             </properties>
         </profile>
+
+        <!-- OpenDistro for Elasticsearch 1.13+ test environment -->
+        <profile>
+            <id>opendistro-elasticsearch-1.13</id>
+            <properties>
+                <failsafe.excludedGroups.elasticsearch.version>
+                    <!-- Nothing here -->
+                </failsafe.excludedGroups.elasticsearch.version>
+            </properties>
+        </profile>
     </profiles>
 
 </project>

--- a/parents/integrationtest/pom.xml
+++ b/parents/integrationtest/pom.xml
@@ -147,25 +147,66 @@
                         <skip>${test.elasticsearch.run.skip}</skip>
                         <images>
                             <image>
-                                <name>docker.elastic.co/elasticsearch/elasticsearch:${test.elasticsearch.connection.version}</name>
+                                <name>${test.elasticsearch.run.elastic.image.name}:${test.elasticsearch.run.elastic.image.tag}</name>
                                 <alias>elasticsearch</alias>
                                 <run>
+                                    <skip>${test.elasticsearch.run.elastic.skip}</skip>
                                     <env>
+                                        <logger.level>WARN</logger.level>
                                         <discovery.type>single-node</discovery.type>
-                                        <!-- fix Docker images for older versions -->
-                                        <xpack.security.enabled>false</xpack.security.enabled>
                                         <!-- Prevent swapping
-                                            This may trigger warnings upon boot if the system is not correctly set up.
-                                            See https://www.elastic.co/guide/en/elasticsearch/reference/7.5/setup-configuration-memory.html#bootstrap-memory_lock
+                                             This may trigger warnings upon boot if the system is not correctly set up.
+                                             See https://www.elastic.co/guide/en/elasticsearch/reference/7.5/setup-configuration-memory.html#bootstrap-memory_lock
                                          -->
                                         <bootstrap.memory_lock>true</bootstrap.memory_lock>
-                                        <logger.level>WARN</logger.level>
+                                        <!-- fix Docker images for older versions -->
+                                        <!-- Older images require HTTP authentication for all requests;
+                                             it's not practical for testing, so we disable that.
+                                         -->
+                                        <xpack.security.enabled>false</xpack.security.enabled>
                                     </env>
                                     <ports>
                                         <port>9200:9200</port>
                                     </ports>
                                     <log>
                                         <prefix>Elasticsearch: </prefix>
+                                        <date>default</date>
+                                        <color>cyan</color>
+                                    </log>
+                                    <wait>
+                                        <http>
+                                            <url>http://localhost:9200</url>
+                                            <method>GET</method>
+                                            <status>200</status>
+                                        </http>
+                                        <time>20000</time>
+                                    </wait>
+                                </run>
+                            </image>
+                            <image>
+                                <name>${test.elasticsearch.run.opendistro.image.name}:${test.elasticsearch.run.opendistro.image.tag}</name>
+                                <alias>opendistro-elasticsearch</alias>
+                                <run>
+                                    <skip>${test.elasticsearch.run.opendistro.skip}</skip>
+                                    <env>
+                                        <logger.level>WARN</logger.level>
+                                        <discovery.type>single-node</discovery.type>
+                                        <!-- Prevent swapping, same as the Elasticsearch image above. -->
+                                        <bootstrap.memory_lock>true</bootstrap.memory_lock>
+                                        <!-- Open Distro for Elasticsearch expects SSL and uses a self-signed certificate by default;
+                                             it's not practical for testing, so we disable that.
+                                         -->
+                                        <opendistro_security.disabled>true</opendistro_security.disabled>
+                                        <!-- ISM floods the logs with errors, and we don't need it.
+                                             See https://opendistro.github.io/for-elasticsearch-docs/docs/im/ism/settings/
+                                         -->
+                                        <opendistro.index_state_management.enabled>false</opendistro.index_state_management.enabled>
+                                    </env>
+                                    <ports>
+                                        <port>9200:9200</port>
+                                    </ports>
+                                    <log>
+                                        <prefix>OpenDistro-ES: </prefix>
                                         <date>default</date>
                                         <color>cyan</color>
                                     </log>
@@ -304,6 +345,7 @@
         <profile>
             <id>elasticsearch-5.6</id>
             <properties>
+                <test.elasticsearch.run.elastic.skip>false</test.elasticsearch.run.elastic.skip>
                 <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-5.6}</test.elasticsearch.connection.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch5TestDialect</test.elasticsearch.testdialect>
             </properties>
@@ -313,6 +355,7 @@
         <profile>
             <id>elasticsearch-6.0</id>
             <properties>
+                <test.elasticsearch.run.elastic.skip>false</test.elasticsearch.run.elastic.skip>
                 <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-6.2}</test.elasticsearch.connection.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch60TestDialect</test.elasticsearch.testdialect>
             </properties>
@@ -322,6 +365,7 @@
         <profile>
             <id>elasticsearch-6.3</id>
             <properties>
+                <test.elasticsearch.run.elastic.skip>false</test.elasticsearch.run.elastic.skip>
                 <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-6.3}</test.elasticsearch.connection.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch63TestDialect</test.elasticsearch.testdialect>
             </properties>
@@ -331,6 +375,7 @@
         <profile>
             <id>elasticsearch-6.4</id>
             <properties>
+                <test.elasticsearch.run.elastic.skip>false</test.elasticsearch.run.elastic.skip>
                 <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-6.6}</test.elasticsearch.connection.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch64TestDialect</test.elasticsearch.testdialect>
             </properties>
@@ -340,6 +385,7 @@
         <profile>
             <id>elasticsearch-6.7</id>
             <properties>
+                <test.elasticsearch.run.elastic.skip>false</test.elasticsearch.run.elastic.skip>
                 <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-6.7}</test.elasticsearch.connection.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch67TestDialect</test.elasticsearch.testdialect>
             </properties>
@@ -349,6 +395,7 @@
         <profile>
             <id>elasticsearch-6.8</id>
             <properties>
+                <test.elasticsearch.run.elastic.skip>false</test.elasticsearch.run.elastic.skip>
                 <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-6.8}</test.elasticsearch.connection.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch68TestDialect</test.elasticsearch.testdialect>
             </properties>
@@ -358,6 +405,7 @@
         <profile>
             <id>elasticsearch-7.0</id>
             <properties>
+                <test.elasticsearch.run.elastic.skip>false</test.elasticsearch.run.elastic.skip>
                 <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-7.2}</test.elasticsearch.connection.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch70TestDialect</test.elasticsearch.testdialect>
             </properties>
@@ -367,6 +415,7 @@
         <profile>
             <id>elasticsearch-7.3</id>
             <properties>
+                <test.elasticsearch.run.elastic.skip>false</test.elasticsearch.run.elastic.skip>
                 <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-7.6}</test.elasticsearch.connection.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch73TestDialect</test.elasticsearch.testdialect>
             </properties>
@@ -376,6 +425,7 @@
         <profile>
             <id>elasticsearch-7.7</id>
             <properties>
+                <test.elasticsearch.run.elastic.skip>false</test.elasticsearch.run.elastic.skip>
                 <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-7.7}</test.elasticsearch.connection.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch77TestDialect</test.elasticsearch.testdialect>
             </properties>
@@ -385,6 +435,7 @@
         <profile>
             <id>elasticsearch-7.8</id>
             <properties>
+                <test.elasticsearch.run.elastic.skip>false</test.elasticsearch.run.elastic.skip>
                 <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-7.9}</test.elasticsearch.connection.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch78TestDialect</test.elasticsearch.testdialect>
             </properties>
@@ -400,6 +451,7 @@
                 </property>
             </activation>
             <properties>
+                <test.elasticsearch.run.elastic.skip>false</test.elasticsearch.run.elastic.skip>
                 <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-7.10}</test.elasticsearch.connection.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch710TestDialect</test.elasticsearch.testdialect>
             </properties>
@@ -409,7 +461,19 @@
         <profile>
             <id>elasticsearch-7.11</id>
             <properties>
+                <test.elasticsearch.run.elastic.skip>false</test.elasticsearch.run.elastic.skip>
                 <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-7.11}</test.elasticsearch.connection.version>
+                <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch710TestDialect</test.elasticsearch.testdialect>
+            </properties>
+        </profile>
+
+        <!-- OpenDistro for Elasticsearch 1.13+ test environment -->
+        <profile>
+            <id>opendistro-elasticsearch-1.13</id>
+            <properties>
+                <test.elasticsearch.run.opendistro.skip>false</test.elasticsearch.run.opendistro.skip>
+                <test.elasticsearch.run.opendistro.image.tag>${version.io.github.opendistro.elasticsearch.latest-1.13}</test.elasticsearch.run.opendistro.image.tag>
+                <test.elasticsearch.connection.version>${version.io.github.opendistro.elasticsearch.latest-1.13.reported}</test.elasticsearch.connection.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch710TestDialect</test.elasticsearch.testdialect>
             </properties>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -224,6 +224,10 @@
         <version.org.elasticsearch.latest-6.3>6.3.2</version.org.elasticsearch.latest-6.3>
         <version.org.elasticsearch.latest-6.2>6.2.4</version.org.elasticsearch.latest-6.2>
         <version.org.elasticsearch.latest-5.6>5.6.16</version.org.elasticsearch.latest-5.6>
+        <!-- The latest micro of other Elasticsearch distributions -->
+        <!-- Using .reported suffixes to indicate the version reported by these distributions when doing a "GET /", if different -->
+        <version.io.github.opendistro.elasticsearch.latest-1.13>1.13.2</version.io.github.opendistro.elasticsearch.latest-1.13>
+        <version.io.github.opendistro.elasticsearch.latest-1.13.reported>7.10.2</version.io.github.opendistro.elasticsearch.latest-1.13.reported>
         <version.com.google.code.gson>2.8.5</version.com.google.code.gson>
         <version.software.amazon.awssdk>2.14.18</version.software.amazon.awssdk>
         <!-- Jackson: used by the Elasticsearch REST client, the AWS SDK and in tests (wiremock, ...) -->
@@ -479,7 +483,19 @@
         <!-- Elasticsearch tests properties -->
 
         <!-- Control how an Elasticsearch instance is run automatically during tests -->
+        <!-- By default, the plugin is not skipped, but each container (elastic, opendistro, etc.) is skipped;
+             Maven profiles will re-enable the right container depending on configuration.
+          -->
         <test.elasticsearch.run.skip>false</test.elasticsearch.run.skip>
+        <test.elasticsearch.run.elastic.skip>true</test.elasticsearch.run.elastic.skip>
+        <test.elasticsearch.run.elastic.image.name>docker.elastic.co/elasticsearch/elasticsearch</test.elasticsearch.run.elastic.image.name>
+        <test.elasticsearch.run.elastic.image.tag>${test.elasticsearch.connection.version}</test.elasticsearch.run.elastic.image.tag>
+        <test.elasticsearch.run.opendistro.skip>true</test.elasticsearch.run.opendistro.skip>
+        <test.elasticsearch.run.opendistro.image.name>amazon/opendistro-for-elasticsearch</test.elasticsearch.run.opendistro.image.name>
+        <!-- We will never use this tag, but the docker-maven-plugin validates the tag
+             even when we disable the OpenDistro run,
+             so we need to put *something* here that matches the regexp. -->
+        <test.elasticsearch.run.opendistro.image.tag>none</test.elasticsearch.run.opendistro.image.tag>
         <!--
              These properties are transparently passed as system properties to integration tests,
              and retrieved by a test utility:
@@ -489,6 +505,7 @@
              (which is located in a dependency of the integration tests modules).
          -->
         <test.elasticsearch.connection.uris></test.elasticsearch.connection.uris>
+        <test.elasticsearch.connection.version></test.elasticsearch.connection.version>
         <test.elasticsearch.connection.username></test.elasticsearch.connection.username>
         <test.elasticsearch.connection.password></test.elasticsearch.connection.password>
         <test.elasticsearch.connection.aws.signing.enabled>false</test.elasticsearch.connection.aws.signing.enabled>

--- a/pom.xml
+++ b/pom.xml
@@ -226,6 +226,7 @@
         <version.org.elasticsearch.latest-5.6>5.6.16</version.org.elasticsearch.latest-5.6>
         <!-- The latest micro of other Elasticsearch distributions -->
         <!-- Using .reported suffixes to indicate the version reported by these distributions when doing a "GET /", if different -->
+        <!-- WARNING: Don't forget to update the version of container images in the Jenkinsfile if you update versions here -->
         <version.io.github.opendistro.elasticsearch.latest-1.13>1.13.2</version.io.github.opendistro.elasticsearch.latest-1.13>
         <version.io.github.opendistro.elasticsearch.latest-1.13.reported>7.10.2</version.io.github.opendistro.elasticsearch.latest-1.13.reported>
         <version.com.google.code.gson>2.8.5</version.com.google.code.gson>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4195

There aren't any binaries for OpenSearch yet, so I falled back to Open Distro for Elasticsearch. Moving to OpenSearch later should be trivial, though.

I will do the move to OpenSearch and document compatibility in another ticket: https://hibernate.atlassian.net/browse/HSEARCH-4212