### PR TITLE
HSEARCH-4202 Test eventual consistency of outbox events in the wrong order

### DIFF
--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/outbox/OutboxPollingOutOfOrderIdsIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/outbox/OutboxPollingOutOfOrderIdsIT.java
@@ -163,7 +163,7 @@ public class OutboxPollingOutOfOrderIdsIT {
 	}
 
 	@Test
-	@Ignore("Probably we need to create an issue for it")
+	@Ignore("HSEARCH-4228 Ensure correct processing of events even if their IDs are out of order")
 	public void processDeleteRecreate_outOfOrder() {
 		// An entity is deleted, then re-created in separate transactions,
 		// but the add event has ID 1, the and the delete event has ID 2.


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4202

Given the three cases provided by the description of the issue, only the second case seems not to be working...
Let's check that on review...