### PR TITLE
HSEARCH-4141 Move the resolution of containing entities to reindex to background processes

### DIFF
--- a/engine/src/main/java/org/hibernate/search/engine/common/impl/BackendBuildContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/engine/common/impl/BackendBuildContextImpl.java
@@ -7,18 +7,19 @@
 package org.hibernate.search.engine.common.impl;
 
 import org.hibernate.search.engine.backend.spi.BackendBuildContext;
+import org.hibernate.search.engine.tenancy.spi.TenancyMode;
 
 class BackendBuildContextImpl extends DelegatingBuildContext implements BackendBuildContext {
 
-	private boolean multiTenancyEnabled;
+	private final TenancyMode tenancyMode;
 
-	BackendBuildContextImpl(RootBuildContext delegate, boolean multiTenancyEnabled) {
+	BackendBuildContextImpl(RootBuildContext delegate, TenancyMode tenancyMode) {
 		super( delegate );
-		this.multiTenancyEnabled = multiTenancyEnabled;
+		this.tenancyMode = tenancyMode;
 	}
 
 	@Override
 	public boolean multiTenancyEnabled() {
-		return multiTenancyEnabled;
+		return TenancyMode.MULTI_TENANCY.equals( tenancyMode );
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/building/spi/BackendsInfo.java
+++ b/engine/src/main/java/org/hibernate/search/engine/mapper/mapping/building/spi/BackendsInfo.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.hibernate.search.engine.logging.impl.Log;
+import org.hibernate.search.engine.tenancy.spi.TenancyMode;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
 public final class BackendsInfo {
@@ -20,16 +21,16 @@ public final class BackendsInfo {
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	// Using a linked hash map to preserve the order
-	private Map<Optional<String>, BackendInfo> backendsByNames = new LinkedHashMap<>();
+	private final Map<Optional<String>, BackendInfo> backendsByNames = new LinkedHashMap<>();
 
 	public Collection<BackendInfo> values() {
 		return backendsByNames.values();
 	}
 
-	public void collect(Optional<String> name, boolean multiTenancyEnabled) {
-		backendsByNames.merge( name, new BackendInfo( name, multiTenancyEnabled ),
+	public void collect(Optional<String> name, TenancyMode tenancyMode) {
+		backendsByNames.merge( name, new BackendInfo( name, tenancyMode ),
 				(info1, info2) -> {
-					if ( info1.multiTenancyEnabled == info2.multiTenancyEnabled ) {
+					if ( info1.tenancyMode == info2.tenancyMode ) {
 						return info1;
 					}
 					if ( name.isPresent() ) {
@@ -43,19 +44,19 @@ public final class BackendsInfo {
 	public static final class BackendInfo {
 		// {@code Optional.empty()} means "the default backend"
 		private final Optional<String> name;
-		private final boolean multiTenancyEnabled;
+		private final TenancyMode tenancyMode;
 
-		public BackendInfo(Optional<String> name, boolean multiTenancyEnabled) {
+		public BackendInfo(Optional<String> name, TenancyMode tenancyMode) {
 			this.name = name;
-			this.multiTenancyEnabled = multiTenancyEnabled;
+			this.tenancyMode = tenancyMode;
 		}
 
 		public Optional<String> name() {
 			return name;
 		}
 
-		public boolean multiTenancyEnabled() {
-			return multiTenancyEnabled;
+		public TenancyMode tenancyStrategy() {
+			return tenancyMode;
 		}
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/engine/tenancy/spi/TenancyMode.java
+++ b/engine/src/main/java/org/hibernate/search/engine/tenancy/spi/TenancyMode.java
@@ -1,0 +1,14 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.engine.tenancy.spi;
+
+public enum TenancyMode {
+
+	SINGLE_TENANCY,
+	MULTI_TENANCY;
+
+}

--- a/engine/src/test/java/org/hibernate/search/engine/common/impl/IndexManagerBuildingStateHolderTest.java
+++ b/engine/src/test/java/org/hibernate/search/engine/common/impl/IndexManagerBuildingStateHolderTest.java
@@ -32,6 +32,7 @@ import org.hibernate.search.engine.environment.bean.BeanRetrieval;
 import org.hibernate.search.engine.reporting.spi.ContextualFailureCollector;
 import org.hibernate.search.engine.reporting.spi.EventContexts;
 import org.hibernate.search.engine.reporting.spi.FailureCollector;
+import org.hibernate.search.engine.tenancy.spi.TenancyMode;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.impl.test.rule.ExpectedLog4jLog;
 
@@ -112,7 +113,7 @@ public class IndexManagerBuildingStateHolderTest {
 				backendPropertySourceCapture.capture()
 		) )
 				.thenReturn( backendMock );
-		holder.createBackends( defaultNoMultiTenancy() );
+		holder.createBackends( defaultSingleTenancy() );
 		verifyNoOtherBackendInteractionsAndReset();
 
 		when( backendMock.createIndexManagerBuilder(
@@ -177,7 +178,7 @@ public class IndexManagerBuildingStateHolderTest {
 				backendPropertySourceCapture.capture()
 		) )
 				.thenReturn( backendMock );
-		holder.createBackends( namedNoMultiTenancy( "myBackend" ) );
+		holder.createBackends( namedSingleTenancy( "myBackend" ) );
 		verifyNoOtherBackendInteractionsAndReset();
 
 		when( backendMock.createIndexManagerBuilder(
@@ -248,7 +249,7 @@ public class IndexManagerBuildingStateHolderTest {
 				.thenReturn( rootFailureCollectorMock );
 		when( rootFailureCollectorMock.withContext( EventContexts.defaultBackend() ) )
 				.thenReturn( backendFailureCollectorMock );
-		holder.createBackends( defaultNoMultiTenancy() );
+		holder.createBackends( defaultSingleTenancy() );
 		verify( backendFailureCollectorMock ).add( throwableCaptor.capture() );
 		verifyNoOtherBackendInteractionsAndReset();
 
@@ -281,7 +282,7 @@ public class IndexManagerBuildingStateHolderTest {
 				.thenReturn( rootFailureCollectorMock );
 		when( rootFailureCollectorMock.withContext( EventContexts.defaultBackend() ) )
 				.thenReturn( backendFailureCollectorMock );
-		holder.createBackends( defaultNoMultiTenancy() );
+		holder.createBackends( defaultSingleTenancy() );
 		verify( backendFailureCollectorMock ).add( throwableCaptor.capture() );
 		verifyNoOtherBackendInteractionsAndReset();
 
@@ -295,22 +296,22 @@ public class IndexManagerBuildingStateHolderTest {
 	}
 
 	@Test
-	public void differentMultiTenancyNamedBackend() {
+	public void differentTenancyModeNamedBackend() {
 		assertThatThrownBy( () -> {
 			BackendsInfo result = new BackendsInfo();
-			result.collect( Optional.of( "backend-name" ), true );
-			result.collect( Optional.of( "backend-name" ), false );
+			result.collect( Optional.of( "backend-name" ), TenancyMode.MULTI_TENANCY );
+			result.collect( Optional.of( "backend-name" ), TenancyMode.SINGLE_TENANCY );
 		} ).hasMessageContaining(
 				"Different mappings trying to define two backends with the same name 'backend-name' " +
 						"but having different expectations on multi-tenancy." );
 	}
 
 	@Test
-	public void differentMultiTenancyDefaultBackend() {
+	public void differentTenancyModeDefaultBackend() {
 		assertThatThrownBy( () -> {
 			BackendsInfo result = new BackendsInfo();
-			result.collect( Optional.empty(), false );
-			result.collect( Optional.empty(), true );
+			result.collect( Optional.empty(), TenancyMode.SINGLE_TENANCY );
+			result.collect( Optional.empty(), TenancyMode.MULTI_TENANCY );
 		} ).hasMessageContaining(
 				"Different mappings trying to define default backends " +
 						"having different expectations on multi-tenancy." );
@@ -321,15 +322,15 @@ public class IndexManagerBuildingStateHolderTest {
 		reset( verifiedMocks.toArray() );
 	}
 
-	public static BackendsInfo defaultNoMultiTenancy() {
+	public static BackendsInfo defaultSingleTenancy() {
 		BackendsInfo result = new BackendsInfo();
-		result.collect( Optional.empty(), false );
+		result.collect( Optional.empty(), TenancyMode.SINGLE_TENANCY );
 		return result;
 	}
 
-	public static BackendsInfo namedNoMultiTenancy(String name) {
+	public static BackendsInfo namedSingleTenancy(String name) {
 		BackendsInfo result = new BackendsInfo();
-		result.collect( Optional.of( name ), false );
+		result.collect( Optional.of( name ), TenancyMode.SINGLE_TENANCY );
 		return result;
 	}
 }

--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/rule/SearchSetupHelper.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/testsupport/util/rule/SearchSetupHelper.java
@@ -27,6 +27,7 @@ import org.hibernate.search.engine.common.spi.SearchIntegrationBuilder;
 import org.hibernate.search.engine.common.spi.SearchIntegrationFinalizer;
 import org.hibernate.search.engine.common.spi.SearchIntegrationPartialBuildState;
 import org.hibernate.search.engine.environment.bean.spi.BeanProvider;
+import org.hibernate.search.engine.tenancy.spi.TenancyMode;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBackendAccessor;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBackendHelper;
 import org.hibernate.search.integrationtest.backend.tck.testsupport.util.TckBackendSetupStrategy;
@@ -159,7 +160,7 @@ public class SearchSetupHelper implements TestRule {
 		private BeanProvider beanManagerBeanProvider = new ForbiddenBeanProvider();
 
 		private final List<StubMappedIndex> mappedIndexes = new ArrayList<>();
-		private boolean multiTenancyEnabled = false;
+		private TenancyMode tenancyMode = TenancyMode.SINGLE_TENANCY;
 		private StubMappingSchemaManagementStrategy schemaManagementStrategy = StubMappingSchemaManagementStrategy.DROP_AND_CREATE_AND_DROP;
 
 		SetupContext(String defaultBackendName, AllAwareConfigurationPropertySource basePropertySource) {
@@ -218,7 +219,7 @@ public class SearchSetupHelper implements TestRule {
 		}
 
 		public SetupContext withMultiTenancy() {
-			multiTenancyEnabled = true;
+			tenancyMode = TenancyMode.MULTI_TENANCY;
 			return this;
 		}
 
@@ -233,7 +234,7 @@ public class SearchSetupHelper implements TestRule {
 
 			integrationBuilder.beanManagerBeanProvider( beanManagerBeanProvider );
 
-			StubMappingInitiator initiator = new StubMappingInitiator( multiTenancyEnabled );
+			StubMappingInitiator initiator = new StubMappingInitiator( tenancyMode );
 			mappedIndexes.forEach( initiator::add );
 			StubMappingKey mappingKey = new StubMappingKey();
 			integrationBuilder.addMappingInitiator( mappingKey, initiator );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/bridge/AutomaticIndexingBridgeExplicitReindexingFunctionalIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/bridge/AutomaticIndexingBridgeExplicitReindexingFunctionalIT.java
@@ -156,9 +156,7 @@ public class AutomaticIndexingBridgeExplicitReindexingFunctionalIT {
 			backendMock.verifyExpectationsMet();
 
 			// Only the indexed and contained entity should have been loaded
-			// (plus the OutboxEvent entity, if we're using the outbox-polling strategy).
-			assertThat( session.getStatistics().getEntityCount() )
-					.isEqualTo( 2 + ( ormSetupHelper.areIndexingEventsPushedAsEntities() ? 1 : 0 ) );
+			assertThat( session.getStatistics().getEntityCount() ).isEqualTo( 2 );
 		} );
 
 		// Remove one contained entity.

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/localheapqueue/LocalHeapQueueAutomaticIndexingStrategyBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/localheapqueue/LocalHeapQueueAutomaticIndexingStrategyBaseIT.java
@@ -37,7 +37,13 @@ import org.junit.runner.RunWith;
 		"!org.hibernate.search.integrationtest.mapper.orm.automaticindexing.session.AutomaticIndexingSynchronizationStrategyIT",
 		// > Sending events outside of transactions, during a flush, doesn't work for some reason;
 		//   entities are only visible from other sessions after the original session is closed.
-		"!org.hibernate.search.integrationtest.mapper.orm.automaticindexing.session.AutomaticIndexingOutOfTransactionIT"
+		"!org.hibernate.search.integrationtest.mapper.orm.automaticindexing.session.AutomaticIndexingOutOfTransactionIT",
+		// > We do not send events for the creation of contained entities,
+		//   and as a result one particular use case involving queries instead of associations
+		//   cannot work.
+		//   We will address that someday with explicit support for queries;
+		//   see https://hibernate.atlassian.net/browse/HSEARCH-1937 .
+		"!org.hibernate.search.integrationtest.mapper.orm.automaticindexing.bridge.AutomaticIndexingBridgeExplicitReindexingFunctionalIT"
 })
 public class LocalHeapQueueAutomaticIndexingStrategyBaseIT {
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/outbox/OutboxPollingAutomaticIndexingStrategyBaseIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/outbox/OutboxPollingAutomaticIndexingStrategyBaseIT.java
@@ -29,7 +29,13 @@ import org.junit.runner.RunWith;
 		"!org.hibernate.search.integrationtest.mapper.orm.automaticindexing.session.AutomaticIndexingSynchronizationStrategyIT",
 		// > Sending events outside of transactions, during a flush, doesn't work for some reason;
 		//   entities are only visible from other sessions after the original session is closed.
-		"!org.hibernate.search.integrationtest.mapper.orm.automaticindexing.session.AutomaticIndexingOutOfTransactionIT"
+		"!org.hibernate.search.integrationtest.mapper.orm.automaticindexing.session.AutomaticIndexingOutOfTransactionIT",
+		// > We do not send events for the creation of contained entities,
+		//   and as a result one particular use case involving queries instead of associations
+		//   cannot work.
+		//   We will address that someday with explicit support for queries;
+		//   see https://hibernate.atlassian.net/browse/HSEARCH-1937 .
+		"!org.hibernate.search.integrationtest.mapper.orm.automaticindexing.bridge.AutomaticIndexingBridgeExplicitReindexingFunctionalIT"
 })
 public class OutboxPollingAutomaticIndexingStrategyBaseIT {
 

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/outbox/OutboxPollingAutomaticIndexingStrategyLifecycleIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/outbox/OutboxPollingAutomaticIndexingStrategyLifecycleIT.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.strategy.outbox;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.search.integrationtest.mapper.orm.automaticindexing.strategy.outbox.OutboxPollingNoProcessingIT.verifyOutboxEntry;
+import static org.hibernate.search.integrationtest.mapper.orm.automaticindexing.strategy.outbox.OutboxPollingEventSendingIT.verifyOutboxEntry;
 
 import java.util.List;
 import javax.persistence.Basic;

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/outbox/OutboxPollingNoProcessingIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/outbox/OutboxPollingNoProcessingIT.java
@@ -23,6 +23,7 @@ import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextFi
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.mapper.pojo.route.DocumentRouteDescriptor;
 import org.hibernate.search.mapper.pojo.route.DocumentRoutesDescriptor;
+import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingQueueEventPayload;
 import org.hibernate.search.util.common.serialization.spi.SerializationUtils;
 import org.hibernate.search.util.impl.integrationtest.common.rule.BackendMock;
 import org.hibernate.search.util.impl.integrationtest.mapper.orm.AutomaticIndexingStrategyExpectations;
@@ -186,9 +187,9 @@ public class OutboxPollingNoProcessingIT {
 		assertThat( outboxEvent.getEntityId() ).isEqualTo( entityId );
 		assertThat( outboxEvent.getType() ).isEqualTo( type );
 
-		byte[] documentRoutes = outboxEvent.getDocumentRoutes();
-		DocumentRoutesDescriptor routesDescriptor = SerializationUtils.deserialize(
-				DocumentRoutesDescriptor.class, documentRoutes );
+		PojoIndexingQueueEventPayload payload = SerializationUtils.deserialize(
+				PojoIndexingQueueEventPayload.class, outboxEvent.getPayload() );
+		DocumentRoutesDescriptor routesDescriptor = payload.routes;
 
 		assertThat( routesDescriptor ).isNotNull();
 		assertThat( routesDescriptor.currentRoute().routingKey() ).isEqualTo( currentRoute );

--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/outbox/OutboxPollingOutOfOrderIdsIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/automaticindexing/strategy/outbox/OutboxPollingOutOfOrderIdsIT.java
@@ -8,7 +8,7 @@ package org.hibernate.search.integrationtest.mapper.orm.automaticindexing.strate
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.hibernate.search.integrationtest.mapper.orm.automaticindexing.strategy.outbox.OutboxPollingNoProcessingIT.verifyOutboxEntry;
+import static org.hibernate.search.integrationtest.mapper.orm.automaticindexing.strategy.outbox.OutboxPollingEventSendingIT.verifyOutboxEntry;
 import static org.hibernate.search.util.impl.integrationtest.mapper.orm.OrmUtils.withinTransaction;
 import static org.junit.Assume.assumeTrue;
 

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/PropertyBridgeBaseIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/PropertyBridgeBaseIT.java
@@ -419,7 +419,7 @@ public class PropertyBridgeBaseIT {
 
 		try ( SearchSession session = mapping.createSession() ) {
 			session.indexingPlan().add( entity );
-			session.indexingPlan().add( containedLevel2Entity );
+			session.indexingPlan().add( 1, null, containedLevel2Entity );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.add( "1", b -> b.field( "someField", "constant" ) )
@@ -429,7 +429,7 @@ public class PropertyBridgeBaseIT {
 
 		try ( SearchSession session = mapping.createSession() ) {
 			containedLevel2Entity.stringProperty = "some string";
-			session.indexingPlan().addOrUpdate( containedLevel2Entity, new String[] { "stringProperty" } );
+			session.indexingPlan().addOrUpdate( 1, null, containedLevel2Entity, new String[] { "stringProperty" } );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.addOrUpdate( "1", b -> b.field( "someField", "constant" ) )

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/TypeBridgeBaseIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/mapping/definition/TypeBridgeBaseIT.java
@@ -281,7 +281,7 @@ public class TypeBridgeBaseIT {
 
 		try ( SearchSession session = mapping.createSession() ) {
 			session.indexingPlan().add( entity );
-			session.indexingPlan().add( containedEntity );
+			session.indexingPlan().add( 1, null, containedEntity );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.add( "1", b -> b.field( "someField", "constant" ) )
@@ -292,7 +292,7 @@ public class TypeBridgeBaseIT {
 		try ( SearchSession session = mapping.createSession() ) {
 			containedEntity.stringProperty = "some string";
 
-			session.indexingPlan().addOrUpdate( containedEntity, new String[] { "stringProperty" } );
+			session.indexingPlan().addOrUpdate( 1, null, containedEntity, new String[] { "stringProperty" } );
 
 			backendMock.expectWorks( INDEX_NAME )
 					.addOrUpdate( "1", b -> b.field( "someField", "constant" ) )

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/operations/ContainedEntity.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/operations/ContainedEntity.java
@@ -1,0 +1,30 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.work.operations;
+
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+
+public final class ContainedEntity {
+
+	public static ContainedEntity of(int id) {
+		ContainedEntity entity = new ContainedEntity();
+		entity.id = id;
+		entity.value = "contained" + id;
+		entity.containing = IndexedEntity.of( id );
+		entity.containing.contained = entity;
+		return entity;
+	}
+
+	@DocumentId
+	Integer id;
+
+	@GenericField
+	String value;
+
+	IndexedEntity containing;
+}

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/operations/IndexedEntity.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/operations/IndexedEntity.java
@@ -6,12 +6,15 @@
  */
 package org.hibernate.search.integrationtest.mapper.pojo.work.operations;
 
-import org.hibernate.search.integrationtest.mapper.pojo.work.PojoIndexingPlanBaseIT;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.AssociationInverseSide;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.ObjectPath;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.PropertyValue;
 
-@Indexed(index = PojoIndexingPlanBaseIT.IndexedEntity.INDEX)
+@Indexed(index = IndexedEntity.INDEX)
 public final class IndexedEntity {
 
 	public static final String INDEX = "IndexedEntity";
@@ -28,4 +31,8 @@ public final class IndexedEntity {
 
 	@GenericField
 	String value;
+
+	@IndexedEmbedded
+	@AssociationInverseSide(inversePath = @ObjectPath(@PropertyValue(propertyName = "containing")))
+	ContainedEntity contained;
 }

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/operations/PojoIndexingPlanOperationContainedNullEntityIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/operations/PojoIndexingPlanOperationContainedNullEntityIT.java
@@ -1,0 +1,127 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.integrationtest.mapper.pojo.work.operations;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assume.assumeTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+
+import org.hibernate.search.mapper.javabean.session.SearchSession;
+import org.hibernate.search.mapper.javabean.work.SearchIndexingPlan;
+import org.hibernate.search.mapper.pojo.route.DocumentRouteDescriptor;
+import org.hibernate.search.mapper.pojo.route.DocumentRoutesDescriptor;
+import org.hibernate.search.util.common.SearchException;
+import org.hibernate.search.util.impl.test.annotation.TestForIssue;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+/**
+ * Tests of individual operations in {@link org.hibernate.search.mapper.pojo.work.spi.PojoIndexingPlan}
+ * when the contained entity passed to the operation is null.
+ */
+@RunWith(Parameterized.class)
+@TestForIssue(jiraKey = "HSEARCH-4141")
+public class PojoIndexingPlanOperationContainedNullEntityIT extends AbstractPojoIndexingOperationIT {
+
+	@Test
+	public void simple() {
+		CompletableFuture<?> futureFromBackend = new CompletableFuture<>();
+		try ( SearchSession session = createSession() ) {
+			SearchIndexingPlan indexingPlan = session.indexingPlan();
+			if ( !isDelete() ) {
+				// Deletes don't trigger reindexing, so we don't expect anything for those.
+				expectContainedEntityLoading( 1 );
+				expectUpdateCausedByContained( futureFromBackend, 1, "1", "contained1" );
+			}
+			operation.addWithoutInstanceTo( indexingPlan, ContainedEntity.class, 1 );
+			// The session will wait for completion of the indexing plan upon closing,
+			// so we need to complete it now.
+			futureFromBackend.complete( null );
+		}
+	}
+
+	@Test
+	public void loadingDoesNotFindEntity() {
+		assumeImplicitLoading();
+
+		try ( SearchSession session = createSession() ) {
+			SearchIndexingPlan indexingPlan = session.indexingPlan();
+			// Only add and update perform implicit loading, and if they cannot load the entity,
+			// they are just skipped, assuming that a delete event will come later
+			// and that containing entities will be updated to no longer reference the contained entity.
+			expectContainedEntityLoading( Collections.singletonList( 1 ), Collections.singletonList( null ) );
+			operation.addWithoutInstanceTo( indexingPlan, ContainedEntity.class, 1 );
+		}
+	}
+
+	@Test
+	public void nullProvidedId() {
+		try ( SearchSession session = createSession() ) {
+			SearchIndexingPlan indexingPlan = session.indexingPlan();
+			assertThatThrownBy( () -> operation.addWithoutInstanceTo( indexingPlan, ContainedEntity.class, null, null ) )
+					.isInstanceOf( SearchException.class )
+					.hasMessageContainingAll( "Invalid indexing request",
+							"if the entity is null, the identifier must be provided explicitly" );
+		}
+	}
+
+	// Provided routes are ignored for contained types
+	@Test
+	public void providedId_providedRoutes() {
+		CompletableFuture<?> futureFromBackend = new CompletableFuture<>();
+		try ( SearchSession session = createSession() ) {
+			SearchIndexingPlan indexingPlan = session.indexingPlan();
+
+			if ( !isDelete() ) {
+				// Deletes don't trigger reindexing, so we don't expect anything for those.
+				expectContainedEntityLoading( Collections.singletonList( 42 ), Collections.singletonList( ContainedEntity.of( 1 ) ) );
+				expectUpdateCausedByContained( futureFromBackend, 1, "1", "contained1" );
+			}
+			operation.addWithoutInstanceTo( indexingPlan, ContainedEntity.class, 42,
+					DocumentRoutesDescriptor.of( DocumentRouteDescriptor.of( "UE-123" ),
+							Arrays.asList( DocumentRouteDescriptor.of( "UE-121" ),
+							DocumentRouteDescriptor.of( "UE-122" ),
+							DocumentRouteDescriptor.of( "UE-123" ) ) ) );
+			// The session will wait for completion of the indexing plan upon closing,
+			// so we need to complete it now.
+			futureFromBackend.complete( null );
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-3108")
+	public void containingNotIndexed() {
+		assumeImplicitRoutingEnabled();
+
+		try ( SearchSession session = createSession() ) {
+			SearchIndexingPlan indexingPlan = session.indexingPlan();
+
+			expectContainedEntityLoading( 1 );
+			MyRoutingBridge.indexed = false;
+			MyRoutingBridge.previouslyIndexed = false;
+			// We don't expect the actual operation, which should be skipped because the containing entity is not indexed.
+			operation.addWithoutInstanceTo( indexingPlan, ContainedEntity.class, 1 );
+		}
+	}
+
+	@Override
+	protected boolean isImplicitRoutingEnabled() {
+		return routingBinder != null && !isDelete();
+	}
+
+	private void assumeImplicitLoading() {
+		assumeTrue( "This test only makes sense when "
+						+ "the operation automatically loads entities",
+				!isDelete() );
+	}
+
+}

--- a/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/operations/PojoIndexingPlanOperationNullEntityIT.java
+++ b/integrationtest/mapper/pojo-base/src/test/java/org/hibernate/search/integrationtest/mapper/pojo/work/operations/PojoIndexingPlanOperationNullEntityIT.java
@@ -39,10 +39,10 @@ public class PojoIndexingPlanOperationNullEntityIT extends AbstractPojoIndexingO
 		try ( SearchSession session = createSession() ) {
 			SearchIndexingPlan indexingPlan = session.indexingPlan();
 			if ( !isDelete() ) {
-				expectLoading( 1 );
+				expectIndexedEntityLoading( 1 );
 			}
 			expectOperation( futureFromBackend, 1, null, "1" );
-			operation.addTo( indexingPlan, 1 );
+			operation.addWithoutInstanceTo( indexingPlan, IndexedEntity.class, 1 );
 			// The session will wait for completion of the indexing plan upon closing,
 			// so we need to complete it now.
 			futureFromBackend.complete( null );
@@ -57,8 +57,8 @@ public class PojoIndexingPlanOperationNullEntityIT extends AbstractPojoIndexingO
 			SearchIndexingPlan indexingPlan = session.indexingPlan();
 			// Only add and update perform implicit loading, and if they cannot load the entity,
 			// they are just skipped, assuming a delete event will come later.
-			expectLoading( Collections.singletonList( 1 ), Collections.singletonList( null ) );
-			operation.addTo( indexingPlan, 1 );
+			expectIndexedEntityLoading( Collections.singletonList( 1 ), Collections.singletonList( null ) );
+			operation.addWithoutInstanceTo( indexingPlan, IndexedEntity.class, 1 );
 		}
 	}
 
@@ -66,7 +66,7 @@ public class PojoIndexingPlanOperationNullEntityIT extends AbstractPojoIndexingO
 	public void nullProvidedId() {
 		try ( SearchSession session = createSession() ) {
 			SearchIndexingPlan indexingPlan = session.indexingPlan();
-			assertThatThrownBy( () -> operation.addTo( indexingPlan, null, (DocumentRoutesDescriptor) null ) )
+			assertThatThrownBy( () -> operation.addWithoutInstanceTo( indexingPlan, IndexedEntity.class, null, null ) )
 					.isInstanceOf( SearchException.class )
 					.hasMessageContainingAll( "Invalid indexing request",
 							"if the entity is null, the identifier must be provided explicitly" );
@@ -80,7 +80,7 @@ public class PojoIndexingPlanOperationNullEntityIT extends AbstractPojoIndexingO
 			SearchIndexingPlan indexingPlan = session.indexingPlan();
 
 			if ( !isDelete() ) {
-				expectLoading( Collections.singletonList( 42 ), Collections.singletonList( IndexedEntity.of( 1 ) ) );
+				expectIndexedEntityLoading( Collections.singletonList( 42 ), Collections.singletonList( IndexedEntity.of( 1 ) ) );
 			}
 			expectOperation( futureFromBackend,
 					worksBeforeInSamePlan -> {
@@ -105,7 +105,7 @@ public class PojoIndexingPlanOperationNullEntityIT extends AbstractPojoIndexingO
 						}
 					},
 					42, "UE-123", "1" );
-			operation.addTo( indexingPlan, 42,
+			operation.addWithoutInstanceTo( indexingPlan, IndexedEntity.class, 42,
 					DocumentRoutesDescriptor.of( DocumentRouteDescriptor.of( "UE-123" ), Collections.emptyList() ) );
 			// The session will wait for completion of the indexing plan upon closing,
 			// so we need to complete it now.
@@ -120,7 +120,7 @@ public class PojoIndexingPlanOperationNullEntityIT extends AbstractPojoIndexingO
 			SearchIndexingPlan indexingPlan = session.indexingPlan();
 
 			if ( !isDelete() ) {
-				expectLoading( Collections.singletonList( 42 ), Collections.singletonList( IndexedEntity.of( 1 ) ) );
+				expectIndexedEntityLoading( Collections.singletonList( 42 ), Collections.singletonList( IndexedEntity.of( 1 ) ) );
 			}
 			expectOperation(
 					futureFromBackend,
@@ -148,7 +148,7 @@ public class PojoIndexingPlanOperationNullEntityIT extends AbstractPojoIndexingO
 					},
 					42, "UE-123", "1"
 			);
-			operation.addTo( indexingPlan, 42,
+			operation.addWithoutInstanceTo( indexingPlan, IndexedEntity.class, 42,
 					DocumentRoutesDescriptor.of( DocumentRouteDescriptor.of( "UE-123" ),
 							Arrays.asList( DocumentRouteDescriptor.of( "UE-121" ),
 									DocumentRouteDescriptor.of( "UE-122" ),
@@ -168,7 +168,7 @@ public class PojoIndexingPlanOperationNullEntityIT extends AbstractPojoIndexingO
 		try ( SearchSession session = createSession() ) {
 			SearchIndexingPlan indexingPlan = session.indexingPlan();
 
-			expectLoading( 1 );
+			expectIndexedEntityLoading( 1 );
 			MyRoutingBridge.previousValues = Arrays.asList( "foo" );
 			expectOperation(
 					futureFromBackend,
@@ -183,7 +183,7 @@ public class PojoIndexingPlanOperationNullEntityIT extends AbstractPojoIndexingO
 					// And only then, expect the actual operation.
 					1, null, "1"
 			);
-			operation.addTo( indexingPlan, 1 );
+			operation.addWithoutInstanceTo( indexingPlan, IndexedEntity.class, 1 );
 			// The session will wait for completion of the indexing plan upon closing,
 			// so we need to complete it now.
 			futureFromBackend.complete( null );
@@ -199,7 +199,7 @@ public class PojoIndexingPlanOperationNullEntityIT extends AbstractPojoIndexingO
 		try ( SearchSession session = createSession() ) {
 			SearchIndexingPlan indexingPlan = session.indexingPlan();
 
-			expectLoading( 1 );
+			expectIndexedEntityLoading( 1 );
 			MyRoutingBridge.previousValues = Arrays.asList( "1", "foo", "3" );
 			expectOperation(
 					futureFromBackend,
@@ -216,7 +216,7 @@ public class PojoIndexingPlanOperationNullEntityIT extends AbstractPojoIndexingO
 					// And only then, expect the actual operation.
 					1, null, "1"
 			);
-			operation.addTo( indexingPlan, 1 );
+			operation.addWithoutInstanceTo( indexingPlan, IndexedEntity.class, 1 );
 			// The session will wait for completion of the indexing plan upon closing,
 			// so we need to complete it now.
 			futureFromBackend.complete( null );
@@ -231,11 +231,11 @@ public class PojoIndexingPlanOperationNullEntityIT extends AbstractPojoIndexingO
 		try ( SearchSession session = createSession() ) {
 			SearchIndexingPlan indexingPlan = session.indexingPlan();
 
-			expectLoading( 1 );
+			expectIndexedEntityLoading( 1 );
 			MyRoutingBridge.indexed = false;
 			MyRoutingBridge.previouslyIndexed = false;
 			// We don't expect the actual operation, which should be skipped because the entity is not indexed.
-			operation.addTo( indexingPlan, 1 );
+			operation.addWithoutInstanceTo( indexingPlan, IndexedEntity.class, 1 );
 		}
 	}
 
@@ -248,7 +248,7 @@ public class PojoIndexingPlanOperationNullEntityIT extends AbstractPojoIndexingO
 		try ( SearchSession session = createSession() ) {
 			SearchIndexingPlan indexingPlan = session.indexingPlan();
 
-			expectLoading( 1 );
+			expectIndexedEntityLoading( 1 );
 			MyRoutingBridge.indexed = false;
 			MyRoutingBridge.previouslyIndexed = true;
 			if ( !isAdd() ) {
@@ -259,7 +259,7 @@ public class PojoIndexingPlanOperationNullEntityIT extends AbstractPojoIndexingO
 						.createdThenExecuted( futureFromBackend );
 			}
 			// However, we don't expect the actual operation, which should be skipped because the entity is not indexed.
-			operation.addTo( indexingPlan, 1 );
+			operation.addWithoutInstanceTo( indexingPlan, IndexedEntity.class, 1 );
 			// The session will wait for completion of the indexing plan upon closing,
 			// so we need to complete it now.
 			futureFromBackend.complete( null );
@@ -275,7 +275,7 @@ public class PojoIndexingPlanOperationNullEntityIT extends AbstractPojoIndexingO
 		try ( SearchSession session = createSession() ) {
 			SearchIndexingPlan indexingPlan = session.indexingPlan();
 
-			expectLoading( 1 );
+			expectIndexedEntityLoading( 1 );
 			MyRoutingBridge.indexed = false;
 			MyRoutingBridge.previouslyIndexed = true;
 			MyRoutingBridge.previousValues = Arrays.asList( "1", "foo", "3" );
@@ -291,7 +291,7 @@ public class PojoIndexingPlanOperationNullEntityIT extends AbstractPojoIndexingO
 						.createdThenExecuted( futureFromBackend );
 			}
 			// However, we don't expect the actual operation, which should be skipped because the entity is not indexed.
-			operation.addTo( indexingPlan, 1 );
+			operation.addWithoutInstanceTo( indexingPlan, IndexedEntity.class, 1 );
 			// The session will wait for completion of the indexing plan upon closing,
 			// so we need to complete it now.
 			futureFromBackend.complete( null );

--- a/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/index/AbstractBackendHolder.java
+++ b/integrationtest/performance/backend/base/src/main/java/org/hibernate/search/integrationtest/performance/backend/base/testsupport/index/AbstractBackendHolder.java
@@ -20,6 +20,7 @@ import org.hibernate.search.engine.common.spi.SearchIntegration;
 import org.hibernate.search.engine.common.spi.SearchIntegrationBuilder;
 import org.hibernate.search.engine.common.spi.SearchIntegrationFinalizer;
 import org.hibernate.search.engine.common.spi.SearchIntegrationPartialBuildState;
+import org.hibernate.search.engine.tenancy.spi.TenancyMode;
 import org.hibernate.search.integrationtest.performance.backend.base.testsupport.filesystem.TemporaryFileHolder;
 import org.hibernate.search.util.common.impl.SuppressingCloser;
 import org.hibernate.search.util.impl.integrationtest.mapper.stub.StubMappingInitiator;
@@ -63,7 +64,7 @@ public abstract class AbstractBackendHolder {
 		SearchIntegrationBuilder integrationBuilder =
 				SearchIntegration.builder( propertySource, unusedPropertyChecker );
 
-		StubMappingInitiator initiator = new StubMappingInitiator( false );
+		StubMappingInitiator initiator = new StubMappingInitiator( TenancyMode.SINGLE_TENANCY );
 		StubMappingKey mappingKey = new StubMappingKey();
 		integrationBuilder.addMappingInitiator( mappingKey, initiator );
 

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/loading/impl/JavaBeanLoadingContext.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/loading/impl/JavaBeanLoadingContext.java
@@ -99,14 +99,14 @@ public final class JavaBeanLoadingContext
 	public <T> Optional<PojoSelectionLoadingStrategy<? super T>> loadingStrategyOptional(
 			PojoLoadingTypeContext<T> type) {
 		PojoRawTypeIdentifier<T> typeId = type.typeIdentifier();
-		return typeContextProvider.indexedForExactType( typeId ).selectionLoadingStrategy()
+		return typeContextProvider.forExactType( typeId ).selectionLoadingStrategy()
 				.map( JavaBeanSelectionLoadingStrategy::new );
 	}
 
 	@Override
 	public <T> PojoMassIndexingLoadingStrategy<? super T, ?> loadingStrategy(
 			PojoRawTypeIdentifier<T> expectedType) {
-		LoadingTypeContext<T> typeContext = typeContextProvider.indexedForExactType( expectedType );
+		LoadingTypeContext<T> typeContext = typeContextProvider.forExactType( expectedType );
 		Optional<MassLoadingStrategy<? super T, ?>> strategyOptional = typeContext.massLoadingStrategy();
 		if ( !strategyOptional.isPresent() ) {
 			throw log.entityLoadingStrategyNotRegistered( typeContext.typeIdentifier() );

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/loading/impl/JavaBeanLoadingTypeGroup.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/loading/impl/JavaBeanLoadingTypeGroup.java
@@ -29,7 +29,7 @@ public final class JavaBeanLoadingTypeGroup<E> implements LoadingTypeGroup<E> {
 		this.introspector = introspector;
 		this.includedTypes = new LinkedHashSet<>();
 		for ( PojoRawTypeIdentifier<? extends E> includedTypeIdentifier : includedTypeIdentifiers ) {
-			includedTypes.add( typeContextProvider.indexedForExactType( includedTypeIdentifier ) );
+			includedTypes.add( typeContextProvider.forExactType( includedTypeIdentifier ) );
 		}
 	}
 
@@ -44,7 +44,7 @@ public final class JavaBeanLoadingTypeGroup<E> implements LoadingTypeGroup<E> {
 	@Override
 	public boolean includesInstance(Object entity) {
 		PojoRawTypeIdentifier<?> targetType = introspector.detectEntityType( entity );
-		LoadingTypeContext<?> typeContextOrNull = typeContextProvider.indexedForExactType( targetType );
+		LoadingTypeContext<?> typeContextOrNull = typeContextProvider.forExactType( targetType );
 		if ( typeContextOrNull == null ) {
 			return false;
 		}

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/loading/impl/LoadingTypeContextProvider.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/loading/impl/LoadingTypeContextProvider.java
@@ -10,7 +10,7 @@ import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeIdentifier;
 
 public interface LoadingTypeContextProvider {
 
-	<E> LoadingTypeContext<E> indexedForExactType(PojoRawTypeIdentifier<E> typeIdentifier);
+	<E> LoadingTypeContext<E> forExactType(PojoRawTypeIdentifier<E> typeIdentifier);
 
 	<E> LoadingTypeContext<E> indexedForExactClass(Class<E> typeIdentifier);
 

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/mapping/SearchMappingBuilder.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/mapping/SearchMappingBuilder.java
@@ -165,6 +165,11 @@ public final class SearchMappingBuilder {
 		return this;
 	}
 
+	public SearchMappingBuilder containedEntityIdentityMappingRequired(boolean required) {
+		mappingInitiator.containedEntityIdentityMappingRequired( required );
+		return this;
+	}
+
 	public SearchMappingBuilder annotatedTypeDiscoveryEnabled(boolean annotatedTypeDiscoveryEnabled) {
 		mappingInitiator.annotatedTypeDiscoveryEnabled( annotatedTypeDiscoveryEnabled );
 		return this;

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/mapping/impl/AbstractJavaBeanTypeContext.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/mapping/impl/AbstractJavaBeanTypeContext.java
@@ -6,21 +6,33 @@
  */
 package org.hibernate.search.mapper.javabean.mapping.impl;
 
+import java.util.Optional;
+
+import org.hibernate.search.mapper.javabean.loading.MassLoadingStrategy;
+import org.hibernate.search.mapper.javabean.loading.SelectionLoadingStrategy;
+import org.hibernate.search.mapper.javabean.loading.impl.LoadingTypeContext;
+import org.hibernate.search.mapper.javabean.mapping.metadata.impl.JavaBeanEntityTypeMetadata;
 import org.hibernate.search.mapper.javabean.work.impl.SearchIndexingPlanTypeContext;
+import org.hibernate.search.mapper.pojo.identity.spi.IdentifierMapping;
 import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoTypeExtendedMappingCollector;
 import org.hibernate.search.mapper.pojo.model.path.spi.PojoPathFilter;
+import org.hibernate.search.mapper.pojo.model.spi.PojoPropertyModel;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeIdentifier;
 
 abstract class AbstractJavaBeanTypeContext<E>
-		implements SearchIndexingPlanTypeContext {
+		implements SearchIndexingPlanTypeContext<E>, LoadingTypeContext<E> {
 
 	private final PojoRawTypeIdentifier<E> typeIdentifier;
 	private final String entityName;
+	private final JavaBeanEntityTypeMetadata<E> metadata;
+	private final IdentifierMapping identifierMapping;
 	private final PojoPathFilter dirtyFilter;
 
 	AbstractJavaBeanTypeContext(AbstractBuilder<E> builder) {
 		this.typeIdentifier = builder.typeIdentifier;
 		this.entityName = builder.entityName;
+		this.metadata = builder.metadata;
+		this.identifierMapping = builder.identifierMapping;
 		this.dirtyFilter = builder.dirtyFilter;
 	}
 
@@ -29,16 +41,32 @@ abstract class AbstractJavaBeanTypeContext<E>
 		return typeIdentifier().toString();
 	}
 
+	@Override
 	public PojoRawTypeIdentifier<E> typeIdentifier() {
 		return typeIdentifier;
 	}
 
+	@Override
 	public String name() {
 		return entityName;
 	}
 
 	public Class<E> javaClass() {
 		return typeIdentifier.javaClass();
+	}
+
+	public IdentifierMapping identifierMapping() {
+		return identifierMapping;
+	}
+
+	@Override
+	public Optional<SelectionLoadingStrategy<? super E>> selectionLoadingStrategy() {
+		return metadata.selectionLoadingStrategy;
+	}
+
+	@Override
+	public Optional<MassLoadingStrategy<? super E, ?>> massLoadingStrategy() {
+		return metadata.massLoadingStrategy;
 	}
 
 	@Override
@@ -49,11 +77,25 @@ abstract class AbstractJavaBeanTypeContext<E>
 	abstract static class AbstractBuilder<E> implements PojoTypeExtendedMappingCollector {
 		private final PojoRawTypeIdentifier<E> typeIdentifier;
 		private final String entityName;
+		private final JavaBeanEntityTypeMetadata<E> metadata;
+		private IdentifierMapping identifierMapping;
 		private PojoPathFilter dirtyFilter;
 
-		AbstractBuilder(PojoRawTypeIdentifier<E> typeIdentifier, String entityName) {
+		AbstractBuilder(PojoRawTypeIdentifier<E> typeIdentifier, String entityName,
+				JavaBeanEntityTypeMetadata<E> metadata) {
 			this.typeIdentifier = typeIdentifier;
 			this.entityName = entityName;
+			this.metadata = metadata;
+		}
+
+		@Override
+		public void documentIdSourceProperty(PojoPropertyModel<?> documentIdSourceProperty) {
+			// Nothing to do
+		}
+
+		@Override
+		public void identifierMapping(IdentifierMapping identifierMapping) {
+			this.identifierMapping = identifierMapping;
 		}
 
 		@Override

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/mapping/impl/JavaBeanContainedTypeContext.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/mapping/impl/JavaBeanContainedTypeContext.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.mapper.javabean.mapping.impl;
 
+import org.hibernate.search.mapper.javabean.mapping.metadata.impl.JavaBeanEntityTypeMetadata;
 import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoContainedTypeExtendedMappingCollector;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeIdentifier;
 
@@ -16,8 +17,8 @@ class JavaBeanContainedTypeContext<E> extends AbstractJavaBeanTypeContext<E> {
 	}
 
 	static class Builder<E> extends AbstractBuilder<E> implements PojoContainedTypeExtendedMappingCollector {
-		Builder(PojoRawTypeIdentifier<E> typeIdentifier, String entityName) {
-			super( typeIdentifier, entityName );
+		Builder(PojoRawTypeIdentifier<E> typeIdentifier, String entityName, JavaBeanEntityTypeMetadata<E> metadata) {
+			super( typeIdentifier, entityName, metadata );
 		}
 
 		JavaBeanContainedTypeContext<E> build() {

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/mapping/impl/JavaBeanIndexedTypeContext.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/mapping/impl/JavaBeanIndexedTypeContext.java
@@ -6,38 +6,22 @@
  */
 package org.hibernate.search.mapper.javabean.mapping.impl;
 
-import java.util.Optional;
-
 import org.hibernate.search.engine.backend.index.IndexManager;
 import org.hibernate.search.engine.mapper.mapping.spi.MappedIndexManager;
-import org.hibernate.search.mapper.javabean.loading.MassLoadingStrategy;
-import org.hibernate.search.mapper.javabean.loading.SelectionLoadingStrategy;
-import org.hibernate.search.mapper.javabean.loading.impl.LoadingTypeContext;
 import org.hibernate.search.mapper.javabean.mapping.metadata.impl.JavaBeanEntityTypeMetadata;
 import org.hibernate.search.mapper.javabean.scope.impl.JavaBeanScopeIndexedTypeContext;
 import org.hibernate.search.mapper.javabean.session.impl.JavaBeanSessionIndexedTypeContext;
-import org.hibernate.search.mapper.pojo.identity.spi.IdentifierMapping;
 import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoIndexedTypeExtendedMappingCollector;
-import org.hibernate.search.mapper.pojo.model.spi.PojoPropertyModel;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeIdentifier;
 
 class JavaBeanIndexedTypeContext<E> extends AbstractJavaBeanTypeContext<E>
-		implements JavaBeanScopeIndexedTypeContext<E>, JavaBeanSessionIndexedTypeContext<E>, LoadingTypeContext<E> {
+		implements JavaBeanScopeIndexedTypeContext<E>, JavaBeanSessionIndexedTypeContext<E> {
 
-	private final JavaBeanEntityTypeMetadata<E> metadata;
-	private final IdentifierMapping identifierMapping;
 	private final MappedIndexManager indexManager;
 
 	private JavaBeanIndexedTypeContext(Builder<E> builder) {
 		super( builder );
-		this.metadata = builder.metadata;
-		this.identifierMapping = builder.identifierMapping;
 		this.indexManager = builder.indexManager;
-	}
-
-	@Override
-	public IdentifierMapping identifierMapping() {
-		return identifierMapping;
 	}
 
 	@Override
@@ -45,34 +29,11 @@ class JavaBeanIndexedTypeContext<E> extends AbstractJavaBeanTypeContext<E>
 		return indexManager.toAPI();
 	}
 
-	@Override
-	public Optional<SelectionLoadingStrategy<? super E>> selectionLoadingStrategy() {
-		return metadata.selectionLoadingStrategy;
-	}
-
-	@Override
-	public Optional<MassLoadingStrategy<? super E, ?>> massLoadingStrategy() {
-		return metadata.massLoadingStrategy;
-	}
-
 	static class Builder<E> extends AbstractBuilder<E> implements PojoIndexedTypeExtendedMappingCollector {
-		private final JavaBeanEntityTypeMetadata<E> metadata;
-		private IdentifierMapping identifierMapping;
 		private MappedIndexManager indexManager;
 
 		Builder(PojoRawTypeIdentifier<E> typeIdentifier, String entityName, JavaBeanEntityTypeMetadata<E> metadata) {
-			super( typeIdentifier, entityName );
-			this.metadata = metadata;
-		}
-
-		@Override
-		public void documentIdSourceProperty(PojoPropertyModel<?> documentIdSourceProperty) {
-			// Nothing to do
-		}
-
-		@Override
-		public void identifierMapping(IdentifierMapping identifierMapping) {
-			this.identifierMapping = identifierMapping;
+			super( typeIdentifier, entityName, metadata );
 		}
 
 		@Override

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/mapping/impl/JavaBeanIndexedTypeContext.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/mapping/impl/JavaBeanIndexedTypeContext.java
@@ -16,7 +16,7 @@ import org.hibernate.search.mapper.javabean.loading.impl.LoadingTypeContext;
 import org.hibernate.search.mapper.javabean.mapping.metadata.impl.JavaBeanEntityTypeMetadata;
 import org.hibernate.search.mapper.javabean.scope.impl.JavaBeanScopeIndexedTypeContext;
 import org.hibernate.search.mapper.javabean.session.impl.JavaBeanSessionIndexedTypeContext;
-import org.hibernate.search.mapper.pojo.bridge.runtime.spi.IdentifierMapping;
+import org.hibernate.search.mapper.pojo.identity.spi.IdentifierMapping;
 import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoIndexedTypeExtendedMappingCollector;
 import org.hibernate.search.mapper.pojo.model.spi.PojoPropertyModel;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeIdentifier;

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/mapping/impl/JavaBeanMapperDelegate.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/mapping/impl/JavaBeanMapperDelegate.java
@@ -38,7 +38,7 @@ public final class JavaBeanMapperDelegate
 	@Override
 	public <E> PojoContainedTypeExtendedMappingCollector createContainedTypeExtendedMappingCollector(
 			PojoRawTypeModel<E> rawTypeModel, String entityName) {
-		return typeContextContainerBuilder.addContained( rawTypeModel, entityName );
+		return typeContextContainerBuilder.addContained( rawTypeModel, entityName, metadataProvider.get( rawTypeModel ) );
 	}
 
 	@Override

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/mapping/impl/JavaBeanTypeContextContainer.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/mapping/impl/JavaBeanTypeContextContainer.java
@@ -40,7 +40,6 @@ class JavaBeanTypeContextContainer implements JavaBeanSearchSessionTypeContextPr
 		}
 	}
 
-	@Override
 	@SuppressWarnings("unchecked")
 	public <E> JavaBeanIndexedTypeContext<E> indexedForExactType(PojoRawTypeIdentifier<E> typeIdentifier) {
 		return (JavaBeanIndexedTypeContext<E>) indexedTypeContexts.get( typeIdentifier );
@@ -83,9 +82,10 @@ class JavaBeanTypeContextContainer implements JavaBeanSearchSessionTypeContextPr
 			return builder;
 		}
 
-		<E> JavaBeanContainedTypeContext.Builder<E> addContained(PojoRawTypeModel<E> typeModel, String entityName) {
+		<E> JavaBeanContainedTypeContext.Builder<E> addContained(PojoRawTypeModel<E> typeModel, String entityName,
+				JavaBeanEntityTypeMetadata<E> metadata) {
 			JavaBeanContainedTypeContext.Builder<E> builder =
-					new JavaBeanContainedTypeContext.Builder<>( typeModel.typeIdentifier(), entityName );
+					new JavaBeanContainedTypeContext.Builder<>( typeModel.typeIdentifier(), entityName, metadata );
 			containedTypeContextBuilders.add( builder );
 			return builder;
 		}

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/session/impl/JavaBeanSessionIndexedTypeContext.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/session/impl/JavaBeanSessionIndexedTypeContext.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.mapper.javabean.session.impl;
 
-import org.hibernate.search.mapper.pojo.bridge.runtime.spi.IdentifierMapping;
+import org.hibernate.search.mapper.pojo.identity.spi.IdentifierMapping;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeIdentifier;
 
 /**

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/SearchIndexingPlan.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/SearchIndexingPlan.java
@@ -108,13 +108,13 @@ public interface SearchIndexingPlan {
 	void addOrUpdate(Class<?> entityClass, Object providedId, DocumentRoutesDescriptor providedRoutes);
 
 	/**
-	 * Update an entity in the index, or add it if it's absent from the index,
-	 * but try to avoid reindexing if the given dirty paths
-	 * are known not to impact the indexed form of that entity.
+	 * Consider an entity updated,
+	 * and perform reindexing of this entity as well as containing entities as necessary.
 	 * <p>
 	 * Assumes that the entity may already be present in the index.
 	 * <p>
-	 * Shorthand for {@code addOrUpdate(null, null, entity, dirtyPaths)}; see {@link #addOrUpdate(Object, DocumentRoutesDescriptor, Object, String...)}.
+	 * Shorthand for {@code addOrUpdate(null, null, entity, false, false, dirtyPaths)};
+	 * see {@link #addOrUpdate(Object, DocumentRoutesDescriptor, Object, boolean, boolean, String...)}.
 	 *
 	 * @param entity The entity to update in the index.
 	 * @param dirtyPaths The paths to consider dirty, formatted using the dot-notation
@@ -123,10 +123,16 @@ public interface SearchIndexingPlan {
 	void addOrUpdate(Object entity, String... dirtyPaths);
 
 	/**
-	 * Update an entity in the index, or add it if it's absent from the index,
-	 * but try to avoid reindexing if the given dirty paths
-	 * are known not to impact the indexed form of that entity.
-	 *  @param providedId A value to extract the document ID from.
+	 * Consider an entity updated,
+	 * and perform reindexing of this entity as well as containing entities as necessary,
+	 * taking into account {@code dirtyPaths}.
+	 * <p>
+	 * Assumes that the entity may already be present in the index.
+	 * <p>
+	 * Shorthand for {@code addOrUpdate(providedId, providedRoutes, entity, false, false, dirtyPaths)};
+	 * see {@link #addOrUpdate(Object, DocumentRoutesDescriptor, Object, boolean, boolean, String...)}.
+	 *
+	 * @param providedId A value to extract the document ID from.
 	 * Generally the expected value is the entity ID, but a different value may be expected depending on the mapping.
 	 * If {@code null}, Hibernate Search will attempt to extract the ID from the entity.
 	 * @param providedRoutes The routes to the current and previous index shards.
@@ -140,6 +146,31 @@ public interface SearchIndexingPlan {
 	 * @param dirtyPaths The paths to consider dirty, formatted using the dot-notation
 	 */
 	void addOrUpdate(Object providedId, DocumentRoutesDescriptor providedRoutes, Object entity, String... dirtyPaths);
+
+	/**
+	 * Consider an entity updated,
+	 * and perform reindexing of this entity as well as containing entities as necessary,
+	 * taking into account {@code dirtyPaths}, {@code forceSelfDirty} and {@code forceContainingDirty}.
+	 * <p>
+	 * Assumes that the entity may already be present in the index.
+	 *
+	 * @param providedId A value to extract the document ID from.
+	 * Generally the expected value is the entity ID, but a different value may be expected depending on the mapping.
+	 * If {@code null}, Hibernate Search will attempt to extract the ID from the entity.
+	 * @param providedRoutes The routes to the current and previous index shards.
+	 * Only required if custom routing is enabled
+	 * and the {@link org.hibernate.search.mapper.pojo.bridge.RoutingBridge} is missing
+	 * or unable to provide all the correct previous routes.
+	 * If a {@link org.hibernate.search.mapper.pojo.bridge.RoutingBridge} is assigned to the entity type,
+	 * the routes will be computed using that bridge instead,
+	 * and provided routes (current and previous) will all be appended to the generated "previous routes".
+	 * @param entity The entity to update in the index.
+	 * @param forceSelfDirty If {@code true}, forces reindexing of this entity regardless of the dirty paths.
+	 * @param forceContainingDirty If {@code true}, forces the resolution of containing entities as dirty
+	 * @param dirtyPaths The paths to consider dirty, formatted using the dot-notation
+	 */
+	void addOrUpdate(Object providedId, DocumentRoutesDescriptor providedRoutes, Object entity,
+			boolean forceSelfDirty, boolean forceContainingDirty, String... dirtyPaths);
 
 	/**
 	 * Delete an entity from the index.

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexingPlanImpl.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexingPlanImpl.java
@@ -69,7 +69,7 @@ public class SearchIndexingPlanImpl implements SearchIndexingPlan {
 	public void addOrUpdate(Object providedId, DocumentRoutesDescriptor providedRoutes, Object entity,
 			String... dirtyPathsAsStrings) {
 		PojoRawTypeIdentifier<?> typeIdentifier = getTypeIdentifier( entity );
-		SearchIndexingPlanTypeContext typeContext = typeContextProvider.forExactType( typeIdentifier );
+		SearchIndexingPlanTypeContext<?> typeContext = typeContextProvider.forExactType( typeIdentifier );
 		BitSet dirtyPaths = typeContext == null ? null : typeContext.dirtyFilter().filter( dirtyPathsAsStrings );
 		delegate.addOrUpdate( typeIdentifier, providedId, providedRoutes, entity, dirtyPaths );
 	}

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexingPlanImpl.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexingPlanImpl.java
@@ -57,27 +57,36 @@ public class SearchIndexingPlanImpl implements SearchIndexingPlan {
 
 	@Override
 	public void addOrUpdate(Object providedId, DocumentRoutesDescriptor providedRoutes, Object entity) {
-		delegate.addOrUpdate( getTypeIdentifier( entity ), providedId, providedRoutes, entity );
+		delegate.addOrUpdate( getTypeIdentifier( entity ), providedId, providedRoutes, entity,
+				true, true, null );
 	}
 
 	@Override
 	public void addOrUpdate(Object entity, String... dirtyPaths) {
-		addOrUpdate( null, null, entity, dirtyPaths );
+		addOrUpdate( null, null, entity, false, false, dirtyPaths );
 	}
 
 	@Override
 	public void addOrUpdate(Object providedId, DocumentRoutesDescriptor providedRoutes, Object entity,
-			String... dirtyPathsAsStrings) {
+			String... dirtyPaths) {
+		addOrUpdate( providedId, providedRoutes, entity, false, false, dirtyPaths );
+	}
+
+	@Override
+	public void addOrUpdate(Object providedId, DocumentRoutesDescriptor providedRoutes, Object entity,
+			boolean forceSelfDirty, boolean forceContainingDirty, String... dirtyPathsAsStrings) {
 		PojoRawTypeIdentifier<?> typeIdentifier = getTypeIdentifier( entity );
 		SearchIndexingPlanTypeContext<?> typeContext = typeContextProvider.forExactType( typeIdentifier );
 		BitSet dirtyPaths = typeContext == null ? null : typeContext.dirtyFilter().filter( dirtyPathsAsStrings );
-		delegate.addOrUpdate( typeIdentifier, providedId, providedRoutes, entity, dirtyPaths );
+		delegate.addOrUpdate( typeIdentifier, providedId, providedRoutes, entity,
+				forceSelfDirty, forceContainingDirty, dirtyPaths );
 	}
 
 	@Override
 	public void addOrUpdate(Class<?> entityClass, Object providedId, DocumentRoutesDescriptor providedRoutes) {
 		PojoRawTypeIdentifier<?> typeIdentifier = getTypeIdentifier( entityClass );
-		delegate.addOrUpdate( typeIdentifier, providedId, providedRoutes, null );
+		delegate.addOrUpdate( typeIdentifier, providedId, providedRoutes, null,
+				true, true, null );
 	}
 
 	@Override

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexingPlanTypeContext.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexingPlanTypeContext.java
@@ -6,9 +6,10 @@
  */
 package org.hibernate.search.mapper.javabean.work.impl;
 
+import org.hibernate.search.mapper.javabean.loading.impl.LoadingTypeContext;
 import org.hibernate.search.mapper.pojo.model.path.spi.PojoPathFilter;
 
-public interface SearchIndexingPlanTypeContext {
+public interface SearchIndexingPlanTypeContext<E> extends LoadingTypeContext<E> {
 
 	PojoPathFilter dirtyFilter();
 

--- a/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexingPlanTypeContextProvider.java
+++ b/mapper/javabean/src/main/java/org/hibernate/search/mapper/javabean/work/impl/SearchIndexingPlanTypeContextProvider.java
@@ -10,6 +10,6 @@ import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeIdentifier;
 
 public interface SearchIndexingPlanTypeContextProvider {
 
-	<T> SearchIndexingPlanTypeContext forExactType(PojoRawTypeIdentifier<T> typeIdentifier);
+	<T> SearchIndexingPlanTypeContext<T> forExactType(PojoRawTypeIdentifier<T> typeIdentifier);
 
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/automaticindexing/impl/AutomaticIndexingQueueEventProcessingPlanImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/automaticindexing/impl/AutomaticIndexingQueueEventProcessingPlanImpl.java
@@ -12,7 +12,7 @@ import org.hibernate.search.engine.backend.common.spi.EntityReferenceFactory;
 import org.hibernate.search.engine.backend.common.spi.MultiEntityOperationExecutionReport;
 import org.hibernate.search.mapper.orm.automaticindexing.spi.AutomaticIndexingQueueEventProcessingPlan;
 import org.hibernate.search.mapper.orm.common.EntityReference;
-import org.hibernate.search.mapper.pojo.route.DocumentRoutesDescriptor;
+import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingQueueEventPayload;
 import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingQueueEventProcessingPlan;
 
 public class AutomaticIndexingQueueEventProcessingPlanImpl implements AutomaticIndexingQueueEventProcessingPlan {
@@ -27,18 +27,18 @@ public class AutomaticIndexingQueueEventProcessingPlanImpl implements AutomaticI
 	}
 
 	@Override
-	public void add(String entityName, String serializedId, DocumentRoutesDescriptor routes) {
-		delegate.add( entityName, serializedId, routes );
+	public void add(String entityName, String serializedId, PojoIndexingQueueEventPayload payload) {
+		delegate.add( entityName, serializedId, payload );
 	}
 
 	@Override
-	public void addOrUpdate(String entityName, String serializedId, DocumentRoutesDescriptor routes) {
-		delegate.addOrUpdate( entityName, serializedId, routes );
+	public void addOrUpdate(String entityName, String serializedId, PojoIndexingQueueEventPayload payload) {
+		delegate.addOrUpdate( entityName, serializedId, payload );
 	}
 
 	@Override
-	public void delete(String entityName, String serializedId, DocumentRoutesDescriptor routes) {
-		delegate.delete( entityName, serializedId, routes );
+	public void delete(String entityName, String serializedId, PojoIndexingQueueEventPayload payload) {
+		delegate.delete( entityName, serializedId, payload );
 	}
 
 	@Override

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/automaticindexing/impl/HibernateOrmIndexingQueueEventSendingPlan.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/automaticindexing/impl/HibernateOrmIndexingQueueEventSendingPlan.java
@@ -11,7 +11,7 @@ import java.util.concurrent.CompletableFuture;
 import org.hibernate.search.engine.backend.common.spi.EntityReferenceFactory;
 import org.hibernate.search.engine.backend.common.spi.MultiEntityOperationExecutionReport;
 import org.hibernate.search.mapper.orm.automaticindexing.spi.AutomaticIndexingQueueEventSendingPlan;
-import org.hibernate.search.mapper.pojo.route.DocumentRoutesDescriptor;
+import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingQueueEventPayload;
 import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingQueueEventSendingPlan;
 
 public class HibernateOrmIndexingQueueEventSendingPlan implements PojoIndexingQueueEventSendingPlan {
@@ -23,18 +23,20 @@ public class HibernateOrmIndexingQueueEventSendingPlan implements PojoIndexingQu
 	}
 
 	@Override
-	public void add(String entityName, Object identifier, String serializedId, DocumentRoutesDescriptor routes) {
-		delegate.add( entityName, identifier, serializedId, routes );
+	public void add(String entityName, Object identifier, String serializedId, PojoIndexingQueueEventPayload payload) {
+		delegate.add( entityName, identifier, serializedId, payload );
 	}
 
 	@Override
-	public void addOrUpdate(String entityName, Object identifier, String serializedId, DocumentRoutesDescriptor routes) {
-		delegate.addOrUpdate( entityName, identifier, serializedId, routes );
+	public void addOrUpdate(String entityName, Object identifier, String serializedId,
+			PojoIndexingQueueEventPayload payload) {
+		delegate.addOrUpdate( entityName, identifier, serializedId, payload );
 	}
 
 	@Override
-	public void delete(String entityName, Object identifier, String serializedId, DocumentRoutesDescriptor routes) {
-		delegate.delete( entityName, identifier, serializedId, routes );
+	public void delete(String entityName, Object identifier, String serializedId,
+			PojoIndexingQueueEventPayload payload) {
+		delegate.delete( entityName, identifier, serializedId, payload );
 	}
 
 	@Override

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/automaticindexing/spi/AutomaticIndexingQueueEventProcessingPlan.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/automaticindexing/spi/AutomaticIndexingQueueEventProcessingPlan.java
@@ -10,7 +10,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.search.engine.backend.common.spi.MultiEntityOperationExecutionReport;
 import org.hibernate.search.mapper.orm.common.EntityReference;
-import org.hibernate.search.mapper.pojo.route.DocumentRoutesDescriptor;
+import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingQueueEventPayload;
 
 public interface AutomaticIndexingQueueEventProcessingPlan {
 
@@ -19,30 +19,30 @@ public interface AutomaticIndexingQueueEventProcessingPlan {
 	 *
 	 * @param entityName The name of the entity type.
 	 * @param serializedId The serialized entity identifier.
-	 * @param routes The document routes.
-	 * @see AutomaticIndexingQueueEventSendingPlan#add(String, Object, String, DocumentRoutesDescriptor)
+	 * @param payload The payload as passed to the sending plan.
+	 * @see AutomaticIndexingQueueEventSendingPlan#add(String, Object, String, PojoIndexingQueueEventPayload)
 	 */
-	void add(String entityName, String serializedId, DocumentRoutesDescriptor routes);
+	void add(String entityName, String serializedId, PojoIndexingQueueEventPayload payload);
 
 	/**
 	 * Appends an "add-or-update" event to the plan, received from a {@link AutomaticIndexingQueueEventSendingPlan}.
 	 *
 	 * @param entityName The name of the entity type.
 	 * @param serializedId The serialized entity identifier.
-	 * @param routes The document routes.
-	 * @see AutomaticIndexingQueueEventSendingPlan#addOrUpdate(String, Object, String, DocumentRoutesDescriptor)
+	 * @param payload The payload as passed to the sending plan.
+	 * @see AutomaticIndexingQueueEventSendingPlan#addOrUpdate(String, Object, String, PojoIndexingQueueEventPayload)
 	 */
-	void addOrUpdate(String entityName, String serializedId, DocumentRoutesDescriptor routes);
+	void addOrUpdate(String entityName, String serializedId, PojoIndexingQueueEventPayload payload);
 
 	/**
 	 * Appends a "delete" event to the plan, received from a {@link AutomaticIndexingQueueEventSendingPlan}.
 	 *
 	 * @param entityName The name of the entity type.
 	 * @param serializedId The serialized entity identifier.
-	 * @param routes The document routes.
-	 * @see AutomaticIndexingQueueEventSendingPlan#delete(String, Object, String, DocumentRoutesDescriptor)
+	 * @param payload The payload as passed to the sending plan.
+	 * @see AutomaticIndexingQueueEventSendingPlan#delete(String, Object, String, PojoIndexingQueueEventPayload)
 	 */
-	void delete(String entityName, String serializedId, DocumentRoutesDescriptor routes);
+	void delete(String entityName, String serializedId, PojoIndexingQueueEventPayload payload);
 
 	/**
 	 * Writes all pending changes to the index now,

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/automaticindexing/spi/AutomaticIndexingQueueEventSendingPlan.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/automaticindexing/spi/AutomaticIndexingQueueEventSendingPlan.java
@@ -10,7 +10,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.search.engine.backend.common.spi.EntityReferenceFactory;
 import org.hibernate.search.engine.backend.common.spi.MultiEntityOperationExecutionReport;
-import org.hibernate.search.mapper.pojo.route.DocumentRoutesDescriptor;
+import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingQueueEventPayload;
 
 /**
  * A set of indexing events to be sent to an external queue.
@@ -27,10 +27,10 @@ public interface AutomaticIndexingQueueEventSendingPlan {
 	 * @param entityName The name of the entity type.
 	 * @param identifier The non-serialized entity identifier, to report sending errors.
 	 * @param serializedId The serialized entity identifier.
-	 * @param routes The document routes.
-	 * @see AutomaticIndexingQueueEventProcessingPlan#add(String, String, DocumentRoutesDescriptor)
+	 * @param payload A payload to be forwarded as-is to the processing plan.
+	 * @see AutomaticIndexingQueueEventProcessingPlan#add(String, String, PojoIndexingQueueEventPayload)
 	 */
-	void add(String entityName, Object identifier, String serializedId, DocumentRoutesDescriptor routes);
+	void add(String entityName, Object identifier, String serializedId, PojoIndexingQueueEventPayload payload);
 
 	/**
 	 * Appends an "add-or-update" event to the plan, to be sent {@link #sendAndReport(EntityReferenceFactory) later}
@@ -39,10 +39,10 @@ public interface AutomaticIndexingQueueEventSendingPlan {
 	 * @param entityName The name of the entity type.
 	 * @param identifier The non-serialized entity identifier, to report sending errors.
 	 * @param serializedId The serialized entity identifier.
-	 * @param routes The document routes.
-	 * @see AutomaticIndexingQueueEventProcessingPlan#addOrUpdate(String, String, DocumentRoutesDescriptor)
+	 * @param payload A payload to be forwarded as-is to the processing plan.
+	 * @see AutomaticIndexingQueueEventProcessingPlan#addOrUpdate(String, String, PojoIndexingQueueEventPayload)
 	 */
-	void addOrUpdate(String entityName, Object identifier, String serializedId, DocumentRoutesDescriptor routes);
+	void addOrUpdate(String entityName, Object identifier, String serializedId, PojoIndexingQueueEventPayload payload);
 
 	/**
 	 * Appends a "delete" event to the plan, to be sent {@link #sendAndReport(EntityReferenceFactory) later}
@@ -51,10 +51,10 @@ public interface AutomaticIndexingQueueEventSendingPlan {
 	 * @param entityName The name of the entity type.
 	 * @param identifier The non-serialized entity identifier, to report sending errors.
 	 * @param serializedId The serialized entity identifier.
-	 * @param routes The document routes.
-	 * @see AutomaticIndexingQueueEventProcessingPlan#delete(String, String, DocumentRoutesDescriptor)
+	 * @param payload A payload to be forwarded as-is to the processing plan.
+	 * @see AutomaticIndexingQueueEventProcessingPlan#delete(String, String, PojoIndexingQueueEventPayload)
 	 */
-	void delete(String entityName, Object identifier, String serializedId, DocumentRoutesDescriptor routes);
+	void delete(String entityName, Object identifier, String serializedId, PojoIndexingQueueEventPayload payload);
 
 	/**
 	 * Discards all events that were added to this plan, without sending them.

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/cfg/HibernateOrmMapperSettings.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/cfg/HibernateOrmMapperSettings.java
@@ -183,8 +183,8 @@ public final class HibernateOrmMapperSettings {
 		public static final String AUTOMATIC_INDEXING = "automatic_indexing";
 		public static final String AUTOMATIC_INDEXING_PREFIX = AUTOMATIC_INDEXING + ".";
 		public static final String AUTOMATIC_INDEXING_STRATEGY = AUTOMATIC_INDEXING_PREFIX + "strategy";
-		public static final String AUTOMATIC_INDEXING_SYNCHRONIZATION_STRATEGY = AUTOMATIC_INDEXING_PREFIX + "synchronization.strategy";
-		public static final String AUTOMATIC_INDEXING_ENABLE_DIRTY_CHECK = AUTOMATIC_INDEXING_PREFIX + "enable_dirty_check";
+		public static final String AUTOMATIC_INDEXING_SYNCHRONIZATION_STRATEGY = AUTOMATIC_INDEXING_PREFIX + AutomaticIndexingRadicals.SYNCHRONIZATION_STRATEGY;
+		public static final String AUTOMATIC_INDEXING_ENABLE_DIRTY_CHECK = AUTOMATIC_INDEXING_PREFIX + AutomaticIndexingRadicals.ENABLE_DIRTY_CHECK;
 		public static final String AUTOMATIC_INDEXING_POLLING_INTERVAL = AUTOMATIC_INDEXING_PREFIX + AutomaticIndexingRadicals.POLLING_INTERVAL;
 		public static final String AUTOMATIC_INDEXING_BATCH_SIZE = AUTOMATIC_INDEXING_PREFIX + AutomaticIndexingRadicals.BATCH_SIZE;
 		public static final String QUERY_LOADING_CACHE_LOOKUP_STRATEGY = "query.loading.cache_lookup.strategy";
@@ -202,6 +202,8 @@ public final class HibernateOrmMapperSettings {
 		private AutomaticIndexingRadicals() {
 		}
 
+		public static final String SYNCHRONIZATION_STRATEGY = "synchronization.strategy";
+		public static final String ENABLE_DIRTY_CHECK = "enable_dirty_check";
 		public static final String POLLING_INTERVAL = "polling_interval";
 		public static final String BATCH_SIZE = "batch_size";
 	}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/event/impl/HibernateSearchEventListener.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/event/impl/HibernateSearchEventListener.java
@@ -143,10 +143,12 @@ public final class HibernateSearchEventListener implements PostDeleteEventListen
 		PojoIndexingPlan plan = getCurrentIndexingPlan( event.getSession() );
 		Object providedId = typeContext.toIndexingPlanProvidedId( event.getId() );
 		if ( dirtyPaths != null ) {
-			plan.addOrUpdate( typeContext.typeIdentifier(), providedId, null, entity, dirtyPaths );
+			plan.addOrUpdate( typeContext.typeIdentifier(), providedId, null, entity,
+					false, false, dirtyPaths );
 		}
 		else {
-			plan.addOrUpdate( typeContext.typeIdentifier(), providedId, null, entity );
+			plan.addOrUpdate( typeContext.typeIdentifier(), providedId, null, entity,
+					true, true, null );
 		}
 	}
 
@@ -277,10 +279,13 @@ public final class HibernateSearchEventListener implements PostDeleteEventListen
 		PojoIndexingPlan plan = getCurrentIndexingPlan( event.getSession() );
 		Object providedId = typeContext.toIndexingPlanProvidedId( event.getAffectedOwnerIdOrNull() );
 		if ( dirtyPaths != null ) {
-			plan.addOrUpdate( typeContext.typeIdentifier(), providedId, null, ownerEntity, dirtyPaths );
+			plan.addOrUpdate( typeContext.typeIdentifier(), providedId, null, ownerEntity,
+					false, false, dirtyPaths
+			);
 		}
 		else {
-			plan.addOrUpdate( typeContext.typeIdentifier(), providedId, null, ownerEntity );
+			plan.addOrUpdate( typeContext.typeIdentifier(), providedId, null, ownerEntity,
+					true, true, null );
 		}
 	}
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/loading/impl/HibernateOrmEntityIdEntityLoadingStrategy.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/loading/impl/HibernateOrmEntityIdEntityLoadingStrategy.java
@@ -56,11 +56,11 @@ public class HibernateOrmEntityIdEntityLoadingStrategy<E, I>
 	}
 
 	@Override
-	public <E2> PojoSelectionEntityLoader<E2> createLoader(Set<LoadingIndexedTypeContext<? extends E2>> targetEntityTypeContexts,
+	public <E2> PojoSelectionEntityLoader<E2> createLoader(Set<LoadingTypeContext<? extends E2>> targetEntityTypeContexts,
 			LoadingSessionContext sessionContext, EntityLoadingCacheLookupStrategy cacheLookupStrategy,
 			MutableEntityLoadingOptions loadingOptions) {
 		if ( targetEntityTypeContexts.size() == 1 ) {
-			LoadingIndexedTypeContext<? extends E2> targetEntityTypeContext =
+			LoadingTypeContext<? extends E2> targetEntityTypeContext =
 					targetEntityTypeContexts.iterator().next();
 			/*
 			 * This cast is safe: the loader will only return instances of E2.
@@ -147,10 +147,10 @@ public class HibernateOrmEntityIdEntityLoadingStrategy<E, I>
 	}
 
 	private static EntityPersister toMostSpecificCommonEntitySuperType(SessionImplementor session,
-			Iterable<? extends LoadingIndexedTypeContext<?>> targetEntityTypeContexts) {
+			Iterable<? extends LoadingTypeContext<?>> targetEntityTypeContexts) {
 		MetamodelImplementor metamodel = session.getSessionFactory().getMetamodel();
 		EntityPersister result = null;
-		for ( LoadingIndexedTypeContext<?> targetTypeContext : targetEntityTypeContexts ) {
+		for ( LoadingTypeContext<?> targetTypeContext : targetEntityTypeContexts ) {
 			EntityPersister type = targetTypeContext.entityPersister();
 			if ( result == null ) {
 				result = type;
@@ -171,13 +171,13 @@ public class HibernateOrmEntityIdEntityLoadingStrategy<E, I>
 	}
 
 	private AssertionFailure invalidTypesException(
-			Set<? extends LoadingIndexedTypeContext<?>> targetEntityTypeContexts) {
+			Set<? extends LoadingTypeContext<?>> targetEntityTypeContexts) {
 		return new AssertionFailure(
 				"Some types among the targeted entity types are not subclasses of the expected root entity type."
 				+ " Expected entity name: " + rootEntityPersister.getEntityName()
 				+ " Targeted entity names: "
 				+ targetEntityTypeContexts.stream()
-						.map( LoadingIndexedTypeContext::entityPersister )
+						.map( LoadingTypeContext::entityPersister )
 						.map( EntityPersister::getEntityName )
 						.collect( Collectors.toList() )
 		);

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/loading/impl/HibernateOrmEntityLoadingStrategy.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/loading/impl/HibernateOrmEntityLoadingStrategy.java
@@ -34,7 +34,7 @@ public interface HibernateOrmEntityLoadingStrategy<E, I> {
 	@Override
 	int hashCode();
 
-	<E2> PojoSelectionEntityLoader<E2> createLoader(Set<LoadingIndexedTypeContext<? extends E2>> targetEntityTypeContexts,
+	<E2> PojoSelectionEntityLoader<E2> createLoader(Set<LoadingTypeContext<? extends E2>> targetEntityTypeContexts,
 			LoadingSessionContext sessionContext, EntityLoadingCacheLookupStrategy cacheLookupStrategy,
 			MutableEntityLoadingOptions loadingOptions);
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/loading/impl/HibernateOrmNonEntityIdPropertyEntityLoadingStrategy.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/loading/impl/HibernateOrmNonEntityIdPropertyEntityLoadingStrategy.java
@@ -75,7 +75,7 @@ public class HibernateOrmNonEntityIdPropertyEntityLoadingStrategy<E, I>
 	}
 
 	@Override
-	public <E2> PojoSelectionEntityLoader<E2> createLoader(Set<LoadingIndexedTypeContext<? extends E2>> targetEntityTypeContexts,
+	public <E2> PojoSelectionEntityLoader<E2> createLoader(Set<LoadingTypeContext<? extends E2>> targetEntityTypeContexts,
 			LoadingSessionContext sessionContext,
 			EntityLoadingCacheLookupStrategy cacheLookupStrategy, MutableEntityLoadingOptions loadingOptions) {
 		if ( targetEntityTypeContexts.size() != 1 ) {
@@ -85,7 +85,7 @@ public class HibernateOrmNonEntityIdPropertyEntityLoadingStrategy<E, I>
 		return doCreate( targetEntityTypeContexts.iterator().next(), sessionContext, cacheLookupStrategy, loadingOptions );
 	}
 
-	private <E2> PojoSelectionEntityLoader<E2> doCreate(LoadingIndexedTypeContext<?> targetEntityTypeContext,
+	private <E2> PojoSelectionEntityLoader<E2> doCreate(LoadingTypeContext<?> targetEntityTypeContext,
 			LoadingSessionContext sessionContext,
 			EntityLoadingCacheLookupStrategy cacheLookupStrategy,
 			MutableEntityLoadingOptions loadingOptions) {
@@ -99,7 +99,7 @@ public class HibernateOrmNonEntityIdPropertyEntityLoadingStrategy<E, I>
 		 */
 		@SuppressWarnings("unchecked")
 		PojoSelectionEntityLoader<E2> result = new HibernateOrmSelectionEntityByNonIdPropertyLoader<>(
-				entityPersister, (LoadingIndexedTypeContext<E2>) targetEntityTypeContext,
+				entityPersister, (LoadingTypeContext<E2>) targetEntityTypeContext,
 				(TypeQueryFactory<E2, ?>) queryFactory,
 				documentIdSourcePropertyName, documentIdSourceHandle,
 				sessionContext, loadingOptions
@@ -129,13 +129,13 @@ public class HibernateOrmNonEntityIdPropertyEntityLoadingStrategy<E, I>
 		);
 	}
 
-	private AssertionFailure multipleTypesException(Set<? extends LoadingIndexedTypeContext<?>> targetEntityTypeContexts) {
+	private AssertionFailure multipleTypesException(Set<? extends LoadingTypeContext<?>> targetEntityTypeContexts) {
 		return new AssertionFailure(
 				"Attempt to use a criteria-based entity loader with multiple target entity types."
 						+ " Expected entity name: " + entityPersister.getEntityName()
 						+ " Targeted entity names: "
 						+ targetEntityTypeContexts.stream()
-						.map( LoadingIndexedTypeContext::entityPersister )
+						.map( LoadingTypeContext::entityPersister )
 						.map( EntityPersister::getEntityName )
 						.collect( Collectors.toList() )
 		);

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/loading/impl/HibernateOrmSelectionEntityByNonIdPropertyLoader.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/loading/impl/HibernateOrmSelectionEntityByNonIdPropertyLoader.java
@@ -29,12 +29,12 @@ class HibernateOrmSelectionEntityByNonIdPropertyLoader<E> extends AbstractHibern
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private final LoadingIndexedTypeContext<E> targetEntityTypeContext;
+	private final LoadingTypeContext<E> targetEntityTypeContext;
 	private final String documentIdSourcePropertyName;
 	private final ValueReadHandle<?> documentIdSourceHandle;
 
 	HibernateOrmSelectionEntityByNonIdPropertyLoader(EntityPersister entityPersister,
-			LoadingIndexedTypeContext<E> targetEntityTypeContext,
+			LoadingTypeContext<E> targetEntityTypeContext,
 			TypeQueryFactory<E, ?> queryFactory,
 			String documentIdSourcePropertyName,
 			ValueReadHandle<?> documentIdSourceHandle,

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/loading/impl/HibernateOrmSelectionLoadingContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/loading/impl/HibernateOrmSelectionLoadingContext.java
@@ -61,7 +61,7 @@ public final class HibernateOrmSelectionLoadingContext implements PojoSelectionL
 	@Override
 	public <T> PojoSelectionLoadingStrategy<? super T> loadingStrategy(PojoLoadingTypeContext<T> type) {
 		return new HibernateOrmSelectionLoadingStrategy<>(
-				typeContextProvider.indexedForExactType( type.typeIdentifier() ).loadingStrategy() );
+				typeContextProvider.forExactType( type.typeIdentifier() ).loadingStrategy() );
 	}
 
 	@Override
@@ -156,10 +156,10 @@ public final class HibernateOrmSelectionLoadingContext implements PojoSelectionL
 		@Override
 		public PojoSelectionEntityLoader<E> createLoader(
 				Set<? extends PojoLoadingTypeContext<? extends E>> expectedTypes) {
-			Set<LoadingIndexedTypeContext<? extends E>> typeContexts = new HashSet<>();
+			Set<LoadingTypeContext<? extends E>> typeContexts = new HashSet<>();
 			for ( PojoLoadingTypeContext<? extends E> type : expectedTypes ) {
-				LoadingIndexedTypeContext<? extends E> typeContext =
-						typeContextProvider.indexedForExactType( type.typeIdentifier() );
+				LoadingTypeContext<? extends E> typeContext =
+						typeContextProvider.forExactType( type.typeIdentifier() );
 				typeContexts.add( typeContext );
 			}
 			return delegate.createLoader( typeContexts, sessionContext, cacheLookupStrategy, loadingOptions );

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/loading/impl/LoadingIndexedTypeContextProvider.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/loading/impl/LoadingIndexedTypeContextProvider.java
@@ -10,6 +10,6 @@ import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeIdentifier;
 
 public interface LoadingIndexedTypeContextProvider {
 
-	<E> LoadingIndexedTypeContext<E> indexedForExactType(PojoRawTypeIdentifier<E> typeIdentifier);
+	<E> LoadingTypeContext<E> forExactType(PojoRawTypeIdentifier<E> typeIdentifier);
 
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/loading/impl/LoadingTypeContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/loading/impl/LoadingTypeContext.java
@@ -8,7 +8,7 @@ package org.hibernate.search.mapper.orm.loading.impl;
 
 import org.hibernate.persister.entity.EntityPersister;
 
-public interface LoadingIndexedTypeContext<E> {
+public interface LoadingTypeContext<E> {
 
 	/**
 	 * @return The name of the entity in the JPA metamodel.

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/AbstractHibernateOrmTypeContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/AbstractHibernateOrmTypeContext.java
@@ -10,24 +10,58 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.spi.MetamodelImplementor;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.search.mapper.orm.event.impl.HibernateOrmListenerTypeContext;
+import org.hibernate.search.mapper.orm.loading.impl.HibernateOrmEntityIdEntityLoadingStrategy;
+import org.hibernate.search.mapper.orm.loading.impl.HibernateOrmEntityLoadingStrategy;
+import org.hibernate.search.mapper.orm.loading.impl.HibernateOrmNonEntityIdPropertyEntityLoadingStrategy;
+import org.hibernate.search.mapper.orm.loading.impl.LoadingTypeContext;
 import org.hibernate.search.mapper.orm.session.impl.HibernateOrmSessionTypeContext;
+import org.hibernate.search.mapper.pojo.identity.spi.IdentifierMapping;
 import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoTypeExtendedMappingCollector;
 import org.hibernate.search.mapper.pojo.model.path.spi.PojoPathFilter;
+import org.hibernate.search.mapper.pojo.model.spi.PojoPropertyModel;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeIdentifier;
+import org.hibernate.search.util.common.reflect.spi.ValueReadHandle;
 
 abstract class AbstractHibernateOrmTypeContext<E>
-		implements HibernateOrmListenerTypeContext, HibernateOrmSessionTypeContext<E> {
+		implements HibernateOrmListenerTypeContext, HibernateOrmSessionTypeContext<E>, LoadingTypeContext<E> {
 
 	private final PojoRawTypeIdentifier<E> typeIdentifier;
 	private final String jpaEntityName;
 	private final EntityPersister entityPersister;
+	private final boolean documentIdIsEntityId;
+	private final HibernateOrmEntityLoadingStrategy<? super E, ?> loadingStrategy;
+	private final IdentifierMapping identifierMapping;
 	private final PojoPathFilter dirtyFilter;
 
+	// Casts are safe because the loading strategy will target either "E" or "? super E", by contract
+	@SuppressWarnings("unchecked")
 	AbstractHibernateOrmTypeContext(AbstractBuilder<E> builder, SessionFactoryImplementor sessionFactory) {
 		this.typeIdentifier = builder.typeIdentifier;
 		this.jpaEntityName = builder.jpaEntityName;
 		MetamodelImplementor metamodel = sessionFactory.getMetamodel();
 		this.entityPersister = metamodel.entityPersister( builder.hibernateOrmEntityName );
+		this.identifierMapping = builder.identifierMapping;
+		if ( builder.documentIdSourcePropertyName != null ) {
+			if ( builder.documentIdSourcePropertyName.equals( entityPersister().getIdentifierPropertyName() ) ) {
+				documentIdIsEntityId = true;
+				loadingStrategy = (HibernateOrmEntityLoadingStrategy<? super E, ?>)
+						HibernateOrmEntityIdEntityLoadingStrategy.create( sessionFactory, entityPersister() );
+			}
+			else {
+				// The entity ID is not the property used to generate the document ID
+				// We need to use a criteria query to load entities from the document IDs
+				documentIdIsEntityId = false;
+				loadingStrategy = (HibernateOrmEntityLoadingStrategy<? super E, ?>)
+						HibernateOrmNonEntityIdPropertyEntityLoadingStrategy.create( sessionFactory, entityPersister(),
+								builder.documentIdSourcePropertyName, builder.documentIdSourcePropertyHandle
+						);
+			}
+		}
+		else {
+			// Can only happen for contained types, which may not be loadable.
+			documentIdIsEntityId = false;
+			loadingStrategy = null;
+		}
 		this.dirtyFilter = builder.dirtyFilter;
 	}
 
@@ -50,8 +84,30 @@ abstract class AbstractHibernateOrmTypeContext<E>
 		return entityPersister.getEntityName();
 	}
 
+	@Override
 	public EntityPersister entityPersister() {
 		return entityPersister;
+	}
+
+	public IdentifierMapping identifierMapping() {
+		return identifierMapping;
+	}
+
+	@Override
+	public HibernateOrmEntityLoadingStrategy<? super E, ?> loadingStrategy() {
+		return loadingStrategy;
+	}
+
+	@Override
+	public Object toIndexingPlanProvidedId(Object entityId) {
+		if ( documentIdIsEntityId ) {
+			return entityId;
+		}
+		else {
+			// The entity ID is not the property used to generate the document ID
+			// Return null, meaning the document ID has to be extracted from the entity
+			return null;
+		}
 	}
 
 	@Override
@@ -63,12 +119,26 @@ abstract class AbstractHibernateOrmTypeContext<E>
 		private final PojoRawTypeIdentifier<E> typeIdentifier;
 		private final String jpaEntityName;
 		private final String hibernateOrmEntityName;
+		private String documentIdSourcePropertyName;
+		private ValueReadHandle<?> documentIdSourcePropertyHandle;
+		private IdentifierMapping identifierMapping;
 		private PojoPathFilter dirtyFilter;
 
 		AbstractBuilder(PojoRawTypeIdentifier<E> typeIdentifier, String jpaEntityName, String hibernateOrmEntityName) {
 			this.typeIdentifier = typeIdentifier;
 			this.jpaEntityName = jpaEntityName;
 			this.hibernateOrmEntityName = hibernateOrmEntityName;
+		}
+
+		@Override
+		public void documentIdSourceProperty(PojoPropertyModel<?> documentIdSourceProperty) {
+			this.documentIdSourcePropertyName = documentIdSourceProperty.name();
+			this.documentIdSourcePropertyHandle = documentIdSourceProperty.handle();
+		}
+
+		@Override
+		public void identifierMapping(IdentifierMapping identifierMapping) {
+			this.identifierMapping = identifierMapping;
 		}
 
 		@Override

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmIndexedTypeContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmIndexedTypeContext.java
@@ -15,7 +15,7 @@ import org.hibernate.search.mapper.orm.loading.impl.HibernateOrmEntityIdEntityLo
 import org.hibernate.search.mapper.orm.loading.impl.HibernateOrmNonEntityIdPropertyEntityLoadingStrategy;
 import org.hibernate.search.mapper.orm.scope.impl.HibernateOrmScopeIndexedTypeContext;
 import org.hibernate.search.mapper.orm.session.impl.HibernateOrmSessionIndexedTypeContext;
-import org.hibernate.search.mapper.pojo.bridge.runtime.spi.IdentifierMapping;
+import org.hibernate.search.mapper.pojo.identity.spi.IdentifierMapping;
 import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoIndexedTypeExtendedMappingCollector;
 import org.hibernate.search.mapper.pojo.model.spi.PojoPropertyModel;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeIdentifier;

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmIndexedTypeContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmIndexedTypeContext.java
@@ -11,47 +11,19 @@ import org.hibernate.search.engine.backend.index.IndexManager;
 import org.hibernate.search.engine.mapper.mapping.spi.MappedIndexManager;
 import org.hibernate.search.mapper.orm.automaticindexing.impl.AutomaticIndexingIndexedTypeContext;
 import org.hibernate.search.mapper.orm.entity.SearchIndexedEntity;
-import org.hibernate.search.mapper.orm.loading.impl.HibernateOrmEntityIdEntityLoadingStrategy;
-import org.hibernate.search.mapper.orm.loading.impl.HibernateOrmNonEntityIdPropertyEntityLoadingStrategy;
 import org.hibernate.search.mapper.orm.scope.impl.HibernateOrmScopeIndexedTypeContext;
 import org.hibernate.search.mapper.orm.session.impl.HibernateOrmSessionIndexedTypeContext;
-import org.hibernate.search.mapper.pojo.identity.spi.IdentifierMapping;
 import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoIndexedTypeExtendedMappingCollector;
-import org.hibernate.search.mapper.pojo.model.spi.PojoPropertyModel;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeIdentifier;
-import org.hibernate.search.util.common.reflect.spi.ValueReadHandle;
-import org.hibernate.search.mapper.orm.loading.impl.HibernateOrmEntityLoadingStrategy;
 
 class HibernateOrmIndexedTypeContext<E> extends AbstractHibernateOrmTypeContext<E>
 		implements SearchIndexedEntity<E>, HibernateOrmSessionIndexedTypeContext<E>,
 				HibernateOrmScopeIndexedTypeContext<E>, AutomaticIndexingIndexedTypeContext {
 
-	private final boolean documentIdIsEntityId;
-	private final HibernateOrmEntityLoadingStrategy<? super E, ?> loadingStrategy;
-	private final IdentifierMapping identifierMapping;
-
 	private final MappedIndexManager indexManager;
 
-	// Casts are safe because the loading strategy will target either "E" or "? super E", by contract
-	@SuppressWarnings("unchecked")
 	private HibernateOrmIndexedTypeContext(Builder<E> builder, SessionFactoryImplementor sessionFactory) {
 		super( builder, sessionFactory );
-
-		if ( builder.documentIdSourcePropertyName.equals( entityPersister().getIdentifierPropertyName() ) ) {
-			documentIdIsEntityId = true;
-			loadingStrategy = (HibernateOrmEntityLoadingStrategy<? super E, ?>)
-					HibernateOrmEntityIdEntityLoadingStrategy.create( sessionFactory, entityPersister() );
-		}
-		else {
-			// The entity ID is not the property used to generate the document ID
-			// We need to use a criteria query to load entities from the document IDs
-			documentIdIsEntityId = false;
-			loadingStrategy = (HibernateOrmEntityLoadingStrategy<? super E, ?>)
-					HibernateOrmNonEntityIdPropertyEntityLoadingStrategy.create( sessionFactory, entityPersister(),
-							builder.documentIdSourcePropertyName, builder.documentIdSourcePropertyHandle );
-		}
-
-		this.identifierMapping = builder.identifierMapping;
 		this.indexManager = builder.indexManager;
 	}
 
@@ -70,49 +42,12 @@ class HibernateOrmIndexedTypeContext<E> extends AbstractHibernateOrmTypeContext<
 		return indexManager.toAPI();
 	}
 
-	@Override
-	public Object toIndexingPlanProvidedId(Object entityId) {
-		if ( documentIdIsEntityId ) {
-			return entityId;
-		}
-		else {
-			// The entity ID is not the property used to generate the document ID
-			// Return null, meaning the document ID has to be extracted from the entity
-			return null;
-		}
-	}
-
-	@Override
-	public IdentifierMapping getIdentifierMapping() {
-		return identifierMapping;
-	}
-
-	@Override
-	public HibernateOrmEntityLoadingStrategy<? super E, ?> loadingStrategy() {
-		return loadingStrategy;
-	}
-
 	static class Builder<E> extends AbstractBuilder<E> implements PojoIndexedTypeExtendedMappingCollector {
-
-		private String documentIdSourcePropertyName;
-		private ValueReadHandle<?> documentIdSourcePropertyHandle;
-		private IdentifierMapping identifierMapping;
 
 		private MappedIndexManager indexManager;
 
 		Builder(PojoRawTypeIdentifier<E> typeIdentifier, String jpaEntityName, String hibernateOrmEntityName) {
 			super( typeIdentifier, jpaEntityName, hibernateOrmEntityName );
-		}
-
-		@Override
-		public void documentIdSourceProperty(PojoPropertyModel<?> documentIdSourceProperty) {
-			this.documentIdSourcePropertyName = documentIdSourceProperty.name();
-			this.documentIdSourcePropertyHandle = documentIdSourceProperty.handle();
-		}
-
-		@Override
-		public void identifierMapping(IdentifierMapping identifierMapping) {
-			this.identifierMapping = identifierMapping;
 		}
 
 		@Override

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMapperDelegate.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMapperDelegate.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.mapper.orm.mapping.impl;
 
 import org.hibernate.search.mapper.orm.model.impl.HibernateOrmBasicTypeMetadataProvider;
+import org.hibernate.search.mapper.orm.session.impl.ConfiguredAutomaticIndexingStrategy;
 import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoContainedTypeExtendedMappingCollector;
 import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoIndexedTypeExtendedMappingCollector;
 import org.hibernate.search.mapper.pojo.mapping.spi.PojoMappingDelegate;
@@ -17,9 +18,12 @@ public final class HibernateOrmMapperDelegate
 		implements PojoMapperDelegate<HibernateOrmMappingPartialBuildState> {
 
 	private final HibernateOrmTypeContextContainer.Builder typeContextContainerBuilder;
+	private final ConfiguredAutomaticIndexingStrategy automaticIndexingStrategy;
 
-	HibernateOrmMapperDelegate(HibernateOrmBasicTypeMetadataProvider basicTypeMetadataProvider) {
+	HibernateOrmMapperDelegate(HibernateOrmBasicTypeMetadataProvider basicTypeMetadataProvider,
+			ConfiguredAutomaticIndexingStrategy automaticIndexingStrategy) {
 		typeContextContainerBuilder = new HibernateOrmTypeContextContainer.Builder( basicTypeMetadataProvider );
+		this.automaticIndexingStrategy = automaticIndexingStrategy;
 	}
 
 	@Override
@@ -41,6 +45,7 @@ public final class HibernateOrmMapperDelegate
 
 	@Override
 	public HibernateOrmMappingPartialBuildState prepareBuild(PojoMappingDelegate mappingDelegate) {
-		return new HibernateOrmMappingPartialBuildState( mappingDelegate, typeContextContainerBuilder );
+		return new HibernateOrmMappingPartialBuildState( mappingDelegate, typeContextContainerBuilder,
+				automaticIndexingStrategy );
 	}
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMappingInitiator.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/mapping/impl/HibernateOrmMappingInitiator.java
@@ -98,8 +98,11 @@ public class HibernateOrmMappingInitiator extends AbstractPojoMappingInitiator<H
 				new HibernateOrmMetatadaContributor( basicTypeMetadataProvider, introspector )
 		);
 
-		// TODO HSEARCH-4141 use this to call containedEntityIdentityMappingRequired()
 		automaticIndexingStrategy = ConfiguredAutomaticIndexingStrategy.create( beanResolver, propertySource );
+		// If the automatic indexing strategy uses an event queue,
+		// it will need to send events relative to contained entities,
+		// and thus contained entities need to have an identity mapping.
+		containedEntityIdentityMappingRequired( automaticIndexingStrategy.usesEventQueue() );
 
 		// Enable annotation mapping if necessary
 		boolean processAnnotations = MAPPING_PROCESS_ANNOTATIONS.get( propertySource );

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/HibernateOrmMassIndexingContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/massindexing/impl/HibernateOrmMassIndexingContext.java
@@ -17,7 +17,7 @@ import org.hibernate.search.mapper.orm.loading.impl.HibernateOrmMassEntityLoader
 import org.hibernate.search.mapper.orm.loading.impl.HibernateOrmMassIdentifierLoader;
 import org.hibernate.search.mapper.orm.loading.impl.HibernateOrmMassLoadingOptions;
 import org.hibernate.search.mapper.orm.loading.impl.HibernateOrmQueryLoader;
-import org.hibernate.search.mapper.orm.loading.impl.LoadingIndexedTypeContext;
+import org.hibernate.search.mapper.orm.loading.impl.LoadingTypeContext;
 import org.hibernate.search.mapper.orm.session.impl.HibernateOrmSessionTypeContextProvider;
 import org.hibernate.search.mapper.pojo.loading.spi.PojoMassEntityLoader;
 import org.hibernate.search.mapper.pojo.loading.spi.PojoMassEntitySink;
@@ -52,7 +52,7 @@ public final class HibernateOrmMassIndexingContext
 
 	@Override
 	public <T> PojoMassIndexingLoadingStrategy<? super T, ?> loadingStrategy(PojoRawTypeIdentifier<T> expectedType) {
-		LoadingIndexedTypeContext<T> typeContext = typeContextProvider.indexedForExactType( expectedType );
+		LoadingTypeContext<T> typeContext = typeContextProvider.forExactType( expectedType );
 		return new HibernateOrmMassIndexingLoadingStrategy<>( typeContext.loadingStrategy() );
 	}
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/outbox/impl/OutboxAdditionalJaxbMappingProducer.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/outbox/impl/OutboxAdditionalJaxbMappingProducer.java
@@ -55,7 +55,7 @@ public class OutboxAdditionalJaxbMappingProducer implements org.hibernate.boot.s
 	"		 </property>\n" +
 	"        <property name=\"entityName\" type=\"string\" />\n" +
 	"        <property name=\"entityId\" type=\"string\" />\n" +
-	"        <property name=\"documentRoutes\" type=\"binary\" length=\"8192\" />\n" +
+	"        <property name=\"payload\" type=\"binary\" length=\"8192\" />\n" +
 	"        <property name=\"retries\" type=\"integer\" />\n" +
 	"    </class>\n" +
 	"</hibernate-mapping>\n";

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/outbox/impl/OutboxAdditionalJaxbMappingProducer.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/outbox/impl/OutboxAdditionalJaxbMappingProducer.java
@@ -67,8 +67,7 @@ public class OutboxAdditionalJaxbMappingProducer implements org.hibernate.boot.s
 		ConfigurationService service = serviceRegistry.getService( ConfigurationService.class );
 
 		Object customIndexingStrategy = service.getSettings().get( HibernateOrmMapperSettings.AUTOMATIC_INDEXING_STRATEGY );
-		if ( customIndexingStrategy == null ||
-				!AutomaticIndexingStrategyNames.OUTBOX_POLLING.equals( customIndexingStrategy ) ) {
+		if ( !AutomaticIndexingStrategyNames.OUTBOX_POLLING.equals( customIndexingStrategy ) ) {
 			return Collections.emptyList();
 		}
 
@@ -79,7 +78,6 @@ public class OutboxAdditionalJaxbMappingProducer implements org.hibernate.boot.s
 		BufferedInputStream bufferedInputStream = new BufferedInputStream( byteArrayInputStream );
 		Binding binding = mappingBinder.bind( bufferedInputStream, origin );
 
-		@SuppressWarnings("unchecked")
 		JaxbHbmHibernateMapping root = (JaxbHbmHibernateMapping) binding.getRoot();
 
 		MappingDocument mappingDocument = new MappingDocument( root, origin, buildingContext );

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/outbox/impl/OutboxEvent.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/outbox/impl/OutboxEvent.java
@@ -10,9 +10,6 @@ import java.util.Arrays;
 import java.util.Objects;
 import javax.persistence.Transient;
 
-import org.hibernate.search.mapper.pojo.route.DocumentRoutesDescriptor;
-import org.hibernate.search.util.common.serialization.spi.SerializationUtils;
-
 public final class OutboxEvent {
 
 	public enum Type {
@@ -24,7 +21,7 @@ public final class OutboxEvent {
 
 	private String entityName;
 	private String entityId;
-	private byte[] documentRoutes;
+	private byte[] payload;
 	private int retries = 0;
 
 	@Transient
@@ -33,20 +30,20 @@ public final class OutboxEvent {
 	public OutboxEvent() {
 	}
 
-	public OutboxEvent(Type type, String entityName, String entityId, DocumentRoutesDescriptor documentRoutesDescriptor,
+	public OutboxEvent(Type type, String entityName, String entityId, byte[] payload,
 			Object originalEntityId) {
 		this.type = type;
 		this.entityName = entityName;
 		this.entityId = entityId;
-		this.documentRoutes = SerializationUtils.serialize( documentRoutesDescriptor );
+		this.payload = payload;
 		this.originalEntityId = originalEntityId;
 	}
 
-	public OutboxEvent(Type type, String entityName, String entityId, byte[] documentRoutes, int retries) {
+	public OutboxEvent(Type type, String entityName, String entityId, byte[] payload, int retries) {
 		this.type = type;
 		this.entityName = entityName;
 		this.entityId = entityId;
-		this.documentRoutes = documentRoutes;
+		this.payload = payload;
 		this.retries = retries;
 		this.originalEntityId = null;
 	}
@@ -83,12 +80,12 @@ public final class OutboxEvent {
 		this.entityId = entityId;
 	}
 
-	public byte[] getDocumentRoutes() {
-		return documentRoutes;
+	public byte[] getPayload() {
+		return payload;
 	}
 
-	public void setDocumentRoutes(byte[] documentRoutes) {
-		this.documentRoutes = documentRoutes;
+	public void setPayload(byte[] payload) {
+		this.payload = payload;
 	}
 
 	public int getRetries() {
@@ -121,13 +118,13 @@ public final class OutboxEvent {
 		}
 		OutboxEvent event = (OutboxEvent) o;
 		return type == event.type && Objects.equals( entityName, event.entityName ) && Objects.equals(
-				entityId, event.entityId ) && Arrays.equals( documentRoutes, event.documentRoutes );
+				entityId, event.entityId ) && Arrays.equals( payload, event.payload );
 	}
 
 	@Override
 	public int hashCode() {
 		int result = Objects.hash( type, entityName, entityId );
-		result = 31 * result + Arrays.hashCode( documentRoutes );
+		result = 31 * result + Arrays.hashCode( payload );
 		return result;
 	}
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/outbox/impl/OutboxEventBackgroundExecutor.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/outbox/impl/OutboxEventBackgroundExecutor.java
@@ -25,8 +25,11 @@ import org.hibernate.search.engine.reporting.FailureHandler;
 import org.hibernate.search.mapper.orm.automaticindexing.spi.AutomaticIndexingMappingContext;
 import org.hibernate.search.mapper.orm.common.impl.TransactionHelper;
 import org.hibernate.search.mapper.orm.logging.impl.Log;
+import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingQueueEventPayload;
+import org.hibernate.search.mapper.pojo.work.spi.UpdateCauseDescriptor;
 import org.hibernate.search.util.common.SearchException;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
+import org.hibernate.search.util.common.serialization.spi.SerializationUtils;
 
 public class OutboxEventBackgroundExecutor {
 
@@ -196,6 +199,12 @@ public class OutboxEventBackgroundExecutor {
 					// but the event marked as failed due to some general failure in this batch of events.
 					// Let's make sure the next try will not create a duplicate document.
 					failedEvent.setType( OutboxEvent.Type.ADD_OR_UPDATE );
+					// Add an update cause that forces reindexing
+					PojoIndexingQueueEventPayload oldPayload =
+							SerializationUtils.deserialize( PojoIndexingQueueEventPayload.class, failedEvent.getPayload() );
+					PojoIndexingQueueEventPayload newPayload = new PojoIndexingQueueEventPayload( oldPayload.routes,
+							new UpdateCauseDescriptor( true, false, null, false ) );
+					failedEvent.setPayload( SerializationUtils.serialize( newPayload ) );
 				}
 
 				log.automaticIndexingRetry( failedEvent.getId(),

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/outbox/impl/OutboxEventProcessingPlan.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/outbox/impl/OutboxEventProcessingPlan.java
@@ -20,7 +20,7 @@ import org.hibernate.search.engine.reporting.FailureHandler;
 import org.hibernate.search.mapper.orm.automaticindexing.spi.AutomaticIndexingMappingContext;
 import org.hibernate.search.mapper.orm.automaticindexing.spi.AutomaticIndexingQueueEventProcessingPlan;
 import org.hibernate.search.mapper.orm.common.EntityReference;
-import org.hibernate.search.mapper.pojo.route.DocumentRoutesDescriptor;
+import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingQueueEventPayload;
 import org.hibernate.search.util.common.impl.Futures;
 import org.hibernate.search.util.common.serialization.spi.SerializationUtils;
 
@@ -77,24 +77,20 @@ public class OutboxEventProcessingPlan {
 
 	private void addEventsToThePlan() {
 		for ( OutboxEvent event : events ) {
-			DocumentRoutesDescriptor routes = getRoutes( event );
+			PojoIndexingQueueEventPayload payload = SerializationUtils.deserialize( PojoIndexingQueueEventPayload.class, event.getPayload() );
 
 			switch ( event.getType() ) {
 				case ADD:
-					processingPlan.add( event.getEntityName(), event.getEntityId(), routes );
+					processingPlan.add( event.getEntityName(), event.getEntityId(), payload );
 					break;
 				case ADD_OR_UPDATE:
-					processingPlan.addOrUpdate( event.getEntityName(), event.getEntityId(), routes );
+					processingPlan.addOrUpdate( event.getEntityName(), event.getEntityId(), payload );
 					break;
 				case DELETE:
-					processingPlan.delete( event.getEntityName(), event.getEntityId(), routes );
+					processingPlan.delete( event.getEntityName(), event.getEntityId(), payload );
 					break;
 			}
 		}
-	}
-
-	private DocumentRoutesDescriptor getRoutes(OutboxEvent event) {
-		return SerializationUtils.deserialize( DocumentRoutesDescriptor.class, event.getDocumentRoutes() );
 	}
 
 	private void reportMapperFailure(Throwable throwable) {

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/outbox/impl/OutboxTableSendingPlan.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/outbox/impl/OutboxTableSendingPlan.java
@@ -15,7 +15,8 @@ import org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode;
 import org.hibernate.search.engine.backend.common.spi.EntityReferenceFactory;
 import org.hibernate.search.engine.backend.common.spi.MultiEntityOperationExecutionReport;
 import org.hibernate.search.mapper.orm.automaticindexing.spi.AutomaticIndexingQueueEventSendingPlan;
-import org.hibernate.search.mapper.pojo.route.DocumentRoutesDescriptor;
+import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingQueueEventPayload;
+import org.hibernate.search.util.common.serialization.spi.SerializationUtils;
 
 public class OutboxTableSendingPlan implements AutomaticIndexingQueueEventSendingPlan {
 
@@ -27,19 +28,26 @@ public class OutboxTableSendingPlan implements AutomaticIndexingQueueEventSendin
 	}
 
 	@Override
-	public void add(String entityName, Object identifier, String serializedId, DocumentRoutesDescriptor routes) {
-		events.add( new OutboxEvent( OutboxEvent.Type.ADD, entityName, serializedId, routes, identifier ) );
+	public void add(String entityName, Object identifier, String serializedId, PojoIndexingQueueEventPayload payload) {
+		events.add( new OutboxEvent( OutboxEvent.Type.ADD, entityName, serializedId,
+				SerializationUtils.serialize( payload ), identifier
+		) );
 	}
 
 	@Override
 	public void addOrUpdate(String entityName, Object identifier, String serializedId,
-			DocumentRoutesDescriptor routes) {
-		events.add( new OutboxEvent( OutboxEvent.Type.ADD_OR_UPDATE, entityName, serializedId, routes, identifier ) );
+			PojoIndexingQueueEventPayload payload) {
+		events.add( new OutboxEvent( OutboxEvent.Type.ADD_OR_UPDATE, entityName, serializedId,
+				SerializationUtils.serialize( payload ), identifier
+		) );
 	}
 
 	@Override
-	public void delete(String entityName, Object identifier, String serializedId, DocumentRoutesDescriptor routes) {
-		events.add( new OutboxEvent( OutboxEvent.Type.DELETE, entityName, serializedId, routes, identifier ) );
+	public void delete(String entityName, Object identifier, String serializedId,
+			PojoIndexingQueueEventPayload payload) {
+		events.add( new OutboxEvent( OutboxEvent.Type.DELETE, entityName, serializedId,
+				SerializationUtils.serialize( payload ), identifier
+		) );
 	}
 
 	@Override

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/scope/impl/HibernateOrmScopeIndexedTypeContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/scope/impl/HibernateOrmScopeIndexedTypeContext.java
@@ -8,7 +8,7 @@ package org.hibernate.search.mapper.orm.scope.impl;
 
 import org.hibernate.search.mapper.orm.entity.SearchIndexedEntity;
 import org.hibernate.search.mapper.orm.massindexing.impl.HibernateOrmMassIndexingIndexedTypeContext;
-import org.hibernate.search.mapper.orm.loading.impl.LoadingIndexedTypeContext;
+import org.hibernate.search.mapper.orm.loading.impl.LoadingTypeContext;
 import org.hibernate.search.mapper.pojo.scope.spi.PojoScopeDelegate;
 import org.hibernate.search.mapper.orm.loading.impl.HibernateOrmEntityLoadingStrategy;
 
@@ -20,7 +20,7 @@ import org.hibernate.search.mapper.orm.loading.impl.HibernateOrmEntityLoadingStr
  * @param <E> The entity type mapped to the index.
  */
 public interface HibernateOrmScopeIndexedTypeContext<E>
-		extends SearchIndexedEntity<E>, LoadingIndexedTypeContext<E>,
+		extends SearchIndexedEntity<E>, LoadingTypeContext<E>,
 				HibernateOrmMassIndexingIndexedTypeContext<E> {
 
 	@Override

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/ConfiguredAutomaticIndexingStrategy.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/ConfiguredAutomaticIndexingStrategy.java
@@ -34,7 +34,6 @@ import org.hibernate.search.mapper.orm.logging.impl.Log;
 import org.hibernate.search.mapper.orm.mapping.impl.AutomaticIndexingStrategyPreStopContextImpl;
 import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingPlan;
 import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingQueueEventProcessingPlan;
-import org.hibernate.search.mapper.pojo.work.spi.PojoWorkSessionContext;
 import org.hibernate.search.util.common.impl.Closer;
 import org.hibernate.search.util.common.impl.SuppressingCloser;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
@@ -198,11 +197,13 @@ public final class ConfiguredAutomaticIndexingStrategy {
 		}
 	}
 
-	public PojoIndexingQueueEventProcessingPlan createIndexingQueueEventProcessingPlan(PojoWorkSessionContext context,
+	public PojoIndexingQueueEventProcessingPlan createIndexingQueueEventProcessingPlan(HibernateOrmSearchSession context,
 			ConfiguredAutomaticIndexingSynchronizationStrategy synchronizationStrategy) {
+		AutomaticIndexingQueueEventSendingPlan delegate = senderFactory.apply( context );
 		return mappingContext.createIndexingQueueEventProcessingPlan( context,
 				synchronizationStrategy.getDocumentCommitStrategy(),
-				synchronizationStrategy.getDocumentRefreshStrategy() );
+				synchronizationStrategy.getDocumentRefreshStrategy(),
+				new HibernateOrmIndexingQueueEventSendingPlan( delegate ) );
 	}
 
 	private ConfiguredAutomaticIndexingSynchronizationStrategy configure(

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/HibernateOrmSearchSession.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/HibernateOrmSearchSession.java
@@ -214,7 +214,7 @@ public class HibernateOrmSearchSession extends AbstractPojoSearchSession
 					"Document reference " + reference + " refers to an unknown type"
 			);
 		}
-		Object id = typeContext.getIdentifierMapping()
+		Object id = typeContext.identifierMapping()
 				.fromDocumentIdentifier( reference.id(), this );
 		return new EntityReferenceImpl( typeContext.typeIdentifier(), typeContext.jpaEntityName(), id );
 	}

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/HibernateOrmSearchSessionMappingContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/HibernateOrmSearchSessionMappingContext.java
@@ -8,6 +8,7 @@ package org.hibernate.search.mapper.orm.session.impl;
 
 import java.util.Collection;
 
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.search.engine.backend.common.spi.EntityReferenceFactory;
 import org.hibernate.search.engine.reporting.FailureHandler;
@@ -24,6 +25,8 @@ public interface HibernateOrmSearchSessionMappingContext
 
 	@Override
 	EntityReferenceFactory<EntityReference> entityReferenceFactory();
+
+	SessionFactoryImplementor sessionFactory();
 
 	<T> SearchScopeImpl<T> createScope(Collection<? extends Class<? extends T>> types);
 

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/HibernateOrmSessionIndexedTypeContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/HibernateOrmSessionIndexedTypeContext.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.mapper.orm.session.impl;
 
-import org.hibernate.search.mapper.pojo.bridge.runtime.spi.IdentifierMapping;
+import org.hibernate.search.mapper.pojo.identity.spi.IdentifierMapping;
 
 /**
  * @param <E> The entity type mapped to the index.

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/HibernateOrmSessionIndexedTypeContext.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/session/impl/HibernateOrmSessionIndexedTypeContext.java
@@ -13,6 +13,6 @@ import org.hibernate.search.mapper.pojo.identity.spi.IdentifierMapping;
  */
 public interface HibernateOrmSessionIndexedTypeContext<E> extends HibernateOrmSessionTypeContext<E> {
 
-	IdentifierMapping getIdentifierMapping();
+	IdentifierMapping identifierMapping();
 
 }

--- a/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/impl/SearchIndexingPlanImpl.java
+++ b/mapper/orm/src/main/java/org/hibernate/search/mapper/orm/work/impl/SearchIndexingPlanImpl.java
@@ -25,7 +25,8 @@ public final class SearchIndexingPlanImpl implements SearchIndexingPlan {
 	@Override
 	public void addOrUpdate(Object entity) {
 		delegate( true )
-				.addOrUpdate( getTypeIdentifier( entity ), null, null, entity );
+				.addOrUpdate( getTypeIdentifier( entity ), null, null, entity,
+						true, true, null );
 	}
 
 	@Override

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/building/impl/PojoImplicitReindexingResolverBuildingHelper.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/building/impl/PojoImplicitReindexingResolverBuildingHelper.java
@@ -26,7 +26,6 @@ import org.hibernate.search.mapper.pojo.model.additionalmetadata.impl.PojoTypeAd
 import org.hibernate.search.mapper.pojo.model.path.PojoModelPathValueNode;
 import org.hibernate.search.mapper.pojo.model.path.spi.PojoPathFilter;
 import org.hibernate.search.mapper.pojo.model.path.impl.PojoPathFilterProvider;
-import org.hibernate.search.mapper.pojo.model.path.spi.PojoPathsDefinition;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeModel;
 import org.hibernate.search.mapper.pojo.model.spi.PojoTypeModel;
 import org.hibernate.search.util.common.impl.Closer;
@@ -86,10 +85,9 @@ public final class PojoImplicitReindexingResolverBuildingHelper {
 	}
 
 	public <T> PojoImplicitReindexingResolver<T> build(PojoRawTypeModel<T> typeModel,
-			PojoPathsDefinition pathsDefinition) {
-		return buildOptional( typeModel, pathsDefinition )
+			PojoPathFilterProvider pathFilterProvider) {
+		return buildOptional( typeModel, pathFilterProvider )
 				.orElseGet( () -> {
-					PojoPathFilterProvider pathFilterProvider = new PojoPathFilterProvider( pathsDefinition );
 					PojoPathFilter emptyFilter = pathFilterProvider
 							.create( Collections.emptySet() );
 					return new PojoImplicitReindexingResolverImpl<>(
@@ -100,7 +98,7 @@ public final class PojoImplicitReindexingResolverBuildingHelper {
 	}
 
 	public <T> Optional<PojoImplicitReindexingResolver<T>> buildOptional(PojoRawTypeModel<T> typeModel,
-			PojoPathsDefinition pathsDefinition) {
+			PojoPathFilterProvider pathFilterProvider) {
 		@SuppressWarnings("unchecked") // We know builders have this type, by construction
 		PojoImplicitReindexingResolverBuilder<T> builder =
 				(PojoImplicitReindexingResolverBuilder<T>) builderByType.get( typeModel );
@@ -108,7 +106,6 @@ public final class PojoImplicitReindexingResolverBuildingHelper {
 			return Optional.empty();
 		}
 		else {
-			PojoPathFilterProvider pathFilterProvider = new PojoPathFilterProvider( pathsDefinition );
 			return builder.build( pathFilterProvider );
 		}
 	}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/impl/PojoImplicitReindexingResolverDirtinessFilterNode.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/impl/PojoImplicitReindexingResolverDirtinessFilterNode.java
@@ -46,7 +46,7 @@ public class PojoImplicitReindexingResolverDirtinessFilterNode<T> extends PojoIm
 	@Override
 	public void resolveEntitiesToReindex(PojoReindexingCollector collector,
 			T dirty, PojoImplicitReindexingResolverRootContext context) {
-		if ( context.isDirty( dirtyPathFilter ) ) {
+		if ( context.isDirtyForReindexingResolution( dirtyPathFilter ) ) {
 			nested.resolveEntitiesToReindex( collector, dirty, context );
 		}
 	}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/impl/PojoImplicitReindexingResolverRootContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/automaticindexing/impl/PojoImplicitReindexingResolverRootContext.java
@@ -28,6 +28,6 @@ public interface PojoImplicitReindexingResolverRootContext {
 	 * @param filter A path filter for dirty paths.
 	 * @return Whether the root is dirty according to the given filter.
 	 */
-	boolean isDirty(PojoPathFilter filter);
+	boolean isDirtyForReindexingResolution(PojoPathFilter filter);
 
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/bridge/binding/impl/DefaultIdentifierBindingContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/bridge/binding/impl/DefaultIdentifierBindingContext.java
@@ -8,6 +8,7 @@ package org.hibernate.search.mapper.pojo.bridge.binding.impl;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Map;
+import java.util.Optional;
 
 import org.hibernate.search.engine.environment.bean.BeanHolder;
 import org.hibernate.search.engine.environment.bean.BeanResolver;
@@ -32,7 +33,7 @@ public class DefaultIdentifierBindingContext<I> extends AbstractBindingContext
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private final PojoBootstrapIntrospector introspector;
-	private final IndexedEntityBindingContext indexedEntityBindingContext;
+	private final Optional<IndexedEntityBindingContext> indexedEntityBindingContext;
 
 	private final PojoGenericTypeModel<I> identifierTypeModel;
 	private final PojoModelValue<I> bridgedElement;
@@ -41,7 +42,7 @@ public class DefaultIdentifierBindingContext<I> extends AbstractBindingContext
 
 	public DefaultIdentifierBindingContext(BeanResolver beanResolver,
 			PojoBootstrapIntrospector introspector,
-			IndexedEntityBindingContext indexedEntityBindingContext,
+			Optional<IndexedEntityBindingContext> indexedEntityBindingContext,
 			PojoGenericTypeModel<I> valueTypeModel, Map<String, Object> params) {
 		super( beanResolver, params );
 		this.introspector = introspector;
@@ -122,12 +123,14 @@ public class DefaultIdentifierBindingContext<I> extends AbstractBindingContext
 			abortBridge( closer, bridgeHolder );
 		}
 
-		BoundIdentifierBridge<I> complete(IndexedEntityBindingContext indexedEntityBindingContext) {
-			indexedEntityBindingContext.idDslConverter(
-					new PojoIdentifierBridgeDocumentIdentifierValueConverter<>(
-							bridgeHolder.get(), expectedValueType
-					)
-			);
+		BoundIdentifierBridge<I> complete(Optional<IndexedEntityBindingContext> indexedEntityBindingContext) {
+			if ( indexedEntityBindingContext.isPresent() ) {
+				indexedEntityBindingContext.get().idDslConverter(
+						new PojoIdentifierBridgeDocumentIdentifierValueConverter<>(
+								bridgeHolder.get(), expectedValueType
+						)
+				);
+			}
 
 			return new BoundIdentifierBridge<>( bridgeHolder );
 		}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/identity/impl/AbstractIdentityMappingCollectorNode.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/identity/impl/AbstractIdentityMappingCollectorNode.java
@@ -1,0 +1,48 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.identity.impl;
+
+import org.hibernate.search.engine.reporting.spi.ContextualFailureCollector;
+import org.hibernate.search.mapper.pojo.mapping.building.impl.PojoMappingHelper;
+import org.hibernate.search.mapper.pojo.model.path.PojoModelPath;
+import org.hibernate.search.mapper.pojo.model.path.impl.BoundPojoModelPath;
+import org.hibernate.search.mapper.pojo.reporting.impl.PojoEventContexts;
+
+abstract class AbstractIdentityMappingCollectorNode {
+
+	final PojoMappingHelper mappingHelper;
+
+	AbstractIdentityMappingCollectorNode(PojoMappingHelper mappingHelper) {
+		this.mappingHelper = mappingHelper;
+	}
+
+	@Override
+	public String toString() {
+		return getClass().getSimpleName() + "[" + getModelPath() + "]";
+	}
+
+	abstract BoundPojoModelPath getModelPath();
+
+	public final ContextualFailureCollector failureCollector() {
+		BoundPojoModelPath modelPath = getModelPath();
+
+		ContextualFailureCollector failureCollector = mappingHelper.failureCollector()
+				.withContext(
+						PojoEventContexts.fromType( modelPath.getRootType().rawType() )
+				);
+
+		PojoModelPath unboundPath = modelPath.toUnboundPath();
+		if ( unboundPath != null ) {
+			failureCollector = failureCollector.withContext(
+					PojoEventContexts.fromPath( modelPath.toUnboundPath() )
+			);
+		}
+
+		return failureCollector;
+	}
+
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/identity/impl/IdentifierMappingImplementor.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/identity/impl/IdentifierMappingImplementor.java
@@ -4,13 +4,13 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.mapper.pojo.bridge.runtime.impl;
+package org.hibernate.search.mapper.pojo.identity.impl;
 
 import java.util.function.Supplier;
 
 import org.hibernate.search.mapper.pojo.bridge.runtime.spi.BridgeMappingContext;
 import org.hibernate.search.mapper.pojo.bridge.runtime.spi.BridgeSessionContext;
-import org.hibernate.search.mapper.pojo.bridge.runtime.spi.IdentifierMapping;
+import org.hibernate.search.mapper.pojo.identity.spi.IdentifierMapping;
 
 /**
  * @param <I> The identifier type for the mapped entity type.

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/identity/impl/IdentityMappingCollectorPropertyNode.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/identity/impl/IdentityMappingCollectorPropertyNode.java
@@ -1,0 +1,61 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.identity.impl;
+
+import java.util.Map;
+
+import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.IdentifierBinder;
+import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.PropertyBinder;
+import org.hibernate.search.mapper.pojo.extractor.impl.BoundContainerExtractorPath;
+import org.hibernate.search.mapper.pojo.extractor.mapping.programmatic.ContainerExtractorPath;
+import org.hibernate.search.mapper.pojo.mapping.building.impl.PojoMappingHelper;
+import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoMappingCollectorPropertyNode;
+import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoMappingCollectorValueNode;
+import org.hibernate.search.mapper.pojo.model.path.impl.BoundPojoModelPath;
+import org.hibernate.search.mapper.pojo.model.path.impl.BoundPojoModelPathPropertyNode;
+
+class IdentityMappingCollectorPropertyNode<P> extends AbstractIdentityMappingCollectorNode
+		implements PojoMappingCollectorPropertyNode {
+
+	private final BoundPojoModelPathPropertyNode<?, P> modelPath;
+	private final PojoIdentityMappingCollector identityMappingCollector;
+
+	IdentityMappingCollectorPropertyNode(BoundPojoModelPathPropertyNode<?, P> modelPath,
+			PojoMappingHelper mappingHelper,
+			PojoIdentityMappingCollector identityMappingCollector) {
+		super( mappingHelper );
+
+		this.modelPath = modelPath;
+
+		this.identityMappingCollector = identityMappingCollector;
+	}
+
+	@Override
+	BoundPojoModelPath getModelPath() {
+		return modelPath;
+	}
+
+	@Override
+	public void propertyBinder(PropertyBinder binder, Map<String, Object> params) {
+		// No-op, we're just collecting the identity mapping.
+	}
+
+	@Override
+	public void identifierBinder(IdentifierBinder binder, Map<String, Object> params) {
+		identityMappingCollector.identifierBridge( modelPath, binder, params );
+	}
+
+	@Override
+	public PojoMappingCollectorValueNode value(ContainerExtractorPath extractorPath) {
+		BoundContainerExtractorPath<P, ?> boundExtractorPath =
+				mappingHelper.indexModelBinder().bindExtractorPath(
+						modelPath.getPropertyModel().typeModel(),
+						extractorPath
+				);
+		return new IdentityMappingCollectorValueNode( modelPath.value( boundExtractorPath ), mappingHelper );
+	}
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/identity/impl/IdentityMappingCollectorTypeNode.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/identity/impl/IdentityMappingCollectorTypeNode.java
@@ -1,0 +1,48 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.identity.impl;
+
+import java.util.Map;
+
+import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.TypeBinder;
+import org.hibernate.search.mapper.pojo.mapping.building.impl.PojoMappingHelper;
+import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoMappingCollectorPropertyNode;
+import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoMappingCollectorTypeNode;
+import org.hibernate.search.mapper.pojo.model.path.impl.BoundPojoModelPathTypeNode;
+
+class IdentityMappingCollectorTypeNode<T> extends AbstractIdentityMappingCollectorNode
+		implements PojoMappingCollectorTypeNode {
+
+	private final BoundPojoModelPathTypeNode<T> modelPath;
+	private final PojoIdentityMappingCollector identityMappingCollector;
+
+	IdentityMappingCollectorTypeNode(BoundPojoModelPathTypeNode<T> modelPath,
+			PojoMappingHelper mappingHelper,
+			PojoIdentityMappingCollector identityMappingCollector) {
+		super( mappingHelper );
+		this.modelPath = modelPath;
+		this.identityMappingCollector = identityMappingCollector;
+	}
+
+	@Override
+	BoundPojoModelPathTypeNode<T> getModelPath() {
+		return modelPath;
+	}
+
+	@Override
+	public void typeBinder(TypeBinder builder, Map<String, Object> params) {
+		// No-op, we're just collecting the identity mapping.
+	}
+
+	@Override
+	public PojoMappingCollectorPropertyNode property(String propertyName) {
+		return new IdentityMappingCollectorPropertyNode<>( modelPath.property( propertyName ),
+				mappingHelper, identityMappingCollector
+		);
+	}
+
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/identity/impl/IdentityMappingCollectorValueNode.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/identity/impl/IdentityMappingCollectorValueNode.java
@@ -1,0 +1,48 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.identity.impl;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.hibernate.search.engine.backend.types.ObjectStructure;
+import org.hibernate.search.mapper.pojo.bridge.binding.spi.FieldModelContributor;
+import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.ValueBinder;
+import org.hibernate.search.mapper.pojo.mapping.building.impl.PojoMappingHelper;
+import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoMappingCollectorValueNode;
+import org.hibernate.search.mapper.pojo.model.path.impl.BoundPojoModelPathValueNode;
+import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeModel;
+
+class IdentityMappingCollectorValueNode extends AbstractIdentityMappingCollectorNode
+		implements PojoMappingCollectorValueNode {
+
+	private final BoundPojoModelPathValueNode<?, ?, ?> modelPath;
+
+	IdentityMappingCollectorValueNode(BoundPojoModelPathValueNode<?, ?, ?> modelPath, PojoMappingHelper mappingHelper) {
+		super( mappingHelper );
+		this.modelPath = modelPath;
+	}
+
+	@Override
+	BoundPojoModelPathValueNode<?, ?, ?> getModelPath() {
+		return modelPath;
+	}
+
+	@Override
+	public void valueBinder(ValueBinder binder, Map<String, Object> params, String relativeFieldName,
+			FieldModelContributor fieldModelContributor) {
+		// No-op, we're just collecting the identity mapping.
+	}
+
+	@Override
+	public void indexedEmbedded(PojoRawTypeModel<?> definingTypeModel, String relativePrefix,
+			ObjectStructure structure,
+			Integer includeDepth, Set<String> includePaths, boolean includeEmbeddedObjectId,
+			Class<?> targetType) {
+		// No-op, we're just collecting the identity mapping.
+	}
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/identity/impl/IdentityMappingMode.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/identity/impl/IdentityMappingMode.java
@@ -4,10 +4,11 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.mapper.orm.massindexing.impl;
+package org.hibernate.search.mapper.pojo.identity.impl;
 
-import org.hibernate.search.mapper.orm.loading.impl.LoadingTypeContext;
+public enum IdentityMappingMode {
 
-public interface HibernateOrmMassIndexingIndexedTypeContext<E> extends LoadingTypeContext<E> {
+	REQUIRED,
+	OPTIONAL;
 
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/identity/impl/PojoIdentityMappingCollector.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/identity/impl/PojoIdentityMappingCollector.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.mapper.pojo.processing.building.impl;
+package org.hibernate.search.mapper.pojo.identity.impl;
 
 import java.util.Map;
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/identity/impl/PojoRootIdentityMappingCollector.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/identity/impl/PojoRootIdentityMappingCollector.java
@@ -11,14 +11,11 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
-import org.hibernate.search.engine.environment.bean.BeanHolder;
 import org.hibernate.search.engine.environment.bean.BeanReference;
 import org.hibernate.search.engine.environment.bean.BeanResolver;
 import org.hibernate.search.engine.mapper.mapping.building.spi.IndexedEntityBindingContext;
 import org.hibernate.search.mapper.pojo.bridge.IdentifierBridge;
-import org.hibernate.search.mapper.pojo.bridge.RoutingBridge;
 import org.hibernate.search.mapper.pojo.bridge.binding.impl.BoundIdentifierBridge;
-import org.hibernate.search.mapper.pojo.bridge.binding.impl.BoundRoutingBridge;
 import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.IdentifierBinder;
 import org.hibernate.search.mapper.pojo.logging.impl.Log;
 import org.hibernate.search.mapper.pojo.mapping.building.impl.PojoMappingHelper;
@@ -40,27 +37,22 @@ public final class PojoRootIdentityMappingCollector<E> implements PojoIdentityMa
 
 	public IdentifierMappingImplementor<?, E> identifierMapping;
 	public Optional<PojoPropertyModel<?>> documentIdSourceProperty;
-	public BoundRoutingBridge<E> routingBridge;
 
 	public PojoRootIdentityMappingCollector(PojoRawTypeModel<E> typeModel,
 			PojoMappingHelper mappingHelper,
 			IndexedEntityBindingContext bindingContext,
 			BeanReference<? extends IdentifierBridge<Object>> providedIdentifierBridge,
-			BoundRoutingBridge<E> routingBridge,
 			BeanResolver beanResolver) {
 		this.typeModel = typeModel;
 		this.mappingHelper = mappingHelper;
 		this.bindingContext = bindingContext;
 		this.providedIdentifierBridge = providedIdentifierBridge;
 		this.beanResolver = beanResolver;
-		this.routingBridge = routingBridge;
 	}
 
 	public void closeOnFailure() {
 		try ( Closer<RuntimeException> closer = new Closer<>() ) {
 			closer.push( IdentifierMappingImplementor::close, identifierMapping );
-			closer.push( RoutingBridge::close, routingBridge, BoundRoutingBridge::getBridge );
-			closer.push( BeanHolder::close, routingBridge, BoundRoutingBridge::getBridgeHolder );
 		}
 	}
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/identity/impl/PojoRootIdentityMappingCollector.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/identity/impl/PojoRootIdentityMappingCollector.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.mapper.pojo.mapping.building.impl;
+package org.hibernate.search.mapper.pojo.identity.impl;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Collections;
@@ -20,18 +20,15 @@ import org.hibernate.search.mapper.pojo.bridge.RoutingBridge;
 import org.hibernate.search.mapper.pojo.bridge.binding.impl.BoundIdentifierBridge;
 import org.hibernate.search.mapper.pojo.bridge.binding.impl.BoundRoutingBridge;
 import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.IdentifierBinder;
-import org.hibernate.search.mapper.pojo.bridge.runtime.impl.IdentifierMappingImplementor;
-import org.hibernate.search.mapper.pojo.bridge.runtime.impl.PropertyIdentifierMapping;
-import org.hibernate.search.mapper.pojo.bridge.runtime.impl.ProvidedIdentifierMapping;
 import org.hibernate.search.mapper.pojo.logging.impl.Log;
+import org.hibernate.search.mapper.pojo.mapping.building.impl.PojoMappingHelper;
 import org.hibernate.search.mapper.pojo.model.path.impl.BoundPojoModelPathPropertyNode;
 import org.hibernate.search.mapper.pojo.model.spi.PojoPropertyModel;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeModel;
-import org.hibernate.search.mapper.pojo.processing.building.impl.PojoIdentityMappingCollector;
 import org.hibernate.search.util.common.impl.Closer;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
-class PojoRootIdentityMappingCollector<E> implements PojoIdentityMappingCollector {
+public final class PojoRootIdentityMappingCollector<E> implements PojoIdentityMappingCollector {
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private final PojoRawTypeModel<E> typeModel;
@@ -41,11 +38,11 @@ class PojoRootIdentityMappingCollector<E> implements PojoIdentityMappingCollecto
 	private final BeanReference<? extends IdentifierBridge<Object>> providedIdentifierBridge;
 	private final BeanResolver beanResolver;
 
-	IdentifierMappingImplementor<?, E> identifierMapping;
-	Optional<PojoPropertyModel<?>> documentIdSourceProperty;
-	BoundRoutingBridge<E> routingBridge;
+	public IdentifierMappingImplementor<?, E> identifierMapping;
+	public Optional<PojoPropertyModel<?>> documentIdSourceProperty;
+	public BoundRoutingBridge<E> routingBridge;
 
-	PojoRootIdentityMappingCollector(PojoRawTypeModel<E> typeModel,
+	public PojoRootIdentityMappingCollector(PojoRawTypeModel<E> typeModel,
 			PojoMappingHelper mappingHelper,
 			IndexedEntityBindingContext bindingContext,
 			BeanReference<? extends IdentifierBridge<Object>> providedIdentifierBridge,
@@ -59,7 +56,7 @@ class PojoRootIdentityMappingCollector<E> implements PojoIdentityMappingCollecto
 		this.routingBridge = routingBridge;
 	}
 
-	void closeOnFailure() {
+	public void closeOnFailure() {
 		try ( Closer<RuntimeException> closer = new Closer<>() ) {
 			closer.push( IdentifierMappingImplementor::close, identifierMapping );
 			closer.push( RoutingBridge::close, routingBridge, BoundRoutingBridge::getBridge );
@@ -81,7 +78,7 @@ class PojoRootIdentityMappingCollector<E> implements PojoIdentityMappingCollecto
 		this.documentIdSourceProperty = Optional.of( propertyModel );
 	}
 
-	void applyDefaults() {
+	public void applyDefaults() {
 		if ( identifierMapping != null ) {
 			return;
 		}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/identity/impl/PropertyIdentifierMapping.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/identity/impl/PropertyIdentifierMapping.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.mapper.pojo.bridge.runtime.impl;
+package org.hibernate.search.mapper.pojo.identity.impl;
 
 import java.lang.invoke.MethodHandles;
 import java.util.function.Supplier;
@@ -20,7 +20,7 @@ import org.hibernate.search.util.common.reflect.spi.ValueReadHandle;
 import org.hibernate.search.util.common.impl.Closer;
 
 
-public class PropertyIdentifierMapping<I, E> implements IdentifierMappingImplementor<I, E> {
+public final class PropertyIdentifierMapping<I, E> implements IdentifierMappingImplementor<I, E> {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/identity/impl/ProvidedIdentifierMapping.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/identity/impl/ProvidedIdentifierMapping.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.mapper.pojo.bridge.runtime.impl;
+package org.hibernate.search.mapper.pojo.identity.impl;
 
 import java.lang.invoke.MethodHandles;
 import java.util.function.Supplier;
@@ -18,7 +18,7 @@ import org.hibernate.search.util.common.impl.Closer;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 
 
-public class ProvidedIdentifierMapping implements IdentifierMappingImplementor<Object, Object> {
+public final class ProvidedIdentifierMapping implements IdentifierMappingImplementor<Object, Object> {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/identity/impl/UnconfiguredIdentifierMapping.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/identity/impl/UnconfiguredIdentifierMapping.java
@@ -1,0 +1,59 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.identity.impl;
+
+import java.lang.invoke.MethodHandles;
+import java.util.function.Supplier;
+
+import org.hibernate.search.mapper.pojo.bridge.runtime.spi.BridgeMappingContext;
+import org.hibernate.search.mapper.pojo.bridge.runtime.spi.BridgeSessionContext;
+import org.hibernate.search.mapper.pojo.logging.impl.Log;
+import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeIdentifier;
+import org.hibernate.search.util.common.logging.impl.LoggerFactory;
+
+
+public final class UnconfiguredIdentifierMapping<E> implements IdentifierMappingImplementor<Object, E> {
+
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+
+	private final PojoRawTypeIdentifier<E> typeIdentifier;
+
+	public UnconfiguredIdentifierMapping(PojoRawTypeIdentifier<E> typeIdentifier) {
+		this.typeIdentifier = typeIdentifier;
+	}
+
+	@Override
+	public String toString() {
+		return getClass().getSimpleName() + "[entityType = " + typeIdentifier + "]";
+	}
+
+	@Override
+	public void close() {
+		// Nothing to close
+	}
+
+	@Override
+	@SuppressWarnings( "unchecked" ) // We can only cast to the raw type, if I is generic we need an unchecked cast
+	public Object getIdentifier(Object providedId, Supplier<? extends E> entitySupplierOrNull) {
+		if ( providedId != null ) {
+			return providedId;
+		}
+		else {
+			throw log.cannotWorkWithIdentifierBecauseUnconfiguredIdentifierMapping( typeIdentifier );
+		}
+	}
+
+	@Override
+	public String toDocumentIdentifier(Object identifier, BridgeMappingContext context) {
+		throw log.cannotWorkWithIdentifierBecauseUnconfiguredIdentifierMapping( typeIdentifier );
+	}
+
+	@Override
+	public Object fromDocumentIdentifier(String documentId, BridgeSessionContext sessionContext) {
+		throw log.cannotWorkWithIdentifierBecauseUnconfiguredIdentifierMapping( typeIdentifier );
+	}
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/identity/spi/IdentifierMapping.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/identity/spi/IdentifierMapping.java
@@ -4,7 +4,9 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.mapper.pojo.bridge.runtime.spi;
+package org.hibernate.search.mapper.pojo.identity.spi;
+
+import org.hibernate.search.mapper.pojo.bridge.runtime.spi.BridgeSessionContext;
 
 public interface IdentifierMapping {
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/logging/impl/Log.java
@@ -234,7 +234,7 @@ public interface Log extends BasicLogger {
 			value = "Type manager for contained type '%1$s': %2$s")
 	void containedTypeManager(
 			@FormatWith(PojoTypeModelFormatter.class) PojoRawTypeModel<?> typeModel,
-			@FormatWith(ToStringTreeAppendableMultilineFormatter.class) PojoContainedTypeManager<?> typeManager);
+			@FormatWith(ToStringTreeAppendableMultilineFormatter.class) PojoContainedTypeManager<?, ?> typeManager);
 
 	@Message(id = ID_OFFSET + 20,
 			value = "Unable to find the inverse side of the association on type '%2$s' at path '%3$s'."
@@ -631,5 +631,9 @@ public interface Log extends BasicLogger {
 
 	@Message(id = ID_OFFSET + 104, value = "Param with name '%1$s' has not been defined for the binder.")
 	SearchException paramNotDefined(String name);
+
+	@Message(id = ID_OFFSET + 105, value = "Cannot work with the identifier of entities of type '%1$s':"
+			+ " identifier mapping (@DocumentId, ...) is not configured for this type.")
+	SearchException cannotWorkWithIdentifierBecauseUnconfiguredIdentifierMapping(PojoRawTypeIdentifier<?> typeIdentifier);
 
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/impl/PojoIndexModelBinder.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/impl/PojoIndexModelBinder.java
@@ -57,7 +57,7 @@ public interface PojoIndexModelBinder {
 			BoundContainerExtractorPath<C, V> boundExtractorPath);
 
 	<I> BoundIdentifierBridge<I> bindIdentifier(
-			IndexedEntityBindingContext bindingContext,
+			Optional<IndexedEntityBindingContext> bindingContext,
 			BoundPojoModelPathPropertyNode<?, I> modelPath, IdentifierBinder binder,
 			Map<String, Object> params);
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/impl/PojoIndexModelBinderImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/impl/PojoIndexModelBinderImpl.java
@@ -92,7 +92,7 @@ public class PojoIndexModelBinderImpl implements PojoIndexModelBinder {
 
 	@Override
 	public <I> BoundIdentifierBridge<I> bindIdentifier(
-			IndexedEntityBindingContext indexedEntityBindingContext,
+			Optional<IndexedEntityBindingContext> indexedEntityBindingContext,
 			BoundPojoModelPathPropertyNode<?, I> modelPath,
 			IdentifierBinder binder, Map<String, Object> params) {
 		PojoGenericTypeModel<I> identifierTypeModel = modelPath.valueWithoutExtractors().getTypeModel();

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/impl/PojoIndexedTypeManagerBuilder.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/impl/PojoIndexedTypeManagerBuilder.java
@@ -20,6 +20,7 @@ import org.hibernate.search.mapper.pojo.bridge.IdentifierBridge;
 import org.hibernate.search.mapper.pojo.bridge.binding.impl.BoundRoutingBridge;
 import org.hibernate.search.mapper.pojo.bridge.runtime.impl.NoOpDocumentRouter;
 import org.hibernate.search.mapper.pojo.bridge.runtime.impl.RoutingBridgeDocumentRouter;
+import org.hibernate.search.mapper.pojo.identity.impl.PojoRootIdentityMappingCollector;
 import org.hibernate.search.mapper.pojo.logging.impl.Log;
 import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoIndexedTypeExtendedMappingCollector;
 import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoMappingCollectorTypeNode;

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/impl/PojoMapper.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/impl/PojoMapper.java
@@ -30,6 +30,7 @@ import org.hibernate.search.engine.mapper.mapping.building.spi.MappingPartialBui
 import org.hibernate.search.engine.mapper.model.spi.MappableTypeModel;
 import org.hibernate.search.engine.reporting.spi.ContextualFailureCollector;
 import org.hibernate.search.engine.reporting.spi.EventContexts;
+import org.hibernate.search.engine.tenancy.spi.TenancyMode;
 import org.hibernate.search.mapper.pojo.automaticindexing.ReindexOnUpdate;
 import org.hibernate.search.mapper.pojo.bridge.IdentifierBridge;
 import org.hibernate.search.mapper.pojo.bridge.binding.impl.BoundRoutingBridge;
@@ -74,7 +75,7 @@ public class PojoMapper<MPBS extends MappingPartialBuildState> implements Mapper
 	private final ContextualFailureCollector failureCollector;
 	private final TypeMetadataContributorProvider<PojoTypeMetadataContributor> contributorProvider;
 	private final BeanReference<? extends IdentifierBridge<Object>> providedIdentifierBridge;
-	private final boolean multiTenancyEnabled;
+	private final TenancyMode tenancyMode;
 	private final ReindexOnUpdate defaultReindexOnUpdate;
 
 	private final FailureHandler failureHandler;
@@ -102,11 +103,11 @@ public class PojoMapper<MPBS extends MappingPartialBuildState> implements Mapper
 			ContainerExtractorBinder extractorBinder,
 			BridgeResolver bridgeResolver,
 			BeanReference<? extends IdentifierBridge<Object>> providedIdentifierBridge,
-			boolean multiTenancyEnabled, ReindexOnUpdate defaultReindexOnUpdate,
+			TenancyMode tenancyMode, ReindexOnUpdate defaultReindexOnUpdate,
 			PojoMapperDelegate<MPBS> delegate) {
 		this.failureCollector = buildContext.failureCollector();
 		this.contributorProvider = contributorProvider;
-		this.multiTenancyEnabled = multiTenancyEnabled;
+		this.tenancyMode = tenancyMode;
 		this.defaultReindexOnUpdate = defaultReindexOnUpdate;
 
 		this.failureHandler = buildContext.failureHandler();
@@ -179,7 +180,7 @@ public class PojoMapper<MPBS extends MappingPartialBuildState> implements Mapper
 				throw log.missingEntityTypeMetadata( rawTypeModel );
 			}
 			PojoIndexedTypeAdditionalMetadata indexedTypeMetadata = indexedTypeMetadataOptional.get();
-			backendsInfo.collect( indexedTypeMetadata.backendName(), multiTenancyEnabled );
+			backendsInfo.collect( indexedTypeMetadata.backendName(), tenancyMode );
 			indexedEntityTypes.add( rawTypeModel );
 		}
 	}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/spi/PojoIndexedTypeExtendedMappingCollector.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/spi/PojoIndexedTypeExtendedMappingCollector.java
@@ -7,8 +7,6 @@
 package org.hibernate.search.mapper.pojo.mapping.building.spi;
 
 import org.hibernate.search.engine.mapper.mapping.spi.MappedIndexManager;
-import org.hibernate.search.mapper.pojo.identity.spi.IdentifierMapping;
-import org.hibernate.search.mapper.pojo.model.spi.PojoPropertyModel;
 
 /**
  * A collector of extended mapping information.
@@ -17,10 +15,6 @@ import org.hibernate.search.mapper.pojo.model.spi.PojoPropertyModel;
  * necessary to implement their {@link org.hibernate.search.mapper.pojo.scope.spi.PojoScopeTypeExtendedContextProvider}.
  */
 public interface PojoIndexedTypeExtendedMappingCollector extends PojoTypeExtendedMappingCollector {
-
-	void documentIdSourceProperty(PojoPropertyModel<?> documentIdSourceProperty);
-
-	void identifierMapping(IdentifierMapping identifierMapping);
 
 	void indexManager(MappedIndexManager indexManager);
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/spi/PojoIndexedTypeExtendedMappingCollector.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/spi/PojoIndexedTypeExtendedMappingCollector.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.mapper.pojo.mapping.building.spi;
 
 import org.hibernate.search.engine.mapper.mapping.spi.MappedIndexManager;
-import org.hibernate.search.mapper.pojo.bridge.runtime.spi.IdentifierMapping;
+import org.hibernate.search.mapper.pojo.identity.spi.IdentifierMapping;
 import org.hibernate.search.mapper.pojo.model.spi.PojoPropertyModel;
 
 /**

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/spi/PojoTypeExtendedMappingCollector.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/building/spi/PojoTypeExtendedMappingCollector.java
@@ -6,7 +6,9 @@
  */
 package org.hibernate.search.mapper.pojo.mapping.building.spi;
 
+import org.hibernate.search.mapper.pojo.identity.spi.IdentifierMapping;
 import org.hibernate.search.mapper.pojo.model.path.spi.PojoPathFilter;
+import org.hibernate.search.mapper.pojo.model.spi.PojoPropertyModel;
 
 /**
  * A collector of extended mapping information.
@@ -15,6 +17,10 @@ import org.hibernate.search.mapper.pojo.model.path.spi.PojoPathFilter;
  * necessary to implement their {@link org.hibernate.search.mapper.pojo.scope.spi.PojoScopeTypeExtendedContextProvider}.
  */
 public interface PojoTypeExtendedMappingCollector {
+
+	void documentIdSourceProperty(PojoPropertyModel<?> documentIdSourceProperty);
+
+	void identifierMapping(IdentifierMapping identifierMapping);
 
 	void dirtyFilter(PojoPathFilter dirtyFilter);
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/AbstractPojoTypeManager.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/AbstractPojoTypeManager.java
@@ -15,6 +15,8 @@ import org.hibernate.search.mapper.pojo.automaticindexing.impl.PojoImplicitReind
 import org.hibernate.search.mapper.pojo.automaticindexing.impl.PojoReindexingCollector;
 import org.hibernate.search.mapper.pojo.identity.impl.IdentifierMappingImplementor;
 import org.hibernate.search.mapper.pojo.logging.impl.Log;
+import org.hibernate.search.mapper.pojo.model.path.impl.PojoPathOrdinals;
+import org.hibernate.search.mapper.pojo.model.path.spi.PojoPathFilter;
 import org.hibernate.search.mapper.pojo.model.spi.PojoCaster;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeIdentifier;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRuntimeIntrospector;
@@ -38,17 +40,19 @@ public class AbstractPojoTypeManager<I, E>
 	protected final PojoCaster<E> caster;
 	private final boolean singleConcreteTypeInEntityHierarchy;
 	protected final IdentifierMappingImplementor<I, E> identifierMapping;
+	private final PojoPathOrdinals pathOrdinals;
 	protected final PojoImplicitReindexingResolver<E> reindexingResolver;
 
 	public AbstractPojoTypeManager(String entityName, PojoRawTypeIdentifier<E> typeIdentifier,
 			PojoCaster<E> caster, boolean singleConcreteTypeInEntityHierarchy,
-			IdentifierMappingImplementor<I, E> identifierMapping,
+			IdentifierMappingImplementor<I, E> identifierMapping, PojoPathOrdinals pathOrdinals,
 			PojoImplicitReindexingResolver<E> reindexingResolver) {
 		this.entityName = entityName;
 		this.typeIdentifier = typeIdentifier;
 		this.caster = caster;
 		this.singleConcreteTypeInEntityHierarchy = singleConcreteTypeInEntityHierarchy;
 		this.identifierMapping = identifierMapping;
+		this.pathOrdinals = pathOrdinals;
 		this.reindexingResolver = reindexingResolver;
 	}
 
@@ -92,6 +96,7 @@ public class AbstractPojoTypeManager<I, E>
 		return typeIdentifier;
 	}
 
+	@Override
 	public String entityName() {
 		return entityName;
 	}
@@ -109,6 +114,16 @@ public class AbstractPojoTypeManager<I, E>
 	@Override
 	public String toDocumentIdentifier(PojoWorkSessionContext sessionContext, I identifier) {
 		return identifierMapping.toDocumentIdentifier( identifier, sessionContext.mappingContext() );
+	}
+
+	@Override
+	public PojoPathOrdinals pathOrdinals() {
+		return pathOrdinals;
+	}
+
+	@Override
+	public PojoPathFilter dirtySelfOrContainingFilter() {
+		return reindexingResolver.dirtySelfOrContainingFilter();
 	}
 
 	@Override

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoContainedTypeManager.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoContainedTypeManager.java
@@ -8,6 +8,7 @@ package org.hibernate.search.mapper.pojo.mapping.impl;
 
 import org.hibernate.search.mapper.pojo.automaticindexing.impl.PojoImplicitReindexingResolver;
 import org.hibernate.search.mapper.pojo.identity.impl.IdentifierMappingImplementor;
+import org.hibernate.search.mapper.pojo.model.path.impl.PojoPathOrdinals;
 import org.hibernate.search.mapper.pojo.model.spi.PojoCaster;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeIdentifier;
 import org.hibernate.search.mapper.pojo.scope.impl.PojoScopeContainedTypeContext;
@@ -21,9 +22,9 @@ public class PojoContainedTypeManager<I, E> extends AbstractPojoTypeManager<I, E
 		implements PojoWorkContainedTypeContext<I, E>, PojoScopeContainedTypeContext<I, E> {
 	public PojoContainedTypeManager(String entityName, PojoRawTypeIdentifier<E> typeIdentifier,
 			PojoCaster<E> caster, boolean singleConcreteTypeInEntityHierarchy,
-			IdentifierMappingImplementor<I, E> identifierMapping,
+			IdentifierMappingImplementor<I, E> identifierMapping, PojoPathOrdinals pathOrdinals,
 			PojoImplicitReindexingResolver<E> reindexingResolver) {
 		super( entityName, typeIdentifier, caster, singleConcreteTypeInEntityHierarchy,
-				identifierMapping, reindexingResolver );
+				identifierMapping, pathOrdinals, reindexingResolver );
 	}
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoContainedTypeManager.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoContainedTypeManager.java
@@ -7,19 +7,23 @@
 package org.hibernate.search.mapper.pojo.mapping.impl;
 
 import org.hibernate.search.mapper.pojo.automaticindexing.impl.PojoImplicitReindexingResolver;
+import org.hibernate.search.mapper.pojo.identity.impl.IdentifierMappingImplementor;
 import org.hibernate.search.mapper.pojo.model.spi.PojoCaster;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeIdentifier;
 import org.hibernate.search.mapper.pojo.scope.impl.PojoScopeContainedTypeContext;
 import org.hibernate.search.mapper.pojo.work.impl.PojoWorkContainedTypeContext;
 
 /**
+ * @param <I> The identifier type for the contained entity type.
  * @param <E> The contained entity type.
  */
-public class PojoContainedTypeManager<E> extends AbstractPojoTypeManager<E>
-		implements PojoWorkContainedTypeContext<E>, PojoScopeContainedTypeContext<E> {
+public class PojoContainedTypeManager<I, E> extends AbstractPojoTypeManager<I, E>
+		implements PojoWorkContainedTypeContext<I, E>, PojoScopeContainedTypeContext<I, E> {
 	public PojoContainedTypeManager(String entityName, PojoRawTypeIdentifier<E> typeIdentifier,
 			PojoCaster<E> caster, boolean singleConcreteTypeInEntityHierarchy,
+			IdentifierMappingImplementor<I, E> identifierMapping,
 			PojoImplicitReindexingResolver<E> reindexingResolver) {
-		super( entityName, typeIdentifier, caster, singleConcreteTypeInEntityHierarchy, reindexingResolver );
+		super( entityName, typeIdentifier, caster, singleConcreteTypeInEntityHierarchy,
+				identifierMapping, reindexingResolver );
 	}
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoContainedTypeManagerContainer.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoContainedTypeManagerContainer.java
@@ -26,8 +26,8 @@ public class PojoContainedTypeManagerContainer
 		return new Builder();
 	}
 
-	private final Map<PojoRawTypeIdentifier<?>, PojoContainedTypeManager<?>> byExactType;
-	private final Set<PojoContainedTypeManager<?>> all;
+	private final Map<PojoRawTypeIdentifier<?>, PojoContainedTypeManager<?, ?>> byExactType;
+	private final Set<PojoContainedTypeManager<?, ?>> all;
 
 	private PojoContainedTypeManagerContainer(Builder builder) {
 		this.byExactType = new HashMap<>( builder.byExactClass );
@@ -36,24 +36,24 @@ public class PojoContainedTypeManagerContainer
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public <E> Optional<? extends PojoContainedTypeManager<E>> forExactType(
+	public <E> Optional<? extends PojoContainedTypeManager<?, E>> forExactType(
 			PojoRawTypeIdentifier<E> typeIdentifier) {
-		return Optional.ofNullable( (PojoContainedTypeManager<E>) byExactType.get( typeIdentifier ) );
+		return Optional.ofNullable( (PojoContainedTypeManager<?, E>) byExactType.get( typeIdentifier ) );
 	}
 
-	Set<PojoContainedTypeManager<?>> all() {
+	Set<PojoContainedTypeManager<?, ?>> all() {
 		return all;
 	}
 
 	public static class Builder {
 
 		// Use a LinkedHashMap for deterministic iteration
-		private final Map<PojoRawTypeIdentifier<?>, PojoContainedTypeManager<?>> byExactClass = new LinkedHashMap<>();
+		private final Map<PojoRawTypeIdentifier<?>, PojoContainedTypeManager<?, ?>> byExactClass = new LinkedHashMap<>();
 
 		private Builder() {
 		}
 
-		public <E> void add(PojoRawTypeModel<E> typeModel, PojoContainedTypeManager<E> typeManager) {
+		public <E> void add(PojoRawTypeModel<E> typeModel, PojoContainedTypeManager<?, E> typeManager) {
 			byExactClass.put( typeModel.typeIdentifier(), typeManager );
 		}
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoIndexedTypeManager.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoIndexedTypeManager.java
@@ -20,7 +20,7 @@ import org.hibernate.search.engine.mapper.mapping.spi.MappedIndexManager;
 import org.hibernate.search.engine.mapper.scope.spi.MappedIndexScopeBuilder;
 import org.hibernate.search.mapper.pojo.automaticindexing.impl.PojoImplicitReindexingResolver;
 import org.hibernate.search.mapper.pojo.bridge.runtime.impl.DocumentRouter;
-import org.hibernate.search.mapper.pojo.bridge.runtime.impl.IdentifierMappingImplementor;
+import org.hibernate.search.mapper.pojo.identity.impl.IdentifierMappingImplementor;
 import org.hibernate.search.mapper.pojo.massindexing.impl.PojoMassIndexingIndexedTypeContext;
 import org.hibernate.search.mapper.pojo.model.path.spi.PojoPathFilter;
 import org.hibernate.search.mapper.pojo.model.spi.PojoCaster;

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoIndexedTypeManager.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoIndexedTypeManager.java
@@ -22,6 +22,7 @@ import org.hibernate.search.mapper.pojo.automaticindexing.impl.PojoImplicitReind
 import org.hibernate.search.mapper.pojo.bridge.runtime.impl.DocumentRouter;
 import org.hibernate.search.mapper.pojo.identity.impl.IdentifierMappingImplementor;
 import org.hibernate.search.mapper.pojo.massindexing.impl.PojoMassIndexingIndexedTypeContext;
+import org.hibernate.search.mapper.pojo.model.path.impl.PojoPathOrdinals;
 import org.hibernate.search.mapper.pojo.model.path.spi.PojoPathFilter;
 import org.hibernate.search.mapper.pojo.model.spi.PojoCaster;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeIdentifier;
@@ -47,11 +48,11 @@ public class PojoIndexedTypeManager<I, E> extends AbstractPojoTypeManager<I, E>
 	public PojoIndexedTypeManager(String entityName, PojoRawTypeIdentifier<E> typeIdentifier,
 			PojoCaster<E> caster, boolean singleConcreteTypeInEntityHierarchy,
 			IdentifierMappingImplementor<I, E> identifierMapping,
-			DocumentRouter<? super E> documentRouter,
+			DocumentRouter<? super E> documentRouter, PojoPathOrdinals pathOrdinals,
 			PojoIndexingProcessor<E> processor, MappedIndexManager indexManager,
 			PojoImplicitReindexingResolver<E> reindexingResolver) {
 		super( entityName, typeIdentifier, caster, singleConcreteTypeInEntityHierarchy,
-				identifierMapping, reindexingResolver );
+				identifierMapping, pathOrdinals, reindexingResolver );
 		this.documentRouter = documentRouter;
 		this.processor = processor;
 		this.indexManager = indexManager;

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoIndexedTypeManager.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoIndexedTypeManager.java
@@ -37,10 +37,9 @@ import org.hibernate.search.util.common.impl.ToStringTreeBuilder;
  * @param <I> The identifier type for the mapped entity type.
  * @param <E> The entity type mapped to the index.
  */
-public class PojoIndexedTypeManager<I, E> extends AbstractPojoTypeManager<E>
+public class PojoIndexedTypeManager<I, E> extends AbstractPojoTypeManager<I, E>
 		implements PojoWorkIndexedTypeContext<I, E>, PojoScopeIndexedTypeContext<I, E>,
-		PojoMassIndexingIndexedTypeContext<E> {
-	private final IdentifierMappingImplementor<I, E> identifierMapping;
+				PojoMassIndexingIndexedTypeContext<E> {
 	private final DocumentRouter<? super E> documentRouter;
 	private final PojoIndexingProcessor<E> processor;
 	private final MappedIndexManager indexManager;
@@ -51,8 +50,8 @@ public class PojoIndexedTypeManager<I, E> extends AbstractPojoTypeManager<E>
 			DocumentRouter<? super E> documentRouter,
 			PojoIndexingProcessor<E> processor, MappedIndexManager indexManager,
 			PojoImplicitReindexingResolver<E> reindexingResolver) {
-		super( entityName, typeIdentifier, caster, singleConcreteTypeInEntityHierarchy, reindexingResolver );
-		this.identifierMapping = identifierMapping;
+		super( entityName, typeIdentifier, caster, singleConcreteTypeInEntityHierarchy,
+				identifierMapping, reindexingResolver );
 		this.documentRouter = documentRouter;
 		this.processor = processor;
 		this.indexManager = indexManager;
@@ -77,16 +76,6 @@ public class PojoIndexedTypeManager<I, E> extends AbstractPojoTypeManager<E>
 				.attribute( "documentRouter", documentRouter )
 				.attribute( "processor", processor )
 				.attribute( "reindexingResolver", reindexingResolver );
-	}
-
-	@Override
-	public IdentifierMappingImplementor<I, E> identifierMapping() {
-		return identifierMapping;
-	}
-
-	@Override
-	public String toDocumentIdentifier(PojoWorkSessionContext sessionContext, I identifier) {
-		return identifierMapping.toDocumentIdentifier( identifier, sessionContext.mappingContext() );
 	}
 
 	@Override

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoMappingDelegateImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoMappingDelegateImpl.java
@@ -116,10 +116,11 @@ public class PojoMappingDelegateImpl implements PojoMappingDelegate {
 
 	@Override
 	public PojoIndexingQueueEventProcessingPlan createEventProcessingPlan(PojoWorkSessionContext context,
-			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
+			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy,
+			PojoIndexingQueueEventSendingPlan sendingPlan) {
 		return new PojoIndexingQueueEventProcessingPlanImpl( indexedTypeManagers, containedTypeManagers, context,
 				new PojoIndexingPlanImpl( indexedTypeManagers, containedTypeManagers, context,
-						new PojoIndexingPlanEventProcessingStrategy( commitStrategy, refreshStrategy ) ) );
+						new PojoIndexingPlanEventProcessingStrategy( commitStrategy, refreshStrategy, sendingPlan ) ) );
 	}
 
 	@Override

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoMappingDelegateImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/impl/PojoMappingDelegateImpl.java
@@ -117,7 +117,7 @@ public class PojoMappingDelegateImpl implements PojoMappingDelegate {
 	@Override
 	public PojoIndexingQueueEventProcessingPlan createEventProcessingPlan(PojoWorkSessionContext context,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
-		return new PojoIndexingQueueEventProcessingPlanImpl( indexedTypeManagers, context,
+		return new PojoIndexingQueueEventProcessingPlanImpl( indexedTypeManagers, containedTypeManagers, context,
 				new PojoIndexingPlanImpl( indexedTypeManagers, containedTypeManagers, context,
 						new PojoIndexingPlanEventProcessingStrategy( commitStrategy, refreshStrategy ) ) );
 	}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/spi/AbstractPojoMappingImplementor.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/spi/AbstractPojoMappingImplementor.java
@@ -83,8 +83,8 @@ public abstract class AbstractPojoMappingImplementor<M>
 	}
 
 	@Override
-	public PojoIndexingPlan createIndexingPlan(PojoWorkSessionContext context, PojoIndexingQueueEventSendingPlan sink) {
-		return delegate.createIndexingPlan( context, sink );
+	public PojoIndexingPlan createIndexingPlan(PojoWorkSessionContext context, PojoIndexingQueueEventSendingPlan sendingPlan) {
+		return delegate.createIndexingPlan( context, sendingPlan );
 	}
 
 	@Override

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/spi/AbstractPojoMappingImplementor.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/spi/AbstractPojoMappingImplementor.java
@@ -94,8 +94,9 @@ public abstract class AbstractPojoMappingImplementor<M>
 
 	@Override
 	public PojoIndexingQueueEventProcessingPlan createIndexingQueueEventProcessingPlan(PojoWorkSessionContext context,
-			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy) {
-		return delegate.createEventProcessingPlan( context, commitStrategy, refreshStrategy );
+			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy,
+			PojoIndexingQueueEventSendingPlan sendingPlan) {
+		return delegate.createEventProcessingPlan( context, commitStrategy, refreshStrategy, sendingPlan );
 	}
 
 	protected final PojoMappingDelegate delegate() {

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/spi/AbstractPojoMappingInitiator.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/spi/AbstractPojoMappingInitiator.java
@@ -24,6 +24,7 @@ import org.hibernate.search.mapper.pojo.bridge.mapping.impl.BridgeResolver;
 import org.hibernate.search.mapper.pojo.extractor.ContainerExtractorConfigurationContext;
 import org.hibernate.search.mapper.pojo.extractor.impl.ContainerExtractorBinder;
 import org.hibernate.search.mapper.pojo.extractor.spi.ContainerExtractorRegistry;
+import org.hibernate.search.mapper.pojo.identity.impl.IdentityMappingMode;
 import org.hibernate.search.mapper.pojo.mapping.building.impl.PojoMapper;
 import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoMapperDelegate;
 import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoTypeMetadataContributor;
@@ -41,6 +42,7 @@ public abstract class AbstractPojoMappingInitiator<MPBS extends MappingPartialBu
 	private final PojoBootstrapIntrospector introspector;
 
 	private BeanReference<? extends IdentifierBridge<Object>> providedIdentifierBridge;
+	private IdentityMappingMode containedEntityIdentityMappingMode = IdentityMappingMode.OPTIONAL;
 	private TenancyMode tenancyMode = TenancyMode.SINGLE_TENANCY;
 	private ReindexOnUpdate defaultReindexOnUpdate = ReindexOnUpdate.DEFAULT;
 
@@ -95,6 +97,10 @@ public abstract class AbstractPojoMappingInitiator<MPBS extends MappingPartialBu
 		this.providedIdentifierBridge = providedIdentifierBridge;
 	}
 
+	public void containedEntityIdentityMappingRequired(boolean required) {
+		this.containedEntityIdentityMappingMode = required ? IdentityMappingMode.REQUIRED : IdentityMappingMode.OPTIONAL;
+	}
+
 	public void multiTenancyEnabled(boolean multiTenancyEnabled) {
 		this.tenancyMode = multiTenancyEnabled ? TenancyMode.MULTI_TENANCY : TenancyMode.SINGLE_TENANCY;
 	}
@@ -130,7 +136,7 @@ public abstract class AbstractPojoMappingInitiator<MPBS extends MappingPartialBu
 				introspector,
 				extractorBinder, bridgeResolver,
 				providedIdentifierBridge,
-				tenancyMode,
+				containedEntityIdentityMappingMode, tenancyMode,
 				defaultReindexOnUpdate,
 				createMapperDelegate()
 		);

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/spi/AbstractPojoMappingInitiator.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/spi/AbstractPojoMappingInitiator.java
@@ -16,6 +16,7 @@ import org.hibernate.search.engine.mapper.mapping.building.spi.MappingInitiator;
 import org.hibernate.search.engine.mapper.model.spi.TypeMetadataContributorProvider;
 import org.hibernate.search.engine.mapper.mapping.building.spi.MappingBuildContext;
 import org.hibernate.search.engine.mapper.mapping.building.spi.MappingPartialBuildState;
+import org.hibernate.search.engine.tenancy.spi.TenancyMode;
 import org.hibernate.search.mapper.pojo.automaticindexing.ReindexOnUpdate;
 import org.hibernate.search.mapper.pojo.bridge.IdentifierBridge;
 import org.hibernate.search.mapper.pojo.bridge.mapping.BridgesConfigurationContext;
@@ -40,7 +41,7 @@ public abstract class AbstractPojoMappingInitiator<MPBS extends MappingPartialBu
 	private final PojoBootstrapIntrospector introspector;
 
 	private BeanReference<? extends IdentifierBridge<Object>> providedIdentifierBridge;
-	private boolean multiTenancyEnabled;
+	private TenancyMode tenancyMode = TenancyMode.SINGLE_TENANCY;
 	private ReindexOnUpdate defaultReindexOnUpdate = ReindexOnUpdate.DEFAULT;
 
 	private final AnnotationMappingConfigurationContextImpl annotationMappingConfiguration;
@@ -95,7 +96,7 @@ public abstract class AbstractPojoMappingInitiator<MPBS extends MappingPartialBu
 	}
 
 	public void multiTenancyEnabled(boolean multiTenancyEnabled) {
-		this.multiTenancyEnabled = multiTenancyEnabled;
+		this.tenancyMode = multiTenancyEnabled ? TenancyMode.MULTI_TENANCY : TenancyMode.SINGLE_TENANCY;
 	}
 
 	public void defaultReindexOnUpdate(ReindexOnUpdate defaultReindexOnUpdate) {
@@ -129,7 +130,7 @@ public abstract class AbstractPojoMappingInitiator<MPBS extends MappingPartialBu
 				introspector,
 				extractorBinder, bridgeResolver,
 				providedIdentifierBridge,
-				multiTenancyEnabled,
+				tenancyMode,
 				defaultReindexOnUpdate,
 				createMapperDelegate()
 		);

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/spi/PojoMappingDelegate.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/spi/PojoMappingDelegate.java
@@ -44,7 +44,7 @@ public interface PojoMappingDelegate extends AutoCloseable {
 	PojoIndexingPlan createIndexingPlan(PojoWorkSessionContext context,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy);
 
-	PojoIndexingPlan createIndexingPlan(PojoWorkSessionContext context, PojoIndexingQueueEventSendingPlan sink);
+	PojoIndexingPlan createIndexingPlan(PojoWorkSessionContext context, PojoIndexingQueueEventSendingPlan sendingPlan);
 
 	PojoIndexingQueueEventProcessingPlan createEventProcessingPlan(PojoWorkSessionContext context,
 			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy);

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/spi/PojoMappingDelegate.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/mapping/spi/PojoMappingDelegate.java
@@ -47,7 +47,8 @@ public interface PojoMappingDelegate extends AutoCloseable {
 	PojoIndexingPlan createIndexingPlan(PojoWorkSessionContext context, PojoIndexingQueueEventSendingPlan sendingPlan);
 
 	PojoIndexingQueueEventProcessingPlan createEventProcessingPlan(PojoWorkSessionContext context,
-			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy);
+			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy,
+			PojoIndexingQueueEventSendingPlan sendingPlan);
 
 	PojoIndexer createIndexer(PojoWorkSessionContext context);
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoMassIndexingIndexedTypeContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoMassIndexingIndexedTypeContext.java
@@ -8,7 +8,7 @@ package org.hibernate.search.mapper.pojo.massindexing.impl;
 
 import java.util.function.Supplier;
 
-import org.hibernate.search.mapper.pojo.bridge.runtime.impl.IdentifierMappingImplementor;
+import org.hibernate.search.mapper.pojo.identity.impl.IdentifierMappingImplementor;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeIdentifier;
 import org.hibernate.search.mapper.pojo.work.spi.PojoWorkSessionContext;
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/path/impl/PojoPathFilterImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/path/impl/PojoPathFilterImpl.java
@@ -7,7 +7,6 @@
 package org.hibernate.search.mapper.pojo.model.path.impl;
 
 import java.util.BitSet;
-import java.util.stream.Collectors;
 
 import org.hibernate.search.mapper.pojo.model.path.spi.PojoPathFilter;
 
@@ -23,15 +22,7 @@ final class PojoPathFilterImpl implements PojoPathFilter {
 
 	@Override
 	public String toString() {
-		return toString( acceptedPaths );
-	}
-
-	@Override
-	public String toString(BitSet pathSelection) {
-		return "{"
-				+ pathSelection.stream().mapToObj( ordinals::toPath )
-				.collect( Collectors.joining( ", " ) )
-				+ "}";
+		return ordinals.toPathSet( acceptedPaths ).toString();
 	}
 
 	@Override

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/path/impl/PojoPathFilterProvider.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/path/impl/PojoPathFilterProvider.java
@@ -20,10 +20,11 @@ import org.hibernate.search.util.common.impl.CollectionHelper;
  */
 public final class PojoPathFilterProvider {
 
+	private final PojoPathOrdinals ordinals;
 	private final PojoPathsDefinition definitions;
-	private final PojoPathOrdinals ordinals = new PojoPathOrdinals();
 
-	public PojoPathFilterProvider(PojoPathsDefinition definitions) {
+	public PojoPathFilterProvider(PojoPathOrdinals ordinals, PojoPathsDefinition definitions) {
+		this.ordinals = ordinals;
 		this.definitions = definitions;
 		for ( String path : definitions.preDefinedOrdinals() ) {
 			ordinals.toExistingOrNewOrdinal( path );

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/path/impl/PojoPathOrdinals.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/path/impl/PojoPathOrdinals.java
@@ -7,14 +7,26 @@
 package org.hibernate.search.mapper.pojo.model.path.impl;
 
 import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
-final class PojoPathOrdinals {
+public final class PojoPathOrdinals {
 
 	private final Map<String, Integer> ordinalByPath = new HashMap<>();
 	private final List<String> pathByOrdinal = new ArrayList<>();
+
+	@Override
+	public String toString() {
+		return "PojoPathOrdinals{"
+				+ "ordinalByPath=" + ordinalByPath
+				+ '}';
+	}
 
 	public Integer toOrdinal(String path) {
 		return ordinalByPath.get( path );
@@ -22,6 +34,26 @@ final class PojoPathOrdinals {
 
 	public String toPath(int ordinal) {
 		return ordinal < pathByOrdinal.size() ? pathByOrdinal.get( ordinal ) : null;
+	}
+
+	public BitSet toPathSelection(Collection<String> paths) {
+		BitSet bitSet = null;
+		for ( String path : paths ) {
+			Integer ordinal = toOrdinal( path );
+			if ( ordinal == null ) {
+				continue;
+			}
+			if ( bitSet == null ) {
+				bitSet = new BitSet();
+			}
+			bitSet.set( ordinal );
+		}
+		return bitSet;
+	}
+
+	public Set<String> toPathSet(BitSet pathSelection) {
+		return pathSelection.stream().mapToObj( this::toPath )
+				.collect( Collectors.toCollection( LinkedHashSet::new ) );
 	}
 
 	public int toExistingOrNewOrdinal(String path) {

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/path/spi/PojoPathFilter.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/model/path/spi/PojoPathFilter.java
@@ -18,13 +18,6 @@ import java.util.BitSet;
 public interface PojoPathFilter {
 
 	/**
-	 * For debugging: turns a path selection into a string.
-	 * @param pathSelection A {@link BitSet} returned by one of the {@code filter} methods.
-	 * @return A string representation of {@code pathSelection}.
-	 */
-	String toString(BitSet pathSelection);
-
-	/**
 	 * Determines if any path in the given set of paths of is accepted by this filter.
 	 * <p>
 	 * This method is optimized to be called very often.

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/processing/building/impl/AbstractPojoIndexingProcessorTypeNodeBuilder.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/processing/building/impl/AbstractPojoIndexingProcessorTypeNodeBuilder.java
@@ -20,6 +20,7 @@ import org.hibernate.search.mapper.pojo.automaticindexing.building.impl.Abstract
 import org.hibernate.search.mapper.pojo.bridge.TypeBridge;
 import org.hibernate.search.mapper.pojo.bridge.binding.impl.BoundTypeBridge;
 import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.TypeBinder;
+import org.hibernate.search.mapper.pojo.identity.impl.PojoIdentityMappingCollector;
 import org.hibernate.search.mapper.pojo.mapping.building.impl.PojoMappingHelper;
 import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoMappingCollectorPropertyNode;
 import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoMappingCollectorTypeNode;

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/processing/building/impl/PojoIndexedEmbeddedIdentityMappingCollector.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/processing/building/impl/PojoIndexedEmbeddedIdentityMappingCollector.java
@@ -16,6 +16,7 @@ import org.hibernate.search.engine.backend.types.Searchable;
 import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.IdentifierBinder;
 import org.hibernate.search.mapper.pojo.bridge.mapping.programmatic.identifiertovalue.impl.IdentifierBinderToValueBinderAdapter;
 import org.hibernate.search.mapper.pojo.extractor.mapping.programmatic.ContainerExtractorPath;
+import org.hibernate.search.mapper.pojo.identity.impl.PojoIdentityMappingCollector;
 import org.hibernate.search.mapper.pojo.logging.impl.Log;
 import org.hibernate.search.mapper.pojo.mapping.building.impl.PojoMappingHelper;
 import org.hibernate.search.mapper.pojo.model.path.impl.BoundPojoModelPathPropertyNode;

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/processing/building/impl/PojoIndexingProcessorCastedTypeNodeBuilder.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/processing/building/impl/PojoIndexingProcessorCastedTypeNodeBuilder.java
@@ -12,6 +12,7 @@ import org.hibernate.search.engine.backend.document.IndexObjectFieldReference;
 import org.hibernate.search.engine.mapper.mapping.building.spi.IndexBindingContext;
 import org.hibernate.search.mapper.pojo.automaticindexing.building.impl.PojoIndexingDependencyCollectorTypeNode;
 import org.hibernate.search.mapper.pojo.automaticindexing.building.impl.AbstractPojoIndexingDependencyCollectorDirectValueNode;
+import org.hibernate.search.mapper.pojo.identity.impl.PojoIdentityMappingCollector;
 import org.hibernate.search.mapper.pojo.mapping.building.impl.PojoMappingHelper;
 import org.hibernate.search.mapper.pojo.model.path.impl.BoundPojoModelPathCastedTypeNode;
 import org.hibernate.search.mapper.pojo.processing.impl.PojoIndexingProcessor;

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/processing/building/impl/PojoIndexingProcessorOriginalTypeNodeBuilder.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/processing/building/impl/PojoIndexingProcessorOriginalTypeNodeBuilder.java
@@ -12,6 +12,7 @@ import org.hibernate.search.engine.backend.document.IndexObjectFieldReference;
 import org.hibernate.search.engine.mapper.mapping.building.spi.IndexBindingContext;
 import org.hibernate.search.mapper.pojo.automaticindexing.building.impl.PojoIndexingDependencyCollectorTypeNode;
 import org.hibernate.search.mapper.pojo.automaticindexing.building.impl.AbstractPojoIndexingDependencyCollectorDirectValueNode;
+import org.hibernate.search.mapper.pojo.identity.impl.PojoIdentityMappingCollector;
 import org.hibernate.search.mapper.pojo.mapping.building.impl.PojoMappingHelper;
 import org.hibernate.search.mapper.pojo.model.path.impl.BoundPojoModelPathTypeNode;
 import org.hibernate.search.mapper.pojo.processing.impl.PojoIndexingProcessor;

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/processing/building/impl/PojoIndexingProcessorPropertyNodeBuilder.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/processing/building/impl/PojoIndexingProcessorPropertyNodeBuilder.java
@@ -24,6 +24,7 @@ import org.hibernate.search.mapper.pojo.extractor.mapping.programmatic.Container
 import org.hibernate.search.mapper.pojo.extractor.impl.BoundContainerExtractorPath;
 import org.hibernate.search.mapper.pojo.extractor.impl.ContainerExtractorHolder;
 import org.hibernate.search.mapper.pojo.bridge.binding.impl.BoundPropertyBridge;
+import org.hibernate.search.mapper.pojo.identity.impl.PojoIdentityMappingCollector;
 import org.hibernate.search.mapper.pojo.mapping.building.impl.PojoMappingHelper;
 import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoMappingCollectorPropertyNode;
 import org.hibernate.search.mapper.pojo.mapping.building.spi.PojoMappingCollectorValueNode;

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/route/DocumentRoutesDescriptor.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/route/DocumentRoutesDescriptor.java
@@ -49,6 +49,14 @@ public final class DocumentRoutesDescriptor implements Serializable {
 		this.previousRoutes = previousRoutes;
 	}
 
+	@Override
+	public String toString() {
+		return "DocumentRoutesDescriptor{" +
+				"currentRoute=" + currentRoute +
+				", previousRoutes=" + previousRoutes +
+				'}';
+	}
+
 	public DocumentRouteDescriptor currentRoute() {
 		return currentRoute;
 	}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/scope/impl/PojoScopeContainedTypeContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/scope/impl/PojoScopeContainedTypeContext.java
@@ -9,9 +9,10 @@ package org.hibernate.search.mapper.pojo.scope.impl;
 import org.hibernate.search.mapper.pojo.work.impl.PojoWorkContainedTypeContext;
 
 /**
- * @param <E> The entity type mapped to the index.
+ * @param <I> The identifier type for the contained entity type.
+ * @param <E> The contained entity type.
  */
-public interface PojoScopeContainedTypeContext<E>
-		extends PojoWorkContainedTypeContext<E> {
+public interface PojoScopeContainedTypeContext<I, E>
+		extends PojoWorkContainedTypeContext<I, E> {
 
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/scope/impl/PojoScopeIndexedTypeContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/scope/impl/PojoScopeIndexedTypeContext.java
@@ -21,8 +21,6 @@ public interface PojoScopeIndexedTypeContext<I, E>
 		extends PojoWorkIndexedTypeContext<I, E>, PojoSchemaManagementIndexedTypeContext,
 				PojoSearchLoadingIndexedTypeContext<E>, PojoMassIndexingIndexedTypeContext<E> {
 
-	String entityName();
-
 	<R, E2> MappedIndexScopeBuilder<R, E2> createScopeBuilder(BackendMappingContext mappingContext);
 
 	void addTo(MappedIndexScopeBuilder<?, ?> builder);

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/search/loading/impl/PojoSearchLoadingIndexedTypeContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/search/loading/impl/PojoSearchLoadingIndexedTypeContext.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.mapper.pojo.search.loading.impl;
 
-import org.hibernate.search.mapper.pojo.bridge.runtime.spi.IdentifierMapping;
+import org.hibernate.search.mapper.pojo.identity.spi.IdentifierMapping;
 import org.hibernate.search.mapper.pojo.loading.spi.PojoLoadingTypeContext;
 
 public interface PojoSearchLoadingIndexedTypeContext<E> extends PojoLoadingTypeContext<E> {

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/session/spi/PojoSearchSessionMappingContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/session/spi/PojoSearchSessionMappingContext.java
@@ -29,6 +29,7 @@ public interface PojoSearchSessionMappingContext extends PojoWorkMappingContext,
 	PojoIndexer createIndexer(PojoWorkSessionContext context);
 
 	PojoIndexingQueueEventProcessingPlan createIndexingQueueEventProcessingPlan(PojoWorkSessionContext context,
-			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy);
+			DocumentCommitStrategy commitStrategy, DocumentRefreshStrategy refreshStrategy,
+			PojoIndexingQueueEventSendingPlan sendingPlan);
 
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/AbstractPojoTypeIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/AbstractPojoTypeIndexingPlan.java
@@ -79,9 +79,11 @@ abstract class AbstractPojoTypeIndexingPlan<I, E, S extends AbstractPojoTypeInde
 		}
 	}
 
-	abstract PojoWorkTypeContext<E> typeContext();
+	abstract PojoWorkTypeContext<I, E> typeContext();
 
-	abstract I toIdentifier(Object providedId, Supplier<E> entitySupplier);
+	I toIdentifier(Object providedId, Supplier<E> entitySupplier) {
+		return typeContext().identifierMapping().getIdentifier( providedId, entitySupplier );
+	}
 
 	final S getState(I identifier) {
 		S state = statesPerId.get( identifier );

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoContainedTypeIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoContainedTypeIndexingPlan.java
@@ -19,8 +19,8 @@ public class PojoContainedTypeIndexingPlan<I, E>
 	private final PojoWorkContainedTypeContext<I, E> typeContext;
 
 	public PojoContainedTypeIndexingPlan(PojoWorkContainedTypeContext<I, E> typeContext,
-			PojoWorkSessionContext sessionContext, PojoIndexingPlanImpl root) {
-		super( sessionContext, root );
+			PojoWorkSessionContext sessionContext) {
+		super( sessionContext );
 		this.typeContext = typeContext;
 	}
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoContainedTypeIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoContainedTypeIndexingPlan.java
@@ -6,43 +6,37 @@
  */
 package org.hibernate.search.mapper.pojo.work.impl;
 
-import java.util.function.Supplier;
-
 import org.hibernate.search.mapper.pojo.route.DocumentRoutesDescriptor;
 import org.hibernate.search.mapper.pojo.work.spi.PojoWorkSessionContext;
 
 /**
+ * @param <I> The identifier type for the contained entity type.
  * @param <E> The contained entity type.
  */
-public class PojoContainedTypeIndexingPlan<E>
-		extends AbstractPojoTypeIndexingPlan<Object, E, PojoContainedTypeIndexingPlan<E>.ContainedEntityState> {
+public class PojoContainedTypeIndexingPlan<I, E>
+		extends AbstractPojoTypeIndexingPlan<I, E, PojoContainedTypeIndexingPlan<I, E>.ContainedEntityState> {
 
-	private final PojoWorkContainedTypeContext<E> typeContext;
+	private final PojoWorkContainedTypeContext<I, E> typeContext;
 
-	public PojoContainedTypeIndexingPlan(PojoWorkContainedTypeContext<E> typeContext,
+	public PojoContainedTypeIndexingPlan(PojoWorkContainedTypeContext<I, E> typeContext,
 			PojoWorkSessionContext sessionContext, PojoIndexingPlanImpl root) {
 		super( sessionContext, root );
 		this.typeContext = typeContext;
 	}
 
 	@Override
-	PojoWorkContainedTypeContext<E> typeContext() {
+	PojoWorkContainedTypeContext<I, E> typeContext() {
 		return typeContext;
 	}
 
 	@Override
-	Object toIdentifier(Object providedId, Supplier<E> entitySupplier) {
-		return providedId;
-	}
-
-	@Override
-	protected ContainedEntityState createState(Object identifier) {
+	protected ContainedEntityState createState(I identifier) {
 		return new ContainedEntityState( identifier );
 	}
 
 	class ContainedEntityState
-			extends AbstractPojoTypeIndexingPlan<Object, E, ContainedEntityState>.AbstractEntityState {
-		private ContainedEntityState(Object identifier) {
+			extends AbstractPojoTypeIndexingPlan<I, E, ContainedEntityState>.AbstractEntityState {
+		private ContainedEntityState(I identifier) {
 			super( identifier );
 		}
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexedTypeIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexedTypeIndexingPlan.java
@@ -82,11 +82,6 @@ public class PojoIndexedTypeIndexingPlan<I, E>
 	}
 
 	@Override
-	I toIdentifier(Object providedId, Supplier<E> entitySupplier) {
-		return typeContext.identifierMapping().getIdentifier( providedId, entitySupplier );
-	}
-
-	@Override
 	protected IndexedEntityState createState(I identifier) {
 		return new IndexedEntityState( identifier );
 	}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexedTypeIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexedTypeIndexingPlan.java
@@ -150,7 +150,7 @@ public class PojoIndexedTypeIndexingPlan<I, E>
 							return;
 						case PRESENT:
 						case UNKNOWN:
-							if ( updatedBecauseOfContained || isDirty( typeContext.dirtySelfFilter() ) ) {
+							if ( updatedBecauseOfContained || isDirtyForAddOrUpdate( typeContext.dirtySelfFilter() ) ) {
 								delegateAddOrUpdate( loadingPlanProvider );
 							}
 							return;

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexedTypeIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexedTypeIndexingPlan.java
@@ -188,7 +188,7 @@ public class PojoIndexedTypeIndexingPlan<I, E>
 				// There's nothing to do.
 				return;
 			}
-			delegate.add( identifier, entitySupplier, currentRoute );
+			delegate.add( identifier, currentRoute, entitySupplier );
 		}
 
 		private void delegateAddOrUpdate(PojoLoadingPlanProvider loadingPlanProvider) {

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanEventProcessingStrategy.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanEventProcessingStrategy.java
@@ -1,0 +1,28 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.work.impl;
+
+import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
+import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
+
+/**
+ * A strategy for processing indexing events sent by a {@link PojoIndexingPlanEventSendingStrategy}.
+ */
+public class PojoIndexingPlanEventProcessingStrategy extends PojoIndexingPlanLocalStrategy {
+	public PojoIndexingPlanEventProcessingStrategy(DocumentCommitStrategy commitStrategy,
+			DocumentRefreshStrategy refreshStrategy) {
+		super( commitStrategy, refreshStrategy );
+	}
+
+	@Override
+	public boolean shouldResolveDirty() {
+		// When processing indexing events sent from a queue,
+		// reindexing resolution is performed before the events are sent to the queue,
+		// so we don't do it again.
+		return false;
+	}
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanEventProcessingStrategy.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanEventProcessingStrategy.java
@@ -6,23 +6,80 @@
  */
 package org.hibernate.search.mapper.pojo.work.impl;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.hibernate.search.engine.backend.common.spi.EntityReferenceFactory;
+import org.hibernate.search.engine.backend.common.spi.MultiEntityOperationExecutionReport;
 import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
+import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingQueueEventSendingPlan;
+import org.hibernate.search.mapper.pojo.work.spi.PojoWorkSessionContext;
 
 /**
  * A strategy for processing indexing events sent by a {@link PojoIndexingPlanEventSendingStrategy}.
  */
-public class PojoIndexingPlanEventProcessingStrategy extends PojoIndexingPlanLocalStrategy {
+public class PojoIndexingPlanEventProcessingStrategy implements PojoIndexingPlanStrategy {
+	final DocumentCommitStrategy commitStrategy;
+	final DocumentRefreshStrategy refreshStrategy;
+	private final PojoIndexingQueueEventSendingPlan sendingPlan;
+
 	public PojoIndexingPlanEventProcessingStrategy(DocumentCommitStrategy commitStrategy,
-			DocumentRefreshStrategy refreshStrategy) {
-		super( commitStrategy, refreshStrategy );
+			DocumentRefreshStrategy refreshStrategy,
+			PojoIndexingQueueEventSendingPlan sendingPlan) {
+		this.commitStrategy = commitStrategy;
+		this.refreshStrategy = refreshStrategy;
+		this.sendingPlan = sendingPlan;
 	}
 
 	@Override
 	public boolean shouldResolveDirty() {
-		// When processing indexing events sent from a queue,
-		// reindexing resolution is performed before the events are sent to the queue,
-		// so we don't do it again.
-		return false;
+		return true;
+	}
+
+	@Override
+	public <R> CompletableFuture<MultiEntityOperationExecutionReport<R>> doExecuteAndReport(
+			Collection<PojoIndexedTypeIndexingPlan<?, ?>> indexedTypeDelegates,
+			PojoLoadingPlanProvider loadingPlanProvider, EntityReferenceFactory<R> entityReferenceFactory) {
+		List<CompletableFuture<MultiEntityOperationExecutionReport<R>>> futures = new ArrayList<>();
+		// Each type has its own index indexing plan to execute.
+		for ( PojoIndexedTypeIndexingPlan<?, ?> delegate : indexedTypeDelegates ) {
+			futures.add( delegate.executeAndReport( entityReferenceFactory ) );
+		}
+		// Additionally, we have a global sending plan for reindexing resolution.
+		futures.add( sendingPlan.sendAndReport( entityReferenceFactory ) );
+		return MultiEntityOperationExecutionReport.allOf( futures );
+	}
+
+	@Override
+	public void doDiscard(Collection<PojoIndexedTypeIndexingPlan<?, ?>> indexedTypeDelegates) {
+		// Each type has its own index indexing plan to discard.
+		for ( PojoIndexedTypeIndexingPlan<?, ?> delegate : indexedTypeDelegates ) {
+			delegate.discard();
+		}
+		// Additionally, we have a global sending plan for reindexing resolution.
+		sendingPlan.discard();
+	}
+
+	@Override
+	public <I, E> PojoIndexedTypeIndexingPlan<I, E> createDelegate(PojoWorkIndexedTypeContext<I, E> typeContext,
+			PojoWorkSessionContext sessionContext) {
+		// Will process indexing events locally, and send additional events upon reindexing resolution.
+		IndexIndexingPlan indexIndexingPlan =
+				typeContext.createIndexingPlan( sessionContext, commitStrategy, refreshStrategy );
+		return new PojoIndexedTypeIndexingPlan<>( typeContext, sessionContext,
+				new PojoTypeIndexingPlanIndexOrEventQueueDelegate<>( typeContext, sessionContext,
+						indexIndexingPlan, sendingPlan ) );
+	}
+
+	@Override
+	public <I, E> PojoContainedTypeIndexingPlan<I, E> createDelegate(PojoWorkContainedTypeContext<I, E> typeContext,
+			PojoWorkSessionContext sessionContext) {
+		return new PojoContainedTypeIndexingPlan<>( typeContext, sessionContext,
+				// Null delegate: we will perform reindexing resolution locally.
+				null );
 	}
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanEventSendingStrategy.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanEventSendingStrategy.java
@@ -27,7 +27,9 @@ public class PojoIndexingPlanEventSendingStrategy implements PojoIndexingPlanStr
 
 	@Override
 	public boolean shouldResolveDirty() {
-		return true;
+		// We will resolve dirty entities to reindex in the background process
+		// that consumes the events we're sending.
+		return false;
 	}
 
 	@Override
@@ -49,6 +51,14 @@ public class PojoIndexingPlanEventSendingStrategy implements PojoIndexingPlanStr
 			PojoWorkSessionContext sessionContext) {
 		// Will send indexing events to an external queue.
 		return new PojoIndexedTypeIndexingPlan<>( typeContext, sessionContext,
+				new PojoTypeIndexingPlanEventQueueDelegate<>( typeContext, sessionContext, sendingPlan ) );
+	}
+
+	@Override
+	public <I, E> PojoContainedTypeIndexingPlan<I, E> createDelegate(PojoWorkContainedTypeContext<I, E> typeContext,
+			PojoWorkSessionContext sessionContext) {
+		// Will send indexing events to an external queue.
+		return new PojoContainedTypeIndexingPlan<>( typeContext, sessionContext,
 				new PojoTypeIndexingPlanEventQueueDelegate<>( typeContext, sessionContext, sendingPlan ) );
 	}
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanImpl.java
@@ -70,23 +70,13 @@ public class PojoIndexingPlanImpl implements PojoIndexingPlan, PojoLoadingPlanPr
 
 	@Override
 	public void addOrUpdate(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId,
-			DocumentRoutesDescriptor providedRoutes,
-			Object entity) {
+			DocumentRoutesDescriptor providedRoutes, Object entity,
+			boolean forceSelfDirty, boolean forceContainingDirty, BitSet dirtyPaths) {
 		AbstractPojoTypeIndexingPlan<?, ?, ?> delegate = getDelegate( typeIdentifier );
 		if ( ! mayRequireLoading && entity == null ) {
 			mayRequireLoading = true;
 		}
-		delegate.addOrUpdate( providedId, providedRoutes, entity );
-	}
-
-	@Override
-	public void addOrUpdate(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId,
-			DocumentRoutesDescriptor providedRoutes, Object entity, BitSet dirtyPaths) {
-		AbstractPojoTypeIndexingPlan<?, ?, ?> delegate = getDelegate( typeIdentifier );
-		if ( ! mayRequireLoading && entity == null ) {
-			mayRequireLoading = true;
-		}
-		delegate.addOrUpdate( providedId, providedRoutes, entity, dirtyPaths );
+		delegate.addOrUpdate( providedId, providedRoutes, entity, dirtyPaths, forceSelfDirty, forceContainingDirty );
 	}
 
 	@Override

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanImpl.java
@@ -48,7 +48,7 @@ public class PojoIndexingPlanImpl implements PojoIndexingPlan, PojoReindexingCol
 
 	// Use a LinkedHashMap for deterministic iteration
 	private final Map<PojoRawTypeIdentifier<?>, PojoIndexedTypeIndexingPlan<?, ?>> indexedTypeDelegates = new LinkedHashMap<>();
-	private final Map<PojoRawTypeIdentifier<?>, PojoContainedTypeIndexingPlan<?>> containedTypeDelegates = new LinkedHashMap<>();
+	private final Map<PojoRawTypeIdentifier<?>, PojoContainedTypeIndexingPlan<?, ?>> containedTypeDelegates = new LinkedHashMap<>();
 
 	private boolean isProcessing = false;
 	private boolean mayRequireLoading = false;
@@ -132,7 +132,7 @@ public class PojoIndexingPlanImpl implements PojoIndexingPlan, PojoReindexingCol
 		isProcessing = true;
 		try {
 			if ( mayRequireLoading ) {
-				for ( PojoContainedTypeIndexingPlan<?> delegate : containedTypeDelegates.values() ) {
+				for ( PojoContainedTypeIndexingPlan<?, ?> delegate : containedTypeDelegates.values() ) {
 					delegate.planLoading();
 				}
 				for ( PojoIndexedTypeIndexingPlan<?, ?> delegate : indexedTypeDelegates.values() ) {
@@ -145,7 +145,7 @@ public class PojoIndexingPlanImpl implements PojoIndexingPlan, PojoReindexingCol
 			// The caller may choose to disable reindexing resolution.
 			// See PojoMappingDelegateImpl#createEventProcessingPlan.
 			if ( enableReindexingResolution ) {
-				for ( PojoContainedTypeIndexingPlan<?> delegate : containedTypeDelegates.values() ) {
+				for ( PojoContainedTypeIndexingPlan<?, ?> delegate : containedTypeDelegates.values() ) {
 					delegate.resolveDirty();
 				}
 				// We need to iterate on a "frozen snapshot" of the indexedTypeDelegates values because of HSEARCH-3857
@@ -252,10 +252,10 @@ public class PojoIndexingPlanImpl implements PojoIndexingPlan, PojoReindexingCol
 			return delegate;
 		}
 		else {
-			Optional<? extends PojoWorkContainedTypeContext<?>> containedTypeContextOptional =
+			Optional<? extends PojoWorkContainedTypeContext<?, ?>> containedTypeContextOptional =
 					containedTypeContextProvider.forExactType( typeIdentifier );
 			if ( containedTypeContextOptional.isPresent() ) {
-				PojoContainedTypeIndexingPlan<?> delegate = createDelegate( containedTypeContextOptional.get() );
+				PojoContainedTypeIndexingPlan<?, ?> delegate = createDelegate( containedTypeContextOptional.get() );
 				containedTypeDelegates.put( typeIdentifier, delegate );
 				return delegate;
 			}
@@ -307,7 +307,7 @@ public class PojoIndexingPlanImpl implements PojoIndexingPlan, PojoReindexingCol
 		}
 	}
 
-	private PojoContainedTypeIndexingPlan<?> createDelegate(PojoWorkContainedTypeContext<?> typeContext) {
+	private PojoContainedTypeIndexingPlan<?, ?> createDelegate(PojoWorkContainedTypeContext<?, ?> typeContext) {
 		return new PojoContainedTypeIndexingPlan<>( typeContext, sessionContext, this );
 	}
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanImpl.java
@@ -117,6 +117,9 @@ public class PojoIndexingPlanImpl implements PojoIndexingPlan, PojoLoadingPlanPr
 					delegate.resolveDirty( this, this );
 				}
 			}
+			for ( PojoContainedTypeIndexingPlan<?, ?> delegate : containedTypeDelegates.values() ) {
+				delegate.process( this );
+			}
 			for ( PojoIndexedTypeIndexingPlan<?, ?> delegate : indexedTypeDelegates.values() ) {
 				delegate.process( this );
 			}
@@ -248,6 +251,6 @@ public class PojoIndexingPlanImpl implements PojoIndexingPlan, PojoLoadingPlanPr
 	}
 
 	private PojoContainedTypeIndexingPlan<?, ?> createDelegate(PojoWorkContainedTypeContext<?, ?> typeContext) {
-		return new PojoContainedTypeIndexingPlan<>( typeContext, sessionContext );
+		return strategy.createDelegate( typeContext, sessionContext );
 	}
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanLocalStrategy.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanLocalStrategy.java
@@ -1,0 +1,69 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.work.impl;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.hibernate.search.engine.backend.common.spi.EntityReferenceFactory;
+import org.hibernate.search.engine.backend.common.spi.MultiEntityOperationExecutionReport;
+import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy;
+import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
+import org.hibernate.search.mapper.pojo.work.spi.PojoWorkSessionContext;
+
+/**
+ * A strategy for handling indexing locally (as opposed to sending events to a remote processor).
+ */
+public class PojoIndexingPlanLocalStrategy implements PojoIndexingPlanStrategy {
+	private final DocumentCommitStrategy commitStrategy;
+	private final DocumentRefreshStrategy refreshStrategy;
+
+	public PojoIndexingPlanLocalStrategy(DocumentCommitStrategy commitStrategy,
+			DocumentRefreshStrategy refreshStrategy) {
+		this.commitStrategy = commitStrategy;
+		this.refreshStrategy = refreshStrategy;
+	}
+
+	@Override
+	public boolean shouldResolveDirty() {
+		return true;
+	}
+
+	@Override
+	public <R> CompletableFuture<MultiEntityOperationExecutionReport<R>> doExecuteAndReport(
+			Collection<PojoIndexedTypeIndexingPlan<?, ?>> indexedTypeDelegates,
+			PojoLoadingPlanProvider loadingPlanProvider,
+			EntityReferenceFactory<R> entityReferenceFactory) {
+		List<CompletableFuture<MultiEntityOperationExecutionReport<R>>> futures = new ArrayList<>();
+		// Each type has its own index indexing plan to execute.
+		for ( PojoIndexedTypeIndexingPlan<?, ?> delegate : indexedTypeDelegates ) {
+			futures.add( delegate.executeAndReport( entityReferenceFactory ) );
+		}
+		return MultiEntityOperationExecutionReport.allOf( futures );
+	}
+
+	@Override
+	public void doDiscard(
+			Collection<PojoIndexedTypeIndexingPlan<?, ?>> indexedTypeDelegates) {
+		// Each type has its own index indexing plan to discard.
+		for ( PojoIndexedTypeIndexingPlan<?, ?> delegate : indexedTypeDelegates ) {
+			delegate.discard();
+		}
+	}
+
+	@Override
+	public <I, E> PojoIndexedTypeIndexingPlan<I, E> createDelegate(PojoWorkIndexedTypeContext<I, E> typeContext,
+			PojoWorkSessionContext sessionContext) {
+		IndexIndexingPlan indexIndexingPlan =
+				typeContext.createIndexingPlan( sessionContext, commitStrategy, refreshStrategy );
+		return new PojoIndexedTypeIndexingPlan<>( typeContext, sessionContext,
+				new PojoTypeIndexingPlanIndexDelegate<>( typeContext, sessionContext, indexIndexingPlan ) );
+	}
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanLocalStrategy.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanLocalStrategy.java
@@ -22,8 +22,8 @@ import org.hibernate.search.mapper.pojo.work.spi.PojoWorkSessionContext;
  * A strategy for handling indexing locally (as opposed to sending events to a remote processor).
  */
 public class PojoIndexingPlanLocalStrategy implements PojoIndexingPlanStrategy {
-	private final DocumentCommitStrategy commitStrategy;
-	private final DocumentRefreshStrategy refreshStrategy;
+	final DocumentCommitStrategy commitStrategy;
+	final DocumentRefreshStrategy refreshStrategy;
 
 	public PojoIndexingPlanLocalStrategy(DocumentCommitStrategy commitStrategy,
 			DocumentRefreshStrategy refreshStrategy) {
@@ -65,5 +65,13 @@ public class PojoIndexingPlanLocalStrategy implements PojoIndexingPlanStrategy {
 				typeContext.createIndexingPlan( sessionContext, commitStrategy, refreshStrategy );
 		return new PojoIndexedTypeIndexingPlan<>( typeContext, sessionContext,
 				new PojoTypeIndexingPlanIndexDelegate<>( typeContext, sessionContext, indexIndexingPlan ) );
+	}
+
+	@Override
+	public <I, E> PojoContainedTypeIndexingPlan<I, E> createDelegate(PojoWorkContainedTypeContext<I, E> typeContext,
+			PojoWorkSessionContext sessionContext) {
+		return new PojoContainedTypeIndexingPlan<>( typeContext, sessionContext,
+				// Null delegate: we will perform reindexing resolution locally.
+				null );
 	}
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanStrategy.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanStrategy.java
@@ -29,4 +29,7 @@ interface PojoIndexingPlanStrategy {
 
 	<I, E> PojoIndexedTypeIndexingPlan<I, E> createDelegate(PojoWorkIndexedTypeContext<I, E> typeContext,
 			PojoWorkSessionContext sessionContext);
+
+	<I, E> PojoContainedTypeIndexingPlan<I, E> createDelegate(PojoWorkContainedTypeContext<I, E> typeContext,
+			PojoWorkSessionContext sessionContext);
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanStrategy.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingPlanStrategy.java
@@ -1,0 +1,32 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.work.impl;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+
+import org.hibernate.search.engine.backend.common.spi.EntityReferenceFactory;
+import org.hibernate.search.engine.backend.common.spi.MultiEntityOperationExecutionReport;
+import org.hibernate.search.mapper.pojo.work.spi.PojoWorkSessionContext;
+
+/**
+ * A strategy implementing the behavior of {@link org.hibernate.search.mapper.pojo.work.spi.PojoIndexingPlan}.
+ */
+interface PojoIndexingPlanStrategy {
+
+	boolean shouldResolveDirty();
+
+	<R> CompletableFuture<MultiEntityOperationExecutionReport<R>> doExecuteAndReport(
+			Collection<PojoIndexedTypeIndexingPlan<?, ?>> indexedTypeDelegates,
+			PojoLoadingPlanProvider loadingPlanProvider,
+			EntityReferenceFactory<R> entityReferenceFactory);
+
+	void doDiscard(Collection<PojoIndexedTypeIndexingPlan<?, ?>> indexedTypeDelegates);
+
+	<I, E> PojoIndexedTypeIndexingPlan<I, E> createDelegate(PojoWorkIndexedTypeContext<I, E> typeContext,
+			PojoWorkSessionContext sessionContext);
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingQueueEventProcessingPlanImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingQueueEventProcessingPlanImpl.java
@@ -12,7 +12,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.search.engine.backend.common.spi.EntityReferenceFactory;
 import org.hibernate.search.engine.backend.common.spi.MultiEntityOperationExecutionReport;
-import org.hibernate.search.mapper.pojo.bridge.runtime.impl.IdentifierMappingImplementor;
+import org.hibernate.search.mapper.pojo.identity.impl.IdentifierMappingImplementor;
 import org.hibernate.search.mapper.pojo.logging.impl.Log;
 import org.hibernate.search.mapper.pojo.route.DocumentRoutesDescriptor;
 import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingPlan;

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingQueueEventProcessingPlanImpl.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoIndexingQueueEventProcessingPlanImpl.java
@@ -46,7 +46,8 @@ public final class PojoIndexingQueueEventProcessingPlanImpl implements PojoIndex
 	public void addOrUpdate(String entityName, String serializedId, DocumentRoutesDescriptor routes) {
 		PojoWorkIndexedTypeContext<?, ?> typeContext = typeContext( entityName );
 		Object id = typeContext.identifierMapping().fromDocumentIdentifier( serializedId, sessionContext );
-		delegate.addOrUpdate( typeContext.typeIdentifier(), id, routes, null );
+		delegate.addOrUpdate( typeContext.typeIdentifier(), id, routes, null,
+				true, true, null );
 	}
 
 	@Override

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoLoadingPlanProvider.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoLoadingPlanProvider.java
@@ -1,0 +1,15 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.work.impl;
+
+import org.hibernate.search.mapper.pojo.loading.impl.PojoLoadingPlan;
+
+public interface PojoLoadingPlanProvider {
+
+	PojoLoadingPlan<Object> loadingPlan();
+
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoTypeIndexingPlanDelegate.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoTypeIndexingPlanDelegate.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.mapper.pojo.work.impl;
 
+import java.util.BitSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
@@ -26,9 +27,13 @@ import org.hibernate.search.mapper.pojo.route.DocumentRoutesDescriptor;
  */
 interface PojoTypeIndexingPlanDelegate<I, E> {
 
+	boolean isDirtyForAddOrUpdate(boolean forceSelfDirty, boolean forceContainingDirty, BitSet dirtyPathsOrNull);
+
 	void add(I identifier, DocumentRouteDescriptor route, Supplier<E> entitySupplier);
 
-	void addOrUpdate(I identifier, DocumentRoutesDescriptor routes, Supplier<E> entitySupplier);
+	void addOrUpdate(I identifier, DocumentRoutesDescriptor routes, Supplier<E> entitySupplier,
+			boolean forceSelfDirty, boolean forceContainingDirty, BitSet dirtyPaths,
+			boolean updatedBecauseOfContained, boolean updateBecauseOfDirty);
 
 	void delete(I identifier, DocumentRoutesDescriptor routes, Supplier<E> entitySupplier);
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoTypeIndexingPlanDelegate.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoTypeIndexingPlanDelegate.java
@@ -26,7 +26,7 @@ import org.hibernate.search.mapper.pojo.route.DocumentRoutesDescriptor;
  */
 interface PojoTypeIndexingPlanDelegate<I, E> {
 
-	void add(I identifier, Supplier<E> entitySupplier, DocumentRouteDescriptor route);
+	void add(I identifier, DocumentRouteDescriptor route, Supplier<E> entitySupplier);
 
 	void addOrUpdate(I identifier, DocumentRoutesDescriptor routes, Supplier<E> entitySupplier);
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoTypeIndexingPlanEventQueueDelegate.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoTypeIndexingPlanEventQueueDelegate.java
@@ -15,6 +15,7 @@ import org.hibernate.search.mapper.pojo.route.DocumentRouteDescriptor;
 import org.hibernate.search.mapper.pojo.route.DocumentRoutesDescriptor;
 import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingQueueEventSendingPlan;
 import org.hibernate.search.mapper.pojo.work.spi.PojoWorkSessionContext;
+import org.hibernate.search.util.common.AssertionFailure;
 
 /**
  * A {@link PojoTypeIndexingPlanDelegate} that sends indexing events to an external queue,
@@ -27,46 +28,46 @@ final class PojoTypeIndexingPlanEventQueueDelegate<I, E> implements PojoTypeInde
 
 	private final PojoWorkIndexedTypeContext<I, E> typeContext;
 	private final PojoWorkSessionContext sessionContext;
-	private final PojoIndexingQueueEventSendingPlan delegate;
+	private final PojoIndexingQueueEventSendingPlan sendingPlan;
 
 	PojoTypeIndexingPlanEventQueueDelegate(PojoWorkIndexedTypeContext<I, E> typeContext,
 			PojoWorkSessionContext sessionContext,
-			PojoIndexingQueueEventSendingPlan delegate) {
+			PojoIndexingQueueEventSendingPlan sendingPlan) {
 		this.typeContext = typeContext;
 		this.sessionContext = sessionContext;
-		this.delegate = delegate;
+		this.sendingPlan = sendingPlan;
 	}
 
 	@Override
 	public void add(I identifier, Supplier<E> entitySupplier, DocumentRouteDescriptor route) {
-		delegate.add( typeContext.entityName(), identifier,
+		sendingPlan.add( typeContext.entityName(), identifier,
 				typeContext.identifierMapping().toDocumentIdentifier( identifier, sessionContext.mappingContext() ),
 				DocumentRoutesDescriptor.of( route ) );
 	}
 
 	@Override
 	public void addOrUpdate(I identifier, DocumentRoutesDescriptor routes, Supplier<E> entitySupplier) {
-		delegate.addOrUpdate( typeContext.entityName(), identifier,
+		sendingPlan.addOrUpdate( typeContext.entityName(), identifier,
 				typeContext.identifierMapping().toDocumentIdentifier( identifier, sessionContext.mappingContext() ),
 				routes );
 	}
 
 	@Override
 	public void delete(I identifier, DocumentRoutesDescriptor routes, Supplier<E> entitySupplier) {
-		delegate.delete( typeContext.entityName(), identifier,
+		sendingPlan.delete( typeContext.entityName(), identifier,
 				typeContext.identifierMapping().toDocumentIdentifier( identifier, sessionContext.mappingContext() ),
 				routes );
 	}
 
 	@Override
 	public void discard() {
-		delegate.discard();
+		throw new AssertionFailure( "discard() should be handled at the strategy level" );
 	}
 
 	@Override
 	public <R> CompletableFuture<MultiEntityOperationExecutionReport<R>> executeAndReport(
 			EntityReferenceFactory<R> entityReferenceFactory) {
-		return delegate.sendAndReport( entityReferenceFactory );
+		throw new AssertionFailure( "executeAndReport() should be handled at the strategy level" );
 	}
 
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoTypeIndexingPlanEventQueueDelegate.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoTypeIndexingPlanEventQueueDelegate.java
@@ -39,7 +39,7 @@ final class PojoTypeIndexingPlanEventQueueDelegate<I, E> implements PojoTypeInde
 	}
 
 	@Override
-	public void add(I identifier, Supplier<E> entitySupplier, DocumentRouteDescriptor route) {
+	public void add(I identifier, DocumentRouteDescriptor route, Supplier<E> entitySupplier) {
 		sendingPlan.add( typeContext.entityName(), identifier,
 				typeContext.identifierMapping().toDocumentIdentifier( identifier, sessionContext.mappingContext() ),
 				DocumentRoutesDescriptor.of( route ) );

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoTypeIndexingPlanIndexDelegate.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoTypeIndexingPlanIndexDelegate.java
@@ -29,13 +29,13 @@ final class PojoTypeIndexingPlanIndexDelegate<I, E> implements PojoTypeIndexingP
 
 	private final PojoWorkIndexedTypeContext<I, E> typeContext;
 	private final PojoWorkSessionContext sessionContext;
-	private final IndexIndexingPlan delegate;
+	private final IndexIndexingPlan indexPlan;
 
 	PojoTypeIndexingPlanIndexDelegate(PojoWorkIndexedTypeContext<I, E> typeContext,
-			PojoWorkSessionContext sessionContext, IndexIndexingPlan delegate) {
+			PojoWorkSessionContext sessionContext, IndexIndexingPlan indexPlan) {
 		this.typeContext = typeContext;
 		this.sessionContext = sessionContext;
-		this.delegate = delegate;
+		this.indexPlan = indexPlan;
 	}
 
 	@Override
@@ -43,7 +43,7 @@ final class PojoTypeIndexingPlanIndexDelegate<I, E> implements PojoTypeIndexingP
 		String documentIdentifier = typeContext.toDocumentIdentifier( sessionContext, identifier );
 		DocumentReferenceProvider referenceProvider = new PojoDocumentReferenceProvider( documentIdentifier,
 				route.routingKey(), identifier );
-		delegate.add( referenceProvider,
+		indexPlan.add( referenceProvider,
 				typeContext.toDocumentContributor( sessionContext, identifier, entitySupplier ) );
 	}
 
@@ -59,7 +59,7 @@ final class PojoTypeIndexingPlanIndexDelegate<I, E> implements PojoTypeIndexingP
 		}
 		DocumentReferenceProvider referenceProvider = new PojoDocumentReferenceProvider( documentIdentifier,
 				routes.currentRoute().routingKey(), identifier );
-		delegate.addOrUpdate( referenceProvider,
+		indexPlan.addOrUpdate( referenceProvider,
 				typeContext.toDocumentContributor( sessionContext, identifier, entitySupplier ) );
 	}
 
@@ -75,18 +75,18 @@ final class PojoTypeIndexingPlanIndexDelegate<I, E> implements PojoTypeIndexingP
 		}
 		DocumentReferenceProvider referenceProvider = new PojoDocumentReferenceProvider( documentIdentifier,
 				routes.currentRoute().routingKey(), identifier );
-		delegate.delete( referenceProvider );
+		indexPlan.delete( referenceProvider );
 	}
 
 	@Override
 	public void discard() {
-		delegate.discard();
+		indexPlan.discard();
 	}
 
 	@Override
 	public <R> CompletableFuture<MultiEntityOperationExecutionReport<R>> executeAndReport(
 			EntityReferenceFactory<R> entityReferenceFactory) {
-		return delegate.executeAndReport( entityReferenceFactory );
+		return indexPlan.executeAndReport( entityReferenceFactory );
 	}
 
 	private void delegateDeletePrevious(I identifier, String documentIdentifier,
@@ -94,7 +94,7 @@ final class PojoTypeIndexingPlanIndexDelegate<I, E> implements PojoTypeIndexingP
 		for ( DocumentRouteDescriptor route : previousRoutes ) {
 			DocumentReferenceProvider referenceProvider = new PojoDocumentReferenceProvider( documentIdentifier,
 					route.routingKey(), identifier );
-			delegate.delete( referenceProvider );
+			indexPlan.delete( referenceProvider );
 		}
 	}
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoTypeIndexingPlanIndexDelegate.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoTypeIndexingPlanIndexDelegate.java
@@ -39,7 +39,7 @@ final class PojoTypeIndexingPlanIndexDelegate<I, E> implements PojoTypeIndexingP
 	}
 
 	@Override
-	public void add(I identifier, Supplier<E> entitySupplier, DocumentRouteDescriptor route) {
+	public void add(I identifier, DocumentRouteDescriptor route, Supplier<E> entitySupplier) {
 		String documentIdentifier = typeContext.toDocumentIdentifier( sessionContext, identifier );
 		DocumentReferenceProvider referenceProvider = new PojoDocumentReferenceProvider( documentIdentifier,
 				route.routingKey(), identifier );

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoTypeIndexingPlanIndexOrEventQueueDelegate.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoTypeIndexingPlanIndexOrEventQueueDelegate.java
@@ -1,0 +1,97 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.work.impl;
+
+import java.util.BitSet;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+import org.hibernate.search.engine.backend.common.spi.EntityReferenceFactory;
+import org.hibernate.search.engine.backend.common.spi.MultiEntityOperationExecutionReport;
+import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
+import org.hibernate.search.mapper.pojo.route.DocumentRouteDescriptor;
+import org.hibernate.search.mapper.pojo.route.DocumentRoutesDescriptor;
+import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingQueueEventSendingPlan;
+import org.hibernate.search.mapper.pojo.work.spi.PojoWorkSessionContext;
+
+/**
+ * A {@link PojoTypeIndexingPlanDelegate} that sends indexing events to the index,
+ * to process them locally,
+ * except when those events were caused exclusively by a change in a contained entity,
+ * in which case it sends indexing events to an external queue,
+ * to process them externally.
+ *
+ * @param <I> The type of identifiers of entities in this plan.
+ * @param <E> The type of entities in this plan.
+ */
+final class PojoTypeIndexingPlanIndexOrEventQueueDelegate<I, E> implements PojoTypeIndexingPlanDelegate<I, E> {
+
+	private final PojoWorkIndexedTypeContext<I, E> typeContext;
+	private final PojoTypeIndexingPlanIndexDelegate<I, E> indexDelegate;
+	private final PojoTypeIndexingPlanEventQueueDelegate<I, E> eventQueueDelegate;
+
+	PojoTypeIndexingPlanIndexOrEventQueueDelegate(PojoWorkIndexedTypeContext<I, E> typeContext,
+			PojoWorkSessionContext sessionContext,
+			IndexIndexingPlan indexPlan, PojoIndexingQueueEventSendingPlan sendingPlan) {
+		this.typeContext = typeContext;
+		this.indexDelegate = new PojoTypeIndexingPlanIndexDelegate<>( typeContext, sessionContext, indexPlan );
+		this.eventQueueDelegate = new PojoTypeIndexingPlanEventQueueDelegate<>( typeContext, sessionContext, sendingPlan );
+	}
+
+	@Override
+	public boolean isDirtyForAddOrUpdate(boolean forceSelfDirty, boolean forceContainingDirty, BitSet dirtyPathsOrNull) {
+		// We will execute the addOrUpdate below
+		// if the dirty paths require the entity itself to be reindexed,
+		// but not if they only require reindexing some containing entities.
+		// Contained entities will be handled through reindexing resolution.
+		return forceSelfDirty
+				|| dirtyPathsOrNull != null && typeContext.dirtySelfFilter().test( dirtyPathsOrNull );
+	}
+
+	@Override
+	public void add(I identifier, DocumentRouteDescriptor route, Supplier<E> entitySupplier) {
+		indexDelegate.add( identifier, route, entitySupplier );
+	}
+
+	@Override
+	public void addOrUpdate(I identifier, DocumentRoutesDescriptor routes, Supplier<E> entitySupplier,
+			boolean forceSelfDirty, boolean forceContainingDirty, BitSet dirtyPaths,
+			boolean updatedBecauseOfContained, boolean updateBecauseOfDirty) {
+		PojoTypeIndexingPlanDelegate<I, E> delegate;
+		if ( updatedBecauseOfContained && !updateBecauseOfDirty ) {
+			// The entity needs to be updated because of a contained entity,
+			// but there was no processed event for this entity proper
+			// (otherwise updateBecauseOfDirty would be true - see
+			// org.hibernate.search.mapper.pojo.work.impl.PojoIndexingQueueEventProcessingPlanImpl.addOrUpdate).
+			// In order to ensure that a given entity instance is always processed
+			// by the same background process, we will send an event to be processed later.
+			delegate = eventQueueDelegate;
+		}
+		else {
+			delegate = indexDelegate;
+		}
+		delegate.addOrUpdate( identifier, routes, entitySupplier,
+				forceSelfDirty, forceContainingDirty, dirtyPaths, updatedBecauseOfContained, updateBecauseOfDirty );
+	}
+
+	@Override
+	public void delete(I identifier, DocumentRoutesDescriptor routes, Supplier<E> entitySupplier) {
+		indexDelegate.delete( identifier, routes, entitySupplier );
+	}
+
+	@Override
+	public void discard() {
+		indexDelegate.discard();
+	}
+
+	@Override
+	public <R> CompletableFuture<MultiEntityOperationExecutionReport<R>> executeAndReport(
+			EntityReferenceFactory<R> entityReferenceFactory) {
+		return indexDelegate.executeAndReport( entityReferenceFactory );
+	}
+
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkContainedTypeContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkContainedTypeContext.java
@@ -7,8 +7,9 @@
 package org.hibernate.search.mapper.pojo.work.impl;
 
 /**
+ * @param <I> The identifier type for the contained entity type.
  * @param <E> The contained entity type.
  */
-public interface PojoWorkContainedTypeContext<E> extends PojoWorkTypeContext<E> {
+public interface PojoWorkContainedTypeContext<I, E> extends PojoWorkTypeContext<I, E> {
 
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkContainedTypeContextProvider.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkContainedTypeContextProvider.java
@@ -14,4 +14,6 @@ public interface PojoWorkContainedTypeContextProvider {
 
 	<E> Optional<? extends PojoWorkContainedTypeContext<?, E>> forExactType(PojoRawTypeIdentifier<E> typeIdentifier);
 
+	Optional<? extends PojoWorkContainedTypeContext<?,?>> forEntityName(String entityName);
+
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkContainedTypeContextProvider.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkContainedTypeContextProvider.java
@@ -12,6 +12,6 @@ import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeIdentifier;
 
 public interface PojoWorkContainedTypeContextProvider {
 
-	<E> Optional<? extends PojoWorkContainedTypeContext<E>> forExactType(PojoRawTypeIdentifier<E> typeIdentifier);
+	<E> Optional<? extends PojoWorkContainedTypeContext<?, E>> forExactType(PojoRawTypeIdentifier<E> typeIdentifier);
 
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkIndexedTypeContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkIndexedTypeContext.java
@@ -14,7 +14,6 @@ import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrateg
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
-import org.hibernate.search.mapper.pojo.identity.impl.IdentifierMappingImplementor;
 import org.hibernate.search.mapper.pojo.bridge.runtime.impl.DocumentRouter;
 import org.hibernate.search.mapper.pojo.model.path.spi.PojoPathFilter;
 import org.hibernate.search.mapper.pojo.work.spi.PojoWorkSessionContext;
@@ -23,13 +22,9 @@ import org.hibernate.search.mapper.pojo.work.spi.PojoWorkSessionContext;
  * @param <I> The identifier type for the mapped entity type.
  * @param <E> The entity type mapped to the index.
  */
-public interface PojoWorkIndexedTypeContext<I, E> extends PojoWorkTypeContext<E> {
+public interface PojoWorkIndexedTypeContext<I, E> extends PojoWorkTypeContext<I, E> {
 
 	String entityName();
-
-	IdentifierMappingImplementor<I, E> identifierMapping();
-
-	String toDocumentIdentifier(PojoWorkSessionContext sessionContext, I identifier);
 
 	DocumentRouter<? super E> router();
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkIndexedTypeContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkIndexedTypeContext.java
@@ -14,7 +14,7 @@ import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrateg
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexer;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexIndexingPlan;
 import org.hibernate.search.engine.backend.work.execution.spi.IndexWorkspace;
-import org.hibernate.search.mapper.pojo.bridge.runtime.impl.IdentifierMappingImplementor;
+import org.hibernate.search.mapper.pojo.identity.impl.IdentifierMappingImplementor;
 import org.hibernate.search.mapper.pojo.bridge.runtime.impl.DocumentRouter;
 import org.hibernate.search.mapper.pojo.model.path.spi.PojoPathFilter;
 import org.hibernate.search.mapper.pojo.work.spi.PojoWorkSessionContext;

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkIndexedTypeContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkIndexedTypeContext.java
@@ -24,8 +24,6 @@ import org.hibernate.search.mapper.pojo.work.spi.PojoWorkSessionContext;
  */
 public interface PojoWorkIndexedTypeContext<I, E> extends PojoWorkTypeContext<I, E> {
 
-	String entityName();
-
 	DocumentRouter<? super E> router();
 
 	PojoDocumentContributor<E> toDocumentContributor(PojoWorkSessionContext sessionContext, I identifier,

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkTypeContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkTypeContext.java
@@ -10,13 +10,19 @@ import java.util.function.Supplier;
 
 import org.hibernate.search.mapper.pojo.automaticindexing.impl.PojoImplicitReindexingResolverRootContext;
 import org.hibernate.search.mapper.pojo.automaticindexing.impl.PojoReindexingCollector;
+import org.hibernate.search.mapper.pojo.identity.impl.IdentifierMappingImplementor;
 import org.hibernate.search.mapper.pojo.loading.spi.PojoLoadingTypeContext;
 import org.hibernate.search.mapper.pojo.work.spi.PojoWorkSessionContext;
 
 /**
- * @param <E> The contained entity type.
+ * @param <I> The identifier type for the entity type.
+ * @param <E> The entity type.
  */
-public interface PojoWorkTypeContext<E> extends PojoLoadingTypeContext<E> {
+public interface PojoWorkTypeContext<I, E> extends PojoLoadingTypeContext<E> {
+
+	IdentifierMappingImplementor<I, E> identifierMapping();
+
+	String toDocumentIdentifier(PojoWorkSessionContext sessionContext, I identifier);
 
 	Supplier<E> toEntitySupplier(PojoWorkSessionContext sessionContext, Object entity);
 

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkTypeContext.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/impl/PojoWorkTypeContext.java
@@ -10,8 +10,10 @@ import java.util.function.Supplier;
 
 import org.hibernate.search.mapper.pojo.automaticindexing.impl.PojoImplicitReindexingResolverRootContext;
 import org.hibernate.search.mapper.pojo.automaticindexing.impl.PojoReindexingCollector;
+import org.hibernate.search.mapper.pojo.model.path.impl.PojoPathOrdinals;
 import org.hibernate.search.mapper.pojo.identity.impl.IdentifierMappingImplementor;
 import org.hibernate.search.mapper.pojo.loading.spi.PojoLoadingTypeContext;
+import org.hibernate.search.mapper.pojo.model.path.spi.PojoPathFilter;
 import org.hibernate.search.mapper.pojo.work.spi.PojoWorkSessionContext;
 
 /**
@@ -24,11 +26,17 @@ public interface PojoWorkTypeContext<I, E> extends PojoLoadingTypeContext<E> {
 
 	String toDocumentIdentifier(PojoWorkSessionContext sessionContext, I identifier);
 
+	String entityName();
+
+	PojoPathFilter dirtySelfOrContainingFilter();
+
 	Supplier<E> toEntitySupplier(PojoWorkSessionContext sessionContext, Object entity);
 
 	void resolveEntitiesToReindex(PojoReindexingCollector collector,
 			PojoWorkSessionContext sessionContext, Object identifier,
 			Supplier<E> entitySupplier,
 			PojoImplicitReindexingResolverRootContext context);
+
+	PojoPathOrdinals pathOrdinals();
 
 }

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexingPlan.java
@@ -39,7 +39,8 @@ public interface PojoIndexingPlan {
 	 * <p>
 	 * <strong>Note:</strong> depending on the backend, this may lead to errors or duplicate entries in the index
 	 * if the entity was actually already present in the index before this call.
-	 * When in doubt, you should rather use {@link #addOrUpdate(PojoRawTypeIdentifier, Object, DocumentRoutesDescriptor, Object)}.
+	 * When in doubt, you should rather use
+	 * {@link #addOrUpdate(PojoRawTypeIdentifier, Object, DocumentRoutesDescriptor, Object, boolean, boolean, BitSet)}.
 	 *
 	 * @param typeIdentifier The identifier of the entity type.
 	 * @param providedId A value to extract the document ID from.
@@ -57,7 +58,9 @@ public interface PojoIndexingPlan {
 			DocumentRoutesDescriptor providedRoutes, Object entity);
 
 	/**
-	 * Update an entity in the index, or add it if it's absent from the index.
+	 * Consider an entity updated,
+	 * and perform reindexing of this entity as well as containing entities as necessary,
+	 * taking into account {@code dirtyPaths}, {@code forceSelfDirty} and {@code forceContainingDirty}.
 	 *
 	 * @param typeIdentifier The identifier of the entity type.
 	 * @param providedId A value to extract the document ID from.
@@ -71,34 +74,16 @@ public interface PojoIndexingPlan {
 	 * the routes will be computed using that bridge instead,
 	 * and provided routes (current and previous) will all be appended to the generated "previous routes".
 	 * @param entity The entity to update in the index.
-	 */
-	void addOrUpdate(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId,
-			DocumentRoutesDescriptor providedRoutes, Object entity);
-
-	/**
-	 * Update an entity in the index, or add it if it's absent from the index,
-	 * but try to avoid reindexing if the given dirty paths
-	 * are known not to impact the indexed form of that entity.
-	 *
-	 * @param typeIdentifier The identifier of the entity type.
-	 * @param providedId A value to extract the document ID from.
-	 * Generally the expected value is the entity ID, but a different value may be expected depending on the mapping.
-	 * If {@code null}, Hibernate Search will attempt to extract the ID from the entity.
-	 * @param providedRoutes The routes to the current and previous index shards.
-	 * Only required if custom routing is enabled
-	 * and the {@link org.hibernate.search.mapper.pojo.bridge.RoutingBridge} is missing
-	 * or unable to provide all the correct previous routes.
-	 * If a {@link org.hibernate.search.mapper.pojo.bridge.RoutingBridge} is assigned to the entity type,
-	 * the routes will be computed using that bridge instead,
-	 * and provided routes (current and previous) will all be appended to the generated "previous routes".
-	 * @param entity The entity to update in the index.
+	 * @param forceSelfDirty If {@code true}, forces reindexing of this entity regardless of the dirty paths.
+	 * @param forceContainingDirty If {@code true}, forces the resolution of containing entities as dirty
 	 * @param dirtyPaths The paths to consider dirty, as a {@link BitSet}.
 	 * You can build such a {@link BitSet} by obtaining the
 	 * {@link org.hibernate.search.mapper.pojo.mapping.building.spi.PojoTypeExtendedMappingCollector#dirtyFilter(PojoPathFilter) dirty filter}
 	 * for the entity type and calling one of the {@code filter} methods.
 	 */
 	void addOrUpdate(PojoRawTypeIdentifier<?> typeIdentifier, Object providedId,
-			DocumentRoutesDescriptor providedRoutes, Object entity, BitSet dirtyPaths);
+			DocumentRoutesDescriptor providedRoutes, Object entity,
+			boolean forceSelfDirty, boolean forceContainingDirty, BitSet dirtyPaths);
 
 	/**
 	 * Delete an entity from the index.

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexingQueueEventPayload.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexingQueueEventPayload.java
@@ -1,0 +1,31 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.work.spi;
+
+import java.io.Serializable;
+
+import org.hibernate.search.mapper.pojo.route.DocumentRoutesDescriptor;
+
+public final class PojoIndexingQueueEventPayload implements Serializable {
+
+	public final DocumentRoutesDescriptor routes;
+	public final UpdateCauseDescriptor updateCause;
+
+	public PojoIndexingQueueEventPayload(DocumentRoutesDescriptor routes,
+			UpdateCauseDescriptor updateCause) {
+		this.routes = routes;
+		this.updateCause = updateCause;
+	}
+
+	@Override
+	public String toString() {
+		return "PojoIndexingQueueEventPayload{" +
+				"routes=" + routes +
+				", updateCause=" + updateCause +
+				'}';
+	}
+}

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexingQueueEventProcessingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexingQueueEventProcessingPlan.java
@@ -10,7 +10,6 @@ import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.search.engine.backend.common.spi.EntityReferenceFactory;
 import org.hibernate.search.engine.backend.common.spi.MultiEntityOperationExecutionReport;
-import org.hibernate.search.mapper.pojo.route.DocumentRoutesDescriptor;
 
 public interface PojoIndexingQueueEventProcessingPlan {
 
@@ -19,30 +18,30 @@ public interface PojoIndexingQueueEventProcessingPlan {
 	 *
 	 * @param entityName The name of the entity type.
 	 * @param serializedId The serialized entity identifier.
-	 * @param routes The document routes.
-	 * @see PojoIndexingQueueEventSendingPlan#add(String, Object, String, DocumentRoutesDescriptor)
+	 * @param payload The payload as passed to the sending plan.
+	 * @see PojoIndexingQueueEventSendingPlan#add(String, Object, String, PojoIndexingQueueEventPayload)
 	 */
-	void add(String entityName, String serializedId, DocumentRoutesDescriptor routes);
+	void add(String entityName, String serializedId, PojoIndexingQueueEventPayload payload);
 
 	/**
 	 * Appends an "add-or-update" event to the plan, received from a {@link PojoIndexingQueueEventSendingPlan}.
 	 *
 	 * @param entityName The name of the entity type.
 	 * @param serializedId The serialized entity identifier.
-	 * @param routes The document routes.
-	 * @see PojoIndexingQueueEventSendingPlan#addOrUpdate(String, Object, String, DocumentRoutesDescriptor)
+	 * @param payload The payload as passed to the sending plan.
+	 * @see PojoIndexingQueueEventSendingPlan#addOrUpdate(String, Object, String, PojoIndexingQueueEventPayload)
 	 */
-	void addOrUpdate(String entityName, String serializedId, DocumentRoutesDescriptor routes);
+	void addOrUpdate(String entityName, String serializedId, PojoIndexingQueueEventPayload payload);
 
 	/**
 	 * Appends a "delete" event to the plan, received from a {@link PojoIndexingQueueEventSendingPlan}.
 	 *
 	 * @param entityName The name of the entity type.
 	 * @param serializedId The serialized entity identifier.
-	 * @param routes The document routes.
-	 * @see PojoIndexingQueueEventSendingPlan#delete(String, Object, String, DocumentRoutesDescriptor)
+	 * @param payload The payload as passed to the sending plan.
+	 * @see PojoIndexingQueueEventSendingPlan#delete(String, Object, String, PojoIndexingQueueEventPayload)
 	 */
-	void delete(String entityName, String serializedId, DocumentRoutesDescriptor routes);
+	void delete(String entityName, String serializedId, PojoIndexingQueueEventPayload payload);
 
 	/**
 	 * Writes all pending changes to the index now,

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexingQueueEventSendingPlan.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/PojoIndexingQueueEventSendingPlan.java
@@ -10,7 +10,6 @@ import java.util.concurrent.CompletableFuture;
 
 import org.hibernate.search.engine.backend.common.spi.EntityReferenceFactory;
 import org.hibernate.search.engine.backend.common.spi.MultiEntityOperationExecutionReport;
-import org.hibernate.search.mapper.pojo.route.DocumentRoutesDescriptor;
 
 /**
  * A set of indexing events to be sent to an external queue.
@@ -27,10 +26,10 @@ public interface PojoIndexingQueueEventSendingPlan {
 	 * @param entityName The name of the entity type.
 	 * @param identifier The non-serialized entity identifier, to report sending errors.
 	 * @param serializedId The serialized entity identifier.
-	 * @param routes The document routes.
-	 * @see PojoIndexingQueueEventProcessingPlan#add(String, String, DocumentRoutesDescriptor)
+	 * @param payload A payload to be forwarded as-is to the processing plan.
+	 * @see PojoIndexingQueueEventProcessingPlan#add(String, String, PojoIndexingQueueEventPayload)
 	 */
-	void add(String entityName, Object identifier, String serializedId, DocumentRoutesDescriptor routes);
+	void add(String entityName, Object identifier, String serializedId, PojoIndexingQueueEventPayload payload);
 
 	/**
 	 * Appends an "add-or-update" event to the plan, to be sent {@link #sendAndReport(EntityReferenceFactory) later}
@@ -39,10 +38,10 @@ public interface PojoIndexingQueueEventSendingPlan {
 	 * @param entityName The name of the entity type.
 	 * @param identifier The non-serialized entity identifier, to report sending errors.
 	 * @param serializedId The serialized entity identifier.
-	 * @param routes The document routes.
-	 * @see PojoIndexingQueueEventProcessingPlan#addOrUpdate(String, String, DocumentRoutesDescriptor)
+	 * @param payload A payload to be forwarded as-is to the processing plan.
+	 * @see PojoIndexingQueueEventProcessingPlan#addOrUpdate(String, String, PojoIndexingQueueEventPayload)
 	 */
-	void addOrUpdate(String entityName, Object identifier, String serializedId, DocumentRoutesDescriptor routes);
+	void addOrUpdate(String entityName, Object identifier, String serializedId, PojoIndexingQueueEventPayload payload);
 
 	/**
 	 * Appends a "delete" event to the plan, to be sent {@link #sendAndReport(EntityReferenceFactory) later}
@@ -51,10 +50,10 @@ public interface PojoIndexingQueueEventSendingPlan {
 	 * @param entityName The name of the entity type.
 	 * @param identifier The non-serialized entity identifier, to report sending errors.
 	 * @param serializedId The serialized entity identifier.
-	 * @param routes The document routes.
-	 * @see PojoIndexingQueueEventProcessingPlan#delete(String, String, DocumentRoutesDescriptor)
+	 * @param payload A payload to be forwarded as-is to the processing plan.
+	 * @see PojoIndexingQueueEventProcessingPlan#delete(String, String, PojoIndexingQueueEventPayload)
 	 */
-	void delete(String entityName, Object identifier, String serializedId, DocumentRoutesDescriptor routes);
+	void delete(String entityName, Object identifier, String serializedId, PojoIndexingQueueEventPayload payload);
 
 	/**
 	 * Discards all events that were added to this plan, without sending them.

--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/UpdateCauseDescriptor.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/work/spi/UpdateCauseDescriptor.java
@@ -1,0 +1,52 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.mapper.pojo.work.spi;
+
+import java.io.Serializable;
+import java.util.Set;
+
+public final class UpdateCauseDescriptor implements Serializable {
+
+	private final boolean forceSelfDirty;
+	private final boolean forceContainingDirty;
+	private final Set<String> dirtyPaths;
+	private final boolean updatedBecauseOfContained;
+
+	public UpdateCauseDescriptor(boolean forceSelfDirty, boolean forceContainingDirty,
+			Set<String> dirtyPaths, boolean updatedBecauseOfContained) {
+		this.forceSelfDirty = forceSelfDirty;
+		this.forceContainingDirty = forceContainingDirty;
+		this.dirtyPaths = dirtyPaths;
+		this.updatedBecauseOfContained = updatedBecauseOfContained;
+	}
+
+	@Override
+	public String toString() {
+		return "UpdateCauseDescriptor{" +
+				"forceSelfDirty=" + forceSelfDirty +
+				", forceContainingDirty=" + forceContainingDirty +
+				", dirtyPaths=" + dirtyPaths +
+				", updatedBecauseOfContained=" + updatedBecauseOfContained +
+				'}';
+	}
+
+	public boolean forceSelfDirty() {
+		return forceSelfDirty;
+	}
+
+	public boolean forceContainingDirty() {
+		return forceContainingDirty;
+	}
+
+	public Set<String> dirtyPaths() {
+		return dirtyPaths;
+	}
+
+	public boolean updatedBecauseOfContained() {
+		return updatedBecauseOfContained;
+	}
+}

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendMock.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/util/impl/integrationtest/common/rule/BackendMock.java
@@ -79,7 +79,7 @@ public class BackendMock implements TestRule {
 		indexingWorkThreadingExpectations = expectations;
 	}
 
-	private BackendWorkThreadingExpectations indexingWorkThreadingExpectations() {
+	public BackendWorkThreadingExpectations indexingWorkThreadingExpectations() {
 		return indexingWorkThreadingExpectations;
 	}
 

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/automaticindexing/LocalHeapQueueAutomaticIndexingStrategy.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/automaticindexing/LocalHeapQueueAutomaticIndexingStrategy.java
@@ -20,7 +20,7 @@ import org.hibernate.search.mapper.orm.automaticindexing.spi.AutomaticIndexingQu
 import org.hibernate.search.mapper.orm.automaticindexing.spi.AutomaticIndexingStrategy;
 import org.hibernate.search.mapper.orm.automaticindexing.spi.AutomaticIndexingStrategyPreStopContext;
 import org.hibernate.search.mapper.orm.automaticindexing.spi.AutomaticIndexingStrategyStartContext;
-import org.hibernate.search.mapper.pojo.route.DocumentRoutesDescriptor;
+import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingQueueEventPayload;
 import org.hibernate.search.util.common.impl.Closer;
 import org.hibernate.search.util.common.serialization.spi.SerializationUtils;
 
@@ -72,25 +72,28 @@ public class LocalHeapQueueAutomaticIndexingStrategy implements AutomaticIndexin
 		private final List<LocalHeapQueueIndexingEvent> content = new ArrayList<>();
 
 		@Override
-		public void add(String entityName, Object identifier, String serializedId, DocumentRoutesDescriptor routes) {
-			plan( LocalHeapQueueIndexingEvent.Type.ADD, entityName, identifier, serializedId, routes );
+		public void add(String entityName, Object identifier, String serializedId,
+				PojoIndexingQueueEventPayload payload) {
+			plan( LocalHeapQueueIndexingEvent.Type.ADD, entityName, identifier, serializedId, payload );
 		}
 
 		@Override
-		public void addOrUpdate(String entityName, Object identifier, String serializedId, DocumentRoutesDescriptor routes) {
-			plan( LocalHeapQueueIndexingEvent.Type.ADD_OR_UPDATE, entityName, identifier, serializedId, routes );
+		public void addOrUpdate(String entityName, Object identifier, String serializedId,
+				PojoIndexingQueueEventPayload payload) {
+			plan( LocalHeapQueueIndexingEvent.Type.ADD_OR_UPDATE, entityName, identifier, serializedId, payload );
 		}
 
 		@Override
-		public void delete(String entityName, Object identifier, String serializedId, DocumentRoutesDescriptor routes) {
-			plan( LocalHeapQueueIndexingEvent.Type.DELETE, entityName, identifier, serializedId, routes );
+		public void delete(String entityName, Object identifier, String serializedId,
+				PojoIndexingQueueEventPayload payload) {
+			plan( LocalHeapQueueIndexingEvent.Type.DELETE, entityName, identifier, serializedId, payload );
 		}
 
-		private void plan(LocalHeapQueueIndexingEvent.Type eventType, String entityName, Object identifier, String serializedId,
-				DocumentRoutesDescriptor routes) {
+		private void plan(LocalHeapQueueIndexingEvent.Type eventType, String entityName, Object identifier,
+				String serializedId, PojoIndexingQueueEventPayload payload) {
 			checkAcceptsEvents();
 			content.add( new LocalHeapQueueIndexingEvent( eventType, entityName, identifier, serializedId,
-					SerializationUtils.serialize( routes ) ) );
+					SerializationUtils.serialize( payload ) ) );
 		}
 
 		@Override

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/automaticindexing/LocalHeapQueueIndexingEvent.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/automaticindexing/LocalHeapQueueIndexingEvent.java
@@ -20,15 +20,15 @@ public class LocalHeapQueueIndexingEvent implements BatchedWork<LocalHeapQueuePr
 	final String entityName;
 	final transient Object identifier;
 	final String serializedId;
-	final byte[] routes;
+	final byte[] payload;
 
 	public LocalHeapQueueIndexingEvent(Type eventType, String entityName, Object identifier, String serializedId,
-			byte[] routes) {
+			byte[] payload) {
 		this.eventType = eventType;
 		this.entityName = entityName;
 		this.identifier = identifier;
 		this.serializedId = serializedId;
-		this.routes = routes;
+		this.payload = payload;
 	}
 
 	@Override

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/automaticindexing/LocalHeapQueueIndexingEvent.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/automaticindexing/LocalHeapQueueIndexingEvent.java
@@ -34,7 +34,8 @@ public class LocalHeapQueueIndexingEvent implements BatchedWork<LocalHeapQueuePr
 	@Override
 	public String toString() {
 		return "LocalHeapQueueIndexingEvent{" +
-				"eventType=" + eventType +
+				"id=" + System.identityHashCode( this ) +
+				", eventType=" + eventType +
 				", entityName='" + entityName + '\'' +
 				", identifier=" + identifier +
 				'}';

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/automaticindexing/LocalHeapQueueProcessor.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/automaticindexing/LocalHeapQueueProcessor.java
@@ -18,7 +18,7 @@ import org.hibernate.search.mapper.orm.automaticindexing.spi.AutomaticIndexingMa
 import org.hibernate.search.mapper.orm.automaticindexing.spi.AutomaticIndexingQueueEventProcessingPlan;
 import org.hibernate.search.mapper.orm.common.EntityReference;
 import org.hibernate.search.mapper.orm.logging.impl.Log;
-import org.hibernate.search.mapper.pojo.route.DocumentRoutesDescriptor;
+import org.hibernate.search.mapper.pojo.work.spi.PojoIndexingQueueEventPayload;
 import org.hibernate.search.util.common.logging.impl.LoggerFactory;
 import org.hibernate.search.util.common.serialization.spi.SerializationUtils;
 
@@ -45,17 +45,17 @@ public class LocalHeapQueueProcessor implements BatchedWorkProcessor {
 	}
 
 	public void process(LocalHeapQueueIndexingEvent event) {
-		DocumentRoutesDescriptor routes = SerializationUtils.deserialize(
-				DocumentRoutesDescriptor.class, event.routes );
+		PojoIndexingQueueEventPayload payload = SerializationUtils.deserialize(
+				PojoIndexingQueueEventPayload.class, event.payload );
 		switch ( event.eventType ) {
 			case ADD:
-				plan.add( event.entityName, event.serializedId, routes );
+				plan.add( event.entityName, event.serializedId, payload );
 				break;
 			case ADD_OR_UPDATE:
-				plan.addOrUpdate( event.entityName, event.serializedId, routes );
+				plan.addOrUpdate( event.entityName, event.serializedId, payload );
 				break;
 			case DELETE:
-				plan.delete( event.entityName, event.serializedId, routes );
+				plan.delete( event.entityName, event.serializedId, payload );
 				break;
 		}
 		eventsInBatch.add( event );

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/automaticindexing/LocalHeapQueueProcessor.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/automaticindexing/LocalHeapQueueProcessor.java
@@ -40,8 +40,8 @@ public class LocalHeapQueueProcessor implements BatchedWorkProcessor {
 	public void beginBatch() {
 		if ( session == null ) {
 			session = mapping.sessionFactory().openSession();
-			plan = mapping.createIndexingQueueEventProcessingPlan( session );
 		}
+		plan = mapping.createIndexingQueueEventProcessingPlan( session );
 	}
 
 	public void process(LocalHeapQueueIndexingEvent event) {

--- a/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/automaticindexing/LocalHeapQueueProcessor.java
+++ b/util/internal/integrationtest/mapper/orm/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/orm/automaticindexing/LocalHeapQueueProcessor.java
@@ -30,8 +30,7 @@ public class LocalHeapQueueProcessor implements BatchedWorkProcessor {
 
 	private Session session;
 	private AutomaticIndexingQueueEventProcessingPlan plan;
-	private CompletableFuture<MultiEntityOperationExecutionReport<EntityReference>> batchReportFuture;
-	private List<LocalHeapQueueIndexingEvent> eventsInBatch = new ArrayList<>();
+	private final List<LocalHeapQueueIndexingEvent> eventsInBatch = new ArrayList<>();
 
 	public LocalHeapQueueProcessor(AutomaticIndexingMappingContext mapping) {
 		this.mapping = mapping;
@@ -43,7 +42,6 @@ public class LocalHeapQueueProcessor implements BatchedWorkProcessor {
 			session = mapping.sessionFactory().openSession();
 			plan = mapping.createIndexingQueueEventProcessingPlan( session );
 		}
-		batchReportFuture = new CompletableFuture<>();
 	}
 
 	public void process(LocalHeapQueueIndexingEvent event) {
@@ -106,7 +104,7 @@ public class LocalHeapQueueProcessor implements BatchedWorkProcessor {
 		else if ( report.throwable().isPresent() ) {
 			// Something failed, but we know which entities are affected.
 			Throwable reportThrowable = report.throwable().get();
-			reportSpecificEntitiesIndexingFailure( throwable, report.failingEntityReferences() );
+			reportSpecificEntitiesIndexingFailure( reportThrowable, report.failingEntityReferences() );
 		}
 	}
 

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMapper.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMapper.java
@@ -25,23 +25,24 @@ import org.hibernate.search.engine.mapper.mapping.spi.MappedIndexManager;
 import org.hibernate.search.engine.mapper.model.spi.MappableTypeModel;
 import org.hibernate.search.engine.reporting.spi.ContextualFailureCollector;
 import org.hibernate.search.engine.reporting.spi.EventContexts;
+import org.hibernate.search.engine.tenancy.spi.TenancyMode;
 
 class StubMapper implements Mapper<StubMappingPartialBuildState>, IndexedEntityBindingMapperContext {
 
 	private final ContextualFailureCollector failureCollector;
 	private final TypeMetadataContributorProvider<StubMappedIndex> contributorProvider;
 
-	private final boolean multiTenancyEnabled;
+	private final TenancyMode tenancyMode;
 
 	private final Map<StubTypeModel, MappedIndexManagerBuilder> indexManagerBuilders = new HashMap<>();
 	private final Map<IndexedEmbeddedDefinition, IndexedEmbeddedPathTracker> pathTrackers = new HashMap<>();
 
 	StubMapper(MappingBuildContext buildContext,
 			TypeMetadataContributorProvider<StubMappedIndex> contributorProvider,
-			boolean multiTenancyEnabled) {
+			TenancyMode tenancyMode) {
 		this.failureCollector = buildContext.failureCollector();
 		this.contributorProvider = contributorProvider;
-		this.multiTenancyEnabled = multiTenancyEnabled;
+		this.tenancyMode = tenancyMode;
 	}
 
 	@Override
@@ -65,7 +66,7 @@ class StubMapper implements Mapper<StubMappingPartialBuildState>, IndexedEntityB
 
 	private void prepareType(MappableTypeModel type, BackendsInfo backendsInfo) {
 		getMappedIndex( type )
-				.ifPresent( mappedIndex -> backendsInfo.collect( mappedIndex.backendName(), multiTenancyEnabled ) );
+				.ifPresent( mappedIndex -> backendsInfo.collect( mappedIndex.backendName(), tenancyMode ) );
 	}
 
 	@Override

--- a/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMappingInitiator.java
+++ b/util/internal/integrationtest/mapper/stub/src/main/java/org/hibernate/search/util/impl/integrationtest/mapper/stub/StubMappingInitiator.java
@@ -14,14 +14,15 @@ import org.hibernate.search.engine.mapper.mapping.building.spi.MappingConfigurat
 import org.hibernate.search.engine.mapper.mapping.building.spi.MappingInitiator;
 import org.hibernate.search.engine.mapper.model.spi.TypeMetadataContributorProvider;
 import org.hibernate.search.engine.mapper.mapping.building.spi.MappingBuildContext;
+import org.hibernate.search.engine.tenancy.spi.TenancyMode;
 
 public class StubMappingInitiator implements MappingInitiator<StubMappedIndex, StubMappingPartialBuildState> {
 
-	private final boolean multiTenancyEnabled;
+	private final TenancyMode tenancyMode;
 	private final List<StubMappedIndex> mappedIndexes = new ArrayList<>();
 
-	public StubMappingInitiator(boolean multiTenancyEnabled) {
-		this.multiTenancyEnabled = multiTenancyEnabled;
+	public StubMappingInitiator(TenancyMode tenancyMode) {
+		this.tenancyMode = tenancyMode;
 	}
 
 	public void add(StubMappedIndex mappedIndex) {
@@ -39,7 +40,7 @@ public class StubMappingInitiator implements MappingInitiator<StubMappedIndex, S
 	@Override
 	public Mapper<StubMappingPartialBuildState> createMapper(MappingBuildContext buildContext,
 			TypeMetadataContributorProvider<StubMappedIndex> contributorProvider) {
-		return new StubMapper( buildContext, contributorProvider, multiTenancyEnabled );
+		return new StubMapper( buildContext, contributorProvider, tenancyMode );
 	}
 
 }


### PR DESCRIPTION
* [HSEARCH-4141](https://hibernate.atlassian.net/browse/HSEARCH-4141): Move the resolution of containing entities to reindex to background processes

~Based on #2582 , which should be merged first.~ => Done

In short, this changes the event-queue-based automatic indexing so that, when a change occurs in a contained entity:

* we create an event for that change (with information about the paths that changed).
* when processing that event, we create one `ADD_OR_UPDATE` event per containing entity that needs to be reindexed.

This will result in more stress on the database, as well as (likely) more latency between when the change occurs and when it's visible in the index.

However, this will also reduce the work needed in the transaction that performs the database changes, which is one of the main goals of asynchronous automatic indexing. That's why this change is definitely appropriate.

As to further work... we may one day offer ways for users to specify some changes to trigger reindexing resolution synchronously in the same transaction where the change occurred, while other changes trigger reindexing resolution asynchronously in the background process. But I'll wait until we have use cases or benchmark results before considering this.