### PR TITLE
Backport of HSEARCH-4204 Expose the Elasticsearch index names in the metamodel API

### DIFF
--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/impl/ElasticsearchIndexModel.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/document/model/impl/ElasticsearchIndexModel.java
@@ -15,13 +15,13 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 
 import org.hibernate.search.backend.elasticsearch.analysis.model.impl.ElasticsearchAnalysisDefinitionRegistry;
+import org.hibernate.search.backend.elasticsearch.metamodel.ElasticsearchIndexDescriptor;
 import org.hibernate.search.backend.elasticsearch.document.model.lowlevel.impl.LowLevelIndexMetadataBuilder;
 import org.hibernate.search.backend.elasticsearch.index.layout.impl.IndexNames;
 import org.hibernate.search.backend.elasticsearch.lowlevel.index.mapping.impl.RootTypeMapping;
 import org.hibernate.search.backend.elasticsearch.search.impl.ElasticsearchSearchIndexContext;
 import org.hibernate.search.engine.backend.document.model.spi.IndexFieldFilter;
 import org.hibernate.search.engine.backend.document.model.spi.IndexFieldInclusion;
-import org.hibernate.search.engine.backend.metamodel.IndexDescriptor;
 import org.hibernate.search.engine.backend.metamodel.IndexFieldDescriptor;
 import org.hibernate.search.engine.backend.types.converter.spi.ToDocumentIdentifierValueConverter;
 import org.hibernate.search.engine.reporting.spi.EventContexts;
@@ -29,7 +29,7 @@ import org.hibernate.search.util.common.impl.CollectionHelper;
 import org.hibernate.search.util.common.reporting.EventContext;
 
 
-public class ElasticsearchIndexModel implements IndexDescriptor, ElasticsearchSearchIndexContext {
+public class ElasticsearchIndexModel implements ElasticsearchIndexDescriptor, ElasticsearchSearchIndexContext {
 
 	private final IndexNames names;
 	private final String mappedTypeName;
@@ -151,5 +151,15 @@ public class ElasticsearchIndexModel implements IndexDescriptor, ElasticsearchSe
 			}
 		}
 		return field;
+	}
+
+	@Override
+	public String readName() {
+		return names.read().toString();
+	}
+
+	@Override
+	public String writeName() {
+		return names.write().toString();
 	}
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/ElasticsearchIndexManager.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/ElasticsearchIndexManager.java
@@ -7,11 +7,15 @@
 package org.hibernate.search.backend.elasticsearch.index;
 
 import org.hibernate.search.backend.elasticsearch.ElasticsearchBackend;
+import org.hibernate.search.backend.elasticsearch.metamodel.ElasticsearchIndexDescriptor;
 import org.hibernate.search.engine.backend.index.IndexManager;
 
 public interface ElasticsearchIndexManager extends IndexManager {
 
 	@Override
 	ElasticsearchBackend backend();
+
+	@Override
+	ElasticsearchIndexDescriptor descriptor();
 
 }

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/impl/ElasticsearchIndexManagerImpl.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/index/impl/ElasticsearchIndexManagerImpl.java
@@ -14,6 +14,7 @@ import org.hibernate.search.backend.elasticsearch.ElasticsearchBackend;
 import org.hibernate.search.backend.elasticsearch.cfg.ElasticsearchIndexSettings;
 import org.hibernate.search.backend.elasticsearch.document.impl.DocumentMetadataContributor;
 import org.hibernate.search.backend.elasticsearch.document.impl.ElasticsearchDocumentObjectBuilder;
+import org.hibernate.search.backend.elasticsearch.metamodel.ElasticsearchIndexDescriptor;
 import org.hibernate.search.backend.elasticsearch.document.model.impl.ElasticsearchIndexModel;
 import org.hibernate.search.backend.elasticsearch.index.ElasticsearchIndexManager;
 import org.hibernate.search.backend.elasticsearch.index.IndexStatus;
@@ -28,7 +29,6 @@ import org.hibernate.search.engine.backend.index.IndexManager;
 import org.hibernate.search.engine.backend.index.spi.IndexManagerImplementor;
 import org.hibernate.search.engine.backend.index.spi.IndexManagerStartContext;
 import org.hibernate.search.engine.backend.mapping.spi.BackendMappingContext;
-import org.hibernate.search.engine.backend.metamodel.IndexDescriptor;
 import org.hibernate.search.engine.backend.schema.management.spi.IndexSchemaManager;
 import org.hibernate.search.engine.backend.scope.spi.IndexScopeBuilder;
 import org.hibernate.search.engine.backend.session.spi.BackendSessionContext;
@@ -239,7 +239,7 @@ class ElasticsearchIndexManagerImpl implements IndexManagerImplementor,
 	}
 
 	@Override
-	public IndexDescriptor descriptor() {
+	public ElasticsearchIndexDescriptor descriptor() {
 		return model;
 	}
 

--- a/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/metamodel/ElasticsearchIndexDescriptor.java
+++ b/backend/elasticsearch/src/main/java/org/hibernate/search/backend/elasticsearch/metamodel/ElasticsearchIndexDescriptor.java
@@ -1,0 +1,29 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.backend.elasticsearch.metamodel;
+
+import org.hibernate.search.engine.backend.metamodel.IndexDescriptor;
+
+/**
+ * A descriptor of an Elasticsearch backend index,
+ * which exposes additional information specific to this backend.
+ */
+public interface ElasticsearchIndexDescriptor extends IndexDescriptor {
+
+	/**
+	 * @return The read name,
+	 * i.e. the name that Hibernate Search is supposed to use when executing searches on the index.
+	 */
+	String readName();
+
+	/**
+	 * @return The write name,
+	 * i.e. the name that Hibernate Search is supposed to use when indexing or purging the index.
+	 */
+	String writeName();
+
+}

--- a/documentation/src/main/asciidoc/reference/backend-elasticsearch.asciidoc
+++ b/documentation/src/main/asciidoc/reference/backend-elasticsearch.asciidoc
@@ -462,6 +462,23 @@ include::{sourcedir}/org/hibernate/search/documentation/backend/elasticsearch/la
 ----
 ====
 
+=== Retrieving the read and write index names
+
+Index or alias names used to read and write can be retrieved from the <<mapper-orm-mapping-inspect,metamodel>>.
+
+.Retrieving the index names from an Elasticsearch index manager
+====
+[source, JAVA, indent=0, subs="+callouts"]
+----
+include::{sourcedir}/org/hibernate/search/documentation/backend/elasticsearch/indexmanager/ElasticsearchIndexManagerIT.java[tags=readWriteName]
+----
+<1> Retrieve the `SearchMapping`.
+<2> Retrieve the `IndexManager`.
+<3> Narrow down the index manager to the `ElasticsearchIndexManager` type.
+<4> Get the index descriptor.
+<5> Get the index (or alias) read and write names.
+====
+
 [[backend-elasticsearch-schema]]
 == Schema ("mapping")
 
@@ -1094,3 +1111,5 @@ Hibernate Search may one day switch to another client with a different Java type
 without prior notice.
 If that happens, the snippet of code above will throw an exception.
 ====
+
+

--- a/documentation/src/test/java/org/hibernate/search/documentation/backend/elasticsearch/indexmanager/Book.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/backend/elasticsearch/indexmanager/Book.java
@@ -1,0 +1,43 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.documentation.backend.elasticsearch.indexmanager;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+@Entity
+@Indexed
+public class Book {
+
+	@Id
+	private Integer id;
+
+	@GenericField
+	private String title;
+
+	public Book() {
+	}
+
+	public Integer getId() {
+		return id;
+	}
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+}

--- a/documentation/src/test/java/org/hibernate/search/documentation/backend/elasticsearch/indexmanager/ElasticsearchIndexManagerIT.java
+++ b/documentation/src/test/java/org/hibernate/search/documentation/backend/elasticsearch/indexmanager/ElasticsearchIndexManagerIT.java
@@ -1,0 +1,51 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.documentation.backend.elasticsearch.indexmanager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.persistence.EntityManagerFactory;
+
+import org.hibernate.search.backend.elasticsearch.metamodel.ElasticsearchIndexDescriptor;
+import org.hibernate.search.backend.elasticsearch.index.ElasticsearchIndexManager;
+import org.hibernate.search.documentation.testsupport.BackendConfigurations;
+import org.hibernate.search.documentation.testsupport.DocumentationSetupHelper;
+import org.hibernate.search.engine.backend.index.IndexManager;
+import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.orm.mapping.SearchMapping;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ElasticsearchIndexManagerIT {
+
+	@Rule
+	public DocumentationSetupHelper setupHelper =
+			DocumentationSetupHelper.withSingleBackend( BackendConfigurations.simple() );
+
+	private EntityManagerFactory entityManagerFactory;
+
+	@Before
+	public void setup() {
+		entityManagerFactory = setupHelper.start().setup( Book.class );
+	}
+
+	@Test
+	public void readWriteName() {
+		//tag::readWriteName[]
+		SearchMapping mapping = Search.mapping( entityManagerFactory ); // <1>
+		IndexManager indexManager = mapping.indexManager( "Book" ); // <2>
+		ElasticsearchIndexManager esIndexManager = indexManager.unwrap( ElasticsearchIndexManager.class ); // <3>
+		ElasticsearchIndexDescriptor descriptor = esIndexManager.descriptor();// <4>
+		String readName = descriptor.readName();// <5>
+		String writeName = descriptor.writeName();// <5>
+		//end::readWriteName[]
+		assertThat( readName ).isEqualTo( "book-read" );
+		assertThat( writeName ).isEqualTo( "book-write" );
+	}
+}

--- a/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/metamodel/ElasticsearchIndexDescriptorIT.java
+++ b/integrationtest/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/backend/elasticsearch/metamodel/ElasticsearchIndexDescriptorIT.java
@@ -1,0 +1,51 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.backend.elasticsearch.metamodel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hibernate.search.backend.elasticsearch.metamodel.ElasticsearchIndexDescriptor;
+import org.hibernate.search.backend.elasticsearch.index.ElasticsearchIndexManager;
+import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.integrationtest.backend.tck.testsupport.util.rule.SearchSetupHelper;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.SimpleMappedIndex;
+import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingSchemaManagementStrategy;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class ElasticsearchIndexDescriptorIT {
+
+	@ClassRule
+	public static final SearchSetupHelper setupHelper = new SearchSetupHelper();
+
+	private static final SimpleMappedIndex<IndexBinding> index = SimpleMappedIndex.of( IndexBinding::new );
+
+	@BeforeClass
+	public static void setup() {
+		setupHelper.start().withIndex( index )
+				.withSchemaManagement( StubMappingSchemaManagementStrategy.NONE )
+				.setup();
+	}
+
+	@Test
+	public void test() {
+		ElasticsearchIndexDescriptor indexDescriptor = index.toApi()
+				.unwrap( ElasticsearchIndexManager.class ).descriptor();
+
+		assertThat( indexDescriptor.readName() ).isEqualTo( "indexname-read" );
+		assertThat( indexDescriptor.writeName() ).isEqualTo( "indexname-write" );
+		assertThat( indexDescriptor.hibernateSearchName() ).isEqualTo( index.name() );
+	}
+
+	private static class IndexBinding {
+		IndexBinding(IndexSchemaElement root) {
+			root.field( "string", f -> f.asString() ).toReference();
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4204