### PR TITLE
HSEARCH-4250 Deprecate ElasticsearcAwsCredentialsProvider and make it extend a new ElasticsearchAwsCredentialsProvider

### DIFF
--- a/backend/elasticsearch-aws/src/main/java/org/hibernate/search/backend/elasticsearch/aws/impl/ElasticsearchAwsBeanConfigurer.java
+++ b/backend/elasticsearch-aws/src/main/java/org/hibernate/search/backend/elasticsearch/aws/impl/ElasticsearchAwsBeanConfigurer.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.backend.elasticsearch.aws.impl;
 
 import org.hibernate.search.backend.elasticsearch.aws.cfg.ElasticsearchAwsCredentialsTypeNames;
-import org.hibernate.search.backend.elasticsearch.aws.spi.ElasticsearcAwsCredentialsProvider;
+import org.hibernate.search.backend.elasticsearch.aws.spi.ElasticsearchAwsCredentialsProvider;
 import org.hibernate.search.backend.elasticsearch.client.ElasticsearchHttpClientConfigurer;
 import org.hibernate.search.engine.environment.bean.BeanHolder;
 import org.hibernate.search.engine.environment.bean.spi.BeanConfigurationContext;
@@ -23,11 +23,11 @@ public class ElasticsearchAwsBeanConfigurer implements BeanConfigurer {
 				beanResolver -> BeanHolder.of( new ElasticsearchAwsHttpClientConfigurer() )
 		);
 		context.define(
-				ElasticsearcAwsCredentialsProvider.class, ElasticsearchAwsCredentialsTypeNames.DEFAULT,
+				ElasticsearchAwsCredentialsProvider.class, ElasticsearchAwsCredentialsTypeNames.DEFAULT,
 				beanResolver -> BeanHolder.of( ignored -> DefaultCredentialsProvider.create() )
 		);
 		context.define(
-				ElasticsearcAwsCredentialsProvider.class, ElasticsearchAwsCredentialsTypeNames.STATIC,
+				ElasticsearchAwsCredentialsProvider.class, ElasticsearchAwsCredentialsTypeNames.STATIC,
 				beanResolver -> BeanHolder.of( new ElasticsearchAwsStaticCredentialsProvider() )
 		);
 	}

--- a/backend/elasticsearch-aws/src/main/java/org/hibernate/search/backend/elasticsearch/aws/impl/ElasticsearchAwsHttpClientConfigurer.java
+++ b/backend/elasticsearch-aws/src/main/java/org/hibernate/search/backend/elasticsearch/aws/impl/ElasticsearchAwsHttpClientConfigurer.java
@@ -11,7 +11,7 @@ import java.lang.invoke.MethodHandles;
 import org.hibernate.search.backend.elasticsearch.aws.cfg.ElasticsearchAwsBackendSettings;
 import org.hibernate.search.backend.elasticsearch.aws.cfg.ElasticsearchAwsCredentialsTypeNames;
 import org.hibernate.search.backend.elasticsearch.aws.logging.impl.Log;
-import org.hibernate.search.backend.elasticsearch.aws.spi.ElasticsearcAwsCredentialsProvider;
+import org.hibernate.search.backend.elasticsearch.aws.spi.ElasticsearchAwsCredentialsProvider;
 import org.hibernate.search.backend.elasticsearch.client.ElasticsearchHttpClientConfigurationContext;
 import org.hibernate.search.backend.elasticsearch.client.ElasticsearchHttpClientConfigurer;
 import org.hibernate.search.engine.cfg.spi.ConfigurationProperty;
@@ -40,10 +40,10 @@ public class ElasticsearchAwsHttpClientConfigurer implements ElasticsearchHttpCl
 					.asString()
 					.build();
 
-	private static final ConfigurationProperty<BeanReference<? extends ElasticsearcAwsCredentialsProvider>> CREDENTIALS_TYPE =
+	private static final ConfigurationProperty<BeanReference<? extends ElasticsearchAwsCredentialsProvider>> CREDENTIALS_TYPE =
 			ConfigurationProperty.forKey( ElasticsearchAwsBackendSettings.CREDENTIALS_TYPE )
-					.asBeanReference( ElasticsearcAwsCredentialsProvider.class )
-					.withDefault( BeanReference.of( ElasticsearcAwsCredentialsProvider.class, ElasticsearchAwsBackendSettings.Defaults.CREDENTIALS_TYPE ) )
+					.asBeanReference( ElasticsearchAwsCredentialsProvider.class )
+					.withDefault( BeanReference.of( ElasticsearchAwsCredentialsProvider.class, ElasticsearchAwsBackendSettings.Defaults.CREDENTIALS_TYPE ) )
 					.build();
 
 	private static final OptionalConfigurationProperty<String> LEGACY_ACCESS_KEY =
@@ -90,7 +90,7 @@ public class ElasticsearchAwsHttpClientConfigurer implements ElasticsearchHttpCl
 					ElasticsearchAwsStaticCredentialsProvider.CREDENTIALS_SECRET_ACCESS_KEY.resolveOrRaw( propertySource ) );
 		}
 
-		try ( BeanHolder<? extends ElasticsearcAwsCredentialsProvider> credentialsProviderHolder =
+		try ( BeanHolder<? extends ElasticsearchAwsCredentialsProvider> credentialsProviderHolder =
 				CREDENTIALS_TYPE.getAndTransform( propertySource, beanResolver::resolve ) ) {
 			return credentialsProviderHolder.get().create( propertySource );
 		}

--- a/backend/elasticsearch-aws/src/main/java/org/hibernate/search/backend/elasticsearch/aws/impl/ElasticsearchAwsStaticCredentialsProvider.java
+++ b/backend/elasticsearch-aws/src/main/java/org/hibernate/search/backend/elasticsearch/aws/impl/ElasticsearchAwsStaticCredentialsProvider.java
@@ -11,7 +11,7 @@ import java.lang.invoke.MethodHandles;
 import org.hibernate.search.backend.elasticsearch.aws.cfg.ElasticsearchAwsBackendSettings;
 import org.hibernate.search.backend.elasticsearch.aws.cfg.ElasticsearchAwsCredentialsTypeNames;
 import org.hibernate.search.backend.elasticsearch.aws.logging.impl.Log;
-import org.hibernate.search.backend.elasticsearch.aws.spi.ElasticsearcAwsCredentialsProvider;
+import org.hibernate.search.backend.elasticsearch.aws.spi.ElasticsearchAwsCredentialsProvider;
 import org.hibernate.search.engine.cfg.spi.ConfigurationProperty;
 import org.hibernate.search.engine.cfg.ConfigurationPropertySource;
 import org.hibernate.search.engine.cfg.spi.OptionalConfigurationProperty;
@@ -21,7 +21,7 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 
-public class ElasticsearchAwsStaticCredentialsProvider implements ElasticsearcAwsCredentialsProvider {
+public class ElasticsearchAwsStaticCredentialsProvider implements ElasticsearchAwsCredentialsProvider {
 
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 

--- a/backend/elasticsearch-aws/src/main/java/org/hibernate/search/backend/elasticsearch/aws/spi/ElasticsearchAwsCredentialsProvider.java
+++ b/backend/elasticsearch-aws/src/main/java/org/hibernate/search/backend/elasticsearch/aws/spi/ElasticsearchAwsCredentialsProvider.java
@@ -10,11 +10,7 @@ import org.hibernate.search.engine.cfg.ConfigurationPropertySource;
 
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
-/**
- * @deprecated Implement {@link ElasticsearchAwsCredentialsProvider} instead.
- */
-@Deprecated
-public interface ElasticsearcAwsCredentialsProvider extends ElasticsearchAwsCredentialsProvider {
+public interface ElasticsearchAwsCredentialsProvider {
 
 	AwsCredentialsProvider create(ConfigurationPropertySource propertySource);
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4250
