### PR TITLE
HSEARCH-4201 Upgrade to Elasticsearch 7.12

### DIFF
--- a/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
+++ b/backend/elasticsearch/src/test/java/org/hibernate/search/backend/elasticsearch/dialect/impl/ElasticsearchDialectFactoryTest.java
@@ -229,7 +229,7 @@ public class ElasticsearchDialectFactoryTest {
 	@TestForIssue(jiraKey = "HSEARCH-3563")
 	public void es7() {
 		testSuccess(
-				"7", "7.11.1",
+				"7", "7.12.1",
 				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
 		);
 	}
@@ -473,6 +473,33 @@ public class ElasticsearchDialectFactoryTest {
 	public void es7_11_1() {
 		testSuccess(
 				"7.11.1", "7.11.1",
+				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4201")
+	public void es7_12() {
+		testSuccess(
+				"7.12", "7.12.1",
+				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4201")
+	public void es7_12_0() {
+		testSuccess(
+				"7.12.0", "7.12.00",
+				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-4201")
+	public void es7_12_1() {
+		testSuccess(
+				"7.12.1", "7.12.1",
 				Elasticsearch7ModelDialect.class, Elasticsearch70ProtocolDialect.class
 		);
 	}

--- a/parents/integrationtest/pom.xml
+++ b/parents/integrationtest/pom.xml
@@ -462,7 +462,7 @@
             <id>elasticsearch-7.11</id>
             <properties>
                 <test.elasticsearch.run.elastic.skip>false</test.elasticsearch.run.elastic.skip>
-                <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-7.11}</test.elasticsearch.connection.version>
+                <test.elasticsearch.connection.version>${version.org.elasticsearch.latest-7.12}</test.elasticsearch.connection.version>
                 <test.elasticsearch.testdialect>org.hibernate.search.util.impl.integrationtest.backend.elasticsearch.dialect.Elasticsearch710TestDialect</test.elasticsearch.testdialect>
             </properties>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
         <!-- >>> Elasticsearch -->
         <!-- The version of the Elasticsearch client used by Hibernate Search, independently from the version of the remote cluster -->
         <!-- Use the latest open-source version here. Currently, low-level clients are open-source even in 7.11+ -->
-        <version.org.elasticsearch.client>${version.org.elasticsearch.latest-7.11}</version.org.elasticsearch.client>
+        <version.org.elasticsearch.client>${version.org.elasticsearch.latest-7.12}</version.org.elasticsearch.client>
         <!-- The main compatible version, advertised by default. Used in documentation links and as the default when testing.
              We're trying to stick to a fully-OSS version as the default, so don't upgrade to 7.11 here. -->
         <!-- When updating the following version you will likely need to update the test profiles as well,
@@ -208,11 +208,11 @@
         <documentation.org.elasticsearch.url>https://www.elastic.co/guide/en/elasticsearch/reference/${parsed-version.org.elasticsearch.compatible.main.majorVersion}.${parsed-version.org.elasticsearch.compatible.main.minorVersion}</documentation.org.elasticsearch.url>
         <!-- The versions of Elasticsearch advertised as compatible with Hibernate Search -->
         <!-- Make sure that 7.10 stays explicitly mentioned here, because that's the last open-source version -->
-        <version.org.elasticsearch.compatible.regularly-tested.text>5.6, 6.8, 7.10 or 7.11</version.org.elasticsearch.compatible.regularly-tested.text>
+        <version.org.elasticsearch.compatible.regularly-tested.text>5.6, 6.8, 7.10 or 7.12</version.org.elasticsearch.compatible.regularly-tested.text>
         <!-- The versions of Elasticsearch that may work, but are not given priority for bugfixes and new features -->
         <version.org.elasticsearch.compatible.not-regularly-tested.text>6.0 or 7.0</version.org.elasticsearch.compatible.not-regularly-tested.text>
         <!-- The latest micro of each Elasticsearch branch -->
-        <version.org.elasticsearch.latest-7.11>7.11.1</version.org.elasticsearch.latest-7.11>
+        <version.org.elasticsearch.latest-7.12>7.12.1</version.org.elasticsearch.latest-7.12>
         <version.org.elasticsearch.latest-7.10>7.10.0</version.org.elasticsearch.latest-7.10>
         <version.org.elasticsearch.latest-7.9>7.9.3</version.org.elasticsearch.latest-7.9>
         <version.org.elasticsearch.latest-7.7>7.7.1</version.org.elasticsearch.latest-7.7>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4201

I didn't create a different slot for ES 7.12, I added it to the ES 7.11.
If we need a different slot ,this pull request must be changed.