### PR TITLE
Backport HSEARCH-4296 to branch 6.0 - Make sure assertion errors in background threads caused by unexpected works will fail a test

### DIFF
--- a/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingInterruptionIT.java
+++ b/integrationtest/mapper/orm/src/test/java/org/hibernate/search/integrationtest/mapper/orm/massindexing/MassIndexingInterruptionIT.java
@@ -170,9 +170,12 @@ public class MassIndexingInterruptionIT {
 		waitForMassIndexingThreadsToSpawn( expectedThreadCount );
 
 		// Cancel mass indexing
-		future.cancel( true );
+		// inLenientMode since, with cancel, the final flush, refresh, and merge are invoked
+		backendMock.inLenientMode( () -> {
+			future.cancel( true );
 
-		waitForMassIndexingThreadsToTerminate( expectedThreadCount );
+			waitForMassIndexingThreadsToTerminate( expectedThreadCount );
+		} );
 	}
 
 	private MassIndexer prepareMassIndexingThatWillNotTerminate() {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-4296

Backport of #2639 .