### PR TITLE
HSEARCH-3878 Maximize utilization of database connections during mass indexing

### DIFF
--- a/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoMassIndexingEntityLoadingRunnable.java
+++ b/mapper/pojo-base/src/main/java/org/hibernate/search/mapper/pojo/massindexing/impl/PojoMassIndexingEntityLoadingRunnable.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.mapper.pojo.massindexing.impl;
 
 import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -16,9 +17,9 @@ import org.hibernate.search.engine.backend.work.execution.DocumentCommitStrategy
 import org.hibernate.search.engine.backend.work.execution.DocumentRefreshStrategy;
 import org.hibernate.search.mapper.pojo.loading.spi.PojoMassEntityLoader;
 import org.hibernate.search.mapper.pojo.loading.spi.PojoMassEntitySink;
+import org.hibernate.search.mapper.pojo.logging.impl.Log;
 import org.hibernate.search.mapper.pojo.massindexing.spi.PojoMassIndexingEntityLoadingContext;
 import org.hibernate.search.mapper.pojo.massindexing.spi.PojoMassIndexingLoadingStrategy;
-import org.hibernate.search.mapper.pojo.logging.impl.Log;
 import org.hibernate.search.mapper.pojo.massindexing.spi.PojoMassIndexingSessionContext;
 import org.hibernate.search.mapper.pojo.model.spi.PojoRawTypeIdentifier;
 import org.hibernate.search.mapper.pojo.work.spi.PojoIndexer;
@@ -59,7 +60,8 @@ public class PojoMassIndexingEntityLoadingRunnable<E, I>
 					entityLoader.load( idList );
 				}
 			}
-			while ( idList != null && !context.done );
+			while ( idList != null );
+			context.waitForLastBatches();
 		}
 		log.trace( "finished" );
 	}
@@ -79,82 +81,24 @@ public class PojoMassIndexingEntityLoadingRunnable<E, I>
 		return log.massIndexingLoadingAndExtractingEntityData( typeGroup.notifiedGroupName() );
 	}
 
-	private void indexList(PojoMassIndexingSessionContext sessionContext, PojoIndexer indexer,
-			List<?> entities) throws InterruptedException {
-		if ( entities == null || entities.isEmpty() ) {
-			return;
-		}
-
-		getNotifier().reportEntitiesLoaded( entities.size() );
-		CompletableFuture<?>[] indexingFutures = new CompletableFuture<?>[entities.size()];
-
-		for ( int i = 0; i < entities.size(); i++ ) {
-			Object entity = entities.get( i );
-			indexingFutures[i] = index( sessionContext, indexer, entity );
-		}
-
-		Futures.unwrappedExceptionGet(
-				CompletableFuture.allOf( indexingFutures )
-						// We handle exceptions on a per-entity basis below, so we ignore them here.
-						.exceptionally( exception -> null )
-		);
-
-		int successfulEntities = 0;
-		for ( int i = 0; i < entities.size(); i++ ) {
-			CompletableFuture<?> future = indexingFutures[i];
-
-			if ( future.isCompletedExceptionally() ) {
-				Object entity = entities.get( i );
-				getNotifier().reportEntityIndexingFailure(
-						// We don't try to detect the exact entity type here,
-						// because that could fail if the type is not indexed
-						// (which should not happen, but well... failures should not happen to begin with).
-						typeGroup, sessionContext, entity,
-						Throwables.expectException( Futures.getThrowableNow( future ) )
-				);
-			}
-			else {
-				++successfulEntities;
-			}
-		}
-
-		getNotifier().reportDocumentsAdded( successfulEntities );
-	}
-
-	private CompletableFuture<?> index(PojoMassIndexingSessionContext sessionContext,
-			PojoIndexer indexer, Object entity) throws InterruptedException {
-		// abort if the thread has been interrupted while not in wait(), I/O or similar which themselves would have
-		// raised the InterruptedException
-		if ( Thread.currentThread().isInterrupted() ) {
-			throw new InterruptedException();
-		}
-
-		CompletableFuture<?> future;
-		try {
-			PojoRawTypeIdentifier<?> typeIdentifier = detectTypeIdentifier( sessionContext, entity );
-			future = indexer.add( typeIdentifier, null, null, entity,
-					// Commit and refresh are handled globally after all documents are indexed.
-					DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE );
-		}
-		catch (RuntimeException e) {
-			future = new CompletableFuture<>();
-			future.completeExceptionally( e );
-			return future;
-		}
-
-		// Only if the above succeeded
-		getNotifier().reportDocumentBuilt();
-
-		return future;
-	}
-
-	private PojoRawTypeIdentifier<?> detectTypeIdentifier(PojoMassIndexingSessionContext sessionContext,
-			Object entity) {
-		return sessionContext.runtimeIntrospector().detectEntityType( entity );
-	}
-
 	private final class LoadingContext implements PojoMassIndexingEntityLoadingContext<E> {
-		private boolean done = false;
+		// The traditional implementation was equivalent to using 1.
+		// Theoretically we could raise this above 2, but it would only help
+		// if loading performance is inconsistent, so as to provide a "buffer"
+		// of ongoing indexing operations that the backend can go through
+		// while the loader is catching up.
+		// So, for now, 2 should be enough.
+		private static final int CONCURRENT_BATCHES = 2;
+
+		private final List<IndexingBatch> batches;
+		private int currentBatchIndex = 0;
+
+		public LoadingContext() {
+			batches = new ArrayList<>( CONCURRENT_BATCHES );
+			for ( int i = 0; i < CONCURRENT_BATCHES; i++ ) {
+				batches.add( new IndexingBatch() );
+			}
+		}
 
 		@Override
 		public Set<PojoRawTypeIdentifier<? extends E>> includedTypes() {
@@ -167,9 +111,119 @@ public class PojoMassIndexingEntityLoadingRunnable<E, I>
 			return new PojoMassEntitySink<E>() {
 				@Override
 				public void accept(List<? extends E> batch) throws InterruptedException {
-					indexList( sessionContext, indexer, batch );
+					if ( batch == null || batch.isEmpty() ) {
+						return;
+					}
+					IndexingBatch currentBatch = batches.get( currentBatchIndex );
+					// Make sure we don't erase state about an ongoing batch:
+					// wait for an ongoing batch to finish before we start a new one.
+					currentBatch.waitForIndexingEndAndReport();
+					// Start indexing the batch. Once this returns,
+					// we know the batch of entities has been processed and turned into documents,
+					// so we can safely call the loader again for the next batch,
+					// even if the loader clears the session before each batch.
+					currentBatch.startIndexingList( sessionContext, indexer, batch );
+					currentBatchIndex = ( currentBatchIndex + 1 ) % CONCURRENT_BATCHES;
+					// We will wait for indexing to finish either the next time this method is called,
+					// or when waitForLastBatches() is called at the end.
 				}
 			};
+		}
+
+		public void waitForLastBatches() throws InterruptedException {
+			for ( IndexingBatch batch : batches ) {
+				batch.waitForIndexingEndAndReport();
+			}
+		}
+	}
+
+	private final class IndexingBatch {
+
+		private PojoMassIndexingSessionContext sessionContext;
+		private List<?> entities;
+		private CompletableFuture<?>[] indexingFutures;
+
+		public void startIndexingList(PojoMassIndexingSessionContext sessionContext, PojoIndexer indexer,
+				List<?> entities) throws InterruptedException {
+			this.sessionContext = sessionContext;
+			this.entities = entities;
+			getNotifier().reportEntitiesLoaded( entities.size() );
+			this.indexingFutures = new CompletableFuture<?>[entities.size()];
+
+			for ( int i = 0; i < entities.size(); i++ ) {
+				Object entity = entities.get( i );
+				indexingFutures[i] = startIndexing( sessionContext, indexer, entity );
+			}
+		}
+
+		private void waitForIndexingEndAndReport() throws InterruptedException {
+			if ( indexingFutures == null ) {
+				// No indexing in progress
+				return;
+			}
+
+			Futures.unwrappedExceptionGet(
+					CompletableFuture.allOf( indexingFutures )
+							// We handle exceptions on a per-entity basis below, so we ignore them here.
+							.exceptionally( exception -> null )
+			);
+
+			int successfulEntities = 0;
+			for ( int i = 0; i < entities.size(); i++ ) {
+				CompletableFuture<?> future = indexingFutures[i];
+
+				if ( future.isCompletedExceptionally() ) {
+					Object entity = entities.get( i );
+					getNotifier().reportEntityIndexingFailure(
+							// We don't try to detect the exact entity type here,
+							// because that could fail if the type is not indexed
+							// (which should not happen, but well... failures should not happen to begin with).
+							typeGroup, sessionContext, entity,
+							Throwables.expectException( Futures.getThrowableNow( future ) )
+					);
+				}
+				else {
+					++successfulEntities;
+				}
+			}
+
+			getNotifier().reportDocumentsAdded( successfulEntities );
+
+			this.sessionContext = null;
+			this.entities = null;
+			this.indexingFutures = null;
+		}
+
+		private CompletableFuture<?> startIndexing(PojoMassIndexingSessionContext sessionContext,
+				PojoIndexer indexer, Object entity) throws InterruptedException {
+			// abort if the thread has been interrupted while not in wait(), I/O or similar which themselves would have
+			// raised the InterruptedException
+			if ( Thread.currentThread().isInterrupted() ) {
+				throw new InterruptedException();
+			}
+
+			CompletableFuture<?> future;
+			try {
+				PojoRawTypeIdentifier<?> typeIdentifier = detectTypeIdentifier( sessionContext, entity );
+				future = indexer.add( typeIdentifier, null, null, entity,
+						// Commit and refresh are handled globally after all documents are indexed.
+						DocumentCommitStrategy.NONE, DocumentRefreshStrategy.NONE );
+			}
+			catch (RuntimeException e) {
+				future = new CompletableFuture<>();
+				future.completeExceptionally( e );
+				return future;
+			}
+
+			// Only if the above succeeded
+			getNotifier().reportDocumentBuilt();
+
+			return future;
+		}
+
+		private PojoRawTypeIdentifier<?> detectTypeIdentifier(PojoMassIndexingSessionContext sessionContext,
+				Object entity) {
+			return sessionContext.runtimeIntrospector().detectEntityType( entity );
 		}
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3878

I didn't have time to run full performance tests, but I did examine how it improves the behavior of backend executors.

Below are Gantt charts of the indexing batches handled by the backend during mass indexing. Each swimlane is an executor, and each "task" is a batch, with the color of each task ranging from dark red (few documents) to light green (many documents).

I generated this data by mass indexing in the [Hibernate Search Wikipedia demo](https://github.com/hibernate/hibernate-demos/tree/main/hibernate-search/hsearch-elasticsearch-wikipedia). The application indexed approximately 35000 entites, a lot of which are quite text-heavy (Wikipedia pages).

(for future reference, here was the command I executed: `logs2gantt --regex "(?P<datetime>[^,]+) TRACE.*((?P<start>Processing)|Processed) (?P<scalar>[0-9]+).*executor '(?P<swimlane>.+)'" --output-format=png --output=lucene-after.png lucene-after.log`)

## Elasticsearch

![es-before](https://user-images.githubusercontent.com/412878/123130303-f6e8ff80-d44c-11eb-9a3d-900b87385b77.png)
![es-after](https://user-images.githubusercontent.com/412878/123130311-f7819600-d44c-11eb-8997-e625d1e75bc0.png)

## Lucene

![lucene-before](https://user-images.githubusercontent.com/412878/123130313-f7819600-d44c-11eb-8381-0130bbbb3244.png)
![lucene-after](https://user-images.githubusercontent.com/412878/123130315-f81a2c80-d44c-11eb-93d5-e66b7d8d7628.png)

## Analysis

It's pretty clear with Lucene; a bit less so with Elasticsearch. The batch sizes are much more consistent, a sign that we're keeping the backend busy enough that it always has leftover work in the queue. All that while using the exact same amount of database connections.

Regarding throughput: before the change, we indexed about 850 doc/s; after the change, we indexed about 900 doc/s (1000 for Lucene). The throughput change is not significant enough to say there was an improvement, especially considering the setup was far from real-world setups (one laptop with postgres + 2 ES nodes running on the same machine). Nevertheless, I think it's a good sign that the throughput did not decrease.

Conclusion: we got exactly what we wanted, but further testing is required to see if we got a throughput improvement as a bonus.