### PR TITLE
Backport HSEARCH-4157 to branch 6.0 - Investigate timeout error on IndexIndexerIT

### DIFF
--- a/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexIndexerIT.java
+++ b/integrationtest/backend/tck/src/main/java/org/hibernate/search/integrationtest/backend/tck/work/IndexIndexerIT.java
@@ -15,6 +15,7 @@ import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 import org.hibernate.search.engine.backend.document.IndexFieldReference;
 import org.hibernate.search.engine.backend.document.model.dsl.IndexSchemaElement;
@@ -91,7 +92,9 @@ public class IndexIndexerIT {
 			);
 		}
 		CompletableFuture<?> future = CompletableFuture.allOf( tasks );
-		Awaitility.await().until( future::isDone );
+		// In the case of commitStrategy=force we're going to do 200 almost concurrent commits,
+		// that is very unrealistic use case. So we will use a very large timeout here.
+		Awaitility.await().timeout( 30, TimeUnit.SECONDS ).until( future::isDone );
 		// The operations should succeed.
 		assertThatFuture( future ).isSuccessful();
 
@@ -114,7 +117,9 @@ public class IndexIndexerIT {
 			);
 		}
 		future = CompletableFuture.allOf( tasks );
-		Awaitility.await().until( future::isDone );
+		// In the case of commitStrategy=force we're going to do 200 almost concurrent commits,
+		// that is very unrealistic use case. So we will use a very large timeout here.
+		Awaitility.await().timeout( 30, TimeUnit.SECONDS ).until( future::isDone );
 		// The operations should succeed.
 		assertThatFuture( future ).isSuccessful();
 
@@ -136,7 +141,9 @@ public class IndexIndexerIT {
 			);
 		}
 		future = CompletableFuture.allOf( tasks );
-		Awaitility.await().until( future::isDone );
+		// In the case of commitStrategy=force we're going to do 200 almost concurrent commits,
+		// that is very unrealistic use case. So we will use a very large timeout here.
+		Awaitility.await().timeout( 30, TimeUnit.SECONDS ).until( future::isDone );
 		// The operations should succeed.
 		assertThatFuture( future ).isSuccessful();
 

--- a/integrationtest/mapper/orm-batch-jsr352/src/test/java/org/hibernate/search/integrationtest/batch/jsr352/massindexing/AbstractBatchIndexingIT.java
+++ b/integrationtest/mapper/orm-batch-jsr352/src/test/java/org/hibernate/search/integrationtest/batch/jsr352/massindexing/AbstractBatchIndexingIT.java
@@ -41,6 +41,8 @@ public abstract class AbstractBatchIndexingIT {
 	// We have three data templates per entity type (see setup)
 	protected static final int INSTANCE_PER_ENTITY_TYPE = INSTANCES_PER_DATA_TEMPLATE * 3;
 
+	static final int JOB_TIMEOUT_MS = 30_000;
+
 	protected JobOperator jobOperator;
 	protected EntityManagerFactory emf;
 

--- a/integrationtest/mapper/orm-batch-jsr352/src/test/java/org/hibernate/search/integrationtest/batch/jsr352/massindexing/BatchIndexingJobIT.java
+++ b/integrationtest/mapper/orm-batch-jsr352/src/test/java/org/hibernate/search/integrationtest/batch/jsr352/massindexing/BatchIndexingJobIT.java
@@ -45,8 +45,6 @@ public class BatchIndexingJobIT extends AbstractBatchIndexingIT {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private static final int JOB_TIMEOUT_MS = 30_000;
-
 	/*
 	 * Make sure to have more than one checkpoint,
 	 * because we had errors related to that in the past.

--- a/integrationtest/mapper/orm-batch-jsr352/src/test/java/org/hibernate/search/integrationtest/batch/jsr352/massindexing/EntityManagerFactoryRetrievalIT.java
+++ b/integrationtest/mapper/orm-batch-jsr352/src/test/java/org/hibernate/search/integrationtest/batch/jsr352/massindexing/EntityManagerFactoryRetrievalIT.java
@@ -30,8 +30,6 @@ public class EntityManagerFactoryRetrievalIT extends AbstractBatchIndexingIT {
 
 	private static final String SESSION_FACTORY_NAME = "primary_session_factory";
 
-	private static final int JOB_TIMEOUT_MS = 10_000;
-
 	@Test
 	public void defaultNamespace() throws Exception {
 		List<Company> companies = JobTestUtil.findIndexedResults( emf, Company.class, "name", "Google" );

--- a/integrationtest/mapper/orm-batch-jsr352/src/test/java/org/hibernate/search/integrationtest/batch/jsr352/massindexing/MassIndexingJobWithCompositeIdIT.java
+++ b/integrationtest/mapper/orm-batch-jsr352/src/test/java/org/hibernate/search/integrationtest/batch/jsr352/massindexing/MassIndexingJobWithCompositeIdIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.integrationtest.batch.jsr352.massindexing;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.integrationtest.batch.jsr352.massindexing.AbstractBatchIndexingIT.JOB_TIMEOUT_MS;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
@@ -40,8 +41,6 @@ import org.junit.Test;
 public class MassIndexingJobWithCompositeIdIT {
 
 	private static final String PERSISTENCE_UNIT_NAME = PersistenceUnitTestUtil.getPersistenceUnitName();
-
-	private static final int JOB_TIMEOUT_MS = 30_000;
 
 	private static final LocalDate START = LocalDate.of( 2017, 6, 1 );
 

--- a/integrationtest/mapper/orm-batch-jsr352/src/test/java/org/hibernate/search/integrationtest/batch/jsr352/massindexing/MassIndexingJobWithMultiTenancyIT.java
+++ b/integrationtest/mapper/orm-batch-jsr352/src/test/java/org/hibernate/search/integrationtest/batch/jsr352/massindexing/MassIndexingJobWithMultiTenancyIT.java
@@ -8,6 +8,7 @@ package org.hibernate.search.integrationtest.batch.jsr352.massindexing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.search.integrationtest.batch.jsr352.util.JobTestUtil.findIndexedResultsInTenant;
+import static org.hibernate.search.integrationtest.batch.jsr352.massindexing.AbstractBatchIndexingIT.JOB_TIMEOUT_MS;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -44,8 +45,6 @@ public class MassIndexingJobWithMultiTenancyIT {
 	private static final String TARGET_TENANT_ID = "targetTenant";
 
 	private static final String UNUSED_TENANT_ID = "unusedTenant";
-
-	private static final int JOB_TIMEOUT_MS = 10_000;
 
 	private SessionFactory sessionFactory;
 

--- a/integrationtest/mapper/orm-batch-jsr352/src/test/java/org/hibernate/search/integrationtest/batch/jsr352/massindexing/RestartChunkIT.java
+++ b/integrationtest/mapper/orm-batch-jsr352/src/test/java/org/hibernate/search/integrationtest/batch/jsr352/massindexing/RestartChunkIT.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.integrationtest.batch.jsr352.massindexing;
 
 import static org.junit.Assert.assertEquals;
+import static org.hibernate.search.integrationtest.batch.jsr352.massindexing.AbstractBatchIndexingIT.JOB_TIMEOUT_MS;
 
 import java.io.IOException;
 import java.util.List;
@@ -40,8 +41,6 @@ public class RestartChunkIT {
 	private static final int CHECKPOINT_INTERVAL = 10;
 
 	private static final String PERSISTENCE_UNIT_NAME = PersistenceUnitTestUtil.getPersistenceUnitName();
-
-	private static final int JOB_TIMEOUT_MS = 10_000;
 
 	protected static final long DB_COMP_ROWS = 150;
 

--- a/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/routing/RoutingBridgeRoutingKeyIT.java
+++ b/integrationtest/mapper/orm-realbackend/src/test/java/org/hibernate/search/integrationtest/mapper/orm/realbackend/routing/RoutingBridgeRoutingKeyIT.java
@@ -52,6 +52,10 @@ public class RoutingBridgeRoutingKeyIT {
 		entityManagerFactory = setupHelper.start()
 				.withProperty( HibernateOrmMapperSettings.AUTOMATIC_INDEXING_SYNCHRONIZATION_STRATEGY,
 						AutomaticIndexingSynchronizationStrategyNames.READ_SYNC )
+				// This call in testLifecycle to Elasticsearch sever may exceed 30 seconds,
+				// from some machine. This is a server (not Hibernate Search) latency.
+				// E.g: > query parameters {} and 1 objects in payload in 30617ms.
+				.withProperty( "hibernate.search.backend.read_timeout", "60000" )
 				.setup( Book.class );
 	}
 

--- a/integrationtest/performance/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/performance/backend/elasticsearch/SmokeIT.java
+++ b/integrationtest/performance/backend/elasticsearch/src/test/java/org/hibernate/search/integrationtest/performance/backend/elasticsearch/SmokeIT.java
@@ -49,8 +49,9 @@ public class SmokeIT {
 				.measurementTime( TimeValue.seconds( 1 ) )
 				.param(
 						"configuration",
-						"",
-						"max_connections_per_route=30"
+						// Overriding read timeout to avoid failures on some super slow machines (Mac?)
+						"read_timeout=120000",
+						"read_timeout=120000&max_connections_per_route=30"
 				)
 				.param( "initialIndexSize", "100" )
 				.param( "batchSize", "10" )

--- a/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/engine/worker/WorkerTestCase.java
+++ b/integrationtest/v5migrationhelper/orm/src/test/java/org/hibernate/search/test/engine/worker/WorkerTestCase.java
@@ -57,7 +57,8 @@ public abstract class WorkerTestCase extends SearchTestBase {
 				numberOfThreads,
 				i -> ( i % 2 == 0 ) ? work : reverseWork
 			)
-				.setTimeout( 1, TimeUnit.MINUTES )
+				// in some machine (e.g. Mac) this call may take more than 2 minutes
+				.setTimeout( 3, TimeUnit.MINUTES )
 				.execute();
 
 		System.out.println(


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4157

I just had a failure while working on the 6.0 branch, so let's backport these fixes.