### PR TITLE
HSEARCH-4223 Outbox event background executor should stop as soon as Hibernate Search stops

### DIFF
--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/logging/impl/Log.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/logging/impl/Log.java
@@ -227,8 +227,8 @@ public interface Log extends BasicLogger {
 	@Message(id = ID_OFFSET + 43, value = "Outbox-generated entity mapping: %1$s")
 	void outboxGeneratedEntityMapping(String xmlMappingDefinition);
 
-	@LogMessage(level = INFO)
-	@Message(id = ID_OFFSET + 44, value = "Session factory is closed. Hibernate Search is probably shutting down.")
+	@LogMessage(level = DEBUG)
+	@Message(id = ID_OFFSET + 44, value = "Session factory closed while processing outbox events. Assuming Hibernate Search is shutting down.")
 	void sessionFactoryIsClosedOnOutboxProcessing();
 
 	@Message(id = ID_OFFSET + 45, value = "Max '%1$s' retries exhausted to process the event. Event will be lost.")


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4223

This fixes problems when testing Hibernate Search against ORM 5.5.

Will merge as soon as the build passes.