### PR TITLE
HSEARCH-4230 Preserve the relative order of events for a given entity even in the case of retries

### DIFF
--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/localheapqueue/LocalHeapQueueAutomaticIndexingStrategyBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/localheapqueue/LocalHeapQueueAutomaticIndexingStrategyBaseIT.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.localheapqueue;
+package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.strategy.localheapqueue;
 
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.AutomaticIndexingStrategyExpectations;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmSetupHelper;
@@ -30,7 +30,9 @@ import org.junit.runner.RunWith;
 @ClasspathSuite.ClassnameFilters({
 		// Just execute all automatic indexing tests
 		"org.hibernate.search.integrationtest.mapper.orm.automaticindexing..*",
-		// ... except these tests that just cannot work with the local-heap queue strategy
+		// ... except tests designed for a particular strategy:
+		"!org.hibernate.search.integrationtest.mapper.orm.automaticindexing.strategy..*",
+		// ... and except these tests that just cannot work with the local-heap queue strategy:
 		// > Synchronization strategies can only be used with the "session" automatic indexing strategy
 		"!org.hibernate.search.integrationtest.mapper.orm.automaticindexing.session.AutomaticIndexingSynchronizationStrategyIT",
 		// > Sending events outside of transactions, during a flush, doesn't work for some reason;

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/outbox/FilteringOutboxEventFinder.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/outbox/FilteringOutboxEventFinder.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.outbox;
+package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.strategy.outbox;
 
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/outbox/FilteringOutboxEventFinder.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/outbox/FilteringOutboxEventFinder.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.query.Query;
+import org.hibernate.search.mapper.orm.outbox.impl.DefaultOutboxEventFinder;
 import org.hibernate.search.mapper.orm.outbox.impl.OutboxEvent;
 import org.hibernate.search.mapper.orm.outbox.impl.OutboxEventFinder;
 
@@ -23,10 +24,18 @@ import org.hibernate.search.mapper.orm.outbox.impl.OutboxEventFinder;
  * thereby simulating a delay in the processing of outbox events.
  */
 class FilteringOutboxEventFinder implements OutboxEventFinder {
+
+	private final DefaultOutboxEventFinder defaultFinder = new DefaultOutboxEventFinder();
+
+	private boolean filter = true;
 	private final Set<Integer> allowedIds = new HashSet<>();
 
 	@Override
 	public synchronized List<OutboxEvent> findOutboxEvents(Session session, int maxResults) {
+		if ( !filter ) {
+			return defaultFinder.findOutboxEvents( session, maxResults );
+		}
+
 		Query<OutboxEvent> query = session.createQuery(
 				"select e from OutboxEvent e where e.id in :ids order by e.id", OutboxEvent.class );
 		query.setMaxResults( maxResults );
@@ -34,28 +43,45 @@ class FilteringOutboxEventFinder implements OutboxEventFinder {
 		return query.list();
 	}
 
+	public synchronized FilteringOutboxEventFinder enableFilter(boolean enable) {
+		filter = enable;
+		return this;
+	}
+
 	public synchronized void showAllEventsUpToNow(SessionFactory sessionFactory) {
+		checkFiltering();
 		withinTransaction( sessionFactory, session -> showOnlyEvents( findOutboxEventIdsNoFilter( session ) ) );
 	}
 
 	public synchronized void showOnlyEvents(List<Integer> eventIds) {
+		checkFiltering();
 		allowedIds.clear();
 		allowedIds.addAll( eventIds );
 	}
 
 	public synchronized void hideAllEvents() {
+		checkFiltering();
 		allowedIds.clear();
 	}
 
 	public List<OutboxEvent> findOutboxEventsNoFilter(Session session) {
+		checkFiltering();
 		Query<OutboxEvent> query = session.createQuery(
 				"select e from OutboxEvent e order by e.id", OutboxEvent.class );
 		return query.list();
 	}
 
 	public List<Integer> findOutboxEventIdsNoFilter(Session session) {
+		checkFiltering();
 		Query<Integer> query = session.createQuery(
 				"select e.id from OutboxEvent e order by e.id", Integer.class );
 		return query.list();
+	}
+
+	private void checkFiltering() {
+		if ( !filter ) {
+			throw new IllegalStateException(
+					"Cannot use filtering features while the filter is disabled; see enableFilter()" );
+		}
 	}
 }

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/outbox/FilteringOutboxEventFinder.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/outbox/FilteringOutboxEventFinder.java
@@ -40,7 +40,13 @@ class FilteringOutboxEventFinder implements OutboxEventFinder {
 				"select e from OutboxEvent e where e.id in :ids order by e.id", OutboxEvent.class );
 		query.setMaxResults( maxResults );
 		query.setParameter( "ids", allowedIds );
-		return query.list();
+		List<OutboxEvent> returned = query.list();
+		// Only return each event once.
+		// This is important because in the case of a retry, the same event will be reused.
+		for ( OutboxEvent outboxEvent : returned ) {
+			allowedIds.remove( outboxEvent.getId() );
+		}
+		return returned;
 	}
 
 	public synchronized FilteringOutboxEventFinder enableFilter(boolean enable) {

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/outbox/OutboxPollingAutomaticIndexingStrategyBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/outbox/OutboxPollingAutomaticIndexingStrategyBaseIT.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.outbox;
+package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.strategy.outbox;
 
 import org.hibernate.search.mapper.orm.automaticindexing.AutomaticIndexingStrategyNames;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.AutomaticIndexingStrategyExpectations;
@@ -22,14 +22,14 @@ import org.junit.runner.RunWith;
 @ClasspathSuite.ClassnameFilters({
 		// Just execute all automatic indexing tests
 		"org.hibernate.search.integrationtest.mapper.orm.automaticindexing..*",
-		// ... except these tests that just cannot work with the outbox table strategy
+		// ... except tests designed for a particular strategy:
+		"!org.hibernate.search.integrationtest.mapper.orm.automaticindexing.strategy..*",
+		// ... and except these tests that just cannot work with the outbox table strategy:
 		// > Synchronization strategies can only be used with the "session" automatic indexing strategy
 		"!org.hibernate.search.integrationtest.mapper.orm.automaticindexing.session.AutomaticIndexingSynchronizationStrategyIT",
 		// > Sending events outside of transactions, during a flush, doesn't work for some reason;
 		//   entities are only visible from other sessions after the original session is closed.
-		"!org.hibernate.search.integrationtest.mapper.orm.automaticindexing.session.AutomaticIndexingOutOfTransactionIT",
-		// > already executed with the outbox table strategy
-		"!org.hibernate.search.integrationtest.mapper.orm.automaticindexing.outboxtable..*"
+		"!org.hibernate.search.integrationtest.mapper.orm.automaticindexing.session.AutomaticIndexingOutOfTransactionIT"
 })
 public class OutboxPollingAutomaticIndexingStrategyBaseIT {
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/outbox/OutboxPollingAutomaticIndexingStrategyEdgeIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/outbox/OutboxPollingAutomaticIndexingStrategyEdgeIT.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.outbox;
+package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.strategy.outbox;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/outbox/OutboxPollingAutomaticIndexingStrategyLifecycleIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/outbox/OutboxPollingAutomaticIndexingStrategyLifecycleIT.java
@@ -4,10 +4,10 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.outbox;
+package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.strategy.outbox;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.integrationtest.mapper.orm.automaticindexing.outbox.OutboxPollingNoProcessingIT.verifyOutboxEntry;
+import static org.hibernate.search.integrationtest.mapper.orm.automaticindexing.strategy.outbox.OutboxPollingNoProcessingIT.verifyOutboxEntry;
 
 import java.util.List;
 import javax.persistence.Basic;

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/outbox/OutboxPollingAutomaticIndexingStrategyRoutingIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/outbox/OutboxPollingAutomaticIndexingStrategyRoutingIT.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.outbox;
+package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.strategy.outbox;
 
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/outbox/OutboxPollingNoProcessingIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/outbox/OutboxPollingNoProcessingIT.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.outbox;
+package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.strategy.outbox;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/outbox/OutboxPollingOutOfOrderIdsIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/outbox/OutboxPollingOutOfOrderIdsIT.java
@@ -4,11 +4,11 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.outbox;
+package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.strategy.outbox;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.hibernate.search.integrationtest.mapper.orm.automaticindexing.outbox.OutboxPollingNoProcessingIT.verifyOutboxEntry;
+import static org.hibernate.search.integrationtest.mapper.orm.automaticindexing.strategy.outbox.OutboxPollingNoProcessingIT.verifyOutboxEntry;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 import static org.junit.Assume.assumeTrue;
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/outbox/RoutedIndexedEntity.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/outbox/RoutedIndexedEntity.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.outbox;
+package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.strategy.outbox;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/outbox/StatusRoutingBridge.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/outbox/StatusRoutingBridge.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.outbox;
+package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.strategy.outbox;
 
 import org.hibernate.search.mapper.pojo.bridge.RoutingBridge;
 import org.hibernate.search.mapper.pojo.bridge.binding.RoutingBindingContext;

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/logging/impl/Log.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/logging/impl/Log.java
@@ -234,4 +234,7 @@ public interface Log extends BasicLogger {
 	@Message(id = ID_OFFSET + 45, value = "Max '%1$s' retries exhausted to process the event. Event will be lost.")
 	SearchException maxRetryExhausted(int retries);
 
+	@LogMessage(level = WARN)
+	@Message(id = ID_OFFSET + 46, value = "Automatic indexing failed for entity of type '%1$s' with ID '%2$s'. Will try again soon. Attempts so far: %3$d.")
+	void automaticIndexingRetry(String entityName, String entityId, int attempts);
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/logging/impl/Log.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/logging/impl/Log.java
@@ -235,6 +235,7 @@ public interface Log extends BasicLogger {
 	SearchException maxRetryExhausted(int retries);
 
 	@LogMessage(level = WARN)
-	@Message(id = ID_OFFSET + 46, value = "Automatic indexing failed for entity of type '%1$s' with ID '%2$s'. Will try again soon. Attempts so far: %3$d.")
-	void automaticIndexingRetry(String entityName, String entityId, int attempts);
+	@Message(id = ID_OFFSET + 46, value = "Automatic indexing failed for event #%1$s on entity of type '%2$s' with ID '%3$s'."
+			+ " Will try again soon. Attempts so far: %4$d.")
+	void automaticIndexingRetry(Integer eventId, String entityName, String entityId, int attempts);
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/outbox/impl/OutboxEventBackgroundExecutor.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/outbox/impl/OutboxEventBackgroundExecutor.java
@@ -194,6 +194,7 @@ public class OutboxEventBackgroundExecutor {
 					minRetries + 1
 			);
 			session.persist( eventRetry );
+			log.automaticIndexingRetry( eventRetry.getEntityName(), eventRetry.getEntityId(), eventRetry.getRetries() );
 		}
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4230
