### PR TITLE
HSEARCH-4214 follow-up (backport to 6.0): fix tests on Elasticsearch 5.6

### DIFF
--- a/integrationtest/backend/elasticsearch/pom.xml
+++ b/integrationtest/backend/elasticsearch/pom.xml
@@ -133,7 +133,8 @@
             <properties>
                 <failsafe.excludedGroups.elasticsearch.version>
                     ,
-                    org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.categories.RequiresIndexAliasIsWriteIndex
+                    org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.categories.RequiresIndexAliasIsWriteIndex,
+                    org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.categories.RequiresSingleModelDialectForMajorVersion
                 </failsafe.excludedGroups.elasticsearch.version>
             </properties>
         </profile>

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/bootstrap/ElasticsearchBootstrapIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/bootstrap/ElasticsearchBootstrapIT.java
@@ -19,6 +19,7 @@ import org.hibernate.search.backend.elasticsearch.cfg.spi.ElasticsearchBackendSp
 import org.hibernate.search.backend.elasticsearch.client.spi.ElasticsearchRequest;
 import org.hibernate.search.engine.cfg.BackendSettings;
 import org.hibernate.search.engine.cfg.spi.ConfigurationPropertySource;
+import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.categories.RequiresSingleModelDialectForMajorVersion;
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchClientSpy;
 import org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.util.ElasticsearchRequestAssertionMode;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
@@ -31,6 +32,7 @@ import org.hibernate.search.util.impl.test.annotation.TestForIssue;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 public class ElasticsearchBootstrapIT {
 
@@ -111,6 +113,7 @@ public class ElasticsearchBootstrapIT {
 	 * while specifying only the major number of the Elasticsearch version.
 	 */
 	@Test
+	@Category(RequiresSingleModelDialectForMajorVersion.class)
 	@TestForIssue(jiraKey = "HSEARCH-3841")
 	public void noVersionCheck_incompleteVersion() {
 		ElasticsearchVersion clusterVersion = ElasticsearchVersion.of( ElasticsearchTestDialect.getClusterVersion() );
@@ -184,6 +187,7 @@ public class ElasticsearchBootstrapIT {
 	 * and specifying a version on backend creation, and a different one on backend start.
 	 */
 	@Test
+	@Category(RequiresSingleModelDialectForMajorVersion.class)
 	@TestForIssue(jiraKey = "HSEARCH-4214")
 	public void noVersionCheck_versionOverrideOnStart_incompatibleVersion() {
 		ElasticsearchVersion clusterVersion = ElasticsearchVersion.of( ElasticsearchTestDialect.getClusterVersion() );
@@ -230,6 +234,7 @@ public class ElasticsearchBootstrapIT {
 	 * and specifying a version on backend creation, and a more precise one on backend start.
 	 */
 	@Test
+	@Category(RequiresSingleModelDialectForMajorVersion.class)
 	@TestForIssue(jiraKey = "HSEARCH-4214")
 	public void noVersionCheck_versionOverrideOnStart_compatibleVersion() {
 		ElasticsearchVersion clusterVersion = ElasticsearchVersion.of( ElasticsearchTestDialect.getClusterVersion() );

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/categories/RequiresSingleModelDialectForMajorVersion.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/testsupport/categories/RequiresSingleModelDialectForMajorVersion.java
@@ -1,0 +1,18 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.elasticsearch.testsupport.categories;
+
+/**
+ * JUnit category marker indicating that a test is only relevant
+ * for Elasticsearch major versions where all minor versions
+ * use the same model dialect.
+ * <p>
+ * It is not the case on ES 5 in particular, since 5.6 has a dialect
+ * but 5.0, 5.1, etc. don't have one.
+ */
+public class RequiresSingleModelDialectForMajorVersion {
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4214

Backport of #2557